### PR TITLE
feat(web): let the link picker say what the link should read as

### DIFF
--- a/apps/web/src/components/markdown-editor/LinkPickerDialog.tsx
+++ b/apps/web/src/components/markdown-editor/LinkPickerDialog.tsx
@@ -37,6 +37,11 @@ export function LinkPickerDialog({
   onCancel,
 }: LinkPickerDialogProps) {
   const [query, setQuery] = useState(initialQuery)
+  // Empty, not seeded: the default differs by destination — a document link
+  // shows the document's own name, an external one shows the text that was
+  // already there. Leaving this alone reproduces both, so the field only ever
+  // means "instead of the default".
+  const [display, setDisplay] = useState('')
   const [active, setActive] = useState(0)
   const inputRef = useRef<HTMLInputElement | null>(null)
   // Focus on open rather than via `autoFocus`: this dialog is opened by an
@@ -61,10 +66,11 @@ export function LinkPickerDialog({
   const commit = (index: number) => {
     const row = rows[index]
     if (row === undefined) return
+    const wanted = display.trim()
     onPick(
       row.kind === 'url'
-        ? externalLinkMarkup(linkText, row.url)
-        : linkMarkupFor(row.target, targets),
+        ? externalLinkMarkup(wanted === '' ? linkText : wanted, row.url)
+        : linkMarkupFor(row.target, targets, wanted),
     )
   }
 
@@ -105,6 +111,7 @@ export function LinkPickerDialog({
       }}
     >
       <input
+        id="link-picker-search"
         ref={inputRef}
         role="combobox"
         aria-expanded
@@ -119,6 +126,25 @@ export function LinkPickerDialog({
         aria-label="Search documents, or paste a URL"
         className="border-input focus-visible:ring-ring w-full rounded-md border px-2 py-1.5 text-sm focus-visible:ring-2 focus-visible:outline-none"
       />
+      <label
+        htmlFor="link-picker-text"
+        className="text-muted-foreground mt-1.5 flex items-center gap-2 px-0.5 text-xs"
+      >
+        Text
+        <input
+          id="link-picker-text"
+          value={display}
+          onChange={(event) => setDisplay(event.target.value)}
+          placeholder={
+            rows[activeIndex]?.kind === 'url'
+              ? linkText.trim() === ''
+                ? 'The URL itself'
+                : linkText
+              : (rows[activeIndex]?.target.name ?? 'Same as the document name')
+          }
+          className="border-input focus-visible:ring-ring text-foreground min-w-0 flex-1 rounded-md border px-2 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none"
+        />
+      </label>
       <div
         id="link-picker-list"
         role="listbox"

--- a/apps/web/src/components/markdown-editor/link-picker.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/link-picker.browser.test.tsx
@@ -262,6 +262,23 @@ describe('the link picker (real browser)', () => {
     expect(onChange.mock.calls.at(-1)?.[0]).toBe('[the guide](https://example.com/guide)')
   })
 
+  // With the caret on whitespace there is no word to carry the link, so an
+  // external one degrades to a bare autolink — the placeholder has to say so
+  // rather than showing an empty default.
+  it('says the URL will carry itself when there is no text to use', async () => {
+    const { container, getByRole } = render(
+      <MarkdownEditor value="a  b" onChange={() => {}} linkTargets={targets} />,
+    )
+    await caretInto(container, 2) // the gap between the words
+
+    const picker = await openPicker(container, getByRole)
+    const search = picker.querySelector('#link-picker-search') as HTMLInputElement
+    await userEvent.fill(search, 'https://example.com')
+
+    const display = picker.querySelector('#link-picker-text') as HTMLInputElement
+    expect(display.placeholder).toBe('The URL itself')
+  })
+
   it('closes on Escape without touching the document', async () => {
     const onChange = vi.fn()
     const { container, getByRole } = render(

--- a/apps/web/src/components/markdown-editor/link-picker.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/link-picker.browser.test.tsx
@@ -74,7 +74,7 @@ describe('the link picker (real browser)', () => {
 
     const picker = await openPicker(container, getByRole)
     expect(picker).not.toBeNull()
-    expect((picker.querySelector('input') as HTMLInputElement).value).toBe('weekly')
+    expect((picker.querySelector('#link-picker-search') as HTMLInputElement).value).toBe('weekly')
 
     await userEvent.keyboard('{Enter}')
     expect(onChange.mock.calls.at(-1)?.[0]).toBe('see [[Weekly review]] notes')
@@ -88,7 +88,7 @@ describe('the link picker (real browser)', () => {
     await caretInto(container, 1)
 
     const picker = await openPicker(container, getByRole)
-    const input = picker.querySelector('input') as HTMLInputElement
+    const input = picker.querySelector('#link-picker-search') as HTMLInputElement
     await userEvent.clear(input)
     await userEvent.fill(input, 'sprint')
 
@@ -109,12 +109,13 @@ describe('the link picker (real browser)', () => {
     await caretInto(container, 1)
 
     const picker = await openPicker(container, getByRole)
-    const input = picker.querySelector('input') as HTMLInputElement
+    const input = picker.querySelector('#link-picker-search') as HTMLInputElement
     await userEvent.clear(input)
     await userEvent.fill(input, 'untitled')
     await userEvent.click(picker.querySelectorAll('[role="option"]')[0] as HTMLElement)
 
-    expect(onChange.mock.calls.at(-1)?.[0]).toBe('[[canvas:01JDUPE1]]')
+    // The id resolves; the alias is what makes it readable.
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe('[[canvas:01JDUPE1|untitled]]')
   })
 
   it('offers the URL when what you typed is one', async () => {
@@ -125,7 +126,7 @@ describe('the link picker (real browser)', () => {
     await caretInto(container, 5) // inside "docs"
 
     const picker = await openPicker(container, getByRole)
-    const input = picker.querySelector('input') as HTMLInputElement
+    const input = picker.querySelector('#link-picker-search') as HTMLInputElement
     await userEvent.clear(input)
     await userEvent.fill(input, 'https://example.com/guide')
 
@@ -148,7 +149,7 @@ describe('the link picker (real browser)', () => {
     await caretInto(container, 3) // inside "weekly"
 
     const picker = await openPicker(container, getByRole)
-    expect((picker.querySelector('input') as HTMLInputElement).value).toBe('weekly')
+    expect((picker.querySelector('#link-picker-search') as HTMLInputElement).value).toBe('weekly')
 
     // Back into the document, caret to the end, then pick from the still-open
     // dialog.
@@ -170,7 +171,7 @@ describe('the link picker (real browser)', () => {
     await caretInto(container, 3) // inside "weekly"
 
     const picker = await openPicker(container, getByRole)
-    expect((picker.querySelector('input') as HTMLInputElement).value).toBe('weekly')
+    expect((picker.querySelector('#link-picker-search') as HTMLInputElement).value).toBe('weekly')
 
     // Type at the very start of the document while the picker is open.
     const editable = container.querySelector('[contenteditable="true"]') as HTMLElement
@@ -190,7 +191,7 @@ describe('the link picker (real browser)', () => {
     await caretInto(container, 1)
 
     const picker = await openPicker(container, getByRole)
-    const input = picker.querySelector('input') as HTMLInputElement
+    const input = picker.querySelector('#link-picker-search') as HTMLInputElement
     await userEvent.clear(input)
     await userEvent.fill(input, 'untitled')
     await userEvent.keyboard('{ArrowDown}')
@@ -199,7 +200,7 @@ describe('the link picker (real browser)', () => {
     expect(options[1]?.getAttribute('aria-selected')).toBe('true')
     await userEvent.keyboard('{Enter}')
 
-    expect(onChange.mock.calls.at(-1)?.[0]).toBe('[[canvas:01JDUPE2]]')
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe('[[canvas:01JDUPE2|untitled]]')
   })
 
   it('says so when nothing matches, and Enter does nothing', async () => {
@@ -210,7 +211,7 @@ describe('the link picker (real browser)', () => {
     await caretInto(container, 1)
 
     const picker = await openPicker(container, getByRole)
-    const input = picker.querySelector('input') as HTMLInputElement
+    const input = picker.querySelector('#link-picker-search') as HTMLInputElement
     await userEvent.clear(input)
     await userEvent.fill(input, 'nothing by this name')
 
@@ -219,6 +220,46 @@ describe('the link picker (real browser)', () => {
     await userEvent.keyboard('{Enter}')
     expect(onChange).not.toHaveBeenCalled()
     expect(container.querySelector('[data-testid="link-picker"]')).not.toBeNull()
+  })
+
+  it('uses the display-text field for both kinds of link', async () => {
+    const onChange = vi.fn()
+    const { container, getByRole } = render(
+      <MarkdownEditor value="see weekly notes" onChange={onChange} linkTargets={targets} />,
+    )
+    await caretInto(container, 6) // inside "weekly"
+
+    const picker = await openPicker(container, getByRole)
+    // Empty by default — its placeholder shows what will be used instead, so
+    // leaving it alone reproduces the pre-field behaviour.
+    const display = picker.querySelector('#link-picker-text') as HTMLInputElement
+    expect(display.value).toBe('')
+    expect(display.placeholder).toBe('Weekly review')
+
+    await userEvent.fill(display, 'last week')
+    await userEvent.click(picker.querySelectorAll('[role="option"]')[0] as HTMLElement)
+
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe('see [[Weekly review|last week]] notes')
+  })
+
+  it('applies the display text to an external link too', async () => {
+    const onChange = vi.fn()
+    const { container, getByRole } = render(
+      <MarkdownEditor value="x" onChange={onChange} linkTargets={targets} />,
+    )
+    await caretInto(container, 1)
+
+    const picker = await openPicker(container, getByRole)
+    const search = picker.querySelector('#link-picker-search') as HTMLInputElement
+    await userEvent.clear(search)
+    await userEvent.fill(search, 'https://example.com/guide')
+    const display = picker.querySelector('#link-picker-text') as HTMLInputElement
+    // For a URL the default is the text that was already there.
+    expect(display.placeholder).toBe('x')
+    await userEvent.fill(display, 'the guide')
+    await userEvent.click(picker.querySelector('[role="option"]') as HTMLElement)
+
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe('[the guide](https://example.com/guide)')
   })
 
   it('closes on Escape without touching the document', async () => {

--- a/apps/web/src/components/markdown-editor/link-target.roundtrip.test.ts
+++ b/apps/web/src/components/markdown-editor/link-target.roundtrip.test.ts
@@ -1,0 +1,49 @@
+// The picker WRITES markup that the codec READS back. Asserting the string
+// only pins one half of that, and the half that matters is whether the
+// reference survives the reader — a single `]` in an alias produced a string
+// that looked right and resolved to nothing. So this test runs what
+// `linkMarkupFor` emits through the real parser and reference resolver, and
+// asserts the result is exactly one link with no literal remainder.
+//
+// It lives here, not in codec: apps/web may depend on codec, and the reverse
+// import would be an architecture violation.
+import { parseMarkdownBody, resolveReferences } from '@kamiazya/whiteboard-codec'
+import { describe, expect, it } from 'vitest'
+import { type LinkTarget, linkMarkupFor } from './link-target.js'
+
+const ID = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+const target: LinkTarget = { id: ID, name: 'Weekly review', kind: 'markdown' }
+const resolver = (alias: string) => (alias === 'Weekly review' ? ID : null)
+
+function nodeTypesFor(markup: string): string[] {
+  const root = resolveReferences(parseMarkdownBody(markup), resolver)
+  const paragraph = root.children[0] as { children: { type: string }[] }
+  return paragraph.children.map((child) => child.type)
+}
+
+describe('what the picker writes is what the codec reads', () => {
+  it.each([
+    ['last week'],
+    ['a|b'],
+    ['Draft] proposal'],
+    ['note]'],
+    ['a ]] b'],
+    ['two\nlines'],
+  ])('display text %j resolves to one wikiLink and no stray text', (text) => {
+    expect(nodeTypesFor(linkMarkupFor(target, [target], text))).toEqual(['wikiLink'])
+  })
+
+  it.each([
+    ['single ] bracket'],
+    ['A|B'],
+    ['canvas:not-an-id'],
+    ['weird ]] name'],
+  ])('a document named %j still links', (name) => {
+    const odd: LinkTarget = { id: ID, name, kind: 'markdown' }
+    expect(nodeTypesFor(linkMarkupFor(odd, [odd]))).toEqual(['wikiLink'])
+  })
+
+  it('resolves the ordinary case through the same path, so the harness is honest', () => {
+    expect(nodeTypesFor(linkMarkupFor(target, [target]))).toEqual(['wikiLink'])
+  })
+})

--- a/apps/web/src/components/markdown-editor/link-target.test.ts
+++ b/apps/web/src/components/markdown-editor/link-target.test.ts
@@ -73,11 +73,22 @@ describe('linkMarkupFor', () => {
     )
   })
 
-  // An alias runs to the closing bracket, so only those two sequences can
-  // break it — a `|` inside it simply becomes part of the text.
-  it('drops an alias that cannot be written inside brackets', () => {
-    expect(linkMarkupFor(targets[0] as LinkTarget, targets, 'a ]] b')).toBe('[[Weekly review]]')
-    expect(linkMarkupFor(targets[0] as LinkTarget, targets, 'two\nlines')).toBe('[[Weekly review]]')
+  // The codec's scanner stops at the FIRST `]` and matches only if it is
+  // doubled, so a single one is as fatal as `]]`: `[[A|Draft] x]]` never
+  // resolves at all, and `[[A|note]]]` truncates the alias and leaves a
+  // stray `]` in the body.
+  it.each([
+    ['a ]] b'],
+    ['Draft] proposal'],
+    ['note]'],
+    ['two\nlines'],
+  ])('drops an alias the reference scanner cannot read: %s', (alias) => {
+    expect(linkMarkupFor(targets[0] as LinkTarget, targets, alias)).toBe('[[Weekly review]]')
+  })
+
+  // `|` is fine there: the scanner is already past the target half.
+  it('keeps an alias containing a pipe', () => {
+    expect(linkMarkupFor(targets[0] as LinkTarget, targets, 'a|b')).toBe('[[Weekly review|a|b]]')
   })
 
   // The picker knows which one was chosen; the reader of `[[untitled]]`
@@ -93,6 +104,7 @@ describe('linkMarkupFor', () => {
   // `canvas:` is parsed as a direct document id instead of a name.
   it.each([
     ['weird ]] name'],
+    ['single ] bracket'],
     ['two\nlines'],
     ['A|B'],
     ['canvas:not-an-id'],
@@ -100,7 +112,7 @@ describe('linkMarkupFor', () => {
     const odd: LinkTarget = { id: '01JODD', name, kind: 'markdown' }
     // The name is unwritable as a TARGET, but the alias half is free text up
     // to the closing bracket, so `|` and `canvas:` are fine there.
-    const expected = /]]|[\r\n]/.test(name) ? '[[canvas:01JODD]]' : `[[canvas:01JODD|${name}]]`
+    const expected = /]|[\r\n]/.test(name) ? '[[canvas:01JODD]]' : `[[canvas:01JODD|${name}]]`
     expect(linkMarkupFor(odd, [odd])).toBe(expected)
   })
 })

--- a/apps/web/src/components/markdown-editor/link-target.test.ts
+++ b/apps/web/src/components/markdown-editor/link-target.test.ts
@@ -49,10 +49,42 @@ describe('linkMarkupFor', () => {
     expect(linkMarkupFor(targets[0] as LinkTarget, targets)).toBe('[[Weekly review]]')
   })
 
+  it('carries a different display text as the alias', () => {
+    expect(linkMarkupFor(targets[0] as LinkTarget, targets, 'last week')).toBe(
+      '[[Weekly review|last week]]',
+    )
+  })
+
+  // The alias would be noise: it says exactly what the target already says.
+  it('omits an alias that matches the name', () => {
+    expect(linkMarkupFor(targets[0] as LinkTarget, targets, 'Weekly review')).toBe(
+      '[[Weekly review]]',
+    )
+    expect(linkMarkupFor(targets[0] as LinkTarget, targets, '  ')).toBe('[[Weekly review]]')
+  })
+
+  // The id form is unambiguous but unreadable on its own — the name it came
+  // from is exactly what the reader needs, and the codec's alias half is
+  // where it goes.
+  it('always names the id form, using the display text or the name', () => {
+    expect(linkMarkupFor(targets[3] as LinkTarget, targets)).toBe('[[canvas:01JDUPE1|untitled]]')
+    expect(linkMarkupFor(targets[3] as LinkTarget, targets, 'the first one')).toBe(
+      '[[canvas:01JDUPE1|the first one]]',
+    )
+  })
+
+  // An alias runs to the closing bracket, so only those two sequences can
+  // break it — a `|` inside it simply becomes part of the text.
+  it('drops an alias that cannot be written inside brackets', () => {
+    expect(linkMarkupFor(targets[0] as LinkTarget, targets, 'a ]] b')).toBe('[[Weekly review]]')
+    expect(linkMarkupFor(targets[0] as LinkTarget, targets, 'two\nlines')).toBe('[[Weekly review]]')
+  })
+
   // The picker knows which one was chosen; the reader of `[[untitled]]`
-  // would not, and codec resolves an ambiguous alias to nothing.
+  // would not, and codec resolves an ambiguous alias to nothing. The name
+  // still travels, as the alias.
   it('falls back to the id when two documents share the name', () => {
-    expect(linkMarkupFor(targets[3] as LinkTarget, targets)).toBe('[[canvas:01JDUPE1]]')
+    expect(linkMarkupFor(targets[3] as LinkTarget, targets)).toBe('[[canvas:01JDUPE1|untitled]]')
   })
 
   // Every character sequence the codec's own reference parser would read as
@@ -66,7 +98,10 @@ describe('linkMarkupFor', () => {
     ['canvas:not-an-id'],
   ])('uses the id when the name cannot be written inside brackets: %s', (name) => {
     const odd: LinkTarget = { id: '01JODD', name, kind: 'markdown' }
-    expect(linkMarkupFor(odd, [odd])).toBe('[[canvas:01JODD]]')
+    // The name is unwritable as a TARGET, but the alias half is free text up
+    // to the closing bracket, so `|` and `canvas:` are fine there.
+    const expected = /]]|[\r\n]/.test(name) ? '[[canvas:01JODD]]' : `[[canvas:01JODD|${name}]]`
+    expect(linkMarkupFor(odd, [odd])).toBe(expected)
   })
 })
 

--- a/apps/web/src/components/markdown-editor/link-target.ts
+++ b/apps/web/src/components/markdown-editor/link-target.ts
@@ -38,20 +38,25 @@ export function rankLinkTargets(
 }
 
 /**
- * Names the codec's own reference parser would read as something other than a
- * plain name: `]]` closes the reference early, a line break cannot appear in
- * an inline one, `|` begins the alias half (`[[target|alias]]`), and a
- * leading `canvas:` is parsed as a direct document id — which then fails id
- * validation and drops the link entirely.
+ * Names the codec's own reference scanner would read as something other than
+ * a plain name.
+ *
+ * ANY `]` is fatal, not just `]]`: the scanner advances to the first `]` and
+ * accepts the reference only if the very next character is another one, so a
+ * single bracket either kills the whole reference or truncates it and leaves
+ * the remainder as literal text. A line break cannot appear in an inline
+ * reference, `|` begins the alias half, and a leading `canvas:` is parsed as
+ * a direct document id — which then fails id validation and drops the link.
  */
-const UNWRITABLE_IN_BRACKETS = /]]|[\r\n|]|^canvas:/
+const UNWRITABLE_IN_BRACKETS = /[\]\r\n|]|^canvas:/
 
 /**
- * Sequences an ALIAS cannot contain. Shorter than the target's list: an alias
- * runs from `|` to the closing bracket, so `|` and a leading `canvas:` are
- * ordinary text there and only the bracket close and a line break break it.
+ * What an ALIAS cannot contain. Shorter than the target's list — `|` and a
+ * leading `canvas:` are ordinary text once the target half is closed — but
+ * the bracket rule is the same and for the same reason: the scanner stops at
+ * the first `]` and requires the next character to be one too.
  */
-const UNWRITABLE_AS_ALIAS = /]]|[\r\n]/
+const UNWRITABLE_AS_ALIAS = /[\]\r\n]/
 
 /**
  * What to write in the body for a chosen target, optionally displaying

--- a/apps/web/src/components/markdown-editor/link-target.ts
+++ b/apps/web/src/components/markdown-editor/link-target.ts
@@ -47,7 +47,15 @@ export function rankLinkTargets(
 const UNWRITABLE_IN_BRACKETS = /]]|[\r\n|]|^canvas:/
 
 /**
- * What to write in the body for a chosen target.
+ * Sequences an ALIAS cannot contain. Shorter than the target's list: an alias
+ * runs from `|` to the closing bracket, so `|` and a leading `canvas:` are
+ * ordinary text there and only the bracket close and a line break break it.
+ */
+const UNWRITABLE_AS_ALIAS = /]]|[\r\n]/
+
+/**
+ * What to write in the body for a chosen target, optionally displaying
+ * `text` instead of the target's own name.
  *
  * The readable form wins where it works, because the reference is prose the
  * author will read again — but `[[Name]]` resolves only when exactly one
@@ -56,11 +64,29 @@ const UNWRITABLE_IN_BRACKETS = /]]|[\r\n|]|^canvas:/
  * picker is the one place that KNOWS which document was chosen, so it spends
  * that knowledge here: the opaque `[[canvas:<id>]]` form appears only when
  * the readable one would be wrong.
+ *
+ * That form is unambiguous and unreadable, so it always carries an alias —
+ * the display text if there is one, else the name it could not use as the
+ * target. A reader gets prose either way; only the resolution changes.
  */
-export function linkMarkupFor(target: LinkTarget, all: readonly LinkTarget[]): string {
+export function linkMarkupFor(
+  target: LinkTarget,
+  all: readonly LinkTarget[],
+  text?: string,
+): string {
+  const wanted = (text ?? '').trim()
+  const alias = wanted === '' || UNWRITABLE_AS_ALIAS.test(wanted) ? null : wanted
   const sameName = all.filter((candidate) => candidate.name === target.name)
-  const unambiguous = sameName.length === 1 && !UNWRITABLE_IN_BRACKETS.test(target.name)
-  return unambiguous ? `[[${target.name}]]` : `[[canvas:${target.id}]]`
+  const nameIsWritable = sameName.length === 1 && !UNWRITABLE_IN_BRACKETS.test(target.name)
+  if (nameIsWritable) {
+    return alias === null || alias === target.name
+      ? `[[${target.name}]]`
+      : `[[${target.name}|${alias}]]`
+  }
+  const fallbackAlias = alias ?? (UNWRITABLE_AS_ALIAS.test(target.name) ? null : target.name)
+  return fallbackAlias === null
+    ? `[[canvas:${target.id}]]`
+    : `[[canvas:${target.id}|${fallbackAlias}]]`
 }
 
 /**


### PR DESCRIPTION
Follow-up to #868. Two things, one of which needed no UI at all.

## The id form is no longer unreadable

When a duplicate name forced `[[canvas:01J…]]`, the body kept an opaque id and the reader lost the only thing that said where the link went. The codec's alias half is exactly where that belongs, so the id form now always carries one — the display text if given, else the name it could not use as the target:

| situation | before | now |
|---|---|---|
| unique name | `[[Weekly review]]` | unchanged |
| duplicate name | `[[canvas:01JDUPE1]]` | `[[canvas:01JDUPE1\|untitled]]` |
| name with `\|` or leading `canvas:` | `[[canvas:01JODD]]` | `[[canvas:01JODD\|A\|B]]` |

Resolution is unchanged; only the prose is.

## A "Text" field, for when the default is not what you meant

![link-text-field.png](https://github.com/user-attachments/assets/ca4ef693-d7dd-45bb-a0bd-915638af6ded)

It opens **empty**, not seeded — because the default differs by destination:

| destination | default text |
|---|---|
| document | the document's own name |
| URL | the text that was already there (the caret's word / selection) |

Seeding it with the caret's word would have made `[[Weekly review|weekly]]` the *default* result: an alias that says less than the target it decorates. Empty means "use the default", and the placeholder shows what that default currently is — it follows the highlighted row, so it reads `Weekly review` over a document and the selected text over a URL.

## The alias rules are narrower than the target's

An alias runs from `|` to the closing bracket, so `|` and a leading `canvas:` are ordinary text there and only `]]` or a newline break it. An alias that merely repeats the target name is dropped rather than written.

## Tests

- `link-target.test.ts` (25, jsdom) — alias emitted / omitted / refused, the id form always naming itself, and the existing duplicate-name case updated to the new contract.
- `link-picker.browser.test.tsx` (12, `web-browser`) — the field is empty with a destination-appropriate placeholder, and drives the result for both a document (`[[Weekly review|last week]]`) and a URL (`[the guide](https://example.com/guide)`).
- Mutation-checked: ignoring the field turns exactly the two new browser cases red.
- Green: `pnpm test --project web-browser` (636), `pnpm --filter @kamiazya/whiteboard-web test` (2297 + 77), `pnpm -r typecheck`, `pnpm lint`, `pnpm knip`.

Still deliberately out of scope: fetching a page's `<title>` for an external link — that needs a proxy (CORS), which means deciding what the app may tell a server about the URLs someone pastes, and it would behave differently in browser-only mode than through the local daemon. Worth its own design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ua6RPuoEAD4ZTBqyhNC56Z