### PR TITLE
fix(mcp-server): mint ULIDs at the third documents-row site; migration 0012 sweeps the rest

### DIFF
--- a/packages/mcp-server/src/server/store/db/migrations/0012-rename-compensation.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0012-rename-compensation.test.ts
@@ -1,0 +1,180 @@
+import { mkdir, mkdtemp, readdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Kysely, type MigrationProvider, Migrator, SqliteDialect, sql } from 'kysely'
+import LibsqlNativeDatabase from 'libsql'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { captureLogsForTests } from '../../../log.js'
+import { migrations } from './index.js'
+
+let dataDir = ''
+vi.mock('../../../config.js', () => ({
+  get DATA_DIR() {
+    return dataDir
+  },
+  getDataDir: () => dataDir,
+}))
+
+// Controllable rename failure: the N-th `rename()` call throws.
+let failOnRenameCalls = new Set<number>()
+let renameCalls = 0
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const real = await importOriginal<typeof import('node:fs/promises')>()
+  return {
+    ...real,
+    rename: async (from: string, to: string) => {
+      renameCalls += 1
+      if (failOnRenameCalls.has(renameCalls)) {
+        const err = new Error(
+          `injected failure on rename call #${renameCalls}`,
+        ) as NodeJS.ErrnoException
+        err.code = 'EACCES'
+        throw err
+      }
+      return real.rename(from, to)
+    },
+  }
+})
+
+const { migration } = await import('./0012-ulid-remaining-document-ids.js')
+
+const PRE_0012 = '0011-import-fs-blobs'
+
+interface Handle {
+  db: Kysely<Record<string, Record<string, unknown>>>
+  migrateToPre0012(): Promise<void>
+}
+
+async function openDb(): Promise<Handle> {
+  const dbPath = join(dataDir, 'whiteboard.db')
+  const db = new Kysely<Record<string, Record<string, unknown>>>({
+    dialect: new SqliteDialect({
+      database: new LibsqlNativeDatabase(dbPath) as unknown as ConstructorParameters<
+        typeof SqliteDialect
+      >[0]['database'],
+    }),
+  })
+  await sql`PRAGMA foreign_keys = ON`.execute(db)
+  const provider: MigrationProvider = { getMigrations: async () => migrations }
+  const migrator = new Migrator({ db: db as never, provider })
+  return {
+    db,
+    async migrateToPre0012() {
+      const { error } = await migrator.migrateTo(PRE_0012)
+      expect(error).toBeUndefined()
+    },
+  }
+}
+
+async function seedLegacyRow(
+  db: Handle['db'],
+  opts: { id: string; workspaceId: string; path: string },
+): Promise<void> {
+  await db
+    .insertInto('workspaces')
+    .values({ id: opts.workspaceId, createdAt: 0, updatedAt: 0 })
+    .onConflict((oc) => oc.doNothing())
+    .execute()
+  await db
+    .insertInto('documents')
+    .values({
+      id: opts.id,
+      workspaceId: opts.workspaceId,
+      path: opts.path,
+      displayName: null,
+      isPinned: 0,
+      pinOrder: null,
+      currentBranch: 'main',
+      createdAt: 0,
+      updatedAt: 0,
+    })
+    .execute()
+  await db
+    .insertInto('branches')
+    .values({ documentId: opts.id, name: 'main', tipFrontiers: '', color: null, createdAt: 0 })
+    .execute()
+  await db
+    .insertInto('versions')
+    .values({
+      id: `v-${opts.path}`,
+      documentId: opts.id,
+      branchName: 'main',
+      auto: 0,
+      operatorKind: 'human',
+      operatorPeerId: 'p-1',
+      operatorDisplayName: 'seed',
+      elementCount: 0,
+      frontiers: '',
+      hasThumbnail: 0,
+      createdAt: 0,
+    })
+    .execute()
+}
+
+describe('0012 blob-rename compensation', () => {
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'whiteboard-0012-comp-'))
+    renameCalls = 0
+    failOnRenameCalls = new Set()
+  })
+
+  it('renames completed blobs BACK before rethrowing, so a rolled-back DB matches the disk', async () => {
+    // A blob rename cannot be rolled back by the DB transaction: if a LATER
+    // row in the loop throws, the first row's already-renamed blob must be
+    // renamed back or it is orphaned forever once the ULID is regenerated on
+    // retry. This pins that undo actually happens, and pins the undo's
+    // rename() argument order (a swapped from/to would fail this test).
+    const handle = await openDb()
+    await handle.migrateToPre0012()
+    await seedLegacyRow(handle.db, { id: 'uH6qTx6Ai2hl', workspaceId: 'ws-1', path: 'doc-a' })
+    await seedLegacyRow(handle.db, { id: 'Go1G4OcJKUBu', workspaceId: 'ws-1', path: 'doc-b' })
+    const blobDir = join(dataDir, 'blobs', 'ws-1', 'canvas')
+    await mkdir(blobDir, { recursive: true })
+    await writeFile(join(blobDir, 'uH6qTx6Ai2hl.loro'), new Uint8Array([1]))
+    await writeFile(join(blobDir, 'Go1G4OcJKUBu.loro'), new Uint8Array([2]))
+
+    failOnRenameCalls = new Set([2])
+
+    await expect(migration.up(handle.db as never)).rejects.toThrow(/injected failure/)
+
+    // Row A's blob was renamed on call 1, then renamed BACK when call 2
+    // failed: the disk carries exactly the legacy names the rolled-back DB
+    // expects.
+    expect((await readdir(blobDir)).sort()).toEqual(['Go1G4OcJKUBu.loro', 'uH6qTx6Ai2hl.loro'])
+    await handle.db.destroy()
+  })
+
+  it('logs an error (and still rethrows the original failure) when the undo rename itself fails', async () => {
+    const handle = await openDb()
+    await handle.migrateToPre0012()
+    await seedLegacyRow(handle.db, { id: 'uH6qTx6Ai2hl', workspaceId: 'ws-1', path: 'doc-a' })
+    await seedLegacyRow(handle.db, { id: 'Go1G4OcJKUBu', workspaceId: 'ws-1', path: 'doc-b' })
+    const blobDir = join(dataDir, 'blobs', 'ws-1', 'canvas')
+    await mkdir(blobDir, { recursive: true })
+    await writeFile(join(blobDir, 'uH6qTx6Ai2hl.loro'), new Uint8Array([1]))
+    await writeFile(join(blobDir, 'Go1G4OcJKUBu.loro'), new Uint8Array([2]))
+
+    // Call 1: row A's forward rename (succeeds). Call 2: row B's forward
+    // rename (the triggering failure). Call 3: the catch block's attempt to
+    // undo row A's rename (also fails) — exercising the log.error branch.
+    failOnRenameCalls = new Set([2, 3])
+    const logs = captureLogsForTests()
+    try {
+      await expect(migration.up(handle.db as never)).rejects.toThrow(
+        /injected failure on rename call #2/,
+      )
+
+      const undoFailure = logs.records.find(
+        (r) => r.scope === 'migration-0012' && r.level === 'error',
+      )
+      expect(undoFailure?.msg).toMatch(/could not undo a blob rename/i)
+      // `to` in the logged undo attempt is the ORIGINAL legacy path it was
+      // trying to restore — the one deterministic side of the pair (`from`
+      // is the freshly generated ULID path, not known ahead of time).
+      expect(undoFailure?.data?.to).toBe(join(blobDir, 'uH6qTx6Ai2hl.loro'))
+    } finally {
+      logs.restore()
+      await handle.db.destroy()
+    }
+  })
+})

