### PR TITLE
feat(mcp-server): say which characters the export fonts cannot draw

### DIFF
--- a/docs/contributing/adr/0011-font-distribution.md
+++ b/docs/contributing/adr/0011-font-distribution.md
@@ -1,0 +1,138 @@
+# ADR-0011: Fonts are installed by whoever needs them, not bundled
+
+**Status:** Accepted
+
+## Context
+
+The export path draws with four vendored Roboto faces and nothing else. resvg is
+given their paths with `loadSystemFonts: false`, deliberately — the system-font
+scan dominates first-call latency, and no other family appears in the SVG
+`canvas-render` produces.
+
+Roboto is Latin-only. resvg does not substitute a face it was not given. So a
+Japanese canvas exports as tofu boxes:
+
+| | |
+|---|---|
+| `Hello world` | renders |
+| `こんにちは世界` | □□□□□□□ |
+
+**The measurement is already right**, which is what makes this worth an ADR
+rather than a bug fix. `createOpentypeMeasureText` falls back to the
+constant-ratio estimator per code point for anything the face lacks, so the box
+is the right size, the text wraps in the right places, and `truncated`,
+`overflows` and the digest all report a healthy render. Layout is correct and
+the reader cannot read it.
+
+Three constraints shape the answer, and each has already rejected an obvious fix
+elsewhere in this repo:
+
+- **Offline.** The widget smoke asserts that rendering triggers **no network
+  fetch at all**. The export path is likewise local-only.
+- **Byte-identical output.** `canvas-render`'s headline guarantee is that the
+  same scene renders identically on Node, in the browser and on Workers.
+- **Package size.** The published `dist` is **5.2 MB**. Noto Sans CJK Regular
+  alone is **18.6 MB** — bundling it makes the package 4.6x larger for every
+  user, including everyone who never writes a non-Latin character.
+
+## Decision
+
+**Fonts beyond the Latin default are separate packages, installed by whoever
+needs them.** The daemon resolves whatever is present and reports what it could
+not draw.
+
+### 1. The unit is a SCRIPT, not a language
+
+A `lang-ja` and a `lang-ko` package would each carry the same CJK face, because
+Noto CJK covers Japanese, Chinese and Korean in one file. Scripts are what fonts
+are actually cut along. A language-shaped package, if one is ever wanted, is a
+thin dependency declaration over script packages and carries no bytes of its own.
+
+**Themes make this decisive rather than merely tidy.** A handwriting style is
+not a language, and putting a handwritten face inside `lang-ja` is incoherent.
+What the resolver keys off is the family the theme already names
+(`SPATIAL_THEME_FONT_FAMILY`), so a font package is a **provider of faces** and
+nothing more. That is one concept, not two, and it is the concept the theme
+layer already has.
+
+### 2. Line-breaking models are NOT part of this
+
+Measured: the vendored BudouX Japanese model is **28 KB**, against 18.6 MB for
+one CJK face — a factor of 650. Adding Chinese, Korean and Thai models would
+cost about 100 KB in total.
+
+So they stay bundled in `canvas-render`, and a script added later is one commit,
+not a package. BudouX runs unchanged on Node, in the browser and in a Worker
+(that is why it was adopted), the lazy-construction shape is already established,
+and putting a resolution seam in front of 28 KB would buy wiring, failure paths
+and a report for nothing. The vendoring itself is about a packaging accident in
+budoux's entry point, not about portability — see
+`packages/canvas-render/src/vendor/budoux/README.md`.
+
+### 3. The resolved font set is part of the render contract, and is reported
+
+This is the price of the decision and is not optional. Once output depends on
+what is installed, "which fonts were used" is as much a part of the answer as
+the pixels. Silent variation by ambient state is the exact failure class this
+repo keeps paying for.
+
+The first half already exists: an export reports `undrawable`, the characters
+its own fonts have no glyph for, and logs a warning when that list is non-empty.
+Absence of a font is a **declared degradation**, not a broken render.
+
+### 4. Measurement and painting resolve the SAME set
+
+A font used to measure but not to paint (or the reverse) makes every derived
+signal a claim about nothing — `overflows` in particular, which asserts what a
+reader sees. `ServerDeps.measure` is the existing seam and both sides go through
+it. A future provider registry supplies faces to that seam and to resvg from one
+place, never two.
+
+### 5. Licensing follows the Roboto precedent
+
+`assets/fonts/Roboto/LICENSE.txt` sits beside the files, and root `NOTICE` names
+the font, its authors, its license and where the full text lives. Any font
+package repeats exactly that.
+
+One difference to plan for: Roboto is Apache-2.0, and the Noto CJK faces are
+**OFL 1.1**. Under OFL a **subset is a modification**, so a subsetted face
+cannot keep a Reserved Font Name. Check the specific face's RFN before
+subsetting, or ship it whole. An Apache-2.0 alternative (Droid Sans Fallback,
+3.8 MB) avoids the question at some cost in coverage and quality — a per-package
+choice, not a project-wide one.
+
+## Alternatives rejected
+
+**Bundle a CJK face in `@kamiazya/whiteboard-mcp`.** 5.2 MB → 23.8 MB for every
+user, most of whom never need it. Rejected on the measurement.
+
+**`loadSystemFonts: true`.** One line, and it makes output depend on the host's
+installed fonts — the same canvas renders differently on two machines, which is
+precisely the guarantee `canvas-render` exists to make. The current code comment
+already warns about this for the whole-font fallback case.
+
+**Download at startup or on first render.** Breaks the offline property the
+widget smoke asserts, makes output depend on when the download succeeded, and
+fails behind corporate proxies. npm already solves distribution, caching,
+offline install and version pinning; a bespoke downloader would re-implement all
+four worse.
+
+**Embed the font in the SVG as `@font-face`, or hand resvg a buffer.**
+Not possible. `@resvg/resvg-js@2.6.2` accepts `fontFiles` and `fontDirs` only —
+there is no `fontBuffers` option and no CSS font loading, so an embedded
+`@font-face` or `data:` URI is ignored. Verified against the installed type
+definitions. Note this is a limitation of the rasteriser, not of "web fonts": the
+bytes a web font is made of work fine, they just have to reach resvg as a **file
+path**, which is what a font package provides.
+
+## Consequences
+
+- A Japanese PNG export is tofu until a CJK font package is installed, and the
+  render says so rather than pretending. Editor and SVG output are unaffected —
+  the browser has its own fonts, and SVG keeps the characters as `<text>`.
+- Adding a script to the line breaker stays a one-commit change.
+- CI installs a small `:lang=ja` face through apt for `widget-smoke`; that is a
+  runner concern and deliberately not the distribution mechanism.
+- The provider registry is not built yet. Until it is, a deployment that needs
+  CJK export can pass font paths to resvg directly — this ADR fixes what the
+  eventual mechanism must satisfy, not its API.

