### PR TITLE
feat(canvas-render): trim to lines, and count what containment hides

### DIFF
--- a/packages/canvas-render/src/layout/frame-containment-quality.test.ts
+++ b/packages/canvas-render/src/layout/frame-containment-quality.test.ts
@@ -1,0 +1,137 @@
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import type { MdastRoot } from '@kamiazya/whiteboard-model/mdast'
+import { describe, expect, it } from 'vitest'
+import {
+  CORPUS_WIDTHS_PX,
+  createCorpusMeasure,
+  TEXT_WRAPPING_CORPUS,
+} from '../test-utils/text-wrapping-corpus.js'
+import { layoutSpatialCanvas, naturalNodeContentSize } from './spatial-canvas.js'
+
+/**
+ * The frame-containment SCOREBOARD — how much content is HIDDEN to keep the
+ * containment law, and how often the law's escape is taken.
+ *
+ * The properties in `spatial-canvas.properties.test.ts` state the law: at
+ * most one element may cross the frame, and only when nothing fits. That is
+ * a BOUND, and a bound says nothing about frequency — every node in the
+ * product could start taking that escape and the properties would stay
+ * green. This is the instrument that would notice, the same reason the
+ * routing scoreboard counts violations instead of asserting one canvas.
+ *
+ * DEBT, both pinned EXACTLY rather than as a ceiling so an improvement is as
+ * loud as a regression:
+ *
+ * - `hidden`  blocks trimmed away, i.e. prose a reader cannot see.
+ * - `crossed` nodes where an element still crosses the frame, i.e. the box
+ *             could not hold even one block.
+ *
+ * Neither targets zero. Truncating is what the law trades for never painting
+ * outside the frame, and a node smaller than one line has no third option —
+ * `apps/web` answers both by GROWING the node on commit, and these numbers
+ * are what that safety net catches when growth never happened (an
+ * agent-authored node, one shrunk by hand).
+ *
+ * Box heights are drawn as fractions of each case's OWN natural content
+ * height, never as flat pixels: a flat height is roomy for a one-line case
+ * and impossible for a ten-line one, so the same number would mean a
+ * different thing per case and the total would measure the corpus rather
+ * than the layout.
+ */
+
+const HEIGHT_FRACTIONS: readonly number[] = [1.2, 0.8, 0.4]
+
+/** The corpus bodies are mdast; the node carries its case NAME as text. */
+function parseByName(text: string): MdastRoot {
+  const entry = TEXT_WRAPPING_CORPUS.find((candidate) => candidate.name === text)
+  if (entry === undefined) throw new Error(`no corpus case named ${text}`)
+  return entry.root
+}
+
+const APPEARANCE = {
+  resolveNode: () => ({}),
+  resolveEdge: () => ({}),
+  resolveLabel: () => ({}),
+}
+
+interface Debt {
+  readonly hidden: number
+  readonly crossed: number
+}
+
+function scoreCase(name: string, width: number, fraction: number): Debt {
+  const measure = createCorpusMeasure().measure
+  const options = { measure, parseBody: parseByName, appearance: APPEARANCE }
+  const node = (height: number) => ({
+    id: 'n',
+    type: 'text' as const,
+    x: 0,
+    y: 0,
+    width,
+    height,
+    text: name,
+  })
+
+  const natural = naturalNodeContentSize(node(1), options)
+  // +2 padding is what `naturalNodeContentSize` documents as containing it.
+  const height = Math.max(1, Math.round((natural.h + 16) * fraction))
+  const canvas: SpatialCanvas = { nodes: [node(height)], edges: [] }
+
+  const painted = layoutSpatialCanvas(canvas, options).nodes.filter(
+    (entry) => entry.kind !== 'shape' && entry.kind !== 'edge',
+  )
+  const whole = layoutSpatialCanvas({ nodes: [node(100_000)], edges: [] }, options).nodes.filter(
+    (entry) => entry.kind !== 'shape' && entry.kind !== 'edge',
+  )
+  const crossed = painted.some((entry) => entry.bbox.y + entry.bbox.h > height)
+
+  return { hidden: whole.length - painted.length, crossed: crossed ? 1 : 0 }
+}
+
+function totalDebt(): Debt {
+  let hidden = 0
+  let crossed = 0
+  for (const entry of TEXT_WRAPPING_CORPUS) {
+    for (const width of CORPUS_WIDTHS_PX) {
+      for (const fraction of HEIGHT_FRACTIONS) {
+        const debt = scoreCase(entry.name, width, fraction)
+        hidden += debt.hidden
+        crossed += debt.crossed
+      }
+    }
+  }
+  return { hidden, crossed }
+}
+
+describe('frame containment scoreboard', () => {
+  it('reports the aggregate debt', () => {
+    expect(totalDebt()).toEqual(PINNED_DEBT)
+  })
+
+  it('hides nothing when every box is roomy, so the corpus is not reporting a constant', () => {
+    // Guards the whole instrument against the failure it cannot otherwise
+    // show: if truncation ran unconditionally, the numbers above would still
+    // look like a stable pin.
+    let hidden = 0
+    for (const entry of TEXT_WRAPPING_CORPUS) {
+      for (const width of CORPUS_WIDTHS_PX) {
+        hidden += scoreCase(entry.name, width, 1.2).hidden
+      }
+    }
+    expect(hidden).toBe(0)
+  })
+})
+
+/**
+ * 11 corpus cases x 3 widths x 3 height fractions = 99 cells.
+ *
+ * `crossed: 13` is the cells whose box is 40% of the natural height, i.e.
+ * too small for even one LINE — keep-first paints that line and there is no
+ * third option short of not rendering the node. Every 0.8 cell is contained,
+ * which was not true before lists were trimmed to their fitting items: a
+ * list escaped its frame at 0.8 while every prose case survived.
+ *
+ * `hidden: 3` is `ja-heading` at 0.4, where a whole heading block is dropped
+ * rather than shown crossing the frame.
+ */
+const PINNED_DEBT: Debt = { hidden: 3, crossed: 13 }

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -541,6 +541,51 @@ function contentBox(
  * passing through here paints outside the frame, which is a rendering
  * defect this package's "what cannot fit is cut" contract forbids.
  */
+/**
+ * Trims a block to the LINES of it that fit, for the two block kinds whose
+ * runs are lines (`layoutMdastBlocks` emits one run per wrapped line).
+ *
+ * Whole-block granularity alone leaves the commonest shape unbounded: a
+ * single long paragraph is ONE block, so a body that is one paragraph either
+ * fits or is kept whole and painted outside the frame. Measured before this
+ * existed — a paragraph laid out at 112px in a 60px node reached y=120,
+ * twice the height of the box it lives in.
+ *
+ * `undefined` when not even the first line fits, leaving the keep-first
+ * decision to the caller. `list`/`table`/`blockquote` stay whole-block: their
+ * children are not lines, and two of them are the `subtreeOffsetX`
+ * transform-boundary class this package keeps at arm's length.
+ */
+function fitBlockLines(
+  block: Exclude<SceneNode, { kind: 'edge' }>,
+  maxBottom: number,
+): SceneNode | undefined {
+  // A list's ITEMS are its lines-equivalent: one row each, laid out with
+  // increasing bottoms, so the same prefix trim applies. Measured as the
+  // worst offender before this — a list escaped its frame even at a box only
+  // 20% too small, where every prose case survived. Only the items are
+  // filtered; their descendants are never read, so the `subtreeOffsetX`
+  // transform-boundary rule is untouched.
+  if (block.kind === 'list') {
+    const items = block.items.filter((item) => item.bbox.y + item.bbox.h <= maxBottom)
+    if (items.length === 0 || items.length === block.items.length) return undefined
+    const bottom = Math.max(...items.map((item) => item.bbox.y + item.bbox.h))
+    return { ...block, items, bbox: { ...block.bbox, h: bottom - block.bbox.y } }
+  }
+  if (block.kind !== 'paragraph' && block.kind !== 'heading') return undefined
+  const kept = block.runs.filter((run) => run.bbox.y + run.bbox.h <= maxBottom)
+  if (kept.length === 0 || kept.length === block.runs.length) return undefined
+
+  // The last surviving line carries the fade the SVG backend already paints
+  // for a horizontally cut run, so a vertical cut says "there is more" in
+  // the same visual language rather than ending silently.
+  const runs = kept.map((run, index) =>
+    index === kept.length - 1 ? { ...run, truncated: true as const } : run,
+  )
+  const bottom = Math.max(...runs.map((run) => run.bbox.y + run.bbox.h))
+  return { ...block, runs, bbox: { ...block.bbox, h: bottom - block.bbox.y } }
+}
+
 function fitSceneInNode(
   scene: Scene,
   node: SpatialNode,
@@ -552,9 +597,20 @@ function fitSceneInNode(
 
   // Neither producer emits an edge (the one SceneNode variant with no
   // `bbox`); that guard is for the type checker, not runtime.
-  const fitted = scene.nodes.filter(
-    (entry) => entry.kind !== 'edge' && entry.bbox.y + entry.bbox.h <= box.h,
-  )
+  const fitted: SceneNode[] = []
+  for (const entry of scene.nodes) {
+    if (entry.kind === 'edge') continue
+    if (entry.bbox.y + entry.bbox.h <= box.h) {
+      fitted.push(entry)
+      continue
+    }
+    // The first block that does not fit is the last one considered: every
+    // block after it starts lower still, and `layoutMdastBlocks` lays them
+    // out with strictly increasing bottoms.
+    const trimmed = fitBlockLines(entry, box.h)
+    if (trimmed !== undefined) fitted.push(trimmed)
+    break
+  }
   return fitted.length === 0 ? undefined : { nodes: fitted }
 }
 


### PR DESCRIPTION
The follow-up to #879 — and the scoreboard found the class was **not** closed.

## Why a scoreboard, when #879 already has properties

#879 states the law: *at most one element may cross the frame*. A law is a **bound**, and nothing counted how **often** the escape is taken — every node in the product could start taking it with the properties still green. Same argument that put a scoreboard under edge routing.

## Its first reading found the hole

`{ hidden: 6, crossed: 61 }` out of 99 cells. The *shape* of those numbers is the finding: almost nothing was being **hidden**, so the crossings were not truncation at work — they were whole blocks kept and painted outside. Measured directly:

```
paragraph y=8 h=112 bottom=120   (frame bottom=60)
```

A single long paragraph is **one block**, so the commonest body of all either fit or escaped whole — at twice the height of its box. **#879's properties pass on it**: one element crossing is exactly what the law allows.

## So truncation goes one level down

To the **lines** `layoutMdastBlocks` already emits one run per, and to a list's **items**. The last surviving line carries the `truncated` fade the backend already paints for a horizontally cut run, so a vertical cut says "there is more" in the same visual language.

`list` was the worst offender and the reason to include it: it escaped its frame at a box only **20% too small**, where every prose case survived.

| | crossed | hidden |
|---|---|---|
| before | 61 | 6 |
| + line trimming | 19 | 3 |
| + list items | **13** | **3** |

The remaining 13 are boxes at 40% of the natural height — too small for even one **line**, where keep-first has no third option short of not rendering the node. `hidden: 3` is a heading dropped whole rather than shown crossing. Both are pinned **with that composition written down**, not just recorded.

`blockquote`/`table`/`code` stay whole-block: their children are not lines, and two are the `subtreeOffsetX` transform-boundary class this package keeps at arm's length. Only a list's *items* are filtered, never their descendants, so that boundary is untouched.

## Mutation-checked

Removing line trimming returns the scoreboard to `{ hidden: 6, crossed: 61 }`. A second test asserts a roomy box hides **nothing**, so unconditional truncation could not masquerade as a stable pin.

## Verification

canvas-render-node **690** · node projects **4355** · browser projects **664** · apps/web jsdom **2322 + 77** · widget smoke **PASS** · typecheck, lint, knip clean.