--- a/packages/mcp-server/src/server/store/db/migrations/0012-ulid-remaining-document-ids.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0012-ulid-remaining-document-ids.test.ts
@@ -1,0 +1,220 @@
+import { mkdir, mkdtemp, readdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Kysely, type MigrationProvider, Migrator, SqliteDialect, sql } from 'kysely'
+import LibsqlNativeDatabase from 'libsql'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { migrations } from './index.js'
+
+let dataDir = ''
+vi.mock('../../../config.js', () => ({
+  get DATA_DIR() {
+    return dataDir
+  },
+  getDataDir: () => dataDir,
+}))
+
+const ULID = /^[0-7][0-9A-HJKMNP-TV-Z]{25}$/
+
+// The last migration a database that predates 0012 had applied — everything
+// up to and including 0011, which is exactly the state a live install is in
+// right before this migration ships. `upsertCanvasRow`'s nanoid rows are
+// created by application code running against THIS schema, not by an older
+// one, so the seed below matches the schema as it stands at 0011 rather than
+// reproducing 0008's pre-rename fixture.
+const PRE_0012 = '0011-import-fs-blobs'
+
+interface Handle {
+  db: Kysely<Record<string, Record<string, unknown>>>
+  migrateToPre0012(): Promise<void>
+  migrateToHead(): Promise<void>
+}
+
+async function openDb(): Promise<Handle> {
+  const dbPath = join(dataDir, 'whiteboard.db')
+  const db = new Kysely<Record<string, Record<string, unknown>>>({
+    dialect: new SqliteDialect({
+      database: new LibsqlNativeDatabase(dbPath) as unknown as ConstructorParameters<
+        typeof SqliteDialect
+      >[0]['database'],
+    }),
+  })
+  await sql`PRAGMA foreign_keys = ON`.execute(db)
+  const provider: MigrationProvider = { getMigrations: async () => migrations }
+  const migrator = new Migrator({ db: db as never, provider })
+  return {
+    db,
+    async migrateToPre0012() {
+      const { error } = await migrator.migrateTo(PRE_0012)
+      expect(error).toBeUndefined()
+    },
+    async migrateToHead() {
+      const { error } = await migrator.migrateToLatest()
+      expect(error).toBeUndefined()
+    },
+  }
+}
+
+async function seedThirdSiteRow(
+  db: Handle['db'],
+  opts: { id: string; workspaceId: string; path: string },
+): Promise<void> {
+  await db
+    .insertInto('workspaces')
+    .values({ id: opts.workspaceId, createdAt: 0, updatedAt: 0 })
+    .onConflict((oc) => oc.doNothing())
+    .execute()
+  // Shaped exactly like `upsertCanvasRow`'s insert: no `kind` (it is left
+  // null for a row created by a version/name/branch write, same as the
+  // production helper).
+  await db
+    .insertInto('documents')
+    .values({
+      id: opts.id,
+      workspaceId: opts.workspaceId,
+      path: opts.path,
+      displayName: null,
+      isPinned: 0,
+      pinOrder: null,
+      currentBranch: 'main',
+      createdAt: 0,
+      updatedAt: 0,
+    })
+    .execute()
+  await db
+    .insertInto('branches')
+    .values({ documentId: opts.id, name: 'main', tipFrontiers: '', color: null, createdAt: 0 })
+    .execute()
+  await db
+    .insertInto('versions')
+    .values({
+      id: `v-${opts.path}`,
+      documentId: opts.id,
+      branchName: 'main',
+      auto: 0,
+      operatorKind: 'human',
+      operatorPeerId: 'p-1',
+      operatorDisplayName: 'seed',
+      elementCount: 0,
+      frontiers: '',
+      hasThumbnail: 0,
+      createdAt: 0,
+    })
+    .execute()
+  const docKey = `canvas:${opts.id}`
+  await db
+    .insertInto('documentSnapshots')
+    .values({
+      docKey,
+      chunkCount: 1,
+      totalBytes: 3,
+      maxChunkBytes: 1_000_000,
+      frontier: new Uint8Array(),
+    })
+    .execute()
+  await db
+    .insertInto('documentSnapshotChunks')
+    .values({ docKey, chunkIndex: 0, bytes: new Uint8Array([1, 2, 3]) })
+    .execute()
+  await db
+    .insertInto('documentDeltas')
+    .values({ docKey, seq: 0, bytes: new Uint8Array([4]), frontier: new Uint8Array() })
+    .execute()
+  await db.insertInto('documentFrontiers').values({ docKey, frontier: new Uint8Array() }).execute()
+}
+
+describe('0012-ulid-remaining-document-ids', () => {
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'whiteboard-0012-'))
+  })
+
+  it('re-mints a third-site nanoid row, carrying versions/branches/docKeys/blob', async () => {
+    const handle = await openDb()
+    await handle.migrateToPre0012()
+    await seedThirdSiteRow(handle.db, {
+      id: 'uH6qTx6Ai2hl',
+      workspaceId: 'ws-1',
+      path: 'third-site-doc',
+    })
+    const blobDir = join(dataDir, 'blobs', 'ws-1', 'canvas')
+    await mkdir(blobDir, { recursive: true })
+    await writeFile(join(blobDir, 'uH6qTx6Ai2hl.loro'), new Uint8Array([1, 2, 3]))
+
+    await handle.migrateToHead()
+
+    const row = (await handle.db
+      .selectFrom('documents')
+      .selectAll()
+      .where('path', '=', 'third-site-doc')
+      .executeTakeFirstOrThrow()) as { id: string }
+    expect(row.id).toMatch(ULID)
+
+    const version = (await handle.db
+      .selectFrom('versions')
+      .selectAll()
+      .executeTakeFirstOrThrow()) as { documentId: string }
+    expect(version.documentId).toBe(row.id)
+    const branch = (await handle.db
+      .selectFrom('branches')
+      .selectAll()
+      .executeTakeFirstOrThrow()) as { documentId: string }
+    expect(branch.documentId).toBe(row.id)
+
+    const newDocKey = `canvas:${row.id}`
+    for (const table of [
+      'documentSnapshots',
+      'documentSnapshotChunks',
+      'documentDeltas',
+      'documentFrontiers',
+    ]) {
+      const docKeyRow = await handle.db.selectFrom(table).select('docKey').executeTakeFirstOrThrow()
+      expect(docKeyRow.docKey).toBe(newDocKey)
+    }
+
+    expect(await readdir(blobDir)).toEqual([`${row.id}.loro`])
+    await handle.db.destroy()
+  })
+
+  it('tolerates a missing blob rather than failing the migration', async () => {
+    const handle = await openDb()
+    await handle.migrateToPre0012()
+    await seedThirdSiteRow(handle.db, {
+      id: 'Go1G4OcJKUBu',
+      workspaceId: 'ws-1',
+      path: 'blobless-doc',
+    })
+
+    await handle.migrateToHead()
+
+    const row = (await handle.db
+      .selectFrom('documents')
+      .selectAll()
+      .where('path', '=', 'blobless-doc')
+      .executeTakeFirstOrThrow()) as { id: string }
+    expect(row.id).toMatch(ULID)
+    await handle.db.destroy()
+  })
+
+  it('leaves a ULID row byte-identical and is idempotent across two runs', async () => {
+    const handle = await openDb()
+    await handle.migrateToPre0012()
+    await seedThirdSiteRow(handle.db, {
+      id: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      workspaceId: 'ws-1',
+      path: 'modern-doc',
+    })
+
+    await handle.migrateToHead()
+    // Re-running migrateToLatest is a no-op once the log already records
+    // 0012 (kysely will not re-apply it), so call the migration function a
+    // second time directly to pin idempotence of its own logic.
+    const { migration } = await import('./0012-ulid-remaining-document-ids.js')
+    await migration.up(handle.db as never)
+
+    const row = (await handle.db.selectFrom('documents').selectAll().executeTakeFirstOrThrow()) as {
+      id: string
+    }
+    expect(row.id).toBe('01ARZ3NDEKTSV4RRFFQ69G5FAV')
+    await handle.db.destroy()
+  })
+})

--- a/packages/mcp-server/src/server/store/db/migrations/0012-ulid-remaining-document-ids.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0012-ulid-remaining-document-ids.ts
@@ -1,0 +1,181 @@
+import { rename } from 'node:fs/promises'
+import { join } from 'node:path'
+import { generateDocumentId } from '@kamiazya/whiteboard-model'
+import type { Kysely, Migration } from 'kysely'
+import { getDataDir } from '../../../config.js'
+import { getLogger } from '../../../log.js'
+
+// 0008 re-minted every nanoid `documents.id` row that existed at the time it
+// ran — but `upsertCanvasRow` (the version/name/branch stores' shared
+// "create the row for this path if it doesn't exist yet" helper) kept
+// minting FRESH nanoid ids for every path first touched by a version save, a
+// display-name set, or a branch upsert, for as long as it shipped after
+// 0008. Those rows are invisible to SqliteDocumentIndex.listDocuments (it
+// skips a non-ULID id so one bad row cannot fail an entire listing) even
+// though they are ordinary rows to the user's gallery. This migration is the
+// follow-up sweep for whatever `upsertCanvasRow`'s fix (generateDocumentId)
+// did not retroactively reach.
+//
+// Model is 0008's: insert-new / repoint-children / delete-old / claim-the-
+// path, then move whatever storage was keyed on the old id — here that is
+// the four `canvas:<id>` docKey tables plus, best-effort, a `.loro` blob left
+// over from before the store flipped to the Libsql-backed doc store (still
+// present on some data dirs as a forensic rollback aid; see
+// document-store.ts). A DB with no surviving legacy blobs simply tolerates
+// ENOENT on every rename.
+//
+// Every table/column named here is the name AS IT EXISTS AT THIS POINT IN
+// THE LOG (current as of 0011) — a migration must not depend on living
+// schema.ts, which can rename out from under a recorded migration key.
+
+interface DocumentRow {
+  id: string
+  workspaceId: string
+  path: string
+  displayName: string | null
+  isPinned: number
+  pinOrder: number | null
+  currentBranch: string
+  createdAt: number
+  updatedAt: number
+  lastCompactedAt: number | null
+  kind: string | null
+}
+
+interface DocumentSnapshotRow {
+  docKey: string
+  chunkCount: number
+  totalBytes: number
+  maxChunkBytes: number
+  frontier: Uint8Array
+}
+
+interface MigrationSchema {
+  documents: DocumentRow
+  versions: { documentId: string }
+  branches: { documentId: string }
+  documentSnapshots: DocumentSnapshotRow
+  documentSnapshotChunks: { docKey: string }
+  documentDeltas: { docKey: string }
+  documentFrontiers: { docKey: string }
+}
+
+const CANONICAL_ULID = /^[0-7][0-9A-HJKMNP-TV-Z]{25}$/
+
+// documentSnapshotChunks.docKey carries a real FK onto documentSnapshots.docKey
+// (its primary key) — SQLite has no ON UPDATE CASCADE here, so renaming the
+// parent's key in place would leave the child pointing at a value that no
+// longer exists and fail the FK check on the very statement that renamed it.
+// insert-new/repoint-child/delete-old sidesteps that the same way the
+// documents/versions/branches rewrite above does. documentDeltas and
+// documentFrontiers carry no FK on docKey, so they take a plain UPDATE.
+
+export const migration: Migration = {
+  async up(db: Kysely<unknown>): Promise<void> {
+    const tdb = db as Kysely<MigrationSchema>
+    const log = getLogger('migration-0012')
+
+    const rows = await tdb.selectFrom('documents').selectAll().execute()
+    const legacy = rows.filter((row) => !CANONICAL_ULID.test(row.id))
+    if (legacy.length === 0) return
+
+    // Same non-transactional-step hazard 0008 documented: a blob rename
+    // cannot be rolled back by the DB transaction, so every completed rename
+    // is tracked and unwound (best effort, loudly) if a LATER row fails —
+    // otherwise a retry would regenerate a fresh ULID and orphan the
+    // already-renamed blob forever.
+    const completedRenames: { from: string; to: string }[] = []
+    try {
+      await rewriteLegacyRows()
+    } catch (err) {
+      for (const done of completedRenames.reverse()) {
+        try {
+          await rename(done.to, done.from)
+        } catch (undoErr) {
+          log.error(
+            { from: done.to, to: done.from, err: undoErr },
+            'could not undo a blob rename while unwinding — reconcile by hand',
+          )
+        }
+      }
+      throw err
+    }
+    return
+
+    async function rewriteLegacyRows(): Promise<void> {
+      for (const row of legacy) {
+        const newId = generateDocumentId()
+
+        await tdb
+          .insertInto('documents')
+          .values({ ...row, id: newId, path: newId })
+          .execute()
+        await tdb
+          .updateTable('versions')
+          .set({ documentId: newId })
+          .where('documentId', '=', row.id)
+          .execute()
+        await tdb
+          .updateTable('branches')
+          .set({ documentId: newId })
+          .where('documentId', '=', row.id)
+          .execute()
+        await tdb.deleteFrom('documents').where('id', '=', row.id).execute()
+        await tdb.updateTable('documents').set({ path: row.path }).where('id', '=', newId).execute()
+
+        const oldDocKey = `canvas:${row.id}`
+        const newDocKey = `canvas:${newId}`
+
+        const snapshot = await tdb
+          .selectFrom('documentSnapshots')
+          .selectAll()
+          .where('docKey', '=', oldDocKey)
+          .executeTakeFirst()
+        if (snapshot) {
+          await tdb
+            .insertInto('documentSnapshots')
+            // Drivers hand a BLOB column back as Buffer or a plain
+            // Uint8Array depending on dialect; only Buffer is bindable on
+            // the way back in, so it is re-wrapped explicitly rather than
+            // spread through unchanged (a fresh copy either way — Buffer
+            // over an existing Uint8Array is a view, not a clone).
+            .values({ ...snapshot, docKey: newDocKey, frontier: Buffer.from(snapshot.frontier) })
+            .execute()
+          await tdb
+            .updateTable('documentSnapshotChunks')
+            .set({ docKey: newDocKey })
+            .where('docKey', '=', oldDocKey)
+            .execute()
+          await tdb.deleteFrom('documentSnapshots').where('docKey', '=', oldDocKey).execute()
+        }
+        await tdb
+          .updateTable('documentDeltas')
+          .set({ docKey: newDocKey })
+          .where('docKey', '=', oldDocKey)
+          .execute()
+        await tdb
+          .updateTable('documentFrontiers')
+          .set({ docKey: newDocKey })
+          .where('docKey', '=', oldDocKey)
+          .execute()
+
+        const blobDir = join(getDataDir(), 'blobs', row.workspaceId, 'canvas')
+        const from = join(blobDir, `${row.id}.loro`)
+        const to = join(blobDir, `${newId}.loro`)
+        try {
+          await rename(from, to)
+          completedRenames.push({ from, to })
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+          log.warning(
+            { workspaceId: row.workspaceId, oldId: row.id },
+            'pre-convergence row had no blob to move',
+          )
+        }
+      }
+    }
+  },
+  async down(): Promise<void> {
+    // The nanoid is gone and nothing can want it back.
+  },
+}

