### PR TITLE
feat(mcp-server): sweep FS blobs once their bytes are proven to live in Libsql

### DIFF
--- a/packages/mcp-server/src/server/store/db/migrations/0011-import-fs-blobs.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0011-import-fs-blobs.ts
@@ -80,8 +80,8 @@ export async function importFsBlobs(db: Kysely<unknown>, dataDir: string): Promi
   }
 }
 
-/** `readdir` a directory that may not exist (or may not BE a directory — a stray file left directly under `blobs/`); both are a clean no-op. */
-async function readDirSafe(dir: string): Promise<string[]> {
+/** `readdir` a directory that may not exist (or may not BE a directory — a stray file left directly under `blobs/`); both are a clean no-op. Exported for `sweep-imported-fs-blobs.ts`, which walks the same frozen blob-tree layout — safe to depend on precisely because this file never changes. */
+export async function readDirSafe(dir: string): Promise<string[]> {
   try {
     return await readdir(dir)
   } catch (err) {

--- a/packages/mcp-server/src/server/store/db/prepare.test.ts
+++ b/packages/mcp-server/src/server/store/db/prepare.test.ts
@@ -4,13 +4,14 @@
 // flip's dataDir is fully warmed up again — would be invisible to the
 // flipped, Libsql-only read path unless prepareDataDir re-invokes the same
 // import routine on every call.
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { access, chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { generateDocumentId } from '@kamiazya/whiteboard-model'
 import { reassembleSnapshot } from '@kamiazya/whiteboard-ports'
 import { LoroDoc } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { captureLogsForTests } from '../../log.js'
 import { LibsqlDocumentStore } from '../libsql/libsql-document-store.js'
 import { closeDb, getDb } from './index.js'
 import { clearPrepareCache, prepareDataDir } from './prepare.js'
@@ -82,5 +83,61 @@ describe('prepareDataDir', () => {
     const reloaded = new LoroDoc()
     reloaded.import(reassembleSnapshot(imported!.manifest, imported!.chunks))
     expect(reloaded.getText('content').toString()).toBe('written during the interim window')
+  })
+
+  it('sweeps a freshly imported FS blob after importing it, on a single prepareDataDir call', async () => {
+    const workspaceId = 'ws-fresh'
+    const documentId = generateDocumentId()
+    const doc = new LoroDoc()
+    doc.getText('content').insert(0, 'imported and swept on first boot')
+    doc.commit()
+    const blobDir = join(tempDir, 'blobs', workspaceId, 'canvas')
+    await mkdir(blobDir, { recursive: true })
+    const blobPath = join(blobDir, `${documentId}.loro`)
+    await writeFile(blobPath, doc.export({ mode: 'snapshot' }))
+
+    await prepareDataDir(tempDir)
+
+    // The blob file is gone...
+    await expect(access(blobPath)).rejects.toThrow()
+
+    // ...but its bytes are provably in Libsql: the same import routine
+    // seeds the documentSnapshots/Frontiers rows independent of the
+    // `documents` row the daemon's own document-store.ts also writes, so
+    // reading straight through LibsqlDocumentStore is enough to prove it.
+    const db = await getDb(tempDir)
+    const libsqlStore = new LibsqlDocumentStore(db)
+    const docRef = { kind: 'canvas' as const, documentId }
+    const imported = await libsqlStore.loadSnapshot({ docRef })
+    expect(imported).not.toBeNull()
+    const reloaded = new LoroDoc()
+    reloaded.import(reassembleSnapshot(imported!.manifest, imported!.chunks))
+    expect(reloaded.getText('content').toString()).toBe('imported and swept on first boot')
+  })
+
+  it('does not block startup when the sweep fails, and logs a warning', async () => {
+    const workspaceId = 'ws-unwritable'
+    const documentId = generateDocumentId()
+    const doc = new LoroDoc()
+    doc.getText('content').insert(0, 'importable but not sweepable')
+    doc.commit()
+    const canvasDir = join(tempDir, 'blobs', workspaceId, 'canvas')
+    await mkdir(canvasDir, { recursive: true })
+    await writeFile(join(canvasDir, `${documentId}.loro`), doc.export({ mode: 'snapshot' }))
+
+    // Read-only directory: readdir/readFile (import) still succeed, but the
+    // sweep's unlink needs write permission on the containing directory and
+    // fails — isolating the failure to the sweep step specifically.
+    await chmod(canvasDir, 0o555)
+
+    const capture = captureLogsForTests()
+    try {
+      await expect(prepareDataDir(tempDir)).resolves.toBeUndefined()
+      const warnings = capture.records.filter((r) => r.level === 'warning')
+      expect(warnings.some((r) => r.msg?.includes('failed to sweep imported FS blobs'))).toBe(true)
+    } finally {
+      capture.restore()
+      await chmod(canvasDir, 0o755)
+    }
   })
 })

--- a/packages/mcp-server/src/server/store/db/prepare.ts
+++ b/packages/mcp-server/src/server/store/db/prepare.ts
@@ -1,7 +1,11 @@
 import type { Kysely } from 'kysely'
+import { getLogger } from '../../log.js'
 import { getDb } from './index.js'
 import { importFsBlobs } from './migrations/0011-import-fs-blobs.js'
 import { runMigrations } from './migrator.js'
+import { sweepImportedFsBlobs } from './sweep-imported-fs-blobs.js'
+
+const log = getLogger('prepare')
 
 // Memoized startup hook. Idempotent across repeated calls per dataDir, so
 // daemon entry, createApp, smoke tests, and unit tests can all call it
@@ -27,6 +31,18 @@ export function prepareDataDir(dataDir: string): Promise<void> {
     // same widening Kysely's own Migrator performs internally when it calls
     // migration.up(db).
     await importFsBlobs(db as unknown as Kysely<unknown>, dataDir)
+    // Best-effort: a sweep failure (e.g. an unreadable blobs root) must not
+    // block startup the way a failed import does — the FS copies it would
+    // have deleted are still safe on disk, so the worst case is deferring
+    // cleanup to the next successful boot.
+    try {
+      await sweepImportedFsBlobs(db, dataDir)
+    } catch (err) {
+      log.warning(
+        { dataDir, err },
+        'failed to sweep imported FS blobs, continuing without deleting them',
+      )
+    }
   })()
   ready.set(dataDir, pending)
   pending.catch(() => {

--- a/packages/mcp-server/src/server/store/db/sweep-imported-fs-blobs.test.ts
+++ b/packages/mcp-server/src/server/store/db/sweep-imported-fs-blobs.test.ts
@@ -1,0 +1,241 @@
+import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { chunkSnapshot, reassembleSnapshot } from '@kamiazya/whiteboard-ports'
+import { LoroDoc } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { captureLogsForTests } from '../../log.js'
+import { closeDb, getDb } from './index.js'
+import { importFsBlobs } from './migrations/0011-import-fs-blobs.js'
+import { runMigrations } from './migrator.js'
+import { sweepImportedFsBlobs } from './sweep-imported-fs-blobs.js'
+
+let tempDir: string
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-sweep-test-'))
+})
+
+afterEach(async () => {
+  await closeDb(tempDir)
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+/** A real, decodable LoroDoc snapshot — sweep gates on `reassembleSnapshot`, not decodability, but this keeps blobs realistic. */
+function snapshotBytes(text: string): Uint8Array {
+  const doc = new LoroDoc()
+  doc.getText('t').insert(0, text)
+  doc.commit()
+  return doc.export({ mode: 'snapshot' })
+}
+
+async function writeBlob(
+  workspaceId: string,
+  documentId: string,
+  bytes: Uint8Array,
+): Promise<string> {
+  const dir = join(tempDir, 'blobs', workspaceId, 'canvas')
+  await mkdir(dir, { recursive: true })
+  const path = join(dir, `${documentId}.loro`)
+  await writeFile(path, bytes)
+  return path
+}
+
+async function seedWorkspace(db: Awaited<ReturnType<typeof getDb>>, workspaceId: string) {
+  await db
+    .insertInto('workspaces')
+    .values({ id: workspaceId, displayName: null, createdAt: 0, updatedAt: 0 })
+    .onConflict((oc) => oc.doNothing())
+    .execute()
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+describe('sweepImportedFsBlobs', () => {
+  it('(a) deletes a blob proven byte-identical to its Libsql row, leaving the row loadable', async () => {
+    const db = await getDb(tempDir)
+    await runMigrations(db)
+    await seedWorkspace(db, 'ws-1')
+
+    const bytes = snapshotBytes('hello sweep')
+    const blobPath = await writeBlob('ws-1', 'doc-a', bytes)
+    await importFsBlobs(db as unknown as Parameters<typeof importFsBlobs>[0], tempDir)
+    expect(await exists(blobPath)).toBe(true) // import never deletes
+
+    await sweepImportedFsBlobs(db, tempDir)
+
+    expect(await exists(blobPath)).toBe(false)
+
+    const header = await db
+      .selectFrom('documentSnapshots')
+      .select(['chunkCount', 'totalBytes', 'maxChunkBytes'])
+      .where('docKey', '=', 'canvas:doc-a')
+      .executeTakeFirstOrThrow()
+    const chunkRows = await db
+      .selectFrom('documentSnapshotChunks')
+      .select(['chunkIndex', 'bytes'])
+      .where('docKey', '=', 'canvas:doc-a')
+      .orderBy('chunkIndex', 'asc')
+      .execute()
+    const reassembled = reassembleSnapshot(
+      header,
+      chunkRows.map((row) => ({
+        index: row.chunkIndex,
+        of: header.chunkCount,
+        bytes: row.bytes instanceof Uint8Array ? row.bytes : new Uint8Array(row.bytes),
+      })),
+    )
+    expect(reassembled).toEqual(bytes)
+  })
+
+  it('(b) never sweeps a blob that diverges from an existing snapshot row, leaving importFsBlobs’s divergence warning intact', async () => {
+    const db = await getDb(tempDir)
+    await runMigrations(db)
+    await seedWorkspace(db, 'ws-1')
+
+    const existingBytes = snapshotBytes('existing content')
+    const { manifest, chunks } = chunkSnapshot(existingBytes, 1_000_000)
+    await db
+      .insertInto('documentSnapshots')
+      .values({
+        docKey: 'canvas:doc-b',
+        chunkCount: manifest.chunkCount,
+        totalBytes: manifest.totalBytes,
+        maxChunkBytes: manifest.maxChunkBytes,
+        frontier: new Uint8Array([9]),
+      })
+      .execute()
+    await db
+      .insertInto('documentSnapshotChunks')
+      .values(chunks.map((c) => ({ docKey: 'canvas:doc-b', chunkIndex: c.index, bytes: c.bytes })))
+      .execute()
+    await db
+      .insertInto('documentFrontiers')
+      .values({ docKey: 'canvas:doc-b', frontier: new Uint8Array([9]) })
+      .execute()
+
+    const divergentBytes = snapshotBytes('a totally different document')
+    const blobPath = await writeBlob('ws-1', 'doc-b', divergentBytes)
+
+    const capture = captureLogsForTests()
+    try {
+      await importFsBlobs(db as unknown as Parameters<typeof importFsBlobs>[0], tempDir)
+      const warnings = capture.records.filter(
+        (r) => r.level === 'warning' && r.data?.documentId === 'doc-b',
+      )
+      expect(warnings).toHaveLength(1)
+
+      await sweepImportedFsBlobs(db, tempDir)
+    } finally {
+      capture.restore()
+    }
+
+    expect(await exists(blobPath)).toBe(true)
+  })
+
+  it('(c) never sweeps a garbage/zero-byte blob that import skipped (no row exists)', async () => {
+    const db = await getDb(tempDir)
+    await runMigrations(db)
+    await seedWorkspace(db, 'ws-1')
+
+    const blobPath = await writeBlob('ws-1', 'doc-garbage', new Uint8Array([1, 2, 3]))
+    const capture = captureLogsForTests()
+    try {
+      await importFsBlobs(db as unknown as Parameters<typeof importFsBlobs>[0], tempDir)
+    } finally {
+      capture.restore()
+    }
+
+    await sweepImportedFsBlobs(db, tempDir)
+
+    expect(await exists(blobPath)).toBe(true)
+  })
+
+  it("(c') never sweeps a byte-matched blob whose documentFrontiers backfill failed (undecodable bytes)", async () => {
+    const db = await getDb(tempDir)
+    await runMigrations(db)
+    await seedWorkspace(db, 'ws-1')
+
+    // A documentSnapshots+chunks pair that byte-matches the FS blob exactly,
+    // but whose bytes are not a decodable LoroDoc snapshot — the shape left
+    // behind when importFsBlobs's frontier backfill itself failed to decode.
+    const garbage = new Uint8Array([9, 9, 9, 9, 9])
+    const { manifest, chunks } = chunkSnapshot(garbage, 1_000_000)
+    await db
+      .insertInto('documentSnapshots')
+      .values({
+        docKey: 'canvas:doc-partial',
+        chunkCount: manifest.chunkCount,
+        totalBytes: manifest.totalBytes,
+        maxChunkBytes: manifest.maxChunkBytes,
+        frontier: new Uint8Array([1]),
+      })
+      .execute()
+    await db
+      .insertInto('documentSnapshotChunks')
+      .values(
+        chunks.map((c) => ({ docKey: 'canvas:doc-partial', chunkIndex: c.index, bytes: c.bytes })),
+      )
+      .execute()
+    // Deliberately no documentFrontiers row.
+
+    const blobPath = await writeBlob('ws-1', 'doc-partial', garbage)
+
+    await sweepImportedFsBlobs(db, tempDir)
+
+    expect(await exists(blobPath)).toBe(true)
+  })
+
+  it('(d) removes empty canvas/workspace dirs after sweeping, but keeps a workspace dir alive for a sibling versions/thumbnail file', async () => {
+    const db = await getDb(tempDir)
+    await runMigrations(db)
+    await seedWorkspace(db, 'ws-1')
+    await seedWorkspace(db, 'ws-2')
+
+    const bytes = snapshotBytes('sole document')
+    await writeBlob('ws-1', 'doc-only', bytes)
+    await importFsBlobs(db as unknown as Parameters<typeof importFsBlobs>[0], tempDir)
+
+    // ws-2 has a thumbnail sibling that must keep its workspace dir alive.
+    const bytes2 = snapshotBytes('other workspace document')
+    await writeBlob('ws-2', 'doc-2', bytes2)
+    await importFsBlobs(db as unknown as Parameters<typeof importFsBlobs>[0], tempDir)
+    const versionsDir = join(tempDir, 'blobs', 'ws-2', 'versions')
+    await mkdir(versionsDir, { recursive: true })
+    await writeFile(join(versionsDir, 'thumb.png'), new Uint8Array([1]))
+
+    await sweepImportedFsBlobs(db, tempDir)
+
+    expect(await exists(join(tempDir, 'blobs', 'ws-1', 'canvas'))).toBe(false)
+    expect(await exists(join(tempDir, 'blobs', 'ws-1'))).toBe(false)
+    expect(await exists(join(tempDir, 'blobs', 'ws-2', 'canvas'))).toBe(false)
+    expect(await exists(join(tempDir, 'blobs', 'ws-2'))).toBe(true)
+    expect(await exists(versionsDir)).toBe(true)
+  })
+
+  it('(e) a second sweep over an already-swept dataDir is a clean no-op', async () => {
+    const db = await getDb(tempDir)
+    await runMigrations(db)
+    await seedWorkspace(db, 'ws-1')
+
+    const bytes = snapshotBytes('sweep once')
+    await writeBlob('ws-1', 'doc-a', bytes)
+    await importFsBlobs(db as unknown as Parameters<typeof importFsBlobs>[0], tempDir)
+    await sweepImportedFsBlobs(db, tempDir)
+
+    const capture = captureLogsForTests()
+    try {
+      await expect(sweepImportedFsBlobs(db, tempDir)).resolves.toBeUndefined()
+      expect(capture.records).toHaveLength(0)
+    } finally {
+      capture.restore()
+    }
+  })
+})

--- a/packages/mcp-server/src/server/store/db/sweep-imported-fs-blobs.test.ts
+++ b/packages/mcp-server/src/server/store/db/sweep-imported-fs-blobs.test.ts
@@ -202,6 +202,48 @@ describe('sweepImportedFsBlobs', () => {
     expect(await exists(blobPath)).toBe(true)
   })
 
+  it('(c’’) never sweeps a blob whose matched snapshot row has internally inconsistent chunks (reassembleSnapshot throws)', async () => {
+    const db = await getDb(tempDir)
+    await runMigrations(db)
+    await seedWorkspace(db, 'ws-1')
+
+    // A documentSnapshots header declaring 2 chunks, a documentFrontiers row
+    // (so both of sweepOneBlob's row-existence gates pass), but only chunk
+    // index 0 actually stored — reassembleSnapshot throws MISSING_CHUNK for
+    // this shape, which is the catch branch under test.
+    const bytes = snapshotBytes('inconsistent chunks')
+    const { manifest, chunks } = chunkSnapshot(bytes, Math.ceil(bytes.byteLength / 2))
+    expect(manifest.chunkCount).toBeGreaterThanOrEqual(2)
+    await db
+      .insertInto('documentSnapshots')
+      .values({
+        docKey: 'canvas:doc-inconsistent',
+        chunkCount: manifest.chunkCount,
+        totalBytes: manifest.totalBytes,
+        maxChunkBytes: manifest.maxChunkBytes,
+        frontier: new Uint8Array([1]),
+      })
+      .execute()
+    await db
+      .insertInto('documentSnapshotChunks')
+      .values({
+        docKey: 'canvas:doc-inconsistent',
+        chunkIndex: chunks[0].index,
+        bytes: chunks[0].bytes,
+      })
+      .execute()
+    await db
+      .insertInto('documentFrontiers')
+      .values({ docKey: 'canvas:doc-inconsistent', frontier: new Uint8Array([1]) })
+      .execute()
+
+    const blobPath = await writeBlob('ws-1', 'doc-inconsistent', bytes)
+
+    await expect(sweepImportedFsBlobs(db, tempDir)).resolves.toBeUndefined()
+
+    expect(await exists(blobPath)).toBe(true)
+  })
+
   it('(d) removes empty canvas/workspace dirs after sweeping, but keeps a workspace dir alive for a sibling versions/thumbnail file', async () => {
     const db = await getDb(tempDir)
     await runMigrations(db)

--- a/packages/mcp-server/src/server/store/db/sweep-imported-fs-blobs.test.ts
+++ b/packages/mcp-server/src/server/store/db/sweep-imported-fs-blobs.test.ts
@@ -1,14 +1,23 @@
-import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { chunkSnapshot, reassembleSnapshot } from '@kamiazya/whiteboard-ports'
 import { LoroDoc } from 'loro-crdt'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { captureLogsForTests } from '../../log.js'
 import { closeDb, getDb } from './index.js'
 import { importFsBlobs } from './migrations/0011-import-fs-blobs.js'
 import { runMigrations } from './migrator.js'
 import { sweepImportedFsBlobs } from './sweep-imported-fs-blobs.js'
+
+// Partial mock so test (f) can force a single readFile rejection (the TOCTOU
+// window sweepOneBlob's own catch guards) while every other call — used
+// throughout this suite's setup helpers and by the production code under
+// test — goes through untouched.
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return { ...actual, readFile: vi.fn(actual.readFile) }
+})
 
 let tempDir: string
 
@@ -218,6 +227,38 @@ describe('sweepImportedFsBlobs', () => {
     expect(await exists(join(tempDir, 'blobs', 'ws-2', 'canvas'))).toBe(false)
     expect(await exists(join(tempDir, 'blobs', 'ws-2'))).toBe(true)
     expect(await exists(versionsDir)).toBe(true)
+  })
+
+  it('(f) tolerates a blob removed between listing and reading it (TOCTOU), leaving the row and file untouched', async () => {
+    const db = await getDb(tempDir)
+    await runMigrations(db)
+    await seedWorkspace(db, 'ws-1')
+
+    const bytes = snapshotBytes('raced away')
+    const blobPath = await writeBlob('ws-1', 'doc-race', bytes)
+    await importFsBlobs(db as unknown as Parameters<typeof importFsBlobs>[0], tempDir)
+
+    // Simulate a writer replacing/removing the blob after readDirSafe listed
+    // it but before sweepOneBlob's readFile runs — the TOCTOU window the
+    // module's own ponytail comment calls out. A mocked rejection (rather
+    // than unlinking before the sweep starts) is what actually reaches this
+    // branch: an unlink beforehand just makes readDirSafe skip the entry.
+    vi.mocked(readFile).mockRejectedValueOnce(
+      Object.assign(new Error('ENOENT simulated'), { code: 'ENOENT' }),
+    )
+    try {
+      await expect(sweepImportedFsBlobs(db, tempDir)).resolves.toBeUndefined()
+    } finally {
+      vi.mocked(readFile).mockClear()
+    }
+
+    expect(await exists(blobPath)).toBe(true)
+    const header = await db
+      .selectFrom('documentSnapshots')
+      .select(['chunkCount'])
+      .where('docKey', '=', 'canvas:doc-race')
+      .executeTakeFirst()
+    expect(header).toBeDefined()
   })
 
   it('(e) a second sweep over an already-swept dataDir is a clean no-op', async () => {

--- a/packages/mcp-server/src/server/store/db/sweep-imported-fs-blobs.ts
+++ b/packages/mcp-server/src/server/store/db/sweep-imported-fs-blobs.ts
@@ -1,7 +1,8 @@
-import { readdir, readFile, rmdir, unlink } from 'node:fs/promises'
+import { readFile, rmdir, unlink } from 'node:fs/promises'
 import { join } from 'node:path'
 import { reassembleSnapshot } from '@kamiazya/whiteboard-ports'
 import type { Database } from './index.js'
+import { readDirSafe } from './migrations/0011-import-fs-blobs.js'
 
 // Identity-convergence cleanup: once migration 0011 (plus its startup
 // re-invocation) has proven a `blobs/<ws>/canvas/<id>.loro` file's bytes
@@ -33,17 +34,6 @@ export async function sweepImportedFsBlobs(db: Database, dataDir: string): Promi
     await rmdirIfEmpty(join(blobsRoot, workspaceId))
   }
   await rmdirIfEmpty(blobsRoot)
-}
-
-/** `readdir` a directory that may not exist (or may not BE a directory); both are a clean no-op. */
-async function readDirSafe(dir: string): Promise<string[]> {
-  try {
-    return await readdir(dir)
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code
-    if (code === 'ENOENT' || code === 'ENOTDIR') return []
-    throw err
-  }
 }
 
 /** `rmdir` a directory that may already be gone or non-empty; both are a clean no-op — a sibling versions/thumbnail or a `.pre-migrate-bak` file is expected to keep it alive. */

--- a/packages/mcp-server/src/server/store/db/sweep-imported-fs-blobs.ts
+++ b/packages/mcp-server/src/server/store/db/sweep-imported-fs-blobs.ts
@@ -1,0 +1,125 @@
+import { readdir, readFile, rmdir, unlink } from 'node:fs/promises'
+import { join } from 'node:path'
+import { reassembleSnapshot } from '@kamiazya/whiteboard-ports'
+import type { Database } from './index.js'
+
+// Identity-convergence cleanup: once migration 0011 (plus its startup
+// re-invocation) has proven a `blobs/<ws>/canvas/<id>.loro` file's bytes
+// live in the Libsql snapshot tables, the FS copy is redundant and safe to
+// delete. Deletion is self-gating on that proof rather than on the import
+// having merely RUN — a matched `documentSnapshots` row whose reassembled
+// bytes diverge from the file, or whose `documentFrontiers` backfill never
+// completed, is left alone for the next import pass or manual triage. This
+// module is deliberately separate from `importFsBlobs`: migration 0011's
+// `up()` never calls it, so the migration's additive-only contract holds
+// structurally, not by convention.
+//
+// ponytail: read-compare-unlink without a lock. A pre-flip writer could
+// replace the blob between the read and the unlink; accepted because the
+// window is single-machine and the next prepare re-imports any survivor.
+// Upgrade to rename-then-verify if concurrent pre-flip writers reappear.
+export async function sweepImportedFsBlobs(db: Database, dataDir: string): Promise<void> {
+  const blobsRoot = join(dataDir, 'blobs')
+  const workspaceIds = await readDirSafe(blobsRoot)
+  for (const workspaceId of workspaceIds) {
+    const canvasDir = join(blobsRoot, workspaceId, 'canvas')
+    const files = await readDirSafe(canvasDir)
+    for (const file of files) {
+      if (!file.endsWith('.loro')) continue
+      const documentId = file.slice(0, -'.loro'.length)
+      await sweepOneBlob(db, documentId, join(canvasDir, file))
+    }
+    await rmdirIfEmpty(canvasDir)
+    await rmdirIfEmpty(join(blobsRoot, workspaceId))
+  }
+  await rmdirIfEmpty(blobsRoot)
+}
+
+/** `readdir` a directory that may not exist (or may not BE a directory); both are a clean no-op. */
+async function readDirSafe(dir: string): Promise<string[]> {
+  try {
+    return await readdir(dir)
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (code === 'ENOENT' || code === 'ENOTDIR') return []
+    throw err
+  }
+}
+
+/** `rmdir` a directory that may already be gone or non-empty; both are a clean no-op — a sibling versions/thumbnail or a `.pre-migrate-bak` file is expected to keep it alive. */
+async function rmdirIfEmpty(dir: string): Promise<void> {
+  try {
+    await rmdir(dir)
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (code === 'ENOTEMPTY' || code === 'ENOENT' || code === 'ENOTDIR') return
+    throw err
+  }
+}
+
+async function sweepOneBlob(db: Database, documentId: string, blobPath: string): Promise<void> {
+  const docKey = `canvas:${documentId}`
+
+  const snapshot = await db
+    .selectFrom('documentSnapshots')
+    .select(['chunkCount', 'totalBytes', 'maxChunkBytes'])
+    .where('docKey', '=', docKey)
+    .executeTakeFirst()
+  // No row yet: the import either hasn't reached this blob or the blob
+  // failed to decode (garbage/zero-byte). Either way, not provably imported.
+  if (!snapshot) return
+
+  // A frontier row is part of a complete import (see importFsBlobs's own
+  // backfill step) — a matched snapshot with no frontier row is a failed
+  // import for this purpose, kept for the next pass to finish.
+  const frontierRow = await db
+    .selectFrom('documentFrontiers')
+    .select('docKey')
+    .where('docKey', '=', docKey)
+    .executeTakeFirst()
+  if (!frontierRow) return
+
+  let blobBytes: Uint8Array
+  try {
+    blobBytes = await readFile(blobPath)
+  } catch {
+    return
+  }
+
+  const chunkRows = await db
+    .selectFrom('documentSnapshotChunks')
+    .select(['chunkIndex', 'bytes'])
+    .where('docKey', '=', docKey)
+    .orderBy('chunkIndex', 'asc')
+    .execute()
+
+  let reassembled: Uint8Array
+  try {
+    reassembled = reassembleSnapshot(
+      {
+        chunkCount: snapshot.chunkCount,
+        totalBytes: snapshot.totalBytes,
+        maxChunkBytes: snapshot.maxChunkBytes,
+      },
+      chunkRows.map((row) => ({
+        index: row.chunkIndex,
+        of: snapshot.chunkCount,
+        // Fresh copy: drivers hand back Buffer or Uint8Array by dialect, and
+        // ports' DTOs require an `ArrayBuffer`-backed `Uint8Array<ArrayBuffer>`.
+        bytes: new Uint8Array(row.bytes),
+      })),
+    )
+  } catch {
+    // Structurally inconsistent row/chunks — leave for manual triage,
+    // matching importFsBlobs's own gate on the same failure shape.
+    return
+  }
+
+  // The self-gating invariant: only a byte-identical reassembly proves the
+  // DB already holds this blob's bytes. Row existence alone is not enough —
+  // a divergent row (the drift-fork case importFsBlobs warns about and
+  // leaves untouched) must never cost the FS copy its only surviving bytes.
+  if (Buffer.compare(reassembled, blobBytes) !== 0) return
+
+  await unlink(blobPath)
+}

--- a/packages/mcp-server/src/server/store/document-store.test.ts
+++ b/packages/mcp-server/src/server/store/document-store.test.ts
@@ -1345,6 +1345,61 @@ describe('deleteDocument', () => {
       .executeTakeFirst()
     expect(after).toBeUndefined()
   })
+
+  it('deletes cleanly a document whose FS blob was already removed by sweepImportedFsBlobs', async () => {
+    const { generateDocumentId } = await import('@kamiazya/whiteboard-model')
+    const { importFsBlobs } = await import('./db/migrations/0011-import-fs-blobs.js')
+    const { sweepImportedFsBlobs } = await import('./db/sweep-imported-fs-blobs.js')
+    const { mkdir, writeFile, access } = await import('node:fs/promises')
+    const { getDb } = await import('./db/index.js')
+    const { upsertWorkspaceRow } = await import('./db/upsert-workspace.js')
+
+    const db = await getDb(tempDir)
+    await upsertWorkspaceRow(db, 'session1')
+    const documentId = generateDocumentId()
+    const now = Date.now()
+    await db
+      .insertInto('documents')
+      .values({
+        id: documentId,
+        workspaceId: 'session1',
+        path: 'swept-then-deleted',
+        displayName: null,
+        isPinned: 0,
+        pinOrder: null,
+        currentBranch: 'main',
+        createdAt: now,
+        updatedAt: now,
+        kind: null,
+      })
+      .execute()
+
+    const blobDoc = new LoroDoc()
+    blobDoc.getText('content').insert(0, 'legacy FS blob, later imported and swept')
+    blobDoc.commit()
+    const blobDir = join(tempDir, 'blobs', 'session1', 'canvas')
+    await mkdir(blobDir, { recursive: true })
+    const blobPath = join(blobDir, `${documentId}.loro`)
+    await writeFile(blobPath, blobDoc.export({ mode: 'snapshot' }))
+
+    await importFsBlobs(db as unknown as Parameters<typeof importFsBlobs>[0], tempDir)
+    await sweepImportedFsBlobs(db, tempDir)
+    await expect(access(blobPath)).rejects.toThrow() // pins the sweep precondition itself
+
+    await expect(deleteDocument('session1', 'swept-then-deleted')).resolves.toBe(true)
+
+    const after = await db
+      .selectFrom('documents')
+      .selectAll()
+      .where('id', '=', documentId)
+      .executeTakeFirst()
+    expect(after).toBeUndefined()
+    const { LibsqlDocumentStore } = await import('./libsql/libsql-document-store.js')
+    const libsqlStore = new LibsqlDocumentStore(db)
+    await expect(
+      libsqlStore.loadSnapshot({ docRef: { kind: 'canvas', documentId } }),
+    ).resolves.toBeNull()
+  })
 })
 
 describe('renameDocumentPath', () => {

--- a/packages/mcp-server/src/server/store/document-store.ts
+++ b/packages/mcp-server/src/server/store/document-store.ts
@@ -7,7 +7,10 @@
  * bytes a `wb_document_*` tool call would — the FS `.loro` blob tree
  * `documentBlobPath` still computes is no longer read or written here; it
  * survives only as an identity label for corrupt-data error messages and as
- * the legacy-migration backup path.
+ * the legacy-migration backup path. Any blob file still on disk is swept
+ * away by `sweep-imported-fs-blobs.ts` once its bytes are proven to live in
+ * Libsql, so `deleteDocument`'s unlink below is a straggler cleanup, not the
+ * primary deletion path.
  *
  * `listDocuments`/`deleteDocument` here are NOT `DocumentIndex`'s methods of
  * the same names — that is the agent-facing side of the same split, reached


### PR DESCRIPTION
## What

Identity-convergence follow-up (user decision: delete the retired FS blobs immediately). After #855 flipped document bytes to `LibsqlDocumentStore`, the `blobs/<ws>/canvas/*.loro` tree is dead weight — but deleting it on a schedule would risk the one case where the bytes are NOT yet in the DB.

`sweepImportedFsBlobs` therefore **self-gates on proof**: a blob file is unlinked only when its `documentSnapshots` row exists, its `documentFrontiers` row exists (an incomplete import counts as failed), its chunks reassemble, and the reassembly is **byte-identical** to the file. Divergent rows (the drift-fork case 0011 warns about), undecodable blobs, and partially-imported ones survive for the next pass or manual triage. Empty dirs are removed bottom-up with `ENOTEMPTY` tolerated, so a sibling `.pre-migrate-bak` or thumbnails dir keeps its parent alive.

It is a **separate module** the migration never imports — 0011's additive-only contract holds structurally, not by convention — and it is invoked from `prepareDataDir` after the startup `importFsBlobs` pass, best-effort so a sweep failure can never block startup.

## Verification

- mcp-node 3532 green (287 files), including 0011's 15 cases and the interim-window test **unmodified**.
- **Mutation check**: weakening the gate to row-existence (dropping the `Buffer.compare`) turns exactly the divergent-blob pin red (`1 failed`), restore returns 3532 green.
- **Live on the dev daemon**: seeded one blob byte-identical to its stored rows and one undecodable blob, restarted → the identical blob was swept, the divergent one survived, and the document still served 357 bytes over the HTTP path route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically cleans up filesystem blob files after they are safely imported and verified in storage.
  * Preserves files when validation is incomplete, data differs, or files are unavailable.
* **Bug Fixes**
  * Document deletion now succeeds even when an imported blob has already been removed.
  * Startup continues with a warning if cleanup fails, while critical migration and import errors still stop startup.
* **Tests**
  * Added coverage for blob cleanup, data preservation, retry behavior, and filesystem edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->