### PR TITLE
feat(web): name a daemon document by its workspace, and retire OpenCanvas

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/kamiazya"
   },
   "metadata": {
-    "description": "Claude Code plugin distribution for the @kamiazya/whiteboard collaborative OpenCanvas MCP.",
+    "description": "Claude Code plugin distribution for the @kamiazya/whiteboard collaborative diagramming MCP.",
     "version": "0.0.19"
   },
   "plugins": [
@@ -16,7 +16,7 @@
         "repo": "kamiazya/whiteboard",
         "ref": "stable"
       },
-      "description": "Collaborative OpenCanvas canvas for Claude Code. Wraps the @kamiazya/whiteboard-mcp server and exposes the bundled /drawing-visuals, /coauthoring-visuals, and /auditing-workspaces skills.",
+      "description": "Collaborative whiteboard for Claude Code. Wraps the @kamiazya/whiteboard-mcp server and exposes the bundled /drawing-visuals, /coauthoring-visuals, and /auditing-workspaces skills.",
       "version": "0.0.19",
       "author": {
         "name": "kamiazya",
@@ -25,9 +25,9 @@
       "homepage": "https://github.com/kamiazya/whiteboard",
       "repository": "https://github.com/kamiazya/whiteboard",
       "license": "MIT",
-      "keywords": ["opencanvas", "diagramming", "mcp", "whiteboard", "claude-code", "codex"],
+      "keywords": ["json-canvas", "diagramming", "mcp", "whiteboard", "claude-code", "codex"],
       "category": "productivity",
-      "tags": ["diagramming", "mcp", "opencanvas", "visualization"]
+      "tags": ["diagramming", "mcp", "json-canvas", "visualization"]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "whiteboard",
   "version": "0.0.19",
-  "description": "Collaborative OpenCanvas whiteboard for Claude Code. Wraps the @kamiazya/whiteboard-mcp server and exposes the shared skills bundled with that package.",
+  "description": "Collaborative whiteboard for Claude Code. Wraps the @kamiazya/whiteboard-mcp server and exposes the shared skills bundled with that package.",
   "repository": "https://github.com/kamiazya/whiteboard",
   "license": "MIT",
   "skills": "./skills",

--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -1,16 +1,16 @@
-# Architecture Map (OpenCanvas)
+# Architecture Map
 
 Package boundaries are cut by **runtime requirements**, not by feature. The shared layer must run unchanged on Node, the browser, and Cloudflare Workers.
 
 | Package | Role | May depend on |
 |---|---|---|
-| `packages/model` | Zod schemas for the OpenCanvas data model (single source of truth) | zod only |
+| `packages/model` | Zod schemas for the whiteboard document model (single source of truth) | zod only |
 | `packages/codec` | OKF Markdown / JSON Canvas serialize+parse, remark pipeline | model, remark |
 | `packages/canvas-render` | scene graph, layout, SVG backend, sceneDigest | model, zod |
 | `packages/ports` | store/sync port contracts + Symbol `TOKENS` | model, zod |
 | `packages/loro-adapter` | LoroDoc<->model bridge | model, ports, loro-crdt |
 | `packages/server-core` | `/api/v1` Hono routes + MCP tool definitions, exposed as `createServer(deps)` | crdt, render, hono, zod, loro-crdt |
-| `packages/canvas-viewer` | Read-only OpenCanvas scene viewer UI (renders canvas-render SVG), shared between `apps/web` and the MCP Apps widget | model, codec, render, `@modelcontextprotocol/ext-apps`, react, zod |
+| `packages/canvas-viewer` | Read-only spatial-canvas scene viewer UI (renders canvas-render SVG), shared between `apps/web` and the MCP Apps widget | model, codec, render, `@modelcontextprotocol/ext-apps`, react, zod |
 | `packages/mcp-server` | Node composition root: CLI, stdio, local store impls, resvg, Inversify container | server-core + port impls |
 | `apps/web` | Browser composition root: Canvas API backend, IndexedDB store impls, read-write spatial canvas editor, markdown editor | loro-adapter, model, codec, render, canvas-viewer, `@kamiazya/whiteboard-mcp`'s browser-safe client subpaths (`/api-client`, `/api-contracts`, `/browser-contract`) + port impls |
 

--- a/.claude/rules/package-canvas-viewer.md
+++ b/.claude/rules/package-canvas-viewer.md
@@ -3,7 +3,7 @@ paths:
   - "packages/canvas-viewer/**"
 ---
 
-# canvas-viewer — read-only OpenCanvas scene viewer UI
+# canvas-viewer — read-only spatial-canvas scene viewer UI
 
 ## What belongs here
 

--- a/.claude/rules/package-model.md
+++ b/.claude/rules/package-model.md
@@ -3,7 +3,7 @@ paths:
   - "packages/model/**"
 ---
 
-# model — OpenCanvas data-model Zod schemas (single source of truth)
+# model — whiteboard document-model Zod schemas (single source of truth)
 
 ## What belongs here
 

--- a/.claude/rules/vocabulary.md
+++ b/.claude/rules/vocabulary.md
@@ -14,6 +14,7 @@ this rule is how it converges without anyone scheduling a big-bang rename.
 | **Body** | an OKF document's markdown body | a spatial document's content |
 | **Node** / **Edge** | JSON Canvas elements | anything in an OKF document |
 | **Canvas** | the spatial surface, and the JSON Canvas format | the container a workspace holds — that is a Document |
+| **OpenCanvas** | nothing. Retired — it was a working name for this project's document world, never a spec | the format (that is **JSON Canvas 1.0**) or the entity (that is a **Document**) |
 | **Scene** | the laid-out projection of a spatial document (what `composeCanvasScene` produces) | stored content |
 | **Version** | a saved point in a document's history | a branch |
 
@@ -88,6 +89,13 @@ Not a work queue — a lookup, so you can recognise one when you open a file.
   `loroCanvases`/`canvasFiles`. The biggest by count and the one the standing
   rule below is actually for: fix it where you already are, never as a sweep.
   `SpatialCanvas` and anything about the spatial surface is CORRECT and stays.
+- `onOpenCanvas`, the React prop meaning "open this document" — 178
+  occurrences across apps/web. It is the `Canvas`-as-container violation
+  above wearing a handler name, so it belongs to the same standing rule and
+  the same "never as a sweep" clause. Called out separately only because a
+  regex for the retired word `OpenCanvas` hits every one of them, and the
+  next person running that search should know they are the expected
+  remainder rather than a miss.
 - The blob tree's `canvas/` path segment
   (`{dataDir}/blobs/{workspaceId}/canvas/{documentId}.loro`), which
   `document-store.ts` and `file-gc-sweeper.ts` both hardcode. Left because
@@ -114,6 +122,31 @@ sync ports are implemented in the composition roots, so "adapter" here can
 only mean an adapter of the vendor library, and the name says so. Renaming it
 to suggest a port relationship would have stated the opposite of the
 dependency graph.
+
+`OpenCanvas` is retired and DONE outside the ADRs. It was never a spec: the
+formats are OKF Markdown and [JSON Canvas 1.0](https://jsoncanvas.org/spec/1.0/),
+which `packages/model/src/spatial.ts` already cites by URL and the whole of
+`packages/codec/src/spatial/` already spells correctly. `OpenCanvas` was this
+project's working name for the post-Excalidraw document world — the thing
+ADR-0009 named a **Document** — so the fix was mostly to DELETE the word, not
+to substitute another spec name for it. It also collided with a real,
+unrelated infinite-canvas interchange spec (OCIF, canvasprotocol.org), which
+made it an actively wrong signal in the npm `keywords`.
+
+Gone from: every published manifest (npm description + keywords, the Claude
+and Codex plugin manifests, `server.json`, the Gemini extension), the READMEs
+and user docs, one piece of user-visible UI copy (*"This workspace has no
+OpenCanvas tree yet"*), and the internal identifiers
+`registerOpenCanvasTools` -> `registerDocumentTools`, `opencanvas-tools.ts` ->
+`document-tools.ts`, `createOpenCanvasServer` -> `createDocumentServer`.
+ADR-0007/0008/0009 keep it and carry a dated vocabulary note instead, exactly
+like `slug`: a decision record is history, and rewriting the reasoning would
+misreport what was decided.
+
+It gets no executable rung. `vocabulary-check.test.ts` could not hold it
+without excluding both the ADR directory and every `onOpenCanvas` handler,
+and a guard that needs two carve-outs to pass is one nobody will trust the
+next time it fires. Same reason `canvas` will never qualify.
 
 `slug` is retired outright, and `vocabulary-check.test.ts` in `tools/arch-lint`
 is what keeps it retired — the one part of this rule that could stop being

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "whiteboard",
   "version": "0.0.19",
-  "description": "Collaborative OpenCanvas whiteboard for Codex. Wraps the @kamiazya/whiteboard-mcp server and exposes the shared skills bundled with that package.",
+  "description": "Collaborative whiteboard for Codex. Wraps the @kamiazya/whiteboard-mcp server and exposes the shared skills bundled with that package.",
   "author": {
     "name": "kamiazya",
     "url": "https://github.com/kamiazya"
@@ -9,13 +9,13 @@
   "homepage": "https://github.com/kamiazya/whiteboard",
   "repository": "https://github.com/kamiazya/whiteboard",
   "license": "MIT",
-  "keywords": ["opencanvas", "diagramming", "mcp", "whiteboard", "codex"],
+  "keywords": ["json-canvas", "diagramming", "mcp", "whiteboard", "codex"],
   "skills": "./skills",
   "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "Whiteboard",
-    "shortDescription": "Collaborative OpenCanvas canvas for AI agents",
-    "longDescription": "Runs a live OpenCanvas whiteboard in your browser and exposes MCP tools so Codex can draw, annotate, and refine diagrams alongside you. Canvases live locally under ~/.whiteboard/ as OKF Markdown or JSON Canvas 1.0.",
+    "shortDescription": "Collaborative whiteboard for AI agents",
+    "longDescription": "Runs a live whiteboard in your browser and exposes MCP tools so Codex can draw, annotate, and refine diagrams alongside you. Canvases live locally under ~/.whiteboard/ as OKF Markdown or JSON Canvas 1.0.",
     "developerName": "kamiazya",
     "category": "Productivity",
     "capabilities": ["Read", "Write"],

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="docs/assets/readme-mark.svg" alt="Whiteboard — a hand sketches nodes and edges, AI tidies them into a diagram, and the mark returns" width="264" height="222" />
 </p>
 
-> A collaborative OpenCanvas whiteboard for Claude Code, Codex, and Gemini CLI. Draw with your AI agent to align on specs, architecture, and workflows — directly on a shared real-time canvas.
+> A collaborative whiteboard for Claude Code, Codex, and Gemini CLI. Draw with your AI agent to align on specs, architecture, and workflows — directly on a shared real-time canvas.
 
 [![npm version](https://img.shields.io/npm/v/@kamiazya/whiteboard-mcp.svg)](https://www.npmjs.com/package/@kamiazya/whiteboard-mcp)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](LICENSE)
@@ -35,7 +35,7 @@ identity provider and TLS. <sub>*Server mode: a shared server you operate.*</sub
 
 ## How whiteboard works
 
-You and your agent both reach the same OpenCanvas whiteboard — they talk, the agent acts, skills shape the prompts. The `kamiazya/whiteboard` plugin packages three skills and a Whiteboard MCP server together; the agent calls MCP tools via stdio and the daemon syncs the canvas to your browser over WebSocket.
+You and your agent both reach the same whiteboard — they talk, the agent acts, skills shape the prompts. The `kamiazya/whiteboard` plugin packages three skills and a Whiteboard MCP server together; the agent calls MCP tools via stdio and the daemon syncs the canvas to your browser over WebSocket.
 
 <p align="center">
   <img src="docs/assets/architecture.png" alt="Architecture diagram: Skills and Whiteboard MCP are packaged in the kamiazya/whiteboard Plugin. You and Agent (Claude/Codex/Gemini) interact via prompts/replies; Agent calls Whiteboard MCP via stdio; MCP controls the Browser Canvas via HTTP/WS." width="780" />
@@ -43,7 +43,7 @@ You and your agent both reach the same OpenCanvas whiteboard — they talk, the 
   <sub><i>Diagram drawn with whiteboard itself — see <a href="docs/assets/architecture.canvas">architecture.canvas</a> to open it as a JSON Canvas document and remix.</i></sub>
 </p>
 
-`@kamiazya/whiteboard-mcp` runs an OpenCanvas spatial editor in your browser and exposes MCP tools so Claude Code, Codex, Gemini CLI, or any MCP-capable agent can draw, annotate, and refine diagrams alongside you. Canvases live locally under `~/.whiteboard/`, sync over WebSocket, and are stored as OKF Markdown or JSON Canvas 1.0 — both round-trip losslessly through the same codec that exports the PNG/SVG images on this page.
+`@kamiazya/whiteboard-mcp` runs a spatial canvas editor in your browser and exposes MCP tools so Claude Code, Codex, Gemini CLI, or any MCP-capable agent can draw, annotate, and refine diagrams alongside you. Canvases live locally under `~/.whiteboard/`, sync over WebSocket, and are stored as OKF Markdown or JSON Canvas 1.0 — both round-trip losslessly through the same codec that exports the PNG/SVG images on this page.
 
 <p align="center">
   <img src="docs/assets/canvas-browser-ui.png" alt="The browser canvas: workspace and canvas selector in the top bar, live diagram synced from the agent in real time" width="780" />

--- a/apps/web/scripts/canvas-sources.test.ts
+++ b/apps/web/scripts/canvas-sources.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url'
 import { parseSpatial } from '@kamiazya/whiteboard-codec'
 import { describe, expect, it } from 'vitest'
 
-// The two OpenCanvas diagram sources rendered by architecture.docs-snapshot,
+// The two spatial-canvas diagram sources rendered by architecture.docs-snapshot,
 // canvas-presentation.docs-snapshot, and canvas-auth-flow.docs-snapshot. A
 // hand-edited .canvas file that fails to parse must fail loudly here rather
 // than silently rendering an empty PNG.

--- a/apps/web/src/components/StorageReportCard.tsx
+++ b/apps/web/src/components/StorageReportCard.tsx
@@ -24,7 +24,7 @@ import { SquiggleLoader } from './SquiggleLoader.js'
 
 // Schema for the daemon's /api/v1/user-libraries response.
 // This is the sole definition — the former api-contracts/libraries.ts was
-// removed during the OpenCanvas migration.
+// removed by the move to the document model.
 const userLibraryRowSchema = z.object({
   name: z.string(),
   path: z.string(),

--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -1430,7 +1430,7 @@ describe('WorkspaceTopBar — titleSlot (merged canvas row)', () => {
         onToggleFullscreen={() => {}}
         onNavigateBack={() => {}}
         onNavigateToCanvas={() => {}}
-        titleSlot={<input aria-label="Merged title" readOnly value="t" />}
+        titleSlot={() => <input aria-label="Merged title" readOnly value="t" />}
       />,
       { container: document.body },
     )

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -25,6 +25,17 @@ import { useSceneExport } from './workspace-top-bar/useSceneExport'
 // Gates which pieces of daemon-only chrome render. Omitted entirely (the
 // default), every capability behaves as if it were `true` — this keeps every
 // pre-existing caller (all of which never pass `capabilities`) byte-identical.
+/** What the top bar knows about the open document's NAME, handed to `titleSlot`. */
+export interface CanvasIdentity {
+  /** The workspace's display name, falling back to the path when none is stored. */
+  readonly name: string
+  /**
+   * Commits a new display name. Absent in local mode, where the host page
+   * owns renaming through its own store rather than through `/names`.
+   */
+  readonly onRename?: (next: string) => void
+}
+
 export interface WorkspaceTopBarCapabilities {
   versions?: boolean
   branches?: boolean
@@ -80,8 +91,15 @@ interface Props {
    * The merged canvas row's flexible middle (title + properties triggers),
    * provided by the page — the header is one row, so pages inject their
    * canvas identity here instead of stacking a second chrome strip.
+   *
+   * A FUNCTION rather than a node because the display NAME lives here, not
+   * in the page: this bar already loads `/names` for the canvas dropdown, so
+   * a page that rendered its own identity would either duplicate that fetch
+   * or invent a second source for the same value. Passing the name down is
+   * what lets `apps/web`'s two pages agree that a document is named by its
+   * workspace (ADR-0009 decision 2) rather than by its content.
    */
-  titleSlot?: ReactNode
+  titleSlot?: (identity: CanvasIdentity) => ReactNode
   // Pass-through to CanvasDropdown's optional Workspaces section — both
   // omitted (every pre-existing caller) keeps this byte-identical.
   workspaces?: string[]
@@ -331,7 +349,10 @@ export default function WorkspaceTopBar({
           </span>
         )}
 
-        {titleSlot}
+        {titleSlot?.({
+          name: canvasCustomName ?? path,
+          ...(isLocalMode ? {} : { onRename: (next: string) => void renameCanvas(path, next) }),
+        })}
 
         {/* Branch chip with switch, create, rename, delete, and merge actions.
             This is the top bar's only destructive control (branch delete,

--- a/apps/web/src/components/canvas-properties/CanvasProperties.tsx
+++ b/apps/web/src/components/canvas-properties/CanvasProperties.tsx
@@ -19,7 +19,11 @@ export interface CanvasPropertiesProps {
    * document; the box shows its placeholder.
    */
   readonly title: string
-  readonly onTitleChange: (next: string) => void
+  /**
+   * Absent when this backend cannot rename — the title then renders
+   * read-only rather than accepting keystrokes it would discard.
+   */
+  readonly onTitleChange?: (next: string) => void
   /**
    * The document's OKF frontmatter, or absent when the document has none to
    * hold: a facet belongs to OKF and a JSON Canvas document has nowhere to
@@ -101,9 +105,11 @@ export function CanvasProperties({
           id={`${suggestionsId}-title`}
           value={draftTitle ?? title}
           onChange={(event) => {
+            if (onTitleChange === undefined) return
             setDraftTitle(event.target.value)
             onTitleChange(event.target.value)
           }}
+          readOnly={onTitleChange === undefined}
           // Dropping the draft is the whole tidy-up: the box falls back to the
           // canonical name, which is already trimmed.
           onBlur={() => setDraftTitle(null)}

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -26,6 +26,7 @@ import type {
   LineJumps,
   SpatialCanvas,
   SpatialNode,
+  StoredCoreFacets,
 } from '@kamiazya/whiteboard-model'
 import { remintClipboardFragment } from '../../lib/clipboard-fragment.js'
 import type { Point } from './viewport.js'
@@ -167,6 +168,12 @@ export type EditorCommand =
    * pipeline beside them.
    */
   | { readonly kind: 'set-body'; readonly text: string }
+  /**
+   * A markdown document's OKF core facets, written to the doc's `core` map.
+   * Same class as `set-body` and not an `EditorLeafCommand` for the same
+   * reasons: no node, no edge, canvas value untouched, never in a batch.
+   */
+  | { readonly kind: 'set-facets'; readonly facets: StoredCoreFacets }
 
 /** spatialCanvasSchema requires integer x/y and non-negative integer w/h. */
 function toPosition(value: number): number {
@@ -473,10 +480,12 @@ export function applyCommand(canvas: SpatialCanvas, command: EditorCommand): Spa
     case 'set-text':
       return setText(canvas, command.id, command.text)
     case 'set-body':
-      // The body is not IN the canvas — it is the doc's own `body` text
-      // container — so applying one leaves the canvas value identical.
-      // Returning the same reference is what keeps a keystroke in the
-      // markdown editor from re-rendering the spatial scene.
+    case 'set-facets':
+      // Neither is IN the canvas — the body is the doc's own `body` text
+      // container and the facets are its `core` map — so applying one leaves
+      // the canvas value identical. Returning the same reference is what
+      // keeps a keystroke in the markdown editor from re-rendering the
+      // spatial scene.
       return canvas
     case 'connect-nodes':
       return connectNodes(canvas, command.edgeId, command.fromNode, command.toNode)

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -16,10 +16,10 @@ type OkfPreview =
   | { kind: 'error'; path: string }
 
 /**
- * The OpenCanvas workspace file tree (/api/v1): nested document paths on the
- * left, a read-only OKF markdown preview of the clicked canvas on the
- * right. Read-only by design — editing OpenCanvas docs stays with the MCP
- * tools until the editor surfaces migrate to the v1 world.
+ * The workspace document tree (`/api/v1`): nested document paths on the
+ * left, a read-only OKF markdown preview of the clicked document on the
+ * right. Read-only by design — editing stays with the MCP tools until the
+ * editor surfaces migrate to the v1 world.
  */
 export function WorkspaceFilesPanel({
   daemonFetch,
@@ -79,9 +79,7 @@ export function WorkspaceFilesPanel({
     )
   }
   if (listStatus === 'not-found') {
-    return (
-      <p className="text-muted-foreground text-sm">This workspace has no OpenCanvas tree yet.</p>
-    )
+    return <p className="text-muted-foreground text-sm">This workspace has no document tree yet.</p>
   }
   if (canvases === null) {
     return <p className="text-muted-foreground text-sm">Loading files…</p>

--- a/apps/web/src/docs-snapshots/canvas-browser-ui.docs-snapshot.test.tsx
+++ b/apps/web/src/docs-snapshots/canvas-browser-ui.docs-snapshot.test.tsx
@@ -13,7 +13,7 @@ import { ARCHITECTURE_SCENE } from './_scenes.js'
 import { TopBarFrame } from './_top-bar-frame.js'
 
 // Generates docs/assets/canvas-browser-ui.png — README hero. Shows the
-// full canvas chrome (workspace + canvas selector top bar, the OpenCanvas
+// full canvas chrome (workspace + canvas selector top bar, the spatial
 // spatial viewport with a populated diagram) so a reader sees what the
 // running app looks like with content. The diagram comes from the
 // canonical architecture.canvas scene file.

--- a/apps/web/src/hooks/useCanvasSync.ts
+++ b/apps/web/src/hooks/useCanvasSync.ts
@@ -1,7 +1,7 @@
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
 import { serializeSpatial } from '@kamiazya/whiteboard-codec'
 import type { CanvasBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
-import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import type { SpatialCanvas, StoredCoreFacets } from '@kamiazya/whiteboard-model'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { EditorCommand } from '../components/spatial-editor/commands.js'
 import { renderCanvasToSvg } from '../components/spatial-editor/scene-render.js'
@@ -60,6 +60,14 @@ export interface UseCanvasSyncResult {
    * whether the document has hydrated reads `loaded`.
    */
   markdownBody: string
+  /**
+   * OKF core facets from the doc's `core` map — `undefined` for a spatial
+   * document, which has none to hold. Republished on the same signal as
+   * `markdownBody`: both live outside the canvas value and change together
+   * on hydration, remote import and undo.
+   */
+  coreFacets: StoredCoreFacets | undefined
+  setCoreFacets: (facets: StoredCoreFacets) => void
   /** OKF core facets from the doc's sidecar map; undefined until hydrated or when never written. */
   lockedEdgeIds: ReadonlySet<string>
   setEdgeLock: (edgeId: string, locked: boolean) => void
@@ -178,6 +186,7 @@ export function useCanvasSync(
   const [, setHistoryVersion] = useState(0)
   const [lockedNodeIds, setLockedNodeIds] = useState<ReadonlySet<string>>(EMPTY_LOCKED_IDS)
   const [markdownBody, setMarkdownBodyState] = useState('')
+  const [coreFacets, setCoreFacetsState] = useState<StoredCoreFacets | undefined>(undefined)
   const [lockedEdgeIds, setLockedEdgeIds] = useState<ReadonlySet<string>>(EMPTY_LOCKED_IDS)
   const [restoreInProgress, setRestoreInProgress] = useState(false)
   const [restoreLabel, setRestoreLabel] = useState<string | null>(null)
@@ -204,6 +213,7 @@ export function useCanvasSync(
     // The body belongs to the session being torn down, exactly as the locks
     // do — left standing it would render against whatever document is next.
     setMarkdownBodyState('')
+    setCoreFacetsState(undefined)
 
     if (backend === null) {
       sessionRef.current = null
@@ -247,6 +257,7 @@ export function useCanvasSync(
     // notification for the same reason locks do.
     const unsubscribeBody = session.subscribeMarkdownBody(() => {
       setMarkdownBodyState(session.getMarkdownBody())
+      setCoreFacetsState(session.getCoreFacets())
     })
     // Seed from the session as well as subscribing: hydration can complete
     // BEFORE this effect runs (the backend may deliver a snapshot
@@ -283,6 +294,12 @@ export function useCanvasSync(
   // the session on each render is always current and never stale.
   const setEdgeLock = useCallback((edgeId: string, locked: boolean) => {
     sessionRef.current?.setEdgeLock(edgeId, locked)
+  }, [])
+
+  const setCoreFacets = useCallback((facets: StoredCoreFacets) => {
+    const session = sessionRef.current
+    if (session === undefined || session === null) return
+    session.onChange(session.getCanvas(), { kind: 'set-facets', facets })
   }, [])
 
   const setNodeLock = useCallback((nodeId: string, locked: boolean) => {
@@ -380,6 +397,8 @@ export function useCanvasSync(
     lockedNodeIds,
     setNodeLock,
     markdownBody,
+    coreFacets,
+    setCoreFacets,
     lockedEdgeIds,
     setEdgeLock,
     canRedo,

--- a/apps/web/src/lib/canvas-sync-session.test.ts
+++ b/apps/web/src/lib/canvas-sync-session.test.ts
@@ -3,7 +3,7 @@
  *
  * Exercises the session module directly (no React, no Excalidraw) against a
  * fake CanvasBackend and SpatialCanvas/EditorCommand fixtures — the
- * OpenCanvas-shaped surface this session now owns.
+ * document-shaped surface this session now owns.
  */
 
 import {

--- a/apps/web/src/lib/canvas-sync-session.ts
+++ b/apps/web/src/lib/canvas-sync-session.ts
@@ -386,7 +386,7 @@ export function createCanvasSyncSession(
    * Reads the doc and publishes it as the session's current canvas value.
    * The apply-generation counter still guards a session swap racing a
    * publish, but since this path is now fully synchronous (no awaited file
-   * fetch in between, unlike the pre-OpenCanvas Excalidraw bridge), the
+   * fetch in between, unlike the older Excalidraw bridge), the
    * generation check collapses to one bump + one isStale() check right
    * before publishing, rather than a capture-then-recheck pair spanning an
    * await.

--- a/apps/web/src/lib/canvas-sync-session.ts
+++ b/apps/web/src/lib/canvas-sync-session.ts
@@ -1,5 +1,6 @@
 import {
   deleteSpatialNode,
+  readCoreFacets,
   readEdgeLocks,
   readMarkdownBody,
   readNodeLocks,
@@ -8,6 +9,7 @@ import {
   withSpatialBatch,
   setEdgeLock as workspaceSetEdgeLock,
   setNodeLock as workspaceSetNodeLock,
+  writeCoreFacets,
   writeMarkdownBody,
   writeSpatialCanvas,
   writeSpatialEdge,
@@ -15,7 +17,7 @@ import {
 } from '@kamiazya/whiteboard-loro-adapter'
 import type { CanvasBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
 import { exportResponseMessageSchema } from '@kamiazya/whiteboard-mcp/browser-shared'
-import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import type { SpatialCanvas, StoredCoreFacets } from '@kamiazya/whiteboard-model'
 import { LoroDoc, UndoManager } from 'loro-crdt'
 import type { z } from 'zod'
 import type { EditorCommand, EditorLeafCommand } from '../components/spatial-editor/commands.js'
@@ -67,6 +69,8 @@ function commandTargetKey(command: EditorCommand): string {
       // so a burst of keystrokes inside one debounce window collapses to the
       // last one — which is the entire point of deduping here.
       return 'body'
+    case 'set-facets':
+      return 'facets'
     case 'batch':
       // Mapped in writeCommandTarget (unlike the default arm), but each
       // batch is one distinct user action — never deduped against another.
@@ -161,6 +165,14 @@ export interface CanvasSyncSession {
   // its own notification. Empty string before the first snapshot.
   getMarkdownBody(): string
   subscribeMarkdownBody(listener: () => void): () => void
+  /**
+   * OKF core facets from the doc's `core` map. `undefined` until hydrated,
+   * when none were ever written, and — by `readCoreFacets`' own rule — for
+   * any SPATIAL document, which has no frontmatter to hold (ADR-0009
+   * decision 3). That last case is why the editor needs no separate flag to
+   * decide whether to offer the disclosure.
+   */
+  getCoreFacets(): StoredCoreFacets | undefined
   // Current published canvas value (empty canvas before the first snapshot).
   getCanvas(): SpatialCanvas
   // Registers a listener for every published canvas value. `origin` tags
@@ -207,6 +219,11 @@ function writeCommandTarget(doc: LoroDoc, next: SpatialCanvas, command: EditorCo
       // whole SpatialCanvas, which would leave the body container untouched
       // and silently drop the edit.
       writeMarkdownBody(doc, command.text)
+      return true
+    case 'set-facets':
+      // Same must-handle reasoning as set-body: the `core` map is outside
+      // the canvas the fallback would rewrite.
+      writeCoreFacets(doc, command.facets)
       return true
     case 'delete-node':
       // Always "handled": deleteSpatialNode is a documented no-op for an
@@ -829,6 +846,10 @@ export function createCanvasSyncSession(
     return doc === null ? '' : readMarkdownBody(doc)
   }
 
+  function getCoreFacets(): StoredCoreFacets | undefined {
+    return doc === null ? undefined : readCoreFacets(doc)
+  }
+
   function notifyBodyChanged(): void {
     for (const listener of bodyListeners) listener()
   }
@@ -867,5 +888,6 @@ export function createCanvasSyncSession(
     subscribeLocks,
     getMarkdownBody,
     subscribeMarkdownBody,
+    getCoreFacets,
   }
 }

--- a/apps/web/src/lib/daemon-api-client.ts
+++ b/apps/web/src/lib/daemon-api-client.ts
@@ -173,7 +173,7 @@ export function setCanvasName(
   )
 }
 
-// ---- OpenCanvas /api/v1 surface (documentId + derived alias world) ----
+// ---- /api/v1 document surface (documentId + derived alias world) ----
 
 export function listCanvasesV1(
   fetchFn: typeof globalThis.fetch,

--- a/apps/web/src/lib/webmcp/tool-definitions.test.ts
+++ b/apps/web/src/lib/webmcp/tool-definitions.test.ts
@@ -37,7 +37,7 @@ describe('webMcpTools manifest', () => {
   })
 
   // Regression guard: this tool read the live scene through
-  // ExcalidrawImperativeAPI, which is going away, and has no OpenCanvas-shaped
+  // ExcalidrawImperativeAPI, which is going away, and has no document-shaped
   // replacement yet. It must stay absent rather than be silently reintroduced
   // by a later merge.
   it('does not register the removed Excalidraw-backed scene-summary tool', () => {

--- a/apps/web/src/pages/BrowserLocalCanvasPage.tsx
+++ b/apps/web/src/pages/BrowserLocalCanvasPage.tsx
@@ -689,7 +689,10 @@ export function BrowserLocalCanvasPage({
             }
           >
             <WorkspaceTopBar
-              titleSlot={canvasTitleSlot}
+              // Local mode names documents through its own store, not through
+              // the daemon's `/names`, so the identity the bar offers is unused
+              // here and `canvasName`/`onTitleChange` stay the source.
+              titleSlot={() => canvasTitleSlot}
               statusSlot={
                 <ConnectionStatus state="local">
                   <p className="text-muted-foreground">

--- a/apps/web/src/pages/DaemonCanvasPage.markdown.test.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.markdown.test.tsx
@@ -54,6 +54,13 @@ const mockListCanvases = vi.mocked(daemonApiClient.listCanvases)
  * an agent-authored document that opened empty here is exactly the interop
  * defect the one-writer rule exists to prevent.
  */
+/** A daemon-held spatial document: empty canvas, stored kind, no facets. */
+function spatialSnapshot(): Uint8Array {
+  const doc = new LoroDoc()
+  writeDocumentKind(doc, 'spatial')
+  return doc.export({ mode: 'snapshot' })
+}
+
 function markdownSnapshot(): Uint8Array {
   const doc = new LoroDoc()
   writeMarkdownBody(doc, '# Hello from an agent')
@@ -84,9 +91,29 @@ class FakeBackend implements CanvasBackend {
 
 const DAEMON_BASE_URL = 'http://127.0.0.1:3099'
 
+/**
+ * Serves the daemon's `/api/workspaces/:id/names` surface, which is where a
+ * document's display NAME lives (the canvas summary carries only a path).
+ * Anything else the page fetches answers 404 so a missing stub shows up as a
+ * failed expectation rather than as a hang.
+ */
+function stubNames(names: { canvases: Record<string, string>; pinned: string[] }): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.includes('/names')) {
+        return new Response(JSON.stringify(names), { status: 200 })
+      }
+      return new Response('{}', { status: 404 })
+    }),
+  )
+}
+
 describe('DaemonCanvasPage markdown documents', () => {
   beforeEach(() => {
     window.localStorage.clear()
+    stubNames({ canvases: { 'agent-note': 'Agent verification note' }, pinned: [] })
     mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
     mockListCanvases.mockResolvedValue({
       canvases: [{ path: 'agent-note', id: 'id-note', updatedAt: '2026-01-01', kind: 'markdown' }],
@@ -95,6 +122,7 @@ describe('DaemonCanvasPage markdown documents', () => {
   afterEach(() => {
     cleanup()
     window.localStorage.clear()
+    vi.unstubAllGlobals()
     vi.clearAllMocks()
   })
 
@@ -132,8 +160,85 @@ describe('DaemonCanvasPage markdown documents', () => {
     await waitFor(() => expect(document.body.textContent).toContain('Hello from an agent'))
   })
 
-  // No title-slot coverage here, deliberately. This page mounts no identity
-  // slot: a document's NAME is the workspace's (ADR-0009 decision 2) and the
-  // daemon's canvas summary carries no display name to render. The tests for
-  // the title box live with the browser-local page, which has one.
+  // The title box shows the WORKSPACE's display name for this document —
+  // never a `title` read out of its content, which ADR-0009 decision 2
+  // forbids and `storedCoreFacetsSchema` no longer even has room for. The
+  // name comes from the daemon's `/names` endpoint, the same one the canvas
+  // dropdown renames through.
+  it("shows the workspace's display name for the open document", async () => {
+    await act(async () => {
+      render(
+        <DaemonCanvasPage
+          daemonBaseUrl={DAEMON_BASE_URL}
+          workspaceId="w1"
+          path="agent-note"
+          createBackend={() => new FakeBackend()}
+        />,
+        { container: document.body },
+      )
+    })
+    await waitFor(() => {
+      const title = screen.getByPlaceholderText('Untitled') as HTMLInputElement
+      expect(title.value).toBe('Agent verification note')
+    })
+  })
+
+  // Facets ARE OKF frontmatter, so a markdown document gets the disclosure
+  // and a spatial one does not — ADR-0009 decision 3, the same split the
+  // browser-local page makes. `readCoreFacets` answering `undefined` for a
+  // spatial document is what makes the second case fall out rather than
+  // needing a flag.
+  it('offers the facets disclosure for a markdown document', async () => {
+    await act(async () => {
+      render(
+        <DaemonCanvasPage
+          daemonBaseUrl={DAEMON_BASE_URL}
+          workspaceId="w1"
+          path="agent-note"
+          createBackend={() => new FakeBackend()}
+        />,
+        { container: document.body },
+      )
+    })
+    await waitFor(() => expect(screen.getByLabelText('Properties')).toBeTruthy())
+  })
+
+  it('hides the facets disclosure for a spatial document', async () => {
+    mockListCanvases.mockResolvedValue({
+      canvases: [{ path: 'board', id: 'id-board', updatedAt: '2026-01-01', kind: 'spatial' }],
+    })
+    stubNames({ canvases: { board: 'A board' }, pinned: [] })
+    await act(async () => {
+      render(
+        <DaemonCanvasPage
+          daemonBaseUrl={DAEMON_BASE_URL}
+          workspaceId="w1"
+          path="board"
+          createBackend={() => new FakeBackend(spatialSnapshot)}
+        />,
+        { container: document.body },
+      )
+    })
+    await waitFor(() => expect(screen.getByPlaceholderText('Untitled')).toBeTruthy())
+    expect(screen.queryByLabelText('Properties')).toBeNull()
+  })
+
+  it('falls back to the path when the workspace has stored no name', async () => {
+    stubNames({ canvases: {}, pinned: [] })
+    await act(async () => {
+      render(
+        <DaemonCanvasPage
+          daemonBaseUrl={DAEMON_BASE_URL}
+          workspaceId="w1"
+          path="agent-note"
+          createBackend={() => new FakeBackend()}
+        />,
+        { container: document.body },
+      )
+    })
+    await waitFor(() => {
+      const title = screen.getByPlaceholderText('Untitled') as HTMLInputElement
+      expect(title.value).toBe('agent-note')
+    })
+  })
 })

--- a/apps/web/src/pages/DaemonCanvasPage.tsx
+++ b/apps/web/src/pages/DaemonCanvasPage.tsx
@@ -6,6 +6,7 @@ import { SseBackend } from '@kamiazya/whiteboard-mcp/sse-backend'
 import { type DocumentKind, isImageRef } from '@kamiazya/whiteboard-model'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { CanvasPageSkeleton } from '../components/CanvasPageSkeleton.js'
+import { CanvasProperties } from '../components/canvas-properties/CanvasProperties.js'
 import { CapabilityTeaser } from '../components/capability-teaser/CapabilityTeaser.js'
 import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
 import { DocumentEditorSurface } from '../components/document-editor/DocumentEditorSurface.js'
@@ -236,6 +237,8 @@ export function DaemonCanvasPage({
     lockedNodeIds,
     setNodeLock,
     markdownBody: syncedMarkdownBody,
+    coreFacets,
+    setCoreFacets,
     lockedEdgeIds,
     setEdgeLock,
     syncStatus,
@@ -577,13 +580,26 @@ export function DaemonCanvasPage({
           {canvas && (
             <WorkspaceTopBar
               statusSlot={connectionStatus}
-              // No identity slot here yet, deliberately. A document's NAME is
-              // the workspace's (ADR-0009 decision 2) and the daemon's canvas
-              // summary carries no display name — only a path — so there is
-              // nothing to render but the path, and nothing to write it back
-              // through. The browser-local page has a real name to show and
-              // does mount one. Restoring this needs the workspace-level
-              // display-name API first, not a title read out of the content.
+              // Document identity in the merged header row, mirroring the
+              // browser-local page. The NAME is the workspace's — the top bar
+              // hands it down from `/names`, the same surface the canvas
+              // dropdown renames through — never a `title` read out of the
+              // content, which ADR-0009 decision 2 forbids and
+              // `storedCoreFacetsSchema` has no room for.
+              titleSlot={(identity) => (
+                <CanvasProperties
+                  inline
+                  key={`${canvas.workspaceId}/${canvas.path}`}
+                  title={identity.name}
+                  onTitleChange={identity.onRename}
+                  // Facets are OKF frontmatter, so only a markdown document
+                  // has any — `readCoreFacets` answers `undefined` for a
+                  // spatial one (ADR-0009 decision 3), which is what decides
+                  // the disclosure here without a second flag to keep in sync.
+                  facets={coreFacets}
+                  onFacetsChange={setCoreFacets}
+                />
+              )}
               workspaceId={canvas.workspaceId}
               path={canvas.path}
               canvases={controller.canvases}
@@ -736,11 +752,7 @@ export function DaemonCanvasPage({
               body: markdownBody,
               setBody: setMarkdownBody,
               theme: resolvedTheme,
-              // Kind only: the daemon has no facets wiring on this page (see
-              // the WorkspaceTopBar note), so there is no stored `type`/`tags`
-              // to show and inventing one would be a value the user could not
-              // edit.
-              meta: { type: documentKind },
+              meta: coreFacets ?? { type: documentKind },
               resolveAlias,
               onOpenCanvas: (id) => controller.switchCanvas(resolveRefPath(id) ?? id),
               resolveEmbed,

--- a/apps/web/src/pages/DaemonIndexPage.files-tab.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.files-tab.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Files tab: the OpenCanvas workspace file tree (/api/v1 path world)
+ * Files tab: the workspace document tree (/api/v1 path world)
  * reachable from the daemon index page, with a read-only OKF preview.
  */
 import { cleanup, fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react'
@@ -97,7 +97,7 @@ describe('DaemonIndexPage tree view', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: 'Tree view' }))
 
-    await screen.findByText('This workspace has no OpenCanvas tree yet.')
+    await screen.findByText('This workspace has no document tree yet.')
     expect(screen.queryByRole('alert')).toBeNull()
   })
 

--- a/docs/assets/architecture.canvas
+++ b/docs/assets/architecture.canvas
@@ -28,7 +28,7 @@
       "width": 260,
       "height": 100,
       "color": "6",
-      "text": "Browser Canvas\nOpenCanvas spatial editor running in the browser"
+      "text": "Browser Canvas\nSpatial canvas editor running in the browser"
     },
     {
       "id": "plugin-group",

--- a/docs/contributing/adr/0007-canvas-identity-and-store-split.md
+++ b/docs/contributing/adr/0007-canvas-identity-and-store-split.md
@@ -2,6 +2,15 @@
 
 **Status:** Accepted
 
+> **Vocabulary note (2026-08-17):** read **OpenCanvas** as **Document** everywhere
+> below. It was this project's own working name for the post-Excalidraw
+> document world, never a spec — the FORMATS are OKF Markdown and
+> [JSON Canvas 1.0](https://jsoncanvas.org/spec/1.0/), and
+> [ADR-0009](0009-mcp-tool-naming.md) named the entity `Document`. The word is
+> retired from prose, manifests and identifiers; this ADR keeps it because a
+> decision record is history, and rewriting the reasoning would misreport what
+> was decided.
+
 > **Vocabulary note (2026-08-16):** this ADR predates [ADR-0009](0009-mcp-tool-naming.md)
 > and says **slug** throughout for what the code, the database column, the URLs
 > and the docs now all call a document's **path**. The identity decision itself

--- a/docs/contributing/adr/0008-slug-derivation-and-rename.md
+++ b/docs/contributing/adr/0008-slug-derivation-and-rename.md
@@ -2,6 +2,15 @@
 
 **Status:** Accepted
 
+> **Vocabulary note (2026-08-17):** read **OpenCanvas** as **Document** everywhere
+> below. It was this project's own working name for the post-Excalidraw
+> document world, never a spec — the FORMATS are OKF Markdown and
+> [JSON Canvas 1.0](https://jsoncanvas.org/spec/1.0/), and
+> [ADR-0009](0009-mcp-tool-naming.md) named the entity `Document`. The word is
+> retired from prose, manifests and identifiers; this ADR keeps it because a
+> decision record is history, and rewriting the reasoning would misreport what
+> was decided.
+
 > **Vocabulary note (2026-08-16):** read **slug** as **path** everywhere below,
 > including in the title. [ADR-0009](0009-mcp-tool-naming.md) renamed the
 > concept; the derivation, rename and sibling-uniqueness rules this ADR decides

--- a/docs/contributing/adr/0009-mcp-tool-naming.md
+++ b/docs/contributing/adr/0009-mcp-tool-naming.md
@@ -2,6 +2,15 @@
 
 **Status:** Accepted
 
+> **Vocabulary note (2026-08-17):** read **OpenCanvas** as **Document** everywhere
+> below. It was this project's own working name for the post-Excalidraw
+> document world, never a spec — the FORMATS are OKF Markdown and
+> [JSON Canvas 1.0](https://jsoncanvas.org/spec/1.0/), and
+> [ADR-0009](0009-mcp-tool-naming.md) named the entity `Document`. The word is
+> retired from prose, manifests and identifiers; this ADR keeps it because a
+> decision record is history, and rewriting the reasoning would misreport what
+> was decided.
+
 > **Addendum (2026-08-16): the field is spelled `kind`, not `format`.** This
 > ADR uses both words for one concept and says so itself ("Kind and format are
 > already the same field"). Implementing it settled the spelling: `kind` won,

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -1,7 +1,7 @@
 # Architecture
 
 <p align="center">
-  <img src="../assets/architecture.png" alt="Agent and user both draw on the same OpenCanvas whiteboard via the Whiteboard MCP server" width="780" />
+  <img src="../assets/architecture.png" alt="Agent and user both draw on the same whiteboard via the Whiteboard MCP server" width="780" />
   <br />
   <sub><i>Source: <a href="../assets/architecture.canvas">architecture.canvas</a> — open as a JSON Canvas document to remix.</i></sub>
 </p>
@@ -10,7 +10,7 @@ This project is split into three main runtime layers:
 
 1. A `stdio` MCP server that tools like Claude Code and Codex connect to.
 2. A local daemon that serves HTTP and WebSocket endpoints on loopback.
-3. A browser canvas built with React, a spatial OpenCanvas editor, and Loro-backed synchronization.
+3. A browser canvas built with React, a spatial canvas editor, and Loro-backed synchronization.
 
 ## Main components
 
@@ -27,7 +27,7 @@ This project is split into three main runtime layers:
     [ADR-0001](../contributing/adr/0001-apps-web-canonical-frontend.md));
     server-mode serves a minimal static placeholder at its root instead
 - **browser canvas**
-  - React app in `apps/web` rendering OpenCanvas content through the
+  - React app in `apps/web` rendering document content through the
     `SpatialEditor` component (select, move, resize, connect, and edit
     existing nodes), deployable standalone or served same-origin by the
     daemon

--- a/docs/explanation/domain-model.md
+++ b/docs/explanation/domain-model.md
@@ -8,7 +8,7 @@ backed by more than one representation today. Read
 ## The nouns
 
 - **Canvas** — one drawable document. It has a `kind`: `spatial` (the
-  OpenCanvas node-and-edge editor) or `markdown` (a single markdown body).
+  spatial node-and-edge editor) or `markdown` (a single markdown body).
   The kind is chosen at creation and does not change afterwards — except
   that restoring a version also restores that version's kind.
 - **Workspace** — a named collection of canvases. Only daemon mode has
@@ -68,7 +68,7 @@ The daemon currently keeps **two separate stores** that both hold
 - The **workspace/path store** backs everything the web app shows and
   edits: the gallery, the editor, names, pins, kinds, branches, versions,
   and sync. Its writers are the daemon's HTTP API only.
-- The **OpenCanvas doc store** backs the agent-facing MCP tools
+- The **document store** backs the agent-facing MCP tools
   (`wb_document_*`, `wb_canvas_tidy`, node/edge patches, facets) and the
   `/api/v1` routes. It organizes canvases as a CRDT tree of
   ULID-identified documents with derived alias paths, and it is what the
@@ -90,7 +90,7 @@ path), is [ADR-0007](../contributing/adr/0007-canvas-identity-and-store-split.md
   through the same surface (for example, an agent driving the daemon's
   HTTP API, or a human using the tree view over `/api/v1` documents).
 - The workspace selector in the daemon gallery lists workspaces from the
-  workspace/path store; the tree view reads the OpenCanvas store. A
+  workspace/path store; the tree view reads the document store. A
   workspace that exists in only one of the two renders as missing or
   empty in the other.
 - Browser-local canvases cross into daemon mode only by an explicit,

--- a/docs/how-to/view-canvas-in-chat.md
+++ b/docs/how-to/view-canvas-in-chat.md
@@ -2,7 +2,7 @@
 
 > **Available, minus the sticky note.** `canvas_view` is wired back up to the widget
 > resource, so the inline view works again. The add-a-sticky-note control is gone:
-> it called an `annotate` tool the OpenCanvas migration removed, so every submission
+> it called an `annotate` tool the move to the document model removed, so every submission
 > failed at the host while the control still looked live. Everything else on this
 > page reflects what ships today.
 
@@ -39,7 +39,7 @@ snapshot instead.
 ## Adding a sticky note from the widget
 
 Removed. The control called an `annotate` tool that no longer exists, so it could
-only ever fail. Restoring it is not just re-wiring: OpenCanvas has no `annotate`
+only ever fail. Restoring it is not just re-wiring: the document model has no `annotate`
 equivalent, and a sticky note is a `wb_node_add` of a text node — so it needs a
 decision about whether this widget should mutate a document at all, given that it
 is otherwise strictly read-only. See the `TODO(annotate)` note in

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "whiteboard",
   "version": "0.0.19",
-  "description": "Collaborative OpenCanvas whiteboard for Gemini CLI. Runs a live whiteboard in your browser and exposes MCP tools so Gemini can draw, annotate, and refine diagrams alongside you.",
+  "description": "Collaborative whiteboard for Gemini CLI. Runs a live whiteboard in your browser and exposes MCP tools so Gemini can draw, annotate, and refine diagrams alongside you.",
   "mcpServers": {
     "whiteboard": {
       "command": "npx",

--- a/packages/canvas-render/package.json
+++ b/packages/canvas-render/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "license": "Apache-2.0",
-  "description": "OpenCanvas scene graph, pure layout, SVG backend, and sceneDigest — shared-layer, runs unchanged on Node/browser/Workers.",
+  "description": "Spatial-canvas scene graph, pure layout, SVG backend, and sceneDigest — shared-layer, runs unchanged on Node/browser/Workers.",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/canvas-viewer/README.md
+++ b/packages/canvas-viewer/README.md
@@ -1,6 +1,6 @@
 # @kamiazya/whiteboard-canvas-viewer
 
-Read-only OpenCanvas scene viewer, rendered through canvas-render's SVG
+Read-only spatial-canvas scene viewer, rendered through canvas-render's SVG
 backend and shared between `apps/web` and embedded surfaces (MCP Apps
 widget, HTML export). Private workspace package — never published to npm.
 

--- a/packages/canvas-viewer/package.json
+++ b/packages/canvas-viewer/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "license": "Apache-2.0",
-  "description": "Read-only OpenCanvas scene viewer rendered through canvas-render's SVG backend, shared between apps/web and future embedded surfaces (MCP Apps widget, HTML export). Never published to npm.",
+  "description": "Read-only spatial-canvas scene viewer rendered through canvas-render's SVG backend, shared between apps/web and future embedded surfaces (MCP Apps widget, HTML export). Never published to npm.",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/canvas-viewer/src/widget-entry.ts
+++ b/packages/canvas-viewer/src/widget-entry.ts
@@ -82,14 +82,14 @@ const HOST_CONNECT_TIMEOUT_MS = 2_000
 
 // TODO(annotate): the add-a-sticky-note affordance is UNWIRED.
 //
-// It called an `annotate` MCP tool that the OpenCanvas migration removed;
+// It called an `annotate` MCP tool that the move to the document model removed;
 // nothing replaced it, so every submission failed at the host with an
 // unknown-tool error while the control still looked live. Showing a control
 // that cannot work is worse than not showing one, so the wiring is gone and
 // `widget/sticky-note-control.ts` + `widget/sticky-placement.ts` are kept
 // unmounted for whoever restores it.
 //
-// Restoring it needs a decision first, not just re-wiring: OpenCanvas has no
+// Restoring it needs a decision first, not just re-wiring: the document model has no
 // annotate equivalent, and a sticky note is a `wb_node_add` of a text node —
 // so the question is whether this widget should mutate a document at all
 // (it is otherwise strictly read-only), and if so under what placement

--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "license": "Apache-2.0",
-  "description": "OpenCanvas single-document codec: OKF-Markdown + JSON Canvas serialize/parse and a remark-based markdown pipeline. Shared layer — no node:*, DOM, inversify, or loro-crdt.",
+  "description": "Single-document codec: OKF-Markdown + JSON Canvas serialize/parse and a remark-based markdown pipeline. Shared layer — no node:*, DOM, inversify, or loro-crdt.",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/codec/src/references/resolve-for-export.ts
+++ b/packages/codec/src/references/resolve-for-export.ts
@@ -73,7 +73,7 @@ function exportTableCell(node: MdastTableCell, resolver: CanvasPathResolver): Md
 
 /**
  * Rewrites `wikiLink`/`embed` nodes into plain relative-path markdown links
- * for export to a non-OpenCanvas-aware reader. Pure, single-document: the
+ * for export to a reader that knows only plain markdown. Pure, single-document: the
  * documentId->path resolver is injected. An unresolved id stays as literal
  * `[[canvas:ID]]` text rather than being dropped, so re-applying export with
  * the same resolver is idempotent (nothing left to resolve differently the

--- a/packages/loro-adapter/package.json
+++ b/packages/loro-adapter/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "license": "Apache-2.0",
-  "description": "Adapter between loro-crdt's LoroDoc and the OpenCanvas model.",
+  "description": "Adapter between loro-crdt's LoroDoc and the whiteboard document model.",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -6,7 +6,8 @@
 
 # `@kamiazya/whiteboard-mcp`
 
-OpenCanvas-based whiteboard MCP server for Claude Code, Codex, and other MCP hosts.
+Whiteboard MCP server for Claude Code, Codex, and other MCP hosts. Documents are
+stored as OKF Markdown or [JSON Canvas 1.0](https://jsoncanvas.org/spec/1.0/).
 
 ## Requirements
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kamiazya/whiteboard-mcp",
   "version": "0.0.19",
-  "description": "MCP server + OpenCanvas whiteboard UI for AI-assisted diagramming (Claude Code / Codex).",
+  "description": "MCP server + whiteboard UI for AI-assisted diagramming (Claude Code / Codex). Documents are stored as OKF Markdown or JSON Canvas 1.0.",
   "author": "kamiazya",
   "license": "Apache-2.0",
   "keywords": [
@@ -13,7 +13,7 @@
     "anthropic",
     "codex",
     "openai",
-    "opencanvas",
+    "json-canvas",
     "json-canvas",
     "whiteboard",
     "diagram",

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -3,7 +3,7 @@
 //
 // Purpose:
 // Start the MCP server outside the parent client's context and verify that each
-// OpenCanvas tool behaves according to spec using JSON-RPC stdio.
+// document tool behaves according to spec using JSON-RPC stdio.
 //
 // Coverage:
 //   1. tools/list matches the authoritative set in mcp-smoke-coverage.ts

--- a/packages/mcp-server/src/server/app-types.ts
+++ b/packages/mcp-server/src/server/app-types.ts
@@ -11,7 +11,7 @@ import type { WsTicketStore } from './security/ws-ticket-store.js'
 
 interface LocalDaemonAppOptions {
   authMode: 'local-daemon'
-  /** OpenCanvas store/sync ports. When present, server-core's /api/v1
+  /** Document store/sync ports. When present, server-core's /api/v1
    *  HTTP surface (createServer(deps).app) is mounted behind the same
    *  /api/* auth as every other API route; when absent, /api/v1 stays
    *  unmounted (404). Optional so ad-hoc callers and legacy tests need no
@@ -62,7 +62,7 @@ export interface ServerModeAppOptions {
   authMode: 'server-mode'
   /** See LocalDaemonAppOptions.identity. */
   identity?: DaemonIdentity
-  /** OpenCanvas store/sync ports. When present, server-core's /api/v1
+  /** Document store/sync ports. When present, server-core's /api/v1
    *  HTTP surface (createServer(deps).app) is mounted behind the same
    *  /api/* auth as every other API route; when absent, /api/v1 stays
    *  unmounted (404). Optional so ad-hoc callers and legacy tests need no

--- a/packages/mcp-server/src/server/app.api-v1.test.ts
+++ b/packages/mcp-server/src/server/app.api-v1.test.ts
@@ -1,5 +1,5 @@
 /**
- * The daemon mounts server-core's /api/v1 OpenCanvas surface when given
+ * The daemon mounts server-core's /api/v1 document surface when given
  * ServerDeps. Until this slice, createServer(deps) was only used for its
  * MCP tools — the HTTP app it returns was never mounted, so the workspace
  * tree (documentId + path world) was unreachable over HTTP even though the
@@ -53,7 +53,7 @@ function createRuntimeOptions(token?: string) {
   }
 }
 
-describe('createApp /api/v1 OpenCanvas mount', () => {
+describe('createApp /api/v1 document mount', () => {
   beforeEach(async () => {
     await mkdir(join(tmp.dir, 'web-app'), { recursive: true })
     await mkdir(join(tmp.dir, 'data'), { recursive: true })

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { serveStatic } from '@hono/node-server/serve-static'
-import { createServer as createOpenCanvasServer } from '@kamiazya/whiteboard-server-core'
+import { createServer as createDocumentServer } from '@kamiazya/whiteboard-server-core'
 import {
   createMcpHandler,
   isLegacyRequest,
@@ -392,11 +392,11 @@ export function createApp(options: AppOptions) {
     app.route('/', createPairingRouter({ ...options.pairing, identity }))
   }
 
-  // server-core's OpenCanvas /api/v1 surface (workspace tree, documentId +
+  // server-core's /api/v1 document surface (workspace tree, documentId +
   // alias world). Mounted at '/' because its routes carry full /api/v1/*
   // paths; the /api/* auth middlewares registered above already cover it.
   if (options.serverDeps) {
-    app.route('/', createOpenCanvasServer(options.serverDeps).app)
+    app.route('/', createDocumentServer(options.serverDeps).app)
   }
 
   app.route(

--- a/packages/mcp-server/src/server/http-server.ts
+++ b/packages/mcp-server/src/server/http-server.ts
@@ -193,7 +193,7 @@ export async function startHttpServer(options: StartHttpServerOptions): Promise<
     return [...envWebOrigins, ...grantOrigins]
   }
 
-  // OpenCanvas /api/v1 surface: same libSQL database as the MCP tools
+  // /api/v1 document surface: same libSQL database as the MCP tools
   // (getDb memoizes per dataDir, so this container shares the connection
   // with the per-session MCP containers rather than opening a second one).
   const dataDir = getDataDir()

--- a/packages/mcp-server/src/server/mcp/document-tools.test.ts
+++ b/packages/mcp-server/src/server/mcp/document-tools.test.ts
@@ -4,11 +4,11 @@ import { describe, expect, it, vi } from 'vitest'
 import { captureLogsForTests } from '../log.js'
 import { InMemoryBlobStore } from '../store/inmemory/in-memory-blob-store.js'
 import { InMemoryDocumentStore } from '../store/inmemory/in-memory-document-store.js'
+import { registerDocumentTools } from './document-tools.js'
 // Side-effect import: registering these tools also installs the server-core
-// log-sink wiring at module scope (see opencanvas-tools.ts).
+// log-sink wiring at module scope (see document-tools.ts).
 import { CANVAS_VIEW_RESOURCE_URI, RESOURCE_URI_META_KEY } from './mcp-apps.js'
 import { UI_LINKED_TOOLS } from './mcp-smoke-coverage.js'
-import { registerOpenCanvasTools } from './opencanvas-tools.js'
 
 function fakeServer() {
   const registerTool = vi.fn()
@@ -22,10 +22,10 @@ function fakeDeps() {
   }
 }
 
-describe('registerOpenCanvasTools', () => {
+describe('registerDocumentTools', () => {
   it('registers wb_version_save, wb_version_list, and wb_version_restore via the server-core wiring', () => {
     const server = fakeServer()
-    registerOpenCanvasTools(server, fakeDeps())
+    registerDocumentTools(server, fakeDeps())
 
     const registerToolMock = vi.mocked(server.registerTool)
     const names = registerToolMock.mock.calls.map((call) => call[0])
@@ -41,7 +41,7 @@ describe('registerOpenCanvasTools', () => {
     // capability and the widget bundle all shipped, and no tool linked
     // them. UI_LINKED_TOOLS is only a claim until this asserts it.
     const server = fakeServer()
-    registerOpenCanvasTools(server, fakeDeps())
+    registerDocumentTools(server, fakeDeps())
 
     const call = vi.mocked(server.registerTool).mock.calls.find((c) => c[0] === name)
     expect(call, `${name} is not registered at all`).toBeDefined()
@@ -55,7 +55,7 @@ describe('registerOpenCanvasTools', () => {
     // The mirror-into-legacy-key branch runs for every tool, so a bug there
     // could stamp the linkage onto tools that must not render as a widget.
     const server = fakeServer()
-    registerOpenCanvasTools(server, fakeDeps())
+    registerDocumentTools(server, fakeDeps())
     const dataPlane = vi
       .mocked(server.registerTool)
       .mock.calls.filter((c) => !UI_LINKED_TOOLS.includes(c[0] as never))
@@ -68,13 +68,13 @@ describe('registerOpenCanvasTools', () => {
 
   it("forwards a server-core log record to this composition root's logger", () => {
     // Registering the tools (via the side-effect import above) installs
-    // the module-scope setServerCoreLogSink wiring in opencanvas-tools.ts.
+    // the module-scope setServerCoreLogSink wiring in document-tools.ts.
     // Without it, any record a server-core call site logs (via its own
     // injectable getLogger) would be silently dropped instead of reaching
     // an operator — see server-core/src/log.ts's doc comment on why this
     // shared layer cannot reach for mcp-server's pino logger directly.
     const server = fakeServer()
-    registerOpenCanvasTools(server, fakeDeps())
+    registerDocumentTools(server, fakeDeps())
 
     const capture = captureLogsForTests('debug')
     try {

--- a/packages/mcp-server/src/server/mcp/document-tools.ts
+++ b/packages/mcp-server/src/server/mcp/document-tools.ts
@@ -44,7 +44,7 @@ setServerCoreLogSink((record) => {
   }
 })
 
-export function registerOpenCanvasTools(server: McpServer, deps: ServerDeps): void {
+export function registerDocumentTools(server: McpServer, deps: ServerDeps): void {
   const { tools } = createServer(deps)
 
   // Every MUTATING tool below runs inside withCanvasDocWriteLock, keyed on

--- a/packages/mcp-server/src/server/mcp/index.test.ts
+++ b/packages/mcp-server/src/server/mcp/index.test.ts
@@ -33,8 +33,8 @@ vi.mock('../store/db/prepare.js', () => ({
 vi.mock('./stdio-lifecycle.js', () => ({
   installStdioLifecycle: vi.fn(() => () => undefined),
 }))
-vi.mock('./opencanvas-tools.js', () => ({
-  registerOpenCanvasTools: vi.fn(),
+vi.mock('./document-tools.js', () => ({
+  registerDocumentTools: vi.fn(),
 }))
 vi.mock('../store/db/index.js', () => ({
   getDb: vi.fn(async () => ({})),

--- a/packages/mcp-server/src/server/mcp/index.ts
+++ b/packages/mcp-server/src/server/mcp/index.ts
@@ -8,9 +8,9 @@ import { PACKAGE_VERSION } from '../../shared/package-version.js'
 import { getDataDir } from '../config.js'
 import { isDirectEntryPoint } from '../entrypoint.js'
 import { getDb } from '../store/db/index.js'
+import { registerDocumentTools } from './document-tools.js'
 import { wireMcpLogging } from './logging.js'
 import { registerMcpAppsExtension } from './mcp-apps.js'
-import { registerOpenCanvasTools } from './opencanvas-tools.js'
 import { ensureWorkspaceId } from './session-resolver.js'
 import {
   buildDrawDiagramPrompt,
@@ -107,7 +107,7 @@ export async function createMcpServer() {
   const dataDir = getDataDir()
   const db = await getDb(dataDir)
   const container = createContainer(createStoreLocalModule({ db, blobDir: dataDir }))
-  registerOpenCanvasTools(server, resolveServerDeps(container))
+  registerDocumentTools(server, resolveServerDeps(container))
 
   return server
 }

--- a/packages/mcp-server/src/server/mcp/mcp-smoke-coverage.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-smoke-coverage.ts
@@ -2,7 +2,7 @@
  * Classification of all registered MCP tools by smoke-test coverage level.
  *
  * ALL_REGISTERED_TOOLS is the authoritative list that mirrors what
- * createMcpServer (index.ts) registers at runtime via registerOpenCanvasTools.
+ * createMcpServer (index.ts) registers at runtime via registerDocumentTools.
  * It is defined independently of the four category arrays below so that the
  * meta-property test can verify category completeness without self-reference.
  *
@@ -33,7 +33,7 @@
  *                         Each entry carries reason and unblock.
  */
 
-// Authoritative list — keep in sync with registerOpenCanvasTools calls.
+// Authoritative list — keep in sync with registerDocumentTools calls.
 export const ALL_REGISTERED_TOOLS = [
   'wb_body_patch',
   'wb_scene_digest',
@@ -85,7 +85,7 @@ export const ERROR_PATH_ONLY_TOOLS = [] as const
 // SEPARATE axis, so an entry here also belongs to exactly one coverage
 // category. Two guards read it: the ADR-0009 naming check exempts these
 // from `wb_<entity>_<action>` (point 7 keeps them outside the data plane),
-// and opencanvas-tools.test.ts asserts each one's real registration
+// and document-tools.test.ts asserts each one's real registration
 // actually carries the linkage — without that second guard this list would
 // be a claim nobody checks.
 export const UI_LINKED_TOOLS = ['canvas_view'] as const

--- a/packages/mcp-server/src/server/mcp/tool-profiles.ts
+++ b/packages/mcp-server/src/server/mcp/tool-profiles.ts
@@ -17,7 +17,7 @@ export const MUTATING = { openWorldHint: false } as const
 // registerToolWithAnnotations when building McpServer annotations.
 export type AnnotationProfile = Readonly<Record<string, boolean>>
 export const TOOL_PROFILES: Record<string, { profile: AnnotationProfile; title: string }> = {
-  // OpenCanvas tools (server-core)
+  // Document tools (server-core)
   wb_facet_set: {
     profile: MUTATING_IDEMPOTENT,
     title: 'Set the OKF frontmatter facets of a document',

--- a/packages/mcp-server/src/server/release/api-contracts-barrel.test.ts
+++ b/packages/mcp-server/src/server/release/api-contracts-barrel.test.ts
@@ -27,7 +27,7 @@ describe('api-contracts barrel scope', () => {
     const source = readFileSync(BARREL_PATH, 'utf-8')
     const specifiers = reExportSpecifiers(source)
     // '@kamiazya/whiteboard-server-core' is a deliberate widening: the
-    // OpenCanvas /api/v1 contracts (canvas list + OKF read) are consumed by
+    // /api/v1 document contracts (canvas list + OKF read) are consumed by
     // apps/web through this barrel so it never imports the shared-layer
     // package directly (architecture-map.md).
     expect(specifiers).toEqual([

--- a/packages/mcp-server/src/server/store/canvas-doc-write-lock.test.ts
+++ b/packages/mcp-server/src/server/store/canvas-doc-write-lock.test.ts
@@ -9,7 +9,7 @@ import { InMemoryDocumentIndex } from '@kamiazya/whiteboard-ports/test-utils'
 import { createNodePatchTool } from '@kamiazya/whiteboard-server-core'
 import { LoroDoc } from 'loro-crdt'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { registerOpenCanvasTools } from '../mcp/opencanvas-tools.js'
+import { registerDocumentTools } from '../mcp/document-tools.js'
 import { InMemoryDocumentStore } from './inmemory/in-memory-document-store.js'
 import { _resetWorkspaceLocksForTests, withCanvasDocWriteLock } from './workspace-lock.js'
 
@@ -184,7 +184,7 @@ describe('withCanvasDocWriteLock', () => {
 describe('registered MCP handlers', () => {
   function registeredHandlers(deps: Awaited<ReturnType<typeof makeDeps>>) {
     const registerTool = vi.fn()
-    registerOpenCanvasTools({ registerTool } as never, deps as never)
+    registerDocumentTools({ registerTool } as never, deps as never)
     const byName = new Map<string, (args: unknown, extra: unknown) => Promise<unknown>>()
     for (const call of registerTool.mock.calls) {
       byName.set(call[0] as string, call[2] as never)

--- a/packages/mcp-server/src/shared/api-contracts/index.ts
+++ b/packages/mcp-server/src/shared/api-contracts/index.ts
@@ -10,7 +10,7 @@
 // from its single definition instead of a hand-written mirror that can
 // silently drift from the server's shape.
 
-// The OpenCanvas /api/v1 list contract, re-exported from server-core so
+// The /api/v1 document list contract, re-exported from server-core so
 // apps/web keeps consuming every daemon HTTP contract through this one
 // barrel instead of importing a shared-layer package it is not allowed to
 // depend on directly (see .claude/rules/architecture-map.md).

--- a/packages/model/README.md
+++ b/packages/model/README.md
@@ -1,6 +1,6 @@
 # @kamiazya/whiteboard-model
 
-OpenCanvas data-model Zod schemas (meta / facets / spatial / markdown /
+Whiteboard document-model Zod schemas (meta / facets / spatial / markdown /
 workspace-tree / mdast subset). Named `model` — sibling to
 `packages/canvas-viewer` in this monorepo's per-concern `packages/*`
 layout — to make clear this package is the pure data-model contract, not

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "license": "Apache-2.0",
-  "description": "OpenCanvas data-model Zod schemas (meta/facets/spatial/markdown/workspace-tree/mdast subset). Package name chosen to match the monorepo's per-concern packages/* layout (sibling to canvas-viewer); \"model\" reflects that this is the pure data-model contract, not rendering or serialization.",
+  "description": "Whiteboard document-model Zod schemas (meta/facets/spatial/markdown/workspace-tree/mdast subset). Package name chosen to match the monorepo's per-concern packages/* layout (sibling to canvas-viewer); \"model\" reflects that this is the pure data-model contract, not rendering or serialization.",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/ports/src/doc-ref.ts
+++ b/packages/ports/src/doc-ref.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 
 /**
  * A DocRef identifies which sync-able document a store/sync operation
- * targets. Two kinds exist because the OpenCanvas model has exactly two
+ * targets. Two kinds exist because the document model has exactly two
  * Loro-backed document types: an individual canvas, and the single
  * workspace-tree document. Adding a third document type extends this
  * union rather than overloading either variant.

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.kamiazya/whiteboard",
-  "description": "Collaborative OpenCanvas whiteboard MCP server. Lets AI agents (Claude Code / Codex) and humans co-author diagrams on a shared canvas: create canvases, patch nodes / edges, save & restore version checkpoints, and export SVG / OKF Markdown / JSON Canvas. Browser canvas is served by a local daemon on 127.0.0.1.",
+  "description": "Collaborative whiteboard MCP server. Lets AI agents (Claude Code / Codex) and humans co-author diagrams on a shared canvas: create canvases, patch nodes / edges, save & restore version checkpoints, and export SVG / OKF Markdown / JSON Canvas. Browser canvas is served by a local daemon on 127.0.0.1.",
   "status": "active",
   "repository": {
     "url": "https://github.com/kamiazya/whiteboard",


### PR DESCRIPTION
## Summary

Two follow-ups #826 left behind, both about calling things what they are.

- **`OpenCanvas` is retired.** It had no definition anywhere in the repo and no citation, unlike OKF, which ADR-0009 introduces with a URL. What this project implements is [JSON Canvas 1.0](https://jsoncanvas.org/spec/1.0/) — `packages/model/src/spatial.ts` cites the URL and all of `packages/codec/src/spatial/` spells it correctly — so the codebase was saying it two ways at once, the fault ADR-0009 criticised for `format`/`kind`. The name is also taken by something adjacent enough to mislead: the Open Canvas Working Group publishes **OCIF**, an infinite-canvas interchange format this project does not implement, and `opencanvas` was in the npm `keywords` and both plugin manifests — so the claim was being made to a search index.
- **The daemon page gets its document identity back.** #826 dropped #837's Properties bar because it read the title out of the document's own core facets, which ADR-0009 decision 2 forbids. It is rebuilt on the workspace's display name instead, and the facets disclosure comes back for markdown documents only.

**Reading all 69 non-handler occurrences changed the first fix.** Very few meant the FORMAT; most were this project's working name for the post-Excalidraw document world — *"the OpenCanvas doc store"*, *"the OpenCanvas /api/v1 surface"*, *"OpenCanvas data-model Zod schemas"*. ADR-0009 already named that entity a **Document**, so the word is mostly **deleted** rather than replaced, and `JSON Canvas` appears only where a file format is genuinely meant.

**And the second fix turned out to need no new API.** The stated reason for deferring it — that the daemon has no display-name API — was wrong:

- `DocumentIndex.setDocumentName` exists and `sqlite-document-index` implements it.
- `GET /api/workspaces/:id/names` and `PUT .../name` have been serving it all along.
- `apps/web` already loads it: `useCanvasNames`, mounted by `WorkspaceTopBar`, is what renames a document from the canvas dropdown.

What was true is narrower, and is what #837's comment actually said: the canvas **summary** carries no name, only a path. The name was one component away the whole time.

## What changed, and why in that shape

**`titleSlot` is now a function of the identity, not a node.** The top bar owns `/names`, so a page rendering its own identity would either duplicate that fetch or invent a second source for the same value — and two sources for a document's name is exactly the shape decision 2 exists to prevent. Passing it down is what lets both pages agree that a document is named by its workspace.

**`CanvasProperties.onTitleChange` becomes optional**, rendering the title read-only when absent. That is the honest contract for a backend that cannot rename, rather than a box that accepts keystrokes and discards them.

**Facets return the way the body did in #826**: `set-facets` beside `set-body`, neither an `EditorLeafCommand` (no node, no edge, canvas value untouched, never in a batch), both republished on the one doc-change notification since they change together on hydration, remote import and undo. **Nothing decides whether to offer the disclosure** — `readCoreFacets` already answers `undefined` for a spatial document, so decision 3 falls out of the data instead of needing a flag a later edit could desync.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [x] `pnpm test` passes locally
- [x] Manual verification completed (describe below)
- [x] E2E coverage added or extended where applicable

Red first, both halves of the identity work. The name test failed on a missing title box; the facets test failed on markdown while **already passing on spatial**, which is the shape that shows the split is real rather than asserted. Mutation-checked: making the bar report `path` instead of the stored name turns the name test red again.

`pnpm test` → **7312 passed**. `pnpm test:browser`, run separately with an explicit chromium path → **115 files / 592 passed**. `pnpm -r typecheck`, `pnpm lint`, `pnpm knip`, `pnpm install --frozen-lockfile` all clean.

Nine failures in `pnpm test` are **this sandbox only** (`CanvasThumb`, `MergeDialog`, `VersionThumbnail` ×4, `VersionTimeline`, `daemon-file-adapter` — all objectURL/thumbnail). They fail identically on `origin/main`; measured, not assumed. CI is the authoritative gate.

## Visual evidence

The daemon page's header row gains a title box showing the workspace's display name for the open document, plus the Properties (type/tags) disclosure on a markdown document — matching the browser-local page. Both are pinned by `DaemonCanvasPage.markdown.test.tsx` rather than by a screenshot, including the negative case (a spatial document shows the title box and **no** disclosure).

The one other user-visible change is a string: *"This workspace has no OpenCanvas tree yet."* → *"This workspace has no document tree yet."*

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

Reached by the retirement: every published manifest (npm description + keywords, the Claude and Codex plugin manifests, `server.json`, the Gemini extension), the READMEs, the user docs and the architecture diagram source, the UI string above, and the internal identifiers — `registerOpenCanvasTools` → `registerDocumentTools`, `opencanvas-tools.ts` → `document-tools.ts`, `createOpenCanvasServer` → `createDocumentServer`, `app.opencanvas-v1.test.ts` → `app.api-v1.test.ts`.

## What is deliberately left

- **ADR-0007/0008/0009 keep the word** and gain a dated vocabulary note, exactly as they did for `slug`. A decision record is history; rewriting the reasoning would misreport what was decided.
- **`onOpenCanvas`, 178 occurrences.** It is the `Canvas`-as-container-noun violation wearing a handler name, so it is the standing rule's *"fix it where you already are, never as a sweep"* case. Recorded under Known violations so the next person grepping the retired word knows they are the expected remainder rather than a miss.
- **No executable rung for `OpenCanvas`.** A `vocabulary-check` entry would need to exclude both the ADR directory and every `onOpenCanvas`, and a guard needing two carve-outs to pass is one nobody trusts the next time it fires. Same reason `canvas` will never qualify.

## Corrections to claims made in #826

Both were stated confidently there and are wrong:

- *"193 of the 262 occurrences are `onOpenCanvas`-style React handlers."* The real count is **178**. The other 16 were `registerOpenCanvasTools` (14) and `createOpenCanvasServer` (2) — not handlers, and renamed here.
- *"The daemon's canvas summary carries only a path, so there is nothing to write a name back through."* The first half is true, the conclusion is not — see above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGjid2m1cEL6t1VtNpHU2D

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGjid2m1cEL6t1VtNpHU2D)_