### PR TITLE
test(server): give each sweeper pass its own gate

### DIFF
--- a/packages/mcp-server/src/server/store/file-gc-sweeper.test.ts
+++ b/packages/mcp-server/src/server/store/file-gc-sweeper.test.ts
@@ -196,13 +196,27 @@ describe('createFileGcSweeper scheduling', () => {
 })
 
 describe('createFileGcSweeper single-flight', () => {
-  it('never starts a second pass via timer advancement while one is in flight (mutation-checked)', async () => {
-    const d = deferred<{ purgedCount: number; purgedBytes: number }>()
+  // What this pins is the BEHAVIOUR — no second pass while one is in flight,
+  // however many intervals elapse — not either mechanism that upholds it.
+  // Two do: the timer is one-shot and rearmed only from the completed pass's
+  // `finally` (so no timer even exists mid-pass), and tick() returns the
+  // in-flight promise. Breaking either alone leaves this green; it reddens
+  // only when both go. The `inFlight` guard on its own is isolated by the
+  // tick() concurrency-seam test below, which is where a mutation check of
+  // that guard belongs.
+  it('never starts a second pass while one is in flight, however many intervals elapse', async () => {
+    // One gate PER PASS, never a shared one. A single deferred leaves the
+    // sweeper permanently unblocked once it resolves, so pass 2 completes
+    // instantly and arms pass 3 — and advanceUntilCalls, whose whole job is
+    // to nudge the clock forward until a count lands, can then overshoot to
+    // 3. Holding pass 2's gate means no pass 3 can exist to be counted, so
+    // the exact counts below hold under any amount of clock advancement.
+    const gates = [
+      deferred<{ purgedCount: number; purgedBytes: number }>(),
+      deferred<{ purgedCount: number; purgedBytes: number }>(),
+    ] as const
     let purgeCalls = 0
-    const purge = vi.fn(async () => {
-      purgeCalls += 1
-      return d.promise
-    })
+    const purge = vi.fn(() => gates[Math.min(purgeCalls++, 1)].promise)
     const sweeper = createFileGcSweeper({
       intervalMs: 1000,
       listWorkspaces: async () => [{ workspaceId: 'ws_a' }],
@@ -222,7 +236,7 @@ describe('createFileGcSweeper single-flight', () => {
     await advanceTimersAndFlush(1000)
     expect(purgeCalls).toBe(1)
 
-    d.resolve({ purgedCount: 0, purgedBytes: 0 })
+    gates[0].resolve({ purgedCount: 0, purgedBytes: 0 })
     // Let the pass's .finally() run and reschedule.
     await Promise.resolve()
     await Promise.resolve()
@@ -231,6 +245,7 @@ describe('createFileGcSweeper single-flight', () => {
     await advanceUntilCalls(purge, 2)
     expect(purgeCalls).toBe(2)
 
+    gates[1].resolve({ purgedCount: 0, purgedBytes: 0 })
     await sweeper.stop()
   })
 


### PR DESCRIPTION
## Summary

The `file-gc-sweeper` single-flight test flaked again in CI (`expected 3 to be 2`), after #788
fixed what looked like the same thing. #788 was right about the cause and applied it to one
test; this one was left on the old shape.

**The cause.** The test drove both passes off ONE shared `deferred`. Resolving it to let pass 1
finish also unblocks pass 2, so pass 2 completes instantly and arms pass 3 — and
`advanceUntilCalls`, whose entire job is to nudge the clock forward until a count lands, can
then overshoot onto it. The count assertion was racing the tolerance loop that exists to make
the count reliable.

**The fix** is the shape the sibling test already uses: one gate per pass. Pass 2 blocks on its
own gate, so no pass 3 can exist to be counted, and the exact counts hold under any amount of
clock advancement. 22 consecutive local runs green.

## The test was claiming a mutation check it did not perform

Its name ended in `(mutation-checked)`. Verifying that claim: removing the `inFlight` guard
leaves it **green** — caught only by the sibling `tick()` concurrency-seam test.

The reason is the sweeper's design. The timer is one-shot and rearmed only from the completed
pass's `finally`, so while a pass is in flight there is no timer at all — advancing the clock
cannot start a second pass whether or not the guard exists. Two independent mechanisms uphold
the behaviour, and breaking either alone leaves the test green; it reddens only when both go
(verified: `expected 4 to be 1`).

That is a legitimate thing to pin — the observable behaviour outlives either mechanism — but
the name promised isolation it does not deliver, which is exactly how a test stops being
trusted. Renamed to what it actually asserts, with a comment recording which mutation reddens
it and pointing at the test that does isolate the guard.

## Verification

- 22 consecutive runs of the file green (12 before the rename, 10 after)
- Mutation checks run explicitly, results as described above
- `pnpm test --project mcp-node` green
