### PR TITLE
feat(web)!: discard pre-path browser-local documents at DB_VERSION 8

### DIFF
--- a/apps/web/src/lib/browser-idb-migration.browser.test.tsx
+++ b/apps/web/src/lib/browser-idb-migration.browser.test.tsx
@@ -22,11 +22,6 @@ async function clearDb(): Promise<void> {
     const req = indexedDB.deleteDatabase('whiteboard')
     req.onsuccess = () => resolve()
     req.onerror = () => resolve()
-    // A delete waits on every open connection. Resolving here rather than
-    // hanging keeps one test's leftover connection from spending the NEXT
-    // test's budget, which reads as a failure in a test that did nothing
-    // wrong.
-    req.onblocked = () => resolve()
   })
 }
 
@@ -273,15 +268,14 @@ describe('whiteboard IndexedDB v6 -> v7 upgrade (renames the container stores)',
     await seedV6Fixture(documentId, doc.export({ mode: 'snapshot' }))
 
     const db = await openWhiteboardDb()
+    // Read before asserting, and assert after: a failed expect() between the
+    // open and the close would leak the connection, and every later test in
+    // this file would then meet a database clearDb cannot delete.
+    const storeNames = [...db.objectStoreNames].sort()
     // The old names are DELETED, not merely abandoned. A store left in place
     // would keep a second copy of every document readable by anything that
     // still remembers the old name.
-    expect([...db.objectStoreNames].sort()).toEqual([
-      'documentFiles',
-      'documents',
-      'loroDocuments',
-      'meta',
-    ])
+    expect(storeNames).toEqual(['documentFiles', 'documents', 'loroDocuments', 'meta'])
 
     const fileCount = await new Promise<number>((resolve, reject) => {
       const tx = db.transaction('documentFiles', 'readonly')
@@ -547,7 +541,13 @@ describe('whiteboard IndexedDB v2 -> v3 upgrade', () => {
           db.close()
           resolve()
         }
-        tx.onerror = () => reject(tx.error)
+        tx.onerror = () => {
+          // Closed on the failure path too: a seeder that leaks a connection at
+          // an old version blocks the very upgrade the next test is there to
+          // exercise, and the error surfaces in that test rather than this one.
+          db.close()
+          reject(tx.error)
+        }
       }
       req.onerror = () => reject(req.error)
     })

--- a/apps/web/src/lib/browser-idb-migration.browser.test.tsx
+++ b/apps/web/src/lib/browser-idb-migration.browser.test.tsx
@@ -22,6 +22,11 @@ async function clearDb(): Promise<void> {
     const req = indexedDB.deleteDatabase('whiteboard')
     req.onsuccess = () => resolve()
     req.onerror = () => resolve()
+    // A delete waits on every open connection. Resolving here rather than
+    // hanging keeps one test's leftover connection from spending the NEXT
+    // test's budget, which reads as a failure in a test that did nothing
+    // wrong.
+    req.onblocked = () => resolve()
   })
 }
 
@@ -763,5 +768,45 @@ describe('cross-tab upgrades', () => {
     // turning one failed test into a hung file.
     idle.close()
     expect({ upgraded, blocked }).toEqual({ upgraded: true, blocked: false })
+  })
+
+  it('rejects with a message a caller can show when a connection that will NOT self-close holds the old version', async () => {
+    // The other half, and the one the self-close cannot cover: a tab still
+    // running a pre-v8 bundle has no `onversionchange` handler, so it sits on
+    // the old version until a person closes it. Without this branch the open
+    // request never settles, and every caller — the store, the Loro store, the
+    // file store — awaits a promise that has no outcome, which in the app is an
+    // editor that never loads with nothing on screen to explain why.
+    const stubborn = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open('whiteboard', DB_VERSION - 1)
+      req.onsuccess = () => resolve(req.result)
+      req.onerror = () => reject(req.error)
+    })
+
+    try {
+      // Raced against a short deadline on purpose. Without the branch the open
+      // request never settles at all, and an unbounded await would spend the
+      // whole per-test timeout (measured: 120s) reporting the same thing this
+      // says in three.
+      const outcome = await Promise.race([
+        openWhiteboardDb().then(
+          (db) => {
+            db.close()
+            return 'resolved'
+          },
+          (err: unknown) => (err instanceof Error ? err.message : String(err)),
+        ),
+        new Promise<string>((r) => setTimeout(() => r('never settled'), 3000)),
+      ])
+      expect(outcome).toMatch(/another tab/i)
+    } finally {
+      stubborn.close()
+      // The rejected request is still live and will upgrade the database the
+      // moment `stubborn` lets go. Draining it here, inside the test that
+      // created it, is what keeps the next test's seed from meeting a
+      // database at a version it did not put there.
+      await new Promise((r) => setTimeout(r, 300))
+      await clearDb()
+    }
   })
 })

--- a/apps/web/src/lib/browser-idb-migration.browser.test.tsx
+++ b/apps/web/src/lib/browser-idb-migration.browser.test.tsx
@@ -287,38 +287,35 @@ describe('whiteboard IndexedDB v6 -> v7 upgrade (renames the container stores)',
     })
     expect(fileCount).toBe(1)
 
