### PR TITLE
build(mcp-server): retire the npm-tarball skills claim — skills ship via the plugin only

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -16,50 +16,6 @@ pnpm exec playwright install --with-deps chromium
 
 This installs Playwright's own Chromium, which is what a local browser-mode run uses. **CI does not**: every browser job in `.github/workflows/ci.yml` sets `WHITEBOARD_CHROME_PATH=/usr/bin/google-chrome-stable`, so CI drives the runner's system Chrome. Local and CI therefore execute browser tests in *different* browser builds — worth remembering when a browser test disagrees between them, since the browser itself is one of the variables. Set `WHITEBOARD_CHROME_PATH` locally to match CI when you are chasing exactly that kind of divergence.
 
-## Bundled skills install
-
-The MCP server ships three slash skills (`drawing-visuals`, `coauthoring-visuals`, `auditing-workspaces`) inside the npm package, but the `claude mcp add` / `npx` install paths only start the server. To make the skills available to the agent, install the package locally and symlink (or copy) them.
-
-```bash
-mkdir -p ~/tools/whiteboard && cd ~/tools/whiteboard
-npm init -y
-npm i @kamiazya/whiteboard-mcp
-```
-
-### macOS / Linux
-
-```bash
-PKG=$(pwd)/node_modules/@kamiazya/whiteboard-mcp
-mkdir -p ~/.claude/skills ~/.codex/skills
-ln -s "$PKG/skills/drawing-visuals"        ~/.claude/skills/drawing-visuals
-ln -s "$PKG/skills/coauthoring-visuals"    ~/.claude/skills/coauthoring-visuals
-ln -s "$PKG/skills/auditing-workspaces"    ~/.claude/skills/auditing-workspaces
-ln -s "$PKG/skills/drawing-visuals"        ~/.codex/skills/drawing-visuals
-ln -s "$PKG/skills/coauthoring-visuals"    ~/.codex/skills/coauthoring-visuals
-ln -s "$PKG/skills/auditing-workspaces"    ~/.codex/skills/auditing-workspaces
-```
-
-### Windows (junction or copy)
-
-```powershell
-$pkg = (Resolve-Path .\node_modules\@kamiazya\whiteboard-mcp).Path
-$skillRoots = @(
-    (Join-Path $HOME ".claude\skills"),
-    (Join-Path $HOME ".codex\skills")
-)
-$skills = "drawing-visuals", "coauthoring-visuals", "auditing-workspaces"
-$skillRoots | ForEach-Object { New-Item -ItemType Directory -Force $_ | Out-Null }
-foreach ($root in $skillRoots) {
-    foreach ($skill in $skills) {
-        cmd /c mklink /J (Join-Path $root $skill) (Join-Path $pkg "skills\$skill")
-    }
-}
-```
-
-If junctions are restricted, copy the skill directories instead. Restart Claude Code or Codex, then confirm `/drawing-visuals`, `/coauthoring-visuals`, and `/auditing-workspaces` appear in the skill list.
-
-The bundled `skills/` inside `@kamiazya/whiteboard-mcp` remain the source of truth; the repo-local `.claude/skills/` directory contains internal-only project skills (smoke selection, restart triage) that are not part of the published artifact.
-
 ## Recommended: develop over HTTP MCP
 
 For active MCP development, connect Claude Code or Codex to the daemon-hosted `/mcp` endpoint over HTTP rather than wiring the client to `stdio` directly. A `tsx watch` daemon restart does not force the MCP client to reconnect.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -34,13 +34,14 @@ Example MCP config:
 }
 ```
 
-Shared skills are published in the package under `skills/`.
+The product skills are NOT part of this package: skills ship with the
+Claude Code / Codex plugin, whose manifests point at the repository's
+`skills/` directory as the single source of truth.
 
 ## What is in this package
 
 - `dist/` contains the runnable MCP server and browser app assets.
-- `skills/` contains the shared skill bundles that Claude Code and Codex wrappers reference as their source of truth.
-- The repo-level plugin manifests are not shipped as separate release artifacts. Public distribution currently happens through this npm package.
+- The repo-level plugin manifests (and the skills they reference) are distributed through the plugin, not this npm package.
 
 ## Development
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -70,7 +70,6 @@
   },
   "files": [
     "dist",
-    "skills",
     "README.md",
     "LICENSE",
     "NOTICE",

--- a/packages/mcp-server/skills/auditing-workspaces/SKILL.md
+++ b/packages/mcp-server/skills/auditing-workspaces/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: auditing-workspaces
+description: Audit a whiteboard workspace's documents to find likely-stale or duplicate spatial canvases before creating new ones. Use when a workspace has been in heavy use and you want to check for clutter, or you want a quick sense of what a document actually contains before opening it.
+---
+
+# auditing-workspaces
+
+List a workspace's documents, then use the spatial ones' scene digests to judge which look empty
+or abandoned. There is no server-side audit endpoint — this skill is a recipe for composing the
+regular document tools toward that end, nothing more.
+
+For the main drawing workflow, see the drawing-visuals skill in `skills/drawing-visuals/SKILL.md`.
+
+---
+
+## When To Use It
+
+- When a workspace has been in heavy use and you want a sense of what is in it before adding more
+- When you want to check for a likely-duplicate path before calling `wb_document_create`
+- When you want to know whether a spatial document is worth opening without rendering it
+
+---
+
+## Execution Flow
+
+### Step 1: List The Workspace's Documents
+
+```js
+wb_document_list({ workspaceId })
+```
+
+Returns `{ canvases: [{ documentId, path, name? }] }` — placement only, no content. An unknown
+`workspaceId` is an error here, not an empty list, so a typo reads as a failure rather than "nothing
+found."
+
+### Step 2: Classify, Then Sample Each Document
+
+Step 1's listing carries no `kind`, and `wb_document_get` is the only tool that reports one — so
+classification comes first, and it costs one `wb_document_get` per document:
+
+```js
+wb_document_get({ workspaceId, documentId })
+// markdown -> { kind: "markdown", content: "...", frontmatter: {...} }  (the body, directly)
+// spatial  -> { kind: "spatial", content: "..." }                        (full JSON Canvas payload)
+// no recorded kind -> throws a "no recorded kind" error — itself a signal worth reporting
+```
+
+**Do not probe with `wb_scene_digest` first.** The digest reads the spatial containers without
+checking the document's kind, so a markdown document — whose body lives elsewhere — digests as
+`{ nodes: [], edges: [] }` with no error. Digest-first therefore cannot distinguish "empty spatial
+document" from "markdown document full of prose."
+
+Once a document is KNOWN spatial (from `wb_document_get`'s `kind`, or because this session created
+it), `wb_scene_digest` is the cheap re-probe for later passes — counts and bounding boxes without
+re-pulling the payload:
+
+```js
+wb_scene_digest({ workspaceId, documentId })  // only meaningful for a known-spatial document
+```
+
+A document with no recorded kind predates format tracking (`wb_document_get` refuses; the digest
+still answers, misleadingly, from the empty spatial containers). The only way to give it a kind is
+to write to it (`wb_node_add`/`wb_node_patch`/`wb_edge_patch` records `spatial`, `wb_document_set`
+records `markdown`).
+
+### Step 3: Judge Staleness
+
+There is no last-modified or last-accessed timestamp exposed through these tools. Judge staleness
+structurally instead:
+
+| Signal | How To Check | Likely Meaning |
+| --- | --- | --- |
+| empty spatial document | `kind` is `spatial` (Step 2) AND digest reports zero nodes | never drawn, or already redrawn elsewhere — candidate for `wb_document_delete`. A zero-node digest ALONE proves nothing: markdown documents always digest empty |
+| near-duplicate path | two `wb_document_list` entries with similar `path`/`name` | probably one abandoned in favor of the other |
+| markdown document with an empty body | `content` is blank apart from frontmatter | scaffolded but never written |
+| document with no recorded kind | `wb_document_get` throws the "no recorded kind" error | predates format tracking; needs deciding, not deleting on sight |
+
+### Step 4: Write The Report
+
+Keep the user-facing summary short and structured:
+
+```text
+## whiteboard audit report — workspace {workspaceId}
+
+Documents: {N}
+Empty or near-empty: {list of path -> documentId}
+Likely-duplicate paths: {pairs}
+No recorded kind: {list}
+
+### Deletion candidates
+- {path} ({documentId}): {reason}
+```
+
+Do **not** delete anything automatically. Always confirm with the user before calling
+`wb_document_delete`.
+
+---
+
+## Notes
+
+- `wb_document_delete` fails if other documents sit below the target's path — deletion is refused
+  rather than silently cascading, so report the blocker back to the user instead of retrying
+  differently.
+- Deletion is not recoverable through these tools beyond a document's own saved versions
+  (`wb_version_list` / `wb_version_restore`), and those do not survive the document itself being
+  deleted.
+- This skill has no bulk operation: auditing N documents means N `wb_document_get` /
+  `wb_scene_digest` calls. For a very large workspace, sample rather than exhaustively walking
+  every document.

--- a/packages/mcp-server/skills/coauthoring-visuals/SKILL.md
+++ b/packages/mcp-server/skills/coauthoring-visuals/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: coauthoring-visuals
+description: Evolve a whiteboard diagram collaboratively through structured context gathering, iterative refinement, and fresh-viewer testing. Use when a diagram feels misunderstood, under-explained, or needs tightening together with the user.
+---
+
+# coauthoring-visuals
+
+This skill is not a drawing API reference.
+`drawing-visuals` is the toolbox for how to draw.
+`coauthoring-visuals` is the workflow for what to ask, in what order, how to tighten the result, and how to break it from a fresh viewer's perspective.
+
+Open [`references/workflow-map.md`](./references/workflow-map.md) first and decide which stage you are entering.
+
+- For canvas operations and diagram recipes, see [`../drawing-visuals/SKILL.md`](../drawing-visuals/SKILL.md)
+- For a quick visual-direction pass, see [`references/visual-direction.md`](./references/visual-direction.md)
+- For depth and visual-argument judgment in technical diagrams, see [`references/visual-argument.md`](./references/visual-argument.md)
+- For selecting diagram family / viewpoint / layout, see [`references/diagram-family-selection.md`](./references/diagram-family-selection.md)
+- For splitting whiteboard vs companion artifact, see [`references/surface-selection.md`](./references/surface-selection.md)
+- For `whiteboard + mermaid` and its canonical-source / validation-first workflow, see [`references/mermaid-companion-patterns.md`](./references/mermaid-companion-patterns.md)
+- For narrative / pacing after choosing slides, see [`references/slide-deck-patterns.md`](./references/slide-deck-patterns.md)
+- For role-based shape / color / edge consistency in technical diagrams, see [`references/technical-role-profiles.md`](./references/technical-role-profiles.md)
+- For overlap / clipped label / edge-collision cleanup after rendering, see [`references/geometry-checks.md`](./references/geometry-checks.md)
+- For prompt entry points, see [`references/prompt-templates.md`](./references/prompt-templates.md)
+
+## When To Use It
+
+- "I want to tighten this diagram together" or "let's evolve the whiteboard as we talk"
+- the requirements or main claim are not stable yet, and thinking-by-drawing is the right move
+- a diagram already exists, but the questions it should answer need to be restructured
+- you want to verify that the result still reads for someone seeing it cold
+
+## Stage 1: Context Gathering
+
+Before drawing, gather context **in batches, not one question at a time**.
+The opening request should collect these ten things together:
+
+- audience: who the diagram is for
+- 5-second takeaway: what should remain after 5 seconds
+- delivery surface: whiteboard only, or hybrid with mermaid / table / memo / slides
+- depth: whether simple/conceptual is enough or comprehensive/technical is needed
+- diagram family: decomposition, layered architecture, workflow/swimlane, trust-boundary, cloud/network zone, comparison split, or pipeline
+- constraints: hard constraints, forbidden expressions, required document count
+- source material: specs, screenshots, existing diagrams, URLs, bullet notes
+- unknowns: unsettled points, in-flight discussion, unresolved claims
+- job-to-be-done: what decision or comparison the diagram should support
+- visual direction: whether it should feel calm, review-heavy, brand-aligned, dense, sparse, and so on
+
+At this stage, welcome an unordered info dump.
+Prompt the user to provide all fragments first: bullets, rough notes, images, links.
+From that, extract:
+
+- candidate sections, one per question the diagram must answer
+- facts that belong on the board vs facts that can be omitted
+- hypotheses that should not yet be presented as settled
+- gaps that must be filled before drawing
+- visual cues that must stay consistent across the whole document
+- sections that should include concrete examples or evidence artifacts
+- the first diagram grammar to try, and the points it cannot explain alone
+- detail that should stay off-canvas
+
+Do not get trapped in narrow back-and-forth questioning.
+Bundle follow-up questions so they are only as detailed as needed to choose the whiteboard shell.
+Treat subtle tone or brand cues as a **foundation**, not as rigid style law.
+Translate them into space, form, color, and composition.
+For technical diagrams, decide early **what concrete examples to show**, not just what generic labels to use.
+If the diagram family is unclear, stop before fully drawing and decide what grammar should organize the material.
+If the content really wants to become a structured table, such as a comparison matrix or long audit, do not force whiteboard-only.
+
+## Stage 2: Refinement & Structure
+
+The working unit is a **section** — one coherent question and its answer — not necessarily a whole
+document. The whiteboard MCP surface has no frame/membership feature and no section-level render, so
+a section is either its own document (`wb_document_create`), or a loosely bounded region within one
+document marked with a `group` node (label + background only — it tracks no membership and cannot be
+exported on its own).
+
+Default rule: 1 section = 1 question.
+Use this loop:
+
+1. clarify: state in one sentence what this section answers
+2. brainstorm: generate 2-3 candidate node / edge compositions
+3. curate: choose one and explicitly name what you are discarding
+4. gap check: find meaning that still exists only in your head
+5. draw/update: `wb_node_add` / `wb_node_patch` / `wb_edge_add` / `wb_edge_patch`
+6. refine: tighten labels, alignment, and reading direction
+
+Stage 2 rules:
+
+- Fix the first conclusion each section should deliver
+- First confirm that the **surface** is correct
+  - whiteboard: structure, causality, boundaries, handoffs
+  - whiteboard + mermaid: when structured grammar should stay diffable / versioned; Mermaid is canonical and should be validated before sharing
+  - companion table/page: dense comparison, audit, inventory
+  - slide deck: only when presentation is explicitly requested; decide one slide = one claim and pacing before building it
+- Choose **one primary diagram family per section**
+  - decomposition / mind map
+  - layered architecture
+  - workflow / swimlane
+  - trust-boundary / security
+  - cloud / network zone
+  - comparison split
+  - pipeline / roadmap
+- In technical architecture / infra / workflow, choose a **semantic role profile**
+  - gateway
+  - service
+  - queue / bus
+  - database / store
+  - external
+  - security / auth
+  - error / failure sink
+  - decision
+  - container / boundary
+  - keep the same role aligned in color intent within the section
+- Check whether the section works as a **visual argument**, not just a display
+  - if text disappears, does the structure still preserve the gist?
+  - does the viewer learn one concrete thing?
+- Before drawing, define a short **mini visual philosophy** for the section or document
+  - dominant color family
+  - text density
+  - where emphasis should live
+- Generate options, then **curate before drawing**. Do not merge every candidate idea into one board
+- Do not mix grammars too casually. If multiple grammars are needed, split sections or name one as primary and one as supporting
+- Do not confuse simple/conceptual with comprehensive/technical
+  - simple: optimize for shared mental model and relationship clarity
+  - comprehensive: show actual events, payloads, method names, sample input/output, and similar specifics
+- Do not overstuff detail into the whiteboard
+  - overview belongs on the canvas
+  - dense tables, long lists, and code-heavy detail belong in a companion artifact
+- When fixing an existing document, prefer local surgery — `wb_node_patch` / `wb_edge_patch` — over a full redraw
+- Build complex sections from the shell outward
+  - layout / reading direction
+  - large-scale shell such as layer, lane, zone, boundary
+  - node contents
+  - edges and detail
+- Within the same section, keep recurring node / edge vocabulary consistent
+- Use family-specific semantic grouping
+  - architecture: layer / subgroup / KPI row
+  - workflow: pool / lane / step
+  - security: trust boundary / access flow / audit flow
+  - cloud/network: region / VPC / subnet / zone / physical vs logical link
+- Technical diagrams should include evidence artifacts
+  - real data format
+  - real event / API / method name
+  - sample input/output
+  - if needed, short code / UI mock / timeline
+- Do not put everything in boxes. Section titles, annotations, and supporting notes are often clearer as free-floating text nodes
+- Use enough text to make the diagram readable, but do not let paragraphs do all the explanatory work
+- If a comparison with 4+ rows or 3+ columns is the real subject, prefer a table surface over a diagram
+- In large technical diagrams, think in multiple zoom levels
+  - summary flow
+  - section boundary
+  - detail / evidence
+- Fix the reading direction in flow-like diagrams
+  - usually left-to-right
+  - layer stacks top-to-bottom
+  - comparisons with stable symmetry
+- Split `current / problem / proposal` and `before / after` into separate sections
+- Do not hide unknowns. Leave them visible as `unknown`, `assumption`, or `TBD`
+- If your instinct is "add more," first see whether spacing, alignment, contrast, or repetition solves it more cleanly
+
+## Stage 3: Fresh-Viewer Testing
+
+Once a draft exists, break it as if you know nothing about the prior chat.
+Review either the whole document or one section at a time, but do it **while looking at the SVG
+`wb_scene_render` returns** (or, when you cannot view an image, the summary `wb_scene_digest`
+returns).
+
+Check:
+
+- can the main subject be understood in 5 seconds?
+- is the reading order across sections natural?
+- do edges and boundaries explain themselves from the diagram alone?
+- do important nodes say both what they are and why they are there?
+- does the diagram pre-answer the questions a viewer is likely to ask?
+- in technical diagrams, are concrete examples visible instead of only generic labels?
+- would the hierarchy survive if unnecessary containers were removed?
+- has the semantic role profile stayed consistent?
+  - do gateway / service / queue / database / external keep stable appearances?
+  - do dashed / accent / danger avoid carrying more than one meaning? (note: JSON Canvas edges have
+    no dash/line-style field, so "different meaning" has to come from color or label, not stroke style)
+- does the chosen diagram family fit the viewer's question?
+  - is a responsibility problem accidentally shown as a workflow?
+  - is a handoff problem being forced into a layer diagram?
+  - is a trust-boundary problem missing zones entirely?
+- is whiteboard even the right surface?
+  - does reading detail require too much zoom?
+  - would a table be faster for the information shown?
+- are geometry failures still present?
+  - overlap
+  - clipped labels (there is no auto-wrap, so this is common)
+  - dangling edges / edges pointing at the wrong node
+  - edges through unrelated nodes
+  - parallel edges collapsing into one visible path
+  - stray nodes left far from the rest unintentionally
+
+When needed, use the prompts in [`references/review-prompts.md`](./references/review-prompts.md) for fresh-viewer review, geometry QA, and question generation.
+Open [`references/question-bank.md`](./references/question-bank.md) when you need question seeds.
+Open [`references/visual-argument.md`](./references/visual-argument.md) when deciding between conceptual and technical treatment.
+Open [`references/diagram-family-selection.md`](./references/diagram-family-selection.md) when the family is still unclear.
+Open [`references/surface-selection.md`](./references/surface-selection.md) when the surface feels wrong.
+Open [`references/technical-role-profiles.md`](./references/technical-role-profiles.md) when technical roles are drifting.
+Open [`references/geometry-checks.md`](./references/geometry-checks.md) when the geometry needs repair.
+
+If the fresh-viewer test surfaces ambiguity, return to Stage 2.
+Do not over-explain by dumping more text.
+Prefer **local whiteboard surgery** — `wb_node_patch` / `wb_edge_patch` — over redrawing everything.
+At this stage, prioritize the **second polish pass** over adding more nodes:
+composition, whitespace, alignment, and label density should get tighter before the board gets bigger.
+
+## Quality Gate
+
+Before calling it done, meet this minimum bar:
+
+- a fresh viewer can identify the audience and takeaway within 5 seconds
+- each section has one stable question and one stable conclusion
+- important edges and boundaries are labeled
+- no essential meaning lives only in the chat context
+- the structure remains readable even without decoration
+- visual hierarchy and text density feel intentional, not accreted
+- in technical diagrams, the viewer can take away concrete detail rather than generic node names
+- the diagram family is clear section by section, and boundary / lane / layer / zone meaning is consistent
+- in technical sections, the semantic role profile remains consistent
+- no obvious geometry failures remain in the rendered SVG
+- detail density matches the chosen surface
+
+## References
+
+- [`references/workflow-map.md`](./references/workflow-map.md): stage entry points and when to go back
+- [`references/visual-direction.md`](./references/visual-direction.md): mini design philosophy and polish pass
+- [`references/visual-argument.md`](./references/visual-argument.md): simple vs comprehensive, evidence artifacts, container judgment
+- [`references/diagram-family-selection.md`](./references/diagram-family-selection.md): choosing viewpoint, layout, and semantic grouping
+- [`references/surface-selection.md`](./references/surface-selection.md): splitting work across whiteboard / table / memo / slides
+- [`references/mermaid-companion-patterns.md`](./references/mermaid-companion-patterns.md): canonical source / validation / family-specific Mermaid use
+- [`references/slide-deck-patterns.md`](./references/slide-deck-patterns.md): narrative and pacing after choosing slides
+- [`references/technical-role-profiles.md`](./references/technical-role-profiles.md): role profiles and visual consistency in technical diagrams
+- [`references/geometry-checks.md`](./references/geometry-checks.md): post-render geometry QA and local fixes
+- [`references/prompt-templates.md`](./references/prompt-templates.md): prompt index
+- [`references/selection-prompts.md`](./references/selection-prompts.md): Stage 1-2 selection prompts
+- [`references/review-prompts.md`](./references/review-prompts.md): Stage 3 review prompts
+- [`references/question-bank.md`](./references/question-bank.md): question seeds for architecture / review / workflow / security / infra

--- a/packages/mcp-server/skills/coauthoring-visuals/references/diagram-family-selection.md
+++ b/packages/mcp-server/skills/coauthoring-visuals/references/diagram-family-selection.md
@@ -1,0 +1,175 @@
+# Diagram Family Selection
+
+The value to borrow from `markdown-viewer/skills` is not syntax, but the judgment of **which diagram family fits which question**.
+
+## Quick Map
+
+- Pick The Family First: choose the family before detailing content
+- Family Cues: which questions and compositions each family suits
+- Build Order: move from shell to detail
+- Per-Layer Patterns: recurring internal patterns for layers / lanes / zones
+- Cross-Cutting Concerns: what should be pushed into sidebars or other frames
+- Corresponding Drawing Notes: where to open the matching `drawing-visuals` notes
+
+## Pick The Family First
+
+Do not start with "what do I want to explain?"
+Start with **which visual grammar should the viewer use to read this?**
+
+- decomposition: topic breakdown, option tree, decision tree
+- layered architecture: responsibilities, tiers, dependencies
+- workflow / swimlane: procedure, handoff, role-based flow
+- trust-boundary / security: authentication, authorization, audit, boundary crossing
+- cloud / network zone: region, VPC, subnet, public/private, physical/logical
+- comparison split: current / problem / proposal, before / after, A/B
+- pipeline / roadmap: stage progression, ETL, CI/CD, migration sequence
+- enterprise landscape: business / application / technology / motivation / implementation
+
+## When Mermaid Is The Better Companion
+
+Before you commit to a whiteboard family, ask whether **structured grammar should live in a separate artifact**.
+
+- sequence: participant order and message grammar should stay text-based
+- flowchart: direction, subgraph, and edge label should remain canonical
+- state: state machine should stay diffable
+- entity relationship: schema should remain text-first
+- timeline / gantt: chronology is the main content
+- C4: context / container / component / deployment should remain canonical
+
+In those cases, consider `whiteboard + mermaid` first.
+The whiteboard carries overview, emphasis, comparison, and commentary.
+Mermaid carries the structured source-of-truth.
+If chosen, also open [`./mermaid-companion-patterns.md`](./mermaid-companion-patterns.md).
+
+## Family Cues
+
+### Decomposition
+
+Use it when:
+- the issues are still scattered
+- you want to split topics before entering architecture
+- you want to show a choice tree or classification
+
+Helpful compositions:
+- tree
+- mind map
+- bilateral pros/cons
+
+### Layered Architecture
+
+Use it when:
+- you want to show responsibilities across user / app / data / infra
+- you want to separate business / application / technology
+- you want cross-cutting concerns to sit outside the main shell
+
+Helpful compositions:
+- vertical layer stack
+- 3-column with sidebars
+- subgroup / product group / KPI row
+
+### Workflow / Swimlane
+
+Use it when:
+- the key question is who hands what to whom and when
+- you are showing an approval chain
+- cross-team handoff matters
+
+Helpful compositions:
+- left-to-right flow
+- pool / lane
+- vertical stack for ordered steps
+
+### Trust-Boundary / Security
+
+Use it when:
+- the flow is user -> auth -> authz -> resource
+- trust boundaries matter
+- audit / async detection matters
+
+Helpful compositions:
+- access flow
+- trust zone
+- dashed audit path
+
+### Cloud / Network Zone
+
+Use it when:
+- the subject is cloud deployment
+- VPC / region / subnet boundaries matter
+- public/private split matters
+- both physical links and logical flow must be shown
+
+Helpful compositions:
+- nested zones
+- region / VPC / subnet grouping
+- cloud boundary plus zone labels
+
+### Comparison Split
+
+Use it when:
+- comparing `current / problem / proposal`
+- comparing before / after
+- comparing option A / B
+
+Helpful compositions:
+- mirrored two-column
+- repeated frame pattern
+- same comparison axis across frames
+
+### Pipeline / Roadmap
+
+Use it when:
+- the subject is ETL
+- the subject is CI/CD
+- migration phases matter
+- a staged rollout matters
+
+Helpful compositions:
+- inline pipeline
+- numbered vertical stack
+- milestone row
+
+## Build Order
+
+Build complex diagrams in this order:
+
+1. choose the family and reading direction
+2. place the shell: frame / sidebar / lane / layer / zone
+3. fill each layer or lane
+4. add connectors
+5. add evidence / legend / KPI / annotations last
+
+## Per-Layer Patterns
+
+For layered families, choose an internal arrangement too:
+
+- simple grid: peer components
+- subgroup: lower-level split such as sync vs async
+- product group: multiple products or domains
+- KPI row: show metrics
+- vertical stack: ordered steps
+- nested zones: isolation boundary
+- mixed width: primary plus secondary
+
+## Cross-Cutting Concerns
+
+Push things that become noisy on the main path into a sidebar or a separate frame:
+
+- monitoring
+- security / compliance
+- governance
+- analytics
+
+Do not let these become scattered boxes crossing the main connectors.
+
+## Corresponding Drawing Notes
+
+Once the family is chosen, open the matching drawing note in the `drawing-visuals` skill:
+
+- decomposition: [`../../drawing-visuals/references/decomposition-and-trees.md`](../../drawing-visuals/references/decomposition-and-trees.md)
+- layered architecture: [`../../drawing-visuals/references/layered-architectures.md`](../../drawing-visuals/references/layered-architectures.md)
+- workflow / swimlane: [`../../drawing-visuals/references/workflows-and-swimlanes.md`](../../drawing-visuals/references/workflows-and-swimlanes.md)
+- trust-boundary / security: [`../../drawing-visuals/references/trust-boundary-and-security.md`](../../drawing-visuals/references/trust-boundary-and-security.md)
+- cloud / network zone: [`../../drawing-visuals/references/cloud-and-network-zones.md`](../../drawing-visuals/references/cloud-and-network-zones.md)
+- comparison split: [`../../drawing-visuals/references/comparison-splits.md`](../../drawing-visuals/references/comparison-splits.md)
+- pipeline / roadmap: [`../../drawing-visuals/references/pipelines-and-roadmaps.md`](../../drawing-visuals/references/pipelines-and-roadmaps.md)

--- a/packages/mcp-server/skills/coauthoring-visuals/references/geometry-checks.md
+++ b/packages/mcp-server/skills/coauthoring-visuals/references/geometry-checks.md
@@ -1,0 +1,51 @@
+# Geometry Checks
+
+Fix **geometry failures separately from meaning failures** after rendering. There is no automated
+overlap or overflow warning on this tool surface — the check is entirely visual, against the SVG
+`wb_scene_render` returns.
+
+## What To Check After Rendering
+
+- overlap: nodes, labels, and edges do not collide
+- clipped label: text is not cut off inside a node (there is no auto-wrap, so this is common)
+- dangling connection: an edge does not visually touch its node, or appears to connect to the wrong side
+- edge-through-node: an edge passes through an unrelated node
+- stacked parallel edges: multiple edges visually collapse into one path
+- stray element: something is left far from the rest of the diagram unintentionally
+- off-balance shell: the shell is correct, but one side is visibly overcrowded
+
+## Order Of Fixes
+
+1. clipped / overlap
+2. dangling connection
+3. edge collision
+4. stray element
+5. spacing / alignment polish
+
+Do not spend time polishing a diagram whose meaning is still weak.
+But if the meaning is already solid, geometry failures are usually the fastest thing to fix first.
+
+## Local Surgery
+
+- overlap: widen the gap, shift one node down a row, or shorten the label — `wb_node_patch`
+- clipped label: widen the node (`width`/`height`) or shorten the text
+- dangling connection: `wb_edge_patch` the `fromSide`/`toSide` hint, or nudge the node it targets
+- edge-through-node: move the intervening node aside, since edges have no manual routing points to bend around it
+- stacked parallel edges: offset the nodes vertically, or demote one edge into a side path
+- stray element: `wb_node_patch` it back near the rest of the diagram (there is no delete tool, so
+  an unwanted node has to be moved or repurposed rather than removed)
+- shell collapse: before rebuilding the shell, re-fix only the outer boundary and reading direction
+
+## Smells
+
+- small collisions remain that only become obvious after rendering
+- there is no warning mechanism, so a label crammed against its neighbor is silent until you look at the SVG
+- edge collision draws more attention than the main path
+- two parallel paths exist, but only one is visible
+
+## Reminder
+
+Geometry QA is not a replacement for fresh-viewer testing.
+
+- geometry QA: remove visible visual breakage
+- fresh-viewer test: find meaning breakage

--- a/packages/mcp-server/skills/coauthoring-visuals/references/mermaid-companion-patterns.md
+++ b/packages/mcp-server/skills/coauthoring-visuals/references/mermaid-companion-patterns.md
@@ -1,0 +1,94 @@
+# Mermaid Companion Patterns
+
+What matters to borrow from `Agents365-ai/mermaid-skill` is not Mermaid syntax itself, but **when auto-layout is the right choice** and **the discipline of treating the companion artifact with validation-first rules**.
+
+## Quick Map
+
+- When Mermaid Helps: what kinds of questions justify `whiteboard + mermaid`
+- Canonical Source Rule: which artifact is the source-of-truth
+- Validation Pass: what to confirm before export
+- Family Notes: how flowchart / sequence / state / ER / C4 differ
+- Import Implications: what meaning a whiteboard import must preserve
+
+## When Mermaid Helps
+
+Mermaid is strongest when **grammar matters more than manual coordinates**.
+
+- participant order or state transition should stay fixed in text
+- the source should stay reviewable in diff / version control
+- auto-layout gives you a fast first pass
+- constructs like subgraph, alt, loop, and par preserve the intended meaning
+- the whiteboard should show overview and commentary while the structured core stays in text
+
+In contrast, if spatial composition itself carries the claim, or whitespace and hierarchy are the point, whiteboard-first is often better.
+
+## Canonical Source Rule
+
+If you choose `whiteboard + mermaid`, split responsibilities explicitly:
+
+- Mermaid: canonical grammar, stable ordering, diffable source
+- whiteboard: framing, emphasis, commentary, comparison, callouts
+
+When Mermaid is the companion, do not treat the whiteboard as the source-of-truth.
+Do not assume manual whiteboard edits must round-trip back into Mermaid.
+
+## Validation Pass
+
+Mermaid companions should follow **validate before export / share**.
+
+- syntax parses cleanly
+- participant / state / relation declaration order matches intent
+- arrow style stays internally consistent
+- labels with special characters are quoted if needed
+- subgraph / boundary / layer names are not over-compressed
+- the rendered SVG can be used in fresh-viewer testing
+
+Even if a future workflow imports Mermaid into the whiteboard, assume the Mermaid grammar must be stable first.
+
+## Family Notes
+
+### Flowchart
+
+Good for:
+- process / pipeline / service topology that should stay text-first
+- cases where direction and subgraph already carry enough meaning
+
+Guidelines:
+- choose `LR` or `TD` first
+- use subgraphs for layers / zones / subsystems
+- preserve shape semantics for decision, database, start/end, and similar nodes
+- use edge labels so branch conditions and handoffs are not lost
+
+### Sequence
+
+Good for:
+- API flow, auth flow, async handoff, retry, or branching
+
+Guidelines:
+- make participant order explicit and keep the left-to-right reading stable
+- do not mix request / response / async arrow grammar casually
+- if `alt`, `opt`, `loop`, or `par` matters, prefer the grammar over adding ad hoc boxes
+- if notes are needed, decide whether they belong in Mermaid or on the whiteboard
+
+### State / ER / C4 / Timeline
+
+Good for:
+- state transitions, schema relations, architecture levels, or chronology
+
+Guidelines:
+- make transition / relation / chronology the canonical grammar
+- let the whiteboard add overview, comparison, risk, and migration commentary
+- do not mix context / container / component / deployment inside one C4 artifact
+
+## Import Implications
+
+If Mermaid import into the whiteboard grows later, it should not just flatten text into boxes.
+At minimum, import should preserve:
+
+- participant order
+- node shape intent
+- subgraph / boundary grouping
+- edge labels and edge style
+- direction (`LR`, `TD`)
+
+Those semantics should survive in the imported shell.

--- a/packages/mcp-server/skills/coauthoring-visuals/references/prompt-templates.md
+++ b/packages/mcp-server/skills/coauthoring-visuals/references/prompt-templates.md
@@ -1,0 +1,11 @@
+# Prompt Templates
+
+As the prompt set grows, read it by stage.
+
+- Stage 1-2 selection / planning: [`selection-prompts.md`](./selection-prompts.md)
+- Stage 3 review / QA: [`review-prompts.md`](./review-prompts.md)
+
+## Which File To Open
+
+- if you want to decide visual direction / depth / role / surface / family: [`selection-prompts.md`](./selection-prompts.md)
+- if you want to run fresh-viewer / geometry QA / viewer-question passes: [`review-prompts.md`](./review-prompts.md)

--- a/packages/mcp-server/skills/coauthoring-visuals/references/question-bank.md
+++ b/packages/mcp-server/skills/coauthoring-visuals/references/question-bank.md
@@ -1,0 +1,49 @@
+# Question Bank
+
+Short seed questions to use when generating viewer questions.
+
+## Architecture
+
+- What does each box own, and where does its responsibility stop?
+- Which arrows are sync, async, or manual?
+- Where do data or events enter, and where do they leave?
+- What has been omitted, and is that omission safe for the decision at hand?
+- Where are the failure points or bottlenecks?
+- Do the boxes for the same role still look like the same kind of thing?
+- Is this a context, container, component, or deployment diagram?
+- Can the system boundary or focal structure be found within 5 seconds?
+- Can the viewer tell the main direction of flow without tracing every line?
+- Can relationships be followed one by one, or do crossings break the reading path?
+
+## Review / Comparison
+
+- What is current, and what is proposal?
+- Where is the problem, and why is it a problem?
+- What is the comparison axis, and can each frame be compared on that same axis?
+- Which changes are essential, and which are side effects?
+- What decision is the viewer supposed to make after reading this?
+
+## Process / Workflow
+
+- Who owns each step, and where does the handoff occur?
+- Can sync and async paths be distinguished?
+- Are messages that cross lanes or pools still visible?
+- Where are the decision points and exception paths?
+- Should this really be explained as a flow, or should it be split into a responsibility diagram?
+
+## Security / Boundaries
+
+- Where is the trust boundary?
+- Can the viewer distinguish access flow from audit flow?
+- Where are authentication, authorization, secrets, and audit handled?
+- Are public / private / internal boundaries visible?
+- Are security concerns mixed into the main flow too heavily?
+
+## Infrastructure
+
+- Where are the public / private / trust boundaries?
+- Are region, subnet, cluster, and namespace boundaries visible?
+- Can the viewer distinguish stateful from stateless components?
+- Where are external dependencies, queues, gateways, and secret handling?
+- Are availability and redundancy assumptions visible in the diagram?
+- Are external / security / async path styles being used with one stable meaning?

--- a/packages/mcp-server/skills/coauthoring-visuals/references/review-prompts.md
+++ b/packages/mcp-server/skills/coauthoring-visuals/references/review-prompts.md
@@ -1,0 +1,140 @@
+# Review Prompts
+
+Prompt set for Stage 3, where the goal is to break the diagram and see whether it still reads.
+
+## Quick Map
+
+- Fresh-Viewer Testing Prompt: first-view review
+- Geometry QA Prompt: look only for visual breakage
+- Viewer Question Generation Prompt: surface the questions the board will trigger
+- Architecture Readability Prompt: review architecture-like diagrams with a rubric
+
+## Fresh-Viewer Testing Prompt
+
+Use this after rendering the diagram to SVG with `wb_scene_render`.
+
+```text
+You are a fresh viewer. You do not know the prior chat.
+
+Audience:
+5-second takeaway:
+What the diagram is supposed to help decide:
+Known constraints:
+
+Review this rendered whiteboard document only.
+
+Tasks:
+1. In one sentence, say what you think this diagram is about.
+2. In one sentence, say what would stick after a 5-second glance.
+3. List the parts that are ambiguous, overloaded, or missing labels.
+4. List the questions a skeptical viewer would ask next.
+5. Point out where icons, screenshots, or color seem to carry meaning without enough text or structure.
+6. For technical diagrams, point out where concrete examples or evidence artifacts are missing.
+7. Point out any containers that could become free-floating text without losing clarity.
+8. Point out where the chosen diagram family seems mismatched to the question being answered.
+9. Point out where the chosen surface seems mismatched to the information density.
+10. Recommend the smallest edits that would make this easier to read.
+11. Assess readability:
+   - edge crossings
+   - visual hierarchy
+   - flow direction consistency
+   - grouping effectiveness
+   - relationship traceability
+   - abstraction level consistency
+
+Output format:
+- inferred takeaway
+- confusion points
+- viewer questions
+- missing evidence
+- removable containers
+- family mismatch
+- surface mismatch
+- readability assessment
+- smallest useful edits
+```
+
+## Geometry QA Prompt
+
+Use this when the issue is geometry, not meaning.
+
+```text
+Review this rendered whiteboard document for geometry issues only.
+
+Tasks:
+1. list overlaps
+2. list clipped or cramped labels
+3. list arrows or connectors that do not visually connect cleanly
+4. list edges that pass through unrelated boxes
+5. list parallel edges that collapse into one visible path
+6. list stray elements that look detached from the rest of the diagram
+7. recommend the smallest local edits to fix each issue
+
+Rules:
+- Focus on visible geometry problems, not missing content.
+- Prefer local surgery over full redraw.
+- If an issue is really a shell problem, say so explicitly.
+
+Output format:
+- overlaps
+- clipped labels
+- connection issues
+- edge collisions
+- stray elements
+- smallest useful fixes
+```
+
+## Viewer Question Generation Prompt
+
+Use this before editing when you want to surface the questions careful viewers will ask.
+
+```text
+Generate the questions a careful viewer would ask after seeing this whiteboard.
+
+Context:
+- audience:
+- intended takeaway:
+- diagram type: architecture / review-comparison / infrastructure / other
+
+Rules:
+- Ask questions that arise from the image alone, not from hidden chat context.
+- Prefer questions that expose missing labels, unclear ownership, weak comparison axes, or invisible assumptions.
+- Group similar questions and keep only the sharpest wording.
+- After the questions, add a short note for each one: "already answered", "partly answered", or "not answered in the diagram".
+
+Return:
+1. top 5 viewer questions
+2. why each question appears
+3. the smallest diagram edit that would answer it
+```
+
+## Architecture Readability Prompt
+
+Use this when you want a rubric-driven review of an architecture / C4 / system-landscape diagram.
+
+```text
+Review this architecture diagram for readability and abstraction discipline.
+
+Context:
+- audience:
+- intended takeaway:
+- intended abstraction level: context / container / component / deployment / unknown
+
+Tasks:
+1. count or estimate meaningful edge crossings
+2. say whether the main system boundary or focal structure is visually prominent enough
+3. identify the primary reading direction and whether it stays consistent
+4. check whether related elements are grouped closely enough to read as one unit
+5. check whether relationships can be traced without confusion
+6. check whether the diagram mixes abstraction levels
+7. recommend the smallest edits that would improve readability without changing the core story
+
+Return:
+- crossings
+- visual hierarchy
+- flow direction
+- grouping
+- traceability
+- abstraction level
+- smallest useful edits
+```

--- a/packages/mcp-server/skills/coauthoring-visuals/references/selection-prompts.md
+++ b/packages/mcp-server/skills/coauthoring-visuals/references/selection-prompts.md
@@ -1,0 +1,185 @@
+# Selection Prompts
+
+Prompt set for Stage 1-2, where the goal is to choose what to draw and in what form.
+
+## Quick Map
+
+- Mini Visual Philosophy Prompt: visual direction
+- Depth And Evidence Prompt: conceptual vs technical
+- Technical Role Profile Prompt: role-based appearance
+- Surface Selection Prompt: whether whiteboard is enough
+- Mermaid Companion Prompt: what must be fixed if Mermaid is the companion
+- Diagram Family Selection Prompt: choose the grammar
+
+## Mini Visual Philosophy Prompt
+
+Use this when you want to define visual direction in four short lines before drawing.
+
+```text
+Create a mini visual philosophy for this collaborative whiteboard.
+
+Context:
+- audience:
+- 5-second takeaway:
+- diagram type:
+- source material:
+- constraints:
+
+Return:
+1. a 1-3 word direction name
+2. dominant color family
+3. shape language
+4. text density
+5. composition rhythm
+6. one warning about what would make the board feel noisy or inconsistent
+
+Rules:
+- This is not poster art. Optimize for diagram clarity first.
+- Use space, form, color, and composition to create tone.
+- Keep the direction specific enough to guide the canvas, but short enough to preserve freedom while drawing.
+```
+
+## Depth And Evidence Prompt
+
+Use this when you need to decide whether a conceptual treatment is enough or whether technical detail is required.
+
+```text
+Assess the required depth for this whiteboard.
+
+Context:
+- audience:
+- 5-second takeaway:
+- what the diagram should help decide:
+- source material:
+
+Return:
+1. choose one: simple/conceptual or comprehensive/technical
+2. explain why
+3. if technical, list the concrete evidence artifacts the diagram should include
+4. if technical, list the facts that must be researched or confirmed before drawing
+5. list the risks of staying too abstract
+
+Rules:
+- Prefer concrete examples when the viewer needs to learn how the system actually works.
+- Do not recommend evidence artifacts that are decorative only.
+```
+
+## Technical Role Profile Prompt
+
+Use this when you want consistent role treatment inside a technical frame.
+
+```text
+Choose a semantic role profile for this technical whiteboard frame.
+
+Context:
+- audience:
+- 5-second takeaway:
+- diagram family:
+- what the frame should help decide:
+- source material:
+
+Return:
+1. which roles are actually present in this frame
+2. for each role, the visual treatment to keep consistent
+   - shape family
+   - color intent
+   - edge treatment
+   - preferred label style
+3. which roles can share the same base silhouette
+4. which roles must stay visually distinct
+5. the main consistency failure to avoid
+
+Rules:
+- Optimize for comprehension, not visual variety.
+- Do not create a separate shape just because a role has a different name.
+- Keep dashed treatment to one meaning per frame.
+```
+
+## Surface Selection Prompt
+
+Use this when deciding whether whiteboard alone is the right surface.
+
+```text
+Choose the right delivery surface for this explanation.
+
+Context:
+- audience:
+- 5-second takeaway:
+- what the artifact should help decide:
+- source material:
+- expected level of detail:
+
+Return:
+1. choose one: whiteboard only / whiteboard + mermaid / whiteboard + table / whiteboard + memo-page / slides
+2. explain why
+3. what belongs on the canvas
+4. what should stay off-canvas
+5. the main failure mode if we force everything into the wrong surface
+
+Rules:
+- Prefer whiteboard for structure, causality, boundaries, and handoffs.
+- Prefer Mermaid as a companion when the canonical artifact should stay text-based, diffable, or version-controlled.
+- Prefer table/page surfaces for dense comparison, audits, inventories, and code-heavy detail.
+- Choose slides only when presentation is explicitly requested.
+- If slides are chosen, optimize for narrative order and one-slide-one-claim, not for dumping the whole whiteboard onto slides.
+```
+
+## Mermaid Companion Prompt
+
+Use this when `whiteboard + mermaid` has been selected and you need to lock down Mermaid's role.
+
+```text
+Plan the Mermaid companion artifact for this collaborative whiteboard.
+
+Context:
+- audience:
+- 5-second takeaway:
+- what the artifact should help decide:
+- source material:
+- chosen diagram family:
+
+Return:
+1. choose one Mermaid family for the canonical artifact
+2. explain why Mermaid should be the source-of-truth instead of whiteboard alone
+3. what belongs in Mermaid vs what belongs on the whiteboard
+4. which ordering or grammar must be explicit
+   - participants
+   - states
+   - subgraphs / boundaries
+   - edge labels / arrow meaning
+5. what must be validated before export or import
+6. the main failure mode if we blur the two artifacts together
+
+Rules:
+- Optimize for stable grammar, not decorative detail.
+- Prefer Mermaid when auto-layout and diffability are more valuable than manual placement.
+- Keep whiteboard responsible for framing, commentary, comparison, and callouts.
+```
+
+## Diagram Family Selection Prompt
+
+Use this when you need to choose the grammar itself.
+
+```text
+Choose the best diagram family for this collaborative whiteboard.
+
+Context:
+- audience:
+- 5-second takeaway:
+- what the diagram should help decide:
+- source material:
+- known constraints:
+
+Return:
+1. primary diagram family
+2. one backup family
+3. recommended reading direction
+4. the semantic groupings to use (for example: layers, lanes, trust boundaries, zones, sidebars)
+5. what should be shown in the main frame vs sidebars vs separate frames
+6. what would become confusing if we chose the wrong family
+
+Rules:
+- Prefer one primary family per frame.
+- If multiple families are needed, explain how to split them across frames.
+- Optimize for viewer comprehension, not tool convenience.
+```

--- a/packages/mcp-server/skills/coauthoring-visuals/references/slide-deck-patterns.md
+++ b/packages/mcp-server/skills/coauthoring-visuals/references/slide-deck-patterns.md
@@ -1,0 +1,72 @@
+# Slide Deck Patterns
+
+If you choose a slide deck, it needs a different rhythm from a whiteboard.
+The important thing here is not decoration, but **one claim per slide and deliberate pacing**.
+
+## Use When
+
+- a presentation is explicitly requested
+- the talk track matters more than open exploration
+- you want to show narrative progression by section
+- the audience needs to understand things in sequence
+
+## Core Rules
+
+- one slide, one claim
+- motivation before formalism
+- telegraphic style: do not replace speaker notes with paragraphs
+- every slide earns its place
+- visual-first: if the structure is not readable in 10 seconds, add a visual
+- include a worked example within 2 slides of introducing a new concept
+
+## Planning Pattern
+
+- opening: why this matters
+- early slides: frame the problem, audience, and stakes
+- middle: mechanism / comparison / evidence
+- late: takeaway, tradeoff, next action
+- appendix / backup: anticipated questions
+
+Compared with a whiteboard, a slide deck carries stronger narrative force.
+It is not just "what is the structure?" but also "in what order should the audience be convinced?"
+
+## Density Rules
+
+- do not mass-produce slides with only 3 short bullets
+- every slide should contain at least one substantive element
+  - diagram
+  - table
+  - chart
+  - formula
+  - figure
+  - stat callout
+- if too many text-only slides appear in a row, merge them or strengthen them visually first
+
+## Rhythm Rules
+
+- do not repeat the same layout type for more than 3 slides in a row
+- if theory-heavy slides pile up, break them with example / diagram / comparison
+- make section changes explicit through a divider or visual shift
+- before the conclusion, organize the evidence / references / summary
+
+## Whiteboard Relation
+
+- whiteboard is strong for exploration and structural alignment
+- slide deck is strong for ordered persuasion
+- a natural flow is to organize with a whiteboard first, then convert to slides
+- if the whiteboard already solves the problem, do not turn it into slides
+
+## Smells
+
+- the slide only works if read top-to-bottom like a paragraph
+- a definition appears, but the example does not come until several slides later
+- one slide contains 2 or more separate claims
+- every slide uses the same two-column / bullet layout and becomes monotonous
+- there is no appendix, so the main deck keeps swelling with supporting detail
+
+## Quick Checks
+
+- can the claim of the slide be stated in one sentence?
+- can a visual anchor be found within 10 seconds?
+- does an example appear close to each new concept?
+- is the boundary between summary and appendix clear?

--- a/packages/mcp-server/skills/coauthoring-visuals/references/surface-selection.md
+++ b/packages/mcp-server/skills/coauthoring-visuals/references/surface-selection.md
@@ -1,0 +1,86 @@
+# Surface Selection
+
+The important idea to borrow from `visual-explainer` is to decide **whether whiteboard is even the right surface before choosing a diagram family**.
+
+## Start With Surface
+
+Decide this first:
+
+- whiteboard only
+- whiteboard + mermaid
+- whiteboard + table
+- whiteboard + memo / visual page
+- slide deck
+
+Whiteboard is strong for structure, causality, boundaries, and handoffs.
+Dense tables, long inventories, and diagrams dominated by structured grammar are often better on another surface.
+
+## Use Whiteboard When
+
+- you want to show topology
+- you want the viewer to follow a flow / sequence / boundary
+- you want to compare `current / problem / proposal`
+- you want the structure to read within 5 seconds
+
+## Use Whiteboard + Mermaid When
+
+- the canonical artifact should stay in text / diff / version control
+- source material already exists in Mermaid
+- the grammar is strongly structured, such as sequence / state / ER / C4 / timeline / gantt
+- even a flowchart gets enough meaning from direction / subgraph / edge label, and auto-layout helps
+- the whiteboard should carry overview and commentary while the diagram source-of-truth remains in code
+
+If you choose this, also open [`./mermaid-companion-patterns.md`](./mermaid-companion-patterns.md).
+Mermaid is the canonical source; the whiteboard handles framing, comparison, and callouts.
+
+## Use A Companion Table Or Page When
+
+- a structured comparison with 4+ rows or 3+ columns is the main content
+- the main task is audit / inventory / requirements matrix
+- you want multiple code snippets or file tables side by side
+- there are 4+ sections and navigation matters
+
+Do not force everything into the whiteboard.
+Keep overview on the canvas and push dense detail into a companion artifact.
+
+## Hybrid Pattern
+
+The most common case is hybrid:
+
+- region 1: overview / system shape
+- region 2: key flow or boundary
+- companion mermaid: canonical flowchart / sequence / state / ER / C4 / timeline
+- companion table/page: detailed comparison, audit, command inventory, file map
+
+Validate the Mermaid companion before sharing it, then include its rendered SVG in the fresh-viewer test.
+
+Let the diagram carry structure and the companion artifact carry detail.
+
+## Slide Deck Rule
+
+Choose slide deck **only when the ask is explicit**.
+
+- presentation
+- review meeting
+- shareable walkthrough
+
+If slides were not explicitly requested, a scrollable page or table is often enough.
+If you choose slides, also open [`./slide-deck-patterns.md`](./slide-deck-patterns.md).
+
+## Smells
+
+Re-cut the surface if any of these appear:
+
+- regions are full of paragraphs
+- the viewer needs excessive zoom just to read detail
+- a comparison is really a table recreated as a cluster of boxes
+- a file list or command list has become a wall of boxes
+- actor order, state transitions, or entity relations are being manually realigned every time
+
+## Quick Heuristic
+
+- shape first -> whiteboard
+- structured grammar + auto-layout + diffability -> mermaid
+- compare many fields -> table
+- explain many sections -> page
+- present a narrative -> slides

--- a/packages/mcp-server/skills/coauthoring-visuals/references/technical-role-profiles.md
+++ b/packages/mcp-server/skills/coauthoring-visuals/references/technical-role-profiles.md
@@ -1,0 +1,79 @@
+# Technical Role Profiles
+
+One of the key ideas borrowed from `drawio-skill` is to lock down **role -> appearance** before expanding a technical frame.
+
+## Start With Roles
+
+In technical architecture / infra / workflow diagrams, decide roles first:
+
+- gateway
+- service
+- queue / bus
+- database / store
+- external
+- security / auth
+- error / failure sink
+- decision
+- container / boundary
+
+If you skip this step, the same kind of thing will keep changing appearance throughout the frame.
+
+## Default Mapping
+
+- gateway: entry / adaptation point. It can share the base box family with services, but it needs an accent that marks it as entry-role
+- service: the main processing role; use the base rectangle family
+- queue / bus: give it a standalone box; do not bury it in arrow labels
+- database / store: make storage legible through silhouette or label
+- external: use neutral treatment, outside-boundary placement, or lighter / dashed treatment
+- security / auth: draw it as a control tied to a crossing or protected asset; avoid a generic `security` box
+- error / failure sink: move it to a side path away from the mainline
+- decision: use a diamond or an equivalent conditional node
+- container / boundary: use it for the outer shell such as frame, lane, zone, or subgroup
+
+## Rules
+
+- Within one frame, keep the same role in the same shape language
+- Prioritize role distinction over brand reproduction
+- Keep dashed to one meaning per frame
+  - external
+  - async
+  - optional
+  Do not make one dashed style serve all three at once
+- Do not rely on color alone; roles should also read from labels, position, and grouping
+- Even when using provider icons, keep the role legible through labels, legends, and boundaries
+- Gateway / service / security / error do not all need separate shapes. The critical distinction is semantic, not ornamental variety
+
+## Good Starting Profiles
+
+### Architecture
+
+- left: client / trigger
+- center-left: gateway / auth
+- center: services / workers
+- right: store / external dependency
+- bottom or side: error / audit / async path
+
+### Infrastructure
+
+- edge: client / CDN / LB / gateway
+- middle: compute / service / worker
+- side path: queue / bus / eventing
+- bottom or inner zone: database / cache / storage
+- outside boundary: external / third-party
+
+### Workflow
+
+- lane title: actor / role / system
+- rectangle step: action
+- diamond: decision
+- dashed path: async / message
+- side sink: exception / failure handling
+
+## Local Surgery
+
+- same role appears in three visual forms: normalize to one
+- queue / bus is buried: promote it to a dedicated box
+- external looks internal: move it outside the boundary or into neutral treatment
+- security is generic: split it into a control name or crossing label
+- error path has the same weight as the mainline: move it to a side path and change line weight or color intent
+- everything looks like the same box: restore role difference through position, label, and grouping first

--- a/packages/mcp-server/skills/coauthoring-visuals/references/visual-argument.md
+++ b/packages/mcp-server/skills/coauthoring-visuals/references/visual-argument.md
@@ -1,0 +1,68 @@
+# Visual Argument
+
+The key idea is to treat a diagram not as a display of information, but as a **visual argument**.
+
+## Two Tests
+
+### Isomorphism Test
+
+If you remove the text, does the high-level meaning still survive through structure alone?
+If not, fix shape, grouping, and flow before adding more boxes.
+
+### Education Test
+
+Can the viewer learn one concrete thing from the diagram?
+If the board only says `API`, `Database`, `Processor`, it is weak.
+When needed, show actual event names, payloads, sample input/output, or method names.
+
+## Depth Assessment
+
+Before drawing, decide which of these is required:
+
+- simple / conceptual:
+  - mental model
+  - role division
+  - coarse relationships
+- comprehensive / technical:
+  - real connections
+  - real data formats
+  - real event / API / method names
+  - enough specificity to revisit the diagram as a learning artifact
+
+If the diagram is technical but you present it with only a simple surface, the viewer leaves with false confidence.
+
+## Evidence Artifacts
+
+In technical diagrams, include at least one of these when relevant:
+
+- data / JSON example
+- sample input / output
+- real event or method names
+- short code snippet
+- short timeline
+- UI mock or visible output
+
+An artifact is not decoration. It is evidence that the diagram is grounded.
+
+## Multi-Zoom
+
+Large technical diagrams should not stop at a single explanatory layer.
+
+- summary flow: the overall shape
+- section boundary: the main grouping
+- detail / evidence: concrete examples inside a section
+
+When you split regions or documents, decide which of these levels each one is responsible for.
+
+## Containers
+
+Do not put everything in boxes.
+
+- use containers for distinct things or connection targets
+- consider free-floating text first for section titles, annotations, and supporting notes
+
+Questions to ask:
+- does the shape itself carry meaning?
+- do you need arrows to connect to it?
+- does it need grouping?
+- would typography alone be enough?

--- a/packages/mcp-server/skills/coauthoring-visuals/references/visual-direction.md
+++ b/packages/mcp-server/skills/coauthoring-visuals/references/visual-direction.md
@@ -1,0 +1,39 @@
+# Visual Direction
+
+Compress the `canvas-design` idea of a "design philosophy" into a **mini visual philosophy** for whiteboards.
+
+## Mini Visual Philosophy
+
+Before drawing, decide only these four things:
+
+- dominant color family: which color family leads
+- shape language: angular or rounded, strong lines or quiet lines
+- text density: label-heavy or annotation-heavy
+- composition rhythm: sparse and airy, or denser like a comparison table
+
+You can name the direction in 1-3 words if helpful.
+Examples:
+
+- `Calm Comparison`: neutral, generous whitespace, easy-to-read comparison axis
+- `Operational Review`: stronger problem areas, conclusion up front
+- `Infra Map`: boundary and connection first, role-based color
+
+## Rules
+
+- Mood and brand are a foundation, not a requirement for exact imitation
+- Create tone through space, form, color, and composition rather than decorative tricks
+- Do not make text too sparse; keep the labels needed to understand the diagram
+- Do not mix too many visual vocabularies on one canvas
+- Keep subtle references subtle, more in hue or rhythm than in direct imitation
+
+## Second Polish Pass
+
+After the fresh-viewer test, check these first:
+
+- can alignment be fixed without adding new boxes?
+- can hierarchy be clarified without adding more accent colors?
+- can long sentences be broken into a shorter label plus legend?
+- do the frames feel unnaturally inconsistent in density?
+- would matching repeated patterns make the board easier to read?
+
+Polish on a whiteboard is often more about removing, aligning, and tightening than about adding more.

--- a/packages/mcp-server/skills/coauthoring-visuals/references/workflow-map.md
+++ b/packages/mcp-server/skills/coauthoring-visuals/references/workflow-map.md
@@ -1,0 +1,43 @@
+# Workflow Map
+
+If you are unsure which stage to enter, start here.
+
+| Situation | Starting Stage | What To Do | Next |
+| --- | --- | --- | --- |
+| No diagram exists yet, or the issues are still scattered | Stage 1: Context Gathering | Gather audience, 5-second takeaway, delivery surface, depth, diagram family, constraints, source material, unknowns, and visual direction in one batch. If needed, decide whether `whiteboard + mermaid` or slide deck is the right surface. If Mermaid is chosen, define canonical source and validation pass via `mermaid-companion-patterns.md` | Stage 2 |
+| A diagram exists, but the frame question or composition is weak | Stage 2: Refinement & Structure | Fix the question frame by frame. Decide surface, mini visual philosophy, visual argument, diagram family, and semantic role profile before redrawing | Repeat Stage 2 |
+| The diagram exists, but you are not sure a fresh viewer can read it | Stage 3: Fresh-Viewer Testing | Review exported PNGs / frames for misreadings, weak evidence, excess containers, family mismatch, surface mismatch, and geometry failures; then run a second polish pass | Return to Stage 2 or finish |
+
+## When To Go Back
+
+- source material is thin and the frame is mostly hypothesis: return to Stage 1
+- the diagram is technical but lacks real examples: return to Stage 1 and gather source material again
+- the diagram family is wrong: return to Stage 1 and recut the question
+- too much detail was forced into the whiteboard: return to Stage 1 and choose the surface again
+- one frame contains more than one main claim: split it in Stage 2
+- a fresh viewer cannot say what is being compared or what changes: return to Stage 2
+
+## Minimal Loop
+
+1. gather context in one batch
+2. choose the delivery surface
+   - whiteboard only / whiteboard + mermaid / whiteboard + table / memo-page / slides
+   - if Mermaid is chosen, define canonical source and validation pass too
+3. fix the frame question
+4. choose the diagram family and reading direction
+5. decide the depth and whether evidence is required
+6. if technical, choose the semantic role profile
+7. write a short visual direction
+8. generate options
+9. choose one
+10. draw
+11. export and break it with fresh-viewer and geometry passes
+12. repeat 2-11 until it reads
+
+## Division Of Labor
+
+- `drawing-visuals`: drawing and canvas operations such as boxes, arrows, frames, export
+- `coauthoring-visuals`: the collaboration workflow for building the visual
+- `whiteboard-smoke` (for repo developers): post-change validation of skills and tools
+
+If a slide deck is chosen, open [`./slide-deck-patterns.md`](./slide-deck-patterns.md) and confirm one-slide-one-claim plus pacing.

--- a/packages/mcp-server/skills/drawing-visuals/SKILL.md
+++ b/packages/mcp-server/skills/drawing-visuals/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: drawing-visuals
+description: Draw diagrams with your AI agent on a shared JSON Canvas whiteboard. Use it when screen layout, structure, flow, or comparison still feels too ambiguous in text alone. Covers node/edge placement and SVG rendering only — no icon libraries, no other export formats, no per-element delete.
+---
+
+# drawing-visuals
+
+Like a whiteboard on the wall of a meeting room, this is a tool for AI and humans to **align by drawing on the same workspace**.
+Use it when drawing and pointing is faster than iterating in prose.
+What you draw stays on the document and can be revisited and refined later.
+
+**Coverage note.** The whiteboard MCP surface is deliberately small: place nodes and edges,
+tidy the layout, render SVG, save/restore versions. There is no icon or template library, no
+align/distribute, no viewport control, and — today — no way to delete a single node or edge once
+added. Plan the diagram with that ceiling in mind rather than assuming a full-featured drawing-app
+tool set.
+
+Use these tools:
+
+- `wb_document_create` / `wb_document_list` / `wb_document_resolve` / `wb_document_delete` — create, find, and remove documents
+- `wb_node_add` / `wb_node_patch` / `wb_node_lock` — place and adjust nodes
+- `wb_edge_add` / `wb_edge_patch` / `wb_edge_lock` — connect nodes
+- `wb_canvas_tidy` — auto re-layout
+- `wb_scene_render` — render the laid-out scene as SVG (the only export format)
+- `wb_scene_digest` — a text summary of the scene, for when you cannot see the rendered image
+- `wb_version_save` / `wb_version_list` / `wb_version_restore` — checkpoint and roll back
+
+**Open [`references/reading-map.md`](./references/reading-map.md) first and read only the note you need.**
+- `references/reading-map.md`: the routing note that tells you which guidance to open for which kind of diagram
+- `style-reference.md`: the deep reference for coordinates, color, and layout recipes; open only when needed
+- `visual-vocabulary.md`: the deep reference for labeling, diagram choice, and anti-patterns; open only when needed
+
+Do not read `style-reference.md` and `visual-vocabulary.md` end-to-end every time.
+Choose the diagram type through the reading map, then open only 1-2 relevant notes.
+
+If you need **the collaborative workflow for tightening the visual together while talking with the user**, also open [`../coauthoring-visuals/SKILL.md`](../coauthoring-visuals/SKILL.md).
+This `drawing-visuals` skill covers canvas operations, diagram vocabulary, and drawing mechanics.
+`coauthoring-visuals` covers context gathering, iterative refinement, and fresh-viewer testing.
+
+---
+
+## When To Reach For The Whiteboard
+
+**Do not wait for the user to ask explicitly.**
+The moment it feels like "drawing would be faster than prose," propose it and use it.
+
+### Structure And Placement
+
+- explaining screen layout, UI mocks, or component placement
+- organizing dependencies and responsibility splits across components or modules
+- sharing the big picture of a directory tree or other hierarchy
+
+### Motion And Order
+
+- following a data flow, processing flow, or request path
+- explaining state transitions, lifecycle, or event order
+- aligning on sequence: who passes what to whom, and when
+
+### Comparison And Diffs
+
+- showing before / after, current / proposal, or option A / option B side by side
+- showing an N x M comparison matrix such as environment-by-feature coverage
+
+### Alignment When Ambiguity Remains
+
+- when a spec or requirement still feels mismatched
+- when three rounds of prose still are not converging
+- when you think both sides may be saying the same thing but are not confident
+
+**When in doubt, draw.**
+The cost of drawing is low; the cost of proceeding under false alignment is high.
+If the diagram turns out unnecessary, `wb_document_delete` it.
+
+### Explicit User Triggers
+
+- `/drawing-visuals` - render the current document and consider the next adjustment
+- `/drawing-visuals <documentId>` - work in the specified document
+- "explain it as a diagram", "use the whiteboard", "share it visually"
+
+---
+
+## The Loop After You Decide To Draw
+
+Repeat **draw -> render -> fix** until the document converges.
+
+### Step 1: State The Intent
+
+Describe the purpose of the diagram in 1-2 lines.
+Examples:
+- "data flow for feature A -> B -> C"
+- "metric comparison matrix for previous vs current"
+
+If the intent is fuzzy, open [`visual-vocabulary.md`](./visual-vocabulary.md), look at "Choose the diagram from the question", and narrow it down to **one question this diagram answers**.
+Do not try to answer multiple questions in one document at once — there is no section-level export, so a document either reads as one story or it reads as clutter.
+
+Once the intent is fixed, choose the node shape that fits:
+
+| Content | Node type |
+| --- | --- |
+| a labeled box, the default building block | `text` (has a plain `text` string; no rich formatting, no auto-wrap) |
+| a reference to another document, image, or file | `file` |
+| a link out to a URL | `link` |
+| a lightweight visual boundary (label + background) | `group` |
+
+### Step 2: Create The Document
+
+```js
+wb_document_create({ workspaceId, path: "diagrams/checkout-flow", kind: "spatial", name: "Checkout flow" })
+```
+
+`kind: "spatial"` is required and cannot change later — a document is either a JSON Canvas (spatial) or OKF Markdown, decided at creation.
+
+### Step 3: Place Nodes And Edges
+
+Every node needs an id, integer `x`/`y`/`width`/`height`, and an optional `color` (either a hex string
+like `#1971c2` or a JSON Canvas preset `"1"`-`"6"` — there is no semantic color name like `"primary"`).
+There is no auto-sizing or auto-wrap: pick a width generous enough for the label up front.
+
+```js
+wb_node_add({
+  workspaceId, documentId,
+  node: { id: "client", type: "text", x: 40, y: 40, width: 160, height: 60, text: "Client", color: "#1971c2" },
+})
+wb_node_add({
+  workspaceId, documentId,
+  node: { id: "server", type: "text", x: 320, y: 40, width: 160, height: 60, text: "Server" },
+})
+wb_edge_add({
+  workspaceId, documentId,
+  edge: { id: "req", fromNode: "client", toNode: "server", label: "request", toEnd: "arrow" },
+})
+```
+
+Edges reference node ids, not coordinates — `wb_edge_add` fails if either endpoint does not already
+exist on the canvas. There is no coordinate math to do for the edge itself: `fromSide`/`toSide`
+(`top`/`right`/`bottom`/`left`) and `fromEnd`/`toEnd` (`none`/`arrow`) are the only routing hints, and
+`wb_scene_render` computes the actual drawn path.
+
+**Fails if the id is taken.** `wb_node_add` / `wb_edge_add` never overwrite an existing id — use
+`wb_node_patch` / `wb_edge_patch` to change something already placed.
+
+**Use a rigid grid.** Do not hand-calculate coordinates case by case. Pick `column * 220 + 40` for x
+and `row * 140 + 40` for y (or similar), assign a row/column to every node, then fill in the numbers.
+See [`style-reference.md`](./style-reference.md) for sizing and color guidance.
+
+### Step 4: Tidy And Render
+
+```js
+wb_canvas_tidy({ workspaceId, documentId })
+// Re-tidy only a subset, leaving everything else as a fixed obstacle:
+wb_canvas_tidy({ workspaceId, documentId, scope: ["client", "server"] })
+
+wb_scene_render({ workspaceId, documentId })
+// Resolve `file` node references (e.g. a node that embeds another document) inline:
+wb_scene_render({ workspaceId, documentId, embedReferences: true })
+```
+
+`wb_canvas_tidy` re-lays-out node positions automatically; it has no `direction`, `pins`, or `groups`
+parameters — it is a one-shot auto-arrange, not a configurable layout engine. It refuses a markdown
+document (there is nothing spatial to tidy) and treats a locked node (see `wb_node_lock`) as fixed.
+
+`wb_scene_render` returns `{ svg, width, height }` — SVG is the only rendered export format, and
+there is no way to render only one section of the document; the whole canvas renders every time.
+Open the returned SVG (or write it to a file and view it) to inspect it visually:
+
+- is text overflowing out of boxes? (there is no auto-wrap, so this is a real risk)
+- do edges connect to the intended nodes?
+- does the main subject read without reading every edge label?
+- are colors distinct and legible enough?
+- are gaps between nodes wide enough?
+
+If you cannot see the rendered image, call `wb_scene_digest({ workspaceId, documentId })` instead —
+it summarizes the laid-out scene (node/edge counts, bounding boxes, and similar) as structured data.
+
+### Step 5: Fine-Tune Or Redraw
+
+| Situation | Best Action |
+| --- | --- |
+| change a node's position, size, color, or label | `wb_node_patch({ nodeId, patch: { ... } })` |
+| change an edge's endpoints, sides, arrowheads, color, or label | `wb_edge_patch({ edgeId, patch: { ... } })` |
+| protect a node/edge from further edits (by anyone) | `wb_node_lock` / `wb_edge_lock` |
+| re-run automatic layout | `wb_canvas_tidy` (optionally scoped) |
+| structure or intent is wrong | create a fresh document with `wb_document_create` and redraw |
+
+**There is no delete tool for a single node or edge.** Once placed, a node or edge stays on the
+document; the only way to "remove" it today is to `wb_node_patch` it into something harmless (a
+small notice) or to start over with a new document via `wb_document_create`. Plan placement
+conservatively rather than expecting to prune afterward.
+
+After each fix, go back to Step 4 and render again.
+Redrawing on a fresh document is normal whiteboard behavior when the structure is wrong, not failure.
+
+---
+
+## Checklist When You Are Unsure
+
+- [ ] did you write down the one question the diagram should answer before drawing?
+- [ ] did you choose the diagram family from [`visual-vocabulary.md`](./visual-vocabulary.md)?
+- [ ] did you plan a rigid coordinate grid before calling `wb_node_add`?
+- [ ] did you size boxes generously, since there is no auto-wrap?
+- [ ] did you use semantic, consistent colors even though the tool has no named color keys?
+- [ ] can the main path / supporting info / problem / proposal be distinguished visually?
+- [ ] are edge labels duplicating what node text already says?
+- [ ] did you render with `wb_scene_render` (or summarize with `wb_scene_digest`) and inspect it?
+- [ ] if structure or intent needed rethinking, did you redraw on a new document instead of trying to prune the old one?
+
+---
+
+## Notes
+
+- **Every write is a remote change.** MCP tool calls apply directly to the document; there is no
+  separate "commit" step and no local undo. Save a `wb_version_save({ documentId, label })` before a
+  risky batch of edits and call `wb_version_restore({ workspaceId, documentId, versionId })` to roll
+  back if it goes wrong.
+- **whiteboard MCP is a local dev tool**: documents live under `~/.whiteboard/`, outside git. If you
+  need the SVG in a PR or other artifact, save the string `wb_scene_render` returns to a file.
+- **A document's format is fixed at creation.** `kind: "spatial"` gives you nodes and edges;
+  `kind: "markdown"` gives you an OKF Markdown body edited through `wb_document_set` / `wb_body_patch`
+  and has no nodes or edges of its own. There is no format parameter on read — `wb_document_get`
+  answers in whichever format the document already is.

