### PR TITLE
fix(docs): correct .env.server.example's usage instructions to match compose's env_file

### DIFF
--- a/.env.server.example
+++ b/.env.server.example
@@ -1,6 +1,7 @@
 # Server-mode environment variables example.
-# Copy to .env.server and fill in your values before running:
-#   docker compose -f docker-compose.server.yml --env-file .env.server up
+# Copy to .env and fill in your values before running:
+#   cp .env.server.example .env
+#   NODE_VERSION="$(cat .node-version)" docker compose -f docker-compose.server.yml up -d --build
 #
 # All WHITEBOARD_SERVER_* vars are required for production auth.
 # Do NOT bake these into the Docker image; supply them at run time.

--- a/packages/mcp-server/src/server/docker-contract.test.ts
+++ b/packages/mcp-server/src/server/docker-contract.test.ts
@@ -22,6 +22,12 @@
 //   - Change port binding to 0.0.0.0 → test "loopback port binding" fails.
 //   - Remove WHITEBOARD_SERVER_JWKS_URI from env example → required vars test fails.
 //   - Add `--allowed-origins=*` to env example → forbidden pattern test fails.
+//   - Revert the env example's usage comment to `cp .env.server.example .env.server`
+//     (or change compose's env_file to .env.server) → test "usage comment names the
+//     same env file that compose env_file declares" fails.
+//   - Drop the `NODE_VERSION="$(cat .node-version)"` prefix from the env example's
+//     compose-up instruction → test "usage comment keeps the NODE_VERSION build-arg
+//     prefix" fails, while the cp-target equality test above stays green.
 
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
@@ -197,6 +203,24 @@ describe('.env.server.example contracts', () => {
 
   it('does not reference the whiteboard daemon run command', () => {
     expect(envExample).not.toMatch(/whiteboard daemon run/)
+  })
+
+  it('usage comment names the same env file that compose env_file declares', () => {
+    const composeEnvFile = compose.match(/env_file:\s*\n\s*-\s*(\S+)/)
+    expect(composeEnvFile).not.toBeNull()
+    const cpTarget = envExample.match(/cp \.env\.server\.example\s+(\S+)/)
+    expect(cpTarget).not.toBeNull()
+    expect(cpTarget![1]).toBe(composeEnvFile![1])
+  })
+
+  it('usage comment keeps the NODE_VERSION build-arg prefix on the compose up line', () => {
+    expect(envExample).toMatch(
+      /NODE_VERSION="\$\(cat \.node-version\)" docker compose -f docker-compose\.server\.yml up -d --build/,
+    )
+  })
+
+  it('does not reference the stale --env-file .env.server instruction', () => {
+    expect(envExample).not.toContain('--env-file .env.server')
   })
 })
 


### PR DESCRIPTION
Audit finding: following the instructions at the top of `.env.server.example` broke the first self-host run — they passed `--env-file`, which only feeds Compose *interpolation*, while the container's auth vars come from `docker-compose.server.yml`'s `env_file: .env`.

The usage comment now shows the working flow (`cp .env.server.example .env` + `NODE_VERSION="$(cat .node-version)" docker compose -f docker-compose.server.yml up -d --build`), and `docker-contract.test.ts` gains three assertions pinning it: the cp target equals compose's declared env_file (so the two files cannot drift again), the NODE_VERSION build-arg prefix stays, and the stale `--env-file .env.server` form cannot return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