### PR TITLE
feat(web): selection-action redesign — ⋯ doorway, banded catalog, bottom sheet, Escape keeps empty notes

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -75,6 +75,29 @@ Tailwind palette colors in chrome.
   globally by the base-layer guard in `src/index.css` — component code
   must not assume an animation ran (never gate logic on motion).
 
+## Object-action surfaces are icon-first
+
+The palette's "+" menu keeps icon AND label on every entry: a creation
+menu is a first-contact reading surface, and ToolPalette says so in its
+header comment. That principle is deliberately NOT extended to
+object-action surfaces (the selection's ⋯ popover, and by extension any
+future action sheet): there the verbs render icon-only, in a grid of
+44px targets, with the name carried by `aria-label` (non-negotiable —
+"no visible text" is a visual statement only) and a `title` tooltip on
+desktop. Rationale: object verbs are conventional symbols (edit, delete,
+lock, open) recovered in one hover/press, misfires inside the menu are
+one Undo away, and the grid keeps every verb visible at once instead of
+scrolling a list. The Copy/Cut/Duplicate trio ships icon-only first; if
+dogfooding observes misfires, labels return by observation, not by
+guess.
+
+Both vessels — the right-click list menu and the ⋯ grid — draw the SAME
+catalog in the SAME band order: property rows (color, z-order, arrows;
+the menu stays open), then verbs (one-shot; the menu closes), then the
+destructive entry alone at the bottom. What is learned in one vessel
+must transfer to the other, so a new action is added to the catalog,
+never to a single vessel.
+
 ## Bottom chrome: one dock, fixed width
 
 All bottom-anchored canvas chrome lives in ONE flex container (the tool

--- a/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
@@ -26,6 +26,7 @@ import {
   ChevronUp,
   ClipboardPaste,
   Copy as CopyIcon,
+  CopyPlus,
   ExternalLink,
   FileBox,
   Frame,
@@ -66,6 +67,8 @@ export interface ContextMenuTarget {
   readonly nodeId: string | undefined
   readonly edgeId: string | undefined
   readonly point: Point
+  /** The ⋯ control opens the same catalog in the icon-grid vessel. */
+  readonly variant?: 'list' | 'grid'
 }
 
 /**
@@ -171,6 +174,7 @@ export function CanvasContextMenu({
     <ContextMenu
       x={contextMenu.x}
       y={contextMenu.y}
+      variant={contextMenu.variant}
       onClose={() => setContextMenu(null)}
       items={(() => {
         const node =
@@ -303,12 +307,6 @@ export function CanvasContextMenu({
           }
           return [
             {
-              label: 'Edit label',
-              icon: <Tag />,
-              onSelect: () => setEdgeLabelEditId(edge.id),
-            },
-            { kind: 'separator' as const },
-            {
               kind: 'options' as const,
               label: 'Arrows',
               options: arrowStates.map((state) => ({
@@ -329,6 +327,12 @@ export function CanvasContextMenu({
             colorRow(edge.color, (color) =>
               applyEdgeCommand({ kind: 'set-edge-color', id: edge.id, color }),
             ),
+            { kind: 'separator' as const },
+            {
+              label: 'Edit label',
+              icon: <Tag />,
+              onSelect: () => setEdgeLabelEditId(edge.id),
+            },
             ...(edgeLockEnabled
               ? [
                   {
@@ -419,15 +423,20 @@ export function CanvasContextMenu({
           }
           return emptyItems
         }
-        const items: ContextMenuItem[] = []
+        // The catalog's band order, shared by both vessels (list and grid):
+        // 1. properties (state pickers — the menu stays open),
+        // 2. verbs (one-shot — the menu closes),
+        // 3. the destructive entry, alone at the bottom.
+        const properties: ContextMenuItem[] = []
+        const verbs: ContextMenuItem[] = []
         if (node.type === 'group') {
-          items.push({
+          verbs.push({
             label: 'Edit label',
             icon: <Tag />,
             onSelect: () => setGroupLabelEditId(node.id),
           })
           if (onAddImage !== undefined) {
-            items.push({
+            verbs.push({
               label: 'Set background image',
               icon: <ImageIcon />,
               onSelect: () => {
@@ -445,7 +454,7 @@ export function CanvasContextMenu({
                   { kind: 'set-group-background', id: node.id, background, backgroundStyle },
                 ],
               })
-            items.push({
+            properties.push({
               kind: 'options',
               label: 'Background',
               options: [
@@ -463,7 +472,7 @@ export function CanvasContextMenu({
                 },
               ],
             })
-            items.push({
+            verbs.push({
               label: 'Remove background',
               icon: <ImageOff />,
               onSelect: () =>
@@ -473,19 +482,17 @@ export function CanvasContextMenu({
                 }),
             })
           }
-          items.push({ kind: 'separator' })
         }
         // Framing an existing multi-selection is reached from any of
         // its members — the frame encloses every selected node,
         // including group frames: nesting is geometric in JSON Canvas,
         // and containment moves already handle nested frames.
         if (extraIds.size > 0) {
-          items.push({
+          verbs.push({
             label: 'Group selection',
             icon: <Frame />,
             onSelect: () => groupSelection([node.id, ...extraIds]),
           })
-          items.push({ kind: 'separator' })
         }
         if (node.type === 'file' && isImageFileRef?.(node.file) !== true) {
           // A missing target makes Open a dead end (worse: the daemon's
@@ -493,38 +500,34 @@ export function CanvasContextMenu({
           // canvas under the dangling ref). Change target stays — it is
           // the repair affordance.
           if (onOpenFileRef !== undefined && missingFileRef?.(node.file) !== true) {
-            items.push({
+            verbs.push({
               label: 'Open canvas',
               icon: <ExternalLink />,
               onSelect: () => onOpenFileRef(node.file, node.subpath),
             })
           }
           if (fileRefOptions !== undefined) {
-            items.push({
+            verbs.push({
               label: 'Change target',
               icon: <FileBox />,
               onSelect: () => setCanvasPicker({ mode: 'retarget', nodeId: node.id }),
             })
           }
-          if (onOpenFileRef !== undefined || fileRefOptions !== undefined) {
-            items.push({ kind: 'separator' })
-          }
         }
         if (node.type === 'link') {
-          items.push({
+          verbs.push({
             label: 'Open link',
             icon: <ExternalLink />,
             onSelect: () => openLinkNode(node),
           })
-          items.push({
+          verbs.push({
             label: 'Edit URL',
             icon: <Pencil />,
             onSelect: () => setLinkDialog({ mode: 'edit', nodeId: node.id }),
           })
-          items.push({ kind: 'separator' })
         }
         if (node.type === 'text') {
-          items.push({
+          verbs.push({
             label: 'Edit text',
             icon: <Pencil />,
             onSelect: () => {
@@ -537,9 +540,6 @@ export function CanvasContextMenu({
               )
             },
           })
-          // Same grouping rule as the edge menu: the destructive
-          // entry sits in its own section.
-          items.push({ kind: 'separator' })
         }
         // Touch path to Cmd/Ctrl+D (see shortcuts.ts). The menu's
         // right-click already made this node the primary selection,
@@ -556,14 +556,14 @@ export function CanvasContextMenu({
             },
           ]
         }
-        items.push({
+        verbs.push({
           label: 'Copy',
           icon: <CopyIcon />,
           onSelect: () => {
             copySelection()
           },
         })
-        items.push({
+        verbs.push({
           label: 'Cut',
           icon: <Scissors />,
           onSelect: () => {
@@ -571,14 +571,16 @@ export function CanvasContextMenu({
             if (copySelection() !== null) deleteSelectionAsBatch()
           },
         })
-        items.push({
+        verbs.push({
           label: 'Duplicate',
-          icon: <CopyIcon />,
+          // Not CopyIcon: in the icon-only grid vessel, Copy and Duplicate
+          // with one glyph would be indistinguishable side by side.
+          icon: <CopyPlus />,
           onSelect: () => {
             duplicateSelection()
           },
         })
-        items.push(
+        properties.push(
           colorRow(node.color, (color) => {
             // Recoloring FROM a multi-selection styles the whole
             // selected AREA: every member, and every edge that runs
@@ -613,7 +615,7 @@ export function CanvasContextMenu({
         // Z-order as one-tap options — the touch path to the [ / ]
         // keyboard shortcuts (see shortcuts.ts). Not a picker: no
         // option is ever "selected", each tap applies a move.
-        items.push({
+        properties.push({
           kind: 'options',
           label: 'Order',
           options: [
@@ -652,7 +654,7 @@ export function CanvasContextMenu({
         // action means something, rather than sitting there inert.
         const alignableCount = extraIds.size + 1
         if (alignableCount >= 2) {
-          items.push({
+          properties.push({
             kind: 'options',
             label: 'Align',
             options: (
@@ -674,7 +676,7 @@ export function CanvasContextMenu({
           })
         }
         if (alignableCount >= 3) {
-          items.push({
+          properties.push({
             kind: 'options',
             label: 'Distribute',
             options: (
@@ -696,7 +698,7 @@ export function CanvasContextMenu({
           })
         }
         if (alignableCount >= 2) {
-          items.push({
+          verbs.push({
             label: 'Tidy',
             icon: <Sparkles />,
             onSelect: () =>
@@ -709,27 +711,31 @@ export function CanvasContextMenu({
           })
         }
         if (lockEnabled) {
-          items.push({
+          verbs.push({
             label: 'Lock',
             icon: <LockIcon />,
             onSelect: () => onToggleNodeLock?.(node.id, true),
           })
         }
-        items.push({ kind: 'separator' })
-        items.push({
-          label: 'Delete',
-          icon: <Trash2 />,
-          danger: true,
-          onSelect: () => {
-            applyResult(
-              reduceGesture(gestureState, canvas, {
-                type: 'delete-selection',
-                nodeId: node.id,
-              }),
-            )
+        return [
+          ...properties,
+          { kind: 'separator' as const },
+          ...verbs,
+          { kind: 'separator' as const },
+          {
+            label: 'Delete',
+            icon: <Trash2 />,
+            danger: true,
+            onSelect: () => {
+              applyResult(
+                reduceGesture(gestureState, canvas, {
+                  type: 'delete-selection',
+                  nodeId: node.id,
+                }),
+              )
+            },
           },
-        })
-        return items
+        ]
       })()}
     />
   )

--- a/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
@@ -67,8 +67,8 @@ export interface ContextMenuTarget {
   readonly nodeId: string | undefined
   readonly edgeId: string | undefined
   readonly point: Point
-  /** The ⋯ control opens the same catalog in the icon-grid vessel. */
-  readonly variant?: 'list' | 'grid'
+  /** The ⋯ control opens the same catalog in the icon-grid or sheet vessel. */
+  readonly variant?: 'list' | 'grid' | 'sheet'
 }
 
 /**

--- a/apps/web/src/components/spatial-editor/ContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/ContextMenu.tsx
@@ -254,7 +254,7 @@ export function ContextMenu({ x, y, items, onClose, variant = 'list' }: ContextM
                       'flex items-center justify-center rounded transition-colors duration-(--motion-duration-fast) ease-(--motion-ease-out) hover:bg-accent focus-visible:bg-accent focus-visible:outline-none',
                       // Thumb-zone targets in the sheet, compact in the popover.
                       sheet ? 'size-12' : 'size-11',
-                      action.danger ? 'text-red-600' : 'text-foreground',
+                      action.danger ? 'text-destructive' : 'text-foreground',
                     )}
                     onClick={() => {
                       onClose()
@@ -353,7 +353,7 @@ export function ContextMenu({ x, y, items, onClose, variant = 'list' }: ContextM
         type="button"
         role="menuitem"
         className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-accent focus-visible:bg-accent focus-visible:outline-none ${
-          item.danger ? 'text-red-600' : ''
+          item.danger ? 'text-destructive' : ''
         }`}
         onClick={() => {
           onClose()

--- a/apps/web/src/components/spatial-editor/ContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/ContextMenu.tsx
@@ -78,6 +78,36 @@ export interface ContextMenuProps {
   readonly y: number
   readonly items: readonly ContextMenuItem[]
   readonly onClose: () => void
+  /**
+   * One catalog, two vessels: 'list' is the right-click reading surface
+   * (icon + label rows); 'grid' is the ⋯ object-action surface, which
+   * renders runs of verbs as icon-only buttons (aria-label + tooltip carry
+   * the name). Property option rows and separators render identically in
+   * both, so what is learned in one vessel transfers to the other.
+   */
+  readonly variant?: 'list' | 'grid'
+}
+
+/** Consecutive action items collapse into one icon row in the grid vessel. */
+type GridChunk =
+  | { readonly kind: 'grid'; readonly actions: readonly ContextMenuActionItem[] }
+  | { readonly kind: 'item'; readonly item: ContextMenuItem }
+
+function chunkForGrid(items: readonly ContextMenuItem[]): readonly GridChunk[] {
+  const chunks: GridChunk[] = []
+  for (const item of items) {
+    if (item.kind === undefined || item.kind === 'action') {
+      const last = chunks[chunks.length - 1]
+      if (last !== undefined && last.kind === 'grid') {
+        chunks[chunks.length - 1] = { kind: 'grid', actions: [...last.actions, item] }
+      } else {
+        chunks.push({ kind: 'grid', actions: [item] })
+      }
+    } else {
+      chunks.push({ kind: 'item', item })
+    }
+  }
+  return chunks
 }
 
 /**
@@ -118,7 +148,7 @@ function CustomColorPanel({
   )
 }
 
-export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
+export function ContextMenu({ x, y, items, onClose, variant = 'list' }: ContextMenuProps) {
   const menuRef = useRef<HTMLDivElement | null>(null)
   // A menu opened near the editor's right/bottom edge would clip outside it,
   // so the requested position is nudged back inside once the real menu size
@@ -164,6 +194,7 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
       data-editor-overlay
       data-context-menu
       data-testid="context-menu"
+      data-variant={variant}
       role="menu"
       aria-label="Canvas actions"
       tabIndex={-1}
@@ -184,102 +215,142 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
         }
       }}
     >
-      {items.map((item, index) =>
-        item.kind === 'separator' ? (
-          <hr key={`separator-${index}`} className="my-1 border-border" />
-        ) : item.kind === 'options' ? (
-          <Fragment key={item.label}>
-            <fieldset
-              aria-label={item.label}
-              className="m-0 flex items-center justify-between gap-2 border-0 p-0 px-3 py-1"
-            >
-              <span className="text-xs text-muted-foreground">{item.label}</span>
-              <span className="flex items-center gap-0.5">
-                {item.options.map((option) => (
+      {(() => {
+        if (variant === 'grid') {
+          return chunkForGrid(items).map((chunk, index) =>
+            chunk.kind === 'grid' ? (
+              <div
+                key={`grid-${chunk.actions[0]?.label ?? index}`}
+                className="flex max-w-56 flex-wrap gap-0.5 px-1.5 py-1"
+              >
+                {chunk.actions.map((action) => (
                   <button
-                    key={option.label}
+                    key={action.label}
                     type="button"
-                    role="menuitemradio"
-                    aria-checked={option.selected}
-                    aria-label={option.ariaLabel ?? option.label}
+                    role="menuitem"
+                    aria-label={action.label}
+                    // The visible name is gone in this vessel; the tooltip is
+                    // the desktop fallback for the icon a reader misreads.
+                    title={action.label}
                     className={cn(
-                      'flex h-7 min-w-7 items-center justify-center rounded px-1 text-xs transition-colors duration-(--motion-duration-fast) ease-(--motion-ease-out) hover:bg-accent focus-visible:bg-accent focus-visible:outline-none',
-                      option.selected
-                        ? 'bg-accent font-medium text-foreground'
-                        : 'text-muted-foreground',
+                      'flex size-11 items-center justify-center rounded transition-colors duration-(--motion-duration-fast) ease-(--motion-ease-out) hover:bg-accent focus-visible:bg-accent focus-visible:outline-none',
+                      action.danger ? 'text-red-600' : 'text-foreground',
                     )}
-                    // Applies immediately and keeps the menu open: option rows
-                    // are property pickers, and closing per pick would force a
-                    // reopen for every adjustment.
-                    onClick={option.onSelect}
+                    onClick={() => {
+                      onClose()
+                      action.onSelect()
+                    }}
                   >
-                    {option.icon !== undefined ? (
-                      <span aria-hidden="true" className="[&>svg]:size-3.5">
-                        {option.icon}
-                      </span>
-                    ) : (
-                      option.label
-                    )}
+                    <span aria-hidden="true" className="[&>svg]:size-4.5">
+                      {action.icon}
+                    </span>
                   </button>
                 ))}
-                {item.customColor !== undefined && (
-                  <button
-                    type="button"
-                    role="menuitemradio"
-                    aria-checked={item.customColor.selected}
-                    aria-expanded={openCustomColor === item.label}
-                    aria-label={item.customColor.ariaLabel}
-                    className={cn(
-                      'flex h-7 min-w-7 items-center justify-center rounded px-1 transition-colors duration-(--motion-duration-fast) ease-(--motion-ease-out) hover:bg-accent focus-visible:bg-accent focus-visible:outline-none',
-                      item.customColor.selected && 'bg-accent',
-                    )}
-                    onClick={() =>
-                      setOpenCustomColor((prev) => (prev === item.label ? null : item.label))
-                    }
-                  >
-                    <span
-                      aria-hidden="true"
-                      className="size-3.5 rounded-full border border-border"
-                      style={{
-                        background: item.customColor.selected
-                          ? item.customColor.value
-                          : 'conic-gradient(red, yellow, lime, cyan, blue, magenta, red)',
-                      }}
-                    />
-                  </button>
-                )}
-              </span>
-            </fieldset>
-            {item.customColor !== undefined && openCustomColor === item.label && (
-              <CustomColorPanel value={item.customColor.value} onPick={item.customColor.onPick} />
-            )}
-          </Fragment>
-        ) : (
-          <button
-            key={item.label}
-            type="button"
-            role="menuitem"
-            className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-accent focus-visible:bg-accent focus-visible:outline-none ${
-              item.danger ? 'text-red-600' : ''
-            }`}
-            onClick={() => {
-              onClose()
-              item.onSelect()
-            }}
-          >
-            {item.icon !== undefined && (
-              // Danger rows keep the destructive color on the icon too.
-              <span
-                aria-hidden="true"
-                className={cn('[&>svg]:size-3.5', !item.danger && 'text-muted-foreground')}
-              >
-                {item.icon}
-              </span>
-            )}
-            {item.label}
-          </button>
-        ),
-      )}
+              </div>
+            ) : (
+              renderCatalogItem(chunk.item, index)
+            ),
+          )
+        }
+        return items.map(renderCatalogItem)
+      })()}
     </div>
   )
+
+  function renderCatalogItem(item: ContextMenuItem, index: number) {
+    return item.kind === 'separator' ? (
+      <hr key={`separator-${index}`} className="my-1 border-border" />
+    ) : item.kind === 'options' ? (
+      <Fragment key={item.label}>
+        <fieldset
+          aria-label={item.label}
+          className="m-0 flex items-center justify-between gap-2 border-0 p-0 px-3 py-1"
+        >
+          <span className="text-xs text-muted-foreground">{item.label}</span>
+          <span className="flex items-center gap-0.5">
+            {item.options.map((option) => (
+              <button
+                key={option.label}
+                type="button"
+                role="menuitemradio"
+                aria-checked={option.selected}
+                aria-label={option.ariaLabel ?? option.label}
+                className={cn(
+                  'flex h-7 min-w-7 items-center justify-center rounded px-1 text-xs transition-colors duration-(--motion-duration-fast) ease-(--motion-ease-out) hover:bg-accent focus-visible:bg-accent focus-visible:outline-none',
+                  option.selected
+                    ? 'bg-accent font-medium text-foreground'
+                    : 'text-muted-foreground',
+                )}
+                // Applies immediately and keeps the menu open: option rows
+                // are property pickers, and closing per pick would force a
+                // reopen for every adjustment.
+                onClick={option.onSelect}
+              >
+                {option.icon !== undefined ? (
+                  <span aria-hidden="true" className="[&>svg]:size-3.5">
+                    {option.icon}
+                  </span>
+                ) : (
+                  option.label
+                )}
+              </button>
+            ))}
+            {item.customColor !== undefined && (
+              <button
+                type="button"
+                role="menuitemradio"
+                aria-checked={item.customColor.selected}
+                aria-expanded={openCustomColor === item.label}
+                aria-label={item.customColor.ariaLabel}
+                className={cn(
+                  'flex h-7 min-w-7 items-center justify-center rounded px-1 transition-colors duration-(--motion-duration-fast) ease-(--motion-ease-out) hover:bg-accent focus-visible:bg-accent focus-visible:outline-none',
+                  item.customColor.selected && 'bg-accent',
+                )}
+                onClick={() =>
+                  setOpenCustomColor((prev) => (prev === item.label ? null : item.label))
+                }
+              >
+                <span
+                  aria-hidden="true"
+                  className="size-3.5 rounded-full border border-border"
+                  style={{
+                    background: item.customColor.selected
+                      ? item.customColor.value
+                      : 'conic-gradient(red, yellow, lime, cyan, blue, magenta, red)',
+                  }}
+                />
+              </button>
+            )}
+          </span>
+        </fieldset>
+        {item.customColor !== undefined && openCustomColor === item.label && (
+          <CustomColorPanel value={item.customColor.value} onPick={item.customColor.onPick} />
+        )}
+      </Fragment>
+    ) : (
+      <button
+        key={item.label}
+        type="button"
+        role="menuitem"
+        className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-accent focus-visible:bg-accent focus-visible:outline-none ${
+          item.danger ? 'text-red-600' : ''
+        }`}
+        onClick={() => {
+          onClose()
+          item.onSelect()
+        }}
+      >
+        {item.icon !== undefined && (
+          // Danger rows keep the destructive color on the icon too.
+          <span
+            aria-hidden="true"
+            className={cn('[&>svg]:size-3.5', !item.danger && 'text-muted-foreground')}
+          >
+            {item.icon}
+          </span>
+        )}
+        {item.label}
+      </button>
+    )
+  }
 }

--- a/apps/web/src/components/spatial-editor/ContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/ContextMenu.tsx
@@ -79,13 +79,16 @@ export interface ContextMenuProps {
   readonly items: readonly ContextMenuItem[]
   readonly onClose: () => void
   /**
-   * One catalog, two vessels: 'list' is the right-click reading surface
-   * (icon + label rows); 'grid' is the ⋯ object-action surface, which
+   * One catalog, three vessels: 'list' is the right-click reading surface
+   * (icon + label rows); 'grid' is the ⋯ object-action popover, which
    * renders runs of verbs as icon-only buttons (aria-label + tooltip carry
-   * the name). Property option rows and separators render identically in
-   * both, so what is learned in one vessel transfers to the other.
+   * the name); 'sheet' is the same grid content anchored to the bottom
+   * edge, full width with thicker targets — the touch-first form the ⋯
+   * takes in a narrow editor. Property option rows and separators render
+   * identically in all three, so what is learned in one vessel transfers
+   * to the others.
    */
