### PR TITLE
feat(web)!: address a browser-local document by path, like the daemon does

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -37,23 +37,23 @@ afterEach(cleanup)
 // page mounts. BrowserLocalDocumentPage pulls in loro-crdt, which needs a
 // real browser (WASM), so it stays mocked.
 let receivedCapabilities: WhiteboardCapabilities | undefined
-// Captures the initialDocumentId prop so a test can assert App derives it from
-// the /local/:documentId URL (parseBrowserLocalRoute) rather than merely
+// Captures the initialPath prop so a test can assert App derives it from
+// the /local/:path URL (parseBrowserLocalRoute) rather than merely
 // mounting the page.
-let receivedInitialCanvasId: string | undefined
+let receivedInitialPath: string | undefined
 // Toggled by the error-boundary test to force the mocked page to throw
 // during render, so App's ErrorBoundary wiring has something real to catch.
 let throwInBrowserLocalDocumentPage = false
 vi.mock('./pages/BrowserLocalDocumentPage.js', () => ({
   BrowserLocalDocumentPage: ({
     capabilities,
-    initialDocumentId,
+    initialPath,
   }: {
     capabilities?: WhiteboardCapabilities
-    initialDocumentId?: string
+    initialPath?: string
   }) => {
     receivedCapabilities = capabilities
-    receivedInitialCanvasId = initialDocumentId
+    receivedInitialPath = initialPath
     if (throwInBrowserLocalDocumentPage) {
       throw new Error('boom')
     }
@@ -63,9 +63,9 @@ vi.mock('./pages/BrowserLocalDocumentPage.js', () => ({
 
 // Captures the open callback so a test can drive list -> editor navigation
 // without rendering the real list (which would pull in the store's IDB path).
-let receivedIndexPageOnOpenCanvas: ((id: string) => void) | undefined
+let receivedIndexPageOnOpenCanvas: ((path: string) => void) | undefined
 vi.mock('./pages/BrowserLocalIndexPage.js', () => ({
-  BrowserLocalIndexPage: ({ onOpenDocument }: { onOpenDocument: (id: string) => void }) => {
+  BrowserLocalIndexPage: ({ onOpenDocument }: { onOpenDocument: (path: string) => void }) => {
     receivedIndexPageOnOpenCanvas = onOpenDocument
     return <div data-testid="browser-local-index-page" />
   },
@@ -390,15 +390,17 @@ describe('App capability wiring', () => {
     expect(receivedCapabilities).toEqual(BROWSER_LOCAL_STATE.capabilities)
   })
 
-  it('derives initialDocumentId from a /local/:documentId cold-load URL', async () => {
-    receivedInitialCanvasId = undefined
+  it('derives initialPath from a /local/:path cold-load URL, folders and all', async () => {
+    receivedInitialPath = undefined
     render(
-      <MemoryRouter initialEntries={['/local/c2']}>
+      <MemoryRouter initialEntries={['/local/design/login%20flow']}>
         <App providerState={BROWSER_LOCAL_STATE} />
       </MemoryRouter>,
     )
     await screen.findByTestId('browser-local-document-page')
-    expect(receivedInitialCanvasId).toBe('c2')
+    // A path has segments and may be percent-encoded; an id never is, so a
+    // single-segment fixture could not tell the two readings apart.
+    expect(receivedInitialPath).toBe('design/login flow')
   })
 
   it('lands a plain "/" cold load on the canvas list, not the editor', async () => {
@@ -412,7 +414,7 @@ describe('App capability wiring', () => {
   })
 
   it('opening a canvas from the list mounts the editor on that canvas', async () => {
-    receivedInitialCanvasId = undefined
+    receivedInitialPath = undefined
     render(
       <MemoryRouter initialEntries={['/']}>
         <App providerState={BROWSER_LOCAL_STATE} />
@@ -420,9 +422,9 @@ describe('App capability wiring', () => {
     )
     await screen.findByTestId('browser-local-index-page')
     expect(receivedIndexPageOnOpenCanvas).toBeDefined()
-    act(() => receivedIndexPageOnOpenCanvas?.('c9'))
+    act(() => receivedIndexPageOnOpenCanvas?.('notes/c9'))
     expect(await screen.findByTestId('browser-local-document-page')).toBeTruthy()
-    expect(receivedInitialCanvasId).toBe('c9')
+    expect(receivedInitialPath).toBe('notes/c9')
   })
 })
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -231,7 +231,7 @@ export function App({ providerState }: AppProps) {
   // initialDocumentId a single time), so App re-routes only when the URL
   // crosses the list/editor boundary — including browser Back from the
   // editor to the list.
-  const browserLocalDocumentId = parseBrowserLocalRoute(location.pathname)?.documentId
+  const browserLocalPath = parseBrowserLocalRoute(location.pathname)?.path
 
   // Keeps the address bar in sync with `daemonView` in both directions.
   //
@@ -625,20 +625,20 @@ export function App({ providerState }: AppProps) {
         )}
         <div className="min-h-0 flex-1 overflow-hidden">
           <Suspense fallback={<LazyPageFallback heightClass="h-full" message="Loading…" />}>
-            {browserLocalDocumentId === undefined ? (
+            {browserLocalPath === undefined ? (
               // '/' (and any non-/local path) lands on the canvas list. The
-              // editor mounts only for /local/:documentId, whose in-editor
+              // editor mounts only for /local/:path, whose in-editor
               // canvas switching it keeps owning — App re-routes solely when
               // the URL crosses the list/editor boundary.
               <BrowserLocalIndexPage
                 store={browserLocalStore}
-                onOpenDocument={(id) => navigate(browserLocalDocumentPath(id))}
+                onOpenDocument={(path) => navigate(browserLocalDocumentPath(path))}
               />
             ) : (
               <BrowserLocalDocumentPage
                 store={browserLocalStore}
                 capabilities={effectiveState.capabilities}
-                initialDocumentId={browserLocalDocumentId}
+                initialPath={browserLocalPath}
               />
             )}
           </Suspense>

--- a/apps/web/src/components/migration/ImportBrowserLocalPanel.browser.test.tsx
+++ b/apps/web/src/components/migration/ImportBrowserLocalPanel.browser.test.tsx
@@ -38,13 +38,17 @@ describe('ImportBrowserLocalPanel (real IndexedDB)', () => {
     const loroStore = new LoroStore()
 
     await browserLocalStore.save({
-      id: 'c1',
+      documentId: '0Y147ADGKPSWZ258BEHMQTX036',
+      workspaceId: 'local',
+      path: 'no-deltas',
       name: 'No Deltas',
       updatedAt: '2026-01-01T00:00:00.000Z',
       kind: 'spatial' as const,
     })
     await browserLocalStore.save({
-      id: 'c2',
+      documentId: '058BEHMQTX0369CFJNRVY147AD',
+      workspaceId: 'local',
+      path: 'with-deltas',
       name: 'With Deltas',
       updatedAt: '2026-01-02T00:00:00.000Z',
       kind: 'spatial' as const,
@@ -53,20 +57,23 @@ describe('ImportBrowserLocalPanel (real IndexedDB)', () => {
     const doc1 = new Loro()
     doc1.getMovableList('elements').push('one')
     doc1.commit()
-    await loroStore.save('c1', doc1.export({ mode: 'snapshot' }))
+    await loroStore.save('0Y147ADGKPSWZ258BEHMQTX036', doc1.export({ mode: 'snapshot' }))
 
     const doc2 = new Loro()
     doc2.getMovableList('elements').push('two-a')
     doc2.commit()
-    await loroStore.save('c2', doc2.export({ mode: 'snapshot' }))
+    await loroStore.save('058BEHMQTX0369CFJNRVY147AD', doc2.export({ mode: 'snapshot' }))
     const prevVV = doc2.version()
     doc2.getMovableList('elements').push('two-b')
     doc2.commit()
-    await loroStore.appendDelta('c2', doc2.export({ mode: 'update', from: prevVV }))
+    await loroStore.appendDelta(
+      '058BEHMQTX0369CFJNRVY147AD',
+      doc2.export({ mode: 'update', from: prevVV }),
+    )
 
     const documentsBefore = await browserLocalStore.listDocuments()
-    const loro1Before = await loroStore.load('c1')
-    const loro2Before = await loroStore.load('c2')
+    const loro1Before = await loroStore.load('0Y147ADGKPSWZ258BEHMQTX036')
+    const loro2Before = await loroStore.load('058BEHMQTX0369CFJNRVY147AD')
 
     const daemonFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
@@ -102,8 +109,8 @@ describe('ImportBrowserLocalPanel (real IndexedDB)', () => {
     expect(updateCalls).toHaveLength(2)
 
     const documentsAfter = await browserLocalStore.listDocuments()
-    const loro1After = await loroStore.load('c1')
-    const loro2After = await loroStore.load('c2')
+    const loro1After = await loroStore.load('0Y147ADGKPSWZ258BEHMQTX036')
+    const loro2After = await loroStore.load('058BEHMQTX0369CFJNRVY147AD')
 
     await waitFor(() => {
       expect(documentsAfter).toEqual(documentsBefore)

--- a/apps/web/src/components/migration/ImportBrowserLocalPanel.test.tsx
+++ b/apps/web/src/components/migration/ImportBrowserLocalPanel.test.tsx
@@ -10,8 +10,24 @@ import { ImportBrowserLocalPanel } from './ImportBrowserLocalPanel.js'
 // The panel loads a Loro snapshot by DOCUMENT ID and creates the destination
 // by PATH, so a fixture has to pin both and the two must not be the same
 // string — otherwise a test cannot tell which one a call site used.
-const documentIdFor = (path: string): string =>
-  `01ARZ3NDEKTSV4RRFFQ69G5${path.toUpperCase().padEnd(3, '0').slice(0, 3)}`
+//
+// Written out rather than derived from the path: a derivation both produced
+// non-ULIDs (`my-canvas` → a trailing `-`, which Crockford base32 has no
+// symbol for) and collided any two paths sharing a prefix. MemoryStore does
+// not parse what it is given, so neither would have failed a test here — but
+// IndexedDBStore skips a row `documentSnapshotSchema` rejects, so the fixture
+// would stop representing what production actually stores.
+const DOCUMENT_IDS: Record<string, string> = {
+  c1: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+  c2: '01ARZ3NDEKTSV4RRFFQ69G5FB0',
+  'my-canvas': '01ARZ3NDEKTSV4RRFFQ69G5FC1',
+}
+
+function documentIdFor(path: string): string {
+  const id = DOCUMENT_IDS[path]
+  if (id === undefined) throw new Error(`no fixture id for path "${path}"`)
+  return id
+}
 
 function makeCanvas(
   path: string,

--- a/apps/web/src/components/migration/ImportBrowserLocalPanel.test.tsx
+++ b/apps/web/src/components/migration/ImportBrowserLocalPanel.test.tsx
@@ -1,18 +1,31 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { Loro } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { MemoryStore } from '../../lib/browser-local-store.js'
+import { LOCAL_WORKSPACE_ID, MemoryStore } from '../../lib/browser-local-store.js'
 import type { LoroLoadResult } from '../../lib/loro-store.js'
 import { createUserSettingsStore } from '../../lib/user-settings-store.js'
 import type { DocumentSnapshot } from '../../lib/whiteboard-client.js'
 import { ImportBrowserLocalPanel } from './ImportBrowserLocalPanel.js'
 
+// The panel loads a Loro snapshot by DOCUMENT ID and creates the destination
+// by PATH, so a fixture has to pin both and the two must not be the same
+// string — otherwise a test cannot tell which one a call site used.
+const documentIdFor = (path: string): string =>
+  `01ARZ3NDEKTSV4RRFFQ69G5${path.toUpperCase().padEnd(3, '0').slice(0, 3)}`
+
 function makeCanvas(
-  id: string,
+  path: string,
   name: string,
   kind: DocumentSnapshot['kind'] = 'spatial',
 ): DocumentSnapshot {
-  return { id, name, updatedAt: new Date().toISOString(), kind }
+  return {
+    documentId: documentIdFor(path),
+    workspaceId: LOCAL_WORKSPACE_ID,
+    path,
+    name,
+    updatedAt: new Date().toISOString(),
+    kind,
+  }
 }
 
 function snapshotFor(tag: string): Uint8Array {
@@ -69,7 +82,9 @@ describe('ImportBrowserLocalPanel', () => {
         workspaceId="ws1"
         daemonFetch={daemonFetch}
         browserLocalStore={store}
-        loroStore={makeLoroStore({ c1: { kind: 'ok', snapshot: snapshotFor('c1') } })}
+        loroStore={makeLoroStore({
+          [documentIdFor('c1')]: { kind: 'ok', snapshot: snapshotFor('c1') },
+        })}
         settingsStore={createUserSettingsStore()}
       />,
     )
@@ -116,8 +131,8 @@ describe('ImportBrowserLocalPanel', () => {
     await store.save(makeCanvas('c2', 'Bad'))
 
     const loroStore = makeLoroStore({
-      c1: { kind: 'ok', snapshot: snapshotFor('good') },
-      c2: { kind: 'not-found' },
+      [documentIdFor('c1')]: { kind: 'ok', snapshot: snapshotFor('good') },
+      [documentIdFor('c2')]: { kind: 'not-found' },
     })
 
     const daemonFetch = vi
@@ -154,7 +169,7 @@ describe('ImportBrowserLocalPanel', () => {
 
     const loroStore = {
       load: vi.fn(async (id: string) => {
-        if (id === 'c1') throw new Error('IndexedDB read failed')
+        if (id === documentIdFor('c1')) throw new Error('IndexedDB read failed')
         return { kind: 'ok', snapshot: snapshotFor('good') } as LoroLoadResult
       }),
     }
@@ -209,7 +224,7 @@ describe('ImportBrowserLocalPanel', () => {
   it('does not write lastImportedAt when every canvas fails', async () => {
     const store = new MemoryStore()
     await store.save(makeCanvas('c1', 'Bad'))
-    const loroStore = makeLoroStore({ c1: { kind: 'corrupt-snapshot' } })
+    const loroStore = makeLoroStore({ [documentIdFor('c1')]: { kind: 'corrupt-snapshot' } })
     const settingsStore = createUserSettingsStore()
 
     render(
@@ -243,7 +258,9 @@ describe('ImportBrowserLocalPanel', () => {
         workspaceId="ws1"
         daemonFetch={daemonFetch}
         browserLocalStore={store}
-        loroStore={makeLoroStore({ c1: { kind: 'ok', snapshot: snapshotFor('alpha') } })}
+        loroStore={makeLoroStore({
+          [documentIdFor('c1')]: { kind: 'ok', snapshot: snapshotFor('alpha') },
+        })}
         settingsStore={createUserSettingsStore()}
       />,
     )
@@ -255,12 +272,14 @@ describe('ImportBrowserLocalPanel', () => {
     expect(after).toEqual(before)
   })
 
-  it('imports two same-named documents sequentially with distinct destination paths on 409', async () => {
+  it('sidesteps a path the destination workspace already owns by suffixing it', async () => {
+    // Two local documents can no longer collide with EACH OTHER — a local path
+    // is unique in its own store. What still collides is the destination: the
+    // daemon workspace may already hold a document at this path.
     const store = new MemoryStore()
-    await store.save(makeCanvas('c1', 'My Canvas!'))
-    await store.save(makeCanvas('c2', 'My Canvas!'))
+    await store.save(makeCanvas('my-canvas', 'My Canvas!'))
 
-    const takenPaths = new Set<string>()
+    const takenPaths = new Set<string>(['my-canvas'])
     const daemonFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
       if (url.endsWith('/documents')) {
@@ -278,16 +297,13 @@ describe('ImportBrowserLocalPanel', () => {
         daemonFetch={daemonFetch}
         browserLocalStore={store}
         loroStore={makeLoroStore({
-          c1: { kind: 'ok', snapshot: snapshotFor('a') },
-          c2: { kind: 'ok', snapshot: snapshotFor('b') },
+          [documentIdFor('my-canvas')]: { kind: 'ok', snapshot: snapshotFor('a') },
         })}
         settingsStore={createUserSettingsStore()}
       />,
     )
 
     fireEvent.click(await screen.findByRole('button', { name: /import/i }))
-
-    await screen.findByText(/^imported as my-canvas$/i)
     await screen.findByText(/^imported as my-canvas-2$/i)
   })
 })

--- a/apps/web/src/components/migration/ImportBrowserLocalPanel.tsx
+++ b/apps/web/src/components/migration/ImportBrowserLocalPanel.tsx
@@ -75,28 +75,28 @@ export function ImportBrowserLocalPanel({
       // Sequential on purpose: each iteration merges a full Loro history into
       // a throwaway doc, which is memory-heavy for large documents.
       for (const canvas of documents) {
-        setResults((prev) => ({ ...prev, [canvas.id]: { status: 'pending' } }))
+        setResults((prev) => ({ ...prev, [canvas.documentId]: { status: 'pending' } }))
         try {
-          const loroLoad = await loroStore.load(canvas.id)
+          const loroLoad = await loroStore.load(canvas.documentId)
           const result = await importOneDocument({
             fetch: daemonFetch,
             daemonBaseUrl,
             workspaceId,
-            documentName: canvas.name,
+            documentPath: canvas.path,
             documentKind: canvas.kind,
             loroLoad,
           })
           if (result.kind === 'ok') {
             anySuccess = true
-            lastSuccessCanvasId = canvas.id
+            lastSuccessCanvasId = canvas.documentId
             setResults((prev) => ({
               ...prev,
-              [canvas.id]: { status: 'success', path: result.path },
+              [canvas.documentId]: { status: 'success', path: result.path },
             }))
           } else {
             setResults((prev) => ({
               ...prev,
-              [canvas.id]: { status: 'error', reason: result.reason },
+              [canvas.documentId]: { status: 'error', reason: result.reason },
             }))
           }
         } catch {
@@ -104,7 +104,7 @@ export function ImportBrowserLocalPanel({
           // must not abort the rest of the batch.
           setResults((prev) => ({
             ...prev,
-            [canvas.id]: {
+            [canvas.documentId]: {
               status: 'error',
               reason: 'Could not read this canvas from the browser.',
             },
@@ -148,9 +148,9 @@ export function ImportBrowserLocalPanel({
     <div className="flex flex-col gap-2">
       <ul className="flex flex-col gap-1">
         {documents.map((canvas) => {
-          const result = results[canvas.id]
+          const result = results[canvas.documentId]
           return (
-            <li key={canvas.id} className="flex items-center justify-between gap-2 text-sm">
+            <li key={canvas.documentId} className="flex items-center justify-between gap-2 text-sm">
               <span>{canvas.name}</span>
               {result?.status === 'success' && (
                 <span className="text-xs text-muted-foreground">{`Imported as ${result.path}`}</span>

--- a/apps/web/src/components/migration/import-browser-local.test.ts
+++ b/apps/web/src/components/migration/import-browser-local.test.ts
@@ -63,7 +63,7 @@ describe('importOneDocument', () => {
       fetch: fetchMock,
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws 1#x',
-      documentPath: 'My Canvas',
+      documentPath: 'my-canvas',
       documentKind: 'markdown',
       loroLoad: loroOkResult(),
     })
@@ -96,7 +96,7 @@ describe('importOneDocument', () => {
       fetch: fetchMock,
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws1',
-      documentPath: 'My Canvas',
+      documentPath: 'my-canvas',
       documentKind: 'spatial',
       loroLoad: loroOkResult(),
     })
@@ -119,7 +119,7 @@ describe('importOneDocument', () => {
       fetch: fetchMock,
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws1',
-      documentPath: 'My Canvas',
+      documentPath: 'my-canvas',
       documentKind: 'spatial',
       loroLoad: loroOkResult(),
     })
@@ -140,7 +140,7 @@ describe('importOneDocument', () => {
       fetch: fetchMock,
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws1',
-      documentPath: 'My Canvas',
+      documentPath: 'my-canvas',
       documentKind: 'spatial',
       loroLoad: loroOkResult(),
     })
@@ -159,7 +159,7 @@ describe('importOneDocument', () => {
       fetch: fetchMock,
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws1',
-      documentPath: 'My Canvas',
+      documentPath: 'my-canvas',
       documentKind: 'spatial',
       loroLoad: loroOkResult(),
     })
@@ -177,7 +177,7 @@ describe('importOneDocument', () => {
       fetch: fetchMock,
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws1',
-      documentPath: 'My Canvas',
+      documentPath: 'my-canvas',
       documentKind: 'spatial',
       loroLoad: loroOkResult(),
     })
@@ -197,7 +197,7 @@ describe('importOneDocument', () => {
       fetch: fetchMock,
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws1',
-      documentPath: 'My Canvas',
+      documentPath: 'my-canvas',
       documentKind: 'spatial',
       loroLoad: loroLoad as LoroLoadResult,
     })

--- a/apps/web/src/components/migration/import-browser-local.test.ts
+++ b/apps/web/src/components/migration/import-browser-local.test.ts
@@ -1,7 +1,7 @@
 import { Loro } from 'loro-crdt'
 import { describe, expect, it, vi } from 'vitest'
 import type { LoroLoadResult } from '../../lib/loro-store.js'
-import { importOneDocument, mergeToSnapshot, toPathSegment } from './import-browser-local.js'
+import { importOneDocument, mergeToSnapshot } from './import-browser-local.js'
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -9,33 +9,6 @@ function jsonResponse(body: unknown, status = 200): Response {
     headers: { 'content-type': 'application/json' },
   })
 }
-
-describe('toPathSegment', () => {
-  it('lowercases and hyphenates', () => {
-    expect(toPathSegment('My Canvas!')).toBe('my-canvas')
-  })
-
-  it('strips leading and trailing hyphens', () => {
-    expect(toPathSegment('--hello--')).toBe('hello')
-  })
-
-  it('collapses runs of invalid characters into a single hyphen', () => {
-    expect(toPathSegment('a!!!b   c')).toBe('a-b-c')
-  })
-
-  it('falls back to "canvas" for empty/all-invalid input', () => {
-    expect(toPathSegment('')).toBe('canvas')
-    expect(toPathSegment('!!!')).toBe('canvas')
-  })
-
-  it('always produces output matching the server path charset (letters/digits/hyphen, non-empty, no leading/trailing hyphen)', () => {
-    const samples = ['日本語', '  spaced  ', 'a.b.c', 'UPPER_case-1', '---', '123']
-    for (const sample of samples) {
-      const path = toPathSegment(sample)
-      expect(path).toMatch(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/)
-    }
-  })
-})
 
 describe('mergeToSnapshot', () => {
   it('imports a snapshot and deltas into one combined snapshot', () => {
@@ -90,7 +63,7 @@ describe('importOneDocument', () => {
       fetch: fetchMock,
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws 1#x',
-      documentName: 'My Canvas',
+      documentPath: 'My Canvas',
       documentKind: 'markdown',
       loroLoad: loroOkResult(),
     })
@@ -123,7 +96,7 @@ describe('importOneDocument', () => {
       fetch: fetchMock,
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws1',
-      documentName: 'My Canvas',
+      documentPath: 'My Canvas',
       documentKind: 'spatial',
       loroLoad: loroOkResult(),
     })
@@ -146,7 +119,7 @@ describe('importOneDocument', () => {
       fetch: fetchMock,
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws1',
-      documentName: 'My Canvas',
+      documentPath: 'My Canvas',
       documentKind: 'spatial',
       loroLoad: loroOkResult(),
     })
@@ -167,7 +140,7 @@ describe('importOneDocument', () => {
       fetch: fetchMock,
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws1',
-      documentName: 'My Canvas',
+      documentPath: 'My Canvas',
       documentKind: 'spatial',
       loroLoad: loroOkResult(),
     })
@@ -186,7 +159,7 @@ describe('importOneDocument', () => {
       fetch: fetchMock,
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws1',
-      documentName: 'My Canvas',
+      documentPath: 'My Canvas',
       documentKind: 'spatial',
       loroLoad: loroOkResult(),
     })
@@ -204,7 +177,7 @@ describe('importOneDocument', () => {
       fetch: fetchMock,
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws1',
-      documentName: 'My Canvas',
+      documentPath: 'My Canvas',
       documentKind: 'spatial',
       loroLoad: loroOkResult(),
     })
@@ -224,7 +197,7 @@ describe('importOneDocument', () => {
       fetch: fetchMock,
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws1',
-      documentName: 'My Canvas',
+      documentPath: 'My Canvas',
       documentKind: 'spatial',
       loroLoad: loroLoad as LoroLoadResult,
     })

--- a/apps/web/src/components/migration/import-browser-local.ts
+++ b/apps/web/src/components/migration/import-browser-local.ts
@@ -12,19 +12,6 @@ import type { LoroLoadResult } from '../../lib/loro-store.js'
 const MAX_CREATE_ATTEMPTS = 3
 
 /**
- * Converts a canvas display name into a path matching the server's
- * validateDocumentPath charset (ASCII letters/digits/hyphen, no leading/trailing
- * hyphen, non-empty). Falls back to 'canvas' when nothing survives.
- */
-export function toPathSegment(name: string): string {
-  const collapsed = name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-  return collapsed === '' ? 'canvas' : collapsed
-}
-
-/**
  * Imports a Loro snapshot plus its delta log into a throwaway LoroDoc and
  * exports one combined snapshot — the shape the daemon's /update route
  * expects (a fresh doc.import(bytes) call, not a delta stream).
@@ -44,7 +31,7 @@ interface ImportOneDocumentOptions {
   fetch: typeof globalThis.fetch
   daemonBaseUrl: string
   workspaceId: string
-  documentName: string
+  documentPath: string
   documentKind: DocumentKind
   loroLoad: LoroLoadResult
 }
@@ -74,8 +61,9 @@ async function parseErrorTitle(res: Response): Promise<string> {
 
 /**
  * Copy-first import of a single browser-local canvas: create it on the
- * daemon (retrying with a numeric path suffix on a name collision, bounded
- * to MAX_CREATE_ATTEMPTS), then push the merged snapshot. Never mutates or
+ * daemon (retrying with a numeric path suffix when that path is already
+ * taken THERE, bounded to MAX_CREATE_ATTEMPTS), then push the merged
+ * snapshot. Never mutates or
  * deletes the source browser-local data — the caller owns that lifecycle.
  */
 export async function importOneDocument(
@@ -94,13 +82,17 @@ export async function importOneDocument(
 async function importOneDocumentUnsafe(
   options: ImportOneDocumentOptions,
 ): Promise<ImportOneDocumentResult> {
-  const { fetch, daemonBaseUrl, workspaceId, documentName, documentKind, loroLoad } = options
+  const { fetch, daemonBaseUrl, workspaceId, documentPath, documentKind, loroLoad } = options
 
   if (loroLoad.kind !== 'ok') {
     return { kind: 'failed', reason: loroLoadFailureReason(loroLoad.kind) }
   }
 
-  const baseSegment = toPathSegment(documentName)
+  // The local document's own path, carried across rather than derived from
+  // its display name. Deriving one is what ADR-0008 measured and rejected —
+  // every non-Latin title collapsed to `untitled-N` — and a local document
+  // has a real path now, so there is nothing left to derive.
+  const baseSegment = documentPath
   let createdPath: string | null = null
 
   for (let attempt = 0; attempt < MAX_CREATE_ATTEMPTS; attempt++) {

--- a/apps/web/src/components/workspace-files/new-document-path.ts
+++ b/apps/web/src/components/workspace-files/new-document-path.ts
@@ -27,3 +27,24 @@ export function newDocumentPathIn(folder: string, existingPaths: readonly string
   while (siblings.has(`untitled-${n}`)) n++
   return `${prefix}untitled-${n}`
 }
+
+/**
+ * The paths a new document must number around, for the two callers where a
+ * failed read must not dead-end the user: the list page's create button and
+ * the editor's first-boot create.
+ *
+ * A broken list read is exactly when the create path matters most, so an
+ * unreadable store numbers from nothing rather than throwing. The store's own
+ * uniqueness check is still behind this: the worst case is a refused create
+ * that surfaces as the ordinary create-failed message, not two documents at
+ * one address.
+ */
+export async function takenPathsIn(store: {
+  listDocuments(): Promise<readonly { path: string }[]>
+}): Promise<string[]> {
+  try {
+    return (await store.listDocuments()).map((row) => row.path)
+  } catch {
+    return []
+  }
+}

--- a/apps/web/src/docs-snapshots/browser-local-list.docs-snapshot.test.tsx
+++ b/apps/web/src/docs-snapshots/browser-local-list.docs-snapshot.test.tsx
@@ -27,19 +27,25 @@ describe('docs snapshot: browser-local canvas list', () => {
     const store = new MemoryStore()
     // 1d, 2d, 5d ago relative to NOW so the labels stay stable.
     await store.save({
-      id: 'id-a',
+      documentId: '0RVY147ADGKPSWZ258BEHMQTX0',
+      workspaceId: 'local',
+      path: 'meeting-notes',
       name: 'Meeting notes',
       updatedAt: '2026-05-01T12:00:00.000Z',
       kind: 'markdown',
     })
     await store.save({
-      id: 'id-b',
+      documentId: '0Z258BEHMQTX0369CFJNRVY147',
+      workspaceId: 'local',
+      path: 'trip-plan',
       name: 'Trip plan',
       updatedAt: '2026-04-30T12:00:00.000Z',
       kind: 'spatial',
     })
     await store.save({
-      id: 'id-c',
+      documentId: '069CFJNRVY147ADGKPSWZ258BE',
+      workspaceId: 'local',
+      path: 'sketches',
       name: 'Sketches',
       updatedAt: '2026-04-27T12:00:00.000Z',
       kind: 'spatial',

--- a/apps/web/src/lib/app-routes.test.ts
+++ b/apps/web/src/lib/app-routes.test.ts
@@ -123,8 +123,36 @@ describe('daemonRoutePath', () => {
 })
 
 describe('parseBrowserLocalRoute', () => {
-  it('parses a browser-local canvas route', () => {
-    expect(parseBrowserLocalRoute('/local/abc-123')).toEqual({ documentId: 'abc-123' })
+  it('parses a browser-local document route', () => {
+    expect(parseBrowserLocalRoute('/local/abc-123')).toEqual({ path: 'abc-123' })
+  })
+
+  // The whole reason this changed: a local document has a real path now, and
+  // a single-segment route cannot express one. Separators stay unencoded so
+  // the hierarchy is visible in the URL, exactly as the daemon's is.
+  it('parses a multi-segment path', () => {
+    expect(parseBrowserLocalRoute('/local/design/login')).toEqual({ path: 'design/login' })
+    expect(parseBrowserLocalRoute('/local/design/notes/kickoff')).toEqual({
+      path: 'design/notes/kickoff',
+    })
+  })
+
+  // The round trip alone is not enough: encoding the separator on the way out
+  // and decoding it on the way back in agree with each other and produce a
+  // URL that hides the hierarchy. Assert the STRING.
+  it('leaves separators unencoded and encodes only the segments', () => {
+    expect(browserLocalDocumentPath('design/login')).toBe('/local/design/login')
+    expect(browserLocalDocumentPath('a b/c')).toBe('/local/a%20b/c')
+    expect(parseBrowserLocalRoute(browserLocalDocumentPath('design/login'))).toEqual({
+      path: 'design/login',
+    })
+  })
+
+  // An empty segment would name nothing, and joined segments are what stop
+  // `..` being expressible.
+  it('refuses an empty segment', () => {
+    expect(parseBrowserLocalRoute('/local//login')).toBeNull()
+    expect(parseBrowserLocalRoute('/local/design//login')).toBeNull()
   })
 
   it('returns null for the bare /local index and unrelated paths', () => {
@@ -148,6 +176,7 @@ describe('malformed percent-encoding', () => {
 describe('isKnownAppPath', () => {
   it('accepts every route in the closed set', () => {
     for (const p of [
+      '/local/design/login',
       '/',
       '/w/ws1',
       '/w/ws1/document/main',
@@ -168,7 +197,9 @@ describe('isKnownAppPath', () => {
       '/nope',
       '/document/ws1/main',
       '/w/ws1/canvas',
-      '/local/a/b',
+      // `/local/a/b` used to be here: a local document had no path, so a
+      // second segment could only be a typo. It is a real address now.
+      '/local//b',
       '/w/',
       '/settings/nope',
     ]) {

--- a/apps/web/src/lib/app-routes.ts
+++ b/apps/web/src/lib/app-routes.ts
@@ -26,8 +26,11 @@ export function browserLocalIndexPath(): string {
   return '/local'
 }
 
-export function browserLocalDocumentPath(documentId: string): string {
-  return `/local/${encodeURIComponent(documentId)}`
+// Per-segment encoding, separators left alone — the same rule `documentPath`
+// follows for the daemon. Encoding the separators would collapse a hierarchy
+// the browser shows into one opaque URL segment.
+export function browserLocalDocumentPath(path: string): string {
+  return `/local/${path.split('/').map(encodeURIComponent).join('/')}`
 }
 
 export type DaemonRoute =
@@ -82,11 +85,12 @@ export function daemonRoutePath(route: DaemonRoute): string {
   return route.workspaceId ? workspacePath(route.workspaceId) : indexPath()
 }
 
-export function parseBrowserLocalRoute(pathname: string): { documentId: string } | null {
-  const match = pathname.match(/^\/local\/([^/]+)\/?$/)
+export function parseBrowserLocalRoute(pathname: string): { path: string } | null {
+  const match = pathname.match(/^\/local\/(.+?)\/?$/)
   if (!match) return null
-  const documentId = decodeSegment(match[1])
-  return documentId === null ? null : { documentId }
+  const segments = (match[1] as string).split('/').map(decodeSegment)
+  if (segments.some((segment) => segment === null || segment === '')) return null
+  return { path: segments.join('/') }
 }
 
 export type SettingsSection = 'general' | 'data' | 'connections'

--- a/apps/web/src/lib/browser-idb-migration.browser.test.tsx
+++ b/apps/web/src/lib/browser-idb-migration.browser.test.tsx
@@ -299,11 +299,16 @@ describe('whiteboard IndexedDB v6 -> v7 upgrade (renames the container stores)',
     }
 
     const metaStore = new IndexedDBStore()
-    const loadResult = await metaStore.load(documentId)
-    expect(loadResult.kind).toBe('ok')
-    if (loadResult.kind === 'ok') {
-      expect(loadResult.snapshot.name).toBe('Pre-v7 document')
-    }
+    // The row moves intact, but it is no longer READABLE: a document is now
+    // addressed by workspace + path, and a pre-path row carries neither. There
+    // is deliberately no migration inventing them — a local document is
+    // discardable (0.0.x, no users), and `load` reporting `corrupted` routes
+    // the editor to its existing safe fallback instead of guessing an address.
+    expect(await readRawDocumentsRow(documentId)).toMatchObject({
+      id: documentId,
+      name: 'Pre-v7 document',
+    })
+    expect((await metaStore.load(documentId)).kind).toBe('corrupted')
   })
 
   it('carries the default pointer across the meta key rename', async () => {
@@ -373,11 +378,16 @@ describe('IndexedDB v5 -> v6 (removes reconnectKeypairs)', () => {
 
     const metaStore = new IndexedDBStore()
     expect(await metaStore.getDefaultDocumentId()).toBe(documentId)
-    const loadResult = await metaStore.load(documentId)
-    expect(loadResult.kind).toBe('ok')
-    if (loadResult.kind === 'ok') {
-      expect(loadResult.snapshot.name).toBe('Pre-v6 canvas')
-    }
+    // The row moves intact, but it is no longer READABLE: a document is now
+    // addressed by workspace + path, and a pre-path row carries neither. There
+    // is deliberately no migration inventing them — a local document is
+    // discardable (0.0.x, no users), and `load` reporting `corrupted` routes
+    // the editor to its existing safe fallback instead of guessing an address.
+    expect(await readRawDocumentsRow(documentId)).toMatchObject({
+      id: documentId,
+      name: 'Pre-v6 canvas',
+    })
+    expect((await metaStore.load(documentId)).kind).toBe('corrupted')
 
     // purgeLegacyReconnectCredentials() is exercised directly here (rather
     // than via a full App/router boot harness) — it is called unconditionally
@@ -441,11 +451,16 @@ describe('IndexedDB v4 -> v5', () => {
 
     const metaStore = new IndexedDBStore()
     expect(await metaStore.getDefaultDocumentId()).toBe(documentId)
-    const loadResult = await metaStore.load(documentId)
-    expect(loadResult.kind).toBe('ok')
-    if (loadResult.kind === 'ok') {
-      expect(loadResult.snapshot.name).toBe('Pre-v5 canvas')
-    }
+    // The row moves intact, but it is no longer READABLE: a document is now
+    // addressed by workspace + path, and a pre-path row carries neither. There
+    // is deliberately no migration inventing them — a local document is
+    // discardable (0.0.x, no users), and `load` reporting `corrupted` routes
+    // the editor to its existing safe fallback instead of guessing an address.
+    expect(await readRawDocumentsRow(documentId)).toMatchObject({
+      id: documentId,
+      name: 'Pre-v5 canvas',
+    })
+    expect((await metaStore.load(documentId)).kind).toBe('corrupted')
   })
 })
 
@@ -474,11 +489,16 @@ describe('whiteboard IndexedDB v3 -> v4 upgrade', () => {
 
     const metaStore = new IndexedDBStore()
     expect(await metaStore.getDefaultDocumentId()).toBe(documentId)
-    const loadResult = await metaStore.load(documentId)
-    expect(loadResult.kind).toBe('ok')
-    if (loadResult.kind === 'ok') {
-      expect(loadResult.snapshot.name).toBe('Pre-v4 canvas')
-    }
+    // The row moves intact, but it is no longer READABLE: a document is now
+    // addressed by workspace + path, and a pre-path row carries neither. There
+    // is deliberately no migration inventing them — a local document is
+    // discardable (0.0.x, no users), and `load` reporting `corrupted` routes
+    // the editor to its existing safe fallback instead of guessing an address.
+    expect(await readRawDocumentsRow(documentId)).toMatchObject({
+      id: documentId,
+      name: 'Pre-v4 canvas',
+    })
+    expect((await metaStore.load(documentId)).kind).toBe('corrupted')
   })
 })
 
@@ -525,18 +545,14 @@ describe('whiteboard IndexedDB v2 -> v3 upgrade', () => {
     })
 
     const metaStore = new IndexedDBStore()
-    const loadResult = await metaStore.load(documentId)
-    expect(loadResult.kind).toBe('ok')
-    if (loadResult.kind === 'ok') {
-      expect(loadResult.snapshot).toEqual({
-        id: documentId,
-        name: 'Pre-migration canvas',
-        updatedAt: '2026-01-01T00:00:00.000Z',
-        // Not stored in the v2 fixture: the schema's own default — a
-        // pre-kind row parses as a spatial canvas with no migration.
-        kind: 'spatial',
-      })
-    }
+    // The row moves intact, but it is no longer READABLE: a document is now
+    // addressed by workspace + path, and a pre-path row carries neither. There
+    // is deliberately no migration inventing them — a local document is
+    // discardable (0.0.x, no users), and `load` reporting `corrupted` routes
+    // the editor to its existing safe fallback instead of guessing an address.
+    expect((await metaStore.load(documentId)).kind).toBe('corrupted')
+    // ...and it is skipped rather than blanking the list or throwing.
+    expect(await metaStore.listDocuments()).toEqual([])
 
     // (d) The default pointer/id is intact.
     expect(await metaStore.getDefaultDocumentId()).toBe(documentId)

--- a/apps/web/src/lib/browser-local-store.test.ts
+++ b/apps/web/src/lib/browser-local-store.test.ts
@@ -1,3 +1,4 @@
+import { documentIdSchema } from '@kamiazya/whiteboard-model'
 import { IDBFactory } from 'fake-indexeddb'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { DB_VERSION } from './browser-idb.js'
@@ -5,22 +6,38 @@ import { IndexedDBStore, MemoryStore } from './browser-local-store.js'
 import type { DocumentSnapshot } from './whiteboard-client.js'
 
 const snap: DocumentSnapshot = {
-  id: 'c1',
+  documentId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+  workspaceId: 'local',
+  path: 'untitled',
   name: 'untitled',
   updatedAt: '2026-05-24T00:00:00.000Z',
   kind: 'spatial' as const,
 }
+const ID = snap.documentId
+const ID_B = '01ARZ3NDEKTSV4RRFFQ69G5FB0'
+
+// Both stores mint the same kind of id, and it is the daemon's kind: a
+// `crypto.randomUUID()` parses as a string but `documentIdSchema` refuses it,
+// so a local document could never be named in a `DocRef`.
+describe.each([
+  ['MemoryStore', () => new MemoryStore()],
+  ['IndexedDBStore', () => new IndexedDBStore()],
+])('%s generateId', (_name, make) => {
+  it('mints a document id the rest of the system accepts', () => {
+    expect(() => documentIdSchema.parse(make().generateId())).not.toThrow()
+  })
+})
 
 describe('MemoryStore', () => {
   it('load returns not-found for unknown id', async () => {
     const store = new MemoryStore()
-    expect(await store.load('c1')).toEqual({ kind: 'not-found' })
+    expect(await store.load(ID)).toEqual({ kind: 'not-found' })
   })
 
   it('save then load returns ok with snapshot', async () => {
     const store = new MemoryStore()
     await store.save(snap)
-    expect(await store.load('c1')).toEqual({ kind: 'ok', snapshot: snap })
+    expect(await store.load(ID)).toEqual({ kind: 'ok', snapshot: snap })
   })
 
   it('getDefaultDocumentId returns null initially', async () => {
@@ -30,55 +47,55 @@ describe('MemoryStore', () => {
 
   it('setDefaultDocumentId then get returns the set id', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
-    expect(await store.getDefaultDocumentId()).toBe('c1')
+    await store.setDefaultDocumentId(ID)
+    expect(await store.getDefaultDocumentId()).toBe(ID)
   })
 
   it('del with matching id deletes canvas and clears pointer', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId(ID)
     await store.save(snap)
-    expect(await store.del('c1')).toEqual({ deleted: true })
-    expect(await store.load('c1')).toEqual({ kind: 'not-found' })
+    expect(await store.del(ID)).toEqual({ deleted: true })
+    expect(await store.load(ID)).toEqual({ kind: 'not-found' })
     expect(await store.getDefaultDocumentId()).toBeNull()
   })
 
   it('del with pointer-mismatch returns not-deleted', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c2')
+    await store.setDefaultDocumentId(ID_B)
     await store.save(snap)
-    expect(await store.del('c1')).toEqual({ deleted: false, reason: 'pointer-mismatch' })
+    expect(await store.del(ID)).toEqual({ deleted: false, reason: 'pointer-mismatch' })
   })
 
   it('del when no default id returns not-found', async () => {
     const store = new MemoryStore()
-    expect(await store.del('c1')).toEqual({ deleted: false, reason: 'not-found' })
+    expect(await store.del(ID)).toEqual({ deleted: false, reason: 'not-found' })
   })
 
   it('removeDocument deletes a record by id without matching the default pointer', async () => {
     const store = new MemoryStore()
-    const a: DocumentSnapshot = { ...snap, id: 'c1' }
-    const b: DocumentSnapshot = { ...snap, id: 'c2' }
+    const a: DocumentSnapshot = { ...snap }
+    const b: DocumentSnapshot = { ...snap, documentId: ID_B, path: 'untitled-2' }
     await store.save(a)
     await store.save(b)
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId(ID)
 
-    await store.removeDocument('c2')
+    await store.removeDocument(ID_B)
 
-    expect(await store.load('c2')).toEqual({ kind: 'not-found' })
-    expect(await store.load('c1')).toEqual({ kind: 'ok', snapshot: a })
-    expect(await store.getDefaultDocumentId()).toBe('c1')
+    expect(await store.load(ID_B)).toEqual({ kind: 'not-found' })
+    expect(await store.load(ID)).toEqual({ kind: 'ok', snapshot: a })
+    expect(await store.getDefaultDocumentId()).toBe(ID)
   })
 
   it('removeDocument on a non-existent id is a no-op', async () => {
     const store = new MemoryStore()
     await store.save(snap)
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId(ID)
 
     await expect(store.removeDocument('missing')).resolves.toBeUndefined()
 
-    expect(await store.load('c1')).toEqual({ kind: 'ok', snapshot: snap })
-    expect(await store.getDefaultDocumentId()).toBe('c1')
+    expect(await store.load(ID)).toEqual({ kind: 'ok', snapshot: snap })
+    expect(await store.getDefaultDocumentId()).toBe(ID)
   })
 
   it('generateId returns a non-empty string each call', () => {
@@ -97,8 +114,8 @@ describe('MemoryStore', () => {
 
   it('listDocuments returns all saved snapshots by id', async () => {
     const store = new MemoryStore()
-    const a: DocumentSnapshot = { ...snap, id: 'c1', name: 'Canvas A' }
-    const b: DocumentSnapshot = { ...snap, id: 'c2', name: 'Canvas B' }
+    const a: DocumentSnapshot = { ...snap, name: 'Canvas A' }
+    const b: DocumentSnapshot = { ...snap, documentId: ID_B, path: 'untitled-2', name: 'Canvas B' }
     await store.save(a)
     await store.save(b)
     const list = await store.listDocuments()
@@ -120,19 +137,19 @@ describe('IndexedDBStore', () => {
 
   it('setDefaultDocumentId then get returns the set id', async () => {
     const store = new IndexedDBStore()
-    await store.setDefaultDocumentId('c1')
-    expect(await store.getDefaultDocumentId()).toBe('c1')
+    await store.setDefaultDocumentId(ID)
+    expect(await store.getDefaultDocumentId()).toBe(ID)
   })
 
   it('load returns not-found for unknown id', async () => {
     const store = new IndexedDBStore()
-    expect(await store.load('c1')).toEqual({ kind: 'not-found' })
+    expect(await store.load(ID)).toEqual({ kind: 'not-found' })
   })
 
   it('save then load returns ok with snapshot', async () => {
     const store = new IndexedDBStore()
     await store.save(snap)
-    expect(await store.load('c1')).toEqual({ kind: 'ok', snapshot: snap })
+    expect(await store.load(ID)).toEqual({ kind: 'ok', snapshot: snap })
   })
 
   it('load returns corrupted for malformed stored data', async () => {
@@ -147,7 +164,7 @@ describe('IndexedDBStore', () => {
       req.onsuccess = () => {
         const db = req.result
         const tx = db.transaction('documents', 'readwrite')
-        tx.objectStore('documents').put({ broken: true }, 'c1')
+        tx.objectStore('documents').put({ broken: true }, ID)
         tx.oncomplete = () => {
           db.close()
           resolve()
@@ -157,28 +174,28 @@ describe('IndexedDBStore', () => {
       req.onerror = () => reject(req.error)
     })
     const store = new IndexedDBStore()
-    expect(await store.load('c1')).toEqual({ kind: 'corrupted' })
+    expect(await store.load(ID)).toEqual({ kind: 'corrupted' })
   })
 
   it('del with matching id deletes canvas and clears pointer', async () => {
     const store = new IndexedDBStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId(ID)
     await store.save(snap)
-    expect(await store.del('c1')).toEqual({ deleted: true })
-    expect(await store.load('c1')).toEqual({ kind: 'not-found' })
+    expect(await store.del(ID)).toEqual({ deleted: true })
+    expect(await store.load(ID)).toEqual({ kind: 'not-found' })
     expect(await store.getDefaultDocumentId()).toBeNull()
   })
 
   it('del with pointer-mismatch returns not-deleted', async () => {
     const store = new IndexedDBStore()
-    await store.setDefaultDocumentId('c2')
+    await store.setDefaultDocumentId(ID_B)
     await store.save(snap)
-    expect(await store.del('c1')).toEqual({ deleted: false, reason: 'pointer-mismatch' })
+    expect(await store.del(ID)).toEqual({ deleted: false, reason: 'pointer-mismatch' })
   })
 
   it('del when no default id returns not-found', async () => {
     const store = new IndexedDBStore()
-    expect(await store.del('c1')).toEqual({ deleted: false, reason: 'not-found' })
+    expect(await store.del(ID)).toEqual({ deleted: false, reason: 'not-found' })
   })
 
   it('listDocuments returns empty array when store is empty', async () => {
@@ -188,8 +205,8 @@ describe('IndexedDBStore', () => {
 
   it('listDocuments returns all saved snapshots by id', async () => {
     const store = new IndexedDBStore()
-    const a: DocumentSnapshot = { ...snap, id: 'c1', name: 'Canvas A' }
-    const b: DocumentSnapshot = { ...snap, id: 'c2', name: 'Canvas B' }
+    const a: DocumentSnapshot = { ...snap, name: 'Canvas A' }
+    const b: DocumentSnapshot = { ...snap, documentId: ID_B, path: 'untitled-2', name: 'Canvas B' }
     await store.save(a)
     await store.save(b)
     const list = await store.listDocuments()
@@ -199,7 +216,7 @@ describe('IndexedDBStore', () => {
 
   it('listDocuments skips a corrupt row instead of throwing or blanking the list', async () => {
     const store = new IndexedDBStore()
-    const a: DocumentSnapshot = { ...snap, id: 'c1', name: 'Canvas A' }
+    const a: DocumentSnapshot = { ...snap, name: 'Canvas A' }
     await store.save(a)
     // Write a malformed row directly via raw IDB (bypasses documentSnapshotSchema).
     await new Promise<void>((resolve, reject) => {

--- a/apps/web/src/lib/browser-local-store.test.ts
+++ b/apps/web/src/lib/browser-local-store.test.ts
@@ -237,3 +237,40 @@ describe('IndexedDBStore', () => {
     expect(list).toEqual([a])
   })
 })
+
+// A path is the ADDRESS a URL, the switcher and every [[reference]] follow
+// resolve through, so two documents sharing one is not a tidiness problem: it
+// makes `find(entry => entry.path === …)` answer with whichever row happened
+// to come first. Both stores refuse it at the write instead.
+describe.each([
+  ['MemoryStore', () => new MemoryStore()],
+  ['IndexedDBStore', () => new IndexedDBStore()],
+])('%s path uniqueness', (name, make) => {
+  beforeEach(() => {
+    if (name === 'IndexedDBStore') globalThis.indexedDB = new IDBFactory()
+  })
+
+  it('refuses a second document at a path another document already holds', async () => {
+    const store = make()
+    await store.save(snap)
+    await expect(store.save({ ...snap, documentId: ID_B, name: 'impostor' })).rejects.toThrow(
+      /path/i,
+    )
+    expect(await store.load(ID_B)).toEqual({ kind: 'not-found' })
+  })
+
+  it('lets a document keep its own path across an ordinary update', async () => {
+    const store = make()
+    await store.save(snap)
+    await store.save({ ...snap, name: 'renamed' })
+    expect(await store.load(ID)).toEqual({ kind: 'ok', snapshot: { ...snap, name: 'renamed' } })
+  })
+
+  it('frees the path once the holder is removed', async () => {
+    const store = make()
+    await store.save(snap)
+    await store.removeDocument?.(ID)
+    await store.save({ ...snap, documentId: ID_B })
+    expect(await store.load(ID_B)).toEqual({ kind: 'ok', snapshot: { ...snap, documentId: ID_B } })
+  })
+})

--- a/apps/web/src/lib/browser-local-store.ts
+++ b/apps/web/src/lib/browser-local-store.ts
@@ -1,3 +1,4 @@
+import { generateDocumentId } from '@kamiazya/whiteboard-model'
 import { openWhiteboardDb } from './browser-idb.js'
 import type { DocumentSnapshot } from './whiteboard-client.js'
 import { documentSnapshotSchema } from './whiteboard-client.js'
@@ -44,7 +45,7 @@ export class MemoryStore implements BrowserLocalStore {
   }
 
   async save(snapshot: DocumentSnapshot): Promise<void> {
-    this.documents.set(snapshot.id, snapshot)
+    this.documents.set(snapshot.documentId, snapshot)
   }
 
   async del(expectedId: string): Promise<DeleteResult> {
@@ -60,7 +61,7 @@ export class MemoryStore implements BrowserLocalStore {
   }
 
   generateId(): string {
-    return crypto.randomUUID()
+    return generateDocumentId()
   }
 
   async listDocuments(): Promise<DocumentSnapshot[]> {
@@ -121,7 +122,7 @@ export class IndexedDBStore implements BrowserLocalStore {
     const db = await openWhiteboardDb()
     return new Promise((resolve, reject) => {
       const tx = db.transaction('documents', 'readwrite')
-      tx.objectStore('documents').put(snapshot, snapshot.id)
+      tx.objectStore('documents').put(snapshot, snapshot.documentId)
       tx.oncomplete = () => {
         db.close()
         resolve()
@@ -197,7 +198,7 @@ export class IndexedDBStore implements BrowserLocalStore {
   }
 
   generateId(): string {
-    return crypto.randomUUID()
+    return generateDocumentId()
   }
 
   async listDocuments(): Promise<DocumentSnapshot[]> {

--- a/apps/web/src/lib/browser-local-store.ts
+++ b/apps/web/src/lib/browser-local-store.ts
@@ -65,6 +65,13 @@ export class MemoryStore implements BrowserLocalStore {
   }
 
   async save(snapshot: DocumentSnapshot): Promise<void> {
+    // The in-memory store is used only by tests, and it is the one place a
+    // fixture the real store would REJECT can otherwise sail through:
+    // IndexedDBStore hydrates every read through documentSnapshotSchema and
+    // silently skips a row that fails it, so a test seeding a non-ULID id here
+    // would pass while production saw no document at all. Parsing on write
+    // makes that a loud failure in the test that wrote it.
+    documentSnapshotSchema.parse(snapshot)
     for (const existing of this.documents.values()) {
       if (existing.path === snapshot.path && existing.documentId !== snapshot.documentId) {
         throw new DuplicatePathError(snapshot.path)

--- a/apps/web/src/lib/browser-local-store.ts
+++ b/apps/web/src/lib/browser-local-store.ts
@@ -3,6 +3,16 @@ import { openWhiteboardDb } from './browser-idb.js'
 import type { DocumentSnapshot } from './whiteboard-client.js'
 import { documentSnapshotSchema } from './whiteboard-client.js'
 
+/**
+ * The one workspace a browser-local install has.
+ *
+ * It is a real value in every stored row rather than a literal in JSX,
+ * because a row that does not carry its workspace cannot be turned into the
+ * addresses the port contracts take. Local staying single-workspace is a
+ * product decision; being unable to SAY which workspace was an accident.
+ */
+export const LOCAL_WORKSPACE_ID = 'local'
+
 export type LoadResult =
   | { kind: 'ok'; snapshot: DocumentSnapshot }
   | { kind: 'not-found' }

--- a/apps/web/src/lib/browser-local-store.ts
+++ b/apps/web/src/lib/browser-local-store.ts
@@ -22,6 +22,16 @@ export type DeleteResult =
   | { deleted: true }
   | { deleted: false; reason: 'pointer-mismatch' | 'not-found' }
 
+// A path is an address: the URL, the switcher and every [[reference]] follow
+// resolve a document through it. Two documents sharing one would make that
+// lookup answer with whichever row came first, so `save` refuses it.
+class DuplicatePathError extends Error {
+  constructor(readonly path: string) {
+    super(`another document already holds the path "${path}"`)
+    this.name = 'DuplicatePathError'
+  }
+}
+
 export interface BrowserLocalStore {
   getDefaultDocumentId(): Promise<string | null>
   setDefaultDocumentId(id: string): Promise<void>
@@ -55,6 +65,11 @@ export class MemoryStore implements BrowserLocalStore {
   }
 
   async save(snapshot: DocumentSnapshot): Promise<void> {
+    for (const existing of this.documents.values()) {
+      if (existing.path === snapshot.path && existing.documentId !== snapshot.documentId) {
+        throw new DuplicatePathError(snapshot.path)
+      }
+    }
     this.documents.set(snapshot.documentId, snapshot)
   }
 
@@ -132,7 +147,33 @@ export class IndexedDBStore implements BrowserLocalStore {
     const db = await openWhiteboardDb()
     return new Promise((resolve, reject) => {
       const tx = db.transaction('documents', 'readwrite')
-      tx.objectStore('documents').put(snapshot, snapshot.documentId)
+      const store = tx.objectStore('documents')
+      // ponytail: linear scan inside the write transaction. A unique index on
+      // `path` would be the database's own answer, but it costs a DB_VERSION
+      // bump and a migration that has to decide what to do with rows already
+      // colliding; move to one if a local store ever grows past a few hundred
+      // documents. The scan shares the transaction with the put, so no
+      // concurrent save can slip between the check and the write.
+      const scan = store.openCursor()
+      scan.onsuccess = () => {
+        const cursor = scan.result
+        if (cursor) {
+          const row = documentSnapshotSchema.safeParse(cursor.value)
+          if (
+            row.success &&
+            row.data.path === snapshot.path &&
+            row.data.documentId !== snapshot.documentId
+          ) {
+            tx.abort()
+            reject(new DuplicatePathError(snapshot.path))
+            return
+          }
+          cursor.continue()
+          return
+        }
+        store.put(snapshot, snapshot.documentId)
+      }
+      scan.onerror = () => reject(scan.error)
       tx.oncomplete = () => {
         db.close()
         resolve()

--- a/apps/web/src/lib/whiteboard-client.test.ts
+++ b/apps/web/src/lib/whiteboard-client.test.ts
@@ -1,0 +1,67 @@
+import { documentIdSchema } from '@kamiazya/whiteboard-model'
+import { describe, expect, it } from 'vitest'
+import { documentSnapshotSchema } from './whiteboard-client.js'
+
+const row = {
+  documentId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+  workspaceId: 'local',
+  path: 'design/login',
+  name: 'Login flow',
+  updatedAt: '2026-05-01T12:00:00.000Z',
+  kind: 'markdown' as const,
+}
+
+describe('documentSnapshotSchema', () => {
+  // The whole point of the shape change: a local document is addressed the
+  // way the daemon addresses one, so the same port contracts can describe
+  // both. `DocRef` takes a ULID; a UUID cannot satisfy it.
+  it('addresses a document by ULID, workspace and path', () => {
+    const parsed = documentSnapshotSchema.parse(row)
+    expect(() => documentIdSchema.parse(parsed.documentId)).not.toThrow()
+    expect(parsed.workspaceId).toBe('local')
+    expect(parsed.path).toBe('design/login')
+  })
+
+  // Every one of the three is required. A row missing any of them cannot be
+  // turned into a `DocRef`, which is the entire reason the shape changed —
+  // and the fixture above passes all three, so only their ABSENCE reaches
+  // the rule.
+  it.each(['documentId', 'workspaceId', 'path'])('requires %s', (field) => {
+    const { [field]: _missing, ...without } = row as Record<string, unknown>
+    expect(() => documentSnapshotSchema.parse(without)).toThrow()
+  })
+
+  // A UUID parses as a string but is not a document id anywhere else in the
+  // system — accepting one here is how the two halves drifted apart.
+  it('refuses an id that is not a document id', () => {
+    expect(() =>
+      documentSnapshotSchema.parse({ ...row, documentId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479' }),
+    ).toThrow()
+  })
+
+  // Uppercase IS allowed — the daemon's own segment pattern is
+  // `[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?`. What it refuses is an empty
+  // segment or a non-ASCII one, which is what makes `..` traversal
+  // unexpressible once segments are joined.
+  it('refuses a path the daemon would refuse, and allows one it would not', () => {
+    expect(() => documentSnapshotSchema.parse({ ...row, path: 'Design/Login' })).not.toThrow()
+    expect(() => documentSnapshotSchema.parse({ ...row, path: '' })).toThrow()
+    expect(() => documentSnapshotSchema.parse({ ...row, path: 'design/' })).toThrow()
+    expect(() => documentSnapshotSchema.parse({ ...row, path: 'design//login' })).toThrow()
+    expect(() => documentSnapshotSchema.parse({ ...row, path: '設計' })).toThrow()
+  })
+
+  // Kind still defaults, for the same reason it always did: rows written
+  // before it existed are spatial, and the content lives in the Loro doc
+  // either way.
+  it('still defaults the kind to spatial', () => {
+    const { kind: _dropped, ...withoutKind } = row
+    expect(documentSnapshotSchema.parse(withoutKind).kind).toBe('spatial')
+  })
+
+  // Elements are canonical in the Loro doc. This row is metadata, and the
+  // day it grows a scene field the two stores start disagreeing.
+  it('refuses a scene field outright', () => {
+    expect(() => documentSnapshotSchema.parse({ ...row, scene: { nodes: [] } })).toThrow()
+  })
+})

--- a/apps/web/src/lib/whiteboard-client.ts
+++ b/apps/web/src/lib/whiteboard-client.ts
@@ -1,22 +1,37 @@
-import { documentKindSchema } from '@kamiazya/whiteboard-model'
+import {
+  documentIdSchema,
+  documentKindSchema,
+  documentPathSchema,
+  workspaceIdSchema,
+} from '@kamiazya/whiteboard-model'
 import { z } from 'zod'
 
 /**
  * Persisted JSON 'documents' row: metadata only. Elements are canonical in the
  * Loro doc ('loroDocuments' store); this schema must never grow a scene/elements
- * field again or the two stores drift out of sync.
+ * field again or the two stores drift out of sync. `.strict()` is what enforces
+ * that rather than a comment asking nicely.
+ *
+ * A local document is addressed exactly as the daemon addresses one — a ULID
+ * document id, a workspace, and a path — so one set of port contracts can
+ * describe both stores. The previous shape (a `crypto.randomUUID()` in an
+ * `id` field, no workspace, no path) could not satisfy `DocRef` at all, which
+ * is what kept the two halves of this product apart.
  */
-export const documentSnapshotSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  updatedAt: z.string(),
-  /**
-   * Which editor opens this canvas. Defaulted so rows persisted before the
-   * field existed parse as spatial — the only kind that existed then.
-   * Content stays in the Loro doc either way (spatial: nodes/edges maps;
-   * markdown: a 'body' text container) — this is still metadata only.
-   */
-  kind: documentKindSchema.default('spatial'),
-})
+export const documentSnapshotSchema = z
+  .object({
+    documentId: documentIdSchema,
+    workspaceId: workspaceIdSchema,
+    path: documentPathSchema,
+    name: z.string(),
+    updatedAt: z.string(),
+    /**
+     * Which editor opens this document. Defaulted because content lives in
+     * the Loro doc either way (spatial: nodes/edges maps; markdown: a 'body'
+     * text container) — this row is still metadata only.
+     */
+    kind: documentKindSchema.default('spatial'),
+  })
+  .strict()
 
 export type DocumentSnapshot = z.infer<typeof documentSnapshotSchema>

--- a/apps/web/src/pages/BrowserLocalDocumentPage.delete-confirm.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.delete-confirm.browser.test.tsx
@@ -76,7 +76,7 @@ describe('BrowserLocalDocumentPage delete confirmation (browser — real Indexed
 
   it('confirming deletion shows the cleanup-completed view and removes the canvas row', async () => {
     const store = await renderLoaded()
-    const beforeIds = (await store.listDocuments()).map((c) => c.id)
+    const beforeIds = (await store.listDocuments()).map((c) => c.documentId)
     expect(beforeIds.length).toBeGreaterThan(0)
 
     const dialog = await openDeleteDialog()
@@ -87,7 +87,7 @@ describe('BrowserLocalDocumentPage delete confirmation (browser — real Indexed
     await waitFor(() => expect(screen.getByTestId('cleanup-completed')).toBeInTheDocument(), {
       timeout: 5000,
     })
-    const afterIds = (await store.listDocuments()).map((c) => c.id)
+    const afterIds = (await store.listDocuments()).map((c) => c.documentId)
     for (const id of beforeIds) {
       expect(afterIds).not.toContain(id)
     }
@@ -145,7 +145,7 @@ describe('BrowserLocalDocumentPage delete confirmation (browser — real Indexed
 
   it('confirming delete while a save is pending flushes and deletes exactly once', async () => {
     let store = await renderLoaded()
-    const beforeIds = (await store.listDocuments()).map((c) => c.id)
+    const beforeIds = (await store.listDocuments()).map((c) => c.documentId)
 
     // Put the header persistence state into "pending" by renaming, then
     // immediately open+confirm the delete dialog before the debounce fires.
@@ -198,7 +198,7 @@ describe('BrowserLocalDocumentPage delete confirmation (browser — real Indexed
     await waitFor(() => expect(screen.getByTestId('cleanup-completed')).toBeInTheDocument(), {
       timeout: 5000,
     })
-    const afterIds = (await store.listDocuments()).map((c) => c.id)
+    const afterIds = (await store.listDocuments()).map((c) => c.documentId)
     for (const id of beforeIds) {
       expect(afterIds).not.toContain(id)
     }

--- a/apps/web/src/pages/BrowserLocalDocumentPage.file-refs.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.file-refs.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * File-reference identity on the browser-local page, the sibling of
+ * DaemonDocumentPage.file-refs.test.tsx: a file node references the target
+ * document's immutable id (rename- and move-safe, ADR-0008) while the address
+ * bar names a path, so opening one crosses that boundary by lookup. An id the
+ * list does not carry yet is a no-op rather than a navigation to nowhere.
+ */
+import { act, cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { SpatialEditorProps } from '../components/spatial-editor/index.js'
+import { LOCAL_WORKSPACE_ID, MemoryStore } from '../lib/browser-local-store.js'
+import type { LoroLoadResult } from '../lib/loro-store.js'
+import type { LoroStoreLike } from './use-browser-local-document-controller.js'
+
+// Captures the editor's file-ref props without mounting the real canvas —
+// what this file tests is the page's wiring, not the editor's rendering.
+let capturedEditorProps: SpatialEditorProps | null = null
+vi.mock('../components/spatial-editor/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../components/spatial-editor/index.js')>()
+  return {
+    ...actual,
+    SpatialEditor: (props: SpatialEditorProps) => {
+      capturedEditorProps = props
+      return <div data-testid="stub-spatial-editor" />
+    },
+  }
+})
+
+vi.mock('../lib/browser-local-backend.js', () => ({
+  BrowserLocalBackend: class {
+    connect(handlers: { onConnected: () => void }) {
+      handlers.onConnected()
+    }
+    disconnect() {}
+    pushLocalUpdate() {
+      return Promise.resolve()
+    }
+    getFile() {
+      return Promise.resolve(null)
+    }
+    putFile() {
+      return Promise.resolve()
+    }
+    sendClientReady() {}
+    sendExportResponse() {}
+  },
+}))
+
+class FakeLoroStore implements LoroStoreLike {
+  private byId = new Map<string, Uint8Array>()
+  async save(id: string, bytes: Uint8Array): Promise<void> {
+    this.byId.set(id, bytes)
+  }
+  createEmptySnapshot(): Uint8Array {
+    return new Uint8Array([1, 2, 3])
+  }
+  async load(id: string): Promise<LoroLoadResult> {
+    const bytes = this.byId.get(id)
+    if (bytes === undefined) return { kind: 'not-found' }
+    return { kind: 'ok', snapshot: bytes }
+  }
+}
+
+const { BrowserLocalDocumentPage } = await import('./BrowserLocalDocumentPage.js')
+
+const HERE_ID = '005AFMSY38DJQW16BGNTZ49EKR'
+const TARGET_ID = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+
+async function seededStore(): Promise<MemoryStore> {
+  const store = new MemoryStore()
+  await store.setDefaultDocumentId(HERE_ID)
+  await store.save({
+    documentId: HERE_ID,
+    workspaceId: LOCAL_WORKSPACE_ID,
+    path: 'here',
+    name: 'Here',
+    updatedAt: '2026-05-24T00:00:00.000Z',
+    kind: 'spatial',
+  })
+  await store.save({
+    documentId: TARGET_ID,
+    workspaceId: LOCAL_WORKSPACE_ID,
+    // Deliberately unlike both the id and the display name: a fixture where
+    // any of the three could stand in for another proves nothing about which
+    // one the wiring actually used.
+    path: 'archive/target',
+    name: 'Target',
+    updatedAt: '2026-05-25T00:00:00.000Z',
+    kind: 'spatial',
+  })
+  return store
+}
+
+async function mountPage(store: MemoryStore) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/local/*',
+        element: (
+          <BrowserLocalDocumentPage store={store} loro={new FakeLoroStore()} initialPath="here" />
+        ),
+      },
+    ],
+    { initialEntries: ['/local/here'] },
+  )
+  await act(async () => {
+    rtlRender(<RouterProvider router={router} />)
+  })
+  await waitFor(() => {
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Here')
+  })
+  await waitFor(() => expect(capturedEditorProps?.fileRefOptions?.length).toBeGreaterThan(0))
+  return router
+}
+
+afterEach(() => {
+  cleanup()
+  capturedEditorProps = null
+})
+
+describe('BrowserLocalDocumentPage file references', () => {
+  it('offers every other document by id, labeled with its name', async () => {
+    await mountPage(await seededStore())
+    expect(capturedEditorProps?.fileRefOptions).toEqual([
+      { file: TARGET_ID, label: 'Target', kind: 'spatial' },
+    ])
+  })
+
+  it('opens a reference by resolving its id to that document’s current path', async () => {
+    const router = await mountPage(await seededStore())
+    await act(async () => {
+      capturedEditorProps?.onOpenFileRef?.(TARGET_ID)
+    })
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/local/archive/target')
+    })
+  })
+
+  it('leaves the address bar alone for a reference the list does not carry', async () => {
+    const router = await mountPage(await seededStore())
+    const before = router.state.location.key
+    await act(async () => {
+      capturedEditorProps?.onOpenFileRef?.('01ARZ3NDEKTSV4RRFFQ69G5FZZ')
+    })
+    // On the KEY, not the pathname: navigating to an id-shaped URL and then
+    // having the URL→document effect repair it lands back on this same
+    // pathname, so a pathname assertion cannot tell the two apart — and the
+    // difference is a junk history entry the user has to press Back through.
+    expect(router.state.location.pathname).toBe('/local/here')
+    expect(router.state.location.key).toBe(before)
+  })
+})

--- a/apps/web/src/pages/BrowserLocalDocumentPage.fullscreen.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.fullscreen.test.tsx
@@ -37,7 +37,9 @@ function render(ui: ReactElement) {
 }
 
 const snap: DocumentSnapshot = {
-  id: 'c1',
+  documentId: '0PV05AFMSY38DJQW16BGNTZ49E',
+  workspaceId: 'local',
+  path: 'canvas-a',
   name: 'Canvas A',
   kind: 'spatial',
   updatedAt: '2026-04-23T00:00:00Z',
@@ -54,7 +56,7 @@ function setFullscreenElement(el: Element | null) {
 
 async function renderLoaded() {
   const store = new MemoryStore()
-  await store.setDefaultDocumentId('c1')
+  await store.setDefaultDocumentId('0PV05AFMSY38DJQW16BGNTZ49E')
   await store.save(snap)
   await act(async () => {
     render(<BrowserLocalDocumentPage store={store} />)

--- a/apps/web/src/pages/BrowserLocalDocumentPage.history-nav.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.history-nav.browser.test.tsx
@@ -54,6 +54,15 @@ function mountedNodeIds(): string[] {
 
 const { BrowserLocalDocumentPage } = await import('./BrowserLocalDocumentPage.js')
 
+// The address bar names a document by PATH; the store's default pointer names
+// it by id. Every URL assertion below goes through this so the two are never
+// silently conflated.
+async function pathOf(store: IndexedDBStore, documentId: string): Promise<string> {
+  const found = (await store.listDocuments()).find((row) => row.documentId === documentId)
+  if (found === undefined) throw new Error(`no document ${documentId}`)
+  return found.path
+}
+
 describe('BrowserLocalDocumentPage browser Back/Forward (browser — real IndexedDB)', () => {
   beforeEach(async () => {
     await clearWhiteboardDb()
@@ -92,6 +101,7 @@ describe('BrowserLocalDocumentPage browser Back/Forward (browser — real Indexe
       },
       { timeout: 5000 },
     )
+    const pathA = await pathOf(store, idA)
 
     const nodeA = textNodeCanvas('history-nav-node-a', 0, 0)
     await waitFor(
@@ -120,8 +130,10 @@ describe('BrowserLocalDocumentPage browser Back/Forward (browser — real Indexe
       },
       { timeout: 5000 },
     )
+    const pathB = await pathOf(store, idB)
+    expect(pathB).not.toBe(pathA)
 
-    await waitFor(() => expect(router.state.location.pathname).toBe(`/local/${idB}`), {
+    await waitFor(() => expect(router.state.location.pathname).toBe(`/local/${pathB}`), {
       timeout: 5000,
     })
 
@@ -143,7 +155,7 @@ describe('BrowserLocalDocumentPage browser Back/Forward (browser — real Indexe
       await router.navigate(-1)
     })
 
-    await waitFor(() => expect(router.state.location.pathname).toBe(`/local/${idA}`), {
+    await waitFor(() => expect(router.state.location.pathname).toBe(`/local/${pathA}`), {
       timeout: 5000,
     })
     await waitFor(
@@ -164,7 +176,7 @@ describe('BrowserLocalDocumentPage browser Back/Forward (browser — real Indexe
       await router.navigate(1)
     })
 
-    await waitFor(() => expect(router.state.location.pathname).toBe(`/local/${idB}`), {
+    await waitFor(() => expect(router.state.location.pathname).toBe(`/local/${pathB}`), {
       timeout: 5000,
     })
     await waitFor(

--- a/apps/web/src/pages/BrowserLocalDocumentPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.markdown.browser.test.tsx
@@ -17,7 +17,7 @@ import type { ReactElement } from 'react'
 import { MemoryRouter, useLocation } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
-import { IndexedDBStore } from '../lib/browser-local-store.js'
+import { IndexedDBStore, LOCAL_WORKSPACE_ID } from '../lib/browser-local-store.js'
 import { LoroStore } from '../lib/loro-store.js'
 import { clearWhiteboardDb } from '../test-utils/browser-local-document.js'
 import { waitForMenuClosed } from '../test-utils/menu.js'
@@ -245,7 +245,7 @@ describe('BrowserLocalDocumentPage markdown 導線 (real IndexedDB)', () => {
     // canvas this flow started from.
     const entry = (await store.listDocuments()).find((row) => row.kind === 'markdown')
     expect(entry?.name).toBe('リリース計画')
-    const loaded = await new LoroStore().load(entry?.id ?? '')
+    const loaded = await new LoroStore().load(entry?.documentId ?? '')
     expect(loaded.kind).toBe('ok')
     if (loaded.kind === 'ok') {
       const doc = new Loro()
@@ -351,9 +351,11 @@ describe('BrowserLocalDocumentPage markdown 導線 (real IndexedDB)', () => {
 
   it('a spatial canvas gets the same properties bar, and its title round-trips', async () => {
     const store = new IndexedDBStore()
-    await store.setDefaultDocumentId('spatial-1')
+    await store.setDefaultDocumentId('0JNRVY147ADGKPSWZ258BEHMQT')
     await store.save({
-      id: 'spatial-1',
+      documentId: '0JNRVY147ADGKPSWZ258BEHMQT',
+      workspaceId: 'local',
+      path: 'diagram-a',
       name: 'Diagram A',
       updatedAt: '2026-05-24T00:00:00.000Z',
       kind: 'spatial' as const,
@@ -400,9 +402,11 @@ describe('BrowserLocalDocumentPage markdown 導線 (real IndexedDB)', () => {
     const store = new IndexedDBStore()
     // Distinctly-named spatial canvas so the round trip back to it is
     // unambiguous (the fresh markdown note is also 'untitled').
-    await store.setDefaultDocumentId('spatial-1')
+    await store.setDefaultDocumentId('0JNRVY147ADGKPSWZ258BEHMQT')
     await store.save({
-      id: 'spatial-1',
+      documentId: '0JNRVY147ADGKPSWZ258BEHMQT',
+      workspaceId: 'local',
+      path: 'diagram-a-2',
       name: 'Diagram A',
       updatedAt: '2026-05-24T00:00:00.000Z',
       kind: 'spatial' as const,
@@ -448,14 +452,18 @@ describe('BrowserLocalDocumentPage markdown 導線 (real IndexedDB)', () => {
   it("offers the page's own documents to the link picker", async () => {
     const store = new IndexedDBStore()
     await store.save({
-      id: '01ARZ3NDEKTSV4RRFFQ69G5FBB',
+      documentId: '0SWZ258BEHMQTX0369CFJNRVY1',
+      workspaceId: 'local',
+      path: 'neighbour-note',
       name: 'Neighbour note',
       updatedAt: '2026-05-24T00:00:00.000Z',
       kind: 'markdown' as const,
     })
     const HERE = '01BX5ZZKBKACTAV9WEVGEMMVAA'
     await store.save({
-      id: HERE,
+      documentId: HERE,
+      workspaceId: LOCAL_WORKSPACE_ID,
+      path: 'this-note',
       name: 'This note',
       updatedAt: '2026-05-24T00:00:01.000Z',
       kind: 'markdown' as const,
@@ -485,13 +493,17 @@ describe('BrowserLocalDocumentPage markdown 導線 (real IndexedDB)', () => {
     const SOURCE_ID = '01BX5ZZKBKACTAV9WEVGEMMVRZ'
     const store = new IndexedDBStore()
     await store.save({
-      id: TARGET_ID,
+      documentId: TARGET_ID,
+      workspaceId: LOCAL_WORKSPACE_ID,
+      path: 'target-note',
       name: 'Target note',
       updatedAt: '2026-05-24T00:00:00.000Z',
       kind: 'markdown' as const,
     })
     await store.save({
-      id: SOURCE_ID,
+      documentId: SOURCE_ID,
+      workspaceId: LOCAL_WORKSPACE_ID,
+      path: 'source-note',
       name: 'Source note',
       updatedAt: '2026-05-24T00:00:01.000Z',
       kind: 'markdown' as const,
@@ -540,7 +552,9 @@ describe('BrowserLocalDocumentPage markdown 導線 (real IndexedDB)', () => {
     // Navigation lands on the target note's route.
     await waitFor(
       () => {
-        expect(screen.getByTestId('location-probe').textContent).toBe(`/local/${TARGET_ID}`)
+        // The link names the target by ID (so it survives a move); the address
+        // bar names it by PATH. Following one crosses that boundary.
+        expect(screen.getByTestId('location-probe').textContent).toBe('/local/target-note')
       },
       { timeout: 10_000 },
     )
@@ -551,13 +565,17 @@ describe('BrowserLocalDocumentPage markdown 導線 (real IndexedDB)', () => {
     const SOURCE_ID = '01BX5ZZKBKACTAV9WEVGEMMVRZ'
     const store = new IndexedDBStore()
     await store.save({
-      id: TARGET_ID,
+      documentId: TARGET_ID,
+      workspaceId: LOCAL_WORKSPACE_ID,
+      path: 'embed-target',
       name: 'Embed target',
       updatedAt: '2026-05-24T00:00:00.000Z',
       kind: 'markdown' as const,
     })
     await store.save({
-      id: SOURCE_ID,
+      documentId: SOURCE_ID,
+      workspaceId: LOCAL_WORKSPACE_ID,
+      path: 'embed-source',
       name: 'Embed source',
       updatedAt: '2026-05-24T00:00:01.000Z',
       kind: 'markdown' as const,
@@ -609,7 +627,9 @@ describe('BrowserLocalDocumentPage markdown 導線 (real IndexedDB)', () => {
 
     async function seedLegacyNote(store: IndexedDBStore, name: string): Promise<void> {
       await store.save({
-        id: LEGACY_ID,
+        documentId: LEGACY_ID,
+        workspaceId: LOCAL_WORKSPACE_ID,
+        path: 'legacy-note',
         name,
         updatedAt: '2026-05-24T00:00:00.000Z',
         kind: 'markdown' as const,
@@ -683,7 +703,9 @@ describe('BrowserLocalDocumentPage markdown 導線 (real IndexedDB)', () => {
       const store = new IndexedDBStore()
       await seedLegacyNote(store, 'Legacy embed target')
       await store.save({
-        id: SOURCE_ID,
+        documentId: SOURCE_ID,
+        workspaceId: LOCAL_WORKSPACE_ID,
+        path: 'embed-source',
         name: 'Embed source',
         updatedAt: '2026-05-24T00:00:01.000Z',
         kind: 'markdown' as const,

--- a/apps/web/src/pages/BrowserLocalDocumentPage.multi-document.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.multi-document.browser.test.tsx
@@ -61,6 +61,14 @@ vi.mock('../components/spatial-editor/index.js', () => ({
 
 const { BrowserLocalDocumentPage } = await import('./BrowserLocalDocumentPage.js')
 
+// The switcher addresses a document by PATH; the store's default pointer and
+// every persistence helper here address it by id. This is the one conversion.
+async function pathOf(store: IndexedDBStore, documentId: string): Promise<string> {
+  const found = (await store.listDocuments()).find((row) => row.documentId === documentId)
+  if (found === undefined) throw new Error(`no document ${documentId}`)
+  return found.path
+}
+
 describe('BrowserLocalDocumentPage multi-canvas UI (real IndexedDB)', () => {
   beforeEach(async () => {
     await clearWhiteboardDb()
@@ -138,13 +146,18 @@ describe('BrowserLocalDocumentPage multi-canvas UI (real IndexedDB)', () => {
     await waitForMenuClosed()
 
     // Switch back to A via the switcher control. Both A and B default to the
-    // "untitled" display name, so disambiguate by the raw id shown in each
-    // menu item's subtitle line (only rendered when the name differs from
-    // the path/id, which it always does for a browser-local canvas).
+    // "untitled" display NAME, so the only thing that separates them in the
+    // menu is their path — which is also what the switcher navigates by.
+    const pathA = await pathOf(store, idA)
+    const pathB = await pathOf(store, idB)
+    expect(pathA).not.toBe(pathB)
     const switcherB = await screen.findByRole('button', { name: /^Workspace:/i })
     fireEvent.pointerDown(switcherB, { button: 0, ctrlKey: false })
-    const idALabel = await screen.findByText(idA)
-    const itemA = idALabel.closest('[role="menuitem"]') as HTMLElement
+    const items = await screen.findAllByRole('menuitem')
+    const itemA = items.find(
+      (item) => item.textContent?.includes(pathA) && !item.textContent.includes(pathB),
+    ) as HTMLElement
+    expect(itemA).toBeDefined()
     // `latestMountedCanvases` accumulates every mount, including the one from
     // when A was originally open. Only mounts recorded from here on can show
     // that switching BACK re-hydrated A — searching the whole history would

--- a/apps/web/src/pages/BrowserLocalDocumentPage.open-in-editor.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.open-in-editor.browser.test.tsx
@@ -5,7 +5,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { IndexedDBStore } from '../lib/browser-local-store.js'
+import { IndexedDBStore, LOCAL_WORKSPACE_ID } from '../lib/browser-local-store.js'
 import { clearWhiteboardDb } from '../test-utils/browser-local-document.js'
 
 type OnChange = (next: SpatialCanvas, command: unknown) => void
@@ -43,7 +43,9 @@ describe('open in editor (page seam)', () => {
     const id = '01ARZ3NDEKTSV4RRFFQ69G5FCC'
     const store = new IndexedDBStore()
     await store.save({
-      id,
+      documentId: id,
+      workspaceId: LOCAL_WORKSPACE_ID,
+      path: 'board',
       name: 'Board',
       updatedAt: '2026-05-24T00:00:00.000Z',
       kind: 'spatial' as const,

--- a/apps/web/src/pages/BrowserLocalDocumentPage.stale-link.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.stale-link.test.tsx
@@ -8,7 +8,7 @@
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { MemoryStore } from '../lib/browser-local-store.js'
+import { LOCAL_WORKSPACE_ID, MemoryStore } from '../lib/browser-local-store.js'
 import type { LoroLoadResult } from '../lib/loro-store.js'
 import type { LoroStoreLike } from './use-browser-local-document-controller.js'
 
@@ -51,12 +51,16 @@ const { BrowserLocalDocumentPage } = await import('./BrowserLocalDocumentPage.js
 
 afterEach(cleanup)
 
-describe('stale /local/:id deep link', () => {
+describe('stale /local/:path deep link', () => {
   it('falls back to the default canvas and replaces the URL', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('real-1')
+    await store.setDefaultDocumentId('005AFMSY38DJQW16BGNTZ49EKR')
     await store.save({
-      id: 'real-1',
+      documentId: '005AFMSY38DJQW16BGNTZ49EKR',
+      workspaceId: LOCAL_WORKSPACE_ID,
+      // Deliberately not the id: the fallback below has to be reached by PATH,
+      // and an id-shaped path could not tell the two apart.
+      path: 'real-canvas',
       name: 'Real canvas',
       updatedAt: '2026-05-24T00:00:00.000Z',
       kind: 'spatial' as const,
@@ -65,12 +69,12 @@ describe('stale /local/:id deep link', () => {
     const router = createMemoryRouter(
       [
         {
-          path: '/local/:documentId?',
+          path: '/local/*',
           element: (
             <BrowserLocalDocumentPage
               store={store}
               loro={new FakeLoroStore()}
-              initialDocumentId="gone-123"
+              initialPath="gone-123"
             />
           ),
         },
@@ -85,7 +89,7 @@ describe('stale /local/:id deep link', () => {
       expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Real canvas')
     })
     await waitFor(() => {
-      expect(router.state.location.pathname).toBe('/local/real-1')
+      expect(router.state.location.pathname).toBe('/local/real-canvas')
     })
     // No degraded dead-end screen.
     expect(screen.queryByText('The canvas could not be switched.')).toBeNull()

--- a/apps/web/src/pages/BrowserLocalDocumentPage.stale-link.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.stale-link.test.tsx
@@ -147,4 +147,78 @@ describe('stale /local/:path deep link', () => {
     // the editor.
     expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Real canvas')
   })
+
+  it('does not repair a path it cannot judge yet, while the document list is still loading', async () => {
+    // `documents` starts empty and fills asynchronously, so during that window
+    // "not in the list" means "not known yet", not "does not exist". Repairing
+    // there would overwrite a navigation to a perfectly valid document with
+    // the current path, and the list arriving later cannot undo it.
+    const store = new MemoryStore()
+    await store.setDefaultDocumentId('005AFMSY38DJQW16BGNTZ49EKR')
+    await store.save({
+      documentId: '005AFMSY38DJQW16BGNTZ49EKR',
+      workspaceId: LOCAL_WORKSPACE_ID,
+      path: 'real-canvas',
+      name: 'Real canvas',
+      updatedAt: '2026-05-24T00:00:00.000Z',
+      kind: 'spatial' as const,
+    })
+    await store.save({
+      documentId: '01ARZ3NDEKTSV4RRFFQ69G5FB0',
+      workspaceId: LOCAL_WORKSPACE_ID,
+      path: 'other-canvas',
+      name: 'Other canvas',
+      updatedAt: '2026-05-25T00:00:00.000Z',
+      kind: 'spatial' as const,
+    })
+
+    // Held open so the navigation below lands inside the enumeration window.
+    // The FIRST call is the controller resolving `initialPath` — letting that
+    // through is what gets a document loaded at all; the page's own list
+    // effect is the second, and that is the one this test suspends.
+    let releaseList: (() => void) | undefined
+    const held = new Promise<void>((resolve) => {
+      releaseList = resolve
+    })
+    const listDocuments = store.listDocuments.bind(store)
+    let calls = 0
+    store.listDocuments = async () => {
+      calls += 1
+      if (calls === 2) await held
+      return listDocuments()
+    }
+
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/local/*',
+          element: (
+            <BrowserLocalDocumentPage
+              store={store}
+              loro={new FakeLoroStore()}
+              initialPath="real-canvas"
+            />
+          ),
+        },
+      ],
+      { initialEntries: ['/local/real-canvas'] },
+    )
+    await act(async () => {
+      render(<RouterProvider router={router} />)
+    })
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Real canvas')
+    })
+
+    await act(async () => {
+      await router.navigate('/local/other-canvas')
+    })
+    expect(router.state.location.pathname).toBe('/local/other-canvas')
+
+    releaseList?.()
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(router.state.location.pathname).toBe('/local/other-canvas')
+  })
 })

--- a/apps/web/src/pages/BrowserLocalDocumentPage.stale-link.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.stale-link.test.tsx
@@ -1,9 +1,10 @@
 /**
- * A stale /local/:id deep link (bookmark to a deleted canvas) must not
- * dead-end: the page falls back to the default canvas, the URL is
- * replaced with the real id, and no degraded screen hides the editor.
- * Before this slice the URL→canvas effect switched to the missing id and
- * parked the page on "The canvas could not be switched." with no editor.
+ * A stale /local/:path deep link (bookmark to a deleted document) must not
+ * dead-end: the page falls back to the default document, the URL is replaced
+ * with the real path, and no degraded screen hides the editor. Two entry
+ * points reach it and they are different code — the initial mount goes
+ * through the controller's store-backed load, a MID-SESSION history
+ * navigation goes through the page's own URL→document effect.
  */
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
@@ -93,5 +94,57 @@ describe('stale /local/:path deep link', () => {
     })
     // No degraded dead-end screen.
     expect(screen.queryByText('The canvas could not be switched.')).toBeNull()
+  })
+
+  it('repairs the address bar when a mid-session navigation names a path this workspace does not have', async () => {
+    // The mounted page never remounts across /local/:path changes (see
+    // App.tsx's routing comment), so the effect below is the ONLY thing that
+    // can answer a Back onto a document that has since been deleted. It
+    // resolves the requested path against the in-memory list, and a path that
+    // is not in it used to make the effect return before reaching its own
+    // documented repair — leaving the address bar naming nothing.
+    const store = new MemoryStore()
+    await store.setDefaultDocumentId('005AFMSY38DJQW16BGNTZ49EKR')
+    await store.save({
+      documentId: '005AFMSY38DJQW16BGNTZ49EKR',
+      workspaceId: LOCAL_WORKSPACE_ID,
+      path: 'real-canvas',
+      name: 'Real canvas',
+      updatedAt: '2026-05-24T00:00:00.000Z',
+      kind: 'spatial' as const,
+    })
+
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/local/*',
+          element: (
+            <BrowserLocalDocumentPage
+              store={store}
+              loro={new FakeLoroStore()}
+              initialPath="real-canvas"
+            />
+          ),
+        },
+      ],
+      { initialEntries: ['/local/real-canvas'] },
+    )
+    await act(async () => {
+      render(<RouterProvider router={router} />)
+    })
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Real canvas')
+    })
+
+    await act(async () => {
+      await router.navigate('/local/gone-123')
+    })
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/local/real-canvas')
+    })
+    // The loaded document is untouched — a dead link costs the address bar, not
+    // the editor.
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Real canvas')
   })
 })

--- a/apps/web/src/pages/BrowserLocalDocumentPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.test.tsx
@@ -73,7 +73,9 @@ vi.mock('../lib/browser-local-backend.js', () => ({
 // The actual LoroDoc is used via the real loro-crdt installed in the workspace.
 
 const snap: DocumentSnapshot = {
-  id: 'c1',
+  documentId: '069CFJNRVY147ADGKPSWZ258BE',
+  workspaceId: 'local',
+  path: 'untitled',
   name: 'untitled',
   updatedAt: '2026-05-24T00:00:00.000Z',
   kind: 'spatial' as const,
@@ -112,7 +114,7 @@ describe('BrowserLocalDocumentPage', () => {
 
   it('renders editor view once canvas is loaded', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     await act(async () => {
       render(<BrowserLocalDocumentPage store={store} />)
@@ -123,7 +125,7 @@ describe('BrowserLocalDocumentPage', () => {
   it('renders load-degraded banner when store load fails', async () => {
     const base = new MemoryStore()
     const failingStore: BrowserLocalStore = {
-      getDefaultDocumentId: async () => 'c1',
+      getDefaultDocumentId: async () => '069CFJNRVY147ADGKPSWZ258BE',
       setDefaultDocumentId: base.setDefaultDocumentId.bind(base),
       load: async () => ({ kind: 'corrupted' }),
       save: base.save.bind(base),
@@ -144,7 +146,7 @@ describe('BrowserLocalDocumentPage', () => {
   it('offers a Start fresh recovery action in the load-degraded banner', async () => {
     const base = new MemoryStore()
     const failingStore: BrowserLocalStore = {
-      getDefaultDocumentId: async () => 'c1',
+      getDefaultDocumentId: async () => '069CFJNRVY147ADGKPSWZ258BE',
       setDefaultDocumentId: base.setDefaultDocumentId.bind(base),
       load: async () => ({ kind: 'corrupted' }),
       save: base.save.bind(base),
@@ -167,7 +169,7 @@ describe('BrowserLocalDocumentPage', () => {
   it('shows a recovery-failed message when Start fresh cannot save', async () => {
     const base = new MemoryStore()
     const failingFreshStore: BrowserLocalStore = {
-      getDefaultDocumentId: async () => 'c1',
+      getDefaultDocumentId: async () => '069CFJNRVY147ADGKPSWZ258BE',
       setDefaultDocumentId: base.setDefaultDocumentId.bind(base),
       load: async () => ({ kind: 'corrupted' }),
       save: async () => {
@@ -194,7 +196,7 @@ describe('BrowserLocalDocumentPage', () => {
   it('renders cleanup-completed view after delete button click and confirm', async () => {
     vi.useRealTimers()
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     await act(async () => {
       render(<BrowserLocalDocumentPage store={store} />)
@@ -214,7 +216,7 @@ describe('BrowserLocalDocumentPage', () => {
   it('does not delete the canvas when the confirmation dialog is cancelled', async () => {
     vi.useRealTimers()
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     await act(async () => {
       render(<BrowserLocalDocumentPage store={store} />)
@@ -235,12 +237,12 @@ describe('BrowserLocalDocumentPage', () => {
   it('duplicates the canvas and switches to the copy when Duplicate is clicked', async () => {
     vi.useRealTimers()
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     const loro = new FakeLoroStore()
     const seed = new Loro()
     seed.getList('elements').push({ id: 'rect-1' })
-    await loro.save('c1', seed.export({ mode: 'snapshot' }))
+    await loro.save('069CFJNRVY147ADGKPSWZ258BE', seed.export({ mode: 'snapshot' }))
     await act(async () => {
       render(<BrowserLocalDocumentPage store={store} loro={loro} />)
     })
@@ -254,12 +256,12 @@ describe('BrowserLocalDocumentPage', () => {
   it('disables the Duplicate button while a duplicate is in flight, and double-clicking produces exactly one copy', async () => {
     vi.useRealTimers()
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     const loro = new FakeLoroStore()
     const seed = new Loro()
     seed.getList('elements').push({ id: 'rect-1' })
-    await loro.save('c1', seed.export({ mode: 'snapshot' }))
+    await loro.save('069CFJNRVY147ADGKPSWZ258BE', seed.export({ mode: 'snapshot' }))
     // Defer the Loro read so the in-flight window is observable and long
     // enough for a second click to land before the first duplicate resolves.
     let releaseLoad: (() => void) | undefined
@@ -298,10 +300,10 @@ describe('BrowserLocalDocumentPage', () => {
   it('shows an alert and re-enables the Duplicate button when duplicateDocument fails', async () => {
     vi.useRealTimers()
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     const loro = new FakeLoroStore()
-    await loro.save('c1', new Loro().export({ mode: 'snapshot' }))
+    await loro.save('069CFJNRVY147ADGKPSWZ258BE', new Loro().export({ mode: 'snapshot' }))
     await act(async () => {
       render(<BrowserLocalDocumentPage store={store} loro={loro} />)
     })
@@ -322,7 +324,7 @@ describe('BrowserLocalDocumentPage', () => {
   it('Copy as JSON Canvas puts the extended document on the clipboard', async () => {
     vi.useRealTimers()
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     const written: string[] = []
     Object.assign(navigator, {
@@ -347,7 +349,7 @@ describe('BrowserLocalDocumentPage', () => {
   it('export lives in the canvas row kebab, not the top bar menu', async () => {
     vi.useRealTimers()
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     await act(async () => {
       render(<BrowserLocalDocumentPage store={store} />)
@@ -369,7 +371,7 @@ describe('BrowserLocalDocumentPage', () => {
 
   it('renders a human-readable save status instead of the raw state enum', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     await act(async () => {
       render(<BrowserLocalDocumentPage store={store} />)
@@ -382,7 +384,7 @@ describe('BrowserLocalDocumentPage', () => {
   it('the canvas row carries state, settings and operations in ONE row (no separate strip)', async () => {
     vi.useRealTimers()
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     await act(async () => {
       render(<BrowserLocalDocumentPage store={store} />)
@@ -416,7 +418,7 @@ describe('BrowserLocalDocumentPage', () => {
 
   it('surfaces the degraded save message in the header when a save fails', async () => {
     const base = new MemoryStore()
-    await base.setDefaultDocumentId('c1')
+    await base.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await base.save(snap)
     const failingSaveStore: BrowserLocalStore = {
       getDefaultDocumentId: base.getDefaultDocumentId.bind(base),
@@ -441,7 +443,7 @@ describe('BrowserLocalDocumentPage', () => {
   it('offers a Start fresh action in the cleanup-completed view', async () => {
     vi.useRealTimers()
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     await act(async () => {
       render(<BrowserLocalDocumentPage store={store} />)
@@ -467,7 +469,7 @@ describe('BrowserLocalDocumentPage', () => {
       .spyOn(globalThis, 'fetch')
       .mockResolvedValue(new Response('', { status: 200 }))
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     await act(async () => {
       render(<BrowserLocalDocumentPage store={store} />)
@@ -487,7 +489,7 @@ describe('BrowserLocalDocumentPage', () => {
   it('keeps a heading landmark distinct from the Delete button and the canvas actions control', async () => {
     vi.useRealTimers()
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     await act(async () => {
       render(<BrowserLocalDocumentPage store={store} />)
@@ -503,7 +505,7 @@ describe('BrowserLocalDocumentPage', () => {
   it("renaming through the top bar's canvas actions updates the heading and flushes a save", async () => {
     vi.useRealTimers()
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     await act(async () => {
       render(<BrowserLocalDocumentPage store={store} />)
@@ -518,7 +520,7 @@ describe('BrowserLocalDocumentPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Renamed canvas')
     })
-    const loadResult = await store.load('c1')
+    const loadResult = await store.load('069CFJNRVY147ADGKPSWZ258BE')
     expect(loadResult.kind).toBe('ok')
     if (loadResult.kind === 'ok') {
       expect(loadResult.snapshot.name).toBe('Renamed canvas')
@@ -527,7 +529,7 @@ describe('BrowserLocalDocumentPage', () => {
 
   it('does not render an "Add rectangle" button — scene writes flow through SpatialEditor gestures', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     await act(async () => {
       render(<BrowserLocalDocumentPage store={store} />)
@@ -538,10 +540,12 @@ describe('BrowserLocalDocumentPage', () => {
   it('lists all documents in the switcher dropdown', async () => {
     vi.useRealTimers()
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     await store.save({
-      id: 'c2',
+      documentId: '0DGKPSWZ258BEHMQTX0369CFJN',
+      workspaceId: 'local',
+      path: 'other-canvas',
       name: 'Other canvas',
       updatedAt: '2026-05-25T00:00:00.000Z',
       kind: 'spatial' as const,
@@ -561,10 +565,12 @@ describe('BrowserLocalDocumentPage', () => {
   it('switching the switcher selection calls switchDocument exactly once', async () => {
     vi.useRealTimers()
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     await store.save({
-      id: 'c2',
+      documentId: '0DGKPSWZ258BEHMQTX0369CFJN',
+      workspaceId: 'local',
+      path: 'other-canvas-2',
       name: 'Other canvas',
       updatedAt: '2026-05-25T00:00:00.000Z',
       kind: 'spatial' as const,
@@ -579,21 +585,23 @@ describe('BrowserLocalDocumentPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Other canvas')
     })
-    expect(await store.getDefaultDocumentId()).toBe('c2')
+    expect(await store.getDefaultDocumentId()).toBe('0DGKPSWZ258BEHMQTX0369CFJN')
   })
 
-  it('honors an explicit initialDocumentId prop over the store default canvas', async () => {
-    // This only proves the page itself respects initialDocumentId — it does NOT
-    // cover the URL->initialDocumentId wiring (App.tsx's parseBrowserLocalRoute),
+  it('honors an explicit initialPath prop over the store default canvas', async () => {
+    // This only proves the page itself respects initialPath — it does NOT
+    // cover the URL->initialPath wiring (App.tsx's parseBrowserLocalRoute),
     // since the pathname and the prop are set independently here. See
-    // App.test.tsx's "derives initialDocumentId from the /local/:documentId URL"
+    // App.test.tsx's "derives initialPath from the /local/:path URL"
     // test for that boundary.
     vi.useRealTimers()
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     await store.save({
-      id: 'c2',
+      documentId: '0DGKPSWZ258BEHMQTX0369CFJN',
+      workspaceId: 'local',
+      path: 'deep-linked',
       name: 'Other canvas',
       updatedAt: '2026-05-25T00:00:00.000Z',
       kind: 'spatial' as const,
@@ -604,7 +612,7 @@ describe('BrowserLocalDocumentPage', () => {
           <BrowserLocalDocumentPage
             store={store}
             loro={new FakeLoroStore()}
-            initialDocumentId="c2"
+            initialPath="deep-linked"
           />
         </MemoryRouter>,
       )
@@ -613,13 +621,15 @@ describe('BrowserLocalDocumentPage', () => {
     expect(heading.textContent).toBe('Other canvas')
   })
 
-  it('updates the URL to /local/:documentId when the switcher opens a different canvas', async () => {
+  it('updates the URL to the switched-to document PATH, not its id', async () => {
     vi.useRealTimers()
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     await store.save({
-      id: 'c2',
+      documentId: '0DGKPSWZ258BEHMQTX0369CFJN',
+      workspaceId: 'local',
+      path: 'archive/other-canvas',
       name: 'Other canvas',
       updatedAt: '2026-05-25T00:00:00.000Z',
       kind: 'spatial' as const,
@@ -641,18 +651,20 @@ describe('BrowserLocalDocumentPage', () => {
     const otherItem = await screen.findByText('Other canvas')
     fireEvent.pointerUp(otherItem)
     await waitFor(() => {
-      expect(router.state.location.pathname).toBe('/local/c2')
+      expect(router.state.location.pathname).toBe('/local/archive/other-canvas')
     })
   })
 
   it('creating a canvas through the top bar switches to a fresh untitled canvas', async () => {
     vi.useRealTimers()
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     // A distinctly-named current canvas so the switch to the new 'untitled' one
     // is observable in the heading, not just an inert re-render.
     await store.save({
-      id: 'c1',
+      documentId: '069CFJNRVY147ADGKPSWZ258BE',
+      workspaceId: 'local',
+      path: 'diagram-a',
       name: 'Diagram A',
       updatedAt: '2026-05-24T00:00:00.000Z',
       kind: 'spatial' as const,
@@ -670,15 +682,17 @@ describe('BrowserLocalDocumentPage', () => {
       expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled')
     })
     const newId = await store.getDefaultDocumentId()
-    expect(newId).not.toBe('c1')
+    expect(newId).not.toBe('069CFJNRVY147ADGKPSWZ258BE')
     const list = await store.listDocuments()
-    expect(list.map((c) => c.id)).toEqual(expect.arrayContaining(['c1', newId]))
+    expect(list.map((c) => c.documentId)).toEqual(
+      expect.arrayContaining(['069CFJNRVY147ADGKPSWZ258BE', newId]),
+    )
   })
 
   it('surfaces an error and stays on the current canvas when creating a new canvas fails', async () => {
     vi.useRealTimers()
     const base = new MemoryStore()
-    await base.setDefaultDocumentId('c1')
+    await base.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await base.save(snap)
     // Fail the metadata save that createDocument performs first, so createDocument()
     // rejects before ever calling switchDocument.
@@ -709,16 +723,18 @@ describe('BrowserLocalDocumentPage', () => {
     expect((await screen.findByRole('alert')).textContent).toBe('Failed to create canvas.')
     // The current canvas is untouched — no switch happened.
     expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled')
-    expect(await failingCreateStore.getDefaultDocumentId()).toBe('c1')
+    expect(await failingCreateStore.getDefaultDocumentId()).toBe('069CFJNRVY147ADGKPSWZ258BE')
   })
 
   it('drops a stale listDocuments resolution that would otherwise clobber a newer refresh from a fast switch', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     vi.useRealTimers()
     await store.save(snap)
     await store.save({
-      id: 'c2',
+      documentId: '0DGKPSWZ258BEHMQTX0369CFJN',
+      workspaceId: 'local',
+      path: 'other-canvas-5',
       name: 'Other canvas',
       updatedAt: '2026-05-25T00:00:00.000Z',
       kind: 'spatial' as const,
@@ -745,7 +761,9 @@ describe('BrowserLocalDocumentPage', () => {
       resolvers[0]!([
         snap,
         {
-          id: 'c2',
+          documentId: '0DGKPSWZ258BEHMQTX0369CFJN',
+          workspaceId: 'local',
+          path: 'other-canvas-6',
           name: 'Other canvas',
           updatedAt: '2026-05-25T00:00:00.000Z',
           kind: 'spatial' as const,
@@ -778,7 +796,9 @@ describe('BrowserLocalDocumentPage', () => {
     const freshList: DocumentSnapshot[] = [
       snap,
       {
-        id: 'c3',
+        documentId: '0MQTX0369CFJNRVY147ADGKPSW',
+        workspaceId: 'local',
+        path: 'other-canvas-fresh',
         name: 'Other canvas (fresh)',
         updatedAt: '2026-05-26T00:00:00.000Z',
         kind: 'spatial' as const,
@@ -786,7 +806,9 @@ describe('BrowserLocalDocumentPage', () => {
     ]
     const staleList: DocumentSnapshot[] = [
       {
-        id: 'c2',
+        documentId: '0DGKPSWZ258BEHMQTX0369CFJN',
+        workspaceId: 'local',
+        path: 'other-canvas-stale',
         name: 'Other canvas (stale)',
         updatedAt: '2026-05-25T00:00:00.000Z',
         kind: 'spatial' as const,
@@ -810,7 +832,7 @@ describe('BrowserLocalDocumentPage', () => {
   it('shows the renamed canvas in the switcher even when the list read wins the race against the save', async () => {
     vi.useRealTimers()
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
 
     const resolvers: Array<(list: DocumentSnapshot[]) => void> = []
@@ -864,10 +886,12 @@ describe('BrowserLocalDocumentPage', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     try {
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
       await store.save(snap)
       await store.save({
-        id: 'c2',
+        documentId: '0DGKPSWZ258BEHMQTX0369CFJN',
+        workspaceId: 'local',
+        path: 'other-canvas-7',
         name: 'Other canvas',
         updatedAt: '2026-05-25T00:00:00.000Z',
         kind: 'spatial' as const,
@@ -907,7 +931,7 @@ describe('BrowserLocalDocumentPage', () => {
 
     it('moves the capability CTA into the Local connection chip popover (D1: no standing copy)', async () => {
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
       await store.save(snap)
       await act(async () => {
         render(<BrowserLocalDocumentPage store={store} />)
@@ -929,7 +953,7 @@ describe('BrowserLocalDocumentPage', () => {
 
     it('does not render any mode-switch control — mode stays a read-only status', async () => {
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
       await store.save(snap)
       await act(async () => {
         render(<BrowserLocalDocumentPage store={store} />)
@@ -943,7 +967,7 @@ describe('BrowserLocalDocumentPage', () => {
 
     it('keeps the existing Delete button and canvas actions control working alongside the CTA line', async () => {
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
       await store.save(snap)
       await act(async () => {
         render(<BrowserLocalDocumentPage store={store} />)
@@ -957,10 +981,12 @@ describe('BrowserLocalDocumentPage', () => {
     it('mounting and opening the canvas switcher renders no daemon thumbnail <img>', async () => {
       vi.useRealTimers()
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
       await store.save(snap)
       await store.save({
-        id: 'c2',
+        documentId: '0DGKPSWZ258BEHMQTX0369CFJN',
+        workspaceId: 'local',
+        path: 'other-canvas-8',
         name: 'Other canvas',
         updatedAt: '2026-05-25T00:00:00.000Z',
         kind: 'spatial' as const,
@@ -982,7 +1008,7 @@ describe('?new=canvas launch shortcut', () => {
     // An existing profile: auto-create is skipped, so the count isolates
     // the shortcut's own create.
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     window.history.replaceState(null, '', '/?new=canvas')
     rtlRender(
@@ -1015,7 +1041,7 @@ describe('?new=canvas launch shortcut', () => {
       }
     }
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     window.history.replaceState(null, '', '/?new=canvas')
     rtlRender(
@@ -1038,7 +1064,7 @@ describe('BrowserLocalDocumentPage — initial tool follows the canvas shape', (
 
   it('an empty canvas opens in Select — the user came to place, not to pan', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     await act(async () => {
       render(<BrowserLocalDocumentPage store={store} loro={new FakeLoroStore()} />)
@@ -1051,7 +1077,7 @@ describe('BrowserLocalDocumentPage — initial tool follows the canvas shape', (
   it("this tab's last choice outranks the canvas-shape guess", async () => {
     sessionStorage.setItem('wb.lastTool', 'hand')
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
     await store.save(snap)
     await act(async () => {
       render(<BrowserLocalDocumentPage store={store} loro={new FakeLoroStore()} />)

--- a/apps/web/src/pages/BrowserLocalDocumentPage.theme.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.theme.test.tsx
@@ -55,7 +55,9 @@ function render(ui: ReactElement) {
 }
 
 const snap: DocumentSnapshot = {
-  id: 'c1',
+  documentId: '0W16BGNTZ49EKRX27CHPV05AFM',
+  workspaceId: 'local',
+  path: 'untitled',
   name: 'untitled',
   updatedAt: '2026-05-24T00:00:00.000Z',
   kind: 'spatial' as const,
@@ -74,7 +76,7 @@ describe('BrowserLocalDocumentPage theme wiring', () => {
   it('threads resolvedTheme=dark into SpatialEditor when the stored preference is dark', async () => {
     window.localStorage.setItem(THEME_STORAGE_KEY, 'dark')
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('0W16BGNTZ49EKRX27CHPV05AFM')
     await store.save(snap)
     await act(async () => {
       render(<BrowserLocalDocumentPage store={store} />)
@@ -86,7 +88,7 @@ describe('BrowserLocalDocumentPage theme wiring', () => {
   it('threads resolvedTheme=light into SpatialEditor when the stored preference is light', async () => {
     window.localStorage.setItem(THEME_STORAGE_KEY, 'light')
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('0W16BGNTZ49EKRX27CHPV05AFM')
     await store.save(snap)
     await act(async () => {
       render(<BrowserLocalDocumentPage store={store} />)

--- a/apps/web/src/pages/BrowserLocalDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.tsx
@@ -365,6 +365,10 @@ export function BrowserLocalDocumentPage({
   // the URL still names the previously-known canvas id, that's this
   // component's own pending push catching up, not an external navigation —
   // skip it and let the other effect finish the sync.
+  // Whether listDocuments has answered at least once. Read by the URL ->
+  // document effect to tell "this path does not exist" from "the list has not
+  // arrived", which look identical in `switcherOptions`.
+  const documentsEnumeratedRef = useRef(false)
   const lastKnownCanvasIdRef = useRef<string | null>(null)
   useEffect(() => {
     if (documentId === null || documentPath === null) return
@@ -391,7 +395,14 @@ export function BrowserLocalDocumentPage({
     // or it resolves and the switch then finds no record.
     const repair = () => navigate(browserLocalDocumentPath(documentPath), { replace: true })
     if (requestedId === null) {
-      repair()
+      // ...but only once the list has actually been enumerated. Until then it
+      // holds this document alone, so "absent" means "not known yet" and
+      // repairing would overwrite a navigation to a perfectly valid document
+      // with nothing to undo it. Leaving the address bar alone keeps the
+      // user's intent visible; recovering the switch itself once the list
+      // lands needs this effect's own-push guard restructured first, since it
+      // assumes one run per loaded document.
+      if (documentsEnumeratedRef.current) repair()
       return
     }
     void switchDocument(requestedId).then((switched) => {
@@ -406,6 +417,7 @@ export function BrowserLocalDocumentPage({
     listDocuments()
       .then((list) => {
         if (generation !== listGenerationRef.current) return
+        documentsEnumeratedRef.current = true
         setDocuments(list)
       })
       .catch((err: unknown) => {

--- a/apps/web/src/pages/BrowserLocalDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.tsx
@@ -101,10 +101,10 @@ interface BrowserLocalDocumentPageProps {
   // Defaults to browser-local so existing callers/tests keep working
   // unedited; App.tsx passes the resolved ProviderState's capabilities.
   capabilities?: WhiteboardCapabilities
-  // A canvas id requested by the URL at mount (e.g. a bookmarked
-  // /local/:documentId deep link), read once — see
+  // A document path requested by the URL at mount (e.g. a bookmarked
+  // /local/:path deep link), read once — see
   // useBrowserLocalDocumentController's own contract for the same parameter.
-  initialDocumentId?: string
+  initialPath?: string
 }
 
 // Map the persistence state machine to user-facing copy. `degraded` carries its
@@ -124,7 +124,7 @@ export function BrowserLocalDocumentPage({
   store,
   loro,
   capabilities = BROWSER_LOCAL_CAPABILITIES,
-  initialDocumentId,
+  initialPath,
 }: BrowserLocalDocumentPageProps) {
   const {
     loro: resolvedLoro,
@@ -139,7 +139,7 @@ export function BrowserLocalDocumentPage({
     createDocument,
     switchDocument,
     duplicateDocument,
-  } = useBrowserLocalDocumentController(store, loro, initialDocumentId)
+  } = useBrowserLocalDocumentController(store, loro, initialPath)
   const location = useLocation()
   const navigate = useNavigate()
 
@@ -237,6 +237,11 @@ export function BrowserLocalDocumentPage({
   const mainRef = useRef<HTMLElement | null>(null)
   // Stable canvas id from the loaded snapshot; null while not yet loaded.
   const documentId = pageState.kind === 'editing' ? pageState.snapshot.documentId : null
+  // The loaded document's own path — the address the URL carries. Read off the
+  // snapshot rather than looked up in the list, so it is known at the same
+  // instant the id is, and so this effect does not re-fire every time the list
+  // refreshes (which would overwrite a Back the user just performed).
+  const documentPath = pageState.kind === 'editing' ? pageState.snapshot.path : null
   const documentName = pageState.kind === 'editing' ? pageState.snapshot.name : null
   const documentKind = pageState.kind === 'editing' ? pageState.snapshot.kind : 'spatial'
   const markdownDoc = useMarkdownDocument(resolvedLoro, documentId, documentKind === 'markdown')
@@ -293,6 +298,17 @@ export function BrowserLocalDocumentPage({
     [switcherOptions],
   )
 
+  // Following a [[reference]]: it names a document id, the address bar names a
+  // path. An id with no path is a document the list has not caught up with —
+  // do nothing rather than navigate somewhere wrong.
+  const navigateToDocument = useCallback(
+    (id: string) => {
+      const path = pathOfDocument(id)
+      if (path !== null) navigate(browserLocalDocumentPath(path))
+    },
+    [pathOfDocument, navigate],
+  )
+
   const linkTargets = useMemo(
     () =>
       switcherOptions.map((entry) => ({
@@ -311,9 +327,9 @@ export function BrowserLocalDocumentPage({
   // Canvas id -> URL: once a canvas has loaded, the address bar reflects it
   // (bookmarkable/shareable, matching the daemon side's
   // /document/:workspaceId/:path contract). This page only mounts on
-  // /local/:documentId (App routes '/' to the list), so on a normal open the
+  // /local/:path (App routes '/' to the list), so on a normal open the
   // first run is a no-op — the URL already matches. The first-sync REPLACE
-  // exists for the stale-deep-link case: a bookmarked id that no longer
+  // exists for the stale-deep-link case: a bookmarked path that no longer
   // exists falls back to the default canvas, and repairing the URL with a
   // push would leave the dead link as a history entry behind it. Every
   // subsequent switch (via the switcher, or create-then-switch) pushes.
@@ -324,14 +340,14 @@ export function BrowserLocalDocumentPage({
   // path — so the other effect sees no drift left to act on.
   const isFirstCanvasUrlSyncRef = useRef(true)
   useEffect(() => {
-    if (documentId === null) return
-    const path = browserLocalDocumentPath(documentId)
+    if (documentPath === null) return
+    const path = browserLocalDocumentPath(documentPath)
     const isFirstSync = isFirstCanvasUrlSyncRef.current
     isFirstCanvasUrlSyncRef.current = false
     if (location.pathname === path) return
     navigate(path, { replace: isFirstSync })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [documentId, navigate])
+  }, [documentPath, navigate])
 
   // URL -> canvas id: browser Back/Forward (and any other history navigation)
   // moves location.pathname without any switcher click firing, so this is the
@@ -831,7 +847,7 @@ export function BrowserLocalDocumentPage({
                   title: titleOf(documentName),
                   resolveAlias,
                   linkTargets,
-                  onOpenDocument: (id) => navigate(browserLocalDocumentPath(id)),
+                  onOpenDocument: (id) => navigateToDocument(id),
                   resolveEmbed,
                 }
           }
@@ -901,7 +917,7 @@ export function BrowserLocalDocumentPage({
                     linkTargets={linkTargets}
                     onCommit={nodeInEditor.commit}
                     onClose={nodeInEditor.close}
-                    onOpenDocument={(id) => navigate(browserLocalDocumentPath(id))}
+                    onOpenDocument={(id) => navigateToDocument(id)}
                   />
                 )}
               </div>

--- a/apps/web/src/pages/BrowserLocalDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.tsx
@@ -367,24 +367,38 @@ export function BrowserLocalDocumentPage({
   // skip it and let the other effect finish the sync.
   const lastKnownCanvasIdRef = useRef<string | null>(null)
   useEffect(() => {
-    if (documentId === null) return
-    const requestedPath = parseBrowserLocalRoute(location.pathname)?.path
-    const requestedId = requestedPath === undefined ? null : documentIdOfPath(requestedPath)
+    if (documentId === null || documentPath === null) return
+    // Recorded before any early return: a run that finds nothing to do still
+    // establishes which document was loaded, and the guard below reads it to
+    // tell an external navigation from this component's own pending push.
     const lastKnownDocumentId = lastKnownCanvasIdRef.current
     lastKnownCanvasIdRef.current = documentId
-    if (requestedId === null || requestedId === documentId) return
-    if (requestedId === lastKnownDocumentId) return
+
+    const requestedPath = parseBrowserLocalRoute(location.pathname)?.path
+    if (requestedPath === undefined) return
+    // Compared against the loaded snapshot's OWN path rather than against the
+    // list, so this is right before the list has arrived — which is also what
+    // makes the unknown-path branch below safe to treat as genuinely unknown.
+    if (requestedPath === documentPath) return
+
+    const requestedId = documentIdOfPath(requestedPath)
+    if (requestedId === documentId) return
+    if (requestedId !== null && requestedId === lastKnownDocumentId) return
+
+    // Two ways the address bar can name something that is not the loaded
+    // document, and both are the same recoverable miss: keep the document and
+    // repair the URL. The path resolves to nothing (deleted, or hand-typed),
+    // or it resolves and the switch then finds no record.
+    const repair = () => navigate(browserLocalDocumentPath(documentPath), { replace: true })
+    if (requestedId === null) {
+      repair()
+      return
+    }
     void switchDocument(requestedId).then((switched) => {
-      // A stale deep link (deleted/unknown canvas) is a recoverable miss:
-      // keep the loaded canvas and repair the address bar instead of
-      // leaving a URL that names nothing.
-      if (!switched) {
-        const here = pathOfDocument(documentId)
-        if (here !== null) navigate(browserLocalDocumentPath(here), { replace: true })
-      }
+      if (!switched) repair()
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [location.pathname, documentId, switchDocument])
+  }, [location.pathname, documentId, documentPath, switchDocument])
 
   useEffect(() => {
     if (documentId === null) return
@@ -886,11 +900,10 @@ export function BrowserLocalDocumentPage({
                       label: entry.name,
                       kind: entry.kind,
                     }))}
-                  onOpenFileRef={(file) => {
-                    // A reference names a document id; the route names a path.
-                    const target = pathOfDocument(file)
-                    if (target !== null) navigate(browserLocalDocumentPath(target))
-                  }}
+                  // A file-node reference names a document id exactly like a
+                  // [[wikiLink]] does, so it follows through the same one
+                  // conversion rather than repeating it here.
+                  onOpenFileRef={navigateToDocument}
                   missingFileRef={missingFileRef}
                   {...fileSeams}
                   lockedNodeIds={lockedNodeIds}

--- a/apps/web/src/pages/BrowserLocalDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.tsx
@@ -3,7 +3,7 @@ import { MARKDOWN_BODY_KEY } from '@kamiazya/whiteboard-loro-adapter'
 import { isImageRef } from '@kamiazya/whiteboard-model'
 import { LoroSyncPlugin } from 'loro-codemirror'
 import { Braces, Copy, Download, EllipsisVertical, Minimize2, Trash2 } from 'lucide-react'
-import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
 import { DocumentPageSkeleton } from '../components/DocumentPageSkeleton.js'
@@ -229,14 +229,14 @@ export function BrowserLocalDocumentPage({
   // keeps everything ordinary.
   const missingFileRef = useMemo(() => {
     if (documents.length === 0) return undefined
-    const known = new Set(documents.map((entry) => entry.id))
+    const known = new Set(documents.map((entry) => entry.documentId))
     return (ref: string) => !isImageRef(ref) && !known.has(ref)
   }, [documents])
   // Fullscreen target for WorkspaceTopBar's onToggleFullscreen; the whole page
   // (editor + chrome), not just the Excalidraw canvas.
   const mainRef = useRef<HTMLElement | null>(null)
   // Stable canvas id from the loaded snapshot; null while not yet loaded.
-  const documentId = pageState.kind === 'editing' ? pageState.snapshot.id : null
+  const documentId = pageState.kind === 'editing' ? pageState.snapshot.documentId : null
   const documentName = pageState.kind === 'editing' ? pageState.snapshot.name : null
   const documentKind = pageState.kind === 'editing' ? pageState.snapshot.kind : 'spatial'
   const markdownDoc = useMarkdownDocument(resolvedLoro, documentId, documentKind === 'markdown')
@@ -257,7 +257,15 @@ export function BrowserLocalDocumentPage({
   // [[Name]] resolution for the markdown preview: display names from the
   // same snapshot list the switcher shows, so a link resolves exactly when
   // the author can see one unambiguous canvas by that name.
-  const resolveAlias = useMemo(() => createSnapshotAliasResolver(documents), [documents])
+  // `createSnapshotAliasResolver` takes {id, name}; a stored row now says
+  // `documentId`, so the projection is explicit rather than structural.
+  const resolveAlias = useMemo(
+    () =>
+      createSnapshotAliasResolver(
+        documents.map((entry) => ({ id: entry.documentId, name: entry.name })),
+      ),
+    [documents],
+  )
   // The list read races the save a rename queues, so this canvas's live
   // truth is its own snapshot and the list is only the copy for the OTHER
   // documents. Both the switcher and the link picker read THIS, or the
@@ -265,12 +273,33 @@ export function BrowserLocalDocumentPage({
   // it entirely right after it was created.
   const switcherOptions =
     pageState.kind === 'editing'
-      ? documents.some((c) => c.id === pageState.snapshot.id)
-        ? documents.map((c) => (c.id === pageState.snapshot.id ? pageState.snapshot : c))
+      ? documents.some((c) => c.documentId === pageState.snapshot.documentId)
+        ? documents.map((c) =>
+            c.documentId === pageState.snapshot.documentId ? pageState.snapshot : c,
+          )
         : [...documents, pageState.snapshot]
       : documents
+  // The URL and the file-node reference speak different addresses: a route
+  // carries a path (so the hierarchy is visible and it matches the daemon's),
+  // while a reference carries the document id (so it survives a move). These
+  // two are the only places that convert, and everything else stays in one
+  // vocabulary.
+  const pathOfDocument = useCallback(
+    (id: string) => switcherOptions.find((entry) => entry.documentId === id)?.path ?? null,
+    [switcherOptions],
+  )
+  const documentIdOfPath = useCallback(
+    (path: string) => switcherOptions.find((entry) => entry.path === path)?.documentId ?? null,
+    [switcherOptions],
+  )
+
   const linkTargets = useMemo(
-    () => switcherOptions.map((entry) => ({ id: entry.id, name: entry.name, kind: entry.kind })),
+    () =>
+      switcherOptions.map((entry) => ({
+        id: entry.documentId,
+        name: entry.name,
+        kind: entry.kind,
+      })),
     [switcherOptions],
   )
   // ![[embed]] bodies, pre-fetched so the layout's sync seam has content.
@@ -323,16 +352,20 @@ export function BrowserLocalDocumentPage({
   const lastKnownCanvasIdRef = useRef<string | null>(null)
   useEffect(() => {
     if (documentId === null) return
-    const requestedId = parseBrowserLocalRoute(location.pathname)?.documentId
+    const requestedPath = parseBrowserLocalRoute(location.pathname)?.path
+    const requestedId = requestedPath === undefined ? null : documentIdOfPath(requestedPath)
     const lastKnownDocumentId = lastKnownCanvasIdRef.current
     lastKnownCanvasIdRef.current = documentId
-    if (requestedId === undefined || requestedId === documentId) return
+    if (requestedId === null || requestedId === documentId) return
     if (requestedId === lastKnownDocumentId) return
     void switchDocument(requestedId).then((switched) => {
       // A stale deep link (deleted/unknown canvas) is a recoverable miss:
       // keep the loaded canvas and repair the address bar instead of
       // leaving a URL that names nothing.
-      if (!switched) navigate(browserLocalDocumentPath(documentId), { replace: true })
+      if (!switched) {
+        const here = pathOfDocument(documentId)
+        if (here !== null) navigate(browserLocalDocumentPath(here), { replace: true })
+      }
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.pathname, documentId, switchDocument])
@@ -405,7 +438,7 @@ export function BrowserLocalDocumentPage({
     canvas,
     adapter: BROWSER_LOCAL_FILE_ADAPTER,
     stampOf: useMemo(
-      () => new Map(documents.map((entry) => [entry.id, entry.updatedAt])),
+      () => new Map(documents.map((entry) => [entry.documentId, entry.updatedAt])),
       [documents],
     ),
   })
@@ -721,21 +754,24 @@ export function BrowserLocalDocumentPage({
               }
               dataMode="local"
               workspaceId="local"
-              path={pageState.snapshot.id}
+              path={pageState.snapshot.path}
               documents={switcherOptions.map((c) => ({
-                path: c.id,
+                path: c.path,
                 name: c.name,
                 updatedAt: c.updatedAt,
               }))}
-              onNavigateToDocument={(id) => void switchDocument(id)}
+              onNavigateToDocument={(path) => {
+                const id = documentIdOfPath(path)
+                if (id !== null) void switchDocument(id)
+              }}
               onRenameDocument={renameDocument}
               onCreateDocument={async () => {
                 const created = await createDocument()
-                await switchDocument(created.id)
+                await switchDocument(created.documentId)
               }}
               onCreateMarkdownCanvas={async () => {
                 const created = await createDocument(undefined, 'markdown')
-                await switchDocument(created.id)
+                await switchDocument(created.documentId)
               }}
               isFullscreen={isFullscreen}
               onToggleFullscreen={() => {
@@ -828,9 +864,17 @@ export function BrowserLocalDocumentPage({
                   // File-node reference = browser-local canvas id; the current
                   // canvas is excluded (a self-reference card is pure noise).
                   fileRefOptions={documents
-                    .filter((entry) => entry.id !== documentId)
-                    .map((entry) => ({ file: entry.id, label: entry.name, kind: entry.kind }))}
-                  onOpenFileRef={(file) => navigate(browserLocalDocumentPath(file))}
+                    .filter((entry) => entry.documentId !== documentId)
+                    .map((entry) => ({
+                      file: entry.documentId,
+                      label: entry.name,
+                      kind: entry.kind,
+                    }))}
+                  onOpenFileRef={(file) => {
+                    // A reference names a document id; the route names a path.
+                    const target = pathOfDocument(file)
+                    if (target !== null) navigate(browserLocalDocumentPath(target))
+                  }}
                   missingFileRef={missingFileRef}
                   {...fileSeams}
                   lockedNodeIds={lockedNodeIds}

--- a/apps/web/src/pages/BrowserLocalDocumentPage.webmcp.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.webmcp.test.tsx
@@ -36,7 +36,9 @@ vi.mock('../lib/browser-local-backend.js', () => ({
 }))
 
 const snap: DocumentSnapshot = {
-  id: 'c1',
+  documentId: '0AFMSY38DJQW16BGNTZ49EKRX2',
+  workspaceId: 'local',
+  path: 'untitled',
   name: 'untitled',
   updatedAt: '2026-05-24T00:00:00.000Z',
   kind: 'spatial' as const,
@@ -69,7 +71,7 @@ describe('BrowserLocalDocumentPage WebMCP wiring', () => {
     document.modelContext = fake
 
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('0AFMSY38DJQW16BGNTZ49EKRX2')
     await store.save(snap)
 
     await act(async () => {
@@ -95,7 +97,7 @@ describe('BrowserLocalDocumentPage WebMCP wiring', () => {
     document.modelContext = fake
 
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId('0AFMSY38DJQW16BGNTZ49EKRX2')
     await store.save(snap)
 
     await act(async () => {

--- a/apps/web/src/pages/BrowserLocalIndexPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalIndexPage.test.tsx
@@ -2,7 +2,7 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { MemoryStore } from '../lib/browser-local-store.js'
+import { LOCAL_WORKSPACE_ID, MemoryStore } from '../lib/browser-local-store.js'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
 import { BrowserLocalIndexPage } from './BrowserLocalIndexPage.js'
 
@@ -32,8 +32,22 @@ function renderPage(store: MemoryStore) {
 describe('BrowserLocalIndexPage', () => {
   it('lists snapshots most-recent first with name and kind marker', async () => {
     const store = await seededStore([
-      { id: 'id-a', name: 'Trip Plan', updatedAt: '2026-08-01T00:00:00Z', kind: 'spatial' },
-      { id: 'id-b', name: 'Meeting Notes', updatedAt: '2026-08-10T00:00:00Z', kind: 'markdown' },
+      {
+        documentId: '0CFJNRVY147ADGKPSWZ258BEHM',
+        workspaceId: 'local',
+        path: 'trip-plan',
+        name: 'Trip Plan',
+        updatedAt: '2026-08-01T00:00:00Z',
+        kind: 'spatial',
+      },
+      {
+        documentId: '0KPSWZ258BEHMQTX0369CFJNRV',
+        workspaceId: 'local',
+        path: 'meeting-notes',
+        name: 'Meeting Notes',
+        updatedAt: '2026-08-10T00:00:00Z',
+        kind: 'markdown',
+      },
     ])
     renderPage(store)
 
@@ -45,19 +59,33 @@ describe('BrowserLocalIndexPage', () => {
     expect(within(cards[1]!).queryByText(/markdown/i)).toBeNull()
   })
 
-  it('opens a canvas by its id on card click', async () => {
+  it('opens a canvas by its path on card click', async () => {
     const store = await seededStore([
-      { id: 'id-a', name: 'Solo', updatedAt: '2026-08-01T00:00:00Z', kind: 'spatial' },
+      {
+        documentId: '0CFJNRVY147ADGKPSWZ258BEHM',
+        workspaceId: 'local',
+        path: 'solo',
+        name: 'Solo',
+        updatedAt: '2026-08-01T00:00:00Z',
+        kind: 'spatial',
+      },
     ])
     const { onOpenDocument } = renderPage(store)
 
     fireEvent.click((await screen.findAllByTestId('document-list-card'))[0]!)
-    expect(onOpenDocument).toHaveBeenCalledWith('id-a')
+    expect(onOpenDocument).toHaveBeenCalledWith('solo')
   })
 
   it('creates a markdown canvas from the + menu, repoints the default, and opens it', async () => {
     const store = await seededStore([
-      { id: 'id-a', name: 'Existing', updatedAt: '2026-08-01T00:00:00Z', kind: 'spatial' },
+      {
+        documentId: '0CFJNRVY147ADGKPSWZ258BEHM',
+        workspaceId: 'local',
+        path: 'existing',
+        name: 'Existing',
+        updatedAt: '2026-08-01T00:00:00Z',
+        kind: 'spatial',
+      },
     ])
     const { onOpenDocument } = renderPage(store)
     await screen.findAllByTestId('document-list-card')
@@ -69,12 +97,14 @@ describe('BrowserLocalIndexPage', () => {
     fireEvent.pointerUp(await screen.findByRole('menuitem', { name: 'New markdown note' }))
 
     await waitFor(() => expect(onOpenDocument).toHaveBeenCalledTimes(1))
-    const newId = onOpenDocument.mock.calls[0]![0] as string
-    expect(newId).not.toBe('id-a')
+    const newPath = onOpenDocument.mock.calls[0]![0] as string
+    expect(newPath).not.toBe('existing')
     const all = await store.listDocuments()
-    const created = all.find((s) => s.id === newId)
+    const created = all.find((s) => s.path === newPath)
     expect(created?.kind).toBe('markdown')
-    expect(await store.getDefaultDocumentId()).toBe(newId)
+    // The default pointer is by id, the callback is by path — the two
+    // addresses have to agree on one document.
+    expect(await store.getDefaultDocumentId()).toBe(created?.documentId)
   })
 
   it('empty store shows the empty state whose action creates a spatial canvas', async () => {
@@ -84,8 +114,8 @@ describe('BrowserLocalIndexPage', () => {
     fireEvent.click(await screen.findByRole('button', { name: /create a canvas/i }))
 
     await waitFor(() => expect(onOpenDocument).toHaveBeenCalledTimes(1))
-    const newId = onOpenDocument.mock.calls[0]![0] as string
-    const created = (await store.listDocuments()).find((s) => s.id === newId)
+    const newPath = onOpenDocument.mock.calls[0]![0] as string
+    const created = (await store.listDocuments()).find((s) => s.path === newPath)
     expect(created?.kind).toBe('spatial')
   })
 
@@ -133,7 +163,14 @@ describe('BrowserLocalIndexPage', () => {
 
   it('Delete opens a dialog naming the canvas; Cancel removes nothing', async () => {
     const store = await seededStore([
-      { id: 'id-a', name: 'Keep Me', updatedAt: '2026-08-01T00:00:00Z', kind: 'spatial' },
+      {
+        documentId: '0CFJNRVY147ADGKPSWZ258BEHM',
+        workspaceId: 'local',
+        path: 'keep-me',
+        name: 'Keep Me',
+        updatedAt: '2026-08-01T00:00:00Z',
+        kind: 'spatial',
+      },
     ])
     renderPage(store)
     await screen.findAllByTestId('document-list-card')
@@ -150,7 +187,14 @@ describe('BrowserLocalIndexPage', () => {
 
   it('confirming Delete removes the canvas; deleting the last one returns the empty state', async () => {
     const store = await seededStore([
-      { id: 'id-a', name: 'Doomed', updatedAt: '2026-08-01T00:00:00Z', kind: 'spatial' },
+      {
+        documentId: '0CFJNRVY147ADGKPSWZ258BEHM',
+        workspaceId: 'local',
+        path: 'doomed',
+        name: 'Doomed',
+        updatedAt: '2026-08-01T00:00:00Z',
+        kind: 'spatial',
+      },
     ])
     const { onOpenDocument } = renderPage(store)
     await screen.findAllByTestId('document-list-card')
@@ -168,7 +212,14 @@ describe('BrowserLocalIndexPage', () => {
 
   it('a failed delete shows the fixed error in the dialog, which stays open, and Cancel clears it', async () => {
     const store = await seededStore([
-      { id: 'id-a', name: 'Sticky', updatedAt: '2026-08-01T00:00:00Z', kind: 'spatial' },
+      {
+        documentId: '0CFJNRVY147ADGKPSWZ258BEHM',
+        workspaceId: 'local',
+        path: 'sticky',
+        name: 'Sticky',
+        updatedAt: '2026-08-01T00:00:00Z',
+        kind: 'spatial',
+      },
     ])
     store.removeDocument = () => Promise.reject(new Error('quota exceeded'))
     renderPage(store)
@@ -189,19 +240,35 @@ describe('BrowserLocalIndexPage', () => {
     expect(screen.getAllByTestId('document-list-card')).toHaveLength(1)
   })
 
-  it('shows the name alone — a browser-local canvas has no path to put under it', async () => {
-    // These names carry no ASCII, so any name-derived path collapses them to
-    // `untitled` / `untitled-2` — indistinguishable in the very column a
-    // secondary line exists to distinguish.
+  it('shows each name over its own real path, which is never derived from that name', async () => {
+    // Neither name carries ASCII, so a name-derived path would collapse both
+    // to `untitled` / `untitled-2` — indistinguishable in the very column the
+    // secondary line exists to distinguish. A local document now has a real
+    // path exactly like a daemon one, and this is what shows it.
     const store = await seededStore([
-      { id: 'id-a', name: '構成図', updatedAt: '2026-08-02T00:00:00Z', kind: 'spatial' },
-      { id: 'id-b', name: '設計メモ', updatedAt: '2026-08-01T00:00:00Z', kind: 'spatial' },
+      {
+        documentId: '0CFJNRVY147ADGKPSWZ258BEHM',
+        workspaceId: LOCAL_WORKSPACE_ID,
+        path: 'diagrams/structure',
+        name: '構成図',
+        updatedAt: '2026-08-02T00:00:00Z',
+        kind: 'spatial',
+      },
+      {
+        documentId: '0KPSWZ258BEHMQTX0369CFJNRV',
+        workspaceId: LOCAL_WORKSPACE_ID,
+        path: 'notes/design',
+        name: '設計メモ',
+        updatedAt: '2026-08-01T00:00:00Z',
+        kind: 'spatial',
+      },
     ])
     renderPage(store)
 
     const cards = await screen.findAllByTestId('document-list-card')
     expect(within(cards[0]!).getByText('構成図')).toBeTruthy()
+    expect(within(cards[0]!).getByTestId('canvas-secondary').textContent).toBe('diagrams/structure')
     expect(within(cards[1]!).getByText('設計メモ')).toBeTruthy()
-    expect(screen.queryAllByTestId('canvas-secondary')).toHaveLength(0)
+    expect(within(cards[1]!).getByTestId('canvas-secondary').textContent).toBe('notes/design')
   })
 })

--- a/apps/web/src/pages/BrowserLocalIndexPage.tsx
+++ b/apps/web/src/pages/BrowserLocalIndexPage.tsx
@@ -2,14 +2,14 @@ import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { DeleteDocumentDialog } from '../components/document-list/DeleteDocumentDialog.js'
 import { DocumentListView } from '../components/document-list/DocumentListView.js'
-import { newDocumentPathIn } from '../components/workspace-files/new-document-path.js'
+import { newDocumentPathIn, takenPathsIn } from '../components/workspace-files/new-document-path.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
 import { LOCAL_WORKSPACE_ID } from '../lib/browser-local-store.js'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
 
 export interface BrowserLocalIndexPageProps {
   store: BrowserLocalStore
-  onOpenDocument: (documentId: string) => void
+  onOpenDocument: (path: string) => void
 }
 
 // The browser-local landing surface: the same shared list the daemon gallery
@@ -57,9 +57,12 @@ export function BrowserLocalIndexPage({ store, onOpenDocument }: BrowserLocalInd
     }))
   }, [snapshots])
 
-  const [pendingDelete, setPendingDelete] = useState<{ id: string; displayName: string } | null>(
-    null,
-  )
+  // The list addresses a document by PATH; the store deletes by id. Carrying
+  // both is what keeps the conversion at one place instead of at the call.
+  const [pendingDelete, setPendingDelete] = useState<{
+    documentId: string
+    displayName: string
+  } | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [deleteError, setDeleteError] = useState<string | null>(null)
 
@@ -71,7 +74,7 @@ export function BrowserLocalIndexPage({ store, onOpenDocument }: BrowserLocalInd
       // Unconditional removal by id. If this was the canvas the default
       // pointer resumes into, the pointer dangles deliberately — the
       // editor's resume path already falls back safely on a dead id.
-      await store.removeDocument?.(pendingDelete.id)
+      await store.removeDocument?.(pendingDelete.documentId)
       setSnapshots(await store.listDocuments())
       setPendingDelete(null)
     } catch {
@@ -86,16 +89,16 @@ export function BrowserLocalIndexPage({ store, onOpenDocument }: BrowserLocalInd
       setCreating(true)
       try {
         const id = store.generateId()
+        // Numbered against the STORE, not against `snapshots`: this callback
+        // is memoized on [store, onOpenDocument], so a rendered list captured
+        // here would be whatever the first render held — `null` on the first
+        // create after a load, which numbers from nothing and lands on a path
+        // the store already holds.
+        const taken = await takenPathsIn(store)
         const fresh: DocumentSnapshot = {
           documentId: id,
           workspaceId: LOCAL_WORKSPACE_ID,
-          // A create while the list is still loading numbers from nothing.
-          // The store rejects a duplicate path, so the worst case is a
-          // refused create rather than two documents at one address.
-          path: newDocumentPathIn(
-            '',
-            (snapshots ?? []).map((row) => row.path),
-          ),
+          path: newDocumentPathIn('', taken),
           name: 'untitled',
           updatedAt: new Date().toISOString(),
           kind,
@@ -104,7 +107,7 @@ export function BrowserLocalIndexPage({ store, onOpenDocument }: BrowserLocalInd
         // Repointed so a later plain load resumes in the new canvas — the
         // same contract the editor's own create/switch flows keep.
         await store.setDefaultDocumentId(id)
-        onOpenDocument(id)
+        onOpenDocument(fresh.path)
       } catch {
         setError('Failed to create a canvas in this browser.')
       } finally {
@@ -147,7 +150,12 @@ export function BrowserLocalIndexPage({ store, onOpenDocument }: BrowserLocalInd
               onClick={(event) => {
                 // Prevents the click from bubbling to the wrapping open-button.
                 event.stopPropagation()
-                setPendingDelete({ id: row.path, displayName: row.displayName })
+                const target = snapshots?.find((entry) => entry.path === row.path)
+                if (target === undefined) return
+                setPendingDelete({
+                  documentId: target.documentId,
+                  displayName: row.displayName,
+                })
               }}
               className="absolute right-1 top-1 rounded-md border bg-background px-1.5 py-0.5 text-xs font-medium opacity-0 transition-opacity hover:bg-accent focus-visible:opacity-100 group-hover:opacity-100"
             >

--- a/apps/web/src/pages/BrowserLocalIndexPage.tsx
+++ b/apps/web/src/pages/BrowserLocalIndexPage.tsx
@@ -2,7 +2,9 @@ import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { DeleteDocumentDialog } from '../components/document-list/DeleteDocumentDialog.js'
 import { DocumentListView } from '../components/document-list/DocumentListView.js'
+import { newDocumentPathIn } from '../components/workspace-files/new-document-path.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
+import { LOCAL_WORKSPACE_ID } from '../lib/browser-local-store.js'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
 
 export interface BrowserLocalIndexPageProps {
@@ -41,13 +43,15 @@ export function BrowserLocalIndexPage({ store, onOpenDocument }: BrowserLocalInd
   const rows = useMemo(() => {
     if (!snapshots) return []
     const sorted = [...snapshots].sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1))
-    // No `secondary`: a browser-local canvas is addressed by UUID and has no
-    // path. Deriving a label from the name instead collapses every non-Latin
-    // name to `untitled`/`untitled-2` — indistinguishable in the one column
-    // that exists to distinguish rows (ADR-0008).
+    // A local document has a real path now, so `secondary` shows it on the
+    // same terms the daemon list does: worth a second line only when a
+    // display name covers the first. It is still never DERIVED from the name
+    // — ADR-0008 measured that and every non-Latin name collapsed to
+    // `untitled-N`.
     return sorted.map((s) => ({
-      path: s.id,
+      path: s.path,
       displayName: s.name,
+      ...(s.name === s.path ? {} : { secondary: s.path }),
       updatedAt: s.updatedAt,
       kind: s.kind,
     }))
@@ -83,7 +87,15 @@ export function BrowserLocalIndexPage({ store, onOpenDocument }: BrowserLocalInd
       try {
         const id = store.generateId()
         const fresh: DocumentSnapshot = {
-          id,
+          documentId: id,
+          workspaceId: LOCAL_WORKSPACE_ID,
+          // A create while the list is still loading numbers from nothing.
+          // The store rejects a duplicate path, so the worst case is a
+          // refused create rather than two documents at one address.
+          path: newDocumentPathIn(
+            '',
+            (snapshots ?? []).map((row) => row.path),
+          ),
           name: 'untitled',
           updatedAt: new Date().toISOString(),
           kind,

--- a/apps/web/src/pages/DaemonDocumentPage.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.test.tsx
@@ -14,7 +14,7 @@ import {
 import type { ReactElement, ReactNode } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { MemoryStore } from '../lib/browser-local-store.js'
+import { LOCAL_WORKSPACE_ID, MemoryStore } from '../lib/browser-local-store.js'
 import * as daemonApiClient from '../lib/daemon-api-client.js'
 import { getShellDaemonAuthError } from '../lib/shell-status-store.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
@@ -2113,7 +2113,9 @@ describe('DaemonDocumentPage', () => {
     it('renders the import-from-this-browser disclosure and lists a local canvas once opened', async () => {
       const browserLocalStore = new MemoryStore()
       await browserLocalStore.save({
-        id: 'local-1',
+        documentId: 'local-1',
+        workspaceId: LOCAL_WORKSPACE_ID,
+        path: 'my-local-canvas',
         name: 'My local canvas',
         updatedAt: '2026-01-01T00:00:00Z',
         kind: 'spatial' as const,

--- a/apps/web/src/pages/DaemonDocumentPage.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.test.tsx
@@ -2113,7 +2113,7 @@ describe('DaemonDocumentPage', () => {
     it('renders the import-from-this-browser disclosure and lists a local canvas once opened', async () => {
       const browserLocalStore = new MemoryStore()
       await browserLocalStore.save({
-        documentId: 'local-1',
+        documentId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
         workspaceId: LOCAL_WORKSPACE_ID,
         path: 'my-local-canvas',
         name: 'My local canvas',

--- a/apps/web/src/pages/browser-local-page-state.test.ts
+++ b/apps/web/src/pages/browser-local-page-state.test.ts
@@ -4,7 +4,9 @@ import { derivePageState } from './browser-local-page-state.js'
 import type { BrowserLocalPersistenceState } from './use-browser-local-document-controller.js'
 
 const snapshot: DocumentSnapshot = {
-  id: 'canvas-A',
+  documentId: '0ADGKPSWZ258BEHMQTX0369CFJ',
+  workspaceId: 'local',
+  path: 'untitled',
   name: 'untitled',
   updatedAt: '2026-05-04T00:00:00.000Z',
   kind: 'spatial' as const,

--- a/apps/web/src/pages/use-browser-local-document-controller.multi-document.browser.test.tsx
+++ b/apps/web/src/pages/use-browser-local-document-controller.multi-document.browser.test.tsx
@@ -44,18 +44,18 @@ describe('multi-canvas foundation (real IndexedDB)', () => {
     let idA = ''
     let idB = ''
     await act(async () => {
-      idA = (await result.current.createDocument('Canvas A')).id
+      idA = (await result.current.createDocument('Canvas A')).documentId
     })
     await act(async () => {
-      idB = (await result.current.createDocument('Canvas B')).id
+      idB = (await result.current.createDocument('Canvas B')).documentId
     })
 
     const list = await result.current.listDocuments()
-    const ids = list.map((c) => c.id)
+    const ids = list.map((c) => c.documentId)
     expect(ids).toContain(idA)
     expect(ids).toContain(idB)
-    expect(list.find((c) => c.id === idA)?.name).toBe('Canvas A')
-    expect(list.find((c) => c.id === idB)?.name).toBe('Canvas B')
+    expect(list.find((c) => c.documentId === idA)?.name).toBe('Canvas A')
+    expect(list.find((c) => c.documentId === idB)?.name).toBe('Canvas B')
 
     // createDocument seeds an empty Loro doc so a switch onto a never-edited
     // canvas delivers a valid empty doc rather than not-found.
@@ -72,10 +72,10 @@ describe('multi-canvas foundation (real IndexedDB)', () => {
     let idA = ''
     let idB = ''
     await act(async () => {
-      idA = (await result.current.createDocument('Canvas A')).id
+      idA = (await result.current.createDocument('Canvas A')).documentId
     })
     await act(async () => {
-      idB = (await result.current.createDocument('Canvas B')).id
+      idB = (await result.current.createDocument('Canvas B')).documentId
     })
 
     await loro.save(idA, snapshotWithElements([{ id: 'rect-a', type: 'rectangle' }]))
@@ -100,23 +100,23 @@ describe('multi-canvas foundation (real IndexedDB)', () => {
     const loro = new LoroStore()
     const { result } = renderHook(() => useBrowserLocalDocumentController(store, loro))
     await waitFor(() => expect(result.current.snapshot).not.toBeNull())
-    const idA = result.current.snapshot!.id
+    const idA = result.current.snapshot!.documentId
 
     let idB = ''
     await act(async () => {
-      idB = (await result.current.createDocument('Canvas B')).id
+      idB = (await result.current.createDocument('Canvas B')).documentId
     })
 
     await act(async () => {
       await result.current.switchDocument(idB)
     })
-    expect(result.current.snapshot?.id).toBe(idB)
+    expect(result.current.snapshot?.documentId).toBe(idB)
     expect(await store.getDefaultDocumentId()).toBe(idB)
 
     await act(async () => {
       await result.current.switchDocument(idA)
     })
-    expect(result.current.snapshot?.id).toBe(idA)
+    expect(result.current.snapshot?.documentId).toBe(idA)
     expect(await store.getDefaultDocumentId()).toBe(idA)
   })
 
@@ -125,15 +125,15 @@ describe('multi-canvas foundation (real IndexedDB)', () => {
     const loro = new LoroStore()
     const { result } = renderHook(() => useBrowserLocalDocumentController(store, loro))
     await waitFor(() => expect(result.current.snapshot).not.toBeNull())
-    const sourceId = result.current.snapshot!.id
+    const sourceId = result.current.snapshot!.documentId
     await loro.save(sourceId, snapshotWithElements([{ id: 'original-element' }]))
 
     let duplicated: Awaited<ReturnType<typeof result.current.duplicateDocument>> | undefined
     await act(async () => {
       duplicated = await result.current.duplicateDocument()
     })
-    expect(duplicated?.id).not.toBe(sourceId)
-    expect(result.current.snapshot?.id).toBe(duplicated?.id)
+    expect(duplicated?.documentId).not.toBe(sourceId)
+    expect(result.current.snapshot?.documentId).toBe(duplicated?.documentId)
 
     // Edit the SOURCE canvas's real IndexedDB record after duplicating.
     const loadedSource = await loro.load(sourceId)
@@ -144,7 +144,7 @@ describe('multi-canvas foundation (real IndexedDB)', () => {
     sourceDoc.getList('elements').push({ id: 'added-after-duplicate' })
     await loro.save(sourceId, sourceDoc.export({ mode: 'snapshot' }))
 
-    const loadedCopy = await loro.load(duplicated!.id)
+    const loadedCopy = await loro.load(duplicated!.documentId)
     expect(loadedCopy.kind).toBe('ok')
     if (loadedCopy.kind !== 'ok') return
     const copyDoc = new Loro()

--- a/apps/web/src/pages/use-browser-local-document-controller.test.ts
+++ b/apps/web/src/pages/use-browser-local-document-controller.test.ts
@@ -367,7 +367,7 @@ describe('useBrowserLocalDocumentController', () => {
       del: base.del.bind(base),
       removeDocument: base.removeDocument.bind(base),
       generateId: () => FRESH,
-      listDocuments: async () => [],
+      listDocuments: base.listDocuments.bind(base),
       setDefaultDocumentId: async () => {
         throw new Error('IndexedDB: meta write aborted')
       },
@@ -557,7 +557,7 @@ describe('useBrowserLocalDocumentController', () => {
     })
   })
 
-  describe('initialDocumentId (deep-linked canvas)', () => {
+  describe('initialPath (deep-linked document)', () => {
     const other: DocumentSnapshot = {
       documentId: C2,
       workspaceId: 'local',
@@ -572,9 +572,23 @@ describe('useBrowserLocalDocumentController', () => {
       await store.setDefaultDocumentId(C1)
       await store.save(snap)
       await store.save(other)
-      const { result } = renderHook(() => useBrowserLocalDocumentController(store, undefined, C2))
+      const { result } = renderHook(() =>
+        useBrowserLocalDocumentController(store, undefined, other.path),
+      )
       await act(async () => {})
       expect(result.current.snapshot).toEqual(other)
+    })
+
+    it('resolves by path only — the document id is not an address here', async () => {
+      const store = new MemoryStore()
+      await store.setDefaultDocumentId(C1)
+      await store.save(snap)
+      await store.save(other)
+      const { result } = renderHook(() =>
+        useBrowserLocalDocumentController(store, undefined, other.documentId),
+      )
+      await act(async () => {})
+      expect(result.current.snapshot).toEqual(snap)
     })
 
     it('repoints the store default to the requested canvas so a later plain load resumes there', async () => {
@@ -582,12 +596,12 @@ describe('useBrowserLocalDocumentController', () => {
       await store.setDefaultDocumentId(C1)
       await store.save(snap)
       await store.save(other)
-      renderHook(() => useBrowserLocalDocumentController(store, undefined, C2))
+      renderHook(() => useBrowserLocalDocumentController(store, undefined, other.path))
       await act(async () => {})
       expect(await store.getDefaultDocumentId()).toBe(C2)
     })
 
-    it('falls back to the normal default-canvas flow when the requested id is not found (stale/bookmarked link)', async () => {
+    it('falls back to the normal default-canvas flow when the requested path is not found (stale/bookmarked link)', async () => {
       const store = new MemoryStore()
       await store.setDefaultDocumentId(C1)
       await store.save(snap)
@@ -596,12 +610,12 @@ describe('useBrowserLocalDocumentController', () => {
       )
       await act(async () => {})
       // No error wall — silently lands on whatever the store's own default
-      // resolves to, exactly like a plain (no initialDocumentId) mount would.
+      // resolves to, exactly like a plain (no initialPath) mount would.
       expect(result.current.snapshot).toEqual(snap)
       expect(result.current.persistence.kind).toBe('saved')
     })
 
-    it('behaves exactly like today when initialDocumentId is omitted', async () => {
+    it('behaves exactly like today when initialPath is omitted', async () => {
       const store = new MemoryStore()
       await store.setDefaultDocumentId(C1)
       await store.save(snap)

--- a/apps/web/src/pages/use-browser-local-document-controller.test.ts
+++ b/apps/web/src/pages/use-browser-local-document-controller.test.ts
@@ -2,7 +2,7 @@ import { act, renderHook } from '@testing-library/react'
 import { Loro } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
-import { MemoryStore } from '../lib/browser-local-store.js'
+import { LOCAL_WORKSPACE_ID, MemoryStore } from '../lib/browser-local-store.js'
 import type { LoroLoadResult } from '../lib/loro-store.js'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
 import {
@@ -44,8 +44,18 @@ function realSnapshotWithElements(elements: unknown[]): Uint8Array {
   return doc.export({ mode: 'snapshot' })
 }
 
+// ULIDs, because the stored schema validates them now. Named constants
+// rather than inline literals: a 26-character id read six times in one
+// assertion is unreadable, and the tests are about which document, not which
+// characters.
+const C1 = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+const C2 = '01ARZ3NDEKTSV4RRFFQ69G5FB0'
+const FRESH = '01ARZ3NDEKTSV4RRFFQ69G5FC1'
+
 const snap: DocumentSnapshot = {
-  id: 'c1',
+  documentId: C1,
+  workspaceId: 'local',
+  path: 'untitled',
   name: 'untitled',
   updatedAt: '2026-05-24T00:00:00.000Z',
   kind: 'spatial' as const,
@@ -87,7 +97,7 @@ describe('useBrowserLocalDocumentController', () => {
 
   it('loads existing canvas from store on mount', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId(C1)
     await store.save(snap)
     const { result } = renderHook(() => useBrowserLocalDocumentController(store))
     await act(async () => {})
@@ -96,7 +106,7 @@ describe('useBrowserLocalDocumentController', () => {
 
   it('renameDocument transitions persistence pending -> saved via an immediate flush (no debounce)', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId(C1)
     await store.save(snap)
     const { result } = renderHook(() => useBrowserLocalDocumentController(store))
     await act(async () => {})
@@ -115,7 +125,7 @@ describe('useBrowserLocalDocumentController', () => {
   it('degraded message is generic safe copy — raw error not exposed', async () => {
     // Explicitly bind all methods; class-instance spread copies data fields but not prototype methods.
     const base = new MemoryStore()
-    await base.setDefaultDocumentId('c1')
+    await base.setDefaultDocumentId(C1)
     await base.save(snap)
     const failingStore: BrowserLocalStore = {
       getDefaultDocumentId: base.getDefaultDocumentId.bind(base),
@@ -144,7 +154,7 @@ describe('useBrowserLocalDocumentController', () => {
 
   it('triggerCleanup flushes pending save then deletes canvas', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId(C1)
     await store.save(snap)
     const { result } = renderHook(() => useBrowserLocalDocumentController(store))
     await act(async () => {})
@@ -162,7 +172,7 @@ describe('useBrowserLocalDocumentController', () => {
 
   it('cleanupError is a generic safe copy when flush fails — raw error not exposed', async () => {
     const base = new MemoryStore()
-    await base.setDefaultDocumentId('c1')
+    await base.setDefaultDocumentId(C1)
     await base.save(snap)
     let shouldFailSave = false
     const store: BrowserLocalStore = {
@@ -205,7 +215,7 @@ describe('useBrowserLocalDocumentController', () => {
     // fix renameDocument's return type was `void`, so a real save failure could
     // never surface as a rejection — the caller always saw success.
     const base = new MemoryStore()
-    await base.setDefaultDocumentId('c1')
+    await base.setDefaultDocumentId(C1)
     await base.save(snap)
     let shouldFailSave = false
     const store: BrowserLocalStore = {
@@ -237,7 +247,7 @@ describe('useBrowserLocalDocumentController', () => {
 
   it('cleanupError is null on successful cleanup', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId(C1)
     await store.save(snap)
     const { result } = renderHook(() => useBrowserLocalDocumentController(store))
     await act(async () => {})
@@ -250,7 +260,7 @@ describe('useBrowserLocalDocumentController', () => {
 
   it('triggerCleanup aborts when flush fails — preserves data copy', async () => {
     const base = new MemoryStore()
-    await base.setDefaultDocumentId('c1')
+    await base.setDefaultDocumentId(C1)
     await base.save(snap)
     let shouldFailSave = false
     const store: BrowserLocalStore = {
@@ -283,12 +293,12 @@ describe('useBrowserLocalDocumentController', () => {
     })
     expect(result.current.cleanupCompleted).toBe(false)
     expect(result.current.snapshot).not.toBeNull()
-    expect(await base.getDefaultDocumentId()).toBe('c1')
+    expect(await base.getDefaultDocumentId()).toBe(C1)
   })
 
   it('triggerCleanup is a no-op when del returns pointer-mismatch', async () => {
     const base = new MemoryStore()
-    await base.setDefaultDocumentId('c1')
+    await base.setDefaultDocumentId(C1)
     await base.save(snap)
     const store: BrowserLocalStore = {
       getDefaultDocumentId: base.getDefaultDocumentId.bind(base),
@@ -310,7 +320,7 @@ describe('useBrowserLocalDocumentController', () => {
 
   it('no phantom save re-populates store after triggerCleanup', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId(C1)
     await store.save(snap)
     const { result } = renderHook(() => useBrowserLocalDocumentController(store))
     await act(async () => {})
@@ -325,12 +335,12 @@ describe('useBrowserLocalDocumentController', () => {
       await vi.advanceTimersByTimeAsync(2000)
     })
     expect(await store.getDefaultDocumentId()).toBeNull()
-    expect((await store.load('c1')).kind).toBe('not-found')
+    expect((await store.load(C1)).kind).toBe('not-found')
   })
 
   it('startFresh deletes the old canvas record before repointing the default', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId(C1)
     await store.save(snap)
     const { result } = renderHook(() => useBrowserLocalDocumentController(store))
     await act(async () => {})
@@ -338,17 +348,17 @@ describe('useBrowserLocalDocumentController', () => {
       await result.current.startFresh()
     })
     // The old canvas must not linger in the store: del() clears the default pointer,
-    // so it has to run while 'c1' is still the default — i.e. before setDefaultDocumentId(new).
-    expect((await store.load('c1')).kind).toBe('not-found')
+    // so it has to run while C1 is still the default — i.e. before setDefaultDocumentId(new).
+    expect((await store.load(C1)).kind).toBe('not-found')
     const newId = await store.getDefaultDocumentId()
     expect(newId).not.toBeNull()
-    expect(newId).not.toBe('c1')
+    expect(newId).not.toBe(C1)
     expect((await store.load(newId as string)).kind).toBe('ok')
   })
 
   it('startFresh degrades and cleans up its orphan when repointing the default fails', async () => {
     const base = new MemoryStore()
-    await base.setDefaultDocumentId('c1')
+    await base.setDefaultDocumentId(C1)
     await base.save(snap)
     const failingStore: BrowserLocalStore = {
       getDefaultDocumentId: base.getDefaultDocumentId.bind(base),
@@ -356,7 +366,7 @@ describe('useBrowserLocalDocumentController', () => {
       save: base.save.bind(base),
       del: base.del.bind(base),
       removeDocument: base.removeDocument.bind(base),
-      generateId: () => 'fresh-1',
+      generateId: () => FRESH,
       listDocuments: async () => [],
       setDefaultDocumentId: async () => {
         throw new Error('IndexedDB: meta write aborted')
@@ -374,14 +384,14 @@ describe('useBrowserLocalDocumentController', () => {
     // del() ran before the failed repoint, so the abandoned canvas is gone and the pointer is
     // null — a retry starts cleanly. The freshly-saved canvas is cleaned up via removeDocument
     // so the failed recovery leaves no orphaned record behind.
-    expect((await base.load('c1')).kind).toBe('not-found')
-    expect((await base.load('fresh-1')).kind).toBe('not-found')
+    expect((await base.load(C1)).kind).toBe('not-found')
+    expect((await base.load(FRESH)).kind).toBe('not-found')
     expect(await base.getDefaultDocumentId()).toBeNull()
   })
 
   it('renameDocument updates snapshot.name and persists it', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId(C1)
     await store.save(snap)
     const { result } = renderHook(() => useBrowserLocalDocumentController(store))
     await act(async () => {})
@@ -389,7 +399,7 @@ describe('useBrowserLocalDocumentController', () => {
       result.current.renameDocument('New name')
     })
     expect(result.current.snapshot?.name).toBe('New name')
-    const loadResult = await store.load('c1')
+    const loadResult = await store.load(C1)
     expect(loadResult.kind).toBe('ok')
     if (loadResult.kind === 'ok') {
       expect(loadResult.snapshot.name).toBe('New name')
@@ -398,7 +408,7 @@ describe('useBrowserLocalDocumentController', () => {
 
   it('renameDocument racing with unmount does not warn or clobber a later mount', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId(C1)
     await store.save(snap)
     const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const { result, unmount } = renderHook(() => useBrowserLocalDocumentController(store))
@@ -424,7 +434,7 @@ describe('useBrowserLocalDocumentController', () => {
   it('renameDocument with whitespace-only input falls back to "untitled" and persists that, not empty', async () => {
     const named: DocumentSnapshot = { ...snap, name: 'My canvas' }
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId(C1)
     await store.save(named)
     const { result } = renderHook(() => useBrowserLocalDocumentController(store))
     await act(async () => {})
@@ -432,7 +442,7 @@ describe('useBrowserLocalDocumentController', () => {
       result.current.renameDocument('   ')
     })
     expect(result.current.snapshot?.name).toBe('untitled')
-    const loadResult = await store.load('c1')
+    const loadResult = await store.load(C1)
     expect(loadResult.kind).toBe('ok')
     if (loadResult.kind === 'ok') {
       expect(loadResult.snapshot.name).toBe('untitled')
@@ -443,7 +453,7 @@ describe('useBrowserLocalDocumentController', () => {
   it('renameDocument with empty string also falls back to "untitled"', async () => {
     const named: DocumentSnapshot = { ...snap, name: 'My canvas' }
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId(C1)
     await store.save(named)
     const { result } = renderHook(() => useBrowserLocalDocumentController(store))
     await act(async () => {})
@@ -455,7 +465,7 @@ describe('useBrowserLocalDocumentController', () => {
 
   it('renameDocument before the initial load resolves is a safe no-op', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId(C1)
     await store.save(snap)
     const { result } = renderHook(() => useBrowserLocalDocumentController(store))
     // No awaited act() yet — the async load hasn't populated snapshotRef/pendingSnapshotRef.
@@ -467,7 +477,7 @@ describe('useBrowserLocalDocumentController', () => {
     expect(result.current.persistence.kind).toBe('saved')
     // Let the load finish and confirm the store was never touched by the no-op call.
     await act(async () => {})
-    const loadResult = await store.load('c1')
+    const loadResult = await store.load(C1)
     expect(loadResult.kind).toBe('ok')
     if (loadResult.kind === 'ok') {
       expect(loadResult.snapshot.name).toBe(snap.name)
@@ -476,7 +486,7 @@ describe('useBrowserLocalDocumentController', () => {
 
   it('renameDocument after cleanup cleared the snapshot is a safe no-op', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId(C1)
     await store.save(snap)
     const { result } = renderHook(() => useBrowserLocalDocumentController(store))
     await act(async () => {})
@@ -493,7 +503,7 @@ describe('useBrowserLocalDocumentController', () => {
 
   it('renameDocument refreshes updatedAt and transitions persistence to saved', async () => {
     const store = new MemoryStore()
-    await store.setDefaultDocumentId('c1')
+    await store.setDefaultDocumentId(C1)
     await store.save(snap)
     const { result } = renderHook(() => useBrowserLocalDocumentController(store))
     await act(async () => {})
@@ -504,9 +514,54 @@ describe('useBrowserLocalDocumentController', () => {
     expect(result.current.persistence.kind).toBe('saved')
   })
 
+  // The shape change is only real if the controller MINTS the new fields.
+  // Converting the fixtures made 44 tests compile again while asserting
+  // nothing about workspace or path — both mutations below stayed green
+  // until these were written.
+  describe('the address a new document is given', () => {
+    it('stamps the local workspace on what it creates', async () => {
+      const store = new MemoryStore()
+      await store.setDefaultDocumentId(C1)
+      await store.save(snap)
+      const { result } = renderHook(() =>
+        useBrowserLocalDocumentController(store, new FakeLoroStore()),
+      )
+      await act(async () => {})
+
+      let created: DocumentSnapshot | undefined
+      await act(async () => {
+        created = await result.current.createDocument('Second')
+      })
+      expect(created?.workspaceId).toBe(LOCAL_WORKSPACE_ID)
+    })
+
+    // Two documents at one address is the failure the path exists to
+    // prevent, and a duplicate is the operation most likely to produce it.
+    it('gives a duplicate its own path, not the source’s', async () => {
+      const store = new MemoryStore()
+      await store.setDefaultDocumentId(C1)
+      await store.save(snap)
+      const loro = new FakeLoroStore()
+      await loro.save(C1, realSnapshotWithElements([{ id: 'rect-1' }]))
+      const { result } = renderHook(() => useBrowserLocalDocumentController(store, loro))
+      await act(async () => {})
+
+      let duplicated: DocumentSnapshot | undefined
+      await act(async () => {
+        duplicated = await result.current.duplicateDocument()
+      })
+
+      expect(duplicated?.path).not.toBe(snap.path)
+      const list = await store.listDocuments()
+      expect(new Set(list.map((row) => row.path)).size).toBe(list.length)
+    })
+  })
+
   describe('initialDocumentId (deep-linked canvas)', () => {
     const other: DocumentSnapshot = {
-      id: 'c2',
+      documentId: C2,
+      workspaceId: 'local',
+      path: 'other-canvas',
       name: 'other canvas',
       updatedAt: '2026-05-24T00:00:00.000Z',
       kind: 'spatial' as const,
@@ -514,27 +569,27 @@ describe('useBrowserLocalDocumentController', () => {
 
     it('loads the requested canvas instead of the store default when given', async () => {
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId(C1)
       await store.save(snap)
       await store.save(other)
-      const { result } = renderHook(() => useBrowserLocalDocumentController(store, undefined, 'c2'))
+      const { result } = renderHook(() => useBrowserLocalDocumentController(store, undefined, C2))
       await act(async () => {})
       expect(result.current.snapshot).toEqual(other)
     })
 
     it('repoints the store default to the requested canvas so a later plain load resumes there', async () => {
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId(C1)
       await store.save(snap)
       await store.save(other)
-      renderHook(() => useBrowserLocalDocumentController(store, undefined, 'c2'))
+      renderHook(() => useBrowserLocalDocumentController(store, undefined, C2))
       await act(async () => {})
-      expect(await store.getDefaultDocumentId()).toBe('c2')
+      expect(await store.getDefaultDocumentId()).toBe(C2)
     })
 
     it('falls back to the normal default-canvas flow when the requested id is not found (stale/bookmarked link)', async () => {
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId(C1)
       await store.save(snap)
       const { result } = renderHook(() =>
         useBrowserLocalDocumentController(store, undefined, 'does-not-exist'),
@@ -548,7 +603,7 @@ describe('useBrowserLocalDocumentController', () => {
 
     it('behaves exactly like today when initialDocumentId is omitted', async () => {
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId(C1)
       await store.save(snap)
       const { result } = renderHook(() => useBrowserLocalDocumentController(store))
       await act(async () => {})
@@ -564,12 +619,12 @@ describe('useBrowserLocalDocumentController', () => {
       await act(async () => {})
       const list = await result.current.listDocuments()
       expect(list).toHaveLength(1)
-      expect(list[0].id).toBe(result.current.snapshot?.id)
+      expect(list[0].documentId).toBe(result.current.snapshot?.documentId)
     })
 
     it('createDocument returns a fresh snapshot, persists metadata, writes an empty Loro doc, and does not change current snapshot', async () => {
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId(C1)
       await store.save(snap)
       const loro = new FakeLoroStore()
       const { result } = renderHook(() => useBrowserLocalDocumentController(store, loro))
@@ -582,14 +637,14 @@ describe('useBrowserLocalDocumentController', () => {
       })
 
       expect(created).toBeDefined()
-      expect(created?.id).not.toBe('c1')
+      expect(created?.documentId).not.toBe(C1)
       expect(created?.name).toBe('Second canvas')
       expect(result.current.snapshot).toEqual(currentBefore)
-      expect(await store.getDefaultDocumentId()).toBe('c1')
+      expect(await store.getDefaultDocumentId()).toBe(C1)
 
-      const persisted = await store.load(created!.id)
+      const persisted = await store.load(created!.documentId)
       expect(persisted).toEqual({ kind: 'ok', snapshot: created })
-      expect(loro.saved.some((s) => s.id === created!.id)).toBe(true)
+      expect(loro.saved.some((s) => s.id === created!.documentId)).toBe(true)
     })
 
     it('createDocument defaults the name to "untitled" when none is given', async () => {
@@ -606,7 +661,7 @@ describe('useBrowserLocalDocumentController', () => {
 
     it('createDocument rolls back the metadata row when the Loro write fails', async () => {
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId(C1)
       await store.save(snap)
       const loro = new FakeLoroStore()
       loro.shouldThrow = true
@@ -625,7 +680,7 @@ describe('useBrowserLocalDocumentController', () => {
 
       const list = await store.listDocuments()
       expect(list).toHaveLength(1)
-      expect(list[0].id).toBe('c1')
+      expect(list[0].documentId).toBe(C1)
     })
 
     it('listDocuments includes documents created via createDocument', async () => {
@@ -642,7 +697,7 @@ describe('useBrowserLocalDocumentController', () => {
 
     it('switchDocument flushes a pending edit on the current canvas, then sets the target as current and updates the default pointer', async () => {
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId(C1)
       await store.save(snap)
       const loro = new FakeLoroStore()
       const { result } = renderHook(() => useBrowserLocalDocumentController(store, loro))
@@ -658,13 +713,13 @@ describe('useBrowserLocalDocumentController', () => {
       })
 
       await act(async () => {
-        await result.current.switchDocument(created!.id)
+        await result.current.switchDocument(created!.documentId)
       })
 
-      expect(result.current.snapshot?.id).toBe(created!.id)
-      expect(await store.getDefaultDocumentId()).toBe(created!.id)
+      expect(result.current.snapshot?.documentId).toBe(created!.documentId)
+      expect(await store.getDefaultDocumentId()).toBe(created!.documentId)
 
-      const flushed = await store.load('c1')
+      const flushed = await store.load(C1)
       expect(flushed).toEqual({
         kind: 'ok',
         snapshot: { ...snap, name: 'Renamed before switch', updatedAt: expect.any(String) },
@@ -673,7 +728,7 @@ describe('useBrowserLocalDocumentController', () => {
 
     it('switchDocument to an unknown id resolves false and leaves the current canvas untouched (recoverable miss)', async () => {
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId(C1)
       await store.save(snap)
       const loro = new FakeLoroStore()
       const { result } = renderHook(() => useBrowserLocalDocumentController(store, loro))
@@ -691,12 +746,12 @@ describe('useBrowserLocalDocumentController', () => {
       expect(switched).toBe(false)
       expect(result.current.persistence.kind).toBe('saved')
       expect(result.current.snapshot).toEqual(before)
-      expect(await store.getDefaultDocumentId()).toBe('c1')
+      expect(await store.getDefaultDocumentId()).toBe(C1)
     })
 
     it('switchDocument clears a stale degraded banner from the previous canvas on a successful switch', async () => {
       const base = new MemoryStore()
-      await base.setDefaultDocumentId('c1')
+      await base.setDefaultDocumentId(C1)
       await base.save(snap)
       // 'corrupt-1' reads as an unreadable record: not-found is a
       // recoverable miss and no longer degrades, so a corrupt read is the
@@ -727,16 +782,16 @@ describe('useBrowserLocalDocumentController', () => {
       expect(result.current.persistence.kind).toBe('degraded')
 
       await act(async () => {
-        await result.current.switchDocument(created!.id)
+        await result.current.switchDocument(created!.documentId)
       })
 
       expect(result.current.persistence.kind).toBe('saved')
-      expect(result.current.snapshot?.id).toBe(created!.id)
+      expect(result.current.snapshot?.documentId).toBe(created!.documentId)
     })
 
     it('switchDocument degrades persistence instead of rejecting when load() throws', async () => {
       const base = new MemoryStore()
-      await base.setDefaultDocumentId('c1')
+      await base.setDefaultDocumentId(C1)
       await base.save(snap)
       const throwingStore: BrowserLocalStore = {
         getDefaultDocumentId: base.getDefaultDocumentId.bind(base),
@@ -761,12 +816,12 @@ describe('useBrowserLocalDocumentController', () => {
       expect(result.current.persistence.kind).toBe('degraded')
       // Current snapshot and default pointer must stay untouched by the failed switch.
       expect(result.current.snapshot).toEqual(snap)
-      expect(await throwingStore.getDefaultDocumentId()).toBe('c1')
+      expect(await throwingStore.getDefaultDocumentId()).toBe(C1)
     })
 
     it('switchDocument degrades persistence instead of rejecting when setDefaultDocumentId() throws', async () => {
       const base = new MemoryStore()
-      await base.setDefaultDocumentId('c1')
+      await base.setDefaultDocumentId(C1)
       await base.save(snap)
       const throwingStore: BrowserLocalStore = {
         getDefaultDocumentId: base.getDefaultDocumentId.bind(base),
@@ -789,17 +844,17 @@ describe('useBrowserLocalDocumentController', () => {
       })
 
       await act(async () => {
-        await result.current.switchDocument(created!.id)
+        await result.current.switchDocument(created!.documentId)
       })
 
       expect(result.current.persistence.kind).toBe('degraded')
       expect(result.current.snapshot).toEqual(snap)
-      expect(await base.getDefaultDocumentId()).toBe('c1')
+      expect(await base.getDefaultDocumentId()).toBe(C1)
     })
 
     it('switchDocument waits for an in-flight fire-and-forget rename flush before switching, and aborts the switch if that flush fails', async () => {
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId(C1)
       await store.save(snap)
       const loro = new FakeLoroStore()
       const { result } = renderHook(() => useBrowserLocalDocumentController(store, loro))
@@ -836,7 +891,7 @@ describe('useBrowserLocalDocumentController', () => {
       expect(firstSaveStarted).toBe(true)
 
       let switchSettled = false
-      const switchPromise = result.current.switchDocument(created!.id).then(() => {
+      const switchPromise = result.current.switchDocument(created!.documentId).then(() => {
         switchSettled = true
       })
 
@@ -847,7 +902,7 @@ describe('useBrowserLocalDocumentController', () => {
         await Promise.resolve()
       })
       expect(switchSettled).toBe(false)
-      expect(await store.getDefaultDocumentId()).toBe('c1')
+      expect(await store.getDefaultDocumentId()).toBe(C1)
 
       await act(async () => {
         rejectFirstSave(new Error('save failed'))
@@ -858,8 +913,8 @@ describe('useBrowserLocalDocumentController', () => {
       expect(result.current.persistence.kind).toBe('degraded')
       // The failed flush must abort the switch: default pointer stays on the
       // original canvas instead of silently losing the rename.
-      expect(await store.getDefaultDocumentId()).toBe('c1')
-      expect(result.current.snapshot?.id).toBe('c1')
+      expect(await store.getDefaultDocumentId()).toBe(C1)
+      expect(result.current.snapshot?.documentId).toBe(C1)
     })
 
     it('two concurrent flush waiters both observe the second save that starts once the first settles', async () => {
@@ -869,7 +924,7 @@ describe('useBrowserLocalDocumentController', () => {
       // and kick off a second save while the other observed an already-null
       // pendingSnapshotRef and returned true before the second save settled.
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId(C1)
       await store.save(snap)
       const loro = new FakeLoroStore()
       const { result } = renderHook(() => useBrowserLocalDocumentController(store, loro))
@@ -919,7 +974,7 @@ describe('useBrowserLocalDocumentController', () => {
 
       // A concurrent switchDocument call is a third waiter on the same save #1.
       let switchSettled = false
-      const switchPromise = result.current.switchDocument(created!.id).then(() => {
+      const switchPromise = result.current.switchDocument(created!.documentId).then(() => {
         switchSettled = true
       })
 
@@ -933,7 +988,7 @@ describe('useBrowserLocalDocumentController', () => {
       expect(saveCallCount).toBe(2)
       // switchDocument must still be waiting — save #2 has not settled yet.
       expect(switchSettled).toBe(false)
-      expect(await store.getDefaultDocumentId()).toBe('c1')
+      expect(await store.getDefaultDocumentId()).toBe(C1)
 
       // Now let save #2 settle and confirm switchDocument only proceeds after it does.
       await act(async () => {
@@ -942,9 +997,9 @@ describe('useBrowserLocalDocumentController', () => {
       })
       expect(switchSettled).toBe(true)
       expect(result.current.persistence.kind).toBe('saved')
-      expect(result.current.snapshot?.id).toBe(created!.id)
-      expect(await store.getDefaultDocumentId()).toBe(created!.id)
-      const flushed = await store.load('c1')
+      expect(result.current.snapshot?.documentId).toBe(created!.documentId)
+      expect(await store.getDefaultDocumentId()).toBe(created!.documentId)
+      const flushed = await store.load(C1)
       expect(flushed).toEqual({
         kind: 'ok',
         snapshot: { ...snap, name: 'Second rename', updatedAt: expect.any(String) },
@@ -955,10 +1010,10 @@ describe('useBrowserLocalDocumentController', () => {
   describe('duplicateDocument', () => {
     it('creates a new canvas named "<name> (copy)", copies the Loro bytes, and switches to it', async () => {
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId(C1)
       await store.save(snap)
       const loro = new FakeLoroStore()
-      await loro.save('c1', realSnapshotWithElements([{ id: 'rect-1' }]))
+      await loro.save(C1, realSnapshotWithElements([{ id: 'rect-1' }]))
       const { result } = renderHook(() => useBrowserLocalDocumentController(store, loro))
       await act(async () => {})
 
@@ -968,12 +1023,12 @@ describe('useBrowserLocalDocumentController', () => {
       })
 
       expect(duplicated?.name).toBe('untitled (copy)')
-      expect(duplicated?.id).not.toBe('c1')
+      expect(duplicated?.documentId).not.toBe(C1)
       // switched to the duplicate
-      expect(result.current.snapshot?.id).toBe(duplicated?.id)
-      expect(await store.getDefaultDocumentId()).toBe(duplicated?.id)
+      expect(result.current.snapshot?.documentId).toBe(duplicated?.documentId)
+      expect(await store.getDefaultDocumentId()).toBe(duplicated?.documentId)
 
-      const copiedLoro = await loro.load(duplicated!.id)
+      const copiedLoro = await loro.load(duplicated!.documentId)
       expect(copiedLoro.kind).toBe('ok')
       if (copiedLoro.kind === 'ok') {
         const doc = new Loro()
@@ -984,16 +1039,18 @@ describe('useBrowserLocalDocumentController', () => {
 
     it('increments the numeric suffix when "(copy)" is already taken', async () => {
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId(C1)
       await store.save(snap)
       await store.save({
-        id: 'existing-copy',
+        documentId: '01ARZ3NDEKTSV4RRFFQ69G5FD2',
+        workspaceId: 'local',
+        path: 'untitled-2',
         name: 'untitled (copy)',
         updatedAt: snap.updatedAt,
         kind: 'spatial' as const,
       })
       const loro = new FakeLoroStore()
-      await loro.save('c1', realSnapshotWithElements([]))
+      await loro.save(C1, realSnapshotWithElements([]))
       const { result } = renderHook(() => useBrowserLocalDocumentController(store, loro))
       await act(async () => {})
 
@@ -1007,10 +1064,10 @@ describe('useBrowserLocalDocumentController', () => {
 
     it('flushes a pending rename before duplicating, so the copy is named from the latest title', async () => {
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId(C1)
       await store.save(snap)
       const loro = new FakeLoroStore()
-      await loro.save('c1', realSnapshotWithElements([]))
+      await loro.save(C1, realSnapshotWithElements([]))
       const { result } = renderHook(() => useBrowserLocalDocumentController(store, loro))
       await act(async () => {})
 
@@ -1028,10 +1085,10 @@ describe('useBrowserLocalDocumentController', () => {
 
     it('rolls back the metadata row when the Loro write fails', async () => {
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId(C1)
       await store.save(snap)
       const loro = new FakeLoroStore()
-      await loro.save('c1', realSnapshotWithElements([]))
+      await loro.save(C1, realSnapshotWithElements([]))
       const { result } = renderHook(() => useBrowserLocalDocumentController(store, loro))
       await act(async () => {})
 
@@ -1048,17 +1105,17 @@ describe('useBrowserLocalDocumentController', () => {
 
       const list = await store.listDocuments()
       expect(list).toHaveLength(1)
-      expect(list[0].id).toBe('c1')
+      expect(list[0].documentId).toBe(C1)
       // Never switched away from the source canvas on failure.
-      expect(result.current.snapshot?.id).toBe('c1')
+      expect(result.current.snapshot?.documentId).toBe(C1)
     })
 
     it('duplicating twice never mutates the original: editing the source after duplicating leaves the copy unchanged', async () => {
       const store = new MemoryStore()
-      await store.setDefaultDocumentId('c1')
+      await store.setDefaultDocumentId(C1)
       await store.save(snap)
       const loro = new FakeLoroStore()
-      await loro.save('c1', realSnapshotWithElements([{ id: 'original-element' }]))
+      await loro.save(C1, realSnapshotWithElements([{ id: 'original-element' }]))
       const { result } = renderHook(() => useBrowserLocalDocumentController(store, loro))
       await act(async () => {})
 
@@ -1070,14 +1127,14 @@ describe('useBrowserLocalDocumentController', () => {
       // Edit the ORIGINAL's stored Loro bytes directly (simulating further
       // edits to the source canvas after duplicating) and confirm the
       // duplicate's already-copied bytes are untouched.
-      const loadedOriginal = await loro.load('c1')
+      const loadedOriginal = await loro.load(C1)
       if (loadedOriginal.kind !== 'ok') throw new Error('unexpected load failure')
       const originalDoc = new Loro()
       originalDoc.import(loadedOriginal.snapshot)
       originalDoc.getList('elements').push({ id: 'added-after-duplicate' })
-      await loro.save('c1', originalDoc.export({ mode: 'snapshot' }))
+      await loro.save(C1, originalDoc.export({ mode: 'snapshot' }))
 
-      const copiedLoro = await loro.load(duplicated!.id)
+      const copiedLoro = await loro.load(duplicated!.documentId)
       expect(copiedLoro.kind).toBe('ok')
       if (copiedLoro.kind === 'ok') {
         const doc = new Loro()

--- a/apps/web/src/pages/use-browser-local-document-controller.test.ts
+++ b/apps/web/src/pages/use-browser-local-document-controller.test.ts
@@ -615,6 +615,35 @@ describe('useBrowserLocalDocumentController', () => {
       expect(result.current.persistence.kind).toBe('saved')
     })
 
+    it('falls back to the default document when the list read itself fails', async () => {
+      // The deep link is resolved by listing, so a store that cannot list is
+      // indistinguishable from a path that is not there — and the fallback is
+      // the same. This is the reachable version of the create path's own
+      // tolerance: App only mounts this page WITH a path, so a throw here
+      // would dead-end every deep link on a degraded store, even though the
+      // default pointer below could still answer.
+      const base = new MemoryStore()
+      await base.setDefaultDocumentId(C1)
+      await base.save(snap)
+      const store: BrowserLocalStore = {
+        ...base,
+        getDefaultDocumentId: base.getDefaultDocumentId.bind(base),
+        setDefaultDocumentId: base.setDefaultDocumentId.bind(base),
+        load: base.load.bind(base),
+        save: base.save.bind(base),
+        del: base.del.bind(base),
+        removeDocument: base.removeDocument.bind(base),
+        generateId: base.generateId.bind(base),
+        listDocuments: () => Promise.reject(new Error('idb blocked')),
+      }
+      const { result } = renderHook(() =>
+        useBrowserLocalDocumentController(store, undefined, 'other-canvas'),
+      )
+      await act(async () => {})
+      expect(result.current.snapshot).toEqual(snap)
+      expect(result.current.persistence.kind).toBe('saved')
+    })
+
     it('behaves exactly like today when initialPath is omitted', async () => {
       const store = new MemoryStore()
       await store.setDefaultDocumentId(C1)

--- a/apps/web/src/pages/use-browser-local-document-controller.ts
+++ b/apps/web/src/pages/use-browser-local-document-controller.ts
@@ -167,7 +167,11 @@ export function useBrowserLocalDocumentController(
 
     async function load() {
       if (initialPath !== undefined) {
-        const listed = await storeRef.current.listDocuments()
+        // A store that cannot list is indistinguishable from a path that is
+        // not there, and both fall through to the same place. Letting the read
+        // throw instead would dead-end EVERY deep link on a degraded store —
+        // and App mounts this page only with a path, so that is every mount.
+        const listed = await storeRef.current.listDocuments().catch(() => [])
         if (cancelled) return
         const requestedId = listed.find((entry) => entry.path === initialPath)?.documentId
         if (requestedId !== undefined) {

--- a/apps/web/src/pages/use-browser-local-document-controller.ts
+++ b/apps/web/src/pages/use-browser-local-document-controller.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { mergeToSnapshot } from '../components/migration/import-browser-local.js'
+import { newDocumentPathIn } from '../components/workspace-files/new-document-path.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
+import { LOCAL_WORKSPACE_ID } from '../lib/browser-local-store.js'
 import { deriveCopyName } from '../lib/derive-copy-name.js'
 import type { LoroLoadResult } from '../lib/loro-store.js'
 import { LoroStore } from '../lib/loro-store.js'
@@ -53,11 +55,19 @@ export interface BrowserLocalDocumentController {
 }
 
 function createCanvasSnapshot(
-  id: string,
+  documentId: string,
+  path: string,
   name?: string,
   kind: DocumentSnapshot['kind'] = 'spatial',
 ): DocumentSnapshot {
-  return { id, name: name?.trim() || 'untitled', updatedAt: new Date().toISOString(), kind }
+  return {
+    documentId,
+    workspaceId: LOCAL_WORKSPACE_ID,
+    path,
+    name: name?.trim() || 'untitled',
+    updatedAt: new Date().toISOString(),
+    kind,
+  }
 }
 
 export function useBrowserLocalDocumentController(
@@ -172,7 +182,7 @@ export function useBrowserLocalDocumentController(
 
       if (id === null) {
         id = storeRef.current.generateId()
-        const newSnapshot = createCanvasSnapshot(id)
+        const newSnapshot = createCanvasSnapshot(id, newDocumentPathIn('', []))
         await storeRef.current.setDefaultDocumentId(id)
         await storeRef.current.save(newSnapshot)
         if (!cancelled) setSnapshot(newSnapshot)
@@ -270,7 +280,7 @@ export function useBrowserLocalDocumentController(
   const startFresh = useCallback(async () => {
     setCleanupError(null)
     const id = storeRef.current.generateId()
-    const fresh = createCanvasSnapshot(id)
+    const fresh = createCanvasSnapshot(id, newDocumentPathIn('', []))
     try {
       // Save the new canvas BEFORE repointing the default id, so a failed write never
       // leaves the pointer aimed at an unsaved canvas (which would reload as degraded).
@@ -321,7 +331,16 @@ export function useBrowserLocalDocumentController(
       kind: DocumentSnapshot['kind'] = 'spatial',
     ): Promise<DocumentSnapshot> => {
       const id = storeRef.current.generateId()
-      const fresh = createCanvasSnapshot(id, name, kind)
+      const existing = await storeRef.current.listDocuments()
+      const fresh = createCanvasSnapshot(
+        id,
+        newDocumentPathIn(
+          '',
+          existing.map((row) => row.path),
+        ),
+        name,
+        kind,
+      )
       // Metadata first, then the Loro doc: if the Loro write fails, the
       // metadata row is rolled back so a failed create never leaves an
       // orphan metadata row with no backing Loro doc.
@@ -409,7 +428,7 @@ export function useBrowserLocalDocumentController(
     const source = snapshotRef.current
     if (source === null) throw new Error('No canvas is open to duplicate.')
 
-    const loroResult = await loroRef.current.load(source.id)
+    const loroResult = await loroRef.current.load(source.documentId)
     if (loroResult.kind !== 'ok') {
       throw new Error('The canvas data could not be read for duplication.')
     }
@@ -420,7 +439,14 @@ export function useBrowserLocalDocumentController(
     const newName = deriveCopyName(source.name, existingNames)
 
     const id = storeRef.current.generateId()
-    const fresh = createCanvasSnapshot(id, newName)
+    const fresh = createCanvasSnapshot(
+      id,
+      newDocumentPathIn(
+        '',
+        existingList.map((row) => row.path),
+      ),
+      newName,
+    )
     await storeRef.current.save(fresh)
     try {
       await loroRef.current.save(id, mergedSnapshot)

--- a/apps/web/src/pages/use-browser-local-document-controller.ts
+++ b/apps/web/src/pages/use-browser-local-document-controller.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { mergeToSnapshot } from '../components/migration/import-browser-local.js'
-import { newDocumentPathIn } from '../components/workspace-files/new-document-path.js'
+import { newDocumentPathIn, takenPathsIn } from '../components/workspace-files/new-document-path.js'
 import type { BrowserLocalStore } from '../lib/browser-local-store.js'
 import { LOCAL_WORKSPACE_ID } from '../lib/browser-local-store.js'
 import { deriveCopyName } from '../lib/derive-copy-name.js'
@@ -73,13 +73,15 @@ function createCanvasSnapshot(
 export function useBrowserLocalDocumentController(
   store: BrowserLocalStore,
   loro: LoroStoreLike = new LoroStore(),
-  // A canvas id requested by the URL (e.g. a bookmarked /local/:documentId
-  // deep link), read once at mount. Takes priority over the store's own
+  // A document PATH requested by the URL (e.g. a bookmarked /local/:path
+  // deep link), read once at mount. The URL addresses a document the way the
+  // daemon does — by workspace-relative path, not by id — so this resolves
+  // through the list before loading. Takes priority over the store's own
   // "default canvas" pointer, which it also repoints on success so a later
   // plain (no deep link) load resumes here — the same contract switchDocument
-  // already has. A stale/deleted id falls back to the normal flow rather
+  // already has. A stale/moved path falls back to the normal flow rather
   // than showing an error: a dead bookmark must not dead-end the user.
-  initialDocumentId?: string,
+  initialPath?: string,
 ): BrowserLocalDocumentController {
   const [snapshot, setSnapshot] = useState<DocumentSnapshot | null>(null)
   const [persistence, setPersistence] = useState<BrowserLocalPersistenceState>({
@@ -164,13 +166,18 @@ export function useBrowserLocalDocumentController(
     let cancelled = false
 
     async function load() {
-      if (initialDocumentId !== undefined) {
-        const requested = await storeRef.current.load(initialDocumentId)
+      if (initialPath !== undefined) {
+        const listed = await storeRef.current.listDocuments()
         if (cancelled) return
-        if (requested.kind === 'ok') {
-          await storeRef.current.setDefaultDocumentId(initialDocumentId)
-          if (!cancelled) setSnapshot(requested.snapshot)
-          return
+        const requestedId = listed.find((entry) => entry.path === initialPath)?.documentId
+        if (requestedId !== undefined) {
+          const requested = await storeRef.current.load(requestedId)
+          if (cancelled) return
+          if (requested.kind === 'ok') {
+            await storeRef.current.setDefaultDocumentId(requestedId)
+            if (!cancelled) setSnapshot(requested.snapshot)
+            return
+          }
         }
         // Not found / corrupted: silently fall through to the normal
         // default-canvas flow below rather than showing a degraded banner —
@@ -182,7 +189,9 @@ export function useBrowserLocalDocumentController(
 
       if (id === null) {
         id = storeRef.current.generateId()
-        const newSnapshot = createCanvasSnapshot(id, newDocumentPathIn('', []))
+        const taken = await takenPathsIn(storeRef.current)
+        if (cancelled) return
+        const newSnapshot = createCanvasSnapshot(id, newDocumentPathIn('', taken))
         await storeRef.current.setDefaultDocumentId(id)
         await storeRef.current.save(newSnapshot)
         if (!cancelled) setSnapshot(newSnapshot)
@@ -280,7 +289,8 @@ export function useBrowserLocalDocumentController(
   const startFresh = useCallback(async () => {
     setCleanupError(null)
     const id = storeRef.current.generateId()
-    const fresh = createCanvasSnapshot(id, newDocumentPathIn('', []))
+    const taken = (await storeRef.current.listDocuments()).map((row) => row.path)
+    const fresh = createCanvasSnapshot(id, newDocumentPathIn('', taken))
     try {
       // Save the new canvas BEFORE repointing the default id, so a failed write never
       // leaves the pointer aimed at an unsaved canvas (which would reload as degraded).


### PR DESCRIPTION
Brings the browser-local side onto the daemon's addressing model: a document is named by **workspace + path**, and its **id** is what a `[[reference]]` carries. Local data has no backward-compatibility obligation (0.0.x, no users), so pre-path databases are discarded rather than migrated.

## What changed

- **Ids**: both local stores mint a `documentId` the rest of the system accepts (`documentIdSchema`), so a local document can be named in a `DocRef`. `crypto.randomUUID()` no longer parses.
- **Shape**: `DocumentSnapshot` carries `documentId` / `workspaceId` / `path` / `name`, matching the daemon row. The name is stored, never derived from the path and never derived into one (ADR-0007/0008).
- **Routes**: `/local/:documentId` → `/local/:path`, segments percent-encoded. `initialDocumentId` → `initialPath` through `App` → page → controller; the controller resolves the path through the list before loading.
- **`toPathSegment` is deleted.** The import flow carries the source document's real path instead of slugifying its display name.

## Two defects the change surfaced, fixed at the cause

Making a path an *address* rather than a label made both of these observable:

1. **Neither store enforced path uniqueness.** Two documents could hold one address, and `find(entry => entry.path === …)` answered with whichever row came first. `save` now refuses a path another document holds, in `MemoryStore` and `IndexedDBStore` alike — the IndexedDB check shares the write transaction, so nothing slips between check and put. Red-first: 2 failed → 31 passed.
2. **`BrowserLocalIndexPage.handleCreate` numbered against a stale closure.** The callback is memoized on `[store, onOpenDocument]`, so the `snapshots` it captured was `null` on the first create after a load — numbering from nothing and landing on a path the store already held. It now reads the live store through `takenPathsIn`, which falls back to `[]` so a broken list read still cannot dead-end the create button. Mutation-checked: reverting it turns `BrowserLocalIndexPage.flow.browser.test.tsx` red.

The canvas → URL effect now reads the loaded snapshot's own `path` rather than looking the id up in the list. Depending on the list made it re-fire on every refresh, which overwrote a Back the user had just performed.

## Discarding pre-path local data

A v2..v7 row carries no workspace and no path. `load` reports `corrupted` and `listDocuments` skips it — the editor's existing safe fallback, no new code. The migration tests now pin exactly that, and still prove the row itself moves, by reading the raw record instead of going through the parse boundary.

## Tests

Fixtures were converted so that a document's **path is never its id** — otherwise a test cannot tell which of the two a call site used, which is how a conversion passes while asserting nothing. Two tests changed subject rather than being mechanically updated:

- `BrowserLocalIndexPage`'s "a browser-local canvas has no path to put under it" became its opposite — each non-Latin name shows over its own real path — and is mutation-checked against the `secondary` projection.
- `import-browser-local`'s 409 test moved from same-**name** collisions (impossible now: a local path is unique in its own store) to the destination workspace already owning the path.

`web-jsdom` 2575 passed · `web-browser` 657 passed · `mcp-node`/`model-node`/`arch-lint-node`/`codec-node` 3891 passed · `pnpm -r typecheck`, `pnpm lint`, `pnpm knip` clean.

## Visual repro

Verified in a real Chromium against the dev server: create → Back → create → deep link → stale link.

Two documents, distinct paths — the markdown note shows `untitled-2` under its name because the name and path differ, and the spatial one shows none because they agree:

![03-list-two-documents.png](https://github.com/user-attachments/assets/79bb3745-818a-4e5f-875b-9691c0361ab0)

A cold load of the bookmarked `/local/untitled-2` opens the right document with its typed body:

![04-cold-deep-link.png](https://github.com/user-attachments/assets/f16c4bde-1d6d-442c-83c8-b0572493cae1)

A nonexistent path (`/local/no/such/document`) falls back to the default document and repairs the URL rather than dead-ending.

## Filed, not fixed here

Back straight after the *first* create shows an empty list until a reload. Measured identically on `origin/main`, so it is pre-existing and out of this diff's scope; the raw IndexedDB row is present and a reload shows the card. Tracked as a whiteboard issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ua6RPuoEAD4ZTBqyhNC56Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser-local documents now use workspace-relative paths for URLs and navigation.
  * Nested document paths are supported, including encoded characters and separators.
  * Document lists display paths and generate unique paths for new and duplicated documents.
  * Importing documents preserves their paths and automatically adds a suffix when a path is already taken.

* **Bug Fixes**
  * Improved routing fallback and stale-link recovery for missing or invalid document paths.
  * Prevented duplicate document paths across local storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->