### PR TITLE
test(server): make the #843 review findings executable; pin the measured no-op broadcast

### DIFF
--- a/packages/mcp-server/src/server/store/branch-merge.test.ts
+++ b/packages/mcp-server/src/server/store/branch-merge.test.ts
@@ -414,7 +414,7 @@ describe('performBranchMerge', () => {
       performBranchMerge(deps, SID, PATH, { source: 'ghost', into: 'main', dryRun: false }),
     ).rejects.toMatchObject({
       name: 'BranchNotFoundError',
-      message: expect.stringContaining(`ghost`),
+      message: expect.stringMatching(new RegExp(`ghost.*${SID}/${PATH}`)),
     })
   })
 
@@ -428,7 +428,7 @@ describe('performBranchMerge', () => {
       performBranchMerge(deps, SID, PATH, { source: 'feature', into: 'ghost', dryRun: false }),
     ).rejects.toMatchObject({
       name: 'BranchNotFoundError',
-      message: expect.stringContaining('ghost'),
+      message: expect.stringMatching(new RegExp(`ghost.*${SID}/${PATH}`)),
     })
   })
 
@@ -449,18 +449,25 @@ describe('performBranchMerge', () => {
     await expect(loadCanvasBranches(SID, PATH)).resolves.toEqual(before)
   })
 
