### PR TITLE
fix(web): keep a dragged node's content visible — from the press, and in the dark theme

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -3306,6 +3306,20 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             top: 0,
             transform: viewportTransformCss(viewport),
             transformOrigin: '0 0',
+            // canvas-render's layoutMdastBlocks assigns no appearance to
+            // markdown body text runs (they carry no `fill` attribute at
+            // all), so they inherit it from whichever ancestor sets one —
+            // the seam that keeps body text visible on the dark canvas
+            // surface without editing canvas-render itself. It sits on the
+            // shared ancestor of EVERY canvas-space layer rather than on
+            // the committed one, because the live drag layers host the same
+            // markup: set on the committed layer alone, a dragged node's
+            // body text fell back to the UA default black and read as
+            // vanishing for the length of the gesture. Any element that DOES
+            // carry its own `fill` presentation attribute is unaffected
+            // (presentation attributes win over an inherited value), which
+            // is every shape the selection overlay draws.
+            fill: editorTextFill(theme),
           }}
         >
           <div
@@ -3314,15 +3328,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               position: 'absolute',
               left: (dragStatic?.bounds ?? bounds).x,
               top: (dragStatic?.bounds ?? bounds).y,
-              // canvas-render's layoutMdastBlocks assigns no appearance to
-              // markdown body text runs (they carry no `fill` attribute at
-              // all), so they inherit this host element's SVG `fill`
-              // instead — the seam that keeps body text visible on the dark
-              // canvas surface without editing canvas-render itself. Any
-              // element that DOES carry its own `fill` presentation
-              // attribute is unaffected (presentation attributes win over
-              // an inherited value).
-              fill: editorTextFill(theme),
             }}
             // canvas-render's SVG serializer is the SOLE producer of this
             // string and escapes text/attrs (see svg/format.ts) — the same

--- a/apps/web/src/components/spatial-editor/drag-preview.test.ts
+++ b/apps/web/src/components/spatial-editor/drag-preview.test.ts
@@ -151,9 +151,19 @@ describe('computeDragPreview — totality on degenerate states', () => {
     expect(computeDragPreview(state, [], { x: 1, y: 1 })).toBeUndefined()
   })
 
-  it('returns undefined when livePoint is null, regardless of gesture kind', () => {
-    expect(computeDragPreview(movingState(), [], null)).toBeUndefined()
-    expect(computeDragPreview(resizingState(), [], null)).toBeUndefined()
+  it('previews a pointerless box gesture at its start geometry', () => {
+    const boxes: readonly NodeBox[] = [{ id: 'n1', box: { x: 10, y: 20, width: 200, height: 80 } }]
+    expect(computeDragPreview(movingState(), boxes, null)).toEqual({
+      kind: 'box',
+      box: { x: 10, y: 20, width: 200, height: 80 },
+    })
+    expect(computeDragPreview(resizingState(), boxes, null)).toEqual({
+      kind: 'box',
+      box: { x: 0, y: 0, width: 200, height: 100 },
+    })
+  })
+
+  it('returns undefined for a pointerless connect — its preview IS the pointer', () => {
     expect(computeDragPreview(connectingState(), [], null)).toBeUndefined()
   })
 })

