### PR TITLE
fix(web): stop a double-tap's new node vanishing when the touch capture is released

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -1913,6 +1913,24 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     }
 
     /**
+     * `lostpointercapture` is NOT a synonym for "the gesture broke". It also
+     * fires on the ordinary release of a captured pointer — and the browser
+     * captures touch pointers IMPLICITLY, so on a touch device it arrives
+     * after every single tap.
+     *
+     * `activePointerIdRef` is what tells the two apart: `handlePointerUp`
+     * clears it, so a null ref means the interaction already ended normally
+     * and there is nothing to recover. Cancelling there deleted the node the
+     * empty-canvas double-TAP had just created for editing — it appeared and
+     * vanished, while the same double-CLICK was fine because a stationary
+     * mouse press takes no capture to lose.
+     */
+    const handleLostPointerCapture = (e: React.PointerEvent<HTMLDivElement>) => {
+      if (activePointerIdRef.current === null) return
+      handlePointerCancel(e)
+    }
+
+    /**
      * The selection as reorder targets, primary + extras, deduped. The
      * command treats ids as a set and takes relative order from the canvas.
      */
@@ -2873,7 +2891,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
         onPointerCancel={handlePointerCancel}
-        onLostPointerCapture={handlePointerCancel}
+        onLostPointerCapture={handleLostPointerCapture}
         onKeyDown={handleKeyDown}
       >
         {/* Screen space, outside the pan/zoom transform — an overview that

--- a/apps/web/src/components/spatial-editor/lost-pointer-capture.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/lost-pointer-capture.browser.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * `lostpointercapture` is wired to the same handler as `pointercancel` so a
+ * capture the browser REFUSES or revokes cannot strand an in-flight gesture
+ * (this component registers no window-level fallback listeners).
+ *
+ * But that event also fires on the perfectly normal release of a captured
+ * pointer, and touch pointers are captured IMPLICITLY by the browser on
+ * every pointerdown. So on a touch device it arrives after every tap —
+ * including the second tap of a double-tap, which is where the empty-canvas
+ * double-press creates a node and opens it for typing. Cancelling there
+ * deletes that node (it is `createdForEdit`), so the note appears and
+ * vanishes. Mouse input never showed it: capture is taken at the first
+ * MOVE, so a stationary double-click holds none to lose.
+ */
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import { cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const start: SpatialCanvas = {
+  nodes: [{ id: 'n1', type: 'text', x: 100, y: 100, width: 200, height: 100, text: 'hello world' }],
+  edges: [],
+}
+
+function Host({ onCommand }: { onCommand?: (kind: string) => void }) {
+  const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor
+        defaultTool="select"
+        canvas={canvas}
+        onChange={(next, command) => {
+          onCommand?.(command.kind)
+          setCanvas(next)
+        }}
+        theme="light"
+      />
+    </div>
+  )
+}
+
+function rootOf(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+}
+
+/** What the browser sends when it hands back an implicitly captured touch. */
+function releaseCapture(root: HTMLElement): void {
+  root.dispatchEvent(
+    new PointerEvent('lostpointercapture', { bubbles: true, pointerId: 1, pointerType: 'touch' }),
+  )
+}
+
+it('keeps the node a double-press just created when the pointer capture is released', async () => {
+  const commands: string[] = []
+  const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)
+  const root = rootOf(container)
+
+  await userEvent.dblClick(root, { position: { x: 600, y: 450 } })
+  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+  expect(commands.filter((kind) => kind === 'create-node')).toHaveLength(1)
+
+  releaseCapture(root)
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  expect(commands).not.toContain('delete-node')
+  expect(container.querySelector('textarea')).not.toBeNull()
+})
+
+it('still discards the new node on a real pointercancel', async () => {
+  // The debris rule this must not trade away: a node that exists only to
+  // hold an edit has nothing to revert TO, so a genuine cancellation takes
+  // the node with it. Only `lostpointercapture` is being reclassified —
+  // `pointercancel` still means what it says.
+  const commands: string[] = []
+  const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)
+  const root = rootOf(container)
+
+  await userEvent.dblClick(root, { position: { x: 600, y: 450 } })
+  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+
+  root.dispatchEvent(
+    new PointerEvent('pointercancel', { bubbles: true, pointerId: 1, pointerType: 'touch' }),
+  )
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  expect(commands).toContain('delete-node')
+})

