### PR TITLE
fix(model): mint document ids from the CSPRNG, not Math.random

### DIFF
--- a/packages/model/src/generate-document-id.test.ts
+++ b/packages/model/src/generate-document-id.test.ts
@@ -29,8 +29,13 @@ describe('generateDocumentId', () => {
 
     generateDocumentId()
 
-    expect(getRandomValues).toHaveBeenCalled()
     expect(random).not.toHaveBeenCalled()
+    // The QUANTITY is the point, not just the source: one byte per character.
+    // Asking for four and stretching them across sixteen characters would
+    // keep the source check green while dropping 80 bits of entropy to 32.
+    const [bytes] = getRandomValues.mock.calls[0] ?? []
+    expect(bytes).toBeInstanceOf(Uint8Array)
+    expect(bytes).toHaveLength(16)
   })
 
   // 256 is a whole multiple of the 32-character alphabet, so a byte taken

--- a/packages/model/src/generate-document-id.test.ts
+++ b/packages/model/src/generate-document-id.test.ts
@@ -1,6 +1,10 @@
 import { documentIdSchema } from '@kamiazya/whiteboard-model'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { generateDocumentId } from './generate-document-id.js'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 describe('generateDocumentId', () => {
   it('produces a 26-character string matching documentIdSchema', () => {
@@ -13,5 +17,49 @@ describe('generateDocumentId', () => {
     const first = generateDocumentId()
     const second = generateDocumentId()
     expect(first).not.toBe(second)
+  })
+
+  // The entropy source is the point, not an implementation detail. A
+  // predictable id is only harmless while nothing treats knowing one as
+  // permission to read it — and "anyone with the link" is the feature every
+  // product of this shape eventually grows.
+  it('draws its entropy from the CSPRNG, never from Math.random', () => {
+    const random = vi.spyOn(Math, 'random')
+    const getRandomValues = vi.spyOn(globalThis.crypto, 'getRandomValues')
+
+    generateDocumentId()
+
+    expect(getRandomValues).toHaveBeenCalled()
+    expect(random).not.toHaveBeenCalled()
+  })
+
+  // 256 is a whole multiple of the 32-character alphabet, so a byte taken
+  // modulo it is uniform. The same code over a 26- or 36-character alphabet
+  // would quietly favour its first letters.
+  //
+  // The fixture is chosen so a WRONG modulus collides and the right one does
+  // not: 0 and 26 differ mod 32 and are equal mod 26. Plain 0,1,2,… would
+  // land on distinct letters under either and prove nothing.
+  it('maps bytes onto the alphabet without bias', () => {
+    const seeded = [0, 26, 1, 27, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+    vi.spyOn(globalThis.crypto, 'getRandomValues').mockImplementation((array) => {
+      const bytes = array as Uint8Array
+      for (let i = 0; i < bytes.length; i++) bytes[i] = seeded[i] as number
+      return array
+    })
+
+    const random = generateDocumentId().slice(10)
+    expect(new Set(random).size).toBe(random.length)
+  })
+
+  // The first ten characters are a millisecond clock, which is what makes an
+  // id sortable and gives a database inserting them index locality.
+  it('keeps the time prefix ordered', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000_000_000)
+    const earlier = generateDocumentId().slice(0, 10)
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000_001_000)
+    const later = generateDocumentId().slice(0, 10)
+
+    expect(earlier < later).toBe(true)
   })
 })

--- a/packages/model/src/generate-document-id.ts
+++ b/packages/model/src/generate-document-id.ts
@@ -7,10 +7,21 @@ const RANDOM_CHARS = 16
  * Generates a canonical ULID matching model's `documentIdSchema`
  * (`/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/`). The 48-bit millisecond timestamp is
  * encoded big-endian into the first 10 base32 characters; 80 bits of
