### PR TITLE
feat(web): brand-aligned canvas manipulation — tokens, touch targets, quiet guides, draw-once

### DIFF
--- a/apps/web/src/components/spatial-editor/ConnectOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/ConnectOverlay.tsx
@@ -49,7 +49,7 @@ export function ConnectOverlay({
             width={source.box.width + 4}
             height={source.box.height + 4}
             fill="none"
-            stroke="#2563eb"
+            stroke="var(--manipulation)"
             strokeWidth={2}
             strokeDasharray="6 3"
           />

--- a/apps/web/src/components/spatial-editor/MemberOutlinesOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/MemberOutlinesOverlay.tsx
@@ -54,7 +54,7 @@ export function MemberOutlinesOverlay({
               data-edge-id={id}
               points={path.map((p) => `${p.x},${p.y}`).join(' ')}
               fill="none"
-              stroke="#2563eb"
+              stroke="var(--manipulation)"
               strokeWidth={2.5 / zoom}
               strokeLinecap="round"
               opacity={0.5}
@@ -69,7 +69,7 @@ export function MemberOutlinesOverlay({
           width={box.width}
           height={box.height}
           fill="none"
-          stroke="#2563eb"
+          stroke="var(--manipulation)"
           strokeWidth={1.5 / zoom}
           opacity={0.7}
         />

--- a/apps/web/src/components/spatial-editor/SelectionOverlay.test.tsx
+++ b/apps/web/src/components/spatial-editor/SelectionOverlay.test.tsx
@@ -23,8 +23,11 @@ describe('SelectionOverlay', () => {
     expect(onHandlePointerDown).toHaveBeenCalledTimes(1)
     const [handle, box] = onHandlePointerDown.mock.calls[0] as [string, typeof BOX, unknown]
     expect(handle).toBe('se')
-    // se handle is centered on the box's bottom-right corner (x+width, y+height).
-    expect(box).toEqual({ x: 106, y: 66, width: 8, height: 8 })
+    // The HIT box (24px, centered on the corner), not the 8px marker: the
+    // interactive element is the hit shape now. Its only consumer names the
+    // parameter _handleBox and anchors resize on selectionBox instead, so
+    // this pins the callback contract, not resize math.
+    expect(box).toEqual({ x: 98, y: 58, width: 24, height: 24 })
   })
 
   it('scales the handle box by zoom (constant on-screen size)', () => {
@@ -40,7 +43,8 @@ describe('SelectionOverlay', () => {
     fireEvent.pointerDown(screen.getByTestId('resize-handle-nw'))
     const [, box] = onHandlePointerDown.mock.calls[0] as [string, typeof BOX, unknown]
     // Handle size is HANDLE_SIZE_PX / zoom = 8 / 2 = 4, centered on (x, y).
-    expect(box).toEqual({ x: 8, y: 18, width: 4, height: 4 })
+    // 24 screen px at zoom 2 → 12 canvas units, still corner-centered.
+    expect(box).toEqual({ x: 4, y: 14, width: 12, height: 12 })
   })
 
   it('invokes onConnectPointerDown when the connect handle is pressed', () => {
@@ -123,7 +127,7 @@ describe('SelectionOverlay', () => {
     expect(onHandleKeyDown).toHaveBeenCalledTimes(1)
     const [kind, box] = onHandleKeyDown.mock.calls[0] as [string, typeof BOX, unknown]
     expect(kind).toBe('se')
-    expect(box).toEqual({ x: 106, y: 66, width: 8, height: 8 })
+    expect(box).toEqual({ x: 98, y: 58, width: 24, height: 24 })
     fireEvent.keyDown(handle, { key: 'Tab' })
     expect(onHandleKeyDown).toHaveBeenCalledTimes(1)
   })

--- a/apps/web/src/components/spatial-editor/SelectionOverlay.test.tsx
+++ b/apps/web/src/components/spatial-editor/SelectionOverlay.test.tsx
@@ -153,3 +153,33 @@ describe('SelectionOverlay', () => {
     expect(onConnectKeyDown).toHaveBeenCalledTimes(2)
   })
 })
+
+it('grows the hit boxes to 32px where the pointer is coarse', () => {
+  const original = window.matchMedia
+  // The repo already stubs matchMedia in jsdom (useThemeMode.test.tsx) —
+  // this branch is plain JS, so unlike dock-button's CSS-only variant it
+  // is testable and therefore tested.
+  window.matchMedia = ((query: string) =>
+    ({
+      matches: query === '(pointer: coarse)',
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }) as unknown as MediaQueryList) as typeof window.matchMedia
+  try {
+    const onHandlePointerDown = vi.fn()
+    render(
+      <SelectionOverlay
+        box={BOX}
+        zoom={1}
+        onHandlePointerDown={onHandlePointerDown}
+        onConnectPointerDown={vi.fn()}
+      />,
+    )
+    fireEvent.pointerDown(screen.getByTestId('resize-handle-se'))
+    const [, box] = onHandlePointerDown.mock.calls[0] as [string, typeof BOX]
+    expect(box.width).toBe(32)
+  } finally {
+    window.matchMedia = original
+  }
+})

--- a/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
@@ -1,6 +1,6 @@
 /** Selection outline + resize handles + in-flight connect line, drawn in canvas space. */
 import type { Box, ResizeHandleKind } from './geometry.js'
-import { resizeHandleBoxes } from './geometry.js'
+import { cornerHitBoxes, edgeBandBoxes, resizeHandleBoxes } from './geometry.js'
 
 export interface SelectionOverlayProps {
   readonly box: Box
@@ -74,7 +74,16 @@ export function SelectionOverlay({
   onEditRequest,
 }: SelectionOverlayProps) {
   const handles = resizeHandleBoxes(box, zoom)
+  // Hitting and drawing are separate questions: the markers stay 8px so
+  // small nodes are not swallowed, while the transparent hit shapes below
+  // meet WCAG 2.5.8's 24px floor — 32px where the pointer is a finger
+  // (matchMedia is cheap and correct here; a resize re-render re-reads it).
+  const hitPx =
+    typeof matchMedia !== 'undefined' && matchMedia('(pointer: coarse)').matches ? 32 : 24
+  const cornerHits = cornerHitBoxes(box, zoom, hitPx)
+  const edgeBands = edgeBandBoxes(box, zoom, hitPx / 2, hitPx)
   const connectHandleSize = 10 / zoom
+  const connectHitRadius = hitPx / 2 / zoom
   return (
     <svg
       data-testid="selection-overlay"
@@ -99,14 +108,68 @@ export function SelectionOverlay({
         strokeWidth={1 / zoom}
         pointerEvents="none"
       />
-      {handles.map((handle) => (
-        // biome-ignore lint/a11y/useSemanticElements: must stay an SVG shape to render/hit-test at this handle's canvas-space box under the ancestor pan/zoom transform; role+tabIndex+onKeyDown reproduce native <button> semantics by hand.
+      {/* Paint order IS the hit priority: edge bands at the bottom, corner
+          hits above them, connect hits last of all — so a press near a
+          corner is a corner, and the connect port outside the edge is never
+          shadowed by the band under it. */}
+      {edgeBands.map((band) => (
+        // biome-ignore lint/a11y/useSemanticElements: must stay an SVG shape to render/hit-test at this canvas-space box under the ancestor pan/zoom transform; role+tabIndex+onKeyDown reproduce native <button> semantics by hand.
         <rect
-          key={handle.kind}
-          data-testid={`resize-handle-${handle.kind}`}
+          key={band.kind}
+          data-testid={`resize-handle-${band.kind}`}
           role="button"
           tabIndex={0}
-          aria-label={HANDLE_LABEL[handle.kind]}
+          aria-label={HANDLE_LABEL[band.kind]}
+          x={band.box.x}
+          y={band.box.y}
+          width={band.box.width}
+          height={band.box.height}
+          fill="transparent"
+          style={{ pointerEvents: 'auto', cursor: `${band.kind}-resize` }}
+          onPointerDown={(e) => {
+            if (e.button !== 0) return
+            e.stopPropagation()
+            onHandlePointerDown(band.kind, band.box, e)
+          }}
+          onKeyDown={(e) => {
+            if (onHandleKeyDown === undefined || !ARROW_KEYS.has(e.key)) return
+            e.stopPropagation()
+            onHandleKeyDown(band.kind, band.box, e)
+          }}
+        />
+      ))}
+      {cornerHits.map((hit) => (
+        // biome-ignore lint/a11y/useSemanticElements: must stay an SVG shape to render/hit-test at this canvas-space box under the ancestor pan/zoom transform; role+tabIndex+onKeyDown reproduce native <button> semantics by hand.
+        <rect
+          key={hit.kind}
+          data-testid={`resize-handle-${hit.kind}`}
+          role="button"
+          tabIndex={0}
+          aria-label={HANDLE_LABEL[hit.kind]}
+          x={hit.box.x}
+          y={hit.box.y}
+          width={hit.box.width}
+          height={hit.box.height}
+          fill="transparent"
+          style={{ pointerEvents: 'auto', cursor: `${hit.kind}-resize` }}
+          onPointerDown={(e) => {
+            if (e.button !== 0) return
+            e.stopPropagation()
+            onHandlePointerDown(hit.kind, hit.box, e)
+          }}
+          onKeyDown={(e) => {
+            if (onHandleKeyDown === undefined || !ARROW_KEYS.has(e.key)) return
+            // Fully handled here — without this the root's own arrow handler
+            // would ALSO nudge the node, double-applying every keypress.
+            e.stopPropagation()
+            onHandleKeyDown(hit.kind, hit.box, e)
+          }}
+        />
+      ))}
+      {handles.map((handle) => (
+        <rect
+          key={`marker-${handle.kind}`}
+          aria-hidden="true"
           x={handle.box.x}
           y={handle.box.y}
           width={handle.box.width}
@@ -114,45 +177,45 @@ export function SelectionOverlay({
           fill="var(--background)"
           stroke={SELECTION_STROKE}
           strokeWidth={1 / zoom}
-          style={{ pointerEvents: 'auto', cursor: `${handle.kind}-resize` }}
-          onPointerDown={(e) => {
-            if (e.button !== 0) return
-            e.stopPropagation()
-            onHandlePointerDown(handle.kind, handle.box, e)
-          }}
-          onKeyDown={(e) => {
-            if (onHandleKeyDown === undefined || !ARROW_KEYS.has(e.key)) return
-            // Fully handled here — without this the root's own arrow handler
-            // would ALSO nudge the node, double-applying every keypress.
-            e.stopPropagation()
-            onHandleKeyDown(handle.kind, handle.box, e)
-          }}
+          pointerEvents="none"
         />
       ))}
       {onConnectPointerDown !== undefined &&
         CONNECT_SIDES.map((side) => (
-          // biome-ignore lint/a11y/useSemanticElements: must stay an SVG shape to render/hit-test at this canvas-space position under the ancestor pan/zoom transform; role+tabIndex+onKeyDown reproduce native <button> semantics by hand.
-          <circle
-            key={side.kind}
-            data-testid={side.kind === 'e' ? 'connect-handle' : `connect-handle-${side.kind}`}
-            role="button"
-            tabIndex={0}
-            aria-label={`Connect to another node (from the ${side.label} side)`}
-            cx={side.cx(box, connectHandleSize)}
-            cy={side.cy(box, connectHandleSize)}
-            r={connectHandleSize / 2}
-            fill={SELECTION_STROKE}
-            style={{ pointerEvents: 'auto', cursor: 'crosshair' }}
-            onPointerDown={(e) => {
-              if (e.button !== 0) return
-              e.stopPropagation()
-              onConnectPointerDown(e)
-            }}
-            onKeyDown={(e) => {
-              if (onConnectKeyDown === undefined || (e.key !== 'Enter' && e.key !== ' ')) return
-              onConnectKeyDown(e)
-            }}
-          />
+          <g key={side.kind}>
+            <circle
+              aria-hidden="true"
+              cx={side.cx(box, connectHandleSize)}
+              cy={side.cy(box, connectHandleSize)}
+              r={connectHandleSize / 2}
+              fill={SELECTION_STROKE}
+              pointerEvents="none"
+            />
+            {/* biome-ignore lint/a11y/useSemanticElements: must stay an SVG shape to render/hit-test at this canvas-space position under the ancestor pan/zoom transform; role+tabIndex+onKeyDown reproduce native <button> semantics by hand. */}
+            <circle
+              data-testid={side.kind === 'e' ? 'connect-handle' : `connect-handle-${side.kind}`}
+              role="button"
+              tabIndex={0}
+              aria-label={`Connect to another node (from the ${side.label} side)`}
+              cx={side.cx(box, connectHandleSize)}
+              cy={side.cy(box, connectHandleSize)}
+              r={connectHitRadius}
+              fill="transparent"
+              // The halo makes the invisible target legible the moment it is
+              // hovered or focused — see index.css's --manipulation-halo.
+              className="connect-hit"
+              style={{ pointerEvents: 'auto', cursor: 'crosshair' }}
+              onPointerDown={(e) => {
+                if (e.button !== 0) return
+                e.stopPropagation()
+                onConnectPointerDown(e)
+              }}
+              onKeyDown={(e) => {
+                if (onConnectKeyDown === undefined || (e.key !== 'Enter' && e.key !== ' ')) return
+                onConnectKeyDown(e)
+              }}
+            />
+          </g>
         ))}
       {onEditRequest !== undefined && (
         // biome-ignore lint/a11y/useSemanticElements: must stay an SVG shape to render/hit-test at this canvas-space position under the ancestor pan/zoom transform; role+tabIndex+onKeyDown reproduce native <button> semantics by hand.

--- a/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
@@ -32,7 +32,7 @@ export interface SelectionOverlayProps {
   readonly onEditRequest?: () => void
 }
 
-const SELECTION_STROKE = '#2563eb'
+const SELECTION_STROKE = 'var(--manipulation)'
 const HANDLE_LABEL: Record<ResizeHandleKind, string> = {
   nw: 'Resize north-west',
   n: 'Resize north',
@@ -111,7 +111,7 @@ export function SelectionOverlay({
           y={handle.box.y}
           width={handle.box.width}
           height={handle.box.height}
-          fill="#fff"
+          fill="var(--background)"
           stroke={SELECTION_STROKE}
           strokeWidth={1 / zoom}
           style={{ pointerEvents: 'auto', cursor: `${handle.kind}-resize` }}
@@ -187,7 +187,7 @@ export function SelectionOverlay({
             y={box.y - 12 / zoom}
             textAnchor="middle"
             fontSize={12 / zoom}
-            fill="#ffffff"
+            fill="var(--background)"
             style={{ userSelect: 'none' }}
           >
             ✎

--- a/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
@@ -94,11 +94,18 @@ export function SelectionOverlay({
           and connect controls, so hiding it would undo their keyboard path. */}
       {/* Purely visual chrome — the interactive controls below carry their own role/label. */}
       <rect
+        data-testid="selection-outline"
         aria-hidden="true"
         // SVG shape elements can be natively focusable in some browsers even
         // without an explicit tabIndex; tabIndex={-1} keeps this decorative
         // outline out of the tab order to match its aria-hidden intent.
         tabIndex={-1}
+        // Draws itself once and stops (BRAND.md motion grammar). pathLength
+        // normalises the perimeter so the keyframes need no measurements;
+        // the caller remounts this component per selection TARGET, which is
+        // what replays the draw for a new selection but not per drag frame.
+        pathLength={100}
+        className="selection-draw"
         x={box.x}
         y={box.y}
         width={box.width}
@@ -170,6 +177,9 @@ export function SelectionOverlay({
         <rect
           key={`marker-${handle.kind}`}
           aria-hidden="true"
+          // Same reason as the outline: SVG shapes can be natively focusable
+          // in some browsers, and aria-hidden on a focusable is a trap.
+          tabIndex={-1}
           x={handle.box.x}
           y={handle.box.y}
           width={handle.box.width}
@@ -185,6 +195,7 @@ export function SelectionOverlay({
           <g key={side.kind}>
             <circle
               aria-hidden="true"
+              tabIndex={-1}
               cx={side.cx(box, connectHandleSize)}
               cy={side.cy(box, connectHandleSize)}
               r={connectHandleSize / 2}

--- a/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
@@ -132,6 +132,10 @@ export function SelectionOverlay({
           width={band.box.width}
           height={band.box.height}
           fill="transparent"
+          // Same legibility rule as .connect-hit: the band has no resting
+          // marker at all, so hover/focus paints the halo to say "this is
+          // grabbable" before anything is committed to.
+          className="resize-hit"
           style={{ pointerEvents: 'auto', cursor: `${band.kind}-resize` }}
           onPointerDown={(e) => {
             if (e.button !== 0) return
@@ -158,6 +162,7 @@ export function SelectionOverlay({
           width={hit.box.width}
           height={hit.box.height}
           fill="transparent"
+          className="resize-hit"
           style={{ pointerEvents: 'auto', cursor: `${hit.kind}-resize` }}
           onPointerDown={(e) => {
             if (e.button !== 0) return

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -3105,6 +3105,10 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           )}
           {selection !== undefined && selectionBox !== undefined && (
             <SelectionOverlay
+              // Keyed by TARGET: a new selection remounts the overlay and
+              // replays the outline's draw-once; dragging or resizing the
+              // same node keeps the element and stays still.
+              key={selection.id}
               box={selectionBox}
               zoom={viewport.zoom}
               onHandlePointerDown={(handle, _handleBox, e) => {

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -3029,29 +3029,61 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 pointerEvents: 'none',
               }}
             >
+              {/* Dashed with a dot at each end: a ruler showing a measured
+                  extent, not an alert line. The dash and dot sizes divide by
+                  zoom for the same reason every handle does — the ruler is
+                  chrome, and chrome keeps its on-screen size. */}
               {snapGuides.x.map((x) => (
-                <line
-                  key={`x${x}`}
-                  data-axis="x"
-                  x1={x}
-                  x2={x}
-                  y1={guideSpan.minY}
-                  y2={guideSpan.maxY}
-                  stroke="var(--manipulation-guide)"
-                  strokeWidth={1 / viewport.zoom}
-                />
+                <g key={`x${x}`}>
+                  <line
+                    data-axis="x"
+                    x1={x}
+                    x2={x}
+                    y1={guideSpan.minY}
+                    y2={guideSpan.maxY}
+                    stroke="var(--manipulation-guide)"
+                    strokeWidth={1 / viewport.zoom}
+                    strokeDasharray={`${4 / viewport.zoom} ${3 / viewport.zoom}`}
+                  />
+                  <circle
+                    cx={x}
+                    cy={guideSpan.minY}
+                    r={2 / viewport.zoom}
+                    fill="var(--manipulation-guide)"
+                  />
+                  <circle
+                    cx={x}
+                    cy={guideSpan.maxY}
+                    r={2 / viewport.zoom}
+                    fill="var(--manipulation-guide)"
+                  />
+                </g>
               ))}
               {snapGuides.y.map((y) => (
-                <line
-                  key={`y${y}`}
-                  data-axis="y"
-                  x1={guideSpan.minX}
-                  x2={guideSpan.maxX}
-                  y1={y}
-                  y2={y}
-                  stroke="var(--manipulation-guide)"
-                  strokeWidth={1 / viewport.zoom}
-                />
+                <g key={`y${y}`}>
+                  <line
+                    data-axis="y"
+                    x1={guideSpan.minX}
+                    x2={guideSpan.maxX}
+                    y1={y}
+                    y2={y}
+                    stroke="var(--manipulation-guide)"
+                    strokeWidth={1 / viewport.zoom}
+                    strokeDasharray={`${4 / viewport.zoom} ${3 / viewport.zoom}`}
+                  />
+                  <circle
+                    cx={guideSpan.minX}
+                    cy={y}
+                    r={2 / viewport.zoom}
+                    fill="var(--manipulation-guide)"
+                  />
+                  <circle
+                    cx={guideSpan.maxX}
+                    cy={y}
+                    r={2 / viewport.zoom}
+                    fill="var(--manipulation-guide)"
+                  />
+                </g>
               ))}
             </svg>
           )}

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -3009,9 +3009,9 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 y={Math.min(marquee.start.y, marquee.current.y)}
                 width={Math.abs(marquee.current.x - marquee.start.x)}
                 height={Math.abs(marquee.current.y - marquee.start.y)}
-                fill="#2563eb"
+                fill="var(--manipulation)"
                 fillOpacity={0.08}
-                stroke="#2563eb"
+                stroke="var(--manipulation)"
                 strokeWidth={1 / viewport.zoom}
                 strokeDasharray={`${4 / viewport.zoom} ${3 / viewport.zoom}`}
               />
@@ -3037,7 +3037,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                   x2={x}
                   y1={guideSpan.minY}
                   y2={guideSpan.maxY}
-                  stroke="#e11d48"
+                  stroke="var(--manipulation-guide)"
                   strokeWidth={1 / viewport.zoom}
                 />
               ))}
@@ -3049,7 +3049,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                   x2={guideSpan.maxX}
                   y1={y}
                   y2={y}
-                  stroke="#e11d48"
+                  stroke="var(--manipulation-guide)"
                   strokeWidth={1 / viewport.zoom}
                 />
               ))}
@@ -3161,7 +3161,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                     data-testid="edge-selection-highlight"
                     points={selected.path.map((p) => `${p.x},${p.y}`).join(' ')}
                     fill="none"
-                    stroke="#2563eb"
+                    stroke="var(--manipulation)"
                     strokeWidth={3}
                     strokeLinecap="round"
                   />

--- a/apps/web/src/components/spatial-editor/geometry.test.ts
+++ b/apps/web/src/components/spatial-editor/geometry.test.ts
@@ -2,6 +2,8 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { describe, expect, it } from 'vitest'
 import {
   boxContains,
+  cornerHitBoxes,
+  edgeBandBoxes,
   findFreeSpot,
   hitTest,
   indexNodeBoxes,
@@ -91,12 +93,60 @@ describe('boxContains', () => {
 })
 
 describe('resizeHandleBoxes', () => {
-  it('produces 8 handles sized inversely to zoom so they stay constant on screen', () => {
+  it('draws CORNERS only, sized inversely to zoom so they stay constant on screen', () => {
     const box = { x: 0, y: 0, width: 100, height: 100 }
     const handles = resizeHandleBoxes(box, 2)
-    expect(handles).toHaveLength(8)
+    // Edge-midpoint handles are gone as chrome: the whole edge is the grab
+    // (edgeBandBoxes below), so only the corners need a visible marker.
+    expect(handles.map((h) => h.kind)).toEqual(['nw', 'ne', 'se', 'sw'])
     for (const h of handles) {
       expect(h.box.width).toBeCloseTo(8 / 2)
+    }
+  })
+})
+
+describe('cornerHitBoxes', () => {
+  it('centers a hit box of the requested SCREEN size on each corner', () => {
+    const box = { x: 0, y: 0, width: 100, height: 100 }
+    const hits = cornerHitBoxes(box, 2, 24)
+    expect(hits.map((h) => h.kind)).toEqual(['nw', 'ne', 'se', 'sw'])
+    for (const h of hits) {
+      expect(h.box.width).toBeCloseTo(12) // 24 screen px at zoom 2
+    }
+    const se = hits.find((h) => h.kind === 'se')
+    if (se === undefined) throw new Error('missing se')
+    expect(se.box.x + se.box.width / 2).toBeCloseTo(100)
+    expect(se.box.y + se.box.height / 2).toBeCloseTo(100)
+  })
+})
+
+describe('edgeBandBoxes', () => {
+  const box = { x: 0, y: 0, width: 100, height: 100 }
+
+  it('lays a band of the requested thickness along each edge, centered on it', () => {
+    const bands = edgeBandBoxes(box, 1, 16, 24)
+    expect(bands.map((b) => b.kind)).toEqual(['n', 'e', 's', 'w'])
+    const east = bands.find((b) => b.kind === 'e')
+    if (east === undefined) throw new Error('missing e')
+    expect(east.box.x + east.box.width / 2).toBeCloseTo(100)
+    expect(east.box.width).toBeCloseTo(16)
+  })
+
+  it('stops each band short of the corner hit zones, so corners always win their ground', () => {
+    const bands = edgeBandBoxes(box, 1, 16, 24)
+    const north = bands.find((b) => b.kind === 'n')
+    if (north === undefined) throw new Error('missing n')
+    // Corner hits are 24px squares centered on (0,0)/(100,0): the band must
+    // start after the nw zone (12) and end before the ne zone (100-12).
+    expect(north.box.x).toBeCloseTo(12)
+    expect(north.box.x + north.box.width).toBeCloseTo(88)
+  })
+
+  it('never inverts on a node smaller than two corner zones', () => {
+    const tiny = { x: 0, y: 0, width: 20, height: 20 }
+    for (const band of edgeBandBoxes(tiny, 1, 16, 24)) {
+      expect(band.box.width).toBeGreaterThanOrEqual(0)
+      expect(band.box.height).toBeGreaterThanOrEqual(0)
     }
   })
 })

--- a/apps/web/src/components/spatial-editor/geometry.ts
+++ b/apps/web/src/components/spatial-editor/geometry.ts
@@ -73,28 +73,82 @@ export interface ResizeHandle {
 /** Constant on-screen handle size in CSS px, at zoom 1. */
 const HANDLE_SIZE_PX = 8
 
+type CornerKind = Extract<ResizeHandleKind, 'nw' | 'ne' | 'se' | 'sw'>
+
+const CORNERS: ReadonlyArray<{
+  kind: CornerKind
+  cx: (b: Box) => number
+  cy: (b: Box) => number
+}> = [
+  { kind: 'nw', cx: (b) => b.x, cy: (b) => b.y },
+  { kind: 'ne', cx: (b) => b.x + b.width, cy: (b) => b.y },
+  { kind: 'se', cx: (b) => b.x + b.width, cy: (b) => b.y + b.height },
+  { kind: 'sw', cx: (b) => b.x, cy: (b) => b.y + b.height },
+]
+
+function cornerBoxes(box: Box, sizeCanvas: number): readonly ResizeHandle[] {
+  const half = sizeCanvas / 2
+  return CORNERS.map(({ kind, cx, cy }) => ({
+    kind,
+    box: { x: cx(box) - half, y: cy(box) - half, width: sizeCanvas, height: sizeCanvas },
+  }))
+}
+
 /**
- * Eight resize-handle hit boxes centered on a node's corners/edge midpoints,
- * in canvas space. Sized by `HANDLE_SIZE_PX / zoom` so the handle stays a
- * constant on-screen size regardless of viewport zoom.
+ * The four VISIBLE corner markers, in canvas space, sized by
+ * `HANDLE_SIZE_PX / zoom` so they stay a constant on-screen size. Edge
+ * midpoints no longer carry a marker: the whole edge is grabbable through
+ * `edgeBandBoxes`, which is what let the touch-size hit areas of
+ * `cornerHitBoxes` grow without colliding with a mid-edge neighbour.
  */
 export function resizeHandleBoxes(box: Box, zoom: number): readonly ResizeHandle[] {
-  const size = HANDLE_SIZE_PX / zoom
-  const half = size / 2
-  const centers: Array<{ kind: ResizeHandleKind; x: number; y: number }> = [
-    { kind: 'nw', x: box.x, y: box.y },
-    { kind: 'n', x: box.x + box.width / 2, y: box.y },
-    { kind: 'ne', x: box.x + box.width, y: box.y },
-    { kind: 'e', x: box.x + box.width, y: box.y + box.height / 2 },
-    { kind: 'se', x: box.x + box.width, y: box.y + box.height },
-    { kind: 's', x: box.x + box.width / 2, y: box.y + box.height },
-    { kind: 'sw', x: box.x, y: box.y + box.height },
-    { kind: 'w', x: box.x, y: box.y + box.height / 2 },
+  return cornerBoxes(box, HANDLE_SIZE_PX / zoom)
+}
+
+/**
+ * Invisible hit areas for the corners: `hitPx` on screen (24, or 32 where
+ * the pointer is coarse), centered on the same corners the visible 8px
+ * markers sit on. Drawing and hitting are separate questions — a marker any
+ * bigger overwhelms small nodes, a target any smaller cannot be touched.
+ */
+export function cornerHitBoxes(box: Box, zoom: number, hitPx: number): readonly ResizeHandle[] {
+  return cornerBoxes(box, hitPx / zoom)
+}
+
+/**
+ * Invisible resize bands along the four edges: `bandPx` thick on screen,
+ * centered on the edge, stopping short of the corner hit zones so a press
+ * near a corner always means the corner. Bands never invert on tiny nodes —
+ * they collapse to zero length instead.
+ */
+export function edgeBandBoxes(
+  box: Box,
+  zoom: number,
+  bandPx: number,
+  cornerHitPx: number,
+): readonly ResizeHandle[] {
+  const band = bandPx / zoom
+  const inset = cornerHitPx / 2 / zoom
+  const spanW = Math.max(0, box.width - inset * 2)
+  const spanH = Math.max(0, box.height - inset * 2)
+  return [
+    {
+      kind: 'n' as const,
+      box: { x: box.x + inset, y: box.y - band / 2, width: spanW, height: band },
+    },
+    {
+      kind: 'e' as const,
+      box: { x: box.x + box.width - band / 2, y: box.y + inset, width: band, height: spanH },
+    },
+    {
+      kind: 's' as const,
+      box: { x: box.x + inset, y: box.y + box.height - band / 2, width: spanW, height: band },
+    },
+    {
+      kind: 'w' as const,
+      box: { x: box.x - band / 2, y: box.y + inset, width: band, height: spanH },
+    },
   ]
-  return centers.map(({ kind, x, y }) => ({
-    kind,
-    box: { x: x - half, y: y - half, width: size, height: size },
-  }))
 }
 
 /** Cascade step (canvas-space px) used by `findFreeSpot` between successive placement attempts. */

--- a/apps/web/src/components/spatial-editor/hit-targets.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/hit-targets.browser.test.tsx
@@ -1,0 +1,147 @@
+// The gap between what a handle SHOWS (8px) and what it CATCHES (24px+).
+//
+// Every assertion here presses deliberately OUTSIDE the visible marker but
+// inside the invisible hit shape — the exact press that used to fall
+// through to the canvas and start a marquee instead of the resize the
+// person aimed for.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const initial: SpatialCanvas = {
+  nodes: [{ id: 'n1', type: 'text', x: 200, y: 150, width: 200, height: 100, text: 'hi' }],
+  edges: [],
+}
+
+function makeHost() {
+  const latest: { canvas: SpatialCanvas } = { canvas: initial }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+function selectNode(container: HTMLElement) {
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const r = root.getBoundingClientRect()
+  // Node occupies root-local (200,150)-(400,250) at identity viewport.
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + 300,
+    clientY: r.top + 200,
+  })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + 300, clientY: r.top + 200 })
+  return { root, r }
+}
+
+/**
+ * The load-bearing detail: the element PRESSED is whatever the browser's
+ * own hit test finds at the coordinates, not an element this test picked.
+ * fireEvent on a queried element would deliver the press no matter where
+ * the coordinates fall, which asserts nothing about hit size — a hit box
+ * shrunk back to 8px kept the first version of these tests green.
+ */
+function pressAt(root: HTMLElement, at: [number, number]): Element {
+  const r = root.getBoundingClientRect()
+  const target = document.elementFromPoint(r.left + at[0], r.top + at[1])
+  if (target === null) throw new Error(`nothing at ${at[0]},${at[1]}`)
+  fireEvent.pointerDown(target, {
+    button: 0,
+    pointerId: 2,
+    clientX: r.left + at[0],
+    clientY: r.top + at[1],
+  })
+  return target
+}
+
+function dragFromScreenPoint(root: HTMLElement, from: [number, number], to: [number, number]) {
+  const r = root.getBoundingClientRect()
+  pressAt(root, from)
+  fireEvent.pointerMove(root, { pointerId: 2, clientX: r.left + to[0], clientY: r.top + to[1] })
+  fireEvent.pointerUp(root, { pointerId: 2, clientX: r.left + to[0], clientY: r.top + to[1] })
+}
+
+it('a press 10px OUTSIDE the corner marker still resizes from that corner', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const { root } = selectNode(container)
+
+  // (410,260) is 10px past the se corner (400,250): outside the old 8px
+  // marker, inside the new 24px hit box.
+  dragFromScreenPoint(root, [410, 260], [440, 290])
+
+  const node = latest.canvas.nodes[0]
+  if (node === undefined) throw new Error('node missing')
+  expect(node.width).toBeGreaterThan(200)
+  expect(node.height).toBeGreaterThan(100)
+})
+
+it('the whole edge is a grab: a press mid-edge, away from any marker, resizes that side', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const { root } = selectNode(container)
+
+  // On the east edge at (400,180): no visible marker here any more — the
+  // band is the affordance. Not the exact midpoint, which belongs to the
+  // connect port's hit circle (paint order makes the port win its ground;
+  // the test below claims that spot deliberately).
+  dragFromScreenPoint(root, [400, 180], [450, 180])
+
+  const node = latest.canvas.nodes[0]
+  if (node === undefined) throw new Error('node missing')
+  expect(node.width).toBeGreaterThan(200)
+  expect(node.height).toBe(100)
+})
+
+it('only the four corner markers are painted — mid-edge chrome is gone', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  selectNode(container)
+
+  const overlay = container.querySelector('[data-testid="selection-overlay"]') as Element
+  const painted = [...overlay.querySelectorAll('rect')].filter(
+    (el) => el.getAttribute('fill') === 'var(--background)',
+  )
+  expect(painted).toHaveLength(4)
+})
+
+it('the exact edge midpoint belongs to the connect port, by design', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const { root } = selectNode(container)
+  const r = root.getBoundingClientRect()
+  const el = document.elementFromPoint(r.left + 400, r.top + 200)
+  expect(el?.getAttribute('data-testid')).toBe('connect-handle')
+})
+
+it('the connect port catches a press outside its 10px dot', () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const { root, r } = selectNode(container)
+
+  // The dot's centre sits just right of the east edge; press 9px below it —
+  // outside the 5px visual radius, inside the 12px hit radius.
+  const pressed = pressAt(root, [410, 209])
+  expect(pressed.getAttribute('data-testid')).toBe('connect-handle')
+  fireEvent.pointerMove(root, { pointerId: 2, clientX: r.left + 500, clientY: r.top + 300 })
+
+  // The connecting gesture's source indicator is the observable that the
+  // press actually armed a connect rather than falling through to the canvas.
+  expect(container.querySelector('[data-testid="connect-source-indicator"]')).not.toBeNull()
+})

--- a/apps/web/src/components/spatial-editor/manipulation-tokens.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/manipulation-tokens.browser.test.tsx
@@ -1,0 +1,31 @@
+// The other half of manipulation-tokens.test.ts: the tokens must EXIST, in
+// both themes, in the real stylesheet — a jsdom string check cannot see
+// that (`?raw` on CSS imports returns an empty string), so this reads the
+// computed values in a real browser.
+import { afterEach, expect, it } from 'vitest'
+import '../../index.css'
+
+const TOKENS = ['--manipulation', '--manipulation-guide', '--manipulation-halo'] as const
+
+afterEach(() => document.documentElement.classList.remove('dark'))
+
+function readAll(): Record<string, string> {
+  const style = getComputedStyle(document.documentElement)
+  return Object.fromEntries(TOKENS.map((t) => [t, style.getPropertyValue(t).trim()]))
+}
+
+it('defines every manipulation token, and dark mode changes each one', () => {
+  const light = readAll()
+  for (const token of TOKENS) {
+    expect({ token, value: light[token] }).not.toEqual({ token, value: '' })
+  }
+
+  document.documentElement.classList.add('dark')
+  const dark = readAll()
+  for (const token of TOKENS) {
+    expect({ token, value: dark[token] }).not.toEqual({ token, value: '' })
+    // A token whose dark value equals its light value was forgotten in one
+    // theme — the exact drift the old hardcoded #2563eb shipped with.
+    expect({ token, changed: dark[token] !== light[token] }).toEqual({ token, changed: true })
+  }
+})

--- a/apps/web/src/components/spatial-editor/manipulation-tokens.test.ts
+++ b/apps/web/src/components/spatial-editor/manipulation-tokens.test.ts
@@ -1,0 +1,53 @@
+/**
+ * The manipulation layer — selection, handles, connect, marquee, snap
+ * guides — speaks ONE color vocabulary, defined once in index.css and read
+ * everywhere as var(--manipulation*).
+ *
+ * Before this, three vocabularies coexisted: a hardcoded #2563eb across
+ * four overlays (blind to dark mode), a hardcoded #e11d48 on the snap
+ * guides (red is this product's reserved destructive color), and one
+ * accidental currentColor. A raw hex in an overlay is how that state
+ * returns, so this guard rejects the next one the way
+ * polite-live-region.test.ts rejects the next display:none live region:
+ * source-level, via Vite's build-time raw glob. (`?raw` on CSS returns an
+ * empty string — the CSS plugin claims it first — so the both-themes half
+ * of this contract lives in manipulation-tokens.browser.test.tsx, where the
+ * real stylesheet is loaded and computed styles can be read.)
+ */
+import { describe, expect, it } from 'vitest'
+
+const overlaySources = import.meta.glob(
+  [
+    './SelectionOverlay.tsx',
+    './ConnectOverlay.tsx',
+    './MemberOutlinesOverlay.tsx',
+    './DragPreviewLayer.tsx',
+    './SpatialEditor.tsx',
+  ],
+  { query: '?raw', eager: true, import: 'default' },
+) as Record<string, string>
+
+/**
+ * A hex color literal in JSX/TSX source. The manipulation tokens are the
+ * only sanctioned way to color an overlay; node/edge CONTENT colors flow
+ * through the palette module, not through literals in these files either.
+ */
+const HEX_LITERAL = /(?:stroke|fill|color)\s*[:=]\s*["'{]*#[0-9a-fA-F]{3,8}\b/g
+
+describe('manipulation overlays read tokens, not hex literals', () => {
+  it('scans the overlay set it claims to', () => {
+    expect(Object.keys(overlaySources)).toHaveLength(5)
+  })
+
+  it('has no raw hex color in any overlay source', () => {
+    const offenders = Object.entries(overlaySources).flatMap(([path, source]) =>
+      [...source.matchAll(HEX_LITERAL)].map(
+        (m) => `${path}:${source.slice(0, m.index).split('\n').length} ${m[0]}`,
+      ),
+    )
+    expect(
+      offenders,
+      `Color through var(--manipulation*) so dark mode and the palette stay one decision: ${offenders.join(', ')}`,
+    ).toEqual([])
+  })
+})

--- a/apps/web/src/components/spatial-editor/selection-draw.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/selection-draw.browser.test.tsx
@@ -1,0 +1,78 @@
+// The selection outline draws itself once (~150ms) and stops — BRAND.md's
+// motion grammar brought to the canvas: draw once, never loop, and the
+// global prefers-reduced-motion collapse (index.css) lands it instantly on
+// the finished form because the motion is a CSS animation, not JS.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const initial: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 100, y: 100, width: 150, height: 80, text: 'a' },
+    { id: 'b', type: 'text', x: 400, y: 300, width: 150, height: 80, text: 'b' },
+  ],
+  edges: [],
+}
+
+function renderHost() {
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return render(<Host />)
+}
+
+function clickNode(container: HTMLElement, at: [number, number]) {
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const r = root.getBoundingClientRect()
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + at[0],
+    clientY: r.top + at[1],
+  })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + at[0], clientY: r.top + at[1] })
+}
+
+const outlineOf = (container: HTMLElement) =>
+  container.querySelector('[data-testid="selection-outline"]') as SVGRectElement
+
+it('the outline is a CSS draw-once animation, so the reduced-motion collapse governs it', () => {
+  const { container } = renderHost()
+  clickNode(container, [175, 140])
+
+  const outline = outlineOf(container)
+  const style = getComputedStyle(outline)
+  expect(style.animationName).toBe('selection-draw')
+  // Never loop: one iteration, and it holds the finished state.
+  expect(style.animationIterationCount).toBe('1')
+  expect(style.animationFillMode).toContain('both')
+})
+
+it('selecting a DIFFERENT node draws again; dragging the same one does not remount', () => {
+  const { container } = renderHost()
+  clickNode(container, [175, 140])
+  const first = outlineOf(container)
+
+  clickNode(container, [475, 340])
+  const second = outlineOf(container)
+  // A new element per selection target is what restarts the CSS animation.
+  expect(second).not.toBe(first)
+
+  // Same target re-selected mid-session keeps the element: no replay storm.
+  clickNode(container, [475, 340])
+  expect(outlineOf(container)).toBe(second)
+})

--- a/apps/web/src/components/spatial-editor/snap.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/snap.browser.test.tsx
@@ -112,6 +112,13 @@ it('draws the guide that justifies the snap while the drag is in flight', () => 
   })
 
   const guide = container.querySelector('[data-testid="snap-guides"] [data-axis="x"]')
+  // A ruler, not an alert: dashed, with a dot at each end marking the
+  // measured extent — and never solid, which is how it used to read as a
+  // destructive-red warning line.
+  expect(guide?.getAttribute('stroke-dasharray')).not.toBeNull()
+  expect(
+    container.querySelectorAll('[data-testid="snap-guides"] circle').length,
+  ).toBeGreaterThanOrEqual(2)
   expect(guide).toBeTruthy()
   expect(guide?.getAttribute('x1')).toBe('137')
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -58,6 +58,18 @@
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
+  /*
+   * The manipulation layer's own vocabulary — selection, handles, connect,
+   * marquee (--manipulation) and snap guides (--manipulation-guide). The
+   * guide color is deliberately a THIRD hue: not the manipulation blue (a
+   * ruler must not read as a selection edge), not any node accent, and
+   * never red, which this product reserves for destruction. The halo is
+   * the touch-target cushion. manipulation-tokens.test.ts holds every
+   * overlay to these and rejects raw hex.
+   */
+  --manipulation: oklch(0.546 0.245 262.88);
+  --manipulation-guide: oklch(0.606 0.219 292.72);
+  --manipulation-halo: color-mix(in srgb, oklch(0.546 0.245 262.88) 12%, transparent);
 }
 
 .dark {
@@ -79,6 +91,9 @@
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
+  --manipulation: oklch(0.707 0.165 254.62);
+  --manipulation-guide: oklch(0.709 0.159 293.54);
+  --manipulation-halo: color-mix(in srgb, oklch(0.707 0.165 254.62) 18%, transparent);
 }
 
 /*

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -138,7 +138,9 @@
      hover or keyboard focus fills it with the halo so the target the finger
      gets is also the target the eye can confirm. */
   .connect-hit:hover,
-  .connect-hit:focus-visible {
+  .connect-hit:focus-visible,
+  .resize-hit:hover,
+  .resize-hit:focus-visible {
     fill: var(--manipulation-halo);
   }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -209,6 +209,22 @@
    * a FINITE iteration count at the use site keeps it a pulse that
    * guides attention on entry, never a standing ping.
    */
+  /* The selection outline sketches itself in — draw once, hold, never
+     loop. A CSS animation on purpose: the global prefers-reduced-motion
+     collapse above turns it into the finished form with no JS branch. */
+  @keyframes selection-draw {
+    from {
+      stroke-dashoffset: 100;
+    }
+    to {
+      stroke-dashoffset: 0;
+    }
+  }
+  .selection-draw {
+    stroke-dasharray: 100;
+    animation: selection-draw var(--motion-duration-fast) var(--motion-ease-out) 1 both;
+  }
+
   @keyframes attention-pulse {
     from {
       transform: scale(1);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -134,6 +134,14 @@
    * `.cm-md-marker` is declared last to win the color and weight it shares
    * with the tokens that enclose it.
    */
+  /* The connect port's oversized hit circle is invisible until it matters:
+     hover or keyboard focus fills it with the halo so the target the finger
+     gets is also the target the eye can confirm. */
+  .connect-hit:hover,
+  .connect-hit:focus-visible {
+    fill: var(--manipulation-halo);
+  }
+
   .cm-md-heading {
     font-weight: 700;
     color: var(--foreground);


### PR DESCRIPTION
The canvas manipulation layer, refreshed as one system (design lab: four slices, one commit each). Started as "the handles are 8px, a third of WCAG 2.5.8's 24px floor" and grew when the inventory showed **three color vocabularies** — a hardcoded `#2563eb` across four overlays, `#e11d48` on the snap guides (red is this product's reserved *destructive* color), one accidental `currentColor` — none aware of dark mode.

## 1. One color vocabulary (`c6a2bed2`)

`--manipulation` / `--manipulation-guide` / `--manipulation-halo`, defined once in `index.css` for both themes. The guide hue is deliberately a **third color** (violet): a ruler must not read as a selection edge, a node accent, or a warning. The brand spark `#3b6ecc` is *not* used — BRAND.md reserves it for the AI's hand, and manipulation is the person's.

Two guards: a jsdom source scan rejects the next raw hex in any overlay, and a **browser test reads the computed tokens in light AND dark** and fails if a theme's value is missing or unchanged. (Why browser: `?raw` on a CSS import returns an empty string — the CSS plugin claims it first. A green string-check against a stylesheet can be checking nothing.)

## 2. Touch-size hit targets, corners-only markers (`e0d9d0e7`)

Drawing and hitting are separate questions now: markers stay 8px, invisible hit shapes are **24px (32px for coarse pointers)**. The mid-edge resize markers are gone — **the whole edge is the grab** through invisible bands — which is what freed the space without colliding with the connect ports. Paint order IS the priority: bands < corners < ports.

Every pre-existing resize/connect/snap/multi-resize browser test passes **unmodified** (behavior preservation), and the handle kinds survive, so the reducer is untouched.

**The honest part:** my first hit tests dispatched `fireEvent` onto queried elements — shrinking the hit boxes back to 8px left them green, because synthetic dispatch ignores geometry. They now resolve the pressed element with `document.elementFromPoint`, and the same mutation turns three of five red.

## 3. Snap guides as a quiet ruler (`fedeaa05`)

Dashed, endpoint dots marking the measured extent, token violet. `snap.ts` untouched.

## 4. The selection outline draws itself in, once (`4ded1b34`)

~150ms, then stillness — BRAND.md's *draw once, never loop*, at exactly one point on the canvas. CSS-driven so the global `prefers-reduced-motion` collapse lands it instantly on the finished form; the test pins `animationName`/`iterationCount`/`fillMode`. Keyed by selection target: a new selection replays the draw, dragging the same node never does.

## Visual evidence (real app, both themes)

| light | dark |
|---|---|
| ![selected-light.png](https://github.com/user-attachments/assets/41ada693-150d-4c6d-8689-a5db4f325cc7) | ![selected-dark.png](https://github.com/user-attachments/assets/ff1e3e90-89d7-4f10-84f4-88903c385fa0) |
| ![guides-light.png](https://github.com/user-attachments/assets/a8884178-15cb-4686-887e-a4d71efd2d72) | ![guides-dark.png](https://github.com/user-attachments/assets/7d8c91fc-0c36-4d26-b1f6-79ec1523b0bf) |

Measured in the running app: corner hit box 24px; a press 10px outside the marker resolves to `resize-handle-se`, 20px outside falls to the canvas; dark tokens differ from light.

## Verification

- Browser project 553 (1 known-flake: the #777 embed test, load-dependent, passes in isolation) · jsdom 2160+77 · typecheck, lint, knip clean
- Mutation checks: hitPx→8 (3 red), raw hex restored (guard red), token dropped from one theme (browser guard red)
- One capture-script lesson worth recording: `Escape` after typing DELETES a freshly created note (that is #704's feature working) — commit with blur instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SZn2v65ZrFoCuJ1ZU45hc