### PR TITLE
feat(web): tap to place a pending cut, with a pending chip that can cancel it

### DIFF
--- a/apps/web/src/components/spatial-editor/PendingCutChip.test.tsx
+++ b/apps/web/src/components/spatial-editor/PendingCutChip.test.tsx
@@ -1,0 +1,22 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { PendingCutChip } from './PendingCutChip.js'
+
+afterEach(cleanup)
+
+it('tells coarse pointers how to place; mice get the count only', () => {
+  render(<PendingCutChip count={2} coarse onCancel={vi.fn()} />)
+  expect(screen.getByTestId('pending-cut-chip').textContent).toContain('2 held — tap to place')
+  cleanup()
+  render(<PendingCutChip count={1} coarse={false} onCancel={vi.fn()} />)
+  const chip = screen.getByTestId('pending-cut-chip')
+  expect(chip.textContent).toContain('1 held')
+  expect(chip.textContent).not.toContain('tap to place')
+})
+
+it('the ✕ carries an accessible name and fires onCancel', () => {
+  const onCancel = vi.fn()
+  render(<PendingCutChip count={1} coarse onCancel={onCancel} />)
+  fireEvent.click(screen.getByRole('button', { name: 'Cancel cut' }))
+  expect(onCancel).toHaveBeenCalledTimes(1)
+})

