### PR TITLE
feat(web): deferred cut — the selection waits as a ghost until paste moves it

### DIFF
--- a/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
@@ -120,7 +120,6 @@ export interface CanvasContextMenuProps {
   readonly copySelection: () => ClipboardFragment | null
   /** Cut-flavoured copy: also records the cut surface for paste to reconnect. */
   readonly cutSelection: () => ClipboardFragment | null
-  readonly deleteSelectionAsBatch: () => boolean
   readonly duplicateSelection: () => boolean
   readonly reorderSelection: (placement: 'forward' | 'backward' | 'front' | 'back') => void
 }
@@ -160,7 +159,6 @@ export function CanvasContextMenu({
   openLinkNode,
   copySelection,
   cutSelection,
-  deleteSelectionAsBatch,
   duplicateSelection,
   reorderSelection,
 }: CanvasContextMenuProps) {
@@ -570,8 +568,9 @@ export function CanvasContextMenu({
           label: 'Cut',
           icon: <Scissors />,
           onSelect: () => {
-            // Menu path mirrors the native cut: copy, then remove.
-            if (cutSelection() !== null) deleteSelectionAsBatch()
+            // The cut defers its delete: cutSelection holds the selection as
+            // a ghost until the paste resolves it.
+            cutSelection()
           },
         })
         verbs.push({

--- a/apps/web/src/components/spatial-editor/GhostOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/GhostOverlay.tsx
@@ -1,0 +1,63 @@
+/**
+ * The pending-cut veil: a cut is the front half of a move, so its nodes
+ * stay in the document and are dimmed here instead of deleted. Pure view
+ * state — never persisted, never synced; a reload resolves to "nothing was
+ * deleted", which is the safe default. Drawn in canvas space under the
+ * viewport transform, like the other selection overlays. The veil paints
+ * the theme background at 55% so both themes dim correctly, and the dashed
+ * outline is deliberately STATIC — a marching-ants loop would break the
+ * draw-once motion grammar.
+ */
+export interface GhostBox {
+  readonly id: string
+  readonly x: number
+  readonly y: number
+  readonly width: number
+  readonly height: number
+}
+
+export interface GhostOverlayProps {
+  readonly boxes: readonly GhostBox[]
+  readonly zoom: number
+}
+
+export function GhostOverlay({ boxes, zoom }: GhostOverlayProps) {
+  return (
+    <svg
+      data-testid="ghost-overlay"
+      aria-hidden="true"
+      style={{
+        position: 'absolute',
+        overflow: 'visible',
+        left: 0,
+        top: 0,
+        pointerEvents: 'none',
+      }}
+    >
+      {boxes.map((box) => (
+        <g key={box.id}>
+          <rect
+            x={box.x}
+            y={box.y}
+            width={box.width}
+            height={box.height}
+            rx={6 / zoom}
+            fill="var(--background)"
+            opacity={0.55}
+          />
+          <rect
+            x={box.x}
+            y={box.y}
+            width={box.width}
+            height={box.height}
+            rx={6 / zoom}
+            fill="none"
+            stroke="var(--manipulation)"
+            strokeWidth={1.5 / zoom}
+            strokeDasharray={`${6 / zoom} ${4 / zoom}`}
+          />
+        </g>
+      ))}
+    </svg>
+  )
+}

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -791,17 +791,14 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * state (never persisted or synced): the nodes stay in the document,
      * dimmed by GhostOverlay, until a same-canvas paste MOVES them, or the
      * hold is lifted (Escape, a newer copy/cut, or any edit that touches a
-     * held node). `geometry` snapshots each node's box at cut time so ANY
-     * change to a held node — local drag, remote edit, delete — reads as
-     * "someone touched it" and cancels the hold; nothing is ever lost by a
-     * cancel, because nothing was deleted.
+     * held node). `snapshot` records each held node's full serialized value
+     * at cut time so ANY change — a drag, a text or color edit, a remote
+     * write, a delete — reads as "someone touched it" and cancels the hold;
+     * nothing is ever lost by a cancel, because nothing was deleted.
      */
     const [pendingCut, setPendingCut] = useState<{
       readonly cutId: string
-      readonly geometry: ReadonlyMap<
-        string,
-        { readonly x: number; readonly y: number; readonly width: number; readonly height: number }
-      >
+      readonly snapshot: ReadonlyMap<string, string>
     } | null>(null)
     useEffect(() => {
       // Anyone touching a held node — local drag, remote edit, delete —
@@ -809,15 +806,9 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // it. The move resolution clears the hold before it applies, so its
       // own geometry change never races this.
       if (pendingCut === null) return
-      const touched = [...pendingCut.geometry].some(([id, g]) => {
+      const touched = [...pendingCut.snapshot].some(([id, frozen]) => {
         const node = canvas.nodes.find((n) => n.id === id)
-        return (
-          node === undefined ||
-          node.x !== g.x ||
-          node.y !== g.y ||
-          node.width !== g.width ||
-          node.height !== g.height
-        )
+        return node === undefined || JSON.stringify(node) !== frozen
       })
       if (touched) setPendingCut(null)
     }, [canvas, pendingCut])
@@ -2108,12 +2099,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // decides what the cut meant (move here, copy elsewhere, or nothing).
       setPendingCut({
         cutId: fragment.cut.id,
-        geometry: new Map(
-          fragment.nodes.map((node) => [
-            node.id,
-            { x: node.x, y: node.y, width: node.width, height: node.height },
-          ]),
-        ),
+        snapshot: new Map(fragment.nodes.map((node) => [node.id, JSON.stringify(node)])),
       })
       return fragment
     }
@@ -2153,7 +2139,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // or boundary — survives without any reconnection machinery. One batch
       // of move-node commands = one undo step that only moves them back.
       if (fragment.cut !== undefined && pendingCut?.cutId === fragment.cut.id) {
-        const held = current.nodes.filter((node) => pendingCut.geometry.has(node.id))
+        const held = current.nodes.filter((node) => pendingCut.snapshot.has(node.id))
         if (held.length > 0) {
           let dx = DUPLICATE_OFFSET_PX
           let dy = DUPLICATE_OFFSET_PX
@@ -3467,7 +3453,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           {pendingCut !== null && (
             <GhostOverlay
               boxes={canvas.nodes.flatMap((n) =>
-                pendingCut.geometry.has(n.id)
+                pendingCut.snapshot.has(n.id)
                   ? [{ id: n.id, x: n.x, y: n.y, width: n.width, height: n.height }]
                   : [],
               )}

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -111,12 +111,13 @@ import {
 import { CanvasPickerDialog, type FileRefOption } from './CanvasPickerDialog.js'
 import { ConnectOverlay } from './ConnectOverlay.js'
 import type { EditorCommand } from './commands.js'
-import { applyCommand, buildFragmentInsertCommand } from './commands.js'
+import { applyCommand, buildFragmentInsertCommand, DUPLICATE_OFFSET_PX } from './commands.js'
 import { CREATION_LABELS } from './creation-labels.js'
 import { DragPreviewLayer } from './DragPreviewLayer.js'
 import { computeDragPreview, isInFlightGesture } from './drag-preview.js'
 import { createEditorAppearance, editorTextFill } from './editor-appearance.js'
 import { isFollowableUrl } from './followable-url.js'
+import { GhostOverlay } from './GhostOverlay.js'
 import type { Box, ResizeHandleKind } from './geometry.js'
 import {
   distanceToPolyline,
@@ -785,6 +786,41 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       [scene],
     )
     const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null)
+    /**
+     * A cut waiting for its paste — the front half of a move. Pure view
+     * state (never persisted or synced): the nodes stay in the document,
+     * dimmed by GhostOverlay, until a same-canvas paste MOVES them, or the
+     * hold is lifted (Escape, a newer copy/cut, or any edit that touches a
+     * held node). `geometry` snapshots each node's box at cut time so ANY
+     * change to a held node — local drag, remote edit, delete — reads as
+     * "someone touched it" and cancels the hold; nothing is ever lost by a
+     * cancel, because nothing was deleted.
+     */
+    const [pendingCut, setPendingCut] = useState<{
+      readonly cutId: string
+      readonly geometry: ReadonlyMap<
+        string,
+        { readonly x: number; readonly y: number; readonly width: number; readonly height: number }
+      >
+    } | null>(null)
+    useEffect(() => {
+      // Anyone touching a held node — local drag, remote edit, delete —
+      // lifts the hold; the veil must never dim a node that changed under
+      // it. The move resolution clears the hold before it applies, so its
+      // own geometry change never races this.
+      if (pendingCut === null) return
+      const touched = [...pendingCut.geometry].some(([id, g]) => {
+        const node = canvas.nodes.find((n) => n.id === id)
+        return (
+          node === undefined ||
+          node.x !== g.x ||
+          node.y !== g.y ||
+          node.width !== g.width ||
+          node.height !== g.height
+        )
+      })
+      if (touched) setPendingCut(null)
+    }, [canvas, pendingCut])
     const [edgeLabelEditId, setEdgeLabelEditId] = useState<string | null>(null)
     // The URL dialog serves both palette-create and context-menu-edit; which
     // one decides what its submit does.
@@ -2049,6 +2085,8 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       )
       if (fragment.nodes.length === 0) return null
       writeClipboardFragment(fragment)
+      // The newest clipboard intent wins: a plain copy lifts a pending cut.
+      setPendingCut(null)
       return fragment
     }
 
@@ -2064,25 +2102,20 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         new Set([selection.id, ...extraIds]),
         { cutId: crypto.randomUUID() },
       )
-      if (fragment.nodes.length === 0) return null
+      if (fragment.nodes.length === 0 || fragment.cut === undefined) return null
       writeClipboardFragment(fragment)
+      // Defer the delete: hold the originals as a ghost until the paste
+      // decides what the cut meant (move here, copy elsewhere, or nothing).
+      setPendingCut({
+        cutId: fragment.cut.id,
+        geometry: new Map(
+          fragment.nodes.map((node) => [
+            node.id,
+            { x: node.x, y: node.y, width: node.width, height: node.height },
+          ]),
+        ),
+      })
       return fragment
-    }
-
-    /** Remove the selection as ONE batch (one undo step). */
-    const deleteSelectionAsBatch = (): boolean => {
-      if (selection === undefined) return false
-      const ids = [selection.id, ...extraIds]
-      const command: EditorCommand = {
-        kind: 'batch',
-        commands: ids.map((id) => ({ kind: 'delete-node', id }) as const),
-      }
-      const running = applyCommand(canvasRef.current, command)
-      if (running === canvasRef.current) return false
-      onChange(running, command)
-      applySelection({ type: 'clear' })
-      setSelectedEdgeId(null)
-      return true
     }
 
     /** A note carrying pasted foreign text, at the viewport center. */
@@ -2115,6 +2148,41 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       at?: Point,
     ): boolean => {
       const current = canvasRef.current
+      // A paste that answers THIS canvas's pending cut is a MOVE: the held
+      // nodes keep their ids and just change place, so every edge — internal
+      // or boundary — survives without any reconnection machinery. One batch
+      // of move-node commands = one undo step that only moves them back.
+      if (fragment.cut !== undefined && pendingCut?.cutId === fragment.cut.id) {
+        const held = current.nodes.filter((node) => pendingCut.geometry.has(node.id))
+        if (held.length > 0) {
+          let dx = DUPLICATE_OFFSET_PX
+          let dy = DUPLICATE_OFFSET_PX
+          if (at !== undefined) {
+            const minX = Math.min(...held.map((node) => node.x))
+            const minY = Math.min(...held.map((node) => node.y))
+            const maxX = Math.max(...held.map((node) => node.x + node.width))
+            const maxY = Math.max(...held.map((node) => node.y + node.height))
+            dx = Math.round(at.x - (minX + maxX) / 2)
+            dy = Math.round(at.y - (minY + maxY) / 2)
+          }
+          const moveCommand: EditorCommand = {
+            kind: 'batch',
+            commands: held.map((node) => ({
+              kind: 'move-node' as const,
+              id: node.id,
+              x: node.x + dx,
+              y: node.y + dy,
+            })),
+          }
+          setPendingCut(null)
+          const running = applyCommand(current, moveCommand)
+          if (running === current) return false
+          onChange(running, moveCommand)
+          applySelection({ type: 'set-members', ids: held.map((node) => node.id) })
+          setSelectedEdgeId(null)
+          return true
+        }
+      }
       // The cut surface reconnects while the document shows no trace of a
       // previous reconnection: as long as any edge a prior paste of this cut
       // created is still on THIS canvas, the fragment behaves as a plain
@@ -2263,6 +2331,14 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           setSelectedEdgeId(null)
           return
         }
+      }
+      if (e.key === 'Escape' && gestureState.kind === 'idle' && pendingCut !== null) {
+        e.preventDefault()
+        // Escape lifts only the HOLD. The envelope stays: the clipboard
+        // keeps working as a plain copy, matching what the OS side already
+        // holds (which no Escape of ours could clear).
+        setPendingCut(null)
+        return
       }
       if (e.key === 'Escape' && gestureState.kind !== 'idle') {
         e.preventDefault()
@@ -2950,7 +3026,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           if (fragment === null) return
           e.preventDefault()
           e.clipboardData?.setData('text/plain', JSON.stringify(fragment))
-          deleteSelectionAsBatch()
         }}
         onPaste={(e) => {
           if (isTextEntryEvent(e.nativeEvent)) return
@@ -3158,7 +3233,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             openLinkNode={openLinkNode}
             copySelection={copySelection}
             cutSelection={cutSelection}
-            deleteSelectionAsBatch={deleteSelectionAsBatch}
             duplicateSelection={duplicateSelection}
             reorderSelection={reorderSelection}
           />
@@ -3390,6 +3464,16 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             ghost, so these outlines (boxes and internal-edge highlights,
             both derived from the committed scene) would mark geometry that
             is no longer drawn there. */}
+          {pendingCut !== null && (
+            <GhostOverlay
+              boxes={canvas.nodes.flatMap((n) =>
+                pendingCut.geometry.has(n.id)
+                  ? [{ id: n.id, x: n.x, y: n.y, width: n.width, height: n.height }]
+                  : [],
+              )}
+              zoom={viewport.zoom}
+            />
+          )}
           {isMultiSelection && gestureState.kind !== 'moving' && (
             <MemberOutlinesOverlay
               selectionMembers={selectionMembers}

--- a/apps/web/src/components/spatial-editor/clipboard.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/clipboard.browser.test.tsx
@@ -103,47 +103,7 @@ it('copy then paste clones the selection with reminted ids, offset, as ONE batch
   expect(new Set(latest.canvas.nodes.map((n) => n.id)).size).toBe(4)
 })
 
-it('cut removes the selection as ONE batch and paste restores a reminted copy', () => {
-  const { Host, latest } = makeHost()
-  const { container } = render(<Host />)
-  const root = rootOf(container)
-  selectAt(root, 120, 80)
-
-  clip(root, 'cut')
-  expect(latest.canvas.nodes.map((n) => n.id)).toEqual(['b'])
-  // The edge cascaded away with its endpoint.
-  expect(latest.canvas.edges).toEqual([])
-  expect(latest.commands.at(-1)?.kind).toBe('batch')
-
-  clip(root, 'paste')
-  expect(latest.canvas.nodes).toHaveLength(2)
-  expect(latest.canvas.nodes[1]).toMatchObject({ text: 'A' })
-})
-
-it('cut then paste restores the boundary edge to its surviving peer — cut is a move, not a delete', () => {
-  const { Host, latest } = makeHost()
-  const { container } = render(<Host />)
-  const root = rootOf(container)
-  selectAt(root, 120, 80)
-
-  clip(root, 'cut')
-  expect(latest.canvas.edges).toEqual([])
-
-  clip(root, 'paste')
-  const pasted = latest.canvas.nodes.find((n) => n.type === 'text' && n.text === 'A')
-  expect(pasted).toBeDefined()
-  // The edge to the untouched peer is back, endpoints reminted-side + peer.
-  expect(latest.canvas.edges).toHaveLength(1)
-  const restored = latest.canvas.edges[0]
-  expect([restored.fromNode, restored.toNode].sort()).toEqual([pasted?.id, 'b'].sort())
-
-  // A second paste of the same cut is a plain copy: no second wire onto the peer.
-  clip(root, 'paste')
-  expect(latest.canvas.nodes).toHaveLength(3)
-  expect(latest.canvas.edges).toHaveLength(1)
-})
-
-it("the context menu's Cut records the cut surface too — menu and keyboard are the same cut", () => {
+it("the context menu's Cut is the same deferred cut as the keyboard's", () => {
   const { Host, latest } = makeHost()
   const { container } = render(<Host />)
   const root = rootOf(container)
@@ -156,14 +116,14 @@ it("the context menu's Cut records the cut surface too — menu and keyboard are
   ) as HTMLElement
   expect(cutItem).toBeDefined()
   fireEvent.click(cutItem)
-  expect(latest.canvas.nodes.map((n) => n.id)).toEqual(['b'])
-  expect(latest.canvas.edges).toEqual([])
+  // Held, not deleted — and a plain-copy menu path would show no veil.
+  expect(latest.canvas.nodes.map((n) => n.id)).toEqual(['a', 'b'])
+  expect(container.querySelector('[data-testid="ghost-overlay"]')).not.toBeNull()
 
   clip(root, 'paste')
-  const pasted = latest.canvas.nodes.find((n) => n.type === 'text' && n.text === 'A')
-  expect(latest.canvas.edges).toHaveLength(1)
-  const restored = latest.canvas.edges[0]
-  expect([restored.fromNode, restored.toNode].sort()).toEqual([pasted?.id, 'b'].sort())
+  // Resolved as a move: same ids, the edge never blinked.
+  expect(latest.canvas.nodes.map((n) => n.id).sort()).toEqual(['a', 'b'])
+  expect(latest.canvas.edges).toEqual(initial.edges)
 })
 
 it('undoing a paste restores the cut surface — the next paste reconnects again', () => {
@@ -172,15 +132,20 @@ it('undoing a paste restores the cut surface — the next paste reconnects again
   const root = rootOf(container)
   selectAt(root, 120, 80)
 
+  // A deleted hold is the case where the cut surface matters: the originals
+  // are gone, so paste has something to reconnect.
   clip(root, 'cut')
-  const afterCut = latest.canvas
+  fireEvent.keyDown(root, { key: 'Delete' })
+  const afterDelete = latest.canvas
+  expect(afterDelete.edges).toEqual([])
+
   clip(root, 'paste')
   expect(latest.canvas.edges).toHaveLength(1)
 
   // The paste landed in the wrong spot and the person undoes it. Undo lives
   // in the host (one batch = one undo step), so from this component's side
   // it arrives as the pre-paste snapshot coming back.
-  act(() => latest.reset(afterCut))
+  act(() => latest.reset(afterDelete))
   expect(latest.canvas.edges).toEqual([])
 
   // The document holds no trace of the first paste, so the next paste is a
@@ -267,5 +232,126 @@ it('Cmd+C or Cmd+V with nothing to act on stays inert (browser keeps its own cop
   clip(root, 'copy')
   clip(root, 'paste')
   expect(latest.commands).toHaveLength(0)
+  expect(latest.canvas.nodes).toHaveLength(2)
+})
+
+// --- Deferred cut (ghost): cut is the front half of a move ---------------
+
+it('cut defers the delete: the document is untouched and the ghost veil appears', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+
+  clip(root, 'cut')
+  // Nothing left the document — the cut is a pending move, not a delete.
+  expect(latest.commands).toHaveLength(0)
+  expect(latest.canvas.nodes.map((n) => n.id)).toEqual(['a', 'b'])
+  expect(latest.canvas.edges).toHaveLength(1)
+  expect(container.querySelector('[data-testid="ghost-overlay"]')).not.toBeNull()
+})
+
+it('pasting a pending cut MOVES the original — same ids, edges untouched, one undo step', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+
+  clip(root, 'cut')
+  clip(root, 'paste')
+
+  // Same node, new place: no remint, so every edge (internal or boundary)
+  // survives without any reconnection machinery.
+  expect(latest.canvas.nodes.map((n) => n.id).sort()).toEqual(['a', 'b'])
+  const moved = latest.canvas.nodes.find((n) => n.id === 'a')
+  expect(moved).toMatchObject({ x: 40 + 16, y: 40 + 16 })
+  expect(latest.canvas.edges).toEqual(initial.edges)
+  const last = latest.commands.at(-1)
+  expect(last?.kind).toBe('batch')
+  if (last?.kind === 'batch') {
+    expect(last.commands.every((c) => c.kind === 'move-node')).toBe(true)
+  }
+  expect(container.querySelector('[data-testid="ghost-overlay"]')).toBeNull()
+
+  // A second paste of the same envelope is a plain copy, and the original
+  // edge still exists — so no second wire onto the peer either.
+  clip(root, 'paste')
+  expect(latest.canvas.nodes).toHaveLength(3)
+  expect(latest.canvas.edges).toHaveLength(1)
+})
+
+it('Escape lifts the ghost; the envelope keeps working as a plain copy', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+
+  clip(root, 'cut')
+  fireEvent.keyDown(rootOf(container), { key: 'Escape' })
+  expect(container.querySelector('[data-testid="ghost-overlay"]')).toBeNull()
+  expect(latest.canvas.nodes).toHaveLength(2)
+
+  // Paste now duplicates — and must NOT wire the copy to the peer, because
+  // the original edge was never severed.
+  clip(root, 'paste')
+  expect(latest.canvas.nodes).toHaveLength(3)
+  expect(latest.canvas.edges).toHaveLength(1)
+  expect(latest.canvas.edges[0]).toMatchObject({ id: 'ab', fromNode: 'a', toNode: 'b' })
+})
+
+it('deleting a ghosted selection is a real delete; the next paste reconnects like a cut', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+
+  clip(root, 'cut')
+  fireEvent.keyDown(rootOf(container), { key: 'Delete' })
+  expect(latest.canvas.nodes.map((n) => n.id)).toEqual(['b'])
+  expect(latest.canvas.edges).toEqual([])
+  expect(container.querySelector('[data-testid="ghost-overlay"]')).toBeNull()
+
+  // The originals are gone now, so the cut surface applies: paste restores
+  // the node wired back to its surviving peer.
+  clip(root, 'paste')
+  const pasted = latest.canvas.nodes.find((n) => n.type === 'text' && n.text === 'A')
+  expect(latest.canvas.edges).toHaveLength(1)
+  const restored = latest.canvas.edges[0]
+  expect([restored.fromNode, restored.toNode].sort()).toEqual([pasted?.id, 'b'].sort())
+})
+
+it('grabbing a ghosted node cancels the hold and the drag proceeds normally', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+  clip(root, 'cut')
+
+  const r = root.getBoundingClientRect()
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 2,
+    clientX: r.left + 120,
+    clientY: r.top + 80,
+  })
+  fireEvent.pointerMove(root, { pointerId: 2, clientX: r.left + 160, clientY: r.top + 120 })
+  fireEvent.pointerUp(root, { pointerId: 2, clientX: r.left + 160, clientY: r.top + 120 })
+
+  expect(container.querySelector('[data-testid="ghost-overlay"]')).toBeNull()
+  const movedNode = latest.canvas.nodes.find((n) => n.id === 'a')
+  expect(movedNode?.x).not.toBe(40)
+  expect(latest.canvas.nodes).toHaveLength(2)
+})
+
+it('a plain copy clears a pending cut — the newest clipboard intent wins', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+  clip(root, 'cut')
+  expect(container.querySelector('[data-testid="ghost-overlay"]')).not.toBeNull()
+
+  clip(root, 'copy')
+  expect(container.querySelector('[data-testid="ghost-overlay"]')).toBeNull()
   expect(latest.canvas.nodes).toHaveLength(2)
 })

