### PR TITLE
ci: stop installing a CJK font for widget-smoke, which needs none

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,37 +211,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # This step cancelled `widget-smoke` in 4 of 25 ci runs, always at the
-      # job's 15-minute ceiling. The log showed no output at all for four
-      # minutes — not a slow download, a connection that never returns.
-      # `Acquire::http::Timeout` fixes THAT shape: a stuck mirror fails in 15s
-      # instead of hanging, and `Acquire::Retries` tries another.
-      #
-      # It then failed three more times in a different shape the timeouts
-      # cannot catch, because nothing is stuck: `fonts-noto-cjk` is a SINGLE
-      # 61.2MB package, and fetching it does not fit in five minutes on a slow
-      # runner. The index before it took 3s for 11.4MB, so the mirror is fine —
-      # the package is just enormous.
-      #
-      # `fonts-vlgothic` is 2.4MB and does the same job here. Nothing asserts a
-      # CJK family: the smoke's only font assertion is on the EMBEDDED Roboto
-      # face, and the Japanese sample exists to exercise the browser-fallback
-      # glyph path and prove no network fetch happens. Any `:lang=ja` face
-      # satisfies that, and this one is 26x smaller.
-      #
-      # A cancelled job is worse than a failed one here: `verify` NEEDS this,
-      # and a cancelled dependency SKIPS it rather than failing it, so the PR
-      # reads `verify: skipping` — no result rather than a red one, on the
-      # check the merge gate treats as authoritative.
-      - name: Install CJK fallback font
-        timeout-minutes: 5
-        env:
-          APT_OPTS: -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15
-        run: |
-          sudo apt-get $APT_OPTS update
-          sudo apt-get $APT_OPTS install -y --no-install-recommends fonts-vlgothic
-          fc-list :lang=ja family | head -3
-
       - name: Build canvas-viewer widget
         run: pnpm --filter @kamiazya/whiteboard-canvas-viewer build:widget
 

--- a/packages/canvas-viewer/scripts/smoke-widget.mjs
+++ b/packages/canvas-viewer/scripts/smoke-widget.mjs
@@ -29,6 +29,16 @@ const SAMPLE_SCENE = {
     // Non-Latin text exercises the browser-fallback glyph path (Roboto's
     // Latin-only vendored subset does not cover CJK) while the zero-network
     // assertion below confirms it never triggers a font fetch.
+    //
+    // NO system CJK font is required, and CI deliberately installs none. The
+    // assertion below reads the SVG's textContent, which a <text> element
+    // carries whether or not a glyph exists for it, and the only font-status
+    // assertion is on the EMBEDDED Roboto face. Measured: with 887 faces
+    // available and none of them `:lang=ja`, the whole smoke passes. Running
+    // WITHOUT a fallback face is the stronger version of the zero-network
+    // claim — it shows the widget fetches nothing even when the glyph is
+    // genuinely unavailable. CI once apt-installed a CJK font for this and it
+    // hung the job in three separate shapes; do not add it back.
     { id: 'text-jp', type: 'text', x: 10, y: 50, width: 200, height: 25, text: JP_TEXT },
   ],
   edges: [],


### PR DESCRIPTION
The `Install CJK fallback font` step has now hung `widget-smoke` in **three distinct shapes**:

1. a mirror connection that never returned — fixed with `Acquire::*::Timeout`
2. a 61.2MB single package that did not fit in five minutes — fixed by swapping `fonts-noto-cjk` for `fonts-vlgothic` (#910)
3. `apt-get update` itself stalling on `archive.ubuntu.com`'s InRelease for the whole five-minute budget — **twice in a row on #913**, past the point where a re-run is the answer

Each fix addressed the shape in front of it. None asked whether the step was needed at all.

## It is not needed — measured, not argued

The smoke's Japanese assertion reads `svg.textContent.includes(JP_TEXT)`. A `<text>` element carries its content whether or not a glyph exists to draw it. The only font-*status* assertion is on the embedded Roboto face.

With a fontconfig exposing **887 faces, none of them `:lang=ja`** — the runner's situation without this step — the whole smoke passes:

```
[widget-smoke] PASS: zero network requests, svg rendered, fonts loaded, JP text present, srcdoc hosting OK
```

A first attempt at that measurement removed *every* font, and is **not** the evidence here: the embedded FontFace itself went to `error`, which is Chrome having no fontconfig at all rather than the runner having no CJK. Recording that because the wrong fixture looked like a decisive negative result:

```
[widget-smoke] FAIL: document.fonts.check reported the Roboto family/text as not available
[widget-smoke] FAIL: expected every widget-registered FontFace to be 'loaded', got: ["error"]
```

The fixture that matters keeps a normal font set and subtracts only the ja faces.

## Running without a fallback face is the stronger test

That is what the JP node is for: it shows the widget fetches nothing **even when the glyph is genuinely unavailable**, rather than when a system font happened to satisfy it. The smoke script now says so at the sample text, so this does not get re-added the next time someone notices the rendering is tofu.

## Why this blocks more than itself

`verify` NEEDS `widget-smoke`, and a timed-out dependency **skips** it rather than failing it — so a PR reads `verify: skipping`. No result at all, on the check the merge gate treats as authoritative. #913 is sitting behind exactly this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ua6RPuoEAD4ZTBqyhNC56Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved widget smoke-test reliability by removing reliance on system-installed CJK fonts.
  - Japanese text checks now verify SVG text content without requiring glyph rendering or network access.
  - Streamlined test setup to work consistently in environments without Japanese font packages.

- **Documentation**
  - Added clarification about how Japanese sample text validation works and why fallback fonts are unnecessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->