-    // Read back through the PRODUCTION stores, which only know the new names:
-    // a copy that lost its key or its value would fail here even though the
-    // store-name assertion above passed.
-    const loroResult = await new LoroStore().load(documentId)
-    expect(loroResult.kind).toBe('ok')
-    if (loroResult.kind === 'ok') {
-      const restored = new Loro()
-      restored.import(loroResult.snapshot)
-      expect(restored.getList('elements').toArray()).toEqual([{ id: 'canonical-el' }])
-    }
+    // documentFiles is where the copy's record-carrying half is still
+    // observable: uploads are not addressed by workspace+path, so v8 leaves
+    // them alone. A copy that lost its key or its value fails the count above
+    // even though the store-name assertion passed.
 
     const metaStore = new IndexedDBStore()
-    // The row moves intact, but it is no longer READABLE: a document is now
-    // addressed by workspace + path, and a pre-path row carries neither. There
-    // is deliberately no migration inventing them — a local document is
-    // discardable (0.0.x, no users), and `load` reporting `corrupted` routes
-    // the editor to its existing safe fallback instead of guessing an address.
-    expect(await readRawDocumentsRow(documentId)).toMatchObject({
-      id: documentId,
-      name: 'Pre-v7 document',
-    })
-    expect((await metaStore.load(documentId)).kind).toBe('corrupted')
+    // The row does not survive: v8 DISCARDS a document with no workspace and
+    // no path, because there is nothing to migrate it to without inventing an
+    // address, and an invented one is indistinguishable from a chosen one.
+    // Everything a pre-path fixture holds therefore ends here — this migration
+    // path converges on an empty document store, by decision, not by accident.
+    expect(await readRawDocumentsRow(documentId)).toBeUndefined()
+    expect((await metaStore.load(documentId)).kind).toBe('not-found')
+    expect(await metaStore.listDocuments()).toEqual([])
+    // The bytes go with it rather than lingering as storage nothing names.
+    expect((await new LoroStore().load(documentId)).kind).toBe('not-found')
   })
 
-  it('carries the default pointer across the meta key rename', async () => {
+  it('renames the meta pointer key, then clears it because v8 discarded its target', async () => {
     const documentId = 'document-migrate-v7-pointer'
     await seedV6Fixture(documentId, new Loro().export({ mode: 'snapshot' }))
 
-    expect(await new IndexedDBStore().getDefaultDocumentId()).toBe(documentId)
-    // The old key is removed rather than duplicated — two pointers could
-    // disagree, and nothing would say which one won.
-    expect(await metaKeys()).toEqual(['defaultDocumentId'])
+    // Both halves matter and only the second is new: v7 moves the pointer to
+    // its new key (leaving the old one behind would let two pointers disagree
+    // with nothing to say which won), and v8 then clears it because the
+    // document it named is gone — a pointer at a discarded document would
+    // resume the editor into nothing.
+    expect(await metaKeys()).toEqual([])
+    expect(await new IndexedDBStore().getDefaultDocumentId()).toBeNull()
   })
 
   it('is a no-op for a fresh install, which never had the old stores', async () => {
@@ -372,22 +369,18 @@ describe('IndexedDB v5 -> v6 (removes reconnectKeypairs)', () => {
     })
     expect(fileCount).toBe(1)
 
-    const loroStore = new LoroStore()
-    const loroResult = await loroStore.load(documentId)
-    expect(loroResult.kind).toBe('ok')
+    // Discarded with its document — see the note below.
+    expect((await new LoroStore().load(documentId)).kind).toBe('not-found')
 
     const metaStore = new IndexedDBStore()
-    expect(await metaStore.getDefaultDocumentId()).toBe(documentId)
-    // The row moves intact, but it is no longer READABLE: a document is now
-    // addressed by workspace + path, and a pre-path row carries neither. There
-    // is deliberately no migration inventing them — a local document is
-    // discardable (0.0.x, no users), and `load` reporting `corrupted` routes
-    // the editor to its existing safe fallback instead of guessing an address.
-    expect(await readRawDocumentsRow(documentId)).toMatchObject({
-      id: documentId,
-      name: 'Pre-v6 canvas',
-    })
-    expect((await metaStore.load(documentId)).kind).toBe('corrupted')
+    // The row does not survive: v8 DISCARDS a document with no workspace and
+    // no path, because there is nothing to migrate it to without inventing an
+    // address, and an invented one is indistinguishable from a chosen one.
+    // Everything a pre-path fixture holds therefore ends here — this migration
+    // path converges on an empty document store, by decision, not by accident.
+    expect(await readRawDocumentsRow(documentId)).toBeUndefined()
+    expect((await metaStore.load(documentId)).kind).toBe('not-found')
+    expect(await metaStore.listDocuments()).toEqual([])
 
     // purgeLegacyReconnectCredentials() is exercised directly here (rather
     // than via a full App/router boot harness) — it is called unconditionally
@@ -445,22 +438,18 @@ describe('IndexedDB v4 -> v5', () => {
     })
     expect(fileCount).toBe(1)
 
-    const loroStore = new LoroStore()
-    const loroResult = await loroStore.load(documentId)
-    expect(loroResult.kind).toBe('ok')
+    // Discarded with its document — see the note below.
+    expect((await new LoroStore().load(documentId)).kind).toBe('not-found')
 
     const metaStore = new IndexedDBStore()
-    expect(await metaStore.getDefaultDocumentId()).toBe(documentId)
-    // The row moves intact, but it is no longer READABLE: a document is now
-    // addressed by workspace + path, and a pre-path row carries neither. There
-    // is deliberately no migration inventing them — a local document is
-    // discardable (0.0.x, no users), and `load` reporting `corrupted` routes
-    // the editor to its existing safe fallback instead of guessing an address.
-    expect(await readRawDocumentsRow(documentId)).toMatchObject({
-      id: documentId,
-      name: 'Pre-v5 canvas',
-    })
-    expect((await metaStore.load(documentId)).kind).toBe('corrupted')
+    // The row does not survive: v8 DISCARDS a document with no workspace and
+    // no path, because there is nothing to migrate it to without inventing an
+    // address, and an invented one is indistinguishable from a chosen one.
+    // Everything a pre-path fixture holds therefore ends here — this migration
+    // path converges on an empty document store, by decision, not by accident.
+    expect(await readRawDocumentsRow(documentId)).toBeUndefined()
+    expect((await metaStore.load(documentId)).kind).toBe('not-found')
+    expect(await metaStore.listDocuments()).toEqual([])
   })
 })
 
