### PR TITLE
test(server): pin the fail-closed branch for undeclared API routes; drop testing.md's phantom section

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -85,19 +85,6 @@ Use PBT when the behavior is better described as an invariant over many inputs t
 
 **Replayability:** Avoid `Math.random()`, wall-clock timing, real network, and unseeded global state inside generated runs.
 
-### Property catalog
-
-The canonical catalog of property IDs lives in `tmp/notes/2026-05-06-property-catalog.md` (`P-<DOMAIN>-NNN` format).
-
-Operational rules:
-
-- When you add a PBT, leave the matching property ID in a test name or comment so `property-catalog-coverage.test.ts` can pair them up. New IDs that are neither covered nor explicitly deferred fail CI.
-- Deferred properties must declare a concrete `reason` (e.g. "no contract yet", "requires HTTPS") and an `unblock` condition in `DEFERRED_PROPERTIES`. "Not implemented yet" alone is not a valid reason — always point at the blocker.
-- The default `pnpm test` keeps `numRuns` low for CI speed. Run `pnpm test:pbt:stress` (sets `PBT_STRESS=1`) for deeper exploration before a release. Race / model tests can request an extra multiplier via `withDefaults(overrides, { stressMultiplier: N })`.
-- Property IDs cited in tests, comments, or smoke must exist in the catalog. The phantom-reference check fails on typos and on stale references to removed catalog entries.
-- When fast-check reports a counterexample, paste the seed / path output into the PR body or `tmp/issues/` note so the failure can be replayed deterministically.
-- The deferred-property table has a hard ceiling (`MAX_DEFERRED_PROPERTIES`). Bumping it is a deliberate review decision — every increase ships with the new entry's `reason`/`unblock` and a brief justification in the PR body.
-
 ---
 
 ## Mutation Testing

--- a/packages/mcp-server/src/server/security/server-mode-middleware.test.ts
+++ b/packages/mcp-server/src/server/security/server-mode-middleware.test.ts
@@ -13,16 +13,11 @@ const allowAllStrategy: AsyncAuthStrategy = {
   authorize: async () => ({ ok: true, context: { kind: 'local-token' } }),
 }
 
-function buildApp() {
-  const app = new Hono()
-  app.use('/api/*', createServerModeApiAuthMiddleware(allowAllStrategy))
-  app.get('/api/undeclared-route-for-test', (c) => c.json({ reached: true }))
-  return app
-}
-
 describe('createServerModeApiAuthMiddleware', () => {
   it('fails closed with auth.route-undeclared for a route absent from the registry', async () => {
-    const app = buildApp()
+    const app = new Hono()
+    app.use('/api/*', createServerModeApiAuthMiddleware(allowAllStrategy))
+    app.get('/api/undeclared-route-for-test', (c) => c.json({ reached: true }))
     const res = await app.request('/api/undeclared-route-for-test')
     expect(res.status).toBe(500)
     await expect(res.json()).resolves.toEqual({ error: 'auth.route-undeclared' })

--- a/packages/mcp-server/src/server/security/server-mode-middleware.test.ts
+++ b/packages/mcp-server/src/server/security/server-mode-middleware.test.ts
@@ -1,0 +1,30 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import type { AsyncAuthStrategy } from './oauth-resource-strategy.js'
+import { createServerModeApiAuthMiddleware } from './server-mode-middleware.js'
+
+// route-scope-registry.ts returns null for any /api/* path no rule claims,
+// and the middleware's contract for that case is fail-closed: refuse with
+// auth.route-undeclared rather than fall through to the auth strategy. An
+// allow-all strategy is the mutation-sensitive witness here — if the branch
+// regressed to `next()`, this strategy would happily authorize the request
+// and the handler's 200 would leak through.
+const allowAllStrategy: AsyncAuthStrategy = {
+  authorize: async () => ({ ok: true, context: { kind: 'local-token' } }),
+}
+
+function buildApp() {
+  const app = new Hono()
+  app.use('/api/*', createServerModeApiAuthMiddleware(allowAllStrategy))
+  app.get('/api/undeclared-route-for-test', (c) => c.json({ reached: true }))
+  return app
+}
+
+describe('createServerModeApiAuthMiddleware', () => {
+  it('fails closed with auth.route-undeclared for a route absent from the registry', async () => {
+    const app = buildApp()
+    const res = await app.request('/api/undeclared-route-for-test')
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({ error: 'auth.route-undeclared' })
+  })
+})


### PR DESCRIPTION
Two audit hygiene items, one increment:

1. The server-mode API auth middleware **fails closed** (`auth.route-undeclared`, 500) for any `/api/*` path the route-scope registry does not claim — the branch whose regression would silently open routes — and it was uncovered. The new test uses an allow-all auth strategy as the mutation-sensitive witness: if the branch regressed to `next()`, the strategy would authorize and the handler's 200 would leak through. Integrator-verified mutation check (mutant confirmed in place): swapping the branch for `next()` turns the test red.
2. `docs/contributing/testing.md`'s "Property catalog" section described machinery that exists nowhere in the repo (`DEFERRED_PROPERTIES`, `property-catalog-coverage.test.ts`, `test:pbt:stress`; the referenced `tmp/` catalog path is gitignored so it could never be tracked) and claimed CI enforcement that was fabricated. Deleted — the canonical doc must not advertise gates that do not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