### PR TITLE
refactor(canvas-render): make "content stays in its frame" one stated law

### DIFF
--- a/apps/web/src/components/spatial-editor/scene-render.ts
+++ b/apps/web/src/components/spatial-editor/scene-render.ts
@@ -6,11 +6,7 @@
  */
 
 import type { MeasureText, ResolvedReference } from '@kamiazya/whiteboard-canvas-render'
-import {
-  layoutSpatialCanvas,
-  SPATIAL_THEME_GEOMETRY,
-  sceneBounds,
-} from '@kamiazya/whiteboard-canvas-render'
+import { naturalNodeContentSize, SPATIAL_THEME_GEOMETRY } from '@kamiazya/whiteboard-canvas-render'
 import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
 import { createEditorAppearance } from './editor-appearance.js'
@@ -31,21 +27,19 @@ export interface RenderCanvasOptions {
 /**
  * The height a text node needs for its laid-out body, in canvas px.
  *
- * Measured by laying out the node ALONE with height 1: the shape chrome
- * always spans the stored height, so measuring at the real height could
- * never report "content is shorter than the box" — collapsing the box to
- * 1px makes the scene's bottom edge the CONTENT's bottom edge. Bottom
- * padding is added back so a grown box keeps the same breathing room the
- * layout gives the top.
+ * `naturalNodeContentSize` is canvas-render's own answer to "how big must
+ * this box be", so this is padding arithmetic and nothing else. It used to
+ * lay the node out at height 1 and read the scene's bottom edge, which
+ * worked only because a box that small cannot bound anything — layout could
+ * not tell this probe apart from a node someone really made 1px tall, so
+ * the escape hatch it needed stayed open for every tiny node as well.
  */
 export function requiredTextNodeHeight(node: SpatialNode, options: RenderCanvasOptions): number {
-  const probe: SpatialCanvas = { nodes: [{ ...node, height: 1 }], edges: [] }
-  const scene = layoutSpatialCanvas(probe, {
+  const content = naturalNodeContentSize(node, {
     measure: options.measure,
     appearance: createEditorAppearance(options.theme ?? 'light'),
   })
-  const bounds = sceneBounds(scene)
-  return bounds.y + bounds.h - node.y + SPATIAL_THEME_GEOMETRY.paddingPx
+  return content.h + 2 * SPATIAL_THEME_GEOMETRY.paddingPx
 }
 
 export function renderCanvasToSvg(

--- a/packages/canvas-render/src/index.ts
+++ b/packages/canvas-render/src/index.ts
@@ -21,6 +21,7 @@ export {
   layoutSpatialCanvas,
   layoutSpatialCanvasWithAnchors,
   layoutSpatialEdges,
+  naturalNodeContentSize,
 } from './layout/spatial-canvas.js'
 export {
   assignEdgeAnchors,

--- a/packages/canvas-render/src/layout/spatial-canvas.properties.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.properties.test.ts
@@ -632,9 +632,19 @@ function containmentNode(
   return { ...base, type, label: text }
 }
 
+/**
+ * The reference RESOLVES to a body, so a file node takes the markdown seam
+ * (`fitBodyInNode`) rather than falling straight to its label. A
+ * label-only resolver leaves that seam — one of the three that put content
+ * in a box — untouched by every property below, which is exactly how the
+ * natural-size defect on small file nodes survived its first review.
+ */
 const containmentOptions = {
   ...fitOptions,
-  resolveReference: () => ({ label: 'A referenced document' }),
+  resolveReference: () => ({
+    label: 'A referenced document',
+    markdown: parseParagraphs('かあらた\n\nかたそ'),
+  }),
 }
 
 describe('every node kind keeps its ink inside its own frame (PBT)', () => {
@@ -672,7 +682,7 @@ describe('every node kind keeps its ink inside its own frame (PBT)', () => {
   )
 
   fcTest.prop([containmentShapeArb], withDefaults())(
-    'nothing is painted above the frame except a single container label',
+    'nothing is painted above the frame except one container label, and only where a container can have one',
     ([width, text, type, fraction]) => {
       const node = nodeFor(width, text, type, fraction)
       const scene = layoutSpatialCanvas({ nodes: [node], edges: [] }, containmentOptions)
@@ -681,9 +691,31 @@ describe('every node kind keeps its ink inside its own frame (PBT)', () => {
           entry.kind !== 'shape' && entry.kind !== 'edge' && entry.bbox.y < node.y,
       )
 
-      // `placeAboveNode` emits exactly one run; a second producer of
-      // outside-the-frame ink would be a new escape nobody declared.
+      // A COUNT alone would accept a brand-new above-frame producer on a
+      // text or link node, which has no outside label at all. `placeAboveNode`
+      // serves the two container-shaped kinds and emits exactly one run.
+      if (type === 'text' || type === 'link') {
+        expect(above).toEqual([])
+        return
+      }
       expect(above.length).toBeLessThanOrEqual(1)
+      for (const entry of above) expect(entry.kind).toBe('textRun')
+    },
+  )
+
+  fcTest.prop([containmentShapeArb], withDefaults())(
+    'the natural content size is independent of the box, for every node kind',
+    ([width, text, type, fraction]) => {
+      // The text-only version of this property missed a real defect: a file
+      // node in a box smaller than its padding fell back to its label, so
+      // the natural size reported the label for a small box and the body for
+      // a large one.
+      const node = nodeFor(width, text, type, fraction)
+      const roomy = containmentNode(width, text, type, 100_000)
+
+      expect(naturalNodeContentSize(node, containmentOptions)).toEqual(
+        naturalNodeContentSize(roomy, containmentOptions),
+      )
     },
   )
 })

--- a/packages/canvas-render/src/layout/spatial-canvas.properties.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.properties.test.ts
@@ -1,6 +1,7 @@
 import type { CanvasEdge, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
 import type { MdastRoot } from '@kamiazya/whiteboard-model/mdast'
 import { describe, expect, it } from 'vitest'
+import type { SceneNode } from '../scene-graph.js'
 import { renderSceneToSvg } from '../svg/backend.js'
 import { createFakeMeasure } from '../test-utils/fake-measure.js'
 import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
@@ -8,6 +9,7 @@ import type { SpatialAppearanceResolver } from './spatial-appearance.js'
 import {
   layoutSpatialCanvas,
   layoutSpatialEdges,
+  naturalNodeContentSize,
   type ResolvedReference,
 } from './spatial-canvas.js'
 
@@ -536,9 +538,8 @@ const fractionArb = fc.integer({ min: 0, max: 120 }).map((n) => n / 100)
 
 /** What the body needs, measured the way the editor's grow probe measures. */
 function naturalHeight(width: number, text: string): number {
-  const blocks = blocksOf(textNodeAt(width, 1, text))
-  const bottom = Math.max(0, ...blocks.map((b) => b.y + b.h))
-  return Math.ceil(bottom + PADDING_PX)
+  const node = textNodeAt(width, 1, text).nodes[0]
+  return Math.ceil(naturalNodeContentSize(node, fitOptions).h + 2 * PADDING_PX)
 }
 
 describe('a text node fits its body to its own box (PBT)', () => {
@@ -569,15 +570,120 @@ describe('a text node fits its body to its own box (PBT)', () => {
     },
   )
 
-  fcTest.prop([widthArb, bodyArb], withDefaults())(
-    'a box with no room to fit against imposes no truncation, so the natural height stays measurable',
-    (width, text) => {
-      // The editor's grow-only auto-fit lays a node out at height 1 to read
-      // its natural content height. Truncating there caps what the probe can
-      // report and the box can never grow past one block.
-      expect(blocksOf(textNodeAt(width, 1, text)).length).toBe(
-        blocksOf(textNodeAt(width, 100_000, text)).length,
+  fcTest.prop([widthArb, bodyArb, fractionArb], withDefaults())(
+    'the natural content size is independent of the box it is stored in',
+    (width, text, fraction) => {
+      // What an auto-fit needs to know cannot be a function of the box it is
+      // trying to resize, or the box can never grow past what it already is.
+      const height = Math.max(1, Math.round(naturalHeight(width, text) * fraction))
+      const node = (h: number) => textNodeAt(width, h, text).nodes[0]
+
+      expect(naturalNodeContentSize(node(height), fitOptions)).toEqual(
+        naturalNodeContentSize(node(100_000), fitOptions),
       )
+    },
+  )
+})
+
+/**
+ * The containment law, stated once for EVERY node kind rather than per seam.
+ *
+ * Several seams put content in a node's box — a text body, a resolved
+ * markdown body, a facet card, an image, a scaled canvas embed, a label —
+ * and each one that grew its own bound is a place the next overflow can
+ * appear. So the guarantee is written against the OUTPUT: whatever a node
+ * paints, wherever it came from, obeys the same rule.
+ *
+ * Two escapes, and they are enumerated rather than discovered:
+ *
+ * 1. A label placed ABOVE the frame. JSON Canvas puts a container's name
+ *    outside its box, and `placeAboveNode` is the one producer of it — an
+ *    element wholly above `node.y` is that label and nothing else.
+ * 2. The single piece of content kept when NOTHING fits, so a node one line
+ *    tall renders its line instead of an empty box.
+ *
+ * Only the vertical axis: horizontal overflow has its own declared
+ * exemptions (inline math is neither split nor cut, an atomic run is not
+ * split) and its own instrument in `text-wrapping-quality.test.ts`.
+ */
+const containmentShapeArb = fc.tuple(
+  fc.integer({ min: 8, max: 240 }),
+  fc.constantFrom(
+    'かあらた\n\nかたそ',
+    'a longer english line that wraps\n\nand a second block\n\nand a third',
+    'short',
+    '',
+    '__THROW__',
+  ),
+  fc.constantFrom('text' as const, 'file' as const, 'link' as const, 'group' as const),
+  fractionArb,
+)
+
+function containmentNode(
+  width: number,
+  text: string,
+  type: 'text' | 'file' | 'link' | 'group',
+  height: number,
+): SpatialNode {
+  const base = { id: 'n', x: 0, y: 0, width, height }
+  if (type === 'text') return { ...base, type, text }
+  if (type === 'file') return { ...base, type, file: 'md.md' }
+  if (type === 'link') return { ...base, type, url: 'https://example.com' }
+  return { ...base, type, label: text }
+}
+
+const containmentOptions = {
+  ...fitOptions,
+  resolveReference: () => ({ label: 'A referenced document' }),
+}
+
+describe('every node kind keeps its ink inside its own frame (PBT)', () => {
+  /**
+   * Height is drawn as a FRACTION OF THE NATURAL CONTENT HEIGHT, per kind
+   * and per body — never from a flat pixel range. Measured: a flat
+   * 1..160 range put roughly 1 run in 140 on a case where two blocks cross
+   * the frame, so the mutation check that deletes the fit entirely passed
+   * on some seeds and failed on others. Density is the fix, not more runs.
+   */
+  function nodeFor(
+    width: number,
+    text: string,
+    type: 'text' | 'file' | 'link' | 'group',
+    fraction: number,
+  ): SpatialNode {
+    const roomy = containmentNode(width, text, type, 100_000)
+    const natural = naturalNodeContentSize(roomy, containmentOptions).h + 2 * PADDING_PX
+    return containmentNode(width, text, type, Math.max(1, Math.round(natural * fraction)))
+  }
+
+  fcTest.prop([containmentShapeArb], withDefaults())(
+    'at most one element crosses the frame bottom, once the outside label is set aside',
+    ([width, text, type, fraction]) => {
+      const node = nodeFor(width, text, type, fraction)
+      const scene = layoutSpatialCanvas({ nodes: [node], edges: [] }, containmentOptions)
+      const inFrame = scene.nodes.filter(
+        (entry): entry is Exclude<SceneNode, { kind: 'edge' }> =>
+          entry.kind !== 'shape' && entry.kind !== 'edge' && entry.bbox.y >= node.y,
+      )
+      const crossing = inFrame.filter((entry) => entry.bbox.y + entry.bbox.h > node.y + node.height)
+
+      expect(crossing.length).toBeLessThanOrEqual(1)
+    },
+  )
+
+  fcTest.prop([containmentShapeArb], withDefaults())(
+    'nothing is painted above the frame except a single container label',
+    ([width, text, type, fraction]) => {
+      const node = nodeFor(width, text, type, fraction)
+      const scene = layoutSpatialCanvas({ nodes: [node], edges: [] }, containmentOptions)
+      const above = scene.nodes.filter(
+        (entry): entry is Exclude<SceneNode, { kind: 'edge' }> =>
+          entry.kind !== 'shape' && entry.kind !== 'edge' && entry.bbox.y < node.y,
+      )
+
+      // `placeAboveNode` emits exactly one run; a second producer of
+      // outside-the-frame ink would be a new escape nobody declared.
+      expect(above.length).toBeLessThanOrEqual(1)
     },
   )
 })

--- a/packages/canvas-render/src/layout/spatial-canvas.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.test.ts
@@ -6,7 +6,11 @@ import { renderSceneToSvg } from '../svg/backend.js'
 import { createFakeMeasure } from '../test-utils/fake-measure.js'
 import type { SpatialAppearanceResolver } from './spatial-appearance.js'
 import type { SpatialLayoutDegradation, SpatialLayoutOptions } from './spatial-canvas.js'
-import { layoutSpatialCanvas, layoutSpatialEdges } from './spatial-canvas.js'
+import {
+  layoutSpatialCanvas,
+  layoutSpatialEdges,
+  naturalNodeContentSize,
+} from './spatial-canvas.js'
 
 const NODE_PADDING_PX = 8
 const NODE_CORNER_RADIUS_PX = 4
@@ -743,31 +747,22 @@ describe('a text node keeps its body inside its own box', () => {
     expect(runBottoms(scene).length).toBeGreaterThan(0)
   })
 
-  it('does not truncate when the box gives no height to fit against', () => {
-    // The editor's grow-only auto-fit measures a text node's NATURAL content
-    // height by laying it out at height 1 and reading the scene's bottom
-    // edge. Truncating there caps what the probe can report, so a box can
-    // never grow past one block — which is how a fit meant to keep content
-    // inside the frame ends up DEFEATING the feature that keeps it inside
-    // the frame. Same reading `fitToWidth` gives an unusable maxWidth.
-    const probe: SpatialCanvas = {
-      nodes: [
-        { id: 'n1', type: 'text', x: 0, y: 0, width: 67, height: 1, text: 'かあらた\n\nかたそ' },
-      ],
-      edges: [],
-    }
-    const roomy: SpatialCanvas = {
-      nodes: [
-        { id: 'n1', type: 'text', x: 0, y: 0, width: 67, height: 400, text: 'かあらた\n\nかたそ' },
-      ],
-      edges: [],
-    }
+  it('reports a natural content size that the stored box cannot influence', () => {
+    // The editor's grow-only auto-fit asks "how big must this box be". That
+    // question is `naturalNodeContentSize`, not a layout at height 1: a box
+    // too small to bound anything answers it only by accident, and the
+    // layout API cannot tell that probe apart from a node someone really
+    // made 1px tall — which is how the escape hatch ended up open for every
+    // tiny node too.
     const opts = baseOptions({ measure: fullWidth, parseBody: parseParagraphs })
+    const sizeAt = (height: number) =>
+      naturalNodeContentSize(
+        { id: 'n1', type: 'text', x: 0, y: 0, width: 67, height, text: 'かあらた\n\nかたそ' },
+        opts,
+      )
 
-    // The degenerate probe must see every block a roomy box would.
-    expect(runBottoms(layoutSpatialCanvas(probe, opts)).length).toBe(
-      runBottoms(layoutSpatialCanvas(roomy, opts)).length,
-    )
+    expect(sizeAt(1)).toEqual(sizeAt(400))
+    expect(sizeAt(1).h).toBeGreaterThan(0)
   })
 
   it('still paints the blocks that do fit', () => {

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -563,7 +563,13 @@ function fitBodyInNode(
   root: MdastRoot,
   options: ResolvedLayoutOptions,
 ): Scene | undefined {
-  if (contentBox(node, options) === undefined) return undefined
+  // The degenerate-box guard is part of FITTING, not of laying out: under
+  // `naturalNodeContentSize` there is no box to be degenerate against, and
+  // returning `undefined` here made a file node fall back to its label, so
+  // the one function whose whole contract is "independent of the stored
+  // box" reported the label's height for a small box and the body's for a
+  // large one.
+  if (options.fitToBox && contentBox(node, options) === undefined) return undefined
   const body = layoutMdastBlocks(root, mdastOptionsFor(contentWidth(node.width, options), options))
   return fitSceneInNode(body, node, options)
 }

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -219,6 +219,15 @@ interface ResolvedLayoutOptions extends SpatialLayoutOptions {
   readonly embedDepth: number
   readonly geometry: SpatialGeometry
   readonly parseBody: (text: string) => MdastRoot
+  /**
+   * Whether content is trimmed to the node's box. INTERNAL — deliberately
+   * not on `SpatialLayoutOptions`, so a normal render can never turn the
+   * fit off by accident. `naturalNodeContentSize` is the one caller that
+   * clears it, and it is a named function precisely so the intent is
+   * legible at the call site instead of being inferred from a degenerate
+   * height.
+   */
+  readonly fitToBox: boolean
 }
 
 /**
@@ -371,13 +380,6 @@ function placeAboveNode(node: SpatialNode, content: Scene): readonly SceneNode[]
  * somewhere better to go — the plain chrome-and-label rendering.
  */
 function fitTextBody(scene: Scene, node: SpatialNode, options: ResolvedLayoutOptions): Scene {
-  // A non-positive content box is "no height to fit against", the same
-  // reading `fitToWidth` gives an unusable `maxWidth`. It is not a
-  // hypothetical: the editor's grow-only auto-fit measures a node's NATURAL
-  // content height by laying it out at height 1 and reading the scene's
-  // bottom edge, so a truncation here would cap what that probe can report
-  // and the box could never grow past one block.
-  if (contentBox(node, options) === undefined) return scene
   return fitSceneInNode(scene, node, options) ?? { nodes: scene.nodes.slice(0, 1) }
 }
 
@@ -544,6 +546,7 @@ function fitSceneInNode(
   node: SpatialNode,
   options: ResolvedLayoutOptions,
 ): Scene | undefined {
+  if (!options.fitToBox) return scene
   const box = contentBox(node, options)
   if (box === undefined) return undefined
 
@@ -861,7 +864,50 @@ export function layoutSpatialCanvasWithAnchors(
     parseBody: options.parseBody ?? parseMarkdownBody,
     embedPath: new Set(),
     embedDepth: 0,
+    fitToBox: true,
   })
+}
+
+/**
+ * The extent a node's content occupies when NOTHING is trimmed to fit it.
+ *
+ * This is the question an auto-fit asks — "how big does this box have to be"
+ * — and it is deliberately a named function rather than a layout option or a
+ * degenerate-height trick. Laying a node out at `height: 1` and reading the
+ * scene's bottom edge answers it too, but only because a box that small
+ * cannot bound anything: the layout API cannot tell that probe apart from a
+ * node someone really made 1px tall, so the escape hatch it needs was open
+ * for every tiny node as well. A node that needs `h` of content is contained
+ * by a height of `h + 2 * geometry.paddingPx`.
+ *
+ * Chrome is excluded (it spans the stored box by definition, so including it
+ * could never report "the content is shorter than its box"), and so is a
+ * label placed ABOVE the frame — that is not content in the box.
+ */
+export function naturalNodeContentSize(
+  node: SpatialNode,
+  options: SpatialLayoutOptions,
+): { readonly w: number; readonly h: number } {
+  const content = composeNode(node, {
+    ...options,
+    geometry: resolveGeometry(options.geometry),
+    parseBody: options.parseBody ?? parseMarkdownBody,
+    embedPath: new Set(),
+    embedDepth: 0,
+    fitToBox: false,
+  }).filter(
+    (entry): entry is Exclude<SceneNode, { kind: 'edge' }> =>
+      entry.kind !== 'shape' && entry.kind !== 'edge' && entry.bbox.y >= node.y,
+  )
+
+  if (content.length === 0) return { w: 0, h: 0 }
+  const right = Math.max(...content.map((entry) => entry.bbox.x + entry.bbox.w))
+  const bottom = Math.max(...content.map((entry) => entry.bbox.y + entry.bbox.h))
+  const padding = resolveGeometry(options.geometry).paddingPx
+  return {
+    w: Math.max(0, right - (node.x + padding)),
+    h: Math.max(0, bottom - (node.y + padding)),
+  }
 }
 
 /** The embed path needs only the scene; the anchor map is per-top-level-canvas. */
@@ -932,5 +978,6 @@ export function layoutSpatialEdges(
     parseBody: options.parseBody ?? parseMarkdownBody,
     embedPath: new Set(),
     embedDepth: 0,
+    fitToBox: true,
   }).content
 }


### PR DESCRIPTION
Closing the *class* rather than the next instance of it. PR #878 fixed one seam; this makes the guarantee something every seam answers to.

## Measured first

Five node kinds × five box sizes, because "which seams leak" should be a table, not a reading exercise:

| case | overflow | what it is |
|---|---|---|
| `text@200x12` | **bottom +36** | the whole body, outside the frame |
| `file@200x12` | bottom +12 | the one-line label |
| `link@200x12` | bottom +12 | the one-line label |
| `group@*` | top +20 | the container label — outside **by design** |
| `file@200x120` | top +20 | the reference label — outside **by design** |

**The +36 was mine, from #878.** The carve-out that lets the editor's grow probe measure a natural height — *"a non-positive content box imposes no bound"* — cannot tell that probe apart from a node someone really made 12px tall. It was open for both.

## The probe's intent becomes a name, not a degenerate height

`naturalNodeContentSize(node, options)` is now canvas-render's answer to "how big must this box be". Fitting is an **internal** flag that only that function clears — deliberately *not* on `SpatialLayoutOptions`, so a normal render cannot turn the bound off by accident.

`apps/web`'s `requiredTextNodeHeight` becomes padding arithmetic on top of it instead of a layout at `height: 1`. Every tiny node is bounded again: **+36 → +12**, the same single kept element every other seam already had.

## The law, stated once against the output

> At most one element crosses the frame bottom, once the outside label is set aside, and nothing is painted above the frame except that one label.

Per node *kind*, not per seam — each seam that grows its own bound is exactly where the next overflow appears. Both escapes are **enumerated, not discovered**: the container label JSON Canvas puts outside the box, and the single element kept when nothing fits so a one-line-tall node is not an empty box.

Vertical only. Horizontal has its own declared exemptions (inline math is neither split nor cut, an atomic run is not split) and its own instrument in `text-wrapping-quality.test.ts`.

## The generator is the interesting part

Height is drawn as a fraction of each node's **own** natural content height. A flat `1..160` range reached the two-blocks-cross case about **once in 140 runs**, so the mutation that deletes the fit entirely passed on some seeds and failed on others — I caught that only because a truncated `head -4` made me re-run it. With the fraction it is **red 5 runs out of 5**. Density, not more runs.

Mutation-checked one rule at a time:

| mutation | reddens |
|---|---|
| delete the fit | the crossing law |
| a second above-frame producer | the label law |
| — | natural size pinned as independent of the stored box |

## Verification

node projects **4431 passed** · apps/web jsdom **2314 + 77** · browser projects **654** · widget smoke **PASS** · `pnpm -r typecheck` and `pnpm knip` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved whiteboard text sizing to accurately account for natural content dimensions and padding.
  * Prevented layout results from depending on a node’s previously stored height.
  * Improved rendering containment for text, file, link, and group nodes, reducing elements crossing frame boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->