### PR TITLE
feat(mcp-server): migration 0011 — additively import FS blobs into the snapshot tables

### DIFF
--- a/docs/contributing/mcp-debugging.md
+++ b/docs/contributing/mcp-debugging.md
@@ -175,6 +175,18 @@ A fresh `WHITEBOARD_DATA_DIR` always works as a quick sanity check:
 WHITEBOARD_DATA_DIR=/tmp/wb-test WHITEBOARD_DEV=1 pnpm mcp:http:dev
 ```
 
+If instead the daemon fails to start with:
+
+```
+Database migration failed: permission denied reading the data directory. Check filesystem
+permissions on the workspace blob directories under <data dir>/blobs and restart.
+```
+
+a migration hit a permission error walking the data dir's filesystem tree (not the SQLite file
+itself) — typically an externally-changed owner/mode on `<data dir>/blobs/<workspaceId>/canvas`,
+or a restrictive umask. Fix the directory's permissions (or ownership) and restart; this is not a
+disposable-database case, so do not delete `whiteboard.db`.
+
 ## MCP Tools Not Visible After Starting Daemon
 
 If you start the daemon **after** opening a Claude Code (or Codex) session, the whiteboard

--- a/packages/mcp-server/src/server/store/db/migrations/0011-import-fs-blobs.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0011-import-fs-blobs.test.ts
@@ -407,6 +407,78 @@ describe('0011-import-fs-blobs', () => {
     await db.destroy()
   })
 
+  it('backfills a missing documentFrontiers row when the snapshot+chunks pair already matches the FS blob', async () => {
+    const db = await memoryDb()
+    expect((await migratorFor(db).migrateTo(BEFORE)).error).toBeUndefined()
+    await seedWorkspace(db, 'ws-1')
+
+    // The shape a prior importOneBlob call would leave if interrupted AFTER
+    // its documentSnapshots/documentSnapshotChunks inserts but BEFORE its
+    // documentFrontiers insert: bytes fully present, frontier row missing.
+    const bytes = snapshotBytes('interrupted before the frontier insert')
+    const { manifest, chunks } = chunkSnapshot(bytes, 1_000_000)
+    await db
+      .insertInto('documentSnapshots')
+      .values({
+        docKey: 'canvas:doc-partial',
+        chunkCount: manifest.chunkCount,
+        totalBytes: manifest.totalBytes,
+        maxChunkBytes: manifest.maxChunkBytes,
+        frontier: new Uint8Array([9]),
+      })
+      .execute()
+    await db
+      .insertInto('documentSnapshotChunks')
+      .values(
+        chunks.map((c) => ({ docKey: 'canvas:doc-partial', chunkIndex: c.index, bytes: c.bytes })),
+      )
+      .execute()
+
+    await writeBlob(dataDir, 'ws-1', 'doc-partial', bytes)
+
+    const capture = captureLogsForTests()
+    try {
+      expect((await migratorFor(db).migrateTo(THIS_ONE)).error).toBeUndefined()
+      expect(capture.records).toHaveLength(0)
+    } finally {
+      capture.restore()
+    }
+
+    const frontierRow = await db
+      .selectFrom('documentFrontiers')
+      .select('frontier')
+      .where('docKey', '=', 'canvas:doc-partial')
+      .executeTakeFirstOrThrow()
+    const frontier =
+      frontierRow.frontier instanceof Uint8Array
+        ? frontierRow.frontier
+        : new Uint8Array(frontierRow.frontier)
+    expect(frontier).toEqual(expectedFrontier(bytes))
+
+    await db.destroy()
+  })
+
+  it('rethrows an unexpected readdir error (e.g. permission denied on a canvas directory) so the whole migration aborts', async () => {
+    const db = await memoryDb()
+    expect((await migratorFor(db).migrateTo(BEFORE)).error).toBeUndefined()
+    await seedWorkspace(db, 'ws-1')
+
+    const canvasDir = join(dataDir, 'blobs', 'ws-1', 'canvas')
+    await writeBlob(dataDir, 'ws-1', 'doc-a', snapshotBytes('unreachable'))
+    const { chmod } = await import('node:fs/promises')
+    await chmod(canvasDir, 0o000)
+
+    try {
+      const result = await migratorFor(db).migrateTo(THIS_ONE)
+      expect(result.error).toBeInstanceOf(Error)
+      expect((result.error as NodeJS.ErrnoException).code).toBe('EACCES')
+    } finally {
+      await chmod(canvasDir, 0o755)
+    }
+
+    await db.destroy()
+  })
+
   it('exports the migration object wrapping the same routine', () => {
     expect(typeof migration.up).toBe('function')
     expect(typeof migration.down).toBe('function')

--- a/packages/mcp-server/src/server/store/db/migrations/0011-import-fs-blobs.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0011-import-fs-blobs.test.ts
@@ -276,6 +276,61 @@ describe('0011-import-fs-blobs', () => {
     await db.destroy()
   })
 
+  it('does not abort the whole import when an existing row is structurally inconsistent with its manifest', async () => {
+    const db = await memoryDb()
+    expect((await migratorFor(db).migrateTo(BEFORE)).error).toBeUndefined()
+    await seedWorkspace(db, 'ws-1')
+
+    // A documentSnapshots row claiming 2 chunks but only 1 persisted — the
+    // shape a prior interrupted importOneBlob call would leave, since its
+    // two inserts are not wrapped in a shared sub-transaction.
+    await db
+      .insertInto('documentSnapshots')
+      .values({
+        docKey: 'canvas:doc-broken',
+        chunkCount: 2,
+        totalBytes: 10,
+        maxChunkBytes: 5,
+        frontier: new Uint8Array([9]),
+      })
+      .execute()
+    await db
+      .insertInto('documentSnapshotChunks')
+      .values({
+        docKey: 'canvas:doc-broken',
+        chunkIndex: 0,
+        bytes: new Uint8Array([1, 2, 3, 4, 5]),
+      })
+      .execute()
+
+    await writeBlob(dataDir, 'ws-1', 'doc-broken', snapshotBytes('anything'))
+    const okBytes = snapshotBytes('the sibling document')
+    await writeBlob(dataDir, 'ws-1', 'doc-ok', okBytes)
+
+    const capture = captureLogsForTests()
+    try {
+      expect((await migratorFor(db).migrateTo(THIS_ONE)).error).toBeUndefined()
+      const warnings = capture.records.filter(
+        (r) => r.level === 'warning' && r.data?.documentId === 'doc-broken',
+      )
+      expect(warnings).toHaveLength(1)
+    } finally {
+      capture.restore()
+    }
+
+    // The broken row itself is left untouched...
+    const header = await db
+      .selectFrom('documentSnapshots')
+      .select(['chunkCount'])
+      .where('docKey', '=', 'canvas:doc-broken')
+      .executeTakeFirstOrThrow()
+    expect(header.chunkCount).toBe(2)
+    // ...but the sibling document still imports.
+    expect(await reassembledRow(db, 'canvas:doc-ok')).toEqual(okBytes)
+
+    await db.destroy()
+  })
+
   it('runs the standalone importFsBlobs a second time against an already-migrated database to catch a later-written blob', async () => {
     const db = await memoryDb()
     expect((await migratorFor(db).migrateToLatest()).error).toBeUndefined()
@@ -318,6 +373,36 @@ describe('0011-import-fs-blobs', () => {
 
     const rows = await db.selectFrom('documentSnapshots').selectAll().execute()
     expect(rows).toEqual([])
+
+    await db.destroy()
+  })
+
+  it('warns and skips a blob that fails to read (e.g. permission denied) without aborting the rest of the import', async () => {
+    const db = await memoryDb()
+    expect((await migratorFor(db).migrateTo(BEFORE)).error).toBeUndefined()
+    await seedWorkspace(db, 'ws-1')
+
+    const unreadablePath = await writeBlob(dataDir, 'ws-1', 'doc-unreadable', snapshotBytes('x'))
+    const { chmod } = await import('node:fs/promises')
+    await chmod(unreadablePath, 0o000)
+
+    const okBytes = snapshotBytes('the sibling document')
+    await writeBlob(dataDir, 'ws-1', 'doc-ok', okBytes)
+
+    const capture = captureLogsForTests()
+    try {
+      expect((await migratorFor(db).migrateTo(THIS_ONE)).error).toBeUndefined()
+      const warnings = capture.records.filter(
+        (r) => r.level === 'warning' && r.data?.documentId === 'doc-unreadable',
+      )
+      expect(warnings).toHaveLength(1)
+    } finally {
+      capture.restore()
+      await chmod(unreadablePath, 0o644)
+    }
+
+    expect(await reassembledRow(db, 'canvas:doc-unreadable')).toBeNull()
+    expect(await reassembledRow(db, 'canvas:doc-ok')).toEqual(okBytes)
 
     await db.destroy()
   })

--- a/packages/mcp-server/src/server/store/db/migrations/0011-import-fs-blobs.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0011-import-fs-blobs.test.ts
@@ -1,0 +1,329 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { chunkSnapshot, reassembleSnapshot } from '@kamiazya/whiteboard-ports'
+import { Kysely, type MigrationProvider, Migrator, SqliteDialect, sql } from 'kysely'
+import LibsqlNativeDatabase from 'libsql'
+import { encodeFrontiers, LoroDoc } from 'loro-crdt'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DatabaseSchema } from '../schema.js'
+
+let dataDir = ''
+vi.mock('../../../config.js', () => ({
+  get DATA_DIR() {
+    return dataDir
+  },
+  getDataDir: () => dataDir,
+}))
+
+const { captureLogsForTests } = await import('../../../log.js')
+const { migrations } = await import('./index.js')
+const { importFsBlobs, migration } = await import('./0011-import-fs-blobs.js')
+
+const BEFORE = '0010-document-path'
+const THIS_ONE = '0011-import-fs-blobs'
+
+async function memoryDb(): Promise<Kysely<DatabaseSchema>> {
+  const db = new Kysely<DatabaseSchema>({
+    dialect: new SqliteDialect({
+      database: new LibsqlNativeDatabase(':memory:') as unknown as ConstructorParameters<
+        typeof SqliteDialect
+      >[0]['database'],
+    }),
+  })
+  await sql`PRAGMA foreign_keys = ON`.execute(db)
+  return db
+}
+
+function migratorFor(db: Kysely<DatabaseSchema>): Migrator {
+  const provider: MigrationProvider = { getMigrations: async () => migrations }
+  return new Migrator({ db: db as never, provider })
+}
+
+async function seedWorkspace(db: Kysely<DatabaseSchema>, workspaceId: string): Promise<void> {
+  await db
+    .insertInto('workspaces')
+    .values({ id: workspaceId, displayName: null, createdAt: 0, updatedAt: 0 })
+    .onConflict((oc) => oc.doNothing())
+    .execute()
+}
+
+/** A real, decodable LoroDoc snapshot — the migration validates via LoroDoc.import. */
+function snapshotBytes(text: string): Uint8Array {
+  const doc = new LoroDoc()
+  doc.getText('t').insert(0, text)
+  doc.commit()
+  return doc.export({ mode: 'snapshot' })
+}
+
+/**
+ * High-entropy text: loro's snapshot encoding compresses low-entropy input
+ * hard enough that a `.repeat()`ed string, or even a simple LCG sequence,
+ * stays under 40KB for 600K characters — nowhere near enough to force a
+ * second chunk. `Math.random()` is good enough here; only the byte count
+ * matters, not reproducibility of the exact bytes.
+ */
+function highEntropyText(length: number): string {
+  let out = ''
+  for (let i = 0; i < length; i++) {
+    out += String.fromCharCode(33 + Math.floor(Math.random() * 90))
+  }
+  return out
+}
+
+function expectedFrontier(bytes: Uint8Array): Uint8Array {
+  const doc = new LoroDoc()
+  doc.import(bytes)
+  return encodeFrontiers(doc.oplogFrontiers())
+}
+
+async function writeBlob(
+  root: string,
+  workspaceId: string,
+  documentId: string,
+  bytes: Uint8Array,
+): Promise<string> {
+  const dir = join(root, 'blobs', workspaceId, 'canvas')
+  await mkdir(dir, { recursive: true })
+  const path = join(dir, `${documentId}.loro`)
+  await writeFile(path, bytes)
+  return path
+}
+
+async function reassembledRow(
+  db: Kysely<DatabaseSchema>,
+  docKey: string,
+): Promise<Uint8Array | null> {
+  const header = await db
+    .selectFrom('documentSnapshots')
+    .select(['chunkCount', 'totalBytes', 'maxChunkBytes'])
+    .where('docKey', '=', docKey)
+    .executeTakeFirst()
+  if (!header) return null
+  const chunkRows = await db
+    .selectFrom('documentSnapshotChunks')
+    .select(['chunkIndex', 'bytes'])
+    .where('docKey', '=', docKey)
+    .orderBy('chunkIndex', 'asc')
+    .execute()
+  return reassembleSnapshot(
+    header,
+    chunkRows.map((row) => ({
+      index: row.chunkIndex,
+      of: header.chunkCount,
+      bytes: row.bytes instanceof Uint8Array ? row.bytes : new Uint8Array(row.bytes),
+    })),
+  )
+}
+
+describe('0011-import-fs-blobs', () => {
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'whiteboard-0011-'))
+  })
+
+  it('imports a blob with no existing row, byte-identical on reassembly, with a matching frontier', async () => {
+    const db = await memoryDb()
+    expect((await migratorFor(db).migrateTo(BEFORE)).error).toBeUndefined()
+    await seedWorkspace(db, 'ws-1')
+
+    const bytes = snapshotBytes('hello world')
+    await writeBlob(dataDir, 'ws-1', 'doc-a', bytes)
+
+    expect((await migratorFor(db).migrateTo(THIS_ONE)).error).toBeUndefined()
+
+    const reassembled = await reassembledRow(db, 'canvas:doc-a')
+    expect(reassembled).toEqual(bytes)
+
+    const frontierRow = await db
+      .selectFrom('documentFrontiers')
+      .select('frontier')
+      .where('docKey', '=', 'canvas:doc-a')
+      .executeTakeFirstOrThrow()
+    const frontier =
+      frontierRow.frontier instanceof Uint8Array
+        ? frontierRow.frontier
+        : new Uint8Array(frontierRow.frontier)
+    expect(frontier).toEqual(expectedFrontier(bytes))
+
+    await db.destroy()
+  })
+
+  it('chunks a blob larger than IMPORT_MAX_CHUNK_BYTES into more than one chunk row', async () => {
+    const db = await memoryDb()
+    expect((await migratorFor(db).migrateTo(BEFORE)).error).toBeUndefined()
+    await seedWorkspace(db, 'ws-1')
+
+    const bigText = highEntropyText(650_000)
+    const bytes = snapshotBytes(bigText)
+    expect(bytes.byteLength).toBeGreaterThan(1_000_000)
+    await writeBlob(dataDir, 'ws-1', 'doc-big', bytes)
+
+    expect((await migratorFor(db).migrateTo(THIS_ONE)).error).toBeUndefined()
+
+    const header = await db
+      .selectFrom('documentSnapshots')
+      .select(['chunkCount', 'totalBytes'])
+      .where('docKey', '=', 'canvas:doc-big')
+      .executeTakeFirstOrThrow()
+    expect(header.chunkCount).toBeGreaterThan(1)
+    expect(header.totalBytes).toBe(bytes.byteLength)
+
+    const reassembled = await reassembledRow(db, 'canvas:doc-big')
+    expect(reassembled).toEqual(bytes)
+
+    await db.destroy()
+  })
+
+  it('logs a structured warning and leaves both sides untouched when a row already exists with different bytes', async () => {
+    const db = await memoryDb()
+    expect((await migratorFor(db).migrateTo(BEFORE)).error).toBeUndefined()
+    await seedWorkspace(db, 'ws-1')
+
+    const existingBytes = snapshotBytes('existing content')
+    const { manifest, chunks } = chunkSnapshot(existingBytes, 1_000_000)
+    await db
+      .insertInto('documentSnapshots')
+      .values({
+        docKey: 'canvas:doc-b',
+        chunkCount: manifest.chunkCount,
+        totalBytes: manifest.totalBytes,
+        maxChunkBytes: manifest.maxChunkBytes,
+        frontier: new Uint8Array([9]),
+      })
+      .execute()
+    await db
+      .insertInto('documentSnapshotChunks')
+      .values(chunks.map((c) => ({ docKey: 'canvas:doc-b', chunkIndex: c.index, bytes: c.bytes })))
+      .execute()
+
+    const blobBytes = snapshotBytes('a totally different document')
+    const blobPath = await writeBlob(dataDir, 'ws-1', 'doc-b', blobBytes)
+    const statBefore = await import('node:fs/promises').then((fs) => fs.stat(blobPath))
+
+    const capture = captureLogsForTests()
+    try {
+      expect((await migratorFor(db).migrateTo(THIS_ONE)).error).toBeUndefined()
+
+      const warnings = capture.records.filter(
+        (r) => r.level === 'warning' && r.data?.documentId === 'doc-b',
+      )
+      expect(warnings).toHaveLength(1)
+      expect(warnings[0]?.data?.workspaceId).toBe('ws-1')
+      expect(warnings[0]?.data?.existingBytes).toBe(existingBytes.byteLength)
+      expect(warnings[0]?.data?.blobBytes).toBe(blobBytes.byteLength)
+    } finally {
+      capture.restore()
+    }
+
+    // Neither side moved.
+    const reassembled = await reassembledRow(db, 'canvas:doc-b')
+    expect(reassembled).toEqual(existingBytes)
+    const statAfter = await import('node:fs/promises').then((fs) => fs.stat(blobPath))
+    expect(statAfter.mtimeMs).toBe(statBefore.mtimeMs)
+    expect(statAfter.size).toBe(blobBytes.byteLength)
+
+    await db.destroy()
+  })
+
+  it('is idempotent: a second run over the same FS state writes nothing and warns nothing', async () => {
+    const db = await memoryDb()
+    expect((await migratorFor(db).migrateTo(BEFORE)).error).toBeUndefined()
+    await seedWorkspace(db, 'ws-1')
+    const bytes = snapshotBytes('idempotent content')
+    await writeBlob(dataDir, 'ws-1', 'doc-c', bytes)
+
+    expect((await migratorFor(db).migrateTo(THIS_ONE)).error).toBeUndefined()
+    const afterFirst = await reassembledRow(db, 'canvas:doc-c')
+
+    const capture = captureLogsForTests()
+    try {
+      // Mutation check: divergence keyed on row-existence (rather than byte
+      // inequality) would warn here every time, since a row now exists.
+      await importFsBlobs(db as unknown as Parameters<typeof importFsBlobs>[0], dataDir)
+      expect(capture.records).toHaveLength(0)
+    } finally {
+      capture.restore()
+    }
+
+    const afterSecond = await reassembledRow(db, 'canvas:doc-c')
+    expect(afterSecond).toEqual(afterFirst)
+
+    await db.destroy()
+  })
+
+  it('skips a zero-byte and a garbage-bytes blob without aborting the rest of the import', async () => {
+    const db = await memoryDb()
+    expect((await migratorFor(db).migrateTo(BEFORE)).error).toBeUndefined()
+    await seedWorkspace(db, 'ws-1')
+
+    await writeBlob(dataDir, 'ws-1', 'doc-empty', new Uint8Array(0))
+    await writeBlob(dataDir, 'ws-1', 'doc-garbage', new Uint8Array([1, 2, 3, 4, 5]))
+    const validBytes = snapshotBytes('the survivor')
+    await writeBlob(dataDir, 'ws-1', 'doc-valid', validBytes)
+
+    const capture = captureLogsForTests()
+    try {
+      expect((await migratorFor(db).migrateTo(THIS_ONE)).error).toBeUndefined()
+      expect(capture.records.filter((r) => r.level === 'warning')).toHaveLength(2)
+    } finally {
+      capture.restore()
+    }
+
+    expect(await reassembledRow(db, 'canvas:doc-empty')).toBeNull()
+    expect(await reassembledRow(db, 'canvas:doc-garbage')).toBeNull()
+    expect(await reassembledRow(db, 'canvas:doc-valid')).toEqual(validBytes)
+
+    await db.destroy()
+  })
+
+  it('runs the standalone importFsBlobs a second time against an already-migrated database to catch a later-written blob', async () => {
+    const db = await memoryDb()
+    expect((await migratorFor(db).migrateToLatest()).error).toBeUndefined()
+    await seedWorkspace(db, 'ws-1')
+
+    // Written AFTER the migration already ran and recorded its key —
+    // simulating the interim-window gap the flip slice closes.
+    const lateBytes = snapshotBytes('written after migration ran')
+    await writeBlob(dataDir, 'ws-1', 'doc-late', lateBytes)
+
+    await importFsBlobs(db as unknown as Parameters<typeof importFsBlobs>[0], dataDir)
+
+    const reassembled = await reassembledRow(db, 'canvas:doc-late')
+    expect(reassembled).toEqual(lateBytes)
+
+    await db.destroy()
+  })
+
+  it('is a clean no-op over a data dir with no blobs directory at all', async () => {
+    const db = await memoryDb()
+    expect((await migratorFor(db).migrateTo(BEFORE)).error).toBeUndefined()
+
+    const result = await migratorFor(db).migrateTo(THIS_ONE)
+    expect(result.error).toBeUndefined()
+
+    await db.destroy()
+  })
+
+  it('ignores non-.loro files and a stray file sitting directly under blobs/', async () => {
+    const db = await memoryDb()
+    expect((await migratorFor(db).migrateTo(BEFORE)).error).toBeUndefined()
+    await seedWorkspace(db, 'ws-1')
+
+    const canvasDir = join(dataDir, 'blobs', 'ws-1', 'canvas')
+    await mkdir(canvasDir, { recursive: true })
+    await writeFile(join(canvasDir, 'notes.txt'), 'not a snapshot')
+    await writeFile(join(dataDir, 'blobs', 'stray-file'), 'not a workspace dir')
+
+    expect((await migratorFor(db).migrateTo(THIS_ONE)).error).toBeUndefined()
+
+    const rows = await db.selectFrom('documentSnapshots').selectAll().execute()
+    expect(rows).toEqual([])
+
+    await db.destroy()
+  })
+
+  it('exports the migration object wrapping the same routine', () => {
+    expect(typeof migration.up).toBe('function')
+    expect(typeof migration.down).toBe('function')
+  })
+})

--- a/packages/mcp-server/src/server/store/db/migrations/0011-import-fs-blobs.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0011-import-fs-blobs.ts
@@ -1,0 +1,216 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { chunkSnapshot, reassembleSnapshot } from '@kamiazya/whiteboard-ports'
+import type { Kysely, Migration } from 'kysely'
+import { encodeFrontiers, LoroDoc } from 'loro-crdt'
+import { getDataDir } from '../../../config.js'
+import { getLogger } from '../../../log.js'
+
+const log = getLogger('migration-0011')
+
+// Identity-convergence prerequisite: import every FS blob that has no
+// documentSnapshots row yet, so the follow-up "flip" slice can point
+// LibsqlDocumentStore at the DB tables without losing history the FS store
+// already wrote. Additive only — the FS tree stays the source of truth for
+// this migration's lifetime, and document-store.ts/file-gc-sweeper.ts keep
+// operating on it unmodified.
+//
+// The blob path segment (`blobs/<workspaceId>/canvas/<documentId>.loro`) and
+// the `canvas:<documentId>` docKey prefix are FROZEN literals copied from
+// document-store.ts / doc-ref-key.ts as they stand today — a migration must
+// not depend on living code that can change out from under a recorded
+// migration key. Same for the table/column shapes in `MigrationSchema`
+// below, current as of 0010.
+const IMPORT_MAX_CHUNK_BYTES = 1_000_000
+
+interface MigrationSchema {
+  documentSnapshots: {
+    docKey: string
+    chunkCount: number
+    totalBytes: number
+    maxChunkBytes: number
+    frontier: Uint8Array
+  }
+  documentSnapshotChunks: {
+    docKey: string
+    chunkIndex: number
+    bytes: Uint8Array
+  }
+  documentFrontiers: {
+    docKey: string
+    frontier: Uint8Array
+  }
+}
+
+export const migration: Migration = {
+  async up(db: Kysely<unknown>): Promise<void> {
+    await importFsBlobs(db, getDataDir())
+  },
+
+  async down(): Promise<void> {
+    // Additive only: nothing was ever overwritten or deleted, so there is
+    // nothing to undo.
+  },
+}
+
+/**
+ * Import every `.loro` blob under `{dataDir}/blobs/*\/canvas/*.loro` that has
+ * no `documentSnapshots` row for its `canvas:<documentId>` docKey.
+ *
+ * Exported standalone (not only via the `Migration.up` wrapper) because the
+ * repo's migrator runs a migration key exactly once per database — the
+ * identity-convergence flip slice needs to call this exact routine a SECOND
+ * time outside migration-table bookkeeping, to close the window between
+ * "this migration ran" and "the flip stopped writing to the FS store", during
+ * which an old process can still write a fresh blob this migration never saw.
+ */
+export async function importFsBlobs(db: Kysely<unknown>, dataDir: string): Promise<void> {
+  const tdb = db as Kysely<MigrationSchema>
+  const blobsRoot = join(dataDir, 'blobs')
+
+  const workspaceIds = await readDirSafe(blobsRoot)
+  for (const workspaceId of workspaceIds) {
+    const canvasDir = join(blobsRoot, workspaceId, 'canvas')
+    const files = await readDirSafe(canvasDir)
+    for (const file of files) {
+      if (!file.endsWith('.loro')) continue
+      const documentId = file.slice(0, -'.loro'.length)
+      await importOneBlob(tdb, workspaceId, documentId, join(canvasDir, file))
+    }
+  }
+}
+
+/** `readdir` a directory that may not exist (or may not BE a directory — a stray file left directly under `blobs/`); both are a clean no-op. */
+async function readDirSafe(dir: string): Promise<string[]> {
+  try {
+    return await readdir(dir)
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (code === 'ENOENT' || code === 'ENOTDIR') return []
+    throw err
+  }
+}
+
+async function importOneBlob(
+  db: Kysely<MigrationSchema>,
+  workspaceId: string,
+  documentId: string,
+  blobPath: string,
+): Promise<void> {
+  const docKey = `canvas:${documentId}`
+
+  let bytes: Uint8Array
+  try {
+    bytes = await readFile(blobPath)
+  } catch (err) {
+    log.warning({ workspaceId, documentId, err }, 'could not read blob during import, skipping')
+    return
+  }
+
+  const existing = await db
+    .selectFrom('documentSnapshots')
+    .select(['chunkCount', 'totalBytes', 'maxChunkBytes'])
+    .where('docKey', '=', docKey)
+    .executeTakeFirst()
+
+  if (existing) {
+    // A row already exists — the drift-fork case. Resolving it is not this
+    // migration's job (it cannot know which side is authoritative), so it
+    // only compares bytes to tell a genuine divergence from an already-
+    // imported, unchanged blob (idempotence) and leaves both sides alone
+    // either way.
+    const chunkRows = await db
+      .selectFrom('documentSnapshotChunks')
+      .select(['chunkIndex', 'bytes'])
+      .where('docKey', '=', docKey)
+      .orderBy('chunkIndex', 'asc')
+      .execute()
+    const existingBytes = reassembleSnapshot(
+      {
+        chunkCount: existing.chunkCount,
+        totalBytes: existing.totalBytes,
+        maxChunkBytes: existing.maxChunkBytes,
+      },
+      chunkRows.map((row) => ({
+        index: row.chunkIndex,
+        of: existing.chunkCount,
+        bytes: toBytes(row.bytes),
+      })),
+    )
+    if (!bytesEqual(existingBytes, bytes)) {
+      log.warning(
+        {
+          workspaceId,
+          documentId,
+          existingBytes: existingBytes.byteLength,
+          blobBytes: bytes.byteLength,
+        },
+        'FS blob diverges from an existing snapshot row — leaving both sides untouched for manual triage',
+      )
+    }
+    return
+  }
+
+  // documentSnapshots.frontier is NOT NULL, so deriving one is load-bearing:
+  // importing through LoroDoc also doubles as the corruption gate — a blob
+  // that fails to decode (garbage bytes, a zero-length file) cannot be given
+  // a fake frontier, so it is skipped rather than aborting the whole import.
+  const doc = new LoroDoc()
+  try {
+    doc.import(bytes)
+  } catch (err) {
+    log.warning(
+      { workspaceId, documentId, byteLength: bytes.byteLength, err },
+      'blob failed to decode as a LoroDoc snapshot, skipping',
+    )
+    return
+  }
+  const frontier = encodeFrontiers(doc.oplogFrontiers())
+
+  const { manifest, chunks } = chunkSnapshot(bytes, IMPORT_MAX_CHUNK_BYTES)
+
+  await db
+    .insertInto('documentSnapshots')
+    .values({
+      docKey,
+      chunkCount: manifest.chunkCount,
+      totalBytes: manifest.totalBytes,
+      maxChunkBytes: manifest.maxChunkBytes,
+      frontier,
+    })
+    .execute()
+
+  if (chunks.length > 0) {
+    await db
+      .insertInto('documentSnapshotChunks')
+      .values(chunks.map((chunk) => ({ docKey, chunkIndex: chunk.index, bytes: chunk.bytes })))
+      .execute()
+  }
+
+  const frontierRow = await db
+    .selectFrom('documentFrontiers')
+    .select('docKey')
+    .where('docKey', '=', docKey)
+    .executeTakeFirst()
+  if (!frontierRow) {
+    await db.insertInto('documentFrontiers').values({ docKey, frontier }).execute()
+  }
+}
+
+/**
+ * Drivers hand blobs back as Buffer or Uint8Array depending on dialect. The
+ * array-like `Uint8Array` constructor overload always allocates a fresh
+ * `ArrayBuffer`-backed copy — unlike a bare `instanceof` passthrough, this is
+ * what keeps the result assignable to ports' `Uint8Array<ArrayBuffer>` DTOs.
+ */
+function toBytes(value: Uint8Array): Uint8Array<ArrayBuffer> {
+  return new Uint8Array(value)
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.byteLength !== b.byteLength) return false
+  for (let i = 0; i < a.byteLength; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}