--- a/apps/web/src/components/spatial-editor/PendingCutChip.tsx
+++ b/apps/web/src/components/spatial-editor/PendingCutChip.tsx
@@ -1,0 +1,39 @@
+/**
+ * Transient status chip for a pending cut. It announces the hold (the veil
+ * alone does not say what state the canvas is in) and carries the one
+ * explicit exit that works everywhere — touch has no Escape key. Floats
+ * above the dock rather than joining its flex row: the dock is the FIXED
+ * creation strip, and this chip exists only while a cut is pending, the
+ * same transient tier as a toast.
+ */
+import { Scissors, X } from 'lucide-react'
+
+export interface PendingCutChipProps {
+  readonly count: number
+  /** Coarse pointers get the tap-to-place hint; mice place via paste. */
+  readonly coarse: boolean
+  readonly onCancel: () => void
+}
+
+export function PendingCutChip({ count, coarse, onCancel }: PendingCutChipProps) {
+  return (
+    <div
+      data-testid="pending-cut-chip"
+      data-editor-overlay
+      className="absolute bottom-20 left-1/2 z-20 flex -translate-x-1/2 items-center gap-2 rounded-full border bg-background px-3 py-1.5 text-sm shadow-lg"
+    >
+      <Scissors aria-hidden="true" className="size-3.5 text-muted-foreground" />
+      <span>
+        {count} held{coarse ? ' — tap to place' : ''}
+      </span>
+      <button
+        type="button"
+        aria-label="Cancel cut"
+        className="flex size-6 items-center justify-center rounded-full hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
+        onClick={onCancel}
+      >
+        <X aria-hidden="true" className="size-3.5" />
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -1830,9 +1830,13 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           // empty tap answers it HERE — one tap instead of long-press →
           // menu → Paste here. Mice keep the explicit paste: an empty click
           // is the deselect reflex, and hijacking it would misplace nodes.
+          // A tap that landed on an EDGE also starts a marquee (the press
+          // handler selects the edge and falls through here), so truly
+          // empty means no edge got selected — an edge tap keeps its normal
+          // meaning, and the hold survives it like any other interaction.
           // Resetting the press memory keeps the NEXT tap from reading as a
           // double press (which would also mint a note at the same spot).
-          else if (e.pointerType === 'touch' && pendingCut !== null) {
+          else if (e.pointerType === 'touch' && pendingCut !== null && selectedEdgeId === null) {
             lastPressRef.current = null
             pasteClipboard(marquee.start)
           }

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -159,6 +159,7 @@ import {
   resolveSpawnPoint,
   textNodeDefaults,
 } from './node-factories.js'
+import { PendingCutChip } from './PendingCutChip.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
 import { renderCanvasToSvg, requiredTextNodeHeight } from './scene-render.js'
 import {
@@ -1825,6 +1826,16 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           // the press; a DOUBLE one creates a node here (resolved at the
           // release, consistent with the node-edit double-press rule).
           if (armed !== null && armed.key === 'empty') createNodeAt(armed.point)
+          // Tap-to-place (touch only): while a cut is pending, a stationary
+          // empty tap answers it HERE — one tap instead of long-press →
+          // menu → Paste here. Mice keep the explicit paste: an empty click
+          // is the deselect reflex, and hijacking it would misplace nodes.
+          // Resetting the press memory keeps the NEXT tap from reading as a
+          // double press (which would also mint a note at the same spot).
+          else if (e.pointerType === 'touch' && pendingCut !== null) {
+            lastPressRef.current = null
+            pasteClipboard(marquee.start)
+          }
           // Double press ON an edge line edits the OBJECT under the pointer
           // (the label), mirroring the node double-press-edits rule; node
           // creation stays the empty-space double press above.
@@ -3099,6 +3110,13 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           exists and double-click-empty-space has no visible cue, so the
           palette is the always-visible, keyboard-reachable way in. Fixed to
           the bottom edge outside the pan/zoom transform. */}
+        {pendingCut !== null && (
+          <PendingCutChip
+            count={pendingCut.snapshot.size}
+            coarse={typeof matchMedia !== 'undefined' && matchMedia('(pointer: coarse)').matches}
+            onCancel={() => setPendingCut(null)}
+          />
+        )}
         <ToolPalette
           // The dock does NOT change with the mode. Navigation belongs to the
           // viewport, not to whichever tool is armed, so nothing is exchanged

--- a/apps/web/src/components/spatial-editor/clipboard.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/clipboard.browser.test.tsx
@@ -488,3 +488,38 @@ it('the pending chip announces the hold and its ✕ cancels it — touch finally
   clip(root, 'paste')
   expect(latest.canvas.nodes).toHaveLength(3)
 })
+
+it('a touch tap on an EDGE during the hold selects the edge — placement is for empty space only', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+  clip(root, 'cut')
+
+  // (260, 80) sits on the straight a→b edge line, away from both boxes.
+  tapEmpty(root, 260, 80)
+
+  // The tap behaved as an edge tap, not a placement: nothing moved and the
+  // hold survives (edge interaction is not "done with the cut").
+  const a = latest.canvas.nodes.find((n) => n.id === 'a')
+  expect(a).toMatchObject({ x: 40, y: 40 })
+  expect(container.querySelector('[data-testid="ghost-overlay"]')).not.toBeNull()
+})
+
+it('a second rapid tap after placing does not mint a note — the press memory resets', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+  clip(root, 'cut')
+
+  tapEmpty(root, 600, 400)
+  // A second quick tap at ANOTHER empty spot: the double-press key is
+  // 'empty' regardless of position, so without the reset these two taps
+  // pair up and mint a note there.
+  tapEmpty(root, 200, 400)
+
+  // Two nodes still: the placement tap must not pair with the next tap as
+  // an empty double press (which creates a note).
+  expect(latest.canvas.nodes).toHaveLength(2)
+})

--- a/apps/web/src/components/spatial-editor/clipboard.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/clipboard.browser.test.tsx
@@ -410,3 +410,81 @@ it("an anchored 'Paste here' moves the held selection so its center lands on the
   expect(Math.round(moved.y + moved.height / 2)).toBe(400)
   expect(latest.canvas.edges).toEqual(initial.edges)
 })