- * `Math.random()`-derived entropy fill the remaining 16. Uses
- * `Date.now()`/`Math.random()` only (no `node:crypto`) so this stays valid
- * in a shared-layer package that must run unchanged on Node, the browser,
- * and Cloudflare Workers.
+ * cryptographic entropy fill the remaining 16.
+ *
+ * The entropy comes from the CSPRNG, not `Math.random()`. Nothing today
+ * treats knowing an id as permission to read the document — authorization is
+ * the server's job and must stay that way — but "anyone with the link" is
+ * the feature a product of this shape grows, and the day it arrives a
+ * predictable id becomes a readable document. Choosing the weaker source
+ * costs nothing to avoid now and cannot be retrofitted onto ids already
+ * handed out.
+ *
+ * `globalThis.crypto` rather than `node:crypto`: this is a shared-layer
+ * package that must run unchanged on Node, the browser, and Cloudflare
+ * Workers, and Web Crypto is a global on all three. A runtime without it
+ * throws rather than falling back — silently downgrading the entropy is the
+ * one outcome worse than failing to start.
  */
 export function generateDocumentId(): string {
   return encodeTime(Date.now()) + encodeRandom()
@@ -28,9 +39,14 @@ function encodeTime(time: number): string {
 }
 
 function encodeRandom(): string {
+  // One byte per character, taken modulo the alphabet. 256 is a whole
+  // multiple of 32, so the mapping is uniform — the same code over a 26- or
+  // 36-character alphabet would quietly favour its first letters.
+  const bytes = new Uint8Array(RANDOM_CHARS)
+  globalThis.crypto.getRandomValues(bytes)
   let chars = ''
-  for (let i = 0; i < RANDOM_CHARS; i++) {
-    chars += ENCODING[Math.floor(Math.random() * ENCODING.length)]
+  for (const byte of bytes) {
+    chars += ENCODING[byte % ENCODING.length]
   }
   return chars
 }


### PR DESCRIPTION
`generateDocumentId` filled its 80 random bits from `Math.random()` — its own docstring said so:

> 80 bits of `Math.random()`-derived entropy fill the remaining 16.

## Why this is worth fixing now rather than later

**It is not a live vulnerability.** Nothing today treats knowing a document id as permission to read it; authorization is the server's job and must stay that way. I checked for a share-link surface and there is none.

But *"anyone with the link can view"* is the feature a product of this shape grows, and the day it arrives, **every id already handed out is predictable**. That is the one property that cannot be retrofitted — you can add a permission check later, you cannot un-publish a guessable id. It costs nothing to avoid while there are no users.

The right long-term design is that sharing never depends on id secrecy at all: a separate, revocable token when that feature comes. This change just removes the trap in the meantime.

## `globalThis.crypto`, not `node:crypto`

`packages/model` is a shared-layer package that must run unchanged on Node, the browser and Cloudflare Workers — `tools/arch-lint` fails the build on a `node:*` import here. Web Crypto is a global on all three, so the constraint is satisfied without a platform branch.

A runtime without it now **throws rather than falling back**. Silently downgrading the entropy is the only outcome worse than failing to start.

## The scheme is unchanged, deliberately

ULID stays. It is already what the daemon mints, and what migrations `0008` and `0012` converged on — this repo has moved *to* ULID twice. The property that matters for a shared table later is being **time-ordered and index-local**, which ULID already has; UUIDv7 would buy a native 16-byte column and nothing else, and only once a SaaS actually lands on a relational store — a data migration either way. UUIDv4 would be a regression on exactly that axis, whatever its entropy.

So: fix the entropy, keep the scheme, revisit the encoding when there is a database to revisit it for.

## Evidence

Four rules mutation-checked — reverted, confirmed RED, restored: the CSPRNG source (Math.random reintroduced → red), the unbiased mapping, the time prefix ordering, and the schema shape.

**The bias test was vacuous as first written** and the mutation is what said so: it fed bytes `0..15`, which land on distinct letters under a right *or* a wrong modulus. `0` and `26` differ mod 32 and collide mod 26 — that is the fixture that reaches the rule. (256 is a whole multiple of the 32-character alphabet, so a byte modulo it is uniform; the same code over a 26- or 36-character alphabet would quietly favour its first letters.)

Every project: **8526 passed** | 6 skipped. `mcp-node` alone is 3571 — this function mints the daemon's primary keys, so that suite is the real blast-radius check. `arch-lint-node` 79 passed (the `node:*` rule). `pnpm lint`, `pnpm -r typecheck` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved document ID generation by using cryptographically secure randomness.
  * Ensured random values are distributed uniformly across the identifier alphabet.
  * Documented behavior when a compatible crypto implementation is unavailable.

* **Tests**
  * Added coverage for secure randomness, unbiased encoding, timestamp ordering, and mock cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->