### PR TITLE
fix(server): stop path operations from stranding a document's children

### DIFF
--- a/packages/mcp-server/src/server/routes/document/workspaces.test.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.test.ts
@@ -433,6 +433,40 @@ describe('PUT /api/workspaces/:workspaceId/documents/:path/path', () => {
     await mkdir(join(tmp.dir, 'session1'), { recursive: true })
   })
 
+  // The store computes WHICH path actually collided; rebuilding the message
+  // from the requested path names one that is free, which is worse than
+  // saying nothing — the caller retries a rename that was never the problem.
+  it('names the descendant that collided, not the free path the caller asked for', async () => {
+    await saveDocument('session1', 'a', new LoroDoc())
+    await saveDocument('session1', 'a/x', new LoroDoc())
+    await saveDocument('session1', 'c/x', new LoroDoc())
+    const app = createDocumentRouter()
+
+    const res = await app.request('/api/workspaces/session1/documents/a/path', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: 'c' }),
+    })
+
+    expect(res.status).toBe(409)
+    const json = (await res.json()) as { title?: string }
+    expect(json.title).toContain('c/x')
+  })
+
+  it('refuses a move into the document’s own subtree with 400, not a generic 500', async () => {
+    await saveDocument('session1', 'a', new LoroDoc())
+    await saveDocument('session1', 'a/x', new LoroDoc())
+    const app = createDocumentRouter()
+
+    const res = await app.request('/api/workspaces/session1/documents/a/path', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: 'a/x' }),
+    })
+
+    expect(res.status).toBe(400)
+  })
+
   it('returns 200 { path }, the list shows the new path and not the old one, the old snapshot URL 404s, and re-creating the old path afterward succeeds as a fresh canvas', async () => {
     await saveDocument('session1', 'a', new LoroDoc())
     const app = createDocumentRouter()

--- a/packages/mcp-server/src/server/routes/document/workspaces.test.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.test.ts
@@ -309,6 +309,22 @@ describe('DELETE /api/workspaces/:workspaceId/documents/:path', () => {
     expect(snapshotRes.status).toBe(404)
   })
 
+  // A refusal the caller can act on, not a server failure: 409 with the
+  // offending descendant named, so the UI can say which one to deal with.
+  it('returns 409 naming a descendant rather than stranding it', async () => {
+    await saveDocument('session1', 'design', new LoroDoc())
+    await saveDocument('session1', 'design/login', new LoroDoc())
+    const app = createDocumentRouter()
+
+    const res = await app.request('/api/workspaces/session1/documents/design', {
+      method: 'DELETE',
+    })
+
+    expect(res.status).toBe(409)
+    const json = (await res.json()) as { title?: string }
+    expect(json.title).toContain('design/login')
+  })
+
   it('returns 404 with Problem Details { title } for a missing canvas', async () => {
     const app = createDocumentRouter()
     const res = await app.request('/api/workspaces/session1/documents/never-created', {

--- a/packages/mcp-server/src/server/routes/document/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.ts
@@ -1,5 +1,5 @@
 import { writeDocumentKind } from '@kamiazya/whiteboard-loro-adapter'
-import { DocumentHasDescendantsError } from '@kamiazya/whiteboard-ports'
+import { DocumentHasDescendantsError, DocumentMoveIntoSelfError } from '@kamiazya/whiteboard-ports'
 import { Hono } from 'hono'
 import { LoroDoc as LoroDocCtor } from 'loro-crdt'
 import type { z } from 'zod'
@@ -199,8 +199,17 @@ export function createWorkspacesRouter() {
         const response: RenameDocumentPathResponse = { path: newPath }
         return c.json(response)
       } catch (err) {
+        // A move into the document's own subtree is an unusable target, not
+        // a race with another document — 400, not 409.
+        if (err instanceof DocumentMoveIntoSelfError) {
+          return c.json({ title: err.message } satisfies ApiErrorBody, 400)
+        }
+        // Forward the store's message rather than rebuilding one from
+        // newPath: a subtree move collides on a PRODUCED path, so the path
+        // the caller asked for is often free and naming it sends them to
+        // retry the one thing that was never the problem.
         if (err instanceof ConflictError) {
-          return c.json({ title: `Canvas "${newPath}" already exists` }, 409)
+          return c.json({ title: err.message } satisfies ApiErrorBody, 409)
         }
         const issue = handleCorruptStoredData(err)
         if (issue) return c.json(issue.body, issue.status)

--- a/packages/mcp-server/src/server/routes/document/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.ts
@@ -1,4 +1,5 @@
 import { writeDocumentKind } from '@kamiazya/whiteboard-loro-adapter'
+import { DocumentHasDescendantsError } from '@kamiazya/whiteboard-ports'
 import { Hono } from 'hono'
 import { LoroDoc as LoroDocCtor } from 'loro-crdt'
 import type { z } from 'zod'
@@ -149,6 +150,10 @@ export function createWorkspacesRouter() {
         const response: DeleteDocumentResponse = { ok: true }
         return c.json(response)
       } catch (err) {
+        // A refusal, not a failure: the caller has to name what it destroys.
+        if (err instanceof DocumentHasDescendantsError) {
+          return c.json({ title: err.message } satisfies ApiErrorBody, 409)
+        }
         const issue = handleCorruptStoredData(err)
         if (issue) return c.json(issue.body, issue.status)
         getLogger('document').error({ err: err as Error }, 'deleteDocument failed unexpectedly')

--- a/packages/mcp-server/src/server/store/document-path-tree.ts
+++ b/packages/mcp-server/src/server/store/document-path-tree.ts
@@ -1,0 +1,98 @@
+/**
+ * The subtree arithmetic behind moving and deleting a document path.
+ *
+ * Two stores write the `documents` table — `document-store.ts` for the HTTP
+ * surface and `sqlite-document-index.ts` for the MCP one — and they are
+ * deliberately kept from importing each other. That is what let them grow
+ * two different answers to the same question: the index moved a whole
+ * subtree while the HTTP path renamed one row and stranded its children,
+ * and the index refused to delete a document with descendants while the
+ * HTTP path stranded them again.
+ *
+ * The rules live here, as pure functions over rows, so both stores keep
+ * their own SQL and neither owns the semantics alone.
+ */
+
+/** How many segments a path has. */
+function depth(path: string): number {
+  return path.split('/').length
+}
+
+/**
+ * Whether `path` is `ancestor` itself or sits below it. Anchored at a
+ * SEGMENT boundary, which is the whole point: `design-system` starts with
+ * `design` and is not inside it.
+ */
+export function isSelfOrDescendant(path: string, ancestor: string): boolean {
+  return path === ancestor || path.startsWith(`${ancestor}/`)
+}
+
+export interface PathRow {
+  readonly id: string
+  readonly path: string
+}
+
+interface PlannedMove {
+  readonly id: string
+  readonly from: string
+  readonly path: string
+}
+
+export type MovePlan =
+  | { readonly ok: true; readonly moves: readonly PlannedMove[] }
+  | { readonly ok: false; readonly reason: 'not-found' }
+  | { readonly ok: false; readonly reason: 'taken'; readonly path: string }
+
+/**
+ * Works out every row a move touches and the order to write them in.
+ * Returns a result rather than throwing so each caller can raise the error
+ * class its own surface already maps to a status code.
+ *
+ * `to` being inside `from` is the caller's check, not this one's — the two
+ * stores disagree about whether it is an error or simply refused, and this
+ * function has no opinion worth imposing.
+ */
+export function planSubtreeMove(rows: readonly PathRow[], from: string, to: string): MovePlan {
+  const moving = rows.filter((row) => isSelfOrDescendant(row.path, from))
+  if (moving.length === 0) return { ok: false, reason: 'not-found' }
+
+  const occupied = new Set(rows.map((row) => row.path))
+  const vacating = new Set(moving.map((row) => row.path))
+  const moves = moving.map((row) => ({
+    id: row.id,
+    from: row.path,
+    path: `${to}${row.path.slice(from.length)}`,
+  }))
+
+  // Every PRODUCED path, not just `to`: moving `a` onto a free `c` still
+  // collides when `a/x` and `c/x` both exist. Paths the move is vacating do
+  // not count as occupied, or relocating a subtree would always collide
+  // with itself.
+  for (const move of moves) {
+    if (occupied.has(move.path) && !vacating.has(move.path)) {
+      return { ok: false, reason: 'taken', path: move.path }
+    }
+  }
+
+  // Shallowest source first, by DEPTH — not by path order. A move up into
+  // its own ancestor namespace sends a deeper row onto the path a shallower
+  // one is vacating, so the shallower write has to land first or the unique
+  // index rejects a move the contract requires to succeed. The two
+  // contending rows need not be ancestor and descendant of each other
+  // (`a/b/x` and `a/b/b/x` both branch below `a/b`), which is why
+  // segment-wise path order is not enough: it would put `a/b/b/x` first
+  // because `b` precedes `x`. Only the depth difference is guaranteed, and
+  // it is — the row producing a contested path is always deeper than the row
+  // vacating it, by exactly the number of segments the move removes.
+  return { ok: true, moves: [...moves].sort((left, right) => depth(left.from) - depth(right.from)) }
+}
+
+/**
+ * The first path strictly below `path`, or `undefined`. Both stores refuse
+ * to delete a document that still has one: every document can hold children,
+ * so a cascade is reachable from a single call naming one path, and deletion
+ * is the operation with nothing to undo it.
+ */
+export function findDescendantPath(rows: readonly PathRow[], path: string): string | undefined {
+  return rows.find((row) => row.path !== path && isSelfOrDescendant(row.path, path))?.path
+}

--- a/packages/mcp-server/src/server/store/document-path-tree.ts
+++ b/packages/mcp-server/src/server/store/document-path-tree.ts
@@ -53,6 +53,11 @@ export type MovePlan =
  * function has no opinion worth imposing.
  */
 export function planSubtreeMove(rows: readonly PathRow[], from: string, to: string): MovePlan {
+  // `from` need not name a document: a prefix that only has descendants is a
+  // legitimate source, and moving it relocates the subtree under it. That is
+  // what makes renaming a FOLDER expressible at all, since a folder is only
+  // ever a shared prefix here — see the depth-ordering conformance case,
+  // which moves `a/b` while no `a/b` document exists.
   const moving = rows.filter((row) => isSelfOrDescendant(row.path, from))
   if (moving.length === 0) return { ok: false, reason: 'not-found' }
 

--- a/packages/mcp-server/src/server/store/document-store.test.ts
+++ b/packages/mcp-server/src/server/store/document-store.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { DocumentHasDescendantsError } from '@kamiazya/whiteboard-ports'
+import { DocumentHasDescendantsError, DocumentMoveIntoSelfError } from '@kamiazya/whiteboard-ports'
 import { LoroDoc, LoroMap } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -1625,6 +1625,34 @@ describe('renameDocumentPath', () => {
 
     const paths = (await listDocuments('session1')).map((c) => c.path).sort()
     expect(paths).toEqual(['design-system', 'product'])
+  })
+
+  // The one rule `planSubtreeMove` deliberately does NOT enforce, so each
+  // caller has to. Without it the depth-ordered write — correct for the
+  // upward move it was written for — is inverted, and the shallow row lands
+  // on a path its own descendant has not vacated yet.
+  it('refuses to move a document inside itself rather than raising a raw constraint error', async () => {
+    await saveDocument('session1', 'a', new LoroDoc())
+    await saveDocument('session1', 'a/x', new LoroDoc())
+
+    await expect(renameDocumentPath('session1', 'a', 'a/x')).rejects.toThrow(
+      DocumentMoveIntoSelfError,
+    )
+
+    const paths = (await listDocuments('session1')).map((c) => c.path).sort()
+    expect(paths).toEqual(['a', 'a/x'])
+  })
+
+  it('refuses to nest a document inside itself even when the destination is free', async () => {
+    await saveDocument('session1', 'a', new LoroDoc())
+    await saveDocument('session1', 'a/b', new LoroDoc())
+
+    await expect(renameDocumentPath('session1', 'a', 'a/nested')).rejects.toThrow(
+      DocumentMoveIntoSelfError,
+    )
+
+    const paths = (await listDocuments('session1')).map((c) => c.path).sort()
+    expect(paths).toEqual(['a', 'a/b'])
   })
 
   it('rejects a rename that would collide with an existing descendant path', async () => {

--- a/packages/mcp-server/src/server/store/document-store.test.ts
+++ b/packages/mcp-server/src/server/store/document-store.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
+import { DocumentHasDescendantsError } from '@kamiazya/whiteboard-ports'
 import { LoroDoc, LoroMap } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -1276,6 +1277,29 @@ describe('deleteDocument', () => {
     await rm(tempDir, { recursive: true, force: true })
   })
 
+  // The MCP surface already refuses this, and for a stated reason: deletion
+  // is the operation with nothing to undo it, so the caller has to name what
+  // it is destroying. The HTTP surface deleting the same document silently
+  // strands every child under a prefix nothing owns.
+  it('refuses to delete a document that still has descendants', async () => {
+    await saveDocument('session1', 'a', new LoroDoc())
+    await saveDocument('session1', 'a/child', new LoroDoc())
+
+    await expect(deleteDocument('session1', 'a')).rejects.toThrow(DocumentHasDescendantsError)
+
+    const paths = (await listDocuments('session1')).map((c) => c.path).sort()
+    expect(paths).toEqual(['a', 'a/child'])
+  })
+
+  it('deletes a document whose name merely prefixes a sibling', async () => {
+    await saveDocument('session1', 'a', new LoroDoc())
+    await saveDocument('session1', 'a-sibling', new LoroDoc())
+
+    await expect(deleteDocument('session1', 'a')).resolves.toBe(true)
+
+    expect((await listDocuments('session1')).map((c) => c.path)).toEqual(['a-sibling'])
+  })
+
   it('removes the documents row, cascades branches/versions rows, deletes the Libsql snapshot rows, and unlinks the version thumbnail PNGs, leaving the workspace row and a sibling canvas untouched', async () => {
     const { getDb } = await import('./db/index.js')
     const { createBranch } = await import('./branches-store.js')
@@ -1573,6 +1597,62 @@ describe('renameDocumentPath', () => {
 
     const list = await listDocuments('session1')
     expect(list.map((c) => c.path)).toEqual(['a'])
+  })
+
+  // A path IS the hierarchy, so renaming one carries everything under it.
+  // Moving only the named row leaves its children addressed below a prefix
+  // no document owns — reachable by nothing the UI can show, and produced by
+  // the ordinary act of renaming a group.
+  it('carries every descendant with the renamed path', async () => {
+    await saveDocument('session1', 'design', new LoroDoc())
+    await saveDocument('session1', 'design/login', new LoroDoc())
+    await saveDocument('session1', 'design/deep/notes', new LoroDoc())
+    await saveDocument('session1', 'designs-elsewhere', new LoroDoc())
+
+    await renameDocumentPath('session1', 'design', 'product')
+
+    const paths = (await listDocuments('session1')).map((c) => c.path).sort()
+    expect(paths).toEqual(['designs-elsewhere', 'product', 'product/deep/notes', 'product/login'])
+  })
+
+  // The prefix test above would pass with a blind string replace; this one
+  // fails unless the rewrite is anchored at a segment boundary.
+  it('does not carry a sibling that merely shares the name as a prefix', async () => {
+    await saveDocument('session1', 'design', new LoroDoc())
+    await saveDocument('session1', 'design-system', new LoroDoc())
+
+    await renameDocumentPath('session1', 'design', 'product')
+
+    const paths = (await listDocuments('session1')).map((c) => c.path).sort()
+    expect(paths).toEqual(['design-system', 'product'])
+  })
+
+  it('rejects a rename that would collide with an existing descendant path', async () => {
+    await saveDocument('session1', 'a', new LoroDoc())
+    await saveDocument('session1', 'a/x', new LoroDoc())
+    await saveDocument('session1', 'c/x', new LoroDoc())
+
+    // `a` -> `c` is free at the top, and still collides: `a/x` would land on
+    // the occupied `c/x`.
+    await expect(renameDocumentPath('session1', 'a', 'c')).rejects.toThrow(ConflictError)
+
+    const paths = (await listDocuments('session1')).map((c) => c.path).sort()
+    expect(paths).toEqual(['a', 'a/x', 'c/x'])
+  })
+
+  it('evicts every moved path from the cache, not only the two named ones', async () => {
+    const { getDoc, peekDoc, clearCache } = await import('./doc-cache.js')
+    clearCache()
+    await saveDocument('session1', 'a', new LoroDoc())
+    await saveDocument('session1', 'a/child', new LoroDoc())
+    await getDoc('session1', 'a/child')
+    expect(peekDoc('session1', 'a/child')).not.toBeUndefined()
+
+    await renameDocumentPath('session1', 'a', 'b')
+
+    // A stale instance cached under the old child path would be resurrected
+    // by the next read through it, shadowing the moved document.
+    expect(peekDoc('session1', 'a/child')).toBeUndefined()
   })
 
   it('evicts the old cache key so a subsequent getDoc under the old path misses the cache', async () => {

--- a/packages/mcp-server/src/server/store/document-store.ts
+++ b/packages/mcp-server/src/server/store/document-store.ts
@@ -24,7 +24,11 @@ import { access, mkdir, unlink, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import { generateDocumentId } from '@kamiazya/whiteboard-model'
-import { chunkSnapshot, reassembleSnapshot } from '@kamiazya/whiteboard-ports'
+import {
+  chunkSnapshot,
+  DocumentHasDescendantsError,
+  reassembleSnapshot,
+} from '@kamiazya/whiteboard-ports'
 import type { Value } from 'loro-crdt'
 import { LoroDoc, LoroMap, VersionVector } from 'loro-crdt'
 import type { DocumentSummary } from '../../shared/api-contracts/document.js'
@@ -39,6 +43,7 @@ import {
 import { getDb, registerDbDisposeHook } from './db/index.js'
 import { prepareDataDir } from './db/prepare.js'
 import { getDocumentIdByPath, upsertWorkspaceRow } from './db/upsert-workspace.js'
+import { findDescendantPath, planSubtreeMove } from './document-path-tree.js'
 import { LibsqlDocumentStore } from './libsql/libsql-document-store.js'
 import type { VersionStore } from './version-store.js'
 import { thumbnailPath } from './version-store.js'
@@ -428,6 +433,22 @@ export async function deleteDocument(workspaceId: string, path: string): Promise
     const documentId = await getDocumentIdByPath(db, workspaceId, path)
     if (!documentId) return false
 
+    // Refusing here rather than cascading is the DocumentIndex contract this
+    // table's other writer already holds: a cascade is reachable from one
+    // call naming one path, and deletion has nothing to undo it.
+    const siblings = await db
+      .selectFrom('documents')
+      .select(['id', 'path'])
+      .where('workspaceId', '=', workspaceId)
+      .execute()
+    const descendant = findDescendantPath(siblings, path)
+    if (descendant !== undefined) {
+      throw new DocumentHasDescendantsError(
+        path,
+        `Delete "${descendant}" and any others below it first.`,
+      )
+    }
+
     // Collect version ids before the row delete — the versions rows are
     // gone the instant the cascade fires, so their ids must be captured
     // first to know which thumbnail files to unlink.
@@ -776,26 +797,45 @@ export async function renameDocumentPath(
     const documentId = await getDocumentIdByPath(db, workspaceId, oldPath)
     if (!documentId) return null
     if (oldPath === newPath) return { documentId }
-    const taken = await getDocumentIdByPath(db, workspaceId, newPath)
-    if (taken) {
-      throw new ConflictError(`Canvas "${workspaceId}/${newPath}" already exists`)
-    }
-    await db
-      .updateTable('documents')
-      .set({ path: newPath, updatedAt: Date.now() })
-      .where('id', '=', documentId)
+
+    const rows = await db
+      .selectFrom('documents')
+      .select(['id', 'path'])
+      .where('workspaceId', '=', workspaceId)
       .execute()
-    // Force the next getDoc() to reload under both path keys. oldPath: a
-    // caller still reading through it should lazily create a fresh canvas
-    // rather than resurrect the renamed doc's cached instance. newPath: a
-    // WS connect or update-route call against the destination path before
-    // this rename can lazily cache an empty phantom doc there (getDoc()
+    const plan = planSubtreeMove(rows, oldPath, newPath)
+    if (!plan.ok) {
+      // `not-found` is unreachable — getDocumentIdByPath already answered
+      // for oldPath — so the only outcome left is a collision.
+      const collided = plan.reason === 'taken' ? plan.path : newPath
+      throw new ConflictError(`Canvas "${workspaceId}/${collided}" already exists`)
+    }
+
+    const now = Date.now()
+    await db.transaction().execute(async (trx) => {
+      for (const move of plan.moves) {
+        await trx
+          .updateTable('documents')
+          .set({ path: move.path, updatedAt: now })
+          .where('id', '=', move.id)
+          .execute()
+      }
+    })
+
+    // Force the next getDoc() to reload under every key the move touched.
+    // A source path: a caller still reading through it should lazily create
+    // a fresh canvas rather than resurrect the moved doc's cached instance.
+    // A destination path: a WS connect or update-route call against it
+    // before this move can lazily cache an empty phantom doc there (getDoc()
     // creates one for any path with no DB row yet) — leaving that phantom
-    // cached would shadow the just-renamed canvas's real content and the
-    // next write through newPath would persist the phantom over it.
+    // cached would shadow the just-moved canvas's real content and the next
+    // write through it would persist the phantom over it. Both halves apply
+    // to every descendant, not only the two paths the caller named.
     const { evictDoc } = await import('./doc-cache.js')
-    evictDoc(workspaceId, oldPath)
-    evictDoc(workspaceId, newPath)
+    for (const move of plan.moves) {
+      evictDoc(workspaceId, move.from)
+      evictDoc(workspaceId, move.path)
+    }
     return { documentId }
   })
 }

--- a/packages/mcp-server/src/server/store/document-store.ts
+++ b/packages/mcp-server/src/server/store/document-store.ts
@@ -27,6 +27,7 @@ import { generateDocumentId } from '@kamiazya/whiteboard-model'
 import {
   chunkSnapshot,
   DocumentHasDescendantsError,
+  DocumentMoveIntoSelfError,
   reassembleSnapshot,
 } from '@kamiazya/whiteboard-ports'
 import type { Value } from 'loro-crdt'
@@ -43,7 +44,7 @@ import {
 import { getDb, registerDbDisposeHook } from './db/index.js'
 import { prepareDataDir } from './db/prepare.js'
 import { getDocumentIdByPath, upsertWorkspaceRow } from './db/upsert-workspace.js'
-import { findDescendantPath, planSubtreeMove } from './document-path-tree.js'
+import { findDescendantPath, isSelfOrDescendant, planSubtreeMove } from './document-path-tree.js'
 import { LibsqlDocumentStore } from './libsql/libsql-document-store.js'
 import type { VersionStore } from './version-store.js'
 import { thumbnailPath } from './version-store.js'
@@ -797,6 +798,14 @@ export async function renameDocumentPath(
     const documentId = await getDocumentIdByPath(db, workspaceId, oldPath)
     if (!documentId) return null
     if (oldPath === newPath) return { documentId }
+    // The one rule planSubtreeMove leaves to its callers, and the index's
+    // moveDocument already enforces. Without it the depth-ordered write —
+    // correct for an upward move — is inverted, and the shallow row lands on
+    // a path its own descendant has not vacated, surfacing as a raw unique
+    // constraint error instead of an answer the caller can act on.
+    if (isSelfOrDescendant(newPath, oldPath)) {
+      throw new DocumentMoveIntoSelfError(oldPath, newPath)
+    }
 
     const rows = await db
       .selectFrom('documents')

--- a/packages/mcp-server/src/server/store/sqlite-document-index.ts
+++ b/packages/mcp-server/src/server/store/sqlite-document-index.ts
@@ -22,6 +22,7 @@ import {
 import { getLogger } from '../log.js'
 import type { Database } from './db/index.js'
 import { upsertWorkspaceRow } from './db/upsert-workspace.js'
+import { findDescendantPath, isSelfOrDescendant, planSubtreeMove } from './document-path-tree.js'
 import { withWorkspaceWriteLock } from './workspace-lock.js'
 
 /**
@@ -41,16 +42,6 @@ function toEntry(row: {
     ...(row.kind === null ? {} : { kind: row.kind as DocumentEntry['kind'] }),
     ...(row.displayName === null ? {} : { name: row.displayName }),
   }
-}
-
-/** How many segments a path has. */
-function depth(path: string): number {
-  return path.split('/').length
-}
-
-/** Whether `path` is `ancestor` itself or sits below it. */
-function isSelfOrDescendant(path: string, ancestor: string): boolean {
-  return path === ancestor || path.startsWith(`${ancestor}/`)
 }
 
 /**
@@ -212,46 +203,19 @@ export class SqliteDocumentIndex implements DocumentIndex {
           .where('workspaceId', '=', workspaceId)
           .execute()
 
-        const moving = rows.filter((row) => isSelfOrDescendant(row.path, from))
-        if (moving.length === 0) {
-          throw new DocumentNotFoundError(workspaceId, from)
+        const plan = planSubtreeMove(rows, from, to)
+        if (!plan.ok) {
+          throw plan.reason === 'not-found'
+            ? new DocumentNotFoundError(workspaceId, from)
+            : new DocumentPathTakenError(workspaceId, plan.path)
         }
-        const occupied = new Set(rows.map((row) => row.path))
-        const rewritten = moving.map((row) => ({
-          id: row.id,
-          from: row.path,
-          path: `${to}${row.path.slice(from.length)}`,
-        }))
-        // Every produced path, not just `to`: moving `a` onto a free `c`
-        // still collides when `a/d` and `c/d` both exist. Paths the move is
-        // vacating do not count as occupied, or relocating a subtree would
-        // always collide with itself.
-        const vacating = new Set(moving.map((row) => row.path))
-        for (const row of rewritten) {
-          if (occupied.has(row.path) && !vacating.has(row.path)) {
-            throw new DocumentPathTakenError(workspaceId, row.path)
-          }
-        }
-
-        // Shallowest source first, by DEPTH — not by path order. A move up
-        // into its own ancestor namespace sends a deeper row onto the path a
-        // shallower one is vacating, so the shallower write has to land
-        // first or the unique index rejects a move the contract requires to
-        // succeed. The two contending rows need not be ancestor and
-        // descendant of each other (`a/b/x` and `a/b/b/x` both branch below
-        // `a/b`), which is why segment-wise path order is not enough here: it
-        // would put `a/b/b/x` first because `b` precedes `x`. Only the depth
-        // difference is guaranteed, and it is: the row producing a contested
-        // path is always deeper than the row vacating it, by exactly the
-        // number of segments the move removes.
-        rewritten.sort((left, right) => depth(left.from) - depth(right.from))
 
         const now = Date.now()
-        for (const row of rewritten) {
+        for (const move of plan.moves) {
           await trx
             .updateTable('documents')
-            .set({ path: row.path, updatedAt: now })
-            .where('id', '=', row.id)
+            .set({ path: move.path, updatedAt: now })
+            .where('id', '=', move.id)
             .execute()
         }
       })
@@ -260,16 +224,16 @@ export class SqliteDocumentIndex implements DocumentIndex {
 
   async deleteDocument({ workspaceId, path }: DeleteDocumentInput): Promise<void> {
     await withWorkspaceWriteLock(workspaceId, async () => {
-      const descendant = await this.db
+      const rows = await this.db
         .selectFrom('documents')
-        .select('path')
+        .select(['id', 'path'])
         .where('workspaceId', '=', workspaceId)
-        .where('path', 'like', `${path}/%`)
-        .executeTakeFirst()
-      if (descendant) {
+        .execute()
+      const descendant = findDescendantPath(rows, path)
+      if (descendant !== undefined) {
         throw new DocumentHasDescendantsError(
           path,
-          `Delete "${descendant.path}" and any others below it first.`,
+          `Delete "${descendant}" and any others below it first.`,
         )
       }
       await this.db


### PR DESCRIPTION
Renaming or deleting a document path could silently strand every document below it. Both defects have the same origin, and it is structural.

## Two stores, one table, two answers

`document-store.ts` (HTTP) and `sqlite-document-index.ts` (MCP) both write the `documents` table, and are deliberately kept from importing each other. That is what let them grow different semantics for the same operation on the same rows.

| | MCP surface | HTTP surface (before) |
|---|---|---|
| rename/move a path | moves the whole subtree | **moved one row** |
| delete with descendants | refuses | **stranded them** |

Renaming `design` left `design/login` addressed below a prefix no document owns — produced by the ordinary act of renaming a group. The port already states the reasoning for the delete half: *deletion is the operation with nothing to undo it*, so the caller has to name what it is destroying. The HTTP surface just never held the same contract.

## The fix

The subtree arithmetic moves into `document-path-tree.ts` as pure functions over rows — collision detection across every *produced* path, and the depth-ordered write sequence — so both stores keep their own SQL and neither owns the semantics alone. Putting it in one place is the point: this is a divergence bug, and a second copy is how it happened.

The index moves onto the shared functions unchanged. Its conformance suite is what proves that: 28 tests, green before and after, unmodified.

Two things the rename needed beyond the arithmetic:

- **Cache eviction now covers every moved path**, not just the two the caller named. A stale doc instance cached under a child's old path would be resurrected by the next read through it and shadow the moved document.
- **Collision detection is per produced path.** Moving `a` onto a free `c` still collides when `a/x` and `c/x` both exist — a test pins exactly that, and it fails against a check that only looks at the destination.

`DELETE` answers **409 naming the offending descendant**, so the UI can say which document to deal with rather than reporting a server failure.

## Tests

Four red-first cases, each failing against the old code with the defect's own signature:

```
× renameDocumentPath > carries every descendant with the renamed path
    expected [ 'design/deep/notes', …(3) ] to deeply equal [ Array(4) ]
× renameDocumentPath > rejects a rename that would collide with an existing descendant path
    promise resolved "{ documentId: … }" instead of rejecting
× renameDocumentPath > evicts every moved path from the cache, not only the two named ones
    expected LoroDoc{ … } to be undefined
× deleteDocument > refuses to delete a document that still has descendants
    promise resolved "true" instead of rejecting
```

Two more guard the boundary the obvious implementation gets wrong: `design-system` is not inside `design`, so it neither moves with it nor blocks its deletion. A blind string replace passes the first rename test and fails that one.

The 409 mapping was written after its route fix, so it was mutation-checked rather than trusted: removing the `instanceof` branch turns it red (`expected 500 to be 409`), and the restore is verified by a printed count.

`mcp-node`: 3565 passed. `knip` and `lint` clean.

## Deliberately not here

A markdown document exports a **blank PNG** — `exportScene` renders its empty `SpatialCanvas` — which affects both the version thumbnail upload and the export menu. Withholding the capability would be the minimal fix, but the thumbnail work now in progress gives markdown a real render instead, so it lands there rather than as a temporary removal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented deletion of documents that contain nested descendants.
  * Added clear conflict responses identifying the descendant path blocking deletion.
  * Renaming a document now correctly moves its entire hierarchy.
  * Improved protection against rename collisions and preserved similarly named sibling documents.
  * Updated cached document data after hierarchical renames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->