+
+// --- Tap-to-place + the pending chip --------------------------------------
+
+function tapEmpty(root: HTMLElement, x: number, y: number, pointerType = 'touch') {
+  const r = root.getBoundingClientRect()
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 9,
+    pointerType,
+    isPrimary: true,
+    clientX: r.left + x,
+    clientY: r.top + y,
+  })
+  fireEvent.pointerUp(root, {
+    pointerId: 9,
+    pointerType,
+    isPrimary: true,
+    clientX: r.left + x,
+    clientY: r.top + y,
+  })
+}
+
+it('a touch tap on empty canvas places the held selection there — no menu needed', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+  clip(root, 'cut')
+
+  tapEmpty(root, 600, 400)
+
+  // Same node, moved so its center lands on the tap (identity viewport).
+  expect(latest.canvas.nodes.map((n) => n.id).sort()).toEqual(['a', 'b'])
+  const moved = latest.canvas.nodes.find((n) => n.id === 'a')
+  if (moved === undefined) throw new Error('unreachable')
+  expect(Math.round(moved.x + moved.width / 2)).toBe(600)
+  expect(Math.round(moved.y + moved.height / 2)).toBe(400)
+  expect(latest.canvas.edges).toEqual(initial.edges)
+  expect(container.querySelector('[data-testid="ghost-overlay"]')).toBeNull()
+})
+
+it('a mouse click on empty canvas does NOT place — desktop keeps the explicit paste', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  selectAt(root, 120, 80)
+  clip(root, 'cut')
+
+  tapEmpty(root, 600, 400, 'mouse')
+
+  // Deselect happened, the hold stays, nothing moved.
+  const a = latest.canvas.nodes.find((n) => n.id === 'a')
+  expect(a).toMatchObject({ x: 40, y: 40 })
+  expect(container.querySelector('[data-testid="ghost-overlay"]')).not.toBeNull()
+})
+
+it('the pending chip announces the hold and its ✕ cancels it — touch finally has an exit', () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  expect(container.querySelector('[data-testid="pending-cut-chip"]')).toBeNull()
+
+  selectAt(root, 120, 80)
+  clip(root, 'cut')
+  const chip = container.querySelector('[data-testid="pending-cut-chip"]') as HTMLElement
+  expect(chip).not.toBeNull()
+
+  const cancel = chip.querySelector('[aria-label="Cancel cut"]') as HTMLElement
+  expect(cancel).not.toBeNull()
+  fireEvent.click(cancel)
+  expect(container.querySelector('[data-testid="pending-cut-chip"]')).toBeNull()
+  expect(container.querySelector('[data-testid="ghost-overlay"]')).toBeNull()
+  expect(latest.canvas.nodes).toHaveLength(2)
+
+  // The envelope still works as a plain copy afterwards.
+  clip(root, 'paste')
+  expect(latest.canvas.nodes).toHaveLength(3)
+})


### PR DESCRIPTION
## What

Per the Canvas Manipulation Lab §⑪-c decision: the cursor-following idea was analyzed and declined (it re-acquires drag semantics and forfeits cut's one advantage — free navigation while the object stays put), but its core insight ships: **visibility of the pending state, and one-tap directness at the destination.**

- **Tap-to-place (touch only).** While a cut is pending, a stationary tap on empty canvas places the held selection there — the same centered move as an anchored 'Paste here', one tap instead of the old 500ms long-press → menu → Paste here. Pan, pinch, marquee, and node interactions never place. Mice deliberately do NOT place on click: an empty click is the deselect reflex, and desktop keeps the explicit paste (⌘V / Paste here). The press memory resets after a placement so the next tap cannot read as a double press and mint a note.
- **Pending chip.** A transient chip above the dock announces the hold — `✂ N held` (+ `— tap to place` on coarse pointers) — and carries a ✕, which is the one explicit cancel that works on touch, where Escape does not exist. It floats at the toast tier rather than joining the dock's fixed flex row: it exists only while a cut is pending.

Graceful-retreat design: if dogfooding ever observes accidental placements from the tap-to-deselect reflex, the tap can be demoted to "tap the chip to arm" without changing anything else.

## Visual

![tap-to-place-chip.png](https://github.com/user-attachments/assets/7e468e21-63ba-4723-b2ca-6e11806e9a95)

## Tests

Red-first in `clipboard.browser.test.tsx`: touch tap places (center on tap, same ids, edges untouched, veil gone); mouse click does not place (hold survives, deselect only); the chip appears with the hold and its ✕ cancels it (envelope keeps working as a plain copy). Full gates: web-browser 597/597, jsdom exit 0, `pnpm -r typecheck`, lint, knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ua6RPuoEAD4ZTBqyhNC56Z