### PR TITLE
fix(server-core): measure CJK at a full em in the agent-facing estimator

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -94,6 +94,17 @@ paths:
    `measureText` in the browser). Layout never passes a string containing
    a newline to `measure`, and clamps any non-finite `advanceWidth` to `0`
    (`clampAdvance`) before it reaches geometry.
+   `isFullWidthCodePoint` also lives here, and is the one exception to "this
+   package never measures text": an ESTIMATING measurer (one with no font to
+   read an advance from) cannot do without it, and two of them exist —
+   server-core's agent-facing `fallbackMeasureText` and the text-wrapping
+   scoreboard's corpus measurer. Sharing it is not tidiness: charging every
+   character one ratio is not an approximation of Japanese but the wrong
+   model (`これは日本語です` measured 56.8px against a true 128px, and
+   `wb_scene_digest` answered `truncated` absent for a node the editor was
+   fading), and two estimators disagreeing about which code points are wide
+   would break the same canvas differently depending on which one ran. Each
+   estimator keeps its OWN Latin ratio. A real measurer never calls it.
 4. **`ResolvedDocBundle` contract** (`layout/embed-recursion.ts`): minimal,
    internal/versioned shape consumed later by loro-adapter's View-
    resolution layer. Root depth is `0`; a 4th nesting level is the cap

--- a/packages/canvas-render/src/index.ts
+++ b/packages/canvas-render/src/index.ts
@@ -32,7 +32,7 @@ export {
 } from './layout/spatial-edges.js'
 export { translateScene } from './layout/translate-scene.js'
 export type { FontDescriptor, MeasureText, TextMetrics } from './measure.js'
-export { clampAdvance } from './measure.js'
+export { clampAdvance, isFullWidthCodePoint } from './measure.js'
 export { MIN_SCENE_EXTENT_PX, sceneBounds } from './scene-bounds.js'
 export type { SceneDigest } from './scene-digest.js'
 export { sceneDigest, sceneDigestSchema } from './scene-digest.js'

--- a/packages/canvas-render/src/measure.ts
+++ b/packages/canvas-render/src/measure.ts
@@ -41,3 +41,32 @@ export type MeasureText = (text: string, font: FontDescriptor) => TextMetrics
 export function clampAdvance(advanceWidth: number): number {
   return Number.isFinite(advanceWidth) && advanceWidth >= 0 ? advanceWidth : 0
 }
+
+/**
+ * Whether a code point occupies a full em rather than the ~half a Latin
+ * letter takes: the fullwidth/CJK blocks of Unicode.
+ *
+ * This package never measures text itself, so this is not a measurer — it is
+ * the one piece of width knowledge an ESTIMATING measurer cannot do without,
+ * and it lives here because two of them exist in different packages. A
+ * measurer that charges every character the same fraction is not an
+ * approximation of Japanese, it is the wrong model, and the two estimators
+ * disagreeing about which code points are wide would put a canvas's line
+ * breaks in different places depending on which one laid it out.
+ *
+ * A real measurer (opentype.js, Canvas `measureText`) has no use for this:
+ * it reads the advance from the font.
+ */
+export function isFullWidthCodePoint(codePoint: number): boolean {
+  return (
+    (codePoint >= 0x1100 && codePoint <= 0x115f) || // Hangul Jamo
+    (codePoint >= 0x3000 && codePoint <= 0x303f) || // CJK symbols and punctuation
+    (codePoint >= 0x3040 && codePoint <= 0x30ff) || // hiragana + katakana
+    (codePoint >= 0x3400 && codePoint <= 0x4dbf) || // CJK extension A
+    (codePoint >= 0x4e00 && codePoint <= 0x9fff) || // CJK unified ideographs
+    (codePoint >= 0xac00 && codePoint <= 0xd7a3) || // Hangul syllables
+    (codePoint >= 0xf900 && codePoint <= 0xfaff) || // CJK compatibility ideographs
+    (codePoint >= 0xff00 && codePoint <= 0xff60) || // fullwidth forms
+    (codePoint >= 0x1f300 && codePoint <= 0x1faff) // emoji
+  )
+}

--- a/packages/canvas-render/src/test-utils/text-wrapping-corpus.ts
+++ b/packages/canvas-render/src/test-utils/text-wrapping-corpus.ts
@@ -1,5 +1,10 @@
 import type { MdastRoot } from '@kamiazya/whiteboard-model/mdast'
