### PR TITLE
feat(mcp-server): flip document storage to the shared Libsql backend — one byte store for web and agents

### DIFF
--- a/packages/mcp-server/src/server/routes/canvas/maintenance.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas/maintenance.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import { Hono } from 'hono'
 import { LoroDoc } from 'loro-crdt'
@@ -57,6 +57,9 @@ describe('POST /api/workspaces/:workspaceId/canvases/:path/compact', () => {
   })
 
   it('returns structured 500 for a broken snapshot', async () => {
+    const { LibsqlDocumentStore } = await import('../../store/libsql/libsql-document-store.js')
+    const { chunkSnapshot } = await import('@kamiazya/whiteboard-ports')
+
     await saveDocument('session1', 'canvas-a', new LoroDoc())
     const db = await getDb(tmp.dir)
     const row = await db
@@ -65,8 +68,16 @@ describe('POST /api/workspaces/:workspaceId/canvases/:path/compact', () => {
       .where('workspaceId', '=', 'session1')
       .where('path', '=', 'canvas-a')
       .executeTakeFirstOrThrow()
-    const blobPath = join(tmp.dir, 'blobs', 'session1', 'canvas', `${row.id}.loro`)
-    await writeFile(blobPath, Buffer.from('not-a-loro-snapshot'))
+    // Corrupt the Libsql snapshot rows directly — content no longer lives in
+    // an FS blob for compactDocument to stat/read.
+    const libsqlStore = new LibsqlDocumentStore(db)
+    const { manifest, chunks } = chunkSnapshot(Buffer.from('not-a-loro-snapshot'), 1_000_000)
+    await libsqlStore.saveSnapshot({
+      docRef: { kind: 'canvas', documentId: row.id },
+      manifest,
+      chunks,
+      frontier: new Uint8Array(),
+    })
 
     const app = createCanvasRouter({ versionStore: createVersionStoreMock() })
     const res = await app.request('/api/workspaces/session1/canvases/canvas-a/compact', {

--- a/packages/mcp-server/src/server/routes/canvas/workspaces.test.ts
+++ b/packages/mcp-server/src/server/routes/canvas/workspaces.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import { readDocumentKind } from '@kamiazya/whiteboard-loro-adapter'
 import { Hono } from 'hono'
@@ -101,20 +101,25 @@ describe('POST /api/workspaces/:workspaceId/canvases', () => {
   })
 
   it('returns 500 with Problem Details title when saveDocument fails unexpectedly', async () => {
-    // Block the canvas blob directory with a file so saveDocument throws a
-    // non-ConflictError, exercising the catch-all 500 branch (mutation-check
-    // guard for the 400 -> 500 change).
-    await mkdir(join(tmp.dir, 'blobs', 'ws1'), { recursive: true })
-    await writeFile(join(tmp.dir, 'blobs', 'ws1', 'canvas'), 'not-a-directory')
-    const app = createCanvasRouter()
-    const res = await app.request('/api/workspaces/ws1/canvases', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ path: 'new-canvas' }),
+    // Force the snapshot export saveDocument makes internally to throw, so
+    // it surfaces a non-ConflictError, exercising the catch-all 500 branch
+    // (mutation-check guard for the 400 -> 500 change).
+    const exportSpy = vi.spyOn(LoroDoc.prototype, 'export').mockImplementationOnce(() => {
+      throw new Error('snapshot serialization failed')
     })
-    expect(res.status).toBe(500)
-    const json = (await res.json()) as { title?: string }
-    expect(json.title).toBe('Failed to create canvas.')
+    try {
+      const app = createCanvasRouter()
+      const res = await app.request('/api/workspaces/ws1/canvases', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: 'new-canvas' }),
+      })
+      expect(res.status).toBe(500)
+      const json = (await res.json()) as { title?: string }
+      expect(json.title).toBe('Failed to create canvas.')
+    } finally {
+      exportSpy.mockRestore()
+    }
   })
 
   it('returns 400 with Problem Details title on invalid path', async () => {

--- a/packages/mcp-server/src/server/routes/ws-real-socket.test.ts
+++ b/packages/mcp-server/src/server/routes/ws-real-socket.test.ts
@@ -19,7 +19,7 @@
 // would still visibly create a `.whiteboard` directory under the fake home.
 
 import { existsSync, mkdtempSync, readdirSync } from 'node:fs'
-import { mkdir, mkdtemp, readdir, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { createServer, type Server } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -240,13 +240,21 @@ describe('handleWsUpgrade over a real WebSocketServer + real ws client', () => {
       await closeWsServer(server, wss)
     }
 
-    // Persistence landed under the injected scratch dir: the sqlite db plus
-    // the canvas blob artifact tree, not just the top-level file.
+    // Persistence landed under the injected scratch dir: the sqlite db file,
+    // plus a real Libsql snapshot row for the canvas the socket wrote to
+    // (content lives in the db now, not a separate blob artifact tree).
     expect(existsSync(join(scratchDir, 'whiteboard.db'))).toBe(true)
-    const blobDir = join(scratchDir, 'blobs', 'session1', 'canvas')
-    expect(existsSync(blobDir)).toBe(true)
-    const blobFiles = await readdir(blobDir)
-    expect(blobFiles.length).toBeGreaterThan(0)
+    const { getDb } = await import('../store/db/index.js')
+    const { getDocumentIdByPath } = await import('../store/db/upsert-workspace.js')
+    const db = await getDb(scratchDir)
+    const documentId = await getDocumentIdByPath(db, 'session1', 'canvas-a')
+    expect(documentId).not.toBeNull()
+    const snapshotRow = await db
+      .selectFrom('documentSnapshots')
+      .select(['docKey'])
+      .where('docKey', '=', `canvas:${documentId}`)
+      .executeTakeFirst()
+    expect(snapshotRow).toBeDefined()
 
     // Nothing wrote to the (fake, per-test) home dir. No concurrent process
     // can perturb this directory the way the real ~/.whiteboard can.

--- a/packages/mcp-server/src/server/store/corrupt-stored-data.test.ts
+++ b/packages/mcp-server/src/server/store/corrupt-stored-data.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { corruptStoredData } from './corrupt-stored-data.js'
+
+describe('corruptStoredData', () => {
+  it('defaults to phrasing the argument as a real file location', () => {
+    const error = corruptStoredData('/tmp/blobs/ws/canvas/doc.loro', 'bad bytes')
+    expect(error.message).toBe(
+      'Stored data at "/tmp/blobs/ws/canvas/doc.loro" is corrupt: bad bytes',
+    )
+  })
+
+  // Canvas snapshots now live in Libsql rows, not at the FS path
+  // documentBlobPath() still computes for identity purposes — the message
+  // must not tell an operator to go looking for a file that no longer
+  // exists there.
+  it('phrases an identity-only label without claiming it is a file location', () => {
+    const error = corruptStoredData('/tmp/blobs/ws/canvas/doc.loro', 'bad bytes', {
+      locationKind: 'identity',
+    })
+    expect(error.message).toBe(
+      'Stored canvas data identified by "/tmp/blobs/ws/canvas/doc.loro" is corrupt: bad bytes',
+    )
+    expect(error.message).not.toContain('Stored data at')
+  })
+})

--- a/packages/mcp-server/src/server/store/corrupt-stored-data.ts
+++ b/packages/mcp-server/src/server/store/corrupt-stored-data.ts
@@ -27,6 +27,21 @@ export function isMissingFileError(error: unknown): error is NodeJS.ErrnoExcepti
   )
 }
 
-export function corruptStoredData(path: string, detail: string): CorruptStoredDataError {
-  return new CorruptStoredDataError(`Stored data at "${path}" is corrupt: ${detail}`)
+// `locationKind` defaults to 'file': most callers (thumbnails, uploaded
+// files, blob-store envelopes) pass a real FS path an operator can go
+// inspect. 'identity' is for callers passing a label that is stable and
+// traceable but is NOT where the corrupt bytes actually live (e.g.
+// document-store.ts's canvas snapshots, which moved into Libsql rows but
+// keep their old blob path as an id) — the wording must not send an
+// operator looking for a file that no longer exists.
+export function corruptStoredData(
+  path: string,
+  detail: string,
+  options?: { locationKind?: 'file' | 'identity' },
+): CorruptStoredDataError {
+  const phrase =
+    options?.locationKind === 'identity'
+      ? `Stored canvas data identified by "${path}" is corrupt`
+      : `Stored data at "${path}" is corrupt`
+  return new CorruptStoredDataError(`${phrase}: ${detail}`)
 }

--- a/packages/mcp-server/src/server/store/data-dir-seam.test.ts
+++ b/packages/mcp-server/src/server/store/data-dir-seam.test.ts
@@ -34,7 +34,7 @@ describe('storage layer follows the effective data dir seam', () => {
     rmSync(importBaseDir, { recursive: true, force: true })
   })
 
-  it('persists canvas blobs and the sqlite db under an overridden data dir, not the import-time snapshot', async () => {
+  it('persists canvas snapshots and the sqlite db under an overridden data dir, not the import-time snapshot', async () => {
     overrideDir = mkdtempSync(join(tmpdir(), 'whiteboard-seam-override-'))
     overrideDataDir(overrideDir)
 
@@ -45,9 +45,23 @@ describe('storage layer follows the effective data dir seam', () => {
 
     const overrideEntries = await readdir(overrideDir)
     expect(overrideEntries).toContain('whiteboard.db')
-    expect(existsSync(join(overrideDir, 'blobs', 'ws-seam-test'))).toBe(true)
+
+    // Canvas content lives in the sqlite db's Libsql snapshot tables now,
+    // not a separate blob tree — confirm the row landed under the override
+    // dir's db, keyed to the document just saved.
+    const { getDb } = await import('./db/index.js')
+    const { getDocumentIdByPath } = await import('./db/upsert-workspace.js')
+    const db = await getDb(overrideDir)
+    const documentId = await getDocumentIdByPath(db, 'ws-seam-test', 'seam-canvas')
+    expect(documentId).not.toBeNull()
+    const snapshotRow = await db
+      .selectFrom('documentSnapshots')
+      .select(['docKey'])
+      .where('docKey', '=', `canvas:${documentId}`)
+      .executeTakeFirst()
+    expect(snapshotRow).toBeDefined()
 
     // The import-time snapshot dir must stay untouched by canvas persistence.
-    expect(existsSync(join(importBaseDir, 'blobs'))).toBe(false)
+    expect(existsSync(join(importBaseDir, 'whiteboard.db'))).toBe(false)
   })
 })

--- a/packages/mcp-server/src/server/store/db/prepare.test.ts
+++ b/packages/mcp-server/src/server/store/db/prepare.test.ts
@@ -1,0 +1,86 @@
+// Deploy-sequencing guard for the identity-convergence flip: migration 0011
+// runs its FS-blob import exactly once (Kysely tracks migrations by key), so
+// a blob written by an old process AFTER that one-time run — but before this
+// flip's dataDir is fully warmed up again — would be invisible to the
+// flipped, Libsql-only read path unless prepareDataDir re-invokes the same
+// import routine on every call.
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { generateDocumentId } from '@kamiazya/whiteboard-model'
+import { reassembleSnapshot } from '@kamiazya/whiteboard-ports'
+import { LoroDoc } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { LibsqlDocumentStore } from '../libsql/libsql-document-store.js'
+import { closeDb, getDb } from './index.js'
+import { clearPrepareCache, prepareDataDir } from './prepare.js'
+
+let tempDir: string
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-prepare-test-'))
+})
+
+afterEach(async () => {
+  await closeDb(tempDir)
+  clearPrepareCache()
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+describe('prepareDataDir', () => {
+  it('re-runs the FS-blob import on every call, closing the interim window between a fresh boot and the flip serving reads', async () => {
+    // First boot: migrations (including 0011's one-time tracked run) apply
+    // to an otherwise-empty dataDir.
+    await prepareDataDir(tempDir)
+    const db = await getDb(tempDir)
+
+    const workspaceId = 'ws-interim'
+    const documentId = generateDocumentId()
+    const now = Date.now()
+    await db
+      .insertInto('workspaces')
+      .values({ id: workspaceId, displayName: null, createdAt: now, updatedAt: now })
+      .execute()
+    await db
+      .insertInto('documents')
+      .values({
+        id: documentId,
+        workspaceId,
+        path: 'interim-doc',
+        displayName: null,
+        isPinned: 0,
+        pinOrder: null,
+        currentBranch: 'main',
+        createdAt: now,
+        updatedAt: now,
+        kind: null,
+      })
+      .execute()
+
+    // Simulate an FS-only blob written by an old (pre-flip) process during
+    // the window between 0011's first tracked run and this flip taking over
+    // the read path.
+    const doc = new LoroDoc()
+    doc.getText('content').insert(0, 'written during the interim window')
+    doc.commit()
+    const blobDir = join(tempDir, 'blobs', workspaceId, 'canvas')
+    await mkdir(blobDir, { recursive: true })
+    await writeFile(join(blobDir, `${documentId}.loro`), doc.export({ mode: 'snapshot' }))
+
+    const libsqlStore = new LibsqlDocumentStore(db)
+    const docRef = { kind: 'canvas' as const, documentId }
+    // Nothing has imported the interim blob yet.
+    await expect(libsqlStore.loadSnapshot({ docRef })).resolves.toBeNull()
+
+    // Second boot: a fresh prepareDataDir call, exactly like every daemon
+    // startup makes against the same dataDir.
+    clearPrepareCache()
+    await prepareDataDir(tempDir)
+
+    const imported = await libsqlStore.loadSnapshot({ docRef })
+    expect(imported).not.toBeNull()
+    const reloaded = new LoroDoc()
+    reloaded.import(reassembleSnapshot(imported!.manifest, imported!.chunks))
+    expect(reloaded.getText('content').toString()).toBe('written during the interim window')
+  })
+})

--- a/packages/mcp-server/src/server/store/db/prepare.ts
+++ b/packages/mcp-server/src/server/store/db/prepare.ts
@@ -1,4 +1,6 @@
+import type { Kysely } from 'kysely'
 import { getDb } from './index.js'
+import { importFsBlobs } from './migrations/0011-import-fs-blobs.js'
 import { runMigrations } from './migrator.js'
 
 // Memoized startup hook. Idempotent across repeated calls per dataDir, so
@@ -12,6 +14,19 @@ export function prepareDataDir(dataDir: string): Promise<void> {
   const pending = (async () => {
     const db = await getDb(dataDir)
     await runMigrations(db)
+    // Migration 0011 itself runs exactly once (Kysely tracks it by key).
+    // The identity-convergence flip needs its import routine to run a
+    // SECOND time here, every prepare — closing the window between "0011
+    // ran" and "document-store.ts stopped writing FS blobs", during which
+    // an old process could still write a fresh blob 0011 never saw. Cheap
+    // and idempotent by design (see importFsBlobs's own doc comment).
+    // importFsBlobs takes Kysely<unknown> (it defines its own frozen
+    // migration-time schema — see its doc comment) and Kysely's method
+    // builders are contravariant in their generic params, so the concrete
+    // Database type is not structurally assignable without this cast; the
+    // same widening Kysely's own Migrator performs internally when it calls
+    // migration.up(db).
+    await importFsBlobs(db as unknown as Kysely<unknown>, dataDir)
   })()
   ready.set(dataDir, pending)
   pending.catch(() => {

--- a/packages/mcp-server/src/server/store/document-store.test.ts
+++ b/packages/mcp-server/src/server/store/document-store.test.ts
@@ -236,6 +236,71 @@ describe('saveDocument nests withCanvasDocWriteLock (identity-convergence flip)'
   })
 })
 
+// The lock alone only makes an overwrite ATOMIC — it cannot make it
+// correct. doc-cache holds a long-lived LoroDoc that WS frames mutate in
+// place; an MCP tool writing the same Libsql rows out of band leaves that
+// cached doc stale, and its next save would export the stale state as the
+// whole new truth, erasing the agent's ops in one atomic write. The save
+// path must MERGE the stored snapshot into the outgoing doc first (a CRDT
+// import: known ops are no-ops), so both writers' ops survive.
+describe('saveDocument merges an out-of-band write instead of clobbering it', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-merge-save-test-'))
+    await setupIsolatedDb()
+  })
+
+  afterEach(async () => {
+    await teardownIsolatedDb()
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('a stale cached doc save preserves ops an MCP-style writer stored since it loaded', async () => {
+    const { getDb } = await import('./db/index.js')
+    const { getDataDir } = await import('../config.js')
+    const { getDocumentIdByPath } = await import('./db/upsert-workspace.js')
+    const { LibsqlDocumentStore } = await import('./libsql/libsql-document-store.js')
+    const { chunkSnapshot, reassembleSnapshot } = await import('@kamiazya/whiteboard-ports')
+
+    // Create, then take the "cached" live doc the WS session would hold.
+    const seed = new LoroDoc()
+    seed.getMap('nodes').set('base', { id: 'base' })
+    seed.commit()
+    await saveDocument('session1', 'merge-race', seed, { overwrite: true })
+    const live = await loadDocument('session1', 'merge-race')
+
+    // Out-of-band MCP-style write: an independent load-modify-save straight
+    // through LibsqlDocumentStore, exactly as server-core's document-io does
+    // — the doc-cache (and `live`) never see it.
+    const db = await getDb(getDataDir())
+    const documentId = (await getDocumentIdByPath(db, 'session1', 'merge-race'))!
+    const docRef = { kind: 'canvas' as const, documentId }
+    const store = new LibsqlDocumentStore(db)
+    const agentDoc = new LoroDoc()
+    const existing = await store.loadSnapshot({ docRef })
+    agentDoc.import(reassembleSnapshot(existing!.manifest, existing!.chunks))
+    agentDoc.getMap('nodes').set('agent', { id: 'agent' })
+    agentDoc.commit()
+    const agentSnapshot = agentDoc.export({ mode: 'snapshot' })
+    const { manifest, chunks } = chunkSnapshot(agentSnapshot, 1_000_000)
+    await store.saveSnapshot({
+      docRef,
+      manifest,
+      chunks,
+      frontier: agentDoc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+    })
+
+    // The stale cached doc makes its own edit and saves.
+    live.getMap('nodes').set('web', { id: 'web' })
+    live.commit()
+    await saveDocument('session1', 'merge-race', live, { overwrite: true })
+
+    // Both writers' ops must survive in the stored truth.
+    const reloaded = await loadDocument('session1', 'merge-race')
+    const keys = reloaded.getMap('nodes').keys().sort()
+    expect(keys).toEqual(['agent', 'base', 'web'])
+  })
+})
+
 describe('legacy LoroList -> MovableList migration reads and persists through Libsql (identity-convergence flip)', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-legacy-migrate-test-'))

--- a/packages/mcp-server/src/server/store/document-store.test.ts
+++ b/packages/mcp-server/src/server/store/document-store.test.ts
@@ -1049,6 +1049,99 @@ describe('compactDocument', () => {
     expect(stamp!).toBeGreaterThanOrEqual(before)
     expect(stamp!).toBeLessThanOrEqual(after)
   })
+
+  // compactDocument's beforeBytes read and its internal doc reload both ran
+  // unlocked before this test's fix, with only the final shallow-snapshot
+  // write taking withCanvasDocWriteLock. A concurrent canvas-doc write (an
+  // MCP tool call, or a WS/HTTP save) landing in that unlocked window was
+  // captured by neither read, so compactDocument's later write silently
+  // discarded it — the same lost-update class saveDocument's own write
+  // already guards against, now reachable against compaction too because
+  // both paths write the same Libsql rows.
+  it('does not lose a concurrent canvas-doc write racing into the window between compactDocument reading the doc and writing its shallow snapshot', async () => {
+    const { getDb } = await import('./db/index.js')
+    const { getDataDir } = await import('../config.js')
+    const { getDocumentIdByPath } = await import('./db/upsert-workspace.js')
+    const { LibsqlDocumentStore } = await import('./libsql/libsql-document-store.js')
+    const { chunkSnapshot, reassembleSnapshot } = await import('@kamiazya/whiteboard-ports')
+    const { withCanvasDocWriteLock } = await import('./workspace-lock.js')
+
+    const doc = new LoroDoc()
+    const list = doc.getMovableList('elements')
+    for (let i = 0; i < 30; i++) {
+      const m = list.insertContainer(list.length, new LoroMap())
+      m.set('id', `elem-${i}`)
+    }
+    doc.commit()
+    await saveDocument('session1', 'test', doc)
+
+    const store = new FileVersionStore()
+    await store.save('session1', 'test', doc, { auto: true })
+
+    for (let i = 0; i < 30; i++) {
+      const m = list.insertContainer(list.length, new LoroMap())
+      m.set('id', `extra-${i}`)
+    }
+    doc.commit()
+    await saveDocument('session1', 'test', doc, { overwrite: true })
+
+    const db = await getDb(getDataDir())
+    const documentId = (await getDocumentIdByPath(db, 'session1', 'test'))!
+
+    // Delay only compactDocument's SECOND loadSnapshot call for this
+    // document (its internal doc reload, after the beforeBytes read) —
+    // AFTER it has already captured the pre-race bytes, so the delay opens
+    // a real wall-clock window without changing what compactDocument reads.
+    const originalLoadSnapshot = LibsqlDocumentStore.prototype.loadSnapshot
+    let loadCallsForDoc = 0
+    LibsqlDocumentStore.prototype.loadSnapshot = async function (
+      this: InstanceType<typeof LibsqlDocumentStore>,
+      input,
+    ) {
+      const forThisDoc = input.docRef.kind === 'canvas' && input.docRef.documentId === documentId
+      const result = await originalLoadSnapshot.call(this, input)
+      if (forThisDoc) {
+        loadCallsForDoc++
+        if (loadCallsForDoc === 2) {
+          await new Promise((r) => setTimeout(r, 60))
+        }
+      }
+      return result
+    }
+
+    try {
+      const compactPromise = compactDocument('session1', 'test', store)
+
+      // Give compactDocument a head start so it is mid-delay inside its
+      // second (doc-reload) read before this fires from a genuinely
+      // separate call chain (not nested inside compactDocument's own).
+      await new Promise((r) => setTimeout(r, 20))
+      const concurrentWrite = withCanvasDocWriteLock(documentId, async () => {
+        const libsqlStore = new LibsqlDocumentStore(db)
+        const existing = await libsqlStore.loadSnapshot({
+          docRef: { kind: 'canvas', documentId },
+        })
+        const base = new LoroDoc()
+        base.import(reassembleSnapshot(existing!.manifest, existing!.chunks))
+        base.getMap('root').set('agentMarker', 'concurrent-edit')
+        base.commit()
+        const chunked = chunkSnapshot(base.export({ mode: 'snapshot' }), 1_000_000)
+        await libsqlStore.saveSnapshot({
+          docRef: { kind: 'canvas', documentId },
+          manifest: chunked.manifest,
+          chunks: chunked.chunks,
+          frontier: base.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+        })
+      })
+
+      await Promise.all([compactPromise, concurrentWrite])
+    } finally {
+      LibsqlDocumentStore.prototype.loadSnapshot = originalLoadSnapshot
+    }
+
+    const after = await loadDocument('session1', 'test')
+    expect(after.getMap('root').get('agentMarker')).toBe('concurrent-edit')
+  })
 })
 
 describe('deleteDocument', () => {

--- a/packages/mcp-server/src/server/store/document-store.test.ts
+++ b/packages/mcp-server/src/server/store/document-store.test.ts
@@ -325,6 +325,24 @@ describe('saveDocument / loadDocument', () => {
     expect(loaded.getMovableList('elements').length).toBe(0)
   })
 
+  it("persists the frontier bytes as the doc's own oplog version, readable back via LibsqlDocumentStore.readFrontier", async () => {
+    const { getDb } = await import('./db/index.js')
+    const { getDocumentIdByPath } = await import('./db/upsert-workspace.js')
+    const { LibsqlDocumentStore } = await import('./libsql/libsql-document-store.js')
+    const doc = new LoroDoc()
+    doc.getMovableList('elements').insert(0, 'x')
+    doc.commit()
+    await saveDocument('session1', 'frontier-check', doc)
+
+    const db = await getDb(tempDir)
+    const documentId = await getDocumentIdByPath(db, 'session1', 'frontier-check')
+    const store = new LibsqlDocumentStore(db)
+    const result = await store.readFrontier({
+      docRef: { kind: 'canvas', documentId: documentId! },
+    })
+    expect(result?.frontier).toEqual(doc.oplogVersion().encode())
+  })
+
   it('mints a canonical ULID for a new row, so both writers share one id space', async () => {
     // The document index and saveDocument both create rows in the same table.
     // The index mints ULIDs (the port's DocumentEntry accepts nothing else),
@@ -964,6 +982,19 @@ describe('compactDocument', () => {
     const past = await store.load('session1', v.id, live)
     expect(past).not.toBeNull()
     expect(past!.getMovableList('elements').length).toBe(30)
+
+    // Compaction prunes history, not state, so the frontier written for the
+    // shallow snapshot must still match the doc's current oplog version.
+    const { getDb } = await import('./db/index.js')
+    const { getDocumentIdByPath } = await import('./db/upsert-workspace.js')
+    const { LibsqlDocumentStore } = await import('./libsql/libsql-document-store.js')
+    const db = await getDb(tempDir)
+    const documentId = await getDocumentIdByPath(db, 'session1', 'test')
+    const libsqlStore = new LibsqlDocumentStore(db)
+    const frontierResult = await libsqlStore.readFrontier({
+      docRef: { kind: 'canvas', documentId: documentId! },
+    })
+    expect(frontierResult?.frontier).toEqual(live.oplogVersion().encode())
   })
 
   it('writes lastCompactedAt only on successful compaction', async () => {

--- a/packages/mcp-server/src/server/store/document-store.test.ts
+++ b/packages/mcp-server/src/server/store/document-store.test.ts
@@ -1,7 +1,7 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { LoroDoc } from 'loro-crdt'
+import { dirname, join } from 'node:path'
+import { LoroDoc, LoroMap } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Swap DATA_DIR to a temp directory through vi.mock.
@@ -46,6 +46,261 @@ async function setupIsolatedDb(): Promise<void> {
 async function teardownIsolatedDb(): Promise<void> {
   await handle.dispose()
 }
+
+// Identity-convergence flip: loadDocument/saveDocument must read/write
+// through the SAME LibsqlDocumentStore rows the MCP tool surface uses,
+// instead of a separate FS blob tree the two paths cannot see into each
+// other's writes. RED today: loadDocument still reads only the FS blob, so
+// content seeded directly into the Libsql snapshot tables reads back empty.
+describe('loadDocument reads through LibsqlDocumentStore (identity-convergence flip)', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-flip-test-'))
+    await setupIsolatedDb()
+  })
+
+  afterEach(async () => {
+    await teardownIsolatedDb()
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('returns real content seeded directly into the Libsql snapshot tables, not an empty doc', async () => {
+    const { getDb } = await import('./db/index.js')
+    const { getDataDir } = await import('../config.js')
+    const { upsertCanvasRow } = await import('./db/upsert-workspace.js')
+    const { LibsqlDocumentStore } = await import('./libsql/libsql-document-store.js')
+    const { chunkSnapshot } = await import('@kamiazya/whiteboard-ports')
+
+    const db = await getDb(getDataDir())
+    const documentId = await upsertCanvasRow(db, 'session1', 'seeded')
+
+    const seedDoc = new LoroDoc()
+    seedDoc.getText('content').insert(0, 'real content')
+    seedDoc.commit()
+    const { manifest, chunks } = chunkSnapshot(seedDoc.export({ mode: 'snapshot' }), 1_000_000)
+    const store = new LibsqlDocumentStore(db)
+    await store.saveSnapshot({
+      docRef: { kind: 'canvas', documentId },
+      manifest,
+      chunks,
+      frontier: seedDoc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+    })
+
+    const loaded = await loadDocument('session1', 'seeded')
+    expect(loaded.getText('content').toString()).toBe('real content')
+  })
+
+  it('a saveDocument write is immediately visible through LibsqlDocumentStore.loadSnapshot directly', async () => {
+    const { getDb } = await import('./db/index.js')
+    const { getDataDir } = await import('../config.js')
+    const { getDocumentIdByPath } = await import('./db/upsert-workspace.js')
+    const { LibsqlDocumentStore } = await import('./libsql/libsql-document-store.js')
+    const { reassembleSnapshot } = await import('@kamiazya/whiteboard-ports')
+
+    const doc = new LoroDoc()
+    doc.getText('content').insert(0, 'written via saveDocument')
+    doc.commit()
+    await saveDocument('session1', 'write-through', doc)
+
+    const db = await getDb(getDataDir())
+    const documentId = await getDocumentIdByPath(db, 'session1', 'write-through')
+    expect(documentId).not.toBeNull()
+    const store = new LibsqlDocumentStore(db)
+    const snapshot = await store.loadSnapshot({
+      docRef: { kind: 'canvas', documentId: documentId! },
+    })
+    expect(snapshot).not.toBeNull()
+    const reloaded = new LoroDoc()
+    reloaded.import(reassembleSnapshot(snapshot!.manifest, snapshot!.chunks))
+    expect(reloaded.getText('content').toString()).toBe('written via saveDocument')
+  })
+})
+
+// Lock-namespace unification: saveDocument (the HTTP/WS path) and every
+// mutating MCP tool now write the SAME LibsqlDocumentStore rows, so they
+// must serialize on the SAME per-document queue (workspace-lock.ts's
+// withCanvasDocWriteLock) or one writer's saveSnapshot transaction can land
+// concurrently with another's on a single shared db connection. Before the
+// flip this was harmless (the two paths wrote disjoint storage); after it,
+// it is the same lost-update class canvas-doc-write-lock.test.ts already
+// pins for two unserialized MCP calls, now reachable from a THIRD writer
+// (saveDocument) that has no lock of its own.
+describe('saveDocument nests withCanvasDocWriteLock (identity-convergence flip)', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-lock-race-test-'))
+    await setupIsolatedDb()
+  })
+
+  afterEach(async () => {
+    await teardownIsolatedDb()
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('a concurrent saveDocument write is never interleaved into an MCP-tool-style write holding the canvas-doc lock on the same document', async () => {
+    const { getDb } = await import('./db/index.js')
+    const { getDataDir } = await import('../config.js')
+    const { getDocumentIdByPath } = await import('./db/upsert-workspace.js')
+    const { LibsqlDocumentStore } = await import('./libsql/libsql-document-store.js')
+    const { chunkSnapshot } = await import('@kamiazya/whiteboard-ports')
+    const { withCanvasDocWriteLock } = await import('./workspace-lock.js')
+
+    await saveDocument('session1', 'race', new LoroDoc())
+    const db = await getDb(getDataDir())
+    const documentId = (await getDocumentIdByPath(db, 'session1', 'race'))!
+    const docRef = { kind: 'canvas' as const, documentId }
+
+    // Patch the class prototype (not one instance) so this observes every
+    // saveSnapshot call for this document, including document-store.ts's
+    // own internally-cached LibsqlDocumentStore instance.
+    const events: string[] = []
+    const originalSaveSnapshot = LibsqlDocumentStore.prototype.saveSnapshot
+    let delayedOnce = false
+    LibsqlDocumentStore.prototype.saveSnapshot = async function (
+      this: InstanceType<typeof LibsqlDocumentStore>,
+      input,
+    ) {
+      const forThisDoc = input.docRef.kind === 'canvas' && input.docRef.documentId === documentId
+      if (forThisDoc) events.push('save-start')
+      // Hold the FIRST save call open (the tool's) so a concurrent,
+      // unserialized saveDocument call has a real window to land its own
+      // save call before the tool's completes — the exact interleaving
+      // the canvas-doc lock exists to rule out.
+      if (forThisDoc && !delayedOnce) {
+        delayedOnce = true
+        await new Promise((r) => setTimeout(r, 50))
+      }
+      const result = await originalSaveSnapshot.call(this, input)
+      if (forThisDoc) events.push('save-end')
+      return result
+    }
+
+    try {
+      const toolWrite = withCanvasDocWriteLock(documentId, async () => {
+        events.push('tool-critical-section-start')
+        const libsqlStore = new LibsqlDocumentStore(db)
+        const doc = new LoroDoc()
+        doc.getMap('root').set('marker', 'tool')
+        doc.commit()
+        const { manifest, chunks } = chunkSnapshot(doc.export({ mode: 'snapshot' }), 1_000_000)
+        await libsqlStore.saveSnapshot({
+          docRef,
+          manifest,
+          chunks,
+          frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+        })
+        events.push('tool-critical-section-end')
+      })
+
+      // Give the tool a head start so it acquires the lock and enters its
+      // (delayed) save before the HTTP write races in.
+      await new Promise((r) => setTimeout(r, 5))
+      const httpDoc = new LoroDoc()
+      httpDoc.getMap('root').set('marker', 'http')
+      httpDoc.commit()
+      const httpWrite = saveDocument('session1', 'race', httpDoc, { overwrite: true })
+
+      await Promise.all([toolWrite, httpWrite])
+    } finally {
+      LibsqlDocumentStore.prototype.saveSnapshot = originalSaveSnapshot
+    }
+
+    // Every save-start for this document is either the tool's own single
+    // save (inside its critical section) or one that started only AFTER
+    // the tool's critical section fully released — never one that started
+    // WHILE the tool's save was still in flight (the lost-update/torn-write
+    // window this slice's lock unification closes).
+    const startIdx = events.indexOf('tool-critical-section-start')
+    const endIdx = events.indexOf('tool-critical-section-end')
+    expect(startIdx).toBeGreaterThanOrEqual(0)
+    expect(endIdx).toBeGreaterThan(startIdx)
+    const saveStarts = events
+      .map((e, i) => [e, i] as const)
+      .filter(([e]) => e === 'save-start')
+      .map(([, i]) => i)
+    expect(saveStarts.length).toBe(2)
+    // Exactly one save-start may fall inside the tool's critical section —
+    // its own. Any OTHER save-start landing in that same window means a
+    // second writer's transaction started while the tool's was still open;
+    // the events array records only ARRIVAL order, so without this exact
+    // count check two same-window save-starts would each individually look
+    // "inside the tool's window" and the loop below would wrongly wave both
+    // through.
+    const withinToolWindow = saveStarts.filter((i) => i > startIdx && i < endIdx)
+    expect(
+      withinToolWindow.length,
+      `save-start(s) landed inside the tool's critical section: ${JSON.stringify(withinToolWindow)}; events were ${events.join(',')}`,
+    ).toBe(1)
+    for (const i of saveStarts) {
+      if (withinToolWindow.includes(i)) continue
+      expect(i, `save-start at index ${i}; events were ${events.join(',')}`).toBeGreaterThan(endIdx)
+    }
+  })
+})
+
+describe('legacy LoroList -> MovableList migration reads and persists through Libsql (identity-convergence flip)', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-legacy-migrate-test-'))
+    await setupIsolatedDb()
+  })
+
+  afterEach(async () => {
+    await teardownIsolatedDb()
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('migrates a legacy LoroList doc seeded directly in Libsql, persists the movable list back through saveDocument, and backs up the pre-migration bytes', async () => {
+    const { getDb } = await import('./db/index.js')
+    const { getDataDir } = await import('../config.js')
+    const { upsertCanvasRow } = await import('./db/upsert-workspace.js')
+    const { LibsqlDocumentStore } = await import('./libsql/libsql-document-store.js')
+    const { chunkSnapshot } = await import('@kamiazya/whiteboard-ports')
+    const { access } = await import('node:fs/promises')
+
+    const db = await getDb(getDataDir())
+    const documentId = await upsertCanvasRow(db, 'session1', 'legacy')
+
+    // Build a legacy doc: elements stored in a plain LoroList, the shape
+    // migrateLegacyListToMovable repairs on load. No production code writes
+    // this shape any more, so it is constructed directly here.
+    const legacyDoc = new LoroDoc()
+    const list = legacyDoc.getList('elements')
+    const item = list.insertContainer(0, new LoroMap())
+    item.set('id', 'legacy-elem')
+    item.set('type', 'rectangle')
+    legacyDoc.commit()
+    const legacyBytes = legacyDoc.export({ mode: 'snapshot' })
+    const { manifest, chunks } = chunkSnapshot(legacyBytes, 1_000_000)
+    const store = new LibsqlDocumentStore(db)
+    await store.saveSnapshot({
+      docRef: { kind: 'canvas', documentId },
+      manifest,
+      chunks,
+      frontier: legacyDoc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+    })
+
+    const loaded = await loadDocument('session1', 'legacy')
+    const movable = loaded.getMovableList('elements').toJSON() as { id: string; type: string }[]
+    expect(movable).toHaveLength(1)
+    expect(movable[0].id).toBe('legacy-elem')
+    expect(loaded.getList('elements').length).toBe(0)
+
+    // Persisted back through saveDocument (the migration's own side effect):
+    // a fresh load must see the movable list, not the legacy shape again.
+    const reloaded = await loadDocument('session1', 'legacy')
+    const reloadedMovable = reloaded.getMovableList('elements').toJSON() as { id: string }[]
+    expect(reloadedMovable).toEqual(movable)
+
+    // Pre-migration bytes were backed up next to the (otherwise unused)
+    // blob path, fixing the cwd-relative bak-path bug in the pre-flip code.
+    const bakPath = join(
+      tempDir,
+      'blobs',
+      'session1',
+      'canvas',
+      `${documentId}.loro.pre-migrate-bak`,
+    )
+    await expect(access(bakPath)).resolves.toBeUndefined()
+  })
+})
 
 describe('saveDocument / loadDocument', () => {
   beforeEach(async () => {
@@ -147,16 +402,23 @@ describe('saveDocument / loadDocument', () => {
 
   it('throws on broken snapshots instead of returning an empty LoroDoc', async () => {
     const { getDb } = await import('./db/index.js')
+    const { getDocumentIdByPath } = await import('./db/upsert-workspace.js')
+    const { LibsqlDocumentStore } = await import('./libsql/libsql-document-store.js')
+    const { chunkSnapshot } = await import('@kamiazya/whiteboard-ports')
     await saveDocument('session1', 'broken', new LoroDoc())
     const db = await getDb(tempDir)
-    const row = await db
-      .selectFrom('documents')
-      .select(['id'])
-      .where('workspaceId', '=', 'session1')
-      .where('path', '=', 'broken')
-      .executeTakeFirstOrThrow()
-    const blobPath = join(tempDir, 'blobs', 'session1', 'canvas', `${row.id}.loro`)
-    await writeFile(blobPath, Buffer.from('not-a-loro-snapshot'))
+    const documentId = await getDocumentIdByPath(db, 'session1', 'broken')
+    // Overwrite the Libsql snapshot rows directly with bytes that are not a
+    // valid Loro snapshot — the corruption a Libsql-backed store can suffer,
+    // now that content no longer lives in an FS blob.
+    const store = new LibsqlDocumentStore(db)
+    const { manifest, chunks } = chunkSnapshot(Buffer.from('not-a-loro-snapshot'), 1_000_000)
+    await store.saveSnapshot({
+      docRef: { kind: 'canvas', documentId: documentId! },
+      manifest,
+      chunks,
+      frontier: new Uint8Array(),
+    })
 
     await expect(loadDocument('session1', 'broken')).rejects.toThrow()
   })
@@ -638,23 +900,31 @@ describe('compactDocument', () => {
 
   it('treats invalid snapshots as corruption instead of falling back to empty state', async () => {
     const { getDb } = await import('./db/index.js')
+    const { getDocumentIdByPath } = await import('./db/upsert-workspace.js')
+    const { LibsqlDocumentStore } = await import('./libsql/libsql-document-store.js')
+    const { chunkSnapshot } = await import('@kamiazya/whiteboard-ports')
     const doc = new LoroDoc()
     const store = new FileVersionStore()
     await saveDocument('session1', 'broken', doc)
     await store.save('session1', 'broken', doc, { auto: true })
     const db = await getDb(tempDir)
-    const row = await db
-      .selectFrom('documents')
-      .select(['id'])
-      .where('workspaceId', '=', 'session1')
-      .where('path', '=', 'broken')
-      .executeTakeFirstOrThrow()
-    const blobPath = join(tempDir, 'blobs', 'session1', 'canvas', `${row.id}.loro`)
-    await writeFile(blobPath, Buffer.from('not-a-loro-snapshot'))
+    const documentId = await getDocumentIdByPath(db, 'session1', 'broken')
+    // Corrupt the Libsql snapshot rows directly — compactDocument's
+    // beforeBytes read succeeds (the header is intact), but its internal
+    // loadDocument() call decodes the garbage chunk bytes and must surface
+    // corruption rather than a silently-empty compaction.
+    const libsqlStore = new LibsqlDocumentStore(db)
+    const { manifest, chunks } = chunkSnapshot(Buffer.from('not-a-loro-snapshot'), 1_000_000)
+    await libsqlStore.saveSnapshot({
+      docRef: { kind: 'canvas', documentId: documentId! },
+      manifest,
+      chunks,
+      frontier: new Uint8Array(),
+    })
 
     await expect(compactDocument('session1', 'broken', store)).rejects.toMatchObject({
       name: 'CorruptStoredDataError',
-      message: expect.stringContaining(`${row.id}.loro`),
+      message: expect.stringContaining(`${documentId}.loro`),
     })
   })
 
@@ -763,10 +1033,11 @@ describe('deleteDocument', () => {
     await rm(tempDir, { recursive: true, force: true })
   })
 
-  it('removes the canvases row, cascades branches/versions rows, and unlinks the .loro blob and version thumbnail PNGs, leaving the workspace row and a sibling canvas untouched', async () => {
+  it('removes the canvases row, cascades branches/versions rows, deletes the Libsql snapshot rows, and unlinks the version thumbnail PNGs, leaving the workspace row and a sibling canvas untouched', async () => {
     const { getDb } = await import('./db/index.js')
     const { createBranch } = await import('./branches-store.js')
     const { stat } = await import('node:fs/promises')
+    const { LibsqlDocumentStore } = await import('./libsql/libsql-document-store.js')
 
     const doc = new LoroDoc()
     await saveDocument('session1', 'canvas-a', doc)
@@ -784,10 +1055,11 @@ describe('deleteDocument', () => {
       .where('path', '=', 'canvas-a')
       .executeTakeFirstOrThrow()
     const documentId = canvasRow.id
+    const docRef = { kind: 'canvas' as const, documentId }
+    const libsqlStore = new LibsqlDocumentStore(db)
 
-    const blobPath = join(tempDir, 'blobs', 'session1', 'canvas', `${documentId}.loro`)
     const thumbPath = join(tempDir, 'blobs', 'session1', 'versions', `${version.id}.png`)
-    await expect(stat(blobPath)).resolves.toBeDefined()
+    await expect(libsqlStore.loadSnapshot({ docRef })).resolves.not.toBeNull()
     await expect(stat(thumbPath)).resolves.toBeDefined()
 
     await expect(deleteDocument('session1', 'canvas-a')).resolves.toBe(true)
@@ -811,7 +1083,8 @@ describe('deleteDocument', () => {
       .execute()
     expect(versionsAfter).toEqual([])
 
-    await expect(stat(blobPath)).rejects.toThrow()
+    await expect(libsqlStore.loadSnapshot({ docRef })).resolves.toBeNull()
+    await expect(libsqlStore.readFrontier({ docRef })).resolves.toBeNull()
     await expect(stat(thumbPath)).rejects.toThrow()
 
     const wsRow = await db
@@ -831,7 +1104,7 @@ describe('deleteDocument', () => {
 
   it('removes the .pre-migrate-bak file the legacy migration leaves beside the blob', async () => {
     const { getDb } = await import('./db/index.js')
-    const { stat, writeFile } = await import('node:fs/promises')
+    const { mkdir, stat, writeFile } = await import('node:fs/promises')
 
     await saveDocument('session1', 'migrated', new LoroDoc())
     const db = await getDb(tempDir)
@@ -842,6 +1115,10 @@ describe('deleteDocument', () => {
       .where('path', '=', 'migrated')
       .executeTakeFirstOrThrow()
     const bakPath = join(tempDir, 'blobs', 'session1', 'canvas', `${row.id}.loro.pre-migrate-bak`)
+    // saveDocument no longer creates the blob directory (no FS blob is
+    // written on the happy path), so the bak file's parent has to be made
+    // explicitly here.
+    await mkdir(dirname(bakPath), { recursive: true })
     await writeFile(bakPath, new Uint8Array([9, 9, 9]))
 
     await expect(deleteDocument('session1', 'migrated')).resolves.toBe(true)
@@ -856,10 +1133,12 @@ describe('deleteDocument', () => {
     await expect(deleteDocument('session1', 'once')).resolves.toBe(false)
   })
 
-  it('deletes a canvas whose blob file is already missing (unlink ignores ENOENT so row-only canvases still delete)', async () => {
+  it('deletes a canvas whose FS blob was never written (unlinkIfExists ignores ENOENT so Libsql-only canvases still delete)', async () => {
     const { getDb } = await import('./db/index.js')
-    const { unlink } = await import('node:fs/promises')
 
+    // saveDocument no longer writes an FS blob at all — this is the normal
+    // case post-flip, not a simulated failure, but deleteDocument's
+    // unconditional unlinkIfExists(blobPath) call must still no-op cleanly.
     await saveDocument('session1', 'row-only', new LoroDoc())
     const db = await getDb(tempDir)
     const row = await db
@@ -868,8 +1147,6 @@ describe('deleteDocument', () => {
       .where('workspaceId', '=', 'session1')
       .where('path', '=', 'row-only')
       .executeTakeFirstOrThrow()
-    const blobPath = join(tempDir, 'blobs', 'session1', 'canvas', `${row.id}.loro`)
-    await unlink(blobPath)
 
     await expect(deleteDocument('session1', 'row-only')).resolves.toBe(true)
     const after = await db
@@ -894,10 +1171,11 @@ describe('renameDocumentPath', () => {
     await rm(tempDir, { recursive: true, force: true })
   })
 
-  it('moves only the path: branches/versions rows and the .loro blob stay byte-identical and keyed to the same documentId', async () => {
+  it('moves only the path: branches/versions rows and the Libsql snapshot stay byte-identical and keyed to the same documentId', async () => {
     const { getDb } = await import('./db/index.js')
     const { createBranch, loadCanvasBranches } = await import('./branches-store.js')
-    const { readFile } = await import('node:fs/promises')
+    const { LibsqlDocumentStore } = await import('./libsql/libsql-document-store.js')
+    const { reassembleSnapshot } = await import('@kamiazya/whiteboard-ports')
 
     const doc = new LoroDoc()
     await saveDocument('session1', 'a', doc)
@@ -913,8 +1191,11 @@ describe('renameDocumentPath', () => {
       .where('path', '=', 'a')
       .executeTakeFirstOrThrow()
     const documentId = before.id
-    const blobPath = join(tempDir, 'blobs', 'session1', 'canvas', `${documentId}.loro`)
-    const blobBefore = await readFile(blobPath)
+    const libsqlStore = new LibsqlDocumentStore(db)
+    const docRef = { kind: 'canvas' as const, documentId }
+    const snapshotBefore = await libsqlStore.loadSnapshot({ docRef })
+    if (snapshotBefore === null) throw new Error('expected a snapshot')
+    const blobBefore = reassembleSnapshot(snapshotBefore.manifest, snapshotBefore.chunks)
 
     await expect(renameDocumentPath('session1', 'a', 'b')).resolves.toEqual({ documentId })
 
@@ -943,7 +1224,9 @@ describe('renameDocumentPath', () => {
       .execute()
     expect(versionsAfter.map((v) => v.id)).toEqual([version.id])
 
-    const blobAfter = await readFile(blobPath)
+    const snapshotAfter = await libsqlStore.loadSnapshot({ docRef })
+    if (snapshotAfter === null) throw new Error('expected a snapshot')
+    const blobAfter = reassembleSnapshot(snapshotAfter.manifest, snapshotAfter.chunks)
     expect(blobAfter).toEqual(blobBefore)
 
     // loadCanvasBranches also resolves under the new path.

--- a/packages/mcp-server/src/server/store/document-store.ts
+++ b/packages/mcp-server/src/server/store/document-store.ts
@@ -255,18 +255,24 @@ export async function loadDocument(workspaceId: string, path: string): Promise<L
     try {
       originalBytes = reassembleSnapshot(snapshot.manifest, snapshot.chunks)
     } catch (error) {
-      throw corruptStoredData(blobPath, `invalid canvas snapshot chunks (${errorMessage(error)})`)
+      throw corruptStoredData(blobPath, `invalid canvas snapshot chunks (${errorMessage(error)})`, {
+        locationKind: 'identity',
+      })
     }
     try {
       doc = LoroDoc.fromSnapshot(originalBytes)
     } catch (error) {
-      throw corruptStoredData(blobPath, `invalid canvas snapshot (${errorMessage(error)})`)
+      throw corruptStoredData(blobPath, `invalid canvas snapshot (${errorMessage(error)})`, {
+        locationKind: 'identity',
+      })
     }
   } catch (error) {
     if (isCorruptStoredDataError(error)) {
       throw error
     }
-    throw corruptStoredData(blobPath, `failed to read canvas snapshot (${errorMessage(error)})`)
+    throw corruptStoredData(blobPath, `failed to read canvas snapshot (${errorMessage(error)})`, {
+      locationKind: 'identity',
+    })
   }
   // One-shot legacy container migration. Older data stored "elements" in
   // LoroList; current code uses LoroMovableList. Repair on load and rewrite.

--- a/packages/mcp-server/src/server/store/document-store.ts
+++ b/packages/mcp-server/src/server/store/document-store.ts
@@ -1,18 +1,27 @@
 /**
- * The daemon's document store: a Loro snapshot per document on disk, plus the
- * `documents` row that gives it a workspace and a path. Everything the web app
- * shows and edits goes through here (ADR-0007's workspace/path store).
+ * The daemon's document store: a Loro snapshot per document, persisted
+ * through the same `LibsqlDocumentStore` the MCP tool surface writes
+ * (`canvas:<documentId>` rows), plus the `documents` row that gives it a
+ * workspace and a path. Everything the web app shows and edits goes through
+ * here (ADR-0007's workspace/path store), and now reads/writes the SAME
+ * bytes a `wb_document_*` tool call would — the FS `.loro` blob tree
+ * `documentBlobPath` still computes is no longer read or written here; it
+ * survives only as an identity label for corrupt-data error messages and as
+ * the legacy-migration backup path.
  *
  * `listDocuments`/`deleteDocument` here are NOT `DocumentIndex`'s methods of
  * the same names — that is the agent-facing side of the same split, reached
  * as `deps.documentIndex.*` and addressing documents by ULID rather than by
  * `(workspaceId, path)`. The names match because the concept does; the two
- * stores are what do not see each other.
+ * stores are what do not see each other. Both now write the same
+ * `LibsqlDocumentStore` rows, which is why `saveDocument`/`compactDocument`
+ * additionally take `withCanvasDocWriteLock` — see their comments.
  */
-import { access, mkdir, readFile, stat, unlink, writeFile } from 'node:fs/promises'
+import { access, mkdir, unlink, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import { generateDocumentId } from '@kamiazya/whiteboard-model'
+import { chunkSnapshot, reassembleSnapshot } from '@kamiazya/whiteboard-ports'
 import type { Value } from 'loro-crdt'
 import { LoroDoc, LoroMap } from 'loro-crdt'
 import type { CanvasSummary } from '../../shared/api-contracts/canvas.js'
@@ -27,9 +36,16 @@ import {
 import { getDb, registerDbDisposeHook } from './db/index.js'
 import { prepareDataDir } from './db/prepare.js'
 import { getDocumentIdByPath, upsertWorkspaceRow } from './db/upsert-workspace.js'
+import { LibsqlDocumentStore } from './libsql/libsql-document-store.js'
 import type { VersionStore } from './version-store.js'
 import { thumbnailPath } from './version-store.js'
-import { withWorkspaceWriteLock } from './workspace-lock.js'
+import { withCanvasDocWriteLock, withWorkspaceWriteLock } from './workspace-lock.js'
+
+// Chunk size shared with the MCP tool write path (server-core's
+// document-io.ts) and migration 0011's FS-blob importer: an arbitrary
+// value, but it must match across every writer of these rows so a snapshot
+// chunked by one path reassembles identically when read by another.
+const SNAPSHOT_MAX_CHUNK_BYTES = 1_000_000
 
 // Give the error a stable name so callers, including MCP tools, can detect overwrite conflicts.
 export class ConflictError extends Error {
@@ -71,6 +87,21 @@ async function dbReady() {
   return getDb(getDataDir())
 }
 
+// One LibsqlDocumentStore per Kysely handle, matching the one-db-per-dataDir
+// cache in db/index.ts — the MCP tool surface (server-core's ServerDeps)
+// builds its own instance from the same handle, so both sides read/write
+// the same `canvas:<documentId>` rows.
+const documentStores = new WeakMap<object, LibsqlDocumentStore>()
+
+async function documentStoreReady(): Promise<LibsqlDocumentStore> {
+  const db = await dbReady()
+  const existing = documentStores.get(db)
+  if (existing) return existing
+  const store = new LibsqlDocumentStore(db)
+  documentStores.set(db, store)
+  return store
+}
+
 // ── save LoroDoc by writing the snapshot binary to the blobs/ tree and
 //    upserting the matching DB rows. ──
 // overwrite defaults to false so canvas_create does not destroy existing
@@ -99,19 +130,35 @@ export async function saveDocument(
         `Canvas "${workspaceId}/${path}" already exists. Pass { overwrite: true } to replace it.`,
       )
     }
-    // Pre-allocate the documentId for new canvases so the blob can be written
-    // before any metadata row commits. If the FS write fails (ENOSPC, EACCES,
-    // transient corruption) we leave no DB row behind, so a retry can succeed
-    // instead of hitting a phantom ConflictError on the orphan.
+    // Pre-allocate the documentId for new canvases so the snapshot can be
+    // written before any metadata row commits. If the snapshot write fails
+    // (driver error, transient corruption) we leave no DB row behind, so a
+    // retry can succeed instead of hitting a phantom ConflictError on the
+    // orphan.
     // A ULID, not a nanoid: the document index creates rows in this same
     // table and the port's DocumentEntry accepts only a canonical ULID, so a
     // second minting policy here would keep producing rows the agent surface
     // has to skip. One table, one id space.
     const documentId = existingCanvasId ?? generateDocumentId()
-    const blobPath = documentBlobPath(workspaceId, documentId)
-    await mkdir(dirname(blobPath), { recursive: true })
     const snapshot = doc.export({ mode: 'snapshot' })
-    await writeFile(blobPath, snapshot)
+    const documentStore = await documentStoreReady()
+    // Every mutating MCP tool serializes its load-modify-save against this
+    // same key (workspace-lock.ts's withCanvasDocWriteLock) — now that both
+    // paths write the same Libsql rows, nesting it here closes the lost-
+    // update window between the HTTP/WS save path and an agent's tool call
+    // racing on the SAME document. Safe in exactly this nesting direction
+    // (workspace lock outer, canvas-doc lock inner): no code path ever
+    // acquires the canvas-doc lock and then reaches for the workspace lock,
+    // so there is no cycle to deadlock on.
+    await withCanvasDocWriteLock(documentId, async () => {
+      const { manifest, chunks } = chunkSnapshot(snapshot, SNAPSHOT_MAX_CHUNK_BYTES)
+      await documentStore.saveSnapshot({
+        docRef: { kind: 'canvas', documentId },
+        manifest,
+        chunks,
+        frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+      })
+    })
     await upsertWorkspaceRow(db, workspaceId)
     if (existingCanvasId) {
       // A plain re-save (WS updates, applyAndPersist, compactDocument) omits
@@ -178,26 +225,36 @@ export async function saveDocument(
   })
 }
 
-// ── load LoroDoc, returning an empty document when the blob is missing ──
+// ── load LoroDoc, returning an empty document when no snapshot exists ──
 export async function loadDocument(workspaceId: string, path: string): Promise<LoroDoc> {
   validateWorkspaceId(workspaceId)
   validateDocumentPath(path)
   const db = await dbReady()
   const documentId = await getDocumentIdByPath(db, workspaceId, path)
   if (!documentId) return new LoroDoc()
+  // Purely a stable identity label for corrupt-data error messages and the
+  // legacy-migration backup file below — no longer an FS path this function
+  // reads from.
   const blobPath = documentBlobPath(workspaceId, documentId)
+  const documentStore = await documentStoreReady()
   let doc: LoroDoc
+  let originalBytes: Uint8Array
   try {
-    const bytes = await readFile(blobPath)
+    const snapshot = await documentStore.loadSnapshot({
+      docRef: { kind: 'canvas', documentId },
+    })
+    if (snapshot === null) return new LoroDoc()
     try {
-      doc = LoroDoc.fromSnapshot(new Uint8Array(bytes))
+      originalBytes = reassembleSnapshot(snapshot.manifest, snapshot.chunks)
+    } catch (error) {
+      throw corruptStoredData(blobPath, `invalid canvas snapshot chunks (${errorMessage(error)})`)
+    }
+    try {
+      doc = LoroDoc.fromSnapshot(originalBytes)
     } catch (error) {
       throw corruptStoredData(blobPath, `invalid canvas snapshot (${errorMessage(error)})`)
     }
   } catch (error) {
-    if (isMissingFileError(error)) {
-      return new LoroDoc()
-    }
     if (isCorruptStoredDataError(error)) {
       throw error
     }
@@ -208,13 +265,13 @@ export async function loadDocument(workspaceId: string, path: string): Promise<L
   const migrated = migrateLegacyListToMovable(doc)
   if (migrated) {
     try {
-      const bakPath = `${path}.pre-migrate-bak`
+      const bakPath = `${blobPath}.pre-migrate-bak`
       const bakExists = await access(bakPath)
         .then(() => true)
         .catch(() => false)
       if (!bakExists) {
-        const origBytes = await readFile(blobPath).catch(() => null)
-        if (origBytes) await writeFile(bakPath, origBytes)
+        await mkdir(dirname(bakPath), { recursive: true })
+        await writeFile(bakPath, originalBytes)
       }
       await saveDocument(workspaceId, path, doc, { overwrite: true })
     } catch (err) {
@@ -319,6 +376,13 @@ export async function deleteDocument(workspaceId: string, path: string): Promise
     // connection in db/index.ts).
     await db.deleteFrom('documents').where('id', '=', documentId).execute()
 
+    // Mirrors wb_document_delete (canvas-crud.ts): the identity row goes
+    // first, then the Libsql snapshot/delta/frontier rows, so a crash
+    // between the two leaves an orphaned-but-unreachable snapshot rather
+    // than a listed canvas with no content.
+    const documentStore = await documentStoreReady()
+    await documentStore.deleteDoc({ docRef: { kind: 'canvas', documentId } })
+
     const blobPath = documentBlobPath(workspaceId, documentId)
     await unlinkIfExists(blobPath)
     await unlinkIfExists(`${blobPath}.pre-migrate-bak`)
@@ -381,16 +445,13 @@ export async function compactDocument(
   if (!documentId) {
     return { compacted: false, beforeBytes: 0, afterBytes: 0, reason: 'no-file' }
   }
-  const blobPath = documentBlobPath(workspaceId, documentId)
-  let beforeBytes: number
-  try {
-    beforeBytes = (await stat(blobPath)).size
-  } catch (error) {
-    if (isMissingFileError(error)) {
-      return { compacted: false, beforeBytes: 0, afterBytes: 0, reason: 'no-file' }
-    }
-    throw corruptStoredData(blobPath, `failed to stat canvas file (${errorMessage(error)})`)
+  const documentStore = await documentStoreReady()
+  const docRef = { kind: 'canvas' as const, documentId }
+  const existing = await documentStore.loadSnapshot({ docRef })
+  if (existing === null) {
+    return { compacted: false, beforeBytes: 0, afterBytes: 0, reason: 'no-file' }
   }
+  const beforeBytes = existing.manifest.totalBytes
 
   const cut = await versionStore.earliestFrontiers(workspaceId, path)
   if (!cut) {
@@ -402,7 +463,17 @@ export async function compactDocument(
   if (shallow.byteLength >= beforeBytes) {
     return { compacted: false, beforeBytes, afterBytes: beforeBytes, reason: 'no-gain' }
   }
-  await writeFile(blobPath, shallow)
+  // Same nesting as saveDocument: the canvas-doc lock guards this snapshot
+  // replace against a concurrent MCP tool write on the same document.
+  await withCanvasDocWriteLock(documentId, async () => {
+    const { manifest, chunks } = chunkSnapshot(shallow, SNAPSHOT_MAX_CHUNK_BYTES)
+    await documentStore.saveSnapshot({
+      docRef,
+      manifest,
+      chunks,
+      frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+    })
+  })
   // Stamp the canvas row so the auto-Optimize loop can skip canvases that
   // have not changed since the last successful compaction, and so the UI
   // can surface "Auto-optimised Ns ago" without reading file mtimes.

--- a/packages/mcp-server/src/server/store/document-store.ts
+++ b/packages/mcp-server/src/server/store/document-store.ts
@@ -23,7 +23,7 @@ import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import { generateDocumentId } from '@kamiazya/whiteboard-model'
 import { chunkSnapshot, reassembleSnapshot } from '@kamiazya/whiteboard-ports'
 import type { Value } from 'loro-crdt'
-import { LoroDoc, LoroMap } from 'loro-crdt'
+import { LoroDoc, LoroMap, VersionVector } from 'loro-crdt'
 import type { CanvasSummary } from '../../shared/api-contracts/canvas.js'
 import { getDataDir } from '../config.js'
 import { getLogger } from '../log.js'
@@ -121,6 +121,56 @@ async function saveSnapshotLocked(
   })
 }
 
+// Merge-then-save for the live-doc path. The lock alone only makes an
+// overwrite ATOMIC — it cannot make it correct: `doc` may be a long-lived
+// cached instance (doc-cache) that has not seen ops an MCP tool wrote to
+// these same rows since it loaded, and exporting it as the whole new truth
+// would erase them in one clean write. When the stored frontier is not
+// already contained in the doc's version (behind or concurrent), import
+// the stored snapshot first so the save is a CRDT merge — ops the doc
+// already carries are no-ops, unseen ops join the history (and, for a
+// cached doc, heal the live session in place). The frontier check is the
+// fast path: one small row read skips the full snapshot load whenever this
+// doc was the last writer. A stored snapshot that fails to import falls
+// back to plain overwrite — the pre-flip semantics for an unreadable
+// snapshot — with a warning.
+async function mergeAndSaveSnapshotLocked(
+  documentStore: LibsqlDocumentStore,
+  workspaceId: string,
+  documentId: string,
+  doc: LoroDoc,
+): Promise<number> {
+  const docRef = { kind: 'canvas' as const, documentId }
+  return withCanvasDocWriteLock(documentId, async () => {
+    const stored = await documentStore.readFrontier({ docRef })
+    if (stored !== null) {
+      const comparison = doc.oplogVersion().compare(VersionVector.decode(stored.frontier))
+      if (comparison === undefined || comparison < 0) {
+        try {
+          const existing = await documentStore.loadSnapshot({ docRef })
+          if (existing !== null) {
+            doc.import(reassembleSnapshot(existing.manifest, existing.chunks))
+          }
+        } catch (err) {
+          getLogger('canvas').warning(
+            { workspaceId, documentId, err: err as Error },
+            'stored snapshot failed to merge before save; overwriting',
+          )
+        }
+      }
+    }
+    const snapshot = doc.export({ mode: 'snapshot' })
+    const { manifest, chunks } = chunkSnapshot(snapshot, SNAPSHOT_MAX_CHUNK_BYTES)
+    await documentStore.saveSnapshot({
+      docRef,
+      manifest,
+      chunks,
+      frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+    })
+    return snapshot.byteLength
+  })
+}
+
 // ── save LoroDoc by writing the snapshot binary to the blobs/ tree and
 //    upserting the matching DB rows. ──
 // overwrite defaults to false so canvas_create does not destroy existing
@@ -159,14 +209,8 @@ export async function saveDocument(
     // second minting policy here would keep producing rows the agent surface
     // has to skip. One table, one id space.
     const documentId = existingCanvasId ?? generateDocumentId()
-    const snapshot = doc.export({ mode: 'snapshot' })
     const documentStore = await documentStoreReady()
-    await saveSnapshotLocked(
-      documentStore,
-      documentId,
-      snapshot,
-      doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
-    )
+    const savedBytes = await mergeAndSaveSnapshotLocked(documentStore, workspaceId, documentId, doc)
     await upsertWorkspaceRow(db, workspaceId)
     if (existingCanvasId) {
       // A plain re-save (WS updates, applyAndPersist, compactDocument) omits
@@ -205,7 +249,7 @@ export async function saveDocument(
         .onConflict((oc) => oc.columns(['workspaceId', 'path']).doUpdateSet({ updatedAt: now }))
         .execute()
     }
-    if (snapshot.byteLength > SNAPSHOT_WARN_BYTES) {
+    if (savedBytes > SNAPSHOT_WARN_BYTES) {
       const key = `${workspaceId}/${path}`
       if (!warnedSnapshots.has(key)) {
         warnedSnapshots.add(key)
@@ -213,7 +257,7 @@ export async function saveDocument(
           {
             workspaceId,
             path,
-            bytes: snapshot.byteLength,
+            bytes: savedBytes,
             thresholdBytes: SNAPSHOT_WARN_BYTES,
           },
           'snapshot exceeds soft cap; consider compactDocument() to GC op-log',

--- a/packages/mcp-server/src/server/store/document-store.ts
+++ b/packages/mcp-server/src/server/store/document-store.ts
@@ -87,19 +87,38 @@ async function dbReady() {
   return getDb(getDataDir())
 }
 
-// One LibsqlDocumentStore per Kysely handle, matching the one-db-per-dataDir
-// cache in db/index.ts — the MCP tool surface (server-core's ServerDeps)
-// builds its own instance from the same handle, so both sides read/write
-// the same `canvas:<documentId>` rows.
-const documentStores = new WeakMap<object, LibsqlDocumentStore>()
-
+// The MCP tool surface (server-core's ServerDeps) builds its own instance
+// from the same one-db-per-dataDir Kysely handle, so both sides read/write
+// the same `canvas:<documentId>` rows. The class is a stateless wrapper
+// around that handle, so a fresh instance per call is equivalent.
 async function documentStoreReady(): Promise<LibsqlDocumentStore> {
-  const db = await dbReady()
-  const existing = documentStores.get(db)
-  if (existing) return existing
-  const store = new LibsqlDocumentStore(db)
-  documentStores.set(db, store)
-  return store
+  return new LibsqlDocumentStore(await dbReady())
+}
+
+// Chunk + replace a document's snapshot rows under the canvas-doc write
+// lock. Every mutating MCP tool serializes its load-modify-save against
+// this same key (workspace-lock.ts's withCanvasDocWriteLock) — since both
+// paths write the same Libsql rows, taking it here closes the lost-update
+// window between the HTTP/WS save path and an agent's tool call racing on
+// the SAME document. Callers hold the workspace lock first; that nesting
+// direction is safe because no code path ever acquires the canvas-doc lock
+// and then reaches for the workspace lock, so there is no cycle to
+// deadlock on.
+async function saveSnapshotLocked(
+  documentStore: LibsqlDocumentStore,
+  documentId: string,
+  snapshot: Uint8Array,
+  frontier: Uint8Array<ArrayBuffer>,
+): Promise<void> {
+  await withCanvasDocWriteLock(documentId, async () => {
+    const { manifest, chunks } = chunkSnapshot(snapshot, SNAPSHOT_MAX_CHUNK_BYTES)
+    await documentStore.saveSnapshot({
+      docRef: { kind: 'canvas', documentId },
+      manifest,
+      chunks,
+      frontier,
+    })
+  })
 }
 
 // ── save LoroDoc by writing the snapshot binary to the blobs/ tree and
@@ -142,23 +161,12 @@ export async function saveDocument(
     const documentId = existingCanvasId ?? generateDocumentId()
     const snapshot = doc.export({ mode: 'snapshot' })
     const documentStore = await documentStoreReady()
-    // Every mutating MCP tool serializes its load-modify-save against this
-    // same key (workspace-lock.ts's withCanvasDocWriteLock) — now that both
-    // paths write the same Libsql rows, nesting it here closes the lost-
-    // update window between the HTTP/WS save path and an agent's tool call
-    // racing on the SAME document. Safe in exactly this nesting direction
-    // (workspace lock outer, canvas-doc lock inner): no code path ever
-    // acquires the canvas-doc lock and then reaches for the workspace lock,
-    // so there is no cycle to deadlock on.
-    await withCanvasDocWriteLock(documentId, async () => {
-      const { manifest, chunks } = chunkSnapshot(snapshot, SNAPSHOT_MAX_CHUNK_BYTES)
-      await documentStore.saveSnapshot({
-        docRef: { kind: 'canvas', documentId },
-        manifest,
-        chunks,
-        frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
-      })
-    })
+    await saveSnapshotLocked(
+      documentStore,
+      documentId,
+      snapshot,
+      doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+    )
     await upsertWorkspaceRow(db, workspaceId)
     if (existingCanvasId) {
       // A plain re-save (WS updates, applyAndPersist, compactDocument) omits
@@ -463,17 +471,12 @@ export async function compactDocument(
   if (shallow.byteLength >= beforeBytes) {
     return { compacted: false, beforeBytes, afterBytes: beforeBytes, reason: 'no-gain' }
   }
-  // Same nesting as saveDocument: the canvas-doc lock guards this snapshot
-  // replace against a concurrent MCP tool write on the same document.
-  await withCanvasDocWriteLock(documentId, async () => {
-    const { manifest, chunks } = chunkSnapshot(shallow, SNAPSHOT_MAX_CHUNK_BYTES)
-    await documentStore.saveSnapshot({
-      docRef,
-      manifest,
-      chunks,
-      frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
-    })
-  })
+  await saveSnapshotLocked(
+    documentStore,
+    documentId,
+    shallow,
+    doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+  )
   // Stamp the canvas row so the auto-Optimize loop can skip canvases that
   // have not changed since the last successful compaction, and so the UI
   // can surface "Auto-optimised Ns ago" without reading file mtimes.

--- a/packages/mcp-server/src/server/store/document-store.ts
+++ b/packages/mcp-server/src/server/store/document-store.ts
@@ -461,45 +461,83 @@ export async function compactDocument(
   }
   const documentStore = await documentStoreReady()
   const docRef = { kind: 'canvas' as const, documentId }
-  const existing = await documentStore.loadSnapshot({ docRef })
-  if (existing === null) {
-    return { compacted: false, beforeBytes: 0, afterBytes: 0, reason: 'no-file' }
-  }
-  const beforeBytes = existing.manifest.totalBytes
 
-  const cut = await versionStore.earliestFrontiers(workspaceId, path)
-  if (!cut) {
-    return { compacted: false, beforeBytes, afterBytes: beforeBytes, reason: 'no-versions' }
-  }
+  // Hold the canvas-doc write lock across the read that decides the shallow
+  // snapshot AND the write that persists it. Previously only the final
+  // saveSnapshotLocked call was locked, so a concurrent canvas-doc write (an
+  // MCP tool call, or a WS/HTTP save) landing between this function's reads
+  // and its write was invisible to both reads and got silently discarded by
+  // the shallow write that followed — the same lost-update class
+  // saveDocument's own write already guards against, now reachable here too
+  // because compaction's target and the tool surface's target are the same
+  // Libsql rows.
+  return withCanvasDocWriteLock(documentId, async () => {
+    const existing = await documentStore.loadSnapshot({ docRef })
+    if (existing === null) {
+      return { compacted: false, beforeBytes: 0, afterBytes: 0, reason: 'no-file' }
+    }
+    const beforeBytes = existing.manifest.totalBytes
 
-  const doc = await loadDocument(workspaceId, path)
-  const shallow = doc.export({ mode: 'shallow-snapshot', frontiers: cut })
-  if (shallow.byteLength >= beforeBytes) {
-    return { compacted: false, beforeBytes, afterBytes: beforeBytes, reason: 'no-gain' }
-  }
-  await saveSnapshotLocked(
-    documentStore,
-    documentId,
-    shallow,
-    doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
-  )
-  // Stamp the canvas row so the auto-Optimize loop can skip canvases that
-  // have not changed since the last successful compaction, and so the UI
-  // can surface "Auto-optimised Ns ago" without reading file mtimes.
-  await db
-    .updateTable('documents')
-    .set({ lastCompactedAt: Date.now() })
-    .where('id', '=', documentId)
-    .execute()
-  // Drop the cached LoroDoc for this canvas. Without this, a still-resident
-  // full doc (held open by an active WS connection or a previous getDoc)
-  // would be re-exported on the next save and clobber the shallow snapshot
-  // we just wrote. Done inside compactDocument so every caller — manual
-  // optimize_canvases route and the debounced auto-compact alike — gets
-  // the same invariant for free.
-  const { evictDoc } = await import('./doc-cache.js')
-  evictDoc(workspaceId, path)
-  return { compacted: true, beforeBytes, afterBytes: shallow.byteLength, reason: 'ok' }
+    const cut = await versionStore.earliestFrontiers(workspaceId, path)
+    if (!cut) {
+      return { compacted: false, beforeBytes, afterBytes: beforeBytes, reason: 'no-versions' }
+    }
+
+    // Decode inline rather than delegating to loadDocument(): that function
+    // also runs a one-shot legacy-migration that calls saveDocument, which
+    // would acquire the workspace lock while this canvas-doc lock is still
+    // held — the opposite of every other caller's nesting order (workspace
+    // lock outer, canvas-doc lock inner, per this module's header comment)
+    // and a lock-order-inversion deadlock waiting to happen against a
+    // concurrent saveDocument on the same document. Skipping migration here
+    // is safe: it is idempotent and re-runs on the next ordinary
+    // loadDocument() call, so compaction just defers it rather than losing it.
+    const blobPath = documentBlobPath(workspaceId, documentId)
+    let originalBytes: Uint8Array
+    try {
+      originalBytes = reassembleSnapshot(existing.manifest, existing.chunks)
+    } catch (error) {
+      throw corruptStoredData(blobPath, `invalid canvas snapshot chunks (${errorMessage(error)})`, {
+        locationKind: 'identity',
+      })
+    }
+    let doc: LoroDoc
+    try {
+      doc = LoroDoc.fromSnapshot(originalBytes)
+    } catch (error) {
+      throw corruptStoredData(blobPath, `invalid canvas snapshot (${errorMessage(error)})`, {
+        locationKind: 'identity',
+      })
+    }
+
+    const shallow = doc.export({ mode: 'shallow-snapshot', frontiers: cut })
+    if (shallow.byteLength >= beforeBytes) {
+      return { compacted: false, beforeBytes, afterBytes: beforeBytes, reason: 'no-gain' }
+    }
+    await saveSnapshotLocked(
+      documentStore,
+      documentId,
+      shallow,
+      doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+    )
+    // Stamp the canvas row so the auto-Optimize loop can skip canvases that
+    // have not changed since the last successful compaction, and so the UI
+    // can surface "Auto-optimised Ns ago" without reading file mtimes.
+    await db
+      .updateTable('documents')
+      .set({ lastCompactedAt: Date.now() })
+      .where('id', '=', documentId)
+      .execute()
+    // Drop the cached LoroDoc for this canvas. Without this, a still-resident
+    // full doc (held open by an active WS connection or a previous getDoc)
+    // would be re-exported on the next save and clobber the shallow snapshot
+    // we just wrote. Done inside compactDocument so every caller — manual
+    // optimize_canvases route and the debounced auto-compact alike — gets
+    // the same invariant for free.
+    const { evictDoc } = await import('./doc-cache.js')
+    evictDoc(workspaceId, path)
+    return { compacted: true, beforeBytes, afterBytes: shallow.byteLength, reason: 'ok' }
+  })
 }
 
 // ── most-recent auto-compact timestamp across all canvases ───────────


### PR DESCRIPTION
## What

Identity-convergence initiative, **slice 2 — the byte-store flip** (approved plan, full single-backend swap). `document-store.ts`'s `loadDocument`/`saveDocument` now read and write through `LibsqlDocumentStore` (the same rows the MCP tool surface uses) instead of FS blobs — one identity, one byte store. Existing FS blobs stay on disk untouched as a forensic rollback aid (a follow-up slice deletes them, per the approved decision).

All six must-fixes from the slice spec:
1. **The flip** — route signatures unchanged; red-first (Libsql-seeded doc read through `loadDocument` returned an empty doc before).
2. **Lock-namespace unification** — `saveDocument` nests `withCanvasDocWriteLock(documentId)` inside its workspace lock (deadlock-safe: no path acquires the reverse order); a concurrency test races the HTTP/WS save against an MCP-style locked write.
3. **`compactDocument`** compares/writes through Libsql (its unlocked read-then-write race also closed in-lane).
4. **`deleteDocument`** deletes the Libsql snapshot rows too (mirroring `wb_document_delete`) — no orphaned rows on web-app deletes.
5. **Interim window** — startup re-invokes migration 0011's idempotent `importFsBlobs` after `runMigrations`, so FS-only blobs written between 0011's tracked run and this deploy stay readable.
6. Regression guards: file-gc referenced-set walk, legacy LoroList→MovableList migration through the new backend, corrupt-rows error path.

**Review HIGH, fixed before this PR — merge-before-save.** The lock only made a clobber *atomic*: doc-cache's long-lived `LoroDoc` never sees ops an MCP tool writes out of band, and its next save exported the stale state as the whole truth, erasing the agent's edits. The snapshot write now merges first — a one-row `readFrontier` + `VersionVector.compare` fast path skips the load when this doc was the last writer; when the store is ahead or concurrent, the stored snapshot is imported inside the same lock hold, making the save a CRDT merge that also heals the live session in place. Mutation-checked (disabling the merge turns exactly the new clobber test red).

## Live verification (worktree daemon, fresh data dir)

- **The original bug is dead**: `wb_document_create` + `wb_node_add`, then `GET /api/w/:ws/canvas/:path/snapshot` → **716 bytes containing the MCP-written node** (pre-flip: a freshly-minted 81-byte empty doc). WS route serves the same content.
- **Three-writer live merge**: with a WS session holding the doc hot — out-of-band `wb_node_add`, then a web-style WS edit from the (stale) client, then the debounced save — `wb_scene_digest` reads back **all three nodes** (`agent-node`, `agent-2`, `web-node`).
- `pnpm smoke:e2e` → ALL OK; mcp-node 3514 green (286 files); knip/typecheck clean; QA startup scenario booted a fresh daemon through all 11 migrations + the second import invocation.

Resolves `mcp-http-slug-snapshot-drift` (deleted on merge). Next slices: FS-blob deletion, flagship E2E lock-in (slice 5), kind-guess removal (slice 6), (a)(b) follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ
