### PR TITLE
perf(web): stop re-running the edge-anchor pass at drag start

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -112,6 +112,7 @@ import { applyCommand, buildFragmentInsertCommand } from './commands.js'
 import { CREATION_LABELS } from './creation-labels.js'
 import { DragPreviewLayer } from './DragPreviewLayer.js'
 import { computeDragPreview, isInFlightGesture } from './drag-preview.js'
+import { useGestureCaptured } from './use-gesture-captured.js'
 import { createEditorAppearance, editorTextFill } from './editor-appearance.js'
 import { isFollowableUrl } from './followable-url.js'
 import type { Box, ResizeHandleKind } from './geometry.js'
@@ -836,6 +837,19 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * edge, re-render the remainder (composeNode is per-node pure, so the
      * prefix equivalence holds while the backdrop stays edge-free).
      */
+    // The committed layout, FROZEN at gesture start. The worker's next
+    // reply may land mid-gesture, and BOTH halves matter: the anchors are
+    // the points bystander edges are pinned to, and the scene is what
+    // decides which edges are pin-eligible at all (frozenSidesOf) — a
+    // swapped scene silently un-pins every bystander even with the anchors
+    // held, which is the same re-fraction by another door.
+    const committedPair = useMemo(() => ({ scene, anchors }), [scene, anchors])
+    const gestureCommitted = useGestureCaptured(
+      gestureState.kind === 'moving' ||
+        gestureState.kind === 'resizing' ||
+        gestureState.kind === 'connecting',
+      committedPair,
+    )
     // Last optimized sides for the gesture's carried edges (see liveEdges).
     const carriedSideCacheRef = useRef<CarriedSideCache | null>(null)
     useEffect(() => {
@@ -878,13 +892,13 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         svg: rendered.svg,
         bounds: rendered.bounds,
         measure,
-        committedAnchors: anchors,
+        committedAnchors: gestureCommitted.anchors,
       }
       // isLocked closes over lockedNodeIds/lockEnabled, both listed.
     }, [
       gestureState,
       canvas,
-      anchors,
+      gestureCommitted,
       extraIds,
       lockEnabled,
       lockedNodeIds,
@@ -954,13 +968,13 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // canvas around the pointer stays still and pointer frames skip the
       // crossing-optimization loop. The prospective edge itself derives
       // fresh each frame.
-      const frozenEdgeSides = frozenSidesOf(scene)
+      const frozenEdgeSides = frozenSidesOf(gestureCommitted.scene)
       return computeDragPreview(gestureState, boxes, livePoint, {
         canvas,
         selectableBoxes,
         frozenEdgeSides,
       })
-    }, [gestureState, livePoint, boxes, canvas, selectableBoxes, scene])
+    }, [gestureState, livePoint, boxes, canvas, selectableBoxes, gestureCommitted])
 
     /**
      * EVERY edge, re-composed against the ghost's snapped live position and
@@ -999,7 +1013,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           .map((edge) => edge.id),
       )
       const frozenSides = new Map(
-        [...frozenSidesOf(scene)]
+        [...frozenSidesOf(gestureCommitted.scene)]
           .filter(([id]) => !carriedEdgeIds.has(id))
           .map(([id, pair]) => {
             const pin = dragStatic.committedAnchors.get(id)
@@ -1051,7 +1065,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         ),
         bounds: liveBounds,
       }
-    }, [gestureState, dragPreview, dragStatic, canvas, theme, scene])
+    }, [gestureState, dragPreview, dragStatic, canvas, theme, gestureCommitted])
 
     /**
      * The resized node's own content, re-rendered at its PREVIEW size each

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -72,7 +72,6 @@ import type {
   TextMetrics,
 } from '@kamiazya/whiteboard-canvas-render'
 import {
-  assignEdgeAnchors,
   BODY_FONT_SIZE_PX,
   edgeLabelAnchor,
   flattenDrawnEdgePath,
@@ -695,7 +694,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     // fast route through carried-side caching, and a round trip per frame
     // would be the wrong trade there. This is the path that blocks on every
     // node added and every drag dropped.
-    const { svg, bounds, scene } = useWorkerScene(
+    const { svg, bounds, scene, anchors } = useWorkerScene(
       canvas,
       { measure: resolvedMeasure, theme },
       fileSeamOptions,
@@ -829,9 +828,13 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * The returned `measure` memoizes per drag: edge labels measure on the
      * first live frame and every later frame re-places the cached metrics,
      * keeping pointermoves free of text measurement.
-     * ponytail: full render at the drag boundary is ~30ms on an 80-node
-     * canvas; if start/commit jank appears on much larger canvases, move
-     * layoutSpatialCanvas + an OffscreenCanvas measurer into a worker.
+     * ponytail: the backdrop render here is ~21ms at 45 nodes (the anchor
+     * pass, formerly ~7x that, now arrives with the committed scene); if
+     * start jank reappears on much larger canvases, the next rung is
+     * reusing the committed scene graph for the backdrop instead of
+     * re-rendering — drop the carried node runs, truncate at the first
+     * edge, re-render the remainder (composeNode is per-node pure, so the
+     * prefix equivalence holds while the backdrop stays edge-free).
      */
     // Last optimized sides for the gesture's carried edges (see liveEdges).
     const carriedSideCacheRef = useRef<CarriedSideCache | null>(null)