--- a/packages/mcp-server/src/server/store/db/migrations/index.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/index.ts
@@ -10,6 +10,7 @@ import { migration as ulidLegacyCanvasIds } from './0008-ulid-legacy-canvas-ids.
 import { migration as documentVocabulary } from './0009-document-vocabulary.js'
 import { migration as documentPath } from './0010-document-path.js'
 import { migration as importFsBlobs } from './0011-import-fs-blobs.js'
+import { migration as ulidRemainingDocumentIds } from './0012-ulid-remaining-document-ids.js'
 
 // Ordered map; kysely sorts by key so the numeric prefix decides execution order.
 // 0003 still says `canvas-doc-store` after the port it creates was renamed to
@@ -31,4 +32,5 @@ export const migrations: Record<string, Migration> = {
   '0009-document-vocabulary': documentVocabulary,
   '0010-document-path': documentPath,
   '0011-import-fs-blobs': importFsBlobs,
+  '0012-ulid-remaining-document-ids': ulidRemainingDocumentIds,
 }

--- a/packages/mcp-server/src/server/store/db/migrator.legacy-upgrade.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrator.legacy-upgrade.test.ts
@@ -75,3 +75,137 @@ it('the REAL migrator upgrades a pre-0008 data dir: nanoid row -> ULID, blob fol
   expect(await readdir(blobDir)).toEqual([`${row.id}.loro`])
   await db.destroy()
 })