--- a/packages/mcp-server/src/server/store/db/migrations/0011-import-fs-blobs.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0011-import-fs-blobs.ts
@@ -134,10 +134,12 @@ async function importOneBlob(
       chunkRows.map((row) => ({
         index: row.chunkIndex,
         of: existing.chunkCount,
-        bytes: toBytes(row.bytes),
+        // Fresh copy: drivers hand back Buffer or Uint8Array by dialect, and
+        // ports' DTOs require an `ArrayBuffer`-backed `Uint8Array<ArrayBuffer>`.
+        bytes: new Uint8Array(row.bytes),
       })),
     )
-    if (!bytesEqual(existingBytes, bytes)) {
+    if (Buffer.compare(existingBytes, bytes) !== 0) {
       log.warning(
         {
           workspaceId,
@@ -187,30 +189,9 @@ async function importOneBlob(
       .execute()
   }
 
-  const frontierRow = await db
-    .selectFrom('documentFrontiers')
-    .select('docKey')
-    .where('docKey', '=', docKey)
-    .executeTakeFirst()
-  if (!frontierRow) {
-    await db.insertInto('documentFrontiers').values({ docKey, frontier }).execute()
-  }
-}
-
-/**
- * Drivers hand blobs back as Buffer or Uint8Array depending on dialect. The
- * array-like `Uint8Array` constructor overload always allocates a fresh
- * `ArrayBuffer`-backed copy — unlike a bare `instanceof` passthrough, this is
- * what keeps the result assignable to ports' `Uint8Array<ArrayBuffer>` DTOs.
- */
-function toBytes(value: Uint8Array): Uint8Array<ArrayBuffer> {
-  return new Uint8Array(value)
-}
-
-function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
-  if (a.byteLength !== b.byteLength) return false
-  for (let i = 0; i < a.byteLength; i++) {
-    if (a[i] !== b[i]) return false
-  }
-  return true
+  await db
+    .insertInto('documentFrontiers')
+    .values({ docKey, frontier })
+    .onConflict((oc) => oc.column('docKey').doNothing())
+    .execute()
 }

--- a/packages/mcp-server/src/server/store/db/migrations/0011-import-fs-blobs.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0011-import-fs-blobs.ts
@@ -119,26 +119,42 @@ async function importOneBlob(
     // only compares bytes to tell a genuine divergence from an already-
     // imported, unchanged blob (idempotence) and leaves both sides alone
     // either way.
+    //
+    // reassembleSnapshot can itself throw (SnapshotReassemblyError) when the
+    // existing row is structurally inconsistent with its chunk rows — e.g. a
+    // prior importOneBlob call was interrupted between its independent
+    // documentSnapshots/documentSnapshotChunks inserts. That is symmetric
+    // with the decode-failure gate below: skip the one document rather than
+    // aborting every other document in this import.
     const chunkRows = await db
       .selectFrom('documentSnapshotChunks')
       .select(['chunkIndex', 'bytes'])
       .where('docKey', '=', docKey)
       .orderBy('chunkIndex', 'asc')
       .execute()
-    const existingBytes = reassembleSnapshot(
-      {
-        chunkCount: existing.chunkCount,
-        totalBytes: existing.totalBytes,
-        maxChunkBytes: existing.maxChunkBytes,
-      },
-      chunkRows.map((row) => ({
-        index: row.chunkIndex,
-        of: existing.chunkCount,
-        // Fresh copy: drivers hand back Buffer or Uint8Array by dialect, and
-        // ports' DTOs require an `ArrayBuffer`-backed `Uint8Array<ArrayBuffer>`.
-        bytes: new Uint8Array(row.bytes),
-      })),
-    )
+    let existingBytes: Uint8Array
+    try {
+      existingBytes = reassembleSnapshot(
+        {
+          chunkCount: existing.chunkCount,
+          totalBytes: existing.totalBytes,
+          maxChunkBytes: existing.maxChunkBytes,
+        },
+        chunkRows.map((row) => ({
+          index: row.chunkIndex,
+          of: existing.chunkCount,
+          // Fresh copy: drivers hand back Buffer or Uint8Array by dialect, and
+          // ports' DTOs require an `ArrayBuffer`-backed `Uint8Array<ArrayBuffer>`.
+          bytes: new Uint8Array(row.bytes),
+        })),
+      )
+    } catch (err) {
+      log.warning(
+        { workspaceId, documentId, err },
+        'existing snapshot row failed to reassemble, leaving both sides untouched for manual triage',
+      )
+      return
+    }
     if (Buffer.compare(existingBytes, bytes) !== 0) {
       log.warning(
         {

--- a/packages/mcp-server/src/server/store/db/migrations/0011-import-fs-blobs.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0011-import-fs-blobs.ts
@@ -91,6 +91,17 @@ async function readDirSafe(dir: string): Promise<string[]> {
   }
 }
 
+/** Decode `bytes` as a LoroDoc snapshot and encode its current frontier, or the decode error. */
+function decodeFrontier(bytes: Uint8Array): { frontier: Uint8Array } | { error: unknown } {
+  const doc = new LoroDoc()
+  try {
+    doc.import(bytes)
+  } catch (error) {
+    return { error }
+  }
+  return { frontier: encodeFrontiers(doc.oplogFrontiers()) }
+}
+
 async function importOneBlob(
   db: Kysely<MigrationSchema>,
   workspaceId: string,
@@ -165,6 +176,38 @@ async function importOneBlob(
         },
         'FS blob diverges from an existing snapshot row — leaving both sides untouched for manual triage',
       )
+      return
+    }
+
+    // Bytes match — already imported by an earlier call. But the three
+    // inserts below (documentSnapshots, documentSnapshotChunks,
+    // documentFrontiers) are not atomic outside the migration's own wrapping
+    // transaction (the standalone export runs without one), so an earlier
+    // call can have been interrupted between the chunk pair landing and the
+    // frontier insert. Backfill the missing row rather than returning
+    // silently: LibsqlDocumentStore.currentFrontier() falls through to an
+    // empty frontier for a docKey with no documentFrontiers row, which would
+    // misreport this document as having no history despite the full
+    // snapshot being present.
+    const frontierExists = await db
+      .selectFrom('documentFrontiers')
+      .select('docKey')
+      .where('docKey', '=', docKey)
+      .executeTakeFirst()
+    if (!frontierExists) {
+      const decoded = decodeFrontier(bytes)
+      if ('error' in decoded) {
+        log.warning(
+          { workspaceId, documentId, err: decoded.error },
+          'existing snapshot matched the FS blob but it failed to decode while backfilling a missing frontier row, skipping',
+        )
+        return
+      }
+      await db
+        .insertInto('documentFrontiers')
+        .values({ docKey, frontier: decoded.frontier })
+        .onConflict((oc) => oc.column('docKey').doNothing())
+        .execute()
     }
     return
   }
@@ -173,17 +216,15 @@ async function importOneBlob(
   // importing through LoroDoc also doubles as the corruption gate — a blob
   // that fails to decode (garbage bytes, a zero-length file) cannot be given
   // a fake frontier, so it is skipped rather than aborting the whole import.
-  const doc = new LoroDoc()
-  try {
-    doc.import(bytes)
-  } catch (err) {
+  const decoded = decodeFrontier(bytes)
+  if ('error' in decoded) {
     log.warning(
-      { workspaceId, documentId, byteLength: bytes.byteLength, err },
+      { workspaceId, documentId, byteLength: bytes.byteLength, err: decoded.error },
       'blob failed to decode as a LoroDoc snapshot, skipping',
     )
     return
   }
-  const frontier = encodeFrontiers(doc.oplogFrontiers())
+  const frontier = decoded.frontier
 
   const { manifest, chunks } = chunkSnapshot(bytes, IMPORT_MAX_CHUNK_BYTES)
 

--- a/packages/mcp-server/src/server/store/db/migrations/index.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/index.ts
@@ -9,6 +9,7 @@ import { migration as adoptWorkspaceTree } from './0007-adopt-workspace-tree.js'
 import { migration as ulidLegacyCanvasIds } from './0008-ulid-legacy-canvas-ids.js'
 import { migration as documentVocabulary } from './0009-document-vocabulary.js'
 import { migration as documentPath } from './0010-document-path.js'
+import { migration as importFsBlobs } from './0011-import-fs-blobs.js'
 
 // Ordered map; kysely sorts by key so the numeric prefix decides execution order.
 // 0003 still says `canvas-doc-store` after the port it creates was renamed to
@@ -29,4 +30,5 @@ export const migrations: Record<string, Migration> = {
   '0008-ulid-legacy-canvas-ids': ulidLegacyCanvasIds,
   '0009-document-vocabulary': documentVocabulary,
   '0010-document-path': documentPath,
+  '0011-import-fs-blobs': importFsBlobs,
 }

--- a/packages/mcp-server/src/server/store/db/migrator.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrator.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, stat } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Migrator } from 'kysely'
@@ -105,6 +105,28 @@ describe('runMigrations', () => {
     // The typed guard recognizes it.
     const err = await runMigrations(db).catch((e: unknown) => e)
     expect(isIncompatibleDatabaseError(err)).toBe(true)
+  })
+
+  // 0011-import-fs-blobs walks {dataDir}/blobs/<workspaceId>/canvas — an
+  // unreadable canvas directory (permissions changed on the data dir, a
+  // restrictive umask) rethrows out of the migration with a raw Node
+  // errno error. runMigrations must reframe it the same way it reframes
+  // the corrupted-migrations case, instead of surfacing the bare
+  // "EACCES ... scandir '<path>'" message with no recovery guidance.
+  it('reframes an EACCES readdir failure during migration into an actionable message', async () => {
+    const canvasDir = join(tempDir, 'blobs', 'ws-1', 'canvas')
+    await mkdir(canvasDir, { recursive: true })
+    await writeFile(join(canvasDir, 'doc-a.loro'), 'irrelevant')
+    await chmod(canvasDir, 0o000)
+
+    try {
+      const db = await getDb(tempDir)
+      await expect(runMigrations(db)).rejects.toThrow(/permission|blobs/i)
+      const err = await runMigrations(db).catch((e: unknown) => e)
+      expect((err as { cause?: unknown }).cause).toMatchObject({ code: 'EACCES' })
+    } finally {
+      await chmod(canvasDir, 0o755)
+    }
   })
 
   it('exposes the expected canvas + branches + versions schema after init', async () => {

--- a/packages/mcp-server/src/server/store/db/migrator.ts
+++ b/packages/mcp-server/src/server/store/db/migrator.ts
@@ -42,6 +42,23 @@ export async function runMigrations(db: Database): Promise<void> {
       )
     }
 
-    throw new Error(`Database migration failed${failed ? ` at ${failed}` : ''}: ${detail}`)
+    // A migration that walks the data dir's filesystem tree (e.g.
+    // 0011-import-fs-blobs reading {dataDir}/blobs/**) can hit a permission
+    // error unrelated to the database itself. Point at the fix instead of
+    // surfacing the raw "EACCES ... scandir '<path>'" errno message, which
+    // names an implementation detail no user can act on directly.
+    if ((error as NodeJS.ErrnoException | undefined)?.code === 'EACCES') {
+      throw new Error(
+        `Database migration failed${failed ? ` at ${failed}` : ''}: permission denied reading ` +
+          'the data directory. Check filesystem permissions on the workspace blob directories ' +
+          'under <data dir>/blobs and restart. See docs/contributing/mcp-debugging.md ' +
+          '(Database Migration Errors).',
+        { cause: error },
+      )
+    }
+
+    throw new Error(`Database migration failed${failed ? ` at ${failed}` : ''}: ${detail}`, {
+      cause: error,
+    })
   }
 }

--- a/packages/mcp-server/src/server/store/db/published-migration-names.ts
+++ b/packages/mcp-server/src/server/store/db/published-migration-names.ts
@@ -21,4 +21,5 @@ export const PUBLISHED_MIGRATION_NAMES = [
   '0008-ulid-legacy-canvas-ids',
   '0009-document-vocabulary',
   '0010-document-path',
+  '0011-import-fs-blobs',
 ] as const satisfies readonly string[]


### PR DESCRIPTION
## What

Identity-convergence initiative, slice 1 (approved plan — the user chose the full single-backend swap; this migration is its prerequisite): **migration `0011-import-fs-blobs`** additively imports every existing FS blob (`{dataDir}/blobs/<ws>/canvas/<id>.loro`) into the `LibsqlDocumentStore` snapshot tables.

- Additive only: never touches or deletes an FS file, never overwrites an existing row. A row that already exists with **different** bytes (the drift-fork case) logs one structured warning naming workspaceId/documentId/both byte sizes and leaves both sides untouched for manual triage; byte-identical rows skip silently, so re-runs are zero-write, zero-warning (idempotence pinned as the mutation check against keying divergence on row-existence).
- Corrupt/zero-byte blobs warn and skip without aborting the walk; missing `blobs/` is a clean no-op (fresh-install startup pinned by a real daemon boot in QA).
- The per-blob routine is exported **standalone** (not only as the Kysely Migration): the migrator runs a key once per database, and the upcoming flip slice must call the same routine a second time outside migration bookkeeping to close the interim window.
- Frozen-snapshot style per 0007–0010: no living store code imported; docKey prefix, blob path shape, table/column names are frozen literals.
- Deviation from "new file only", deliberate: the migrator now maps `EACCES` during a migration's FS walk to an actionable message (fix permissions, do **not** delete the DB) — a failure surface this migration introduces — with the matching runbook entry in `docs/contributing/mcp-debugging.md`.

## Verification

- 9/9 migration tests over real SQLite + real temp-dir blob trees + real LoroDoc fixtures: byte-identical reassembly (incl. multi-chunk), divergence warning with both sides untouched (mtime/size checked), double-run idempotence, corrupt/empty-blob skip, standalone-path import into an already-migrated DB, missing-dir/stray-file no-ops.
- QA startup scenario: full build, daemon booted on a fresh data dir — exactly `READY`, all 11 migrations recorded in order, MCP initialize/tools-list 200.
- mcp-node 3472 green (281 files). Review gate: 2 findings (frontier-row self-heal, corrupted-row resilience) fixed in-lane before this PR.

Nothing reads the imported rows yet — this lands standalone ahead of the flip (slice 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ
