### PR TITLE
fix(server-core): scene tools refuse a known-markdown document instead of projecting an empty scene

### DIFF
--- a/packages/server-core/src/render/load-spatial-canvas.ts
+++ b/packages/server-core/src/render/load-spatial-canvas.ts
@@ -1,5 +1,5 @@
-import { readSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
-import type { DocumentId, SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { readDocumentKind, readSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+import type { DocumentId, SpatialCanvas, WorkspaceId } from '@kamiazya/whiteboard-model'
 import { reassembleSnapshot } from '@kamiazya/whiteboard-ports'
 import { LoroDoc } from 'loro-crdt'
 import type { ServerDeps } from '../server-deps.js'
@@ -33,4 +33,41 @@ export async function loadSpatialCanvas(
   const doc = new LoroDoc()
   doc.import(reassembleSnapshot(existing.manifest, existing.chunks))
   return { doc, canvas: readSpatialCanvas(doc) }
+}
+
+/**
+ * Thrown when a scene tool is pointed at a document whose kind says it is
+ * not spatial. Without this, a markdown document — whose body lives outside
+ * the nodes/edges containers — digested or rendered as an EMPTY scene with
+ * no error, indistinguishable from a genuinely empty spatial canvas.
+ */
+class NotASpatialDocumentError extends Error {
+  constructor(documentId: string, kind: string, toolName: string) {
+    super(
+      `Document ${documentId} is a ${kind} document; ${toolName} projects spatial scenes only. Read it with wb_document_get instead.`,
+    )
+    this.name = 'NotASpatialDocumentError'
+  }
+}
+
+/**
+ * Refuses a document KNOWN to be markdown: the doc's own recorded kind
+ * wins, the workspace-scoped index row is the fallback (mirroring
+ * wb_document_get's read path). A document with no recorded kind anywhere
+ * passes — pre-kind spatial documents must keep working, so only a
+ * positively-known markdown document is refused.
+ */
+export async function assertSpatialDocument(
+  deps: ServerDeps,
+  workspaceId: WorkspaceId,
+  documentId: DocumentId,
+  doc: LoroDoc,
+  toolName: string,
+): Promise<void> {
+  const docKind = readDocumentKind(doc)
+  const kind =
+    docKind ?? (await deps.documentIndex.resolveDocumentById({ workspaceId, documentId }))?.kind
+  if (kind === 'markdown') {
+    throw new NotASpatialDocumentError(documentId, kind, toolName)
+  }
 }

--- a/packages/server-core/src/tools/canvas-digest.test.ts
+++ b/packages/server-core/src/tools/canvas-digest.test.ts
@@ -1,5 +1,9 @@
 import { sceneDigestSchema } from '@kamiazya/whiteboard-canvas-render'
-import { writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+import {
+  writeDocumentKind,
+  writeMarkdownBody,
+  writeSpatialCanvas,
+} from '@kamiazya/whiteboard-loro-adapter'
 import { describe, expect, test } from 'vitest'
 import { CanvasNotFoundError } from '../render/load-spatial-canvas.js'
 import { FakeDocumentStore, seedDoc } from '../test-utils/fake-document-store.js'
@@ -55,6 +59,59 @@ describe('wb_scene_digest tool', () => {
     })
     expect(result.overlaps.length).toBeGreaterThan(0)
     expect(() => sceneDigestSchema.parse(result)).not.toThrow()
+  })
+
+  test('refuses a markdown document instead of digesting its empty spatial containers', async () => {
+    // A markdown document's body lives outside the nodes/edges containers,
+    // so digesting them silently answered { nodes: [], edges: [] } — which
+    // an auditor cannot tell apart from a genuinely empty spatial canvas.
+    const store = new FakeDocumentStore()
+    await seedDoc(store, CANVAS_ID, (doc) => {
+      writeDocumentKind(doc, 'markdown')
+      writeMarkdownBody(doc, '# Real prose\n\nThis document is not empty.')
+    })
+    const tool = createCanvasDigestTool(makeDeps(store))
+
+    await expect(
+      tool.execute({ workspaceId: WORKSPACE_ID, documentId: CANVAS_ID }),
+    ).rejects.toMatchObject({
+      name: 'NotASpatialDocumentError',
+      message: expect.stringMatching(/markdown.*wb_document_get/s),
+    })
+  })
+
+  test('refuses when only the index row records the markdown kind (legacy doc bytes)', async () => {
+    const store = new FakeDocumentStore()
+    await seedDoc(store, CANVAS_ID, (doc) => {
+      writeMarkdownBody(doc, 'row-kind only')
+    })
+    store.documentIndex.seed({
+      workspaceId: WORKSPACE_ID,
+      documentId: CANVAS_ID,
+      path: 'legacy-md',
+      kind: 'markdown',
+    })
+    const tool = createCanvasDigestTool(makeDeps(store))
+
+    await expect(
+      tool.execute({ workspaceId: WORKSPACE_ID, documentId: CANVAS_ID }),
+    ).rejects.toMatchObject({ name: 'NotASpatialDocumentError' })
+  })
+
+  test('still digests a document with no recorded kind anywhere (legacy spatial)', async () => {
+    // Pre-kind spatial documents must keep digesting — the guard refuses
+    // only a KNOWN markdown document, never an unknown one.
+    const store = new FakeDocumentStore()
+    await seedDoc(store, CANVAS_ID, (doc) => {
+      writeSpatialCanvas(doc, {
+        nodes: [{ id: 'n1', type: 'group' as const, x: 0, y: 0, width: 10, height: 10 }],
+        edges: [],
+      })
+    })
+    const tool = createCanvasDigestTool(makeDeps(store))
+
+    const result = await tool.execute({ workspaceId: WORKSPACE_ID, documentId: CANVAS_ID })
+    expect(result.nodes).toHaveLength(1)
   })
 
   test('rejects when the canvas has no stored snapshot', async () => {

--- a/packages/server-core/src/tools/canvas-digest.ts
+++ b/packages/server-core/src/tools/canvas-digest.ts
@@ -4,7 +4,7 @@ import { documentIdSchema, workspaceIdSchema } from '@kamiazya/whiteboard-model'
 import { z } from 'zod'
 import { composeCanvasScene } from '../render/compose-canvas-scene.js'
 import { fallbackMeasureText } from '../render/fallback-measure.js'
-import { loadSpatialCanvas } from '../render/load-spatial-canvas.js'
+import { assertSpatialDocument, loadSpatialCanvas } from '../render/load-spatial-canvas.js'
 import type { ServerDeps } from '../server-deps.js'
 
 /**
@@ -25,7 +25,8 @@ export function createCanvasDigestTool(deps: ServerDeps) {
     inputSchema: canvasDigestInputSchema,
     outputSchema: sceneDigestSchema,
     async execute(input: CanvasDigestInput): Promise<SceneDigest> {
-      const { canvas } = await loadSpatialCanvas(deps, input.documentId)
+      const { doc, canvas } = await loadSpatialCanvas(deps, input.documentId)
+      await assertSpatialDocument(deps, input.workspaceId, input.documentId, doc, 'wb_scene_digest')
       const scene = composeCanvasScene(canvas, fallbackMeasureText)
       return sceneDigest(scene)
     },

--- a/packages/server-core/src/tools/canvas-render-svg.test.ts
+++ b/packages/server-core/src/tools/canvas-render-svg.test.ts
@@ -1,4 +1,8 @@
-import { writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+import {
+  writeDocumentKind,
+  writeMarkdownBody,
+  writeSpatialCanvas,
+} from '@kamiazya/whiteboard-loro-adapter'
 import { describe, expect, test } from 'vitest'
 import { CanvasNotFoundError } from '../render/load-spatial-canvas.js'
 import { FakeDocumentStore, seedDoc } from '../test-utils/fake-document-store.js'
@@ -48,5 +52,21 @@ describe('wb_scene_render tool', () => {
         embedReferences: false,
       }),
     ).rejects.toThrow(CanvasNotFoundError)
+  })
+
+  test('refuses a markdown document instead of rendering an empty SVG', async () => {
+    const store = new FakeDocumentStore()
+    await seedDoc(store, CANVAS_ID, (doc) => {
+      writeDocumentKind(doc, 'markdown')
+      writeMarkdownBody(doc, '# Real prose')
+    })
+    const tool = createCanvasRenderSvgTool(makeDeps(store))
+
+    await expect(
+      tool.execute({ workspaceId: WORKSPACE_ID, documentId: CANVAS_ID, embedReferences: false }),
+    ).rejects.toMatchObject({
+      name: 'NotASpatialDocumentError',
+      message: expect.stringMatching(/markdown.*wb_document_get/s),
+    })
   })
 })

--- a/packages/server-core/src/tools/canvas-render-svg.test.ts
+++ b/packages/server-core/src/tools/canvas-render-svg.test.ts
@@ -69,4 +69,25 @@ describe('wb_scene_render tool', () => {
       message: expect.stringMatching(/markdown.*wb_document_get/s),
     })
   })
+
+  test('refuses when only the index row records the markdown kind (legacy doc bytes)', async () => {
+    // Pins wb_scene_render's OWN wiring of the index-row fallback — the
+    // shared guard is covered through digest, but a call-site mistake here
+    // (swapped ids, wrong workspace) would otherwise stay green.
+    const store = new FakeDocumentStore()
+    await seedDoc(store, CANVAS_ID, (doc) => {
+      writeMarkdownBody(doc, 'row-kind only')
+    })
+    store.documentIndex.seed({
+      workspaceId: WORKSPACE_ID,
+      documentId: CANVAS_ID,
+      path: 'legacy-md',
+      kind: 'markdown',
+    })
+    const tool = createCanvasRenderSvgTool(makeDeps(store))
+
+    await expect(
+      tool.execute({ workspaceId: WORKSPACE_ID, documentId: CANVAS_ID, embedReferences: false }),
+    ).rejects.toMatchObject({ name: 'NotASpatialDocumentError' })
+  })
 })

--- a/packages/server-core/src/tools/canvas-render-svg.ts
+++ b/packages/server-core/src/tools/canvas-render-svg.ts
@@ -3,7 +3,7 @@ import { documentIdSchema, workspaceIdSchema } from '@kamiazya/whiteboard-model'
 import { z } from 'zod'
 import { composeCanvasScene, computeSceneDimensions } from '../render/compose-canvas-scene.js'
 import { fallbackMeasureText } from '../render/fallback-measure.js'
-import { loadSpatialCanvas } from '../render/load-spatial-canvas.js'
+import { assertSpatialDocument, loadSpatialCanvas } from '../render/load-spatial-canvas.js'
 import { resolveFileReferences } from '../render/resolve-file-references.js'
 import type { ServerDeps } from '../server-deps.js'
 
@@ -40,7 +40,8 @@ export function createCanvasRenderSvgTool(deps: ServerDeps) {
     inputSchema: canvasRenderSvgInputSchema,
     outputSchema: canvasRenderSvgOutputSchema,
     async execute(input: CanvasRenderSvgInput): Promise<CanvasRenderSvgOutput> {
-      const { canvas } = await loadSpatialCanvas(deps, input.documentId)
+      const { doc, canvas } = await loadSpatialCanvas(deps, input.documentId)
+      await assertSpatialDocument(deps, input.workspaceId, input.documentId, doc, 'wb_scene_render')
       const references = input.embedReferences
         ? await resolveFileReferences(deps, input.workspaceId, canvas)
         : undefined

--- a/packages/server-core/src/tools/canvas-view.test.ts
+++ b/packages/server-core/src/tools/canvas-view.test.ts
@@ -6,7 +6,11 @@
 // no store of its own — it receives a snapshot and lays it out itself, so a
 // file node's referenced markdown can only reach it if the server puts it in
 // the payload.
-import { writeDocumentKind, writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+import {
+  writeDocumentKind,
+  writeMarkdownBody,
+  writeSpatialCanvas,
+} from '@kamiazya/whiteboard-loro-adapter'
 import { describe, expect, test } from 'vitest'
 import { FakeDocumentStore, seedDoc } from '../test-utils/fake-document-store.js'
 import { canvasViewOutputSchema, createCanvasViewTool } from './canvas-view.js'
@@ -130,5 +134,21 @@ describe('canvas_view tool', () => {
     const result = await tool.execute({ workspaceId: WORKSPACE_ID, documentId: CANVAS_ID })
 
     expect(result.references).toEqual({})
+  })
+
+  test('refuses a markdown document instead of returning an empty scene to the widget', async () => {
+    const store = new FakeDocumentStore()
+    await seedDoc(store, CANVAS_ID, (doc) => {
+      writeDocumentKind(doc, 'markdown')
+      writeMarkdownBody(doc, '# Real prose')
+    })
+    const tool = createCanvasViewTool(makeDeps(store))
+
+    await expect(
+      tool.execute({ workspaceId: WORKSPACE_ID, documentId: CANVAS_ID }),
+    ).rejects.toMatchObject({
+      name: 'NotASpatialDocumentError',
+      message: expect.stringMatching(/markdown.*wb_document_get/s),
+    })
   })
 })

--- a/packages/server-core/src/tools/canvas-view.ts
+++ b/packages/server-core/src/tools/canvas-view.ts
@@ -5,7 +5,7 @@ import {
 } from '@kamiazya/whiteboard-model'
 import { mdastRootSchema } from '@kamiazya/whiteboard-model/mdast'
 import { z } from 'zod'
-import { loadSpatialCanvas } from '../render/load-spatial-canvas.js'
+import { assertSpatialDocument, loadSpatialCanvas } from '../render/load-spatial-canvas.js'
 import { resolveFileReferences } from '../render/resolve-file-references.js'
 import type { ServerDeps } from '../server-deps.js'
 
@@ -72,7 +72,8 @@ export function createCanvasViewTool(deps: ServerDeps) {
     inputSchema: canvasViewInputSchema,
     outputSchema: canvasViewOutputSchema,
     async execute(input: CanvasViewInput): Promise<CanvasViewOutput> {
-      const { canvas } = await loadSpatialCanvas(deps, input.documentId)
+      const { doc, canvas } = await loadSpatialCanvas(deps, input.documentId)
+      await assertSpatialDocument(deps, input.workspaceId, input.documentId, doc, 'canvas_view')
       const resolved = await resolveFileReferences(deps, input.workspaceId, canvas)
       return {
         documentId: input.documentId,


### PR DESCRIPTION
## What

`wb_scene_digest`, `wb_scene_render`, and `canvas_view` read the nodes/edges containers with no kind check, so a markdown document — whose body lives in the body container, with the canvas deliberately emptied — digested/rendered as an **empty scene with no error**, indistinguishable from a genuinely empty spatial canvas. The auditing skill turned exactly that into deletion recommendations before its own fix (#846); the widget got a silently blank view.

`assertSpatialDocument`, shared by all three tools **at the tool boundary** (not in `loadSpatialCanvas`, whose other callers legitimately read markdown docs' spatial projection): the doc's own recorded kind wins, the workspace-scoped index row is the fallback (mirroring `wb_document_get`'s read path, #847), and only a positively-known markdown document is refused — pre-kind spatial documents keep digesting (pinned). The error names the kind and points at `wb_document_get`.

Review-gate findings folded in before this PR: `canvas_view` (the third live caller, initially missed — the fix-every-caller rule made executable) and a dedicated index-fallback refusal test for `wb_scene_render`'s own wiring.

## Verification

- Red-first: 3 refusal cases failed as empty digests/SVGs before the guard; legacy no-kind spatial pin green throughout.
- Mutation check: removing the markdown throw turns exactly the 3 refusal tests red; restore verified (271→273 green after review additions).
- server-core-node 273/273; mcp-node 3490 green; `pnpm smoke:e2e` ALL OK (per review QA, in a built worktree); knip/typecheck clean.

Resolves `issue/scene-digest-no-kind-guard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Canvas tools now reject markdown documents with a clear error instead of returning empty or invalid canvas results.
  * Validation works for both current documents and legacy documents identified through workspace records.
  * Legacy spatial documents without recorded document types continue to work correctly.
  * Canvas viewing, digest, and SVG rendering now verify that documents belong to the requested workspace before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->