### PR TITLE
refactor(canvas-render): one signal for every way content is hidden

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -581,10 +581,32 @@ paths:
     byte-identical. Verified honoured by resvg (the PNG export path) as well
     as browsers. A page embedding several of these SVGs repeats the mask id,
     which is harmless precisely because every copy is byte-identical.
-    NOT done, and deliberately: `sceneDigest` does not report truncation. A
-    fade says "there is more" without saying how much, and the digest carries
-    no text content to be inconsistent with — add it when a reader has a
-    reason to act on it.
+    **The SIGNAL is one fact with three readers, and that is the part to keep
+    uniform.** The POLICIES above differ for reasons — math is not cut, an
+    edge label has no box, a single code point has nothing below it to split.
+    The signal differing had none, and it left the commonest case silent:
+    three paragraphs in a box holding two rendered as a tidy two-paragraph
+    box, while a cut LINE faded. Anything removed now marks the last surviving
+    run (`markLastRun`), so a dropped block, a trimmed list item and a cut
+    line all say the same thing.
+    `sceneDigest` DOES report it now, as `truncated` on the node entry. This
+    reverses the earlier "add it when a reader has a reason to act on it" —
+    an agent authoring and reading canvases is that reader, and the fade is
+    only legible to someone looking at pixels. The fact rides the chrome
+    SHAPE because a node's content is a SIBLING of its chrome in the flat
+    scene list, so a digest walking top-level nodes could never correlate the
+    two on its own.
+    **Where the cut is DECIDED is `mdast-blocks.ts`** (`fitBlocksToHeight`),
+    not the spatial fitter that calls it: "which part of a block is a line"
+    is that module's own knowledge. Granularity steps down blocks -> lines
+    (a paragraph's runs) -> list items; `blockquote`/`table`/`code` stay
+    whole-block, their children not being lines. Whole-block alone leaves the
+    commonest body unbounded — a single long paragraph is ONE block, measured
+    at 112px in a 60px node before lines were reachable. Keep-first ("a text
+    node never renders empty") stays in `spatial-canvas.ts`, being a
+    spatial-node policy rather than a block one.
+    `layout/frame-containment-quality.test.ts` counts what the law hides —
+    a bound says nothing about how often its escape is taken.
     `layout/text-wrapping-quality.test.ts` is the scoreboard for all of this;
     see the Tests section.
 

--- a/packages/canvas-render/src/layout/mdast-blocks.ts
+++ b/packages/canvas-render/src/layout/mdast-blocks.ts
@@ -900,3 +900,100 @@ export function layoutMdastBlocks(root: MdastRoot, options: MdastLayoutOptions):
   const nodes = root.children.map((child) => layoutBlock(child, cursor, options, 0))
   return { nodes }
 }
+
+export interface FittedBlocks {
+  readonly nodes: readonly SceneNode[]
+  /** Something a reader cannot see was removed to make the rest fit. */
+  readonly truncated: boolean
+}
+
+/**
+ * Marks the LAST run in paint order, which is the one thing a reader can see
+ * next to whatever was removed.
+ *
+ * Rebuilds only the spine down to that run — every bbox is left exactly as
+ * laid out, so the wrapper-relative x convention (`subtreeOffsetX`) is
+ * untouched.
+ */
+function markLastRun(nodes: readonly SceneNode[]): readonly SceneNode[] {
+  for (let index = nodes.length - 1; index >= 0; index -= 1) {
+    const node = nodes[index] as SceneNode & {
+      runs?: readonly SceneNode[]
+      children?: readonly SceneNode[]
+      items?: readonly SceneNode[]
+    }
+    if (node.kind === 'textRun') {
+      const copy = [...nodes]
+      copy[index] = { ...node, truncated: true as const }
+      return copy
+    }
+    for (const key of ['runs', 'children', 'items'] as const) {
+      const branch = node[key]
+      if (branch === undefined || branch.length === 0) continue
+      const marked = markLastRun(branch)
+      if (marked !== branch) {
+        const copy = [...nodes]
+        copy[index] = { ...node, [key]: marked } as SceneNode
+        return copy
+      }
+    }
+  }
+  return nodes
+}
+
+/**
+ * Trims laid-out blocks to what fits `maxHeight`, and says whether anything
+ * was removed.
+ *
+ * Granularity steps down the way the wrap does: whole blocks first, then the
+ * LINES of the block that straddles the edge (`layoutPhrasing` emits one run
+ * per wrapped line) or the ITEMS of a list. Whole-block alone leaves the
+ * commonest body of all unbounded — a single long paragraph is ONE block, so
+ * it either fits or is kept whole and painted outside its box.
+ *
+ * `blockquote`/`table`/`code` stay whole-block: their children are not lines,
+ * and two of them are the `subtreeOffsetX` transform-boundary class.
+ *
+ * This lives here rather than beside the spatial fitter that calls it because
+ * "which part of a block is a line" is this module's own knowledge — the
+ * caller supplies a height and learns nothing about block internals.
+ */
+export function fitBlocksToHeight(nodes: readonly SceneNode[], maxHeight: number): FittedBlocks {
+  const kept: SceneNode[] = []
+  let truncated = false
+  for (const entry of nodes) {
+    // `layoutMdastBlocks` never emits an edge (the one variant with no
+    // `bbox`); that guard is for the type checker, not runtime.
+    if (entry.kind === 'edge') continue
+    if (entry.bbox.y + entry.bbox.h <= maxHeight) {
+      kept.push(entry)
+      continue
+    }
+    // The first block that does not fit is the last one considered: blocks
+    // are laid out with strictly increasing bottoms, so everything after it
+    // starts lower still.
+    const trimmed = trimBlock(entry, maxHeight)
+    if (trimmed !== undefined) kept.push(trimmed)
+    truncated = true
+    break
+  }
+  if (kept.length < nodes.length) truncated = true
+  return { nodes: truncated ? markLastRun(kept) : kept, truncated }
+}
+
+function trimBlock(
+  block: Exclude<SceneNode, { kind: 'edge' }>,
+  maxBottom: number,
+): SceneNode | undefined {
+  if (block.kind === 'list') {
+    const items = block.items.filter((item) => item.bbox.y + item.bbox.h <= maxBottom)
+    if (items.length === 0) return undefined
+    const bottom = Math.max(...items.map((item) => item.bbox.y + item.bbox.h))
+    return { ...block, items, bbox: { ...block.bbox, h: bottom - block.bbox.y } }
+  }
+  if (block.kind !== 'paragraph' && block.kind !== 'heading') return undefined
+  const runs = block.runs.filter((run) => run.bbox.y + run.bbox.h <= maxBottom)
+  if (runs.length === 0) return undefined
+  const bottom = Math.max(...runs.map((run) => run.bbox.y + run.bbox.h))
+  return { ...block, runs, bbox: { ...block.bbox, h: bottom - block.bbox.y } }
+}

--- a/packages/canvas-render/src/layout/overflow-signal.test.ts
+++ b/packages/canvas-render/src/layout/overflow-signal.test.ts
@@ -1,0 +1,146 @@
+// Every way content can vanish to keep a node inside its frame must SAY so,
+// in one language. The policies differ for reasons — inline math is never
+// cut, an edge label has no box to fit — but the SIGNAL differing has no
+// reason, and it left the commonest case silent: three paragraphs in a box
+// that holds two rendered as a tidy two-paragraph box with nothing to say a
+// third existed.
+
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import type { MdastRoot } from '@kamiazya/whiteboard-model/mdast'
+import { describe, expect, it } from 'vitest'
+import { sceneDigest } from '../scene-digest.js'
+import type { Scene, ShapeSceneNode } from '../scene-graph.js'
+import { createCorpusMeasure } from '../test-utils/text-wrapping-corpus.js'
+import { layoutSpatialCanvas } from './spatial-canvas.js'
+
+const APPEARANCE = {
+  resolveNode: () => ({}),
+  resolveEdge: () => ({}),
+  resolveLabel: () => ({}),
+}
+
+const paragraph = (value: string) => ({
+  type: 'paragraph' as const,
+  children: [{ type: 'text' as const, value }],
+})
+
+function layout(height: number, root: MdastRoot): Scene {
+  const canvas: SpatialCanvas = {
+    nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 200, height, text: 'x' }],
+    edges: [],
+  }
+  return layoutSpatialCanvas(canvas, {
+    measure: createCorpusMeasure().measure,
+    parseBody: () => root,
+    appearance: APPEARANCE,
+  })
+}
+
+/** Every text run in the scene, in paint order, with its fade flag. */
+function runs(scene: Scene): ReadonlyArray<{ text: string; truncated: boolean }> {
+  const out: { text: string; truncated: boolean }[] = []
+  const walk = (nodes: readonly unknown[]): void => {
+    for (const raw of nodes) {
+      const node = raw as {
+        kind: string
+        text?: string
+        truncated?: true
+        runs?: readonly unknown[]
+        children?: readonly unknown[]
+        items?: readonly unknown[]
+      }
+      if (node.kind === 'textRun') {
+        out.push({ text: node.text ?? '', truncated: node.truncated === true })
+      }
+      walk(node.runs ?? node.children ?? node.items ?? [])
+    }
+  }
+  walk(scene.nodes)
+  return out
+}
+
+function chrome(scene: Scene): ShapeSceneNode {
+  const shape = scene.nodes.find((node): node is ShapeSceneNode => node.kind === 'shape')
+  if (shape === undefined) throw new Error('no chrome shape')
+  return shape
+}
+
+const THREE_PARAGRAPHS: MdastRoot = {
+  type: 'root',
+  children: [
+    paragraph('これは段落0です。'),
+    paragraph('これは段落1です。'),
+    paragraph('これは段落2です。'),
+  ],
+}
+
+const ONE_LONG_PARAGRAPH: MdastRoot = {
+  type: 'root',
+  children: [paragraph('これは十分に長い日本語の文章で、折り返すと何行にもなります。')],
+}
+
+const LIST: MdastRoot = {
+  type: 'root',
+  children: [
+    {
+      type: 'list',
+      ordered: false,
+      children: [0, 1, 2, 3].map((i) => ({
+        type: 'listItem' as const,
+        children: [paragraph(`項目${i}`)],
+      })),
+    },
+  ],
+}
+
+describe('a node that hides content says so, however it was hidden', () => {
+  it('fades the last surviving line when a whole BLOCK was dropped', () => {
+    const painted = runs(layout(56, THREE_PARAGRAPHS))
+
+    expect(painted.length).toBeGreaterThan(0)
+    expect(painted.length).toBeLessThan(3)
+    expect(painted.at(-1)?.truncated).toBe(true)
+  })
+
+  it('fades the last surviving line when a LINE was cut', () => {
+    const painted = runs(layout(56, ONE_LONG_PARAGRAPH))
+
+    expect(painted.at(-1)?.truncated).toBe(true)
+  })
+
+  it('fades the last surviving line when a LIST ITEM was dropped', () => {
+    const painted = runs(layout(56, LIST))
+
+    expect(painted.length).toBeGreaterThan(0)
+    expect(painted.length).toBeLessThan(4)
+    expect(painted.at(-1)?.truncated).toBe(true)
+  })
+
+  it('marks nothing when everything fits', () => {
+    const painted = runs(layout(400, THREE_PARAGRAPHS))
+
+    expect(painted.length).toBe(3)
+    expect(painted.some((run) => run.truncated)).toBe(false)
+  })
+})
+
+describe('sceneDigest reports a node whose content did not fit', () => {
+  it('reports it, so a reader that cannot see a fade still knows', () => {
+    // The fade is for a human looking at pixels. An agent reads the digest,
+    // and until now had no way at all to learn that a node hides prose.
+    const digest = sceneDigest(layout(56, THREE_PARAGRAPHS))
+
+    expect(digest.nodes.find((node) => node.id === 'n1')?.truncated).toBe(true)
+  })
+
+  it('leaves it off a node that shows everything', () => {
+    const digest = sceneDigest(layout(400, THREE_PARAGRAPHS))
+
+    expect(digest.nodes.find((node) => node.id === 'n1')?.truncated).toBeUndefined()
+  })
+
+  it('carries the same fact the chrome does', () => {
+    expect(chrome(layout(56, THREE_PARAGRAPHS)).truncated).toBe(true)
+    expect(chrome(layout(400, THREE_PARAGRAPHS)).truncated).toBeUndefined()
+  })
+})

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -39,7 +39,12 @@ import type {
 import { SPATIAL_THEME_GEOMETRY, type SpatialGeometry } from '../theme/spatial-geometry.js'
 import { computeEdgeJumps } from './edge-jumps.js'
 import { edgeLabelAnchor } from './edge-label-anchor.js'
-import { layoutMdastBlocks, type MdastLayoutOptions } from './mdast-blocks.js'
+import {
+  type FittedBlocks,
+  fitBlocksToHeight,
+  layoutMdastBlocks,
+  type MdastLayoutOptions,
+} from './mdast-blocks.js'
 import { scaleScene } from './scale-scene.js'
 import type { SpatialAppearanceResolver } from './spatial-appearance.js'
 import {
@@ -332,6 +337,24 @@ function labelRun(text: string, options: ResolvedLayoutOptions, maxWidth: number
 }
 
 /** Moves a node's content from its own origin to the node's padded top-left. */
+/**
+ * The node's chrome, carrying whether its content had to be cut to fit.
+ *
+ * The same fact the fade marks on the last surviving run, put where a READER
+ * of the scene can find it: `sceneDigest` reports per addressable node, and a
+ * node's content is a SIBLING of its chrome in the flat scene list, so a
+ * digest could never correlate the two on its own. A fade is for a human
+ * looking at pixels; an agent reads the digest and otherwise learns nothing.
+ */
+function chromeWithFit(
+  node: SpatialNode,
+  options: ResolvedLayoutOptions,
+  truncated: boolean,
+): ShapeSceneNode {
+  const chrome = chromeShape(node, options)
+  return truncated ? { ...chrome, truncated: true } : chrome
+}
+
 function placeInNode(
   node: SpatialNode,
   content: Scene,
@@ -379,8 +402,17 @@ function placeAboveNode(node: SpatialNode, content: Scene): readonly SceneNode[]
  * The sibling seams keep `fitSceneInNode`'s `undefined` because they DO have
  * somewhere better to go — the plain chrome-and-label rendering.
  */
-function fitTextBody(scene: Scene, node: SpatialNode, options: ResolvedLayoutOptions): Scene {
-  return fitSceneInNode(scene, node, options) ?? { nodes: scene.nodes.slice(0, 1) }
+function fitTextBody(
+  scene: Scene,
+  node: SpatialNode,
+  options: ResolvedLayoutOptions,
+): FittedBlocks {
+  return (
+    fitSceneInNode(scene, node, options) ?? {
+      nodes: scene.nodes.slice(0, 1),
+      truncated: scene.nodes.length > 1,
+    }
+  )
 }
 
 function composeTextNode(
@@ -388,7 +420,7 @@ function composeTextNode(
   options: ResolvedLayoutOptions,
 ): readonly SceneNode[] {
   const maxWidth = contentWidth(node.width, options)
-  let body: Scene
+  let body: FittedBlocks
   try {
     const laid = layoutMdastBlocks(options.parseBody(node.text), mdastOptionsFor(maxWidth, options))
     body = fitTextBody(laid, node, options)
@@ -396,7 +428,10 @@ function composeTextNode(
     options.onDegrade?.({ kind: 'body-parse-failed', nodeId: node.id, err })
     body = fitTextBody({ nodes: [labelRun(node.text, options, maxWidth)] }, node, options)
   }
-  return [chromeShape(node, options), ...placeInNode(node, body, options)]
+  return [
+    chromeWithFit(node, options, body.truncated),
+    ...placeInNode(node, { nodes: body.nodes }, options),
+  ]
 }
 
 /**
@@ -541,84 +576,23 @@ function contentBox(
  * passing through here paints outside the frame, which is a rendering
  * defect this package's "what cannot fit is cut" contract forbids.
  */
-/**
- * Trims a block to the LINES of it that fit, for the two block kinds whose
- * runs are lines (`layoutMdastBlocks` emits one run per wrapped line).
- *
- * Whole-block granularity alone leaves the commonest shape unbounded: a
- * single long paragraph is ONE block, so a body that is one paragraph either
- * fits or is kept whole and painted outside the frame. Measured before this
- * existed — a paragraph laid out at 112px in a 60px node reached y=120,
- * twice the height of the box it lives in.
- *
- * `undefined` when not even the first line fits, leaving the keep-first
- * decision to the caller. `list`/`table`/`blockquote` stay whole-block: their
- * children are not lines, and two of them are the `subtreeOffsetX`
- * transform-boundary class this package keeps at arm's length.
- */
-function fitBlockLines(
-  block: Exclude<SceneNode, { kind: 'edge' }>,
-  maxBottom: number,
-): SceneNode | undefined {
-  // A list's ITEMS are its lines-equivalent: one row each, laid out with
-  // increasing bottoms, so the same prefix trim applies. Measured as the
-  // worst offender before this — a list escaped its frame even at a box only
-  // 20% too small, where every prose case survived. Only the items are
-  // filtered; their descendants are never read, so the `subtreeOffsetX`
-  // transform-boundary rule is untouched.
-  if (block.kind === 'list') {
-    const items = block.items.filter((item) => item.bbox.y + item.bbox.h <= maxBottom)
-    if (items.length === 0 || items.length === block.items.length) return undefined
-    const bottom = Math.max(...items.map((item) => item.bbox.y + item.bbox.h))
-    return { ...block, items, bbox: { ...block.bbox, h: bottom - block.bbox.y } }
-  }
-  if (block.kind !== 'paragraph' && block.kind !== 'heading') return undefined
-  const kept = block.runs.filter((run) => run.bbox.y + run.bbox.h <= maxBottom)
-  if (kept.length === 0 || kept.length === block.runs.length) return undefined
-
-  // The last surviving line carries the fade the SVG backend already paints
-  // for a horizontally cut run, so a vertical cut says "there is more" in
-  // the same visual language rather than ending silently.
-  const runs = kept.map((run, index) =>
-    index === kept.length - 1 ? { ...run, truncated: true as const } : run,
-  )
-  const bottom = Math.max(...runs.map((run) => run.bbox.y + run.bbox.h))
-  return { ...block, runs, bbox: { ...block.bbox, h: bottom - block.bbox.y } }
-}
-
 function fitSceneInNode(
   scene: Scene,
   node: SpatialNode,
   options: ResolvedLayoutOptions,
-): Scene | undefined {
-  if (!options.fitToBox) return scene
+): FittedBlocks | undefined {
+  if (!options.fitToBox) return { nodes: scene.nodes, truncated: false }
   const box = contentBox(node, options)
   if (box === undefined) return undefined
-
-  // Neither producer emits an edge (the one SceneNode variant with no
-  // `bbox`); that guard is for the type checker, not runtime.
-  const fitted: SceneNode[] = []
-  for (const entry of scene.nodes) {
-    if (entry.kind === 'edge') continue
-    if (entry.bbox.y + entry.bbox.h <= box.h) {
-      fitted.push(entry)
-      continue
-    }
-    // The first block that does not fit is the last one considered: every
-    // block after it starts lower still, and `layoutMdastBlocks` lays them
-    // out with strictly increasing bottoms.
-    const trimmed = fitBlockLines(entry, box.h)
-    if (trimmed !== undefined) fitted.push(trimmed)
-    break
-  }
-  return fitted.length === 0 ? undefined : { nodes: fitted }
+  const fitted = fitBlocksToHeight(scene.nodes, box.h)
+  return fitted.nodes.length === 0 ? undefined : fitted
 }
 
 function fitBodyInNode(
   node: SpatialNode,
   root: MdastRoot,
   options: ResolvedLayoutOptions,
-): Scene | undefined {
+): FittedBlocks | undefined {
   // The degenerate-box guard is part of FITTING, not of laying out: under
   // `naturalNodeContentSize` there is no box to be degenerate against, and
   // returning `undefined` here made a file node fall back to its label, so
@@ -661,7 +635,7 @@ function composeFileMarkdown(
   // per-node guard in the composition loop, takes the WHOLE canvas with it.
   // That would break this package's documented never-throw rule
   // (package-canvas-render.md) at the one seam that made it reachable.
-  let body: Scene | undefined
+  let body: FittedBlocks | undefined
   try {
     body = fitBodyInNode(node, root, options)
   } catch (err) {
@@ -670,9 +644,9 @@ function composeFileMarkdown(
   }
   if (body === undefined) return undefined
 
-  const chrome = chromeShape(node, options)
+  const chrome = chromeWithFit(node, options, body.truncated)
   const label = labelOf(node, resolved)
-  const placed = placeInNode(node, body, options)
+  const placed = placeInNode(node, { nodes: body.nodes }, options)
   return label === undefined
     ? [chrome, ...placed]
     : [
@@ -728,7 +702,10 @@ function composeFileFacets(
   const body = fitBodyInNode(node, { type: 'root', children: blocks }, options)
   if (body === undefined) return undefined
 
-  return [chromeShape(node, options), ...placeInNode(node, body, options)]
+  return [
+    chromeWithFit(node, options, body.truncated),
+    ...placeInNode(node, { nodes: body.nodes }, options),
+  ]
 }
 
 /**

--- a/packages/canvas-render/src/scene-digest.ts
+++ b/packages/canvas-render/src/scene-digest.ts
@@ -14,7 +14,20 @@ import type { BoundingBox, Scene } from './scene-graph.js'
 const bboxSchema = z.object({ x: z.number(), y: z.number(), w: z.number(), h: z.number() })
 
 export const sceneDigestSchema = z.object({
-  nodes: z.array(z.object({ id: z.string(), bbox: bboxSchema, z: z.number().int() })),
+  nodes: z.array(
+    z.object({
+      id: z.string(),
+      bbox: bboxSchema,
+      z: z.number().int(),
+      /**
+       * Present only when this node's content was cut to fit its box, so a
+       * reader knows the document holds more than the canvas shows. The
+       * painted half of the same fact is a fade on the last surviving line,
+       * which a reader of this JSON never sees.
+       */
+      truncated: z.literal(true).optional(),
+    }),
+  ),
   overlaps: z.array(z.tuple([z.string(), z.string()])),
   containment: z.array(z.object({ parent: z.string(), child: z.string() })),
   clusters: z.array(z.array(z.string())),
@@ -47,6 +60,7 @@ interface DigestEntry {
   readonly id: string
   readonly bbox: BoundingBox
   readonly z: number
+  readonly truncated?: true
 }
 
 function overlapArea(a: BoundingBox, b: BoundingBox): number {
@@ -224,9 +238,13 @@ function computeFreeRegions(entries: readonly DigestEntry[]): BoundingBox[] {
  * every bbox-carrying node, named by position. There is nothing better to
  * name them by, and the alternative is answering with nothing.
  */
-function collectEntries(scene: Scene): { readonly id?: string; readonly bbox: BoundingBox }[] {
+function collectEntries(
+  scene: Scene,
+): { readonly id?: string; readonly bbox: BoundingBox; readonly truncated?: true }[] {
   const identified = scene.nodes.flatMap((node) =>
-    node.kind === 'shape' && node.id !== undefined ? [{ id: node.id, bbox: node.bbox }] : [],
+    node.kind === 'shape' && node.id !== undefined
+      ? [{ id: node.id, bbox: node.bbox, ...(node.truncated ? { truncated: true as const } : {}) }]
+      : [],
   )
   if (identified.length > 0) return identified
   return scene.nodes.flatMap((node) => (node.kind === 'edge' ? [] : [{ bbox: node.bbox }]))
@@ -243,10 +261,16 @@ export function sceneDigest(scene: Scene): SceneDigest {
     id: entry.id ?? `n${index}`,
     bbox: entry.bbox,
     z: index,
+    ...(entry.truncated ? { truncated: true as const } : {}),
   }))
 
   return {
-    nodes: entries.map((e) => ({ id: e.id, bbox: e.bbox, z: e.z })),
+    nodes: entries.map((e) => ({
+      id: e.id,
+      bbox: e.bbox,
+      z: e.z,
+      ...(e.truncated ? { truncated: true as const } : {}),
+    })),
     overlaps: computeOverlaps(entries),
     containment: computeContainment(entries),
     clusters: computeClusters(entries),

--- a/packages/canvas-render/src/scene-graph.ts
+++ b/packages/canvas-render/src/scene-graph.ts
@@ -91,6 +91,14 @@ export interface TextRunNode {
 export interface ShapeSceneNode {
   readonly kind: 'shape'
   /**
+   * The node's content had to be cut to fit this box, so a reader is seeing
+   * less than the document holds. Semantic provenance like `id`: the SVG
+   * backend never emits it — the FADE on the last surviving run is the
+   * painted half of the same fact — and `sceneDigest` reports it, which is
+   * the only way a reader that is not looking at pixels can learn it.
+   */
+  readonly truncated?: true
+  /**
    * The DOCUMENT node this chrome belongs to, when the scene was built from
    * one. Semantic provenance in the same sense as a heading's `level` — the
    * SVG backend never emits it, but `sceneDigest` needs it to name what it


### PR DESCRIPTION
Answering "aren't the text primitives handling overflow inconsistently?" — they were, and the useful split is that the **policies** differ for reasons while the **signal** differed for none.

## The map

Eleven decision points, three of which said anything:

| primitive | axis | behaviour | signal |
|---|---|---|---|
| node label | width | cut | ✅ fade |
| code / raw HTML run | width | cut | ✅ fade |
| **inline math** | width | **left to overflow** | — *(declared: `a+b+c` cut to `a+b` reads as a complete formula that is wrong)* |
| normal text | width | wrapped | n/a |
| **single code point** | width | **left to overflow** | — *(declared: nothing below it to split)* |
| **edge label** | width | **not cut** | — *(declared: no box to fit against)* |
| **block** | height | **dropped whole** | ❌ **none** |
| paragraph/heading line | height | prefix kept | ✅ fade |
| **list item** | height | **prefix kept** | ❌ **none** |
| **keep-first element** | height | kept, paints outside | ❌ none |

Measured before this:

```
BLOCK DROP: [{"text":"これは段落0です。","truncated":false},
             {"text":"これは段落1です。","truncated":false}]
LINE CUT:   truncated flags = false,true
```

Three paragraphs in a box that holds two rendered as a tidy two-paragraph box with **nothing to say a third existed**, while a cut line faded. Same function, same meaning, two answers — both written in #883.

## Three changes, one fact

**Where it is decided.** `fitBlocksToHeight` moves to `mdast-blocks.ts`, which owns block structure and knows a paragraph's runs are its lines. The spatial fitter had been reaching into `block.runs` from another module since #883; it now supplies a height and learns nothing about internals. Keep-first stays in `spatial-canvas.ts` — *"a text node never renders empty"* is a spatial-node policy.

**The fade, uniformly.** Anything removed marks the last surviving run. `markLastRun` rebuilds only the spine down to that run, so every bbox is exactly as laid out and the wrapper-relative x convention is untouched.

**The digest.** `sceneDigest` reported nothing about truncation, recorded in the package rule as deliberate — *"add it when a reader has a reason to act on it"*. **An agent authoring and reading canvases is that reader**: the fade is for a human looking at pixels, and an agent could not learn that a node hides prose at all. The fact rides the chrome shape because a node's content is a **sibling** of its chrome in the flat scene list, so a digest could never correlate the two on its own. The rule is updated to record what shipped.

## Behaviour is unchanged, and the scoreboard proves it

Same `{ hidden: 3, crossed: 13 }` over the same corpus. This changes what is **said**, not what is shown.

## Mutation-checked

| mutation | reddens |
|---|---|
| drop the marking | the three fade tests, nothing else |
| drop the chrome fact | the two digest tests, nothing else |

One property (`edge-crossing-sweep`) failed once mid-verification with `seed=1242995680`. **Re-running with that seed pinned passes**, so it was not a counterexample — failure counts varied 4/5/1/0 across identical runs, which is the load-dependent family in task #35, not this diff.

## Verification

node projects **4463** · browser projects **665** · apps/web jsdom **2329 + 77** · widget smoke **PASS** · typecheck, lint, knip clean.