### PR TITLE
fix(mcp-server): stamp document kind onto web-created Loro doc bytes

### DIFF
--- a/packages/mcp-server/src/server/routes/canvas/workspaces.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas/workspaces.test.ts
@@ -1,5 +1,6 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { readDocumentKind } from '@kamiazya/whiteboard-loro-adapter'
 import { Hono } from 'hono'
 import { LoroDoc, LoroMap } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -189,6 +190,40 @@ describe('POST /api/workspaces/:workspaceId/canvases', () => {
     const listRes = await app.request('/api/workspaces/ws1/canvases')
     const listJson = (await listRes.json()) as { canvases: { path: string; kind: string }[] }
     expect(listJson.canvases.find((c) => c.path === 'legacy')?.kind).toBe('spatial')
+  })
+
+  it('writes kind onto the stored Loro doc itself, not only the SQL row', async () => {
+    const app = createCanvasRouter()
+
+    const markdownRes = await app.request('/api/workspaces/ws1/canvases', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: 'markdown-note', kind: 'markdown' }),
+    })
+    expect(markdownRes.status).toBe(200)
+    const markdownDoc = await canvasStore.loadDocument('ws1', 'markdown-note')
+    expect(readDocumentKind(markdownDoc)).toBe('markdown')
+
+    const spatialRes = await app.request('/api/workspaces/ws1/canvases', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: 'board', kind: 'spatial' }),
+    })
+    expect(spatialRes.status).toBe(200)
+    const spatialDoc = await canvasStore.loadDocument('ws1', 'board')
+    expect(readDocumentKind(spatialDoc)).toBe('spatial')
+  })
+
+  it('stamps the schema-defaulted kind onto the doc bytes when kind is omitted', async () => {
+    const app = createCanvasRouter()
+    const res = await app.request('/api/workspaces/ws1/canvases', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: 'legacy-kind-bytes' }),
+    })
+    expect(res.status).toBe(200)
+    const doc = await canvasStore.loadDocument('ws1', 'legacy-kind-bytes')
+    expect(readDocumentKind(doc)).toBe('spatial')
   })
 
   it('returns 400 with Problem Details title naming the actual failing field on an invalid kind', async () => {

--- a/packages/mcp-server/src/server/routes/canvas/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/canvas/workspaces.ts
@@ -1,3 +1,4 @@
+import { writeDocumentKind } from '@kamiazya/whiteboard-loro-adapter'
 import { Hono } from 'hono'
 import { LoroDoc as LoroDocCtor } from 'loro-crdt'
 import type { z } from 'zod'
@@ -115,6 +116,11 @@ export function createWorkspacesRouter() {
     }
     try {
       const doc = new LoroDocCtor()
+      // The doc's own bytes must be self-describing exactly like an
+      // MCP-created (wb_document_create) doc — kind lives on the SQL row
+      // AND on the doc, so a reader of the blob alone (an editor opening it,
+      // a snapshot export) doesn't need the row to know what it's looking at.
+      writeDocumentKind(doc, parsed.data.kind)
       await saveDocument(workspaceId, path, doc, { overwrite: false, kind: parsed.data.kind })
       const response: CreateCanvasResponse = { path }
       return c.json(response)


### PR DESCRIPTION
## What

Identity-convergence initiative, slice 3 (approved plan): a document created through `POST /api/workspaces/:workspaceId/canvases` now stamps its kind onto the Loro doc bytes via the same `writeDocumentKind` helper `wb_document_create` has always used — so a web-created document's own bytes are self-describing exactly like an MCP-created one, closing one of the three "kind lives in three stores that disagree" gaps.

- Red-first tests in `workspaces.test.ts`: POST with `kind: markdown` / `kind: spatial` / kind omitted (schema default) → `loadDocument` the stored blob and assert `readDocumentKind` matches (all failed with `undefined` before the fix).
- SQL-row kind write, response shape, and every contract untouched; the 409-conflict path never persists the in-memory doc, so existing documents' bytes (including legacy kind-lessness) stay intact.

## Verification

mcp-node: 3460 passed / 6 skipped (280 files). Review gate: 0 findings, QA pass.

Part of the ADR-0007 convergence plan (issues `document-format-three-stores-three-answers` / `mcp-http-slug-snapshot-drift` cluster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ
