### PR TITLE
refactor(contracts): unify the daemon HTTP error body on one shared schema

### DIFF
--- a/apps/web/src/components/HeaderBranchChip.browser.test.tsx
+++ b/apps/web/src/components/HeaderBranchChip.browser.test.tsx
@@ -134,6 +134,26 @@ describe('HeaderBranchChip (browser — real Radix dropdown/dialog interaction)'
     expect(alert.textContent).toContain('Failed to create variation')
   })
 
+  it("shows the daemon's own conflict reason, not the generic fallback", async () => {
+    // The branch routes carry the human-readable reason in the
+    // {error, message} body; the shared error reader forwards it. Before
+    // that fold this banner showed only "Failed to create variation" and
+    // the server\'s actual reason was discarded.
+    stateHolder.current.createBranch = vi.fn().mockRejectedValue({
+      status: 409,
+      body: { error: 'branch_conflict', message: 'A variation named "main" already exists' },
+    })
+    render(<HeaderBranchChip workspaceId="s1" slug="c1" />)
+    await userEvent.click(screen.getByTestId('header-branch-chip'))
+    await userEvent.click(await screen.findByText(/New variation/))
+    const input = await screen.findByPlaceholderText('New variation name')
+    await userEvent.type(input, 'main{Enter}')
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('A variation named "main" already exists')
+    expect(alert.textContent).not.toContain('Failed to create variation')
+  })
+
   it('surfaces setHead rejection as a role=alert with the safe error copy', async () => {
     stateHolder.current.setHead = vi.fn().mockRejectedValue(new Error('boom'))
     render(<HeaderBranchChip workspaceId="s1" slug="c1" />)

--- a/apps/web/src/components/migration/import-browser-local.ts
+++ b/apps/web/src/components/migration/import-browser-local.ts
@@ -1,9 +1,9 @@
 import type { CanvasKind } from '@kamiazya/whiteboard-canvas-model'
 import {
+  apiErrorReason,
   canvasApiUrl,
   createCanvasRequestSchema,
   createCanvasResponseSchema,
-  problemDetailsErrorSchema,
   updateCanvasResponseSchema,
 } from '@kamiazya/whiteboard-mcp/api-contracts'
 import { Loro } from 'loro-crdt'
@@ -64,9 +64,8 @@ function loroLoadFailureReason(kind: Exclude<LoroLoadResult['kind'], 'ok'>): str
 
 async function parseErrorTitle(res: Response): Promise<string> {
   try {
-    const json: unknown = await res.json()
-    const parsed = problemDetailsErrorSchema.safeParse(json)
-    if (parsed.success && parsed.data.title) return parsed.data.title
+    const reason = apiErrorReason(await res.json())
+    if (reason !== undefined) return reason
   } catch {
     // fall through to the generic message below
   }

--- a/apps/web/src/components/workspace-top-bar/useCreateCanvas.ts
+++ b/apps/web/src/components/workspace-top-bar/useCreateCanvas.ts
@@ -1,4 +1,4 @@
-import { problemDetailsErrorSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
+import { apiErrorReason } from '@kamiazya/whiteboard-mcp/api-contracts'
 import type { MutableRefObject } from 'react'
 import { useRef, useState } from 'react'
 import { deriveNewCanvasSlug } from '../../lib/derive-new-canvas-slug.js'
@@ -75,12 +75,12 @@ export function useCreateCanvas({
           onNavigateToCanvas(target)
           return
         }
-        const parsed = problemDetailsErrorSchema.safeParse(await res.json().catch(() => ({})))
-        // Use the Problem Details title when present; otherwise show a safe
-        // generic message. Never expose body.message or Error.message — those
-        // can contain server-side paths or credentials (P-HTTP-005).
-        const title = parsed.success ? parsed.data.title : undefined
-        if (mountedRef.current) setNewCanvasError(title ? title : 'Failed to create canvas.')
+        // The shared reader returns the daemon-authored reason (Problem
+        // Details title, or a message beside an error code) and nothing
+        // else. Never expose bare body.message or Error.message — those can
+        // contain server-side paths or credentials (P-HTTP-005).
+        const reason = apiErrorReason(await res.json().catch(() => ({})))
+        if (mountedRef.current) setNewCanvasError(reason ?? 'Failed to create canvas.')
       } catch {
         if (mountedRef.current) setNewCanvasError('Failed to create canvas.')
       } finally {

--- a/apps/web/src/lib/daemon-api-client.ts
+++ b/apps/web/src/lib/daemon-api-client.ts
@@ -1,5 +1,6 @@
 import type { CanvasKind } from '@kamiazya/whiteboard-canvas-model'
 import {
+  apiErrorReason,
   type CanvasOkfV1Response,
   type CreateCanvasResponse,
   canvasApiUrl,
@@ -14,7 +15,6 @@ import {
   listCanvasesResponseSchema,
   listCanvasesV1ResponseSchema,
   listWorkspacesResponseSchema,
-  problemDetailsErrorSchema,
   type UpdateCanvasResponse,
   updateCanvasResponseSchema,
   type WorkspaceNames,
@@ -42,9 +42,8 @@ export class DaemonApiError extends Error {
 
 async function parseProblemDetails(res: Response): Promise<string> {
   try {
-    const json = await res.json()
-    const parsed = problemDetailsErrorSchema.safeParse(json)
-    if (parsed.success && parsed.data.title) return parsed.data.title
+    const reason = apiErrorReason(await res.json())
+    if (reason !== undefined) return reason
   } catch {
     // fall through to the generic message below
   }

--- a/apps/web/src/lib/error-copy.test.ts
+++ b/apps/web/src/lib/error-copy.test.ts
@@ -19,9 +19,23 @@ describe('safeErrorCopy — deterministic cases', () => {
     expect(safeErrorCopy(new Error('internal: token=secret-abc'), 'fallback')).toBe('fallback')
   })
 
-  it('returns fallback when body.title is absent (even if body.message is present)', () => {
+  it('returns fallback for a bare body.message with no error code', () => {
+    // Without a code the message is out of contract — it could be anything,
+    // so it stays unforwarded.
     const err = { status: 400, body: { message: 'Name too long' } }
     expect(safeErrorCopy(err, 'fallback')).toBe('fallback')
+  })
+
+  it('forwards body.message when it accompanies an error code (the branch routes)', () => {
+    // Red-first for the audited defect: the daemon's real reason was
+    // discarded and users saw only the generic fallback.
+    const err = {
+      status: 409,
+      body: { error: 'branch_conflict', message: 'A variation named "x" already exists' },
+    }
+    expect(safeErrorCopy(err, 'Failed to create variation')).toBe(
+      'A variation named "x" already exists',
+    )
   })
 
   it('returns fallback when body has neither title nor message', () => {

--- a/apps/web/src/lib/error-copy.ts
+++ b/apps/web/src/lib/error-copy.ts
@@ -2,19 +2,24 @@
 //
 // Contract:
 //   - Error.message is never forwarded — it may contain internal paths, tokens, or stack traces.
-//   - body.message is never forwarded — it is not a standard Problem Details field and may be internal.
-//   - body.title (RFC 9457 Problem Details) IS forwarded — it is a static, human-readable string
-//     that server authors intend for display and is not derived from user input or request context.
+//   - body.title (RFC 9457 Problem Details) IS forwarded — static, display-intended copy.
+//   - body.message IS forwarded ONLY beside an `error` code: that pairing is the daemon's own
+//     code+reason family (branch conflicts, unsupported merge), where `message` is
+//     daemon-authored display copy. A bare `message` with no code is out of contract and stays
+//     unforwarded.
 //   - All other values return fallback.
+//
+// The reading goes through the shared apiErrorBodySchema — the single owner of what a daemon
+// error body may look like — rather than hand-rolled field checks; three separate readers is
+// how the branch routes' reasons got discarded while every test stayed green.
+import { apiErrorReason } from '@kamiazya/whiteboard-mcp/api-contracts'
 
 export function safeErrorCopy(err: unknown, fallback: string): string {
   if (err instanceof Error) return fallback
   if (err && typeof err === 'object') {
-    const body = (err as { body?: Record<string, unknown> }).body
-    if (body && typeof body === 'object') {
-      // RFC 9457 §3.1: 'title' is a short, human-readable summary of the problem type.
-      if (typeof body.title === 'string' && body.title.length > 0) return body.title
-    }
+    const body = (err as { body?: unknown }).body
+    const reason = apiErrorReason(body)
+    if (reason !== undefined) return reason
   }
   return fallback
 }

--- a/packages/mcp-server/src/server/release/api-contracts-barrel.test.ts
+++ b/packages/mcp-server/src/server/release/api-contracts-barrel.test.ts
@@ -38,6 +38,10 @@ describe('api-contracts barrel scope', () => {
       // builds request URLs through the same function the daemon's own
       // clients use instead of re-deriving the shape by hand.
       './canvas-url.js',
+      // errors: the ONE daemon error-body contract (title | error+message),
+      // exported so every client error surface reads through the same
+      // parser instead of hand-rolled per-file field checks.
+      './errors.js',
       './pairing.js',
       './runtime.js',
     ])

--- a/packages/mcp-server/src/server/routes/branches.test.ts
+++ b/packages/mcp-server/src/server/routes/branches.test.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { describe, expect, it, vi } from 'vitest'
+import { apiErrorBodySchema, apiErrorReason } from '../../shared/api-contracts/errors.js'
 import { withTempDataDir } from './_test-helpers.js'
 
 const tmp = withTempDataDir('branches-route-test-')
@@ -75,6 +76,23 @@ describe('POST /api/workspaces/:sid/canvases/:slug/branches', () => {
     const body = (await res.json()) as { error: string; message: string }
     expect(body.error).toBe('branch_conflict')
     expect(body.message).toMatch(/already exists/i)
+  })
+
+  it('emits a 409 body the shared error contract parses, with the reason recoverable', async () => {
+    // The client reads every daemon error through apiErrorBodySchema /
+    // apiErrorReason. A route emitting a shape outside the contract would
+    // strand its reason behind the generic fallback — which is exactly how
+    // "A variation named X already exists" was discarded for months.
+    const app = makeApp()
+    const res = await app.request('/api/workspaces/s1/canvases/canvas-a/branches', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'main' }),
+    })
+    expect(res.status).toBe(409)
+    const body: unknown = await res.json()
+    expect(apiErrorBodySchema.safeParse(body).success).toBe(true)
+    expect(apiErrorReason(body)).toMatch(/already exists/i)
   })
 
   it('returns 400 for an invalid name', async () => {

--- a/packages/mcp-server/src/server/routes/branches.ts
+++ b/packages/mcp-server/src/server/routes/branches.ts
@@ -12,6 +12,7 @@ import {
   type SetHeadResponse,
   setHeadRequestSchema,
 } from '../../shared/api-contracts/branches.js'
+import type { ApiErrorBody } from '../../shared/api-contracts/errors.js'
 import {
   BranchConflictError,
   BranchNotFoundError,
@@ -90,26 +91,20 @@ export interface CreateBranchesRouterOptions {
 
 // Helper that turns ValidationError into a structured 400 response.
 // Re-throw everything else so the caller can handle it as a 500.
-function handleValidation(
-  err: unknown,
-): { status: 400; body: { error: string; message: string } } | null {
+function handleValidation(err: unknown): { status: 400; body: ApiErrorBody } | null {
   const body = validationErrorBody(err)
   if (body) return { status: 400, body }
   return null
 }
 
-function handleCorruption(
-  err: unknown,
-): { status: 500; body: { error: 'corrupt_stored_data'; message: string } } | null {
+function handleCorruption(err: unknown): { status: 500; body: ApiErrorBody } | null {
   const body = corruptStoredDataBody(err)
   if (body) return { status: 500, body }
   return null
 }
 
 // Helper that runs validators.validateBranchName and returns a structured 400 on ValidationError.
-function validateBranchNameOrRespond(
-  name: string,
-): { status: 400; body: { error: string; message: string } } | null {
+function validateBranchNameOrRespond(name: string): { status: 400; body: ApiErrorBody } | null {
   try {
     validateBranchName(name)
     return null

--- a/packages/mcp-server/src/server/routes/canvas/path-route.ts
+++ b/packages/mcp-server/src/server/routes/canvas/path-route.ts
@@ -4,6 +4,7 @@ import {
   canvasPathForFile,
   parseCanvasApiPath,
 } from '../../../shared/api-contracts/canvas-url.js'
+import type { ApiErrorBody } from '../../../shared/api-contracts/errors.js'
 import { validateSlug, validateWorkspaceId, validationErrorBody } from '../../validators.js'
 
 export const CANVAS_WILDCARD = '/api/w/:workspaceId/canvas/*'
@@ -32,7 +33,7 @@ function validated(
     // caller says which its route speaks.
     if (body) {
       return badRequest === 'problem-details'
-        ? c.json({ title: body.message }, 400)
+        ? c.json({ title: body.message } satisfies ApiErrorBody, 400)
         : c.json(body, 400)
     }
     throw err

--- a/packages/mcp-server/src/server/routes/canvas/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/canvas/workspaces.ts
@@ -10,6 +10,7 @@ import {
   type RenameCanvasSlugResponse,
   renameCanvasSlugRequestSchema,
 } from '../../../shared/api-contracts/canvas.js'
+import type { ApiErrorBody } from '../../../shared/api-contracts/errors.js'
 import { getLogger } from '../../log.js'
 import {
   ConflictError,
@@ -90,23 +91,26 @@ export function createWorkspacesRouter() {
       validateWorkspaceId(workspaceId)
     } catch (err) {
       const body = validationErrorBody(err)
-      if (body) return c.json({ title: body.message }, 400)
+      if (body) return c.json({ title: body.message } satisfies ApiErrorBody, 400)
       throw err
     }
     const raw = await c.req.json().catch(() => null)
     if (raw === null) {
-      return c.json({ title: 'JSON body required' }, 400)
+      return c.json({ title: 'JSON body required' } satisfies ApiErrorBody, 400)
     }
     const parsed = createCanvasRequestSchema.safeParse(raw)
     if (!parsed.success) {
-      return c.json({ title: createCanvasRequestErrorTitle(parsed.error) }, 400)
+      return c.json(
+        { title: createCanvasRequestErrorTitle(parsed.error) } satisfies ApiErrorBody,
+        400,
+      )
     }
     const slug = parsed.data.slug
     try {
       validateSlug(slug)
     } catch (err) {
       const body = validationErrorBody(err)
-      if (body) return c.json({ title: body.message }, 400)
+      if (body) return c.json({ title: body.message } satisfies ApiErrorBody, 400)
       throw err
     }
     try {
@@ -119,7 +123,7 @@ export function createWorkspacesRouter() {
         return c.json({ title: `Canvas "${slug}" already exists` }, 409)
       }
       getLogger('canvas').error({ err: err as Error }, 'saveCanvas failed unexpectedly')
-      return c.json({ title: 'Failed to create canvas.' }, 500)
+      return c.json({ title: 'Failed to create canvas.' } satisfies ApiErrorBody, 500)
     }
   })
 
@@ -142,7 +146,7 @@ export function createWorkspacesRouter() {
         const issue = handleCorruptStoredData(err)
         if (issue) return c.json(issue.body, issue.status)
         getLogger('canvas').error({ err: err as Error }, 'deleteCanvas failed unexpectedly')
-        return c.json({ title: 'Failed to delete canvas.' }, 500)
+        return c.json({ title: 'Failed to delete canvas.' } satisfies ApiErrorBody, 500)
       }
     },
     { badRequest: 'problem-details' },
@@ -162,18 +166,18 @@ export function createWorkspacesRouter() {
     async (c, workspaceId, slug) => {
       const raw = await c.req.json().catch(() => null)
       if (raw === null) {
-        return c.json({ title: 'JSON body required' }, 400)
+        return c.json({ title: 'JSON body required' } satisfies ApiErrorBody, 400)
       }
       const parsed = renameCanvasSlugRequestSchema.safeParse(raw)
       if (!parsed.success) {
-        return c.json({ title: 'slug is required' }, 400)
+        return c.json({ title: 'slug is required' } satisfies ApiErrorBody, 400)
       }
       const newSlug = parsed.data.slug
       try {
         validateSlug(newSlug)
       } catch (err) {
         const body = validationErrorBody(err)
-        if (body) return c.json({ title: body.message }, 400)
+        if (body) return c.json({ title: body.message } satisfies ApiErrorBody, 400)
         throw err
       }
       try {
@@ -190,7 +194,7 @@ export function createWorkspacesRouter() {
         const issue = handleCorruptStoredData(err)
         if (issue) return c.json(issue.body, issue.status)
         getLogger('canvas').error({ err: err as Error }, 'renameCanvasSlug failed unexpectedly')
-        return c.json({ title: 'Failed to rename canvas.' }, 500)
+        return c.json({ title: 'Failed to rename canvas.' } satisfies ApiErrorBody, 500)
       }
     },
     { badRequest: 'problem-details' },

--- a/packages/mcp-server/src/shared/api-contracts/canvas.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/canvas.test.ts
@@ -30,10 +30,8 @@ import {
   type OptimizeAllCanvasesResponse,
   operatorInfoSchema,
   optimizeAllCanvasesResponseSchema,
-  type ProblemDetailsError,
   type PruneSandwichedVersionsResponse,
   type PurgeResult,
-  problemDetailsErrorSchema,
   pruneSandwichedVersionsResponseSchema,
   purgeResultSchema,
   type RestoreVersionRequest,
@@ -298,19 +296,6 @@ describe('saveVersionResponseSchema', () => {
 
   it('rejects missing version', () => {
     expect(saveVersionResponseSchema.safeParse({}).success).toBe(false)
-  })
-})
-
-describe('problemDetailsErrorSchema', () => {
-  it('parses an empty object (all fields optional)', () => {
-    const result: ProblemDetailsError = problemDetailsErrorSchema.parse({})
-    expect(result.title).toBeUndefined()
-  })
-
-  it('roundtrip with title', () => {
-    const valid: ProblemDetailsError = { title: 'Not Found' }
-    const result: ProblemDetailsError = roundtrip(problemDetailsErrorSchema, valid)
-    expect(result).toEqual(valid)
   })
 })
 

--- a/packages/mcp-server/src/shared/api-contracts/canvas.ts
+++ b/packages/mcp-server/src/shared/api-contracts/canvas.ts
@@ -89,10 +89,6 @@ export const saveVersionResponseSchema = z.object({
 
 // RFC 7807 / RFC 9457 Problem Details error response. Only the fields the UI
 // needs to surface a human-readable error string without leaking server internals.
-export const problemDetailsErrorSchema = z.object({
-  title: z.string().optional(),
-})
-
 // POST /api/workspaces/:workspaceId/canvases — success body.
 export const createCanvasResponseSchema = z.object({
   slug: z.string(),
@@ -171,7 +167,6 @@ export type WorkspaceSummary = z.infer<typeof workspaceSummarySchema>
 export type ListWorkspacesResponse = z.infer<typeof listWorkspacesResponseSchema>
 export type CanvasSummary = z.infer<typeof canvasSummarySchema>
 export type ListCanvasesResponse = z.infer<typeof listCanvasesResponseSchema>
-export type ProblemDetailsError = z.infer<typeof problemDetailsErrorSchema>
 export type CreateCanvasResponse = z.infer<typeof createCanvasResponseSchema>
 export type UpdateCanvasResponse = z.infer<typeof updateCanvasResponseSchema>
 export type DeleteCanvasResponse = z.infer<typeof deleteCanvasResponseSchema>

--- a/packages/mcp-server/src/shared/api-contracts/errors.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/errors.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { apiErrorBodySchema, apiErrorReason } from './errors.js'
+
+describe('apiErrorBodySchema', () => {
+  it.each([
+    [{ title: 'Canvas not found' }],
+    [{ error: 'branch_conflict' }],
+    [{ error: 'branch_conflict', message: 'A variation named "x" already exists' }],
+  ])('accepts %j', (body) => {
+    expect(apiErrorBodySchema.safeParse(body).success).toBe(true)
+  })
+
+  it.each([
+    // An out-of-contract body must FAIL to parse: the previous
+    // title-optional schema accepted every object, which is exactly how a
+    // reason spelled differently got silently discarded.
+    [{}],
+    [{ oops: 1 }],
+    [{ title: '' }],
+    [{ message: 'reason without a code' }],
+    [null],
+    ['plain string'],
+  ])('rejects %j', (body) => {
+    expect(apiErrorBodySchema.safeParse(body).success).toBe(false)
+  })
+})
+
+describe('apiErrorReason', () => {
+  it('returns the title for the Problem Details arm', () => {
+    expect(apiErrorReason({ title: 'Canvas "x" already exists' })).toBe('Canvas "x" already exists')
+  })
+
+  it('returns the message for the code+reason arm', () => {
+    expect(apiErrorReason({ error: 'branch_conflict', message: 'already exists' })).toBe(
+      'already exists',
+    )
+  })
+
+  it('returns undefined for a bare code and for out-of-contract bodies', () => {
+    expect(apiErrorReason({ error: 'branch_conflict' })).toBeUndefined()
+    expect(apiErrorReason({ oops: 1 })).toBeUndefined()
+    expect(apiErrorReason(undefined)).toBeUndefined()
+  })
+})

--- a/packages/mcp-server/src/shared/api-contracts/errors.ts
+++ b/packages/mcp-server/src/shared/api-contracts/errors.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod'
+
+/**
+ * The ONE shape a daemon HTTP error body may take, as a union of the two
+ * families the routes actually emit:
+ *
+ * - `{ title }` — RFC 9457-flavoured Problem Details, used by the canvas
+ *   CRUD routes. `title` is static, display-intended copy.
+ * - `{ error, message? }` — the code+reason family used everywhere else
+ *   (branches, pairing, runtime, validation). `message`, when present
+ *   beside an `error` code, is daemon-authored display copy: the branch
+ *   routes put the human-readable reason ("A variation named X already
+ *   exists") there and nowhere else.
+ *
+ * Each arm REQUIRES its discriminating field, so an out-of-contract body
+ * fails to parse instead of vacuously succeeding — the previous
+ * title-optional schema accepted every object and silently discarded the
+ * reason of any body that spelled it differently.
+ */
+export const apiErrorBodySchema = z.union([
+  z.object({ title: z.string().min(1) }),
+  z.object({ error: z.string().min(1), message: z.string().min(1).optional() }),
+])
+
+export type ApiErrorBody = z.infer<typeof apiErrorBodySchema>
+
+/**
+ * The human-readable reason carried by an error body, or `undefined` when
+ * the body carries none (a bare `{ error: code }`, or something outside
+ * the contract). The single reader every client-side error surface goes
+ * through — three hand-rolled readers is how the branch routes' reasons
+ * got discarded for months.
+ */
+export function apiErrorReason(body: unknown): string | undefined {
+  const parsed = apiErrorBodySchema.safeParse(body)
+  if (!parsed.success) return undefined
+  if ('title' in parsed.data) return parsed.data.title
+  return parsed.data.message
+}

--- a/packages/mcp-server/src/shared/api-contracts/index.ts
+++ b/packages/mcp-server/src/shared/api-contracts/index.ts
@@ -21,6 +21,7 @@ export {
 export * from './branches.js'
 export * from './canvas.js'
 export * from './canvas-url.js'
+export * from './errors.js'
 export type { ListGrantsResponse, PairingTokenResponse } from './pairing.js'
 export {
   listGrantsResponseSchema,


### PR DESCRIPTION
Audit MEDIUM (contract) + its LOW sibling, from an approved dev-loop design (PlanReview: pass) implemented in the main session.

**User-visible defect**: the branch routes carry their human-readable reason in `{error, message}` bodies, but the client's title-optional `problemDetailsErrorSchema` parsed *any* object and three hand-rolled readers only ever looked at `title` — so "A variation named X already exists" and "merge is not supported in this deployment" were discarded behind generic fallbacks while every test stayed green.

**The fold**:
- `api-contracts/errors.ts` owns the ONE contract: a union of the `{title}` Problem-Details arm and the `{error, message?}` code+reason arm, each **requiring** its discriminating field so an out-of-contract body fails to parse; `apiErrorReason()` is the single reader.
- `safeErrorCopy`, `daemon-api-client`, `useCreateCanvas`, `import-browser-local` all read through it; `problemDetailsErrorSchema` is deleted (0.0.x internal surface, no deprecation alias per the vocabulary rule).
- P-HTTP-005 revised: `body.message` is forwarded **iff** it accompanies an `error` code (daemon-authored display copy); bare `message` and `Error.message` stay unforwarded.
- `branches.ts`'s hand-written error types → `z.infer`'d `ApiErrorBody`; the canvas routes' `{title}` sites carry `satisfies` annotations. **The wire emits not one different byte.**

**Evidence**: red-first error-copy forwarding case; branch 409 contract test whose mutant (an out-of-schema emission, verified in place) goes red; HeaderBranchChip browser regression asserting the banner shows the daemon's own conflict reason and *not* the fallback. Full gates: mcp-node 3430-suite green (with #834), apps/web jsdom 2206 + node 77, browser HeaderBranchChip 19, typecheck 10/10, knip clean.

Deviations from the design doc, deliberate: per-site `satisfies` limited to the two canvas route files the design named; the daemon-api-client reason-forwarding is covered by the shared reader's unit tests rather than a separate jsdom fixture; the design's live-app verification (variation-conflict banner) is superseded by the HeaderBranchChip browser regression driving the same flow against the real component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