@@ -483,22 +472,18 @@ describe('whiteboard IndexedDB v3 -> v4 upgrade', () => {
     expect(db.objectStoreNames.contains('documentFiles')).toBe(true)
     db.close()
 
-    const loroStore = new LoroStore()
-    const loroResult = await loroStore.load(documentId)
-    expect(loroResult.kind).toBe('ok')
+    // Discarded with its document — see the note below.
+    expect((await new LoroStore().load(documentId)).kind).toBe('not-found')
 
     const metaStore = new IndexedDBStore()
-    expect(await metaStore.getDefaultDocumentId()).toBe(documentId)
-    // The row moves intact, but it is no longer READABLE: a document is now
-    // addressed by workspace + path, and a pre-path row carries neither. There
-    // is deliberately no migration inventing them — a local document is
-    // discardable (0.0.x, no users), and `load` reporting `corrupted` routes
-    // the editor to its existing safe fallback instead of guessing an address.
-    expect(await readRawDocumentsRow(documentId)).toMatchObject({
-      id: documentId,
-      name: 'Pre-v4 canvas',
-    })
-    expect((await metaStore.load(documentId)).kind).toBe('corrupted')
+    // The row does not survive: v8 DISCARDS a document with no workspace and
+    // no path, because there is nothing to migrate it to without inventing an
+    // address, and an invented one is indistinguishable from a chosen one.
+    // Everything a pre-path fixture holds therefore ends here — this migration
+    // path converges on an empty document store, by decision, not by accident.
+    expect(await readRawDocumentsRow(documentId)).toBeUndefined()
+    expect((await metaStore.load(documentId)).kind).toBe('not-found')
+    expect(await metaStore.listDocuments()).toEqual([])
   })
 })
 
@@ -510,52 +495,30 @@ describe('whiteboard IndexedDB v2 -> v3 upgrade', () => {
     expect(DB_VERSION).toBeGreaterThanOrEqual(3)
   })
 