+
+// The last migration a database applied that predates 0012, i.e. every
+// install that has run 0008 but not yet the fix for the THIRD id-minting
+// site (`upsertCanvasRow`, shared by the version/name/branch stores). A
+// nanoid row created by that site AFTER 0008 ran is real production data —
+// 0008 could not have seen it, because it did not exist yet — so this models
+// it the honest way: migrate up to the point the bug was still live, then
+// insert exactly the shape that call site produced, then let the rest of
+// the chain (0009 onward, including 0012) run over it.
+const PRE_0012 = '0011-import-fs-blobs'
+
+it('the REAL migrator upgrades a third-site nanoid row that postdates 0008: zero non-ULID ids remain', async () => {
+  dataDir = await mkdtemp(join(tmpdir(), 'wb-boot-verify-third-site-'))
+  const dbPath = join(dataDir, 'whiteboard.db')
+  const db = new Kysely<Record<string, Record<string, unknown>>>({
+    dialect: new SqliteDialect({
+      database: new LibsqlNativeDatabase(dbPath) as unknown as ConstructorParameters<
+        typeof SqliteDialect
+      >[0]['database'],
+    }),
+  })
+  await sql`PRAGMA foreign_keys = ON`.execute(db)
+
+  const provider: MigrationProvider = { getMigrations: async () => migrations }
+  const { error } = await new Migrator({ db: db as never, provider }).migrateTo(PRE_0012)
+  expect(error).toBeUndefined()
+
+  // Shaped exactly like `upsertCanvasRow`'s insert (documents/versions/branches
+  // plus the four docKey tables a version save's document content would have
+  // populated) at the CURRENT schema — 0009/0010 have already renamed
+  // canvases->documents and slug->path by this point in the chain.
+  await db
+    .insertInto('workspaces')
+    .values({ id: 'ws-third-site', createdAt: 0, updatedAt: 0 })
+    .execute()
+  await db
+    .insertInto('documents')
+    .values({
+      id: 'uH6qTx6Ai2hl',
+      workspaceId: 'ws-third-site',
+      path: 'third-site-doc',
+      displayName: null,
+      isPinned: 0,
+      pinOrder: null,
+      currentBranch: 'main',
+      createdAt: 0,
+      updatedAt: 0,
+    })
+    .execute()
+  await db
+    .insertInto('branches')
+    .values({
+      documentId: 'uH6qTx6Ai2hl',
+      name: 'main',
+      tipFrontiers: '',
+      color: null,
+      createdAt: 0,
+    })
+    .execute()
+  await db
+    .insertInto('versions')
+    .values({
+      id: 'v-third-site',
+      documentId: 'uH6qTx6Ai2hl',
+      branchName: 'main',
+      auto: 0,
+      operatorKind: 'human',
+      operatorPeerId: 'p-1',
+      operatorDisplayName: 'seed',
+      elementCount: 0,
+      frontiers: '',
+      hasThumbnail: 0,
+      createdAt: 0,
+    })
+    .execute()
+  const docKey = 'canvas:uH6qTx6Ai2hl'
+  await db
+    .insertInto('documentSnapshots')
+    .values({
+      docKey,
+      chunkCount: 1,
+      totalBytes: 3,
+      maxChunkBytes: 1_000_000,
+      frontier: Buffer.from([]),
+    })
+    .execute()
+  await db
+    .insertInto('documentSnapshotChunks')
+    .values({ docKey, chunkIndex: 0, bytes: Buffer.from([1, 2, 3]) })
+    .execute()
+  await db
+    .insertInto('documentDeltas')
+    .values({ docKey, seq: 0, bytes: Buffer.from([4]), frontier: Buffer.from([]) })
+    .execute()
+  await db
+    .insertInto('documentFrontiers')
+    .values({ docKey, frontier: Buffer.from([]) })
+    .execute()
+  const blobDir = join(dataDir, 'blobs', 'ws-third-site', 'canvas')
+  await mkdir(blobDir, { recursive: true })
+  await writeFile(join(blobDir, 'uH6qTx6Ai2hl.loro'), new Uint8Array([9]))
+
+  // What the next boot does.
+  await runMigrations(db as never)
+
+  const documentRows = (await db.selectFrom('documents').selectAll().execute()) as { id: string }[]
+  for (const documentRow of documentRows) {
+    expect(documentRow.id).toMatch(ULID)
+  }
+  const newRow = documentRows.find((r) => r.id !== 'uH6qTx6Ai2hl')
+  expect(newRow).toBeDefined()
+
+  const versionRows = (await db.selectFrom('versions').selectAll().execute()) as {
+    documentId: string
+  }[]
+  for (const v of versionRows) expect(v.documentId).not.toBe('uH6qTx6Ai2hl')
+  const branchRows = (await db.selectFrom('branches').selectAll().execute()) as {
+    documentId: string
+  }[]
+  for (const b of branchRows) expect(b.documentId).not.toBe('uH6qTx6Ai2hl')
+
+  for (const table of [
+    'documentSnapshots',
+    'documentSnapshotChunks',
+    'documentDeltas',
+    'documentFrontiers',
+  ]) {
+    const rows = (await db.selectFrom(table).select('docKey').execute()) as { docKey: string }[]
+    for (const r of rows) expect(r.docKey).not.toBe(docKey)
+  }
+
+  expect(await readdir(blobDir)).toEqual([`${newRow?.id}.loro`])
+  await db.destroy()
+})