--- a/apps/web/src/components/spatial-editor/drag-preview.ts
+++ b/apps/web/src/components/spatial-editor/drag-preview.ts
@@ -75,33 +75,44 @@ export function computeDragPreview(
   livePoint: Point | null,
   connect?: ConnectPreviewContext,
 ): DragPreview | undefined {
-  if (livePoint === null) return undefined
   switch (gestureState.kind) {
     case 'moving': {
       const box = boxes.find((b) => b.id === gestureState.nodeId)?.box
       if (box === undefined) return undefined
+      // A box gesture previews from its press, not from its first move: the
+      // committed scene hands the node to the live layers the moment the
+      // press lands, so a preview withheld until a pointer arrives leaves a
+      // window where nothing draws the node at all. With no pointer yet the
+      // gesture's own start point IS the live point — a zero delta, i.e. the
+      // node exactly where it already sits.
+      const point = livePoint ?? gestureState.startPoint
       return {
         kind: 'box',
         box: {
           ...box,
-          x: gestureState.startX + (livePoint.x - gestureState.startPoint.x),
-          y: gestureState.startY + (livePoint.y - gestureState.startPoint.y),
+          x: gestureState.startX + (point.x - gestureState.startPoint.x),
+          y: gestureState.startY + (point.y - gestureState.startPoint.y),
         },
       }
     }
-    case 'resizing':
+    case 'resizing': {
+      const point = livePoint ?? gestureState.startPoint
       return {
         kind: 'box',
         box: resizeBoxByDelta(
           gestureState.startBox,
           gestureState.handle,
-          livePoint.x - gestureState.startPoint.x,
-          livePoint.y - gestureState.startPoint.y,
+          point.x - gestureState.startPoint.x,
+          point.y - gestureState.startPoint.y,
         ),
       }
+    }
     case 'connecting': {
       const box = boxes.find((b) => b.id === gestureState.fromNodeId)?.box
-      if (box === undefined || connect === undefined) return undefined
+      // Unlike the box gestures above, a connect has nothing to draw before
+      // the pointer moves: its preview IS the line to the pointer, and the
+      // committed scene keeps drawing every node meanwhile.
+      if (box === undefined || connect === undefined || livePoint === null) return undefined
       // Route the PROSPECTIVE edge through the same producer the drop
       // uses (routeEdge + assignEdgeAnchors over the tentative edge set),
       // so the preview attaches where the committed edge will — the old

--- a/apps/web/src/components/spatial-editor/drag-preview.ts
+++ b/apps/web/src/components/spatial-editor/drag-preview.ts
@@ -59,10 +59,13 @@ export interface ConnectPreviewContext {
 
 /**
  * Returns the preview geometry for the gesture currently in flight, or
- * `undefined` when there is nothing to preview (idle/editing-text state, no
- * live pointer yet, or the gesture's target node has since disappeared from
- * `boxes` — e.g. deleted mid-drag by a canvas-replaced event). Total: never
- * throws, never returns non-finite geometry for finite inputs.
+ * `undefined` when there is nothing to preview (idle/editing-text state, a
+ * connect with no live pointer yet, or the gesture's target node has since
+ * disappeared from `boxes` — e.g. deleted mid-drag by a canvas-replaced
+ * event). A box gesture with no live pointer yet previews at its start
+ * geometry rather than returning `undefined`; see the branches below for
+ * why. Total: never throws, never returns non-finite geometry for finite
+ * inputs.
  *
  * The resize branch must keep calling `resizeBoxByDelta` — the SAME function
  * `reducePointerUpResizing` (gestures.ts) commits with at pointerup — rather

--- a/apps/web/src/components/spatial-editor/live-layer-fill.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/live-layer-fill.browser.test.tsx
@@ -1,0 +1,104 @@
+// canvas-render assigns markdown body runs no `fill` at all — they inherit it
+// from the host element (see SpatialEditor's canvas-content). The live drag
+// layers host the same markup and did NOT set it, so mid-gesture the body
+// text fell back to the UA default black. On the dark canvas that is
+// invisible: the node reads as empty for the whole drag and its content
+// "returns" only when the committed scene takes it back on release.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const start: SpatialCanvas = {
+  nodes: [{ id: 'a', type: 'text', x: 100, y: 100, width: 220, height: 100, text: 'hello resize' }],
+  edges: [],
+}
+
+function Host() {
+  const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor defaultTool="select" canvas={canvas} onChange={setCanvas} theme="dark" />
+    </div>
+  )
+}
+
+const rootOf = (container: HTMLElement) =>
+  container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+/** The colour the body text actually paints with, resolved through inheritance. */
+const paintedFill = (container: HTMLElement, testId: string): string => {
+  const host = container.querySelector(`[data-testid="${testId}"]`)
+  expect(host).not.toBeNull()
+  const text = (host as HTMLElement).querySelector('text')
+  expect(text).not.toBeNull()
+  return getComputedStyle(text as Element).fill
+}
+
+it('paints live drag layers with the same text fill as the committed scene', async () => {
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  const r = root.getBoundingClientRect()
+  const committed = paintedFill(container, 'canvas-content')
+
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + 200,
+    clientY: r.top + 150,
+  })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + 200, clientY: r.top + 150 })
+  const handle = await vi.waitFor(() => {
+    const el = container.querySelector('[data-testid="resize-handle-se"]')
+    expect(el).not.toBeNull()
+    return el as SVGElement
+  })
+  const hr = handle.getBoundingClientRect()
+  fireEvent.pointerDown(handle, {
+    button: 0,
+    pointerId: 2,
+    clientX: hr.left + hr.width / 2,
+    clientY: hr.top + hr.height / 2,
+  })
+  fireEvent.pointerMove(root, {
+    pointerId: 2,
+    clientX: hr.left + hr.width / 2 + 40,
+    clientY: hr.top + hr.height / 2 + 30,
+  })
+
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="live-node"]')).not.toBeNull(),
+  )
+  expect(paintedFill(container, 'live-node')).toBe(committed)
+
+  fireEvent.pointerUp(root, {
+    pointerId: 2,
+    clientX: hr.left + hr.width / 2 + 40,
+    clientY: hr.top + hr.height / 2 + 30,
+  })
+})
+
+it('paints the move ghost with the same text fill as the committed scene', async () => {
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  const r = root.getBoundingClientRect()
+  const committed = paintedFill(container, 'canvas-content')
+
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 3,
+    clientX: r.left + 200,
+    clientY: r.top + 150,
+  })
+  fireEvent.pointerMove(root, { pointerId: 3, clientX: r.left + 260, clientY: r.top + 190 })
+
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="drag-preview"] text')).not.toBeNull(),
+  )
+  expect(paintedFill(container, 'drag-preview')).toBe(committed)
+
+  fireEvent.pointerUp(root, { pointerId: 3, clientX: r.left + 260, clientY: r.top + 190 })
+})

