### PR TITLE
feat(web): cut remembers its cut surface — paste reconnects boundary edges

### DIFF
--- a/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
@@ -118,6 +118,8 @@ export interface CanvasContextMenuProps {
   readonly onOpenFileRef?: (file: string, subpath?: string) => void
   readonly openLinkNode: (node: Extract<SpatialNode, { type: 'link' }>) => void
   readonly copySelection: () => ClipboardFragment | null
+  /** Cut-flavoured copy: also records the cut surface for paste to reconnect. */
+  readonly cutSelection: () => ClipboardFragment | null
   readonly deleteSelectionAsBatch: () => boolean
   readonly duplicateSelection: () => boolean
   readonly reorderSelection: (placement: 'forward' | 'backward' | 'front' | 'back') => void
@@ -157,6 +159,7 @@ export function CanvasContextMenu({
   onOpenFileRef,
   openLinkNode,
   copySelection,
+  cutSelection,
   deleteSelectionAsBatch,
   duplicateSelection,
   reorderSelection,
@@ -568,7 +571,7 @@ export function CanvasContextMenu({
           icon: <Scissors />,
           onSelect: () => {
             // Menu path mirrors the native cut: copy, then remove.
-            if (copySelection() !== null) deleteSelectionAsBatch()
+            if (cutSelection() !== null) deleteSelectionAsBatch()
           },
         })
         verbs.push({

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -94,9 +94,9 @@ import { writeLastTool } from '@/lib/initial-tool'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
 import { extractClipboardFragment, parseClipboardText } from '../../lib/clipboard-fragment.js'
 import {
-  isCutConsumed,
-  markCutConsumed,
   readClipboardFragment,
+  recordedReconnection,
+  recordReconnection,
   writeClipboardFragment,
 } from '../../lib/clipboard-store.js'
 import { hapticTick } from '../../lib/haptics.js'
@@ -2115,10 +2115,18 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       at?: Point,
     ): boolean => {
       const current = canvasRef.current
-      // The cut surface reconnects on the FIRST paste only; after that the
-      // fragment behaves as a plain copy (no second wire onto the peer).
+      // The cut surface reconnects while the document shows no trace of a
+      // previous reconnection: as long as any edge a prior paste of this cut
+      // created is still on THIS canvas, the fragment behaves as a plain
+      // copy (no second wire onto the peer). Undo removes those edges, so
+      // the next paste is a first paste again.
       const cut =
-        fragment.cut !== undefined && !isCutConsumed(fragment.cut.id) ? fragment.cut : undefined
+        fragment.cut !== undefined &&
+        !recordedReconnection(fragment.cut.id).some((id) =>
+          current.edges.some((edge) => edge.id === id),
+        )
+          ? fragment.cut
+          : undefined
       const command = buildFragmentInsertCommand(
         current,
         { nodes: fragment.nodes, edges: fragment.edges, cut },
@@ -2128,7 +2136,22 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       if (command === undefined) return false
       const running = applyCommand(current, command)
       if (running === current) return false
-      if (cut !== undefined) markCutConsumed(cut.id)
+      if (cut !== undefined && command.kind === 'batch') {
+        // The boundary edges are the created edges with an endpoint OUTSIDE
+        // the created node set — that endpoint is the surviving peer.
+        const createdNodeIds = new Set(
+          command.commands.flatMap((c) => (c.kind === 'create-node' ? [c.node.id] : [])),
+        )
+        recordReconnection(
+          cut.id,
+          command.commands.flatMap((c) =>
+            c.kind === 'create-edge' &&
+            (!createdNodeIds.has(c.edge.fromNode) || !createdNodeIds.has(c.edge.toNode))
+              ? [c.edge.id]
+              : [],
+          ),
+        )
+      }
       onChange(running, command)
       const remintedIds =
         command.kind === 'batch'

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -93,7 +93,12 @@ import {
 import { writeLastTool } from '@/lib/initial-tool'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
 import { extractClipboardFragment, parseClipboardText } from '../../lib/clipboard-fragment.js'
-import { readClipboardFragment, writeClipboardFragment } from '../../lib/clipboard-store.js'
+import {
+  isCutConsumed,
+  markCutConsumed,
+  readClipboardFragment,
+  writeClipboardFragment,
+} from '../../lib/clipboard-store.js'
 import { hapticTick } from '../../lib/haptics.js'
 import { composeReferenceSeam } from '../../lib/layout-worker-protocol.js'
 import type { BoxMove } from './align.js'
@@ -2047,6 +2052,23 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       return fragment
     }
 
+    /**
+     * Cut-flavoured copy: the fragment also records the cut surface (the
+     * edges the deletion is about to sever), so the FIRST same-canvas paste
+     * reconnects them — a cut is the front half of a move, not a delete.
+     */
+    const cutSelection = (): ClipboardFragment | null => {
+      if (selection === undefined) return null
+      const fragment = extractClipboardFragment(
+        canvasRef.current,
+        new Set([selection.id, ...extraIds]),
+        { cutId: crypto.randomUUID() },
+      )
+      if (fragment.nodes.length === 0) return null
+      writeClipboardFragment(fragment)
+      return fragment
+    }
+
     /** Remove the selection as ONE batch (one undo step). */
     const deleteSelectionAsBatch = (): boolean => {
       if (selection === undefined) return false
@@ -2089,19 +2111,24 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
 
     /** Paste an explicit fragment (in-app slot, or one parsed off the OS clipboard). */
     const pasteFragment = (
-      fragment: Pick<ClipboardFragment, 'nodes' | 'edges'>,
+      fragment: Pick<ClipboardFragment, 'nodes' | 'edges' | 'cut'>,
       at?: Point,
     ): boolean => {
       const current = canvasRef.current
+      // The cut surface reconnects on the FIRST paste only; after that the
+      // fragment behaves as a plain copy (no second wire onto the peer).
+      const cut =
+        fragment.cut !== undefined && !isCutConsumed(fragment.cut.id) ? fragment.cut : undefined
       const command = buildFragmentInsertCommand(
         current,
-        fragment,
+        { nodes: fragment.nodes, edges: fragment.edges, cut },
         () => createId?.() ?? crypto.randomUUID(),
         at,
       )
       if (command === undefined) return false
       const running = applyCommand(current, command)
       if (running === current) return false
+      if (cut !== undefined) markCutConsumed(cut.id)
       onChange(running, command)
       const remintedIds =
         command.kind === 'batch'
@@ -2896,7 +2923,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         }}
         onCut={(e) => {
           if (isTextEntryEvent(e.nativeEvent)) return
-          const fragment = copySelection()
+          const fragment = cutSelection()
           if (fragment === null) return
           e.preventDefault()
           e.clipboardData?.setData('text/plain', JSON.stringify(fragment))
@@ -3107,6 +3134,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             onOpenFileRef={onOpenFileRef}
             openLinkNode={openLinkNode}
             copySelection={copySelection}
+            cutSelection={cutSelection}
             deleteSelectionAsBatch={deleteSelectionAsBatch}
             duplicateSelection={duplicateSelection}
             reorderSelection={reorderSelection}

--- a/apps/web/src/components/spatial-editor/clipboard.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/clipboard.browser.test.tsx
@@ -2,7 +2,7 @@
 // the module-level clipboard store — cross-canvas within the tab, every
 // mutation ONE batch command (one undo step), reminted ids on every paste.
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
-import { cleanup, fireEvent, render } from '@testing-library/react'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, beforeEach, expect, it } from 'vitest'
 import { clearClipboardFragmentForTests } from '../../lib/clipboard-store.js'
@@ -21,13 +21,19 @@ const initial: SpatialCanvas = {
 }
 
 function makeHost(start: SpatialCanvas = initial) {
-  const latest: { canvas: SpatialCanvas; commands: EditorCommand[] } = {
+  const latest: {
+    canvas: SpatialCanvas
+    commands: EditorCommand[]
+    reset: (canvas: SpatialCanvas) => void
+  } = {
     canvas: start,
     commands: [],
+    reset: () => {},
   }
   function Host() {
     const [canvas, setCanvas] = useState<SpatialCanvas>(start)
     latest.canvas = canvas
+    latest.reset = setCanvas
     return (
       <div style={{ width: 800, height: 600 }}>
         <SpatialEditor
@@ -135,6 +141,55 @@ it('cut then paste restores the boundary edge to its surviving peer — cut is a
   clip(root, 'paste')
   expect(latest.canvas.nodes).toHaveLength(3)
   expect(latest.canvas.edges).toHaveLength(1)
+})
+
+it("the context menu's Cut records the cut surface too — menu and keyboard are the same cut", () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+
+  const r = root.getBoundingClientRect()
+  fireEvent.contextMenu(root, { clientX: r.left + 120, clientY: r.top + 80 })
+  const cutItem = [...container.querySelectorAll('[role="menuitem"]')].find(
+    (el) => (el.getAttribute('aria-label') ?? el.textContent) === 'Cut',
+  ) as HTMLElement
+  expect(cutItem).toBeDefined()
+  fireEvent.click(cutItem)
+  expect(latest.canvas.nodes.map((n) => n.id)).toEqual(['b'])
+  expect(latest.canvas.edges).toEqual([])
+
+  clip(root, 'paste')
+  const pasted = latest.canvas.nodes.find((n) => n.type === 'text' && n.text === 'A')
+  expect(latest.canvas.edges).toHaveLength(1)
+  const restored = latest.canvas.edges[0]
+  expect([restored.fromNode, restored.toNode].sort()).toEqual([pasted?.id, 'b'].sort())
+})
+
+it('undoing a paste restores the cut surface — the next paste reconnects again', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+
+  clip(root, 'cut')
+  const afterCut = latest.canvas
+  clip(root, 'paste')
+  expect(latest.canvas.edges).toHaveLength(1)
+
+  // The paste landed in the wrong spot and the person undoes it. Undo lives
+  // in the host (one batch = one undo step), so from this component's side
+  // it arrives as the pre-paste snapshot coming back.
+  act(() => latest.reset(afterCut))
+  expect(latest.canvas.edges).toEqual([])
+
+  // The document holds no trace of the first paste, so the next paste is a
+  // first paste again: the boundary edge must reconnect, not silently drop.
+  clip(root, 'paste')
+  const pasted = latest.canvas.nodes.find((n) => n.type === 'text' && n.text === 'A')
+  expect(latest.canvas.edges).toHaveLength(1)
+  const restored = latest.canvas.edges[0]
+  expect([restored.fromNode, restored.toNode].sort()).toEqual([pasted?.id, 'b'].sort())
 })
 
 it('copy then paste never wires the duplicate to the original peer', () => {

--- a/apps/web/src/components/spatial-editor/clipboard.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/clipboard.browser.test.tsx
@@ -114,6 +114,43 @@ it('cut removes the selection as ONE batch and paste restores a reminted copy', 
   expect(latest.canvas.nodes[1]).toMatchObject({ text: 'A' })
 })
 
+it('cut then paste restores the boundary edge to its surviving peer — cut is a move, not a delete', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+
+  clip(root, 'cut')
+  expect(latest.canvas.edges).toEqual([])
+
+  clip(root, 'paste')
+  const pasted = latest.canvas.nodes.find((n) => n.type === 'text' && n.text === 'A')
+  expect(pasted).toBeDefined()
+  // The edge to the untouched peer is back, endpoints reminted-side + peer.
+  expect(latest.canvas.edges).toHaveLength(1)
+  const restored = latest.canvas.edges[0]
+  expect([restored.fromNode, restored.toNode].sort()).toEqual([pasted?.id, 'b'].sort())
+
+  // A second paste of the same cut is a plain copy: no second wire onto the peer.
+  clip(root, 'paste')
+  expect(latest.canvas.nodes).toHaveLength(3)
+  expect(latest.canvas.edges).toHaveLength(1)
+})
+
+it('copy then paste never wires the duplicate to the original peer', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+
+  clip(root, 'copy')
+  clip(root, 'paste')
+  // The original edge a–b survives untouched; the duplicate arrives bare.
+  expect(latest.canvas.nodes).toHaveLength(3)
+  expect(latest.canvas.edges).toHaveLength(1)
+  expect(latest.canvas.edges[0]).toMatchObject({ fromNode: 'a', toNode: 'b' })
+})
+
 it('a multi-selection copy carries the internal edge with properties; paste remaps endpoints', () => {
   const { Host, latest } = makeHost()
   const { container } = render(<Host />)

--- a/apps/web/src/components/spatial-editor/commands.test.ts
+++ b/apps/web/src/components/spatial-editor/commands.test.ts
@@ -739,6 +739,36 @@ describe('buildFragmentInsertCommand', () => {
     return () => `new-${n++}`
   }
 
+  it('a cut fragment reconnects its boundary edges to surviving peers, reminted on the cut side', () => {
+    // The peer stayed on the canvas; the cut node comes back with a new id.
+    const canvas: SpatialCanvas = {
+      nodes: [{ id: 'peer', type: 'text', x: 400, y: 0, width: 100, height: 50, text: 'peer' }],
+      edges: [],
+    }
+    const cutFragment = {
+      ...fragment(),
+      cut: {
+        id: 'cut-1',
+        boundaryEdges: [
+          { id: 'src-boundary', fromNode: 'src-b', toNode: 'peer', label: 'kept' },
+          // This peer is gone (cross-canvas, or deleted since): silently dropped.
+          { id: 'src-gone', fromNode: 'src-a', toNode: 'vanished' },
+        ],
+      },
+    }
+    const command = buildFragmentInsertCommand(canvas, cutFragment, sequentialIds())
+    if (command?.kind !== 'batch') throw new Error('expected a batch command')
+    const edgeCommands = command.commands.filter((c) => c.kind === 'create-edge')
+    const nodeCommands = command.commands.filter((c) => c.kind === 'create-node')
+    const remintedB = nodeCommands.find((c) => c.node.type === 'text' && c.node.text === 'b')?.node
+      .id
+    expect(remintedB).toBeDefined()
+    const boundary = edgeCommands.find((c) => c.edge.label === 'kept')?.edge
+    expect(boundary).toMatchObject({ fromNode: remintedB, toNode: 'peer' })
+    expect(boundary?.id).not.toBe('src-boundary')
+    expect(edgeCommands.some((c) => c.edge.toNode === 'vanished')).toBe(false)
+  })
+
   it('returns undefined for an empty-node fragment', () => {
     const canvas: SpatialCanvas = { nodes: [], edges: [] }
     expect(buildFragmentInsertCommand(canvas, { nodes: [], edges: [] }, sequentialIds())).toBe(

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -623,7 +623,7 @@ const DUPLICATE_OFFSET_PX = 16
  */
 export function buildFragmentInsertCommand(
   canvas: SpatialCanvas,
-  fragment: Pick<ClipboardFragment, 'nodes' | 'edges'>,
+  fragment: Pick<ClipboardFragment, 'nodes' | 'edges' | 'cut'>,
   createId: () => string,
   anchor?: Point,
 ): EditorCommand | undefined {
@@ -643,6 +643,26 @@ export function buildFragmentInsertCommand(
     dx = Math.round(anchor.x - (minX + maxX) / 2)
     dy = Math.round(anchor.y - (minY + maxY) / 2)
   }
+  // A cut fragment reconnects its severed boundary edges to peers that
+  // still exist on THIS canvas (same-canvas paste is a move); a missing
+  // peer means a cross-canvas paste or a deleted neighbour, and the edge
+  // drops silently — exactly what a plain copy would have done.
+  const canvasNodeIds = new Set(canvas.nodes.map((node) => node.id))
+  const boundaryEdges = (fragment.cut?.boundaryEdges ?? []).flatMap((edge) => {
+    const from = reminted.idMap.get(edge.fromNode)
+    const to = reminted.idMap.get(edge.toNode)
+    if ((from === undefined) === (to === undefined)) return []
+    const peer = from === undefined ? edge.fromNode : edge.toNode
+    if (!canvasNodeIds.has(peer)) return []
+    return [
+      {
+        ...edge,
+        id: reminted.mintId(),
+        fromNode: from ?? edge.fromNode,
+        toNode: to ?? edge.toNode,
+      },
+    ]
+  })
   return {
     kind: 'batch',
     commands: [
@@ -650,7 +670,9 @@ export function buildFragmentInsertCommand(
         (node) =>
           ({ kind: 'create-node', node: { ...node, x: node.x + dx, y: node.y + dy } }) as const,
       ),
-      ...reminted.edges.map((edge) => ({ kind: 'create-edge', edge }) as const),
+      ...[...reminted.edges, ...boundaryEdges].map(
+        (edge) => ({ kind: 'create-edge', edge }) as const,
+      ),
     ],
   }
 }

--- a/apps/web/src/components/spatial-editor/os-clipboard.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/os-clipboard.browser.test.tsx
@@ -158,6 +158,38 @@ it('a native cut copies to the OS clipboard AND removes the selection in one bat
   expect(latest.commands.at(-1)?.kind).toBe('batch')
 })
 
+it('an OS-clipboard cut→paste reconnects the boundary edge once — the JSON carries the cut surface', () => {
+  const wired: SpatialCanvas = {
+    nodes: [
+      { id: 'a', type: 'text', x: 40, y: 40, width: 160, height: 80, text: 'A' },
+      { id: 'b', type: 'text', x: 320, y: 40, width: 160, height: 80, text: 'B' },
+    ],
+    edges: [{ id: 'ab', fromNode: 'a', toNode: 'b', label: 'kept' }],
+  }
+  const { Host, latest } = makeHost(wired)
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectFirst(root)
+
+  const clipboardData = clipboardWith()
+  dispatchClipboard(root, 'cut', clipboardData)
+  expect(latest.canvas.edges).toEqual([])
+  const written = clipboardData.getData('text/plain')
+  // The cut surface survives the JSON round trip Ctrl+V re-parses.
+  expect(JSON.parse(written).cut.boundaryEdges).toHaveLength(1)
+
+  // Each paste re-parses the SAME text, exactly like repeated Ctrl+V.
+  dispatchClipboard(root, 'paste', clipboardWith(written))
+  const pasted = latest.canvas.nodes.find((n) => n.type === 'text' && n.text === 'A')
+  expect(latest.canvas.edges).toHaveLength(1)
+  const restored = latest.canvas.edges[0]
+  expect([restored.fromNode, restored.toNode].sort()).toEqual([pasted?.id, 'b'].sort())
+
+  dispatchClipboard(root, 'paste', clipboardWith(written))
+  expect(latest.canvas.nodes).toHaveLength(3)
+  expect(latest.canvas.edges).toHaveLength(1)
+})
+
 it('the in-app store still round-trips when the event carries no clipboardData', () => {
   const { Host, latest } = makeHost()
   const { container } = render(<Host />)

--- a/apps/web/src/lib/clipboard-fragment.test.ts
+++ b/apps/web/src/lib/clipboard-fragment.test.ts
@@ -29,6 +29,19 @@ describe('extractClipboardFragment', () => {
     expect(clipboardFragmentSchema.safeParse(fragment).success).toBe(true)
   })
 
+  it('a cut extraction records boundary edges — the cut remembers its own cut surface', () => {
+    const fragment = extractClipboardFragment(canvas, new Set(['a', 'b']), { cutId: 'cut-1' })
+    expect(fragment.edges.map((edge) => edge.id)).toEqual(['ab'])
+    // 'bc' crosses the border (b in, c out): carried as a boundary edge so a
+    // same-canvas paste can reconnect it; a copy never records it.
+    expect(fragment.cut).toEqual({
+      id: 'cut-1',
+      boundaryEdges: [{ id: 'bc', fromNode: 'b', toNode: 'c' }],
+    })
+    expect(clipboardFragmentSchema.safeParse(fragment).success).toBe(true)
+    expect(extractClipboardFragment(canvas, new Set(['a', 'b'])).cut).toBeUndefined()
+  })
+
   it('an empty or unknown selection yields an empty (still valid) fragment', () => {
     const fragment = extractClipboardFragment(canvas, new Set(['ghost']))
     expect(fragment.nodes).toEqual([])

--- a/apps/web/src/lib/clipboard-fragment.ts
+++ b/apps/web/src/lib/clipboard-fragment.ts
@@ -40,18 +40,31 @@ export function parseClipboardText(text: string): ClipboardFragment | null {
 export function extractClipboardFragment(
   canvas: SpatialCanvas,
   selectedIds: ReadonlySet<string>,
+  options?: { readonly cutId?: string },
 ): ClipboardFragment {
   const nodes = canvas.nodes.filter((node) => selectedIds.has(node.id))
   const included = new Set(nodes.map((node) => node.id))
   const edges = canvas.edges.filter(
     (edge) => included.has(edge.fromNode) && included.has(edge.toNode),
   )
-  return { type: 'whiteboard/clipboard', version: 1, nodes, edges }
+  const base = { type: 'whiteboard/clipboard', version: 1, nodes, edges } as const
+  if (options?.cutId === undefined) return base
+  // A cut also records its cut surface — the edges it severs (exactly one
+  // endpoint selected) — so a same-canvas paste can reconnect them. The
+  // fragment proper stays self-contained; peers live only on the source.
+  const boundaryEdges = canvas.edges.filter(
+    (edge) => included.has(edge.fromNode) !== included.has(edge.toNode),
+  )
+  return { ...base, cut: { id: options.cutId, boundaryEdges } }
 }
 
 export interface RemintedFragment {
   readonly nodes: readonly SpatialNode[]
   readonly edges: readonly CanvasEdge[]
+  /** Source id → reminted id, for reconnecting a cut's boundary edges. */
+  readonly idMap: ReadonlyMap<string, string>
+  /** Mints further ids from the same collision-free pool (boundary edges). */
+  readonly mintId: () => string
 }
 
 export function remintClipboardFragment(
@@ -79,5 +92,5 @@ export function remintClipboardFragment(
     if (fromNode === undefined || toNode === undefined) return []
     return [{ ...edge, id: freshId(), fromNode, toNode }]
   })
-  return { nodes, edges }
+  return { nodes, edges, idMap, mintId: freshId }
 }

--- a/apps/web/src/lib/clipboard-store.ts
+++ b/apps/web/src/lib/clipboard-store.ts
@@ -27,7 +27,24 @@ export function hasClipboardFragment(): boolean {
   return current !== null && current.nodes.length > 0
 }
 
+/**
+ * Cut ids whose boundary edges have already been reconnected by a paste.
+ * Module-scoped like the slot: the "first paste only" rule must hold even
+ * when the paste arrives via the OS clipboard (Ctrl+V re-parses the JSON
+ * fresh each time, so the envelope itself cannot be consumed).
+ */
+const consumedCutIds = new Set<string>()
+
+export function isCutConsumed(cutId: string): boolean {
+  return consumedCutIds.has(cutId)
+}
+
+export function markCutConsumed(cutId: string): void {
+  consumedCutIds.add(cutId)
+}
+
 /** Test isolation only — production never clears the slot. */
 export function clearClipboardFragmentForTests(): void {
   current = null
+  consumedCutIds.clear()
 }

--- a/apps/web/src/lib/clipboard-store.ts
+++ b/apps/web/src/lib/clipboard-store.ts
@@ -28,23 +28,27 @@ export function hasClipboardFragment(): boolean {
 }
 
 /**
- * Cut ids whose boundary edges have already been reconnected by a paste.
- * Module-scoped like the slot: the "first paste only" rule must hold even
- * when the paste arrives via the OS clipboard (Ctrl+V re-parses the JSON
- * fresh each time, so the envelope itself cannot be consumed).
+ * Edge ids a cut's boundary reconnection created, per cut id. Module-scoped
+ * like the slot: the "reconnect once" rule must hold even when the paste
+ * arrives via the OS clipboard (Ctrl+V re-parses the JSON fresh each time,
+ * so the envelope itself cannot be consumed). Kept as the CREATED ids, not
+ * a boolean, so the decision can follow the document: an undone paste
+ * removes these edges from the canvas, and the next paste is a first paste
+ * again. An empty result is never recorded — a cross-canvas paste that
+ * found no peers must not erase the record of a real reconnection at home.
  */
-const consumedCutIds = new Set<string>()
+const reconnections = new Map<string, readonly string[]>()
 
-export function isCutConsumed(cutId: string): boolean {
-  return consumedCutIds.has(cutId)
+export function recordedReconnection(cutId: string): readonly string[] {
+  return reconnections.get(cutId) ?? []
 }
 
-export function markCutConsumed(cutId: string): void {
-  consumedCutIds.add(cutId)
+export function recordReconnection(cutId: string, edgeIds: readonly string[]): void {
+  if (edgeIds.length > 0) reconnections.set(cutId, edgeIds)
 }
 
 /** Test isolation only — production never clears the slot. */
 export function clearClipboardFragmentForTests(): void {
   current = null
-  consumedCutIds.clear()
+  reconnections.clear()
 }

--- a/packages/model/src/clipboard.test.ts
+++ b/packages/model/src/clipboard.test.ts
@@ -73,6 +73,37 @@ describe('clipboardFragmentSchema', () => {
     ).toBe(false)
   })
 
+  it('accepts a cut fragment whose boundary edges each cross the selection border', () => {
+    const fragment = {
+      type: 'whiteboard/clipboard',
+      version: 1,
+      nodes: [NODE],
+      edges: [],
+      cut: {
+        id: 'cut-1',
+        // n1 is in the fragment; 'outside' is the peer left on the canvas.
+        boundaryEdges: [{ id: 'e-b', fromNode: 'n1', toNode: 'outside' }],
+      },
+    }
+    expect(clipboardFragmentSchema.safeParse(fragment).success).toBe(true)
+  })
+
+  it('rejects a boundary edge that does not cross the border (both endpoints in, or none)', () => {
+    const base = { type: 'whiteboard/clipboard', version: 1, nodes: [NODE, NODE2], edges: [] }
+    expect(
+      clipboardFragmentSchema.safeParse({
+        ...base,
+        cut: { id: 'cut-1', boundaryEdges: [{ id: 'e-b', fromNode: 'n1', toNode: 'n2' }] },
+      }).success,
+    ).toBe(false)
+    expect(
+      clipboardFragmentSchema.safeParse({
+        ...base,
+        cut: { id: 'cut-1', boundaryEdges: [{ id: 'e-b', fromNode: 'x', toNode: 'y' }] },
+      }).success,
+    ).toBe(false)
+  })
+
   it('rejects extra keys and malformed file assets (strict envelope)', () => {
     expect(
       clipboardFragmentSchema.safeParse({

--- a/packages/model/src/clipboard.ts
+++ b/packages/model/src/clipboard.ts
@@ -28,6 +28,22 @@ export const clipboardFragmentSchema = z
     edges: z.array(canvasEdgeSchema),
     /** Inline assets keyed by the file-node `file` reference they carry. */
     files: z.record(z.string(), clipboardFileAssetSchema).optional(),
+    /**
+     * Present only on a CUT fragment: the cut surface. `boundaryEdges` are
+     * the edges the cut severed — exactly one endpoint in the fragment, the
+     * other a peer left behind on the source canvas. A same-canvas paste
+     * reconnects them to peers that still exist (cut is a move, not a
+     * delete); anywhere else the peers are absent and they drop silently.
+     * `id` is minted per cut so the reconnect happens on the FIRST paste
+     * only — later pastes are plain copies.
+     */
+    cut: z
+      .object({
+        id: z.string().min(1),
+        boundaryEdges: z.array(canvasEdgeSchema),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .superRefine((value, ctx) => {
@@ -65,6 +81,17 @@ export const clipboardFragmentSchema = z
           code: 'custom',
           message: `edge "${edge.id}" references toNode "${edge.toNode}" outside the fragment`,
           path: ['edges', index, 'toNode'],
+        })
+      }
+    })
+    value.cut?.boundaryEdges.forEach((edge, index) => {
+      // A boundary edge must CROSS the border: exactly one endpoint inside.
+      const inFragment = Number(seen.has(edge.fromNode)) + Number(seen.has(edge.toNode))
+      if (inFragment !== 1) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `boundary edge "${edge.id}" must have exactly one endpoint in the fragment`,
+          path: ['cut', 'boundaryEdges', index],
         })
       }
     })


### PR DESCRIPTION
## What

Cutting a node with edges to unselected neighbours lost those edges for good — paste brought the node back bare. The clipboard envelope is deliberately self-contained (edges need both endpoints in the fragment; that is what makes cross-canvas paste sound), so the same-canvas cut→paste — the one case that is semantically a **move** — had no way to restore its wiring.

Per the Canvas Manipulation Lab §⑪ decision (option A): the envelope now carries an optional **cut surface** — `cut: { id, boundaryEdges }` — where each boundary edge crosses the selection border (exactly one endpoint in the fragment, schema-refined). On paste:

- a peer that still exists on the target canvas gets reconnected, with the cut-side endpoint reminted alongside the node;
- a missing peer (cross-canvas paste, or the neighbour was deleted meanwhile) drops silently — exactly what a plain copy always did;
- the cut id is **consumed on the first paste**, so pasting again is a plain copy (no second wire onto the peer);
- **copy** fragments never record the surface — a duplicate arriving pre-wired to the original's neighbours would be a new surprise.

Works through both paste routes (in-app slot and the OS-clipboard JSON that Ctrl+V re-parses — consumption lives in the module-scoped store, not the envelope). Option B from the same Lab section (deferred "ghost" cut) is a separate design increment.

## Tests

- `packages/model` `clipboard.test.ts`: cut-surface field accepted; boundary edges that do not cross the border rejected (red-first)
- `clipboard-fragment.test.ts`: cut extraction records the surface, copy does not
- `commands.test.ts`: reconnection reminted onto the surviving peer; vanished peer dropped
- `clipboard.browser.test.tsx`: cut→paste restores the edge to the untouched peer; second paste adds no second wire; copy→paste stays bare — **mutation-checked** (removing reconnection or consumption each turns the browser test red)
- Full gates: model 146/146, jsdom exit 0, web-browser 584/585 (the one failure is the pre-existing markdown load-flake, 11/11 in isolation, file untouched), `pnpm -r typecheck`, lint, knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ua6RPuoEAD4ZTBqyhNC56Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cutting and pasting selected canvas items now preserves connections to remaining items on the first paste.
  * Cut operations behave as moves, while repeated pastes avoid creating duplicate connections.
  * Copy and paste behavior remains unchanged.

* **Bug Fixes**
  * Improved handling of connections when selected items are cut from the canvas, including safely omitting invalid connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->