-  readonly variant?: 'list' | 'grid'
+  readonly variant?: 'list' | 'grid' | 'sheet'
 }
 
 /** Consecutive action items collapse into one icon row in the grid vessel. */
@@ -154,7 +157,10 @@ export function ContextMenu({ x, y, items, onClose, variant = 'list' }: ContextM
   // so the requested position is nudged back inside once the real menu size
   // is measurable. useLayoutEffect corrects before paint — no visible jump.
   const [pos, setPos] = useState({ x, y })
+  const sheet = variant === 'sheet'
   useLayoutEffect(() => {
+    // A sheet is edge-anchored, not point-anchored — nothing to clamp.
+    if (sheet) return
     const el = menuRef.current
     const parent = el?.offsetParent
     if (el == null || !(parent instanceof HTMLElement)) {
@@ -171,7 +177,7 @@ export function ContextMenu({ x, y, items, onClose, variant = 'list' }: ContextM
       y: clamp(y, parent.clientHeight - Math.ceil(menuRect.height) - MENU_EDGE_MARGIN_PX),
     }
     setPos((prev) => (prev.x === next.x && prev.y === next.y ? prev : next))
-  }, [x, y])
+  }, [x, y, sheet])
 
   // Which options row's custom-color panel is expanded (by row label).
   const [openCustomColor, setOpenCustomColor] = useState<string | null>(null)
