### PR TITLE
ci: let every required check run on merge_group

### DIFF
--- a/.claude/rules/dev-flow.md
+++ b/.claude/rules/dev-flow.md
@@ -110,4 +110,40 @@ Native **Task list** = live board (in-flight / blocked / done; main session owns
 
 The integrator's push is guarded on two sides. **Local (pre-push, `lefthook`)**: `pnpm -r typecheck` + `pnpm test --project mcp-node` + `pnpm lint:noconsole` run before the commit leaves the machine (pre-commit only formats staged files, to not slow the dev-loop's worktree commits). **Cloud (post-push)**: GitHub Actions CI (`verify`) + CodeRabbit + AccessLint + WIP + CodeQL — monitor with the `Monitor` tool and triage with the `ci-triage` workflow/skill into Tasks / whiteboard canvases.
 
+**A green PR check does not say the MERGE is green.** `on: pull_request` builds
+a merge commit, so CI already tests a branch against main — but only as main
+stood when the PR last moved, and nothing re-runs it when main advances.
+Measured: #881's head was pushed at 11:37Z, #886 merged at 13:07Z, and #881
+stayed green the whole time against a base that no longer existed. Merging it
+broke `main` outright — three files importing a module #886 had deleted — and
+`MERGEABLE`, a zero-conflict `git merge-tree`, and 19/19 green all called it
+safe. None of them was answering the question: a branch that merely IMPORTS
+what the trunk deleted has nothing to conflict with. The same shape appeared
+four times in one stack, twice more as a clean auto-merge that duplicated a
+registration block and silently dropped a signal.
+
+"Require branches to be up to date" is the obvious fix and is deliberately NOT
+used (`strict: false`, user decision 2026-08-19): with several dev-loops in
+flight it makes every merge invalidate every other PR, which is the parallelism
+this whole flow is built on. The answer is a **merge queue** — it tests the
+speculative merge (main + anything queued ahead + this PR) at merge time,
+batched, so development stays parallel and only the final verification is
+ordered. `gh stack merge` composes with it: a stack is added to the queue.
+
+Its one hard prerequisite: **every required check must also run on
+`merge_group`**, or the queue waits forever for a check that cannot fire.
+`ci.yml` and `pr-title.yml` both declare that trigger; `pr-title` short-circuits
+there, because a merge group has no PR title to validate. Adding a required
+check means adding the trigger with it.
+
+Until the queue is enabled, the manual stand-in is to typecheck the MERGE
+RESULT rather than either side — and for a stacked set, to merge the reconciled
+PARENT into each child rather than main separately, which keeps one
+reconciliation instead of one per layer:
+
+```bash
+git worktree add -q --detach /tmp/premerge origin/<branch>
+cd /tmp/premerge && git merge --no-edit origin/main && pnpm -r typecheck
+```
+
 **PR merge gate.** `verify` + CodeQL are the authoritative gate. AI review is consulted **when it has actually run**, and its absence does not block a merge (user decision, 2026-08-02): CodeRabbit is on a plan whose per-developer rolling limit this repo's merge pace exhausts, so waiting on it serialises delivery behind a quota rather than behind a real signal. Batching several PRs at once is what burns the quota fastest — when a review matters for a specific change, open that PR alone and let it land. Before merging, still fetch **every bot's** PR review comments and triage each finding; the discipline below applies whenever there *are* comments. Fetch with `gh api repos/<owner>/<repo>/pulls/<n>/comments` + `gh pr view <n> --json reviews,comments`, then **read the comments from ALL bot authors — do not filter to a hardcoded reviewer list.** The surface currently includes **CodeRabbit** (`coderabbitai[bot]`, AI review — Free Plan so not guaranteed) and **`github-advanced-security[bot]`** (CodeQL code-scanning — its findings arrive as ordinary PR review comments on the plain `/pulls/<n>/comments` feed, no `security_events` scope needed, and are same-priority-or-higher security signal). (Gemini Code Assist is **sunset** as of 2026-07-27 — no longer reviews; do not wait on it.) Missing a bot because you scoped the sweep to two named reviewers is exactly the gap that let a CodeQL ReDoS comment slip past this gate — enumerate authors from the feed, don't assume. Triage each finding: (a) verify validity against the actual code (do not trust or dismiss blindly — check the claimed line/behavior; CodeQL security findings on untrusted-input paths get the same red-test-first + fix treatment as any CRITICAL, per the `ci-triage` skill's CodeQL rubric), (b) apply valid findings as commits on the PR branch, (c) for findings judged invalid/stale, record the reason (reply on the PR thread or note in the merge summary to the user). A reviewer skipping a PR (rate limits, plan limits) is acceptable to proceed past — note it when it happens, rather than waiting it out. **Dependabot** (dep-bump PRs + security alerts) has its own `dependabot-triage` workflow + `dependabot-review` skill. Hooks are a net, not the gate — CI is authoritative; `LEFTHOOK=0` / `--no-verify` bypass when justified.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,13 @@ name: ci
 
 on:
   pull_request:
