### PR TITLE
feat(server-core): give a node the height its own text needs

### DIFF
--- a/packages/server-core/src/render/compose-canvas-scene.ts
+++ b/packages/server-core/src/render/compose-canvas-scene.ts
@@ -16,7 +16,7 @@ import { getLogger } from '../log.js'
 // decision #8): a user's ambient UI theme must never change what wb_scene_render
 // or wb_canvas_snapshot's layout analysis emit. Built once — the resolver
 // is stateless.
-const MCP_SCENE_APPEARANCE = createSpatialTheme({ mode: 'light' })
+export const MCP_SCENE_APPEARANCE = createSpatialTheme({ mode: 'light' })
 
 const log = getLogger('compose-canvas-scene')
 

--- a/packages/server-core/src/tools/canvas-edit.test.ts
+++ b/packages/server-core/src/tools/canvas-edit.test.ts
@@ -1,4 +1,10 @@
 import {
+  constantRatioMeasureText,
+  createSpatialTheme,
+  naturalNodeContentSize,
+  SPATIAL_THEME_GEOMETRY,
+} from '@kamiazya/whiteboard-canvas-render'
+import {
   readDocumentKind,
   readEdgeLocks,
   readNodeLocks,
@@ -1190,5 +1196,71 @@ describe('wb_canvas_edit — region.set', () => {
 
     const { canvas } = await loadDocument(makeDeps(store), DOCUMENT_ID)
     expect(canvas.edges).toEqual([])
+  })
+})
+
+/**
+ * The last gap in "content stays inside its frame": a node created without a
+ * height got a fixed default, so an agent that did not invent geometry got a
+ * box its own text did not fit. The fade and `overflows` report that
+ * afterwards; this is about not producing it in the first place.
+ */
+const DEFAULT_TEXT_HEIGHT = 120
+
+describe('wb_canvas_edit — a node created without a height', () => {
+  // Long enough to need 176px in a 260-wide box, against the 120px default.
+  // One repetition measures 96px and FITS — a fixture that short would pass
+  // against the unfixed code and assert nothing, which is why the first test
+  // below re-checks that it is still reaching the case.
+  const LONG_JA = (
+    'これは日本語の長い文章です。ノードの幅を超えても折り返されるべきですが、' +
+    '既定の高さのままだと入りきりません。だから作るときに測ります。'
+  ).repeat(2)
+
+  async function addAndMeasure(text: string, height?: number) {
+    const store = new FakeDocumentStore()
+    await seedCanvas(store, EMPTY)
+    const tool = createCanvasEditTool(makeDeps(store))
+    await tool.execute({
+      workspaceId: WORKSPACE_ID,
+      documentId: DOCUMENT_ID,
+      ops: [
+        {
+          op: 'node.add',
+          node: { id: 'n', type: 'text', text, ...(height === undefined ? {} : { height }) },
+        },
+      ],
+    })
+    const { canvas } = await loadDocument(makeDeps(store), DOCUMENT_ID)
+    const node = canvas.nodes[0]
+    const natural = naturalNodeContentSize(node, {
+      measure: constantRatioMeasureText,
+      appearance: createSpatialTheme({ mode: 'light' }),
+    })
+    return { node, needs: natural.h + 2 * SPATIAL_THEME_GEOMETRY.paddingPx }
+  }
+
+  test('is tall enough for its own text', async () => {
+    const { node, needs } = await addAndMeasure(LONG_JA)
+
+    // The fixture has to out-grow the default, or this asserts nothing.
+    expect(needs).toBeGreaterThan(DEFAULT_TEXT_HEIGHT)
+    expect(node.height).toBeGreaterThanOrEqual(needs)
+  })
+
+  test('respects a height that was named, however small', async () => {
+    // "no height" and "a small height" are different inputs. Someone who
+    // asked for 40 gets 40 — the fade is the honest answer there.
+    const { node } = await addAndMeasure(LONG_JA, 40)
+
+    expect(node.height).toBe(40)
+  })
+
+  test('does not shrink a short node below the default', async () => {
+    // Grow-only. A one-word node measuring 32px tall would still look wrong
+    // next to its neighbours, and nothing about the defect asks for that.
+    const { node } = await addAndMeasure('short')
+
+    expect(node.height).toBe(DEFAULT_TEXT_HEIGHT)
   })
 })

