### PR TITLE
test(web): keep browser test titles short enough that a failure keeps its file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,15 @@ pnpm run test:browser:trace  # same, with trace artifacts on failure
 
 - Failure traces are stored under `<package>/tmp/vitest-traces`.
 - Check traces before adding temporary debug code.
+- **Keep a browser test's `describe` + `it` titles under 155 characters
+  combined.** vitest copies the trace into `.vitest-attachments/` under a name
+  flattened from its path, and past the filesystem's 255-byte limit that copy
+  throws `ENAMETOOLONG` during teardown — so vitest abandons the REST OF THE
+  FILE. Measured: one forced failure with a 194-char title reported
+  `1 failed | 2 passed (6)`, the same failure with a 58-char title reported
+  `1 failed | 5 passed (6)`. Three tests silently did not run, and the smaller
+  total reads like good news. `apps/web/src/browser-test-name-length.test.ts`
+  enforces the budget.
 - Remove temporary debug overlays, logging, and instrumentation before finishing.
 
 ## MCP Development Mode

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,9 @@ pnpm run test:browser:trace  # same, with trace artifacts on failure
 - Failure traces are stored under `<package>/tmp/vitest-traces`.
 - Check traces before adding temporary debug code.
 - **Keep a browser test's `describe` + `it` titles under 155 characters
-  combined.** vitest copies the trace into `.vitest-attachments/` under a name
+  combined** (characters, not UTF-8 bytes: vitest replaces every
+  non-alphanumeric character with one ASCII `-` before the name reaches the
+  filesystem, so `導線` costs two, not six). vitest copies the trace into `.vitest-attachments/` under a name
   flattened from its path, and past the filesystem's 255-byte limit that copy
   throws `ENAMETOOLONG` during teardown — so vitest abandons the REST OF THE
   FILE. Measured: one forced failure with a 194-char title reported

