### PR TITLE
fix(web): stop the dev-mode #wb= route sync ping-ponging the daemon page

### DIFF
--- a/apps/web/src/App.route-sync-stale-replay.test.tsx
+++ b/apps/web/src/App.route-sync-stale-replay.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * The dev-mode `#wb=` route-sync bug, pinned deterministically: a real
+ * router propagates navigation into `useLocation` ASYNCHRONOUSLY, so under
+ * StrictMode's effect replay the URL->state sync effect used to run a
+ * second time against the STALE pre-navigation pathname ('/'), overwrite
+ * the payload-derived canvas view with 'index', and (in a live browser)
+ * the two sync effects then chased each other's one-step-old snapshots
+ * forever — remounting DaemonCanvasPage and reopening its WebSocket ~170
+ * times per second against a real daemon.
+ *
+ * MemoryRouter cannot reproduce this (act() flushes its state before the
+ * replay runs) and vitest's browser mode cannot host a real BrowserRouter
+ * (rewriting the iframe URL severs the runner), so this harness fakes only
+ * the two router hooks App uses, with the one property that matters:
+ * navigation reaches `useLocation` on a later tick.
+ */
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { StrictMode, useSyncExternalStore } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ProviderState } from './lib/provider.js'
+
+interface FakeLocation {
+  pathname: string
+  search: string
+  hash: string
+  state: unknown
+  key: string
+}
+
+let fakeLocation: FakeLocation = { pathname: '/', search: '', hash: '', state: null, key: 'k0' }
+const listeners = new Set<() => void>()
+const navigateCalls: string[] = []
+let keySeq = 0
+
+function fakeNavigate(to: string): void {
+  navigateCalls.push(to)
+  if (navigateCalls.length > 25) {
+    throw new Error(`route-sync ping-pong: ${navigateCalls.length} navigations`)
+  }
+  // The property under test: the pathname reaches useLocation on a LATER
+  // tick, exactly as a real browser router behaves — an effect replay that
+  // runs before this fires sees the stale pre-navigation location.
+  setTimeout(() => {
+    keySeq += 1
+    fakeLocation = { ...fakeLocation, pathname: to, key: `k${keySeq}` }
+    for (const listener of listeners) listener()
+  }, 0)
+}
+
+vi.mock('react-router-dom', () => ({
+  useLocation: () =>
+    useSyncExternalStore(
+      (listener: () => void) => {
+        listeners.add(listener)
+        return () => listeners.delete(listener)
+      },
+      () => fakeLocation,
+    ),
+  useNavigate: () => fakeNavigate,
+}))
+
+let indexPageMounts = 0
+vi.mock('./pages/DaemonCanvasPage.js', () => ({
+  DaemonCanvasPage: () => <div data-testid="daemon-canvas-page" />,
+}))
+vi.mock('./pages/DaemonIndexPage.js', () => ({
+  DaemonIndexPage: () => {
+    indexPageMounts += 1
+    return <div data-testid="daemon-index-page" />
+  },
+}))
+// The shell renders router-coupled chrome (Link) that the two-hook fake
+// router cannot host; the shell is not this test's subject.
+vi.mock('./components/AppShell.js', () => ({
+  AppShell: () => <div data-testid="mock-shell" />,
+  default: () => <div data-testid="mock-shell" />,
+}))
+vi.mock('./hooks/useDaemonConnection.js', () => ({
+  useDaemonConnection: () => ({
+    status: 'paired',
+    payload: {
+      baseUrl: 'http://127.0.0.1:3099',
+      workspaceId: 'w1',
+      path: 'main',
+      authMode: 'bootstrap',
+      bootstrapToken: 'tok-123456',
+    },
+  }),
+}))
+
+const { App } = await import('./App.js')
+
+const BROWSER_LOCAL_STATE: ProviderState = {
+  kind: 'browser-local',
+  capabilities: {
+    canvasReadWrite: true,
+    migrationExport: true,
+    migrationImport: false,
+    workspaces: false,
+    versions: false,
+    branches: false,
+    merge: false,
+  },
+}
+
+describe('App route sync against an asynchronously-propagating router', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    fakeLocation = { pathname: '/', search: '', hash: '', state: null, key: 'k0' }
+    navigateCalls.length = 0
+    indexPageMounts = 0
+    window.localStorage.clear()
+  })
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+    window.localStorage.clear()
+  })
+
+  it('a StrictMode replay must not overwrite the #wb= canvas view with the stale pathname', async () => {
+    render(
+      <StrictMode>
+        <App providerState={BROWSER_LOCAL_STATE} />
+      </StrictMode>,
+    )
+    // Drain the navigation timers until the system settles (or the storm
+    // guard in fakeNavigate throws).
+    for (let i = 0; i < 10; i += 1) {
+      await act(async () => {
+        vi.runAllTimers()
+      })
+    }
+    expect(screen.getByTestId('daemon-canvas-page')).toBeTruthy()
+    expect(fakeLocation.pathname).toBe('/w/w1/canvas/main')
+    // The payload said "open this canvas": the gallery must never flash in,
+    // and one navigation ('/' -> canvas URL) is all the sync needs.
+    expect(indexPageMounts).toBe(0)
+    expect(navigateCalls).toEqual(['/w/w1/canvas/main'])
+  })
+})

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -241,6 +241,11 @@ export function App({ providerState }: AppProps) {
   // consumed and re-visiting it would silently do nothing); every
   // subsequent sync pushes, so browser back/forward has real steps to walk.
   const isFirstUrlSyncRef = useRef(true)
+  // The path this effect last navigated to. StrictMode's effect replay
+  // re-runs the effect with the PRE-navigation location still in its
+  // closure, so without this the replay pushes a duplicate history entry
+  // for the navigation the first run already performed.
+  const lastNavigatedPathRef = useRef<string | null>(null)
   useEffect(() => {
     if (isPairRoute) return
     // /local/:documentId belongs to the browser-local world, not daemonView —
@@ -260,7 +265,12 @@ export function App({ providerState }: AppProps) {
     // it's the first one and wrongly replacing instead of pushing.
     const isFirstSync = isFirstUrlSyncRef.current
     isFirstUrlSyncRef.current = false
-    if (location.pathname === path) return
+    if (location.pathname === path) {
+      lastNavigatedPathRef.current = null
+      return
+    }
+    if (lastNavigatedPathRef.current === path) return
+    lastNavigatedPathRef.current = path
     navigate(path, { replace: isFirstSync })
     // location.pathname is read, not depended on: including it would refire
     // this effect on every navigation (including the one it just performed),
@@ -270,16 +280,21 @@ export function App({ providerState }: AppProps) {
 
   // URL -> state: handles the browser back/forward buttons (and, in
   // principle, any other code path that changes the route without going
-  // through setDaemonView). Skips its own first run so it never overrides
-  // the payload-preferring lazy initializer above with a stale pathname
-  // that hasn't caught up to the #wb= sync effect yet.
-  const isFirstRouteSyncRef = useRef(true)
+  // through setDaemonView).
+  // Guarded by pathname VALUE, not a first-run flag: StrictMode's effect
+  // replay re-runs this effect with the pre-navigation pathname still in
+  // its closure, and a run-count flag let that replay read the stale '/'
+  // as user intent — overwriting the #wb= payload-derived canvas view with
+  // the gallery and, in a live browser, seeding a perpetual navigation
+  // ping-pong that remounted the canvas page (and its WebSocket) ~170
+  // times a second. Only an actual pathname CHANGE is a URL-driven
+  // navigation; the ref seeds from the mount pathname so the mount run and
+  // any replay of it are no-ops.
+  const lastRouteSyncPathRef = useRef(location.pathname)
   useEffect(() => {
     if (isPairRoute) return
-    if (isFirstRouteSyncRef.current) {
-      isFirstRouteSyncRef.current = false
-      return
-    }
+    if (lastRouteSyncPathRef.current === location.pathname) return
+    lastRouteSyncPathRef.current = location.pathname
     const parsed = parseDaemonRoute(location.pathname)
     if (parsed === null) return
     // parseDaemonRoute returns a fresh object every time, and React compares


### PR DESCRIPTION
## What

Opening the vite dev server with a `#wb=` daemon fragment made `DaemonCanvasPage` open and close its WebSocket in a tight loop — **measured 1844–2059 socket opens in 12 seconds** — while the page never hydrated. Production builds were unaffected (no StrictMode), which is why it survived: the natural inner-loop way to open a daemon canvas against local changes was silently broken.

Root cause: two StrictMode-replay staleness bugs in `App`'s bidirectional route sync, each independently verified as load-bearing:

1. **URL→state used a first-run flag.** StrictMode's effect replay re-ran the sync with the stale pre-navigation `'/'` still in its closure; the flag said "not first" so the replay read `'/'` as user intent, parsed it as the gallery, and overwrote the `#wb=` payload-derived canvas view — seeding a perpetual chase in which each sync effect reacted to the other's one-step-old snapshot. Now guarded by pathname **value** (ref seeded from the mount pathname): only an actual change is a URL-driven navigation. *Reverting just this guard brings the loop back: 2059 opens/12s vs 3.*
2. **state→URL's replay re-navigated** to the path its first run had already navigated to (same stale closure), pushing a duplicate history entry. Now tracked via `lastNavigatedPathRef`. *Reverting just this guard turns the new regression test red.*

## Regression test

`App.route-sync-stale-replay.test.tsx` fakes only `useLocation`/`useNavigate`, with the one property that matters: **navigation reaches `useLocation` on a later tick**. MemoryRouter cannot reproduce the bug (act() flushes router state before the replay runs) and vitest's browser mode cannot host a real `BrowserRouter` (rewriting the iframe URL severs the runner) — both dead ends are documented in the test header. A >25-navigation storm guard turns any future runaway into a clean failure instead of a hung suite.

## Verification (real environment: vite dev + daemon + headless Chromium, 12s window)

| build | WS opens | page hydrated |
|---|---|---|
| unfixed (current main) | 1844 | no |
| guard B reverted (mutation check) | 2059 | no |
| **fixed** | **3** (StrictMode's expected double-mount) | **yes, URL settled** |

Suites: apps/web jsdom 2222 + 77 green, `App.test.tsx` 55/55, typecheck/knip/lint clean.

Resolves the whiteboard issue `issue/dev-wb-fragment-ws-reconnect-loop` (deleted on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ
