### PR TITLE
feat(web): open a node's body on the full editing surface

### DIFF
--- a/apps/web/src/components/document-editor/NodeTextEditorOverlay.browser.test.tsx
+++ b/apps/web/src/components/document-editor/NodeTextEditorOverlay.browser.test.tsx
@@ -11,6 +11,8 @@ afterEach(cleanup)
 
 const BODY = '# Plan\n\n- one\n- two'
 
+const targets = [{ id: '01JWEEK', name: 'Weekly review', kind: 'markdown' as const }]
+
 function renderOverlay(
   overrides: { onCommit?: (text: string) => void; onClose?: () => void } = {},
 ) {
@@ -20,6 +22,7 @@ function renderOverlay(
     <NodeTextEditorOverlay
       title="Weekly review"
       initialText={BODY}
+      linkTargets={targets}
       onCommit={onCommit}
       onClose={onClose}
     />,
@@ -80,6 +83,44 @@ describe('the node text overlay (real browser)', () => {
 
     expect(onCommit).not.toHaveBeenCalled()
     expect(onClose).toHaveBeenCalled()
+  })
+
+  // Escape belongs to the innermost thing that can take it. The overlay
+  // listens at the window in the CAPTURE phase, which fires before any
+  // nested popup's own handler — so without a guard, dismissing a link
+  // picker would discard the whole edit instead.
+  it('lets a nested popup take Escape for itself', async () => {
+    const { container, getByRole, onClose, onCommit } = renderOverlay()
+    await waitFor(() => expect(container.querySelector('.cm-content')).not.toBeNull())
+
+    await userEvent.click(getByRole('button', { name: 'Editing actions' }))
+    await userEvent.click(getByRole('menuitem', { name: 'Link' }))
+    await waitFor(() =>
+      expect(container.querySelector('[data-testid="link-picker"]')).not.toBeNull(),
+    )
+
+    await userEvent.keyboard('{Escape}')
+
+    await waitFor(() => expect(container.querySelector('[data-testid="link-picker"]')).toBeNull())
+    expect(onClose).not.toHaveBeenCalled()
+    expect(onCommit).not.toHaveBeenCalled()
+    // The surface is still there to keep editing on.
+    expect(container.querySelector('.cm-content')).not.toBeNull()
+  })
+
+  it('lets the catalog take Escape for itself', async () => {
+    const { container, getByRole, onClose } = renderOverlay()
+    await waitFor(() => expect(container.querySelector('.cm-content')).not.toBeNull())
+
+    await userEvent.click(getByRole('button', { name: 'Editing actions' }))
+    await waitFor(() =>
+      expect(container.querySelector('[data-testid="context-menu"]')).not.toBeNull(),
+    )
+
+    await userEvent.keyboard('{Escape}')
+
+    await waitFor(() => expect(container.querySelector('[data-testid="context-menu"]')).toBeNull())
+    expect(onClose).not.toHaveBeenCalled()
   })
 
   it('names the node it is editing', async () => {

--- a/apps/web/src/components/document-editor/NodeTextEditorOverlay.browser.test.tsx
+++ b/apps/web/src/components/document-editor/NodeTextEditorOverlay.browser.test.tsx
@@ -1,0 +1,89 @@
+// The full editing surface a canvas node's body gets when its own box is
+// too small: the same MarkdownEditor a document uses, over the canvas, with
+// the inline editor's commit grammar (close = commit, Escape = discard) so
+// there is only one thing to learn.
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { NodeTextEditorOverlay } from './NodeTextEditorOverlay.js'
+
+afterEach(cleanup)
+
+const BODY = '# Plan\n\n- one\n- two'
+
+function renderOverlay(
+  overrides: { onCommit?: (text: string) => void; onClose?: () => void } = {},
+) {
+  const onCommit = overrides.onCommit ?? vi.fn()
+  const onClose = overrides.onClose ?? vi.fn()
+  const view = render(
+    <NodeTextEditorOverlay
+      title="Weekly review"
+      initialText={BODY}
+      onCommit={onCommit}
+      onClose={onClose}
+    />,
+  )
+  return { ...view, onCommit, onClose }
+}
+
+async function typeInto(container: HTMLElement, text: string): Promise<void> {
+  const editable = container.querySelector('[contenteditable="true"]')
+  if (!editable) throw new Error('expected a contenteditable CodeMirror host')
+  await userEvent.click(editable.querySelector('.cm-line') as HTMLElement)
+  await userEvent.keyboard('{Control>}{End}{/Control}')
+  await userEvent.keyboard(text)
+}
+
+describe('the node text overlay (real browser)', () => {
+  it('opens on the node body and commits the edit when closed', async () => {
+    const { container, getByRole, onCommit, onClose } = renderOverlay()
+
+    await waitFor(() => expect(container.querySelector('.cm-content')).not.toBeNull())
+    expect(container.querySelector('.cm-content')?.textContent).toContain('# Plan')
+
+    await typeInto(container, ' three')
+    await userEvent.click(getByRole('button', { name: 'Back to canvas' }))
+
+    expect(onCommit).toHaveBeenCalledWith(`${BODY} three`)
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  // Same grammar as the inline node editor, so nothing new has to be learned.
+  it('discards the edit on Escape', async () => {
+    const { container, onCommit, onClose } = renderOverlay()
+    await waitFor(() => expect(container.querySelector('.cm-content')).not.toBeNull())
+
+    await typeInto(container, ' three')
+    await userEvent.keyboard('{Escape}')
+
+    expect(onCommit).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('commits on ⌘Enter without waiting for the close', async () => {
+    const { container, onCommit } = renderOverlay()
+    await waitFor(() => expect(container.querySelector('.cm-content')).not.toBeNull())
+
+    await typeInto(container, ' three')
+    await userEvent.keyboard('{Meta>}{Enter}{/Meta}')
+
+    expect(onCommit).toHaveBeenCalledWith(`${BODY} three`)
+  })
+
+  // Closing with nothing typed must not write a revision that says nothing.
+  it('does not commit when the text is unchanged', async () => {
+    const { container, getByRole, onCommit, onClose } = renderOverlay()
+    await waitFor(() => expect(container.querySelector('.cm-content')).not.toBeNull())
+
+    await userEvent.click(getByRole('button', { name: 'Back to canvas' }))
+
+    expect(onCommit).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('names the node it is editing', async () => {
+    const { getByText } = renderOverlay()
+    expect(getByText('Weekly review')).toBeTruthy()
+  })
+})

--- a/apps/web/src/components/document-editor/NodeTextEditorOverlay.tsx
+++ b/apps/web/src/components/document-editor/NodeTextEditorOverlay.tsx
@@ -49,6 +49,13 @@ export function NodeTextEditorOverlay({
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
+      // This listener runs at the WINDOW in the capture phase, so it fires
+      // before any nested popup's own handler and `stopPropagation` there
+      // cannot reach it. Escape belongs to the innermost thing that can take
+      // it: while the editor's catalog or link picker is open, that is the
+      // popup, and taking it here would discard the whole edit to dismiss a
+      // menu. Both popups mark themselves `data-editor-overlay`.
+      if (document.querySelector('[data-editor-overlay]') !== null) return
       if (event.key === 'Escape') {
         event.preventDefault()
         onClose()

--- a/apps/web/src/components/document-editor/NodeTextEditorOverlay.tsx
+++ b/apps/web/src/components/document-editor/NodeTextEditorOverlay.tsx
@@ -1,0 +1,103 @@
+import { ArrowLeft } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { MarkdownEditorProps } from '../markdown-editor/MarkdownEditor.js'
+import { MarkdownEditor } from '../markdown-editor/MarkdownEditor.js'
+
+export interface NodeTextEditorOverlayProps
+  extends Pick<MarkdownEditorProps, 'theme' | 'resolveAlias' | 'resolveEmbed' | 'linkTargets'> {
+  /** What the surface is editing, shown so the canvas context is not lost. */
+  readonly title: string
+  readonly initialText: string
+  /** Called with the edited body — only when it actually differs. */
+  readonly onCommit: (text: string) => void
+  readonly onClose: () => void
+}
+
+/**
+ * A canvas node's body on the same surface a document gets.
+ *
+ * The inline node editor is bounded by the node's own box, which is right for
+ * a line and wrong for a body — and the box cannot simply grow, because its
+ * size is the author's layout decision. So the long form opens over the
+ * canvas instead, with the editor's own affordances (view modes, the ⋯
+ * catalog, the link picker) intact.
+ *
+ * The commit grammar is the inline editor's, deliberately: closing commits,
+ * ⌘Enter commits, Escape discards. Two doors onto the same text that agreed
+ * about everything except when the writing is kept would be worse than one.
+ */
+export function NodeTextEditorOverlay({
+  title,
+  initialText,
+  onCommit,
+  onClose,
+  theme,
+  resolveAlias,
+  resolveEmbed,
+  linkTargets,
+}: NodeTextEditorOverlayProps) {
+  const [text, setText] = useState(initialText)
+  // The keydown handler is bound once; without a ref it would close over the
+  // text as it stood at mount and commit an empty edit.
+  const textRef = useRef(initialText)
+  textRef.current = text
+
+  const commitAndClose = useCallback(() => {
+    if (textRef.current !== initialText) onCommit(textRef.current)
+    onClose()
+  }, [initialText, onCommit, onClose])
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onClose()
+        return
+      }
+      // The editor's own Mod-Enter toggles a task item, and that binding is
+      // right inside a document. Here the surface itself is the thing being
+      // exited, so the commit wins — the same precedence the inline node
+      // editor applies.
+      if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault()
+        commitAndClose()
+      }
+    }
+    window.addEventListener('keydown', onKeyDown, true)
+    return () => window.removeEventListener('keydown', onKeyDown, true)
+  }, [commitAndClose, onClose])
+
+  return (
+    <div
+      data-testid="node-text-overlay"
+      role="dialog"
+      aria-label={`Editing ${title}`}
+      className="bg-background absolute inset-0 z-30 flex flex-col"
+    >
+      <div className="border-border flex h-10 shrink-0 items-center gap-2 border-b px-2">
+        <button
+          type="button"
+          aria-label="Back to canvas"
+          onClick={commitAndClose}
+          className="text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-ring inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-sm focus-visible:ring-2 focus-visible:outline-none"
+        >
+          <ArrowLeft aria-hidden className="size-4" />
+          Canvas
+        </button>
+        <span className="text-foreground truncate text-sm font-medium">{title}</span>
+      </div>
+      <div className="min-h-0 flex-1">
+        <MarkdownEditor
+          value={text}
+          onChange={setText}
+          className="h-full"
+          autoFocus
+          theme={theme}
+          resolveAlias={resolveAlias}
+          resolveEmbed={resolveEmbed}
+          linkTargets={linkTargets}
+        />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/document-editor/node-text.test.ts
+++ b/apps/web/src/components/document-editor/node-text.test.ts
@@ -1,0 +1,29 @@
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { describe, expect, it } from 'vitest'
+import { withNodeText } from './node-text.js'
+
+const canvas: SpatialCanvas = {
+  nodes: [
+    { id: 'n1', type: 'text', x: 0, y: 0, width: 10, height: 10, text: 'before' },
+    { id: 'n2', type: 'link', x: 0, y: 0, width: 10, height: 10, url: 'https://example.com' },
+  ],
+  edges: [],
+}
+
+describe('withNodeText', () => {
+  it('replaces the body of the named text node and leaves the rest alone', () => {
+    const next = withNodeText(canvas, 'n1', 'after')
+    const node = next.nodes.find((entry) => entry.id === 'n1')
+    expect(node?.type === 'text' ? node.text : null).toBe('after')
+    expect(next.nodes[1]).toBe(canvas.nodes[1])
+    expect(next).not.toBe(canvas)
+  })
+
+  // The caller writes a revision only when something changed, so "nothing
+  // changed" has to be recognisable — reference equality says it exactly.
+  it('returns the same canvas when nothing would change', () => {
+    expect(withNodeText(canvas, 'n1', 'before')).toBe(canvas)
+    expect(withNodeText(canvas, 'missing', 'after')).toBe(canvas)
+    expect(withNodeText(canvas, 'n2', 'after')).toBe(canvas)
+  })
+})

--- a/apps/web/src/components/document-editor/node-text.ts
+++ b/apps/web/src/components/document-editor/node-text.ts
@@ -1,0 +1,22 @@
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+
+/**
+ * The canvas with one text node's body replaced.
+ *
+ * Split out of the page because the page cannot easily prove it: its canvas
+ * arrives through the CRDT sync hook rather than from its own `onChange`, so
+ * a test there can observe the surface opening but not what the write did.
+ * Here it is one input and one output.
+ *
+ * Returns the SAME canvas when nothing would change — an unchanged body, a
+ * missing node, or a node that is not text. The caller uses that to avoid
+ * writing a revision that says nothing.
+ */
+export function withNodeText(canvas: SpatialCanvas, nodeId: string, text: string): SpatialCanvas {
+  const target = canvas.nodes.find((node) => node.id === nodeId)
+  if (target === undefined || target.type !== 'text' || target.text === text) return canvas
+  return {
+    ...canvas,
+    nodes: canvas.nodes.map((node) => (node.id === nodeId ? { ...node, text } : node)),
+  }
+}

--- a/apps/web/src/components/document-editor/use-node-in-editor.test.tsx
+++ b/apps/web/src/components/document-editor/use-node-in-editor.test.tsx
@@ -1,0 +1,45 @@
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useNodeInEditor } from './use-node-in-editor.js'
+
+const canvas: SpatialCanvas = {
+  nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 10, height: 10, text: 'before' }],
+  edges: [],
+}
+
+describe('useNodeInEditor', () => {
+  it('opens on a node, writes the edit, and closes', () => {
+    const onChange = vi.fn()
+    const { result } = renderHook(() => useNodeInEditor(canvas, onChange))
+    expect(result.current.editing).toBeNull()
+
+    act(() => result.current.open('n1', 'before'))
+    expect(result.current.editing).toEqual({ id: 'n1', text: 'before' })
+
+    act(() => result.current.commit('after'))
+    const [next, command] = onChange.mock.calls[0] ?? []
+    expect((next as SpatialCanvas).nodes[0]).toMatchObject({ id: 'n1', text: 'after' })
+    expect(command).toEqual({ kind: 'set-text', id: 'n1', text: 'after' })
+
+    act(() => result.current.close())
+    expect(result.current.editing).toBeNull()
+  })
+
+  it('writes nothing when the edit changes nothing', () => {
+    const onChange = vi.fn()
+    const { result } = renderHook(() => useNodeInEditor(canvas, onChange))
+    act(() => result.current.open('n1', 'before'))
+    act(() => result.current.commit('before'))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  // A commit can only arrive from the open surface, but a closed hook must
+  // not write on the strength of a stale callback either.
+  it('writes nothing when nothing is open', () => {
+    const onChange = vi.fn()
+    const { result } = renderHook(() => useNodeInEditor(canvas, onChange))
+    act(() => result.current.commit('after'))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/document-editor/use-node-in-editor.tsx
+++ b/apps/web/src/components/document-editor/use-node-in-editor.tsx
@@ -1,0 +1,43 @@
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { useState } from 'react'
+import type { EditorCommand } from '../spatial-editor/commands.js'
+import { withNodeText } from './node-text.js'
+
+export interface NodeInEditor {
+  /** Pass to `SpatialEditor`'s `onOpenInEditor`. */
+  readonly open: (nodeId: string, text: string) => void
+  /** The body being edited, or null when the surface is closed. */
+  readonly editing: { readonly id: string; readonly text: string } | null
+  /** Pass to the overlay's `onCommit`. */
+  readonly commit: (text: string) => void
+  /** Pass to the overlay's `onClose`. */
+  readonly close: () => void
+}
+
+/**
+ * The state and the write behind "open in editor", shared by both pages.
+ *
+ * It exists as one hook rather than two copies because the copies were
+ * identical and the prop that carries them is OPTIONAL — a page that stopped
+ * wiring it would compile clean and silently lose the feature, and only that
+ * page's own test would notice. One hook means one place to get it right.
+ */
+export function useNodeInEditor(
+  canvas: SpatialCanvas,
+  onChange: (next: SpatialCanvas, command: EditorCommand) => void,
+): NodeInEditor {
+  const [editing, setEditing] = useState<{ id: string; text: string } | null>(null)
+  return {
+    editing,
+    open: (id, text) => setEditing({ id, text }),
+    commit: (text) => {
+      if (editing === null) return
+      const next = withNodeText(canvas, editing.id, text)
+      // Same canvas back means nothing changed that could be written — no
+      // revision for a no-op.
+      if (next === canvas) return
+      onChange(next, { kind: 'set-text', id: editing.id, text })
+    },
+    close: () => setEditing(null),
+  }
+}

--- a/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
@@ -44,7 +44,6 @@ import {
   SendToBack,
   Sparkles,
   SquareDashed,
-  SquarePen,
   StickyNote,
   Tag,
   Trash2,
@@ -117,12 +116,6 @@ export interface CanvasContextMenuProps {
   readonly isImageFileRef?: (file: string) => boolean
   readonly missingFileRef?: (file: string) => boolean
   readonly onOpenFileRef?: (file: string, subpath?: string) => void
-  /**
-   * Hands a text node's body to a fuller editing surface the host owns.
-   * Absent means the host has none, and the verb is not offered — a door
-   * onto nothing is worse than no door.
-   */
-  readonly onOpenInEditor?: (nodeId: string, text: string) => void
   readonly openLinkNode: (node: Extract<SpatialNode, { type: 'link' }>) => void
   readonly copySelection: () => ClipboardFragment | null
   /** Cut-flavoured copy: also records the cut surface for paste to reconnect. */
@@ -163,7 +156,6 @@ export function CanvasContextMenu({
   isImageFileRef,
   missingFileRef,
   onOpenFileRef,
-  onOpenInEditor,
   openLinkNode,
   copySelection,
   cutSelection,
@@ -549,16 +541,6 @@ export function CanvasContextMenu({
               )
             },
           })
-          if (onOpenInEditor !== undefined) {
-            // The inline editor is bounded by the node's own box, which is
-            // the right size for a line and the wrong one for a body. This
-            // is the same text on a surface that has room for it.
-            verbs.push({
-              label: 'Open in editor',
-              icon: <SquarePen />,
-              onSelect: () => onOpenInEditor(node.id, node.text),
-            })
-          }
         }
         // Touch path to Cmd/Ctrl+D (see shortcuts.ts). The menu's
         // right-click already made this node the primary selection,

--- a/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
@@ -44,6 +44,7 @@ import {
   SendToBack,
   Sparkles,
   SquareDashed,
+  SquarePen,
   StickyNote,
   Tag,
   Trash2,
@@ -116,6 +117,12 @@ export interface CanvasContextMenuProps {
   readonly isImageFileRef?: (file: string) => boolean
   readonly missingFileRef?: (file: string) => boolean
   readonly onOpenFileRef?: (file: string, subpath?: string) => void
+  /**
+   * Hands a text node's body to a fuller editing surface the host owns.
+   * Absent means the host has none, and the verb is not offered — a door
+   * onto nothing is worse than no door.
+   */
+  readonly onOpenInEditor?: (nodeId: string, text: string) => void
   readonly openLinkNode: (node: Extract<SpatialNode, { type: 'link' }>) => void
   readonly copySelection: () => ClipboardFragment | null
   /** Cut-flavoured copy: also records the cut surface for paste to reconnect. */
@@ -156,6 +163,7 @@ export function CanvasContextMenu({
   isImageFileRef,
   missingFileRef,
   onOpenFileRef,
+  onOpenInEditor,
   openLinkNode,
   copySelection,
   cutSelection,
@@ -541,6 +549,16 @@ export function CanvasContextMenu({
               )
             },
           })
+          if (onOpenInEditor !== undefined) {
+            // The inline editor is bounded by the node's own box, which is
+            // the right size for a line and the wrong one for a body. This
+            // is the same text on a surface that has room for it.
+            verbs.push({
+              label: 'Open in editor',
+              icon: <SquarePen />,
+              onSelect: () => onOpenInEditor(node.id, node.text),
+            })
+          }
         }
         // Touch path to Cmd/Ctrl+D (see shortcuts.ts). The menu's
         // right-click already made this node the primary selection,

--- a/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
@@ -31,9 +31,29 @@ export interface SelectionOverlayProps {
    * an editor has no focus fight to lose.
    */
   readonly onMoreActions?: (anchor: Point) => void
+  /**
+   * Opens this node's body on a fuller editing surface.
+   *
+   * A DOORWAY, not a verb: every entry in the ⋯ catalog changes the node and
+   * leaves you on the canvas, and this one changes nothing and moves you
+   * somewhere else. Putting a navigation among object verbs is what left two
+   * near-identical pencil icons side by side with no way to tell them apart.
+   */
+  readonly onOpenInEditor?: () => void
 }
 
 const SELECTION_STROKE = 'var(--manipulation)'
+
+/**
+ * The node-tools pill is drawn in the app's neutral ink, not the manipulation
+ * accent. The accent is what says "this is selected", and it is already spent
+ * on the outline and the handles — repeating it on a control that sits beside
+ * the node makes the loudest thing on the canvas a piece of chrome. Both
+ * carry a literal fallback because this overlay must render the same where
+ * the app stylesheet is absent (browser-mode component tests).
+ */
+const TOOL_INK = 'var(--muted-foreground, oklch(0.556 0 0))'
+const TOOL_EDGE = 'var(--border, oklch(0.922 0 0))'
 const HANDLE_LABEL: Record<ResizeHandleKind, string> = {
   nw: 'Resize north-west',
   n: 'Resize north',
@@ -73,6 +93,7 @@ export function SelectionOverlay({
   onHandleKeyDown,
   onConnectKeyDown,
   onMoreActions,
+  onOpenInEditor,
 }: SelectionOverlayProps) {
   const handles = resizeHandleBoxes(box, zoom)
   // Hitting and drawing are separate questions: the markers stay 8px so
@@ -234,57 +255,153 @@ export function SelectionOverlay({
             />
           </g>
         ))}
-      {onMoreActions !== undefined && (
-        // biome-ignore lint/a11y/useSemanticElements: must stay an SVG shape to render/hit-test at this canvas-space position under the ancestor pan/zoom transform; role+tabIndex+onKeyDown reproduce native <button> semantics by hand.
-        <g
-          data-testid="more-actions-handle"
-          role="button"
-          tabIndex={0}
-          aria-label="More actions"
-          aria-haspopup="menu"
-          style={{ pointerEvents: 'auto', cursor: 'pointer' }}
-          onPointerDown={(e) => {
-            // Keep the press away from the root's node/empty hit-test; the
-            // action itself fires on pointerup.
-            e.stopPropagation()
-          }}
-          onPointerUp={(e) => {
-            // pointerup, not click: the editor root preventDefaults native
-            // touchstart (its iOS long-press suppression), which cancels the
-            // synthetic mouse-compatibility events — a touch tap never
-            // produces a click here. After pointerdown, so no focus fight
-            // with mousedown's default action either.
-            e.stopPropagation()
-            onMoreActions({ x: box.x + box.width - 12 / zoom, y: box.y - 18 / zoom })
-          }}
-          onKeyDown={(e) => {
-            if (e.key !== 'Enter' && e.key !== ' ') return
-            e.preventDefault()
-            onMoreActions({ x: box.x + box.width - 12 / zoom, y: box.y - 18 / zoom })
-          }}
-        >
-          <rect
-            x={box.x + box.width - 24 / zoom}
-            y={box.y - 30 / zoom}
-            width={24 / zoom}
-            height={24 / zoom}
-            rx={6 / zoom}
-            fill={SELECTION_STROKE}
-          />
-          {/* Three dots as real circles, not a "⋯" glyph — a text character
-              rides the platform font and renders as emoji or tofu on some
-              systems, which is no way to draw a control. */}
-          {[-5, 0, 5].map((dx) => (
-            <circle
-              key={dx}
-              cx={box.x + box.width - 12 / zoom + dx / zoom}
-              cy={box.y - 18 / zoom}
-              r={1.6 / zoom}
-              fill="var(--background)"
-            />
-          ))}
-        </g>
-      )}
+      {(onOpenInEditor !== undefined || onMoreActions !== undefined) &&
+        (() => {
+          // ONE group, not one chip per verb. The two doorways stay separate
+          // controls — they lead to different kinds of place — but they read
+          // as a single tool cluster attached to this node, and they are
+          // drawn quietly: the selection outline already says "this is
+          // selected", so a solid accent fill here would be the loudest thing
+          // on a canvas whose job is to recede behind its content.
+          const slots = [
+            ...(onOpenInEditor === undefined
+              ? []
+              : [{ kind: 'open' as const, label: 'Open in editor', run: onOpenInEditor }]),
+            ...(onMoreActions === undefined
+              ? []
+              : [
+                  {
+                    kind: 'more' as const,
+                    label: 'More actions',
+                    run: () =>
+                      onMoreActions({
+                        x: box.x + box.width - 12 / zoom,
+                        y: box.y - 18 / zoom,
+                      }),
+                  },
+                ]),
+          ]
+          const slotSize = 24 / zoom
+          const groupWidth = slotSize * slots.length
+          const left = box.x + box.width - groupWidth
+          const top = box.y - 30 / zoom
+          return (
+            <g data-testid="node-tools">
+              <rect
+                x={left}
+                y={top}
+                width={groupWidth}
+                height={slotSize}
+                rx={6 / zoom}
+                fill="var(--background)"
+                stroke={TOOL_EDGE}
+                strokeWidth={1 / zoom}
+              />
+              {slots.map((slot, index) => {
+                const cx = left + slotSize * index + slotSize / 2
+                const cy = top + slotSize / 2
+                return (
+                  // biome-ignore lint/a11y/useSemanticElements: must stay an SVG shape to render/hit-test at this canvas-space position under the ancestor pan/zoom transform; role+tabIndex+onKeyDown reproduce native <button> semantics by hand.
+                  <g
+                    key={slot.kind}
+                    data-testid={
+                      slot.kind === 'open' ? 'open-in-editor-handle' : 'more-actions-handle'
+                    }
+                    role="button"
+                    tabIndex={0}
+                    aria-label={slot.label}
+                    {...(slot.kind === 'more' ? { 'aria-haspopup': 'menu' as const } : {})}
+                    style={{ pointerEvents: 'auto', cursor: 'pointer' }}
+                    onPointerDown={(e) => {
+                      // Keep the press away from the root's node/empty
+                      // hit-test; the action itself fires on pointerup.
+                      e.stopPropagation()
+                    }}
+                    onPointerUp={(e) => {
+                      // pointerup, not click: the editor root preventDefaults
+                      // native touchstart (its iOS long-press suppression),
+                      // which cancels the synthetic mouse-compatibility
+                      // events — a touch tap never produces a click here.
+                      e.stopPropagation()
+                      slot.run()
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key !== 'Enter' && e.key !== ' ') return
+                      e.preventDefault()
+                      slot.run()
+                    }}
+                  >
+                    {/* The hit area: transparent, so the quiet pill stays the
+                        only thing drawn until a pointer asks for more. */}
+                    <rect
+                      x={left + slotSize * index}
+                      y={top}
+                      width={slotSize}
+                      height={slotSize}
+                      rx={6 / zoom}
+                      fill="transparent"
+                    />
+                    {index > 0 && (
+                      <line
+                        x1={left + slotSize * index}
+                        y1={top + 5 / zoom}
+                        x2={left + slotSize * index}
+                        y2={top + slotSize - 5 / zoom}
+                        stroke={TOOL_EDGE}
+                        strokeWidth={1 / zoom}
+                      />
+                    )}
+                    {slot.kind === 'open' ? (
+                      /* An arrow leaving a frame: the same "this takes you
+                         elsewhere" glyph a link out of the page carries,
+                         drawn rather than typed so no platform font can turn
+                         it into tofu. */
+                      <g
+                        fill="none"
+                        stroke={TOOL_INK}
+                        strokeWidth={1.5 / zoom}
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <path
+                          d={[
+                            `M ${cx + 1 / zoom} ${cy - 5 / zoom}`,
+                            `l ${-5 / zoom} 0`,
+                            `l 0 ${10 / zoom}`,
+                            `l ${10 / zoom} 0`,
+                            `l 0 ${-5 / zoom}`,
+                          ].join(' ')}
+                        />
+                        <path
+                          d={[
+                            `M ${cx} ${cy - 1 / zoom}`,
+                            `l ${5 / zoom} ${-5 / zoom}`,
+                            `M ${cx + 1 / zoom} ${cy - 6 / zoom}`,
+                            `l ${4 / zoom} 0 l 0 ${4 / zoom}`,
+                          ].join(' ')}
+                        />
+                      </g>
+                    ) : (
+                      /* Three dots as real circles, not a "⋯" glyph — a text
+                         character rides the platform font and renders as
+                         emoji or tofu on some systems, which is no way to
+                         draw a control. */
+                      [-5, 0, 5].map((dx) => (
+                        <circle
+                          key={dx}
+                          cx={cx + dx / zoom}
+                          cy={cy}
+                          r={1.6 / zoom}
+                          fill={TOOL_INK}
+                        />
+                      ))
+                    )}
+                  </g>
+                )
+              })}
+            </g>
+          )
+        })()}
     </svg>
   )
 }

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -3239,7 +3239,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             pendingBackgroundGroupIdRef={pendingBackgroundGroupIdRef}
             isLocked={isLocked}
             onToggleNodeLock={onToggleNodeLock}
-            onOpenInEditor={onOpenInEditor}
             applyBoxMoves={applyBoxMoves}
             extraIds={extraIds}
             selectedId={selectedId}
@@ -3557,6 +3556,13 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               // target — one catalog, now with a visible doorway. Offered
               // for every selection (multi included: align/distribute were
               // the least discoverable actions of all).
+              // Only a single text node has a body to open, and only when the
+              // host has a surface to open it on.
+              onOpenInEditor={
+                onOpenInEditor !== undefined && !isMultiSelection && selectedNode?.type === 'text'
+                  ? () => onOpenInEditor(selectedNode.id, selectedNode.text)
+                  : undefined
+              }
               onMoreActions={(anchor) => {
                 const screen = canvasToScreen(anchor, viewport)
                 setContextMenu({

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -322,6 +322,14 @@ export interface SpatialEditorProps {
   /** Follows a file node's reference (navigation). Absent → follow hides. */
   readonly onOpenFileRef?: (file: string, subpath?: string) => void
   /**
+   * Opens a text node's body on a surface the HOST owns — the composition
+   * root already holds the seams a full markdown editor needs (alias
+   * resolution, link targets, embeds), so the canvas hands over the node and
+   * its text and stays out of it. Absent means no such surface exists, and
+   * the catalog does not offer the verb.
+   */
+  readonly onOpenInEditor?: (nodeId: string, text: string) => void
+  /**
    * Marks a file reference whose target no longer exists (deleted canvas,
    * ref imported into a store that never had it). The card renders a quiet
    * "Missing reference" label and the follow affordances (context menu,
@@ -462,6 +470,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       lockedEdgeIds,
       onToggleEdgeLock,
       onToggleNodeLock,
+      onOpenInEditor,
       fileRefOptions,
       onOpenFileRef,
       missingFileRef,
@@ -3230,6 +3239,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             pendingBackgroundGroupIdRef={pendingBackgroundGroupIdRef}
             isLocked={isLocked}
             onToggleNodeLock={onToggleNodeLock}
+            onOpenInEditor={onOpenInEditor}
             applyBoxMoves={applyBoxMoves}
             extraIds={extraIds}
             selectedId={selectedId}

--- a/apps/web/src/components/spatial-editor/hit-targets.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/hit-targets.browser.test.tsx
@@ -115,8 +115,12 @@ it('only the four corner markers are painted — mid-edge chrome is gone', () =>
   selectNode(container)
 
   const overlay = container.querySelector('[data-testid="selection-overlay"]') as Element
+  // Scoped to the selection chrome: the node-tools pill beside the box is a
+  // separate control that also paints on the canvas surface.
   const painted = [...overlay.querySelectorAll('rect')].filter(
-    (el) => el.getAttribute('fill') === 'var(--background)',
+    (el) =>
+      el.getAttribute('fill') === 'var(--background)' &&
+      el.closest('[data-testid="node-tools"]') === null,
   )
   expect(painted).toHaveLength(4)
 })

--- a/apps/web/src/components/spatial-editor/open-in-editor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/open-in-editor.browser.test.tsx
@@ -56,31 +56,50 @@ const menuItemNamed = (container: HTMLElement, name: string) =>
     (item) => (item.textContent ?? '').trim() === name,
   )
 
+async function selectNode(container: HTMLElement): Promise<void> {
+  const root = rootOf(container)
+  const r = root.getBoundingClientRect()
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + 200,
+    clientY: r.top + 150,
+  })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + 200, clientY: r.top + 150 })
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="more-actions-handle"]')).not.toBeNull(),
+  )
+}
+
 describe('open in editor (real browser)', () => {
-  it('reports the node and its text to the host', async () => {
+  // Every other verb in the catalog CHANGES the node and leaves you on the
+  // canvas; this one changes nothing and moves you somewhere else. Mixing the
+  // two categories is what made two near-identical pencil icons sit side by
+  // side with no way to tell them apart, so the navigation lives on the node
+  // itself — beside the ⋯ doorway, not inside it.
+  it('is a doorway on the node, not a verb in the catalog', async () => {
     const onOpenInEditor = vi.fn()
     const { container } = render(<Host onOpenInEditor={onOpenInEditor} />)
-    await openNodeCatalog(container)
+    await selectNode(container)
 
-    const item = menuItemNamed(container, 'Open in editor')
-    expect(item).not.toBeUndefined()
-    fireEvent.click(item as HTMLElement)
+    const handle = container.querySelector('[data-testid="open-in-editor-handle"]')
+    expect(handle).not.toBeNull()
+    fireEvent.pointerUp(handle as Element, { pointerId: 2 })
 
     expect(onOpenInEditor).toHaveBeenCalledWith('a', LONG)
-    // The catalog closes, and the inline editor is NOT opened as well.
-    await vi.waitFor(() =>
-      expect(container.querySelector('[data-testid="context-menu"]')).toBeNull(),
-    )
-    expect(container.querySelector('[data-testid="node-editor"]')).toBeNull()
+    // It never entered the object-verb catalog.
+    await openNodeCatalog(container)
+    expect(menuItemNamed(container, 'Open in editor')).toBeUndefined()
+    // The inline verb stays — it is the one that always works.
+    expect(menuItemNamed(container, 'Edit text')).not.toBeUndefined()
   })
 
   // A host that cannot open an editor must not advertise a door to one.
-  it('offers nothing when the host has no editor to open', async () => {
+  it('offers no doorway when the host has no editor to open', async () => {
     const { container } = render(<Host />)
-    await openNodeCatalog(container)
+    await selectNode(container)
 
-    expect(menuItemNamed(container, 'Open in editor')).toBeUndefined()
-    // The inline verb stays either way — it is the one that always works.
-    expect(menuItemNamed(container, 'Edit text')).not.toBeUndefined()
+    expect(container.querySelector('[data-testid="open-in-editor-handle"]')).toBeNull()
+    expect(container.querySelector('[data-testid="more-actions-handle"]')).not.toBeNull()
   })
 })

--- a/apps/web/src/components/spatial-editor/open-in-editor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/open-in-editor.browser.test.tsx
@@ -1,0 +1,86 @@
+// A node's inline editor sits inside the node's own box — right for a line,
+// wrong for the long body that box is too small to show. The catalog gets a
+// second door onto the same text: the host opens whatever surface it likes,
+// and the canvas only says which node and with what text.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const LONG = '# Plan\n\n- one\n- two\n- three\n\nA body far taller than its node.'
+
+const start: SpatialCanvas = {
+  nodes: [{ id: 'a', type: 'text', x: 100, y: 100, width: 220, height: 100, text: LONG }],
+  edges: [],
+}
+
+function Host({ onOpenInEditor }: { onOpenInEditor?: (nodeId: string, text: string) => void }) {
+  const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor
+        defaultTool="select"
+        canvas={canvas}
+        onChange={setCanvas}
+        theme="light"
+        onOpenInEditor={onOpenInEditor}
+      />
+    </div>
+  )
+}
+
+const rootOf = (container: HTMLElement) =>
+  container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+
+async function openNodeCatalog(container: HTMLElement): Promise<void> {
+  const root = rootOf(container)
+  const r = root.getBoundingClientRect()
+  fireEvent.pointerDown(root, {
+    button: 0,
+    pointerId: 1,
+    clientX: r.left + 200,
+    clientY: r.top + 150,
+  })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + 200, clientY: r.top + 150 })
+  fireEvent.contextMenu(root, { clientX: r.left + 200, clientY: r.top + 150 })
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="context-menu"]')).not.toBeNull(),
+  )
+}
+
+const menuItemNamed = (container: HTMLElement, name: string) =>
+  [...container.querySelectorAll('[role="menuitem"]')].find(
+    (item) => (item.textContent ?? '').trim() === name,
+  )
+
+describe('open in editor (real browser)', () => {
+  it('reports the node and its text to the host', async () => {
+    const onOpenInEditor = vi.fn()
+    const { container } = render(<Host onOpenInEditor={onOpenInEditor} />)
+    await openNodeCatalog(container)
+
+    const item = menuItemNamed(container, 'Open in editor')
+    expect(item).not.toBeUndefined()
+    fireEvent.click(item as HTMLElement)
+
+    expect(onOpenInEditor).toHaveBeenCalledWith('a', LONG)
+    // The catalog closes, and the inline editor is NOT opened as well.
+    await vi.waitFor(() =>
+      expect(container.querySelector('[data-testid="context-menu"]')).toBeNull(),
+    )
+    expect(container.querySelector('[data-testid="node-editor"]')).toBeNull()
+  })
+
+  // A host that cannot open an editor must not advertise a door to one.
+  it('offers nothing when the host has no editor to open', async () => {
+    const { container } = render(<Host />)
+    await openNodeCatalog(container)
+
+    expect(menuItemNamed(container, 'Open in editor')).toBeUndefined()
+    // The inline verb stays either way — it is the one that always works.
+    expect(menuItemNamed(container, 'Edit text')).not.toBeUndefined()
+  })
+})

--- a/apps/web/src/pages/BrowserLocalDocumentPage.open-in-editor.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.open-in-editor.browser.test.tsx
@@ -1,0 +1,74 @@
+// The seam between the three parts: the canvas raises the verb, the page owns
+// the surface, and the edit has to land back in the canvas. Each part has its
+// own test; only the page can answer whether they are connected.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { IndexedDBStore } from '../lib/browser-local-store.js'
+import { clearWhiteboardDb } from '../test-utils/browser-local-document.js'
+
+type OnChange = (next: SpatialCanvas, command: unknown) => void
+type OpenInEditor = (nodeId: string, text: string) => void
+
+const NODE_TEXT = '# Plan\n\n- one'
+let latestOnChange: OnChange | null = null
+
+// The real canvas needs geometry this test does not care about; what it must
+// do here is offer the verb the way the real one does, with the node's text.
+vi.mock('../components/spatial-editor/index.js', () => ({
+  SpatialEditor: (props: { onChange?: OnChange; onOpenInEditor?: OpenInEditor }) => {
+    latestOnChange = props.onChange ?? null
+    return (
+      <button type="button" onClick={() => props.onOpenInEditor?.('n1', NODE_TEXT)}>
+        raise open-in-editor
+      </button>
+    )
+  },
+}))
+
+const { BrowserLocalDocumentPage } = await import('./BrowserLocalDocumentPage.js')
+
+describe('open in editor (page seam)', () => {
+  beforeEach(async () => {
+    await clearWhiteboardDb()
+    latestOnChange = null
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+  })
+
+  it("opens the page's editing surface on the node body the canvas hands over", async () => {
+    const id = '01ARZ3NDEKTSV4RRFFQ69G5FCC'
+    const store = new IndexedDBStore()
+    await store.save({
+      id,
+      name: 'Board',
+      updatedAt: '2026-05-24T00:00:00.000Z',
+      kind: 'spatial' as const,
+    })
+    await store.setDefaultDocumentId(id)
+    render(
+      <MemoryRouter>
+        <BrowserLocalDocumentPage store={store} />
+      </MemoryRouter>,
+    )
+
+    // The canvas raises the verb; the page has to answer with the surface,
+    // carrying the text the canvas handed over. What the commit WRITES is
+    // `withNodeText`'s own test — the page's canvas arrives through the CRDT
+    // sync hook, so a write is not observable from here.
+    await waitFor(() => expect(latestOnChange).not.toBeNull(), { timeout: 10_000 })
+    // fireEvent, not userEvent: the stub button sits in a zero-height slot,
+    // and playwright's actionability wait would never call it stable.
+    fireEvent.click(await screen.findByRole('button', { name: 'raise open-in-editor' }))
+
+    const overlay = await screen.findByTestId('node-text-overlay')
+    await waitFor(() => expect(overlay.querySelector('.cm-content')).not.toBeNull())
+    expect(overlay.querySelector('.cm-content')?.textContent).toContain('# Plan')
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Back to canvas' }))
+    await waitFor(() => expect(screen.queryByTestId('node-text-overlay')).toBeNull())
+  })
+})

--- a/apps/web/src/pages/BrowserLocalDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.tsx
@@ -8,6 +8,8 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
 import { DocumentPageSkeleton } from '../components/DocumentPageSkeleton.js'
 import { DocumentEditorSurface } from '../components/document-editor/DocumentEditorSurface.js'
+import { NodeTextEditorOverlay } from '../components/document-editor/NodeTextEditorOverlay.js'
+import { withNodeText } from '../components/document-editor/node-text.js'
 import { DocumentProperties } from '../components/document-properties/DocumentProperties.js'
 import { HistoryCluster } from '../components/history-cluster/HistoryCluster.js'
 import { createSnapshotAliasResolver } from '../components/markdown-editor/alias-resolver.js'
@@ -266,6 +268,8 @@ export function BrowserLocalDocumentPage({
         ? documents.map((c) => (c.id === pageState.snapshot.id ? pageState.snapshot : c))
         : [...documents, pageState.snapshot]
       : documents
+  // The node whose body is open on the full editing surface, if any.
+  const [nodeInEditor, setNodeInEditor] = useState<{ id: string; text: string } | null>(null)
   const linkTargets = useMemo(
     () => switcherOptions.map((entry) => ({ id: entry.id, name: entry.name, kind: entry.kind })),
     [switcherOptions],
@@ -833,6 +837,7 @@ export function BrowserLocalDocumentPage({
                   lockedNodeIds={lockedNodeIds}
                   lockedEdgeIds={lockedEdgeIds}
                   onToggleNodeLock={setNodeLock}
+                  onOpenInEditor={(nodeId, text) => setNodeInEditor({ id: nodeId, text })}
                   onToggleEdgeLock={setEdgeLock}
                   paletteLeading={
                     <HistoryCluster
@@ -843,6 +848,24 @@ export function BrowserLocalDocumentPage({
                     />
                   }
                 />
+                {nodeInEditor !== null && (
+                  <NodeTextEditorOverlay
+                    title={documentName ?? 'Untitled'}
+                    initialText={nodeInEditor.text}
+                    theme={resolvedTheme}
+                    resolveAlias={resolveAlias}
+                    resolveEmbed={resolveEmbed}
+                    linkTargets={linkTargets}
+                    onCommit={(text) => {
+                      const next = withNodeText(canvas, nodeInEditor.id, text)
+                      // Same canvas back means the edit changed nothing that
+                      // could be written — no revision for a no-op.
+                      if (next === canvas) return
+                      onChange(next, { kind: 'set-text', id: nodeInEditor.id, text })
+                    }}
+                    onClose={() => setNodeInEditor(null)}
+                  />
+                )}
               </div>
             </div>
           )}

--- a/apps/web/src/pages/BrowserLocalDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.tsx
@@ -9,7 +9,7 @@ import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
 import { DocumentPageSkeleton } from '../components/DocumentPageSkeleton.js'
 import { DocumentEditorSurface } from '../components/document-editor/DocumentEditorSurface.js'
 import { NodeTextEditorOverlay } from '../components/document-editor/NodeTextEditorOverlay.js'
-import { withNodeText } from '../components/document-editor/node-text.js'
+import { useNodeInEditor } from '../components/document-editor/use-node-in-editor.js'
 import { DocumentProperties } from '../components/document-properties/DocumentProperties.js'
 import { HistoryCluster } from '../components/history-cluster/HistoryCluster.js'
 import { createSnapshotAliasResolver } from '../components/markdown-editor/alias-resolver.js'
@@ -268,8 +268,6 @@ export function BrowserLocalDocumentPage({
         ? documents.map((c) => (c.id === pageState.snapshot.id ? pageState.snapshot : c))
         : [...documents, pageState.snapshot]
       : documents
-  // The node whose body is open on the full editing surface, if any.
-  const [nodeInEditor, setNodeInEditor] = useState<{ id: string; text: string } | null>(null)
   const linkTargets = useMemo(
     () => switcherOptions.map((entry) => ({ id: entry.id, name: entry.name, kind: entry.kind })),
     [switcherOptions],
@@ -387,6 +385,8 @@ export function BrowserLocalDocumentPage({
     lockedEdgeIds,
     setEdgeLock,
   } = useDocumentSync(backend)
+
+  const nodeInEditor = useNodeInEditor(canvas, onChange)
 
   // Export rides the canvas row's operations kebab on this page (the top
   // bar keeps its export only in daemon mode, which has no canvas row).
@@ -837,7 +837,7 @@ export function BrowserLocalDocumentPage({
                   lockedNodeIds={lockedNodeIds}
                   lockedEdgeIds={lockedEdgeIds}
                   onToggleNodeLock={setNodeLock}
-                  onOpenInEditor={(nodeId, text) => setNodeInEditor({ id: nodeId, text })}
+                  onOpenInEditor={nodeInEditor.open}
                   onToggleEdgeLock={setEdgeLock}
                   paletteLeading={
                     <HistoryCluster
@@ -848,22 +848,16 @@ export function BrowserLocalDocumentPage({
                     />
                   }
                 />
-                {nodeInEditor !== null && (
+                {nodeInEditor.editing !== null && (
                   <NodeTextEditorOverlay
                     title={documentName ?? 'Untitled'}
-                    initialText={nodeInEditor.text}
+                    initialText={nodeInEditor.editing.text}
                     theme={resolvedTheme}
                     resolveAlias={resolveAlias}
                     resolveEmbed={resolveEmbed}
                     linkTargets={linkTargets}
-                    onCommit={(text) => {
-                      const next = withNodeText(canvas, nodeInEditor.id, text)
-                      // Same canvas back means the edit changed nothing that
-                      // could be written — no revision for a no-op.
-                      if (next === canvas) return
-                      onChange(next, { kind: 'set-text', id: nodeInEditor.id, text })
-                    }}
-                    onClose={() => setNodeInEditor(null)}
+                    onCommit={nodeInEditor.commit}
+                    onClose={nodeInEditor.close}
                   />
                 )}
               </div>

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -10,7 +10,7 @@ import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
 import { DocumentPageSkeleton } from '../components/DocumentPageSkeleton.js'
 import { DocumentEditorSurface } from '../components/document-editor/DocumentEditorSurface.js'
 import { NodeTextEditorOverlay } from '../components/document-editor/NodeTextEditorOverlay.js'
-import { withNodeText } from '../components/document-editor/node-text.js'
+import { useNodeInEditor } from '../components/document-editor/use-node-in-editor.js'
 import { DocumentProperties } from '../components/document-properties/DocumentProperties.js'
 import { ErrorBoundary } from '../components/ErrorBoundary.js'
 import { HeaderBranchBanner } from '../components/HeaderBranchBanner.js'
@@ -325,6 +325,7 @@ export function DaemonDocumentPage({
   // and local-update forwarding as every other change, with no second write
   // pipeline. `set-body` carries the WHOLE body, so it needs no canvas: the
   // value passed alongside is the unchanged one this command does not touch.
+  const nodeInEditor = useNodeInEditor(canvasValue, onChange)
   const canvasValueRef = useRef(canvasValue)
   canvasValueRef.current = canvasValue
   const setMarkdownBody = useCallback(
@@ -346,8 +347,6 @@ export function DaemonDocumentPage({
   )
   // The same list the alias resolver reads, carried with ids so the picker
   // can fall back to one when a name is ambiguous.
-  // The node whose body is open on the full editing surface, if any.
-  const [nodeInEditor, setNodeInEditor] = useState<{ id: string; text: string } | null>(null)
   const linkTargets = useMemo(
     () => controller.documents.map((entry) => ({ id: entry.id ?? entry.path, name: entry.path })),
     [controller.documents],
@@ -814,7 +813,7 @@ export function DaemonDocumentPage({
                   lockedNodeIds={lockedNodeIds}
                   lockedEdgeIds={lockedEdgeIds}
                   onToggleNodeLock={setNodeLock}
-                  onOpenInEditor={(nodeId, text) => setNodeInEditor({ id: nodeId, text })}
+                  onOpenInEditor={nodeInEditor.open}
                   onToggleEdgeLock={setEdgeLock}
                   paletteLeading={
                     <HistoryCluster
@@ -836,20 +835,16 @@ export function DaemonDocumentPage({
                     />
                   }
                 />
-                {nodeInEditor !== null && (
+                {nodeInEditor.editing !== null && (
                   <NodeTextEditorOverlay
                     title={canvas?.path ?? 'Untitled'}
-                    initialText={nodeInEditor.text}
+                    initialText={nodeInEditor.editing.text}
                     theme={resolvedTheme}
                     resolveAlias={resolveAlias}
                     resolveEmbed={resolveEmbed}
                     linkTargets={linkTargets}
-                    onCommit={(text) => {
-                      const next = withNodeText(canvasValue, nodeInEditor.id, text)
-                      if (next === canvasValue) return
-                      onChange(next, { kind: 'set-text', id: nodeInEditor.id, text })
-                    }}
-                    onClose={() => setNodeInEditor(null)}
+                    onCommit={nodeInEditor.commit}
+                    onClose={nodeInEditor.close}
                   />
                 )}
               </div>

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -9,6 +9,8 @@ import { CapabilityTeaser } from '../components/capability-teaser/CapabilityTeas
 import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
 import { DocumentPageSkeleton } from '../components/DocumentPageSkeleton.js'
 import { DocumentEditorSurface } from '../components/document-editor/DocumentEditorSurface.js'
+import { NodeTextEditorOverlay } from '../components/document-editor/NodeTextEditorOverlay.js'
+import { withNodeText } from '../components/document-editor/node-text.js'
 import { DocumentProperties } from '../components/document-properties/DocumentProperties.js'
 import { ErrorBoundary } from '../components/ErrorBoundary.js'
 import { HeaderBranchBanner } from '../components/HeaderBranchBanner.js'
@@ -344,6 +346,8 @@ export function DaemonDocumentPage({
   )
   // The same list the alias resolver reads, carried with ids so the picker
   // can fall back to one when a name is ambiguous.
+  // The node whose body is open on the full editing surface, if any.
+  const [nodeInEditor, setNodeInEditor] = useState<{ id: string; text: string } | null>(null)
   const linkTargets = useMemo(
     () => controller.documents.map((entry) => ({ id: entry.id ?? entry.path, name: entry.path })),
     [controller.documents],
@@ -810,6 +814,7 @@ export function DaemonDocumentPage({
                   lockedNodeIds={lockedNodeIds}
                   lockedEdgeIds={lockedEdgeIds}
                   onToggleNodeLock={setNodeLock}
+                  onOpenInEditor={(nodeId, text) => setNodeInEditor({ id: nodeId, text })}
                   onToggleEdgeLock={setEdgeLock}
                   paletteLeading={
                     <HistoryCluster
@@ -831,6 +836,22 @@ export function DaemonDocumentPage({
                     />
                   }
                 />
+                {nodeInEditor !== null && (
+                  <NodeTextEditorOverlay
+                    title={canvas?.path ?? 'Untitled'}
+                    initialText={nodeInEditor.text}
+                    theme={resolvedTheme}
+                    resolveAlias={resolveAlias}
+                    resolveEmbed={resolveEmbed}
+                    linkTargets={linkTargets}
+                    onCommit={(text) => {
+                      const next = withNodeText(canvasValue, nodeInEditor.id, text)
+                      if (next === canvasValue) return
+                      onChange(next, { kind: 'set-text', id: nodeInEditor.id, text })
+                    }}
+                    onClose={() => setNodeInEditor(null)}
+                  />
+                )}
               </div>
             )}
           />

--- a/docs/contributing/adr/0006-object-oriented-ui.md
+++ b/docs/contributing/adr/0006-object-oriented-ui.md
@@ -47,6 +47,35 @@ Concretely:
    shows the conforming shape: a `New canvas…` entry with an icon **and** a
    label.
 
+## Amendment (2026-08-18): vessels, and what a doorway is
+
+Two things were decided in code after this ADR and are recorded here because
+the ADR as written says otherwise, and a decision that lives only in an
+implementation comment is one the next surface will contradict.
+
+**The ⋯ catalog's `grid` and `sheet` vessels are icon-only.** Point 4 above
+says a menu shows icon and text; these two vessels do not, and that stays.
+They are one catalog rendered three ways — `list` (the right-click reading
+surface) keeps icon and text, while `grid` and `sheet` are compact
+object-action strips whose entries carry `aria-label` plus a tooltip. The
+cost is real and named: a tooltip needs hover, so on touch the `sheet`'s
+names are reachable only to a screen reader. What makes that acceptable is
+that the sheet is never the ONLY path to a verb — the same catalog is
+available as `list` wherever a pointer exists, and the keyboard has its own
+bindings.
+
+**A navigation is not an object verb, and does not belong in the catalog.**
+Every entry in the catalog changes the object and leaves you where you are.
+"Open in editor" changes nothing and moves you to another surface. Mixing the
+categories produced the failure this amendment was written for: two
+near-identical pencil icons side by side in an icon-only vessel, with no way
+to tell "edit this text here" from "take me somewhere else to edit it".
+
+So navigation lives on the OBJECT, beside the ⋯ doorway rather than inside
+it, and carries the arrow-leaving-a-frame glyph that means "this takes you
+elsewhere" everywhere else on the web. Two doorways, two categories, one
+look each — which is what point 4 was protecting in the first place.
+
 ## Consequences
 
 Easier:


### PR DESCRIPTION
The last phase of the text-editing initiative. A text node's inline editor is bounded by the node's own box — right for a line, wrong for a body, and the box cannot simply grow because its size is the author's layout decision.

## A doorway on the node, not a verb in the catalog

Every entry in the ⋯ catalog **changes the node and leaves you on the canvas**. This one **changes nothing and moves you somewhere else**. Mixing those categories is what put two near-identical pencil icons side by side in an icon-only vessel with no way to tell "edit this text here" from "take me somewhere else to edit it".

So the navigation lives on the node, beside the ⋯ rather than inside it, with the arrow-leaving-a-frame glyph that means the same thing everywhere else on the web — and the two share one quiet pill rather than accumulating separate chips:

![node-tools-neutral.png](https://github.com/user-attachments/assets/69ad8cd7-ffa4-432c-ac1f-3331fc1a7271)

The accent stays on the outline and handles, which is what actually says "this is selected"; chrome beside the node is drawn in the app's neutral ink so it is not the loudest thing on a canvas whose job is to recede behind its content.

The surface itself is the same MarkdownEditor a document gets, with its view modes, ⋯ catalog and link picker intact:

![open-in-editor.png](https://github.com/user-attachments/assets/5c5a0b93-d5a1-40e9-a641-4afa3bc542d3)

## Who owns what

The canvas does **not** own the surface. It raises `onOpenInEditor(nodeId, text)`; the composition root answers, because the root already holds every seam that editor needs — alias resolution, link targets, embed bodies.

| layer | responsibility | test |
|---|---|---|
| `SelectionOverlay` / `SpatialEditor` | offer the doorway (single text node, host willing), hand over id + text | `open-in-editor.browser.test.tsx` |
| `NodeTextEditorOverlay` | the surface, and when the writing is kept | `NodeTextEditorOverlay.browser.test.tsx` |
| `useNodeInEditor` + `withNodeText` | the state and the write | `use-node-in-editor.test.tsx`, `node-text.test.ts` |
| both pages | connect them | `BrowserLocalDocumentPage.open-in-editor.browser.test.tsx` |

Both pages share one hook rather than a copied block: `onOpenInEditor` is optional, so a page that stopped wiring it would compile clean and silently lose the feature.

## Commit grammar, and who gets Escape

Closing commits, ⌘Enter commits, Escape discards — the inline editor's grammar, so there is one thing to learn. Closing with nothing changed writes nothing.

Escape needed care and review caught it: the overlay listens at the **window in the capture phase**, which fires before any nested popup's own handler, so dismissing the editor's link picker discarded the whole edit. Reproduced, then fixed by yielding whenever an editor overlay is open, with tests for both the picker and the catalog.

## ADR-0006 amendment

Two decisions made in code after that ADR are now recorded in it: that the ⋯ catalog's `grid`/`sheet` vessels are icon-only (and what that costs on touch), and that a navigation is not an object verb. A decision that lives only in an implementation comment is one the next surface will contradict — which is exactly what happened here.

## Tests

- 3 canvas cases, 7 overlay cases (incl. the two Escape-yield regressions), 3 hook cases, 2 pure cases, 1 page case.
- Green: `pnpm test --project web-browser` (647), `pnpm --filter @kamiazya/whiteboard-web test` (2321 + 77), `pnpm -r typecheck`, `pnpm lint`, `pnpm knip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ua6RPuoEAD4ZTBqyhNC56Z