### PR TITLE
fix(deps): patch the GFM task-list crash instead of generating around it

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -46,6 +46,12 @@ WORKDIR /workspace
 FROM base AS fetched
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+# patches/ travels WITH the lockfile, not with the sources copied later:
+# pnpm-workspace.yaml's patchedDependencies makes the patch part of what
+# `pnpm fetch` resolves, so a missing file here fails the fetch outright
+# (ERR_PNPM_PATCH_NOT_FOUND) rather than silently shipping an unpatched
+# dependency.
+COPY patches ./patches
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm fetch --store-dir /pnpm/store

--- a/packages/canvas-codec/src/markdown/parse-totality.property.test.ts
+++ b/packages/canvas-codec/src/markdown/parse-totality.property.test.ts
@@ -27,18 +27,28 @@ describe('markdown body parse totality (including lists)', () => {
   )
 })
 
-describe('upstream task-list continuation crash (canary)', () => {
-  // A GFM checkbox stranded on a bullet's continuation line trips a
-  // DEV-ONLY assert inside mdast-util-gfm-task-list-item@2.0.0 (exitCheck,
-  // via devlop — production builds no-op it, so deployed parsing does not
-  // throw; the dev server and this test runner do). The totality
-  // arbitrary excludes the one model shape whose serialization produces
-  // this text (a blank-valued html node emptying a checked item's first
-  // paragraph — unreachable from any real parse). This canary pins the
-  // upstream behavior itself: when a dependency bump makes it stop
-  // throwing, delete this test and the html-value exclusion in
-  // canvas-model's arbitraries together.
-  it('still throws on a checkbox stranded on a continuation line', () => {
-    expect(() => parseMarkdownBody('*\n[ ] x')).toThrow()
+describe('patched upstream: task-list checkbox on a continuation line', () => {
+  // `mdast-util-gfm-task-list-item@2.0.0`'s exitCheck assumed a checkbox is
+  // always inside a paragraph inside a listItem and asserted it. The
+  // micromark side emits the token for a checkbox on a bullet's
+  // CONTINUATION line too, where the paragraph is not in a list item — so
+  // that input crashed the whole parse in any development build (production
+  // no-ops devlop's assert, and instead stamps a bogus `checked` onto the
+  // paragraph). patches/mdast-util-gfm-task-list-item@2.0.0.patch makes the
+  // handler bail when the node is not a listItem, which is both total and
+  // more correct than what production did.
+  //
+  // These pin the patch: they fail if it is ever dropped (the first throws,
+  // the second is what the patch must not have broken to buy it).
+  it('parses instead of crashing', () => {
+    expect(() => parseMarkdownBody('*\n[ ] x')).not.toThrow()
+  })
+
+  it('still reads a real task list item as checked', () => {
+    const root = parseMarkdownBody('- [x] done\n')
+    const list = root.children[0]
+    expect(list?.type).toBe('list')
+    if (list?.type !== 'list') throw new Error('unreachable')
+    expect(list.children[0]?.checked).toBe(true)
   })
 })

--- a/packages/canvas-model/src/test-utils/arbitraries.ts
+++ b/packages/canvas-model/src/test-utils/arbitraries.ts
@@ -187,18 +187,9 @@ const inlineCodeLeafArbitrary = fc
   .string({ maxLength: 20 })
   .map((value) => ({ type: 'inlineCode' as const, value }))
 const breakLeafArbitrary: fc.Arbitrary<{ type: 'break' }> = fc.constant({ type: 'break' })
-// html values carry a non-whitespace character by construction: a real
-// parse can never produce an html node whose value is blank (the value IS
-// the raw source of an html construct), and a blank one serializes to
-// nothing — which strands a GFM task-list checkbox onto a continuation
-// line (`*\n[ ] x`) and trips a dev-only upstream assert
-// (mdast-util-gfm-task-list-item@2.0.0 exitCheck, via devlop; production
-// builds no-op the assert). Exclusion, not a fix: tracked as the
-// remark-taskitem-continuation-crash issue until upstream repairs it.
-const nonBlankHtmlValue = fc
-  .string({ minLength: 1, maxLength: 20 })
-  .filter((value) => value.trim().length > 0)
-const htmlLeafArbitrary = nonBlankHtmlValue.map((value) => ({ type: 'html' as const, value }))
+const htmlLeafArbitrary = fc
+  .string({ maxLength: 20 })
+  .map((value) => ({ type: 'html' as const, value }))
 const imageLeafArbitrary = fc
   .record({ url: fc.webUrl(), title: optionalNullableString, alt: optionalNullableString })
   .map(({ url, title, alt }) => ({ type: 'image' as const, url, title, alt }))
@@ -331,11 +322,9 @@ const definitionLeafArbitrary: fc.Arbitrary<MdastFlowContent> = fc
     url,
     title,
   }))
-// Same non-blank rule as htmlLeafArbitrary above, same upstream reason.
-const flowHtmlLeafArbitrary: fc.Arbitrary<MdastFlowContent> = nonBlankHtmlValue.map((value) => ({
-  type: 'html',
-  value,
-}))
+const flowHtmlLeafArbitrary: fc.Arbitrary<MdastFlowContent> = fc
+  .string({ maxLength: 20 })
+  .map((value) => ({ type: 'html', value }))
 const mathLeafArbitrary: fc.Arbitrary<MdastFlowContent> = fc
   .record({
     value: fc.string({ maxLength: 20 }),

--- a/packages/mcp-server/src/server/docker-contract.test.ts
+++ b/packages/mcp-server/src/server/docker-contract.test.ts
@@ -41,6 +41,21 @@ const envExample = readText('.env.server.example')
 const docs = readText('docs/how-to/self-host-with-docker.md')
 
 describe('Dockerfile.server contracts', () => {
+  it('gives the fetch stage every file pnpm fetch resolves from', () => {
+    // `pnpm fetch` runs against a hand-picked subset of the repo, so any
+    // file the lockfile RESOLUTION depends on has to be copied before it —
+    // and a missing one fails the image build outright
+    // (ERR_PNPM_PATCH_NOT_FOUND), which is how patches/ was found missing.
+    const workspace = readText('pnpm-workspace.yaml')
+    if (!/^patchedDependencies:/m.test(workspace)) return
+    // Comments stripped first: the Dockerfile explains this requirement in
+    // prose right above the COPY, and matching that mention instead of the
+    // RUN line put the boundary before the very line being checked.
+    const instructions = dockerfile.replace(/^\s*#.*$/gm, '')
+    const beforeFetch = instructions.slice(0, instructions.indexOf('pnpm fetch'))
+    expect(beforeFetch).toMatch(/^COPY\s+patches\b/m)
+  })
+
   it('entrypoint uses whiteboard server run --json (not daemon run)', () => {
     expect(dockerfile).toMatch(/ENTRYPOINT.*server.*run.*--json/)
     // Comments may mention "daemon run" to explain what the image does NOT support.

--- a/patches/mdast-util-gfm-task-list-item@2.0.0.patch
+++ b/patches/mdast-util-gfm-task-list-item@2.0.0.patch
@@ -1,0 +1,23 @@
+diff --git a/lib/index.js b/lib/index.js
+index 80a713c56a91675a3a1fd71b275a65af2ab67d3f..dcac49172c72c14a1b6424f341a81c580776c340 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -47,9 +47,16 @@ export function gfmTaskListItemToMarkdown() {
+  * @type {FromMarkdownHandle}
+  */
+ function exitCheck(token) {
+-  // We’re always in a paragraph, in a list item.
++  // Usually we’re in a paragraph, in a list item — but not always. The
++  // micromark side emits this token for a checkbox on a bullet’s
++  // CONTINUATION line (`*\n[ ] x`), where the paragraph is not in a list
++  // item at all, and the assert below then crashes the whole parse in a
++  // development build. There is no `checked` to set on a non-list-item, so
++  // the only thing to do is leave it alone: bailing keeps the parse total
++  // AND avoids stamping a bogus `checked` field onto a paragraph, which is
++  // what the production build (where the assert is a no-op) does today.
+   const node = this.stack[this.stack.length - 2]
+-  assert(node.type === 'listItem')
++  if (!node || node.type !== 'listItem') return
+   node.checked = token.type === 'taskListCheckValueChecked'
+ }
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ overrides:
 
 packageExtensionsChecksum: sha256-u12wT5x9skXDbQswB0QA0cyMb8Rq77Un0zgbIGMqFDY=
 
+patchedDependencies:
+  mdast-util-gfm-task-list-item@2.0.0: 46e4f9426ff571630f8e987deac6af7f16e9d14a26162919c60324588270db47
+
 importers:
 
   .:
@@ -4494,9 +4497,6 @@ packages:
 
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
-
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
   brace-expansion@2.1.4:
     resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
@@ -11755,14 +11755,9 @@ snapshots:
 
   boundary@2.0.0: {}
 
-  brace-expansion@2.1.1:
-    dependencies:
-      balanced-match: 1.0.2
-
   brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
-    optional: true
 
   brace-expansion@5.0.9:
     dependencies:
@@ -13558,7 +13553,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0:
+  mdast-util-gfm-task-list-item@2.0.0(patch_hash=46e4f9426ff571630f8e987deac6af7f16e9d14a26162919c60324588270db47):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
@@ -13574,7 +13569,7 @@ snapshots:
       mdast-util-gfm-footnote: 2.1.0
       mdast-util-gfm-strikethrough: 2.0.0
       mdast-util-gfm-table: 2.0.0
-      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0(patch_hash=46e4f9426ff571630f8e987deac6af7f16e9d14a26162919c60324588270db47)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -13879,7 +13874,7 @@ snapshots:
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -131,3 +131,6 @@ allowBuilds:
   msw: false
   sharp: false
   workerd: false
+
+patchedDependencies:
+  mdast-util-gfm-task-list-item@2.0.0: patches/mdast-util-gfm-task-list-item@2.0.0.patch


### PR DESCRIPTION
## Summary

Patches the upstream crash PR #803 worked around, and takes the workaround back out.

`mdast-util-gfm-task-list-item@2.0.0`'s `exitCheck` assumes a checkbox token is always inside a paragraph inside a `listItem`, and asserts it. micromark emits that token for a checkbox on a bullet's **continuation line** too (`*\n[ ] x`), where the paragraph is not in a list item — so that input crashed the entire parse in any development build. Production is no better, just quieter: `devlop` no-ops the assert there, and the handler stamps a bogus `checked` onto a *paragraph*. There was no correct behaviour anywhere.

**The patch** (`patches/mdast-util-gfm-task-list-item@2.0.0.patch`) makes the handler bail when the node is not a `listItem`. That is total, and strictly better than the production behaviour it replaces — there is no `checked` to set on a non-list-item, so leaving it alone is the only sound answer.

**It does not buy that with the feature.** A real `- [x] done` still parses as `checked: true`, pinned as a test beside the no-longer-throws one; both fail if the patch is ever dropped.

**The workaround comes out.** `canvas-model`'s arbitraries generate blank `html` values again, so `parse-totality` covers the full space instead of the space minus the shape that used to crash it — re-verified under the seed that originally failed (609638238).

## Verification

- [x] `parseMarkdownBody('*\n[ ] x')` parses instead of throwing; `- [x] done` still reads as checked
- [x] parse-totality property green under seed 609638238 with the exclusion removed
- [x] `pnpm test` (all projects), `pnpm -r typecheck`, lint, knip green
- [x] Patch survives install: `pnpm-lock.yaml` records the patch hash, so a clean clone applies it; the behavioural test passes after `pnpm install --frozen-lockfile`

Drop the patch when an upstream release fixes this — the repro and upstream state are recorded in the `remark-taskitem-continuation-crash` issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash when parsing continuation-line task-list syntax.
  * Valid task-list items continue to parse correctly with their checked state preserved.
* **Tests**
  * Added coverage for malformed and valid task-list input.
  * Expanded generated HTML content cases to include whitespace-only values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->