### PR TITLE
chore(lint): clear every standing Biome warning; document lint as enforced

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ pnpm lint        # list violations
 pnpm lint:fix    # apply auto-fixable changes
 ```
 
-This is not yet enforced as a hard CI gate because the existing codebase still has many warnings. The expectation is to improve it incrementally.
+The codebase is warning-free and `pnpm lint` runs as part of the pre-push gate (see Git hooks below), so a new warning blocks the push. Intentional exceptions carry a `biome-ignore` comment with a reason.
 
 ## Git hooks
 

--- a/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
@@ -236,9 +236,9 @@ export function CanvasContextMenu({
           // the native color input covers the hex half the swatches
           // cannot.
           customColor: {
-            value: current !== undefined && current.startsWith('#') ? current : '#808080',
+            value: current?.startsWith('#') === true ? current : '#808080',
             ariaLabel: 'Custom color',
-            selected: current !== undefined && current.startsWith('#'),
+            selected: current?.startsWith('#') === true,
             onPick: (hex: string) => apply(hex as CanvasColor),
           },
         })

--- a/apps/web/src/components/spatial-editor/ContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/ContextMenu.tsx
@@ -186,7 +186,6 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
     >
       {items.map((item, index) =>
         item.kind === 'separator' ? (
-          // biome-ignore lint/suspicious/noArrayIndexKey: separators are positional by nature and the items list is rebuilt per open
           <hr key={`separator-${index}`} className="my-1 border-border" />
         ) : item.kind === 'options' ? (
           <Fragment key={item.label}>

--- a/apps/web/src/components/spatial-editor/DragPreviewLayer.tsx
+++ b/apps/web/src/components/spatial-editor/DragPreviewLayer.tsx
@@ -88,7 +88,6 @@ export function DragPreviewLayer({ preview, zoom, contentSvg }: DragPreviewLayer
           {preview.arrows.map((arrow, i) => (
             <polygon
               // Arrow identity is positional within one preview frame.
-              // biome-ignore lint/suspicious/noArrayIndexKey: static per-frame list
               key={i}
               points={arrow.map((p) => `${p.x},${p.y}`).join(' ')}
               fill="currentColor"

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -800,7 +800,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      */
     const lockEnabled = onToggleNodeLock !== undefined
     const isLocked = (nodeId: string): boolean =>
-      lockEnabled && lockedNodeIds !== undefined && lockedNodeIds.has(nodeId)
+      lockEnabled && (lockedNodeIds?.has(nodeId) ?? false)
     /** Boxes a pointer or marquee may target: locked nodes are invisible to both. */
     const selectableBoxes = useMemo(
       () => (lockEnabled ? boxes.filter((entry) => !isLocked(entry.id)) : boxes),
@@ -810,7 +810,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     /** Same seam rule as the node lock: no callback, no enforcement. */
     const edgeLockEnabled = onToggleEdgeLock !== undefined
     const isEdgeLocked = (edgeId: string): boolean =>
-      edgeLockEnabled && lockedEdgeIds !== undefined && lockedEdgeIds.has(edgeId)
+      edgeLockEnabled && (lockedEdgeIds?.has(edgeId) ?? false)
 
     /**
      * A lock can arrive from a peer or an agent while the node is ALREADY

--- a/apps/web/src/components/spatial-editor/link-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/link-node.browser.test.tsx
@@ -187,7 +187,6 @@ it('a javascript: URL is neither followable nor accepted by the dialog', async (
         y: 100,
         width: 200,
         height: 60,
-        // biome-ignore lint/suspicious/noTemplateCurlyInString: literal fixture
         url: 'javascript:alert(1)',
       },
     ],

--- a/apps/web/src/components/spatial-editor/use-worker-scene.ts
+++ b/apps/web/src/components/spatial-editor/use-worker-scene.ts
@@ -187,7 +187,6 @@ export function useWorkerScene(
     }
     // `renderNow` closes over the current inputs by design: a fallback must
     // lay out what was asked for, not what the effect last saw.
-    // biome-ignore lint/correctness/useExhaustiveDependencies: see above.
   }, [inputs, offloadable])
 
   // Started at MOUNT, not on the first edit. The worker's module load and its

--- a/apps/web/src/components/workspace-top-bar/fullscreen-affordance.browser.test.tsx
+++ b/apps/web/src/components/workspace-top-bar/fullscreen-affordance.browser.test.tsx
@@ -74,9 +74,7 @@ it('hides Fullscreen on the real iPhone shape: no element API at all', async () 
     await openKebab(container)
     expect(document.body.textContent).not.toContain('Fullscreen')
   } finally {
-    // biome-ignore lint/performance/noDelete: restoring an own-property shadow is exactly what delete is for
     delete (root as { requestFullscreen?: unknown }).requestFullscreen
-    // biome-ignore lint/performance/noDelete: same
     delete (root as { webkitRequestFullscreen?: unknown }).webkitRequestFullscreen
     expect(original).toBeDefined()
   }

--- a/apps/web/src/lib/daemon-auth-seam.test.ts
+++ b/apps/web/src/lib/daemon-auth-seam.test.ts
@@ -75,13 +75,16 @@ describe('daemon Authorization header single-seam guard', () => {
    * under a receiver this guard never sees.
    */
   it.each([
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: the string IS the code shape under test
     ['headers.set, canonical case', "headers.set('Authorization', `Bearer ${token}`)"],
     ['headers.append', "headers.append('Authorization', value)"],
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: the string IS the code shape under test
     ['object literal', 'fetch(url, { headers: { Authorization: `Bearer ${token}` } })'],
     ['computed key', "h['Authorization'] = value"],
     ['lowercase name', "headers.set('authorization', value)"],
     ['arbitrary receiver', "h.set('Authorization', value)"],
     ['Headers from array entries', "new Headers([['authorization', token]])"],
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: the string IS the code shape under test
     ['Headers from object', 'new Headers({ authorization: `Bearer ${token}` })'],
   ])('the guard catches %s', (_form, sample) => {
     const matched = AUTHORIZATION_HEADER_PATTERNS.some((pattern) => pattern.test(sample))

--- a/apps/web/src/pages/BrowserLocalCanvasPage.fullscreen.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.fullscreen.test.tsx
@@ -28,7 +28,6 @@ beforeEach(() => {
 afterEach(() => {
   cleanup()
   setFullscreenElement(null)
-  // biome-ignore lint/performance/noDelete: restore jsdom's real (absent) shape rather than leaving a stub for other files
   delete (Element.prototype as { requestFullscreen?: unknown }).requestFullscreen
   vi.restoreAllMocks()
 })
@@ -130,7 +129,6 @@ it('starts OUT of fullscreen under jsdom, where fullscreenElement is undefined',
   // is UNDEFINED, and `undefined !== null` read as "in fullscreen" — so every
   // first mount hid the top bar. Delete the test override to expose the real
   // jsdom default rather than the null this file installs elsewhere.
-  // biome-ignore lint/performance/noDelete: restoring the prototype default IS the scenario
   delete (document as { fullscreenElement?: Element | null }).fullscreenElement
   await renderLoaded()
 })

--- a/apps/web/src/pages/BrowserLocalCanvasPage.theme.test.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.theme.test.tsx
@@ -19,7 +19,6 @@ vi.mock('../components/spatial-editor/index.js', async (importOriginal) => {
   const CapturingSpatialEditor = forwardRef<unknown, Parameters<typeof actual.SpatialEditor>[0]>(
     (props, ref) => {
       capturedThemes.push(props.theme)
-      // biome-ignore lint/suspicious/noExplicitAny: forwarding to the real forwardRef component
       return <actual.SpatialEditor {...props} ref={ref as any} />
     },
   )

--- a/apps/web/src/pages/DaemonCanvasPage.theme.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.theme.test.tsx
@@ -36,7 +36,6 @@ vi.mock('../components/spatial-editor/index.js', async (importOriginal) => {
   const CapturingSpatialEditor = forwardRef<unknown, Parameters<typeof actual.SpatialEditor>[0]>(
     (props, ref) => {
       capturedThemes.push(props.theme)
-      // biome-ignore lint/suspicious/noExplicitAny: forwarding to the real forwardRef component
       return <actual.SpatialEditor {...props} ref={ref as any} />
     },
   )

--- a/packages/canvas-render/src/theme/spatial-theme.ts
+++ b/packages/canvas-render/src/theme/spatial-theme.ts
@@ -54,7 +54,7 @@ function presetAccent(color: CanvasColor | undefined, palette: SpatialPalette) {
 
 /** An author-supplied raw hex, passed through untouched; undefined otherwise. */
 function rawHex(color: CanvasColor | undefined): string | undefined {
-  return color !== undefined && color.startsWith('#') ? color : undefined
+  return color?.startsWith('#') ? color : undefined
 }
 
 function buildTheme(palette: SpatialPalette): SpatialAppearanceResolver {

--- a/packages/mcp-server/src/server/routes/canvas/maintenance.ts
+++ b/packages/mcp-server/src/server/routes/canvas/maintenance.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 import { compactCanvas, listCanvases } from '../../store/canvas-store.js'
 import { evictDoc } from '../../store/doc-cache.js'
 import type { VersionStore } from '../../store/version-store.js'
-import { validateSlug, validateWorkspaceId, validationErrorBody } from '../../validators.js'
+import { validateWorkspaceId, validationErrorBody } from '../../validators.js'
 import { handleCorruptStoredData } from './_shared.js'
 import { onCanvasesRoute } from './path-route.js'
 

--- a/packages/mcp-server/src/server/routes/canvas/metadata.ts
+++ b/packages/mcp-server/src/server/routes/canvas/metadata.ts
@@ -9,7 +9,7 @@ import {
   setCanvasPinned,
   setWorkspaceName,
 } from '../../store/names-store.js'
-import { validateSlug, validateWorkspaceId, validationErrorBody } from '../../validators.js'
+import { validateWorkspaceId, validationErrorBody } from '../../validators.js'
 import { handleCorruptStoredData } from './_shared.js'
 import { onCanvasesRoute } from './path-route.js'
 

--- a/packages/mcp-server/src/server/routes/canvas/restore.ts
+++ b/packages/mcp-server/src/server/routes/canvas/restore.ts
@@ -7,12 +7,7 @@ import { countAliveNodes } from '../../store/count-alive-nodes.js'
 import { evictDoc, getDoc } from '../../store/doc-cache.js'
 import type { VersionStore } from '../../store/version-store.js'
 import { withWorkspaceWriteLock } from '../../store/workspace-lock.js'
-import {
-  validateSlug,
-  validateVersionId,
-  validateWorkspaceId,
-  validationErrorBody,
-} from '../../validators.js'
+import { validateSlug, validateVersionId, validationErrorBody } from '../../validators.js'
 import { getBroadcastFn, handleCorruptStoredData } from './_shared.js'
 import { onCanvasesRoute } from './path-route.js'
 

--- a/packages/mcp-server/src/server/routes/canvas/thumbnails.ts
+++ b/packages/mcp-server/src/server/routes/canvas/thumbnails.ts
@@ -1,12 +1,7 @@
 import { Hono } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
 import type { VersionStore } from '../../store/version-store.js'
-import {
-  validateSlug,
-  validateVersionId,
-  validateWorkspaceId,
-  validationErrorBody,
-} from '../../validators.js'
+import { validateVersionId, validationErrorBody } from '../../validators.js'
 import { isValidPngSignature } from '../canvas-thumbnail.js'
 import { handleCorruptStoredData } from './_shared.js'
 import { onCanvasesRoute } from './path-route.js'
@@ -31,7 +26,7 @@ export function createThumbnailsRouter(options: ThumbnailsRouterOptions) {
     app,
     'put',
     ['versions', ':id', 'thumbnail'],
-    async (c, workspaceId, slug, params) => {
+    async (c, workspaceId, _slug, params) => {
       const id = params.id as string
       try {
         validateVersionId(id)
@@ -71,7 +66,7 @@ export function createThumbnailsRouter(options: ThumbnailsRouterOptions) {
     app,
     'get',
     ['versions', ':id', 'thumbnail'],
-    async (c, workspaceId, slug, params) => {
+    async (c, workspaceId, _slug, params) => {
       const id = params.id as string
       try {
         validateVersionId(id)

--- a/packages/mcp-server/src/server/routes/canvas/versions.ts
+++ b/packages/mcp-server/src/server/routes/canvas/versions.ts
@@ -7,7 +7,6 @@ import {
 import { isCorruptStoredDataError } from '../../store/corrupt-stored-data.js'
 import { getDoc } from '../../store/doc-cache.js'
 import type { OperatorInfo, VersionStore } from '../../store/version-store.js'
-import { validateSlug, validateWorkspaceId, validationErrorBody } from '../../validators.js'
 import { defaultHumanDisplayName, handleCorruptStoredData } from './_shared.js'
 import { onCanvasesRoute } from './path-route.js'
 

--- a/packages/mcp-server/src/server/store/canvas-doc-write-lock.test.ts
+++ b/packages/mcp-server/src/server/store/canvas-doc-write-lock.test.ts
@@ -5,11 +5,7 @@
 import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
 import { chunkSnapshot, reassembleSnapshot } from '@kamiazya/whiteboard-canvas-ports'
 import { InMemoryDocumentIndex } from '@kamiazya/whiteboard-canvas-ports/test-utils'
-import {
-  writeSpatialCanvas as _w,
-  readSpatialCanvas,
-  WorkspaceTree,
-} from '@kamiazya/whiteboard-canvas-workspace'
+import { writeSpatialCanvas as _w, readSpatialCanvas } from '@kamiazya/whiteboard-canvas-workspace'
 import { createNodePatchTool } from '@kamiazya/whiteboard-server-core'
 import { LoroDoc } from 'loro-crdt'
 import { beforeEach, describe, expect, it, vi } from 'vitest'


### PR DESCRIPTION
Audit MEDIUM (devx): `pnpm lint` runs in the pre-push gate, but 20+ standing warnings meant every push's lint output needed hand-triage to find the one real error — a cost this session paid several times over.

Now **zero warnings**:
- 5 `useOptionalChain` sites rewritten — with explicit `=== true` / `?? false` where the bare optional chain would widen a declared `boolean` (the naive `--unsafe` fix broke typecheck; each site reviewed).
- 5 dead imports + 2 unused route-handler parameters dropped.
- 10 stale `biome-ignore` suppressions deleted — Biome itself reports each as unused.
- `daemon-auth-seam.test.ts`'s three template-curly fixtures get reasoned ignores (the string IS the code shape under test).
- CONTRIBUTING's stale "not yet enforced … still has many warnings" claim replaced with the actual state.

Gates: typecheck 10/10, mcp-node 3430-suite, apps/web jsdom 2206 + node 77, browser 589 — all green; `pnpm lint` exits clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