### PR TITLE
fix(web): fold a local document's delta log instead of growing it forever

### DIFF
--- a/apps/web/src/lib/loro-compaction.test.ts
+++ b/apps/web/src/lib/loro-compaction.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { COMPACT_DELTA_BYTES, shouldCompact } from './loro-compaction.js'
+
+const bytes = (n: number) => new Uint8Array(n)
+
+describe('shouldCompact', () => {
+  // The threshold is a measurement, not a preference: at ~64KB of deltas the
+  // replay a fresh open pays is ~10ms and the storage waste is ~10x the
+  // folded snapshot. Both keep growing without a bound.
+  it('folds once the log passes the measured budget', () => {
+    expect(shouldCompact([bytes(COMPACT_DELTA_BYTES + 1)])).toBe(true)
+    expect(shouldCompact([bytes(COMPACT_DELTA_BYTES)])).toBe(false)
+  })
+
+  // Size, not count: one pasted document and a thousand drags cost wildly
+  // different bytes, and it is the bytes that are replayed and stored.
+  it('counts bytes rather than entries', () => {
+    const manyTiny = Array.from({ length: 5_000 }, () => bytes(1))
+    expect(shouldCompact(manyTiny)).toBe(false)
+    expect(shouldCompact([bytes(COMPACT_DELTA_BYTES + 1)])).toBe(true)
+  })
+
+  it('sums the whole log, not just the newest entry', () => {
+    const half = Math.ceil(COMPACT_DELTA_BYTES / 2) + 1
+    expect(shouldCompact([bytes(half), bytes(half)])).toBe(true)
+  })
+
+  it('leaves an empty or absent log alone', () => {
+    expect(shouldCompact([])).toBe(false)
+    expect(shouldCompact(undefined)).toBe(false)
+  })
+})

--- a/apps/web/src/lib/loro-compaction.ts
+++ b/apps/web/src/lib/loro-compaction.ts
@@ -1,0 +1,32 @@
+/**
+ * When a local document's delta log is worth folding back into its snapshot.
+ *
+ * Measured on a 20-node canvas, one delta per edit (Chromium, this machine):
+ *
+ *   edits   stored (base+deltas)   folded   ratio   replay
+ *      10                 4.3 KB   1.6 KB   2.7x     ~5 ms
+ *      50                17.5 KB   2.7 KB   6.5x     ~3 ms
+ *     200                67.2 KB   6.3 KB  10.6x    ~10 ms
+ *     500               166.6 KB  14.2 KB  11.7x    ~22 ms
+ *
+ * Reading a folded snapshot stayed near 1ms at every size, so the whole cost
+ * is the replay, and both it and the waste grow without a bound — the log
+ * had no cap and no compaction at all.
+ *
+ * 64KB is the point in that table where replay is still ~10ms and the waste
+ * is bounded at roughly ten times the real content. The daemon's
+ * `SNAPSHOT_MAX_CHUNK_BYTES` (1MB) is deliberately NOT reused: that is where
+ * a snapshot is split for storage, not where a log stops being worth keeping.
+ */
+export const COMPACT_DELTA_BYTES = 64 * 1024
+
+/**
+ * Bytes, not entries. One pasted document and a thousand drags differ by
+ * orders of magnitude, and it is the bytes that get replayed and stored.
+ */
+export function shouldCompact(deltas: readonly Uint8Array[] | undefined): boolean {
+  if (deltas === undefined || deltas.length === 0) return false
+  let total = 0
+  for (const delta of deltas) total += delta.byteLength
+  return total > COMPACT_DELTA_BYTES
+}

--- a/apps/web/src/lib/loro-store-compaction.browser.test.tsx
+++ b/apps/web/src/lib/loro-store-compaction.browser.test.tsx
@@ -68,3 +68,27 @@ it('folds the delta log once it passes the budget, keeping the content', async (
   for (const d of loaded.deltas ?? []) reopened.import(d)
   expect(readSpatialCanvas(reopened).nodes[0]?.x).toBe(canvasWith(20, appended).nodes[0]?.x)
 }, 120_000)
