### PR TITLE
test(server): pin the SPA-shell inline-JSON XSS escape and its neighbors

### DIFF
--- a/packages/mcp-server/src/server/app-helpers.test.ts
+++ b/packages/mcp-server/src/server/app-helpers.test.ts
@@ -13,20 +13,10 @@ describe('toInlineScriptJson', () => {
     expect(toInlineScriptJson({ port: 3099 })).toBe(JSON.stringify({ port: 3099 }))
   })
 
-  // Bias the generator toward '<'-bearing strings: JSON values drawn uniformly
-  // almost never contain '<', which would make this property pass vacuously
-  // even with the escape deleted.
-  const jsonValue = fc.letrec((tie) => ({
-    value: fc.oneof(
-      { depthSize: 'small' },
-      fc.constant(null),
-      fc.boolean(),
-      fc.double({ noNaN: true }),
-      fc.oneof(fc.string(), fc.constantFrom('</script>', '<img src=x onerror=alert(1)>')),
-      fc.array(tie('value') as fc.Arbitrary<unknown>, { maxLength: 5 }),
-      fc.dictionary(fc.string(), tie('value') as fc.Arbitrary<unknown>, { maxKeys: 5 }),
-    ),
-  })).value
+  // Bias string content toward '<': JSON values drawn uniformly almost never
+  // contain it, which would make this property pass vacuously even with the
+  // escape deleted.
+  const jsonValue = fc.jsonValue({ stringUnit: fc.constantFrom('<', '/script>', 'a') })
 
   fcTest.prop([jsonValue], withDefaults())(
     'escape is complete and semantics-preserving for any JSON value',

--- a/packages/mcp-server/src/server/app-helpers.test.ts
+++ b/packages/mcp-server/src/server/app-helpers.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { fc, fcTest, withDefaults } from '../shared/test-utils/fast-check.js'
+import { isReservedUiPath, setBaselineSecurityHeaders, toInlineScriptJson } from './app-helpers.js'
+
+describe('toInlineScriptJson', () => {
+  it('escapes </script> so an inlined value cannot terminate the surrounding <script> tag', () => {
+    const output = toInlineScriptJson('</script><script>alert(1)</script>')
+    expect(output).not.toContain('</script')
+    expect(output).not.toContain('<')
+  })
+
+  it('serializes a plain safe value unchanged (no mangling of the common case)', () => {
+    expect(toInlineScriptJson({ port: 3099 })).toBe(JSON.stringify({ port: 3099 }))
+  })
+
+  // Bias the generator toward '<'-bearing strings: JSON values drawn uniformly
+  // almost never contain '<', which would make this property pass vacuously
+  // even with the escape deleted.
+  const jsonValue = fc.letrec((tie) => ({
+    value: fc.oneof(
+      { depthSize: 'small' },
+      fc.constant(null),
+      fc.boolean(),
+      fc.double({ noNaN: true }),
+      fc.oneof(fc.string(), fc.constantFrom('</script>', '<img src=x onerror=alert(1)>')),
+      fc.array(tie('value') as fc.Arbitrary<unknown>, { maxLength: 5 }),
+      fc.dictionary(fc.string(), tie('value') as fc.Arbitrary<unknown>, { maxKeys: 5 }),
+    ),
+  })).value
+
+  fcTest.prop([jsonValue], withDefaults())(
+    'escape is complete and semantics-preserving for any JSON value',
+    (value) => {
+      const output = toInlineScriptJson(value)
+      expect(output).not.toContain('<')
+      expect(JSON.parse(output)).toEqual(value)
+    },
+  )
+})
+
+describe('isReservedUiPath', () => {
+  it.each([
+    ['/api', true],
+    ['/api/x', true],
+    ['/mcp', true],
+    ['/mcp/tools', true],
+    ['/ws', true],
+    ['/ws/anything', true],
+    ['/.well-known/oauth-authorization-server', true],
+    ['/token', true],
+    ['/', false],
+    ['/apix', false],
+    ['/api2', false],
+    ['/mcpx', false],
+    ['/wsx', false],
+    ['/.well-known', false],
+    ['/token/refresh', false],
+    ['/w/default/canvas/foo', false],
+    ['/tokens', false],
+    ['/local/abc', false],
+  ])('isReservedUiPath(%s) === %s', (path, expected) => {
+    expect(isReservedUiPath(path)).toBe(expected)
+  })
+})
+
+describe('setBaselineSecurityHeaders', () => {
+  it('does not clobber a pre-set Content-Security-Policy', () => {
+    const headers = new Headers({ 'Content-Security-Policy': "default-src 'none'" })
+    setBaselineSecurityHeaders(headers)
+    expect(headers.get('Content-Security-Policy')).toBe("default-src 'none'")
+  })
+
+  it('sets the floor CSP plus the unconditional headers on empty Headers', () => {
+    const headers = new Headers()
+    setBaselineSecurityHeaders(headers)
+    expect(headers.get('Content-Security-Policy')).toBe("frame-ancestors 'none'")
+    expect(headers.get('X-Frame-Options')).toBe('DENY')
+    expect(headers.get('X-Content-Type-Options')).toBe('nosniff')
+    expect(headers.get('Referrer-Policy')).toBe('no-referrer')
+    expect(headers.get('Cross-Origin-Opener-Policy')).toBe('same-origin')
+    expect(headers.get('Cross-Origin-Resource-Policy')).toBe('same-origin')
+  })
+
+  it('overwrites a pre-set unconditional header (only CSP is guarded)', () => {
+    const headers = new Headers({ 'X-Frame-Options': 'SAMEORIGIN' })
+    setBaselineSecurityHeaders(headers)
+    expect(headers.get('X-Frame-Options')).toBe('DENY')
+  })
+})

--- a/packages/mcp-server/stryker.config.mjs
+++ b/packages/mcp-server/stryker.config.mjs
@@ -7,6 +7,7 @@ export default {
   },
   mutate: [
     'src/shared/diagnostics/redact.ts',
+    'src/server/app-helpers.ts',
     'src/server/store/path-guard.ts',
     'src/server/output-path.ts',
     'src/shared/api-contracts/libraries.ts',


### PR DESCRIPTION
Audit finding (adversarially verified): `toInlineScriptJson` — the escape that keeps the daemon token + runtime config inlined into the SPA shell from terminating its `<script>` — had **no test**; deleting the `.replace(/</g, …)` kept the whole suite green.

New `app-helpers.test.ts` (mcp-node): the `</script>` injection case, a property over arbitrary JSON values with a `<`-biased string generator (a uniform generator would pass vacuously), the full `isReservedUiPath` prefix truth table, and `setBaselineSecurityHeaders` CSP no-clobber + unconditional-header overwrite. File registered in stryker's mutate array. Mutation-checked by the integrator with the mutant verified in place: removing the escape turns exactly the two escape tests red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for secure inline JSON handling, including neutralization of potentially unsafe script content and JSON round-tripping.
  - Added validation for reserved UI paths and path boundary behavior.
  - Added checks for preserving content security policies and applying default security headers correctly.
  - Included mutation-testing coverage for application helper security behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->