### PR TITLE
test(web): stop the browser suite failing 3 runs in 4

### DIFF
--- a/.claude/rules/integrator-flow.md
+++ b/.claude/rules/integrator-flow.md
@@ -92,6 +92,33 @@ When a preview contradicts a green test, suspect the cache before suspecting the
   from the page that owns it — `/title/i` matched on the outgoing page too, which is how it
   bound to the wrong one. Made likelier by anything that speeds up a transition; here it
   surfaced when a dropdown became non-modal and stopped waiting out a focus trap.
+- **An eighth, and the one that multiplies the others: a timed-out browser test
+  keeps typing.** Vitest abandons the test at `testTimeout`, but the
+  `userEvent.keyboard` it was awaiting is a real key-event stream into a real
+  browser and nothing cancels it — so the NEXT test in the file receives the
+  leftover keystrokes interleaved with its own. Measured:
+  `'nadn dm oarne  atpyppeinndged line'`, one test's `and an appended line`
+  shuffled into the previous test's `and more typing`. The victim reads as lost
+  input, names a test that is not the problem, and hides the one that is. One
+  overrun therefore fails two or three tests, so **triage the EARLIEST failure
+  in a file first and re-measure before believing the later ones are real.**
+  `web-browser`'s budget is 60s for exactly this reason: the overrun is not
+  merely a slow test, it is a corrupter.
+  - Its companion, from the same run: **type ASCII.** A character with no
+    keycode (an em dash) is synthesized separately from the plain keystrokes
+    around it and is the one that goes missing under load — observed as
+    `'# Hello from an agent  edited here'`, both spaces present and the dash
+    gone, indistinguishable from an edit that never reached the backend.
+- **Whether the whole browser PROJECT is in flight is itself a variable, and
+  the only one that mattered here.** The costliest `web-browser` test measured
+  1.5s with its file alone, 1.6s with the twelve IndexedDB-heavy page files
+  together, and 30–39s with all 115 browser files running — so an isolated
+  green proves nothing about the run that flakes, and a mutation check that
+  stays green in isolation has not exonerated the guard it removed (one did,
+  against a comment claiming the test would fail *every* run without it).
+  Two obvious causes were refuted by measurement rather than argument: cutting
+  `--maxWorkers` to 4 made it WORSE (33–39s, 40% more wall clock), and the
+  shared-IndexedDB theory died on the twelve-file run.
 - **A seventh: clicking a trigger whose menu is still dismissing.** The click is consumed and
   the menu stays shut, so the failure reads as "the list does not contain this item" when no
   list was ever opened — and raising the query's timeout only buys a slower identical failure.

--- a/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import type { ComponentProps } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
+import { waitForMenuClosed } from '../test-utils/menu.js'
 import '../index.css'
 import WorkspaceTopBar from './WorkspaceTopBar'
 
@@ -181,6 +182,7 @@ describe('WorkspaceTopBar browser mode', () => {
     })
 
     // Second activation: 500 without title → generic fallback, internals never shown.
+    await waitForMenuClosed()
     fireEvent.pointerDown(switcher, { button: 0, ctrlKey: false })
     await waitFor(() => screen.getByTestId('new-document-menu-item'))
     fireEvent.pointerUp(screen.getByTestId('new-document-menu-item'))

--- a/apps/web/src/pages/BrowserLocalDocumentPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.markdown.browser.test.tsx
@@ -20,6 +20,7 @@ import { userEvent } from 'vitest/browser'
 import { IndexedDBStore } from '../lib/browser-local-store.js'
 import { LoroStore } from '../lib/loro-store.js'
 import { clearWhiteboardDb } from '../test-utils/browser-local-document.js'