--- a/packages/server-core/src/tools/canvas-edit.ts
+++ b/packages/server-core/src/tools/canvas-edit.ts
@@ -1,4 +1,10 @@
-import { tidyNodes } from '@kamiazya/whiteboard-canvas-render'
+import {
+  constantRatioMeasureText,
+  type MeasureText,
+  naturalNodeContentSize,
+  SPATIAL_THEME_GEOMETRY,
+  tidyNodes,
+} from '@kamiazya/whiteboard-canvas-render'
 import {
   readDocumentKind,
   readEdgeLocks,
@@ -20,6 +26,7 @@ import {
   workspaceIdSchema,
 } from '@kamiazya/whiteboard-model'
 import { z } from 'zod'
+import { MCP_SCENE_APPEARANCE } from '../render/compose-canvas-scene.js'
 import type { CanvasOpSummaryInput, ServerDeps } from '../server-deps.js'
 import { assertDocumentInWorkspace } from './assert-document-in-workspace.js'
 import { canvasSnapshotSchema, projectCanvasSnapshot } from './canvas-snapshot.js'
@@ -41,6 +48,25 @@ const DEFAULT_SIZE: Record<SpatialNode['type'], { width: number; height: number 
   file: { width: 260, height: 120 },
   link: { width: 260, height: 120 },
   group: { width: 400, height: 300 },
+}
+
+/**
+ * The height a node needs for its own text, never less than the default it
+ * would otherwise get.
+ *
+ * GROW-ONLY on purpose. A one-word node measures about 32px, and shrinking
+ * every short node to that would redraw how a whole diagram looks for a
+ * defect that is only ever about content NOT FITTING. The default stays the
+ * floor; this only lifts it.
+ *
+ * Position does not matter here: `naturalNodeContentSize` lays the content
+ * out unbounded, so only the width it wraps against is an input. That is what
+ * breaks the circularity — placement needs a height, and the height needs a
+ * width, not a position.
+ */
+function fittedHeight(node: SpatialNode, measure: MeasureText, fallback: number): number {
+  const natural = naturalNodeContentSize(node, { measure, appearance: MCP_SCENE_APPEARANCE })
+  return Math.max(fallback, natural.h + 2 * SPATIAL_THEME_GEOMETRY.paddingPx)
 }
 
 /**
@@ -401,6 +427,19 @@ export function createCanvasEditTool(deps: ServerDeps) {
       const geometry = new Map<string, z.infer<typeof geometryEntrySchema>>()
       const cursor = new PlacementCursor()
 
+      // Resolved once, and only when some op actually creates a text node
+      // without naming a height — the composition root's measurer parses a
+      // font on first use, and a batch of patches should not pay for that.
+      // `region.set` is deliberately NOT included: what it declares must fit
+      // inside its group, so growing a node there could refuse the very op
+      // that asked for it. A node created there keeps the flat default.
+      const wantsFit = input.ops.some(
+        (op) => op.op === 'node.add' && op.node.type === 'text' && op.node.height === undefined,
+      )
+      const measure: MeasureText | undefined = wantsFit
+        ? ((await deps.measure?.()) ?? constantRatioMeasureText)
+        : undefined
+
       const nodeAt = (id: string) => nodes.find((node) => node.id === id)
       const edgeAt = (id: string) => edges.find((edge) => edge.id === id)
 
@@ -421,7 +460,15 @@ export function createCanvasEditTool(deps: ServerDeps) {
             }
             const size = DEFAULT_SIZE[draft.type]
             const width = draft.width ?? size.width
-            const height = draft.height ?? size.height
+            const height =
+              draft.height ??
+              (draft.type === 'text' && measure !== undefined
+                ? fittedHeight(
+                    { ...draft, id, x: 0, y: 0, width, height: size.height },
+                    measure,
+                    size.height,
+                  )
+                : size.height)
             // Partial geometry is treated as none: a node given an x but no
             // y has no position, and guessing the other half would put it
             // somewhere the caller did not ask for either.


### PR DESCRIPTION
The last gap in **"content stays inside its frame"** — the thread that started from a phone screenshot of a text node whose lines ran out the bottom.

A node created through `wb_canvas_edit` without a height got a flat 120px. Geometry is optional precisely so an agent does not have to invent four integers per node, and the reward for taking that offer was a box its own text did not fit. #891's fade and #895's `overflows` report that *afterwards*; this is about not producing it.

`node.add` on a text node with no declared height now measures the content: `naturalNodeContentSize().h + 2 * padding`, the same formula `apps/web`'s `requiredTextNodeHeight` already uses, through the same injected measurer as the render tools (so it agrees with what gets drawn).

## Three rules, each mutation-checked on its own

| rule | why |
|---|---|
| **Grow-only** — the 120px default is the floor | A one-word node measures ~32px. Shrinking every short node to that redraws how a whole diagram looks, for a defect that is only ever about content **not fitting**. |
| **A named height is respected, however small** | "No height" and "a small height" are different inputs. Ask for 40 and you get 40 — the fade is the honest answer there. |
| **Existing nodes untouched** | A creation default, not a migration. |

Reverting any one reddens exactly the test that pins it and leaves the other two green.

`region.set` deliberately keeps the flat default: what it declares must fit inside its group, so growing a node there could refuse the very op that asked for it.

## Verified end-to-end through the real stdio MCP server

```
long   height= 176  overflows=-      needs 176; would have been 120
named  height=  40  overflows=true   asked for 40, kept, honestly faded
orig   height= 120  overflows=-      short; floor holds
```

`orig` is the node from the original report.

## One thing worth flagging about the fixture

My first version of these tests **passed against the unfixed code**. One repetition of the Japanese sample measures 96px and fits the old 120px default, so the fixture never reached the case it was named for. The fixture is now two repetitions (176px), and the first test re-checks that its own input still out-grows the default — so it cannot quietly stop asserting anything if the measurer or the default moves.

Verified: `pnpm -r typecheck` clean, **401 files / 4643 passed**, `pnpm knip` clean, `pnpm smoke:e2e` ALL OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Text nodes added without a specified height now automatically expand to fit their content.
  - Short text continues using the standard default height for consistent layouts.

- **Bug Fixes**
  - Improved canvas text rendering to prevent content from being clipped when text requires more vertical space.
  - Explicitly specified heights remain unchanged, preserving intentional sizing and existing region updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->