--- a/packages/mcp-server/skills/drawing-visuals/references/cloud-and-network-zones.md
+++ b/packages/mcp-server/skills/drawing-visuals/references/cloud-and-network-zones.md
@@ -1,0 +1,69 @@
+# Cloud And Network Zones
+
+In cloud / network zone diagrams, separate **nested boundaries and path types** before anything else.
+
+## Good Fits
+
+- AWS / GCP / Azure / Kubernetes deployments
+- organizing regions / VPCs / subnets / clusters
+- public / private split
+- showing physical links alongside logical flow
+- hub-and-spoke networks
+
+## Shell
+
+- Place the outer boundary first
+  - region / account / VPC / cluster / subnet
+- Decide on one main path
+- Separate physical / bidirectional links from logical / request flows
+- Before routing through the center, see whether cross-zone relations can be pushed to the perimeter
+- Put the legend and glossary outside the zones
+
+## Reading Direction
+
+- Request / data flow goes left-to-right
+- Nested zones should read outer -> inner
+- Push failover or replicas below or to the right
+- Separate sync and async paths into different bands
+
+## Semantic Grouping
+
+- zone: region / VPC / subnet / namespace / cluster
+- edge: ingress / gateway / LB / CDN
+- compute: service / pod / function / VM
+- data: DB / cache / queue / bus
+- external: third-party / on-prem / client
+
+## Hard Rules
+
+- Do not omit zone labels
+- Put zone labels in separate text at the top-left, not in the zone rect `text`
+- Keep legends / notes outside the zone
+- Do not bury queues / buses in arrow labels
+- Do not style physical links and logical flows the same way
+- Do not overload solid / dashed / dotted with multiple meanings in one frame
+- Do not run long diagonal cross-zone arrows through the middle of zones
+- Do not recolor provider icons in ways that hurt recognizability
+
+## Common Failures
+
+- Too many zones make components stop being the focal point
+- Subnet and namespace levels get mixed together
+- External dependencies blend into the internal zone
+- The failover path is louder than the main path
+- Cross-zone arrows create spaghetti through the middle of zones
+- It is unclear whether the diagram is a network view or an app-flow view
+
+## Local Surgery
+
+- If the zone stack is too heavy: remove one layer or split into another frame
+- If paths cross: push external / async paths above or below
+- If the zone label is buried: stop using rect text and return to free-standing labels
+- If cross-zone relations are messy: move zones adjacent to each other or use elbow / perimeter routing
+- If DB / queue elements are buried: promote them to dedicated labeled boxes
+- If icons are too loud: move more meaning back into the legend, frame, and labels
+
+## If Stuck
+
+- For broad guidance, see [`./infrastructure-diagrams.md`](./infrastructure-diagrams.md)
+- If trust crossings are the focal point, see [`./trust-boundary-and-security.md`](./trust-boundary-and-security.md)