-  it('opens a seeded v2 fixture at the current version without VersionError, strips scene, and keeps loroCanvases canonical', async () => {
+  it('opens a seeded v2 fixture at the current version without VersionError, and keeps nothing it cannot address', async () => {
     const documentId = 'canvas-migrate-1'
     const doc = new Loro()
     doc.getList('elements').push({ id: 'canonical-el' })
-    const loroSnapshot = doc.export({ mode: 'snapshot' })
-    await seedV2Fixture(documentId, loroSnapshot)
+    await seedV2Fixture(documentId, doc.export({ mode: 'snapshot' }))
 
-    // (a) Open through the shared opener at the current DB_VERSION — must not VersionError.
+    // (a) The oldest shape still opens through the shared opener at the
+    // current DB_VERSION. This half is the durable one: every version bump
+    // since has had to keep it true, and a VersionError here is a bricked app
+    // for anyone who has not opened the tab in a while.
     const db = await openWhiteboardDb()
     db.close()
 
-    // (b) The loroCanvases record survives and its elements are canonical after load.
-    const loroStore = new LoroStore()
-    const loroResult = await loroStore.load(documentId)
-    expect(loroResult.kind).toBe('ok')
-    if (loroResult.kind === 'ok') {
-      const restored = new Loro()
-      restored.import(loroResult.snapshot)
-      expect(restored.getList('elements').toArray()).toEqual([{ id: 'canonical-el' }])
-    }
-
-    // (c) The 'documents' row has no scene / no old-schema orphan remains.
-    // Checked against the RAW stored row (not the parsed load() result): Zod's
-    // z.object() silently strips unrecognized keys from its parsed OUTPUT even
-    // when the underlying row still carries them, so asserting only against
-    // loadResult.snapshot would pass even if the upgrade never ran.
-    const rawRow = await readRawDocumentsRow(documentId)
-    expect(rawRow).not.toHaveProperty('scene')
-    expect(rawRow).toEqual({
-      id: documentId,
-      name: 'Pre-migration canvas',
-      updatedAt: '2026-01-01T00:00:00.000Z',
-    })
-
+    // (b) Nothing else survives. A v2 row carries no workspace and no path —
+    // and could not, they did not exist — so v8 discards it along with its
+    // Loro record. What the pre-v3 `scene` strip did to this row on the way
+    // through is no longer observable; the guard that it must not THROW on a
+    // corrupt row still is, and is the next test.
     const metaStore = new IndexedDBStore()
-    // The row moves intact, but it is no longer READABLE: a document is now
-    // addressed by workspace + path, and a pre-path row carries neither. There
-    // is deliberately no migration inventing them — a local document is
-    // discardable (0.0.x, no users), and `load` reporting `corrupted` routes
-    // the editor to its existing safe fallback instead of guessing an address.
-    expect((await metaStore.load(documentId)).kind).toBe('corrupted')
-    // ...and it is skipped rather than blanking the list or throwing.
+    expect(await readRawDocumentsRow(documentId)).toBeUndefined()
+    expect((await metaStore.load(documentId)).kind).toBe('not-found')
     expect(await metaStore.listDocuments()).toEqual([])
-
-    // (d) The default pointer/id is intact.
-    expect(await metaStore.getDefaultDocumentId()).toBe(documentId)
+    expect((await new LoroStore().load(documentId)).kind).toBe('not-found')
+    expect(await metaStore.getDefaultDocumentId()).toBeNull()
   })
 
   it('upgrades without aborting when a legacy canvases row is a non-object (corrupt data)', async () => {
@@ -616,5 +579,186 @@ describe('whiteboard IndexedDB v2 -> v3 upgrade', () => {
       tx.oncomplete = () => rawDb.close()
     })
     expect(raw).toHaveProperty('scene')
+  })
+})
+
+/** Seed a v7-shape fixture: current store names, rows in whatever shape is passed. */
+async function seedV7Fixture(rows: {
+  documents: readonly (readonly [key: string, value: unknown])[]
+  loro?: readonly string[]
+  defaultDocumentId?: string
+}): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open('whiteboard', 7)
+    req.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result
+      for (const name of ['meta', 'documents', 'loroDocuments', 'documentFiles']) {
+        if (!db.objectStoreNames.contains(name)) db.createObjectStore(name)
+      }
+    }
+    req.onsuccess = () => {
+      const db = req.result
+      const tx = db.transaction(['meta', 'documents', 'loroDocuments'], 'readwrite')
+      if (rows.defaultDocumentId !== undefined) {
+        tx.objectStore('meta').put(rows.defaultDocumentId, 'defaultDocumentId')
+      }
+      for (const [key, value] of rows.documents) tx.objectStore('documents').put(value, key)
+      for (const key of rows.loro ?? []) {
+        tx.objectStore('loroDocuments').put(
+          { v: 1, snapshot: new Loro().export({ mode: 'snapshot' }), updatedAt: 'x' },
+          key,
+        )
+      }
+      tx.oncomplete = () => {
+        db.close()
+        resolve()
+      }
+      tx.onerror = () => {
+        db.close()
+        reject(tx.error)
+      }
+    }
+    req.onerror = () => reject(req.error)
+  })
+}
+
+async function storeKeys(name: string): Promise<string[]> {
+  const db = await openWhiteboardDb()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(name, 'readonly')
+    const req = tx.objectStore(name).getAllKeys()
+    req.onsuccess = () => resolve(req.result as string[])
+    req.onerror = () => reject(req.error)
+    tx.oncomplete = () => db.close()
+  })
+}
+
+const POST_PATH_ID = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+const PRE_PATH_ID = 'f81d4fae-7dec-11d0-a765-00a0c91e6bf6'
+
+describe('whiteboard IndexedDB v7 -> v8 upgrade (discards pre-path documents)', () => {
+  beforeEach(clearDb)
+  afterEach(clearDb)
+
+  it('current DB_VERSION is 8 or higher (guards against reverting the bump alone)', () => {
+    expect(DB_VERSION).toBeGreaterThanOrEqual(8)
+  })
+
+  it('deletes a document that carries no workspace or path, and its Loro record with it', async () => {
+    await seedV7Fixture({
+      documents: [
+        [PRE_PATH_ID, { id: PRE_PATH_ID, name: 'Old canvas', updatedAt: 'x', kind: 'spatial' }],
+      ],
+      loro: [PRE_PATH_ID],
+      defaultDocumentId: PRE_PATH_ID,
+    })
+
+    expect(await storeKeys('documents')).toEqual([])
+    // The bytes go too: a Loro record no document names is unreachable
+    // storage that nothing would ever clean up.
+    expect(await storeKeys('loroDocuments')).toEqual([])
+    // ...and the pointer, or the next load resumes into a document that is gone.
+    expect(await metaKeys()).toEqual([])
+  })
+
+  it('leaves a document that already carries workspace and path completely alone', async () => {
+    const row = {
+      documentId: POST_PATH_ID,
+      workspaceId: 'local',
+      path: 'design/login',
+      name: 'Login',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      kind: 'spatial',
+    }
+    await seedV7Fixture({
+      documents: [[POST_PATH_ID, row]],
+      loro: [POST_PATH_ID],
+      defaultDocumentId: POST_PATH_ID,
+    })
+
+    expect(await readRawDocumentsRow(POST_PATH_ID)).toEqual(row)
+    expect(await storeKeys('loroDocuments')).toEqual([POST_PATH_ID])
+    expect(await new IndexedDBStore().getDefaultDocumentId()).toBe(POST_PATH_ID)
+  })
+
+  it('discards only the pre-path rows when a store holds both', async () => {
+    const keep = {
+      documentId: POST_PATH_ID,
+      workspaceId: 'local',
+      path: 'keep',
+      name: 'Keep',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      kind: 'spatial',
+    }
+    await seedV7Fixture({
+      documents: [
+        [POST_PATH_ID, keep],
+        [PRE_PATH_ID, { id: PRE_PATH_ID, name: 'Drop', updatedAt: 'x', kind: 'spatial' }],
+      ],
+      loro: [POST_PATH_ID, PRE_PATH_ID],
+      // Pointed at the SURVIVOR: a blanket clear would pass the first test
+      // while silently logging every user out of their remaining document.
+      defaultDocumentId: POST_PATH_ID,
+    })
+
+    expect(await storeKeys('documents')).toEqual([POST_PATH_ID])
+    expect(await storeKeys('loroDocuments')).toEqual([POST_PATH_ID])
+    expect(await new IndexedDBStore().getDefaultDocumentId()).toBe(POST_PATH_ID)
+  })
+
+  it('survives a corrupt (non-object) row rather than aborting the whole upgrade', async () => {
+    await seedV7Fixture({ documents: [['junk', 42]], loro: ['junk'] })
+    expect(await storeKeys('documents')).toEqual([])
+  })
+})
+
+describe('v6 -> v8 in one upgrade (the discard must see what the v7 copy produced)', () => {
+  beforeEach(clearDb)
+  afterEach(clearDb)
+
+  it('discards a pre-path row that arrives in `documents` via the v7 rename copy', async () => {
+    // The two passes share ONE versionchange transaction: the rename copies
+    // `canvases` -> `documents` through a cursor whose puts land in its own
+    // callbacks, and the discard walks `documents`. A discard cursor opened
+    // before those puts have run sees an empty store and deletes nothing —
+    // which looks exactly like a successful upgrade.
+    const doc = new Loro()
+    doc.getList('elements').push({ id: 'el' })
+    await seedV6Fixture('pre-path-v6', doc.export({ mode: 'snapshot' }))
+
+    expect(await storeKeys('documents')).toEqual([])
+    expect(await storeKeys('loroDocuments')).toEqual([])
+  })
+})
+
+describe('cross-tab upgrades', () => {
+  beforeEach(clearDb)
+  afterEach(clearDb)
+
+  it('an open connection closes itself so a newer version is not blocked behind it', async () => {
+    // Stands in for the second tab: a connection this module handed out and
+    // that nobody closed. Without `onversionchange` it holds the database at
+    // its own version and the upgrade below never fires — the request sits in
+    // `blocked` forever, which in the app is an editor that never loads and
+    // no error to explain why.
+    const idle = await openWhiteboardDb()
+
+    let blocked = false
+    const upgraded = await new Promise<boolean>((resolve) => {
+      const req = indexedDB.open('whiteboard', DB_VERSION + 1)
+      req.onblocked = () => {
+        blocked = true
+      }
+      req.onsuccess = () => {
+        req.result.close()
+        resolve(true)
+      }
+      req.onerror = () => resolve(false)
+      // Bounded so a genuine block fails the test instead of hanging it.
+      setTimeout(() => resolve(false), 4000)
+    })
+
+    expect({ upgraded, blocked }).toEqual({ upgraded: true, blocked: false })
+    idle.close()
   })
 })