--- a/apps/web/src/browser-test-name-length.test.ts
+++ b/apps/web/src/browser-test-name-length.test.ts
@@ -1,0 +1,93 @@
+// A browser test that fails writes a Playwright trace, and vitest then COPIES
+// that trace into `.vitest-attachments/` under a name flattened from its path.
+// When that name exceeds the filesystem's 255-byte limit the copy throws
+// ENAMETOOLONG — and the throw lands in the file's teardown, so vitest abandons
+// the REST OF THE FILE.
+//
+// Measured, by forcing one failure in BrowserLocalDocumentPage.rename twice:
+//
+//   failed test with a 194-char name -> ENAMETOOLONG, "1 failed | 2 passed (6)"
+//   failed test with a  58-char name -> no error,     "1 failed | 5 passed (6)"
+//
+// Three tests silently did not run, and the run reported a smaller total —
+// which reads like good news. The trace itself is fine either way (it is
+// written to tmp/vitest-traces first, and only the copy fails), so the cost is
+// entirely the lost coverage.
+//
+// A comment cannot hold this: the limit is only reached by names nobody counts.
+// Source is captured at build time via `?raw` rather than read at runtime, so
+// this stays free of `node:fs` — apps/web is browser-only (see
+// web-app-boundary.test.ts).
+
+import { describe, expect, it } from 'vitest'
+
+const sources = import.meta.glob('./**/*.browser.test.tsx', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+/** ext4/APFS both stop at 255 bytes for a single path component. */
+const NAME_LIMIT = 255
+
+/**
+ * What the attachment name costs before the test's own title:
+ * `tmp-vitest-traces-` (the flattened `tracesDir`), `web-browser--chromium--`
+ * (project + browser), and a `-0-0-trace-zip-<40-char sha>.zip` suffix.
+ */
+const FIXED_OVERHEAD = 'tmp-vitest-traces-'.length + 'web-browser--chromium--'.length + 59
+
+const TITLE_BUDGET = NAME_LIMIT - FIXED_OVERHEAD
+
+/**
+ * Every `describe`/`it` title in a file, with nesting resolved by brace depth.
+ * Titles built from a template with a substitution are skipped — their length
+ * is not knowable here, and none of them are near the limit.
+ */
+function titlePaths(source: string): string[] {
+  const paths: string[] = []
+  const stack: { title: string; depth: number }[] = []
+  let depth = 0
+  const pattern = /\b(describe|it)(?:\.\w+)?\(\s*(['"`])((?:\\.|(?!\2)[^\\])*)\2|[{}]/g
+  for (const match of source.matchAll(pattern)) {
+    const token = match[0]
+    if (token === '{') {
+      depth += 1
+      continue
+    }
+    if (token === '}') {
+      depth -= 1
+      continue
+    }
+    const [, kind, , title] = match
+    if (title === undefined || title.includes('${')) continue
+    // A SIBLING describe opens at the same depth as the one that just closed,
+    // so drop anything at or below this depth before pushing — otherwise every
+    // sibling accumulates and the reported title path is one nobody wrote.
+    while (stack.length > 0 && (stack[stack.length - 1]?.depth ?? 0) >= depth) stack.pop()
+    if (kind === 'describe') stack.push({ title, depth })
+    else paths.push([...stack.map((entry) => entry.title), title].join('-'))
+  }
+  return paths
+}
+
+describe('browser test names fit the trace attachment filename', () => {
+  it('leaves no title over the budget, so one failure never abandons its file', () => {
+    const files = Object.keys(sources)
+    // A glob that silently matched nothing would make this guard vacuous.
+    expect(files.length).toBeGreaterThan(50)
+
+    const overBudget = files
+      .flatMap((file) =>
+        titlePaths(sources[file] ?? '').map((title) => ({ file, title, length: title.length })),
+      )
+      .filter((entry) => entry.length > TITLE_BUDGET)
+      .sort((a, b) => b.length - a.length)
+      .map((entry) => `${entry.length}/${TITLE_BUDGET} ${entry.file}: ${entry.title}`)
+
+    expect(
+      overBudget,
+      `these describe+it titles exceed ${TITLE_BUDGET} characters, so a failure in one abandons the rest of its file`,
+    ).toEqual([])
+  })
+})

--- a/apps/web/src/browser-test-name-length.test.ts
+++ b/apps/web/src/browser-test-name-length.test.ts
@@ -27,8 +27,21 @@ const sources = import.meta.glob('./**/*.browser.test.tsx', {
   eager: true,
 }) as Record<string, string>
 
-/** ext4/APFS both stop at 255 bytes for a single path component. */
+/** ext4/APFS both stop at 255 BYTES for a single path component. */
 const NAME_LIMIT = 255
+
+/**
+ * The name as it reaches the filesystem. vitest replaces every non-alphanumeric
+ * CHARACTER with one ASCII `-`, including multi-byte ones, so the sanitized
+ * form is pure ASCII and its length in characters IS its length in bytes.
+ *
+ * Measured against a real attachment name: the title path
+ * `…markdown 導線 (browser — real IndexedDB)-…-is editable…` is 207 characters
+ * and 213 UTF-8 bytes raw, and landed on disk as 207 characters — `導`, `線`
+ * and `—` each cost one dash, not three. Counting the raw title's bytes would
+ * therefore reject titles that fit.
+ */
+const sanitize = (title: string): string => title.replace(/[^a-zA-Z0-9]/g, '-')
 
 /**
  * What the attachment name costs before the test's own title:
@@ -79,7 +92,11 @@ describe('browser test names fit the trace attachment filename', () => {
 
     const overBudget = files
       .flatMap((file) =>
-        titlePaths(sources[file] ?? '').map((title) => ({ file, title, length: title.length })),
+        titlePaths(sources[file] ?? '').map((title) => ({
+          file,
+          title,
+          length: sanitize(title).length,
+        })),
       )
       .filter((entry) => entry.length > TITLE_BUDGET)
       .sort((a, b) => b.length - a.length)

--- a/apps/web/src/components/HeaderBranchChip.browser.test.tsx
+++ b/apps/web/src/components/HeaderBranchChip.browser.test.tsx
@@ -54,7 +54,7 @@ afterEach(() => {
   stateHolder.current = makeState()
 })
 
-describe('HeaderBranchChip (browser — real Radix dropdown/dialog interaction)', () => {
+describe('HeaderBranchChip (real Radix dropdown/dialog)', () => {
   it('selecting another branch from the dropdown calls setHead', async () => {
     render(<HeaderBranchChip workspaceId="s1" path="c1" />)
     const chip = screen.getByTestId('header-branch-chip')
@@ -380,7 +380,7 @@ describe('HeaderBranchChip (browser — real Radix dropdown/dialog interaction)'
     await waitFor(() => expect(screen.queryByRole('tooltip')).toBeNull())
   })
 
-  it('does not poison the next genuine hover when the dropdown closes without returning focus to the chip', async () => {
+  it('does not poison the next hover when the dropdown closes without refocusing', async () => {
     render(<HeaderBranchChip workspaceId="s1" path="c1" />)
     const chip = screen.getByTestId('header-branch-chip')
     const kebab = screen.getByTestId('header-branch-kebab')

--- a/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
@@ -226,7 +226,7 @@ describe('WorkspaceTopBar browser mode', () => {
     window.removeEventListener('excalidraw:wb_version_saved', versionSavedFired)
   })
 
-  it('dispatches excalidraw:wb_version_saved with {workspaceId, path} on a schema-conforming save, clearing the useDirtyState-driven HeaderSaveDot', async () => {
+  it('dispatches wb_version_saved on a conforming save, clearing HeaderSaveDot', async () => {
     // Override the beforeEach stub so POST /versions returns a valid saveVersionResponseSchema body.
     const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input, init) => {
       const url =

--- a/apps/web/src/lib/browser-idb-migration.browser.test.tsx
+++ b/apps/web/src/lib/browser-idb-migration.browser.test.tsx
@@ -328,7 +328,7 @@ describe('whiteboard IndexedDB v6 -> v7 upgrade (renames the container stores)',
   })
 })
 
-describe('whiteboard IndexedDB v5 -> v6 upgrade (removes reconnectKeypairs)', () => {
+describe('IndexedDB v5 -> v6 (removes reconnectKeypairs)', () => {
   const LEGACY_RECONNECT_SECRET_KEY = 'whiteboard.reconnect-secret.v1'
 
   beforeEach(clearDb)
@@ -341,7 +341,7 @@ describe('whiteboard IndexedDB v5 -> v6 upgrade (removes reconnectKeypairs)', ()
     expect(DB_VERSION).toBeGreaterThanOrEqual(6)
   })
 
-  it('removes the reconnectKeypairs store and the legacy localStorage secret while preserving canvases/loroCanvases/canvasFiles/meta', async () => {
+  it('drops the store and the legacy localStorage secret, preserving the rest', async () => {
     const documentId = 'canvas-migrate-v6'
     const doc = new Loro()
     doc.getList('elements').push({ id: 'canonical-el' })
@@ -404,7 +404,7 @@ describe('whiteboard IndexedDB v5 -> v6 upgrade (removes reconnectKeypairs)', ()
   })
 })
 
-describe('whiteboard IndexedDB v4 -> v5 upgrade', () => {
+describe('IndexedDB v4 -> v5', () => {
   beforeEach(clearDb)
   afterEach(clearDb)
 
@@ -412,7 +412,7 @@ describe('whiteboard IndexedDB v4 -> v5 upgrade', () => {
     expect(DB_VERSION).toBeGreaterThanOrEqual(5)
   })
 
-  it('opening a v4 database at the current version never leaves reconnectKeypairs behind and preserves existing canvasFiles/loroCanvases/documents/meta contents', async () => {
+  it('opening a v4 database at the current version preserves every other store', async () => {
     const documentId = 'canvas-migrate-v5'
     const doc = new Loro()
     doc.getList('elements').push({ id: 'canonical-el' })

--- a/apps/web/src/pages/BrowserLocalDocumentPage.create-delete-node.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.create-delete-node.browser.test.tsx
@@ -57,7 +57,7 @@ vi.mock('../components/spatial-editor/index.js', () => ({
 
 const { BrowserLocalDocumentPage } = await import('./BrowserLocalDocumentPage.js')
 
-describe('BrowserLocalDocumentPage create/delete-node reload persistence (browser — real IndexedDB)', () => {
+describe('BrowserLocalDocumentPage create/delete-node persistence (real IndexedDB)', () => {
   let documentId = ''
 
   beforeEach(async () => {
@@ -126,7 +126,7 @@ describe('BrowserLocalDocumentPage create/delete-node reload persistence (browse
     )
   })
 
-  it('a node created via create-node survives remount; deleting it via delete-node stays gone after another remount', async () => {
+  it('a created node survives remount, and a deleted one stays gone', async () => {
     render(<BrowserLocalDocumentPage store={new IndexedDBStore()} />)
     await waitFor(
       () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),

--- a/apps/web/src/pages/BrowserLocalDocumentPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.markdown.browser.test.tsx
@@ -93,7 +93,7 @@ async function expectTitleValue(expected: string): Promise<void> {
   )
 }
 
-describe('BrowserLocalDocumentPage markdown 導線 (browser — real IndexedDB)', () => {
+describe('BrowserLocalDocumentPage markdown 導線 (real IndexedDB)', () => {
   beforeEach(async () => {
     await clearWhiteboardDb()
     spatialMounts = 0
@@ -598,7 +598,7 @@ describe('BrowserLocalDocumentPage markdown 導線 (browser — real IndexedDB)'
     )
   })
 
-  describe('a document written by the daemon before the body writers were unified', () => {
+  describe('a body written the pre-unification way', () => {
     // `wb_document_set` used to store a body as an `okf-body` TEXT NODE
     // rather than the `body` text container CodeMirror binds to. Both sides
     // now write the container, but documents in the old shape are already in
@@ -633,7 +633,7 @@ describe('BrowserLocalDocumentPage markdown 導線 (browser — real IndexedDB)'
       await new LoroStore().save(LEGACY_ID, doc.export({ mode: 'snapshot' }))
     }
 
-    it('is editable in the real editor without losing the body it was opened with', async () => {
+    it('stays editable without losing the body it opened with', async () => {
       // This needs a real browser for the CRDT binding. `LoroSyncPlugin`
       // syncs the `body` CONTAINER into CodeMirror on mount, overwriting the
       // `value` prop — so for a document whose prose is still in a node, the

--- a/apps/web/src/pages/BrowserLocalDocumentPage.multi-document.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.multi-document.browser.test.tsx
@@ -61,7 +61,7 @@ vi.mock('../components/spatial-editor/index.js', () => ({
 
 const { BrowserLocalDocumentPage } = await import('./BrowserLocalDocumentPage.js')
 
-describe('BrowserLocalDocumentPage multi-canvas UI (browser — real IndexedDB)', () => {
+describe('BrowserLocalDocumentPage multi-canvas UI (real IndexedDB)', () => {
   beforeEach(async () => {
     await clearWhiteboardDb()
     latestOnChange = null
@@ -167,7 +167,7 @@ describe('BrowserLocalDocumentPage multi-canvas UI (browser — real IndexedDB)'
     expect(await loroDocumentsKeys()).not.toContain('__placeholder__')
   })
 
-  it('persists an edit made immediately (within the 300ms debounce window) before switching to a new canvas', async () => {
+  it('persists an edit made inside the 300ms debounce before switching canvas', async () => {
     const store = new IndexedDBStore()
     render(<BrowserLocalDocumentPage store={store} />)
     await waitFor(

--- a/apps/web/src/pages/BrowserLocalDocumentPage.rename.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.rename.browser.test.tsx
@@ -80,7 +80,7 @@ async function openRenameInput(): Promise<HTMLElement> {
   return allTitleInputs[allTitleInputs.length - 1]!
 }
 
-describe('BrowserLocalDocumentPage rename (browser — real IndexedDB)', () => {
+describe('BrowserLocalDocumentPage rename (real IndexedDB)', () => {
   beforeEach(async () => {
     await clearDb()
   })
@@ -117,7 +117,7 @@ describe('BrowserLocalDocumentPage rename (browser — real IndexedDB)', () => {
     expect(container.clientWidth).toBeGreaterThan(600)
   })
 
-  it("keyboard isolation: Enter/Escape/Backspace/Delete typed in the title do not reach the spatial editor's document-level shortcut handlers", async () => {
+  it("keyboard isolation: title keys never reach the editor's shortcut handlers", async () => {
     await renderLoaded()
     const documentKeyDown = vi.fn()
     document.addEventListener('keydown', documentKeyDown)

--- a/apps/web/src/pages/DaemonIndexPage.create.browser.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.create.browser.test.tsx
@@ -58,7 +58,7 @@ function stubFetch(onCreateDocument: (workspaceId: string, path: string) => void
   )
 }
 
-describe('DaemonIndexPage New canvas control (browser — real Radix Tooltip)', () => {
+describe('DaemonIndexPage New canvas control (real Radix Tooltip)', () => {
   it('reveals the tooltip on real hover', async () => {
     stubFetch(() => {})
     render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenDocument={vi.fn()} />)
@@ -71,7 +71,7 @@ describe('DaemonIndexPage New canvas control (browser — real Radix Tooltip)', 
     await userEvent.unhover(button)
   })
 
-  it('reveals the tooltip on real keyboard focus, and Enter opens the kind menu whose entry creates', async () => {
+  it('reveals the tooltip on keyboard focus; Enter opens the kind menu', async () => {
     const created: Array<[string, string]> = []
     stubFetch((workspaceId, path) => created.push([workspaceId, path]))
     const onOpenDocument = vi.fn()

--- a/apps/web/src/pages/use-browser-local-document-controller.multi-document.browser.test.tsx
+++ b/apps/web/src/pages/use-browser-local-document-controller.multi-document.browser.test.tsx
@@ -25,7 +25,7 @@ function snapshotWithElements(elements: unknown[]): Uint8Array {
   return doc.export({ mode: 'snapshot' })
 }
 
-describe('multi-canvas foundation (browser — real IndexedDB)', () => {
+describe('multi-canvas foundation (real IndexedDB)', () => {
   beforeEach(async () => {
     await clearDb()
   })
@@ -120,7 +120,7 @@ describe('multi-canvas foundation (browser — real IndexedDB)', () => {
     expect(await store.getDefaultDocumentId()).toBe(idA)
   })
 
-  it('duplicateDocument deep-copies the real IndexedDB-backed Loro doc: later edits to the source never appear in the copy', async () => {
+  it('duplicateDocument deep-copies the Loro doc: later source edits never leak', async () => {
     const store = new IndexedDBStore()
     const loro = new LoroStore()
     const { result } = renderHook(() => useBrowserLocalDocumentController(store, loro))


### PR DESCRIPTION
A failing browser test writes a Playwright trace, and vitest then copies it into `.vitest-attachments/` under a name flattened from its path. Past the filesystem's 255-byte limit that copy throws `ENAMETOOLONG` in the file's teardown — and **vitest abandons the rest of the file**.

## Measured

The same forced failure in `BrowserLocalDocumentPage.rename`, twice:

| failing test's title | result |
|---|---|
| 194 chars | `ENAMETOOLONG` → **`1 failed \| 2 passed (6)`** |
| 58 chars | no error → `1 failed \| 5 passed (6)` |

Three tests silently did not run, and the run reported a **smaller total** — which reads like good news. It is the same trap AGENTS.md already warns about for filtered runs, and it is why a load-flaked run showed `1 failed | 630 passed (634)`.

The trace itself was never lost: it is written to `tmp/vitest-traces/` first and only the copy fails (verified — the zip opens, 6 entries, trace + network + resources). So this cost coverage, not diagnosability, which is what makes the fix about the abandoned tests rather than about the error message.

## The guard

`browser-test-name-length.test.ts` computes the projected attachment name for every `describe`+`it` path across the browser suites and fails past the budget. Two details worth knowing:

- It reads source at build time via `?raw`, so apps/web stays free of `node:fs` (`web-app-boundary.test.ts`), following `App.lazy-coverage.test.ts`.
- It resolves `describe` nesting by brace depth. A sibling `describe` opens at the depth the previous one closed at, so a naive stack reports a title path nobody wrote — the first version of this guard produced `SpatialEditor (browser)-SpatialEditor (browser) — spatial text layout defects-…` and over-counted by tens of characters.

Mutation-checked: restoring the 194-char title fails it. It also caught a real slip during this change — a `git checkout --` reverted one rename and the guard failed on exactly that title.

## The renames

Thirteen titles were over. The redundant part came out first: `(browser — real IndexedDB)` says "browser" in a `*.browser.test.tsx` file whose project already appears as `web-browser--chromium--` in the attachment name. The rest were shortened without losing what they claim. **No test's subject changed** — only its wording.

## Verification

`pnpm --filter @kamiazya/whiteboard-web test` (2314 + 77), `pnpm test:browser`, `typecheck`, `knip`, `biome` pass. End-to-end: forcing the failure again on the renamed title writes the attachment successfully and reports `1 failed | 5 passed (6)`.

## Not fixed here

`test:browser` still loses one test to load under a saturated machine (`New markdown note… …` times out with focus still on `<body>`). That is the separate, already-documented contention problem in `vitest.browser.config.ts`; this PR only stops one failure from taking its file's other tests with it. Traces for it are now obtainable, which is the prerequisite for chasing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation to ensure browser test names stay within filesystem limits, preventing trace-related failures and protecting subsequent test runs.
  * Improved coverage for nested test titles, escaped text, and test discovery.

* **Documentation**
  * Documented browser test naming limits, related trace attachment errors, and their impact on test execution.

* **Chores**
  * Simplified and clarified browser test descriptions across workspace, document, migration, and canvas workflows without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->