### PR TITLE
docs(claude): add a diagnosis-evidence skill and two more flake shapes

### DIFF
--- a/.claude/rules/dev-flow.md
+++ b/.claude/rules/dev-flow.md
@@ -86,8 +86,9 @@ saying nothing about what was actually exercised. In one session that produced t
 wrong conclusions: a cause read off an assertion string without checking which of two identical
 assertions failed; a regression denied by a property of the diff instead of an A/B of the
 behaviour; and a mutation check whose restore had already run, so eleven "mutated" runs used the
-original file. Each was one printed line away from being caught. Load the `diagnosis-evidence`
-skill before reporting a cause.
+original file. Each was one printed line away from being caught. Load the `diagnosis-evidence` skill before
+reporting ANY diagnostic or verification conclusion — a cause, a "not a regression", a mutation
+result, or a fix you are calling verified by hand.
 
 **Visual evidence for a change that moves pixels** is a repeatable procedure, not a screenshot of whatever was on screen: render the SAME canvas through the real pipeline before and after, side by side, chosen by the metric the change targets rather than by eye. Load the `visual-evidence` skill — its traps (a no-op `git stash` producing identical panels, unfilled rects rendering black) have each produced a misleading figure at least once.
 

--- a/.claude/rules/dev-flow.md
+++ b/.claude/rules/dev-flow.md
@@ -80,6 +80,15 @@ TDD red-first; Zod single source of truth (`z.infer`, never a parallel hand-writ
 
 **Measure before you change what you cannot see in the diff.** A heuristic, a cost model, a search or an optimisation is correct-looking code whose worth is entirely in numbers nobody has taken — so the INSTRUMENT lands first, in its own commit, and the change is judged by it. Two exist: `edge-routing-quality.test.ts` (quality: a corpus plus aggregate counts pinned EXACTLY, so an improvement is as loud as a regression, with debt metrics separated from price metrics) and `pnpm bench` (performance: `vitest bench`, compared across INTERLEAVED paired runs because machine drift between separate runs exceeds the effect). For a behaviour-preserving optimisation the scoreboard NOT moving is the proof. This is not ceremony: the instruments rejected three changes that were obviously right on argument — per-blocker detours, a placement cache, and an excess-length penalty tier — and one cheap reachability probe (67 of 68 remaining defects had a clean path available) retired a planned task and redirected the work. They also **rescued** one: an aligned re-score was rejected in its first two shapes on cost (13x, then 4.5x layout time) and shipped in a third that reused machinery already in the file, at 2x — the measurement did not veto the idea, it priced each shape until one was worth paying for. Load the `measured-change` skill. When a change buys one metric with another, `PENALTY_RULES`' declared tier order decides it; when the currencies are genuinely different, that is a human decision worth interrupting for.
 
+**The same scepticism applies one step earlier, to a DIAGNOSIS.** A failure message, a "not a
+regression", a mutation check, a hand-verified fix — each arrives looking like evidence while
+saying nothing about what was actually exercised. In one session that produced three published
+wrong conclusions: a cause read off an assertion string without checking which of two identical
+assertions failed; a regression denied by a property of the diff instead of an A/B of the
+behaviour; and a mutation check whose restore had already run, so eleven "mutated" runs used the
+original file. Each was one printed line away from being caught. Load the `diagnosis-evidence`
+skill before reporting a cause.
+
 **Visual evidence for a change that moves pixels** is a repeatable procedure, not a screenshot of whatever was on screen: render the SAME canvas through the real pipeline before and after, side by side, chosen by the metric the change targets rather than by eye. Load the `visual-evidence` skill — its traps (a no-op `git stash` producing identical panels, unfilled rects rendering black) have each produced a misleading figure at least once.
 
 **Docs sync**: a user-visible / API / contract / config change ships with its docs in the same increment (`technical-writer` + `docs-sync` skill; honesty — document the shipped state, never the aspiration). **`./docs/**` is USER docs (Diátaxis); developer docs are OSS-convention root files (README / SECURITY / CONTRIBUTING / CODE_OF_CONDUCT / .github). All project docs are in ENGLISH.** Marketing/release notes are drafts only (`marketing` agent), human ships.
@@ -92,7 +101,7 @@ Native **Task list** = live board (in-flight / blocked / done; main session owns
 
 ## Skills (load for detail)
 
-`ticketing`, `workflow-authoring`, `zod-schema-discipline`, `test-layer-selection`, `measured-change`, `visual-evidence`, `docs-sync`, `whiteboard-mcp-smoke`, `review-gate`, `audit-triage`, `ci-triage`, `dependabot-review`, `stacking-pull-requests`.
+`ticketing`, `workflow-authoring`, `zod-schema-discipline`, `test-layer-selection`, `measured-change`, `diagnosis-evidence`, `visual-evidence`, `docs-sync`, `whiteboard-mcp-smoke`, `review-gate`, `audit-triage`, `ci-triage`, `dependabot-review`, `stacking-pull-requests`.
 
 ## Gates: local + cloud
 

--- a/.claude/rules/integrator-flow.md
+++ b/.claude/rules/integrator-flow.md
@@ -83,3 +83,17 @@ When a preview contradicts a green test, suspect the cache before suspecting the
     breaks it, so a reproduction has to get that order right (the first attempt
     here did not, and its mutation check passed against the unfixed code).
 - **A third shape: `await import()` of a heavy module INSIDE a test body.** It charges the transform-and-load of that whole module graph to the per-test timeout (10s in `mcp-node`), which is ample on an idle machine and the first thing to blow once the full suite runs every project in parallel — aggregate import time there is measured in minutes. It reads as a mysterious load-dependent failure and the message names the test, not the import. Hoist it to a static top-level `import`, where the cost lands in the collection phase that no per-test timeout bounds. A dynamic import is only necessary when the file mocks what it imports (`vi.mock` + top-level `await import` is a different, legitimate shape), so **an in-body `await import()` with no `vi.mock` in the file is the tell**.
+- **A sixth shape: an element reference held across an action that remounts it.** A query
+  resolves, the page swaps, and the assertion reads a node that is no longer in the document —
+  reporting the value it had when it was detached. Measured at one such failure:
+  `held.isConnected=false held.value='' live.value='Fast switch'`. The typing was always fine;
+  only the node being read was dead, and the message (`expected '' to be 'Fast switch'`) is
+  indistinguishable from a genuine loss. Query inside the assertion, and resolve the element
+  from the page that owns it — `/title/i` matched on the outgoing page too, which is how it
+  bound to the wrong one. Made likelier by anything that speeds up a transition; here it
+  surfaced when a dropdown became non-modal and stopped waiting out a focus trap.
+- **A seventh: clicking a trigger whose menu is still dismissing.** The click is consumed and
+  the menu stays shut, so the failure reads as "the list does not contain this item" when no
+  list was ever opened — and raising the query's timeout only buys a slower identical failure.
+  Measured: `menus=0 expanded=false connected=true`. Wait for `[role="menu"]` to be gone before
+  re-opening.

--- a/.claude/skills/diagnosis-evidence/SKILL.md
+++ b/.claude/skills/diagnosis-evidence/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: diagnosis-evidence
+description: Make a diagnosis prove it measured what it claims — before reporting a cause, a "not a regression", a mutation check, or a passing verification. Use when debugging a failing test, a CI failure, a flake, or verifying a fix by hand.
+---
+
+# A diagnosis is only as good as the proof that you measured what you think
+
+`measured-change` is about instrumenting a CHANGE whose effect you cannot see.
+This is about the step before: a FAILURE you are explaining, or a fix you are
+calling verified. Both fail the same way — a number arrives, it looks like
+evidence, and nothing in it says what was actually exercised.
+
+Every rule below cost a wrong public conclusion in one session.
+
+## Read the stack line before explaining the message
+
+`expected '' to be 'Fast switch'` was diagnosed from the string alone, blamed on
+a change that had made a reload slower, and reported as such. The stack line said
+`278`, which was the assertion BEFORE the unmount — a different assertion in the
+same test comparing to the same literal. The change had nothing to do with it.
+
+Two assertions comparing to one string is ordinary. **The message names the
+expectation; only the line names the assertion.**
+
+## An argument about the shape of a change is not a measurement of its effect
+
+A guard was defended with: it can only ever REMOVE cancels, so the set after is a
+subset of the set before, so nothing new can break. True, and irrelevant — the
+harm was a *needed* cancel going missing. The A/B took one command per side:
+
+| | later double-tap |
+|---|---|
+| without the guard | `create-node` |
+| with the guard | `[]` |
+
+If a claim is about behaviour, run both sides. A property of the diff is not a
+property of the product.
+
+## A mutation check must print the state it mutated
+
+A "mutation check" reported the guard as not load-bearing. The restore step had
+already run; every one of those eleven runs used the UNMUTATED file. The
+conclusion was backwards and was published before anyone noticed.
+
+Make the command prove its own premise:
+
+```bash
+cp $F /tmp/orig.tsx
+python3 - "$F" <<'EOF'
+import sys; p=sys.argv[1]; s=open(p).read()
+old="the exact line"
+assert old in s, "pattern not found"      # fails loudly instead of silently no-op'ing
+open(p,'w').write(s.replace(old, "the mutation"))
+EOF
+echo "mutated: $(grep -c 'the exact line' $F)"   # expect 0
+<run the test>
+cp /tmp/orig.tsx $F
+echo "restored: $(grep -c 'the exact line' $F)"  # expect 1
+```
+
+A mutation check under conditions where the baseline is green is **inconclusive,
+not negative** — you cannot detect the removal of something that was not being
+exercised. Reproduce the failure first, then mutate.
+
+## Assert the count, not the absence of failures
+
+Six runs reported `0 failures`. Six runs had executed zero tests: the command
+died at startup with `No projects matched the filter "web-browser"` because it
+ran from `apps/web`, where that project is not defined. "Nothing failed" was one
+grep away from being reported as "could not reproduce".
+
+Read the `Tests N passed` line. A suite that did not run is not a suite that
+passed — and `dev-flow.md` documents the quieter variant, where a bogus
+`--project` is silently ignored as long as one other filter matches.
+
+## A verification must assert that the trigger fired
+
+A touch fix "verified" locally: the node survived, exactly as designed. It also
+survived on the unfixed build, because the event that triggers the bug was never
+dispatched in that environment. The check proved nothing and looked identical to
+one that proved everything.
+
+State the trigger as an assertion beside the outcome:
+
+```js
+expect(events).toContain('lostpointercapture')   // the cause happened
+expect(node).not.toBeNull()                      // and the effect did not
+```
+
+Whenever a test can pass because the interesting thing never happened, that is
+the assertion it is missing.
+
+## Prefer a control to an explanation
+
+"After the pinch, the later double-tap does nothing" means nothing on its own —
+maybe that gesture never worked in this harness. The same sequence with the
+prelude removed produced `create-node`, and the finding became real in one extra
+run. When a measurement is a single number with no comparison, the cheapest next
+step is almost always the control, not another theory.

--- a/.claude/skills/diagnosis-evidence/SKILL.md
+++ b/.claude/skills/diagnosis-evidence/SKILL.md
@@ -45,22 +45,42 @@ conclusion was backwards and was published before anyone noticed.
 Make the command prove its own premise:
 
 ```bash
-cp $F /tmp/orig.tsx
+F=path/to/file.tsx
+BAK=$(mktemp)
+cp "$F" "$BAK"
+trap 'cp "$BAK" "$F"; rm -f "$BAK"' EXIT   # restore even on ^C or a set -e exit
+
 python3 - "$F" <<'EOF'
-import sys; p=sys.argv[1]; s=open(p).read()
-old="the exact line"
-assert old in s, "pattern not found"      # fails loudly instead of silently no-op'ing
-open(p,'w').write(s.replace(old, "the mutation"))
+import sys
+p = sys.argv[1]; s = open(p).read()
+old = "the exact line"
+assert s.count(old) == 1, f"expected 1 occurrence, found {s.count(old)}"
+open(p, 'w').write(s.replace(old, "the mutation", 1))   # once, not everywhere
 EOF
-echo "mutated: $(grep -c 'the exact line' $F)"   # expect 0
-<run the test>
-cp /tmp/orig.tsx $F
-echo "restored: $(grep -c 'the exact line' $F)"  # expect 1
+echo "mutated: $(grep -c 'the exact line' "$F")"        # expect 0
+
+<run the test — expect RED>
+
+trap - EXIT; cp "$BAK" "$F"; rm -f "$BAK"
+echo "restored: $(grep -c 'the exact line' "$F")"       # expect 1
 ```
 
-A mutation check under conditions where the baseline is green is **inconclusive,
-not negative** — you cannot detect the removal of something that was not being
-exercised. Reproduce the failure first, then mutate.
+The `trap` and the count assertion are the parts that matter. Without the trap a
+failure between mutate and restore leaves the working tree mutated, and the next
+command you run measures something you did not intend. Without the count, a
+pattern that appears twice mutates both sites and the red you get may not be the
+red you were testing for.
+
+A green baseline is the normal starting point — that is what the fix bought, and
+`test-layer-selection` asks for exactly that shape: fixed code green, revert,
+confirm red, restore. What makes a run **inconclusive rather than negative** is a
+mutated run that *stays* green while you never saw the original failure. Then the
+scenario was not being reached at all, and the check could not have detected the
+removal either way.
+
+The sweeper case: the flake only appeared under parallel load, so on a quiet
+machine both the fixed and the mutated build passed. The mutation only became
+informative once the failure had been reproduced first.
 
 ## Assert the count, not the absence of failures
 


### PR DESCRIPTION
## Summary

`measured-change` covers instrumenting a change whose effect you cannot see by reading the diff.
Nothing covered the step **before** it: a failure you are explaining, or a fix you are calling
verified. Both fail the same way — a number arrives, it looks like evidence, and nothing in it
says what was actually exercised.

Every rule in the new `diagnosis-evidence` skill cost a wrong **published** conclusion in one
session:

| what was reported | what was true |
|---|---|
| a cause read off `expected '' to be 'Fast switch'` | two assertions in that test compared to the same literal; only the stack line (`:278`) said which failed, and it was the one before the unmount |
| "not a regression — the change can only remove cancels, so the set is a subset" | true and irrelevant: the harm was a *needed* cancel going missing. The A/B was one command per side (`create-node` vs `[]`) |
| "the guard is not load-bearing — mutation check stayed green" | the restore step had already run; all eleven "mutated" runs used the original file |
| "6 runs, 0 failures — cannot reproduce" | 6 runs had executed **zero tests** (`No projects matched the filter`) |
| "verified locally: the node survives" | it survives on the unfixed build too, because the triggering event never fired in that environment |

The corrective in each case was one printed line — assert the pattern before replacing it, print
the grep count after mutating *and* after restoring, read `Tests N passed`, assert the trigger
alongside the outcome, run the control.

`integrator-flow.md` gains the two test shapes found the same way, alongside the existing five:
an element reference held across an action that remounts it (`held.isConnected=false` while
`live.value` has the text), and a trigger clicked while its menu is still dismissing
(`menus=0 expanded=false connected=true`). Both produce failure messages that name the wrong
cause, which is why they are worth writing down rather than re-deriving.

## Notes

- Docs only — no source, no tests. `dev-flow.md`'s skill list and the `measured-change` paragraph
  gain the cross-reference so the skill is reachable from where the related discipline already is.
- Deliberately NOT included: the pointer-capture semantics from the same investigation. Those are
  specific to one component, and they already live where a reader will meet them — in
  `SpatialEditor.tsx`'s handler comment, in `lost-pointer-capture.browser.test.tsx`, and in the
  `local-dev-emits-no-pointer-capture-events` issue. A rule file would be a third copy that goes
  stale independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for evidence-based diagnosis when reporting failures, regressions, mutation checks, and manually verified fixes.
  * Documented common CI flake patterns involving stale elements and menus still dismissing.
  * Added verification practices for confirming test execution, state changes, triggers, and control comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->