--- a/packages/mcp-server/src/server/store/db/published-migration-names.ts
+++ b/packages/mcp-server/src/server/store/db/published-migration-names.ts
@@ -22,4 +22,5 @@ export const PUBLISHED_MIGRATION_NAMES = [
   '0009-document-vocabulary',
   '0010-document-path',
   '0011-import-fs-blobs',
+  '0012-ulid-remaining-document-ids',
 ] as const satisfies readonly string[]

--- a/packages/mcp-server/src/server/store/db/schema.ts
+++ b/packages/mcp-server/src/server/store/db/schema.ts
@@ -14,7 +14,7 @@ interface WorkspacesTable {
 }
 
 interface DocumentsTable {
-  // Stable nanoid that survives path renames. PK so child tables can FK on it.
+  // Stable ULID that survives path renames. PK so child tables can FK on it.
   id: string
   workspaceId: string
   // Mutable display path; UNIQUE within (workspaceId, path).

--- a/packages/mcp-server/src/server/store/db/upsert-workspace.ts
+++ b/packages/mcp-server/src/server/store/db/upsert-workspace.ts
@@ -1,4 +1,4 @@
-import { nanoid } from 'nanoid'
+import { generateDocumentId } from '@kamiazya/whiteboard-model'
 import type { Database } from './index.js'
 
 // Upsert helpers for the FK targets that downstream stores write to. Each one
@@ -49,7 +49,10 @@ export async function upsertCanvasRow(
   await upsertWorkspaceRow(db, workspaceId)
   const existing = await getDocumentIdByPath(db, workspaceId, path)
   if (existing) return existing
-  const id = nanoid(12)
+  // ULID, matching every other documents-row minting site (createDocument,
+  // saveDocument): the port's documentIdSchema accepts only a canonical
+  // ULID, and a nanoid row here is invisible to SqliteDocumentIndex.
+  const id = generateDocumentId()
   const now = Date.now()
   await db
     .insertInto('documents')

--- a/packages/mcp-server/src/server/store/sqlite-document-index.test.ts
+++ b/packages/mcp-server/src/server/store/sqlite-document-index.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { documentEntrySchema } from '@kamiazya/whiteboard-ports'
 import { describeDocumentIndexConformance } from '@kamiazya/whiteboard-ports/test-utils'
 import { describe, expect, it } from 'vitest'
+import { captureLogsForTests } from '../log.js'
 import { createIsolatedDb } from './db/test-helpers.js'
 import { SqliteDocumentIndex } from './sqlite-document-index.js'
 
@@ -124,6 +125,22 @@ describe('rows written before canvasIds were ULIDs', () => {
       const entries = await index.listDocuments({ workspaceId: 'ws-legacy' })
       expect(entries.map((entry) => entry.path)).not.toContain('pre-ulid-doc')
     })
+  })
+
+  it('logs the exclusion at error level — every minting site converges on ULID now, so this is corruption', async () => {
+    // 0008 and 0012 (plus the ULID fix in every minting site) mean a non-ULID
+    // row reaching this branch is no longer an anticipated legacy shape, so
+    // it is loud rather than a routine warning.
+    const captured = captureLogsForTests('debug')
+    try {
+      await withLegacyRow(async (index) => {
+        await index.listDocuments({ workspaceId: 'ws-legacy' })
+      })
+      const record = captured.records.find((r) => r.data?.path === 'pre-ulid-doc')
+      expect(record?.level).toBe('error')
+    } finally {
+      captured.restore()
+    }
   })
 })
 