-import type { FontDescriptor, MeasureText, TextMetrics } from '../measure.js'
+import {
+  type FontDescriptor,
+  isFullWidthCodePoint,
+  type MeasureText,
+  type TextMetrics,
+} from '../measure.js'
 
 /**
  * The text-wrapping scoreboard's corpus and its measurer.
@@ -19,24 +24,12 @@ import type { FontDescriptor, MeasureText, TextMetrics } from '../measure.js'
  * arithmetic — no font, no platform text API — so results are identical on
  * every machine.
  *
- * Ranges are the fullwidth/CJK blocks of Unicode: CJK ideographs and their
- * extension A, hiragana, katakana, Hangul syllables, CJK symbols and
- * punctuation, and the fullwidth forms.
+ * Which code points are wide is `measure.ts`'s `isFullWidthCodePoint`, shared
+ * with server-core's agent-facing estimator: two estimators disagreeing about
+ * that would lay the same canvas out differently depending on which one ran.
+ * The Latin ratio is each estimator's own — this one reports a scoreboard,
+ * that one drives a `truncated` verdict.
  */
-function isFullWidth(codePoint: number): boolean {
-  return (
-    (codePoint >= 0x1100 && codePoint <= 0x115f) || // Hangul Jamo
-    (codePoint >= 0x3000 && codePoint <= 0x303f) || // CJK symbols and punctuation
-    (codePoint >= 0x3040 && codePoint <= 0x30ff) || // hiragana + katakana
-    (codePoint >= 0x3400 && codePoint <= 0x4dbf) || // CJK extension A
-    (codePoint >= 0x4e00 && codePoint <= 0x9fff) || // CJK unified ideographs
-    (codePoint >= 0xac00 && codePoint <= 0xd7a3) || // Hangul syllables
-    (codePoint >= 0xf900 && codePoint <= 0xfaff) || // CJK compatibility ideographs
-    (codePoint >= 0xff00 && codePoint <= 0xff60) || // fullwidth forms
-    (codePoint >= 0x1f300 && codePoint <= 0x1faff) // emoji
-  )
-}
-
 const LATIN_RATIO = 0.6
 
 /** Advance width in em units — the width-model half of the measurer. */
@@ -44,7 +37,7 @@ function advanceEm(text: string): number {
   let em = 0
   for (const char of text) {
     const codePoint = char.codePointAt(0)
-    em += codePoint !== undefined && isFullWidth(codePoint) ? 1 : LATIN_RATIO
+    em += codePoint !== undefined && isFullWidthCodePoint(codePoint) ? 1 : LATIN_RATIO
   }
   return em
 }

--- a/packages/server-core/src/render/fallback-measure.test.ts
+++ b/packages/server-core/src/render/fallback-measure.test.ts
@@ -50,3 +50,36 @@ describe('fallbackMeasureText', () => {
     expect(metrics.advanceWidth).toBeGreaterThan(0)
   })
 })
+
+describe('fullwidth text', () => {
+  const font = {
+    family: 'Roboto',
+    fallbackChain: ['sans-serif'],
+    weight: 400 as const,
+    style: 'normal' as const,
+    sizePx: 16,
+  }
+
+  // A uniform per-character ratio is not an approximation of Japanese, it is
+  // the wrong model: a kana occupies a full em where a Latin letter occupies
+  // about half of one. The agent-facing digest and SVG are laid out with this
+  // measurer, so a canvas written in Japanese came back with line breaks and
+  // a `truncated` verdict computed from widths roughly half the truth.
+  it('charges a fullwidth character a full em', () => {
+    expect(fallbackMeasureText('あ', font).advanceWidth).toBeCloseTo(16, 5)
+    expect(fallbackMeasureText('日本語', font).advanceWidth).toBeCloseTo(48, 5)
+  })
+
+  it('still charges a Latin character about half an em', () => {
+    const perChar = fallbackMeasureText('abcdefghij', font).advanceWidth / 10
+    expect(perChar).toBeGreaterThan(16 * 0.4)
+    expect(perChar).toBeLessThan(16 * 0.7)
+  })
+
+  it('adds the two up for mixed text', () => {
+    // 3 fullwidth + 3 Latin.
+    const mixed = fallbackMeasureText('日本語abc', font).advanceWidth
+    const latin = fallbackMeasureText('abc', font).advanceWidth
+    expect(mixed).toBeCloseTo(48 + latin, 5)
+  })
+})

