### PR TITLE
refactor: default canvas-render's parseBody to codec and drop the seam from callers

### DIFF
--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -6,7 +6,7 @@ Package boundaries are cut by **runtime requirements**, not by feature. The shar
 |---|---|---|
 | `packages/model` | Zod schemas for the whiteboard document model (single source of truth) | zod only |
 | `packages/codec` | OKF Markdown / JSON Canvas serialize+parse, remark pipeline | model, remark |
-| `packages/canvas-render` | scene graph, layout, SVG backend, sceneDigest | model, zod |
+| `packages/canvas-render` | scene graph, layout, SVG backend, sceneDigest | model, codec, zod |
 | `packages/ports` | store/sync port contracts + Symbol `TOKENS` | model, zod |
 | `packages/loro-adapter` | LoroDoc<->model bridge | model, ports, loro-crdt |
 | `packages/server-core` | `/api/v1` Hono routes + MCP tool definitions, exposed as `createServer(deps)` | crdt, render, hono, zod, loro-crdt |

--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -64,8 +64,10 @@ paths:
 ## Dependency rules
 
 - Runtime dependencies: `@kamiazya/whiteboard-model` (spatial nodes/
-  edges + the `./mdast` subset) and `zod` (via `catalog:`), for
-  `sceneDigestSchema` only.
+  edges + the `./mdast` subset), `@kamiazya/whiteboard-codec` (the DEFAULT
+  `parseBody`; every consumer already bundled it to pass that same function
+  in), `css-line-break` (UAX #14 break opportunities) and `zod` (via
+  `catalog:`), for `sceneDigestSchema` only.
 - Forbidden imports: `node:*`, DOM globals (`document`/`window`/`navigator`/
   `HTMLElement`), `inversify`. Enforced by `src/import-guard.test.ts`, which
   captures every production source at build time via `import.meta.glob`
@@ -472,6 +474,34 @@ paths:
       so it stays a pure function of the canvas snapshot, exactly parallel
       to the style opt-in above.
 
+11. **ONE reference seam, not one per content kind.** `SpatialLayoutOptions`
+    carries a single `resolveReference?: (ref: string) => ResolvedReference
+    | undefined`, where `ResolvedReference` is a record of independent
+    optional fields — `label`, `missing`, `image`, `canvas`, `markdown`,
+    `facets` — ranked in that order by `composeNode`. It replaced six
+    parallel callbacks (`resolveFileLabel`/`Missing`/`Canvas`/`Image`/
+    `Markdown`/`Facets`).
+    Three things the six could not do. A caller has ONE document per
+    reference, so six closures over the same lookup meant the same key was
+    resolved four times per file node. A record is plain DATA, which a
+    function can never be — the layout worker refuses a canvas whose file
+    seams are wired precisely because a function cannot cross
+    `postMessage`, and `apps/web`'s `composeReferenceSeam` is now the ONE
+    producer both threads build their seam through. And a content kind added
+    later is a field rather than a seventh callback threaded through every
+    consumer, of which there are four.
+    The price, stated because it is a real behaviour change: one resolver
+    means one failure. A throw used to cost the reference one RANK and now
+    costs it the whole resolution, falling straight to the plain label. A
+    caller that can partially fail has to handle that in its own lookup,
+    which is where it has the information to.
+    `expandFileNode` stays a separate seam: it is the caller's POLICY over a
+    node (the editor decides by on-screen size, export by intrinsic size),
+    not something known about the reference.
+    `MdastLayoutOptions.resolveEmbed` also stays its own — it is keyed by a
+    canvasId appearing in PROSE, a different key space from a spatial node's
+    reference, and it serves markdown documents with no file nodes at all.
+
 12. **Line breaking is UAX #14, not a hand-rolled character table**
     (`layout/mdast-blocks.ts`, `breakSegments`). `css-line-break` with
     `lineBreak: 'strict'` supplies the break opportunities, which is what
@@ -510,7 +540,18 @@ paths:
     The parser is built on first Japanese text, NOT at module load: its
     constructor turns a ~24KB model into a Map, and charging that to whichever
     lazily-imported chunk pulls this module in turned two apps/web browser
