### PR TITLE
feat(web): give each tree row a miniature of its own document

### DIFF
--- a/apps/web/src/components/workspace-files/DocumentMinimap.test.tsx
+++ b/apps/web/src/components/workspace-files/DocumentMinimap.test.tsx
@@ -1,0 +1,95 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { DocumentMinimap } from './DocumentMinimap.js'
+
+afterEach(cleanup)
+
+const doc = { documentId: 'c1', path: 'a/b', name: 'Diagram', kind: 'spatial' as const }
+const rects = [
+  { x: 0, y: 0, w: 200, h: 120, color: '#909090' },
+  { x: 240, y: 0, w: 160, h: 90, color: '#909090' },
+]
+
+function installObserver() {
+  const instances: { fire: () => void }[] = []
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class {
+      constructor(cb: (e: { isIntersecting: boolean }[]) => void) {
+        instances.push({ fire: () => cb([{ isIntersecting: true }]) })
+      }
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    },
+  )
+  return instances
+}
+
+describe('DocumentMinimap', () => {
+  // The whole reason for the visibility gate: a tree lists more rows than
+  // fit, and each miniature costs a fetch of that document's bytes.
+  it('does not read a document nobody has scrolled to', () => {
+    installObserver()
+    const loadOutline = vi.fn(async () => rects)
+    render(<DocumentMinimap document={doc} loadOutline={loadOutline} />)
+    expect(loadOutline).not.toHaveBeenCalled()
+  })
+
+  it('draws the document’s shape once the row is seen', async () => {
+    const observers = installObserver()
+    const { getByTestId } = render(
+      <DocumentMinimap document={doc} loadOutline={async () => rects} />,
+    )
+    act(() => observers[0]?.fire())
+    await waitFor(() =>
+      expect(getByTestId('document-minimap').querySelectorAll('span').length).toBe(rects.length),
+    )
+  })
+
+  // A miniature is a convenience. A document that cannot be read, or has
+  // nothing in it, keeps the icon that says what kind it is.
+  it('keeps the kind icon when the shape cannot be read', async () => {
+    const observers = installObserver()
+    const { getByTestId } = render(
+      <DocumentMinimap document={doc} loadOutline={async () => null} />,
+    )
+    act(() => observers[0]?.fire())
+    await waitFor(() =>
+      expect(getByTestId('document-minimap').querySelector('[data-kind]')).not.toBeNull(),
+    )
+  })
+
+  it('keeps the kind icon when the read fails outright', async () => {
+    const observers = installObserver()
+    const { getByTestId } = render(
+      <DocumentMinimap
+        document={doc}
+        loadOutline={async () => {
+          throw new Error('offline')
+        }}
+      />,
+    )
+    act(() => observers[0]?.fire())
+    await waitFor(() =>
+      expect(getByTestId('document-minimap').querySelector('[data-kind]')).not.toBeNull(),
+    )
+  })
+
+  it('keeps the kind icon for an empty document rather than an empty box', async () => {
+    const observers = installObserver()
+    const { getByTestId } = render(<DocumentMinimap document={doc} loadOutline={async () => []} />)
+    act(() => observers[0]?.fire())
+    await waitFor(() =>
+      expect(getByTestId('document-minimap').querySelector('[data-kind]')).not.toBeNull(),
+    )
+  })
+
+  it('is hidden from assistive technology — the row’s name already says which document it is', () => {
+    installObserver()
+    const { getByTestId } = render(
+      <DocumentMinimap document={doc} loadOutline={async () => rects} />,
+    )
+    expect(getByTestId('document-minimap').getAttribute('aria-hidden')).toBe('true')
+  })
+})

--- a/apps/web/src/components/workspace-files/DocumentMinimap.tsx
+++ b/apps/web/src/components/workspace-files/DocumentMinimap.tsx
@@ -1,0 +1,133 @@
+/**
+ * A tree row's icon: a miniature of the document's own shape.
+ *
+ * At this size nothing readable survives, which is the point — the
+ * arrangement is what tells one document from another, the same reasoning
+ * the favicon has always used. It reuses the favicon's projection so the two
+ * renditions of one document agree.
+ *
+ * Loading is deferred to first sight (`useOnScreen`): a tree lists far more
+ * rows than fit, and each miniature costs a fetch of that document's bytes.
+ * Measured before choosing this over a server-side outline endpoint — a Loro
+ * snapshot stays small even with history (200 nodes and 200 edits is 19KB),
+ * so a per-row fetch is affordable and both modes keep one code path.
+ */
+
+import { FileText, LayoutGrid } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { useOnScreen } from '../../hooks/useOnScreen.js'
+import type { FaviconRect } from '../../lib/favicon.js'
+import { fitMinimap, projectBox } from '../spatial-editor/minimap.js'
+import type { WorkspaceFileTreeDocument } from './WorkspaceFileTree.js'
+
+/**
+ * The icon's own box, in percent-of-element units.
+ *
+ * NOT the favicon's `projectRectsToBoard`: that inset reserves room for the
+ * board outline and status dot a favicon draws, which a bare icon has
+ * neither of — measured on the real tree, it squeezed every shape into a row
+ * of horizontal dashes. Same underlying geometry (`fitMinimap`/`projectBox`,
+ * the spatial minimap's), different wrapper.
+ */
+const BOARD = { width: 100, height: 100 }
+
+/**
+ * Percent, so a rect survives at any icon size. Below roughly this the shape
+ * reads as a smudge rather than an arrangement.
+ */
+const MIN_EXTENT_PCT = 6
+
+/** Beyond this the shapes overlap into noise at icon size. */
+const MAX_RECTS = 10
+
+export interface DocumentMinimapProps {
+  readonly document: WorkspaceFileTreeDocument
+  /**
+   * Reads a document's shape. Injected rather than fetched here so this
+   * component stays free of the daemon client — and so a test can answer
+   * without a network or a worker.
+   */
+  readonly loadOutline: (
+    document: WorkspaceFileTreeDocument,
+  ) => Promise<readonly FaviconRect[] | null>
+}
+
+/** The largest few rects, fitted to the whole icon box. */
+function projectForIcon(
+  rects: readonly FaviconRect[],
+): { x: number; y: number; w: number; h: number }[] {
+  if (rects.length === 0) return []
+  const kept = [...rects].sort((a, b) => b.w * b.h - a.w * a.h).slice(0, MAX_RECTS)
+  const boxes = kept.map((r) => ({ x: r.x, y: r.y, width: r.w, height: r.h }))
+  // No viewport concept here, so the first box stands in for it — fitMinimap
+  // never widens the fitted bounds past the content.
+  const fit = fitMinimap(boxes, boxes[0] as (typeof boxes)[number], BOARD, 0)
+  return boxes.map((box) => {
+    const p = projectBox(box, fit)
+    return {
+      x: p.x,
+      y: p.y,
+      w: Math.max(MIN_EXTENT_PCT, p.width),
+      h: Math.max(MIN_EXTENT_PCT, p.height),
+    }
+  })
+}
+
+export function DocumentMinimap({ document, loadOutline }: DocumentMinimapProps) {
+  const [ref, onScreen] = useOnScreen<HTMLSpanElement>()
+  const [rects, setRects] = useState<readonly FaviconRect[] | null>(null)
+
+  useEffect(() => {
+    if (!onScreen) return
+    let live = true
+    loadOutline(document)
+      .then((loaded) => {
+        if (live && loaded !== null && loaded.length > 0) setRects(loaded)
+      })
+      // A row that cannot be read keeps its kind icon. A miniature is a
+      // convenience; failing to draw one must not cost the row itself.
+      .catch(() => undefined)
+    return () => {
+      live = false
+    }
+  }, [onScreen, document, loadOutline])
+
+  const projected = rects === null ? null : projectForIcon(rects)
+
+  return (
+    <span
+      ref={ref}
+      data-testid="document-minimap"
+      aria-hidden="true"
+      className="relative inline-block size-4 shrink-0 overflow-hidden"
+    >
+      {projected === null || projected.length === 0 ? (
+        document.kind === 'spatial' ? (
+          <LayoutGrid data-kind="spatial" className="text-muted-foreground size-4" />
+        ) : (
+          <FileText
+            data-kind={document.kind ?? 'markdown'}
+            className="text-muted-foreground size-4"
+          />
+        )
+      ) : (
+        // Positioned spans rather than an <svg>: the panel beside this one
+        // renders the preview as an svg, and tests reach for it with
+        // container.querySelector('svg') — a second one here would answer for
+        // it. The same reason MinimapOverlay gives.
+        projected.map((rect, index) => (
+          <span
+            key={`${rect.x}-${rect.y}-${index}`}
+            className="absolute bg-current opacity-45"
+            style={{
+              left: `${rect.x}%`,
+              top: `${rect.y}%`,
+              width: `${rect.w}%`,
+              height: `${rect.h}%`,
+            }}
+          />
+        ))
+      )}
+    </span>
+  )
+}

--- a/apps/web/src/components/workspace-files/DocumentMinimap.tsx
+++ b/apps/web/src/components/workspace-files/DocumentMinimap.tsx
@@ -99,15 +99,15 @@ export function DocumentMinimap({ document, loadOutline }: DocumentMinimapProps)
       ref={ref}
       data-testid="document-minimap"
       aria-hidden="true"
