### PR TITLE
fix(web): decide a lost pointer capture per pointer, not per editor

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -529,6 +529,14 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * used to blur the just-mounted textarea when we opened at the press.
      */
     const doublePressRef = useRef<{ key: string; point: Point } | null>(null)
+    /**
+     * Every pointer currently down on the root, by id. Read by
+     * `handleLostPointerCapture` to tell a capture handed back with its own
+     * release from one lost out from under a pointer that is still down.
+     * A set, not a single slot: a pinch holds two at once and they end
+     * independently.
+     */
+    const downPointersRef = useRef<Set<number>>(new Set())
     /** In-flight marquee selection rect, in canvas space (Excalidraw
      * semantics: plain drag on empty space selects; pan is Space+drag,
      * middle-button drag, or wheel). */
@@ -1332,7 +1340,15 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      */
     const beginOverlayGesture = (e: React.PointerEvent): HTMLDivElement | null => {
       const root = rootRef.current
-      if (root !== null) capturePointer(root, e.pointerId)
+      if (root !== null) {
+        // These presses never reach handlePointerDown, so this is where the
+        // pointer joins the down set. Without it a capture lost mid-resize
+        // would be read as an ordinary handback and never recovered. Their
+        // release does reach handlePointerUp, because capture redirects the
+        // rest of the sequence to the root.
+        downPointersRef.current.add(e.pointerId)
+        capturePointer(root, e.pointerId)
+      }
       return root
     }
 
@@ -1379,6 +1395,10 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       if (isOverlayEvent(e)) return
       const root = rootRef.current
       if (root === null) return