--- a/packages/mcp-server/skills/drawing-visuals/references/comparison-splits.md
+++ b/packages/mcp-server/skills/drawing-visuals/references/comparison-splits.md
@@ -1,0 +1,59 @@
+# Comparison Splits
+
+In comparison splits, **keep the comparison axis aligned and emphasize only the differences**.
+
+## Good Fits
+
+- `current / problem / proposal`
+- before / after
+- option A / option B
+- migration comparison
+- side-by-side comparison for a review artifact
+
+## Shell
+
+- Limit the comparison to 2-3 dimensions
+- Arrange columns or frames in a mirrored layout
+- Use the same anchors in each column / frame
+- Put the conclusion in the frame name or the first large text block
+
+## Reading Direction
+
+- Usually left-to-right
+- For `current -> problem -> proposal`, preserve time order
+- In A/B comparisons, keep the left/right meaning fixed
+- Fix the comparison axis to one direction only
+
+## Labels
+
+- State the comparison axis explicitly
+- Prioritize `name + role` in each box and push evaluative language into `subText`
+- Add callouts only where there is an actual difference
+- Keep arrow labels to a small number
+
+## Hard Rules
+
+- Do not vary the composition too much across the compared targets
+- Do not mix the problem and the proposal into the same annotation
+- Do not rename the same kind of box with different wording in each column
+- Do not add decorative differences where no actual difference exists
+- Do not mix unrelated flows into a comparison frame
+
+## Common Failures
+
+- The axes drift between before and after
+- Only the `problem` frame carries too much information
+- Too many callouts bury the actual comparison
+- The box grammar changes by column, forcing relearning instead of comparison
+
+## Local Surgery
+
+- If the axis drifts: align anchor box position and size
+- If one side is too dense: move detail into a side note
+- If the claim is weak: put the conclusion first in the frame title or opening text
+- If the differences are scattered: narrow hotspots / callouts to 1-2 places
+
+## If Stuck
+
+- For broad guidance, see [`./review-and-comparison.md`](./review-and-comparison.md)
+- For tree-like pros/cons, see [`./decomposition-and-trees.md`](./decomposition-and-trees.md)

