### PR TITLE
test(server-core): pin the fitted height exactly, not as a lower bound

### DIFF
--- a/packages/server-core/src/tools/canvas-edit.test.ts
+++ b/packages/server-core/src/tools/canvas-edit.test.ts
@@ -1245,7 +1245,10 @@ describe('wb_canvas_edit — a node created without a height', () => {
 
     // The fixture has to out-grow the default, or this asserts nothing.
     expect(needs).toBeGreaterThan(DEFAULT_TEXT_HEIGHT)
-    expect(node.height).toBeGreaterThanOrEqual(needs)
+    // EXACTLY what it needs. A lower bound would also accept extra height,
+    // and height is placement geometry — a node taller than its content
+    // pushes whatever the cursor lays out after it.
+    expect(node.height).toBe(needs)
   })
 
   test('respects a height that was named, however small', async () => {


### PR DESCRIPTION
CodeRabbit's finding on #905, which **I merged past before reading it** — I put the comment count and the merge in one command, so I saw `1` only after the merge had already happened. Closing the loop here instead of leaving it.

The finding is right. The test already proves the fixture needs more than the default, so `fittedHeight` must produce *exactly* that. `toBeGreaterThanOrEqual` additionally accepts slack, and height is placement geometry — a node taller than its content pushes whatever the cursor lays out after it.

**Mutation-checked, to show the assertion is genuinely stronger and not merely stricter-looking.** Adding 40px of slack to `fittedHeight`:

```
AssertionError: expected 216 to be 176
```

That mutant passes under the old lower bound and fails under this one, which is the whole point of the change.

Verified: `server-core-node` + `mcp-node` **324 files / 3856 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