+import { waitForMenuClosed } from '../test-utils/menu.js'
 import '../index.css'
 
 function render(ui: ReactElement) {
@@ -138,16 +139,19 @@ describe('BrowserLocalDocumentPage markdown 導線 (browser — real IndexedDB)'
     // exact identity is what real keyboard-event delivery depends on, and a
     // looser containment check can pass while focus still sits on some other
     // in-flight descendant (e.g. mid-mount) and races the first keystrokes.
-    // Same 10s budget every other wait in this file carries: this one waits on
-    // mount PLUS autofocus against a real browser and real IndexedDB, and the
-    // testing-library default is 1s. Under CI load that expires with focus
-    // still on <body>, which reads as "autofocus is broken" when it only means
-    // "autofocus had not happened yet".
+    // Wider than the 10s the rest of this file carries, because this one waits
+    // on mount PLUS autofocus against a real browser and real IndexedDB, and
+    // the testing-library default is 1s. Under a full browser-project run that
+    // expires with focus still on <body>, which reads as "autofocus is broken"
+    // when it only means "autofocus had not happened yet" — measured failing
+    // twice at ~11s while the same test costs 1.3s with its file alone. The
+    // guarantee under test is that focus arrives before typing, not that it
+    // arrives within any particular budget.
     await waitFor(
       () => {
         expect(document.activeElement).toBe(editable)
       },
-      { timeout: 10_000 },
+      { timeout: 30_000 },
     )
     await userEvent.keyboard('# Persisted note')
     await waitFor(() => {
@@ -424,17 +428,10 @@ describe('BrowserLocalDocumentPage markdown 導線 (browser — real IndexedDB)'
       { name: /^Workspace:/i },
       { timeout: 10_000 },
     )
-    // The previous menu must be GONE before its trigger is clicked again.
-    // Clicking it while the non-modal menu is still mounted leaves the menu
-    // CLOSED — measured at the failure: no [role=menu], trigger connected,
-    // aria-expanded=false. The failure then reads as "the list does not
-    // contain this canvas", when no list was ever opened, so raising the
-    // query's timeout only buys a slower identical failure.
-    //
-    // Load-bearing: drop this wait and the test fails every run.
-    await waitFor(() => expect(document.querySelector('[role="menu"]')).toBeNull(), {
-      timeout: 10_000,
-    })
+    // Removing this wait no longer fails the file in isolation — the race it
+    // guards only opens up once the whole browser project is in flight. Keep
+    // it: an isolated green says nothing about the run that actually flakes.
+    await waitForMenuClosed()
     await userEvent.click(switcher2)
     await userEvent.click(await screen.findByText('Diagram A', undefined, { timeout: 10_000 }))
 

--- a/apps/web/src/pages/BrowserLocalDocumentPage.multi-document.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.multi-document.browser.test.tsx
@@ -31,6 +31,7 @@ import {
   setTextCommand,
   textNodeCanvas,
 } from '../test-utils/browser-local-document.js'
+import { waitForMenuClosed } from '../test-utils/menu.js'
 import '../index.css'
 
 // The page reads/writes the canvas id through the router, so it needs a router
@@ -133,17 +134,8 @@ describe('BrowserLocalDocumentPage multi-canvas UI (browser — real IndexedDB)'
     // No stray placeholder row from the backend re-key.
     expect(await loroDocumentsKeys()).not.toContain('__placeholder__')
 
-    // The switcher's menu is still dismissing from the "New canvas" click
-    // above, and it is non-modal — so re-opening the trigger while it is
-    // mounted has the click CONSUMED and the menu stays shut. Measured at one
-    // such CI failure: no [role=menu] anywhere and every aria-expanded=false,
-    // which makes the failure read as "the list does not contain this canvas"
-    // when no list was ever opened. Raising the query timeout only buys a
-    // slower identical failure. Same shape, and same wait, as the markdown
-    // suite's canvas-switch test.
-    await waitFor(() => expect(document.querySelector('[role="menu"]')).toBeNull(), {
-      timeout: 10_000,
-    })
+    // The switcher's menu is still dismissing from the "New canvas" click above.
+    await waitForMenuClosed()
 
     // Switch back to A via the switcher control. Both A and B default to the
     // "untitled" display name, so disambiguate by the raw id shown in each

--- a/apps/web/src/pages/DaemonDocumentPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.markdown.browser.test.tsx
@@ -141,7 +141,12 @@ describe('DaemonDocumentPage markdown editing', () => {
     // A click lands the cursor wherever the pointer hit; pin it to the end
     // so the typed suffix has one deterministic destination.
     await userEvent.keyboard('{Control>}{End}{/Control}')
-    await userEvent.keyboard(' — edited here')
+    // ASCII only: a character with no keycode (an em dash, say) is
+    // synthesized separately from the plain keystrokes around it, and under
+    // load it is the one that goes missing — observed as
+    // `'# Hello from an agent  edited here'`, both spaces present and the
+    // dash gone, which reads like a lost edit rather than a lost keystroke.
+    await userEvent.keyboard(' - edited here')
 
     // The edit reaches the backend through the session's own local-update
     // forwarding: replaying pushed updates over the original snapshot must
@@ -154,7 +159,7 @@ describe('DaemonDocumentPage markdown editing', () => {
         const replay = new LoroDoc()
         replay.import(backend.snapshot)
         for (const update of backend.pushed) replay.import(update)
-        expect(replay.getText(MARKDOWN_BODY_KEY).toString()).toBe(`${BODY} — edited here`)
+        expect(replay.getText(MARKDOWN_BODY_KEY).toString()).toBe(`${BODY} - edited here`)
       },
       { timeout: 10_000 },
     )

--- a/apps/web/src/test-utils/menu.ts
+++ b/apps/web/src/test-utils/menu.ts
@@ -1,0 +1,19 @@
+import { waitFor } from '@testing-library/react'
+import { expect } from 'vitest'
+
+/**
+ * Resolves once no Radix menu is mounted.
+ *
+ * Call this before activating a menu trigger for the SECOND time in a test.
+ * The menus here are non-modal, so a click that arrives while the previous
+ * one is still dismissing is consumed by the dismissal and the menu stays
+ * shut. The failure then reads as "the list does not contain this item" when
+ * no list was ever opened — measured at one such failure: no `[role="menu"]`,
+ * trigger connected, `aria-expanded="false"` — so raising the following
+ * query's timeout only buys a slower identical failure.
+ */
+export async function waitForMenuClosed(): Promise<void> {
+  await waitFor(() => expect(document.querySelector('[role="menu"]')).toBeNull(), {
+    timeout: 10_000,
+  })
+}

--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -77,10 +77,26 @@ export default defineConfig({
     // failures, and the same tests pass 4/4 when their file runs alone.
     //
     // A timeout costs nothing while tests pass; it only decides how long a
-    // genuinely hung test takes to report. 30s matches the precedent already
-    // set by vitest.docs-snapshots.config.ts.
-    testTimeout: 30_000,
-    hookTimeout: 30_000,
+    // genuinely hung test takes to report.
+    //
+    // 30s was not enough either, and the measurements say the budget is the
+    // only lever that works. The costliest test here (a markdown embed that
+    // types into real CodeMirror and lays the preview out through the render
+    // pipeline) takes 1.5s with its file alone and 1.6s with the twelve
+    // IndexedDB-heavy page files running together — but 30–39s once all 115
+    // browser files are in flight. Neither of the obvious causes survives
+    // contact: cutting `--maxWorkers` to 4 made it WORSE (33–39s, and 40%
+    // more wall clock), and the IndexedDB-contention theory is refuted by
+    // the 1.6s twelve-file run.
+    //
+    // What makes the overrun expensive is the collateral: vitest abandons the
+    // test but its in-flight `userEvent.keyboard` keeps typing, so the NEXT
+    // test in the file receives the leftover keystrokes interleaved with its
+    // own — observed as `'nadn dm oarne  atpyppeinndged line'`, which reads
+    // like lost input rather than like someone else's typing. One overrun
+    // therefore fails two or three tests.
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
     // Every browser test renders against the app's real stylesheet — see
     // browser-setup.ts for what silently breaks without it.
     setupFiles: ['./src/test-utils/browser-setup.ts'],


### PR DESCRIPTION
The `web-browser` project failed on **3 of 4** full runs on this machine, while the same files passed **11/11 in isolation**. Root-caused rather than re-run; four measured causes, none of them random.

## Measurements

| condition | costliest test (`![[embed]]` preview) |
|---|---|
| its file alone | **1.5s** |
| + the 12 IndexedDB-heavy page files | **1.6s** |
| all 115 browser files in flight | **30–39s** (budget was 30s) |

Baseline vs. fixed, full `--project web-browser` runs:

| | runs | runs with a failure |
|---|---|---|
| before | 4 | **3** (1, 3, 3 failing tests) |
| after | 4 | **0** (621 passed each) |

## The four causes

1. **The overrun itself.** 30s was not enough once the whole project runs.
2. **The overrun corrupts its neighbours.** Vitest abandons the test, but the in-flight `userEvent.keyboard` keeps typing into the real browser, so the *next* test gets the leftover keystrokes interleaved with its own — observed as `'nadn dm oarne  atpyppeinndged line'` (`and an appended line` shuffled into `and more typing`). That is why one overrun failed two or three tests, and why the victims read as lost input.
3. **A typed em dash.** No keycode, synthesized separately from the plain keystrokes around it, and the character that goes missing under load: `'# Hello from an agent  edited here'` — both spaces present, dash gone.
4. **An unguarded menu re-open** in `WorkspaceTopBar.browser.test.tsx`: the switcher trigger was re-activated with no wait for the previous menu to dismiss. At the observed failure the DOM carried the 409 alert (so the first activation had completed), had no `[role="menu"]`, and every `aria-expanded="false"` — the second click was consumed by the dismissal.

## Two hypotheses refuted by measurement

- Cutting `--maxWorkers` to 4 made it **worse**: 33–39s, and 40% more wall clock.
- Shared-IndexedDB contention died on the 1.6s twelve-file run.

## One honest negative result

The mutation check on `waitForMenuClosed()` came back **green** in isolation. The existing comment claiming that test "fails every run" without the wait is therefore corrected rather than carried forward — an isolated green says nothing about the run that actually flakes.

No production code is touched; this is test infrastructure only.