-  it('does not broadcast when the exported update is zero-length', async () => {
-    // HEAD===into with an already-identical target/source doc produces a
-    // zero-byte update export, which must not reach broadcastLoroUpdate.
+  it('a no-op reconcile still broadcasts a header-only envelope (loro never exports zero bytes)', async () => {
+    // HEAD===into with an INITIALIZED source tip pointing at the same state
+    // as the live doc: reconcileLiveDocToPreview runs and the import adds no
+    // ops. loro's update export is never truly empty — the no-op case is a
+    // 22-byte header-only envelope, which clients import as a no-op — so the
+    // byteLength guard does not (and cannot) filter it. This pins the
+    // MEASURED behavior; an earlier version of this test claimed the guard
+    // suppressed the broadcast, which no loro export can actually trigger.
     const deps = createDeps()
     const doc = makeSpatialDoc({
       nodes: [{ id: 'A', type: 'text', text: 'a', x: 0, y: 0, width: 10, height: 10 }],
       edges: [],
     })
     await saveDocument(SID, PATH, doc, { overwrite: true })
-    const branch = await createBranch(SID, PATH, { name: 'feature' })
-    // feature's tip stays uninitialized (tracks the live doc identically to main).
-    expect(branch.tipFrontiers).toBe('')
+    await createBranch(SID, PATH, { name: 'feature' })
+    const state = await loadCanvasBranches(SID, PATH)
+    const feature = state.branches.find((b) => b.name === 'feature')!
+    feature.tipFrontiers = Buffer.from(encodeFrontiers(doc.frontiers())).toString('base64')
+    await saveCanvasBranches(SID, PATH, state)
 
     await performBranchMerge(deps, SID, PATH, {
       source: 'feature',
@@ -468,10 +475,59 @@ describe('performBranchMerge', () => {
       dryRun: false,
     })
 
-    // Uninitialized source tip means updateBranchTip/reconcile never ran at
-    // all (see the earlier "falls back to the live snapshot" case) — this
-    // pins the same zero-update guard from the HEAD===source cleanup branch.
-    expect(deps.broadcastLoroUpdate).not.toHaveBeenCalled()
+    expect(deps.broadcastLoroUpdate).toHaveBeenCalledTimes(1)
+    const [, , update] = deps.broadcastLoroUpdate.mock.calls[0]!
+    expect((update as Uint8Array).byteLength).toBeLessThan(30)
+  })
+
+  it('still reports switchedHead when reconciliation fails AFTER the head switch persisted', async () => {
+    // The head switch and the live-doc reconcile are separate effects:
+    // setHeadPersist has already durably moved HEAD when reconciliation
+    // throws, so the response reports the switch that DID happen (hiding it
+    // would tell clients nothing changed when it durably did) and the
+    // failure is a warning. Faithful to the pre-extraction inline behavior.
+    const deps = createDeps()
+    const doc = makeSpatialDoc({
+      nodes: [{ id: 'A', type: 'text', text: 'a', x: 0, y: 0, width: 10, height: 10 }],
+      edges: [],
+    })
+    await saveDocument(SID, PATH, doc, { overwrite: true })
+    await createBranch(SID, PATH, { name: 'feature' })
+    // Diverge feature from main so the cleanup-branch reconcile has real
+    // bytes to broadcast — that broadcast is the injection point below.
+    const state = await loadCanvasBranches(SID, PATH)
+    const feature = state.branches.find((b) => b.name === 'feature')!
+    const diverged = makeSpatialDoc({
+      nodes: [
+        { id: 'A', type: 'text', text: 'a', x: 0, y: 0, width: 10, height: 10 },
+        { id: 'B', type: 'text', text: 'b', x: 50, y: 0, width: 10, height: 10 },
+      ],
+      edges: [],
+    })
+    feature.tipFrontiers = Buffer.from(encodeFrontiers(diverged.frontiers())).toString('base64')
+    await saveCanvasBranches(SID, PATH, state)
+    await saveDocument(SID, PATH, diverged, { overwrite: true })
+    await branchesStore.setHead(SID, PATH, 'feature')
+    deps.broadcastLoroUpdate.mockImplementationOnce(() => {
+      throw new Error('broadcast boom')
+    })
+    const cap = captureLogsForTests('warning')
+
+    try {
+      const result = await performBranchMerge(deps, SID, PATH, {
+        source: 'feature',
+        into: 'main',
+        dryRun: false,
+      })
+
+      expect(result.committed).toBe(true)
+      expect(result.switchedHead).toEqual({ from: 'feature', to: 'main' })
+      expect(cap.records).toContainEqual(
+        expect.objectContaining({ scope: 'merge', msg: 'post-merge head switch failed' }),
+      )
+    } finally {
+      cap.restore()
+    }
   })
 
   it('surfaces a resurrected badge across a two-sided divergence in both badges and conflictElementIds', async () => {

--- a/packages/mcp-server/src/server/store/branch-merge.ts
+++ b/packages/mcp-server/src/server/store/branch-merge.ts
@@ -70,18 +70,15 @@ export interface PerformBranchMergeResult extends PerformMergeHookResult {
 // (3) detect LWW edge cases with detectMergeBadges
 // (4) on commit, update target tipFrontiers to source and, if target is HEAD,
 //     reconcile the live doc to the preview and broadcast the change
-// The whole read-modify-write (branch lookup, live-doc read, the
-// pre-merge snapshot, the tip/HEAD writes, and their doc
-// reconcile+save) runs inside one workspace-lock hold. getDoc(sid,
-// path) alone is unlocked, so a concurrent rename/delete that runs
-// its whole lock-protected section between this unlocked read and
-// the later saveDocument() calls below would find no row left at
-// this path and silently insert a phantom canvas (or resurrect
-// deleted content) instead of erroring or landing on the renamed
-// row. updateBranchTip/setHeadPersist/deleteBranch already acquire
-// this same per-workspace lock internally (branches-store.ts), so
-// they re-enter via the AsyncLocalStorage chain rather than
-// deadlocking — mirrors live-doc.ts's POST /update handler.
+// The whole read-modify-write (branch lookup, live-doc read via
+// getDoc, the pre-merge snapshot, the tip/HEAD writes, and their doc
+// reconcile+save) runs inside one workspace-lock hold, so document
+// rename/delete and branch rename/delete — which take the same
+// per-workspace lock — cannot interleave with a merge in flight.
+// updateBranchTip/setHeadPersist/deleteBranch also acquire this lock
+// internally (branches-store.ts) and re-enter via the
+// AsyncLocalStorage chain rather than deadlocking — mirrors
+// live-doc.ts's POST /update handler.
 export function performBranchMerge(
   deps: PerformBranchMergeDeps,
   sid: string,
@@ -226,6 +223,11 @@ export function performBranchMerge(
       liveDoc.commit()
       await saveDocument(sid, path, liveDoc, { overwrite: true })
       const update = liveDoc.export({ mode: 'update', from: prevVV }) as Uint8Array
+      // loro's update export is never truly empty — a no-op exports a 22-byte
+      // header-only envelope (measured against loro-crdt directly) — so a
+      // no-op reconcile still broadcasts, and clients import the envelope as
+      // a no-op. This guard only defends against a hypothetical zero-byte
+      // export.
       if (update.byteLength > 0) {
         broadcastLoroUpdate(sid, path, update)
       }
@@ -255,6 +257,10 @@ export function performBranchMerge(
       const afterCommit = await loadCanvasBranches(sid, path)
       if (afterCommit.head === source && source !== into) {
         await setHeadPersist(sid, path, into)
+        // switchedHead reports the PERSISTED head switch. It is deliberately
+        // assigned before the reconcile below: if reconciliation then fails,
+        // HEAD has still durably moved, and hiding the switch would tell
+        // clients nothing changed when it did — the failure itself is warned.
         switchedHead = { from: source, to: into }
         sendHeadChanged(sid, path, into)
         // Already done when HEAD===target, but HEAD===source needs it here.

--- a/packages/mcp-server/src/server/store/branch-merge.types.test.ts
+++ b/packages/mcp-server/src/server/store/branch-merge.types.test.ts
@@ -2,12 +2,10 @@ import { expectTypeOf, it } from 'vitest'
 import type { CreateBranchesRouterOptions } from '../routes/branches.js'
 import type { PerformBranchMergeResult, PerformMergeHookResult } from './branch-merge.js'
 
-// Compile-time only: routes/branches.ts's pluggable performMerge hook used
-// to duplicate this shape by hand as a second, independently-maintained
-// interface — the two had already drifted (required vs optional counts,
-// MergeBadge[] vs Array<Record<string, unknown>>) before anyone noticed.
-// branches.ts now imports PerformMergeHookResult instead of re-declaring
-// it, so this test fails to compile the moment the two diverge again.
+// Compile-time only: routes/branches.ts's pluggable performMerge hook must
+// stay assignable to the store module's result type — branches.ts imports
+// PerformMergeHookResult rather than re-declaring it, and this test fails
+// to compile the moment the two diverge.
 // expectTypeOf is erased at runtime — `vitest run` always shows this file
 // green regardless of whether the types actually match — so the guard is
 // `pnpm typecheck`, not the test run. tsconfig.server.json's `files` array


### PR DESCRIPTION
## What

Post-merge triage of the five CodeRabbit findings on #843, each verified against the code before acting (per the merge-gate discipline; the findings arrived after the merge decision):

1. **Ghost-branch error tests** now assert the workspace/path context their names promise.
2. **The "zero-length update" test pinned a fiction.** Measured directly against loro-crdt: a no-op update export is a **22-byte header-only envelope, never zero bytes**, so the `byteLength > 0` guard is unreachable as a no-op filter. The test now pins the measured reality (a no-op reconcile broadcasts the envelope; clients import it as a no-op) and the guard's comment states the measurement.
3. **New pin for the Major finding — deliberately NOT the reviewer's proposed reorder.** Reconciliation failing after `setHeadPersist` still reports `switchedHead`: the head switch durably happened (verified this is the pre-extraction inline behavior at `0b7a445e`), and hiding it would tell clients nothing changed when it did. The semantic is now pinned by a test plus a comment at the assignment.
4. **Lock comment corrected**: inside `performBranchMerge`, `getDoc` runs within the workspace lock, so document/branch rename/delete cannot interleave; the stale "getDoc alone is unlocked" scenario is gone, reentrancy explanation retained.
5. `branch-merge.types.test.ts`'s comment drops the change-history anecdote per source-comment discipline.

## Verification

mcp-node: 3479 passed / 6 skipped (282 files); typecheck + biome clean. Tests-only plus two comments — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ
