### PR TITLE
feat(web): open daemon markdown documents in the markdown editor

### DIFF
--- a/apps/web/src/components/document-editor/DocumentEditorSurface.test.tsx
+++ b/apps/web/src/components/document-editor/DocumentEditorSurface.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * The kind switch every canvas page routes through. The contract under
+ * test: a markdown-kind document NEVER falls through to the spatial slot
+ * (the corruption path this component exists to close), and a page cannot
+ * mount the surface without deciding what markdown looks like — `markdown`
+ * is a required prop, which is the compile-time half of the same guard.
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { DocumentEditorSurface } from './DocumentEditorSurface.js'
+
+afterEach(cleanup)
+
+describe('DocumentEditorSurface', () => {
+  it('renders the spatial slot for a spatial document', () => {
+    render(
+      <DocumentEditorSurface
+        kind="spatial"
+        documentKey="doc-1"
+        spatial={() => <div data-testid="spatial-slot" />}
+        markdown={null}
+      />,
+    )
+    expect(screen.getByTestId('spatial-slot')).toBeTruthy()
+  })
+
+  it('renders the markdown editor, not the spatial slot, for a markdown document', () => {
+    render(
+      <DocumentEditorSurface
+        kind="markdown"
+        documentKey="doc-1"
+        spatial={() => <div data-testid="spatial-slot" />}
+        markdown={{ body: '# From the surface', setBody: () => {} }}
+      />,
+    )
+    expect(screen.getByTestId('markdown-source-wrap')).toBeTruthy()
+    expect(screen.queryByTestId('spatial-slot')).toBeNull()
+  })
+
+  it('renders nothing while a markdown body has not hydrated', () => {
+    const { container } = render(
+      <DocumentEditorSurface
+        kind="markdown"
+        documentKey="doc-1"
+        spatial={() => <div data-testid="spatial-slot" />}
+        markdown={{ body: null, setBody: () => {} }}
+      />,
+    )
+    expect(container.textContent).toBe('')
+    expect(screen.queryByTestId('spatial-slot')).toBeNull()
+  })
+})

--- a/apps/web/src/components/document-editor/DocumentEditorSurface.tsx
+++ b/apps/web/src/components/document-editor/DocumentEditorSurface.tsx
@@ -1,0 +1,88 @@
+/**
+ * The one kind switch between a document and its editor. Every canvas page
+ * (browser-local, daemon) routes through this component instead of choosing
+ * an editor itself, because the pages choosing independently is exactly how
+ * a markdown document opened in the spatial editor on one backend after
+ * being wired correctly on the other — and drawing on that view corrupts
+ * the document.
+ *
+ * Two guards, one per compile/runtime half:
+ *
+ * - `markdown` is a REQUIRED prop. A page cannot mount the surface without
+ *   deciding what a markdown document looks like on its backend, so "this
+ *   page only does spatial" stops being expressible by omission.
+ * - The switch below is exhaustive over `CanvasKind` with a `never` default,
+ *   so adding a third kind to `canvasKindSchema` fails compilation HERE, in
+ *   the one place every page shares, rather than silently falling through
+ *   to whichever editor a page happened to hardcode.
+ */
+import type { CanvasKind } from '@kamiazya/whiteboard-canvas-model'
+import type { ReactNode } from 'react'
+import { MarkdownEditor, type MarkdownEditorProps } from '../markdown-editor/MarkdownEditor.js'
+
+/**
+ * What a backend must supply to edit a markdown document, independent of
+ * how it stores the body (browser-local: the `body` text container via a
+ * CRDT binding; daemon: the `okf-body` node through the sync session's
+ * command path). Editor-facing options are picked from the editor's own
+ * props so this never becomes a second, drifting copy of that contract.
+ */
+export interface MarkdownDocumentSession
+  extends Pick<
+    MarkdownEditorProps,
+    | 'sourceExtensions'
+    | 'theme'
+    | 'meta'
+    | 'resolveAlias'
+    | 'onOpenCanvas'
+    | 'resolveEmbed'
+    | 'autoFocus'
+  > {
+  /** Null until the document has hydrated — nothing editable renders before. */
+  readonly body: string | null
+  readonly setBody: (next: string) => void
+}
+
+export interface DocumentEditorSurfaceProps {
+  kind: CanvasKind
+  /** Keys the editor to the document identity so a switch resets its state. */
+  documentKey: string
+  /** The spatial editor, fully wired by the page (its prop surface is page-specific). */
+  spatial: () => ReactNode
+  /** Null only while the page cannot say yet (no document open). */
+  markdown: MarkdownDocumentSession | null
+}
+
+function noopChange(): void {}
+
+export function DocumentEditorSurface(props: DocumentEditorSurfaceProps): ReactNode {
+  switch (props.kind) {
+    case 'spatial':
+      return <>{props.spatial()}</>
+    case 'markdown': {
+      const session = props.markdown
+      if (session === null || session.body === null) return null
+      const { body, setBody, sourceExtensions, ...editorOptions } = session
+      return (
+        <div className="flex h-full min-h-0 flex-col">
+          <div className="min-h-0 flex-1">
+            <MarkdownEditor
+              key={props.documentKey}
+              value={body}
+              // A CRDT binding owns the write path when present; `value`
+              // then flows only outward (preview, word count).
+              onChange={sourceExtensions === undefined ? setBody : noopChange}
+              sourceExtensions={sourceExtensions}
+              className="h-full"
+              {...editorOptions}
+            />
+          </div>
+        </div>
+      )
+    }
+    default: {
+      const exhaustive: never = props.kind
+      return exhaustive
+    }
+  }
+}

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -3,14 +3,14 @@ import type { CanvasCoreMeta } from '@kamiazya/whiteboard-canvas-model'
 import { isImageRef } from '@kamiazya/whiteboard-canvas-model'
 import { LoroSyncPlugin } from 'loro-codemirror'
 import { Braces, Copy, Download, EllipsisVertical, Minimize2, Trash2 } from 'lucide-react'
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { CanvasPageSkeleton } from '../components/CanvasPageSkeleton.js'
 import { CanvasProperties } from '../components/canvas-properties/CanvasProperties.js'
 import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
+import { DocumentEditorSurface } from '../components/document-editor/DocumentEditorSurface.js'
 import { HistoryCluster } from '../components/history-cluster/HistoryCluster.js'
 import { createSnapshotAliasResolver } from '../components/markdown-editor/alias-resolver.js'
-import { MarkdownEditor } from '../components/markdown-editor/MarkdownEditor.js'
 import { SaveStatusChip } from '../components/SaveStatusChip.js'
 import { CanvasDisplaySettings } from '../components/spatial-editor/CanvasDisplaySettings.js'
 import { SpatialEditor } from '../components/spatial-editor/index.js'
@@ -254,7 +254,6 @@ export function BrowserLocalCanvasPage({
         : [LoroSyncPlugin(markdownDoc.doc, (d) => d.getText('body'))],
     [markdownDoc.doc],
   )
-  const noopChange = useCallback(() => {}, [])
   const currentUpdatedAt = pageState.kind === 'editing' ? pageState.snapshot.updatedAt : null
 
   // [[Name]] resolution for the markdown preview: display names from the
@@ -776,77 +775,75 @@ export function BrowserLocalCanvasPage({
         </Button>
       )}
       <div data-testid="spatial-editor-container" className="relative h-full min-h-0">
-        {canvasKind === 'markdown' ? (
-          markdownDoc.body !== null &&
-          markdownDoc.coreMeta !== null && (
+        <DocumentEditorSurface
+          kind={canvasKind}
+          documentKey={canvasId ?? 'no-canvas'}
+          markdown={
+            markdownDoc.coreMeta === null
+              ? { body: null, setBody: markdownDoc.setBody }
+              : {
+                  body: markdownDoc.body,
+                  setBody: markdownDoc.setBody,
+                  sourceExtensions: markdownBinding,
+                  autoFocus: true,
+                  theme: resolvedTheme,
+                  meta: markdownDoc.coreMeta,
+                  resolveAlias,
+                  onOpenCanvas: (id) => navigate(browserLocalCanvasPath(id)),
+                  resolveEmbed,
+                }
+          }
+          spatial={() => (
             <div className="flex h-full min-h-0 flex-col">
-              <div className="min-h-0 flex-1">
-                <MarkdownEditor
-                  key={canvasId ?? 'no-canvas'}
-                  value={markdownDoc.body}
-                  onChange={markdownBinding === undefined ? markdownDoc.setBody : noopChange}
-                  sourceExtensions={markdownBinding}
-                  autoFocus
-                  className="h-full"
-                  theme={resolvedTheme}
-                  meta={markdownDoc.coreMeta}
-                  resolveAlias={resolveAlias}
-                  onOpenCanvas={(id) => navigate(browserLocalCanvasPath(id))}
-                  resolveEmbed={resolveEmbed}
-                />
-              </div>
-            </div>
-          )
-        ) : (
-          <div className="flex h-full min-h-0 flex-col">
-            <div className="relative min-h-0 flex-1">
-              {/* Keyed on canvas identity: the editor's pan/zoom, in-flight
+              <div className="relative min-h-0 flex-1">
+                {/* Keyed on canvas identity: the editor's pan/zoom, in-flight
                   gesture and open text editor all describe ONE canvas, and
                   `SpatialCanvas` carries no id for the editor to notice a
                   switch by. Without the key, switching canvases silently
                   inherits the previous canvas's viewport. (The markdown
                   branch keys for the same reason.) */}
-              <SpatialEditor
-                key={canvasId ?? 'no-canvas'}
-                // Decided from the canvas's own shape, but only once its
-                // document has loaded — at mount every canvas still looks
-                // empty.
-                initialTool={
-                  canvasLoaded
-                    ? resolveInitialTool({
-                        isEmpty: canvas.nodes.length === 0,
-                        lastTool: readLastTool(),
-                      })
-                    : undefined
-                }
-                canvas={canvas}
-                onChange={onChange}
-                externalVersion={externalVersion}
-                theme={resolvedTheme}
-                // File-node reference = browser-local canvas id; the current
-                // canvas is excluded (a self-reference card is pure noise).
-                fileRefOptions={canvases
-                  .filter((entry) => entry.id !== canvasId)
-                  .map((entry) => ({ file: entry.id, label: entry.name, kind: entry.kind }))}
-                onOpenFileRef={(file) => navigate(browserLocalCanvasPath(file))}
-                missingFileRef={missingFileRef}
-                {...fileSeams}
-                lockedNodeIds={lockedNodeIds}
-                lockedEdgeIds={lockedEdgeIds}
-                onToggleNodeLock={setNodeLock}
-                onToggleEdgeLock={setEdgeLock}
-                paletteLeading={
-                  <HistoryCluster
-                    onUndo={() => void undo()}
-                    onRedo={() => void redo()}
-                    canUndo={canUndo()}
-                    canRedo={canRedo()}
-                  />
-                }
-              />
+                <SpatialEditor
+                  key={canvasId ?? 'no-canvas'}
+                  // Decided from the canvas's own shape, but only once its
+                  // document has loaded — at mount every canvas still looks
+                  // empty.
+                  initialTool={
+                    canvasLoaded
+                      ? resolveInitialTool({
+                          isEmpty: canvas.nodes.length === 0,
+                          lastTool: readLastTool(),
+                        })
+                      : undefined
+                  }
+                  canvas={canvas}
+                  onChange={onChange}
+                  externalVersion={externalVersion}
+                  theme={resolvedTheme}
+                  // File-node reference = browser-local canvas id; the current
+                  // canvas is excluded (a self-reference card is pure noise).
+                  fileRefOptions={canvases
+                    .filter((entry) => entry.id !== canvasId)
+                    .map((entry) => ({ file: entry.id, label: entry.name, kind: entry.kind }))}
+                  onOpenFileRef={(file) => navigate(browserLocalCanvasPath(file))}
+                  missingFileRef={missingFileRef}
+                  {...fileSeams}
+                  lockedNodeIds={lockedNodeIds}
+                  lockedEdgeIds={lockedEdgeIds}
+                  onToggleNodeLock={setNodeLock}
+                  onToggleEdgeLock={setEdgeLock}
+                  paletteLeading={
+                    <HistoryCluster
+                      onUndo={() => void undo()}
+                      onRedo={() => void redo()}
+                      canUndo={canUndo()}
+                      canRedo={canRedo()}
+                    />
+                  }
+                />
+              </div>
             </div>
-          </div>
-        )}
+          )}
+        />
         {/* Markdown canvases keep CodeMirror's own history (its keymap
             already handles undo); the history group rides the spatial
             editor's dock via paletteLeading above. */}

--- a/apps/web/src/pages/DaemonCanvasPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.markdown.browser.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * Daemon-mode markdown 導線 (real CodeMirror): a markdown-kind document
+ * served by the daemon opens in the markdown editor, and typing into it
+ * reaches the backend as ordinary local updates on the SAME doc the
+ * snapshot hydrated — the sync session's forwarding, not a second write
+ * path. The backend is fake (this suite's subject is the page wiring, not
+ * the transport); MarkdownEditor is REAL because CodeMirror's input path
+ * is exactly what jsdom cannot exercise.
+ */
+import type { SpatialCanvas } from '@kamiazya/whiteboard-canvas-model'
+import {
+  markdownBodyFromCanvas,
+  readSpatialCanvas,
+  writeCoreFacets,
+  writeDocumentKind,
+  writeSpatialCanvas,
+} from '@kamiazya/whiteboard-canvas-workspace'
+import type {
+  CanvasBackend,
+  CanvasBackendHandlers,
+} from '@kamiazya/whiteboard-mcp/browser-contract'
+import { cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import { LoroDoc } from 'loro-crdt'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import * as daemonApiClient from '../lib/daemon-api-client.js'
+import '../index.css'
+
+function render(ui: ReactElement) {
+  return rtlRender(
+    <div style={{ height: '100vh' }}>
+      <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
+    </div>,
+  )
+}
+
+vi.mock('../lib/daemon-api-client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/daemon-api-client.js')>()
+  return {
+    ...actual,
+    listWorkspaces: vi.fn(),
+    listCanvases: vi.fn(),
+    createCanvas: vi.fn(),
+  }
+})
+
+vi.mock('../components/spatial-editor/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../components/spatial-editor/index.js')>()
+  return {
+    ...actual,
+    SpatialEditor: (_props: { canvas: SpatialCanvas }) => <div data-testid="mock-spatial-editor" />,
+  }
+})
+
+const { DaemonCanvasPage } = await import('./DaemonCanvasPage.js')
+
+const mockListWorkspaces = vi.mocked(daemonApiClient.listWorkspaces)
+const mockListCanvases = vi.mocked(daemonApiClient.listCanvases)
+
+const BODY = '# Hello from an agent'
+
+/** The daemon shape: body as the okf-body node, kind stored on the doc. */
+function markdownSnapshot(): Uint8Array {
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, {
+    nodes: [{ id: 'okf-body', type: 'text', x: 0, y: 0, width: 600, height: 400, text: BODY }],
+    edges: [],
+  })
+  writeCoreFacets(doc, { type: 'markdown' })
+  writeDocumentKind(doc, 'markdown')
+  return doc.export({ mode: 'snapshot' })
+}
+
+class FakeBackend implements CanvasBackend {
+  readonly pushed: Uint8Array[] = []
+  // The exact bytes the page hydrated from: the replay assertion must
+  // import updates into the SAME doc lineage, not a structurally-equal
+  // rebuild with different Loro op ids.
+  snapshot: Uint8Array = new Uint8Array()
+  connect(handlers: CanvasBackendHandlers): void {
+    handlers.onConnected()
+    this.snapshot = markdownSnapshot()
+    handlers.onSnapshot(this.snapshot)
+  }
+  disconnect(): void {}
+  pushLocalUpdate(update: Uint8Array): void {
+    this.pushed.push(update)
+  }
+  getFile(): Promise<Blob | null> {
+    return Promise.resolve(null)
+  }
+  putFile(): Promise<void> {
+    return Promise.resolve()
+  }
+  sendClientReady(): void {}
+  sendExportResponse(): void {}
+}
+
+const DAEMON_BASE_URL = 'http://127.0.0.1:3099'
+
+describe('DaemonCanvasPage markdown editing', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
+    mockListCanvases.mockResolvedValue({
+      canvases: [{ slug: 'agent-note', id: 'id-note', updatedAt: '2026-01-01', kind: 'markdown' }],
+    })
+  })
+  afterEach(() => {
+    cleanup()
+    window.localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('typing into the daemon markdown editor pushes the edit to the backend as a doc update', async () => {
+    const backend = new FakeBackend()
+    render(
+      <DaemonCanvasPage
+        daemonBaseUrl={DAEMON_BASE_URL}
+        workspaceId="w1"
+        slug="agent-note"
+        createBackend={() => backend}
+      />,
+    )
+
+    // Markdown editor mounts with the daemon-held body; spatial never does.
+    const editable = await waitFor(
+      () => {
+        const el = document.querySelector('[contenteditable="true"]')
+        expect(el).not.toBeNull()
+        return el as HTMLElement
+      },
+      { timeout: 10_000 },
+    )
+    await waitFor(() => {
+      expect(document.querySelector('.cm-content')?.textContent).toBe(BODY)
+    })
+    expect(screen.queryByTestId('mock-spatial-editor')).toBeNull()
+
+    await userEvent.click(editable)
+    await waitFor(() => expect(document.activeElement).toBe(editable), { timeout: 10_000 })
+    // A click lands the cursor wherever the pointer hit; pin it to the end
+    // so the typed suffix has one deterministic destination.
+    await userEvent.keyboard('{Control>}{End}{/Control}')
+    await userEvent.keyboard(' — edited here')
+
+    // The edit reaches the backend through the session's own local-update
+    // forwarding: replaying pushed updates over the original snapshot must
+    // yield the typed body in the okf-body node (the daemon storage shape).
+    await waitFor(
+      () => {
+        expect(backend.pushed.length).toBeGreaterThan(0)
+        const replay = new LoroDoc()
+        replay.import(backend.snapshot)
+        for (const update of backend.pushed) replay.import(update)
+        expect(markdownBodyFromCanvas(readSpatialCanvas(replay))).toBe(`${BODY} — edited here`)
+      },
+      { timeout: 10_000 },
+    )
+  })
+})