--- a/packages/mcp-server/src/server/store/sqlite-document-index.ts
+++ b/packages/mcp-server/src/server/store/sqlite-document-index.ts
@@ -58,13 +58,15 @@ function isSelfOrDescendant(path: string, ancestor: string): boolean {
  * canvas list, versions, branches and file GC already hang off, which is what
  * makes an agent-created document one a user can see.
  *
- * New rows are assigned a ULID, not the nanoid `saveDocument` mints for its own
- * rows: ADR-0007 point 5 fixed the ULID as the `documentId` and the nanoid as a
- * storage detail, and `documentIdSchema` in the port's `DocumentEntry` accepts
- * only the former. A row predating this cannot round-trip through the port —
- * a deliberate consequence of converging the two id spaces — so `listDocuments`
- * skips such rows (see its comment) rather than letting one of them fail
- * validation for the whole listing.
+ * Every row-minting site in this codebase (`createDocument` here,
+ * `saveDocument`, and `upsertCanvasRow` shared by the version/name/branch
+ * stores) now assigns a ULID: `documentIdSchema` in the port's
+ * `DocumentEntry` accepts only that shape, and migrations 0008 and 0012 swept
+ * every nanoid row minted before each fix shipped. A non-ULID row reaching
+ * `listDocuments` today is not an expected legacy shape — it is evidence one
+ * of those three guarantees broke — so it is still excluded (one bad row must
+ * not fail output validation for the entire listing) but logged as loudly as
+ * corruption, not as an anticipated skip.
  */
 const log = getLogger('document-index')
 
@@ -177,20 +179,19 @@ export class SqliteDocumentIndex implements DocumentIndex {
     // Sorted here rather than in SQL: segment-wise order is not what any
     // collation gives, and the row count per workspace is a list a human reads.
     //
-    // Rows whose id is not a canonical ULID are SKIPPED, not surfaced:
-    // `saveDocument` minted nanoid row ids before the id spaces converged, and
-    // rows outlive minting policy. The port's DocumentEntry accepts only a
-    // ULID, so mapping such a row does not degrade to one bad entry — it
-    // fails output validation for the ENTIRE listing, and one legacy row per
-    // workspace turns the whole agent surface dark. Skipping keeps those
-    // rows exactly as reachable as they were before the convergence (the
-    // user's gallery), and the log is where the absence is said.
+    // Rows whose id is not a canonical ULID are SKIPPED, not surfaced: the
+    // port's DocumentEntry accepts only a ULID, so mapping such a row does
+    // not degrade to one bad entry — it fails output validation for the
+    // ENTIRE listing, and one bad row per workspace would turn the whole
+    // agent surface dark. Every minting site converged on ULID (see the class
+    // doc comment), so reaching this branch means one of those guarantees
+    // broke — an ERROR, not the anticipated-legacy warning this used to log.
     const entries: DocumentEntry[] = []
     for (const row of rows) {
       if (!documentIdSchema.safeParse(row.id).success) {
-        log.warning(
+        log.error(
           { workspaceId, path: row.path },
-          'skipping a pre-convergence row the port cannot carry',
+          'documents row has a non-ULID id — corruption, not expected legacy data; excluded from this listing',
         )
         continue
       }

--- a/packages/mcp-server/src/server/store/version-store.test.ts
+++ b/packages/mcp-server/src/server/store/version-store.test.ts
@@ -5,6 +5,7 @@ import { documentIdSchema } from '@kamiazya/whiteboard-model'
 import { LoroDoc, LoroMap } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { makeSpatialDoc } from '../../shared/test-utils/spatial-doc.js'
+import { SqliteDocumentIndex } from './sqlite-document-index.js'
 
 // Tests for the native Loro version store backed by the sqlite metadata DB.
 // Frontiers and metadata live in the versions table; thumbnails live as PNG
@@ -85,7 +86,6 @@ describe('FileVersionStore (Loro native, sqlite-backed)', () => {
       .executeTakeFirstOrThrow()
     expect(documentIdSchema.safeParse(row.id).success).toBe(true)
 
-    const { SqliteDocumentIndex } = await import('./sqlite-document-index.js')
     const index = new SqliteDocumentIndex(handle.db)
     const entries = await index.listDocuments({ workspaceId: 'sess-1' })
     expect(entries.map((entry) => entry.path)).toContain('canvas-fresh')

--- a/packages/mcp-server/src/server/store/version-store.test.ts
+++ b/packages/mcp-server/src/server/store/version-store.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { documentIdSchema } from '@kamiazya/whiteboard-model'
 import { LoroDoc, LoroMap } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { makeSpatialDoc } from '../../shared/test-utils/spatial-doc.js'
@@ -64,6 +65,30 @@ describe('FileVersionStore (Loro native, sqlite-backed)', () => {
     expect(entry.label).toBeUndefined()
     expect(entry.hasThumbnail).toBe(false)
     expect(entry.branchName).toBe('main')
+  })
+
+  it('save on a fresh path mints a ULID documents row the agent index can see', async () => {
+    // FileVersionStore.save is a third id-minting site (via upsertCanvasRow):
+    // it creates the `documents` row for a path with no prior row, just like
+    // saveDocument/createDocument do. Before this row's id was a nanoid, it
+    // never round-tripped through documentIdSchema, so SqliteDocumentIndex
+    // skipped it — a version saved on an unindexed path was invisible to
+    // every agent-facing listing despite being visible in the user's gallery.
+    const doc = new LoroDoc()
+    appendElement(doc, 'e1')
+    await store.save('sess-1', 'canvas-fresh', doc, { auto: true })
+
+    const row = await handle.db
+      .selectFrom('documents')
+      .select(['id'])
+      .where('path', '=', 'canvas-fresh')
+      .executeTakeFirstOrThrow()
+    expect(documentIdSchema.safeParse(row.id).success).toBe(true)
+
+    const { SqliteDocumentIndex } = await import('./sqlite-document-index.js')
+    const index = new SqliteDocumentIndex(handle.db)
+    const entries = await index.listDocuments({ workspaceId: 'sess-1' })
+    expect(entries.map((entry) => entry.path)).toContain('canvas-fresh')
   })
 
   it('save counts nodes-model nodes, not the retired legacy elements list', async () => {


### PR DESCRIPTION
## What

Identity-convergence follow-ups (a) + (b), both settled by measurement rather than by the plan's assumption.

**(a) was a live bug, not dead code.** `upsertCanvasRow` — shared by the version, name and branch stores — still minted `nanoid(12)` ids for `documents` rows it created. Because `SqliteDocumentIndex` skips non-ULID rows, every such row was **invisible to the agent surface**: save a version (or set a name, or create a branch) on a path with no document row yet, and the resulting document never appeared in `wb_document_list`. Fixed to `generateDocumentId()`; red-first tests pin that fresh rows from those paths are ULIDs **and** visible through the index.

**Migration 0012** re-mints every remaining non-ULID `documents.id` on existing databases, following 0008's model: repoints `versions`/`branches` children, rewrites `canvas:<id>` docKeys across the four snapshot/chunk/delta/frontier tables, renames the FS blob (ENOENT tolerated, renames unwound on failure), and is idempotent.

**(b) the `SqliteDocumentIndex` skip stays — deliberately.** One invalid row must never fail output validation for the whole listing (the #801 contract), so the exclusion is kept; what changed is its *meaning*: with all three minting sites now on ULIDs and 0008 + 0012 sweeping history, a non-ULID row is no longer an anticipated legacy shape but evidence a guarantee broke — so the log escalates from `warning` to `error` and the comments say corruption instead of legacy.

## Verification

- A migrator-level probe seeds a synthetic legacy dataset **including third-site-shaped rows** with versions/branches children, docKeys and blobs, runs 0001→head, and asserts zero non-ULID ids and no orphaned child/docKey/blob remain — the evidence behind every coverage claim above.
- **Mutation checks**: reverting `upsertCanvasRow` to a nanoid-shaped id turns the ULID/visibility pins red; 0012's blob-rename undo path has its own test.
- mcp-node: 3529 green (288 files) across four consecutive runs; knip + typecheck clean. One earlier run showed a single failure while three other full suites ran concurrently on this machine and did not reproduce in any of the four repeats — noted rather than hidden; CI is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ
