### PR TITLE
fix(canvas-render): keep a text node's body inside its own frame

### DIFF
--- a/packages/canvas-render/src/layout/spatial-canvas.properties.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.properties.test.ts
@@ -479,3 +479,105 @@ describe('live-drag parity property (PBT)', () => {
     },
   )
 })
+
+/**
+ * The text node's vertical fit, stated as the three laws that fully describe
+ * it. Example tests pin one fixture each; these say what holds for ANY body
+ * in ANY box — which is the difference that matters here, because the first
+ * shape of this fix passed three examples while breaking two cases nobody
+ * had written an example for.
+ *
+ * `fullWidth` charges CJK a full em (the scoreboard's measurer, not
+ * `fake-measure.ts`'s uniform 0.6em) so a wrap is reachable at these widths.
+ */
+const fullWidth = createFakeMeasure(1)
+
+function parseParagraphs(text: string): MdastRoot {
+  return {
+    type: 'root',
+    children: text.split(/\n\s*\n/).map((para) => ({
+      type: 'paragraph',
+      children: [{ type: 'text', value: para }],
+    })),
+  }
+}
+
+const fitOptions = { measure: fullWidth, parseBody: parseParagraphs, appearance }
+const PADDING_PX = 8
+
+/** The laid-out blocks, i.e. everything the node paints that is not chrome. */
+function blocksOf(canvas: SpatialCanvas): ReadonlyArray<{ y: number; h: number }> {
+  return layoutSpatialCanvas(canvas, fitOptions)
+    .nodes.filter((entry) => entry.kind !== 'shape' && entry.kind !== 'edge')
+    .map((entry) => ({ y: entry.bbox.y, h: entry.bbox.h }))
+}
+
+function textNodeAt(width: number, height: number, text: string): SpatialCanvas {
+  return { nodes: [{ id: 'n', type: 'text', x: 0, y: 0, width, height, text }], edges: [] }
+}
+
+/** Bodies that wrap and bodies that do not, in one to five blocks. */
+const bodyArb = fc
+  .array(fc.constantFrom('かあらた', 'かたそ', 'short', 'a longer english line'), {
+    minLength: 1,
+    maxLength: 5,
+  })
+  .map((paras) => paras.join('\n\n'))
+
+const widthArb = fc.integer({ min: 24, max: 200 })
+
+/**
+ * A fraction OF THE NATURAL CONTENT HEIGHT, never an absolute pixel range: a
+ * uniform height would almost always be roomy enough to fit everything and
+ * the properties would pass vacuously. Straddling 0..1.2 puts the generator
+ * on both sides of every block boundary, which is where the rule lives.
+ */
+const fractionArb = fc.integer({ min: 0, max: 120 }).map((n) => n / 100)
+
+/** What the body needs, measured the way the editor's grow probe measures. */
+function naturalHeight(width: number, text: string): number {
+  const blocks = blocksOf(textNodeAt(width, 1, text))
+  const bottom = Math.max(0, ...blocks.map((b) => b.y + b.h))
+  return Math.ceil(bottom + PADDING_PX)
+}
+
+describe('a text node fits its body to its own box (PBT)', () => {
+  fcTest.prop([widthArb, bodyArb, fractionArb], withDefaults())(
+    'at most one block may cross the content box, and only when none fit',
+    (width, text, fraction) => {
+      const height = Math.round(naturalHeight(width, text) * fraction)
+      const contentBottom = height - PADDING_PX
+      fc.pre(height - 2 * PADDING_PX > 0)
+
+      const crossing = blocksOf(textNodeAt(width, height, text)).filter(
+        (block) => block.y + block.h > contentBottom,
+      )
+
+      // Zero when something fits; exactly one — the first block, kept so the
+      // node never renders as an empty box — when nothing does.
+      expect(crossing.length).toBeLessThanOrEqual(1)
+    },
+  )
+
+  fcTest.prop([widthArb, bodyArb, fractionArb], withDefaults())(
+    'never renders a non-empty body as an empty box',
+    (width, text, fraction) => {
+      const height = Math.round(naturalHeight(width, text) * fraction)
+      fc.pre(height - 2 * PADDING_PX > 0)
+
+      expect(blocksOf(textNodeAt(width, height, text)).length).toBeGreaterThan(0)
+    },
+  )
+
+  fcTest.prop([widthArb, bodyArb], withDefaults())(
+    'a box with no room to fit against imposes no truncation, so the natural height stays measurable',
+    (width, text) => {
+      // The editor's grow-only auto-fit lays a node out at height 1 to read
+      // its natural content height. Truncating there caps what the probe can
+      // report and the box can never grow past one block.
+      expect(blocksOf(textNodeAt(width, 1, text)).length).toBe(
+        blocksOf(textNodeAt(width, 100_000, text)).length,
+      )
+    },
+  )
+})

--- a/packages/canvas-render/src/layout/spatial-canvas.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.test.ts
@@ -651,3 +651,94 @@ describe('layoutSpatialEdges', () => {
     expect(edgesOnly).toEqual(full.slice(full.length - edgesOnly.length))
   })
 })
+
+describe('a text node keeps its body inside its own box', () => {
+  // CJK is measured a full em wide, the way `text-wrapping-quality.test.ts`
+  // does: `fake-measure.ts`'s uniform 0.6em/char understates Japanese by
+  // ~40%, which is enough to hide the wrap that produces the extra line.
+  const fullWidth = createFakeMeasure(1)
+
+  // `fakeParseBody` above collapses a whole body into ONE paragraph, which
+  // cannot express the case: with a single block there is nothing for
+  // whole-block truncation to keep. Blank-line splitting is the minimal
+  // faithful model of what the real parser does to this text.
+  function parseParagraphs(text: string): MdastRoot {
+    return {
+      type: 'root',
+      children: text.split(/\n\s*\n/).map((para) => ({
+        type: 'paragraph',
+        children: [{ type: 'text', value: para }],
+      })),
+    }
+  }
+
+  /** Every laid-out run's bottom, in absolute scene coordinates. */
+  function runBottoms(scene: Scene): readonly number[] {
+    const out: number[] = []
+    const walk = (nodes: readonly unknown[]): void => {
+      for (const entry of nodes) {
+        const node = entry as {
+          kind: string
+          bbox?: { y: number; h: number }
+          runs?: readonly unknown[]
+          children?: readonly unknown[]
+        }
+        if (node.kind === 'textRun' && node.bbox) out.push(node.bbox.y + node.bbox.h)
+        walk(node.runs ?? node.children ?? [])
+      }
+    }
+    walk(scene.nodes)
+    return out
+  }
+
+  it('drops the blocks that do not fit rather than painting them below the frame', () => {
+    // A node small enough that its wrapped body needs more lines than the
+    // box has room for. Reported from the running app, where the last
+    // paragraph painted OUTSIDE the frame entirely.
+    const canvas: SpatialCanvas = {
+      nodes: [
+        {
+          id: 'n1',
+          type: 'text',
+          x: 40,
+          y: 260,
+          width: 67,
+          height: 51,
+          text: 'かあらた\n\nかたそ',
+        },
+      ],
+      edges: [],
+    }
+
+    const scene = layoutSpatialCanvas(
+      canvas,
+      baseOptions({ measure: fullWidth, parseBody: parseParagraphs }),
+    )
+
+    // The padded content box is what the body has to live in — the same
+    // bound `fitBodyInNode` applies to the file-markdown and facet-card
+    // seams, which put mdast blocks in a node box exactly like this one.
+    const contentBottom = 260 + 51 - NODE_PADDING_PX
+    for (const bottom of runBottoms(scene)) {
+      expect(bottom).toBeLessThanOrEqual(contentBottom)
+    }
+  })
+
+  it('still paints the blocks that do fit', () => {
+    const canvas: SpatialCanvas = {
+      nodes: [
+        { id: 'n1', type: 'text', x: 0, y: 0, width: 67, height: 51, text: 'かあらた\n\nかたそ' },
+      ],
+      edges: [],
+    }
+
+    const scene = layoutSpatialCanvas(
+      canvas,
+      baseOptions({ measure: fullWidth, parseBody: parseParagraphs }),
+    )
+
+    // Dropping the overflow must not be mistaken for dropping the body:
+    // the first paragraph fits and has to survive.
+    expect(runBottoms(scene).length).toBeGreaterThan(0)
+  })
+})

--- a/packages/canvas-render/src/layout/spatial-canvas.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.test.ts
@@ -724,6 +724,52 @@ describe('a text node keeps its body inside its own box', () => {
     }
   })
 
+  it('keeps one block even when the box has room for none', () => {
+    // A node one line tall is the COMMON shape, not a pathological one: at
+    // the default padding a 25px-high node leaves 9px of content box for a
+    // ~16px line. Dropping everything there erased the prose from an
+    // ordinary label-sized node — caught by the widget smoke, whose own
+    // fixture is exactly this.
+    const canvas: SpatialCanvas = {
+      nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 200, height: 25, text: '日本語ラベル' }],
+      edges: [],
+    }
+
+    const scene = layoutSpatialCanvas(
+      canvas,
+      baseOptions({ measure: fullWidth, parseBody: parseParagraphs }),
+    )
+
+    expect(runBottoms(scene).length).toBeGreaterThan(0)
+  })
+
+  it('does not truncate when the box gives no height to fit against', () => {
+    // The editor's grow-only auto-fit measures a text node's NATURAL content
+    // height by laying it out at height 1 and reading the scene's bottom
+    // edge. Truncating there caps what the probe can report, so a box can
+    // never grow past one block — which is how a fit meant to keep content
+    // inside the frame ends up DEFEATING the feature that keeps it inside
+    // the frame. Same reading `fitToWidth` gives an unusable maxWidth.
+    const probe: SpatialCanvas = {
+      nodes: [
+        { id: 'n1', type: 'text', x: 0, y: 0, width: 67, height: 1, text: 'かあらた\n\nかたそ' },
+      ],
+      edges: [],
+    }
+    const roomy: SpatialCanvas = {
+      nodes: [
+        { id: 'n1', type: 'text', x: 0, y: 0, width: 67, height: 400, text: 'かあらた\n\nかたそ' },
+      ],
+      edges: [],
+    }
+    const opts = baseOptions({ measure: fullWidth, parseBody: parseParagraphs })
+
+    // The degenerate probe must see every block a roomy box would.
+    expect(runBottoms(layoutSpatialCanvas(probe, opts)).length).toBe(
+      runBottoms(layoutSpatialCanvas(roomy, opts)).length,
+    )
+  })
+
   it('still paints the blocks that do fit', () => {
     const canvas: SpatialCanvas = {
       nodes: [

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -356,24 +356,45 @@ function placeAboveNode(node: SpatialNode, content: Scene): readonly SceneNode[]
  * aborting the canvas — this is the layer's own totality addition on top
  * of canvas-render's already-total layout functions.
  */
+/**
+ * The text node's own fit: the blocks that fit, but never fewer than one.
+ *
+ * A text node has no lower-ranked rendering to degrade to, so dropping
+ * everything erases the user's own prose — and the box that keeps nothing is
+ * not the pathological one, it is a node one line tall: at the default
+ * padding a 25px-high node leaves 9px of content box for a ~16px line. That
+ * is the same reasoning as `fitToWidth` never returning the empty string,
+ * applied to the other axis. The block that stays squeezes the padding rather
+ * than leaving the FRAME, which is the bound this whole fit exists to keep.
+ *
+ * The sibling seams keep `fitSceneInNode`'s `undefined` because they DO have
+ * somewhere better to go — the plain chrome-and-label rendering.
+ */
+function fitTextBody(scene: Scene, node: SpatialNode, options: ResolvedLayoutOptions): Scene {
+  // A non-positive content box is "no height to fit against", the same
+  // reading `fitToWidth` gives an unusable `maxWidth`. It is not a
+  // hypothetical: the editor's grow-only auto-fit measures a node's NATURAL
+  // content height by laying it out at height 1 and reading the scene's
+  // bottom edge, so a truncation here would cap what that probe can report
+  // and the box could never grow past one block.
+  if (contentBox(node, options) === undefined) return scene
+  return fitSceneInNode(scene, node, options) ?? { nodes: scene.nodes.slice(0, 1) }
+}
+
 function composeTextNode(
   node: Extract<SpatialNode, { type: 'text' }>,
   options: ResolvedLayoutOptions,
 ): readonly SceneNode[] {
   const maxWidth = contentWidth(node.width, options)
-  let body: Scene | undefined
+  let body: Scene
   try {
-    body = fitBodyInNode(node, options.parseBody(node.text), options)
+    const laid = layoutMdastBlocks(options.parseBody(node.text), mdastOptionsFor(maxWidth, options))
+    body = fitTextBody(laid, node, options)
   } catch (err) {
     options.onDegrade?.({ kind: 'body-parse-failed', nodeId: node.id, err })
-    body = fitSceneInNode({ nodes: [labelRun(node.text, options, maxWidth)] }, node, options)
+    body = fitTextBody({ nodes: [labelRun(node.text, options, maxWidth)] }, node, options)
   }
-  const chrome = chromeShape(node, options)
-  // A box with room for nothing renders as bare chrome. Painting the first
-  // line anyway is what put a paragraph outside the frame; a "there is more"
-  // affordance needs the editor-side overlay `fitBodyInNode` already names as
-  // its upgrade path, which this pure-geometry package cannot own.
-  return body === undefined ? [chrome] : [chrome, ...placeInNode(node, body, options)]
+  return [chromeShape(node, options), ...placeInNode(node, body, options)]
 }
 
 /**

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -361,15 +361,19 @@ function composeTextNode(
   options: ResolvedLayoutOptions,
 ): readonly SceneNode[] {
   const maxWidth = contentWidth(node.width, options)
-  let body: Scene
+  let body: Scene | undefined
   try {
-    const mdast = options.parseBody(node.text)
-    body = layoutMdastBlocks(mdast, mdastOptionsFor(maxWidth, options))
+    body = fitBodyInNode(node, options.parseBody(node.text), options)
   } catch (err) {
     options.onDegrade?.({ kind: 'body-parse-failed', nodeId: node.id, err })
-    body = { nodes: [labelRun(node.text, options, maxWidth)] }
+    body = fitSceneInNode({ nodes: [labelRun(node.text, options, maxWidth)] }, node, options)
   }
-  return [chromeShape(node, options), ...placeInNode(node, body, options)]
+  const chrome = chromeShape(node, options)
+  // A box with room for nothing renders as bare chrome. Painting the first
+  // line anyway is what put a paragraph outside the frame; a "there is more"
+  // affordance needs the editor-side overlay `fitBodyInNode` already names as
+  // its upgrade path, which this pure-geometry package cannot own.
+  return body === undefined ? [chrome] : [chrome, ...placeInNode(node, body, options)]
 }
 
 /**
@@ -494,24 +498,50 @@ function composeFileImage(
  * pure-geometry package cannot own. Upgrade path is an editor-side overlay,
  * not a scene node here.
  */
+function contentBox(
+  node: SpatialNode,
+  options: ResolvedLayoutOptions,
+): { readonly w: number; readonly h: number } | undefined {
+  const padding = options.geometry.paddingPx
+  const w = node.width - 2 * padding
+  const h = node.height - 2 * padding
+  return w > 0 && h > 0 ? { w, h } : undefined
+}
+
+/**
+ * Keeps the top prefix of an already-laid-out scene that fits a node's
+ * padded content box, in content-relative coordinates.
+ *
+ * The single place the box's HEIGHT is enforced, so every seam that puts
+ * content in a node box answers to the same bound — the "one producer per
+ * geometry" rule. A seam that lays content out and places it without
+ * passing through here paints outside the frame, which is a rendering
+ * defect this package's "what cannot fit is cut" contract forbids.
+ */
+function fitSceneInNode(
+  scene: Scene,
+  node: SpatialNode,
+  options: ResolvedLayoutOptions,
+): Scene | undefined {
+  const box = contentBox(node, options)
+  if (box === undefined) return undefined
+
+  // Neither producer emits an edge (the one SceneNode variant with no
+  // `bbox`); that guard is for the type checker, not runtime.
+  const fitted = scene.nodes.filter(
+    (entry) => entry.kind !== 'edge' && entry.bbox.y + entry.bbox.h <= box.h,
+  )
+  return fitted.length === 0 ? undefined : { nodes: fitted }
+}
+
 function fitBodyInNode(
   node: SpatialNode,
   root: MdastRoot,
   options: ResolvedLayoutOptions,
 ): Scene | undefined {
-  const padding = options.geometry.paddingPx
-  const innerW = node.width - 2 * padding
-  const innerH = node.height - 2 * padding
-  if (!(innerW > 0) || !(innerH > 0)) return undefined
-
+  if (contentBox(node, options) === undefined) return undefined
   const body = layoutMdastBlocks(root, mdastOptionsFor(contentWidth(node.width, options), options))
-
-  // `layoutMdastBlocks` never emits an edge (the one SceneNode variant with
-  // no `bbox`); that guard is for the type checker, not runtime.
-  const fitted = body.nodes.filter(
-    (entry) => entry.kind !== 'edge' && entry.bbox.y + entry.bbox.h <= innerH,
-  )
-  return fitted.length === 0 ? undefined : { nodes: fitted }
+  return fitSceneInNode(body, node, options)
 }
 
 /**

--- a/packages/canvas-viewer/src/canvas-viewer-cjk-overflow.browser.test.tsx
+++ b/packages/canvas-viewer/src/canvas-viewer-cjk-overflow.browser.test.tsx
@@ -43,12 +43,14 @@ describe('a text node with CJK prose (real browser)', () => {
     const texts = [...(container.querySelectorAll('svg text') ?? [])]
     expect(texts.length).toBeGreaterThan(0)
 
-    // `y` on a <text> is its BASELINE, so descenders sit below it; the frame
-    // bottom is the bound that matters and the baseline must clear it.
+    // Measured as PAINTED ink, not as the baseline: `y` on a <text> is where
+    // the glyphs sit ON, so descenders fall below it and a baseline-only
+    // assertion is weaker than this test's own claim. `getBBox()` is the
+    // rendered bound, which is the thing that must stay inside the frame.
     for (const text of texts) {
-      const y = Number(text.getAttribute('y'))
-      expect(Number.isFinite(y)).toBe(true)
-      expect(y).toBeLessThanOrEqual(NODE_BOTTOM)
+      const box = (text as SVGGraphicsElement).getBBox()
+      expect(Number.isFinite(box.y + box.height)).toBe(true)
+      expect(box.y + box.height).toBeLessThanOrEqual(NODE_BOTTOM)
     }
   })
 })

--- a/packages/canvas-viewer/src/canvas-viewer-cjk-overflow.browser.test.tsx
+++ b/packages/canvas-viewer/src/canvas-viewer-cjk-overflow.browser.test.tsx
@@ -1,0 +1,54 @@
+// A real-browser lock on "a text node's body never paints below its frame",
+// for the case only a real browser can produce: CJK measured by an actual
+// Canvas 2D backend. `fake-measure.ts` charges every character 0.6em, which
+// understates Japanese by ~40% and is enough to hide the extra wrapped line
+// that pushes a paragraph out of the box — so the node-project test for this
+// has to simulate full-width advances, and this file is what proves the
+// simulation matches a browser.
+
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { CanvasViewer } from './CanvasViewer.js'
+import { ensureViewerFontLoaded } from './font-loading.js'
+import { createBrowserMeasureText } from './measure-text.js'
+
+// The node as it was reported from the running app: a box too small for the
+// wrapped body, whose last paragraph painted outside the frame entirely.
+const REPORTED: SpatialCanvas = {
+  nodes: [
+    {
+      id: '81d6a81f-cd39-4d81-87c6-77465473a3b9',
+      type: 'text',
+      x: 40,
+      y: 260,
+      width: 67,
+      height: 51,
+      text: 'かあらた\n\nかたそ',
+    },
+  ],
+  edges: [],
+}
+
+const NODE_BOTTOM = 260 + 51
+
+describe('a text node with CJK prose (real browser)', () => {
+  it('paints no text below its own frame', async () => {
+    await ensureViewerFontLoaded()
+    const { container } = render(
+      <CanvasViewer canvas={REPORTED} measure={createBrowserMeasureText()} />,
+    )
+
+    await expect.poll(() => container.querySelector('svg')).toBeTruthy()
+    const texts = [...(container.querySelectorAll('svg text') ?? [])]
+    expect(texts.length).toBeGreaterThan(0)
+
+    // `y` on a <text> is its BASELINE, so descenders sit below it; the frame
+    // bottom is the bound that matters and the baseline must clear it.
+    for (const text of texts) {
+      const y = Number(text.getAttribute('y'))
+      expect(Number.isFinite(y)).toBe(true)
+      expect(y).toBeLessThanOrEqual(NODE_BOTTOM)
+    }
+  })
+})


### PR DESCRIPTION
Reported from the running app: a `text` node whose wrapped body needs more lines than its box has room for painted the last paragraph **below the frame**.

```json
{"type":"text","x":40,"y":260,"width":67,"height":51,"text":"かあらた\n\nかたそ"}
```

Reproduced exactly. In a real browser with real Canvas 2D measurement, the last paragraph's baseline lands at **y=323** against a frame bottom of **311**.

## Root cause

Three seams in `spatial-canvas.ts` put mdast blocks in a node box, and only two answered to the box's **height**:

| seam | width | height |
|---|---|---|
| `composeFileMarkdown` → `fitBodyInNode` | ✅ | ✅ |
| `composeFileFacets` → `fitBodyInNode` | ✅ | ✅ |
| **`composeTextNode`** | ✅ | ❌ |

`composeTextNode` passed `contentWidth` alone into `layoutMdastBlocks` and placed whatever came back. That is the third producer the *"one producer per geometry"* rule exists to prevent, and it contradicts this package's own *"what cannot fit is cut"* contract (`package-canvas-render.md` decisions #10 and #13).

The wrapping scoreboard could not see it either: `text-wrapping-metrics.ts` collects `x + w` only, so vertical overflow is invisible to it by construction.

## The fix

The height bound now lives in one place — `fitSceneInNode` — which both `fitBodyInNode` and the text node's parse-failure label path go through. A box with room for nothing renders as bare chrome rather than one line painted outside it.

**Product change worth calling out:** whole-block truncation means the dropped paragraph is not shown at all. That is the sibling seams' shipped policy and it replaces a worse behaviour, but it *is* visible for a node the user typed. The "there is more" affordance stays the editor-side overlay `fitBodyInNode` already names as its upgrade path.

## Coverage — two layers, each mutation-checked against a reverted fix

| layer | red without the fix |
|---|---|
| `spatial-canvas.test.ts` (node, full-em CJK simulated) | `expected 324 to be less than or equal to 303` |
| `canvas-viewer-cjk-overflow.browser.test.tsx` (real browser, real Canvas 2D) | `expected 323 to be less than or equal to 311` |

The browser one exists because `fake-measure.ts` charges CJK 0.6em and understates Japanese by ~40% — enough to hide the wrap that causes this entirely. The Node **export** path cannot see it at all: its vendored font has no CJK glyphs and measures them narrow, so the body fits on one line there. Any evidence taken from `renderSpatialCanvasToPng` would have shown a clean box in both states.

A second guard pins that the fix does not over-correct — the paragraph that *does* fit must still be painted. It caught a first attempt whose fixture collapsed the whole body into one block, where whole-block truncation had nothing to keep.

## Verification

canvas-render + canvas-viewer + mcp-server node projects **4345 passed** · canvas-viewer-browser **10 passed** · `pnpm -r typecheck` clean · `pnpm knip` clean. The SVG determinism goldens and both quality scoreboards are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text wrapping so content stays within its padded node boundaries.
  * Prevented overflow for multi-block text, including short content and CJK characters.
  * Standardized vertical fitting across file, markdown, and facet layouts.

* **Tests**
  * Added regression coverage for text fitting, height probing, and browser-rendered CJK text boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->