--- a/apps/web/src/pages/DaemonCanvasPage.markdown.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.markdown.test.tsx
@@ -69,17 +69,26 @@ function markdownSnapshot(): Uint8Array {
     ],
     edges: [],
   })
-  writeCoreFacets(doc, { type: 'markdown' })
+  writeCoreFacets(doc, { type: 'markdown', title: 'Agent verification note' })
   writeDocumentKind(doc, 'markdown')
+  return doc.export({ mode: 'snapshot' })
+}
+
+/** A daemon-held spatial document: empty canvas, stored kind. */
+function spatialSnapshot(): Uint8Array {
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, { nodes: [], edges: [] })
+  writeDocumentKind(doc, 'spatial')
   return doc.export({ mode: 'snapshot' })
 }
 
 class FakeBackend implements CanvasBackend {
   handlers: CanvasBackendHandlers | null = null
+  constructor(private readonly snapshot: () => Uint8Array = markdownSnapshot) {}
   connect(handlers: CanvasBackendHandlers): void {
     this.handlers = handlers
     handlers.onConnected()
-    handlers.onSnapshot(markdownSnapshot())
+    handlers.onSnapshot(this.snapshot())
   }
   disconnect(): void {}
   pushLocalUpdate(): void {}
@@ -141,5 +150,46 @@ describe('DaemonCanvasPage markdown documents', () => {
       )
     })
     await waitFor(() => expect(document.body.textContent).toContain('Hello from an agent'))