--- a/docs/contributing/adr/0011-font-distribution.md
+++ b/docs/contributing/adr/0011-font-distribution.md
@@ -9,6 +9,12 @@ given their paths with `loadSystemFonts: false`, deliberately — the system-fon
 scan dominates first-call latency, and no other family appears in the SVG
 `canvas-render` produces.
 
+**With one existing exception**, which decision 5 below makes explicit: when the
+vendored Regular face cannot be resolved at all, `headless-renderer.ts` falls
+back to `{ loadSystemFonts: true }` and logs a warning. That branch is a
+last-resort degradation, not the normal path, and it is the one place today
+where host fonts can change exported pixels.
+
 Roboto is Latin-only. resvg does not substitute a face it was not given. So a
 Japanese canvas exports as tofu boxes:
 
@@ -88,7 +94,30 @@ reader sees. `ServerDeps.measure` is the existing seam and both sides go through
 it. A future provider registry supplies faces to that seam and to resvg from one
 place, never two.
 
-### 5. Licensing follows the Roboto precedent
+### 5. The whole-font fallback is a declared exception, and stays one
+
+`headless-renderer.ts` uses `{ loadSystemFonts: true }` when the vendored
+Regular face is unresolvable. It contradicts decision 3's reproducibility
+requirement, and it is kept anyway: the alternative is an export that fails
+outright because an asset is missing from a packaging accident, which is worse
+for the user than a render that is legible but not byte-reproducible. It logs a
+warning, which is what keeps it from being silent.
+
+Two bounds on it:
+
+- **It is per-install, not per-canvas.** The condition is "this deployment has
+  no vendored font", not "this text needs a glyph". A working install never
+  reaches it.
+- **`undrawable` reports `[]` in that branch**, because nothing was measured
+  against a known face — the same rule as `overflows`, where absence means NOT
+  MEASURED rather than "fine". Reporting every character as undrawable there
+  would be a louder and wronger answer than reporting nothing.
+
+Making the renderer fail closed instead is a real option and deliberately not
+taken here; it is a behaviour change for a condition nobody has hit, and this
+ADR is about distribution.
+
+### 6. Licensing follows the Roboto precedent
 
 `assets/fonts/Roboto/LICENSE.txt` sits beside the files, and root `NOTICE` names
 the font, its authors, its license and where the full text lives. Any font
