### PR TITLE
feat(web): one link verb, one picker — documents and URLs on the same surface

### DIFF
--- a/apps/web/src/components/document-editor/DocumentEditorSurface.tsx
+++ b/apps/web/src/components/document-editor/DocumentEditorSurface.tsx
@@ -34,6 +34,7 @@ export interface MarkdownDocumentSession
     | 'theme'
     | 'meta'
     | 'resolveAlias'
+    | 'linkTargets'
     | 'onOpenDocument'
     | 'resolveEmbed'
     | 'autoFocus'

--- a/apps/web/src/components/markdown-editor/EditorToolbar.tsx
+++ b/apps/web/src/components/markdown-editor/EditorToolbar.tsx
@@ -38,6 +38,10 @@ const MODE_OPTIONS: readonly ModeOption[] = [
  * thing: **how this document is shown** (word count + view mode), plus the
  * doorway to everything that CHANGES the document.
  *
+ * The doorway's name is "Editing actions" rather than the generic "More
+ * actions" the app shell's own ⋯ uses: two controls with the same accessible
+ * name on one screen are indistinguishable to anyone reading it aloud.
+ *
  * Formatting buttons used to sit here and no longer do. They were redundant
  * for the audience that could reach them (⌘B already exists) and out of
  * reach for the one that needed them — a 28px target at the top edge is the
@@ -96,7 +100,7 @@ export function EditorToolbar({
             <TooltipTrigger asChild>
               <button
                 type="button"
-                aria-label="More actions"
+                aria-label="Editing actions"
                 aria-haspopup="menu"
                 data-testid="editor-catalog-trigger"
                 // Keep focus (and therefore the caret) in the source pane: the
@@ -112,7 +116,7 @@ export function EditorToolbar({
                 <MoreHorizontal aria-hidden className="size-4" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>More actions</TooltipContent>
+            <TooltipContent>Editing actions</TooltipContent>
           </Tooltip>
         )}
       </div>

--- a/apps/web/src/components/markdown-editor/LinkPickerDialog.tsx
+++ b/apps/web/src/components/markdown-editor/LinkPickerDialog.tsx
@@ -1,0 +1,163 @@
+import { FileSymlink, SquareArrowOutUpRight } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { cn } from '../../lib/utils.js'
+import {
+  externalLinkMarkup,
+  type LinkTarget,
+  linkMarkupFor,
+  rankLinkTargets,
+  urlFromQuery,
+} from './link-target.js'
+
+export interface LinkPickerDialogProps {
+  readonly targets: readonly LinkTarget[]
+  /** Seeded from the text the verb would have acted on — usually the caret's word. */
+  readonly initialQuery: string
+  /** The text an external link should carry; empty yields a bare autolink. */
+  readonly linkText: string
+  readonly onPick: (markup: string) => void
+  readonly onCancel: () => void
+}
+
+/**
+ * One surface for both kinds of link, because the author knows where they
+ * want to go and not what we call it. What is typed decides: a name narrows
+ * the workspace's documents, something URL-shaped puts "Link to <url>" at the
+ * top of the same list. Nothing has to be classified before it is typed.
+ *
+ * The box is seeded with the word the verb would otherwise have wrapped, so
+ * the pre-picker gesture still ends in one Enter rather than becoming a
+ * search someone has to retype.
+ */
+export function LinkPickerDialog({
+  targets,
+  initialQuery,
+  linkText,
+  onPick,
+  onCancel,
+}: LinkPickerDialogProps) {
+  const [query, setQuery] = useState(initialQuery)
+  const [active, setActive] = useState(0)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  // Focus on open rather than via `autoFocus`: this dialog is opened by an
+  // explicit verb, so typing is the next step and there is nowhere else for
+  // focus to sit.
+  useEffect(() => {
+    inputRef.current?.focus()
+    inputRef.current?.select()
+  }, [])
+
+  const url = urlFromQuery(query)
+  const matches = useMemo(() => rankLinkTargets(targets, query), [targets, query])
+  const rows = useMemo(
+    () => [
+      ...(url === null ? [] : [{ kind: 'url' as const, url }]),
+      ...matches.map((target) => ({ kind: 'document' as const, target })),
+    ],
+    [url, matches],
+  )
+  const activeIndex = Math.min(active, Math.max(0, rows.length - 1))
+
+  const commit = (index: number) => {
+    const row = rows[index]
+    if (row === undefined) return
+    onPick(
+      row.kind === 'url'
+        ? externalLinkMarkup(linkText, row.url)
+        : linkMarkupFor(row.target, targets),
+    )
+  }
+
+  return (
+    <div
+      data-editor-overlay
+      data-testid="link-picker"
+      role="dialog"
+      aria-label="Link"
+      className="bg-background rounded-md border p-2 shadow-lg"
+      style={{
+        position: 'absolute',
+        zIndex: 30,
+        left: '50%',
+        top: '20%',
+        transform: 'translateX(-50%)',
+        width: 'min(22rem, calc(100% - 2rem))',
+      }}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') {
+          event.stopPropagation()
+          onCancel()
+          return
+        }
+        if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+          event.preventDefault()
+          const delta = event.key === 'ArrowDown' ? 1 : -1
+          setActive((current) => {
+            const next = Math.min(rows.length - 1, Math.max(0, current + delta))
+            return next
+          })
+          return
+        }
+        if (event.key === 'Enter') {
+          event.preventDefault()
+          commit(activeIndex)
+        }
+      }}
+    >
+      <input
+        ref={inputRef}
+        role="combobox"
+        aria-expanded
+        aria-controls="link-picker-list"
+        aria-activedescendant={rows.length === 0 ? undefined : `link-picker-row-${activeIndex}`}
+        value={query}
+        onChange={(event) => {
+          setQuery(event.target.value)
+          setActive(0)
+        }}
+        placeholder="Search documents, or paste a URL"
+        aria-label="Search documents, or paste a URL"
+        className="border-input focus-visible:ring-ring w-full rounded-md border px-2 py-1.5 text-sm focus-visible:ring-2 focus-visible:outline-none"
+      />
+      <div
+        id="link-picker-list"
+        role="listbox"
+        aria-label="Link targets"
+        className="mt-1 max-h-56 overflow-y-auto"
+      >
+        {rows.length === 0 && (
+          <p className="text-muted-foreground px-2 py-3 text-xs">No document matches.</p>
+        )}
+        {rows.map((row, index) => {
+          const key = row.kind === 'url' ? `url:${row.url}` : row.target.id
+          const label = row.kind === 'url' ? row.url : row.target.name
+          return (
+            <button
+              key={key}
+              id={`link-picker-row-${index}`}
+              type="button"
+              role="option"
+              aria-selected={index === activeIndex}
+              onMouseEnter={() => setActive(index)}
+              onClick={() => commit(index)}
+              className={cn(
+                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm',
+                index === activeIndex ? 'bg-accent text-foreground' : 'text-muted-foreground',
+              )}
+            >
+              {row.kind === 'url' ? (
+                <SquareArrowOutUpRight aria-hidden className="size-4 shrink-0" />
+              ) : (
+                <FileSymlink aria-hidden className="size-4 shrink-0" />
+              )}
+              <span className="truncate">{label}</span>
+              {row.kind === 'url' && (
+                <span className="text-muted-foreground ml-auto shrink-0 text-xs">External</span>
+              )}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/markdown-editor/MarkdownEditor.test.tsx
+++ b/apps/web/src/components/markdown-editor/MarkdownEditor.test.tsx
@@ -112,13 +112,13 @@ describe('MarkdownEditor', () => {
     // nothing to act on: the doorway goes away rather than opening onto
     // disabled entries.
     const { getByRole, queryByRole } = render(<MarkdownEditor value="# Hi" onChange={() => {}} />)
-    expect(queryByRole('button', { name: 'More actions' })).not.toBeNull()
+    expect(queryByRole('button', { name: 'Editing actions' })).not.toBeNull()
 
     fireEvent.click(getByRole('button', { name: 'Read' }))
-    expect(queryByRole('button', { name: 'More actions' })).toBeNull()
+    expect(queryByRole('button', { name: 'Editing actions' })).toBeNull()
 
     fireEvent.click(getByRole('button', { name: 'Write' }))
-    expect(queryByRole('button', { name: 'More actions' })).not.toBeNull()
+    expect(queryByRole('button', { name: 'Editing actions' })).not.toBeNull()
   })
 
   it('falls back from Split to Write in a narrow container, reflecting it in the toolbar without overwriting the stored preference', () => {

--- a/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
@@ -3,7 +3,7 @@ import type { MdastLayoutOptions, MeasureText } from '@kamiazya/whiteboard-canva
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
 import type { AliasResolver } from '@kamiazya/whiteboard-codec'
 import { documentIdSchema, type StoredCoreFacets } from '@kamiazya/whiteboard-model'
-import { Bold, Code, FileSymlink, Italic, SquareCheck } from 'lucide-react'
+import { Bold, Code, Italic, Link2, SquareCheck } from 'lucide-react'
 import {
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
@@ -20,6 +20,8 @@ import { cn } from '../../lib/utils.js'
 import { ContextMenu, type ContextMenuItem } from '../spatial-editor/ContextMenu.js'
 import { DocumentHeader } from './DocumentHeader.js'
 import { EditorToolbar, type MarkdownViewMode } from './EditorToolbar.js'
+import { LinkPickerDialog } from './LinkPickerDialog.js'
+import type { LinkTarget } from './link-target.js'
 import { PreviewPane } from './PreviewPane.js'
 import type { PreviewBlockAnchor } from './render-preview.js'
 import { SourcePane, type SourcePaneApi } from './SourcePane.js'
@@ -56,6 +58,13 @@ export interface MarkdownEditorProps {
    * separate resolution pass). Absent, only `[[canvas:ULID]]` resolves.
    */
   resolveAlias?: AliasResolver
+  /**
+   * Documents this editor may link to. Supplied by the composition root,
+   * which already holds the list its switcher shows. Absent (or empty) keeps
+   * the link verb's selection-free wrap: a picker onto an empty list would
+   * be a dead end.
+   */
+  linkTargets?: readonly LinkTarget[]
   /**
    * Called with the target canvas id when a resolved wikiLink is activated
    * in the preview. The host owns navigation; without it, wikiLink anchors
@@ -216,6 +225,7 @@ export function MarkdownEditor({
   meta,
   title,
   resolveAlias,
+  linkTargets,
   onOpenDocument,
   resolveEmbed,
   fragmentLoaders,
@@ -264,6 +274,7 @@ export function MarkdownEditor({
    * The open catalog and where it is anchored, in coordinates relative to
    * the editor root (ContextMenu positions against its offsetParent).
    */
+  const [linkPicker, setLinkPicker] = useState<{ query: string; text: string } | null>(null)
   const [catalog, setCatalog] = useState<{
     x: number
     y: number
@@ -436,14 +447,21 @@ export function MarkdownEditor({
       { label: 'Italic', icon: <Italic aria-hidden className="size-4" />, onSelect: wrap('*') },
       { label: 'Code', icon: <Code aria-hidden className="size-4" />, onSelect: wrap('`') },
       {
-        // Named for its destination, not its syntax: a chain icon and the
-        // word "link" would have to cover an external URL too, and this
-        // verb cannot — it wraps text in `[[ ]]`, which only ever resolves
-        // to a document in this workspace. The distinction has to survive
-        // an external-link verb arriving beside it.
-        label: 'Link to document',
-        icon: <FileSymlink aria-hidden className="size-4" />,
-        onSelect: wrap('[[', ']]'),
+        // One verb for both kinds of link: the picker's search box decides
+        // where it goes, so nothing asks the author to classify a
+        // destination before typing it. With no targets to pick from there
+        // is nothing to open, and the verb keeps its bracket wrap.
+        label: 'Link',
+        icon: <Link2 aria-hidden className="size-4" />,
+        onSelect:
+          linkTargets === undefined || linkTargets.length === 0
+            ? wrap('[[', ']]')
+            : () => {
+                const api = sourceApiRef.current
+                const text = api?.scopeText() ?? ''
+                setCatalog(null)
+                setLinkPicker({ query: text, text })
+              },
       },
       { kind: 'separator' },
       {
@@ -452,7 +470,7 @@ export function MarkdownEditor({
         onSelect: run(toggleTaskCheckbox),
       },
     ]
-  }, [catalog])
+  }, [catalog, linkTargets])
 
   const wordCount = useMemo(() => countWords(debouncedValue), [debouncedValue])
   const previewEmpty = debouncedValue.trim() === ''
@@ -543,6 +561,21 @@ export function MarkdownEditor({
           </div>
         )}
       </div>
+      {linkPicker !== null && linkTargets !== undefined && (
+        <LinkPickerDialog
+          targets={linkTargets}
+          initialQuery={linkPicker.query}
+          linkText={linkPicker.text}
+          onPick={(markup) => {
+            sourceApiRef.current?.replaceScope(markup)
+            setLinkPicker(null)
+          }}
+          onCancel={() => {
+            setLinkPicker(null)
+            sourceApiRef.current?.focus()
+          }}
+        />
+      )}
       {catalog !== null && (
         <ContextMenu
           x={catalog.x}

--- a/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
@@ -274,12 +274,9 @@ export function MarkdownEditor({
    * The open catalog and where it is anchored, in coordinates relative to
    * the editor root (ContextMenu positions against its offsetParent).
    */
-  const [linkPicker, setLinkPicker] = useState<{
-    query: string
-    text: string
-    /** Pinned at open: the caret may move under this non-modal dialog. */
-    range: { from: number; to: number }
-  } | null>(null)
+  // The range itself lives in the editor state (see SourcePane's pinnedRange),
+  // which maps it through any edit made while the dialog is open.
+  const [linkPicker, setLinkPicker] = useState<{ query: string; text: string } | null>(null)
   const [catalog, setCatalog] = useState<{
     x: number
     y: number
@@ -462,10 +459,10 @@ export function MarkdownEditor({
           linkTargets === undefined || linkTargets.length === 0
             ? wrap('[[', ']]')
             : () => {
-                const scope = sourceApiRef.current?.scopeRange()
+                const scope = sourceApiRef.current?.pinScope()
                 if (scope === undefined) return
                 setCatalog(null)
-                setLinkPicker({ query: scope.text, text: scope.text, range: scope })
+                setLinkPicker({ query: scope.text, text: scope.text })
               },
       },
       { kind: 'separator' },
@@ -572,11 +569,12 @@ export function MarkdownEditor({
           initialQuery={linkPicker.query}
           linkText={linkPicker.text}
           onPick={(markup) => {
-            sourceApiRef.current?.replaceRange(linkPicker.range, markup)
+            sourceApiRef.current?.replacePinned(markup)
             setLinkPicker(null)
           }}
           onCancel={() => {
             setLinkPicker(null)
+            sourceApiRef.current?.clearPin()
             sourceApiRef.current?.focus()
           }}
         />

--- a/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
@@ -274,7 +274,12 @@ export function MarkdownEditor({
    * The open catalog and where it is anchored, in coordinates relative to
    * the editor root (ContextMenu positions against its offsetParent).
    */
-  const [linkPicker, setLinkPicker] = useState<{ query: string; text: string } | null>(null)
+  const [linkPicker, setLinkPicker] = useState<{
+    query: string
+    text: string
+    /** Pinned at open: the caret may move under this non-modal dialog. */
+    range: { from: number; to: number }
+  } | null>(null)
   const [catalog, setCatalog] = useState<{
     x: number
     y: number
@@ -457,10 +462,10 @@ export function MarkdownEditor({
           linkTargets === undefined || linkTargets.length === 0
             ? wrap('[[', ']]')
             : () => {
-                const api = sourceApiRef.current
-                const text = api?.scopeText() ?? ''
+                const scope = sourceApiRef.current?.scopeRange()
+                if (scope === undefined) return
                 setCatalog(null)
-                setLinkPicker({ query: text, text })
+                setLinkPicker({ query: scope.text, text: scope.text, range: scope })
               },
       },
       { kind: 'separator' },
@@ -567,7 +572,7 @@ export function MarkdownEditor({
           initialQuery={linkPicker.query}
           linkText={linkPicker.text}
           onPick={(markup) => {
-            sourceApiRef.current?.replaceScope(markup)
+            sourceApiRef.current?.replaceRange(linkPicker.range, markup)
             setLinkPicker(null)
           }}
           onCancel={() => {

--- a/apps/web/src/components/markdown-editor/SourcePane.tsx
+++ b/apps/web/src/components/markdown-editor/SourcePane.tsx
@@ -7,6 +7,8 @@ import {
   type Extension,
   Prec,
   type StateCommand,
+  StateEffect,
+  StateField,
 } from '@codemirror/state'
 import { EditorView, keymap, placeholder } from '@codemirror/view'
 import { tags } from '@lezer/highlight'
@@ -45,6 +47,34 @@ function wrapSelectionWith(open: string, close: string = open): StateCommand {
     return true
   }
 }
+
+/**
+ * The range a surface that ASKS the user something (the link picker) will
+ * write to when it finally commits.
+ *
+ * It has to be a `StateField` rather than a remembered pair of offsets: the
+ * dialog is not modal, so the document can change under it, and text typed
+ * BEFORE the range shifts every later position. CodeMirror maps positions
+ * through a change set for exactly this, so the pin travels with the text it
+ * points at instead of pointing at whatever now occupies those offsets.
+ *
+ * Bias points INWARD at both ends (`1` at the start, `-1` at the end) so an
+ * insertion at either boundary stays OUTSIDE the pinned range: text typed
+ * immediately before the word must not become part of what the link
+ * replaces. The outward-looking pair is the intuitive choice and is wrong —
+ * `mapPos(from, -1)` keeps the start before an insertion at that offset, so
+ * the range swallows it.
+ */
+const setPinnedRange = StateEffect.define<{ from: number; to: number } | null>()
+
+const pinnedRange = StateField.define<{ from: number; to: number } | null>({
+  create: () => null,
+  update(value, tr) {
+    for (const effect of tr.effects) if (effect.is(setPinnedRange)) return effect.value
+    if (value === null) return null
+    return { from: tr.changes.mapPos(value.from, 1), to: tr.changes.mapPos(value.to, -1) }
+  },
+})
 
 /**
  * Shared with the spatial node editor (markdown-editor and spatial-editor
@@ -107,18 +137,18 @@ export interface SourcePaneApi {
   /** Heading level of the line the caret sits on; 0 for body text. */
   headingLevel: () => number
   /**
-   * The range an inline verb would act on — the selection, else the caret's
-   * word — with the text it currently holds.
+   * Pins the range an inline verb would act on — the selection, else the
+   * caret's word — and answers the text it holds.
    *
-   * Handed out rather than kept internal because a surface that ASKS the
-   * user something (the link picker) commits later, and the caret can move
-   * under a non-modal dialog in between. The range the user was shown must
-   * be the range that gets written, so the caller pins this and passes it
-   * back to `replaceRange`.
+   * For a surface that commits LATER (the link picker): the caret can move
+   * and the document can change under a non-modal dialog, and the range the
+   * user was shown must still be the range that gets written.
    */
-  scopeRange: () => { from: number; to: number; text: string }
-  /** Replaces a pinned range with `markup`, leaving the caret after it. */
-  replaceRange: (range: { from: number; to: number }, markup: string) => void
+  pinScope: () => { text: string }
+  /** Replaces the pinned range with `markup` and clears the pin. */
+  replacePinned: (markup: string) => void
+  /** Drops the pin without writing anything. */
+  clearPin: () => void
   focus: () => void
   /**
    * The 1-based document line at the top of the visible scroll area, plus
@@ -199,6 +229,7 @@ export function SourcePane({
         // an escaped-source placeholder anyway (see render-preview.ts), so
         // there is nothing yet for a source-side math grammar to agree with.
         markdown({ extensions: [GFM] }),
+        pinnedRange,
         // Above the language keymap's own Enter (`markdown()` registers
         // lang-markdown's auto-continuation at high precedence): Enter on
         // an EMPTY list item must delete the marker, not march it down
@@ -261,24 +292,25 @@ export function SourcePane({
           view.focus()
         },
         headingLevel: () => headingLevelAt(view.state),
-        scopeRange: () => {
+        pinScope: () => {
           const scope = rangeToActOn(view.state)
-          return { ...scope, text: view.state.doc.sliceString(scope.from, scope.to) }
+          view.dispatch({ effects: setPinnedRange.of(scope) })
+          return { text: view.state.doc.sliceString(scope.from, scope.to) }
         },
-        replaceRange: (range, markup) => {
-          // Clamped because the pinned range predates whatever else may have
-          // been typed: a stale offset past the end would throw rather than
-          // write.
-          const end = view.state.doc.length
-          const from = Math.min(range.from, end)
-          const to = Math.min(Math.max(range.to, from), end)
+        replacePinned: (markup) => {
+          const pin = view.state.field(pinnedRange)
+          if (pin === null) return
           view.dispatch({
-            changes: { from, to, insert: markup },
-            selection: { anchor: from + markup.length },
+            changes: { from: pin.from, to: pin.to, insert: markup },
+            selection: { anchor: pin.from + markup.length },
+            effects: setPinnedRange.of(null),
             scrollIntoView: true,
             userEvent: 'input',
           })
           view.focus()
+        },
+        clearPin: () => {
+          view.dispatch({ effects: setPinnedRange.of(null) })
         },
         focus: () => view.focus(),
         topVisibleLine: () => {

--- a/apps/web/src/components/markdown-editor/SourcePane.tsx
+++ b/apps/web/src/components/markdown-editor/SourcePane.tsx
@@ -106,6 +106,14 @@ export interface SourcePaneApi {
   run: (command: StateCommand) => void
   /** Heading level of the line the caret sits on; 0 for body text. */
   headingLevel: () => number
+  /**
+   * The text an inline verb would act on — the selection, else the caret's
+   * word. What the link picker seeds its search box with, so the gesture
+   * that used to wrap that word still ends in one keystroke.
+   */
+  scopeText: () => string
+  /** Replaces that same range with `markup`, leaving the caret after it. */
+  replaceScope: (markup: string) => void
   focus: () => void
   /**
    * The 1-based document line at the top of the visible scroll area, plus
@@ -248,6 +256,20 @@ export function SourcePane({
           view.focus()
         },
         headingLevel: () => headingLevelAt(view.state),
+        scopeText: () => {
+          const scope = rangeToActOn(view.state)
+          return view.state.doc.sliceString(scope.from, scope.to)
+        },
+        replaceScope: (markup) => {
+          const scope = rangeToActOn(view.state)
+          view.dispatch({
+            changes: { from: scope.from, to: scope.to, insert: markup },
+            selection: { anchor: scope.from + markup.length },
+            scrollIntoView: true,
+            userEvent: 'input',
+          })
+          view.focus()
+        },
         focus: () => view.focus(),
         topVisibleLine: () => {
           const scrollTop = view.scrollDOM.scrollTop

--- a/apps/web/src/components/markdown-editor/SourcePane.tsx
+++ b/apps/web/src/components/markdown-editor/SourcePane.tsx
@@ -107,13 +107,18 @@ export interface SourcePaneApi {
   /** Heading level of the line the caret sits on; 0 for body text. */
   headingLevel: () => number
   /**
-   * The text an inline verb would act on — the selection, else the caret's
-   * word. What the link picker seeds its search box with, so the gesture
-   * that used to wrap that word still ends in one keystroke.
+   * The range an inline verb would act on — the selection, else the caret's
+   * word — with the text it currently holds.
+   *
+   * Handed out rather than kept internal because a surface that ASKS the
+   * user something (the link picker) commits later, and the caret can move
+   * under a non-modal dialog in between. The range the user was shown must
+   * be the range that gets written, so the caller pins this and passes it
+   * back to `replaceRange`.
    */
-  scopeText: () => string
-  /** Replaces that same range with `markup`, leaving the caret after it. */
-  replaceScope: (markup: string) => void
+  scopeRange: () => { from: number; to: number; text: string }
+  /** Replaces a pinned range with `markup`, leaving the caret after it. */
+  replaceRange: (range: { from: number; to: number }, markup: string) => void
   focus: () => void
   /**
    * The 1-based document line at the top of the visible scroll area, plus
@@ -256,15 +261,20 @@ export function SourcePane({
           view.focus()
         },
         headingLevel: () => headingLevelAt(view.state),
-        scopeText: () => {
+        scopeRange: () => {
           const scope = rangeToActOn(view.state)
-          return view.state.doc.sliceString(scope.from, scope.to)
+          return { ...scope, text: view.state.doc.sliceString(scope.from, scope.to) }
         },
-        replaceScope: (markup) => {
-          const scope = rangeToActOn(view.state)
+        replaceRange: (range, markup) => {
+          // Clamped because the pinned range predates whatever else may have
+          // been typed: a stale offset past the end would throw rather than
+          // write.
+          const end = view.state.doc.length
+          const from = Math.min(range.from, end)
+          const to = Math.min(Math.max(range.to, from), end)
           view.dispatch({
-            changes: { from: scope.from, to: scope.to, insert: markup },
-            selection: { anchor: scope.from + markup.length },
+            changes: { from, to, insert: markup },
+            selection: { anchor: from + markup.length },
             scrollIntoView: true,
             userEvent: 'input',
           })

--- a/apps/web/src/components/markdown-editor/editor-catalog.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/editor-catalog.browser.test.tsx
@@ -39,7 +39,7 @@ describe('the editor catalog (real browser)', () => {
     )
     await caretInto(container, 6) // inside "this"
 
-    await userEvent.click(getByRole('button', { name: 'More actions' }))
+    await userEvent.click(getByRole('button', { name: 'Editing actions' }))
     await userEvent.click(getByRole('menuitem', { name: 'Bold' }))
 
     expect(onChange.mock.calls.at(-1)?.[0]).toBe('make **this** bold')
@@ -52,7 +52,7 @@ describe('the editor catalog (real browser)', () => {
     )
     await caretInto(container, 5)
 
-    await userEvent.click(getByRole('button', { name: 'More actions' }))
+    await userEvent.click(getByRole('button', { name: 'Editing actions' }))
     expect(getByRole('menuitemradio', { name: 'H2' }).getAttribute('aria-checked')).toBe('true')
     await userEvent.click(getByRole('menuitemradio', { name: 'H1' }))
 
@@ -66,7 +66,7 @@ describe('the editor catalog (real browser)', () => {
     )
     await caretInto(container, 6) // inside "weekly"
 
-    await userEvent.click(getByRole('button', { name: 'More actions' }))
+    await userEvent.click(getByRole('button', { name: 'Editing actions' }))
     // With no targets supplied there is nothing to pick from, so the verb
     // keeps the selection-free wrap (the picker's own file covers the rest).
     await userEvent.click(getByRole('menuitem', { name: 'Link' }))
@@ -81,7 +81,7 @@ describe('the editor catalog (real browser)', () => {
     )
     await caretInto(container, 8)
 
-    await userEvent.click(getByRole('button', { name: 'More actions' }))
+    await userEvent.click(getByRole('button', { name: 'Editing actions' }))
     await userEvent.click(getByRole('menuitem', { name: 'Toggle task' }))
 
     expect(onChange.mock.calls.at(-1)?.[0]).toBe('- [x] ship it')
@@ -99,7 +99,7 @@ describe('the editor catalog (real browser)', () => {
       </div>,
     )
     await caretInto(container, 6)
-    await userEvent.click(getByRole('button', { name: 'More actions' }))
+    await userEvent.click(getByRole('button', { name: 'Editing actions' }))
 
     const menu = container.querySelector('[data-testid="context-menu"]') as HTMLElement
     expect(menu).not.toBeNull()

--- a/apps/web/src/components/markdown-editor/editor-catalog.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/editor-catalog.browser.test.tsx
@@ -67,9 +67,9 @@ describe('the editor catalog (real browser)', () => {
     await caretInto(container, 6) // inside "weekly"
 
     await userEvent.click(getByRole('button', { name: 'More actions' }))
-    // The label says the destination, so an external-link verb can join the
-    // band later without either one becoming ambiguous.
-    await userEvent.click(getByRole('menuitem', { name: 'Link to document' }))
+    // With no targets supplied there is nothing to pick from, so the verb
+    // keeps the selection-free wrap (the picker's own file covers the rest).
+    await userEvent.click(getByRole('menuitem', { name: 'Link' }))
 
     expect(onChange.mock.calls.at(-1)?.[0]).toBe('see [[weekly]] review')
   })

--- a/apps/web/src/components/markdown-editor/link-picker.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/link-picker.browser.test.tsx
@@ -1,0 +1,142 @@
+// One verb, one surface: the search box decides whether you are linking to a
+// document in this workspace or to a URL. Nothing asks the author to classify
+// the destination before they have typed it.
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import type { LinkTarget } from './link-target.js'
+import { MarkdownEditor } from './MarkdownEditor.js'
+
+afterEach(() => {
+  cleanup()
+  window.localStorage.clear()
+})
+
+const targets: readonly LinkTarget[] = [
+  { id: '01JWEEK', name: 'Weekly review', kind: 'markdown' },
+  { id: '01JSPRINT', name: 'Sprint board', kind: 'spatial' },
+  { id: '01JDUPE1', name: 'untitled', kind: 'markdown' },
+  { id: '01JDUPE2', name: 'untitled', kind: 'markdown' },
+]
+
+async function caretInto(container: HTMLElement, right: number): Promise<void> {
+  const editable = container
+    .querySelector('[data-testid="markdown-source-pane"]')
+    ?.querySelector('[contenteditable="true"]')
+  if (!editable) throw new Error('expected a contenteditable CodeMirror host')
+  await userEvent.click(editable.querySelector('.cm-line') as HTMLElement)
+  await userEvent.keyboard('{Control>}{Home}{/Control}')
+  for (let i = 0; i < right; i++) await userEvent.keyboard('{ArrowRight}')
+}
+
+async function openPicker(container: HTMLElement, getByRole: RenderResult['getByRole']) {
+  await userEvent.click(getByRole('button', { name: 'More actions' }))
+  await userEvent.click(getByRole('menuitem', { name: 'Link' }))
+  return container.querySelector('[data-testid="link-picker"]') as HTMLElement
+}
+
+type RenderResult = ReturnType<typeof render>
+
+describe('the link picker (real browser)', () => {
+  it("seeds the search box with the caret's word, so the fast path stays one Enter", async () => {
+    const onChange = vi.fn()
+    const { container, getByRole } = render(
+      <MarkdownEditor value="see weekly notes" onChange={onChange} linkTargets={targets} />,
+    )
+    await caretInto(container, 6) // inside "weekly"
+
+    const picker = await openPicker(container, getByRole)
+    expect(picker).not.toBeNull()
+    expect((picker.querySelector('input') as HTMLInputElement).value).toBe('weekly')
+
+    await userEvent.keyboard('{Enter}')
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe('see [[Weekly review]] notes')
+  })
+
+  it('narrows as you type and links what you pick', async () => {
+    const onChange = vi.fn()
+    const { container, getByRole } = render(
+      <MarkdownEditor value="x" onChange={onChange} linkTargets={targets} />,
+    )
+    await caretInto(container, 1)
+
+    const picker = await openPicker(container, getByRole)
+    const input = picker.querySelector('input') as HTMLInputElement
+    await userEvent.clear(input)
+    await userEvent.fill(input, 'sprint')
+
+    const options = picker.querySelectorAll('[role="option"]')
+    expect(options).toHaveLength(1)
+    await userEvent.click(options[0] as HTMLElement)
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe('[[Sprint board]]')
+  })
+
+  // The picker is the one place that knows WHICH document was chosen, so it
+  // spends that knowledge on the ambiguous case instead of writing a link
+  // that would silently stay literal text.
+  it('writes the id when two documents share a name', async () => {
+    const onChange = vi.fn()
+    const { container, getByRole } = render(
+      <MarkdownEditor value="x" onChange={onChange} linkTargets={targets} />,
+    )
+    await caretInto(container, 1)
+
+    const picker = await openPicker(container, getByRole)
+    const input = picker.querySelector('input') as HTMLInputElement
+    await userEvent.clear(input)
+    await userEvent.fill(input, 'untitled')
+    await userEvent.click(picker.querySelectorAll('[role="option"]')[0] as HTMLElement)
+
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe('[[canvas:01JDUPE1]]')
+  })
+
+  it('offers the URL when what you typed is one', async () => {
+    const onChange = vi.fn()
+    const { container, getByRole } = render(
+      <MarkdownEditor value="the docs" onChange={onChange} linkTargets={targets} />,
+    )
+    await caretInto(container, 5) // inside "docs"
+
+    const picker = await openPicker(container, getByRole)
+    const input = picker.querySelector('input') as HTMLInputElement
+    await userEvent.clear(input)
+    await userEvent.fill(input, 'https://example.com/guide')
+
+    const first = picker.querySelector('[role="option"]') as HTMLElement
+    expect(first.textContent).toContain('https://example.com/guide')
+    await userEvent.click(first)
+
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe('the [docs](https://example.com/guide)')
+  })
+
+  it('closes on Escape without touching the document', async () => {
+    const onChange = vi.fn()
+    const { container, getByRole } = render(
+      <MarkdownEditor value="untouched" onChange={onChange} linkTargets={targets} />,
+    )
+    await caretInto(container, 3)
+
+    await openPicker(container, getByRole)
+    await userEvent.keyboard('{Escape}')
+
+    expect(container.querySelector('[data-testid="link-picker"]')).toBeNull()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  // Without a host-supplied list there is nothing to pick from, and a picker
+  // that opens onto an empty list is a dead end — the verb keeps its
+  // selection-free wrap instead.
+  it('falls back to wrapping the word when the host supplies no targets', async () => {
+    const onChange = vi.fn()
+    const { container, getByRole } = render(
+      <MarkdownEditor value="see weekly notes" onChange={onChange} />,
+    )
+    await caretInto(container, 6)
+
+    await userEvent.click(getByRole('button', { name: 'More actions' }))
+    await userEvent.click(getByRole('menuitem', { name: 'Link' }))
+
+    expect(container.querySelector('[data-testid="link-picker"]')).toBeNull()
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe('see [[weekly]] notes')
+  })
+})

--- a/apps/web/src/components/markdown-editor/link-picker.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/link-picker.browser.test.tsx
@@ -30,7 +30,7 @@ async function caretInto(container: HTMLElement, right: number): Promise<void> {
 }
 
 async function openPicker(container: HTMLElement, getByRole: RenderResult['getByRole']) {
-  await userEvent.click(getByRole('button', { name: 'More actions' }))
+  await userEvent.click(getByRole('button', { name: 'Editing actions' }))
   await userEvent.click(getByRole('menuitem', { name: 'Link' }))
   return container.querySelector('[data-testid="link-picker"]') as HTMLElement
 }
@@ -109,6 +109,69 @@ describe('the link picker (real browser)', () => {
     expect(onChange.mock.calls.at(-1)?.[0]).toBe('the [docs](https://example.com/guide)')
   })
 
+  // The dialog is not modal, so the caret can move under it — and the range
+  // the verb showed you is the range it must write to. Re-deriving it at
+  // commit time splices the markup wherever the caret ended up, silently
+  // destroying whatever was there.
+  it('writes to the range it was opened for, even if the caret moved meanwhile', async () => {
+    const onChange = vi.fn()
+    const { container, getByRole } = render(
+      <MarkdownEditor value="weekly beta" onChange={onChange} linkTargets={targets} />,
+    )
+    await caretInto(container, 3) // inside "weekly"
+
+    const picker = await openPicker(container, getByRole)
+    expect((picker.querySelector('input') as HTMLInputElement).value).toBe('weekly')
+
+    // Back into the document, caret to the end, then pick from the still-open
+    // dialog.
+    const editable = container.querySelector('[contenteditable="true"]') as HTMLElement
+    await userEvent.click(editable.querySelector('.cm-line') as HTMLElement)
+    await userEvent.keyboard('{Control>}{End}{/Control}')
+    await userEvent.click(container.querySelectorAll('[role="option"]')[0] as HTMLElement)
+
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe('[[Weekly review]] beta')
+  })
+
+  it('moves the highlight with the arrow keys and commits the active row', async () => {
+    const onChange = vi.fn()
+    const { container, getByRole } = render(
+      <MarkdownEditor value="x" onChange={onChange} linkTargets={targets} />,
+    )
+    await caretInto(container, 1)
+
+    const picker = await openPicker(container, getByRole)
+    const input = picker.querySelector('input') as HTMLInputElement
+    await userEvent.clear(input)
+    await userEvent.fill(input, 'untitled')
+    await userEvent.keyboard('{ArrowDown}')
+
+    const options = picker.querySelectorAll('[role="option"]')
+    expect(options[1]?.getAttribute('aria-selected')).toBe('true')
+    await userEvent.keyboard('{Enter}')
+
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe('[[canvas:01JDUPE2]]')
+  })
+
+  it('says so when nothing matches, and Enter does nothing', async () => {
+    const onChange = vi.fn()
+    const { container, getByRole } = render(
+      <MarkdownEditor value="x" onChange={onChange} linkTargets={targets} />,
+    )
+    await caretInto(container, 1)
+
+    const picker = await openPicker(container, getByRole)
+    const input = picker.querySelector('input') as HTMLInputElement
+    await userEvent.clear(input)
+    await userEvent.fill(input, 'nothing by this name')
+
+    expect(picker.querySelectorAll('[role="option"]')).toHaveLength(0)
+    expect(picker.textContent).toContain('No document matches')
+    await userEvent.keyboard('{Enter}')
+    expect(onChange).not.toHaveBeenCalled()
+    expect(container.querySelector('[data-testid="link-picker"]')).not.toBeNull()
+  })
+
   it('closes on Escape without touching the document', async () => {
     const onChange = vi.fn()
     const { container, getByRole } = render(
@@ -133,7 +196,7 @@ describe('the link picker (real browser)', () => {
     )
     await caretInto(container, 6)
 
-    await userEvent.click(getByRole('button', { name: 'More actions' }))
+    await userEvent.click(getByRole('button', { name: 'Editing actions' }))
     await userEvent.click(getByRole('menuitem', { name: 'Link' }))
 
     expect(container.querySelector('[data-testid="link-picker"]')).toBeNull()

--- a/apps/web/src/components/markdown-editor/link-picker.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/link-picker.browser.test.tsx
@@ -2,6 +2,7 @@
 // document in this workspace or to a URL. Nothing asks the author to classify
 // the destination before they have typed it.
 import { cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
 import type { LinkTarget } from './link-target.js'
@@ -36,6 +37,32 @@ async function openPicker(container: HTMLElement, getByRole: RenderResult['getBy
 }
 
 type RenderResult = ReturnType<typeof render>
+
+/**
+ * A host that actually keeps what is typed. The other cases can pass a fixed
+ * `value` because they make exactly one edit, but a case that types INTO the
+ * document mid-flow needs the controlled value to follow — otherwise
+ * SourcePane's reconcile effect rewinds the typing before the assertion.
+ */
+function StatefulHost({
+  initial,
+  onChange,
+}: {
+  initial: string
+  onChange: (next: string) => void
+}) {
+  const [value, setValue] = useState(initial)
+  return (
+    <MarkdownEditor
+      value={value}
+      onChange={(next) => {
+        setValue(next)
+        onChange(next)
+      }}
+      linkTargets={targets}
+    />
+  )
+}
 
 describe('the link picker (real browser)', () => {
   it("seeds the search box with the caret's word, so the fast path stays one Enter", async () => {
@@ -131,6 +158,28 @@ describe('the link picker (real browser)', () => {
     await userEvent.click(container.querySelectorAll('[role="option"]')[0] as HTMLElement)
 
     expect(onChange.mock.calls.at(-1)?.[0]).toBe('[[Weekly review]] beta')
+  })
+
+  // Pinning an offset is not enough: text typed BEFORE it shifts every later
+  // position, so the pin has to travel with the document, not just survive it.
+  it('follows its range when text is inserted before it', async () => {
+    const onChange = vi.fn()
+    const { container, getByRole } = render(
+      <StatefulHost initial="weekly beta" onChange={onChange} />,
+    )
+    await caretInto(container, 3) // inside "weekly"
+
+    const picker = await openPicker(container, getByRole)
+    expect((picker.querySelector('input') as HTMLInputElement).value).toBe('weekly')
+
+    // Type at the very start of the document while the picker is open.
+    const editable = container.querySelector('[contenteditable="true"]') as HTMLElement
+    await userEvent.click(editable.querySelector('.cm-line') as HTMLElement)
+    await userEvent.keyboard('{Control>}{Home}{/Control}')
+    await userEvent.keyboard('SEE ')
+    await userEvent.click(container.querySelectorAll('[role="option"]')[0] as HTMLElement)
+
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe('SEE [[Weekly review]] beta')
   })
 
   it('moves the highlight with the arrow keys and commits the active row', async () => {

--- a/apps/web/src/components/markdown-editor/link-target.test.ts
+++ b/apps/web/src/components/markdown-editor/link-target.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import {
+  externalLinkMarkup,
+  type LinkTarget,
+  linkMarkupFor,
+  rankLinkTargets,
+  urlFromQuery,
+} from './link-target.js'
+
+const targets: readonly LinkTarget[] = [
+  { id: '01JWEEK', name: 'Weekly review', kind: 'markdown' },
+  { id: '01JWEEK2', name: 'Weekly review 2026-08', kind: 'markdown' },
+  { id: '01JSPRINT', name: 'Sprint board', kind: 'spatial' },
+  { id: '01JDUPE1', name: 'untitled', kind: 'markdown' },
+  { id: '01JDUPE2', name: 'untitled', kind: 'markdown' },
+]
+
+describe('rankLinkTargets', () => {
+  it('returns every target for an empty query', () => {
+    expect(rankLinkTargets(targets, '').map((t) => t.id)).toEqual(targets.map((t) => t.id))
+  })
+
+  it('matches on any part of the name, case-insensitively', () => {
+    expect(rankLinkTargets(targets, 'sprint').map((t) => t.name)).toEqual(['Sprint board'])
+    expect(rankLinkTargets(targets, 'BOARD').map((t) => t.name)).toEqual(['Sprint board'])
+  })
+
+  // Typing more should narrow toward what you meant, so an exact name and a
+  // prefix both outrank a match buried mid-name.
+  it('ranks exact name, then prefix, then contained', () => {
+    const ranked = rankLinkTargets(
+      [
+        { id: 'a', name: 'my weekly review', kind: 'markdown' },
+        { id: 'b', name: 'Weekly review 2026-08', kind: 'markdown' },
+        { id: 'c', name: 'Weekly review', kind: 'markdown' },
+      ],
+      'weekly review',
+    )
+    expect(ranked.map((t) => t.id)).toEqual(['c', 'b', 'a'])
+  })
+
+  it('drops targets that do not match at all', () => {
+    expect(rankLinkTargets(targets, 'zzz')).toEqual([])
+  })
+})
+
+describe('linkMarkupFor', () => {
+  it('writes the display name when it is unambiguous', () => {
+    expect(linkMarkupFor(targets[0] as LinkTarget, targets)).toBe('[[Weekly review]]')
+  })
+
+  // The picker knows which one was chosen; the reader of `[[untitled]]`
+  // would not, and codec resolves an ambiguous alias to nothing.
+  it('falls back to the id when two documents share the name', () => {
+    expect(linkMarkupFor(targets[3] as LinkTarget, targets)).toBe('[[canvas:01JDUPE1]]')
+  })
+
+  // `]]` inside a name would close the reference early, and a newline
+  // cannot survive an inline reference at all.
+  it('uses the id when the name cannot be written inside brackets', () => {
+    const odd: LinkTarget = { id: '01JODD', name: 'weird ]] name', kind: 'markdown' }
+    expect(linkMarkupFor(odd, [odd])).toBe('[[canvas:01JODD]]')
+  })
+})
+
+describe('urlFromQuery', () => {
+  it('recognises an http(s) URL', () => {
+    expect(urlFromQuery('https://example.com/a?b=1')).toBe('https://example.com/a?b=1')
+    expect(urlFromQuery('  http://example.com  ')).toBe('http://example.com')
+  })
+
+  it('promotes a bare domain to https', () => {
+    expect(urlFromQuery('example.com/docs')).toBe('https://example.com/docs')
+  })
+
+  it('is not fooled by ordinary prose or a document name', () => {
+    expect(urlFromQuery('Weekly review')).toBeNull()
+    expect(urlFromQuery('')).toBeNull()
+    expect(urlFromQuery('notes about node.js')).toBeNull()
+  })
+
+  // A scheme we do not want to write into a document from a search box.
+  it('refuses non-http schemes', () => {
+    expect(urlFromQuery('javascript:alert(1)')).toBeNull()
+    expect(urlFromQuery('file:///etc/passwd')).toBeNull()
+  })
+})
+
+describe('externalLinkMarkup', () => {
+  it('keeps the text that was there as the link text', () => {
+    expect(externalLinkMarkup('the docs', 'https://example.com')).toBe(
+      '[the docs](https://example.com)',
+    )
+  })
+
+  it('writes a bare autolink when there is no text to carry it', () => {
+    expect(externalLinkMarkup('', 'https://example.com')).toBe('<https://example.com>')
+    expect(externalLinkMarkup('   ', 'https://example.com')).toBe('<https://example.com>')
+  })
+
+  // A `]` in the text would close the label early and leave the rest as prose.
+  it('escapes brackets in the link text', () => {
+    expect(externalLinkMarkup('a [b] c', 'https://example.com')).toBe(
+      '[a \\[b\\] c](https://example.com)',
+    )
+  })
+
+  // Spaces and parens in a URL break the inline form; angle brackets are the
+  // CommonMark answer for exactly that.
+  it('wraps a destination that needs it in angle brackets', () => {
+    expect(externalLinkMarkup('docs', 'https://example.com/a(b)')).toBe(
+      '[docs](<https://example.com/a(b)>)',
+    )
+  })
+})

--- a/apps/web/src/components/markdown-editor/link-target.test.ts
+++ b/apps/web/src/components/markdown-editor/link-target.test.ts
@@ -55,10 +55,17 @@ describe('linkMarkupFor', () => {
     expect(linkMarkupFor(targets[3] as LinkTarget, targets)).toBe('[[canvas:01JDUPE1]]')
   })
 
-  // `]]` inside a name would close the reference early, and a newline
-  // cannot survive an inline reference at all.
-  it('uses the id when the name cannot be written inside brackets', () => {
-    const odd: LinkTarget = { id: '01JODD', name: 'weird ]] name', kind: 'markdown' }
+  // Every character sequence the codec's own reference parser would read as
+  // something other than a plain name: `]]` closes the reference, a newline
+  // cannot appear in an inline one, `|` starts the alias half, and a leading
+  // `canvas:` is parsed as a direct document id instead of a name.
+  it.each([
+    ['weird ]] name'],
+    ['two\nlines'],
+    ['A|B'],
+    ['canvas:not-an-id'],
+  ])('uses the id when the name cannot be written inside brackets: %s', (name) => {
+    const odd: LinkTarget = { id: '01JODD', name, kind: 'markdown' }
     expect(linkMarkupFor(odd, [odd])).toBe('[[canvas:01JODD]]')
   })
 })
@@ -71,6 +78,12 @@ describe('urlFromQuery', () => {
 
   it('promotes a bare domain to https', () => {
     expect(urlFromQuery('example.com/docs')).toBe('https://example.com/docs')
+  })
+
+  // `example.com:` satisfies the URL scheme grammar, so the first parse
+  // succeeds with a protocol nobody meant.
+  it('promotes a bare host:port too', () => {
+    expect(urlFromQuery('example.com:8080/path')).toBe('https://example.com:8080/path')
   })
 
   it('is not fooled by ordinary prose or a document name', () => {
@@ -96,6 +109,21 @@ describe('externalLinkMarkup', () => {
   it('writes a bare autolink when there is no text to carry it', () => {
     expect(externalLinkMarkup('', 'https://example.com')).toBe('<https://example.com>')
     expect(externalLinkMarkup('   ', 'https://example.com')).toBe('<https://example.com>')
+  })
+
+  // A trailing backslash would escape the closing bracket the escape itself
+  // adds, so backslashes go first.
+  it('escapes a backslash before it can escape our bracket', () => {
+    expect(externalLinkMarkup('ends with \\', 'https://example.com')).toBe(
+      '[ends with \\\\](https://example.com)',
+    )
+  })
+
+  // An angle-bracketed destination is closed by the first `>` inside it.
+  it('percent-encodes angle brackets in a destination that needs wrapping', () => {
+    expect(externalLinkMarkup('docs', 'https://example.com/a(b)>c')).toBe(
+      '[docs](<https://example.com/a(b)%3Ec>)',
+    )
   })
 
   // A `]` in the text would close the label early and leave the rest as prose.

--- a/apps/web/src/components/markdown-editor/link-target.ts
+++ b/apps/web/src/components/markdown-editor/link-target.ts
@@ -38,10 +38,13 @@ export function rankLinkTargets(
 }
 
 /**
- * Names that cannot survive being written between `[[` and `]]`: `]]` closes
- * the reference early, and a line break cannot appear inside an inline one.
+ * Names the codec's own reference parser would read as something other than a
+ * plain name: `]]` closes the reference early, a line break cannot appear in
+ * an inline one, `|` begins the alias half (`[[target|alias]]`), and a
+ * leading `canvas:` is parsed as a direct document id — which then fails id
+ * validation and drops the link entirely.
  */
-const UNWRITABLE_IN_BRACKETS = /]]|[\r\n]/
+const UNWRITABLE_IN_BRACKETS = /]]|[\r\n|]|^canvas:/
 
 /**
  * What to write in the body for a chosen target.
@@ -72,14 +75,24 @@ export function linkMarkupFor(target: LinkTarget, all: readonly LinkTarget[]): s
 export function urlFromQuery(query: string): string | null {
   const trimmed = query.trim()
   if (trimmed === '' || /\s/.test(trimmed)) return null
-  const candidate = /^[a-z][a-z0-9+.-]*:/i.test(trimmed) ? trimmed : `https://${trimmed}`
-  let parsed: URL
-  try {
-    parsed = new URL(candidate)
-  } catch {
-    return null
+  const parse = (value: string): URL | null => {
+    try {
+      return new URL(value)
+    } catch {
+      return null
+    }
   }
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+  const isHttp = (url: URL | null): boolean =>
+    url !== null && (url.protocol === 'http:' || url.protocol === 'https:')
+
+  // `example.com:8080/path` satisfies the URL scheme grammar — `.` is a legal
+  // scheme character — so the first parse succeeds with protocol
+  // `example.com:`. A second parse behind `https://` is what recognises a
+  // pasted host:port as the address it obviously is.
+  const asWritten = parse(trimmed)
+  const candidate = isHttp(asWritten) ? trimmed : `https://${trimmed}`
+  const parsed = isHttp(asWritten) ? asWritten : parse(candidate)
+  if (!isHttp(parsed) || parsed === null) return null
   // `https://notes` parses fine; a host with no dot is a word, not an address.
   if (!parsed.hostname.includes('.')) return null
   return candidate
@@ -96,7 +109,12 @@ export function urlFromQuery(query: string): string | null {
  */
 export function externalLinkMarkup(text: string, url: string): string {
   if (text.trim() === '') return `<${url}>`
-  const label = text.replace(/[[\]]/g, (bracket) => `\\${bracket}`)
-  const destination = /[\s()]/.test(url) ? `<${url}>` : url
+  // Backslash first, or the escape added for a trailing `\` would itself be
+  // escaped and the closing bracket would lose its meaning.
+  const label = text.replace(/[\\[\]]/g, (char) => `\\${char}`)
+  const destination = /[\s()]/.test(url)
+    ? // The angle-bracket form is closed by the first `>` inside it.
+      `<${url.replace(/</g, '%3C').replace(/>/g, '%3E')}>`
+    : url
   return `[${label}](${destination})`
 }

--- a/apps/web/src/components/markdown-editor/link-target.ts
+++ b/apps/web/src/components/markdown-editor/link-target.ts
@@ -1,0 +1,102 @@
+import type { DocumentKind } from '@kamiazya/whiteboard-model'
+
+/** A document this editor can link to, as the composition root knows it. */
+export interface LinkTarget {
+  readonly id: string
+  readonly name: string
+  readonly kind?: DocumentKind
+}
+
+/** Matched name, best first; `null` when the name does not match at all. */
+function scoreOf(name: string, query: string): number | null {
+  const haystack = name.toLowerCase()
+  if (haystack === query) return 0
+  if (haystack.startsWith(query)) return 1
+  return haystack.includes(query) ? 2 : null
+}
+
+/**
+ * The targets worth showing for `query`, best match first. Substring
+ * matching rather than fuzzy: a document list is small and the author is
+ * typing a name they can already see, so a fuzzy matcher would mostly add
+ * surprising middle results. Ties keep the caller's order, which is the
+ * list the switcher shows.
+ */
+export function rankLinkTargets(
+  targets: readonly LinkTarget[],
+  query: string,
+): readonly LinkTarget[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return targets
+  return targets
+    .flatMap((target) => {
+      const score = scoreOf(target.name, needle)
+      return score === null ? [] : [{ target, score }]
+    })
+    .sort((a, b) => a.score - b.score)
+    .map((entry) => entry.target)
+}
+
+/**
+ * Names that cannot survive being written between `[[` and `]]`: `]]` closes
+ * the reference early, and a line break cannot appear inside an inline one.
+ */
+const UNWRITABLE_IN_BRACKETS = /]]|[\r\n]/
+
+/**
+ * What to write in the body for a chosen target.
+ *
+ * The readable form wins where it works, because the reference is prose the
+ * author will read again — but `[[Name]]` resolves only when exactly one
+ * document carries that name (see `createSnapshotAliasResolver`), so a
+ * duplicate name would produce a link that silently stays literal text. The
+ * picker is the one place that KNOWS which document was chosen, so it spends
+ * that knowledge here: the opaque `[[canvas:<id>]]` form appears only when
+ * the readable one would be wrong.
+ */
+export function linkMarkupFor(target: LinkTarget, all: readonly LinkTarget[]): string {
+  const sameName = all.filter((candidate) => candidate.name === target.name)
+  const unambiguous = sameName.length === 1 && !UNWRITABLE_IN_BRACKETS.test(target.name)
+  return unambiguous ? `[[${target.name}]]` : `[[canvas:${target.id}]]`
+}
+
+/**
+ * The URL a search query stands for, or null when it is just text.
+ *
+ * Only http(s) — this writes into a document that other people open, and a
+ * `javascript:` or `file:` target typed into a search box is never what an
+ * author meant. A bare domain is promoted rather than rejected, since that
+ * is how a pasted address usually arrives; anything without a dot in its
+ * first segment stays text, so ordinary prose does not become a link.
+ */
+export function urlFromQuery(query: string): string | null {
+  const trimmed = query.trim()
+  if (trimmed === '' || /\s/.test(trimmed)) return null
+  const candidate = /^[a-z][a-z0-9+.-]*:/i.test(trimmed) ? trimmed : `https://${trimmed}`
+  let parsed: URL
+  try {
+    parsed = new URL(candidate)
+  } catch {
+    return null
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+  // `https://notes` parses fine; a host with no dot is a word, not an address.
+  if (!parsed.hostname.includes('.')) return null
+  return candidate
+}
+
+/**
+ * The markdown for an external link over `text`.
+ *
+ * With nothing to carry the link, CommonMark's autolink (`<url>`) is the
+ * honest form — an empty label renders as an invisible link. Brackets in the
+ * text are escaped because a stray `]` closes the label early and silently
+ * turns the rest into prose, and a destination containing spaces or parens
+ * goes in angle brackets, which is CommonMark's own answer for it.
+ */
+export function externalLinkMarkup(text: string, url: string): string {
+  if (text.trim() === '') return `<${url}>`
+  const label = text.replace(/[[\]]/g, (bracket) => `\\${bracket}`)
+  const destination = /[\s()]/.test(url) ? `<${url}>` : url
+  return `[${label}](${destination})`
+}

--- a/apps/web/src/components/markdown-editor/markdown-editor.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/markdown-editor.browser.test.tsx
@@ -43,7 +43,7 @@ describe('MarkdownEditor (real browser)', () => {
     await userEvent.keyboard('{Home}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}')
     await userEvent.keyboard('{Shift>}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}{/Shift}')
 
-    await userEvent.click(getByRole('button', { name: 'More actions' }))
+    await userEvent.click(getByRole('button', { name: 'Editing actions' }))
     await userEvent.click(getByRole('menuitem', { name: 'Bold' }))
     expect(onChange.mock.calls.at(-1)?.[0]).toBe('make **this** bold')
 

--- a/apps/web/src/pages/BrowserLocalDocumentPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.markdown.browser.test.tsx
@@ -444,6 +444,45 @@ describe('BrowserLocalDocumentPage markdown 導線 (browser — real IndexedDB)'
     expect(spatialMounts).toBeGreaterThan(before)
   })
 
+  // The picker is only useful if the PAGE hands it the document list it
+  // already holds. Nothing else fails when that one prop stops being passed:
+  // `linkTargets` is optional, so the verb quietly degrades to its bracket
+  // wrap while typecheck and every component test stay green.
+  it("offers the page's own documents to the link picker", async () => {
+    const store = new IndexedDBStore()
+    await store.save({
+      id: '01ARZ3NDEKTSV4RRFFQ69G5FBB',
+      name: 'Neighbour note',
+      updatedAt: '2026-05-24T00:00:00.000Z',
+      kind: 'markdown' as const,
+    })
+    const HERE = '01BX5ZZKBKACTAV9WEVGEMMVAA'
+    await store.save({
+      id: HERE,
+      name: 'This note',
+      updatedAt: '2026-05-24T00:00:01.000Z',
+      kind: 'markdown' as const,
+    })
+    await store.setDefaultDocumentId(HERE)
+    render(<BrowserLocalDocumentPage store={store} />)
+
+    const editable = await waitFor(
+      () => {
+        const el = document.querySelector('[contenteditable="true"]')
+        expect(el).not.toBeNull()
+        return el as HTMLElement
+      },
+      { timeout: 10_000 },
+    )
+    editable.focus()
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Editing actions' }))
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Link' }))
+
+    const picker = await screen.findByTestId('link-picker')
+    expect(picker.textContent).toContain('Neighbour note')
+  })
+
   it('a [[Name]] wikiLink resolves against the canvas list and clicking it opens that note', async () => {
     const TARGET_ID = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
     const SOURCE_ID = '01BX5ZZKBKACTAV9WEVGEMMVRZ'

--- a/apps/web/src/pages/BrowserLocalDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.tsx
@@ -255,6 +255,12 @@ export function BrowserLocalDocumentPage({
   // same snapshot list the switcher shows, so a link resolves exactly when
   // the author can see one unambiguous canvas by that name.
   const resolveAlias = useMemo(() => createSnapshotAliasResolver(documents), [documents])
+  // The same list, for the link picker: it needs the id as well, so an
+  // ambiguous display name can still produce a link that resolves.
+  const linkTargets = useMemo(
+    () => documents.map((entry) => ({ id: entry.id, name: entry.name, kind: entry.kind })),
+    [documents],
+  )
   // ![[embed]] bodies, pre-fetched so the layout's sync seam has content.
   const resolveEmbed = useMarkdownEmbedContent({
     body: documentKind === 'markdown' ? (markdownDoc.body ?? '') : '',
@@ -782,6 +788,7 @@ export function BrowserLocalDocumentPage({
                   meta: markdownDoc.coreFacets,
                   title: titleOf(documentName),
                   resolveAlias,
+                  linkTargets,
                   onOpenDocument: (id) => navigate(browserLocalDocumentPath(id)),
                   resolveEmbed,
                 }

--- a/apps/web/src/pages/BrowserLocalDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.tsx
@@ -255,11 +255,20 @@ export function BrowserLocalDocumentPage({
   // same snapshot list the switcher shows, so a link resolves exactly when
   // the author can see one unambiguous canvas by that name.
   const resolveAlias = useMemo(() => createSnapshotAliasResolver(documents), [documents])
-  // The same list, for the link picker: it needs the id as well, so an
-  // ambiguous display name can still produce a link that resolves.
+  // The list read races the save a rename queues, so this canvas's live
+  // truth is its own snapshot and the list is only the copy for the OTHER
+  // documents. Both the switcher and the link picker read THIS, or the
+  // picker would offer a stale name for the document being edited — or omit
+  // it entirely right after it was created.
+  const switcherOptions =
+    pageState.kind === 'editing'
+      ? documents.some((c) => c.id === pageState.snapshot.id)
+        ? documents.map((c) => (c.id === pageState.snapshot.id ? pageState.snapshot : c))
+        : [...documents, pageState.snapshot]
+      : documents
   const linkTargets = useMemo(
-    () => documents.map((entry) => ({ id: entry.id, name: entry.name, kind: entry.kind })),
-    [documents],
+    () => switcherOptions.map((entry) => ({ id: entry.id, name: entry.name, kind: entry.kind })),
+    [switcherOptions],
   )
   // ![[embed]] bodies, pre-fetched so the layout's sync seam has content.
   const resolveEmbed = useMarkdownEmbedContent({
@@ -467,12 +476,6 @@ export function BrowserLocalDocumentPage({
   // a read that resolves first pins the pre-rename name with nothing left to
   // schedule another refresh. The snapshot is this canvas's live truth; the
   // list is only the copy the switcher reads for the OTHER documents.
-  const switcherOptions =
-    pageState.kind === 'editing'
-      ? documents.some((c) => c.id === pageState.snapshot.id)
-        ? documents.map((c) => (c.id === pageState.snapshot.id ? pageState.snapshot : c))
-        : [...documents, pageState.snapshot]
-      : documents
 
   if (pageState.kind === 'load-degraded') {
     return (

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -342,6 +342,12 @@ export function DaemonDocumentPage({
       ),
     [controller.documents],
   )
+  // The same list the alias resolver reads, carried with ids so the picker
+  // can fall back to one when a name is ambiguous.
+  const linkTargets = useMemo(
+    () => controller.documents.map((entry) => ({ id: entry.id ?? entry.path, name: entry.path })),
+    [controller.documents],
+  )
   const loadEmbedSource = useCallback<MarkdownEmbedLoader>(
     async (documentId) => {
       const target = await fileAdapter.loadDocument(documentId)
@@ -756,6 +762,7 @@ export function DaemonDocumentPage({
               theme: resolvedTheme,
               meta: coreFacets ?? { type: documentKind },
               resolveAlias,
+              linkTargets,
               onOpenDocument: (id) => controller.switchDocument(resolveRefPath(id) ?? id),
               resolveEmbed,
             }}


### PR DESCRIPTION
Follow-up to #865. The editor's link verb wrapped text in `[[ ]]` and nothing more: you had to know the target's name, type it exactly, and hope it was unique. An external URL had no verb at all.

## One surface, because the author knows the destination and not our taxonomy

The search box decides what the verb does:

| what you type | what the list offers |
|---|---|
| part of a name | this workspace's documents, ranked exact → prefix → contained |
| something URL-shaped | `<url> · External` at the top of the same list |
| nothing | every document |

Nothing has to be classified before it is typed — the alternative (two verbs) makes you pick a category while you already know the destination. The box is **seeded with the word the verb would otherwise have wrapped**, so the pre-picker gesture still ends in one Enter instead of becoming a search someone has to retype.

| document mode | URL mode |
|---|---|
| ![link-picker-document.png](https://github.com/user-attachments/assets/26a35fcf-b771-4cee-9e16-284afa2292b1) | ![link-picker-url.png](https://github.com/user-attachments/assets/47812859-b5b2-42a8-8034-9e303929a402) |

## Readable form where it works, stable form where it does not

`createSnapshotAliasResolver` resolves `[[Name]]` only when **exactly one** document carries that name, so writing the readable form for a duplicate produces a link that silently stays literal text. The picker is the one place that KNOWS which document was chosen:

- `[[Weekly review]]` normally
- `[[canvas:<id>]]` when two documents share the name, or the name contains `]]` / a newline and cannot survive between brackets

External links go in as `[text](url)`, or a bare `<url>` autolink when there is no text to carry them. A destination containing spaces or parens is wrapped in angle brackets (CommonMark's own answer). Only **http(s)** — a `javascript:` or `file:` target typed into a search box is never what an author meant, and this writes into a document other people open.

## Wiring

Both composition roots already hold the list their switcher shows, so each supplies it (`BrowserLocalDocumentPage` from `documents`, `DaemonDocumentPage` from `controller.documents`). With **no** list supplied the verb keeps its selection-free bracket wrap — a picker onto an empty list is a dead end, not a feature.

## Tests

- `link-target.test.ts` (15, jsdom) — ranking, the ambiguity/unwritable-name fallbacks, URL detection (including the rejected schemes and the bare-domain promotion), and the external-link markup rules. Red before the module existed.
- `link-picker.browser.test.tsx` (6, `web-browser`) — the seeded query committing with one Enter; narrowing and picking; the id fallback for duplicate names; the URL row; Escape leaving the document untouched; and the no-targets fallback.
- Mutation-checked through the real UI: forcing `unambiguous = true` turns exactly the duplicate-name test red.
- `editor-catalog.browser.test.tsx`'s link case now names the verb `Link` and pins the no-targets fallback.
- Green: `pnpm test --project web-browser` (627), `pnpm --filter @kamiazya/whiteboard-web test` (2281 + 77), `pnpm -r typecheck`, `pnpm lint`, `pnpm knip`.

Deliberately NOT in this increment: `[[` autocomplete in the source pane (a keyboard shortcut to the same picker, needs `@codemirror/autocomplete`), and rename-following for existing links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ua6RPuoEAD4ZTBqyhNC56Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a link picker for searching documents and inserting internal or external links.
  * Added keyboard navigation, URL detection, filtering, and safe link formatting.
  * Improved link resolution for documents with duplicate names.
* **Improvements**
  * Renamed the toolbar control to “Editing actions” for clearer accessibility.
  * Preserved selection, focus, and cursor placement when inserting or cancelling links.
* **Tests**
  * Added comprehensive coverage for link picking, ranking, navigation, URL handling, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->