+  })
+
+  // The top-bar title slot: canvas identity lives in the merged header row,
+  // backed by the sync session's core facets (mirrors the browser-local page).
+  it('shows the document title from core facets and the facets disclosure for markdown', async () => {
+    await act(async () => {
+      render(
+        <DaemonCanvasPage
+          daemonBaseUrl={DAEMON_BASE_URL}
+          workspaceId="w1"
+          slug="agent-note"
+          createBackend={() => new FakeBackend()}
+        />,
+        { container: document.body },
+      )
+    })
+    await waitFor(() => {
+      const title = screen.getByPlaceholderText('Untitled') as HTMLInputElement
+      expect(title.value).toBe('Agent verification note')
+    })
+    // Facets are OKF frontmatter, so a markdown document gets the disclosure.
+    expect(screen.getByLabelText('Properties')).toBeTruthy()
+  })
+
+  it('hides the facets disclosure for a spatial document (no OKF frontmatter to hold)', async () => {
+    mockListCanvases.mockResolvedValue({
+      canvases: [{ slug: 'board', id: 'id-board', updatedAt: '2026-01-01', kind: 'spatial' }],
+    })
+    await act(async () => {
+      render(
+        <DaemonCanvasPage
+          daemonBaseUrl={DAEMON_BASE_URL}
+          workspaceId="w1"
+          slug="board"
+          createBackend={() => new FakeBackend(spatialSnapshot)}
+        />,
+        { container: document.body },
+      )
+    })
+    await waitFor(() => expect(screen.getByPlaceholderText('Untitled')).toBeTruthy())
+    expect(screen.queryByLabelText('Properties')).toBeNull()
   })
 })