--- a/packages/mcp-server/skills/drawing-visuals/references/dark-mode-techniques.md
+++ b/packages/mcp-server/skills/drawing-visuals/references/dark-mode-techniques.md
@@ -1,0 +1,63 @@
+# Dark Mode Techniques
+
+Dark mode is not about splashing bright colors onto a black background. It is about drawing so that **meaning survives across themes**.
+
+## Good Fits
+
+- boards viewed in both dark and light mode
+- screenshots or exports where the background color may change
+- dense infra / architecture / review boards
+- cases where you want glow or fill without breaking meaning
+
+## Core Rules
+
+- do not make meaning depend on canvas background color
+- keep role colors stable across themes
+- use stroke-first for containers / boundaries
+- evaluate both `text vs box` contrast and `box vs canvas` contrast
+- dark-mode decoration is optional; structure and labels come first
+
+## Switch-Safe Drawing
+
+- Read primary boxes through stroke and labels before fill
+- Keep grouping / zone fill at low opacity
+- Use glow only for emphasis, never as the meaning itself
+- Neutral text disappears easily on dark backgrounds, so do not weaken subtitles too far
+- Dashed / dotted differences are easier to miss in dark mode; reinforce the meaning with labels too
+
+## Techniques That Work Well On A Dark Canvas
+
+- On dense boards, use transparent or near-transparent cards
+- Let boundaries read through labels more than through stroke weight
+- Place zone / boundary labels as separate top-left text
+- Raise fill intensity on only the emphasized box and leave the others stroke-first
+- If you use glow, confine it to one main-path location
+
+## Constraints That Keep It Safe In Light Mode Too
+
+- Do not rely too much on pure black / pure white contrast
+- Do not build hierarchy from faint gray alone
+- Do not over-recolor provider icons or logos to match the theme
+- Do not express optional / future-state only through opacity
+- Do not express warning / danger only through background fill
+
+## Palette Mindset
+
+- Decide `primary / success / warning / danger / info / neutral` roles first
+- Even if the dark-mode appearance changes, do not change those semantic mappings
+- Absorb theme differences mainly through brightness / opacity / stroke weight rather than hue
+- Do not let the same role drift semantically, such as blue in light mode and purple in dark mode
+
+## Quality Check
+
+- Can the main path still be followed in 5 seconds in both dark and light mode?
+- Does any neutral text disappear?
+- Are dashed / dotted lines still legible?
+- If you remove the glow, does the meaning remain?
+- Does the rendered SVG still preserve zone / boundary presence?
+
+## If Stuck
+
+- For the base rules, see [`../style-reference.md`](../style-reference.md)
+- If the main subject is infra / boundaries, see [`./cloud-and-network-zones.md`](./cloud-and-network-zones.md)
+- If the main subject is trust crossings, see [`./trust-boundary-and-security.md`](./trust-boundary-and-security.md)

--- a/packages/mcp-server/skills/drawing-visuals/references/decomposition-and-trees.md
+++ b/packages/mcp-server/skills/drawing-visuals/references/decomposition-and-trees.md
@@ -1,0 +1,57 @@
+# Decomposition And Trees
+
+In decomposition and tree diagrams, handle **the same kind of question at the same depth**.
+
+## Good Fits
+
+- topic breakdown
+- option tree
+- taxonomy
+- separating pros / cons
+- structuring the discussion before moving into architecture
+
+## Shell
+
+- Start with one root
+- Keep level-1 branches to 2-5 items
+- Preserve the same classification axis at the same depth
+- In bilateral comparisons, keep left and right meanings fixed
+
+## Reading Direction
+
+- Keep the tree either top-to-bottom or left-to-right
+- In bilateral layouts, assign stable meaning to left and right
+- Do not change direction branch by branch
+
+## Labels
+
+- root: the main claim or question
+- branch: a short noun phrase along the classification axis
+- leaf: a concrete example, decision input, or exception
+- In decision trees, keep branch labels aligned as `YES / NO + condition`
+
+## Hard Rules
+
+- Do not mix chronology into a decomposition diagram
+- Do not let parent and child levels drift too far apart in granularity
+- Do not mix unrelated categories such as actor / data / policy at the same depth
+- If lines would cross, split the work into separate frames
+
+## Common Failures
+
+- The root is so broad that level 1 becomes a catch-all
+- Children are longer and heavier than their parent
+- The tree turns into a comparison or flow diagram halfway through
+- The classification axis and evaluation axis are mixed into the same branch
+
+## Local Surgery
+
+- If a branch is too wide: split it into two levels
+- If the same term repeats in many leaves: promote it one level up
+- If exceptions break the tree: move them into a dedicated frame
+- If pros / cons muddy the tree: split into a bilateral frame
+
+## If Stuck
+
+- For structural framing, see [`./flow-and-architecture.md`](./flow-and-architecture.md)
+- If the branching is really conditional logic, see [`./sequence-and-decisions.md`](./sequence-and-decisions.md)

--- a/packages/mcp-server/skills/drawing-visuals/references/flow-and-architecture.md
+++ b/packages/mcp-server/skills/drawing-visuals/references/flow-and-architecture.md
@@ -1,0 +1,78 @@
+# Flow And Architecture
+
+For structural and data-flow diagrams, decide first **what you want to lock down**.
+
+If you need family-specific techniques:
+- layered tiers: [`./layered-architectures.md`](./layered-architectures.md)
+- decomposition / trees: [`./decomposition-and-trees.md`](./decomposition-and-trees.md)
+
+- Show responsibility boundaries
+- Make the viewer follow the main path
+- Push external dependencies off to the side
+
+## Basic Shell
+
+- Keep the main flow to one path
+- Fix the gaze either left/right or top/bottom
+- Put only parallel elements from the same layer in the same row / column
+- Push secondary elements to the right or below the main flow
+
+## Abstraction Level
+
+For architecture diagrams, fix **which abstraction level the diagram uses**.
+
+- context: actors / external systems / boundary of the target system
+- container: major runtime pieces, services, databases, queues
+- component: internal modules or responsibility splits inside one container
+- deployment: nodes, clusters, runtime placement
+
+Do not mix these in one frame.
+In particular, avoid showing too many internal components in a context diagram or dropping a container diagram all the way down to tables / fields / methods.
+
+Recommended reading path:
+- left: user / client / trigger
+- center: gateway / API / service
+- right: data / storage / external dependency
+
+## Labels
+
+- Center boxes on `name + role`
+- Use short verbs on arrows
+  - `calls`
+  - `reads`
+  - `writes`
+  - `persists`
+  - `broadcasts`
+- Push long explanations into box `subText`
+
+## Color
+
+- `primary`: entrypoint / client
+- `success`: service / compute
+- `info`: metadata / side info
+- `neutral`: external / structure
+
+## Role Consistency
+
+- client / trigger
+- gateway / adapter
+- service / worker
+- store / database
+- queue / bus
+- external dependency
+
+Use the same silhouette and color intent for the same role within one frame.
+Optimize for recognizability of roles, not visual variety.
+
+## Common Failures
+
+- Mixing structural explanation with problem callouts or proposals
+- Arrow labels drawing more attention than the boxes
+- Mixing context / container / component / deployment in one frame
+- Mixing actor / service / storage in the same layer
+- Flattening gateway / service / queue / store into the same generic box
+
+## If Stuck
+
+- For recipes, see `Architecture / Data flow diagrams` in [`../style-reference.md`](../style-reference.md)
+- For vocabulary, see `Show structure` and `Make the viewer follow the flow` in [`../visual-vocabulary.md`](../visual-vocabulary.md)

--- a/packages/mcp-server/skills/drawing-visuals/references/infrastructure-diagrams.md
+++ b/packages/mcp-server/skills/drawing-visuals/references/infrastructure-diagrams.md
@@ -1,0 +1,102 @@
+# Infrastructure Diagrams
+
+In infrastructure diagrams, lock down not just component names but **which boundary each component belongs to and how it connects**.
+
+## Quick Map
+
+- Decide first: boundary / main path / async path
+- Drawing basics: boundary-first, main-path-first
+- Semantic color and role consistency: prefer meaning over decoration
+- Brand adaptation: adapt surrounding elements rather than forcing a component's own look
+- Common failures: bad legend placement, hidden queues, overbearing boundaries
+
+**No icon library.** This tool surface has no icon or template catalog — every component is a
+labeled `text` or `group` node. Represent provider/product identity through labels, legends, and
+consistent color, not through inserted artwork.
+
+If you need nested cloud/network zones or physical vs logical path techniques, also open [`./cloud-and-network-zones.md`](./cloud-and-network-zones.md).
+If trust boundaries / auth / audit are the main subject, also open [`./trust-boundary-and-security.md`](./trust-boundary-and-security.md).
+
+## Decide These First
+
+- Which boundary is the focal one?
+  - `AWS Region`
+  - `VPC`
+  - `Kubernetes Cluster`
+  - `Private Subnet`
+  - `Trust Boundary`
+- What is the main path?
+  - `client -> edge -> gateway -> service -> data`
+- Is there an async path?
+  - Should the queue / topic / bus be a standalone element?
+
+## Drawing Basics
+
+- If brand or design guidelines exist, apply them through labels, legends, and palette choice, not through custom shapes
+- Define boundaries with a `group` node before placing components inside it
+- Keep the main path left-to-right
+- Push branches and async paths above or below the main path
+- Represent the event bus as a small standalone node, not just an edge label
+
+## Connection Labels
+
+In infrastructure diagrams, edge labels may prioritize **protocol / transport over verbs**.
+
+Good examples:
+- `HTTPS`
+- `gRPC`
+- `SQL`
+- `events`
+- `JWT`
+- `TLS`
+
+Bad examples:
+- `backend sends validated messages`
+- `service talks to database securely`
+
+## Semantic Color Guide
+
+Pick a hex per role (see [`../style-reference.md`](../style-reference.md#colors) — the tool itself has no named color keys) and hold it steady:
+
+- primary hex: client / edge / frontend
+- success hex: service / compute
+- warning hex: cloud / managed infra / provider boundary
+- danger hex: security / auth / trust crossing
+- info hex: region / cluster / metadata
+- neutral hex: external system / legend / supporting boundary
+
+## Role Consistency
+
+- Keep gateway / LB / ingress consistent as entry-role elements
+- Keep service / worker consistent as compute-role elements
+- Keep queue / topic / bus consistent as standalone elements
+- Keep database / cache / storage consistent as store-role elements
+- Push external / third-party systems outside the boundary or into neutral treatment
+
+Do not redraw the same role with a different look every time — keep it legible through labels, legends, and boundaries.
+
+## Brand Adaptation
+
+- Apply company / product brand colors through headings, legends, and boundaries
+- If brand colors conflict with semantic colors, prioritize the semantic meaning for paths, security, trust boundaries, and similar elements
+- Use branding as a reading aid, not as decoration; it is safer in legends than on the main path
+- Adjust brand strength depending on whether the diagram is a review artifact or an external-facing asset
+
+## Hard Rules
+
+- Put legends / glossaries / notes outside the boundary
+- Keep boundary labels short and place them in the top-left
+- Limit node contents to `name + role + tech/port` by default
+- Do not style sync and async paths the same way
+
+## Common Failures
+
+- The legend ends up inside a region or cluster
+- A queue / bus is buried in an edge label
+- Boundaries outshine the components
+- A service node is overloaded with role / tech / port / SLA details
+
+## If Stuck
+
+- For layout recipes, see [`../style-reference.md`](../style-reference.md#architecture--data-flow-diagrams)
+- For vocabulary, see `Show boundaries` and `Connection types` in [`../visual-vocabulary.md`](../visual-vocabulary.md)

--- a/packages/mcp-server/skills/drawing-visuals/references/layered-architectures.md
+++ b/packages/mcp-server/skills/drawing-visuals/references/layered-architectures.md
@@ -1,0 +1,58 @@
+# Layered Architectures
+
+In layered architecture diagrams, separate **responsibility tiers and cross-cutting concerns**.
+
+## Good Fits
+
+- splitting user / app / data / infra
+- splitting business / application / technology
+- showing dependencies by tier
+- placing monitoring / security / analytics as side concerns
+
+## Shell
+
+- Start with 3-6 layers
+- Make layer names semantic
+- Push cross-cutting concerns to a sidebar or another frame
+- Keep the main flow to one path across layers
+
+## Reading Direction
+
+- Default to a top-to-bottom layer stack
+- You may switch the emphasized flow to left-to-right, but do not break the layer meaning
+- Put only parallel elements from the same layer in the same row / column
+
+## Per-Layer Patterns
+
+- simple grid: peer components
+- subgroup: lower-level splits such as sync / async
+- product group: parallel products or domains
+- KPI row: metrics or SLOs
+- mixed width: different visual weight for primary vs secondary elements
+
+## Hard Rules
+
+- Do not mix actors, services, and storage in the same tier
+- Keep layer labels short
+- If arrows cross layer titles, redo the layout
+- Do not scatter cross-cutting concerns inside the main layers
+- If an arrow skips a layer, make the reason explicit
+
+## Common Failures
+
+- Too many layers kill hierarchy
+- The tier meaning is unreadable from the box arrangement alone
+- Monitoring / governance sticks to the main path
+- The data layer turns into a list of technology names only
+
+## Local Surgery
+
+- If a layer is too thin: merge it with an adjacent layer
+- If a layer is too thick: split it into subgroups or product groups
+- If a cross-cutting concern gets in the way: move it to a sidebar
+- If dependencies cross too much: separate the main flow from side flows
+
+## If Stuck
+
+- For basic structural diagrams, see [`./flow-and-architecture.md`](./flow-and-architecture.md)
+- For cloud / subnet issues inside a layer, see [`./infrastructure-diagrams.md`](./infrastructure-diagrams.md)

--- a/packages/mcp-server/skills/drawing-visuals/references/pipelines-and-roadmaps.md
+++ b/packages/mcp-server/skills/drawing-visuals/references/pipelines-and-roadmaps.md
@@ -1,0 +1,59 @@
+# Pipelines And Roadmaps
+
+In pipeline / roadmap diagrams, do not mix **phase progression and system structure**.
+
+## Good Fits
+
+- CI/CD
+- ETL
+- migration phases
+- rollout stages
+- milestone planning
+
+## Shell
+
+- For a pipeline, line up stages in one line
+- For a roadmap, treat phases as columns and workstreams as rows
+- Choose one main progression path
+- Keep gates, milestones, and readiness criteria close to their stage
+
+## Reading Direction
+
+- Pipelines go left-to-right
+- Roadmaps progress left-to-right by phase
+- Put stage notes below or to the right
+
+## Semantic Grouping
+
+- stage: unit of progression
+- gate: pass condition
+- milestone: arrival point
+- workstream: parallel work
+- footer / legend: readiness, KPI, owner
+
+## Hard Rules
+
+- Do not pull too much architecture detail back into the mainline
+- Do not overuse backward arrows
+- Keep stage names in the same part of speech
+- Represent rollback / retry / exception consistently
+- Do not cram the rollout plan and the target architecture into one frame
+
+## Common Failures
+
+- Phases and components share the same box grammar
+- Stage exit criteria turn into long paragraphs inside boxes
+- The roadmap collapses into a bullet list
+- Exception arrows outshine the mainline
+
+## Local Surgery
+
+- If there are too many stages: merge them and keep the milestones
+- If architecture details leak in: move the target architecture to another frame
+- If readiness conditions are too heavy: move them into a footer or side note
+- If retry / rollback is scattered: create a separate exception band
+
+## If Stuck
+
+- If you need role-based lanes, see [`./workflows-and-swimlanes.md`](./workflows-and-swimlanes.md)
+- If it is really a message flow, see [`./sequence-and-decisions.md`](./sequence-and-decisions.md)

--- a/packages/mcp-server/skills/drawing-visuals/references/reading-map.md
+++ b/packages/mcp-server/skills/drawing-visuals/references/reading-map.md
@@ -1,0 +1,84 @@
+# Reading Map
+
+Read only this first.
+
+`style-reference.md` and `visual-vocabulary.md` are the deep references.
+Do **not** open them end-to-end every time. Pick the diagram type first, then open only the notes you need.
+
+If the request is really about **how to collaborate on the diagram itself** such as "let's evolve this together," "tighten it together," or "stress-test it for a fresh viewer," open [`../../coauthoring-visuals/SKILL.md`](../../coauthoring-visuals/SKILL.md) before choosing any notes.
+
+## Which Note To Open
+
+### 1. Flow / Architecture / Structural Framing
+
+Open:
+- [`flow-and-architecture.md`](./flow-and-architecture.md)
+- If you need layered-tier techniques, also open [`layered-architectures.md`](./layered-architectures.md)
+- If it is closer to a tree or argument breakdown, also open [`decomposition-and-trees.md`](./decomposition-and-trees.md)
+
+Typical requests:
+- I want to diagram the system structure
+- I want to show component responsibilities and dependencies
+- I want to share a data flow
+
+### 2. Infrastructure / Network / Cloud Boundaries
+
+Open:
+- [`infrastructure-diagrams.md`](./infrastructure-diagrams.md)
+- If you need zones / nested boundaries / physical-vs-logical path techniques, also open [`cloud-and-network-zones.md`](./cloud-and-network-zones.md)
+- If trust boundary / authz / audit flow is the main subject, also open [`trust-boundary-and-security.md`](./trust-boundary-and-security.md)
+- If you need dark / light switching guidance or dark-canvas-safe color choices, also open [`dark-mode-techniques.md`](./dark-mode-techniques.md)
+
+Typical requests:
+- AWS / GCP / Kubernetes / VPC / subnet
+- I need to show regions / clusters / trust boundaries
+- I need a diagram with queues / buses / gateways / databases
+
+### 3. UI Review / Before-After / Comparison
+
+Open:
+- [`review-and-comparison.md`](./review-and-comparison.md)
+- If you need mirrored axes or split techniques, also open [`comparison-splits.md`](./comparison-splits.md)
+
+Typical requests:
+- `current / problem / proposal`
+- screenshot annotation
+- A/B comparison or before/after
+
+### 4. Sequence / Branching / Procedures
+
+Open:
+- [`sequence-and-decisions.md`](./sequence-and-decisions.md)
+- If lanes / handoffs are the main subject, also open [`workflows-and-swimlanes.md`](./workflows-and-swimlanes.md)
+- If it is phase progression / rollout, also open [`pipelines-and-roadmaps.md`](./pipelines-and-roadmaps.md)
+
+Typical requests:
+- interactions between actors
+- conditional branching
+- procedures or state transitions
+
+### 5. Theme Switching / Dark-Mode-Safe Diagrams
+
+Open:
+- [`dark-mode-techniques.md`](./dark-mode-techniques.md)
+
+Typical requests:
+- I want the diagram to survive both dark mode and light mode
+- I want a dense technical board designed for a dark canvas
+- I want to use glow / fill / low-opacity zones without breaking meaning
+
+## When To Open The Deep References
+
+Open the deep references only when one of these is true:
+
+- you need concrete coordinates or layout recipes
+- you want to confirm detailed rules for colors or `group` node usage
+- you are unsure which diagram type to choose
+- you need to fix a layout that broke after export
+
+Recommended order:
+1. this `reading-map.md`
+2. 1-2 relevant notes
+3. one extra family-specific playbook if needed
+4. [`../style-reference.md`](../style-reference.md) if needed
+5. [`../visual-vocabulary.md`](../visual-vocabulary.md) if needed

--- a/packages/mcp-server/skills/drawing-visuals/references/review-and-comparison.md
+++ b/packages/mcp-server/skills/drawing-visuals/references/review-and-comparison.md
@@ -1,0 +1,48 @@
+# Review And Comparison
+
+For `current / problem / proposal` and before/after work, keep **1 frame = 1 question** intact.
+
+If you need mirrored axes or split-specific techniques, also open [`./comparison-splits.md`](./comparison-splits.md).
+
+## Basic Policy
+
+- If the frames belong to the same discussion, prefer 1 canvas + multiple frames
+- Use the frame name as the section heading
+- Use large text inside the frame for the conclusion or claim
+- Even in related frames, vary the composition slightly by role
+
+Examples:
+- `current`: neutral and easy to read
+- `problem`: stronger hotspots and callouts
+- `proposal`: more whitespace and a calmer tone
+
+## Labels
+
+- Use roughly 1-2 arrow labels per frame
+- Push causes and evaluative wording into the box `title` / `subText`
+- Do not mix the problem and the proposal in one annotation
+
+## Visual Direction
+
+Before drawing, decide only these:
+- the impression that should remain after 5 seconds
+- the dominant color family
+- the text density
+
+## Cleanup
+
+- Delete elements that are no longer needed instead of leaving them empty
+- Do not leave placeholder or template debris behind
+- Do not mechanically duplicate the same composition across every frame
+
+## 5-Second Review
+
+- Can the main subject be read in 5 seconds?
+- Does the intent come through even without reading arrow labels?
+- Do the frame name and the section title avoid duplicating each other?
+- Are there any placeholders left behind?
+
+## If Stuck
+
+- For style details, see [`../style-reference.md`](../style-reference.md)
+- For vocabulary and anti-patterns, see [`../visual-vocabulary.md`](../visual-vocabulary.md)

--- a/packages/mcp-server/skills/drawing-visuals/references/sequence-and-decisions.md
+++ b/packages/mcp-server/skills/drawing-visuals/references/sequence-and-decisions.md
@@ -1,0 +1,50 @@
+# Sequence And Decisions
+
+For chronological and branching diagrams, prioritize **not interrupting the viewer's gaze**.
+
+If you need family-specific techniques:
+- role / lane / handoff: [`./workflows-and-swimlanes.md`](./workflows-and-swimlanes.md)
+- phase progression / rollout: [`./pipelines-and-roadmaps.md`](./pipelines-and-roadmaps.md)
+
+## Sequence Diagrams
+
+- Arrange actor headers horizontally
+- Do not omit lifelines
+- Keep messages horizontal
+- Default to solid for requests and dashed for responses
+- When placing text near an activation, push it to the side without overlap
+- Let participants read as their roles; do not flatten boundaries / controls / queues / databases into generic actors
+
+Good fits:
+- request / response
+- event sequence
+- broadcast / sync
+
+## Decision Trees / Branching
+
+- Keep the YES path in the main column
+- Push the NO path to the same side consistently
+- Phrase decision nodes as questions
+- Use color to distinguish terminal meanings
+
+Good fits:
+- fallback
+- auth / validation
+- retry / conflict handling
+
+## Labels
+
+- Use short labels that still reveal actor roles on sequence arrows
+- Write decision branches as `YES / NO + condition`
+- For sequence responses, say only what comes back instead of restating the request
+
+## Common Failures
+
+- Omitting lifelines
+- Packing in too many actors so the lanes become cramped
+- Styling request and response the same way
+- Letting the NO path scatter in a different direction every time
+
+## If Stuck
+
+- For detailed recipes, see `Sequence diagrams` and `Decision tree / branching flow` in [`../style-reference.md`](../style-reference.md)

--- a/packages/mcp-server/skills/drawing-visuals/references/trust-boundary-and-security.md
+++ b/packages/mcp-server/skills/drawing-visuals/references/trust-boundary-and-security.md
@@ -1,0 +1,61 @@
+# Trust Boundary And Security
+
+For security-oriented diagrams, lock down **what is being protected and where boundaries are crossed** first.
+
+## Good Fits
+
+- auth / authz
+- trust boundary
+- public / private / internal split
+- audit / detection / secret handling
+
+## Shell
+
+- Place boundaries before components
+- Choose one access flow as the main path
+- Move audit / telemetry / async detection to side paths
+- Keep legends / glossaries outside the boundary
+
+## Reading Direction
+
+- Access flow should be left-to-right
+- Nested boundaries should read outer -> inner
+- Audit / async paths should look different from the main flow
+
+## Labels
+
+- Keep boundary labels short in the top-left
+- Do not use the boundary rect `text`; place separate text instead
+- Prioritize protocol / credential / control names in crossing labels
+  - `JWT`
+  - `mTLS`
+  - `IAM`
+  - `audit`
+
+## Hard Rules
+
+- Do not use danger color on every security box
+- Do not style access flow and audit flow with the same arrow treatment
+- Default to solid = access and dashed = audit / async, and do not overload meanings in one frame
+- Do not hide secret / key / token handling behind a generic `security` box
+- Tie each security control to the protected asset or the crossing it governs
+- If public / private / internal boundaries appear, do not omit their names
+
+## Common Failures
+
+- The trust boundary becomes a mere background rectangle
+- The audit path carries the same weight as the access path
+- Authentication and authorization are flattened into one box
+- The diagram turns into a list of security products without showing what is being protected
+
+## Local Surgery
+
+- If the boundary is weak: rebuild the nested zones
+- If there are too many security boxes: narrow each one to a clearer role
+- If the access path disappears: demote audit into a side path
+- If a generic `security` box remains: replace it with a concrete control name
+
+## If Stuck
+
+- For cloud / subnet context, see [`./infrastructure-diagrams.md`](./infrastructure-diagrams.md)
+- For conditional flow, see [`./sequence-and-decisions.md`](./sequence-and-decisions.md)

--- a/packages/mcp-server/skills/drawing-visuals/references/workflows-and-swimlanes.md
+++ b/packages/mcp-server/skills/drawing-visuals/references/workflows-and-swimlanes.md
@@ -1,0 +1,58 @@
+# Workflows And Swimlanes
+
+In workflow / swimlane diagrams, treat **who hands off to whom and where** as first-class information.
+
+## Good Fits
+
+- approval chains
+- cross-team handoffs
+- division of labor between user and system
+- business flows that include sync / async behavior
+
+## Shell
+
+- Place lanes first
+- Decide the start / end on the main lane
+- Keep the main path straight
+- Push messages / exceptions / retries to the same side off the main path
+
+## Reading Direction
+
+- Usually left-to-right
+- Top-to-bottom is fine if you want it to read like an ordered list
+- Minimize crossings for messages that span lanes
+
+## Semantic Grouping
+
+- lane: actor / role / system
+- step: action
+- gateway: condition
+- dashed path: async / message / audit
+
+## Hard Rules
+
+- Do not put long paragraphs in lane titles
+- Do not give one step more than one responsibility
+- Push every decision NO path to the same side
+- Do not overload the mainline with trivial retries
+- Do not use dashed for both `async` and `optional`; keep one meaning per frame
+- Do not force role decomposition and step flow into one frame if they fight each other
+
+## Common Failures
+
+- Lanes start representing phases instead of actors
+- Every step has the same weight, so the handoff disappears
+- Async paths cross the mainline repeatedly
+- Exceptions multiply until the main path is unreadable
+
+## Local Surgery
+
+- If there are too many lanes: merge trivial roles
+- If there are too many exceptions: create an exception-only frame
+- If the handoff is buried: split the step at the lane boundary
+- If stages and roles are mixed: split into a workflow frame and a layered frame
+
+## If Stuck
+
+- If it is closer to sequence or decision logic, see [`./sequence-and-decisions.md`](./sequence-and-decisions.md)
+- If it is really about phase progression, see [`./pipelines-and-roadmaps.md`](./pipelines-and-roadmaps.md)

--- a/packages/mcp-server/skills/drawing-visuals/style-reference.md
+++ b/packages/mcp-server/skills/drawing-visuals/style-reference.md
@@ -1,0 +1,279 @@
+# Style Reference
+
+Read this document **before** drawing.
+Its job is to keep you from hand-calculating coordinates ad hoc or redrawing the same structure from scratch.
+
+## Reasoning Budget
+
+**Do not:**
+- second-guess the diagram topic forever; choose the first strong fit among flowchart / architecture / sequence and commit
+- overthink direction; if the material is tall, go vertical; if it is wide, go horizontal
+- calculate coordinates in prose; choose `row` / `col` on a rigid grid and move on
+- revisit every placement after the fact; place it, continue, and repair only visible overflow later
+
+**Do:**
+- state the diagram type and actors in 1-2 sentences
+- place nodes on a rigid grid
+- connect edges by node id (`wb_edge_add`'s `fromNode`/`toNode`)
+
+There is no coordinate math for the edge itself — `wb_scene_render` computes the drawn path from the
+two node ids. The math you do own is node placement: `x`, `y`, `width`, `height` on every
+`wb_node_add` / `wb_node_patch` call.
+
+## Rigid Grid
+
+Use the following grid in all diagrams.
+Minor deviations are not worth the cognitive cost.
+
+| Item | Formula | Example |
+| --- | --- | --- |
+| column x | `col * 220 + 40` | col=0 -> 40, col=1 -> 260, col=2 -> 480 |
+| row y | `row * 140 + 40` | row=0 -> 40, row=1 -> 180, row=2 -> 320 |
+
+**Box sizes** (there is no auto-sizing, so pick generously)
+
+| Shape | width x height |
+| --- | --- |
+| short label (1 line) | 160 x 60 |
+| longer text (2+ lines) | 280 x 90 |
+| a `group` boundary node | size it to enclose its members with margin |
+
+Pick row and column indices, then fill in `x`, `y`, `width`, and `height` on the node object.
+
+## Colors
+
+`wb_node_add` / `wb_node_patch` / `wb_edge_add` / `wb_edge_patch` accept `color` as either a 6-digit
+hex string (`#1971c2`) or one of the JSON Canvas numbered presets `"1"`-`"6"`. There is no semantic
+color name — `"primary"` is not a valid value. Pick your own hex-to-role mapping and keep it
+consistent across the document:
+
+| Suggested Role | Example Hex |
+| --- | --- |
+| primary / entrypoint | `#1971c2` |
+| success / service | `#2f9e44` |
+| danger / error path | `#e03131` |
+| warning / caution | `#f59f00` |
+| info / supporting | `#228be6` |
+| neutral / structure | `#495057` |
+
+Keep the same role on the same color throughout one document.
+Aim for four colors or fewer.
+
+Think in a **palette budget**:
+- 60% whitespace / neutral / structure
+- 30% primary role colors
+- 10% warning / danger / emphasis
+
+Hierarchy should come mostly from layout, not from painting everything in emphasis colors.
+
+## Edges
+
+```js
+wb_edge_add({
+  workspaceId, documentId,
+  edge: { id: "req", fromNode: "client", toNode: "server", label: "request", toEnd: "arrow" },
+})
+```
+
+- both `fromNode` and `toNode` must already exist on the canvas — `wb_edge_add` refuses otherwise
+- `fromSide`/`toSide` (`top`/`right`/`bottom`/`left`) hint which face of the node the edge leaves from
+- `fromEnd`/`toEnd` (`none`/`arrow`) control arrowheads independently on each end
+- there is no dash/line-style field on an edge — a distinction like "async vs sync" has to be carried
+  by color or label, not by stroke style
+
+## Labels
+
+- keep them short: 1-3 words is the target for a node's `text`
+- use only 1-2 labeled edges per diagram section when possible
+- if an edge label only restates what the connected nodes already say, drop it
+- keep one language per diagram
+- there is no automatic text wrapping — a node's `text` renders as given, so break long text into
+  `\n`-separated lines yourself and size `width`/`height` to fit
+
+### Width Heuristics
+
+- for mostly Latin text, start with `max(160, charCount * 9)`
+- for mostly CJK text, start with `max(160, charCount * 18)`
+- for mixed text, do not estimate as if it were ASCII-only
+- secure readable width before adding more nodes
+
+## Boundary / Zone Labels
+
+A `group` node (label + optional background) is the only built-in boundary shape. It has no
+membership tracking — nothing "belongs to" a group automatically, so drawing a boundary means
+sizing the group node to visually enclose the nodes you intend it to cover, and keeping them there
+when you move things later.
+
+- do not put a large boundary/zone label inside a regular `text` node meant for content
+- place the boundary's own label as a short `group.label`, not repeated inside a child node
+- do not omit boundary or trust-zone names if they matter to the reading path
+
+## Direction Consistency
+
+**Keep one dominant flow direction.**
+Readers track either left-to-right or top-to-bottom.
+If edges constantly run backward, attention stalls.
+
+### Recommended Semantics For Direction
+
+| Diagram Type | Left / Top | Center | Right / Bottom |
+| --- | --- | --- | --- |
+| user-driven architecture | user / client | gateway / API / auth | services / persistence |
+| system integration | internal system | adapter / integration point | counterpart / external system |
+| data pipeline | source | transform / aggregate | sink / BI / notification |
+| deploy / release | code / build | staging | production |
+| authorization flow | resource owner / user | auth server / STS | resource server / API |
+
+If unsure, keep user-facing or front-stage elements to the left / top and backstage systems to the right / bottom.
+
+### Automatic Layout
+
+`wb_canvas_tidy({ workspaceId, documentId, scope? })` re-lays-out node positions. It has no
+`direction`, `pins`, or `groups` parameters — it is a single automatic pass, not a configurable
+layout engine. Pass `scope` (a list of node ids) to restrict which nodes it moves; everything
+outside `scope` acts as a fixed obstacle. A locked node (`wb_node_lock`) is also treated as fixed,
+whether or not it is in `scope`.
+
+If you need a layout `wb_canvas_tidy` cannot produce, place nodes by hand on the rigid grid instead.
+
+### When Backward Flow Is Unavoidable
+
+- use a visibly different color for response / callback edges
+- or leave the return path implicit and draw only the main forward path, then explain the return in text
+
+---
+
+## Layout patterns
+
+Each diagram family has a best-practice shell.
+Read the relevant recipe before drawing so you know the shell, the must-have pieces, and the common traps.
+All recipes below use only `text`/`link`/`file`/`group` nodes, `wb_edge_add`, and manual grid
+coordinates — nothing here assumes a feature the tool surface does not have.
+
+| What You Need To Show | Recipe |
+| --- | --- |
+| layered structure / data flow | [Architecture / data flow diagrams](#architecture--data-flow-diagrams) |
+| time-ordered message exchange | [Sequence diagrams](#sequence-diagrams) |
+| decision or branching flow | [Decision trees / branching flows](#decision-trees--branching-flows) |
+| filesystem or hierarchy plus annotation | [Directory trees / hierarchical diagrams](#directory-trees--hierarchical-diagrams) |
+| N-axis x M-axis comparison | [Comparison matrices](#comparison-matrices) |
+
+---
+
+### Architecture / data flow diagrams
+
+**Use for**: component dependencies and responsibility splits, such as Plugin -> MCP -> Hono -> Browser -> Storage
+
+**Shell**
+- vertical axis = abstraction or dependency direction
+- horizontal axis = parallel components within the same layer
+- keep the main flow in one band
+- place external resources to the right as secondary elements
+
+**Must-have**
+- fix color by layer or role
+- edge labels should be verbs or API names
+- safe box size is roughly 280-360 x 90-120 for text-heavy nodes
+
+**Watch out for**
+- if 3+ edges cross repeatedly, split into a second document
+- connect side elements from the same row rather than bundling everything into one choke point
+
+---
+
+### Sequence diagrams
+
+**Use for**: time-ordered actor interactions such as Browser <-> Hono <-> Browser over WS
+
+**Shell**
+- put actor headers across the top as `text` nodes
+- place a vertical lifeline (a tall, narrow `text` or `group` node) under each header
+- draw messages as horizontal edges between lifelines
+- place local notes beside the lifeline they annotate, without overlap
+
+**Must-have**
+- do not omit lifelines
+- draw external triggers as separate nodes in the left margin and feed them into the sequence
+- separate qualitatively different phases with a visible gap or a `group` boundary
+- keep message y-spacing generous — there is no collision detection to catch a cramped layout
+
+**Watch out for**
+- 4+ actors often overcrowd edge labels; split into two documents or reduce lanes
+- keep message y-spacing around 80-120px
+- response direction should match actor roles
+
+---
+
+### Decision trees / branching flows
+
+**Use for**: conditional logic such as workspace resolution or validation branches
+
+**Shell**
+- stack decision nodes down the center
+- keep the YES path on the main column
+- push the NO path consistently to one side
+- place terminal outcomes at the outer edges
+
+**Must-have**
+- use a distinct color for terminal-node outcomes
+- label every branch with `YES` / `NO` plus a short condition
+
+**Watch out for**
+- phrase decision nodes as questions
+- if there are 3+ decisions, keep all YES branches centered and all NO branches on one side
+
+---
+
+### Directory trees / hierarchical diagrams
+
+**Use for**: filesystems or hierarchies paired with concepts such as tools / APIs / responsibilities
+
+**Shell**
+- build the tree on the left, top to bottom
+- indent children by a fixed 40px per level
+- place annotation nodes on the right near the matching tree node
+- connect annotations back to tree nodes with edges
+
+**Must-have**
+- align all nodes strictly by indent level
+- show parent-child grouping with a `group` node when it helps
+
+**Watch out for**
+- leave more initial `height` than you think you need — there is no auto-expand
+- ASCII branch lines are optional if spatial hierarchy already reads clearly
+
+---
+
+### Comparison matrices
+
+**Use for**: feature-by-environment coverage, before/after comparison grids, option matrices
+
+**Shell**
+- lay out a grid of `text` nodes by hand: fixed `cellWidth`/`cellHeight`/`gap`, and `x = col *
+  (cellWidth + gap), y = row * (cellHeight + gap)`
+- assign each item its own `row` / `col` before calling `wb_node_add`
+- give the header row / column a distinct `color` from body cells
+
+**Must-have**
+- keep cell widths and heights consistent
+- even an empty cell should usually still get a faint placeholder node so the grid stays legible
+
+**Watch out for**
+- beyond roughly 6 x 6, the board often needs to be split into a second document
+- pre-split longer cell text into `\n`-joined lines when helpful
+
+## Anti-patterns
+
+- hand-calculating large batches of coordinates in prose instead of following the rigid grid
+- reacting to one broken render by overfitting tiny x/y tweaks instead of returning to the grid
+- choosing colors arbitrarily instead of by a fixed role mapping
+- cramming 15+ elements into one document when a second document would read faster
+- expecting `wb_canvas_tidy` to accept a layout direction, pin, or grouping hint it does not have
+
+## After Drawing
+
+1. call `wb_scene_render({ workspaceId, documentId })` and inspect the SVG for overflow / overlap / directionality
+2. if you cannot see the image, call `wb_scene_digest` and read the structural summary
+3. if refinement is needed, use `wb_node_patch` / `wb_edge_patch` locally before considering a full redraw on a new document
+
+If you are unsure, think in this order: **logical structure -> rigid grid -> color -> label -> commit**.

--- a/packages/mcp-server/skills/drawing-visuals/visual-vocabulary.md
+++ b/packages/mcp-server/skills/drawing-visuals/visual-vocabulary.md
@@ -1,0 +1,504 @@
+# Visual Vocabulary
+
+What a diagram should deliver is not "a picture" but **decision support**.
+This document helps choose the right diagram family and the right words so that people align faster.
+For coordinates, colors, and layout rules, see [`style-reference.md`](./style-reference.md).
+
+## Decide This First
+
+Before drawing, answer only one question:
+
+- **what question is this diagram answering?**
+- what should the reader understand in **5 seconds**?
+- is this about structure, flow, comparison, a problem, or a proposal?
+
+Do not make one document answer multiple questions at once.
+
+Examples that should usually be separated:
+- structural explanation
+- cause analysis
+- improvement proposal
+- before / after comparison
+
+Default rule: **1 question per document**.
+
+## Choose Visual Direction Early
+
+For persuasive, comparative, or review-oriented boards, decide not just the diagram family but also the **visual direction**.
+This is not about ornate styling.
+It is a short declaration of what the viewer should read first.
+
+Decide:
+- dominant color family
+- the impression that should remain after 5 seconds
+- text density (`whisper` / `normal` / `strong`)
+- visual motif (`quiet grid`, `review markup`, `before/after contrast`, `editorial callout`, and similar)
+
+Typical use cases:
+- `current / problem / proposal`
+- before / after comparison
+- UI review diagrams with comments mixed in
+- proposal boards that need persuasive framing
+
+Cases where you can skip it:
+- simple system flow
+- purely utilitarian structure diagram
+- temporary scratch note
+
+Named themes are easier to reuse.
+Examples: `systems`, `review`, `proposal`, `executive`.
+
+## Split Across Documents Or Group Nodes?
+
+There is no frame or membership feature on this tool surface — a document is one flat canvas of
+nodes and edges, and `wb_scene_render` always renders all of it. A `group` node (label + optional
+background) can loosely mark a region, but nothing tracks which other nodes are "inside" it, and
+there is no way to render or export just that region.
+
+That leaves two real choices when a discussion has multiple related questions:
+
+- **One document, multiple visually-separated regions**: use a `group` node per region and keep
+  each region's nodes physically clustered together on the grid. Cheap, but the whole SVG renders
+  every time — there is no way to inspect one region in isolation.
+- **Separate documents** (`wb_document_create` per question): each renders independently, can be
+  shared or exported on its own, and keeps unrelated revision history apart.
+
+Use one document with visually-separated regions when:
+- you want to move between `current / problem / proposal` in one glance
+- you want side-by-side or stacked comparison
+- you expect to add cross-region edges or supporting notes later
+
+Use separate documents when:
+- each board should be shared or exported independently
+- putting everything on one canvas makes the subject unreadable within 5 seconds
+- the audience or usage context differs
+- revision history should stay separate
+
+If unsure:
+- for **chapters of the same discussion**, prefer one document with visually-separated regions
+- for **separate artifacts**, prefer separate documents
+
+In either case, do not mix multiple questions inside one region.
+
+## Choose The Diagram From The Question
+
+| What The Reader Should Understand | Suitable Diagram | Short Intent |
+| --- | --- | --- |
+| what belongs where | structure / containment | `cut responsibility boundaries` |
+| what flows where | flow / architecture | `make the main path visible` |
+| where decisions split | decision tree / branch diagram | `show the decision points` |
+| what happens first | sequence diagram | `fix the order` |
+| what changed | before / after comparison | `float only the change` |
+| what should be compared | comparison matrix | `align the comparison axis` |
+| where the problem is | hotspot annotation | `point to the problem area` |
+| what is still unresolved | note / dashed grouping / neutral node | `make uncertainty explicit` |
+| what boundary something belongs to and how it connects | infrastructure / network topology | `fix boundaries and connection type` |
+
+## Intent -> Diagram Mapping
+
+### Show Structure
+
+Good fits:
+- layered structure
+- ownership
+- dependency direction
+
+Useful words:
+- `responsibility`
+- `boundary`
+- `ownership`
+- `dependency direction`
+- `input side`
+- `output side`
+
+Example labels:
+- `UI Layer`
+- `API Boundary`
+- `Persistent Store`
+- `Owned by Browser`
+
+Avoid:
+- mixing time-sequence edges into a structural board
+- drawing structure and problem callouts in the same visual language
+
+For infrastructure diagrams, decide boundary vocabulary first:
+- `region`
+- `cluster`
+- `trust boundary`
+- `public`
+- `private`
+
+Make "where it belongs" legible before "what it is called."
+
+### Make The Reader Follow A Flow
+
+Good fits:
+- data flow
+- processing flow
+- request / response path
+
+Useful words:
+- `main path`
+- `side path`
+- `input`
+- `transform`
+- `output`
+- `side effect`
+
+Edge labels should usually prioritize **verbs over nouns**.
+
+Keep edge labels sparse:
+- 1-2 labeled edges per document region is often enough
+- if the node text already explains the relation, omit the edge label
+- keep only the minimum relationship verb on the edge
+
+Good arrow-label examples:
+- `validate`
+- `persist`
+- `broadcast`
+- `hydrate`
+
+Weak examples:
+- `data`
+- `process`
+- `thing`
+
+Infrastructure diagrams are a partial exception:
+there, edge labels may prioritize **protocol / transport over verbs**.
+
+Good examples:
+- `HTTPS`
+- `gRPC`
+- `SQL`
+- `events`
+- `JWT`
+
+Avoid:
+- long descriptive sentences as connection labels
+- representing a bus only as edge-label text
+
+If an async path matters, give the bus / queue / topic a standalone node such as `Kafka`, `SQS`, or `EventBridge`, then split the flow into two edges around it.
+
+### Show Boundaries
+
+Good fits:
+- AWS / GCP / Azure infrastructure
+- VPC / subnet / DMZ
+- Kubernetes clusters / namespaces
+- internal vs external system integration
+
+Useful words:
+- `region`
+- `cluster`
+- `namespace`
+- `public`
+- `private`
+- `dmz`
+- `trust boundary`
+
+Rules:
+- show the boundary as a `group` node sized to enclose its members, not as a background fill on the components themselves
+- keep boundary labels short — the `group.label` field, not a separate node
+- move legends and helper notes outside boundaries
+- components are the main subject; boundaries provide context
+
+Good labels:
+- `AWS Region: ap-northeast-1`
+- `Kubernetes Cluster`
+- `Private Subnet`
+- `Trust Boundary`
+
+### Show Decision Points
+
+Good fits:
+- branching
+- feature flag logic
+- exception handling
+
+Useful words:
+- `decision`
+- `condition`
+- `branch`
+- `allow`
+- `deny`
+- `fallback`
+
+Rules:
+- do not stop at `Yes / No`; say what the condition means
+- keep exception paths slightly away from the main path
+
+Good labels:
+- `snapshot exists?`
+- `auth ok`
+- `conflict detected`
+
+### Align Comparison Axes
+
+Good fits:
+- before / after
+- option A / B
+- component x environment matrix
+
+Useful words:
+- `current`
+- `proposal`
+- `diff`
+- `common`
+- `change`
+- `out of scope`
+
+Rules:
+- fix the axis either left/right or top/bottom
+- keep comparison targets in the same order and same granularity
+- use color or annotation to surface differences, but do **not** rely on color alone
+
+### Point To A Problem Area
+
+Good fits:
+- screenshot annotation via a `file` node plus overlaid `text` nodes
+- existing-screen review
+- local explanation of a failure point
+
+Useful words:
+- `problem`
+- `bottleneck`
+- `crowding`
+- `mismatch`
+- `split gaze`
+- `unclear intent`
+
+Rules:
+- 1 annotation = 1 problem
+- do not cram both the problem and the proposal into one label
+
+Good split:
+- one node: `Problem: primary CTA is buried`
+- a second node nearby: `Proposal: isolate CTA into top band`
+
+### Make Uncertainty Explicit
+
+Good fits:
+- hypothesis-stage design
+- unsettled requirements
+- rough notes before comparing multiple options
+
+Useful words:
+- `hypothesis`
+- `unresolved`
+- `needs confirmation`
+- `candidate`
+- `pending`
+- `out of scope`
+
+Rules:
+- push uncertain information toward neutral treatment
+- do not style it like a final decision
+- if you use `?`, also say what is unknown
+
+## Recommended Label Vocabulary
+
+Prefer compact vocabulary that still carries meaning.
+
+### Roles
+
+- `actor`
+- `owner`
+- `client`
+- `gateway`
+- `worker`
+- `store`
+- `reviewer`
+
+### Relationships
+
+- `depends on`
+- `emits`
+- `reads`
+- `writes`
+- `calls`
+- `returns`
+- `blocks`
+- `unblocks`
+
+### Connection Types
+
+- `HTTPS`
+- `gRPC`
+- `SQL`
+- `TCP`
+- `events`
+- `webhook`
+- `JWT`
+- `TLS`
+
+### States
+
+- `planned`
+- `active`
+- `stale`
+- `blocked`
+- `optional`
+- `deprecated`
+- `draft`
+
+### Problem Analysis
+
+- `bottleneck`
+- `ambiguity`
+- `collision`
+- `duplication`
+- `gap`
+- `leak`
+- `drift`
+
+### Proposal Verbs
+
+- `split`
+- `merge`
+- `move`
+- `rename`
+- `isolate`
+- `simplify`
+- `promote`
+- `defer`
+
+## Differentiate State Visually
+
+Fix the appearance by meaning so explanation becomes lighter. There is no semantic color name in the
+tool itself — pick your own hex-to-role mapping once (see [`style-reference.md`](./style-reference.md#colors)) and apply it consistently.
+
+| State | Recommended Treatment |
+| --- | --- |
+| main path | primary / success hex, centered |
+| supporting information | neutral / info hex, toward the edge |
+| problem | danger / warning hex, local annotation |
+| proposal | separate region such as before/after, or its own document |
+| uncertainty | neutral hex and note-like treatment, kept away from settled facts |
+| out of scope | faint support node or pushed outside the section |
+| boundary | faint `group` node in warning / info hex, weaker than components |
+| async path | standalone event-bus node plus a color distinct from the main path |
+
+## Anti-patterns
+
+### 1. Do Everything In One Board
+
+Warning signs:
+- a structural diagram contains both problem callouts and proposal edges
+- the reader loses track of which conversation they are in
+
+Fix:
+split into separate regions or documents such as:
+- `Current state`
+- `Problem`
+- `Proposal`
+
+### 2. Edge Labels Eat The Main Subject
+
+Warning signs:
+- the board is noisy from edge labels alone
+- callouts and edge labels explain the same thing twice
+- the viewer reads edge words before node meaning
+
+Fix:
+- keep labeled edges to 1-2 per region
+- move causes and intent into the node's own `text`
+- leave only short relation verbs such as `move`, `attach`, `split` on edges
+
+### 3. Section Header And Inner Node Duplicate Each Other
+
+Warning signs:
+- a `group` node is labeled `Current`, and there is also a large `text` node saying `Current` inside it
+- the section label can be read twice before any real claim
+
+Fix:
+- let the `group.label` act as the section heading
+- assign the large inner text node to the conclusion or question
+- do not repeat the same word as both the group label and an inner node
+
+### 4. The Edge Has No Meaning
+
+Bad examples:
+- `data`
+- `sync`
+- `flow`
+
+Fix:
+- write the action as a verb
+- if only a noun comes to mind, the node's responsibility is often still too vague
+
+### 5. The Comparison Axis Drifts
+
+Warning signs:
+- before has 3 items but after has 5
+- order changes left to right
+
+Fix:
+- compare the same dimensions in the same order
+- add only the difference as annotation
+
+### 6. Abstraction Levels Are Mixed
+
+Warning signs:
+- `user action`, `Redis`, and `deploy job` sit in the same column as if they were peers
+
+Fix:
+- separate actor / service / storage / process into different bands
+
+### 7. Problem And Proposal Look The Same
+
+Warning signs:
+- two colors are mixed without any explicit meaning
+
+Fix:
+- label problem areas as `Problem`
+- label proposal areas as `Proposal`
+
+### 8. Placeholders Remain
+
+Warning signs:
+- a node was patched down to near-nothing but its empty `group` boundary still remains
+- template headings or helper text survive after losing their meaning
+
+Fix:
+- there is no delete tool, so an unwanted node has to be repurposed with `wb_node_patch` (shrink it,
+  relabel it as a stray note) rather than left as dead placeholder text
+- do not force a fixed node count to match a source-item count mechanically
+- if multiple items are getting crammed into one node, add more nodes and reorganize instead
+
+### 9. Legend Or Notes Slip Inside A Boundary
+
+Warning signs:
+- a legend sits inside an `AWS Region` or `Cluster` `group` node
+- a helper note remains inside a private subnet and looks like part of the actual topology
+
+Fix:
+- keep legends / glossaries / support notes visually outside the boundary's `group`
+- use a `group` only to show membership by proximity, not to host explanatory text
+
+### 10. Async Paths Disappear Into Edge Labels
+
+Warning signs:
+- `events` or `Kafka` exists only as edge text
+- the responsibility cut between services is unreadable
+
+Fix:
+- make bus / queue / topic a standalone node
+- split the flow into producer -> bus -> consumer
+
+## 5-Second Review
+
+After rendering with `wb_scene_render`, check:
+
+- can the main subject be read in 5 seconds?
+- can the main path be traced as a single continuous reading path?
+- is it obvious where the decision points are?
+- can problem / proposal / uncertainty be distinguished visually?
+- are labels short while still keeping relationships readable?
+- is supporting information quieter than the main subject?
+- does the claim survive without reading every edge label?
+- are section labels and inner node text doing different jobs?
+- are there any leftover placeholders or forgotten template fragments?
+- are the roles of boundary and legend still separate?
+- can async paths be read as independent elements?
+
+If any of these feel shaky, re-check the framing of the question before doing cosmetic tweaks.

--- a/packages/mcp-server/src/server/plugin-support.test.ts
+++ b/packages/mcp-server/src/server/plugin-support.test.ts
@@ -17,9 +17,12 @@ describe('plugin support packaging', () => {
   const claudePlugin = readJson(resolve(repoRoot, '.claude-plugin/plugin.json'))
   const releasePlease = readJson(resolve(repoRoot, 'release-please-config.json'))
 
-  it('ships shared skills with the MCP package', () => {
+  it('ships dist but deliberately NOT skills in the npm package', () => {
+    // Skills distribute through the plugin (repo-root skills/); nothing in
+    // the published server reads a packaged skills/ directory, so a files
+    // entry for it was a false claim — pinned absent.
     expect(mcpPackage.files).toContain('dist')
-    expect(mcpPackage.files).toContain('skills')
+    expect(mcpPackage.files).not.toContain('skills')
   })
 
   it('includes a Codex plugin manifest wired to the shared skills and MCP config', () => {

--- a/packages/mcp-server/src/server/publish-contract.test.ts
+++ b/packages/mcp-server/src/server/publish-contract.test.ts
@@ -242,27 +242,20 @@ describe('publish contract', () => {
     expect(claudeMarketplace.metadata.version).toBe(mcpPackage.version)
     expect(claudeMarketplace.plugins[0].version).toBe(mcpPackage.version)
 
-    // The manual symlink / junction recipes for skill linking moved to docs/contributing/development.md
-    // (the npx and claude-mcp-add paths only start the MCP server; skills are an opt-in extra).
-    expect(developmentDoc).toContain('## Bundled skills install')
-    expect(developmentDoc).toContain('node_modules/@kamiazya/whiteboard-mcp')
-    expect(developmentDoc).toContain('"$PKG/skills/drawing-visuals"')
-    expect(developmentDoc).toContain('"$PKG/skills/coauthoring-visuals"')
-    expect(developmentDoc).toContain('"$PKG/skills/auditing-workspaces"')
-    expect(developmentDoc).toContain('### macOS / Linux')
-    expect(developmentDoc).toContain('### Windows (junction or copy)')
-    expect(developmentDoc).toContain('$skillRoots = @(')
-    expect(developmentDoc).toContain('foreach ($root in $skillRoots)')
-    expect(developmentDoc).toContain('foreach ($skill in $skills)')
+    // The npm-sourced skill-symlink recipe is RETIRED: skills distribute
+    // through the Claude Code / Codex plugin (repo-root skills/) only, and
+    // the npm tarball deliberately ships none — the recipe documented an
+    // install path that never worked (the tarball never contained skills).
+    // Pin the absence so it cannot quietly return without a real consumer.
+    expect(developmentDoc).not.toContain('## Bundled skills install')
+    expect(developmentDoc).not.toContain('$PKG/skills/')
   })
 
-  it('explains why dist and skills are both shipped in the npm tarball', () => {
+  it('states that skills ship via the plugin, not the npm tarball', () => {
     expect(packageReadme).toContain('## What is in this package')
     expect(packageReadme).toContain('`dist/` contains the runnable MCP server')
-    expect(packageReadme).toContain('`skills/` contains the shared skill bundles')
-    expect(packageReadme).toContain(
-      'The repo-level plugin manifests are not shipped as separate release artifacts.',
-    )
+    expect(packageReadme).toContain('skills are NOT part of this package')
+    expect(packageReadme).not.toContain('`skills/` contains the shared skill bundles')
   })
 
   it('keeps published wrappers on @latest so release-please does not need extra-files sync', () => {

--- a/packages/mcp-server/src/server/skills-tool-surface.test.ts
+++ b/packages/mcp-server/src/server/skills-tool-surface.test.ts
@@ -170,11 +170,11 @@ describe('skills tool-surface guard', () => {
   })
 
   it('plugin manifests point at a repo-root skills/ dir carrying three named SKILL.md files', () => {
-    // Scoped to the repo-root path deliberately: packages/mcp-server/skills/
-    // (the npm tarball's declared `files` entry) does not exist today and
-    // nothing copies root skills/ into it at pack time, so the published
-    // tarball ships no skills despite `files: ['skills']` — a separate
-    // packaging gap, filed for the integrator rather than fixed here.
+    // The repo root is the ONLY distribution point for skills: the Claude
+    // Code / Codex plugin manifests resolve here, and the npm package
+    // deliberately ships none — nothing in the published server reads a
+    // packaged skills/ directory, so a files-array entry for it was a
+    // false claim (removed 2026-08-17), not a missing copy step.
     const readJson = (path: string) => JSON.parse(readFileSync(path, 'utf-8'))
     const claudePlugin = readJson(resolve(repoRoot, '.claude-plugin/plugin.json'))
     const codexPlugin = readJson(resolve(repoRoot, '.codex-plugin/plugin.json'))
@@ -182,8 +182,10 @@ describe('skills tool-surface guard', () => {
     expect(codexPlugin.skills).toBe('./skills')
     expect(existsSync(SKILLS_ROOT)).toBe(true)
 
+    // Pin the deliberate ABSENCE: reintroducing 'skills' to the npm files
+    // array without a consumer would revive the false shipped-skills claim.
     const mcpPackage = readJson(resolve(repoRoot, 'packages/mcp-server/package.json'))
-    expect(mcpPackage.files).toContain('skills')
+    expect(mcpPackage.files).not.toContain('skills')
 
     const skillDirs = ['drawing-visuals', 'coauthoring-visuals', 'auditing-workspaces']
     expect(skillDirs).toHaveLength(3)


### PR DESCRIPTION
## What

**Reworked after review discussion** (the original PR made the tarball claim true; the user pointed out nothing consumes it — verified, and the honest fix is deleting the claim):

- Nothing in the published server reads a packaged `skills/` directory; the only runtime "skills" reference is a distribution smoke checking the **repo** plugin-manifest paths. Plugin distribution (Claude Code / Codex) never touches npm.
- `package.json`'s `files` drops `skills` — it pointed at a directory that never existed, so every published tarball shipped none anyway.
- README now states skills are **not** part of the package and ship via the plugin.
- `docs/contributing/development.md`'s "Bundled skills install" section (an npm-sourced symlink recipe that never once worked) is deleted; its `publish-contract.test.ts` pins now assert the recipe's **absence** so it cannot quietly return without a real consumer.
- `plugin-support.test.ts` / `skills-tool-surface.test.ts` pins flipped to the deliberate absence, reasoning in comments.

User decision (2026-08-17): the plugin is the single skills-distribution channel; npx-only users get no skills — as they effectively always had.

## Verification

mcp-node 3490 green (283 files) including the flipped pins; knip/typecheck via pre-push.

Resolves `issue/ship-skills-in-npm-tarball` (as won't-ship-by-design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