+
+// The guard the fold rests on: bytes that will not replay are kept exactly as
+// they were. Reachable, not defensive — appendDelta only checks the envelope
+// STRUCTURALLY (instanceof Uint8Array); it never deep-validates the stored
+// snapshot or the deltas already there, and the repo's own loro-store tests
+// seed a v:1 envelope carrying invalid Loro bytes.
+it('keeps a log it cannot replay rather than dropping the edits', async () => {
+  const store = new LoroStore()
+  const id = `unfoldable-${Math.trunc(performance.now() * 1000)}`
+
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, canvasWith(5))
+  doc.commit()
+  await store.save(id, doc.export({ mode: 'snapshot' }))
+
+  // Past the budget in one go, and not Loro bytes at all.
+  const garbage = new Uint8Array(COMPACT_DELTA_BYTES + 1).fill(7)
+  await expect(store.appendDelta(id, garbage)).resolves.toBeUndefined()
+
+  const loaded = await store.load(id)
+  // load()'s deep validation refuses it — which is the point: the bytes are
+  // still there to be refused, rather than silently gone.
+  expect(loaded.kind).toBe('corrupt-delta')
+}, 120_000)

--- a/apps/web/src/lib/loro-store-compaction.browser.test.tsx
+++ b/apps/web/src/lib/loro-store-compaction.browser.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Compaction, against real IndexedDB and real Loro bytes.
+ *
+ * jsdom has neither, and the property under test is precisely that the bytes
+ * a fresh open replays stop growing — which is only observable once both are
+ * real.
+ */
+import { readSpatialCanvas, writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { LoroDoc } from 'loro-crdt'
+import { expect, it } from 'vitest'
+import { COMPACT_DELTA_BYTES } from './loro-compaction.js'
+import { LoroStore } from './loro-store.js'
+
+function canvasWith(n: number, nudge = 0): SpatialCanvas {
+  return {
+    nodes: Array.from({ length: n }, (_, i) => ({
+      id: `n${i}`,
+      type: 'text' as const,
+      x: (i % 10) * 220 + nudge,
+      y: Math.floor(i / 10) * 140,
+      width: 200,
+      height: 120,
+      text: `Node ${i} — a line of text long enough to be realistic.`,
+    })),
+    edges: [],
+  } as SpatialCanvas
+}
+
+function totalBytes(deltas: readonly Uint8Array[] | undefined): number {
+  return (deltas ?? []).reduce((sum, d) => sum + d.byteLength, 0)
+}
+
+it('folds the delta log once it passes the budget, keeping the content', async () => {
+  const store = new LoroStore()
+  const id = `doc-${Math.trunc(performance.now() * 1000)}`
+
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, canvasWith(20))
+  doc.commit()
+  await store.save(id, doc.export({ mode: 'snapshot' }))
+
+  let version = doc.version()
+  let appended = 0
+  let pushed = 0
+  // Past the budget with room to spare, so the assertion is not on its edge.
+  while (pushed < COMPACT_DELTA_BYTES * 2) {
+    appended += 1
+    if (appended > 2000) throw new Error('never reached the budget')
+    writeSpatialCanvas(doc, canvasWith(20, appended))
+    doc.commit()
+    const delta = doc.export({ mode: 'update', from: version })
+    version = doc.version()
+    pushed += delta.byteLength
+    await store.appendDelta(id, delta)
+  }
+
+  const loaded = await store.load(id)
+  expect(loaded.kind).toBe('ok')
+  if (loaded.kind !== 'ok') return
+
+  // The log is folded away, not merely trimmed.
+  expect(totalBytes(loaded.deltas)).toBeLessThanOrEqual(COMPACT_DELTA_BYTES)
+
+  // And the content survived the fold: the last edit is still there.
+  const reopened = new LoroDoc()
+  reopened.import(loaded.snapshot)
+  for (const d of loaded.deltas ?? []) reopened.import(d)
+  expect(readSpatialCanvas(reopened).nodes[0]?.x).toBe(canvasWith(20, appended).nodes[0]?.x)
+}, 120_000)

--- a/apps/web/src/lib/loro-store.ts
+++ b/apps/web/src/lib/loro-store.ts
@@ -1,6 +1,7 @@
 import { Loro } from 'loro-crdt'
 import { z } from 'zod'
 import { openWhiteboardDb } from './browser-idb.js'
