### PR TITLE
ci: stop a slow apt mirror from cancelling widget-smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,8 +211,30 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # This step cancelled `widget-smoke` in 4 of 25 ci runs, always at the
+      # job's 15-minute ceiling. The log shows WHY it is worth bounding at the
+      # apt level rather than only at the step: it produced no output at all
+      # for four minutes — not a slow download, a connection that never
+      # returns. `-qq` was hiding that.
+      #
+      # `Acquire::http::Timeout` is what actually fixes it: a stuck mirror
+      # fails in 15s instead of hanging, and `Acquire::Retries` then tries
+      # another. `--no-install-recommends` skips `fonts-noto-cjk-extra`, every
+      # remaining weight and none of what this smoke renders — worth having,
+      # but it was not the cause.
+      #
+      # A cancelled job is worse than a failed one here: `verify` NEEDS this,
+      # and a cancelled dependency SKIPS it rather than failing it, so the PR
+      # reads `verify: skipping` — no result rather than a red one, on the
+      # check the merge gate treats as authoritative.
       - name: Install CJK fallback font
-        run: sudo apt-get update -qq && sudo apt-get install -yqq fonts-noto-cjk
+        timeout-minutes: 5
+        env:
+          APT_OPTS: -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15
+        run: |
+          sudo apt-get $APT_OPTS update
+          sudo apt-get $APT_OPTS install -y --no-install-recommends fonts-noto-cjk
+          fc-list :lang=ja family | head -3
 
       - name: Build canvas-viewer widget
         run: pnpm --filter @kamiazya/whiteboard-canvas-viewer build:widget


### PR DESCRIPTION
`widget-smoke` was cancelled in **4 of the last 25 `ci` runs**, always at the same step, always at the job's 15-minute ceiling.

```
09:11:15Z  widget-smoke started
09:26:32Z  widget-smoke cancelled   ← "Install CJK fallback font"
           Build canvas-viewer widget   skipped
           Widget smoke                 skipped
```

## Why this is worse than an ordinary failure

`verify` `needs` this job, and a **cancelled** dependency **skips** it rather than failing it. So the PR shows `verify: skipping` — *no result* rather than a red one, on the check the merge gate treats as authoritative. A reviewer scanning for red sees nothing wrong. That is what it did to #905.

## My first diagnosis was wrong, and the fix disproved it

The first version of this PR bounded the *step* and blamed volume — `fonts-noto-cjk` recommends `fonts-noto-cjk-extra`, so a slow mirror was supposedly eating the budget. Bounding the step is what proved otherwise:

```
09:30:46Z  Run install_cjk() { ... }
09:34:59Z  ##[error]The action 'Install CJK fallback font' has timed out after 4 minutes.
```

**No apt output at all**, and no `retrying after a failed mirror fetch` either — so the first call never returned. That is not a slow download, it is a connection that never comes back, and `-qq` had been hiding it.

## What this actually does

- **`Acquire::http::Timeout=15`** — the real fix. A stuck mirror fails in fifteen seconds instead of hanging.
- **`Acquire::Retries=3`** — then try another, at the apt level where the retry can see which fetch failed.
- **`--no-install-recommends`** stays, because it is right, not because it was the cause.
- **`-qq` removed**, so the next occurrence is diagnosable at all.
- **`fc-list :lang=ja`** confirms a Japanese face actually landed, rather than assuming the package did its job.

Per `integrator-flow.md`, a second occurrence of the same flake promotes it to a root-cause lane rather than another `gh run rerun`. This was the fourth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