### PR TITLE
feat(web): the node text editor speaks markdown — CodeMirror with the document editor's grammar

### DIFF
--- a/apps/web/src/components/markdown-editor/SourcePane.tsx
+++ b/apps/web/src/components/markdown-editor/SourcePane.tsx
@@ -36,7 +36,14 @@ function wrapSelectionWith(delimiter: string): StateCommand {
   }
 }
 
-const styleKeymap = [
+/**
+ * Shared with the spatial node editor (markdown-editor and spatial-editor
+ * are sibling features of one app): the same wrap shortcuts everywhere a
+ * markdown source is edited. Note Mod-Enter (task toggle) is deliberately
+ * OUTRANKED by the node editor's commit binding — the overlay's exit verb
+ * wins there; the document editor keeps the toggle.
+ */
+export const markdownStyleKeymap = [
   { key: 'Mod-b', run: wrapSelectionWith('**') },
   { key: 'Mod-i', run: wrapSelectionWith('*') },
   { key: 'Mod-e', run: wrapSelectionWith('`') },
@@ -60,7 +67,7 @@ const styleKeymap = [
  * rule — so `.cm-md-marker` has to win on the shared properties by order in
  * the stylesheet, not by being the only match.
  */
-const markdownHighlightStyle = HighlightStyle.define([
+export const markdownHighlightStyle = HighlightStyle.define([
   { tag: tags.heading, class: 'cm-md-heading' },
   { tag: tags.strong, class: 'cm-md-strong' },
   { tag: tags.emphasis, class: 'cm-md-emphasis' },
@@ -174,7 +181,7 @@ export function SourcePane({
         // default binding; indentWithTab keeps Tab in the editor (Escape
         // then Tab remains the keyboard escape hatch, per CodeMirror's
         // own accessibility guidance).
-        keymap.of([...styleKeymap, ...defaultKeymap, ...historyKeymap, indentWithTab]),
+        keymap.of([...markdownStyleKeymap, ...defaultKeymap, ...historyKeymap, indentWithTab]),
         // Prose, not code: long paragraphs soft-wrap instead of growing a
         // horizontal scrollbar.
         EditorView.lineWrapping,

--- a/apps/web/src/components/spatial-editor/MarkdownNodeEditor.tsx
+++ b/apps/web/src/components/spatial-editor/MarkdownNodeEditor.tsx
@@ -14,7 +14,12 @@
  *   just-created node).
  * `finishedRef` makes the commit/cancel transition terminal, exactly as
  * the textarea's doc described: once either has fired, the other is a
- * no-op, so Escape-then-blur cannot resurrect a discarded value.
+ * no-op, so Escape-then-blur cannot resurrect a discarded value. And
+ * `mountedRef` guards the unmount path the textarea also guarded:
+ * `EditorView.destroy()` blurs a focused content DOM, and on the everyday
+ * click-away exit the gesture reducer has ALREADY committed the pending
+ * text — a destroy-fired blur re-committing through this component's
+ * stale pre-unmount closure would write a duplicate set-text every time.
  *
  * The wrapper carries the node's own fill/font/padding (style parity with
  * the rendered SVG); an OPAQUE background is load-bearing — it is what
@@ -26,7 +31,7 @@ import { syntaxHighlighting } from '@codemirror/language'
 import { EditorState, Prec } from '@codemirror/state'
 import { EditorView, keymap } from '@codemirror/view'
 import { GFM } from '@lezer/markdown'
-import { type CSSProperties, useEffect, useRef } from 'react'
+import { type CSSProperties, useLayoutEffect, useRef } from 'react'
 import { exitEmptyListItem } from '../markdown-editor/exit-empty-list-item.js'
 import { markdownHighlightStyle, markdownStyleKeymap } from '../markdown-editor/SourcePane.js'
 import type { Box } from './geometry.js'
@@ -53,16 +58,23 @@ export function MarkdownNodeEditor({
   const hostRef = useRef<HTMLDivElement | null>(null)
   const viewRef = useRef<EditorView | null>(null)
   const finishedRef = useRef(false)
+  const mountedRef = useRef(false)
   // Latest callbacks without recreating the EditorView per parent render.
   const callbacksRef = useRef({ onCommit, onCancel, onChange })
   callbacksRef.current = { onCommit, onCancel, onChange }
 
-  useEffect(() => {
+  // useLayoutEffect, not useEffect: passive cleanups run AFTER React has
+  // detached the host DOM, and detaching a focused contentDOM fires a
+  // native blur while our handler is still attached and mountedRef is
+  // still true — the duplicate-commit hole in person. A layout cleanup
+  // runs BEFORE the detach, so destroy()'s own blur is the only one left,
+  // and the mounted guard retires it.
+  useLayoutEffect(() => {
     const host = hostRef.current
     if (host === null) return
 
     const commit = (view: EditorView) => {
-      if (finishedRef.current) return
+      if (!mountedRef.current || finishedRef.current) return
       finishedRef.current = true
       callbacksRef.current.onCommit(view.state.doc.toString())
     }
@@ -126,6 +138,7 @@ export function MarkdownNodeEditor({
         }),
       ],
     })
+    mountedRef.current = true
     const view = new EditorView({ state, parent: host })
     viewRef.current = view
     view.focus()
@@ -134,6 +147,9 @@ export function MarkdownNodeEditor({
     view.dispatch({ selection: { anchor: view.state.doc.length } })
 
     return () => {
+      // BEFORE destroy: EditorView.destroy() blurs a focused content DOM,
+      // and that blur must find this editor already retired.
+      mountedRef.current = false
       viewRef.current = null
       view.destroy()
     }

--- a/apps/web/src/components/spatial-editor/MarkdownNodeEditor.tsx
+++ b/apps/web/src/components/spatial-editor/MarkdownNodeEditor.tsx
@@ -1,0 +1,168 @@
+/**
+ * The spatial text node's editor: a positioned CodeMirror overlay speaking
+ * the SAME markdown as the document editor — one grammar (GFM), one
+ * highlight style, one set of wrap shortcuts and list behaviors — so what
+ * a hand learns in one surface transfers to the other.
+ *
+ * What stays node-shaped is the EXIT semantics, unchanged from the
+ * textarea this replaces:
+ * - ⌘/Ctrl+Enter commits and closes. It deliberately outranks the
+ *   document editor's Mod-Enter task toggle: an overlay's most important
+ *   verb is "done", and this binding predates the grammar upgrade.
+ * - losing focus commits — nothing typed is ever lost to a stray click.
+ * - Escape cancels (the gesture reducer decides what a cancel means for a
+ *   just-created node).
+ * `finishedRef` makes the commit/cancel transition terminal, exactly as
+ * the textarea's doc described: once either has fired, the other is a
+ * no-op, so Escape-then-blur cannot resurrect a discarded value.
+ *
+ * The wrapper carries the node's own fill/font/padding (style parity with
+ * the rendered SVG); an OPAQUE background is load-bearing — it is what
+ * hides the committed render underneath while editing.
+ */
+import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
+import { markdown } from '@codemirror/lang-markdown'
+import { syntaxHighlighting } from '@codemirror/language'
+import { EditorState, Prec } from '@codemirror/state'
+import { EditorView, keymap } from '@codemirror/view'
+import { GFM } from '@lezer/markdown'
+import { type CSSProperties, useEffect, useRef } from 'react'
+import { exitEmptyListItem } from '../markdown-editor/exit-empty-list-item.js'
+import { markdownHighlightStyle, markdownStyleKeymap } from '../markdown-editor/SourcePane.js'
+import type { Box } from './geometry.js'
+
+export interface MarkdownNodeEditorProps {
+  readonly box: Box
+  readonly initialText: string
+  readonly style?: CSSProperties
+  readonly testId?: string
+  readonly onCommit: (text: string) => void
+  readonly onCancel: () => void
+  readonly onChange?: (text: string) => void
+}
+
+export function MarkdownNodeEditor({
+  box,
+  initialText,
+  style,
+  testId = 'text-node-editor',
+  onCommit,
+  onCancel,
+  onChange,
+}: MarkdownNodeEditorProps) {
+  const hostRef = useRef<HTMLDivElement | null>(null)
+  const viewRef = useRef<EditorView | null>(null)
+  const finishedRef = useRef(false)
+  // Latest callbacks without recreating the EditorView per parent render.
+  const callbacksRef = useRef({ onCommit, onCancel, onChange })
+  callbacksRef.current = { onCommit, onCancel, onChange }
+
+  useEffect(() => {
+    const host = hostRef.current
+    if (host === null) return
+
+    const commit = (view: EditorView) => {
+      if (finishedRef.current) return
+      finishedRef.current = true
+      callbacksRef.current.onCommit(view.state.doc.toString())
+    }
+    const cancel = () => {
+      if (finishedRef.current) return
+      finishedRef.current = true
+      callbacksRef.current.onCancel()
+    }
+
+    const state = EditorState.create({
+      doc: initialText,
+      extensions: [
+        markdown({ extensions: [GFM] }),
+        // The exit verbs outrank EVERYTHING, including the language
+        // keymap's Enter continuation and the style keymap's Mod-Enter.
+        Prec.highest(
+          keymap.of([
+            {
+              key: 'Mod-Enter',
+              run: (view) => {
+                commit(view)
+                return true
+              },
+            },
+            {
+              key: 'Escape',
+              run: () => {
+                cancel()
+                return true
+              },
+            },
+            { key: 'Enter', run: exitEmptyListItem },
+          ]),
+        ),
+        syntaxHighlighting(markdownHighlightStyle),
+        history(),
+        keymap.of([...markdownStyleKeymap, ...defaultKeymap, ...historyKeymap]),
+        EditorView.lineWrapping,
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged) callbacksRef.current.onChange?.(update.state.doc.toString())
+        }),
+        EditorView.domEventHandlers({
+          blur: (_event, view) => {
+            commit(view)
+            return false
+          },
+        }),
+        // Inherit the node's own typography from the wrapper — the parity
+        // styles live there so the SVG render and the editor agree.
+        EditorView.theme({
+          '&': { height: '100%', backgroundColor: 'transparent' },
+          '.cm-scroller': {
+            fontFamily: 'inherit',
+            fontSize: 'inherit',
+            lineHeight: 'inherit',
+            overflow: 'auto',
+          },
+          '.cm-content': { padding: '0', caretColor: 'currentColor' },
+          '.cm-line': { padding: '0' },
+          '&.cm-focused': { outline: 'none' },
+        }),
+      ],
+    })
+    const view = new EditorView({ state, parent: host })
+    viewRef.current = view
+    view.focus()
+    // Continue typing where the text ends — programmatic focus leaves the
+    // caret at position 0, which reads as "my text got replaced".
+    view.dispatch({ selection: { anchor: view.state.doc.length } })
+
+    return () => {
+      viewRef.current = null
+      view.destroy()
+    }
+    // Mount-once by design: initialText is the seed, later parent renders
+    // must not reset the document under the caret.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: see above
+  }, [])
+
+  return (
+    <div
+      ref={hostRef}
+      data-testid={testId}
+      data-editor-overlay
+      // Caret placement must not bubble into the root's hit-test and turn
+      // into a move gesture that unmounts this editor mid-edit.
+      onPointerDown={(e) => e.stopPropagation()}
+      style={{
+        position: 'absolute',
+        left: box.x,
+        top: box.y,
+        width: box.width,
+        height: box.height,
+        boxSizing: 'border-box',
+        overflow: 'hidden',
+        // Explicit, because the canvas root turns selection OFF and this
+        // inherits from it.
+        userSelect: 'text',
+        ...style,
+      }}
+    />
+  )
+}

--- a/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.browser.test.tsx
@@ -12,6 +12,7 @@ import { page, userEvent } from 'vitest/browser'
 // unstyled-DOM defaults.
 import '../../index.css'
 import type { EditorCommand } from './commands.js'
+import { fillNodeEditor, nodeEditorContent } from './node-editor-test-utils.js'
 import { SpatialEditor, type SpatialEditorHandle } from './SpatialEditor.js'
 
 function fakeMeasure() {
@@ -474,9 +475,8 @@ describe('SpatialEditor (browser)', () => {
         new PointerEvent('pointerup', { bubbles: true, clientX: 40, clientY: 40, pointerId: 90 }),
       )
 
-    const textEditor = page.getByTestId('text-node-editor')
-    await textEditor.fill('edited')
-    ;(textEditor.element() as HTMLTextAreaElement).blur()
+    fillNodeEditor(document, 'edited')
+    ;(nodeEditorContent(document) as HTMLElement).blur()
 
     expect(onChange).toHaveBeenCalledTimes(1)
     const [, command] = onChange.mock.calls[0] as [SpatialCanvas, unknown]
@@ -526,7 +526,7 @@ describe('SpatialEditor (browser)', () => {
       )
 
     const textEditor = page.getByTestId('text-node-editor')
-    await textEditor.fill('edited')
+    fillNodeEditor(document, 'edited')
     // Placing the caret inside the already-open textarea must not bubble to
     // the root's hit-test and hijack the gesture into a node move — that
     // would unmount the editor and silently drop the in-progress edit.
@@ -543,7 +543,7 @@ describe('SpatialEditor (browser)', () => {
     expect(page.getByTestId('text-node-editor').element()).toBeTruthy()
     expect(onChange).not.toHaveBeenCalled()
 
-    ;(textEditor.element() as HTMLTextAreaElement).blur()
+    ;(nodeEditorContent(document) as HTMLElement).blur()
     expect(onChange).toHaveBeenCalledTimes(1)
     const [, command] = onChange.mock.calls[0] as [SpatialCanvas, unknown]
     expect(command).toEqual({ kind: 'set-text', id: 'a', text: 'edited' })
@@ -1266,10 +1266,10 @@ describe('SpatialEditor (browser)', () => {
 
     const textEditor = page.getByTestId('text-node-editor')
     expect(textEditor.element()).toBeTruthy()
-    expect(document.activeElement).toBe(textEditor.element())
+    expect(document.activeElement).toBe(nodeEditorContent(document))
 
-    await textEditor.fill('my first note')
-    ;(textEditor.element() as HTMLTextAreaElement).blur()
+    fillNodeEditor(document, 'my first note')
+    ;(nodeEditorContent(document) as HTMLElement).blur()
 
     expect(onChange).toHaveBeenCalledTimes(2)
     const [firstNext, firstCommand] = onChange.mock.calls[0] as [SpatialCanvas, unknown]
@@ -1412,7 +1412,7 @@ describe('SpatialEditor (browser)', () => {
     expect(command).toEqual({ kind: 'delete-node', id: 'a' })
   })
 
-  it('while the text editor is open, Backspace edits the textarea and does NOT delete the node', async () => {
+  it('while the text editor is open, Backspace edits the text and does NOT delete the node', async () => {
     const onChange = vi.fn()
     render(
       <div style={{ width: 600, height: 400 }}>
@@ -1454,22 +1454,21 @@ describe('SpatialEditor (browser)', () => {
         new PointerEvent('pointerup', { bubbles: true, clientX: 40, clientY: 40, pointerId: 90 }),
       )
 
-    const textEditor = page.getByTestId('text-node-editor')
-    await textEditor.fill('hell')
-    await textEditor
-      .element()
-      .dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true, cancelable: true }),
-      )
+    fillNodeEditor(document, 'hell')
+    nodeEditorContent(document)?.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true, cancelable: true }),
+    )
 
     // The node must still exist — the reducer's editing-text guard means no
     // delete-node command was ever emitted from this keystroke.
     expect(onChange).not.toHaveBeenCalled()
     expect(page.getByTestId('text-node-editor').element()).toBeTruthy()
-    ;(textEditor.element() as HTMLTextAreaElement).blur()
+    ;(nodeEditorContent(document) as HTMLElement).blur()
     expect(onChange).toHaveBeenCalledTimes(1)
     const [, command] = onChange.mock.calls[0] as [SpatialCanvas, unknown]
-    expect(command).toEqual({ kind: 'set-text', id: 'a', text: 'hell' })
+    // CodeMirror handles the keystroke itself: the character came off the
+    // TEXT ('hell' → 'hel'), and no delete-node command ever fired.
+    expect(command).toEqual({ kind: 'set-text', id: 'a', text: 'hel' })
   })
 
   it('creating two nodes, connecting them, then deleting one leaves no dangling edge in the canvas or the rendered SVG', async () => {
@@ -1515,8 +1514,7 @@ describe('SpatialEditor (browser)', () => {
       .dispatchEvent(
         new PointerEvent('pointerup', { bubbles: true, clientX: 100, clientY: 100, pointerId: 92 }),
       )
-    let textEditor = page.getByTestId('text-node-editor')
-    ;(textEditor.element() as HTMLTextAreaElement).blur()
+    ;(nodeEditorContent(document) as HTMLElement).blur()
     let canvas = onChange.mock.calls.at(-1)![0] as SpatialCanvas
     expect(canvas.nodes).toHaveLength(1)
     // Wait for ControlledEditor's setCanvas to actually flush and re-render
@@ -1557,8 +1555,7 @@ describe('SpatialEditor (browser)', () => {
       .dispatchEvent(
         new PointerEvent('pointerup', { bubbles: true, clientX: 400, clientY: 100, pointerId: 93 }),
       )
-    textEditor = page.getByTestId('text-node-editor')
-    ;(textEditor.element() as HTMLTextAreaElement).blur()
+    ;(nodeEditorContent(document) as HTMLElement).blur()
     canvas = onChange.mock.calls.at(-1)![0] as SpatialCanvas
     expect(canvas.nodes).toHaveLength(2)
     await waitFor(() => {
@@ -1928,8 +1925,7 @@ describe('node placement and affordances', () => {
     const editor = page.getByTestId('spatial-editor')
     await addNoteViaMenu()
 
-    const textEditor = page.getByTestId('text-node-editor')
-    await textEditor.fill('typed before clicking away')
+    fillNodeEditor(document, 'typed before clicking away')
 
     // Click far-away empty canvas space rather than blurring the textarea
     // directly — this is the pointerdown-empty path the reducer must commit
@@ -1972,11 +1968,10 @@ describe('node placement and affordances', () => {
     )
     await addNoteViaMenu()
 
-    const textEditor = page.getByTestId('text-node-editor')
-    await textEditor.fill('should be discarded')
-    await textEditor
-      .element()
-      .dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    fillNodeEditor(document, 'should be discarded')
+    nodeEditorContent(document)?.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    )
 
     // The note existed only to hold this edit, so cancelling takes it too —
     // an empty box the user has to clean up is debris, not a discarded edit.

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -141,6 +141,7 @@ import type { GestureState } from './gestures.js'
 import { createIdleState, NEW_NODE_HEIGHT, NEW_NODE_WIDTH, reduceGesture } from './gestures.js'
 import { LinkEmbedLayer } from './LinkEmbedLayer.js'
 import { LinkUrlDialog } from './LinkUrlDialog.js'
+import { MarkdownNodeEditor } from './MarkdownNodeEditor.js'
 import { MemberOutlinesOverlay } from './MemberOutlinesOverlay.js'
 import { MinimapOverlay } from './MinimapOverlay.js'
 import {
@@ -3668,7 +3669,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           {gestureState.kind === 'editing-text' &&
             selectedNode?.type === 'text' &&
             selection !== undefined && (
-              <TextNodeEditor
+              <MarkdownNodeEditor
                 box={selection.box}
                 initialText={selectedNode.text}
                 style={(() => {

--- a/apps/web/src/components/spatial-editor/add-note-real-pointer.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/add-note-real-pointer.browser.test.tsx
@@ -41,7 +41,7 @@ it('a real pointer click on "Note" creates a node and opens its editor', async (
 
   expect(commands).toEqual(['create-node'])
   expect(container.querySelectorAll('svg rect').length).toBeGreaterThan(0)
-  expect(container.querySelectorAll('textarea').length).toBe(1)
+  expect(container.querySelectorAll('[data-testid="text-node-editor"]').length).toBe(1)
 })
 
 it('committing the new note untouched keeps a visible empty node, not a blank canvas', async () => {
@@ -60,6 +60,6 @@ it('committing the new note untouched keeps a visible empty node, not a blank ca
   })
 
   expect(commands[0]).toBe('create-node')
-  expect(container.querySelectorAll('textarea').length).toBe(0)
+  expect(container.querySelectorAll('[data-testid="text-node-editor"]').length).toBe(0)
   expect(container.querySelectorAll('svg rect').length).toBeGreaterThan(0)
 })

--- a/apps/web/src/components/spatial-editor/auto-grow-height.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/auto-grow-height.browser.test.tsx
@@ -9,6 +9,7 @@ import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { fillNodeEditor, nodeEditorContent } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -49,11 +50,11 @@ function rootOf(container: HTMLElement): HTMLElement {
 async function editNodeText(container: HTMLElement, text: string) {
   const root = rootOf(container)
   await userEvent.dblClick(root, { position: { x: 200, y: 130 } })
-  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
-  await userEvent.fill(container.querySelector('textarea') as HTMLTextAreaElement, text)
+  await vi.waitFor(() => expect(nodeEditorContent(container)).not.toBeNull())
+  fillNodeEditor(container, text)
   // Click far outside the node to blur-commit.
   await userEvent.click(root, { position: { x: 700, y: 500 } })
-  await vi.waitFor(() => expect(container.querySelector('textarea')).toBeNull())
+  await vi.waitFor(() => expect(nodeEditorContent(container)).toBeNull())
 }
 
 it('committing a tall body grows the node height to contain it', async () => {

--- a/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 import { CREATION_LABELS } from './creation-labels.js'
+import { nodeEditorContent } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -60,7 +61,7 @@ it('right-clicking a text node opens its action menu; Edit text opens the editor
   await expect.element(page.getByTestId('context-menu')).toBeInTheDocument()
   await userEvent.click(page.getByRole('menuitem', { name: 'Edit text' }))
 
-  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+  await vi.waitFor(() => expect(nodeEditorContent(container)).not.toBeNull())
   expect(container.querySelector('[data-testid="context-menu"]')).toBeNull()
 })
 
@@ -87,7 +88,7 @@ it('right-clicking empty space offers creation at that point', async () => {
   await userEvent.click(page.getByRole('menuitem', { name: 'Note' }))
 
   expect(commands).toContain('create-node')
-  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+  await vi.waitFor(() => expect(nodeEditorContent(container)).not.toBeNull())
 })
 
 it('empty space offers the full creation set, anchored at the click point', async () => {

--- a/apps/web/src/components/spatial-editor/double-press-text-edit.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/double-press-text-edit.browser.test.tsx
@@ -11,6 +11,7 @@ import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { fillNodeEditor, nodeEditorContent, nodeEditorText } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -45,8 +46,8 @@ it('a real double-click on a text node opens its editor with the existing text',
   const { container } = render(<Host />)
   await userEvent.dblClick(rootOf(container), { position: { x: 200, y: 150 } })
 
-  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
-  expect(container.querySelector('textarea')?.value).toBe('hello world')
+  await vi.waitFor(() => expect(nodeEditorContent(container)).not.toBeNull())
+  expect(nodeEditorText(container)).toBe('hello world')
 })
 
 it('a real double-click on an already-selected node still opens the editor', async () => {
@@ -56,7 +57,7 @@ it('a real double-click on an already-selected node still opens the editor', asy
   expect(container.querySelectorAll('[data-testid="selection-overlay"]').length).toBe(1)
 
   await userEvent.dblClick(root, { position: { x: 200, y: 150 } })
-  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+  await vi.waitFor(() => expect(nodeEditorContent(container)).not.toBeNull())
 })
 
 it('a real double-click on empty space creates exactly one node and opens it', async () => {
@@ -65,7 +66,7 @@ it('a real double-click on empty space creates exactly one node and opens it', a
   await userEvent.dblClick(rootOf(container), { position: { x: 600, y: 450 } })
 
   expect(commands.filter((kind) => kind === 'create-node')).toHaveLength(1)
-  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+  await vi.waitFor(() => expect(nodeEditorContent(container)).not.toBeNull())
 })
 
 it('typing into the opened editor and committing persists the text', async () => {
@@ -73,13 +74,12 @@ it('typing into the opened editor and committing persists the text', async () =>
   const { container } = render(<Host onCommand={(kind) => commands.push(kind)} />)
   const root = rootOf(container)
   await userEvent.dblClick(root, { position: { x: 200, y: 150 } })
-  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
-  const textarea = container.querySelector('textarea')
+  await vi.waitFor(() => expect(nodeEditorContent(container)).not.toBeNull())
 
-  await userEvent.fill(textarea as HTMLTextAreaElement, 'edited body')
+  fillNodeEditor(container, 'edited body')
   // Click far outside the node to blur-commit.
   await userEvent.click(root, { position: { x: 700, y: 500 } })
 
   expect(commands).toContain('set-text')
-  expect(container.querySelector('textarea')).toBeNull()
+  expect(nodeEditorContent(container)).toBeNull()
 })

--- a/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
@@ -8,6 +8,7 @@ import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
+import { nodeEditorText } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -51,8 +52,8 @@ it('selecting a node shows one More-actions control; it opens the object menu HE
   await expect.element(page.getByRole('menuitem', { name: 'Edit text' })).toBeInTheDocument()
 
   await userEvent.click(page.getByRole('menuitem', { name: 'Edit text' }))
-  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
-  expect(container.querySelector('textarea')?.value).toBe('hello world')
+  await vi.waitFor(() => expect(nodeEditorText(container)).not.toBeNull())
+  expect(nodeEditorText(container)).toBe('hello world')
 })
 
 it('the More-actions control is keyboard-operable (Enter opens the menu)', async () => {

--- a/apps/web/src/components/spatial-editor/hand-tool.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/hand-tool.browser.test.tsx
@@ -6,6 +6,7 @@ import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { nodeEditorContent } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -266,9 +267,9 @@ it('entering hand mode clears edit state: selection, open text editor, armed con
   // An open text editor closes (uncommitted text is discarded, like Escape).
   fireEvent.click(selectBtn)
   await userEvent.dblClick(root, { position: { x: 150, y: 130 } })
-  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+  await vi.waitFor(() => expect(nodeEditorContent(container)).not.toBeNull())
   fireEvent.click(handBtn)
-  expect(container.querySelector('textarea')).toBeNull()
+  expect(nodeEditorContent(container)).toBeNull()
 
   // An armed connect never completes across the mode switch.
   fireEvent.click(container.querySelector('[data-testid="connect-tool-button"]') as HTMLElement)

--- a/apps/web/src/components/spatial-editor/lost-pointer-capture.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/lost-pointer-capture.browser.test.tsx
@@ -17,6 +17,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
+import { nodeEditorContent } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -77,11 +78,11 @@ it('keeps the node a double-TAP just created when the touch capture is handed ba
   touchTap(root, 600, 450)
   await new Promise((resolve) => setTimeout(resolve, 30))
   touchTap(root, 600, 450)
-  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+  await vi.waitFor(() => expect(nodeEditorContent(container)).not.toBeNull())
 
   expect(commands.filter((kind) => kind === 'create-node')).toHaveLength(1)
   expect(commands).not.toContain('delete-node')
-  expect(container.querySelector('textarea')).not.toBeNull()
+  expect(nodeEditorContent(container)).not.toBeNull()
 })
 
 it('recovers a capture lost while its own finger is still down, mid-pinch', async () => {
@@ -130,7 +131,7 @@ it('recovers a capture lost while its own finger is still down, mid-pinch', asyn
   }
 
   expect(commands).toContain('create-node')
-  expect(container.querySelector('textarea')).not.toBeNull()
+  expect(nodeEditorContent(container)).not.toBeNull()
 })
 
 it('recovers a capture lost mid-resize, which never went through the root press', async () => {
@@ -186,7 +187,7 @@ it('still discards the new node on a real pointercancel', async () => {
   touchTap(root, 600, 450)
   await new Promise((resolve) => setTimeout(resolve, 30))
   touchTap(root, 600, 450)
-  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
+  await vi.waitFor(() => expect(nodeEditorContent(container)).not.toBeNull())
 
   root.dispatchEvent(
     new PointerEvent('pointercancel', { bubbles: true, pointerId: 1, pointerType: 'touch' }),

--- a/apps/web/src/components/spatial-editor/markdown-node-editor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/markdown-node-editor.browser.test.tsx
@@ -18,7 +18,7 @@ function makeHost(text: string) {
     nodes: [{ id: 'n1', type: 'text', x: 100, y: 100, width: 260, height: 120, text }],
     edges: [],
   }
-  const latest: { canvas: SpatialCanvas } = { canvas: start }
+  const latest: { canvas: SpatialCanvas; commands: string[] } = { canvas: start, commands: [] }
   function Host() {
     const [canvas, setCanvas] = useState<SpatialCanvas>(start)
     latest.canvas = canvas
@@ -27,7 +27,11 @@ function makeHost(text: string) {
         <SpatialEditor
           defaultTool="select"
           canvas={canvas}
-          onChange={(next) => setCanvas(next)}
+          onChange={(next, command) => {
+            const flat = command.kind === 'batch' ? command.commands : [command]
+            latest.commands.push(...flat.map((c) => c.kind))
+            setCanvas(next)
+          }}
           theme="light"
         />
       </div>
@@ -117,4 +121,49 @@ it('Enter continues a list item, and Enter on an empty item exits the list', asy
     const node = latest.canvas.nodes[0]
     expect(node?.type === 'text' ? node.text : undefined).toBe('- alpha\n- beta\ndone')
   })
+})
+
+it('click-away commits EXACTLY once — unmount must not fire a second stale commit', async () => {
+  const { Host, latest } = makeHost('start')
+  const { container } = render(<Host />)
+  openEditor(container)
+  await vi.waitFor(() => expect(container.querySelector('.cm-content')).not.toBeNull())
+  await userEvent.keyboard(' typed')
+
+  // The everyday exit: click empty canvas. The gesture reducer commits the
+  // pending text itself and unmounts the editor; EditorView.destroy() then
+  // fires a native blur on the focused content, which must NOT commit again
+  // through the stale pre-unmount closure.
+  const root = rootOf(container)
+  const r = root.getBoundingClientRect()
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 5,
+    clientX: r.left + 700,
+    clientY: r.top + 500,
+  })
+  fireEvent.pointerUp(root, { pointerId: 5, clientX: r.left + 700, clientY: r.top + 500 })
+
+  await vi.waitFor(() => expect(container.querySelector('.cm-content')).toBeNull())
+  const node = latest.canvas.nodes[0]
+  expect(node?.type === 'text' ? node.text : undefined).toBe('start typed')
+  expect(latest.commands.filter((k) => k === 'set-text')).toHaveLength(1)
+})
+
+it('a blur after Escape does not resurrect the cancelled edit as a commit', async () => {
+  const { Host, latest } = makeHost('keep me')
+  const { container } = render(<Host />)
+  openEditor(container)
+  await vi.waitFor(() => expect(container.querySelector('.cm-content')).not.toBeNull())
+  const content = container.querySelector('.cm-content') as HTMLElement
+
+  await userEvent.keyboard(' discarded')
+  content.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+  // A stray blur may still fire while React unmounts the editor.
+  fireEvent.blur(content)
+
+  await vi.waitFor(() => expect(container.querySelector('.cm-content')).toBeNull())
+  const node = latest.canvas.nodes[0]
+  expect(node?.type === 'text' ? node.text : undefined).toBe('keep me')
+  expect(latest.commands.filter((k) => k === 'set-text')).toHaveLength(0)
 })

--- a/apps/web/src/components/spatial-editor/markdown-node-editor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/markdown-node-editor.browser.test.tsx
@@ -1,0 +1,120 @@
+// The node text editor speaks the same markdown as the document editor:
+// CodeMirror with the GFM grammar, the same highlight classes, the same
+// list continuation and Mod-b/i/e wraps. What stays node-shaped is the
+// exit semantics: ⌘Enter COMMITS (the overlay's most important verb — it
+// deliberately outranks the document editor's task-toggle binding), and
+// losing focus commits too, so nothing typed is ever lost.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+function makeHost(text: string) {
+  const start: SpatialCanvas = {
+    nodes: [{ id: 'n1', type: 'text', x: 100, y: 100, width: 260, height: 120, text }],
+    edges: [],
+  }
+  const latest: { canvas: SpatialCanvas } = { canvas: start }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { Host, latest }
+}
+
+const rootOf = (container: HTMLElement) =>
+  container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+function openEditor(container: HTMLElement) {
+  const root = rootOf(container)
+  const r = root.getBoundingClientRect()
+  const at = { clientX: r.left + 200, clientY: r.top + 150 }
+  fireEvent.pointerDown(root, { button: 0, pointerId: 1, ...at })
+  fireEvent.pointerUp(root, { pointerId: 1, ...at })
+  fireEvent.pointerDown(root, { button: 0, pointerId: 1, ...at })
+  fireEvent.pointerUp(root, { pointerId: 1, ...at })
+}
+
+it('the node editor is CodeMirror with markdown highlighting — same grammar as the document editor', async () => {
+  const { Host } = makeHost('plain **bold** text')
+  const { container } = render(<Host />)
+  openEditor(container)
+
+  await vi.waitFor(() => {
+    const editor = container.querySelector('[data-testid="text-node-editor"]')
+    expect(editor).not.toBeNull()
+    expect(editor?.querySelector('.cm-editor')).not.toBeNull()
+  })
+  // The **bold** span carries a highlight class from the shared style —
+  // typing markdown VISIBLY means something while editing.
+  const styled = container.querySelector('[data-testid="text-node-editor"] [class*="cm-md-"]')
+  expect(styled).not.toBeNull()
+})
+
+it('⌘Enter COMMITS — it does not toggle a task checkbox inside a node', async () => {
+  const { Host, latest } = makeHost('- [ ] todo item')
+  const { container } = render(<Host />)
+  openEditor(container)
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="text-node-editor"]')).not.toBeNull(),
+  )
+
+  await userEvent.keyboard('{Control>}{Enter}{/Control}')
+
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="text-node-editor"]')).toBeNull(),
+  )
+  const node = latest.canvas.nodes[0]
+  expect(node?.type === 'text' ? node.text : undefined).toBe('- [ ] todo item')
+})
+
+it('losing focus commits what was typed — nothing is ever lost to a stray click', async () => {
+  const { Host, latest } = makeHost('start')
+  const { container } = render(<Host />)
+  openEditor(container)
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="text-node-editor"] .cm-content')).not.toBeNull(),
+  )
+
+  await userEvent.keyboard(' typed')
+  const content = container.querySelector(
+    '[data-testid="text-node-editor"] .cm-content',
+  ) as HTMLElement
+  fireEvent.blur(content)
+
+  await vi.waitFor(() => {
+    const node = latest.canvas.nodes[0]
+    expect(node?.type === 'text' ? node.text : undefined).toBe('start typed')
+  })
+})
+
+it('Enter continues a list item, and Enter on an empty item exits the list', async () => {
+  const { Host, latest } = makeHost('- alpha')
+  const { container } = render(<Host />)
+  openEditor(container)
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="text-node-editor"] .cm-content')).not.toBeNull(),
+  )
+
+  await userEvent.keyboard('{Enter}beta{Enter}{Enter}done')
+  await userEvent.keyboard('{Control>}{Enter}{/Control}')
+
+  await vi.waitFor(() => {
+    const node = latest.canvas.nodes[0]
+    expect(node?.type === 'text' ? node.text : undefined).toBe('- alpha\n- beta\ndone')
+  })
+})

--- a/apps/web/src/components/spatial-editor/marquee.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/marquee.browser.test.tsx
@@ -6,6 +6,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
+import { nodeEditorContent } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -111,6 +112,6 @@ it('a stationary empty double press still creates a node at the point', async ()
 
   await vi.waitFor(() => {
     expect(latest.nodes.length).toBe(4)
-    expect(container.querySelector('textarea')).not.toBeNull()
+    expect(nodeEditorContent(container)).not.toBeNull()
   })
 })

--- a/apps/web/src/components/spatial-editor/node-editor-test-utils.ts
+++ b/apps/web/src/components/spatial-editor/node-editor-test-utils.ts
@@ -1,0 +1,40 @@
+// Browser-test helpers for the CodeMirror node editor. The old textarea
+// exposed `.value`; CodeMirror renders one `.cm-line` element per document
+// line, so reading and writing go through these instead of ad-hoc
+// selectors duplicated per test file.
+import { fireEvent } from '@testing-library/react'
+
+export const nodeEditor = (container: ParentNode): HTMLElement | null =>
+  container.querySelector('[data-testid="text-node-editor"]')
+
+export const nodeEditorContent = (container: ParentNode): HTMLElement | null =>
+  container.querySelector('[data-testid="text-node-editor"] .cm-content')
+
+/** The open editor's full document, newline-joined; null when closed. */
+export function nodeEditorText(container: ParentNode): string | null {
+  const content = nodeEditorContent(container)
+  if (content === null) return null
+  return Array.from(content.querySelectorAll('.cm-line'))
+    .map((line) => line.textContent ?? '')
+    .join('\n')
+}
+
+/**
+ * Replaces the open editor's document. Select-all + paste, both handled
+ * natively by CodeMirror — paste is deterministic for multiline text where
+ * per-key typing is not.
+ */
+export function fillNodeEditor(container: ParentNode, text: string): void {
+  const content = nodeEditorContent(container)
+  if (content === null) throw new Error('node editor is not open')
+  content.focus()
+  fireEvent.keyDown(content, { key: 'a', ctrlKey: true })
+  const clipboardData = new DataTransfer()
+  clipboardData.setData('text/plain', text)
+  // A REAL ClipboardEvent carrying a real DataTransfer — the init-object
+  // form does not deliver clipboardData to CodeMirror's paste handler.
+  fireEvent(
+    content,
+    new ClipboardEvent('paste', { clipboardData, bubbles: true, cancelable: true }),
+  )
+}

--- a/apps/web/src/components/spatial-editor/select-none.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/select-none.browser.test.tsx
@@ -6,6 +6,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
+import { nodeEditorContent } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -44,9 +45,9 @@ it('keeps the text a node is being edited with selectable', async () => {
   }
 
   await vi.waitFor(() => {
-    const editor = container.querySelector('textarea')
+    const editor = nodeEditorContent(container)
     expect(editor).not.toBeNull()
     // Inherited `none` would leave the caret unable to select its own text.
-    expect(getComputedStyle(editor as HTMLTextAreaElement).userSelect).toBe('text')
+    expect(getComputedStyle(editor as HTMLElement).userSelect).toBe('text')
   })
 })

--- a/apps/web/src/components/spatial-editor/text-edit-experience.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/text-edit-experience.browser.test.tsx
@@ -9,6 +9,7 @@ import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { nodeEditor, nodeEditorContent, nodeEditorText } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -36,10 +37,12 @@ function rootOf(container: HTMLElement): HTMLElement {
   return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
-async function openEditor(container: HTMLElement): Promise<HTMLTextAreaElement> {
+async function openEditor(container: HTMLElement): Promise<HTMLElement> {
   await userEvent.dblClick(rootOf(container), { position: { x: 200, y: 150 } })
-  await vi.waitFor(() => expect(container.querySelector('textarea')).not.toBeNull())
-  return container.querySelector('textarea') as HTMLTextAreaElement
+  await vi.waitFor(() => expect(nodeEditorContent(container)).not.toBeNull())
+  // The WRAPPER carries the parity styles (background, typography); the
+  // CodeMirror surface inside it inherits them.
+  return nodeEditor(container) as HTMLElement
 }
 
 it('covers the rendered text: opaque background matching the node, same typography', async () => {
@@ -58,10 +61,13 @@ it('covers the rendered text: opaque background matching the node, same typograp
 
 it('opens with the caret at the end of the existing text', async () => {
   const { container } = render(<Host />)
-  const editor = await openEditor(container)
+  await openEditor(container)
 
-  expect(editor.selectionStart).toBe('hello world'.length)
-  expect(editor.selectionEnd).toBe('hello world'.length)
+  // Behavioral pin (CodeMirror keeps its selection internal): typing
+  // immediately APPENDS — a caret left at position 0 would prepend and
+  // read as "my text got replaced".
+  await userEvent.keyboard('!')
+  expect(nodeEditorText(container)).toBe('hello world!')
 })
 
 it('uses the dark node fill when the theme is dark', async () => {

--- a/apps/web/src/components/spatial-editor/text-edit-style-parity.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/text-edit-style-parity.browser.test.tsx
@@ -11,6 +11,7 @@ import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
 import { createEditorAppearance } from './editor-appearance.js'
+import { nodeEditor } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -39,16 +40,16 @@ it('the edit overlay box styling equals the rendered chrome (shared theme produc
   const { container } = render(<Host />)
   const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
   await userEvent.dblClick(root, { position: { x: 200, y: 150 } })
-  const textarea = await vi.waitFor(() => {
-    const el = container.querySelector('textarea')
+  const editor = await vi.waitFor(() => {
+    const el = nodeEditor(container)
     expect(el).not.toBeNull()
-    return el as HTMLTextAreaElement
+    return el as HTMLElement
   })
   const resolved = createEditorAppearance('light').resolveNode(node)
-  expect(textarea.style.borderRadius).toBe(`${resolved.radius}px`)
-  expect(textarea.style.padding).toBe(`${SPATIAL_THEME_GEOMETRY.paddingPx}px`)
+  expect(editor.style.borderRadius).toBe(`${resolved.radius}px`)
+  expect(editor.style.padding).toBe(`${SPATIAL_THEME_GEOMETRY.paddingPx}px`)
   // The rendered layout advances one font-size per line (mdast-blocks);
   // the overlay's line height restates that invariant.
-  expect(textarea.style.lineHeight).toBe(`${BODY_FONT_SIZE_PX}px`)
-  expect(textarea.style.fontSize).toBe(`${BODY_FONT_SIZE_PX}px`)
+  expect(editor.style.lineHeight).toBe(`${BODY_FONT_SIZE_PX}px`)
+  expect(editor.style.fontSize).toBe(`${BODY_FONT_SIZE_PX}px`)
 })

--- a/apps/web/src/components/spatial-editor/text-wrap-parity.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/text-wrap-parity.browser.test.tsx
@@ -7,12 +7,13 @@
 // (see text-edit-style-parity.browser.test.tsx's header, which names the
 // same divergence and defers pinning it to here).
 
-import { BODY_FONT_SIZE_PX, SPATIAL_THEME_GEOMETRY } from '@kamiazya/whiteboard-canvas-render'
+import { BODY_FONT_SIZE_PX } from '@kamiazya/whiteboard-canvas-render'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { nodeEditorContent } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -66,10 +67,10 @@ it('pins the CSS-vs-injected-measure wrap-line-count relationship for a canonica
 
   const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
   await userEvent.dblClick(root, { position: { x: 200, y: 110 } })
-  const textarea = await vi.waitFor(() => {
-    const el = container.querySelector('textarea')
+  const cmContent = await vi.waitFor(() => {
+    const el = nodeEditorContent(container)
     expect(el).not.toBeNull()
-    return el as HTMLTextAreaElement
+    return el as HTMLElement
   })
 
   // CSS engine: derive the wrapped line count from scrollHeight using the
@@ -77,7 +78,14 @@ it('pins the CSS-vs-injected-measure wrap-line-count relationship for a canonica
   // own computed lineHeight/fontSize — that would make the mutation check
   // below vacuous, since a lineHeight/fontSize change would just silently
   // relabel itself).
-  const contentHeight = textarea.scrollHeight - 2 * SPATIAL_THEME_GEOMETRY.paddingPx
+  // Measure the line boxes themselves (first line top to last line
+  // bottom): .cm-content's scrollHeight carries a stray extra pixel from
+  // the contenteditable itself, which would break the whole-line check.
+  const lines = [...cmContent.querySelectorAll('.cm-line')]
+  const first = lines[0]?.getBoundingClientRect()
+  const last = lines[lines.length - 1]?.getBoundingClientRect()
+  if (!first || !last) throw new Error('expected at least one rendered line')
+  const contentHeight = last.bottom - first.top
   const cssLineCountRaw = contentHeight / BODY_FONT_SIZE_PX
   // Non-vacuity: must divide out to a whole number of lines using the
   // shared constants, or the arithmetic itself is wrong for this fixture.

--- a/apps/web/src/components/spatial-editor/z-order.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/z-order.browser.test.tsx
@@ -5,6 +5,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it } from 'vitest'
+import { nodeEditorContent } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -95,9 +96,9 @@ it('never fires from a text-entry surface or with a browser modifier held', () =
   fireEvent.pointerUp(root, { pointerId: 2, clientX: 320, clientY: 140 })
   fireEvent.pointerDown(root, { button: 0, pointerId: 3, clientX: 320, clientY: 140 })
   fireEvent.pointerUp(root, { pointerId: 3, clientX: 320, clientY: 140 })
-  const textarea = container.querySelector('textarea')
-  if (textarea !== null) {
-    fireEvent.keyDown(textarea, { code: 'BracketRight', key: ']' })
+  const editorContent = nodeEditorContent(container)
+  if (editorContent !== null) {
+    fireEvent.keyDown(editorContent, { code: 'BracketRight', key: ']' })
     expect(orderOf(latest.canvas)).toEqual(['a', 'b', 'c'])
   }
 })


### PR DESCRIPTION
## What

Phase 1 of the text-editing integration (Canvas Manipulation Lab §⑫, direction A1; complements #853's Phase 0 which made the emphasis *render*). The spatial text node's editor is no longer a bare `<textarea>`: it is a positioned **CodeMirror** overlay built from the document editor's exact ingredients — the GFM grammar, the shared achromatic highlight style, `Mod-b/i/e` wraps, list auto-continuation, and empty-item exit. One grammar, one highlight, one set of habits across both surfaces.

What stays node-shaped (all signed-off requirements, unchanged semantics):
- **⌘Enter commits** — it deliberately outranks the document editor's `Mod-Enter` task toggle (the overlay's most important verb is *done*); pinned by a test on a `- [ ] task` line that must commit unchanged.
- **Losing focus commits** — the signed-off must-keep; pinned.
- **Escape cancels** through the gesture reducer (all the deferred-cut / created-for-edit semantics untouched — the full escape/lost-capture suites pass unmodified in behavior).
- Style parity moves to the wrapper (same fill/font/padding/radius as the rendered node; the opaque background still hides the committed render underneath). Edge/group **label editors keep the plain textarea** — one-line labels have no markdown (signed-off).

`markdownStyleKeymap` / `markdownHighlightStyle` are now exported from `SourcePane` as the single shared source. A small `node-editor-test-utils` module replaces the textarea selectors across ~12 browser test files (CodeMirror renders `.cm-line` per document line; fills go through native select-all + paste). One expectation strengthened: a synthetic Backspace now genuinely edits the text — which is what that test's name always promised.

## Visual

The editor open on a node — markdown source with live highlighting (bold bold, italic italic, code in mono), same typography as the rendered node:

![cm-node-editor.png](https://github.com/user-attachments/assets/d5427c13-0230-4fce-aed9-1fe6c896b0b2)

## Tests

Red-first: `markdown-node-editor.browser.test.tsx` (CM present + highlight classes; ⌘Enter-commits-not-toggles; blur commits typed text; list continuation + empty-item exit). Full runs: web-browser **601/603** (the 2 are the session's known untouched-file load flakes, green in isolation), jsdom exit 0, typecheck / lint / knip clean. The zoom-transform question from the Lab resolved empirically: CodeMirror inside the viewport transform behaves correctly in the real-browser suite (same mount point as the textarea).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ua6RPuoEAD4ZTBqyhNC56Z