### PR TITLE
fix(server): break the ws/canvas import cycle that TDZ'd connections

### DIFF
--- a/packages/mcp-server/src/server/routes/ws.ts
+++ b/packages/mcp-server/src/server/routes/ws.ts
@@ -15,7 +15,14 @@ import { saveCanvas, workspaceExists } from '../store/canvas-store.js'
 import { evictDoc, getDoc } from '../store/doc-cache.js'
 import type { VersionEntry } from '../store/version-store.js'
 import { withWorkspaceWriteLock } from '../store/workspace-lock.js'
-import { setBroadcastFn } from './canvas.js'
+// From _shared, not from canvas.js which merely re-exports it: importing the
+// router barrel pulls its whole graph — including restore.ts and live-doc.ts,
+// which close the loop back here with `await import('../ws.js')`. That cycle
+// let a request reach `sendRestoreEvent` while this module's own body had not
+// run, so `connections` was still in its TDZ and the restore 500'd with a bare
+// ReferenceError. Taking the setter from the 42-line module that defines it
+// keeps the seam and drops the edge.
+import { setBroadcastFn } from './canvas/_shared.js'
 import {
   setSyncSseHooks,
   sseBroadcastText,

--- a/tools/arch-lint/src/architecture-map.ts
+++ b/tools/arch-lint/src/architecture-map.ts
@@ -132,21 +132,21 @@ export const ARCHITECTURE_MAP: Readonly<Record<string, PackageArchEntry>> = {
  * either is its own lane, not this one's.
  */
 export const KNOWN_IMPORT_CYCLES: readonly (readonly string[])[] = [
-  // doc-cache.ts imports canvas-store.ts statically; canvas-store.ts closes
-  // the loop with `await import('./doc-cache.js')` at three eviction call
-  // sites — resolved at call time, so no module-eval TDZ risk.
+  // doc-cache.ts imports canvas-store.ts statically; canvas-store.ts closes the
+  // loop with `await import('./doc-cache.js')` at three eviction call sites.
+  //
+  // This list used to say a call-time dynamic import carries "no module-eval
+  // TDZ risk". It does not follow, and the sibling entry that said it was
+  // removed after the risk landed: a request reached ws.ts's `sendRestoreEvent`
+  // while ws.ts's own body had not run, so its module-level `const connections`
+  // was still in its TDZ and the restore route 500'd with a bare ReferenceError
+  // — intermittently, under a full parallel suite. A dynamic import defers
+  // WHEN the module is fetched, not whether the fetch can observe a module that
+  // is mid-evaluation somewhere up the stack. Treat an entry here as debt with
+  // a known failure mode, not as a cycle that has been reasoned safe.
   [
     'packages/mcp-server/src/server/store/canvas-store.ts',
     'packages/mcp-server/src/server/store/doc-cache.ts',
-  ],
-  // ws.ts imports canvas.ts statically (setBroadcastFn); canvas.ts and its
-  // live-doc.ts/restore.ts routers close the loop with `await import('../ws.js')` /
-  // `await import('./ws.js')` — resolved at call time, so no module-eval TDZ risk.
-  [
-    'packages/mcp-server/src/server/routes/canvas.ts',
-    'packages/mcp-server/src/server/routes/canvas/live-doc.ts',
-    'packages/mcp-server/src/server/routes/canvas/restore.ts',
-    'packages/mcp-server/src/server/routes/ws.ts',
   ],
 ]
 


### PR DESCRIPTION
## Summary

The restore route intermittently returned a bare `Internal Server Error` — not Problem Details,
because nothing in the route produced it:

```
ReferenceError: Cannot access 'connections' before initialization
  at forEachClient (routes/ws.ts:53)
  at sendRestoreEvent (routes/ws.ts:141)
  at reconcileCommitSaveBroadcast (routes/canvas/restore.ts:38)
```

`ws.ts` took `setBroadcastFn` from `canvas.js`, which only **re-exports** it from the 42-line
`canvas/_shared.js`. The barrel dragged in its whole router graph — including `restore.ts` and
`live-doc.ts`, which close the loop at request time with `await import('../ws.js')`. Reached in the
wrong evaluation order, that import hands back a `ws.ts` whose body has not run: the hoisted
function is callable while the module-level `const connections` is still in its TDZ.

Taking the setter from the module that defines it drops the edge, and the cycle with it. It is the
idiom `sync-sse.ts` already documents for this same pair.

## The allowlist entry was wrong, not just stale

`KNOWN_IMPORT_CYCLES` carried this cycle with the note *"resolved at call time, so no module-eval
TDZ risk"*. That does not follow — a dynamic import defers **when** a module is fetched, not whether
the fetch can observe one that is mid-evaluation further up the stack. This bug is the failure that
reasoning did not prevent.

The entry is removed (arch-lint's own "every entry is still an actually-detected cycle" guard went
red, which is how it should behave), and the remaining `canvas-store`/`doc-cache` entry no longer
repeats the claim: it now says an entry here is debt with a known failure mode, not a cycle that has
been reasoned safe.

## Measured

Under the condition that produced it — the full `mcp-node` suite racing `typecheck` and `lint`, the
way pre-push runs it. A single file with external load does **not** reproduce it.

| | reproductions |
|---|---|
| before | 2/8, then 1/2, then 1/4 |
| after | **0/12** |

Also green: `arch-lint-node` (76), and pre-push (`typecheck`, `lint`, `noconsole`, `test-node`).

## Notes

This was filed as a test flake (`canvas-routes-post-500-under-load`). It is a product bug: any
restore that lands in the wrong module-evaluation order 500s. The ticket's earlier "Established"
section blamed an `EEXIST` seen in the failing logs — that was wrong, and the control shows why: the
same `EEXIST` appears exactly once in *passing* runs too. It is expected output from the sibling
test at `canvas.test.ts:113`, which deliberately blocks the blob dir with a file to force the 500
branch. The ticket has been corrected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause restore requests to fail with a `ReferenceError`.
  * Improved WebSocket route initialization to ensure connection handling works reliably.

* **Chores**
  * Updated architecture checks to accurately document remaining internal dependency risks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->