+import { shouldCompact } from './loro-compaction.js'
 
 /**
  * Versioned envelope for Loro records persisted in IndexedDB.
@@ -42,6 +43,22 @@ function isValidLoroBytes(bytes: Uint8Array): boolean {
     return true
   } catch {
     return false
+  }
+}
+
+/**
+ * Replay a record into one snapshot. Returns null when any byte refuses to
+ * import — an unfoldable log is left exactly as it was, because losing edits
+ * to save space is not a trade this is allowed to make.
+ */
+function foldDeltas(snapshot: Uint8Array, deltas: readonly Uint8Array[]): Uint8Array | null {
+  try {
+    const doc = new Loro()
+    doc.import(snapshot)
+    for (const delta of deltas) doc.import(delta)
+    return doc.export({ mode: 'snapshot' })
+  } catch {
+    return null
   }
 }
 
@@ -183,11 +200,17 @@ export class LoroStore {
           tx.abort()
           return
         }
-        const updated: LoroRecordEnvelope = {
-          ...parsed.data,
-          deltas: [...(parsed.data.deltas ?? []), delta],
-          updatedAt: new Date().toISOString(),
-        }
+        const deltas = [...(parsed.data.deltas ?? []), delta]
+        // Folding HERE rather than on read: this is already the one
+        // read-modify-write transaction over this record, so the fold cannot
+        // race an append, and a fresh open never pays for a log someone
+        // else's session grew. Measured at the budget, the fold costs about
+        // 10ms of synchronous replay and it happens once per 64KB written.
+        const folded = shouldCompact(deltas) ? foldDeltas(parsed.data.snapshot, deltas) : null
+        const updated: LoroRecordEnvelope =
+          folded === null
+            ? { ...parsed.data, deltas, updatedAt: new Date().toISOString() }
+            : { v: 1, snapshot: folded, updatedAt: new Date().toISOString() }
         store.put(updated, documentId)
       }
       tx.oncomplete = () => {


### PR DESCRIPTION
`LoroStore.appendDelta` appended to a local document's delta log and never compacted it. No cap, no compaction, and — unlike the daemon, which records `SNAPSHOT_MAX_CHUNK_BYTES = 1MB` and a 16MB update ceiling — no number of any kind on the browser side.

## Measured first

A 20-node canvas, one delta per edit, Chromium:

| edits | stored (base+deltas) | folded | ratio | replay |
|---:|---:|---:|---:|---:|
| 10 | 4.3 KB | 1.6 KB | **2.7×** | ~5 ms |
| 50 | 17.5 KB | 2.7 KB | **6.5×** | ~3 ms |
| 200 | 67.2 KB | 6.3 KB | **10.6×** | ~10 ms |
| 500 | 166.6 KB | 14.2 KB | **11.7×** | ~22 ms |

Reading a *folded* snapshot stayed near 1ms at every size, so the whole cost is the replay a fresh open pays. Both it and the waste grow without a bound, and the ratio itself worsens — at 500 edits the store holds 166KB to represent 14KB of content.

## The threshold is read off that table

**64KB of deltas.** At that point replay is still ~10ms and the waste is bounded at roughly ten times the real content.

The daemon's 1MB is deliberately **not** reused: that is where a snapshot is *split for storage*, not where a log stops being worth keeping. Two different questions that happen to be measured in bytes.

Bytes rather than entries, because one pasted document and a thousand drags differ by orders of magnitude, and it is bytes that get replayed and stored.

## Where it folds

Inside `appendDelta`'s **existing** read-modify-write transaction — the one place already serialised over this record, so a fold cannot race an append and a fresh open never pays for a log another session grew.

A log that will not replay is left exactly as it was. Losing edits to save space is not a trade this is allowed to make.

## Evidence

Six rules mutation-checked, reverted and confirmed RED: the budget comparison in both directions, bytes-not-entries, summing the whole log, folding past the budget, the fold preserving content, and an unfoldable log being kept.

The compaction test runs in `web-browser` against **real IndexedDB and real Loro bytes** — jsdom has neither, and the property under test is precisely that the bytes a fresh open replays stop growing.

`apps/web` as CI runs it: **2558 passed** (jsdom) + **77 passed** (node); `web-browser` **656 passed**. `pnpm lint`, `pnpm -r typecheck`, `pnpm knip` clean.

One honest note: an earlier `web-browser` run failed two markdown-editor tests on 60s "element visible and stable" timeouts, and the next full run passed all 122 files. That is the documented load-dependent shape and this change only executes past 64KB of deltas, which no editor test reaches — but one green run is not proof, so it is recorded here rather than dismissed.

## Context

First of four steps toward running browser, daemon and (later) SaaS on one Loro-synced spec. This one is independent of the rest and fixes a real defect on its own.