--- a/apps/web/src/components/spatial-editor/clipboard.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/clipboard.browser.test.tsx
@@ -355,3 +355,58 @@ it('a plain copy clears a pending cut — the newest clipboard intent wins', () 
   expect(container.querySelector('[data-testid="ghost-overlay"]')).toBeNull()
   expect(latest.canvas.nodes).toHaveLength(2)
 })
+
+it('a content-only change to a held node lifts the hold — ANY touch counts, not just geometry', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+  clip(root, 'cut')
+  expect(container.querySelector('[data-testid="ghost-overlay"]')).not.toBeNull()
+
+  // A remote collaborator edits the held node's TEXT — same geometry.
+  act(() =>
+    latest.reset({
+      ...latest.canvas,
+      nodes: latest.canvas.nodes.map((n) =>
+        n.id === 'a' && n.type === 'text' ? { ...n, text: 'rewritten' } : n,
+      ),
+    }),
+  )
+  expect(container.querySelector('[data-testid="ghost-overlay"]')).toBeNull()
+
+  // With the hold lifted, paste is a plain copy — never a silent move of
+  // the node someone just rewrote.
+  clip(root, 'paste')
+  expect(latest.canvas.nodes).toHaveLength(3)
+  expect(
+    latest.canvas.nodes.filter((n) => n.type === 'text' && n.text === 'rewritten'),
+  ).toHaveLength(1)
+})
+
+it("an anchored 'Paste here' moves the held selection so its center lands on the click", async () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+  clip(root, 'cut')
+
+  // Right-click empty space, far from both nodes, and choose Paste here.
+  const r = root.getBoundingClientRect()
+  fireEvent.contextMenu(root, { clientX: r.left + 600, clientY: r.top + 400 })
+  const pasteItem = [...container.querySelectorAll('[role="menuitem"]')].find(
+    (el) => (el.getAttribute('aria-label') ?? el.textContent) === 'Paste here',
+  ) as HTMLElement
+  expect(pasteItem).toBeDefined()
+  fireEvent.click(pasteItem)
+
+  // Same node, no remint; the held box's center lands on the click point
+  // (the default viewport is identity, so screen = canvas coordinates).
+  expect(latest.canvas.nodes.map((n) => n.id).sort()).toEqual(['a', 'b'])
+  const moved = latest.canvas.nodes.find((n) => n.id === 'a')
+  expect(moved).toBeDefined()
+  if (moved === undefined) throw new Error('unreachable')
+  expect(Math.round(moved.x + moved.width / 2)).toBe(600)
+  expect(Math.round(moved.y + moved.height / 2)).toBe(400)
+  expect(latest.canvas.edges).toEqual(initial.edges)
+})

