### PR TITLE
refactor(web): delete the three capability flags nothing reads

### DIFF
--- a/apps/web/src/App.route-sync-stale-replay.test.tsx
+++ b/apps/web/src/App.route-sync-stale-replay.test.tsx
@@ -93,9 +93,6 @@ const { App } = await import('./App.js')
 const BROWSER_LOCAL_STATE: ProviderState = {
   kind: 'browser-local',
   capabilities: {
-    canvasReadWrite: true,
-    migrationExport: true,
-    migrationImport: false,
     workspaces: false,
     versions: false,
     branches: false,

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -125,9 +125,6 @@ vi.mock('./pages/DaemonIndexPage.js', () => ({
 const BROWSER_LOCAL_STATE: ProviderState = {
   kind: 'browser-local',
   capabilities: {
-    canvasReadWrite: true,
-    migrationExport: true,
-    migrationImport: false,
     workspaces: false,
     versions: false,
     branches: false,
@@ -139,9 +136,6 @@ const LOCAL_DAEMON_STATE: ProviderState = {
   kind: 'local-daemon',
   daemonBaseUrl: 'http://127.0.0.1:3000',
   capabilities: {
-    canvasReadWrite: true,
-    migrationExport: false,
-    migrationImport: true,
     workspaces: true,
     versions: true,
     branches: true,

--- a/apps/web/src/lib/provider.capability-reach.test.ts
+++ b/apps/web/src/lib/provider.capability-reach.test.ts
@@ -1,0 +1,42 @@
+// A capability flag that nothing reads is a wiring gap that every other gate
+// passes: the const map compiles, both provider kinds set it, and the unit
+// tests assert its value — so it looks covered while gating nothing. Three
+// (`canvasReadWrite`, `migrationExport`, `migrationImport`) sat that way until
+// an audit found them. This is the executable rung that stops the next one:
+// every declared capability must be read somewhere outside its own module.
+
+import { describe, expect, it } from 'vitest'
+import { BROWSER_LOCAL_CAPABILITIES } from './provider.js'
+
+// `?raw` rather than node:fs — apps/web is browser-only and must not import a
+// Node builtin (the same reason App.lazy-coverage.test.ts reads files this way).
+const sources = import.meta.glob('/src/**/*.{ts,tsx}', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+function readerModules(): Array<[string, string]> {
+  return Object.entries(sources).filter(
+    ([path]) => !path.includes('.test.') && !path.endsWith('/lib/provider.ts'),
+  )
+}
+
+describe('every declared capability is read by production code', () => {
+  const capabilities = Object.keys(BROWSER_LOCAL_CAPABILITIES)
+
+  it('declares at least one capability, so an empty map cannot pass vacuously', () => {
+    expect(capabilities.length).toBeGreaterThan(0)
+  })
+
+  it.each(capabilities)('%s gates something', (name) => {
+    const readers = readerModules()
+      .filter(([, text]) => new RegExp(`capabilities\\??\\.${name}\\b`).test(text))
+      .map(([path]) => path)
+
+    expect(
+      readers,
+      `capabilities.${name} is declared but never read — wire it to the surface it is meant to gate, or delete it from WhiteboardCapabilities`,
+    ).not.toEqual([])
+  })
+})

--- a/apps/web/src/lib/provider.test.ts
+++ b/apps/web/src/lib/provider.test.ts
@@ -22,27 +22,19 @@ describe('resolveProviderState', () => {
     expect(state).toMatchObject({ kind: 'local-daemon', daemonBaseUrl: 'http://127.0.0.1:3099' })
   })
 
-  it('browser-local capabilities: canvasReadWrite and migrationExport are true', () => {
+  it('browser-local capabilities: workspaces and versions are false', () => {
     const state = resolveProviderState(EMPTY_RUNTIME_CONFIG)
     expect(state).toMatchObject({
       kind: 'browser-local',
-      capabilities: { canvasReadWrite: true, migrationExport: true },
+      capabilities: { workspaces: false, versions: false },
     })
   })
 
-  it('browser-local capabilities: migrationImport workspaces versions are false', () => {
-    const state = resolveProviderState(EMPTY_RUNTIME_CONFIG)
-    expect(state).toMatchObject({
-      kind: 'browser-local',
-      capabilities: { migrationImport: false, workspaces: false, versions: false },
-    })
-  })
-
-  it('local-daemon capabilities: workspaces versions migrationImport are true', () => {
+  it('local-daemon capabilities: workspaces and versions are true', () => {
     const state = resolveProviderState({ daemonBaseUrl: 'http://127.0.0.1:3099' })
     expect(state).toMatchObject({
       kind: 'local-daemon',
-      capabilities: { workspaces: true, versions: true, migrationImport: true },
+      capabilities: { workspaces: true, versions: true },
     })
   })
 

--- a/apps/web/src/lib/provider.ts
+++ b/apps/web/src/lib/provider.ts
@@ -22,9 +22,6 @@ function toInvalidConfigState(err: unknown): Extract<ProviderState, { kind: 'inv
 // or persisted contract (no negotiation, no wire payload), so this stays a
 // plain type + const map rather than a Zod schema. Deliberate, not an oversight.
 export type WhiteboardCapabilities = {
-  readonly canvasReadWrite: boolean
-  readonly migrationExport: boolean
-  readonly migrationImport: boolean
   readonly workspaces: boolean
   readonly versions: boolean
   readonly branches: boolean
@@ -41,9 +38,6 @@ export type ProviderState =
   | { readonly kind: 'invalid-config'; readonly message: string }
 
 export const BROWSER_LOCAL_CAPABILITIES: WhiteboardCapabilities = {
-  canvasReadWrite: true,
-  migrationExport: true,
-  migrationImport: false,
   workspaces: false,
   versions: false,
   branches: false,
@@ -51,9 +45,6 @@ export const BROWSER_LOCAL_CAPABILITIES: WhiteboardCapabilities = {
 }
 
 export const LOCAL_DAEMON_CAPABILITIES: WhiteboardCapabilities = {
-  canvasReadWrite: true,
-  migrationExport: false,
-  migrationImport: true,
   workspaces: true,
   versions: true,
   branches: true,

--- a/apps/web/src/pages/DaemonDocumentPage.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.test.tsx
@@ -427,9 +427,6 @@ describe('DaemonDocumentPage', () => {
             daemonBaseUrl={DAEMON_BASE_URL}
             createBackend={makeCreateBackend()}
             capabilities={{
-              canvasReadWrite: true,
-              migrationExport: false,
-              migrationImport: true,
               workspaces: false,
               versions: true,
               branches: true,
@@ -1148,9 +1145,6 @@ describe('DaemonDocumentPage', () => {
             daemonBaseUrl={DAEMON_BASE_URL}
             createBackend={makeCreateBackend()}
             capabilities={{
-              canvasReadWrite: true,
-              migrationExport: false,
-              migrationImport: true,
               workspaces: true,
               versions: false,
               branches: true,
@@ -1365,9 +1359,6 @@ describe('DaemonDocumentPage', () => {
             daemonBaseUrl={DAEMON_BASE_URL}
             createBackend={makeCreateBackend()}
             capabilities={{
-              canvasReadWrite: true,
-              migrationExport: false,
-              migrationImport: true,
               workspaces: true,
               versions: false,
               branches: true,
@@ -1565,9 +1556,6 @@ describe('DaemonDocumentPage', () => {
             daemonBaseUrl={DAEMON_BASE_URL}
             createBackend={makeCreateBackend()}
             capabilities={{
-              canvasReadWrite: true,
-              migrationExport: false,
-              migrationImport: true,
               workspaces: true,
               versions: true,
               branches: false,
@@ -1736,9 +1724,6 @@ describe('DaemonDocumentPage', () => {
             daemonBaseUrl={DAEMON_BASE_URL}
             createBackend={makeCreateBackend()}
             capabilities={{
-              canvasReadWrite: true,
-              migrationExport: false,
-              migrationImport: true,
               workspaces: true,
               versions: true,
               branches: false,
@@ -1811,9 +1796,6 @@ describe('DaemonDocumentPage', () => {
             daemonBaseUrl={DAEMON_BASE_URL}
             createBackend={makeCreateBackend()}
             capabilities={{
-              canvasReadWrite: true,
-              migrationExport: false,
-              migrationImport: true,
               workspaces: true,
               versions: true,
               branches: true,


### PR DESCRIPTION
`canvasReadWrite`, `migrationExport` and `migrationImport` were declared on `WhiteboardCapabilities`, set by both provider kinds, and asserted by unit tests — so they **looked** covered while gating nothing. No production module reads any of the three. The four that remain (`workspaces`, `versions`, `branches`, `merge`) all gate real surfaces in `DaemonDocumentPage`.

Deleted rather than wired: a flag with no reader is speculative, and the two const maps are a couple of lines away if a gate is ever needed.

## The guard is the point

`provider.capability-reach.test.ts` derives the capability names at **runtime** from the const map and fails on any that no non-test module outside `provider.ts` reads:

```
× canvasReadWrite gates something
× migrationExport gates something
× migrationImport gates something
  AssertionError: capabilities.canvasReadWrite is declared but never read —
  wire it to the surface it is meant to gate, or delete it from WhiteboardCapabilities
Tests  3 failed | 5 passed (8)
```

It named exactly the three the audit found and left the other four green. Mutation-checked in the other direction too: adding an unread `mutantUnreadFlag` fails it (`× mutantUnreadFlag gates something`), so it is not passing vacuously.

It reads sources through `?raw` rather than `node:fs`, since `apps/web` must not import a Node builtin — same reason `App.lazy-coverage.test.ts` does.

## Verification

`pnpm --filter @kamiazya/whiteboard-web test` → 2270 + 77 passed · `pnpm -r typecheck` clean · `pnpm knip` clean.

Not marked breaking: `apps/web` is private and `WhiteboardCapabilities` crosses no published surface.