--- a/apps/web/src/components/spatial-editor/lost-pointer-capture.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/lost-pointer-capture.browser.test.tsx
@@ -1,22 +1,22 @@
 /**
- * `lostpointercapture` is wired to the same handler as `pointercancel` so a
- * capture the browser REFUSES or revokes cannot strand an in-flight gesture
- * (this component registers no window-level fallback listeners).
+ * `lostpointercapture` cancels the in-flight gesture ONLY while a pointer is
+ * still active — a capture the browser refuses or revokes mid-gesture must
+ * not strand the editor, which registers no window-level fallback listeners.
  *
- * But that event also fires on the perfectly normal release of a captured
- * pointer, and touch pointers are captured IMPLICITLY by the browser on
- * every pointerdown. So on a touch device it arrives after every tap —
- * including the second tap of a double-tap, which is where the empty-canvas
- * double-press creates a node and opens it for typing. Cancelling there
- * deletes that node (it is `createdForEdit`), so the note appears and
- * vanishes. Mouse input never showed it: capture is taken at the first
- * MOVE, so a stationary double-click holds none to lose.
+ * The guard is what these tests hold in place. That event also fires on the
+ * perfectly normal release of a captured pointer, and touch pointers are
+ * captured IMPLICITLY by the browser on every pointerdown, so on a touch
+ * device it arrives after every tap — including the second tap of a
+ * double-tap, which is where the empty-canvas double-press creates a node
+ * and opens it for typing. Cancelling there deletes that node (it is
+ * `createdForEdit`), so the note appears and vanishes. Mouse input never
+ * showed it: capture is taken at the first MOVE, so a stationary
+ * double-click holds none to lose.
  */
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
-import { userEvent } from 'vitest/browser'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -47,25 +47,39 @@ function rootOf(container: HTMLElement): HTMLElement {
   return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
-/** What the browser sends when it hands back an implicitly captured touch. */
-function releaseCapture(root: HTMLElement): void {
-  root.dispatchEvent(
-    new PointerEvent('lostpointercapture', { bubbles: true, pointerId: 1, pointerType: 'touch' }),
-  )
+/**
+ * One tap, as a touch device delivers it — including the capture handback.
+ * The browser captures a touch pointer implicitly at `pointerdown` and gives
+ * it back right after `pointerup`, so `lostpointercapture` belongs in every
+ * tap, not only in the failure case. Driving it here is what keeps this a
+ * test of the TOUCH path rather than of the handler in isolation.
+ */
+function touchTap(root: HTMLElement, x: number, y: number): void {
+  const rect = root.getBoundingClientRect()
+  const init = {
+    bubbles: true,
+    pointerId: 1,
+    pointerType: 'touch',
+    isPrimary: true,
+    clientX: rect.left + x,
+    clientY: rect.top + y,
+  }
+  root.dispatchEvent(new PointerEvent('pointerdown', { ...init, button: 0 }))
+  root.dispatchEvent(new PointerEvent('pointerup', init))
+  root.dispatchEvent(new PointerEvent('lostpointercapture', init))
 }
 
-it('keeps the node a double-press just created when the pointer capture is released', async () => {
+it('keeps the node a double-TAP just created when the touch capture is handed back', async () => {
   const commands: string[] = []
   const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)
   const root = rootOf(container)
 
-  await userEvent.dblClick(root, { position: { x: 600, y: 450 } })
+  touchTap(root, 600, 450)
+  await new Promise((resolve) => setTimeout(resolve, 30))
+  touchTap(root, 600, 450)
   await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+
   expect(commands.filter((kind) => kind === 'create-node')).toHaveLength(1)
-
-  releaseCapture(root)
-  await new Promise((resolve) => setTimeout(resolve, 0))
-
   expect(commands).not.toContain('delete-node')
   expect(container.querySelector('textarea')).not.toBeNull()
 })
@@ -79,7 +93,9 @@ it('still discards the new node on a real pointercancel', async () => {
   const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)
   const root = rootOf(container)
 
-  await userEvent.dblClick(root, { position: { x: 600, y: 450 } })
+  touchTap(root, 600, 450)
+  await new Promise((resolve) => setTimeout(resolve, 30))
+  touchTap(root, 600, 450)
   await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
 
   root.dispatchEvent(


### PR DESCRIPTION
## Summary

In select mode, a double-TAP on empty canvas created a note, opened it for typing, and then
the note vanished. Double-CLICK was fine, which is why the existing coverage stayed green.

`lostpointercapture` was wired to the same handler as `pointercancel`, so a capture the browser
refuses or revokes mid-gesture could not strand an in-flight gesture. But that event also fires
on the **ordinary release** of a captured pointer — and browsers capture touch pointers
**implicitly** on every `pointerdown`. On a touch device it therefore arrives after every tap,
including the second tap of the double-tap that had *just* created the node. The node is
`createdForEdit`, and cancelling such an edit takes the node with it rather than leaving an empty
box behind, so it was created and immediately deleted.

Mouse never showed it: capture is taken at the first **move**, so a stationary double-click holds
none to lose.

**The fix** uses state that already exists. `handlePointerUp` clears `activePointerIdRef`, so a
null ref at `lostpointercapture` time means the interaction already ended normally and there is
nothing to recover; a non-null ref means the capture went away mid-gesture, which is the case the
handler was written for. `pointercancel` itself is untouched and still discards the node.

## Repro, measured in the running app

CDP touch emulation against the deployed preview (pre-fix), double-tapping empty canvas:

```
pointerdown:touch → gotpointercapture:touch → pointerup:touch → lostpointercapture:touch
textarea count: 0 → 1 → 0
```

`gotpointercapture` right after `pointerdown` is the implicit touch capture; `lostpointercapture`
right after `pointerup` is it being handed back on a perfectly normal release.

## Verification

- [x] New `lost-pointer-capture.browser.test.tsx`: red before the fix
      (`expected [ 'create-node', 'delete-node' ] to not include 'delete-node'`), green after
- [x] Second case pins the property NOT being traded away: a real `pointercancel` still discards
      the node
- [x] `pnpm test --project web-browser` 566 passed; apps/web jsdom 2188 + 77 passed;
      `pnpm -r typecheck` clean

- [x] Same probe re-run against the preview built from THIS branch — same environment, same
      steps, so the difference is attributable to the change:

| | before (main's preview) | after (this branch's preview) |
|---|---|---|
| events | `pointerdown → gotpointercapture → pointerup → lostpointercapture` | **identical** |
| textarea count | `0,0,0,0,1,0` — **vanishes** | `0,0,0,1,1` — **stays** |
| end state | `0` | `1`, `focused: TEXTAREA` |

`lostpointercapture` still fires after the fix, so the trigger genuinely occurred and the node
survived it. (A local dev run was NOT accepted as verification: the capture events never fired
there under the same CDP emulation, so the node surviving proved only that the trigger was
absent.)

## Noticed while writing the guard, not fixed here

A `lostpointercapture` arriving mid-drag does not actually cancel the drag today — the gesture
survives and the later `pointerup` still commits a `move-node`. That is the recovery this handler
claims to provide, so it is worth its own look; it is out of scope for this fix and nothing here
makes it worse.