-    tests red before it was made lazy. BudouX is VENDORED
+    tests red before it was made lazy.
+
+13. **`parseBody` DEFAULTS to codec's `parseMarkdownBody`** and stays
+    overridable. It was a required injected seam only because this package was
+    forbidden to depend on codec, and every production caller passed that one
+    function — seven identical lines across apps/web (x3), canvas-viewer,
+    server-core and mcp-server, plus an option threaded through apps/web's
+    `scene-render-core.ts` for a worker chunk that imported codec directly
+    anyway. It remains injectable because layout tests parse with a stub for
+    the same reason they measure with one: a layout assertion should not fail
+    because a markdown parser changed. No bundle grew — every one of those
+    consumers already bundled codec in order to pass the function in. BudouX is VENDORED
     (`src/vendor/budoux/`, Apache-2.0, with the equivalence check that was run
     before the dependency was dropped recorded in its README) and NOT a
     dependency: its only entry point re-exports the HTML processor, which
@@ -546,34 +587,6 @@ paths:
     reason to act on it.
     `layout/text-wrapping-quality.test.ts` is the scoreboard for all of this;
     see the Tests section.
-
-11. **ONE reference seam, not one per content kind.** `SpatialLayoutOptions`
-    carries a single `resolveReference?: (ref: string) => ResolvedReference
-    | undefined`, where `ResolvedReference` is a record of independent
-    optional fields — `label`, `missing`, `image`, `canvas`, `markdown`,
-    `facets` — ranked in that order by `composeNode`. It replaced six
-    parallel callbacks (`resolveFileLabel`/`Missing`/`Canvas`/`Image`/
-    `Markdown`/`Facets`).
-    Three things the six could not do. A caller has ONE document per
-    reference, so six closures over the same lookup meant the same key was
-    resolved four times per file node. A record is plain DATA, which a
-    function can never be — the layout worker refuses a canvas whose file
-    seams are wired precisely because a function cannot cross
-    `postMessage`, and `apps/web`'s `composeReferenceSeam` is now the ONE
-    producer both threads build their seam through. And a content kind added
-    later is a field rather than a seventh callback threaded through every
-    consumer, of which there are four.
-    The price, stated because it is a real behaviour change: one resolver
-    means one failure. A throw used to cost the reference one RANK and now
-    costs it the whole resolution, falling straight to the plain label. A
-    caller that can partially fail has to handle that in its own lookup,
-    which is where it has the information to.
-    `expandFileNode` stays a separate seam: it is the caller's POLICY over a
-    node (the editor decides by on-screen size, export by intrinsic size),
-    not something known about the reference.
-    `MdastLayoutOptions.resolveEmbed` also stays its own — it is keyed by a
-    canvasId appearing in PROSE, a different key space from a spatial node's
-    reference, and it serves markdown documents with no file nodes at all.
 
 ## Conventions
 

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -78,7 +78,6 @@ import {
   sceneBounds,
 } from '@kamiazya/whiteboard-canvas-render'
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
-import { parseMarkdownBody } from '@kamiazya/whiteboard-codec'
 import type { ClipboardFragment, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
 import {
   forwardRef,
@@ -1129,7 +1128,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         { ...canvas, nodes: liveNodes },
         {
           measure: dragStatic.measure,
-          parseBody: parseMarkdownBody,
           appearance: createEditorAppearance(theme),
           edgeSideOverrides: overrides,
         },

--- a/apps/web/src/components/spatial-editor/scene-render-core.ts
+++ b/apps/web/src/components/spatial-editor/scene-render-core.ts
@@ -1,14 +1,16 @@
 /**
- * The `SpatialCanvas` -> `Scene` -> SVG composition, with NO markdown parser
- * of its own.
+ * The `SpatialCanvas` -> `Scene` -> SVG composition.
  *
- * Split out of scene-render.ts so the layout worker can import it: that module
- * supplies codec's `parseMarkdownBody` as the default, and a static
- * import of the codec drags remark and unified into whatever imports it —
- * a worker chunk that has no use for them, and (under the dev server) cannot
- * even evaluate them. This is NOT a second scene builder: scene-render.ts
- * calls straight through to here, so there is still exactly one composition
- * of `layoutSpatialCanvas` + `sceneBounds` + `renderSceneToSvg`.
+ * Split out of scene-render.ts so the layout worker can import this without
+ * the editor-side module graph hanging off scene-render.ts. This is NOT a
+ * second scene builder: scene-render.ts calls straight through to here, so
+ * there is still exactly one composition of `layoutSpatialCanvas` +
+ * `sceneBounds` + `renderSceneToSvg`.
+ *
+ * It used to take a `parseBody` too, so that a static codec import stayed out
+ * of the worker chunk. canvas-render now DEFAULTS to codec's parser, and the
+ * worker imported codec directly anyway, so the option was one more copy of
+ * the same line rather than a boundary.
  */
 
 import type {
@@ -24,14 +26,11 @@ import {
   sceneBounds,
 } from '@kamiazya/whiteboard-canvas-render'
 import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
-import type { MdastRoot } from '@kamiazya/whiteboard-model/mdast'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
 import { createEditorAppearance } from './editor-appearance.js'
 
 export interface RenderCanvasCoreOptions {
   readonly measure: MeasureText
-  /** Required here; scene-render.ts is where the codec default is applied. */
-  readonly parseBody: (text: string) => MdastRoot
   readonly theme?: ResolvedTheme
   readonly resolveReference?: (ref: string) => ResolvedReference | undefined
   readonly expandFileNode?: (node: Extract<SpatialNode, { type: 'file' }>) => boolean
@@ -56,7 +55,6 @@ export function renderCanvasToSvgWith(
 ): RenderedCanvas {
   const { scene, anchors } = layoutSpatialCanvasWithAnchors(canvas, {
     measure: options.measure,
-    parseBody: options.parseBody,
     appearance: createEditorAppearance(options.theme ?? 'light'),
     resolveReference: options.resolveReference,
     expandFileNode: options.expandFileNode,

--- a/apps/web/src/components/spatial-editor/scene-render.ts
+++ b/apps/web/src/components/spatial-editor/scene-render.ts
@@ -11,7 +11,6 @@ import {
   SPATIAL_THEME_GEOMETRY,
   sceneBounds,
 } from '@kamiazya/whiteboard-canvas-render'
-import { parseMarkdownBody } from '@kamiazya/whiteboard-codec'
 import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
 import { createEditorAppearance } from './editor-appearance.js'
@@ -43,7 +42,6 @@ export function requiredTextNodeHeight(node: SpatialNode, options: RenderCanvasO
   const probe: SpatialCanvas = { nodes: [{ ...node, height: 1 }], edges: [] }
   const scene = layoutSpatialCanvas(probe, {
     measure: options.measure,
-    parseBody: parseMarkdownBody,
     appearance: createEditorAppearance(options.theme ?? 'light'),
   })
   const bounds = sceneBounds(scene)
@@ -54,5 +52,5 @@ export function renderCanvasToSvg(
   canvas: SpatialCanvas,
   options: RenderCanvasOptions,
 ): RenderedCanvas {
-  return renderCanvasToSvgWith(canvas, { ...options, parseBody: parseMarkdownBody })
+  return renderCanvasToSvgWith(canvas, options)
 }

--- a/apps/web/src/lib/layout-worker.ts
+++ b/apps/web/src/lib/layout-worker.ts
@@ -29,7 +29,6 @@
 
 import { ensureViewerFontLoaded } from '@kamiazya/whiteboard-canvas-viewer/font-loading'
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer/measure-text'
-import { parseMarkdownBody } from '@kamiazya/whiteboard-codec'
 import { renderCanvasToSvgWith } from '../components/spatial-editor/scene-render-core.js'
 import {
   composeReferenceSeam,
@@ -67,7 +66,6 @@ self.onmessage = async (event: MessageEvent<LayoutRequest>) => {
       measure,
       theme: request.theme,
       resolveReference: composeReferenceSeam({ labels, missing: missingRefs }),
-      parseBody: parseMarkdownBody,
     })
     const response: LayoutResponse = {
       type: 'laid-out',

--- a/packages/canvas-render/package.json
+++ b/packages/canvas-render/package.json
@@ -19,6 +19,7 @@
     "test": "vitest run --config vitest.node.config.ts"
   },
   "dependencies": {
+    "@kamiazya/whiteboard-codec": "workspace:*",
     "@kamiazya/whiteboard-model": "workspace:*",
     "css-line-break": "catalog:",
     "zod": "catalog:"

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -4,12 +4,12 @@
 // decision. Process-internal (a value in, a value out), so per
 // zod-schema-discipline no Zod schema is warranted.
 //
-// A markdown parser is an injected dependency, the same seam class as
-// `measure`/`renderMath`: this package never imports codec, so
-// `parseBody` is supplied by the caller (codec's
-// `parseMarkdownBody` in both current consumers). Likewise `appearance` is
-// an injected `SpatialAppearanceResolver` (spatial-appearance.ts) — layout
-// never chooses a color.
+// The markdown parser DEFAULTS to codec's `parseMarkdownBody` and stays
+// overridable: every production caller passed that exact function, so the
+// seam was seven identical lines, but layout tests parse with a stub for the
+// same reason they measure with one. `appearance` is a genuinely injected
+// `SpatialAppearanceResolver` (spatial-appearance.ts) — layout never chooses
+// a color.
 //
 // Total by construction: canvas-render's own layout/routing entry points
 // already degrade instead of throwing, and this module's one addition —
@@ -24,6 +24,7 @@
 // reproducibility does not need a sort to hold: document order is already
 // a total function of a deterministic canvas, so the same canvas renders
 // the same SVG twice regardless.
+import { parseMarkdownBody } from '@kamiazya/whiteboard-codec'
 import type { CanvasEdge, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
 import type { MdastFlowContent, MdastRoot } from '@kamiazya/whiteboard-model/mdast'
 import type { MeasureText } from '../measure.js'
@@ -86,7 +87,16 @@ export interface FacetCardData {
 
 export interface SpatialLayoutOptions {
   readonly measure: MeasureText
-  readonly parseBody: (text: string) => MdastRoot
+  /**
+   * How a `text` node's body becomes mdast. Defaults to codec's
+   * `parseMarkdownBody`, which is what EVERY production caller passed —
+   * seven identical lines whose only reason to exist was this package once
+   * being forbidden to depend on codec. It stays injectable because layout
+   * tests deliberately parse with a stub, the same way they measure with
+   * one: a layout assertion should not fail because a markdown parser
+   * changed.
+   */
+  readonly parseBody?: (text: string) => MdastRoot
   readonly appearance: SpatialAppearanceResolver
   /**
    * Geometry constants (padding/label font size/min content width).
@@ -208,6 +218,7 @@ interface ResolvedLayoutOptions extends SpatialLayoutOptions {
   readonly embedPath: ReadonlySet<string>
   readonly embedDepth: number
   readonly geometry: SpatialGeometry
+  readonly parseBody: (text: string) => MdastRoot
 }
 
 /**
@@ -796,6 +807,7 @@ export function layoutSpatialCanvasWithAnchors(
   return layoutSpatialCanvasInternal(canvas, {
     ...options,
     geometry: resolveGeometry(options.geometry),
+    parseBody: options.parseBody ?? parseMarkdownBody,
     embedPath: new Set(),
     embedDepth: 0,
   })
@@ -866,6 +878,7 @@ export function layoutSpatialEdges(
   return composeEdgesAndLabels(canvas, {
     ...options,
     geometry: resolveGeometry(options.geometry),
+    parseBody: options.parseBody ?? parseMarkdownBody,
     embedPath: new Set(),
     embedDepth: 0,
   }).content

--- a/packages/canvas-viewer/src/CanvasViewer.tsx
+++ b/packages/canvas-viewer/src/CanvasViewer.tsx
@@ -5,7 +5,6 @@ import {
   renderSceneToSvg,
   type SvgDocumentOptions,
 } from '@kamiazya/whiteboard-canvas-render'
-import { parseMarkdownBody } from '@kamiazya/whiteboard-codec'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { useMemo } from 'react'
 import { createBrowserMeasureText } from './measure-text.js'
@@ -79,7 +78,6 @@ export function CanvasViewer({
   const svg = useMemo(() => {
     const scene = layoutSpatialCanvas(canvas, {
       measure: resolvedMeasure,
-      parseBody: parseMarkdownBody,
       appearance: VIEWER_APPEARANCE,
       ...(resolveReference === undefined ? {} : { resolveReference }),
       // No onDegrade: the viewer degrades silently by choice — it has no

--- a/packages/mcp-server/src/server/export/headless-renderer.ts
+++ b/packages/mcp-server/src/server/export/headless-renderer.ts
@@ -34,7 +34,6 @@ import {
   SPATIAL_DARK_PALETTE,
   SPATIAL_LIGHT_PALETTE,
 } from '@kamiazya/whiteboard-canvas-render'
-import { parseMarkdownBody } from '@kamiazya/whiteboard-codec'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 
 import { getLogger } from '../log.js'
@@ -137,7 +136,6 @@ export function buildSpatialScene(
 ): Scene {
   return layoutSpatialCanvas(canvas, {
     measure,
-    parseBody: parseMarkdownBody,
     appearance: EXPORT_APPEARANCE_BY_MODE[mode],
     onDegrade,
   })

--- a/packages/server-core/src/render/compose-canvas-scene.ts
+++ b/packages/server-core/src/render/compose-canvas-scene.ts
@@ -9,7 +9,6 @@ import {
   layoutSpatialCanvas,
   sceneBounds,
 } from '@kamiazya/whiteboard-canvas-render'
-import { parseMarkdownBody } from '@kamiazya/whiteboard-codec'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { getLogger } from '../log.js'
 
@@ -67,7 +66,6 @@ export function composeCanvasScene(
   const references = options?.references
   return layoutSpatialCanvas(canvas, {
     measure,
-    parseBody: parseMarkdownBody,
     appearance: MCP_SCENE_APPEARANCE,
     onDegrade,
     ...(references === undefined ? {} : { resolveReference: (ref: string) => references.get(ref) }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,9 @@ importers:
 
   packages/canvas-render:
     dependencies:
+      '@kamiazya/whiteboard-codec':
+        specifier: workspace:*
+        version: link:../codec
       '@kamiazya/whiteboard-model':
         specifier: workspace:*
         version: link:../model

--- a/tools/arch-lint/src/architecture-map.ts
+++ b/tools/arch-lint/src/architecture-map.ts
@@ -42,7 +42,10 @@ export const ARCHITECTURE_MAP: Readonly<Record<string, PackageArchEntry>> = {
     ],
   },
   '@kamiazya/whiteboard-canvas-render': {
-    allowedInternalDeps: ['@kamiazya/whiteboard-model'],
+    // codec: the mdast body parser this package DEFAULTS to. Every consumer
+    // already bundles codec to pass it in, so the dependency adds nothing to
+    // any bundle and removes the same line from seven call sites.
+    allowedInternalDeps: ['@kamiazya/whiteboard-model', '@kamiazya/whiteboard-codec'],
     // css-line-break: deciding WHERE a line may break is this package's own
     // job, and the answer is a Unicode standard (UAX #14 + CSS `line-break`,
     // which is where Japanese kinsoku lives), not something to hand-roll from


### PR DESCRIPTION
`parseBody` was a required injected seam for exactly one reason: `canvas-render` was forbidden to depend on `codec`. Every production caller then passed the same function — `parseMarkdownBody` — seven identical times:

| where | |
|---|---|
| `apps/web` | `layout-worker.ts`, `scene-render.ts`, `SpatialEditor.tsx` |
| `canvas-viewer` | `CanvasViewer.tsx` |
| `server-core` | `compose-canvas-scene.ts` |
| `mcp-server` | `headless-renderer.ts` |

…plus an option threaded through `scene-render-core.ts`, whose comment said it existed to keep a static codec import out of the layout worker's chunk. The worker imports codec directly on the line above, so that boundary was not one; the comment is corrected rather than preserved.

## What changed

`canvas-render` depends on `codec` and `parseBody` defaults to `parseMarkdownBody`. **The option stays**, because layout tests parse with a stub for the same reason they measure with one: a layout assertion should not fail because a markdown parser changed. Roughly twenty tests in this package rely on that.

**No bundle grows.** Every one of those consumers already bundled codec in order to pass the function in — which is what makes the dependency-rule change safe rather than merely convenient, and it is why the architecture-map row can move without anything downstream noticing.

Also renumbers the line-breaking decision in `package-canvas-render.md`, which landed as "12" ahead of "11" in #866.

## Verification

`pnpm test` (8100+), `pnpm test:browser` (639), `pnpm -r typecheck`, `pnpm build`, `pnpm knip` — all pass. `arch-lint` is the executable half: the dependency-direction and allowed-third-party checks pass with `codec` added to `canvas-render`'s allowed internal deps, and would have failed without it.

No visual evidence: this is a pure wiring change with no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)