--- a/packages/server-core/src/render/fallback-measure.truncation.test.ts
+++ b/packages/server-core/src/render/fallback-measure.truncation.test.ts
@@ -1,0 +1,41 @@
+// The agent-facing verdict this measurer decides: `wb_scene_digest` reports
+// `truncated` per node, and it is laid out here rather than in a browser. A
+// measurer that thinks Japanese is half as wide as it is tells an agent a
+// node hides nothing while the editor is showing the reader a fade.
+import { layoutSpatialCanvas } from '@kamiazya/whiteboard-canvas-render'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { describe, expect, it } from 'vitest'
+import { fallbackMeasureText } from './fallback-measure.js'
+
+const APPEARANCE = { resolveNode: () => ({}), resolveEdge: () => ({}), resolveLabel: () => ({}) }
+
+function truncatedOf(text: string, width: number, height: number): boolean {
+  const canvas: SpatialCanvas = {
+    nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width, height, text }],
+    edges: [],
+  }
+  const scene = layoutSpatialCanvas(canvas, {
+    measure: fallbackMeasureText,
+    appearance: APPEARANCE,
+  })
+  const shape = scene.nodes.find((node) => node.kind === 'shape')
+  return (shape as { truncated?: true } | undefined)?.truncated === true
+}
+
+describe('the truncation verdict a Japanese canvas gets from the server', () => {
+  it('sees the wrap that a half-width model missed', () => {
+    // 18 fullwidth characters in a 200px box: 18 em = 288px of ink against
+    // 184px of content width, so it wraps to two lines and the second does
+    // not fit a 32px-high node. A 0.55/char model put the same text at 158px
+    // — one line — and reported nothing hidden.
+    expect(truncatedOf('これは日本語のテキストで折り返します', 200, 32)).toBe(true)
+  })
+
+  it('leaves a node that genuinely fits alone', () => {
+    expect(truncatedOf('これは日本語のテキストで折り返します', 200, 400)).toBe(false)
+  })
+
+  it('does not start truncating Latin text that used to fit', () => {
+    expect(truncatedOf('short latin line', 200, 32)).toBe(false)
+  })
+})

--- a/packages/server-core/src/render/fallback-measure.ts
+++ b/packages/server-core/src/render/fallback-measure.ts
@@ -1,17 +1,44 @@
-import type { MeasureText } from '@kamiazya/whiteboard-canvas-render'
+import { isFullWidthCodePoint, type MeasureText } from '@kamiazya/whiteboard-canvas-render'
 
 /**
- * Deterministic average-character-width estimator. Not a real font metric —
- * server-core is a shared layer forbidden from loading fonts
- * (architecture-map.md) — just enough to produce stable, finite bounding
- * boxes for the render/digest tools until a composition root injects a
- * real measurer via a future ServerDeps extension.
+ * Deterministic width estimator for the agent-facing layout tools.
+ *
+ * Not a real font metric — server-core is a shared layer forbidden from
+ * loading fonts (architecture-map.md) — but it is SCRIPT-AWARE, which a
+ * single per-character ratio is not. A kana or ideograph occupies a full em
+ * where a Latin letter occupies about half of one, so charging every
+ * character the same fraction is not an approximation of Japanese, it is the
+ * wrong model: measured, a uniform ratio put `これは日本語です` at 56.8px
+ * against a true 128px.
+ *
+ * That mattered because `wb_scene_digest` and `wb_scene_render` are laid out
+ * with this measurer. A canvas written in Japanese came back with line breaks
+ * and a `truncated` verdict computed from widths roughly half the truth — an
+ * agent was told a node hid nothing while the editor showed the reader a fade.
+ *
+ * Node's own vendored font is NOT the answer here: it carries no CJK glyphs,
+ * so `createOpentypeMeasureText` measures `あ` at 7.1px — worse than this
+ * estimator, and wrong in the same direction. Replacing this with a real
+ * measurer means shipping a CJK face, which is a font-distribution decision
+ * rather than a layout one.
+ *
+ * Which code points are wide is canvas-render's `isFullWidthCodePoint`,
+ * shared with `text-wrapping-corpus.ts`'s scoreboard measurer so the two
+ * estimators cannot drift apart on it. The Latin ratio is this estimator's
+ * own.
  */
