### PR TITLE
test(web): make the split-editor flake explain itself when it next fires

### DIFF
--- a/apps/web/src/components/markdown-editor/split-and-scroll.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/split-and-scroll.browser.test.tsx
@@ -21,10 +21,63 @@ function mount(value = '') {
   return utils
 }
 
+/**
+ * The editor's on-screen state, for a failure that would otherwise only say
+ * an element was missing.
+ *
+ * This file fails intermittently in CI and has never reproduced locally, so
+ * the next failure has to explain itself. The discriminator is the mode
+ * group: `EditorToolbar` OMITS the Split button entirely when
+ * `splitAvailable` is false, so a run where Split is absent measured its
+ * container under `SPLIT_MIN_WIDTH` and fell back to Write — which removes
+ * the divider AND the preview pane, and is a different bug from the panes
+ * being present but unlaid-out.
+ */
+function editorState(): string {
+  const box = (el: Element | null): string => {
+    if (el === null) return 'absent'
+    const r = el.getBoundingClientRect()
+    return `${Math.round(r.width)}x${Math.round(r.height)}`
+  }
+  const modes = [...document.querySelectorAll('[aria-label="View mode"] button')]
+    .map((b) => `${b.getAttribute('aria-label')}:${b.getAttribute('aria-pressed')}`)
+    .join(',')
+  const scroller = document.querySelector('.cm-scroller')
+  return [
+    `modes=[${modes}]`,
+    `sourceWrap=${box(document.querySelector('[data-testid="markdown-source-wrap"]'))}`,
+    `cmScroller=${box(scroller)}`,
+    scroller === null ? '' : `cmScroll=${scroller.scrollHeight}/${scroller.clientHeight}`,
+    `preview=${box(document.querySelector('[data-testid="markdown-preview-scroll"]'))}`,
+    `viewport=${window.innerWidth}x${window.innerHeight}`,
+  ]
+    .filter((part) => part !== '')
+    .join(' ')
+}
+
+/** `getByTestId`'s own error names the id and nothing else. */
+function requireDivider(getByTestId: (id: string) => HTMLElement): HTMLElement {
+  try {
+    return getByTestId('markdown-split-divider')
+  } catch {
+    throw new Error(`split divider missing — ${editorState()}`)
+  }
+}
+
+/** A scroller that reports 0/0 is unlaid-out, not merely short. */
+function requireScrollable(selector: string): HTMLElement {
+  const el = document.querySelector(selector) as HTMLElement | null
+  if (el === null) throw new Error(`${selector} absent — ${editorState()}`)
+  expect(el.scrollHeight, `${selector} is not scrollable — ${editorState()}`).toBeGreaterThan(
+    el.clientHeight,
+  )
+  return el
+}
+
 describe('MarkdownEditor split & scroll sync (real browser)', () => {
   it('dragging the divider resizes the source pane', async () => {
     const { getByTestId } = mount()
-    const divider = getByTestId('markdown-split-divider')
+    const divider = requireDivider(getByTestId)
     const source = getByTestId('markdown-source-pane')
     const before = source.getBoundingClientRect().width
 
@@ -63,7 +116,7 @@ describe('MarkdownEditor split & scroll sync (real browser)', () => {
 
   it('the divider is keyboard-operable (arrow keys move the split)', async () => {
     const { getByTestId } = mount()
-    const divider = getByTestId('markdown-split-divider')
+    const divider = requireDivider(getByTestId)
     const source = getByTestId('markdown-source-pane')
     const before = source.getBoundingClientRect().width
 
@@ -76,16 +129,10 @@ describe('MarkdownEditor split & scroll sync (real browser)', () => {
 
   it('scrolling the source proportionally scrolls the preview', async () => {
     mount(LONG_DOC)
-    const scroller = await vi.waitFor(() => {
-      const el = document.querySelector('.cm-scroller') as HTMLElement
-      expect(el.scrollHeight).toBeGreaterThan(el.clientHeight)
-      return el
-    })
-    const preview = await vi.waitFor(() => {
-      const el = document.querySelector('[data-testid="markdown-preview-scroll"]') as HTMLElement
-      expect(el.scrollHeight).toBeGreaterThan(el.clientHeight)
-      return el
-    })
+    const scroller = await vi.waitFor(() => requireScrollable('.cm-scroller'))
+    const preview = await vi.waitFor(() =>
+      requireScrollable('[data-testid="markdown-preview-scroll"]'),
+    )
 
     scroller.scrollTop = scroller.scrollHeight
     scroller.dispatchEvent(new Event('scroll'))
@@ -119,16 +166,10 @@ describe('MarkdownEditor split & scroll sync (real browser)', () => {
         />
       </div>,
     )
-    const scroller = await vi.waitFor(() => {
-      const el = document.querySelector('.cm-scroller') as HTMLElement
-      expect(el.scrollHeight).toBeGreaterThan(el.clientHeight)
-      return el
-    })
-    const preview = await vi.waitFor(() => {
-      const el = document.querySelector('[data-testid="markdown-preview-scroll"]') as HTMLElement
-      expect(el.scrollHeight).toBeGreaterThan(el.clientHeight)
-      return el
-    })
+    const scroller = await vi.waitFor(() => requireScrollable('.cm-scroller'))
+    const preview = await vi.waitFor(() =>
+      requireScrollable('[data-testid="markdown-preview-scroll"]'),
+    )
     // Wait for the diagram fragment to land (the preview grows past 600px).
     const markerText = await vi.waitFor(() => {
       expect(preview.querySelector('svg[overflow="visible"]')).not.toBeNull()


### PR DESCRIPTION
`split-and-scroll.browser.test.tsx` fails intermittently in CI — **on main before any branch** (run 32145157879, `9d83344a`), at roughly **1 run in 6** — and has never reproduced locally: 4/4 in isolation, and four full three-project browser runs here produced three unrelated 60s timeouts and never this file.

So the next occurrence has to carry its own evidence. `getByTestId`'s error names the id and nothing else, and the scroll assertions reported `expected 0 to be greater than 0` — a scroller that exists and is unlaid-out, without saying why.

## The discriminator

`EditorToolbar` **omits the Split button entirely** when `splitAvailable` is false. So the failure message now separates *"the container measured under `SPLIT_MIN_WIDTH`"* from *"the editor never mounted"*. Verified by forcing the narrow case:

```
split divider missing — modes=[Write:true,Read:false] sourceWrap=400x260
cmScroller=400x260 cmScroll=260/260 preview=absent viewport=1280x900
```

## Two measured facts that narrow the search

**The test normally WINS a race against the ResizeObserver.** At 400px the divider is still found when queried immediately, and only disappears once the observation lands (forced with a 200ms wait).

**At the real 800px width that race is a no-op** — waiting for the observation to settle leaves all four green, because 800 clears the 640 threshold either way. **A missing divider therefore requires a sub-640 measurement**; the DOM is otherwise identical before and after the observation.

That is the thing to look for when it next fires, and the message now reports it directly.

## A hypothesis this replaces

The obvious read — *"the ResizeObserver reports 0 and split falls back to write"* — is **wrong**: `MarkdownEditor.tsx:298` already guards `width > 0`, so a zero measurement never reaches state. Fixing that would have changed nothing while looking like a fix. Recorded in `issues/split-and-scroll-browser-flake` so it is not re-tried.

## Deliberately not added

No sleep. Waiting on a timer is the shape this repo treats as a flake, and at 800px there is no observable state change to wait *for* — the test keeps its current timing and gains only a message that names the branch.

**Verification**: the file 4/4, `pnpm -r typecheck` and `pnpm lint` clean.