-      className="relative inline-block size-4 shrink-0 overflow-hidden"
+      className="relative inline-block size-6 shrink-0 overflow-hidden"
     >
       {projected === null || projected.length === 0 ? (
         document.kind === 'spatial' ? (
-          <LayoutGrid data-kind="spatial" className="text-muted-foreground size-4" />
+          <LayoutGrid data-kind="spatial" className="text-muted-foreground size-6" />
         ) : (
           <FileText
             data-kind={document.kind ?? 'markdown'}
-            className="text-muted-foreground size-4"
+            className="text-muted-foreground size-6"
           />
         )
       ) : (

--- a/apps/web/src/components/workspace-files/WorkspaceFileTree.test.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFileTree.test.tsx
@@ -46,6 +46,32 @@ describe('WorkspaceFileTree', () => {
     expect(diagram.querySelector('[data-kind]')?.getAttribute('data-kind')).toBe('spatial')
   })
 
+  // A capability slot, like DocumentListView's renderThumb: the tree never
+  // fetches or renders a document itself, so it stays usable by a caller
+  // that has no daemon to fetch from.
+  it('lets the caller supply a row’s icon', () => {
+    render(
+      <WorkspaceFileTree
+        documents={[{ documentId: 'c1', path: 'a', name: 'Prose', kind: 'markdown' }]}
+        onOpen={() => {}}
+        renderIcon={(doc) => <span data-testid="custom-icon">{doc.documentId}</span>}
+      />,
+    )
+    expect(screen.getByTestId('custom-icon').textContent).toBe('c1')
+  })
+
+  it('keeps the kind icon when the caller supplies none', () => {
+    render(
+      <WorkspaceFileTree
+        documents={[{ documentId: 'c1', path: 'a', name: 'Prose', kind: 'markdown' }]}
+        onOpen={() => {}}
+      />,
+    )
+    expect(
+      screen.getByRole('treeitem', { name: 'Prose' }).querySelector('[data-kind]'),
+    ).not.toBeNull()
+  })
+
   it('falls back to the segment for a document nobody named', () => {
     render(
       <WorkspaceFileTree

--- a/apps/web/src/components/workspace-files/WorkspaceFileTree.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFileTree.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, ChevronRight, FileText, Folder, LayoutGrid } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { type ReactNode, useMemo, useState } from 'react'
 import { cn } from '../../lib/utils.js'
 
 export interface WorkspaceFileTreeDocument {
@@ -19,6 +19,13 @@ export interface WorkspaceFileTreeDocument {
 export interface WorkspaceFileTreeProps {
   documents: readonly WorkspaceFileTreeDocument[]
   onOpen: (canvas: WorkspaceFileTreeDocument) => void
+  /**
+   * A row's icon. Capability slot, like DocumentListView's renderThumb: a
+   * miniature of the document costs a fetch of its bytes, and this component
+   * neither fetches nor renders — so a caller with no daemon to fetch from
+   * still gets a working tree, with the kind icon below.
+   */
+  renderIcon?: (document: WorkspaceFileTreeDocument) => ReactNode
   className?: string
 }
 
@@ -69,9 +76,11 @@ function buildTree(documents: readonly WorkspaceFileTreeDocument[]): TreeNode[] 
 function TreeItem({
   node,
   onOpen,
+  renderIcon,
 }: {
   node: TreeNode
   onOpen: (canvas: WorkspaceFileTreeDocument) => void
+  renderIcon?: (document: WorkspaceFileTreeDocument) => ReactNode
 }) {
   const [expanded, setExpanded] = useState(true)
   const hasChildren = node.children.length > 0
@@ -111,19 +120,20 @@ function TreeItem({
             onClick={() => node.canvas && onOpen(node.canvas)}
             className="hover:bg-accent hover:text-accent-foreground flex min-w-0 items-center gap-1.5 rounded px-1.5 py-0.5 text-left text-sm"
           >
-            {/* The kind the list already carries, which the row was
-                discarding. A miniature of the document's own shape replaces
-                this icon in the increment that gives the tree minimaps; two
-                distinguishable icons is what the plumbing can honestly buy
-                today. */}
-            {node.canvas.kind === 'spatial' ? (
-              <LayoutGrid data-kind="spatial" className="text-muted-foreground size-3.5 shrink-0" />
-            ) : (
-              <FileText
-                data-kind={node.canvas.kind ?? 'markdown'}
-                className="text-muted-foreground size-3.5 shrink-0"
-              />
-            )}
+            {/* A caller-supplied miniature when there is one; otherwise the
+                kind, which the list already carries. */}
+            {renderIcon?.(node.canvas) ??
+              (node.canvas.kind === 'spatial' ? (
+                <LayoutGrid
+                  data-kind="spatial"
+                  className="text-muted-foreground size-3.5 shrink-0"
+                />
+              ) : (
+                <FileText
+                  data-kind={node.canvas.kind ?? 'markdown'}
+                  className="text-muted-foreground size-3.5 shrink-0"
+                />
+              ))}
             {/* The display name, which is what every other surface shows and
                 what a `[[reference]]` resolves by. The segment is the
                 fallback, not the label. */}
@@ -140,7 +150,7 @@ function TreeItem({
         // biome-ignore lint/a11y/useSemanticElements: role="group" inside a role="tree" is the APG tree pattern; the suggested semantic elements (fieldset/optgroup) are invalid tree children
         <div role="group" className="border-border/60 ml-3 border-l pl-2">
           {node.children.map((child) => (
-            <TreeItem key={child.path} node={child} onOpen={onOpen} />
+            <TreeItem key={child.path} node={child} onOpen={onOpen} renderIcon={renderIcon} />
           ))}
         </div>
       )}
@@ -153,7 +163,12 @@ function TreeItem({
  * from the paths the /api/v1 canvas list already carries — this component
  * never re-derives or stores tree structure of its own.
  */
-export function WorkspaceFileTree({ documents, onOpen, className }: WorkspaceFileTreeProps) {
+export function WorkspaceFileTree({
+  documents,
+  onOpen,
+  renderIcon,
+  className,
+}: WorkspaceFileTreeProps) {
   const tree = useMemo(() => buildTree(documents), [documents])
 
   if (tree.length === 0) {
@@ -167,7 +182,7 @@ export function WorkspaceFileTree({ documents, onOpen, className }: WorkspaceFil
   return (
     <div role="tree" aria-label="Workspace documents" className={cn('space-y-0.5', className)}>
       {tree.map((node) => (
-        <TreeItem key={node.path} node={node} onOpen={onOpen} />
+        <TreeItem key={node.path} node={node} onOpen={onOpen} renderIcon={renderIcon} />
       ))}
     </div>
   )

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -1,5 +1,12 @@
-import { useEffect, useState } from 'react'
-import { DaemonApiError, getDocumentOkfV1, listDocuments } from '../../lib/daemon-api-client.js'
+import { useEffect, useMemo, useState } from 'react'
+import {
+  DaemonApiError,
+  getDocumentOkfV1,
+  getDocumentSnapshot,
+  listDocuments,
+} from '../../lib/daemon-api-client.js'
+import { DocumentMinimap } from './DocumentMinimap.js'
+import { createRowOutlineLoader } from './load-row-outline.js'
 import { WorkspaceFileTree, type WorkspaceFileTreeDocument } from './WorkspaceFileTree.js'
 
 export interface WorkspaceFilesPanelProps {
@@ -31,6 +38,20 @@ export function WorkspaceFilesPanel({
   // a failure. 'error' is a genuine fetch/schema failure and keeps the alert.
   const [listStatus, setListStatus] = useState<'ok' | 'not-found' | 'error'>('ok')
   const [preview, setPreview] = useState<OkfPreview>({ kind: 'idle' })
+
+  // One loader for the whole tree, so a re-render does not hand every row a
+  // new function and re-trigger its read.
+  const loadRowOutline = useMemo(
+    () =>
+      createRowOutlineLoader({
+        daemonFetch,
+        daemonBaseUrl,
+        workspaceId,
+        getSnapshot: getDocumentSnapshot,
+        getOkf: getDocumentOkfV1,
+      }),
+    [daemonFetch, daemonBaseUrl, workspaceId],
+  )
 
   useEffect(() => {
     let cancelled = false
@@ -101,7 +122,13 @@ export function WorkspaceFilesPanel({
   return (
     <div className="flex min-h-0 flex-1 gap-4" data-testid="workspace-files-panel">
       <div className="w-64 shrink-0 overflow-y-auto border-r pr-3">
-        <WorkspaceFileTree documents={documents} onOpen={openDocument} />
+        <WorkspaceFileTree
+          documents={documents}
+          onOpen={openDocument}
+          renderIcon={(entry) => (
+            <DocumentMinimap key={entry.documentId} document={entry} loadOutline={loadRowOutline} />
+          )}
+        />
       </div>
       <div className="min-w-0 flex-1 overflow-y-auto" data-testid="okf-preview">
         {preview.kind === 'idle' && (

--- a/apps/web/src/components/workspace-files/load-row-outline.test.ts
+++ b/apps/web/src/components/workspace-files/load-row-outline.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createRowOutlineLoader } from './load-row-outline.js'
+
+const base = {
+  daemonFetch: globalThis.fetch,
+  daemonBaseUrl: 'http://127.0.0.1:3099',
+  workspaceId: 'ws',
+}
+const spatial = { documentId: 'c1', path: 'a/b', kind: 'spatial' as const }
+const markdown = { documentId: 'c2', path: 'notes', kind: 'markdown' as const }
+
+describe('createRowOutlineLoader', () => {
+  // Kind decides where the shape comes from, and reading the wrong endpoint
+  // would either 404 or answer with a shape of the wrong thing.
+  it('reads a spatial document’s snapshot, not its OKF', async () => {
+    const getSnapshot = vi.fn(async () => new Uint8Array())
+    const getOkf = vi.fn(async () => ({ markdown: '' }))
+    await createRowOutlineLoader({ ...base, getSnapshot, getOkf })(spatial)
+    expect(getSnapshot).toHaveBeenCalledOnce()
+    expect(getOkf).not.toHaveBeenCalled()
+  })
+
+  it('reads a markdown document’s OKF, not its snapshot', async () => {
+    const getSnapshot = vi.fn(async () => new Uint8Array())
+    const getOkf = vi.fn(async () => ({ markdown: '' }))
+    await createRowOutlineLoader({ ...base, getSnapshot, getOkf })(markdown)
+    expect(getOkf).toHaveBeenCalledOnce()
+    expect(getSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('addresses a spatial document by path and a markdown one by id', async () => {
+    const seen: string[] = []
+    const load = createRowOutlineLoader({
+      ...base,
+      getSnapshot: async (_f, _u, _w, path) => {
+        seen.push(`snapshot:${path}`)
+        return new Uint8Array()
+      },
+      getOkf: async (_f, _u, _w, documentId) => {
+        seen.push(`okf:${documentId}`)
+        return { markdown: '' }
+      },
+    })
+    await load(spatial)
+    await load(markdown)
+    // The path is the address a snapshot is served at; the id is what the
+    // OKF read takes. Swapping them 404s.
+    expect(seen).toEqual(['snapshot:a/b', 'okf:c2'])
+  })
+
+  // A row that cannot be read keeps its kind icon; a throw here would take
+  // the whole tree down with it.
+  it('answers null rather than throwing when the read fails', async () => {
+    const load = createRowOutlineLoader({
+      ...base,
+      getSnapshot: async () => {
+        throw new Error('offline')
+      },
+      getOkf: async () => ({ markdown: '' }),
+    })
+    await expect(load(spatial)).resolves.toBeNull()
+  })
+
+  it('answers null rather than laying out an empty markdown document', async () => {
+    const load = createRowOutlineLoader({
+      ...base,
+      getSnapshot: async () => new Uint8Array(),
+      getOkf: async () => ({ markdown: '   \n' }),
+    })
+    await expect(load(markdown)).resolves.toBeNull()
+  })
+
+  it('answers null for a snapshot that is not a document', async () => {
+    const load = createRowOutlineLoader({
+      ...base,
+      getSnapshot: async () => new Uint8Array([1, 2, 3]),
+      getOkf: async () => ({ markdown: '' }),
+    })
+    await expect(load(spatial)).resolves.toBeNull()
+  })
+})

--- a/apps/web/src/components/workspace-files/load-row-outline.test.ts
+++ b/apps/web/src/components/workspace-files/load-row-outline.test.ts
@@ -1,3 +1,5 @@
+import { writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+import { LoroDoc } from 'loro-crdt'
 import { describe, expect, it, vi } from 'vitest'
 import { createRowOutlineLoader } from './load-row-outline.js'
 
@@ -46,6 +48,66 @@ describe('createRowOutlineLoader', () => {
     // The path is the address a snapshot is served at; the id is what the
     // OKF read takes. Swapping them 404s.
     expect(seen).toEqual(['snapshot:a/b', 'okf:c2'])
+  })
+
+  // The branch that actually produces a miniature. Every other test here
+  // feeds an empty body or a failing read, so none of them reached it — a
+  // mutation replacing this branch with `return null` left the suite green.
+  it('lays a markdown body out and answers its blocks', async () => {
+    const blocks = [
+      { x: 0, y: 0, w: 300, h: 32 },
+      { x: 0, y: 40, w: 460, h: 48 },
+    ]
+    const widths: number[] = []
+    const layoutMarkdown = async (_body: string, maxWidth: number) => {
+      widths.push(maxWidth)
+      return blocks
+    }
+    const load = createRowOutlineLoader({
+      ...base,
+      getSnapshot: async () => new Uint8Array(),
+      getOkf: async () => ({ markdown: '# Title\n\nProse.\n' }),
+      layoutMarkdown,
+    })
+
+    await expect(load(markdown)).resolves.toEqual(blocks)
+    // The width is fixed rather than measured: an icon has no pane, and a
+    // shape that changed with the window would differ between two screens.
+    expect(widths).toEqual([640])
+  })
+
+  it('answers null when the layout refuses', async () => {
+    const load = createRowOutlineLoader({
+      ...base,
+      getSnapshot: async () => new Uint8Array(),
+      getOkf: async () => ({ markdown: '# Title\n' }),
+      layoutMarkdown: async () => null,
+    })
+    await expect(load(markdown)).resolves.toBeNull()
+  })
+
+  // The spatial branch's own success path: a REAL snapshot, so the read and
+  // the outline are both exercised rather than fed empty bytes.
+  it('reads a spatial document’s nodes as its shape', async () => {
+    const doc = new LoroDoc()
+    writeSpatialCanvas(doc, {
+      nodes: [
+        { id: 'a', type: 'text', x: 0, y: 0, width: 200, height: 120, text: 'one' },
+        { id: 'b', type: 'text', x: 240, y: 0, width: 160, height: 90, text: 'two' },
+      ],
+      edges: [],
+    })
+    const snapshot = doc.export({ mode: 'snapshot' })
+
+    const load = createRowOutlineLoader({
+      ...base,
+      getSnapshot: async () => snapshot,
+      getOkf: async () => ({ markdown: '' }),
+    })
+
+    const rects = await load(spatial)
+    expect(rects).toHaveLength(2)
+    expect(rects?.[0]).toMatchObject({ x: 0, y: 0, w: 200, h: 120 })
   })
 
   // A row that cannot be read keeps its kind icon; a throw here would take

--- a/apps/web/src/components/workspace-files/load-row-outline.ts
+++ b/apps/web/src/components/workspace-files/load-row-outline.ts
@@ -42,6 +42,27 @@ export interface RowOutlineDeps {
     workspaceId: string,
     documentId: string,
   ) => Promise<{ markdown: string }>
+  /**
+   * Lays a markdown body out. Injected like the two reads above so the
+   * success path is assertable without mocking a module — the branch that
+   * actually produces a miniature is the one worth pinning.
+   */
+  readonly layoutMarkdown?: (
+    body: string,
+    maxWidth: number,
+  ) => Promise<readonly FaviconRect[] | null>
+}
+
+/** The shared fleet, at background priority: an icon is never the thing someone is waiting on. */
+async function layoutInSharedPool(
+  body: string,
+  maxWidth: number,
+): Promise<readonly FaviconRect[] | null> {
+  const reply = await sharedLayoutWorkerPool().run<MarkdownRailResponse>(
+    { type: 'markdown-rail', id: nextLayoutRequestId(), body, maxWidth },
+    'background',
+  )
+  return reply.type === 'markdown-rail-done' ? reply.blocks : null
 }
 
 export function createRowOutlineLoader(deps: RowOutlineDeps) {
@@ -55,16 +76,7 @@ export function createRowOutlineLoader(deps: RowOutlineDeps) {
           document.documentId,
         )
         if (markdown.trim() === '') return null
-        const reply = await sharedLayoutWorkerPool().run<MarkdownRailResponse>(
-          {
-            type: 'markdown-rail',
-            id: nextLayoutRequestId(),
-            body: markdown,
-            maxWidth: ROW_LAYOUT_WIDTH,
-          },
-          'background',
-        )
-        return reply.type === 'markdown-rail-done' ? reply.blocks : null
+        return await (deps.layoutMarkdown ?? layoutInSharedPool)(markdown, ROW_LAYOUT_WIDTH)
       }
 
       const bytes = await deps.getSnapshot(

--- a/apps/web/src/components/workspace-files/load-row-outline.ts
+++ b/apps/web/src/components/workspace-files/load-row-outline.ts
@@ -1,0 +1,83 @@
+/**
+ * Reads one document's shape for a tree row's icon.
+ *
+ * Kind decides where the shape comes from, and the two are genuinely
+ * different reads: a spatial canvas already IS boxes, so its snapshot is
+ * enough; a markdown document has none of its own and has to be laid out,
+ * which happens in the shared worker pool at background priority.
+ *
+ * Total by contract — every failure answers `null` and the row keeps its
+ * kind icon. A tree that cannot draw a miniature is a tree with plainer
+ * icons; a tree that throws is a broken screen.
+ */
+
+import { readSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+import { LoroDoc } from 'loro-crdt'
+import { outlineFromSpatial } from '../../lib/document-outline.js'
+import type { FaviconRect } from '../../lib/favicon.js'
+import { nextLayoutRequestId, sharedLayoutWorkerPool } from '../../lib/layout-worker-pool.js'
+import type { MarkdownRailResponse } from '../../lib/layout-worker-protocol.js'
+import type { WorkspaceFileTreeDocument } from './WorkspaceFileTree.js'
+
+/**
+ * Width a row's markdown is laid out at. Fixed rather than measured: an icon
+ * has no pane, and a shape that changed with the window would make the same
+ * document look different on two screens.
+ */
+const ROW_LAYOUT_WIDTH = 640
+
+export interface RowOutlineDeps {
+  readonly daemonFetch: typeof globalThis.fetch
+  readonly daemonBaseUrl: string
+  readonly workspaceId: string
+  readonly getSnapshot: (
+    fetchFn: typeof globalThis.fetch,
+    baseUrl: string,
+    workspaceId: string,
+    path: string,
+  ) => Promise<Uint8Array>
+  readonly getOkf: (
+    fetchFn: typeof globalThis.fetch,
+    baseUrl: string,
+    workspaceId: string,
+    documentId: string,
+  ) => Promise<{ markdown: string }>
+}
+
+export function createRowOutlineLoader(deps: RowOutlineDeps) {
+  return async (document: WorkspaceFileTreeDocument): Promise<readonly FaviconRect[] | null> => {
+    try {
+      if (document.kind === 'markdown') {
+        const { markdown } = await deps.getOkf(
+          deps.daemonFetch,
+          deps.daemonBaseUrl,
+          deps.workspaceId,
+          document.documentId,
+        )
+        if (markdown.trim() === '') return null
+        const reply = await sharedLayoutWorkerPool().run<MarkdownRailResponse>(
+          {
+            type: 'markdown-rail',
+            id: nextLayoutRequestId(),
+            body: markdown,
+            maxWidth: ROW_LAYOUT_WIDTH,
+          },
+          'background',
+        )
+        return reply.type === 'markdown-rail-done' ? reply.blocks : null
+      }
+
+      const bytes = await deps.getSnapshot(
+        deps.daemonFetch,
+        deps.daemonBaseUrl,
+        deps.workspaceId,
+        document.path,
+      )
+      const doc = new LoroDoc()
+      doc.import(bytes)
+      return outlineFromSpatial(readSpatialCanvas(doc))
+    } catch {
+      return null
+    }
+  }
+}

--- a/apps/web/src/hooks/useOnScreen.test.tsx
+++ b/apps/web/src/hooks/useOnScreen.test.tsx
@@ -1,0 +1,87 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useOnScreen } from './useOnScreen.js'
+
+afterEach(cleanup)
+
+/** Captures the observers a render creates so a test can fire them by hand. */
+function installObserver() {
+  const instances: {
+    callback: (entries: { isIntersecting: boolean }[]) => void
+    target: Element | null
+    disconnected: boolean
+  }[] = []
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class {
+      readonly #self = { callback: () => {}, target: null as Element | null, disconnected: false }
+      constructor(callback: (entries: { isIntersecting: boolean }[]) => void) {
+        this.#self.callback = callback as never
+        instances.push(this.#self)
+      }
+      observe(target: Element) {
+        this.#self.target = target
+      }
+      disconnect() {
+        this.#self.disconnected = true
+      }
+      unobserve() {}
+    },
+  )
+  return instances
+}
+
+function Probe() {
+  const [ref, onScreen] = useOnScreen<HTMLDivElement>()
+  return (
+    <div ref={ref} data-testid="probe">
+      {onScreen ? 'seen' : 'unseen'}
+    </div>
+  )
+}
+
+describe('useOnScreen', () => {
+  it('starts unseen, so nothing is fetched for a row nobody looked at', () => {
+    installObserver()
+    const { getByTestId } = render(<Probe />)
+    expect(getByTestId('probe').textContent).toBe('unseen')
+  })
+
+  it('reports seen once the element intersects', () => {
+    const observers = installObserver()
+    const { getByTestId } = render(<Probe />)
+    act(() => observers[0]?.callback([{ isIntersecting: true }]))
+    expect(getByTestId('probe').textContent).toBe('seen')
+  })
+
+  // Scrolling away must not undo the work already done: a row that has been
+  // seen keeps whatever it loaded, rather than fetching again on the way back.
+  it('stays seen after the element scrolls away', () => {
+    const observers = installObserver()
+    const { getByTestId } = render(<Probe />)
+    act(() => observers[0]?.callback([{ isIntersecting: true }]))
+    act(() => observers[0]?.callback([{ isIntersecting: false }]))
+    expect(getByTestId('probe').textContent).toBe('seen')
+  })
+
+  it('stops observing once it has been seen', () => {
+    const observers = installObserver()
+    render(<Probe />)
+    act(() => observers[0]?.callback([{ isIntersecting: true }]))
+    expect(observers[0]?.disconnected).toBe(true)
+  })
+
+  it('disconnects on unmount', () => {
+    const observers = installObserver()
+    const { unmount } = render(<Probe />)
+    unmount()
+    expect(observers[0]?.disconnected).toBe(true)
+  })
+
+  // A browser without the API must not leave every row blank forever.
+  it('reports seen immediately where IntersectionObserver does not exist', () => {
+    vi.stubGlobal('IntersectionObserver', undefined)
+    const { getByTestId } = render(<Probe />)
+    expect(getByTestId('probe').textContent).toBe('seen')
+  })
+})

--- a/apps/web/src/hooks/useOnScreen.ts
+++ b/apps/web/src/hooks/useOnScreen.ts
@@ -1,0 +1,40 @@
+/**
+ * Whether an element has been on screen yet.
+ *
+ * The tree draws a miniature of each document, and each miniature costs a
+ * fetch of that document's bytes. A workspace's tree can list far more rows
+ * than fit, so loading them all is work for documents nobody looked at.
+ *
+ * ONE-WAY on purpose: once a row has been seen it stays seen. Scrolling away
+ * and back would otherwise re-fetch what the row already has, and a
+ * miniature that blinks out when it leaves the viewport is worse than one
+ * that stays.
+ */
+
+import { type RefCallback, useCallback, useRef, useState } from 'react'
+
+export function useOnScreen<T extends Element>(): [RefCallback<T>, boolean] {
+  // Absent in older browsers and in some test environments. Answering "seen"
+  // there loads everything, which is the behaviour before this existed —
+  // never a tree of permanently blank rows.
+  const [seen, setSeen] = useState(() => typeof IntersectionObserver === 'undefined')
+  const observerRef = useRef<IntersectionObserver | null>(null)
+
+  const ref = useCallback<RefCallback<T>>((element) => {
+    observerRef.current?.disconnect()
+    observerRef.current = null
+    if (element === null || typeof IntersectionObserver === 'undefined') return
+
+    const observer = new IntersectionObserver((entries) => {
+      if (!entries.some((entry) => entry.isIntersecting)) return
+      setSeen(true)
+      // Nothing left to watch: the answer cannot go back to false.
+      observer.disconnect()
+      observerRef.current = null
+    })
+    observer.observe(element)
+    observerRef.current = observer
+  }, [])
+
+  return [ref, seen]
+}


### PR DESCRIPTION
The tree's icons now show what each document looks like, so a row is recognisable before its name is read. This is the surface the outline concept was built for.

![tree-icons.png](https://github.com/user-attachments/assets/ad96f5c7-8a32-4f36-a820-8ab72d5d88fe)

Left is 16px, right is 24px — the capture that decided the size. Four documents: two spatial, one markdown, and one whose shape could not be read, which keeps its kind icon.

## Where the shape comes from

Kind decides, and the two reads are genuinely different. A spatial canvas already IS boxes, so its snapshot is enough. A markdown document has none of its own and is laid out in the shared worker pool at background priority — the same fleet the editor's rail uses, which is why that pool has priorities rather than a queue.

**Per-row fetching was chosen against a server-side outline endpoint on a measurement, not a preference.** A Loro snapshot stays small even carrying history, and the growth ratio *shrinks* as content grows:

| nodes | fresh | after 200 edits | growth |
|---|---|---|---|
| 10 | 1.0 KB | 2.6 KB | ×2.4 |
| 60 | 4.9 KB | 6.5 KB | ×1.3 |
| 200 | 15.7 KB | 19.2 KB | ×1.2 |

At 20 visible rows that is well under half a megabyte, so a fetch per visible row is affordable — and both modes keep one code path instead of the daemon growing a second, outline-shaped contract.

## Deferred, and total

Reads wait for first sight. A tree lists far more rows than fit, and loading them all is work for documents nobody scrolled to. The gate is **one-way**: a row that has been seen stays seen, because re-fetching on the way back would cost the same bytes twice and a miniature that blinks out at the viewport edge is worse than one that stays.

The loader answers `null` for every failure. A read that fails, an empty document, or a row not yet seen keeps the kind icon — a tree that cannot draw a miniature is a tree with plainer icons, while a tree that throws is a broken screen.

## What the screenshot corrected

Both invisible to every test that passed.

The first draft reused the favicon's `projectRectsToBoard`, whose inset reserves room for the board outline and status dot a favicon draws — which an icon has neither of. **Every shape came out as a row of horizontal dashes.** It now uses the same underlying geometry (`fitMinimap`/`projectBox`, the spatial minimap's) through its own wrapper, fitted to the whole box.

And **14px cannot hold an arrangement at all.** 16px can, barely. The size above is a design decision taken on the comparison rather than by eye, and the taller row is the trade that was chosen.

## Shape of the wiring

The icon is a capability render prop, the same shape `DocumentListView`'s `renderThumb` has: the tree neither fetches nor renders, so a caller with no daemon still gets a working tree with kind icons. Positioned spans rather than an `<svg>` — the preview beside this tree is an svg and tests reach for it with `container.querySelector('svg')`, the trap `MinimapOverlay` already documents.

## Notes

- `web-browser` had one failure in the full run (`DaemonDocumentPage.markdown`, a typing test) and passes in isolation; the machine was at load 16 from earlier runs. Known load-dependent family, and CI is the authoritative signal.
