### PR TITLE
fix(canvas-viewer): report a malformed embedded scene through ViewerSceneError

### DIFF
--- a/packages/canvas-viewer/src/mount.test.tsx
+++ b/packages/canvas-viewer/src/mount.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { mountCanvasViewer } from './mount.js'
+import { mountCanvasViewer, ViewerSceneError } from './mount.js'
 
 function resetDom() {
   document.body.innerHTML = ''
@@ -33,6 +33,31 @@ describe('mountCanvasViewer', () => {
     expect(() => mountCanvasViewer(container, { scene: { nodes: 'not an array' } })).toThrow(
       /json-canvas-schema/,
     )
+  })
+
+  it('reports a malformed embedded <script> as a ViewerSceneError, not a bare SyntaxError', () => {
+    // The embedded slot is the one input this entrypoint reads that it did
+    // not receive as an argument, and a host that serves truncated or
+    // hand-edited HTML lands here. Without this it surfaces as a raw
+    // SyntaxError, so a caller catching ViewerSceneError — the documented
+    // failure of this API — misses the JSON-syntax case entirely.
+    const script = document.createElement('script')
+    script.type = 'application/json'
+    script.setAttribute('data-whiteboard-scene', '')
+    script.textContent = '{"nodes": ['
+    document.head.appendChild(script)
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    let thrown: unknown
+    try {
+      mountCanvasViewer(container)
+    } catch (err) {
+      thrown = err
+    }
+    expect(thrown).toBeInstanceOf(ViewerSceneError)
+    expect((thrown as Error).message).toMatch(/^json-syntax: /)
   })
 
   it('falls back to the embedded <script data-whiteboard-scene> when no scene option is given', () => {

--- a/packages/canvas-viewer/src/mount.ts
+++ b/packages/canvas-viewer/src/mount.ts
@@ -61,7 +61,14 @@ declare global {
 function readEmbeddedScene(): unknown {
   const script = document.querySelector(EMBEDDED_SCENE_SCRIPT_SELECTOR)
   if (script?.textContent) {
-    return JSON.parse(script.textContent)
+    // `json-syntax` is parseViewerScene's own stage name for this failure, so
+    // a truncated embedded payload reports through the same contract as a
+    // structurally-invalid one instead of escaping as a bare SyntaxError.
+    try {
+      return JSON.parse(script.textContent)
+    } catch (err) {
+      throw new ViewerSceneError(`json-syntax: ${err instanceof Error ? err.message : String(err)}`)
+    }
   }
   return window.__WHITEBOARD_VIEWER_SCENE__
 }


### PR DESCRIPTION
`mountCanvasViewer` documents `ViewerSceneError` as its failure and converts `parseViewerScene`'s result into one — but the embedded `<script data-whiteboard-scene>` slot went through a **raw `JSON.parse`**, so a truncated or hand-edited payload escaped as a bare `SyntaxError`.

That is the one input this entrypoint reads without receiving it as an argument, so it is exactly the case a host cannot control — and a caller catching the documented error missed it entirely.

Red first, on the real gap:

```
AssertionError: expected SyntaxError: Unexpected end of JSON input
  to be an instance of ViewerSceneError
Tests  1 failed | 6 passed (7)
```

The parse now throws `ViewerSceneError` prefixed `json-syntax:` — `parseViewerScene`'s own stage name for this failure — so both halves of the same failure class read the same way, and an existing test already pins the sibling stage (`/json-canvas-schema/`).

**Verification**: `canvas-viewer-jsdom` + `canvas-viewer-node` 109 passed · `pnpm -r typecheck` clean.

Clears one `effort: S` finding from the 2026-08-15 audit backlog.