### PR TITLE
refactor(contracts): collapse the two runtimeConfigSchema owners into one

### DIFF
--- a/apps/web/src/runtime-config.test.ts
+++ b/apps/web/src/runtime-config.test.ts
@@ -1,3 +1,4 @@
+import { runtimeConfigSchema as sharedRuntimeConfigSchema } from '@kamiazya/whiteboard-mcp/api-client'
 import { describe, expect, it } from 'vitest'
 import { isProductionPagesOrigin } from './lib/pages-origin-policy.js'
 import {
@@ -7,6 +8,16 @@ import {
   resolveRuntimeConfig,
   runtimeConfigSchema,
 } from './runtime-config.js'
+
+describe('single-owner schema (Zod discipline)', () => {
+  // Mutation-check target: restoring a local `z.object({...})` definition in
+  // runtime-config.ts (instead of re-exporting the shared schema) must make
+  // this fail — a structurally-equal-but-distinct schema is exactly the
+  // silent-drift shape this pin exists to catch.
+  it('re-exports the same schema instance as @kamiazya/whiteboard-mcp/api-client', () => {
+    expect(runtimeConfigSchema).toBe(sharedRuntimeConfigSchema)
+  })
+})
 
 describe('runtimeConfigSchema', () => {
   it('parses an empty object as a valid config', () => {

--- a/apps/web/src/runtime-config.ts
+++ b/apps/web/src/runtime-config.ts
@@ -1,17 +1,17 @@
 import {
-  type RuntimeConfig,
   bareOriginSchema,
+  type RuntimeConfig,
   runtimeConfigSchema,
 } from '@kamiazya/whiteboard-mcp/api-client'
 import { classifyPagesOrigin } from './lib/pages-origin-policy.js'
 
+export type { RuntimeConfig }
 // The wire contract is owned by the daemon package's published /api-client
 // subpath (single source of truth across mcp-server and apps/web) — this
 // module re-exports it rather than redefining it, and adds only the
 // deployment-target policy that decides which parsed configs are acceptable
 // here (hosted-origin allowlisting).
 export { bareOriginSchema, runtimeConfigSchema }
-export type { RuntimeConfig }
 
 export function resolveRuntimeConfig(raw: unknown): RuntimeConfig {
   return runtimeConfigSchema.parse(raw)

--- a/apps/web/src/runtime-config.ts
+++ b/apps/web/src/runtime-config.ts
@@ -1,40 +1,17 @@
-import { z } from 'zod'
+import {
+  type RuntimeConfig,
+  bareOriginSchema,
+  runtimeConfigSchema,
+} from '@kamiazya/whiteboard-mcp/api-client'
 import { classifyPagesOrigin } from './lib/pages-origin-policy.js'
 
-// Validates that a URL string is a bare origin: scheme + host + optional port, no path/query/hash/credentials.
-// Downstream CORS, OAuth, and Cloudflare config all require a strict origin, not an arbitrary URL.
-// Exported so other cross-boundary contracts (e.g. daemon-connection-payload.ts) reuse the same
-// origin-validation rules instead of redefining them.
-export const bareOriginSchema = z
-  .string()
-  .url()
-  .refine(
-    (v) => {
-      try {
-        const url = new URL(v)
-        return url.origin === v && !url.hostname.includes('*')
-      } catch {
-        return false
-      }
-    },
-    {
-      message:
-        'must be a bare origin (scheme + host + optional port, no path, query, hash, credentials, or wildcards)',
-    },
-  )
-
-export const runtimeConfigSchema = z
-  .object({
-    // Public origin of this deployed app (e.g., 'https://app.example.com').
-    // Used to construct absolute URLs for same-origin API calls.
-    publicOrigin: bareOriginSchema.optional(),
-    // Base URL of the local whiteboard daemon for daemon-pairing mode.
-    // e.g. 'http://127.0.0.1:3099'
-    daemonBaseUrl: bareOriginSchema.optional(),
-  })
-  .strict()
-
-export type RuntimeConfig = z.infer<typeof runtimeConfigSchema>
+// The wire contract is owned by the daemon package's published /api-client
+// subpath (single source of truth across mcp-server and apps/web) — this
+// module re-exports it rather than redefining it, and adds only the
+// deployment-target policy that decides which parsed configs are acceptable
+// here (hosted-origin allowlisting).
+export { bareOriginSchema, runtimeConfigSchema }
+export type { RuntimeConfig }
 
 export function resolveRuntimeConfig(raw: unknown): RuntimeConfig {
   return runtimeConfigSchema.parse(raw)

--- a/packages/mcp-server/src/server/app.test.ts
+++ b/packages/mcp-server/src/server/app.test.ts
@@ -1511,15 +1511,6 @@ describe('createApp daemon mutation auth', () => {
       const badPayload = { daemonToken: 'secret', daemonBaseUrl: 'http://127.0.0.1:3099' }
       expect(() => runtimeConfigSchema.parse(badPayload)).toThrow()
     })
-
-    it('apps/web strict runtimeConfigSchema REJECTS a payload that includes daemonToken', async () => {
-      // apps/web/src/runtime-config.ts uses .strict() which forbids unknown keys.
-      // daemonToken is NOT in the apps/web schema, so .parse({ daemonToken, daemonBaseUrl })
-      // must throw. This locks the token-channel split for apps/web as a deliberate guarded step.
-      const { runtimeConfigSchema } = await import('../../../../apps/web/src/runtime-config.js')
-      const badPayload = { daemonToken: 'secret', daemonBaseUrl: 'http://127.0.0.1:3099' }
-      expect(() => runtimeConfigSchema.parse(badPayload)).toThrow()
-    })
   })
 
   describe('/api/runtime/ping Zod schema', () => {

--- a/packages/mcp-server/src/shared/api-client.test.ts
+++ b/packages/mcp-server/src/shared/api-client.test.ts
@@ -23,6 +23,36 @@ describe('runtimeConfigSchema', () => {
   it('rejects a payload that still carries daemonToken (.strict() rejection, not silent drop)', () => {
     expect(runtimeConfigSchema.safeParse({ daemonToken: 'secret' }).success).toBe(false)
   })
+
+  // Single-owner fold (was apps/web's separate, stricter schema): the wire
+  // contract carries publicOrigin alongside daemonBaseUrl, and both fields
+  // are bare-origin-validated everywhere they are read, not just in apps/web.
+  it('accepts a payload carrying a production publicOrigin', () => {
+    expect(runtimeConfigSchema.safeParse({ publicOrigin: 'https://app.example.com' }).success).toBe(
+      true,
+    )
+  })
+
+  it('accepts publicOrigin and daemonBaseUrl together', () => {
+    expect(
+      runtimeConfigSchema.safeParse({
+        publicOrigin: 'https://app.example.com',
+        daemonBaseUrl: 'http://127.0.0.1:3099',
+      }).success,
+    ).toBe(true)
+  })
+
+  it('rejects a daemonBaseUrl that is not a bare origin (trailing slash)', () => {
+    expect(runtimeConfigSchema.safeParse({ daemonBaseUrl: 'http://127.0.0.1:3099/' }).success).toBe(
+      false,
+    )
+  })
+
+  it('rejects a daemonBaseUrl carrying a path', () => {
+    expect(
+      runtimeConfigSchema.safeParse({ daemonBaseUrl: 'http://127.0.0.1:3099/pair' }).success,
+    ).toBe(false)
+  })
 })
 
 describe('readRuntimeConfig', () => {

--- a/packages/mcp-server/src/shared/api-client.ts
+++ b/packages/mcp-server/src/shared/api-client.ts
@@ -7,6 +7,28 @@ import { readDaemonTokenOnce } from './token-store.js'
 // without a separate package export just for pairing/test access.
 export { readDaemonTokenOnce, resetTokenStoreForTests } from './token-store.js'
 
+// Validates that a URL string is a bare origin: scheme + host + optional port, no path/query/hash/credentials.
+// Downstream CORS, OAuth, and Cloudflare config all require a strict origin, not an arbitrary URL.
+// Exported so other cross-boundary contracts (e.g. apps/web's daemon-connection-payload.ts) reuse
+// the same origin-validation rules instead of redefining them.
+export const bareOriginSchema = z
+  .string()
+  .url()
+  .refine(
+    (v) => {
+      try {
+        const url = new URL(v)
+        return url.origin === v && !url.hostname.includes('*')
+      } catch {
+        return false
+      }
+    },
+    {
+      message:
+        'must be a bare origin (scheme + host + optional port, no path, query, hash, credentials, or wildcards)',
+    },
+  )
+
 // The server injects this shape into `window.__WHITEBOARD_RUNTIME_CONFIG__`
 // via a same-origin inline <script> (see server/app.ts). It crosses a
 // process boundary (server -> browser), so it is validated on read rather
@@ -21,7 +43,12 @@ export { readDaemonTokenOnce, resetTokenStoreForTests } from './token-store.js'
 // a token back into this object undetected.
 export const runtimeConfigSchema = z
   .object({
-    daemonBaseUrl: z.string().optional(),
+    // Public origin of this deployed app (e.g., 'https://app.example.com').
+    // Used to construct absolute URLs for same-origin API calls.
+    publicOrigin: bareOriginSchema.optional(),
+    // Base URL of the local whiteboard daemon for daemon-pairing mode.
+    // e.g. 'http://127.0.0.1:3099'
+    daemonBaseUrl: bareOriginSchema.optional(),
   })
   .strict()
 


### PR DESCRIPTION
Audit HIGH (contract): the runtime-config wire contract had two owners with asymmetric validation — the daemon's published `/api-client` subpath (strict, `daemonBaseUrl` as a loose string, no `publicOrigin`, so a payload carrying `publicOrigin` strict-failed there) and `apps/web/src/runtime-config.ts` (strict, both fields bare-origin-validated).

`api-client.ts` is now the sole owner: `publicOrigin` and `bareOriginSchema` fold in, and `daemonBaseUrl` tightens from loose string to bare origin. `apps/web` re-exports the shared schema and keeps only its hosted-origin policy layer (`resolveHostedRuntimeConfig`). The re-export is pinned by **instance identity** (`toBe`, not structural equality) — integrator-verified mutation check: restoring a structurally-identical local schema in `runtime-config.ts` turns exactly that pin red. The `app.test.ts` cross-package import of apps/web's schema is deleted; the daemonToken strict-rejection it checked is the shared schema's own test now.

Gates: `pnpm -r typecheck` (10/10), mcp-node api-client+app 78, apps/web jsdom full 2205 + node 77 (exit 0), runtime-config + daemon-connection-payload 55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