### PR TITLE
fix(server-core): repoint the snapshot tools at the consolidated loader

### DIFF
--- a/packages/server-core/src/tools/canvas-edit.test.ts
+++ b/packages/server-core/src/tools/canvas-edit.test.ts
@@ -7,13 +7,13 @@ import {
 } from '@kamiazya/whiteboard-loro-adapter'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { describe, expect, test } from 'vitest'
-import { loadSpatialCanvas } from '../render/load-spatial-canvas.js'
 import {
   FakeDocumentStore,
   registerDocumentInWorkspace,
   seedDoc,
 } from '../test-utils/fake-document-store.js'
 import { createCanvasEditTool, PLACEMENT_COLUMNS, PLACEMENT_GUTTER_PX } from './canvas-edit.js'
+import { loadDocument } from './document-io.js'
 
 const DOCUMENT_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 const WORKSPACE_ID = 'ws-1'
@@ -93,7 +93,7 @@ describe('wb_canvas_edit tool', () => {
       message: expect.stringMatching(/ops\[1\]/),
     })
 
-    const { canvas } = await loadSpatialCanvas(makeDeps(store), DOCUMENT_ID)
+    const { canvas } = await loadDocument(makeDeps(store), DOCUMENT_ID)
     expect(canvas.nodes.map((n) => n.id)).toEqual(['a'])
   })
 
@@ -119,7 +119,7 @@ describe('wb_canvas_edit tool', () => {
     expect(placed?.width).toBeGreaterThan(0)
     expect(placed?.height).toBeGreaterThan(0)
 
-    const { canvas } = await loadSpatialCanvas(makeDeps(store), DOCUMENT_ID)
+    const { canvas } = await loadDocument(makeDeps(store), DOCUMENT_ID)
     const stored = canvas.nodes.find((n) => n.id === 'free')
     // What the tool REPORTS and what it STORED have to be the same numbers.
     expect(stored).toMatchObject({ x: placed?.x, y: placed?.y })
@@ -178,7 +178,7 @@ describe('wb_canvas_edit tool', () => {
     })
 
     expect(result.touched).toEqual({ nodes: ['a', 'b'], edges: ['e'] })
-    const { canvas } = await loadSpatialCanvas(makeDeps(store), DOCUMENT_ID)
+    const { canvas } = await loadDocument(makeDeps(store), DOCUMENT_ID)
     expect(canvas.nodes.map((n) => n.id)).toEqual(['a'])
     expect(canvas.nodes[0]).toMatchObject({ x: 7, color: '3' })
     expect(canvas.edges).toEqual([])
@@ -205,7 +205,7 @@ describe('wb_canvas_edit tool', () => {
     })
 
     expect(result.touched.edges).toEqual(['e'])
-    const { canvas } = await loadSpatialCanvas(makeDeps(store), DOCUMENT_ID)
+    const { canvas } = await loadDocument(makeDeps(store), DOCUMENT_ID)
     expect(canvas.edges).toEqual([])
   })
 
@@ -248,7 +248,7 @@ describe('wb_canvas_edit tool', () => {
     ).rejects.toMatchObject({ name: 'CanvasEditError', opIndex: 0 })
 
     // The rejected batch above must not have persisted its own lock on 'b'.
-    const { doc } = await loadSpatialCanvas(makeDeps(store), DOCUMENT_ID)
+    const { doc } = await loadDocument(makeDeps(store), DOCUMENT_ID)
     expect(readNodeLocks(doc).has('a')).toBe(true)
     expect(readNodeLocks(doc).has('b')).toBe(false)
   })
@@ -278,7 +278,7 @@ describe('wb_canvas_edit tool', () => {
     })
 
     expect(result.applied).toBe(2)
-    const { doc, canvas } = await loadSpatialCanvas(makeDeps(store), DOCUMENT_ID)
+    const { doc, canvas } = await loadDocument(makeDeps(store), DOCUMENT_ID)
     expect(readNodeLocks(doc).has('a')).toBe(false)
     expect(canvas.nodes[0]).toMatchObject({ x: 9 })
   })
@@ -299,7 +299,7 @@ describe('wb_canvas_edit tool', () => {
       documentId: DOCUMENT_ID,
       ops: [{ op: 'edge.lock', id: 'e', locked: true }],
     })
-    const { doc } = await loadSpatialCanvas(makeDeps(store), DOCUMENT_ID)
+    const { doc } = await loadDocument(makeDeps(store), DOCUMENT_ID)
     expect(readEdgeLocks(doc).has('e')).toBe(true)
 
     await expect(
@@ -334,7 +334,7 @@ describe('wb_canvas_edit tool', () => {
     })
 
     expect(result.geometry.length).toBeGreaterThan(0)
-    const { canvas } = await loadSpatialCanvas(makeDeps(store), DOCUMENT_ID)
+    const { canvas } = await loadDocument(makeDeps(store), DOCUMENT_ID)
     // Every geometry entry names where the node really ended up.
     for (const entry of result.geometry) {
       expect(canvas.nodes.find((n) => n.id === entry.id)).toMatchObject({
@@ -393,7 +393,7 @@ describe('wb_canvas_edit tool', () => {
     expect(result.touched.nodes).toHaveLength(1)
     const minted = result.touched.nodes[0]
     expect(minted).toMatch(/\S/)
-    const { canvas } = await loadSpatialCanvas(makeDeps(store), DOCUMENT_ID)
+    const { canvas } = await loadDocument(makeDeps(store), DOCUMENT_ID)
     expect(canvas.nodes.map((n) => n.id)).toEqual([minted])
   })
 

--- a/packages/server-core/src/tools/canvas-snapshot.test.ts
+++ b/packages/server-core/src/tools/canvas-snapshot.test.ts
@@ -7,7 +7,6 @@ import {
 } from '@kamiazya/whiteboard-loro-adapter'
 import type { SpatialNode } from '@kamiazya/whiteboard-model'
 import { describe, expect, test } from 'vitest'
-import { SnapshotNotFoundError } from '../render/load-spatial-canvas.js'
 import { FakeDocumentStore, seedDoc } from '../test-utils/fake-document-store.js'
 import {
   canvasSnapshotSchema,
@@ -16,6 +15,7 @@ import {
   SNAPSHOT_MAX_NODES,
   SNAPSHOT_TEXT_MAX_CHARS,
 } from './canvas-snapshot.js'
+import { SnapshotNotFoundError } from './document-io.js'
 
 const DOCUMENT_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
 const WORKSPACE_ID = 'ws-1'

--- a/packages/server-core/src/tools/canvas-snapshot.ts
+++ b/packages/server-core/src/tools/canvas-snapshot.ts
@@ -9,8 +9,9 @@ import {
   workspaceIdSchema,
 } from '@kamiazya/whiteboard-model'
 import { z } from 'zod'
-import { assertSpatialDocument, loadSpatialCanvas } from '../render/load-spatial-canvas.js'
+import { assertSpatialDocument } from '../render/assert-spatial-document.js'
 import type { ServerDeps } from '../server-deps.js'
+import { loadDocument } from './document-io.js'
 
 /**
  * Per-node text budget, in characters. A text node can hold a whole markdown
@@ -194,7 +195,7 @@ export function createCanvasSnapshotTool(deps: ServerDeps) {
     inputSchema: canvasSnapshotInputSchema,
     outputSchema: canvasSnapshotSchema,
     async execute(input: CanvasSnapshotInput): Promise<CanvasSnapshot> {
-      const { doc, canvas } = await loadSpatialCanvas(deps, input.documentId)
+      const { doc, canvas } = await loadDocument(deps, input.documentId)
       await assertSpatialDocument(
         deps,
         input.workspaceId,


### PR DESCRIPTION
**`main` does not compile.** Merging #881 + #884 landed a tree that references a file #886 had already deleted.

```
src/tools/canvas-snapshot.ts:12      TS2307: Cannot find module '../render/load-spatial-canvas.js'
src/tools/canvas-snapshot.test.ts:10 TS2307: Cannot find module '../render/load-spatial-canvas.js'
src/tools/canvas-edit.test.ts:10     TS2307: Cannot find module '../render/load-spatial-canvas.js'
```

#886 (`refactor(server-core)!: one loader for a document, one class for its absence`) consolidated every document load into `tools/document-io.ts` and deleted `render/load-spatial-canvas.ts`. #881 and #884 were branched before that and kept importing the old path.

**Nothing caught it, and it is worth naming why.** Both PRs reported `MERGEABLE`, both had 19/19 checks green, and `git merge-tree` found zero conflicts — because neither PR *touched* the deleted file, so there was nothing to conflict with. Their CI was green against their own base, which still had the file. A stack whose bottom predates a rename on the trunk can be textually clean and semantically broken at the same time, and every signal available before the merge says it is fine.

## The fix

`loadDocument` returns the same `{ doc, canvas }` shape `loadSpatialCanvas` did, and `assertSpatialDocument` still lives in `render/assert-spatial-document.ts`, so this is a pure repointing — no behaviour change.

Verified on the merge result: `pnpm -r typecheck` clean, `server-core-node` + `mcp-node` **330 files / 3870 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