--- a/apps/web/src/components/spatial-editor/press-keeps-content.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/press-keeps-content.browser.test.tsx
@@ -1,0 +1,92 @@
+// A press hands the node from the committed scene to the live layers
+// immediately, but the live layers derive from the pointer — so between the
+// press and the first move there was a window where NOTHING drew the node.
+// Measured on a real drag: the committed layer dropped the node 4ms after
+// pointerdown and the live layer appeared 65ms later. Hold a handle without
+// moving and the box stays empty for as long as you hold, which reads as the
+// content being lost rather than as a gesture starting.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const start: SpatialCanvas = {
+  nodes: [{ id: 'a', type: 'text', x: 100, y: 100, width: 220, height: 100, text: 'hello resize' }],
+  edges: [],
+}
+
+function Host() {
+  const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor defaultTool="select" canvas={canvas} onChange={setCanvas} theme="light" />
+    </div>
+  )
+}
+
+const rootOf = (container: HTMLElement) =>
+  container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+const textOf = (container: HTMLElement, testId: string) =>
+  container.querySelector(`[data-testid="${testId}"]`)?.textContent ?? ''
+
+it('keeps the node content visible while a resize handle is held still', async () => {
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  const r = root.getBoundingClientRect()
+
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + 200,
+    clientY: r.top + 150,
+  })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + 200, clientY: r.top + 150 })
+  const handle = await vi.waitFor(() => {
+    const el = container.querySelector('[data-testid="resize-handle-se"]')
+    expect(el).not.toBeNull()
+    return el as SVGElement
+  })
+
+  // The press alone — no pointermove, the way a finger lands on a handle
+  // before it starts to drag.
+  fireEvent.pointerDown(handle, {
+    button: 0,
+    pointerId: 2,
+    clientX: r.left + 320,
+    clientY: r.top + 200,
+  })
+
+  // The gesture really did start (otherwise the assertion below would pass
+  // on a canvas that simply never handed the node over).
+  await vi.waitFor(() => expect(textOf(container, 'canvas-content')).not.toContain('hello resize'))
+  const live = await vi.waitFor(() => {
+    const el = container.querySelector('[data-testid="live-node"]')
+    expect(el).not.toBeNull()
+    return el as HTMLElement
+  })
+  expect(live.textContent).toContain('hello resize')
+
+  fireEvent.pointerUp(root, { pointerId: 2, clientX: r.left + 320, clientY: r.top + 200 })
+})
+
+it('keeps the node content visible while a grabbed node is held still', async () => {
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  const r = root.getBoundingClientRect()
+
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 3,
+    clientX: r.left + 200,
+    clientY: r.top + 150,
+  })
+
+  await vi.waitFor(() => expect(textOf(container, 'canvas-content')).not.toContain('hello resize'))
+  await vi.waitFor(() => expect(textOf(container, 'drag-preview')).toContain('hello resize'))
+
+  fireEvent.pointerUp(root, { pointerId: 3, clientX: r.left + 200, clientY: r.top + 150 })
+})

--- a/apps/web/src/components/spatial-editor/spatial-editor-theme.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/spatial-editor-theme.browser.test.tsx
@@ -82,7 +82,7 @@ describe('SpatialEditor theme chrome (real browser)', () => {
     }
   })
 
