### PR TITLE
test(web): stop driving select-all with a platform-dependent chord

### DIFF
--- a/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.markdown.browser.test.tsx
@@ -310,8 +310,13 @@ describe('BrowserLocalCanvasPage markdown 導線 (browser — real IndexedDB)', 
     // an empty box the user would have to retype.
     expect((title as HTMLInputElement).value).toBe('Diagram A')
 
+    // clear(), not a select-all chord: the browser's select-all is Cmd+A on
+    // macOS and Ctrl+A elsewhere, so `{Control>}a{/Control}` selects nothing
+    // on a Mac and the new title appends to the old one ("Diagram
+    // AArchitecture map"). clear() drives the field's own selection API and
+    // means the same thing on every platform.
     await userEvent.click(title)
-    await userEvent.keyboard('{Control>}a{/Control}')
+    await userEvent.clear(title)
     await userEvent.keyboard('Architecture map')
     await userEvent.click(await screen.findByRole('button', { name: /^Workspace:/i }))
     await screen.findByRole('menuitem', { name: /Architecture map/ }, { timeout: 10_000 })

--- a/apps/web/src/platform-independent-keys.test.ts
+++ b/apps/web/src/platform-independent-keys.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Guard: no test may drive a BROWSER shortcut whose chord differs per
+ * platform.
+ *
+ * The one that actually bit: `{Control>}a{/Control}` to select a field's
+ * contents. Select-all is Cmd+A on macOS and Ctrl+A everywhere else, so
+ * that chord selects nothing on a Mac and whatever is typed next appends
+ * to the old value instead of replacing it — a failure that looks like a
+ * flake, reproduces only on one developer's machine, and passes CI (Linux)
+ * forever. `userEvent.clear(el)` drives the field's own selection API and
+ * means the same thing everywhere.
+ *
+ * Scope is deliberately narrow: this bans the chords the BROWSER owns, not
+ * the app's own bindings. `{Control>}{Enter}{/Control}` stays legal because
+ * the handler behind it accepts `metaKey || ctrlKey`, so the chord already
+ * means the same thing on both platforms.
+ */
+import { describe, expect, it } from 'vitest'
+
+const sources = import.meta.glob('./**/*.test.{ts,tsx}', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+/** Browser-owned chords whose modifier differs between macOS and the rest. */
+const PLATFORM_DEPENDENT_CHORDS: readonly { pattern: RegExp; use: string }[] = [
+  { pattern: /\{Control>\}a\{\/Control\}/, use: 'userEvent.clear(element)' },
+  { pattern: /\{Meta>\}a\{\/Meta\}/, use: 'userEvent.clear(element)' },
+]
+
+/**
+ * Comments are stripped before scanning: a test explaining WHY it avoids a
+ * chord has to be able to name it, and this file itself is nothing but
+ * such an explanation. Crude enough to mangle a comment marker inside a
+ * string literal, which costs nothing here — the result is only ever fed
+ * to these two chord patterns.
+ */
+function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+}
+
+describe('test sources', () => {
+  it('drive no platform-dependent browser shortcut', () => {
+    const offenders: string[] = []
+    for (const [path, source] of Object.entries(sources)) {
+      const code = withoutComments(source)
+      for (const { pattern, use } of PLATFORM_DEPENDENT_CHORDS) {
+        if (pattern.test(code)) offenders.push(`${path}: ${pattern.source} — use ${use}`)
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

The title round-trip test in `BrowserLocalCanvasPage.markdown.browser.test.tsx` selected the field with `{Control>}a{/Control}`. Select-all is **Cmd+A on macOS** and Ctrl+A elsewhere, so on a Mac that chord selected nothing and the typed title appended to the old one (`'Diagram AArchitecture map'` vs `'Architecture map'`).

That failure mode is the worst kind: it looks like a flake, reproduces only on one platform, and passes CI (Linux) forever — which is why it sat unexplained across several sessions, absorbing a re-run each time it appeared.

- **Fix**: `userEvent.clear(title)` drives the field's own selection API and means the same thing on every platform.
- **Guard** (`platform-independent-keys.test.ts`): scans the test sources for the browser-owned chords whose modifier differs by platform, so the pattern cannot return silently. Comments are stripped before scanning — a test avoiding a chord has to be able to name it, and the guard file is nothing but such an explanation.

Deliberately narrow: the app's **own** bindings stay legal. `{Control>}{Enter}{/Control}` is fine because its handler accepts `metaKey || ctrlKey` (TextNodeEditor.tsx:110), so the chord already means one thing on both platforms. Only chords the **browser** owns are banned.

## Test plan

- [x] The formerly-failing suite is green **on macOS** (9/9) — the platform where it failed; CI covers Linux
- [x] Guard is mutation-checked: reinstating the chord turns it red, removing it green
- [x] Full web suite, typecheck, lint, knip green
