### PR TITLE
ci: install a 2.4MB Japanese font instead of a 61MB one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,16 +212,22 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # This step cancelled `widget-smoke` in 4 of 25 ci runs, always at the
-      # job's 15-minute ceiling. The log shows WHY it is worth bounding at the
-      # apt level rather than only at the step: it produced no output at all
-      # for four minutes — not a slow download, a connection that never
-      # returns. `-qq` was hiding that.
+      # job's 15-minute ceiling. The log showed no output at all for four
+      # minutes — not a slow download, a connection that never returns.
+      # `Acquire::http::Timeout` fixes THAT shape: a stuck mirror fails in 15s
+      # instead of hanging, and `Acquire::Retries` tries another.
       #
-      # `Acquire::http::Timeout` is what actually fixes it: a stuck mirror
-      # fails in 15s instead of hanging, and `Acquire::Retries` then tries
-      # another. `--no-install-recommends` skips `fonts-noto-cjk-extra`, every
-      # remaining weight and none of what this smoke renders — worth having,
-      # but it was not the cause.
+      # It then failed three more times in a different shape the timeouts
+      # cannot catch, because nothing is stuck: `fonts-noto-cjk` is a SINGLE
+      # 61.2MB package, and fetching it does not fit in five minutes on a slow
+      # runner. The index before it took 3s for 11.4MB, so the mirror is fine —
+      # the package is just enormous.
+      #
+      # `fonts-vlgothic` is 2.4MB and does the same job here. Nothing asserts a
+      # CJK family: the smoke's only font assertion is on the EMBEDDED Roboto
+      # face, and the Japanese sample exists to exercise the browser-fallback
+      # glyph path and prove no network fetch happens. Any `:lang=ja` face
+      # satisfies that, and this one is 26x smaller.
       #
       # A cancelled job is worse than a failed one here: `verify` NEEDS this,
       # and a cancelled dependency SKIPS it rather than failing it, so the PR
@@ -233,7 +239,7 @@ jobs:
           APT_OPTS: -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15
         run: |
           sudo apt-get $APT_OPTS update
-          sudo apt-get $APT_OPTS install -y --no-install-recommends fonts-noto-cjk
+          sudo apt-get $APT_OPTS install -y --no-install-recommends fonts-vlgothic
           fc-list :lang=ja family | head -3
 
       - name: Build canvas-viewer widget


### PR DESCRIPTION
`widget-smoke` has failed three more times today on `Install CJK fallback font`, in a shape the timeouts added earlier cannot catch — because nothing is stuck.

## Measured, from the failing log

```
Get:2 ... fonts-noto-cjk all 1:20230817+repack1-3 [61.2 MB]
##[error]The action 'Install CJK fallback font' has timed out after 5 minutes.
```

The index fetch immediately before it moved **11.4MB in 3s (3290 kB/s)**, so the mirror is healthy. The package is simply enormous, and one 61.2MB file does not reliably fit in the step's five minutes.

That is a different failure mode from the one the existing comment documents ("no output at all for four minutes — a connection that never returns"). `Acquire::http::Timeout` fixes a *stalled* socket; it cannot help a transfer that is progressing and merely large. Both are now recorded in the step's comment, because a future reader who sees only the timeouts will not understand why they did not save it.

## Nothing needs it to be that font

The smoke's only font assertion names the **embedded Roboto face**:

```
fail('document.fonts.check reported the Roboto family/text as not available')
```

The Japanese sample (`日本語ラベル`) exists for a different purpose, stated in the script: exercise the browser-fallback glyph path (Roboto's vendored subset is Latin-only) while a zero-network assertion proves the render triggers no font fetch. Any `:lang=ja` face satisfies both, and the `fc-list :lang=ja family` check at the end of the step still holds.

| package | download |
|---|---:|
| `fonts-noto-cjk` (current) | 61.2 MB |
| `fonts-ipafont-gothic` | 3.5 MB |
| **`fonts-vlgothic`** | **2.4 MB** — 26× smaller |

## Why not cache instead

Caching would still move 61MB, just from a different host, and would add a key to keep correct. Downloading 26× less is the smaller change and removes the failure mode rather than relocating it.

## Impact

This step is a dependency of `verify`, which the merge gate treats as authoritative — and a cancelled dependency makes `verify` report `skipping` rather than red. So every occurrence blocks a PR with *no* result, which is exactly what happened to #906 and #909 today.