--- a/apps/web/src/pages/DaemonCanvasPage.markdown.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.markdown.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * A markdown-kind document opened in daemon mode must get the MARKDOWN
+ * editor. Before this branch existed the page always mounted SpatialEditor,
+ * so a note created by an agent (wb_document_create + wb_body_patch) opened
+ * as an empty spatial canvas — and drawing on it corrupted the document.
+ */
+
+import {
+  writeCoreFacets,
+  writeDocumentKind,
+  writeSpatialCanvas,
+} from '@kamiazya/whiteboard-canvas-workspace'
+import type {
+  CanvasBackend,
+  CanvasBackendHandlers,
+} from '@kamiazya/whiteboard-mcp/browser-contract'
+import {
+  act,
+  cleanup,
+  type RenderOptions,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { LoroDoc } from 'loro-crdt'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as daemonApiClient from '../lib/daemon-api-client.js'
+
+function render(ui: ReactElement, options?: RenderOptions) {
+  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>, options)
+}
+
+vi.mock('../lib/daemon-api-client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/daemon-api-client.js')>()
+  return {
+    ...actual,
+    listWorkspaces: vi.fn(),
+    listCanvases: vi.fn(),
+    createCanvas: vi.fn(),
+  }
+})
+
+const { DaemonCanvasPage } = await import('./DaemonCanvasPage.js')
+
+const mockListWorkspaces = vi.mocked(daemonApiClient.listWorkspaces)
+const mockListCanvases = vi.mocked(daemonApiClient.listCanvases)
+
+/**
+ * A daemon-held markdown document in the shape `wb_document_set` actually
+ * writes: the body as the single `okf-body` text node of the spatial
+ * canvas (NOT the browser-local `body` text container), plus core facets
+ * and the stored kind.
+ */
+function markdownSnapshot(): Uint8Array {
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, {
+    nodes: [
+      {
+        id: 'okf-body',
+        type: 'text',
+        x: 0,
+        y: 0,
+        width: 600,
+        height: 400,
+        text: '# Hello from an agent',
+      },
+    ],
+    edges: [],
+  })
+  writeCoreFacets(doc, { type: 'markdown' })
+  writeDocumentKind(doc, 'markdown')
+  return doc.export({ mode: 'snapshot' })
+}
+
+class FakeBackend implements CanvasBackend {
+  handlers: CanvasBackendHandlers | null = null
+  connect(handlers: CanvasBackendHandlers): void {
+    this.handlers = handlers
+    handlers.onConnected()
+    handlers.onSnapshot(markdownSnapshot())
+  }
+  disconnect(): void {}
+  pushLocalUpdate(): void {}
+  getFile(): Promise<Blob | null> {
+    return Promise.resolve(null)
+  }
+  putFile(): Promise<void> {
+    return Promise.resolve()
+  }
+  sendClientReady(): void {}
+  sendExportResponse(): void {}
+}
+
+const DAEMON_BASE_URL = 'http://127.0.0.1:3099'
+
+describe('DaemonCanvasPage markdown documents', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
+    mockListCanvases.mockResolvedValue({
+      canvases: [{ slug: 'agent-note', id: 'id-note', updatedAt: '2026-01-01', kind: 'markdown' }],
+    })
+  })
+  afterEach(() => {
+    cleanup()
+    window.localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('opens a markdown-kind document in the markdown editor, never the spatial editor', async () => {
+    await act(async () => {
+      render(
+        <DaemonCanvasPage
+          daemonBaseUrl={DAEMON_BASE_URL}
+          workspaceId="w1"
+          slug="agent-note"
+          createBackend={() => new FakeBackend()}
+        />,
+        { container: document.body },
+      )
+    })
+
+    // The markdown editor's source pane is the positive signal; the spatial
+    // editor's absence is what stops a stray stroke from corrupting the doc.
+    await waitFor(() => expect(screen.getByTestId('markdown-source-wrap')).toBeTruthy())
+    expect(screen.queryByTestId('spatial-editor')).toBeNull()
+  })
+
+  it('shows the daemon-held body text', async () => {
+    await act(async () => {
+      render(
+        <DaemonCanvasPage
+          daemonBaseUrl={DAEMON_BASE_URL}
+          workspaceId="w1"
+          slug="agent-note"
+          createBackend={() => new FakeBackend()}
+        />,
+        { container: document.body },
+      )
+    })
+    await waitFor(() => expect(document.body.textContent).toContain('Hello from an agent'))
+  })
+})

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -1,4 +1,8 @@
-import { isImageRef } from '@kamiazya/whiteboard-canvas-model'
+import { type CanvasKind, isImageRef } from '@kamiazya/whiteboard-canvas-model'
+import {
+  canvasWithMarkdownBody,
+  markdownBodyFromCanvas,
+} from '@kamiazya/whiteboard-canvas-workspace'
 import { canvasesApiUrl, saveVersionResponseSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
 import type { CanvasBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
 import { DaemonBackend } from '@kamiazya/whiteboard-mcp/daemon-backend'
@@ -6,18 +10,25 @@ import { selectCanvasTransport } from '@kamiazya/whiteboard-mcp/select-canvas-tr
 import { SseBackend } from '@kamiazya/whiteboard-mcp/sse-backend'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { CanvasPageSkeleton } from '../components/CanvasPageSkeleton.js'
+import { CanvasProperties } from '../components/canvas-properties/CanvasProperties.js'
 import { CapabilityTeaser } from '../components/capability-teaser/CapabilityTeaser.js'
 import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
+import { DocumentEditorSurface } from '../components/document-editor/DocumentEditorSurface.js'
 import { ErrorBoundary } from '../components/ErrorBoundary.js'
 import { HeaderBranchBanner } from '../components/HeaderBranchBanner.js'
 import { HistoryCluster } from '../components/history-cluster/HistoryCluster.js'
 import { MergeToast } from '../components/MergeToast.js'
+import { createSnapshotAliasResolver } from '../components/markdown-editor/alias-resolver.js'
 import type { SpatialEditorHandle } from '../components/spatial-editor/index.js'
 import { SpatialEditor } from '../components/spatial-editor/index.js'
 import { Button } from '../components/ui/button.js'
 import WorkspaceTopBar from '../components/WorkspaceTopBar.js'
 import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
 import { useCanvasFileSeams } from '../hooks/use-canvas-file-seams.js'
+import {
+  type MarkdownEmbedLoader,
+  useMarkdownEmbedContent,
+} from '../hooks/use-markdown-embed-content.js'
 import { dispatchIdentityEvent, useCanvasSync } from '../hooks/useCanvasSync.js'
 import { useDirtyState } from '../hooks/useDirtyState.js'
 import { useFavicon } from '../hooks/useFavicon.js'
@@ -231,6 +242,8 @@ export function DaemonCanvasPage({
     setNodeLock,
     lockedEdgeIds,
     setEdgeLock,
+    coreFacets,
+    setCoreFacets,
     syncStatus,
   } = useCanvasSync(backend, {
     onAuthError: () => setAuthError(true),
@@ -267,22 +280,24 @@ export function DaemonCanvasPage({
     return (ref: string) => !isImageRef(ref) && !known.has(ref)
   }, [controller.canvases])
 
+  const fileAdapter = useMemo(
+    () =>
+      createDaemonFileAdapter({
+        daemonFetch,
+        daemonBaseUrl,
+        workspaceId: canvas?.workspaceId ?? '',
+        slug: canvas?.slug ?? '',
+        resolveRefSlug,
+      }),
+    [daemonFetch, daemonBaseUrl, canvas?.workspaceId, canvas?.slug, resolveRefSlug],
+  )
+
   // Canvas embeds (J5a) and image nodes (J5b), over the daemon's own file and
   // snapshot routes. The staleness stamp is the referenced canvas's
   // updatedAt, exactly as in browser-local mode.
   const fileSeams = useCanvasFileSeams({
     canvas: canvasValue,
-    adapter: useMemo(
-      () =>
-        createDaemonFileAdapter({
-          daemonFetch,
-          daemonBaseUrl,
-          workspaceId: canvas?.workspaceId ?? '',
-          slug: canvas?.slug ?? '',
-          resolveRefSlug,
-        }),
-      [daemonFetch, daemonBaseUrl, canvas?.workspaceId, canvas?.slug, resolveRefSlug],
-    ),
+    adapter: fileAdapter,
     // Keyed by BOTH id and slug so id refs and legacy slug refs each find
     // their staleness stamp.
     stampOf: useMemo(
@@ -295,6 +310,64 @@ export function DaemonCanvasPage({
         ),
       [controller.canvases],
     ),
+  })
+
+  // The open document's kind, from the canvases list summary (default
+  // 'spatial'). It picks which editor DocumentEditorSurface mounts — the
+  // page itself no longer chooses an editor.
+  const documentKind: CanvasKind =
+    controller.canvases.find((entry) => entry.slug === controller.slug)?.kind ?? 'spatial'
+
+  // A markdown document's body lives in the canvas's single `okf-body` text
+  // node (the shape wb_document_set writes), so reads derive from the same
+  // synced canvas the spatial editor uses and writes travel the session's
+  // ordinary command path — debounce, undo and local-update forwarding
+  // included, with no second write pipeline. The ref keeps setMarkdownBody
+  // total under bursts: `next` is the whole body, so a canvas one commit
+  // behind only affects node identity, never content.
+  const canvasValueRef = useRef(canvasValue)
+  canvasValueRef.current = canvasValue
+  const setMarkdownBody = useCallback(
+    (next: string) => {
+      const {
+        canvas: nextCanvas,
+        node,
+        created,
+      } = canvasWithMarkdownBody(canvasValueRef.current, next)
+      onChange(
+        nextCanvas,
+        created ? { kind: 'create-node', node } : { kind: 'set-text', id: node.id, text: next },
+      )
+    },
+    [onChange],
+  )
+  const markdownBody =
+    documentKind === 'markdown' && canvasLoaded ? markdownBodyFromCanvas(canvasValue) : null
+
+  // `[[Name]]` aliases resolve against the same list the user can see; the
+  // daemon summary carries no display name yet, so the slug doubles as one.
+  const resolveAlias = useMemo(
+    () =>
+      createSnapshotAliasResolver(
+        controller.canvases.map((entry) => ({ id: entry.id ?? entry.slug, name: entry.slug })),
+      ),
+    [controller.canvases],
+  )
+  const loadEmbedSource = useCallback<MarkdownEmbedLoader>(
+    async (canvasId) => {
+      const target = await fileAdapter.loadDocument(canvasId)
+      if (target?.body === undefined) return undefined
+      return {
+        body: target.body,
+        ...(target.facets?.title !== undefined ? { title: target.facets.title } : {}),
+      }
+    },
+    [fileAdapter],
+  )
+  const resolveEmbed = useMarkdownEmbedContent({
+    body: markdownBody ?? '',
+    resolveAlias,
+    load: loadEmbedSource,
   })
 
   const commands = useWhiteboardCommands({
@@ -518,6 +591,21 @@ export function DaemonCanvasPage({
           {canvas && (
             <WorkspaceTopBar
               statusSlot={connectionStatus}
+              // Canvas identity (title + core facets) in the merged header
+              // row, mirroring the browser-local page. Facets are OKF
+              // frontmatter, so only markdown documents get the disclosure
+              // (ADR-0009 decision 3); writes travel the sync session's
+              // facet path. The daemon summary has no display name, so the
+              // title here is the document's own core facet, not a rename.
+              titleSlot={
+                <CanvasProperties
+                  inline
+                  key={`${canvas.workspaceId}/${canvas.slug}`}
+                  showFacets={documentKind === 'markdown'}
+                  meta={coreFacets ?? { type: documentKind }}
+                  onChange={setCoreFacets}
+                />
+              }
               workspaceId={canvas.workspaceId}
               slug={canvas.slug}
               canvases={controller.canvases}
@@ -663,74 +751,86 @@ export function DaemonCanvasPage({
             </Button>
           </div>
         ) : (
-          // Spatial is the only view this slice supports; markdown-view
-          // persistence is deferred (canvas-workspace has no markdown-body
-          // container to write to yet).
-          <div data-testid="spatial-editor-container" className="relative h-full min-h-0">
-            {/* Keyed on canvas identity: the editor's pan/zoom, in-flight
+          <DocumentEditorSurface
+            kind={documentKind}
+            documentKey={canvas ? `${canvas.workspaceId}/${canvas.slug}` : 'no-canvas'}
+            markdown={{
+              body: markdownBody,
+              setBody: setMarkdownBody,
+              theme: resolvedTheme,
+              meta: coreFacets ?? { type: documentKind },
+              resolveAlias,
+              onOpenCanvas: (id) => controller.switchCanvas(resolveRefSlug(id) ?? id),
+              resolveEmbed,
+            }}
+            spatial={() => (
+              <div data-testid="spatial-editor-container" className="relative h-full min-h-0">
+                {/* Keyed on canvas identity: the editor's pan/zoom, in-flight
                 gesture and open text editor all describe ONE canvas, and
                 `SpatialCanvas` carries no id for the editor to notice a switch
                 by. Without the key, switching canvases silently inherits the
                 previous canvas's viewport. */}
-            <SpatialEditor
-              key={canvas ? `${canvas.workspaceId}/${canvas.slug}` : 'no-canvas'}
-              // Decided from the canvas's own shape, but only once its
-              // document has loaded — at mount every canvas still looks
-              // empty.
-              initialTool={
-                canvasLoaded
-                  ? resolveInitialTool({
-                      isEmpty: canvasValue.nodes.length === 0,
-                      lastTool: readLastTool(),
-                    })
-                  : undefined
-              }
-              ref={spatialEditorRef}
-              canvas={canvasValue}
-              onChange={onChange}
-              externalVersion={externalVersion}
-              theme={resolvedTheme}
-              // File-node reference = the target's immutable id (rename-
-              // safe); the label shows its current slug and the current
-              // canvas is excluded. Legacy documents still carry slug refs,
-              // which resolveRefSlug misses and switchCanvas takes as-is.
-              // An older daemon's list has no ids yet; those entries fall
-              // back to slug refs (same behavior as before ids existed).
-              fileRefOptions={controller.canvases
-                .filter((entry) => entry.slug !== canvas?.slug)
-                .map((entry) => ({
-                  file: entry.id ?? entry.slug,
-                  label: entry.slug,
-                  kind: entry.kind,
-                }))}
-              onOpenFileRef={(file) => controller.switchCanvas(resolveRefSlug(file) ?? file)}
-              missingFileRef={missingFileRef}
-              {...fileSeams}
-              lockedNodeIds={lockedNodeIds}
-              lockedEdgeIds={lockedEdgeIds}
-              onToggleNodeLock={setNodeLock}
-              onToggleEdgeLock={setEdgeLock}
-              paletteLeading={
-                <HistoryCluster
-                  onUndo={() => void undo()}
-                  onRedo={() => void redo()}
-                  canUndo={canUndo()}
-                  canRedo={canRedo()}
-                  versions={
-                    capabilities.versions && canvas
-                      ? {
-                          workspaceId: canvas.workspaceId,
-                          slug: canvas.slug,
-                          onRestored: clearLocalUndo,
-                          refreshSignal: versionRefreshSignal,
-                          versionPanelExtra,
-                        }
+                <SpatialEditor
+                  key={canvas ? `${canvas.workspaceId}/${canvas.slug}` : 'no-canvas'}
+                  // Decided from the canvas's own shape, but only once its
+                  // document has loaded — at mount every canvas still looks
+                  // empty.
+                  initialTool={
+                    canvasLoaded
+                      ? resolveInitialTool({
+                          isEmpty: canvasValue.nodes.length === 0,
+                          lastTool: readLastTool(),
+                        })
                       : undefined
                   }
+                  ref={spatialEditorRef}
+                  canvas={canvasValue}
+                  onChange={onChange}
+                  externalVersion={externalVersion}
+                  theme={resolvedTheme}
+                  // File-node reference = the target's immutable id (rename-
+                  // safe); the label shows its current slug and the current
+                  // canvas is excluded. Legacy documents still carry slug refs,
+                  // which resolveRefSlug misses and switchCanvas takes as-is.
+                  // An older daemon's list has no ids yet; those entries fall
+                  // back to slug refs (same behavior as before ids existed).
+                  fileRefOptions={controller.canvases
+                    .filter((entry) => entry.slug !== canvas?.slug)
+                    .map((entry) => ({
+                      file: entry.id ?? entry.slug,
+                      label: entry.slug,
+                      kind: entry.kind,
+                    }))}
+                  onOpenFileRef={(file) => controller.switchCanvas(resolveRefSlug(file) ?? file)}
+                  missingFileRef={missingFileRef}
+                  {...fileSeams}
+                  lockedNodeIds={lockedNodeIds}
+                  lockedEdgeIds={lockedEdgeIds}
+                  onToggleNodeLock={setNodeLock}
+                  onToggleEdgeLock={setEdgeLock}
+                  paletteLeading={
+                    <HistoryCluster
+                      onUndo={() => void undo()}
+                      onRedo={() => void redo()}
+                      canUndo={canUndo()}
+                      canRedo={canRedo()}
+                      versions={
+                        capabilities.versions && canvas
+                          ? {
+                              workspaceId: canvas.workspaceId,
+                              slug: canvas.slug,
+                              onRestored: clearLocalUndo,
+                              refreshSignal: versionRefreshSignal,
+                              versionPanelExtra,
+                            }
+                          : undefined
+                      }
+                    />
+                  }
                 />
-              }
-            />
-          </div>
+              </div>
+            )}
+          />
         )}
         {capabilities.merge && canvas && (
           <MergeToast

--- a/packages/canvas-workspace/src/index.ts
+++ b/packages/canvas-workspace/src/index.ts
@@ -1,7 +1,9 @@
 export {
+  canvasWithMarkdownBody,
   deleteSpatialEdge,
   deleteSpatialNode,
   MARKDOWN_BODY_NODE_ID,
+  markdownBodyFromCanvas,
   readCoreFacets,
   readDocumentKind,
   readEdgeLocks,

--- a/packages/canvas-workspace/src/loro-bridge.ts
+++ b/packages/canvas-workspace/src/loro-bridge.ts
@@ -567,7 +567,12 @@ export function canvasWithMarkdownBody(
     ...MARKDOWN_BODY_NODE_FRAME,
     text: body,
   }
-  return { canvas: { ...canvas, nodes: [...canvas.nodes, node] }, node, created: true }
+  // The reserved id belongs to the body. A NON-text node squatting on it is
+  // already unreadable as a body (the read path ignores it), so it is
+  // replaced rather than duplicated — two nodes sharing an id would make
+  // the keyed-by-id persistence layer silently drop one of them.
+  const withoutSquatter = canvas.nodes.filter((candidate) => candidate.id !== node.id)
+  return { canvas: { ...canvas, nodes: [...withoutSquatter, node] }, node, created: true }
 }
 
 /**

--- a/packages/canvas-workspace/src/loro-bridge.ts
+++ b/packages/canvas-workspace/src/loro-bridge.ts
@@ -507,10 +507,67 @@ export function readMarkdownBody(doc: LoroDoc): string {
   const container = doc.getText(MARKDOWN_BODY_KEY).toString()
   if (container.length > 0) return container
 
-  const { nodes } = readSpatialCanvas(doc)
+  return markdownBodyFromCanvas(readSpatialCanvas(doc))
+}
+
+type SpatialTextNode = Extract<SpatialNode, { type: 'text' }>
+
+/**
+ * The node a markdown document's body lives in, given an already-read
+ * canvas: the stable id first, then the first text node (pre-stable-id
+ * documents), matching `readMarkdownBody`'s node-side selection exactly.
+ */
+function findMarkdownBodyNode(nodes: SpatialCanvas['nodes']): SpatialTextNode | undefined {
   const byId = nodes.find((node) => node.id === MARKDOWN_BODY_NODE_ID)
-  if (byId?.type === 'text') return byId.text
-  return nodes.find((node) => node.type === 'text')?.text ?? ''
+  if (byId?.type === 'text') return byId
+  return nodes.find((node): node is SpatialTextNode => node.type === 'text')
+}
+
+/**
+ * The node-side half of `readMarkdownBody`, for callers that already hold
+ * the canvas (a live sync session, say) and must not re-read the doc.
+ */
+export function markdownBodyFromCanvas(canvas: SpatialCanvas): string {
+  return findMarkdownBodyNode(canvas.nodes)?.text ?? ''
+}
+
+/**
+ * The geometry `wb_document_set` gives the single body node — the UI's
+ * created node must match, or which side wrote a body would be visible in
+ * its layout.
+ */
+const MARKDOWN_BODY_NODE_FRAME = { x: 0, y: 0, width: 600, height: 400 } as const
+
+/**
+ * An immutable canvas update that stores `body` where the daemon side
+ * keeps a markdown document's body: the existing body node when there is
+ * one (geometry untouched — `wb_body_patch` edits in place the same way),
+ * else a fresh `okf-body` node. `created` tells the caller which happened,
+ * so an editor command can say create-node vs set-text truthfully.
+ */
+export function canvasWithMarkdownBody(
+  canvas: SpatialCanvas,
+  body: string,
+): { canvas: SpatialCanvas; node: SpatialTextNode; created: boolean } {
+  const existing = findMarkdownBodyNode(canvas.nodes)
+  if (existing) {
+    const node: SpatialTextNode = { ...existing, text: body }
+    return {
+      canvas: {
+        ...canvas,
+        nodes: canvas.nodes.map((candidate) => (candidate.id === existing.id ? node : candidate)),
+      },
+      node,
+      created: false,
+    }
+  }
+  const node: SpatialTextNode = {
+    id: MARKDOWN_BODY_NODE_ID,
+    type: 'text',
+    ...MARKDOWN_BODY_NODE_FRAME,
+    text: body,
+  }
+  return { canvas: { ...canvas, nodes: [...canvas.nodes, node] }, node, created: true }
 }
 
 /**

--- a/packages/canvas-workspace/src/markdown-body.test.ts
+++ b/packages/canvas-workspace/src/markdown-body.test.ts
@@ -125,4 +125,23 @@ describe('canvasWithMarkdownBody', () => {
     const { canvas } = canvasWithMarkdownBody({ nodes: [], edges: [] }, BODY)
     expect(markdownBodyFromCanvas(canvas)).toBe(BODY)
   })
+
+  it('replaces a non-text node squatting on the reserved id instead of duplicating it', () => {
+    // Mirrors the read path's 'ignores a non-text node' case: a file node
+    // holding okf-body is unreadable as a body, and the write must not
+    // produce two nodes with one id (keyed persistence would drop one).
+    const squatter = {
+      id: 'okf-body',
+      type: 'file',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      file: 'x',
+    } as const
+    const { canvas, node, created } = canvasWithMarkdownBody({ nodes: [squatter], edges: [] }, BODY)
+    expect(created).toBe(true)
+    expect(canvas.nodes).toEqual([node])
+    expect(markdownBodyFromCanvas(canvas)).toBe(BODY)
+  })
 })

--- a/packages/canvas-workspace/src/markdown-body.test.ts
+++ b/packages/canvas-workspace/src/markdown-body.test.ts
@@ -11,7 +11,12 @@
 // not have to know which side wrote it.
 import { LoroDoc } from 'loro-crdt'
 import { describe, expect, it } from 'vitest'
-import { readMarkdownBody, writeSpatialCanvas } from './loro-bridge.js'
+import {
+  canvasWithMarkdownBody,
+  markdownBodyFromCanvas,
+  readMarkdownBody,
+  writeSpatialCanvas,
+} from './loro-bridge.js'
 
 const BODY = '# Weekly notes\n\nShipped the markdown file node.'
 
@@ -69,5 +74,55 @@ describe('readMarkdownBody', () => {
       edges: [],
     })
     expect(readMarkdownBody(doc)).toBe('')
+  })
+})
+
+const bodyNode = (text: string) =>
+  ({ id: 'okf-body', type: 'text', x: 0, y: 0, width: 600, height: 400, text }) as const
+
+describe('markdownBodyFromCanvas', () => {
+  it('reads the okf-body text node', () => {
+    expect(markdownBodyFromCanvas({ nodes: [bodyNode(BODY)], edges: [] })).toBe(BODY)
+  })
+
+  it('falls back to the first text node for a document written before the id was stable', () => {
+    const legacy = { ...bodyNode(BODY), id: 'legacy' }
+    expect(markdownBodyFromCanvas({ nodes: [legacy], edges: [] })).toBe(BODY)
+  })
+
+  it('answers with the empty string for a canvas with no text node', () => {
+    expect(markdownBodyFromCanvas({ nodes: [], edges: [] })).toBe('')
+  })
+})
+
+describe('canvasWithMarkdownBody', () => {
+  it('replaces the body node text, preserving its geometry', () => {
+    const before = { nodes: [{ ...bodyNode('old'), x: 40, width: 320 }], edges: [] }
+    const { canvas, node, created } = canvasWithMarkdownBody(before, 'new body')
+    expect(created).toBe(false)
+    expect(node).toEqual({ ...bodyNode('new body'), x: 40, width: 320 })
+    expect(canvas.nodes).toEqual([node])
+    // Immutable update: the input canvas is untouched.
+    expect(before.nodes[0]?.text).toBe('old')
+  })
+
+  it('targets the first text node in a legacy document without the stable id', () => {
+    const legacy = { ...bodyNode('old'), id: 'legacy' }
+    const { canvas, node, created } = canvasWithMarkdownBody({ nodes: [legacy], edges: [] }, 'new')
+    expect(created).toBe(false)
+    expect(node.id).toBe('legacy')
+    expect(canvas.nodes[0]?.type === 'text' && canvas.nodes[0].text).toBe('new')
+  })
+
+  it('creates the okf-body node when the document has none', () => {
+    const { canvas, node, created } = canvasWithMarkdownBody({ nodes: [], edges: [] }, BODY)
+    expect(created).toBe(true)
+    expect(node).toEqual(bodyNode(BODY))
+    expect(canvas.nodes).toEqual([node])
+  })
+
+  it('round-trips through markdownBodyFromCanvas', () => {
+    const { canvas } = canvasWithMarkdownBody({ nodes: [], edges: [] }, BODY)
+    expect(markdownBodyFromCanvas(canvas)).toBe(BODY)
   })
 })


### PR DESCRIPTION
## What

A markdown-kind document opened in daemon mode used to mount the SPATIAL editor unconditionally — a note created by an agent (`wb_document_create` + `wb_document_set`) opened as a drawing canvas, and a stray stroke corrupted the document. This PR wires the markdown editor into `DaemonCanvasPage`, mounts `CanvasProperties` in the daemon top bar, and abstracts the choice behind a shared component so this class of wiring gap cannot recur.

- **`DocumentEditorSurface`** (new): the one kind switch between a document and its editor. `markdown` is a **required** prop and the switch is never-default over `CanvasKind` — a page cannot mount the surface without deciding what markdown looks like on its backend, and a third kind fails compilation in the one place every page shares.
- **Daemon markdown storage-shape aware**: the body lives in the canvas's single `okf-body` text node (the shape `wb_document_set` writes — NOT the browser-local `body` text container). Reads derive from the same synced canvas the spatial editor uses (`markdownBodyFromCanvas`); writes travel the sync session's ordinary command path (`set-text` / `create-node` via `canvasWithMarkdownBody`), so debounce, undo and local-update forwarding are the same pipeline spatial edits use — no second write path.
- **`CanvasProperties` in the daemon top bar** (audit MEDIUM): title + facets, backed by the session's existing `coreFacets`/`setCoreFacets`; facet disclosure only for markdown (ADR-0009 decision 3).
- `BrowserLocalCanvasPage`'s inline kind branch is deleted in favor of the surface (deletion is the enforcement).

## Tests

- `canvas-workspace-node`: `markdownBodyFromCanvas` + `canvasWithMarkdownBody` unit tests; `readMarkdownBody` refactored through the same node selection (existing tests unchanged).
- jsdom: `DaemonCanvasPage.markdown.test.tsx` (red-first — markdown-kind doc mounts the markdown editor, never spatial; daemon-held body visible) + `DocumentEditorSurface.test.tsx`.
- browser-mode: `DaemonCanvasPage.markdown.browser.test.tsx` — real CodeMirror typing; pushed updates replayed over the hydration snapshot yield the typed body in the `okf-body` node.
- Suites: apps/web jsdom 2212+77 green, web-browser 573/574 (one failure in `BrowserLocalCanvasPage.markdown.browser.test.tsx` under full parallel load only — different test each run, passes standalone 9/9; that file has a documented flake history, see #814/#818. Watching, not waving through: if CI reproduces it, it gets the flake protocol).
- Root `pnpm test`, `pnpm knip`, typecheck: green.

## Visual repro

Same daemon document (`wb_document_create` + body written server-side), before and after.

**Before** — markdown note opens as an empty spatial canvas (drawing here corrupts the document):

![daemon-markdown-before-spatial.png](https://github.com/user-attachments/assets/fb19086f-abdd-48f5-99d3-bb68f88b6688)

**After** — markdown editor with the daemon-held body; typed edit synced back and read via MCP; title from core facets in the top bar:

![daemon-markdown-typed.png](https://github.com/user-attachments/assets/e1725d2f-317e-4334-a27c-23dbf951f553)

Verified end-to-end against the production bundle + real daemon over a single stable WS connection (typing in the UI persists daemon-side and reads back over the sync channel).

## Known adjacent issues (not this PR)

- MCP-created documents are stored under `canvas:<ULID>` while the slug snapshot/WS routes serve a separate empty doc — previously filed; verification seeded the slug-keyed doc directly over the sync channel to work around it.
- `pnpm dev` (vite) + `#wb=` bootstrap flow enters a WS reconnect loop (~2000 socket opens in 12s) — reproduces on unmodified `main`; filed as a whiteboard issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Markdown document editing for local and daemon-backed canvases.
  - Markdown content now loads from saved documents and persists edits back to the canvas.
  - Unified editing experience supports switching between spatial and Markdown documents.
  - Document metadata, aliases, and embeds are available while editing Markdown documents.

- **Bug Fixes**
  - Improved Markdown content hydration and editor reset behavior when switching documents.
  - Preserved canvas layout information when updating Markdown content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->