### PR TITLE
test(server): compare the inline-JSON property against JSON's own projection

### DIFF
--- a/packages/mcp-server/src/server/app-helpers.test.ts
+++ b/packages/mcp-server/src/server/app-helpers.test.ts
@@ -23,7 +23,11 @@ describe('toInlineScriptJson', () => {
     (value) => {
       const output = toInlineScriptJson(value)
       expect(output).not.toContain('<')
-      expect(JSON.parse(output)).toEqual(value)
+      // Compared against JSON's own projection of the value, not the value:
+      // JSON.stringify collapses -0 to 0 (fc.jsonValue generates -0, found
+      // by seed 1616450870), and that loss is JSON's, not the escape's. The
+      // invariant worth stating is that the ESCAPE adds no loss beyond it.
+      expect(JSON.parse(output)).toEqual(JSON.parse(JSON.stringify(value)))
     },
   )
 })


### PR DESCRIPTION
The #827 property `escape is complete and semantics-preserving for any JSON value` fails whenever fc.jsonValue draws a `-0` (seed `1616450870`; surfaced blocking an unrelated branch): `JSON.stringify(-0)` is `"0"`, so the parse-back comparison against the original value trips on a loss that is JSON's own, not the escape's. Diagnosis-evidence applied: seed-reproduced red, fixed, seed-reproduced green, and the escape-deletion mutant re-verified red via the property's no-`<` half.

The comparison now targets `JSON.parse(JSON.stringify(value))` — stating exactly that the escape adds no loss beyond JSON's own projection, with no input class excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated property testing for inline script JSON serialization to account for standard JSON normalization.
  * Continued validating correct escaping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->