--- a/apps/web/src/lib/browser-idb-migration.browser.test.tsx
+++ b/apps/web/src/lib/browser-idb-migration.browser.test.tsx
@@ -758,7 +758,10 @@ describe('cross-tab upgrades', () => {
       setTimeout(() => resolve(false), 4000)
     })
 
-    expect({ upgraded, blocked }).toEqual({ upgraded: true, blocked: false })
+    // Closed BEFORE the assertion: a failure here would otherwise leave the
+    // connection open, and `afterEach`'s deleteDatabase then blocks on it —
+    // turning one failed test into a hung file.
     idle.close()
+    expect({ upgraded, blocked }).toEqual({ upgraded: true, blocked: false })
   })
 })

--- a/apps/web/src/lib/browser-idb.ts
+++ b/apps/web/src/lib/browser-idb.ts
@@ -209,8 +209,7 @@ export function openWhiteboardDb(): Promise<IDBDatabase> {
       db.onversionchange = () => db.close()
       resolve(db)
     }
-    req.onblocked = () =>
-      reject(new Error('another tab has this app open at an older version; close it and reload'))
+    // MUTATION-CHECK: onblocked handler removed on purpose. Restore.
     req.onerror = () => reject(req.error)
   })
 }

--- a/apps/web/src/lib/browser-idb.ts
+++ b/apps/web/src/lib/browser-idb.ts
@@ -43,13 +43,25 @@ const DB_NAME = 'whiteboard'
  * guarded no-op on every v3+ row, and running it inside the copy avoids two
  * cursors contending over the same source store.
  *
- * Known limitation (accepted, not handled): if another tab holds a
- * connection open at the previous version, this open blocks
- * (onblocked/onversionchange) until that tab closes or upgrades — the same
- * behavior every prior DB_VERSION bump in this file has had. No new handling
- * is added for it here.
+ * v7 -> v8: DISCARDS every document row that predates workspace+path
+ * addressing. A pre-v8 row carries only `{id, name, updatedAt, kind}` — no
+ * workspace, no path, and a `crypto.randomUUID()` id the model's canonical
+ * ULID schema refuses — so there is nothing to migrate it TO without
+ * inventing an address, and an invented address is worse than none: it is
+ * indistinguishable from one the user chose. Local documents are discardable
+ * by explicit decision (0.0.x, no users), so the row and its Loro record are
+ * deleted outright, and the default pointer is cleared when it named one of
+ * them. Deleting the bytes matters as much as the row: a Loro record no
+ * document names is unreachable storage nothing would ever collect.
+ *
+ * Cross-tab upgrades are handled rather than accepted from v8 on: every
+ * connection this module opens closes itself on `versionchange`, so a newer
+ * tab's upgrade is not blocked by an older one sitting idle, and a block that
+ * happens anyway (a tab still running a pre-v8 bundle) rejects with a
+ * message a caller can show instead of hanging on a request that never
+ * settles.
  */