@@ -863,19 +866,25 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         metricsCache.set(key, metrics)
         return metrics
       }
-      // The committed anchor state, captured once per gesture: liveEdges
-      // pins bystander edges to these exact points so a carried edge
-      // joining their (node, side) group cannot re-fraction them mid-drag.
-      const committedAnchors = assignEdgeAnchors(
-        canvas.nodes,
-        canvas.edges,
-        canvas['x-whiteboard']?.edgeRouting?.style,
-      )
-      return { carried, svg: rendered.svg, bounds: rendered.bounds, measure, committedAnchors }
+      // The committed anchor state: liveEdges pins bystander edges to these
+      // exact points so a carried edge joining their (node, side) group
+      // cannot re-fraction them mid-drag. Taken from the committed scene's
+      // OWN layout rather than re-run here — the anchor pass is the most
+      // expensive step of a layout (measured: ~7x the backdrop render), and
+      // these are also the anchors the pixels on screen were routed with,
+      // which a fresh pass over a newer canvas is not.
+      return {
+        carried,
+        svg: rendered.svg,
+        bounds: rendered.bounds,
+        measure,
+        committedAnchors: anchors,
+      }
       // isLocked closes over lockedNodeIds/lockEnabled, both listed.
     }, [
       gestureState,
       canvas,
+      anchors,
       extraIds,
       lockEnabled,
       lockedNodeIds,

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -112,7 +112,6 @@ import { applyCommand, buildFragmentInsertCommand } from './commands.js'
 import { CREATION_LABELS } from './creation-labels.js'
 import { DragPreviewLayer } from './DragPreviewLayer.js'
 import { computeDragPreview, isInFlightGesture } from './drag-preview.js'
-import { useGestureCaptured } from './use-gesture-captured.js'
 import { createEditorAppearance, editorTextFill } from './editor-appearance.js'
 import { isFollowableUrl } from './followable-url.js'
 import type { Box, ResizeHandleKind } from './geometry.js'
@@ -173,6 +172,7 @@ import {
   ToolPalette,
 } from './ToolPalette.js'
 import { computePinchUpdate } from './touch-pinch.js'
+import { useGestureCaptured } from './use-gesture-captured.js'
 import { useWorkerScene } from './use-worker-scene.js'
 import {
   type ContainerSize,

--- a/apps/web/src/components/spatial-editor/drag-start-responsiveness.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/drag-start-responsiveness.browser.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * The instrument for the drag-start block, landed before any change to it.
+ *
+ * Starting a move gesture renders the drag-static backdrop and the ghost
+ * synchronously on the main thread (see SpatialEditor's dragStatic memo and
+ * its ponytail marker naming the worker upgrade path). That block happens at
+ * the worst perceptual moment — the user's hand is literally in motion — so
+ * before anything is promoted to a worker, this file measures how big the
+ * block actually is on a canvas past the offload threshold.
+ *
+ * It REPORTS the longest inter-frame gap across the gesture start and pins
+ * only what must be true for the number to mean anything: the drag really
+ * started (the ghost layer is in the DOM mid-gesture). The gap itself is
+ * logged, not asserted — machine-dependent wall time pinned as a threshold
+ * is a flake generator, and the number's job is to price the ponytail
+ * upgrade, not to gate CI. Read it from the test output.
+ *
+ * One interaction, one test, same reasoning as
+ * worker-scene-responsiveness.browser.test.tsx: heavy canvases measurably
+ * raise the parallel project's flake rate, so this file spends its budget
+ * once.
+ */
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const NODES = 45
+const EDGES = 90
+
+// Same shape as worker-scene-responsiveness: enough text to wrap, enough
+// edges to route, comfortably past the 12-element offload threshold.
+const heavy = (): SpatialCanvas => ({
+  nodes: Array.from({ length: NODES }, (_, i) => ({
+    id: `n${i}`,
+    type: 'text' as const,
+    x: (i % 8) * 260,
+    y: Math.floor(i / 8) * 180,
+    width: 200,
+    height: 120,
+    text: `node ${i} carries a sentence long enough to wrap somewhere`,
+  })),
+  edges: Array.from({ length: EDGES }, (_, i) => ({
+    id: `e${i}`,
+    fromNode: `n${i % NODES}`,
+    toNode: `n${(i * 7 + 3) % NODES}`,
+  })).filter((e) => e.fromNode !== e.toNode),
+})
+
+const frame = () => new Promise((r) => requestAnimationFrame(r))
+
+it('measures the main-thread block at drag start on a heavy canvas', async () => {
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(heavy)
+    return (
+      <div style={{ width: 1000, height: 700 }}>
+        <SpatialEditor defaultTool="select" canvas={canvas} onChange={setCanvas} theme="light" />
+      </div>
+    )
+  }
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  // Let the mount settle (first scene is synchronous; the worker warms in the
+  // background) so the measurement window contains only the gesture start.
+  for (let i = 0; i < 5; i++) await frame()
+
+  // Frame-gap recorder, running across the whole gesture start.
+  const gaps: number[] = []
+  let last = performance.now()
+  const recording = true
+  const tick = () => {
+    const now = performance.now()
+    gaps.push(now - last)
+    last = now
+    if (recording) requestAnimationFrame(tick)
+  }
+  requestAnimationFrame(tick)
+
+  // Node n0 sits at canvas (0,0)-(200,120); the editor fits the scene into
+  // view, so hit it through the DOM rect of its rendered text instead of
+  // guessing screen coordinates: pointerdown selects, the first past-threshold
+  // pointermove starts the move gesture and pays the dragStatic render.
+  const r = root.getBoundingClientRect()
+  const dragOnce = async (id: number, offset: number) => {
+    // The previous gesture MOVED the node by (+80,+60); grab where it is now.
+    const grabX = r.left + 60 + offset * 80
+    const grabY = r.top + 60 + offset * 60
+    const gaps: number[] = []
+    let last = performance.now()
+    let recording = true
+    const tick = () => {
+      const now = performance.now()
+      gaps.push(now - last)
+      last = now
+      if (recording) requestAnimationFrame(tick)
+    }
+    requestAnimationFrame(tick)
+    fireEvent.pointerDown(root, { pointerId: id, clientX: grabX, clientY: grabY, buttons: 1 })
+    await frame()
+    fireEvent.pointerMove(root, {
+      pointerId: id,
+      clientX: grabX + 40,
+      clientY: grabY + 40,
+      buttons: 1,
+    })
+    await frame()
+    fireEvent.pointerMove(root, {
+      pointerId: id,
+      clientX: grabX + 80,
+      clientY: grabY + 60,
+      buttons: 1,
+    })
+    for (let i = 0; i < 10; i++) await frame()
+    recording = false
+    // The number only prices anything if a move gesture genuinely started.
+    const ghost = container.querySelector('[data-testid="drag-preview"]')
+    expect(ghost, 'drag ghost layer should be mounted mid-gesture').not.toBeNull()
+    fireEvent.pointerUp(root, { pointerId: id, clientX: grabX + 80, clientY: grabY + 60 })
+    for (let i = 0; i < 5; i++) await frame()
+    return gaps
+  }
+
+  // Twice: the first gesture pays one-time costs (first Canvas 2D measure of
+  // this font, lazily-transformed modules under the dev pipeline); the second
+  // is the steady state a user feels on every later drag.
+  const first = await dragOnce(7, 0)
+  const second = await dragOnce(8, 1)
+  const summarize = (gaps: number[]) =>
+    `maxGapMs=${Math.max(...gaps).toFixed(1)} gapsOver50ms=${gaps.filter((g) => g > 50).length}`
+  const report = `[drag-start-instrument] nodes=${NODES} edges=${EDGES} first: ${summarize(first)} second: ${summarize(second)}`
+  // eslint-disable-next-line no-console -- the instrument's output IS the point
+  console.log(report)
+}, 30_000)

--- a/apps/web/src/components/spatial-editor/live-drag.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/live-drag.browser.test.tsx
@@ -276,3 +276,106 @@ it('re-sides a carried edge mid-drag while freezing bystanders', async () => {
   )
   expect(points.some(([x, y]) => x === 300 && y! >= 100 && y! <= 200)).toBe(true)
 })