+  # A merge queue tests the SPECULATIVE merge — this branch on top of current
+  # main plus anything queued ahead of it — which is the only thing that
+  # answers "does the result compile". `pull_request` already builds a merge
+  # commit, but only as main stood when the PR last moved, and nothing re-runs
+  # it when main advances. That staleness let two PRs whose merge base
+  # predated a file deletion land a `main` that did not compile.
+  merge_group:
   push:
     branches: [main]
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,6 +12,10 @@ name: pr-title
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+  # Required checks must report on `merge_group` too, or a merge queue waits
+  # forever for one that cannot run. A merge group has no PR title to check,
+  # so the job short-circuits rather than pretending to validate anything.
+  merge_group:
 
 permissions:
   contents: read
@@ -28,6 +32,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate PR title
+        if: github.event_name == 'pull_request'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: node tools/check-pr-title.mjs "$PR_TITLE"


### PR DESCRIPTION
Groundwork for enabling a **merge queue** on `main`. Inert until the queue is turned on in branch protection — `merge_group` never fires before that.

## Why this, and not "require branches to be up to date"

That setting would have caught the incident below, and it is the wrong tool here: with several dev-loops in flight it makes every merge invalidate every other open PR, forcing each to update and re-run CI. That serialises exactly the parallel development this repo's flow is built on, so `strict` stays `false`.

A merge queue answers the same question without that cost: it tests the **speculative merge** — main, plus anything queued ahead, plus this PR — at merge time, batched. Branches never need updating by hand; only the final verification is ordered. `gh stack merge` composes with it (a stack is added to the queue).

## Why it is needed

`on: pull_request` already builds a merge commit, so CI does test a branch against main — but only as main stood **when the PR last moved**, and nothing re-runs it when main advances.

| | |
|---|---|
| #881 head pushed | `2026-08-18T11:37:31Z` |
| #886 merged | `2026-08-18T13:06:55Z` |

#881 stayed green that whole time against a base that no longer existed. Merging it landed a `main` that did not compile — three files importing `server-core/src/render/load-spatial-canvas.js`, which #886 had deleted (fixed by #901). `MERGEABLE`, a zero-conflict `git merge-tree`, and 19/19 green all said it was safe, and none of them was answering the question: **a branch that merely imports what the trunk deleted has nothing to conflict with.**

The same shape appeared four more times while reconciling that stack — a contract test importing a retired tool, a stale error-class expectation, and two more stale import paths — plus a clean auto-merge that duplicated a tool-registration block (twelve MCP tests failing as HTTP 500s that never named the cause) and another that silently dropped a per-node signal. Conflict markers are not a proxy for correctness when a branch predates a rename on the trunk.

## The prerequisite this PR supplies

Every required check must also run on `merge_group`, or the queue waits forever for one that cannot fire. Required today: `verify`, `pr-title`, `check`, `test-unit (1)`, `test-unit (2)`, `test-jsdom`, `test-browser`, `widget-smoke`.

- `ci.yml` owns all of them but one — a single trigger covers it.
- **`pr-title` is the trap.** It lives in its own workflow deliberately (so it can re-run on `edited`, which `ci.yml` must not), so it needs the trigger separately — and a merge group has no PR title, so the validation step short-circuits rather than pretending to check something. Adding a required check in future means adding the trigger with it.

## To enable

Settings → Branches → `main` → **Require merge queue**. Squash is already the only permitted method, which is what the queue should use. Worth knowing before flipping it: the queue runs the full required set per batch at merge time, and this repo's CI is not cheap — batching is what keeps that affordable, so leave the batch size above 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added validation for merge-queue commits to help ensure changes remain safe to merge.
  * Updated automated checks to support merge-queue workflows.
  * Added guidance for handling stale checks and performing manual pre-merge validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->