+      // Before every early return below: what is down has to be recorded even
+      // for presses this handler goes on to ignore, or their handback is read
+      // as a capture loss.
+      downPointersRef.current.add(e.pointerId)
       if (e.pointerType === 'touch') {
         touchPointsRef.current.set(e.pointerId, clientPointToRootLocal(e, root))
         if (pinchActiveRef.current) return
@@ -1732,6 +1752,9 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
 
     const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
       if (longPressRef.current?.pointerId === e.pointerId) clearLongPress()
+      // Ahead of the gather/pinch early returns: this pointer is up whatever
+      // the rest of the handler decides to do about it.
+      downPointersRef.current.delete(e.pointerId)
       const root = rootRef.current
       // Gathering fingers act on the press, so their release carries no
       // meaning — running the click/marquee logic here would re-collapse the
@@ -1899,6 +1922,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
 
     const handlePointerCancel = (e: React.PointerEvent<HTMLDivElement>) => {
       if (longPressRef.current?.pointerId === e.pointerId) clearLongPress()
+      downPointersRef.current.delete(e.pointerId)
       // Pointer ids are reused, so a gathering finger left in these refs by a
       // cancel would silently deaden whichever later touch inherits its id.
       gatherPointersRef.current.delete(e.pointerId)
@@ -1916,17 +1940,21 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * `lostpointercapture` is NOT a synonym for "the gesture broke". It also
      * fires on the ordinary release of a captured pointer — and the browser
      * captures touch pointers IMPLICITLY, so on a touch device it arrives
-     * after every single tap.
+     * after every single tap. Cancelling there deleted the node the
+     * empty-canvas double-TAP had just created for editing: it appeared and
+     * vanished. (The same double-CLICK was fine — capture is taken at the
+     * first MOVE, so a stationary mouse press holds none to lose.)
      *
-     * `activePointerIdRef` is what tells the two apart: `handlePointerUp`
-     * clears it, so a null ref means the interaction already ended normally
-     * and there is nothing to recover. Cancelling there deleted the node the
-     * empty-canvas double-TAP had just created for editing — it appeared and
-     * vanished, while the same double-CLICK was fine because a stationary
-     * mouse press takes no capture to lose.
+     * The question is per-POINTER, not per-editor: is THIS pointer still
+     * down? A pinch captures both fingers, so lifting one leaves the other
+     * held. Deciding from any editor-wide "is something active" flag lets
+     * the lifted finger's ordinary handback answer for the finger still
+     * down — which then leaves the pinch bookkeeping holding a pointer id
+     * nothing will ever release, silently deadening whichever later touch
+     * inherits it.
      */
     const handleLostPointerCapture = (e: React.PointerEvent<HTMLDivElement>) => {
-      if (activePointerIdRef.current === null) return
+      if (!downPointersRef.current.has(e.pointerId)) return
       handlePointerCancel(e)
     }
 

--- a/apps/web/src/components/spatial-editor/lost-pointer-capture.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/lost-pointer-capture.browser.test.tsx
@@ -54,11 +54,11 @@ function rootOf(container: HTMLElement): HTMLElement {
  * tap, not only in the failure case. Driving it here is what keeps this a
  * test of the TOUCH path rather than of the handler in isolation.
  */
-function touchTap(root: HTMLElement, x: number, y: number): void {
+function touchTap(root: HTMLElement, x: number, y: number, pointerId = 1): void {
   const rect = root.getBoundingClientRect()
   const init = {
     bubbles: true,
-    pointerId: 1,
+    pointerId,
     pointerType: 'touch',
     isPrimary: true,
     clientX: rect.left + x,
@@ -82,6 +82,96 @@ it('keeps the node a double-TAP just created when the touch capture is handed ba
   expect(commands.filter((kind) => kind === 'create-node')).toHaveLength(1)
   expect(commands).not.toContain('delete-node')
   expect(container.querySelector('textarea')).not.toBeNull()
+})
+
+it('recovers a capture lost while its own finger is still down, mid-pinch', async () => {
+  // The guard has to be per-pointer, not "is any pointer active". A pinch
+  // captures both fingers; lifting one leaves the other down. If the lifted
+  // finger's ordinary handback is allowed to stand in for the whole
+  // interaction, the pinch bookkeeping is left holding the finger that is
+  // STILL down, and the next touch to inherit its id is silently deadened —
+  // no selection, no double-tap, nothing.
+  const commands: string[] = []
+  const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)
+  const root = rootOf(container)
+  const rect = root.getBoundingClientRect()
+  const p = (type: string, id: number, x: number, y: number) =>
+    new PointerEvent(type, {
+      bubbles: true,
+      pointerId: id,
+      pointerType: 'touch',
+      isPrimary: id === 1,
+      button: 0,
+      clientX: rect.left + x,
+      clientY: rect.top + y,
+    })
+  const settle = () => new Promise((resolve) => setTimeout(resolve, 20))
+
+  root.dispatchEvent(p('pointerdown', 1, 300, 300))
+  await settle()
+  root.dispatchEvent(p('pointerdown', 2, 500, 300))
+  await settle()
+  root.dispatchEvent(p('pointermove', 1, 290, 300))
+  await settle()
+
+  // Finger 1 lifts normally; its capture comes back with it.
+  root.dispatchEvent(p('pointerup', 1, 290, 300))
+  await settle()
+  root.dispatchEvent(p('lostpointercapture', 1, 290, 300))
+  await settle()
+  // Finger 2's capture is genuinely lost while finger 2 is still down.
+  root.dispatchEvent(p('lostpointercapture', 2, 500, 300))
+  await settle()
+
+  // The editor must be usable again: a double-tap reusing id 2 creates a node.
+  for (let i = 0; i < 2; i++) {
+    touchTap(root, 620, 460, 2)
+    await settle()
+  }
+
+  expect(commands).toContain('create-node')
+  expect(container.querySelector('textarea')).not.toBeNull()
+})
+
+it('recovers a capture lost mid-resize, which never went through the root press', async () => {
+  // Resize/connect presses start on the overlay and bypass handlePointerDown
+  // entirely, so a down-set fed only from that handler would not know their
+  // pointer exists — and the recovery this guard performs would be skipped
+  // for exactly the gestures that hold a node hostage.
+  const commands: string[] = []
+  const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)
+  const root = rootOf(container)
+
+  touchTap(root, 200, 150)
+  const handle = await vi.waitFor(() => {
+    const el = container.querySelector('[data-testid^="resize-handle-"]')
+    expect(el).not.toBeNull()
+    return el as HTMLElement
+  })
+
+  const hb = handle.getBoundingClientRect()
+  const at = (dx: number, dy: number) => ({
+    clientX: hb.x + hb.width / 2 + dx,
+    clientY: hb.y + hb.height / 2 + dy,
+  })
+  handle.dispatchEvent(
+    new PointerEvent('pointerdown', { bubbles: true, pointerId: 7, button: 0, ...at(0, 0) }),
+  )
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  root.dispatchEvent(
+    new PointerEvent('pointermove', { bubbles: true, pointerId: 7, ...at(40, 40) }),
+  )
+  await new Promise((resolve) => setTimeout(resolve, 20))
+
+  root.dispatchEvent(new PointerEvent('lostpointercapture', { bubbles: true, pointerId: 7 }))
+  await new Promise((resolve) => setTimeout(resolve, 20))
+
+  // Cancelled, so the release commits nothing and the node keeps its size.
+  root.dispatchEvent(
+    new PointerEvent('pointerup', { bubbles: true, pointerId: 7, ...at(120, 120) }),
+  )
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  expect(commands).not.toContain('resize-node')
 })
 
 it('still discards the new node on a real pointercancel', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #821, and a correction to what I wrote there.

#821 stopped `lostpointercapture` cancelling the gesture by gating on
`activePointerIdRef !== null`. That ref is a **single slot**, and `handlePointerUp` deliberately
leaves it alone on the gather and pinch early-return paths. So a pinch went:

1. finger 1 lifts — pinch path returns early, ref untouched
2. finger 1's ordinary handback arrives — ref is non-null, so the guard lets a **full cancel**
   run, which nulls the ref for the finger **still down**
3. finger 2's capture is genuinely lost — ref is now null, so the recovery is **skipped**

The pinch bookkeeping is left holding a pointer id nothing will ever release, and the next touch
to inherit that id does nothing at all.

**I claimed in #821 that this was pre-existing and not a regression, on the grounds that the
change could only ever remove cancels, never add them. That argument was wrong** — it shows no
*new* cancel occurs, which says nothing about a *needed* cancel going missing. Measured both ways
on the same sequence:

| | later double-tap |
|---|---|
| without the guard (pre-#821) | `create-node` |
| with the guard (#821 as merged) | `[]` — nothing happens |

So #821 introduced it. This PR fixes it.

## The fix

The question was never "is the editor busy" but "is **this** pointer still down", which a set of
down pointer ids answers directly. Two fingers are held at once and end independently, so a
single slot cannot express it.

Overlay presses (resize, connect) never reach `handlePointerDown` — they start on the overlay —
so they join the set in `beginOverlayGesture`. Capture redirects the rest of their sequence to
the root, where `handlePointerUp` clears them. **Without that line the recovery would be skipped
for exactly the gestures that hold a node hostage**, which is a hole this PR would otherwise have
opened; it has its own test.

## Also retracted from #821

I reported there that a mid-drag `lostpointercapture` does not actually cancel the drag. **That
was wrong too.** It was an artifact of dispatching pointerdown/move/lostpointercapture in one
task, so the handler closed over a stale `gestureState`. With a render between the events the
cancel works (`afterCancel=[] final=[]`). Nothing to fix; the note in #821 should be disregarded.

## Verification

- [x] New pinch case: red before this fix (`expected [] to include 'create-node'`), green after
- [x] New overlay case: red when `beginOverlayGesture` does not record the pointer, green with it
- [x] The two #821 cases still pass, and all four go red if the guard is removed entirely
- [x] `pnpm test --project web-browser` 568 passed; apps/web jsdom 2188 + 77; typecheck, lint clean

**One thing the tests do NOT pin:** they do not distinguish the per-pointer predicate from an
editor-wide "is the down set empty". Both restore the recovery, and on touch a second finger is
always a pinch, so I could not construct an observable difference. Per-pointer is the predicate
I chose because it is the question actually being asked, not because a test forced it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved touch and pointer gesture handling in the spatial editor.
  * Prevented normal touch releases from being mistaken for lost pointer capture.
  * Improved recovery during multi-finger pinch and overlay-initiated resize gestures.
  * Ensured canceled resize operations do not apply unintended changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->