+
+it('keeps bystander pins frozen when a layout-worker reply lands mid-gesture', async () => {
+  // Past the offload threshold the committed anchors arrive asynchronously;
+  // a reply for an edit made just before the drag can land while the gesture
+  // is in flight. The points bystander edges are pinned to must not track
+  // it — swapping them under a moving hand is the exact re-fraction the
+  // committed-anchors capture exists to prevent. A stubbed Worker makes the
+  // reply land at a chosen moment.
+  class FakeWorker {
+    static instances: FakeWorker[] = []
+    static respond(data: unknown) {
+      for (const w of FakeWorker.instances)
+        for (const fn of w.listeners.get('message') ?? []) fn({ data })
+    }
+    private listeners = new Map<string, Set<(e: unknown) => void>>()
+    requests: { id?: number }[] = []
+    constructor() {
+      FakeWorker.instances.push(this)
+    }
+    addEventListener(type: string, fn: (e: unknown) => void) {
+      let set = this.listeners.get(type)
+      if (!set) {
+        set = new Set()
+        this.listeners.set(type, set)
+      }
+      set.add(fn)
+    }
+    removeEventListener(type: string, fn: (e: unknown) => void) {
+      this.listeners.get(type)?.delete(fn)
+    }
+    postMessage(msg: { id?: number }) {
+      this.requests.push(msg)
+    }
+    terminate() {}
+  }
+  vi.stubGlobal('Worker', FakeWorker)
+  try {
+    const big = (shift: number): SpatialCanvas => ({
+      nodes: [
+        { id: 'a', type: 'text', x: 100, y: 100, width: 120, height: 60, text: 'Alpha' },
+        { id: 'p', type: 'text', x: 500, y: 100 + shift, width: 120, height: 60, text: 'P' },
+        { id: 'q', type: 'text', x: 500, y: 400 + shift, width: 120, height: 60, text: 'Q' },
+        ...Array.from({ length: 9 }, (_, i) => ({
+          id: `f${i}`,
+          type: 'text' as const,
+          x: 900 + i * 160,
+          y: 600,
+          width: 120,
+          height: 60,
+          text: `f${i}`,
+        })),
+      ],
+      edges: [{ id: 'bystander', fromNode: 'p', toNode: 'q' }],
+    })
+    function Host() {
+      const [canvas, setCanvas] = useState<SpatialCanvas>(() => big(0))
+      return (
+        <div style={{ width: 1200, height: 800 }}>
+          <button type="button" data-testid="edit" onClick={() => setCanvas(big(60))}>
+            edit
+          </button>
+          <SpatialEditor defaultTool="select" canvas={canvas} onChange={setCanvas} theme="light" />
+        </div>
+      )
+    }
+    const { container } = render(<Host />)
+    const root = rootOf(container)
+
+    // The edit whose worker reply will land mid-drag.
+    fireEvent.click(container.querySelector('[data-testid="edit"]') as HTMLElement)
+    await frame()
+
+    await dragWithoutRelease(root, [160, 130], [260, 280])
+    const live = container.querySelector('[data-testid="live-edges"]')
+    expect(live, 'the move gesture should be live').not.toBeNull()
+    const pathsBefore = [...(live?.querySelectorAll('polyline, path') ?? [])].map(
+      (el) => el.getAttribute('points') ?? el.getAttribute('d'),
+    )
+    expect(pathsBefore.length).toBeGreaterThan(0)
+
+    const lastId = FakeWorker.instances.flatMap((w) => w.requests).at(-1)?.id ?? 1
+    const { assignEdgeAnchors } = await import('@kamiazya/whiteboard-canvas-render')
+    FakeWorker.respond({
+      type: 'laid-out',
+      id: lastId,
+      svg: '<svg xmlns="http://www.w3.org/2000/svg"/>',
+      bounds: { x: 0, y: 0, w: 10, h: 10 },
+      scene: { nodes: [] },
+      anchors: assignEdgeAnchors(big(60).nodes, big(60).edges),
+    })
+    await frame()
+    await frame()
+
+    const pathsAfter = [
+      ...(container
+        .querySelector('[data-testid="live-edges"]')
+        ?.querySelectorAll('polyline, path') ?? []),
+    ].map((el) => el.getAttribute('points') ?? el.getAttribute('d'))
+    expect(pathsAfter).toEqual(pathsBefore)
+  } finally {
+    vi.unstubAllGlobals()
+  }
+})