--- a/apps/web/src/components/spatial-editor/commands.test.ts
+++ b/apps/web/src/components/spatial-editor/commands.test.ts
@@ -769,6 +769,29 @@ describe('buildFragmentInsertCommand', () => {
     expect(edgeCommands.some((c) => c.edge.toNode === 'vanished')).toBe(false)
   })
 
+  it('never reconnects a boundary edge whose original still exists — a lifted cut was not severed', () => {
+    const canvas: SpatialCanvas = {
+      nodes: [
+        { id: 'src-b', type: 'text', x: 150, y: 20, width: 60, height: 40, text: 'b' },
+        { id: 'peer', type: 'text', x: 400, y: 0, width: 100, height: 50, text: 'peer' },
+      ],
+      // The severed edge is still on the canvas: the hold was lifted (or
+      // resolved as a move), so this paste is a plain duplicate.
+      edges: [{ id: 'src-boundary', fromNode: 'src-b', toNode: 'peer' }],
+    }
+    const cutFragment = {
+      ...fragment(),
+      cut: {
+        id: 'cut-1',
+        boundaryEdges: [{ id: 'src-boundary', fromNode: 'src-b', toNode: 'peer' }],
+      },
+    }
+    const command = buildFragmentInsertCommand(canvas, cutFragment, sequentialIds())
+    if (command?.kind !== 'batch') throw new Error('expected a batch command')
+    const edgeCommands = command.commands.filter((c) => c.kind === 'create-edge')
+    expect(edgeCommands.some((c) => c.edge.toNode === 'peer')).toBe(false)
+  })
+
   it('returns undefined for an empty-node fragment', () => {
     const canvas: SpatialCanvas = { nodes: [], edges: [] }
     expect(buildFragmentInsertCommand(canvas, { nodes: [], edges: [] }, sequentialIds())).toBe(

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -619,7 +619,7 @@ function reorderNodes(
 
 /** Standard duplicate-again cascade offset — also `pasteFragment`'s
  * fallback when it is given no anchor point. */
-const DUPLICATE_OFFSET_PX = 16
+export const DUPLICATE_OFFSET_PX = 16
 
 /**
  * The shared core of `pasteFragment` and `duplicateSelection`: remint a
@@ -657,7 +657,12 @@ export function buildFragmentInsertCommand(
   // peer means a cross-canvas paste or a deleted neighbour, and the edge
   // drops silently — exactly what a plain copy would have done.
   const canvasNodeIds = new Set(canvas.nodes.map((node) => node.id))
+  const canvasEdgeIds = new Set(canvas.edges.map((edge) => edge.id))
   const boundaryEdges = (fragment.cut?.boundaryEdges ?? []).flatMap((edge) => {
+    // The original edge still exists → it was never actually severed (the
+    // cut was lifted, or resolved as a move): nothing to reconnect, and a
+    // second wire onto the peer would be the new defect.
+    if (canvasEdgeIds.has(edge.id)) return []
     const from = reminted.idMap.get(edge.fromNode)
     const to = reminted.idMap.get(edge.toNode)
     if ((from === undefined) === (to === undefined)) return []

--- a/apps/web/src/components/spatial-editor/os-clipboard.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/os-clipboard.browser.test.tsx
@@ -144,7 +144,7 @@ it('an empty clipboard paste is a no-op', () => {
   expect(latest.commands).toHaveLength(0)
 })
 
-it('a native cut copies to the OS clipboard AND removes the selection in one batch', () => {
+it('a native cut copies to the OS clipboard AND holds the selection as a ghost', () => {
   const { Host, latest } = makeHost()
   const { container } = render(<Host />)
   const root = rootOf(container)
@@ -154,8 +154,10 @@ it('a native cut copies to the OS clipboard AND removes the selection in one bat
   dispatchClipboard(root, 'cut', clipboardData)
 
   expect(JSON.parse(clipboardData.getData('text/plain') || '{}').nodes).toHaveLength(1)
-  expect(latest.canvas.nodes).toEqual([])
-  expect(latest.commands.at(-1)?.kind).toBe('batch')
+  // The cut defers its delete: the document is untouched, the veil shows.
+  expect(latest.commands).toHaveLength(0)
+  expect(latest.canvas.nodes).toHaveLength(1)
+  expect(container.querySelector('[data-testid="ghost-overlay"]')).not.toBeNull()
 })
 
 it('an OS-clipboard cut→paste reconnects the boundary edge once — the JSON carries the cut surface', () => {
@@ -173,10 +175,13 @@ it('an OS-clipboard cut→paste reconnects the boundary edge once — the JSON c
 
   const clipboardData = clipboardWith()
   dispatchClipboard(root, 'cut', clipboardData)
-  expect(latest.canvas.edges).toEqual([])
   const written = clipboardData.getData('text/plain')
   // The cut surface survives the JSON round trip Ctrl+V re-parses.
   expect(JSON.parse(written).cut.boundaryEdges).toHaveLength(1)
+  // Deleting the held selection makes the cut real — the case where the
+  // surface has something to reconnect.
+  fireEvent.keyDown(root, { key: 'Delete' })
+  expect(latest.canvas.edges).toEqual([])
 
   // Each paste re-parses the SAME text, exactly like repeated Ctrl+V.
   dispatchClipboard(root, 'paste', clipboardWith(written))


### PR DESCRIPTION
## What

Per the Canvas Manipulation Lab §⑪-b design (signed off: navigate-away cancels; Escape keeps the envelope): a cut no longer deletes on the spot. The intent behind a cut is a **move**, not a delete — so the selection is **held as a ghost** (background veil + static dashed outline, pure view state: never persisted, never synced, a reload resolves to nothing-was-deleted) until the paste decides what the cut meant.

| event | outcome |
|---|---|
| cut (⌘X / menu) | envelope written as before; originals held as a ghost — **no document write** |
| paste, same canvas | **move**: same ids, one `move-node` batch, every edge (internal or boundary) intact with zero reconnection machinery; one undo step that only moves them back |
| Escape / newer copy or cut | hold lifts, nothing lost; the envelope keeps working as a plain copy |
| touching a held node (drag, remote edit) | hold lifts via a geometry snapshot — the veil never dims a node that changed under it |
| Delete on the held selection | real delete; the next paste reconnects through the #841 cut surface exactly as before |
| second paste | plain copy — and boundary reconnection now also **skips any edge whose original still exists**, so a lifted cut can never double-wire a peer |

`deleteSelectionAsBatch` and the menu's copy-then-delete pairing are deleted — no cut path deletes anything itself anymore.

## Visual

The held selection after ⌘X: dimmed under the veil, dashed outline, edge and peer untouched:

![deferred-cut-ghost.png](https://github.com/user-attachments/assets/d52d4ef0-c549-4315-935f-dca6d450ec3c)

## Tests

Red-first browser coverage in `clipboard.browser.test.tsx`: cut-defers-delete, paste-as-move (ids + edges + one batch), Escape lift, Delete-then-reconnect, drag-cancels-hold, copy-clears-hold, menu Cut parity; OS-clipboard variants updated in `os-clipboard.browser.test.tsx` (cut holds; delete-then-double-paste consumption). `commands.test.ts` pins the skip-when-original-exists rule (mutation-checked red). Full gates: jsdom exit 0, web-browser 591/592 (the 1 is the known untouched-file load flake, 1/1 isolated), typecheck / lint / knip clean; the S10 purity tripwire held (`onChange(running…)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ua6RPuoEAD4ZTBqyhNC56Z