### PR TITLE
feat(web): search the whole workspace from the document browser

### DIFF
--- a/apps/web/src/components/workspace-files/SearchResults.tsx
+++ b/apps/web/src/components/workspace-files/SearchResults.tsx
@@ -1,0 +1,69 @@
+/**
+ * What a search found, from anywhere in the workspace.
+ *
+ * Every row carries its full path, which the folder view deliberately does
+ * not: there, the path is the pane you are standing in and repeating it on
+ * every card would be noise. Here it is the only thing that says where the
+ * document actually is, and the reason someone searched.
+ */
+
+import type { ReactNode } from 'react'
+import { cn } from '../../lib/utils.js'
+import type { WorkspaceDocumentEntry } from './document-entry.js'
+
+export interface SearchResultsProps {
+  results: readonly WorkspaceDocumentEntry[]
+  selectedPath?: string
+  onSelect: (document: WorkspaceDocumentEntry) => void
+  renderThumbnail?: (document: WorkspaceDocumentEntry) => ReactNode
+  className?: string
+}
+
+export function SearchResults({
+  results,
+  selectedPath,
+  onSelect,
+  renderThumbnail,
+  className,
+}: SearchResultsProps) {
+  if (results.length === 0) {
+    return <p className={cn('text-muted-foreground text-sm', className)}>Nothing matches.</p>
+  }
+
+  return (
+    <ul className={cn('space-y-1 p-0.5', className)}>
+      {results.map((entry) => (
+        <li key={entry.documentId}>
+          <button
+            type="button"
+            aria-current={entry.path === selectedPath ? 'true' : undefined}
+            onClick={() => onSelect(entry)}
+            className="hover:bg-accent/40 aria-[current]:border-primary aria-[current]:ring-primary/40 flex w-full min-w-0 items-center gap-2 rounded-md border p-1.5 text-left aria-[current]:ring-1"
+          >
+            {/* 80x44, not smaller: measured on a real document, a faithful
+                render is a smear below roughly this and only here do the
+                heading and the blocks separate. Recognising the document is
+                the whole job of a search result, so this is the one list that
+                pays for the height. */}
+            <span className="bg-muted/40 flex h-11 w-20 shrink-0 items-center justify-center overflow-hidden rounded">
+              {renderThumbnail?.(entry) ?? (
+                <span
+                  data-kind={entry.kind ?? 'markdown'}
+                  className="text-muted-foreground text-xs"
+                >
+                  {entry.kind ?? 'markdown'}
+                </span>
+              )}
+            </span>
+            <span className="flex min-w-0 flex-col">
+              <span data-testid="result-title" className="truncate text-sm">
+                {entry.name ?? entry.path.split('/').at(-1)}
+              </span>
+              <span className="text-muted-foreground truncate font-mono text-xs">{entry.path}</span>
+            </span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -218,6 +218,30 @@ export function WorkspaceFilesPanel({
     [daemonFetch, daemonBaseUrl, workspaceId, readList, folder, documents],
   )
 
+  /**
+   * Leaving a search puts the folder view back, and the selection has to be
+   * put back with it: a result can come from anywhere, and the preview must
+   * never show a document the list beside it does not contain.
+   *
+   * Kept when it IS in the open folder — unlike a move, that case is real
+   * here (search from inside `design`, pick `design/login`, clear), and
+   * dropping it would lose a selection for no reason anyone could see.
+   */
+  const changeQuery = useCallback(
+    (next: string) => {
+      if (query.trim() !== '' && next.trim() === '') {
+        setSelected((current) => {
+          if (current === null) return null
+          const cut = current.path.lastIndexOf('/')
+          const parent = cut === -1 ? '' : current.path.slice(0, cut)
+          return parent === folder ? current : null
+        })
+      }
+      setQuery(next)
+    },
+    [query, folder],
+  )
+
   const moveDocument = useCallback(
     async (entry: WorkspaceDocumentEntry, newPath: string) => {
       await renameDocumentPath(daemonFetch, daemonBaseUrl, workspaceId, entry.path, newPath)
@@ -278,7 +302,7 @@ export function WorkspaceFilesPanel({
             aria-label="Search documents"
             placeholder="Search"
             value={query}
-            onChange={(event) => setQuery(event.target.value)}
+            onChange={(event) => changeQuery(event.target.value)}
             className="w-36 rounded border py-1 pl-7 pr-2 text-xs sm:w-48"
           />
         </div>

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -1,5 +1,5 @@
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
-import { Columns2, FilePlus2, LayoutGrid, List } from 'lucide-react'
+import { Columns2, FilePlus2, LayoutGrid, List, Search } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useThemeMode } from '../../hooks/useThemeMode.js'
 import {
@@ -19,6 +19,8 @@ import { FolderContentsList } from './FolderContentsList.js'
 import { createRowOutlineLoader } from './load-row-outline.js'
 import { createRowRenderLoader } from './load-row-render.js'
 import { newDocumentPathIn } from './new-document-path.js'
+import { SearchResults } from './SearchResults.js'
+import { searchDocuments } from './search-documents.js'
 import { WorkspaceFileTree } from './WorkspaceFileTree.js'
 import { WorkspaceFolderTree } from './WorkspaceFolderTree.js'
 
@@ -90,6 +92,7 @@ export function WorkspaceFilesPanel({
   const [folder, setFolder] = useState('')
   const [columns, setColumns] = useState<BrowserColumns>('two')
   const [createError, setCreateError] = useState<string | null>(null)
+  const [query, setQuery] = useState('')
 
   // One loader for the whole panel, so a re-render does not hand every card
   // a new function and re-trigger its render.
@@ -257,9 +260,27 @@ export function WorkspaceFilesPanel({
     <div className="flex min-h-0 flex-1 flex-col gap-2" data-testid="workspace-files-panel">
       <div className="flex items-center gap-2">
         <div className="min-w-0 flex-1">
-          {/* The trail belongs to whatever narrows the view, and in one-column
-              mode nothing does — the tree already shows every level at once. */}
-          {columns === 'two' && <FolderBreadcrumb folder={folder} onSelect={selectFolder} />}
+          {/* The trail belongs to whatever narrows the view. In one-column
+              mode nothing does — the tree already shows every level at once —
+              and while searching the results are from everywhere, so a trail
+              would name a folder the list is not confined to. */}
+          {columns === 'two' && query.trim() === '' && (
+            <FolderBreadcrumb folder={folder} onSelect={selectFolder} />
+          )}
+        </div>
+        <div className="relative shrink-0">
+          <Search
+            aria-hidden="true"
+            className="text-muted-foreground pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2"
+          />
+          <input
+            type="search"
+            aria-label="Search documents"
+            placeholder="Search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            className="w-36 rounded border py-1 pl-7 pr-2 text-xs sm:w-48"
+          />
         </div>
         <div className="flex shrink-0 items-center gap-1">
           <button
@@ -309,7 +330,29 @@ export function WorkspaceFilesPanel({
       )}
 
       <div className="flex min-h-0 flex-1 flex-col gap-4 md:flex-row">
-        {columns === 'one' ? (
+        {query.trim() !== '' ? (
+          // Results come from everywhere, so neither the folder tree nor the
+          // folder's own contents describes them. One flat list, in both
+          // column modes — a search that behaved differently per mode would
+          // be two features wearing one box.
+          <div className="min-w-0 flex-1 overflow-y-auto md:border-r md:pr-3">
+            <div data-testid="search-results">
+              <SearchResults
+                results={searchDocuments(documents, query)}
+                selectedPath={selected?.path}
+                onSelect={setSelected}
+                renderThumbnail={(entry) => (
+                  <DocumentThumbnail
+                    key={entry.documentId}
+                    document={entry}
+                    loadRender={loadRender}
+                    className="size-full"
+                  />
+                )}
+              />
+            </div>
+          </div>
+        ) : columns === 'one' ? (
           <div className="min-w-0 flex-1 overflow-y-auto md:border-r md:pr-3">
             <WorkspaceFileTree
               documents={documents}

--- a/apps/web/src/components/workspace-files/search-documents.test.ts
+++ b/apps/web/src/components/workspace-files/search-documents.test.ts
@@ -19,9 +19,21 @@ describe('searchDocuments', () => {
     ])
   })
 
+  // `flow`, not `kickoff`: every other name in this fixture is a substring of
+  // its own path, so a query that hits both proves nothing about which half
+  // answered. Only a name the path does NOT contain reaches the rule —
+  // without this, deleting name-matching outright leaves the file green.
   it('matches the display name as well as the path', () => {
+    expect(searchDocuments(docs, 'flow').map((d) => d.path)).toEqual(['design/login'])
     expect(searchDocuments(docs, 'kickoff').map((d) => d.path)).toEqual(['design/notes/kickoff'])
-    expect(searchDocuments(docs, 'Triage').map((d) => d.path)).toEqual(['inbox/triage'])
+  })
+
+  // The name has to survive the hand-off into the shared matcher, which is
+  // this module's own wiring: the other caller's tests guard the matcher,
+  // not the row shape handed to it from here.
+  it('passes the whole row to the matcher, not just its path', () => {
+    const named = [{ documentId: 'x', path: 'a/b', name: 'Quarterly plan' }]
+    expect(searchDocuments(named, 'quarterly').map((d) => d.path)).toEqual(['a/b'])
   })
 
   it('ignores case and surrounding space', () => {

--- a/apps/web/src/components/workspace-files/search-documents.test.ts
+++ b/apps/web/src/components/workspace-files/search-documents.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import type { WorkspaceDocumentEntry } from './document-entry.js'
+import { searchDocuments } from './search-documents.js'
+
+const docs: WorkspaceDocumentEntry[] = [
+  { documentId: 'd1', path: 'design/login', name: 'Login flow' },
+  { documentId: 'd2', path: 'design/notes/kickoff', name: 'Kickoff' },
+  { documentId: 'd3', path: 'inbox/triage', name: 'Triage' },
+  { documentId: 'd4', path: 'archive/old-login' },
+]
+
+describe('searchDocuments', () => {
+  // You search because you do not know where it is: the results come from
+  // everywhere, including folders that are collapsed or unvisited.
+  it('searches the whole workspace', () => {
+    expect(searchDocuments(docs, 'login').map((d) => d.path)).toEqual([
+      'archive/old-login',
+      'design/login',
+    ])
+  })
+
+  it('matches the display name as well as the path', () => {
+    expect(searchDocuments(docs, 'kickoff').map((d) => d.path)).toEqual(['design/notes/kickoff'])
+    expect(searchDocuments(docs, 'Triage').map((d) => d.path)).toEqual(['inbox/triage'])
+  })
+
+  it('ignores case and surrounding space', () => {
+    expect(searchDocuments(docs, '  LOGIN  ').map((d) => d.path)).toEqual([
+      'archive/old-login',
+      'design/login',
+    ])
+  })
+
+  // Results come from everywhere, so the order has to be one a reader can
+  // predict — by address, which is also how they are grouped on screen.
+  it('orders results by path', () => {
+    expect(searchDocuments(docs, 'i').map((d) => d.path)).toEqual([
+      'archive/old-login',
+      'design/login',
+      'design/notes/kickoff',
+      'inbox/triage',
+    ])
+  })
+
+  // An empty query is not a search: the caller shows the folder instead, and
+  // answering "everything" here would make that decision twice.
+  it('answers nothing at all for an empty query', () => {
+    expect(searchDocuments(docs, '')).toEqual([])
+    expect(searchDocuments(docs, '   ')).toEqual([])
+  })
+})

--- a/apps/web/src/components/workspace-files/search-documents.ts
+++ b/apps/web/src/components/workspace-files/search-documents.ts
@@ -1,0 +1,25 @@
+/**
+ * Finding a document by name, from anywhere in the workspace.
+ *
+ * Deliberately not scoped to the open folder. Searching is what someone does
+ * when they do NOT know where a document is; a search that only looked where
+ * they were standing would answer the one question they could already
+ * answer by looking.
+ *
+ * An empty query answers nothing rather than everything. The caller shows
+ * the folder's own contents in that case, and returning the whole workspace
+ * here would put that decision in two places.
+ */
+
+import { documentMatchesSearch } from '../workspace-top-bar/document-list.js'
+import type { WorkspaceDocumentEntry } from './document-entry.js'
+
+export function searchDocuments<T extends WorkspaceDocumentEntry>(
+  documents: readonly T[],
+  query: string,
+): readonly T[] {
+  if (query.trim() === '') return []
+  return documents
+    .filter((entry) => documentMatchesSearch(query, entry))
+    .sort((left, right) => left.path.localeCompare(right.path))
+}

--- a/apps/web/src/components/workspace-top-bar/document-list.test.ts
+++ b/apps/web/src/components/workspace-top-bar/document-list.test.ts
@@ -23,6 +23,14 @@ describe('sortDocumentsByRecency', () => {
 })
 
 describe('filterDocumentsBySearch', () => {
+  // browser-local has no daemon /names endpoint, so its display name arrives
+  // on the row itself. Reading only the table left such a document findable
+  // by path alone — by the auto-generated `untitled-2`, never by its name.
+  it('matches an inline display name when the names table has none', () => {
+    const local = [{ path: 'untitled-2', updatedAt: 'x', name: 'Weekly review' }]
+    expect(filterDocumentsBySearch(local, 'weekly', {}).map((c) => c.path)).toEqual(['untitled-2'])
+  })
+
   const documents = [canvas('team/roadmap', '2024-01-01'), canvas('personal', '2024-01-02')]
   const names: Record<string, string> = { personal: 'My Notes' }
 

--- a/apps/web/src/components/workspace-top-bar/document-list.test.ts
+++ b/apps/web/src/components/workspace-top-bar/document-list.test.ts
@@ -23,9 +23,11 @@ describe('sortDocumentsByRecency', () => {
 })
 
 describe('filterDocumentsBySearch', () => {
-  // browser-local has no daemon /names endpoint, so its display name arrives
-  // on the row itself. Reading only the table left such a document findable
-  // by path alone — by the auto-generated `untitled-2`, never by its name.
+  // A CONTRACT test, not a regression: no caller today can produce a row with
+  // a name and no table entry, because both build the table from the field
+  // the row carries. It pins that the two arguments are two sources rather
+  // than one plus decoration, so a caller that ever populates only one is
+  // not silently searching by path.
   it('matches an inline display name when the names table has none', () => {
     const local = [{ path: 'untitled-2', updatedAt: 'x', name: 'Weekly review' }]
     expect(filterDocumentsBySearch(local, 'weekly', {}).map((c) => c.path)).toEqual(['untitled-2'])

--- a/apps/web/src/components/workspace-top-bar/document-list.ts
+++ b/apps/web/src/components/workspace-top-bar/document-list.ts
@@ -34,9 +34,13 @@ export function filterDocumentsBySearch(
   namesByPath: Readonly<Record<string, string>>,
 ): DocumentInfo[] {
   if (query.trim() === '') return [...documents]
-  // Either source: `namesByPath` is the daemon's /names table, `c.name` is
-  // the inline one browser-local supplies because it has no daemon to ask.
-  // Reading only the table made a local document searchable by path alone.
+  // Either source, though today neither caller can tell them apart:
+  // DocumentListView builds its table from `r.displayName` on the line above
+  // the rows themselves, and useDocumentNames builds local-mode's from
+  // `c.name`. So this `??` is the function's contract matching its own
+  // signature — it takes rows that carry a name AND a table of names — and
+  // not a live defect. A caller that populated only one would otherwise
+  // search by path alone with nothing to say so.
   return documents.filter((c) =>
     documentMatchesSearch(query, { path: c.path, name: namesByPath[c.path] ?? c.name }),
   )

--- a/apps/web/src/components/workspace-top-bar/document-list.ts
+++ b/apps/web/src/components/workspace-top-bar/document-list.ts
@@ -5,18 +5,38 @@ export function sortDocumentsByRecency(documents: readonly DocumentInfo[]): Docu
   return [...documents].sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1))
 }
 
+/**
+ * The one rule for "does this document match what was typed": its path or
+ * its display name contains the query, case-insensitively.
+ *
+ * Exported so the document browser can apply it to its own row shape, which
+ * carries the name inline instead of in a side table. Two matchers would be
+ * two searches that disagree about the same query.
+ *
+ * An empty query matches everything — callers decide whether that means
+ * "show all" or "not searching".
+ */
+export function documentMatchesSearch(
+  query: string,
+  document: { readonly path: string; readonly name?: string | undefined },
+): boolean {
+  const q = query.trim().toLowerCase()
+  if (q === '') return true
+  return (
+    document.path.toLowerCase().includes(q) || (document.name?.toLowerCase().includes(q) ?? false)
+  )
+}
+
 // Matches by path or by the caller-supplied display name, case-insensitively.
 export function filterDocumentsBySearch(
   documents: readonly DocumentInfo[],
   query: string,
   namesByPath: Readonly<Record<string, string>>,
 ): DocumentInfo[] {
-  const q = query.trim().toLowerCase()
-  if (!q) return [...documents]
-  return documents.filter((c) => {
-    const n = namesByPath[c.path]
-    return c.path.toLowerCase().includes(q) || (n?.toLowerCase().includes(q) ?? false)
-  })
+  if (query.trim() === '') return [...documents]
+  return documents.filter((c) =>
+    documentMatchesSearch(query, { path: c.path, name: namesByPath[c.path] }),
+  )
 }
 
 // Preserves the user-defined order in `pinnedPaths` instead of resorting

--- a/apps/web/src/components/workspace-top-bar/document-list.ts
+++ b/apps/web/src/components/workspace-top-bar/document-list.ts
@@ -34,8 +34,11 @@ export function filterDocumentsBySearch(
   namesByPath: Readonly<Record<string, string>>,
 ): DocumentInfo[] {
   if (query.trim() === '') return [...documents]
+  // Either source: `namesByPath` is the daemon's /names table, `c.name` is
+  // the inline one browser-local supplies because it has no daemon to ask.
+  // Reading only the table made a local document searchable by path alone.
   return documents.filter((c) =>
-    documentMatchesSearch(query, { path: c.path, name: namesByPath[c.path] }),
+    documentMatchesSearch(query, { path: c.path, name: namesByPath[c.path] ?? c.name }),
   )
 }
 

--- a/apps/web/src/pages/DaemonIndexPage.files-tab.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.files-tab.test.tsx
@@ -604,6 +604,67 @@ describe('DaemonIndexPage tree view', () => {
     })
   })
 
+  // Searching is what someone does when they do NOT know where a document
+  // is, so the results have to come from folders they are not standing in —
+  // including ones they have never opened.
+  it('finds a document from a folder it is not standing in', async () => {
+    installFetchMock()
+    render(
+      <DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} token="secret" onOpenDocument={() => {}} />,
+    )
+    fireEvent.click(await screen.findByRole('button', { name: 'Tree view' }))
+    const contents = await screen.findByTestId('folder-contents')
+    // Standing at the root, where `notes/design` is NOT listed.
+    expect(contents.textContent).not.toContain('design')
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search documents' }), {
+      target: { value: 'design' },
+    })
+
+    const results = await screen.findByTestId('search-results')
+    expect(results.textContent).toContain('notes/design')
+    // The folder view is replaced, not shown beside the results.
+    expect(screen.queryByTestId('folder-contents')).toBeNull()
+    // And the trail is gone, because the results are not confined to a folder.
+    expect(screen.queryByRole('navigation', { name: 'Folder path' })).toBeNull()
+  })
+
+  it('previews a result, and goes back to the folder when the search is cleared', async () => {
+    installFetchMock()
+    render(
+      <DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} token="secret" onOpenDocument={() => {}} />,
+    )
+    fireEvent.click(await screen.findByRole('button', { name: 'Tree view' }))
+    await screen.findByTestId('folder-contents')
+
+    const box = screen.getByRole('searchbox', { name: 'Search documents' })
+    fireEvent.change(box, { target: { value: 'design' } })
+    const results = await screen.findByTestId('search-results')
+
+    fireEvent.click(within(results).getByRole('button', { name: /design/ }))
+    await waitFor(() => {
+      expect(screen.getByTestId('okf-preview').textContent).toContain('notes/design')
+    })
+
+    fireEvent.change(box, { target: { value: '' } })
+    await screen.findByTestId('folder-contents')
+    expect(screen.queryByTestId('search-results')).toBeNull()
+  })
+
+  it('says nothing matches rather than showing an empty pane', async () => {
+    installFetchMock()
+    render(
+      <DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} token="secret" onOpenDocument={() => {}} />,
+    )
+    fireEvent.click(await screen.findByRole('button', { name: 'Tree view' }))
+    await screen.findByTestId('folder-contents')
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search documents' }), {
+      target: { value: 'zzzz' },
+    })
+    expect((await screen.findByTestId('search-results')).textContent).toContain('Nothing matches')
+  })
+
   it('shows a calm no-tree message (not an alert) when the list 404s', async () => {
     installFetchMock({ status: 404, body: { error: 'Workspace not found: "default".' } })
     render(

--- a/apps/web/src/pages/DaemonIndexPage.files-tab.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.files-tab.test.tsx
@@ -651,6 +651,58 @@ describe('DaemonIndexPage tree view', () => {
     expect(screen.queryByTestId('search-results')).toBeNull()
   })
 
+  // The invariant the three panes rest on: the preview must never show a
+  // document the list beside it does not contain. Searching can reach one
+  // from another folder, so clearing the query has to put that right.
+  it('drops a result from elsewhere when the search is cleared', async () => {
+    installFetchMock()
+    render(
+      <DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} token="secret" onOpenDocument={() => {}} />,
+    )
+    fireEvent.click(await screen.findByRole('button', { name: 'Tree view' }))
+    await screen.findByTestId('folder-contents')
+
+    const box = screen.getByRole('searchbox', { name: 'Search documents' })
+    fireEvent.change(box, { target: { value: 'design' } })
+    const results = await screen.findByTestId('search-results')
+    fireEvent.click(within(results).getByRole('button', { name: /design/ }))
+    await waitFor(() => {
+      expect(screen.getByTestId('okf-preview').textContent).toContain('notes/design')
+    })
+
+    // Back at the root, where `notes/design` is not listed.
+    fireEvent.change(box, { target: { value: '' } })
+    await screen.findByTestId('folder-contents')
+    expect(screen.queryByTestId('okf-preview')).toBeNull()
+  })
+
+  // ...but a result that lives where you were already standing is not from
+  // elsewhere, and dropping it would lose a selection for no reason.
+  it('keeps a result that is in the folder already open', async () => {
+    installFetchMock()
+    render(
+      <DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} token="secret" onOpenDocument={() => {}} />,
+    )
+    fireEvent.click(await screen.findByRole('button', { name: 'Tree view' }))
+    const contents = await screen.findByTestId('folder-contents')
+    fireEvent.click(within(contents).getByRole('button', { name: 'Open folder notes' }))
+    await waitFor(() => {
+      expect(screen.getByTestId('folder-contents').textContent).toContain('design')
+    })
+
+    const box = screen.getByRole('searchbox', { name: 'Search documents' })
+    fireEvent.change(box, { target: { value: 'design' } })
+    const results = await screen.findByTestId('search-results')
+    fireEvent.click(within(results).getByRole('button', { name: /design/ }))
+    await waitFor(() => {
+      expect(screen.getByTestId('okf-preview').textContent).toContain('notes/design')
+    })
+
+    fireEvent.change(box, { target: { value: '' } })
+    await screen.findByTestId('folder-contents')
+    expect(screen.getByTestId('okf-preview').textContent).toContain('notes/design')
+  })
+
   it('says nothing matches rather than showing an empty pane', async () => {
     installFetchMock()
     render(


### PR DESCRIPTION
The browser can show a hierarchy and move around it, but not answer *"where is the one called login"*. The grid it is meant to replace has search — so until the browser does too, retiring the grid would lose a capability rather than consolidate one. This is the prerequisite, landed on its own.

![browser-search.png](https://github.com/user-attachments/assets/01c4f03b-025d-488f-b820-7109290fd0a4)

## The one design decision

**Results come from the whole workspace.** Searching is what someone does when they do *not* know where a document is; a search scoped to the open folder would answer the one question they could already answer by looking. Two consequences follow from that and are wired accordingly:

- the results **replace** whichever list is on screen, in both column modes — a search that behaved differently per mode would be two features wearing one box;
- the **breadcrumb goes away** while searching, because a trail would name a folder the results are not confined to.

Every result carries its full path, which the folder view deliberately does not: there the path is the pane you are standing in, and repeating it on every card is noise. Here it is the answer.

## Shared rule, separate shapes

The match rule moves into `documentMatchesSearch` and both callers use it. Two matchers would be two searches that disagree about the same query. The *shapes* stay different on purpose — the browser's row carries its display name inline, the top bar keeps a side table — and adapting one to the other's signature would have meant building a throwaway record per keystroke.

## Sized by an existing measurement

Result thumbnails are **80×44**, not the 56×40 they started at. This repo already measured where a faithful render stops carrying information (#902): a square 24px is a single dash, 56×32 is a smear, and around 80×44 the heading and the blocks separate. The first capture of this branch showed exactly that smear at 56×40. Recognising the document is the whole job of a search result, so this is the one list that pays for the height.

## Evidence

Seven rules mutation-checked — reverted, confirmed RED, restored: the empty query answering nothing rather than everything, the path ordering, results replacing the folder view, the breadcrumb hiding, a result selecting into the preview, the empty state, and the path on every row.

An unused `folder` parameter was removed from `searchDocuments` rather than kept "for later": a parameter the function ignores is a promise it does not keep.

`apps/web` as CI runs it: **2549 passed** (jsdom) + **77 passed** (node). `pnpm lint`, `pnpm -r typecheck`, `pnpm knip` clean.

## Next

With search present, retiring the grid becomes a diff whose whole content is "delete the grid, move its tests" — plus deciding what happens to pinned-first ordering, which the browser still has no equivalent for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace-wide document search from the files panel.
  * Search matches document names and paths, regardless of letter case or surrounding whitespace.
  * Results display thumbnails, document names, and full paths.
  * Selecting a result opens its document preview.
  * Clearing the search restores the appropriate folder view and breadcrumbs.
  * Displays “Nothing matches.” when no documents are found.

* **Bug Fixes**
  * Improved consistency of document filtering and search behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->