--- a/apps/web/src/components/spatial-editor/scene-render-core.ts
+++ b/apps/web/src/components/spatial-editor/scene-render-core.ts
@@ -15,12 +15,13 @@ import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-canvas-mod
 import type { MdastRoot } from '@kamiazya/whiteboard-canvas-model/mdast'
 import type {
   BoundingBox,
+  EdgeAnchorPair,
   FacetCardData,
   MeasureText,
   Scene,
 } from '@kamiazya/whiteboard-canvas-render'
 import {
-  layoutSpatialCanvas,
+  layoutSpatialCanvasWithAnchors,
   renderSceneToSvg,
   sceneBounds,
 } from '@kamiazya/whiteboard-canvas-render'
@@ -46,13 +47,20 @@ export interface RenderedCanvas {
   readonly svg: string
   readonly bounds: BoundingBox
   readonly scene: Scene
+  /**
+   * The edge-anchor map the layout routed with. Carried out so a consumer
+   * that needs the committed anchors (the drag overlay pins bystander edges
+   * to them) never re-runs the anchor pass — it is the most expensive step
+   * of the layout, and it already ran to produce this scene.
+   */
+  readonly anchors: ReadonlyMap<string, EdgeAnchorPair>
 }
 
 export function renderCanvasToSvgWith(
   canvas: SpatialCanvas,
   options: RenderCanvasCoreOptions,
 ): RenderedCanvas {
-  const scene = layoutSpatialCanvas(canvas, {
+  const { scene, anchors } = layoutSpatialCanvasWithAnchors(canvas, {
     measure: options.measure,
     parseBody: options.parseBody,
     appearance: createEditorAppearance(options.theme ?? 'light'),
@@ -65,5 +73,5 @@ export function renderCanvasToSvgWith(
   })
   const bounds = sceneBounds(scene)
   const svg = renderSceneToSvg(scene, { width: bounds.w, height: bounds.h, viewBox: bounds })
-  return { svg, bounds, scene }
+  return { svg, bounds, scene, anchors }
 }

--- a/apps/web/src/components/spatial-editor/use-gesture-captured.test.ts
+++ b/apps/web/src/components/spatial-editor/use-gesture-captured.test.ts
@@ -1,0 +1,41 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useGestureCaptured } from './use-gesture-captured.js'
+
+describe('useGestureCaptured', () => {
+  it('freezes the value for the lifetime of one gesture', () => {
+    // The committed anchors arrive asynchronously from the layout worker; a
+    // reply landing MID-GESTURE must not swap the points bystander edges are
+    // pinned to — that is the exact re-fraction the capture exists to stop.
+    const a = new Map([['e1', 1]])
+    const b = new Map([['e1', 2]])
+    const { result, rerender } = renderHook(
+      ({ active, value }: { active: boolean; value: Map<string, number> }) =>
+        useGestureCaptured(active, value),
+      { initialProps: { active: false, value: a } },
+    )
+    expect(result.current).toBe(a)
+
+    act(() => rerender({ active: true, value: a }))
+    expect(result.current).toBe(a)
+
+    // The worker reply lands while the gesture is still in flight.
+    act(() => rerender({ active: true, value: b }))
+    expect(result.current).toBe(a)
+  })
+
+  it('releases the capture when the gesture ends, so the next gesture sees fresh state', () => {
+    const a = new Map([['e1', 1]])
+    const b = new Map([['e1', 2]])
+    const { result, rerender } = renderHook(
+      ({ active, value }: { active: boolean; value: Map<string, number> }) =>
+        useGestureCaptured(active, value),
+      { initialProps: { active: true, value: a } },
+    )
+    expect(result.current).toBe(a)
+
+    act(() => rerender({ active: false, value: b }))
+    act(() => rerender({ active: true, value: b }))
+    expect(result.current).toBe(b)
+  })
+})

--- a/apps/web/src/components/spatial-editor/use-gesture-captured.ts
+++ b/apps/web/src/components/spatial-editor/use-gesture-captured.ts
@@ -1,0 +1,28 @@
+import { useRef } from 'react'
+
+/**
+ * The value as it was when `active` became true, held for as long as it stays
+ * true.
+ *
+ * Exists because the committed layout (scene, anchors) arrives ASYNCHRONOUSLY
+ * from the layout worker, and a reply can land while a drag gesture is in
+ * flight. Anything derived from the committed layout at gesture start — the
+ * anchor points bystander edges are pinned to, above all — must not swap
+ * mid-gesture: the pin exists precisely so those edges cannot re-fraction
+ * while the user's hand is moving. Capturing here, rather than depending on
+ * the live value, is what makes the freeze hold.
+ *
+ * The ref is written during render on purpose: the capture must be visible to
+ * the same render that starts the gesture (an effect would lag one frame and
+ * hand that first frame the live value). The write is idempotent for a given
+ * `active` run, which is what keeps it safe under re-renders.
+ */
+export function useGestureCaptured<T>(active: boolean, value: T): T {
+  const captured = useRef<T | null>(null)
+  if (!active) {
+    captured.current = null
+    return value
+  }
+  captured.current ??= value
+  return captured.current
+}

--- a/apps/web/src/lib/layout-worker-parity.browser.test.tsx
+++ b/apps/web/src/lib/layout-worker-parity.browser.test.tsx
@@ -99,6 +99,10 @@ it('the worker scene is deeply equal to the main-thread scene', async () => {
   expect(fromWorker.svg).toBe(onMain.svg)
   expect(fromWorker.bounds).toEqual(onMain.bounds)
   expect(fromWorker.scene).toEqual(onMain.scene)
+  // The anchor map crosses as a structuredClone'd Map; the drag overlay pins
+  // bystander edges to it, so a worker that dropped or reordered entries
+  // would silently re-fraction shared anchor groups mid-drag.
+  expect([...fromWorker.anchors.entries()]).toEqual([...onMain.anchors.entries()])
 }, 60_000)
 
 it('carries the file-label seam across the wire', async () => {

--- a/apps/web/src/lib/layout-worker-protocol.ts
+++ b/apps/web/src/lib/layout-worker-protocol.ts
@@ -24,7 +24,7 @@
  */
 
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
-import type { BoundingBox, Scene } from '@kamiazya/whiteboard-canvas-render'
+import type { BoundingBox, EdgeAnchorPair, Scene } from '@kamiazya/whiteboard-canvas-render'
 import type { ResolvedTheme } from '../hooks/useThemeMode.js'
 
 /** Opaque file reference -> readable label, the plain-data form of the seam. */
@@ -50,6 +50,10 @@ export type LayoutResponse =
       readonly svg: string
       readonly bounds: BoundingBox
       readonly scene: Scene
+      /** The layout's own anchor pass, carried out with the scene: Maps
+       * survive structuredClone, and the drag overlay pins bystander edges
+       * to exactly these without re-running the pass on the main thread. */
+      readonly anchors: ReadonlyMap<string, EdgeAnchorPair>
     }
   | {
       // A worker that throws, or that is asked to lay out a body nobody

--- a/apps/web/src/lib/layout-worker.ts
+++ b/apps/web/src/lib/layout-worker.ts
@@ -57,14 +57,21 @@ self.onmessage = async (event: MessageEvent<LayoutRequest>) => {
     }
     const labels = new Map((request.fileRefLabels ?? []).map((o) => [o.file, o.label]))
     const missingRefs = new Set(request.missingFileRefs ?? [])
-    const { svg, bounds, scene } = renderCanvasToSvgWith(request.canvas, {
+    const { svg, bounds, scene, anchors } = renderCanvasToSvgWith(request.canvas, {
       measure,
       theme: request.theme,
       resolveFileLabel: labels.size === 0 ? undefined : (file) => labels.get(file),
       resolveFileMissing: missingRefs.size === 0 ? undefined : (file) => missingRefs.has(file),
       parseBody: parseMarkdownBody,
     })
-    const response: LayoutResponse = { type: 'laid-out', id: request.id, svg, bounds, scene }
+    const response: LayoutResponse = {
+      type: 'laid-out',
+      id: request.id,
+      svg,
+      bounds,
+      scene,
+      anchors,
+    }
     self.postMessage(response)
   } catch (error) {
     const response: LayoutResponse = {

--- a/packages/canvas-render/src/index.ts
+++ b/packages/canvas-render/src/index.ts
@@ -16,10 +16,15 @@ export type {
   SpatialLayoutDegradation,
   SpatialLayoutOptions,
 } from './layout/spatial-canvas.js'
-export { layoutSpatialCanvas, layoutSpatialEdges } from './layout/spatial-canvas.js'
+export {
+  layoutSpatialCanvas,
+  layoutSpatialCanvasWithAnchors,
+  layoutSpatialEdges,
+} from './layout/spatial-canvas.js'
 export {
   assignEdgeAnchors,
   type EdgeAnchorOverride,
+  type EdgeAnchorPair,
   type EdgeSides,
   routeEdge,
 } from './layout/spatial-edges.js'

--- a/packages/canvas-render/src/layout/spatial-canvas-with-anchors.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas-with-anchors.test.ts
@@ -1,9 +1,8 @@
-import { describe, expect, it } from 'vitest'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
-import { assignEdgeAnchors } from './spatial-edges.js'
-import { layoutSpatialCanvas, layoutSpatialCanvasWithAnchors } from './spatial-canvas.js'
-
+import { describe, expect, it } from 'vitest'
 import type { SpatialLayoutOptions } from './spatial-canvas.js'
+import { layoutSpatialCanvas, layoutSpatialCanvasWithAnchors } from './spatial-canvas.js'
+import { assignEdgeAnchors } from './spatial-edges.js'
 
 const measure = () => ({ advanceWidth: 12, ascent: 10, descent: 2, lineGap: 0 })
 const parseBody = () => ({ type: 'root' as const, children: [] })

--- a/packages/canvas-render/src/layout/spatial-canvas-with-anchors.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas-with-anchors.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { assignEdgeAnchors } from './spatial-edges.js'
+import { layoutSpatialCanvas, layoutSpatialCanvasWithAnchors } from './spatial-canvas.js'
+
+import type { SpatialLayoutOptions } from './spatial-canvas.js'
+
+const measure = () => ({ advanceWidth: 12, ascent: 10, descent: 2, lineGap: 0 })
+const parseBody = () => ({ type: 'root' as const, children: [] })
+const appearance = {
+  resolveNode: () => ({ radius: 8 }),
+  resolveEdge: () => ({ stroke: '#606060', strokeWidth: 1.5 }),
+  resolveLabel: () => ({ fill: '#303030', fontFamily: 'sans-serif' }),
+}
+
+const canvas: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 0, y: 0, width: 120, height: 60, text: 'a' },
+    { id: 'b', type: 'text', x: 400, y: 0, width: 120, height: 60, text: 'b' },
+    { id: 'c', type: 'text', x: 200, y: 300, width: 120, height: 60, text: 'c' },
+  ],
+  edges: [
+    { id: 'e1', fromNode: 'a', toNode: 'b' },
+    { id: 'e2', fromNode: 'b', toNode: 'c' },
+  ],
+  'x-whiteboard': { edgeRouting: { style: 'orthogonal' } },
+} as SpatialCanvas
+
+const options: SpatialLayoutOptions = { measure, parseBody, appearance }
+
+describe('layoutSpatialCanvasWithAnchors', () => {
+  it('returns the scene layoutSpatialCanvas would produce, unchanged', () => {
+    const { scene } = layoutSpatialCanvasWithAnchors(canvas, options)
+    expect(scene).toEqual(layoutSpatialCanvas(canvas, options))
+  })
+
+  it('returns the anchor map the layout itself routed with', () => {
+    // The whole point: a caller holding the scene should never re-run the
+    // anchor pass (it is the most expensive part of a drag start) — the
+    // layout already computed it, so it travels out alongside the scene.
+    const { anchors } = layoutSpatialCanvasWithAnchors(canvas, options)
+    const expected = assignEdgeAnchors(canvas.nodes, canvas.edges, 'orthogonal')
+    expect([...anchors.entries()]).toEqual([...expected.entries()])
+  })
+})

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -362,7 +362,7 @@ function composeFileEmbed(
   }
   if (child === undefined) return undefined
 
-  const childScene = layoutSpatialCanvasInternal(child, {
+  const childScene = layoutSpatialCanvasInternalScene(child, {
     ...options,
     embedPath: new Set([...options.embedPath, node.file]),
     embedDepth: options.embedDepth + 1,
@@ -644,6 +644,21 @@ function composeEdgeLabel(
  * `resolveGeometry`) and threaded to every helper as `ResolvedLayoutOptions`.
  */
 export function layoutSpatialCanvas(canvas: SpatialCanvas, options: SpatialLayoutOptions): Scene {
+  return layoutSpatialCanvasWithAnchors(canvas, options).scene
+}
+
+/**
+ * `layoutSpatialCanvas` plus the edge-anchor map the layout itself routed
+ * with. The anchor pass is the most expensive step of the whole layout, and
+ * the editor's drag start needs exactly the committed anchors — so a caller
+ * holding the scene must never have to re-run the pass to get them. Same
+ * one-producer rule as `layoutSpatialEdges`: this IS the layout, not a
+ * second computation beside it.
+ */
+export function layoutSpatialCanvasWithAnchors(
+  canvas: SpatialCanvas,
+  options: SpatialLayoutOptions,
+): { scene: Scene; anchors: ReadonlyMap<string, EdgeAnchorPair> } {
   return layoutSpatialCanvasInternal(canvas, {
     ...options,
     geometry: resolveGeometry(options.geometry),
@@ -652,18 +667,27 @@ export function layoutSpatialCanvas(canvas: SpatialCanvas, options: SpatialLayou
   })
 }
 
-function layoutSpatialCanvasInternal(
+/** The embed path needs only the scene; the anchor map is per-top-level-canvas. */
+function layoutSpatialCanvasInternalScene(
   canvas: SpatialCanvas,
   resolved: ResolvedLayoutOptions,
 ): Scene {
+  return layoutSpatialCanvasInternal(canvas, resolved).scene
+}
+
+function layoutSpatialCanvasInternal(
+  canvas: SpatialCanvas,
+  resolved: ResolvedLayoutOptions,
+): { scene: Scene; anchors: ReadonlyMap<string, EdgeAnchorPair> } {
   const nodeContent = canvas.nodes.flatMap((node) => composeNode(node, resolved))
-  return { nodes: [...nodeContent, ...composeEdgesAndLabels(canvas, resolved)] }
+  const { content, anchors } = composeEdgesAndLabels(canvas, resolved)
+  return { scene: { nodes: [...nodeContent, ...content] }, anchors }
 }
 
 function composeEdgesAndLabels(
   canvas: SpatialCanvas,
   resolved: ResolvedLayoutOptions,
-): SceneNode[] {
+): { content: SceneNode[]; anchors: ReadonlyMap<string, EdgeAnchorPair> } {
   // One anchor pass for the whole edge set: fan-out needs to see every end
   // sharing a side, which a per-edge route cannot.
   const anchors = assignEdgeAnchors(
@@ -689,7 +713,7 @@ function composeEdgesAndLabels(
   const labelContent = canvas.edges
     .map((edge, index) => composeEdgeLabel(edge, edgeContent[index]!, resolved))
     .filter((label): label is TextRunNode => label !== undefined)
-  return [...edgeContent, ...labelContent]
+  return { content: [...edgeContent, ...labelContent], anchors }
 }
 
 /**
@@ -710,5 +734,5 @@ export function layoutSpatialEdges(
     geometry: resolveGeometry(options.geometry),
     embedPath: new Set(),
     embedDepth: 0,
-  })
+  }).content
 }


### PR DESCRIPTION
## What

The remaining half of #39's drag-start work, instrument-first per the measured-change discipline:

1. **Commit 1 — the instrument.** `drag-start-responsiveness.browser.test.tsx` drives two real move gestures on a 45-node/90-edge canvas and logs the longest inter-frame gap; only "the gesture really started" is asserted (wall time pinned as a threshold is a flake generator). Baseline: steady-state maxGap ~90-96ms — past the ~50ms perceptibility line, at the worst possible moment (mid-motion).
2. **Commit 2 — the fix.** A throwaway split showed the block was **~21ms backdrop render + ~150ms `assignEdgeAnchors`** — an anchor pass the committed layout had *already run in the worker* to produce the scene on screen, recomputed synchronously at gesture start. Now the anchors travel out with the scene:
   - `canvas-render`: `layoutSpatialCanvasWithAnchors` returns the layout **and** the anchor map it routed with (`layoutSpatialEdges` precedent — this IS the layout, not a second computation). `layoutSpatialCanvas` delegates; its four external callers see no diff.
   - The map rides the worker protocol as a structuredClone'd `Map`; the parity browser test pins entry-for-entry equality across the thread boundary.
   - `SpatialEditor.dragStatic` consumes the committed anchors; the synchronous `assignEdgeAnchors` call (and its import) is deleted outright.

## Measured (interleaved before/after, same session)

| | first gesture maxGap | steady-state maxGap | gaps >50ms |
|---|---|---|---|
| before (stashed) | 150.9ms | **95.8ms** | 1 |
| after | 85.0ms | **36.1ms** | 0 |

The stash genuinely reverted (numbers regressed), avoiding the no-op-stash trap.

## Design record

An adversarial consult (3 rounds, accepted) rejected two alternatives: a `data-node-id`/CSS-hiding change to the shared SVG backend (no contiguous per-node subtree exists — a canvas node emits sibling scene nodes with only the chrome shape carrying the id — so it would force per-node `<g>` restructuring and byte-golden/export churn), and speculative selection-time pre-rendering in the worker (strictly dominated: the worker already produced the committed scene). It made the anchors move **conditional on splitting the 90ms**, which the split then won decisively. Semantics improve as a side effect: the overlay now pins bystander edges to the anchors of the scene actually on screen, provenance-consistent with `frozenSidesOf`, instead of a fresh pass over a possibly newer canvas. The backdrop-reuse rung (~21ms remaining) stays documented in the ponytail marker for canvases where it grows past the line.

## Tests

canvas-render 615, apps/web jsdom 2167 + node 77, browser 557 (parity anchors case included), consumer projects 365, typecheck, knip — all green on the merged base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