-export const DB_VERSION = 7
+export const DB_VERSION = 8
 
 const RENAMED_STORES: readonly (readonly [from: string, to: string])[] = [
   ['canvases', 'documents'],
@@ -65,8 +77,17 @@ const RENAMED_STORES: readonly (readonly [from: string, to: string])[] = [
  * but calling it while the copy's cursor is still walking would kill the
  * source out from under the requests that have not run yet.
  */
-function copyStoreThenDelete(db: IDBDatabase, tx: IDBTransaction, from: string, to: string): void {
-  if (!db.objectStoreNames.contains(from)) return
+function copyStoreThenDelete(
+  db: IDBDatabase,
+  tx: IDBTransaction,
+  from: string,
+  to: string,
+  onDone: () => void,
+): void {
+  if (!db.objectStoreNames.contains(from)) {
+    onDone()
+    return
+  }
   const source = tx.objectStore(from)
   const target = tx.objectStore(to)
   const cursorReq = source.openCursor()
@@ -74,6 +95,7 @@ function copyStoreThenDelete(db: IDBDatabase, tx: IDBTransaction, from: string, 
     const cursor = cursorReq.result
     if (!cursor) {
       db.deleteObjectStore(from)
+      onDone()
       return
     }
     target.put(stripLegacySceneField(cursor.value), cursor.key)
@@ -91,6 +113,49 @@ function stripLegacySceneField(value: unknown): unknown {
   if (typeof value !== 'object' || value === null || !('scene' in value)) return value
   const { scene: _scene, ...metadataOnly } = value as Record<string, unknown>
   return metadataOnly
+}
+
+/**
+ * True for a row already addressed the way v8 stores one.
+ *
+ * Written out rather than delegating to `documentSnapshotSchema`: a migration
+ * has to keep meaning what it meant on the day it ran, and a live schema is
+ * free to gain a required field later, which would silently turn this into a
+ * discard of rows it was never meant to touch. Guarded against a non-object
+ * value — a corrupt row must not throw out of an upgrade transaction, which
+ * would abort it and brick the database open.
+ */
+function isPathAddressed(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false
+  const row = value as Record<string, unknown>
+  return (
+    typeof row.documentId === 'string' &&
+    typeof row.workspaceId === 'string' &&
+    typeof row.path === 'string'
+  )
+}
+
+function discardPrePathDocuments(tx: IDBTransaction): void {
+  const documents = tx.objectStore('documents')
+  const loro = tx.objectStore('loroDocuments')
+  const meta = tx.objectStore('meta')
+  const cursorReq = documents.openCursor()
+  cursorReq.onsuccess = () => {
+    const cursor = cursorReq.result
+    if (!cursor) return
+    if (!isPathAddressed(cursor.value)) {
+      const key = cursor.primaryKey
+      cursor.delete()
+      loro.delete(key)
+      // Cleared only when it named THIS row: a blanket clear would log a user
+      // out of the documents that survive.
+      const pointer = meta.get('defaultDocumentId')
+      pointer.onsuccess = () => {
+        if (pointer.result === key) meta.delete('defaultDocumentId')
+      }
+    }
+    cursor.continue()
+  }
 }
 
 function renameMetaKey(tx: IDBTransaction, from: string, to: string): void {
@@ -122,10 +187,30 @@ export function openWhiteboardDb(): Promise<IDBDatabase> {
       // req.transaction is always non-null inside onupgradeneeded; narrowed for TS.
       const tx = req.transaction
       if (!tx) return
-      for (const [from, to] of RENAMED_STORES) copyStoreThenDelete(db, tx, from, to)
       renameMetaKey(tx, 'defaultCanvasId', 'defaultDocumentId')
+      // The discard runs only once every rename copy has drained, because it
+      // walks the store those copies are still filling. Calling it beside them
+      // is NOT equivalent: a cursor opened while the copy's puts are still
+      // queued in their own callbacks sees an empty store, deletes nothing,
+      // and looks exactly like a successful upgrade. Measured — a v6 pre-path
+      // row survived a v6->v8 open until this was ordered.
+      let pendingCopies = RENAMED_STORES.length
+      const onCopyDone = () => {
+        pendingCopies -= 1
+        if (pendingCopies === 0) discardPrePathDocuments(tx)
+      }
+      for (const [from, to] of RENAMED_STORES) copyStoreThenDelete(db, tx, from, to, onCopyDone)
     }
-    req.onsuccess = () => resolve(req.result)
+    req.onsuccess = () => {
+      const db = req.result
+      // Without this, an idle tab holding an older version blocks every newer
+      // tab's upgrade until someone closes it — the connection has no reason
+      // to outlive the schema it was opened against.
+      db.onversionchange = () => db.close()
+      resolve(db)
+    }
+    req.onblocked = () =>
+      reject(new Error('another tab has this app open at an older version; close it and reload'))
     req.onerror = () => reject(req.error)
   })
 }

--- a/apps/web/src/lib/browser-idb.ts
+++ b/apps/web/src/lib/browser-idb.ts
@@ -209,7 +209,13 @@ export function openWhiteboardDb(): Promise<IDBDatabase> {
       db.onversionchange = () => db.close()
       resolve(db)
     }
-    // MUTATION-CHECK: onblocked handler removed on purpose. Restore.
+    // The request is not aborted by this rejection: if the blocking tab later
+    // closes, `onsuccess` still runs and opens a connection nobody holds. That
+    // is deliberately left alone rather than closed — the `onversionchange`
+    // handler above is set on it too, so it steps aside for the next upgrade
+    // or delete, which is the only harm an unowned connection can do here.
+    req.onblocked = () =>
+      reject(new Error('another tab has this app open at an older version; close it and reload'))
     req.onerror = () => reject(req.error)
   })
 }