@@ -106,10 +135,11 @@ choice, not a project-wide one.
 **Bundle a CJK face in `@kamiazya/whiteboard-mcp`.** 5.2 MB → 23.8 MB for every
 user, most of whom never need it. Rejected on the measurement.
 
-**`loadSystemFonts: true`.** One line, and it makes output depend on the host's
-installed fonts — the same canvas renders differently on two machines, which is
-precisely the guarantee `canvas-render` exists to make. The current code comment
-already warns about this for the whole-font fallback case.
+**`loadSystemFonts: true` as the ANSWER for missing scripts.** One line, and it
+makes output depend on the host's installed fonts — the same canvas renders
+differently on two machines, which is precisely the guarantee `canvas-render`
+exists to make. Rejected as a solution; it survives only as the last-resort
+branch described in decision 5, on a condition a working install never meets.
 
 **Download at startup or on first render.** Breaks the offline property the
 widget smoke asserts, makes output depend on when the download succeeded, and

--- a/docs/contributing/adr/README.md
+++ b/docs/contributing/adr/README.md
@@ -43,3 +43,4 @@ See [template.md](template.md) for the standard structure (MADR-lite: Title, Sta
 | [ADR-0008](0008-slug-derivation-and-rename.md) | Slug derivation, rename, and sibling uniqueness | Accepted — read *slug* as *path* |
 | [ADR-0009](0009-mcp-tool-naming.md) | The Document model, and `wb_<entity>_<action>` tool naming | Accepted — decisions 3-4 now implemented; *format* is spelled `kind` |
 | [ADR-0010](0010-canvas-edit-batch-tool.md) | One batch tool for spatial editing, and why it is not `apply` | Accepted |
+| [ADR-0011](0011-font-distribution.md) | Fonts are installed by whoever needs them, not bundled | Accepted — provider registry not built yet |

--- a/packages/mcp-server/src/server/export/headless-renderer.test.ts
+++ b/packages/mcp-server/src/server/export/headless-renderer.test.ts
@@ -257,6 +257,11 @@ describe('headless-renderer', () => {
     vi.doMock('./measure-text.js', () => ({
       createOpentypeMeasureText: buildSpy,
       _resetExportMeasureTextCacheForTests: vi.fn(),
+      // `headless-renderer` asks this what the export face cannot draw. These
+      // mocks replace the module wholesale, so an export it omits is a runtime
+      // failure rather than a type error. `null` is the documented "no parsed
+      // face" answer and keeps these tests about the singleton, not fonts.
+      loadExportFont: vi.fn().mockResolvedValue(null),
     }))
     try {
       const { renderSpatialCanvasToSvg } = await importRenderer()
@@ -281,6 +286,11 @@ describe('headless-renderer', () => {
         .mockRejectedValueOnce(new Error('boom'))
         .mockResolvedValue(() => ({ advanceWidth: 0, ascent: 0, descent: 0, lineGap: 0 })),
       _resetExportMeasureTextCacheForTests: vi.fn(),
+      // `headless-renderer` asks this what the export face cannot draw. These
+      // mocks replace the module wholesale, so an export it omits is a runtime
+      // failure rather than a type error. `null` is the documented "no parsed
+      // face" answer and keeps these tests about the singleton, not fonts.
+      loadExportFont: vi.fn().mockResolvedValue(null),
     }))
     const { renderSpatialCanvasToSvg } = await importRenderer()
     await expect(renderSpatialCanvasToSvg(rectCanvas())).rejects.toThrow('boom')
@@ -294,6 +304,11 @@ describe('headless-renderer', () => {
     vi.doMock('./measure-text.js', () => ({
       createOpentypeMeasureText: vi.fn().mockRejectedValue(new Error('font load failed')),
       _resetExportMeasureTextCacheForTests: vi.fn(),
+      // `headless-renderer` asks this what the export face cannot draw. These
+      // mocks replace the module wholesale, so an export it omits is a runtime
+      // failure rather than a type error. `null` is the documented "no parsed
+      // face" answer and keeps these tests about the singleton, not fonts.
+      loadExportFont: vi.fn().mockResolvedValue(null),
     }))
     // `captureLogsForTests` must come from the SAME fresh module instance
     // `headless-renderer.js` resolves its own `getLogger` through — both

--- a/packages/mcp-server/src/server/export/headless-renderer.ts
+++ b/packages/mcp-server/src/server/export/headless-renderer.ts
@@ -39,6 +39,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { getLogger } from '../log.js'
 import { EXPORT_FONT_FAMILY, resolveExportFontFaces } from './export-font.js'
 import { createOpentypeMeasureText } from './measure-text.js'
+import { undrawableCharacters } from './undrawable-characters.js'
 
 // Export never has its own theme switch (the composition root always
 // exports light, see package-canvas-render.md decision #8), so this
@@ -81,10 +82,31 @@ export interface HeadlessExportResult {
   png: Buffer
   width: number
   height: number
+  /**
+   * Characters this renderer's own fonts have no glyph for, which resvg has
+   * therefore painted as tofu boxes.
+   *
+   * Reported because of HOW that fails: measurement falls back to the
+   * estimator per code point, so the box is the right size, the text wraps
+   * correctly, and every other signal says the render is fine. The only thing
+   * wrong is that the reader cannot read it.
+   *
+   * Empty is the answer for a Latin canvas, and for one where the vendored
+   * face was unreachable at all — that degradation is a different condition,
+   * logged where it happens.
+   */
+  undrawable: readonly string[]
 }
 
 export interface HeadlessSvgExportResult {
   svg: string
+  /**
+   * Same question as `HeadlessExportResult.undrawable`, but SVG keeps the
+   * characters as `<text>` — a viewer whose system carries the face reads
+   * them normally. This says what THIS renderer could not draw, which is what
+   * the PNG of the same canvas would lose.
+   */
+  undrawable: readonly string[]
 }
 
 interface HeadlessExporter {
@@ -199,16 +221,36 @@ async function buildExporter(): Promise<HeadlessExporter> {
         fitTo,
       })
       const png = resvg.render()
+      const undrawable = await reportUndrawable(canvas)
       return {
         png: Buffer.from(png.asPng()),
         width: png.width,
         height: png.height,
+        undrawable,
       }
     },
     async renderSvg(canvas, options) {
-      return { svg: buildSvg(canvas, options, measure) }
+      return { svg: buildSvg(canvas, options, measure), undrawable: await reportUndrawable(canvas) }
     },
   }
+}
+
+/**
+ * Same discipline as the "Roboto TTF not found" warning above, one level
+ * finer: a silent degradation that diverges visually is worth a record. The
+ * whole-font case is logged once when the singleton is built; this is the
+ * per-character case, and it is logged per render because it depends on the
+ * canvas rather than on the install.
+ */
+async function reportUndrawable(canvas: SpatialCanvas): Promise<readonly string[]> {
+  const undrawable = await undrawableCharacters(canvas)
+  if (undrawable.length > 0) {
+    log.warning(
+      { count: undrawable.length, characters: undrawable.join('') },
+      'export fonts have no glyph for some characters; they render as tofu',
+    )
+  }
+  return undrawable
 }
 
 // Pre-warm the singleton during daemon startup so the first user-facing

--- a/packages/mcp-server/src/server/export/measure-text.ts
+++ b/packages/mcp-server/src/server/export/measure-text.ts
@@ -161,6 +161,27 @@ async function parseFace(path: string | null): Promise<opentype.Font | null> {
   return opentypeApi.parse(buffer)
 }
 
+/**
+ * The parsed Regular face the export path draws with, or `null` when the
+ * vendored asset is unreachable and the render has already degraded to system
+ * fonts.
+ *
+ * Exposed for `undrawableCharacters`, which asks the same question the
+ * measurer asks internally — does this face carry a glyph for this code point
+ * — but reports the answer instead of silently estimating around it. Parsed
+ * on demand and NOT cached here: the answer is needed once per export, while
+ * the measurer's own cache exists because layout calls it per line.
+ */
+export async function loadExportFont(
+  resolveFontFiles: () => Promise<Record<ExportFontFace, string | null>> = resolveExportFontFaces,
+): Promise<opentype.Font | null> {
+  try {
+    return await parseFace((await resolveFontFiles()).regular)
+  } catch {
+    return null
+  }
+}
+
 async function loadRealMeasurer(
   resolveFontFiles: () => Promise<Record<ExportFontFace, string | null>>,
 ): Promise<MeasureText> {

--- a/packages/mcp-server/src/server/export/undrawable-characters.test.ts
+++ b/packages/mcp-server/src/server/export/undrawable-characters.test.ts
@@ -1,0 +1,56 @@
+// The export path draws with the vendored Roboto and nothing else
+// (`loadSystemFonts: false`), so a code point Roboto has no glyph for is not
+// approximated or substituted — resvg paints a tofu box. Silently. That is
+// the worst shape a failure can take: layout is correct, the box is the right
+// size, the wrapping is right, and the reader cannot read a word of it.
+//
+// The information to say so is already on hand — `charToGlyphIndex` is what
+// the measurer uses to decide when to fall back to the estimator. This makes
+// it an answer instead of an internal detail.
+import { describe, expect, test } from 'vitest'
+import { undrawableCharacters } from './undrawable-characters.js'
+
+const CANVAS = (text: string) => ({
+  nodes: [{ id: 'n', type: 'text' as const, x: 0, y: 0, width: 200, height: 60, text }],
+  edges: [],
+})
+
+describe('undrawableCharacters', () => {
+  test('says nothing about a canvas the export font can draw', async () => {
+    expect(await undrawableCharacters(CANVAS('Hello world 123'))).toEqual([])
+  })
+
+  test('names the Japanese characters Roboto has no glyph for', async () => {
+    const missing = await undrawableCharacters(CANVAS('こんにちは'))
+
+    expect(missing).toEqual(['こ', 'ん', 'に', 'ち', 'は'])
+  })
+
+  test('reports each character once, in first-seen order, across every node', async () => {
+    const missing = await undrawableCharacters({
+      nodes: [
+        { id: 'a', type: 'text', x: 0, y: 0, width: 10, height: 10, text: '漢字' },
+        { id: 'b', type: 'text', x: 0, y: 20, width: 10, height: 10, text: '漢字も' },
+      ],
+      edges: [],
+    })
+
+    // Deterministic and de-duplicated: this is reported to an agent, and a
+    // list that reshuffles between identical renders is not something anyone
+    // can act on or diff.
+    expect(missing).toEqual(['漢', '字', 'も'])
+  })
+
+  test('reads group labels and edge labels too, not just node text', async () => {
+    const missing = await undrawableCharacters({
+      nodes: [
+        { id: 'g', type: 'group', x: 0, y: 0, width: 100, height: 100, label: 'グループ' },
+        { id: 'a', type: 'text', x: 0, y: 0, width: 10, height: 10, text: 'a' },
+        { id: 'b', type: 'text', x: 0, y: 20, width: 10, height: 10, text: 'b' },
+      ],
+      edges: [{ id: 'e', fromNode: 'a', toNode: 'b', label: '矢印' }],
+    })
+
+    expect(missing).toEqual(['グ', 'ル', 'ー', 'プ', '矢', '印'])
+  })
+})

--- a/packages/mcp-server/src/server/export/undrawable-characters.ts
+++ b/packages/mcp-server/src/server/export/undrawable-characters.ts
@@ -1,0 +1,56 @@
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { loadExportFont } from './measure-text.js'
+
+/**
+ * The characters this renderer's own fonts have no glyph for.
+ *
+ * The export path draws with the vendored Roboto and nothing else
+ * (`loadSystemFonts: false` in `headless-renderer.ts` — a deliberate choice,
+ * since the system-font scan dominates first-call latency). resvg does not
+ * substitute a face it was not given, so a code point Roboto lacks is painted
+ * as a tofu box.
+ *
+ * It is worth reporting because of HOW it fails. Measurement is correct
+ * (`createOpentypeMeasureText` falls back to the estimator per code point), so
+ * the box is the right size, the text wraps in the right places, and every
+ * other signal — `truncated`, `overflows`, the digest — says the render is
+ * fine. The only thing wrong is that the reader cannot read it, and nothing
+ * says so.
+ *
+ * This is deliberately about the RENDERER's fonts, not about the text. An SVG
+ * export still carries the characters as `<text>`, so a viewer whose system
+ * has the face reads it normally; only rasterisation is lossy. Callers that
+ * report this should say which of the two they mean.
+ */
+export async function undrawableCharacters(canvas: SpatialCanvas): Promise<readonly string[]> {
+  const font = await loadExportFont()
+  // No parsed face means the whole render already degraded to system fonts,
+  // which is logged where it happens. Claiming every character is undrawable
+  // there would be a second, louder, and wrong report.
+  if (font === null) return []
+
+  const seen = new Set<string>()
+  const missing: string[] = []
+  const scan = (text: string | undefined): void => {
+    if (text === undefined) return
+    for (const char of text) {
+      if (seen.has(char)) continue
+      seen.add(char)
+      // Whitespace and control characters have no glyph to miss.
+      if (char.trim() === '') continue
+      if (font.charToGlyphIndex(char) === 0) missing.push(char)
+    }
+  }
+
+  // First-seen order over document order: reproducible for the same canvas,
+  // which a set's iteration order would not be across engines.
+  for (const node of canvas.nodes) {
+    if (node.type === 'text') scan(node.text)
+    else if (node.type === 'group') scan(node.label)
+    else if (node.type === 'file') scan(node.file)
+    else if (node.type === 'link') scan(node.url)
+  }
+  for (const edge of canvas.edges) scan(edge.label)
+
+  return missing
+}

--- a/packages/mcp-server/src/shared/document-backend-contract.test.ts
+++ b/packages/mcp-server/src/shared/document-backend-contract.test.ts
@@ -42,7 +42,9 @@ beforeAll(() => {
     encoding: 'utf8',
   })
   if (result.status !== 0) {
-    throw new Error(`tsc failed:\n${result.stderr}`)
+    // tsc writes diagnostics to STDOUT; stderr alone reports the failure with
+    // an empty body, which says a build broke without saying how.
+    throw new Error(`tsc failed:\n${result.stdout}${result.stderr}`)
   }
 }, 60_000)
 


### PR DESCRIPTION
A PNG export draws with the vendored Roboto and nothing else (`loadSystemFonts: false`), and resvg does not substitute a face it was not given. So a Japanese canvas exports as tofu boxes — **silently**.

## What it looks like

Same canvas, same SVG, the only difference being which files reach `fontFiles`:

![cjk-roboto-only.png](https://github.com/user-attachments/assets/6c54bd33-032e-443a-afda-ec737c4a94d1)

![cjk-roboto+cjk.png](https://github.com/user-attachments/assets/3dacae63-661d-4c76-ae2f-aac8837431eb)

**This PR does not ship the second picture** — which font to distribute is a separate decision. It makes the first one stop being silent.

## Why silence is the actual defect

Measurement is already correct: since the per-code-point fallback landed, the box is the right size, the text wraps in the right places, and `truncated`, `overflows` and the digest all report a perfectly healthy render. The layout is right. The only thing wrong is that the reader cannot read a word of it, and nothing anywhere says so.

`undrawableCharacters` answers it by reusing the question the measurer already asks internally — `charToGlyphIndex(char) === 0` — instead of leaving it an implementation detail that is computed, used for estimation, and thrown away. Both export results carry it, and a non-empty answer is logged: the same discipline as the existing `Roboto TTF not found` warning, one level finer. That one is per-install and logged once; this is per-canvas and logged per render.

```
こんにちは世界 -> undrawable: ["こ","ん","に","ち","は","世","界"]
Hello world    -> undrawable: []
```

```json
{"level":"warning","scope":"headless-renderer","count":7,"characters":"こんにちは世界",
 "msg":"export fonts have no glyph for some characters; they render as tofu"}
```

Deliberately about the **renderer's fonts**, not about the text: an SVG export keeps the characters as `<text>`, so a viewer whose system carries the face reads them normally, and only rasterisation loses them. Both result types document which they mean.

## Two things this turned up on the way

**`headless-renderer.test.ts` mocks `measure-text.js` wholesale in three places**, so a new export from that module is a runtime failure rather than a type error. They now answer `loadExportFont` too.

**`document-backend-contract.test.ts` reported `tsc failed:` with an empty body.** It interpolated `result.stderr`, and tsc writes diagnostics to **stdout** — so a build break announced that something broke without saying what. It now includes both streams, and that is how I found my own logger misuse (`log.warning(msg, data)` instead of `log.warning(data, msg)`) at all: the first report of it was a blank error.

Verified: `mcp-node` + `server-core-node` + `arch-lint-node` **333 files / 3940 passed**, `pnpm -r typecheck` clean, `pnpm knip` clean, `pnpm smoke:e2e` ALL OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PNG and SVG exports now identify characters that cannot be rendered by available fonts.
  * Export results include missing characters, with warnings when detected.
  * Font loading failures are handled gracefully, allowing exports to continue.

* **Bug Fixes**
  * Build failure diagnostics now include both standard output and error details.

* **Documentation**
  * Documented font distribution and rendering behavior for non-Latin characters.

* **Tests**
  * Added coverage for missing glyph detection and export handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->