-const AVERAGE_CHAR_WIDTH_FACTOR = 0.55
+const LATIN_WIDTH_FACTOR = 0.55
 
-export const fallbackMeasureText: MeasureText = (text, font) => ({
-  advanceWidth: text.length * AVERAGE_CHAR_WIDTH_FACTOR * font.sizePx,
-  ascent: font.sizePx * 0.8,
-  descent: font.sizePx * 0.2,
-  lineGap: font.sizePx * 0.1,
-})
+export const fallbackMeasureText: MeasureText = (text, font) => {
+  let em = 0
+  for (const char of text) {
+    const codePoint = char.codePointAt(0)
+    em += codePoint !== undefined && isFullWidthCodePoint(codePoint) ? 1 : LATIN_WIDTH_FACTOR
+  }
+  return {
+    advanceWidth: em * font.sizePx,
+    ascent: font.sizePx * 0.8,
+    descent: font.sizePx * 0.2,
+    lineGap: font.sizePx * 0.1,
+  }
+}


### PR DESCRIPTION
## What

`fallbackMeasureText` — the measurer behind `wb_scene_digest` and `wb_scene_render` — charged every character 0.55 em. That is not an approximation of Japanese, it is the wrong model, so agent-facing layout put CJK canvases at roughly half width.

## Evidence

Through the **real MCP server** (stdio, `wb_document_create` → `wb_node_add` → `wb_scene_digest`), one node `{width: 200, height: 32, text: 'これは日本語のテキストで折り返します'}`:

| | digest entry |
|---|---|
| before (uniform 0.55/char) | `{"id":"jp","bbox":{"x":0,"y":0,"w":200,"h":32},"z":0}` — `truncated` **absent** |
| after (script-aware) | `{"id":"jp","bbox":{"x":0,"y":0,"w":200,"h":32},"z":0,"truncated":true}` |

So the `truncated` signal shipped in #891 was telling an agent a node hid nothing, while the editor showed the reader a fade. The A/B above is the same call against the same daemon with only the measurer swapped.

## Two hypotheses refuted by measurement first

1. **A differently-tuned uniform ratio.** Any single ratio is wrong for mixed text in one direction or the other. The model has to be script-aware, not better-calibrated.
2. **Inject mcp-server's "real" opentype measurer.** The vendored Roboto carries no CJK glyphs, so `createOpentypeMeasureText` returns the `.notdef` advance:

   ```
   "abcdefghij"      -> 74.6  (full-em 160)
   "これは日本語です" -> 56.8  (full-em 128)
   "あ"              ->  7.1  (full-em  16)
   ```

   Worse than the estimator and wrong in the same direction. A real measurer here means shipping a CJK face — a font-distribution decision, not a layout one.

## Shared, not duplicated

Which code points are wide moves to canvas-render's `isFullWidthCodePoint`, shared with the text-wrapping scoreboard's corpus measurer. Two estimators disagreeing about that would break the same canvas differently depending on which one laid it out. Each keeps its own Latin ratio (0.55 here, 0.6 there). The scoreboard's pinned numbers do not move — the extraction is behavior-preserving.

## Tests

- `fallback-measure.test.ts` — three new cases: a fullwidth character costs a full em, mixed text adds up, and a wrap a half-width model missed.
- `fallback-measure.truncation.test.ts` (new) — pins the digest verdict for Japanese through the real `layoutSpatialCanvas` + `sceneDigest`.
- **Mutation check**: reverting to a uniform ratio reddens exactly those three and leaves every Latin test green.

Verified: `server-core-node` + `mcp-node` 3846 passed, `canvas-render-node` + `canvas-viewer-node` + `arch-lint-node` 1058 passed, `pnpm -r typecheck` clean, `pnpm lint` exit 0, `pnpm knip` exit 0, `pnpm smoke:e2e` ALL OK.

## Not fixed here

`headless-renderer`'s PNG/SVG **export** path uses the opentype measurer above, so exported Japanese is still laid out against `.notdef` advances. Separate defect, separate fix (ship a CJK face, or blend the estimator for code points the font lacks) — filed as a backlog issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