--- a/apps/web/src/lib/browser-local-store.test.ts
+++ b/apps/web/src/lib/browser-local-store.test.ts
@@ -1,7 +1,7 @@
 import { documentIdSchema } from '@kamiazya/whiteboard-model'
 import { IDBFactory } from 'fake-indexeddb'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { DB_VERSION } from './browser-idb.js'
+import { DB_VERSION, openWhiteboardDb } from './browser-idb.js'
 import { IndexedDBStore, MemoryStore } from './browser-local-store.js'
 import type { DocumentSnapshot } from './whiteboard-client.js'
 
@@ -152,29 +152,29 @@ describe('IndexedDBStore', () => {
     expect(await store.load(ID)).toEqual({ kind: 'ok', snapshot: snap })
   })
 
-  it('load returns corrupted for malformed stored data', async () => {
-    // Write garbage directly via raw IDB
+  it('load returns corrupted for a row that is addressed but does not parse', async () => {
+    // The row has to survive the v8 discard to reach the parse boundary at
+    // all, and the two checks are deliberately different strictnesses: the
+    // migration's frozen predicate asks only whether the three address fields
+    // are strings, while documentSnapshotSchema demands a canonical ULID. A
+    // row in between is exactly what `corrupted` is for — a shape written at
+    // the current version that no longer parses, rather than one from before
+    // addressing existed (that one is discarded and reads as not-found).
+    const db = await openWhiteboardDb()
     await new Promise<void>((resolve, reject) => {
-      const req = indexedDB.open('whiteboard', 1)
-      req.onupgradeneeded = (e) => {
-        const db = (e.target as IDBOpenDBRequest).result
-        db.createObjectStore('meta')
-        db.createObjectStore('documents')
+      const tx = db.transaction('documents', 'readwrite')
+      tx.objectStore('documents').put(
+        { documentId: 'not-a-ulid', workspaceId: 'local', path: 'broken', broken: true },
+        'not-a-ulid',
+      )
+      tx.oncomplete = () => {
+        db.close()
+        resolve()
       }
-      req.onsuccess = () => {
-        const db = req.result
-        const tx = db.transaction('documents', 'readwrite')
-        tx.objectStore('documents').put({ broken: true }, ID)
-        tx.oncomplete = () => {
-          db.close()
-          resolve()
-        }
-        tx.onerror = () => reject(tx.error)
-      }
-      req.onerror = () => reject(req.error)
+      tx.onerror = () => reject(tx.error)
     })
     const store = new IndexedDBStore()
-    expect(await store.load(ID)).toEqual({ kind: 'corrupted' })
+    expect(await store.load('not-a-ulid')).toEqual({ kind: 'corrupted' })
   })
 
   it('del with matching id deletes canvas and clears pointer', async () => {

--- a/docs/explanation/domain-model.md
+++ b/docs/explanation/domain-model.md
@@ -12,9 +12,11 @@ backed by more than one representation today. Read
   The kind is chosen at creation and does not change afterwards — except
   that restoring a version also restores that version's kind.
 - **Workspace** — a named collection of canvases. Only daemon mode has
-  real, multiple workspaces; browser-local mode behaves as one fixed,
-  implicit workspace (that constraint is modeled as "a single workspace
-  that is always present", not as the absence of the concept).
+  real, multiple workspaces; browser-local mode has exactly one, and it is
+  stored rather than implied — every browser-local canvas carries the
+  workspace it belongs to, the same field a daemon canvas carries. The
+  constraint is "a single workspace that is always present", not the absence
+  of the concept.
 - **Display name** — the human title of a canvas. Optional; a canvas
   without one shows its identifier instead. Renaming changes only the
   display name, never the identity.
@@ -39,7 +41,7 @@ backed by more than one representation today. Read
 
 | mode | identity of a canvas | shown to the user |
 |---|---|---|
-| Browser-local | a random UUID, generated at creation | display name, plus a *display path* derived from the name |
+| Browser-local | a ULID `documentId` plus the pair `(workspaceId, path)` | display name, plus the path |
 | Daemon (gallery, editing, sync) | the pair `(workspaceId, path)` | display name, plus the path |
 | Daemon (agent/MCP tree) | a ULID `documentId` plus a `segment` path | alias path derived from segments |
 
@@ -52,13 +54,21 @@ is deliberately an open question (see
 [ADR-0007](../contributing/adr/0007-canvas-identity-and-store-split.md),
 which predates the rename and calls this a *slug* throughout).
 
-Browser-local canvases have no persisted or canonical path. The
-path-shaped label under a
-card in the browser-local list is **cosmetic**: it is derived from the
-display name on every render, is never stored, and collisions are
-suffixed (`notes`, `notes-2`). It deliberately uses the same character
-set as daemon paths so that, if browser-local canvases ever gain real
-paths, the labels users already see can be promoted without changing.
+Browser-local canvases are addressed the same way. A path is stored, not
+derived: it is assigned at creation (`untitled`, `untitled-2`, …) exactly as
+in daemon mode, it is what `/local/:path` names, and it is unique within the
+browser — the store refuses a second canvas at a path another one holds,
+because a duplicate would make that address ambiguous rather than merely
+untidy.
+
+A path is never derived from a display name, in either mode.
+[ADR-0008](../contributing/adr/0008-slug-derivation-and-rename.md) measured
+that and found every non-Latin title collapsing to `untitled-N`, which is
+indistinguishable in the very column a path exists to distinguish.
+
+The identifier stays the durable one: a `[[reference]]` between canvases
+names the target's `documentId`, so it survives both a rename and a move,
+and following one resolves that identifier to the target's current path.
 
 ## One product concept, one daemon-side store
 


### PR DESCRIPTION
Completes the local/daemon alignment #912 started, and closes the two items its ticket still had open.

A document written before workspace+path addressing carries `{id, name, updatedAt, kind}` — no workspace, no path, and a `crypto.randomUUID()` id the model's ULID schema refuses. #912 left those rows in place and let them read as `corrupted`; this deletes them, so **"gone" is a state the database records rather than one every reader has to infer**.

There is nothing to migrate them *to* without inventing an address, and an invented address is worse than none: it is indistinguishable from one the user chose. Local data is discardable by explicit decision (0.0.x, no users).

## What the migration does

- Deletes any `documents` row that is not addressed by `documentId` + `workspaceId` + `path`.
- Deletes its `loroDocuments` record with it — a snapshot no document names is unreachable storage nothing would ever collect.
- Clears `meta.defaultDocumentId` **only when it named a discarded row**. A blanket clear passes the simple test while logging a user with one surviving document out of it; that asymmetry is what the third test pins.
- Leaves `documentFiles` alone: uploads are not addressed by workspace+path.

## The ordering is the part that needed measuring

A v6 database reaches v8 in **one** versionchange transaction, where the v7 rename copies `canvases` → `documents` through a cursor whose puts land in its own callbacks. A discard cursor opened *beside* that copy sees an empty store, deletes nothing, and looks exactly like a successful upgrade.

I wrote it that way first — with a comment claiming the ordering was fine — and a v6 fixture survived the upgrade:

```
AssertionError: expected [ 'pre-path-v6' ] to deeply equal []
```

The discard now starts only once every rename copy has drained. Mutation-checked: reverting to the beside-the-copies form turns four migration tests red.

## Frozen predicate, deliberately unlike the read schema

The migration asks only whether the three address fields are strings, rather than delegating to `documentSnapshotSchema` — a migration has to keep meaning what it meant on the day it ran, and a live schema is free to gain a required field later, which would silently turn this into a discard of rows it was never meant to touch.

That gap is now load-bearing in the other direction too: a row that *is* addressed but does not parse (a non-ULID `documentId`) survives the discard and still reads as `corrupted`. That is what `browser-local-store.test.ts`'s renamed case pins — the old fixture for it was a pre-path row, which this change turns into `not-found`.

## Cross-tab upgrades: handled, no longer "accepted"

Every connection this module hands out now closes itself on `versionchange`, so an idle tab no longer blocks a newer one's upgrade indefinitely — the failure that produces an editor that never loads with nothing to explain why. A block that happens anyway (a tab still running a pre-v8 bundle) rejects with a message a caller can show, instead of a request that never settles.

The previous `DB_VERSION` comment called this a known accepted limitation, in the same words every bump before it used. It is no longer either. Mutation-checked: removing `onversionchange` makes the new test block and fail.

## Consequence for the older migration tests

The v2–v7 fixtures are all pre-path by construction, so every one of those paths now converges on an empty document store. Their assertions said "the row moves intact but is unreadable" (written in #912); they now say it is gone, along with its bytes and the pointer that named it.

What each still proves is narrower and stated explicitly — the v2 case keeps the VersionError regression guard, and the v6→v7 rename keeps `documentFiles` as the place its record-carrying half is still observable.

## Docs

`domain-model.md` described browser-local identity as a random UUID with a **cosmetic**, name-derived path label. Both stopped being true at #912. Now: a stored ULID plus `(workspaceId, path)`, unique within the browser, never derived from a display name (ADR-0008), with the identifier as the durable thing a `[[reference]]` carries.

## Verification

Real Chromium against the dev server: seeded a pre-path v7 database by hand, reloaded, read back

```
after upgrade: {"version":8,"documents":[],"loro":[],"meta":[]}
page shows: ALPHA | Canvases | No documents yet | ...
```

— the app lands on its empty state rather than a broken screen.

`web-browser` 664 passed · `web-jsdom` 2581 passed · `mcp-node`/`arch-lint-node` 3655 passed · `typecheck`, `lint`, `knip` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ua6RPuoEAD4ZTBqyhNC56Z