@@ -198,7 +204,11 @@ export function ContextMenu({ x, y, items, onClose, variant = 'list' }: ContextM
       role="menu"
       aria-label="Canvas actions"
       tabIndex={-1}
-      className="min-w-36 rounded-md border bg-background py-1 shadow-lg focus:outline-none"
+      className={
+        sheet
+          ? 'rounded-t-xl border-t bg-background py-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] shadow-lg focus:outline-none'
+          : 'min-w-36 rounded-md border bg-background py-1 shadow-lg focus:outline-none'
+      }
       // Positioning (incl. stacking) is inline, not utility classes: the
       // edge-clamping above measures the absolutely-positioned box, and it
       // must behave the same where the app stylesheet is absent
@@ -207,7 +217,11 @@ export function ContextMenu({ x, y, items, onClose, variant = 'list' }: ContextM
       // box otherwise shrinks to fit the space left of the containing-block
       // edge, so a menu opened near the edge would measure (and wrap) narrow
       // and the clamp would compute from the wrong width.
-      style={{ position: 'absolute', zIndex: 20, width: 'max-content', left: pos.x, top: pos.y }}
+      style={
+        sheet
+          ? { position: 'absolute', zIndex: 20, left: 0, right: 0, bottom: 0 }
+          : { position: 'absolute', zIndex: 20, width: 'max-content', left: pos.x, top: pos.y }
+      }
       onKeyDown={(e) => {
         if (e.key === 'Escape') {
           e.stopPropagation()
@@ -216,12 +230,16 @@ export function ContextMenu({ x, y, items, onClose, variant = 'list' }: ContextM
       }}
     >
       {(() => {
-        if (variant === 'grid') {
+        if (variant === 'grid' || variant === 'sheet') {
           return chunkForGrid(items).map((chunk, index) =>
             chunk.kind === 'grid' ? (
               <div
                 key={`grid-${chunk.actions[0]?.label ?? index}`}
-                className="flex max-w-56 flex-wrap gap-0.5 px-1.5 py-1"
+                className={
+                  sheet
+                    ? 'flex flex-wrap gap-1 px-2 py-1'
+                    : 'flex max-w-56 flex-wrap gap-0.5 px-1.5 py-1'
+                }
               >
                 {chunk.actions.map((action) => (
                   <button
@@ -233,7 +251,9 @@ export function ContextMenu({ x, y, items, onClose, variant = 'list' }: ContextM
                     // the desktop fallback for the icon a reader misreads.
                     title={action.label}
                     className={cn(
-                      'flex size-11 items-center justify-center rounded transition-colors duration-(--motion-duration-fast) ease-(--motion-ease-out) hover:bg-accent focus-visible:bg-accent focus-visible:outline-none',
+                      'flex items-center justify-center rounded transition-colors duration-(--motion-duration-fast) ease-(--motion-ease-out) hover:bg-accent focus-visible:bg-accent focus-visible:outline-none',
+                      // Thumb-zone targets in the sheet, compact in the popover.
+                      sheet ? 'size-12' : 'size-11',
                       action.danger ? 'text-red-600' : 'text-foreground',
                     )}
                     onClick={() => {

--- a/apps/web/src/components/spatial-editor/SelectionOverlay.test.tsx
+++ b/apps/web/src/components/spatial-editor/SelectionOverlay.test.tsx
@@ -152,6 +152,28 @@ describe('SelectionOverlay', () => {
     fireEvent.keyDown(connect, { key: 'Tab' })
     expect(onConnectKeyDown).toHaveBeenCalledTimes(2)
   })
+
+  it('anchors More-actions at the top-right corner in canvas units, scaled by zoom', () => {
+    const onMoreActions = vi.fn()
+    render(
+      <SelectionOverlay
+        box={BOX}
+        zoom={2}
+        onHandlePointerDown={vi.fn()}
+        onConnectPointerDown={vi.fn()}
+        onMoreActions={onMoreActions}
+      />,
+    )
+    const more = screen.getByTestId('more-actions-handle')
+    fireEvent.click(more)
+    // 12/18 screen px inset from the box's top-right corner; at zoom 2 that
+    // is 6/9 canvas units, so the menu lands beside the handle at any zoom.
+    expect(onMoreActions).toHaveBeenCalledWith({ x: 10 + 100 - 6, y: 20 - 9 })
+
+    fireEvent.keyDown(more, { key: 'Enter' })
+    expect(onMoreActions).toHaveBeenCalledTimes(2)
+    expect(onMoreActions).toHaveBeenLastCalledWith({ x: 104, y: 11 })
+  })
 })
 
 it('grows the hit boxes to 32px where the pointer is coarse', () => {

--- a/apps/web/src/components/spatial-editor/SelectionOverlay.test.tsx
+++ b/apps/web/src/components/spatial-editor/SelectionOverlay.test.tsx
@@ -165,7 +165,9 @@ describe('SelectionOverlay', () => {
       />,
     )
     const more = screen.getByTestId('more-actions-handle')
-    fireEvent.click(more)
+    // pointerup, not click — a touch tap inside the editor never synthesises
+    // a click (the root preventDefaults native touchstart).
+    fireEvent.pointerUp(more)
     // 12/18 screen px inset from the box's top-right corner; at zoom 2 that
     // is 6/9 canvas units, so the menu lands beside the handle at any zoom.
     expect(onMoreActions).toHaveBeenCalledWith({ x: 10 + 100 - 6, y: 20 - 9 })

--- a/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
@@ -246,10 +246,18 @@ export function SelectionOverlay({
           style={{ pointerEvents: 'auto', cursor: 'pointer' }}
           onPointerDown={(e) => {
             // Keep the press away from the root's node/empty hit-test; the
-            // action itself fires on click.
+            // action itself fires on pointerup.
             e.stopPropagation()
           }}
-          onClick={() => onMoreActions({ x: box.x + box.width - 12 / zoom, y: box.y - 18 / zoom })}
+          onPointerUp={(e) => {
+            // pointerup, not click: the editor root preventDefaults native
+            // touchstart (its iOS long-press suppression), which cancels the
+            // synthetic mouse-compatibility events — a touch tap never
+            // produces a click here. After pointerdown, so no focus fight
+            // with mousedown's default action either.
+            e.stopPropagation()
+            onMoreActions({ x: box.x + box.width - 12 / zoom, y: box.y - 18 / zoom })
+          }}
           onKeyDown={(e) => {
             if (e.key !== 'Enter' && e.key !== ' ') return
             e.preventDefault()

--- a/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
@@ -1,5 +1,6 @@
 /** Selection outline + resize handles + in-flight connect line, drawn in canvas space. */
 import type { Box, ResizeHandleKind } from './geometry.js'
+import type { Point } from './viewport.js'
 import { cornerHitBoxes, edgeBandBoxes, resizeHandleBoxes } from './geometry.js'
 
 export interface SelectionOverlayProps {
@@ -21,7 +22,8 @@ export interface SelectionOverlayProps {
   /** Enter/Space on the focused connect handle — the keyboard equivalent of a pointer connect-drag. */
   readonly onConnectKeyDown?: (e: React.KeyboardEvent) => void
   /**
-   * Opens the selected node's text editor. Rendered only when provided
+   * Opens the object's action menu, anchored at the control. Rendered only
+   * when provided
    * (non-text nodes have no text to edit). Fired on CLICK, not pointerdown:
    * the editor mount (autofocus included) flushes synchronously inside a
    * discrete event, and mousedown's default focus action would then blur
@@ -29,7 +31,7 @@ export interface SelectionOverlayProps {
    * double-press path suppresses with preventDefault. Click fires after
    * those defaults, so it needs no suppression at all.
    */
-  readonly onEditRequest?: () => void
+  readonly onMoreActions?: (anchor: Point) => void
 }
 
 const SELECTION_STROKE = 'var(--manipulation)'
@@ -71,7 +73,7 @@ export function SelectionOverlay({
   onConnectPointerDown,
   onHandleKeyDown,
   onConnectKeyDown,
-  onEditRequest,
+  onMoreActions,
 }: SelectionOverlayProps) {
   const handles = resizeHandleBoxes(box, zoom)
   // Hitting and drawing are separate questions: the markers stay 8px so
@@ -233,44 +235,47 @@ export function SelectionOverlay({
             />
           </g>
         ))}
-      {onEditRequest !== undefined && (
+      {onMoreActions !== undefined && (
         // biome-ignore lint/a11y/useSemanticElements: must stay an SVG shape to render/hit-test at this canvas-space position under the ancestor pan/zoom transform; role+tabIndex+onKeyDown reproduce native <button> semantics by hand.
         <g
-          data-testid="edit-handle"
+          data-testid="more-actions-handle"
           role="button"
           tabIndex={0}
-          aria-label="Edit text"
+          aria-label="More actions"
+          aria-haspopup="menu"
           style={{ pointerEvents: 'auto', cursor: 'pointer' }}
           onPointerDown={(e) => {
             // Keep the press away from the root's node/empty hit-test; the
-            // action itself fires on click (see onEditRequest's doc).
+            // action itself fires on click.
             e.stopPropagation()
           }}
-          onClick={() => onEditRequest()}
+          onClick={() => onMoreActions({ x: box.x + box.width - 12 / zoom, y: box.y - 18 / zoom })}
           onKeyDown={(e) => {
             if (e.key !== 'Enter' && e.key !== ' ') return
             e.preventDefault()
-            onEditRequest()
+            onMoreActions({ x: box.x + box.width - 12 / zoom, y: box.y - 18 / zoom })
           }}
         >
           <rect
-            x={box.x + box.width - 22 / zoom}
-            y={box.y - 26 / zoom}
-            width={22 / zoom}
-            height={20 / zoom}
-            rx={4 / zoom}
+            x={box.x + box.width - 24 / zoom}
+            y={box.y - 30 / zoom}
+            width={24 / zoom}
+            height={24 / zoom}
+            rx={6 / zoom}
             fill={SELECTION_STROKE}
           />
-          <text
-            x={box.x + box.width - 11 / zoom}
-            y={box.y - 12 / zoom}
-            textAnchor="middle"
-            fontSize={12 / zoom}
-            fill="var(--background)"
-            style={{ userSelect: 'none' }}
-          >
-            ✎
-          </text>
+          {/* Three dots as real circles, not a "⋯" glyph — a text character
+              rides the platform font and renders as emoji or tofu on some
+              systems, which is no way to draw a control. */}
+          {[-5, 0, 5].map((dx) => (
+            <circle
+              key={dx}
+              cx={box.x + box.width - 12 / zoom + dx / zoom}
+              cy={box.y - 18 / zoom}
+              r={1.6 / zoom}
+              fill="var(--background)"
+            />
+          ))}
         </g>
       )}
     </svg>

--- a/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
@@ -1,7 +1,7 @@
 /** Selection outline + resize handles + in-flight connect line, drawn in canvas space. */
 import type { Box, ResizeHandleKind } from './geometry.js'
-import type { Point } from './viewport.js'
 import { cornerHitBoxes, edgeBandBoxes, resizeHandleBoxes } from './geometry.js'
+import type { Point } from './viewport.js'
 
 export interface SelectionOverlayProps {
   readonly box: Box

--- a/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
@@ -22,14 +22,13 @@ export interface SelectionOverlayProps {
   /** Enter/Space on the focused connect handle — the keyboard equivalent of a pointer connect-drag. */
   readonly onConnectKeyDown?: (e: React.KeyboardEvent) => void
   /**
-   * Opens the object's action menu, anchored at the control. Rendered only
-   * when provided
-   * (non-text nodes have no text to edit). Fired on CLICK, not pointerdown:
-   * the editor mount (autofocus included) flushes synchronously inside a
-   * discrete event, and mousedown's default focus action would then blur
-   * the just-mounted textarea and instantly close it — the same fight the
-   * double-press path suppresses with preventDefault. Click fires after
-   * those defaults, so it needs no suppression at all.
+   * Opens the object's action menu, anchored at the control. Offered for
+   * every selection (multi included). Fired on POINTERUP, not click: the
+   * editor root preventDefaults native touchstart (its iOS long-press
+   * suppression), which cancels the synthetic mouse-compatibility events,
+   * so a touch tap never produces a click here — and pointerup still lands
+   * after mousedown's default focus action, so a menu action that mounts
+   * an editor has no focus fight to lose.
    */
   readonly onMoreActions?: (anchor: Point) => void
 }

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -176,13 +176,13 @@ import { useGestureCaptured } from './use-gesture-captured.js'
 import { useWorkerScene } from './use-worker-scene.js'
 import {
   type ContainerSize,
+  canvasToScreen,
   fitViewportToBoxes,
   frameViewport,
   IDENTITY_VIEWPORT,
   type Point,
   panBy,
   panToShowTarget,
-  canvasToScreen,
   screenToCanvas,
   contentBounds as unionContentBounds,
   type Viewport,
@@ -2216,7 +2216,12 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       }
       if (e.key === 'Escape' && gestureState.kind !== 'idle') {
         e.preventDefault()
-        applyResult(reduceGesture(gestureState, canvas, { type: 'pointercancel' }))
+        // Escape is the PERSON's cancel, not the platform's: it routes to
+        // cancel-text-edit, whose empty-note branch keeps a freshly placed
+        // box. pointercancel is reserved for genuine gesture teardown (see
+        // the lost-capture handling), where the half-made node is debris.
+        // For every non-editing gesture the two arms behave identically.
+        applyResult(reduceGesture(gestureState, canvas, { type: 'cancel-text-edit' }))
         return
       }
       // Delete/Backspace deletes the current selection — but never while the

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -182,6 +182,7 @@ import {
   type Point,
   panBy,
   panToShowTarget,
+  canvasToScreen,
   screenToCanvas,
   contentBounds as unionContentBounds,
   type Viewport,
@@ -3390,19 +3391,20 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               }
               onHandleKeyDown={handleResizeHandleKeyDown}
               onConnectKeyDown={handleConnectKeyDown}
-              onEditRequest={
-                !isMultiSelection && selectedNode?.type === 'text'
-                  ? () => {
-                      applyResult(
-                        reduceGesture(gestureState, canvas, {
-                          type: 'start-text-edit',
-                          nodeId: selectedNode.id,
-                          text: selectedNode.text,
-                        }),
-                      )
-                    }
-                  : undefined
-              }
+              // The ⋯ opens the SAME menu right-click does, for the same
+              // target — one catalog, now with a visible doorway. Offered
+              // for every selection (multi included: align/distribute were
+              // the least discoverable actions of all).
+              onMoreActions={(anchor) => {
+                const screen = canvasToScreen(anchor, viewport)
+                setContextMenu({
+                  x: screen.x,
+                  y: screen.y,
+                  nodeId: isMultiSelection ? selection.id : (selectedNode?.id ?? selection.id),
+                  edgeId: undefined,
+                  point: anchor,
+                })
+              }}
             />
           )}
           {/* In-flight gesture preview. Drawn from component-local pointer

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -3408,7 +3408,11 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                   nodeId: selection.id,
                   edgeId: undefined,
                   point: anchor,
-                  variant: 'grid',
+                  // The ⋯ vessel follows the editor's width, decided at open
+                  // time (the menu is transient): below the minimap
+                  // breakpoint the popover becomes a bottom sheet — keyed
+                  // off the CONTAINER for the same reason the minimap is.
+                  variant: rootSize.width < MINIMAP_MIN_ROOT_WIDTH_PX ? 'sheet' : 'grid',
                 })
               }}
             />

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -3405,7 +3405,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 setContextMenu({
                   x: screen.x,
                   y: screen.y,
-                  nodeId: isMultiSelection ? selection.id : (selectedNode?.id ?? selection.id),
+                  nodeId: selection.id,
                   edgeId: undefined,
                   point: anchor,
                 })

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -3408,6 +3408,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                   nodeId: selection.id,
                   edgeId: undefined,
                   point: anchor,
+                  variant: 'grid',
                 })
               }}
             />

--- a/apps/web/src/components/spatial-editor/ToolPalette.tsx
+++ b/apps/web/src/components/spatial-editor/ToolPalette.tsx
@@ -17,8 +17,10 @@
  * surface — it must never grow per-object actions.
  *
  * Icon-only dock buttons keep their accessible names via aria-label; the
- * "+" menu's entries show icon AND label (a menu is a reading surface,
- * not a memorized strip).
+ * "+" menu's entries show icon AND label (a creation menu is a reading
+ * surface, not a memorized strip). Scope note: this labels-on rule covers
+ * CREATION surfaces only — object-action surfaces are icon-first by
+ * design (see DESIGN.md, "Object-action surfaces are icon-first").
  *
  * Marked `data-editor-overlay` so the canvas root's gesture handlers
  * ignore presses originating here (see SpatialEditor's isOverlayEvent).

--- a/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
@@ -215,6 +215,27 @@ it('right-clicking an edge offers Edit label and Delete, not node creation', asy
   expect(latest.canvas.edges).toHaveLength(1)
 })
 
+it('the edge menu keeps the shared band order: properties, then verbs, Delete last', async () => {
+  const { EdgeHost } = makeEdgeHost()
+  const { container } = render(<EdgeHost />)
+
+  const mid = edgeMidpoint(container)
+  rightClick(rootOf(container), mid.x, mid.y)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+
+  // Same catalog discipline as the node menu: property rows (Arrows, sides,
+  // Color) come first, verbs (Edit label) after, and the destructive entry
+  // sits alone at the bottom.
+  const menu = container.querySelector('[data-testid="context-menu"]') as HTMLElement
+  const names = Array.from(
+    menu.querySelectorAll('[role="menuitem"], [role="menuitemradio"], fieldset'),
+  ).map((el) => el.getAttribute('aria-label') ?? el.textContent)
+  expect(names.indexOf('Arrows')).toBeGreaterThanOrEqual(0)
+  expect(names.indexOf('Arrows')).toBeLessThan(names.indexOf('Edit label'))
+  expect(names.indexOf('Color')).toBeLessThan(names.indexOf('Edit label'))
+  expect(names[names.length - 1]).toBe('Delete')
+})
+
 // Deterministic option-click for the inline property rows: applying an
 // option re-routes the edge and re-renders the scene under the pointer,
 // which Playwright's stability check intermittently reads as "element not

--- a/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
@@ -39,8 +39,8 @@ it('selecting a node shows one More-actions control; it opens the object menu HE
   const { container } = render(<Host />)
   await userEvent.click(rootOf(container), { position: { x: 200, y: 150 } })
 
-  // C from the discoverability analysis: the pencil promoted ONE verb and
-  // left ten invisible. The ⋯ is the visible doorway to all of them.
+  // One visible control exposes the FULL object-action catalog — the menu
+  // that opens here is the same one the right-click path shows.
   const more = page.getByTestId('more-actions-handle')
   await expect.element(more).toBeInTheDocument()
   expect(container.querySelector('[data-testid="edit-handle"]')).toBeNull()

--- a/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
@@ -121,6 +121,65 @@ it('a multi-selection gets the same doorway, opening align/distribute', async ()
   )
 })
 
+it('both vessels draw the same catalog in the same band order: properties, verbs, Delete last', async () => {
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  await userEvent.click(root, { position: { x: 200, y: 150 } })
+
+  const namesInDomOrder = () => {
+    const menu = container.querySelector('[data-testid="context-menu"]') as HTMLElement
+    return Array.from(
+      menu.querySelectorAll('[role="menuitem"], [role="menuitemradio"], fieldset'),
+    ).map((el) => el.getAttribute('aria-label') ?? el.textContent)
+  }
+
+  // Vessel 2: the ⋯ popover.
+  await userEvent.click(page.getByTestId('more-actions-handle'))
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+  const fromMore = namesInDomOrder()
+
+  // Band order: the Color property row precedes every verb, and Delete is
+  // physically last — the destructive entry keeps its distance.
+  expect(fromMore.indexOf('Color')).toBeGreaterThanOrEqual(0)
+  expect(fromMore.indexOf('Color')).toBeLessThan(fromMore.indexOf('Copy'))
+  expect(fromMore.indexOf('Order')).toBeLessThan(fromMore.indexOf('Edit text'))
+  expect(fromMore[fromMore.length - 1]).toBe('Delete')
+
+  // Close, reopen as vessel 1 (right-click): same catalog, same order.
+  await userEvent.keyboard('{Escape}')
+  await vi.waitFor(() => expect(container.querySelector('[data-testid="context-menu"]')).toBeNull())
+  const r = root.getBoundingClientRect()
+  fireEvent.contextMenu(root, { clientX: r.left + 200, clientY: r.top + 150 })
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+  expect(namesInDomOrder()).toEqual(fromMore)
+})
+
+it('the ⋯ vessel is an icon grid: verbs are icon-only with accessible names intact', async () => {
+  const { container } = render(<Host />)
+  await userEvent.click(rootOf(container), { position: { x: 200, y: 150 } })
+  await userEvent.click(page.getByTestId('more-actions-handle'))
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+
+  const menu = container.querySelector('[data-testid="context-menu"]') as HTMLElement
+  expect(menu.dataset.variant).toBe('grid')
+  // Icon discipline: the verb carries its name for assistive tech (and the
+  // hover tooltip), while showing no visible text.
+  const copy = menu.querySelector('[role="menuitem"][aria-label="Copy"]') as HTMLElement
+  expect(copy).not.toBeNull()
+  expect(copy.textContent).toBe('')
+  expect(copy.title).toBe('Copy')
+  // The right-click vessel keeps its reading-surface labels.
+  await userEvent.keyboard('{Escape}')
+  await vi.waitFor(() => expect(container.querySelector('[data-testid="context-menu"]')).toBeNull())
+  const root = rootOf(container)
+  const r = root.getBoundingClientRect()
+  fireEvent.contextMenu(root, { clientX: r.left + 200, clientY: r.top + 150 })
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+  const listMenu = container.querySelector('[data-testid="context-menu"]') as HTMLElement
+  expect(listMenu.dataset.variant).not.toBe('grid')
+  expect(listMenu.textContent).toContain('Copy')
+})
+
 it('arrow keys nudge the selected node; Shift enlarges the step', async () => {
   const { container } = render(<Host />)
   const root = rootOf(container)

--- a/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
@@ -180,6 +180,51 @@ it('the ⋯ vessel is an icon grid: verbs are icon-only with accessible names in
   expect(listMenu.textContent).toContain('Copy')
 })
 
+it('under 768px of editor width, the ⋯ opens a bottom sheet instead of a popover', async () => {
+  function NarrowHost() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+    return (
+      <div style={{ width: 390, height: 640 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  const { container } = render(<NarrowHost />)
+  await userEvent.click(rootOf(container), { position: { x: 150, y: 150 } })
+  await userEvent.click(page.getByTestId('more-actions-handle'))
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+
+  // The ⋯ is the touch entrance, so what it opens is touch-first below the
+  // minimap breakpoint: a bottom sheet in the thumb zone, full width, with
+  // the selection still visible above it. Keyed off the CONTAINER, exactly
+  // like the minimap — a narrow editor column on a wide screen needs the
+  // sheet the same way.
+  const menu = container.querySelector('[data-testid="context-menu"]') as HTMLElement
+  expect(menu.dataset.variant).toBe('sheet')
+  const root = rootOf(container)
+  const menuRect = menu.getBoundingClientRect()
+  const rootRect = root.getBoundingClientRect()
+  expect(Math.abs(menuRect.bottom - rootRect.bottom)).toBeLessThan(2)
+  expect(menuRect.width).toBeGreaterThan(rootRect.width * 0.9)
+  // Same catalog: the icon-grid verbs and the isolated Delete are all here.
+  expect(menu.querySelector('[role="menuitem"][aria-label="Edit text"]')).not.toBeNull()
+  expect(menu.querySelector('[role="menuitem"][aria-label="Delete"]')).not.toBeNull()
+
+  // The right-click vessel stays a popover at any width.
+  await userEvent.keyboard('{Escape}')
+  await vi.waitFor(() => expect(container.querySelector('[data-testid="context-menu"]')).toBeNull())
+  const r = root.getBoundingClientRect()
+  fireEvent.contextMenu(root, { clientX: r.left + 150, clientY: r.top + 150 })
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+  const listMenu = container.querySelector('[data-testid="context-menu"]') as HTMLElement
+  expect(listMenu.dataset.variant).toBe('list')
+})
+
 it('arrow keys nudge the selected node; Shift enlarges the step', async () => {
   const { container } = render(<Host />)
   const root = rootOf(container)

--- a/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
@@ -4,7 +4,7 @@
 // discrete pointerdown loses the focus fight with mousedown's default
 // action (see SelectionOverlay's onEditRequest doc).
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
@@ -62,6 +62,22 @@ it('the More-actions control is keyboard-operable (Enter opens the menu)', async
   const more = container.querySelector('[data-testid="more-actions-handle"]') as SVGGElement
   more.focus()
   await userEvent.keyboard('{Enter}')
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+})
+
+it('a touch tap opens the menu — the root suppresses synthetic clicks on touch', async () => {
+  const { container } = render(<Host />)
+  await userEvent.click(rootOf(container), { position: { x: 200, y: 150 } })
+  const more = container.querySelector('[data-testid="more-actions-handle"]') as SVGGElement
+  expect(more).not.toBeNull()
+
+  // A real touch inside the editor never synthesises a click: the root's
+  // non-passive touchstart listener calls preventDefault to keep iOS from
+  // hijacking long-presses, and that cancels the whole mouse-compatibility
+  // family. The control must complete on the pointer events themselves.
+  fireEvent.pointerDown(more, { pointerType: 'touch', pointerId: 7, isPrimary: true })
+  fireEvent.pointerUp(more, { pointerType: 'touch', pointerId: 7, isPrimary: true })
+
   await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
 })
 

--- a/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
@@ -65,6 +65,46 @@ it('the More-actions control is keyboard-operable (Enter opens the menu)', async
   await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
 })
 
+it('a multi-selection gets the same doorway, opening align/distribute', async () => {
+  const spread: SpatialCanvas = {
+    nodes: [
+      { id: 'a', type: 'text', x: 100, y: 100, width: 120, height: 60, text: 'A' },
+      { id: 'b', type: 'text', x: 300, y: 220, width: 120, height: 60, text: 'B' },
+    ],
+    edges: [],
+  }
+  function MultiHost() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(spread)
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  const { container } = render(<MultiHost />)
+  const root = rootOf(container)
+  root.dispatchEvent(
+    new KeyboardEvent('keydown', { key: 'a', code: 'KeyA', metaKey: true, bubbles: true }),
+  )
+
+  // Align/distribute were the least discoverable actions of all; the multi-
+  // selection's ⋯ is the first visible route to them.
+  const more = page.getByTestId('more-actions-handle')
+  await expect.element(more).toBeInTheDocument()
+  await userEvent.click(more)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+  await vi.waitFor(() =>
+    expect(
+      container.querySelector('[data-testid="context-menu"] [aria-label="Align left"]'),
+    ).not.toBeNull(),
+  )
+})
+
 it('arrow keys nudge the selected node; Shift enlarges the step', async () => {
   const { container } = render(<Host />)
   const root = rootOf(container)

--- a/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
@@ -35,25 +35,34 @@ function rootOf(container: HTMLElement): HTMLElement {
   return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
-it('selecting a text node shows an Edit control; clicking it opens the editor', async () => {
+it('selecting a node shows one More-actions control; it opens the object menu HERE', async () => {
   const { container } = render(<Host />)
   await userEvent.click(rootOf(container), { position: { x: 200, y: 150 } })
 
-  const editHandle = page.getByTestId('edit-handle')
-  await expect.element(editHandle).toBeInTheDocument()
+  // C from the discoverability analysis: the pencil promoted ONE verb and
+  // left ten invisible. The ⋯ is the visible doorway to all of them.
+  const more = page.getByTestId('more-actions-handle')
+  await expect.element(more).toBeInTheDocument()
+  expect(container.querySelector('[data-testid="edit-handle"]')).toBeNull()
 
-  await userEvent.click(editHandle)
+  await userEvent.click(more)
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
+  // The SAME catalog the right-click shows — no second menu to learn.
+  await expect.element(page.getByRole('menuitem', { name: 'Edit text' })).toBeInTheDocument()
+
+  await userEvent.click(page.getByRole('menuitem', { name: 'Edit text' }))
   await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
   expect(container.querySelector('textarea')?.value).toBe('hello world')
 })
 
-it('the Edit control is keyboard-operable (Enter opens the editor)', async () => {
+it('the More-actions control is keyboard-operable (Enter opens the menu)', async () => {
   const { container } = render(<Host />)
   await userEvent.click(rootOf(container), { position: { x: 200, y: 150 } })
-  ;(page.getByTestId('edit-handle').element() as SVGElement & { focus(): void }).focus()
-  await userEvent.keyboard('{Enter}')
 
-  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+  const more = container.querySelector('[data-testid="more-actions-handle"]') as SVGGElement
+  more.focus()
+  await userEvent.keyboard('{Enter}')
+  await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
 })
 
 it('arrow keys nudge the selected node; Shift enlarges the step', async () => {

--- a/apps/web/src/components/spatial-editor/escape-cancels-new-note.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/escape-cancels-new-note.browser.test.tsx
@@ -46,6 +46,24 @@ describe('Escape while typing a brand-new note (real browser)', () => {
     await waitFor(() => expect(latest.nodes).toHaveLength(0))
   })
 
+  it('keeps the box when Escape lands before any typing — sketching layouts', async () => {
+    let latest: SpatialCanvas = { nodes: [], edges: [] }
+    render(<Host onCanvas={(c) => (latest = c)} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }))
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Note' }))
+    await screen.findByRole('textbox')
+    await waitFor(() => expect(latest.nodes).toHaveLength(1))
+
+    await userEvent.keyboard('{Escape}')
+
+    // The editor closes; the empty box stays. Someone placing boxes to think
+    // about a layout is not cancelling the box — only the typing.
+    await waitFor(() => expect(screen.queryByRole('textbox')).toBeNull())
+    expect(latest.nodes).toHaveLength(1)
+    expect(latest.nodes[0]?.type === 'text' ? latest.nodes[0].text : 'unset').toBe('')
+  })
+
   it('keeps an existing note and its stored text when the edit is cancelled', async () => {
     let latest: SpatialCanvas = { nodes: [], edges: [] }
     render(<Host onCanvas={(c) => (latest = c)} />)

--- a/apps/web/src/components/spatial-editor/gestures.test.ts
+++ b/apps/web/src/components/spatial-editor/gestures.test.ts
@@ -467,6 +467,38 @@ describe('text-edit gesture', () => {
   })
 })
 
+describe('cancel-text-edit on a freshly created node', () => {
+  it('keeps the box when NOTHING was typed — an empty note is a layout tool', () => {
+    const c = canvas()
+    const created = reduceGesture(
+      createIdleState(),
+      c,
+      { type: 'dblclick-empty', point: { x: 100, y: 100 } },
+      { createId: () => 'fresh' },
+    )
+    const result = reduceGesture(created.state, c, { type: 'cancel-text-edit' })
+    // Escape closes the editor; it does not eat the box someone placed to
+    // sketch a layout. Discard-with-the-node stays reserved for the case
+    // where text WAS typed (pinned in escape-cancels-new-note.browser).
+    expect(result.commands).toEqual([])
+    expect(result.state).toEqual({ kind: 'idle' })
+    expect(result.selectedId).toBe('fresh')
+  })
+
+  it('still takes the node with it when text was typed and then discarded', () => {
+    const c = canvas()
+    const created = reduceGesture(
+      createIdleState(),
+      c,
+      { type: 'dblclick-empty', point: { x: 100, y: 100 } },
+      { createId: () => 'fresh' },
+    )
+    const typing = reduceGesture(created.state, c, { type: 'update-text-edit', text: 'oops' })
+    const result = reduceGesture(typing.state, c, { type: 'cancel-text-edit' })
+    expect(result.commands).toEqual([{ kind: 'delete-node', id: 'fresh' }])
+  })
+})
+
 describe('dblclick-empty (create-node)', () => {
   it('creates a text node centered on the point, selects it, and opens it for typing immediately', () => {
     const c = canvas()
@@ -619,7 +651,7 @@ describe('multi-selection resize', () => {
 describe('cancel-text-edit removes a node that only existed for the cancelled edit', () => {
   const empty = (): SpatialCanvas => ({ nodes: [], edges: [] })
 
-  it('deletes the just-created node — nothing was typed, so nothing should remain', () => {
+  it('keeps the just-created node on cancel — an empty box is a deliberate layout tool', () => {
     const created = reduceGesture(
       createIdleState(),
       empty(),
@@ -634,8 +666,10 @@ describe('cancel-text-edit removes a node that only existed for the cancelled ed
     }
     const cancelled = reduceGesture(created.state, withNode, { type: 'cancel-text-edit' })
     expect(cancelled.state).toEqual({ kind: 'idle' })
-    expect(cancelled.commands).toEqual([{ kind: 'delete-node', id: 'n-new' }])
-    expect(cancelled.selectedId).toBeNull()
+    // Escape closes the editor and nothing more: no delete command, and the
+    // box stays selected so it can be moved or resized immediately.
+    expect(cancelled.commands).toEqual([])
+    expect(cancelled.selectedId).toBe('n-new')
   })
 
   it('keeps an existing node — cancel reverts the edit, it does not delete', () => {

--- a/apps/web/src/components/spatial-editor/gestures.test.ts
+++ b/apps/web/src/components/spatial-editor/gestures.test.ts
@@ -479,7 +479,7 @@ describe('cancel-text-edit on a freshly created node', () => {
     const result = reduceGesture(created.state, c, { type: 'cancel-text-edit' })
     // Escape closes the editor; it does not eat the box someone placed to
     // sketch a layout. Discard-with-the-node stays reserved for the case
-    // where text WAS typed (pinned in escape-cancels-new-note.browser).
+    // where text WAS typed.
     expect(result.commands).toEqual([])
     expect(result.state).toEqual({ kind: 'idle' })
     expect(result.selectedId).toBe('fresh')
@@ -488,8 +488,8 @@ describe('cancel-text-edit on a freshly created node', () => {
   it('a real pointercancel still discards the untouched new node — OS-broken is not "done here"', () => {
     // The keep-the-box rule is for the EXPLICIT cancel (Escape): a person
     // saying "done here". pointercancel is the platform tearing the gesture
-    // down mid-flight; the half-made node it strands is debris, and #821's
-    // capture fix relies on this staying a discard.
+    // down mid-flight; the half-made node it strands is debris, and the
+    // lost-capture handling relies on this staying a discard.
     const c = canvas()
     const created = reduceGesture(
       createIdleState(),

--- a/apps/web/src/components/spatial-editor/gestures.test.ts
+++ b/apps/web/src/components/spatial-editor/gestures.test.ts
@@ -485,6 +485,22 @@ describe('cancel-text-edit on a freshly created node', () => {
     expect(result.selectedId).toBe('fresh')
   })
 
+  it('a real pointercancel still discards the untouched new node — OS-broken is not "done here"', () => {
+    // The keep-the-box rule is for the EXPLICIT cancel (Escape): a person
+    // saying "done here". pointercancel is the platform tearing the gesture
+    // down mid-flight; the half-made node it strands is debris, and #821's
+    // capture fix relies on this staying a discard.
+    const c = canvas()
+    const created = reduceGesture(
+      createIdleState(),
+      c,
+      { type: 'dblclick-empty', point: { x: 100, y: 100 } },
+      { createId: () => 'fresh' },
+    )
+    const result = reduceGesture(created.state, c, { type: 'pointercancel' })
+    expect(result.commands).toEqual([{ kind: 'delete-node', id: 'fresh' }])
+  })
+
   it('still takes the node with it when text was typed and then discarded', () => {
     const c = canvas()
     const created = reduceGesture(

--- a/apps/web/src/components/spatial-editor/gestures.ts
+++ b/apps/web/src/components/spatial-editor/gestures.ts
@@ -389,6 +389,14 @@ export function reduceGesture(
     case 'pointercancel':
     case 'cancel-text-edit':
       if (state.kind === 'editing-text' && state.createdForEdit === true) {
+        // Cancel discards what was TYPED, and takes the node with it only
+        // when there is typed text to discard. With nothing typed, Escape
+        // just closes the editor: an empty note is a layout tool (it is the
+        // rectangle this product deliberately does not have a second kind
+        // for), and eating it punished exactly the person sketching boxes.
+        if (state.pendingText === '') {
+          return { state: { kind: 'idle' }, commands: [], selectedId: state.nodeId }
+        }
         return {
           state: { kind: 'idle' },
           commands: [{ kind: 'delete-node', id: state.nodeId }],

--- a/apps/web/src/components/spatial-editor/gestures.ts
+++ b/apps/web/src/components/spatial-editor/gestures.ts
@@ -387,9 +387,21 @@ export function reduceGesture(
     case 'canvas-replaced':
       return reduceCanvasReplaced(state, event.canvas, event.origin ?? 'local')
     case 'pointercancel':
+      // The platform tore the gesture down mid-flight; a node created for
+      // the edit it interrupted is debris, not a decision. Distinct from the
+      // explicit cancel below on purpose — the lost-capture handling relies
+      // on a real pointercancel staying a discard.
+      if (state.kind === 'editing-text' && state.createdForEdit === true) {
+        return {
+          state: { kind: 'idle' },
+          commands: [{ kind: 'delete-node', id: state.nodeId }],
+          selectedId: null,
+        }
+      }
+      return idle
     case 'cancel-text-edit':
       if (state.kind === 'editing-text' && state.createdForEdit === true) {
-        // Cancel discards what was TYPED, and takes the node with it only
+        // Escape discards what was TYPED, and takes the node with it only
         // when there is typed text to discard. With nothing typed, Escape
         // just closes the editor: an empty note is a layout tool (it is the
         // rectangle this product deliberately does not have a second kind


### PR DESCRIPTION
## What

All four approved slices from the Canvas Manipulation Lab (design signed off in the Lab artifact before implementation):

1. **Escape before typing keeps the freshly created box.** Someone placing boxes to sketch a layout is cancelling the *typing*, not the box. Escape on a brand-new note with nothing typed now closes the editor and keeps the empty box selected; Escape after typing still deletes the node (the text was the point, and it was discarded). A platform `pointercancel` still discards the half-made node — the reducer now distinguishes the person's cancel from the platform's teardown, and the root keydown handler routes the Escape *key* to the explicit-cancel arm instead of speaking the platform's word. #821's lost-pointer-capture semantics are untouched (its 4 browser tests pass unmodified).

2. **The pencil becomes the doorway to every action.** A selected node used to show one visible verb (✎ edit) while 10+ implemented actions hid behind a context menu whose entrance itself is invisible. The pencil is replaced by a ⋯ More-actions control that opens the existing object menu anchored at the selection — one catalog, discoverable entrance. Keyboard-operable (`role="button"`, Enter/Space), `aria-haspopup="menu"`. Phase 1 of the approved three-phase plan (Phase 2: catalog extraction + 3-band re-banding; Phase 3: bottom sheet <768px).

3. **One catalog, two vessels (Phase 2).** Every object menu now draws from one re-banded catalog: **properties** (color, z-order, arrows — state pickers, the menu stays open), then **verbs** (one-shot, the menu closes), then the **destructive** entry alone at the bottom — for nodes and edges alike. The right-click vessel keeps its reading-surface list; the ⋯ vessel renders verb runs as an icon-only grid (44px targets, `aria-label` + `title` carry every name). Duplicate switches to `CopyPlus` so it stays distinguishable from Copy without a label. `DESIGN.md` records the deliberate scope split with ToolPalette's labels-on rule (creation surfaces keep labels; object-action surfaces are icon-first), and a guard test pins both vessels to the same catalog in the same order.

4. **The ⋯ becomes a bottom sheet below the minimap breakpoint (Phase 3).** The ⋯ is the touch entrance, so what it opens is touch-first in a narrow editor: below 768px of **container** width (the minimap's own breakpoint, keyed off the container for the minimap's own reason) the grid popover becomes a full-width bottom sheet in the thumb zone — thicker 48px targets, safe-area padding, the selection still visible above it. Same catalog, same band order; the vessel is decided at open time. Right-click stays a popover at any width.

## Why the reducer split

Post-rebase, main's #821 relies on a real `pointercancel` discarding a node created for the interrupted edit ("OS-broken is not done-here"). The previously shared reducer arm couldn't serve both masters, so `pointercancel` (always discard the fresh node) and `cancel-text-edit` (keep the box when nothing was typed) are now separate arms, each pinned by its own test.

## Visual repro

Selection shows the ⋯ doorway (top-right); tapping it opens the icon-grid vessel — properties on top, verbs as icons, red Delete isolated:

![phase2-grid-vessel.png](https://github.com/user-attachments/assets/f9cb57d8-d556-4768-ba8e-c3fa8ae51424)

The right-click vessel draws the same catalog in the same band order, keeping its labeled list:

![phase2-list-vessel.png](https://github.com/user-attachments/assets/73161d67-0a59-4986-a23e-1846ec12c89b)

In a phone-width editor the same catalog arrives as a bottom sheet, selection visible above:

![phase3-bottom-sheet.png](https://github.com/user-attachments/assets/4c95b036-5ff3-40fd-83c1-8e959be0bab5)

Captured from the real-browser (Chromium) test harness driving actual clicks against `SpatialEditor`.

## Tests

- `gestures.test.ts` 41/41 — including the new pointercancel-vs-Escape split pins (red-first)
- `escape-cancels-new-note.browser.test.tsx` 3/3 — keep-when-empty, delete-when-typed, existing-note cancel
- `edit-handle.browser.test.tsx` 8/8 — ⋯ present / opens menu / keyboard / touch tap (pointerup, no synthetic click) / multi-selection / band-order + catalog-equality guards / icon-grid discipline / bottom-sheet vessel under 768px — ⋯ present / pencil absent / opens menu with Edit text; keyboard operability
- `lost-pointer-capture.browser.test.tsx` 4/4 — #821 semantics preserved unmodified
- Full gates: `pnpm --filter @kamiazya/whiteboard-web test` (jsdom, exit 0), `pnpm test --project web-browser` (573/573), `pnpm -r typecheck`, `pnpm lint`, `pnpm knip` all clean

## Merge order

Merge **after** #826 (Document-vocabulary convergence, touches `SpatialEditor.tsx`); this branch will be rebased on top once #826 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ua6RPuoEAD4ZTBqyhNC56Z


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a universal “More actions” control for selected canvas items, accessible by mouse, touch, and keyboard.
  - Added compact icon-grid menus and responsive bottom-sheet menus for smaller screens.
  - Standardized action ordering across context menus, with deletion consistently placed last.
  - Added tooltips and accessible labels for icon-only actions.

- **Bug Fixes**
  - Pressing Escape now closes a newly created empty note without removing it.
  - Cancelled text edits continue to remove notes only when text was entered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->