-  it('sets the host element fill to the theme text color, the seam markdown body runs inherit', () => {
+  it('paints body text in the theme text color, the seam markdown body runs inherit', () => {
     const { container } = render(
       <SpatialEditor
         defaultTool="select"
@@ -92,9 +92,12 @@ describe('SpatialEditor theme chrome (real browser)', () => {
         theme="dark"
       />,
     )
-    const svg = container.querySelector('[data-testid="viewport-transform"] svg')
-    const host = svg?.parentElement
-    expect(host?.style.fill).toBe(hexToRgb(EDITOR_DARK_PALETTE.textFill))
+    // Asserted on the RESOLVED color rather than on whichever ancestor
+    // carries the style: the fill sits on the shared canvas-space ancestor
+    // so the live drag layers inherit it too (see SpatialEditor).
+    const text = container.querySelector('[data-testid="canvas-content"] text')
+    expect(text).not.toBeNull()
+    expect(getComputedStyle(text as Element).fill).toBe(hexToRgb(EDITOR_DARK_PALETTE.textFill))
   })
 
   it('does not change scene geometry between themes — only color attributes differ', () => {


### PR DESCRIPTION
Two defects that both make a node's content vanish while you drag it. They are independent, and only the second one is visible on the dark theme.

## 1. Nothing drew the node between the press and the first move

A press hands the node from the committed scene to the live layers immediately — `dragStatic` filters it out the moment a move or resize gesture starts. But every live layer derives from `dragPreview`, and `computeDragPreview` returned `undefined` while `livePoint === null` (i.e. before the first pointermove). **In between, nothing drew the node at all.**

Measured against the deployed `main` build with a real pointer:

| t (ms) | canvas-content | live-node |
|---|---|---|
| 10615 | — | pointerdown |
| 10619 | 28 → **17** (node dropped) | absent |
| 10684 | 17 | **11** (finally drawn) |

Start dragging and it comes back after 65ms, but hold a handle still — a finger landing on it before it starts to travel — and the box stays empty for as long as you hold.

**Fix**: with no pointer yet, a box gesture's own `startPoint` IS its live point — a zero delta, the node exactly where it already sits. The fallback costs nothing and cannot drift from the committed geometry. A connect keeps returning `undefined`: its preview IS the line to the pointer, and the committed scene keeps drawing every node meanwhile.

| before (`main`) | after |
|---|---|
| ![press-hold-before.png](https://github.com/user-attachments/assets/48451d90-a51c-4b66-9c71-7f8ace0a29c7) | ![press-hold-after.png](https://github.com/user-attachments/assets/f82fe336-722c-4a54-b2bb-114d2526f9a5) |

## 2. On the dark theme the live layers painted body text black

canvas-render assigns markdown body runs no `fill` at all — they inherit it from an ancestor, and that ancestor was the **committed** layer's host element. The live drag layers host the same markup, so mid-gesture the body text fell back to the UA default black. On the dark canvas that is invisible: the node reads as empty for the whole drag, and its content "returns" only when the committed scene takes it back on release.

Reported from a real device. The light theme hides it entirely — black on white is still legible — which is why every existing test missed it.

**Fix**: the fill moves up to `viewport-transform`, the shared ancestor of every canvas-space layer, so a new live layer cannot be added without it again. Safe by the same rule that made the original placement safe — an element carrying its own `fill` presentation attribute wins over an inherited value, and every shape the selection overlay draws carries one.

Same canvas, same mid-resize frame, dark theme:

| before (`main`) | after |
|---|---|
| ![resize-dark-before.png](https://github.com/user-attachments/assets/f332c75f-16db-44e0-8b62-5f1ae5cf3d2c) | ![resize-dark-after.png](https://github.com/user-attachments/assets/240f8dae-dac0-45f4-b8b5-0c67cb479b99) |

## Tests

- `press-keeps-content.browser.test.tsx` (new): for resize and for move, a press-and-hold keeps the node's text visible. Each case also asserts that the gesture really started (the committed layer dropped the node), so it cannot pass vacuously.
- `live-layer-fill.browser.test.tsx` (new): on the dark theme, the resolved `fill` of the text inside the live layers equals the committed scene's. Asserted on the painted colour, not on which element carries the declaration.
- `spatial-editor-theme.browser.test.tsx`'s host-fill case is rewritten the same way — the contract is what the text paints with, not where the style sits.
- `drag-preview.test.ts`'s "returns undefined when livePoint is null, regardless of gesture kind" is rewritten to the new contract; the function-level doc is narrowed to match (review finding, LOW).
- Mutation-checked, one at a time: reverting either preview fallback, or moving the fill back down to the committed layer, turns exactly the corresponding test red.
- Green: `pnpm test --project web-browser` (603), `pnpm --filter @kamiazya/whiteboard-web test` (2240 + 77), `pnpm -r typecheck`, `pnpm lint`, `pnpm knip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ua6RPuoEAD4ZTBqyhNC56Z