### PR TITLE
feat(mcp-server): export with the fonts the user installed

### DIFF
--- a/docs/contributing/adr/0012-user-installed-fonts.md
+++ b/docs/contributing/adr/0012-user-installed-fonts.md
@@ -1,0 +1,140 @@
+# ADR-0012: A user installs a font by naming it, and the daemon keeps it
+
+**Status:** Accepted — not yet implemented
+
+## Context
+
+[ADR-0011](0011-font-distribution.md) decided that fonts beyond the Latin
+default are installed by whoever needs them, and named npm packages as the
+channel. That serves a deployment. It does not serve the case this ADR is
+about: **someone using the app wants a different font** — a CJK face so their
+exports stop being tofu, or a handwritten one because the diagram should look
+handwritten.
+
+Two facts make the shape of the answer non-obvious.
+
+**`@resvg/resvg-js@2.6.2` accepts `fontFiles` and `fontDirs` and nothing else.**
+There is no `fontBuffers`, and no CSS font loading, so a font embedded in the
+SVG as `@font-face` or a `data:` URI is ignored (verified against the installed
+type definitions). A font the export path can use must exist **as a file on
+disk**.
+
+**The editor and the exporter are already required to agree.**
+`canvas-viewer/src/font-loading.ts` loads the vendored Roboto as a real webfont
+for exactly this reason, and says so: without it, "Canvas 2D silently falls
+back to a system font, and the editor's on-screen layout diverges from what a
+user exports." A font that reaches only the browser re-creates that divergence
+on purpose.
+
+Together those say the same thing from both ends: a font the user picks has to
+land **as bytes on the daemon's disk**, not only in the browser.
+
+This introduces something the product has never had. Every MCP tool today
+operates headlessly on persisted documents; **none makes an outbound network
+request**. Font installation would be the first, so its trigger and its
+destination are a security-model decision, not an implementation detail.
+
+## Decision
+
+**A user installs a font by naming a family. The daemon fetches it, verifies
+it, and keeps it under its data directory, where both the measurer and resvg
+read it as a file.**
+
+Google Fonts is the source. It is the one the user knows, and picking a single
+well-known catalogue keeps the first version legible.
+
+### 1. The input is a family NAME, never a URL
+
+```
+installFont({ family: 'Noto Sans JP' })     ← the daemon builds the URL
+installFont({ url: 'https://…' })           ← rejected by construction
+```
+
+A domain allowlist is the obvious control and is **the weaker form of this
+one**. An allowlist validates an input an attacker can influence; taking a
+family name means there is no such input. The daemon constructs the request
+from a pinned template, so "which hosts can this reach" is a property of our
+code rather than of a validator someone has to keep correct.
+
+This also avoids following Google Fonts' two-hop shape, where
+`fonts.googleapis.com` returns CSS naming files on `fonts.gstatic.com` — a
+fetch whose destination comes from a response body is the thing worth not
+building.
+
+### 2. Only a human triggers it — it is NOT an MCP tool
+
+This is the control that matters most, and it is about the trigger rather than
+the destination.
+
+The daemon is driven by AI agents, and agents act on instructions found in the
+documents they read. An MCP tool that fetches a URL completes a chain:
+malicious canvas → agent calls the tool → daemon issues a request to somewhere
+on the user's network. Restricting *where* it can go limits the damage; keeping
+the trigger human removes the chain.
+
+Font installation is therefore a user action in the browser UI, authenticated
+to the daemon like any other mutation. Exposing it to MCP later is a separate
+decision that must re-examine this paragraph, not a natural extension.
+
+### 3. The fetch is bounded, and its result is verified before it is kept
+
+- **Redirects are not followed.** An allowlisted host that answers `302` can
+  otherwise send the daemon anywhere, which would undo decision 1.
+- **The on-disk name is derived by us**, never from the URL or a
+  `Content-Disposition` header — the same rule as the existing "export and
+  upload flows stay within daemon-controlled storage paths".
+- **Size cap and timeout**, so a hostile or broken response cannot exhaust
+  disk or hang the daemon.
+- **It must parse as a font before it is installed.** `opentype.js` parses the
+  bytes, and a failure means nothing is written. This doubles as the check that
+  the measurer can actually use what was downloaded — the file lands only if
+  both halves of ADR-0011 decision 4 can read it.
+
+### 4. Installed state is per-surface, and both sides report it
+
+The browser registers a `FontFace`; the daemon keeps a file. **Either can be
+present without the other**, and each single-sided state is visibly wrong in a
+different direction:
+
+| | on screen | exported |
+|---|---|---|
+| daemon only | system fallback | the chosen font |
+| browser only | the chosen font | tofu |
+
+So a font is not a boolean. Each surface reports what it resolved, the same
+discipline `undrawable` already follows for the export path: a missing font is
+a **declared degradation**, never silence.
+
+## Consequences
+
+- **The daemon makes outbound requests for the first time.** That is a change
+  to the trust boundary and is recorded in `docs/explanation/security-model.md`
+  alongside this ADR, not only here.
+- Offline use is unaffected. ADR-0011 rejected fetching at startup or at render
+  time; this is neither. A user pressing "install" is not a render, and once the
+  file is on disk every later render is local. The widget's zero-network
+  assertion continues to hold unchanged.
+- A font the user installed is available to `wb_scene_render` and PNG export
+  without any MCP tool having network access.
+- Licensing follows ADR-0011 decision 6, with a wrinkle worth stating: fonts
+  fetched at runtime are **not redistributed by us**, so the obligation is to
+  surface the license to the user rather than to ship its text in the package.
+
+## Alternatives considered
+
+**A domain allowlist over user-supplied URLs.** The user's own proposal, and
+correct in instinct. Rejected as the primary control because decision 1 achieves
+the same goal structurally: an allowlist is a validator that must stay right,
+where a pinned template cannot be wrong. The allowlist survives as the
+host-pinning inside that template.
+
+**Expose installation as an MCP tool.** Convenient — an agent could fix its own
+tofu export. It also hands the prompt-injection surface a network primitive, on
+a daemon whose tools have deliberately never had one. Not now.
+
+**Browser-only download.** Simplest, and it breaks the property
+`font-loading.ts` exists to protect: the editor would show the chosen font while
+every export ignored it. That is the divergence, not a step toward fixing it.
+
+**Bundle a font picker's worth of fonts.** ADR-0011 measured this: the published
+`dist` is 5.2 MB and one CJK face is 18.6 MB. A picker implies many.

--- a/docs/contributing/adr/README.md
+++ b/docs/contributing/adr/README.md
@@ -44,3 +44,4 @@ See [template.md](template.md) for the standard structure (MADR-lite: Title, Sta
 | [ADR-0009](0009-mcp-tool-naming.md) | The Document model, and `wb_<entity>_<action>` tool naming | Accepted — decisions 3-4 now implemented; *format* is spelled `kind` |
 | [ADR-0010](0010-canvas-edit-batch-tool.md) | One batch tool for spatial editing, and why it is not `apply` | Accepted |
 | [ADR-0011](0011-font-distribution.md) | Fonts are installed by whoever needs them, not bundled | Accepted — provider registry not built yet |
+| [ADR-0012](0012-user-installed-fonts.md) | A user installs a font by naming it, and the daemon keeps it | Accepted — not yet implemented; extends ADR-0011 |

--- a/docs/explanation/security-model.md
+++ b/docs/explanation/security-model.md
@@ -109,6 +109,35 @@ token exchange. Until that lands, discovery is convenience, not proof.
 - Canvas identifiers are validated before they are mapped to file paths.
 - Export and upload flows stay within daemon-controlled storage paths unless explicitly extended.
 
+## Outbound requests (font installation — decided, not yet implemented)
+
+The daemon makes **no outbound network requests today**. Every MCP tool operates
+headlessly on persisted documents, and nothing fetches a remote resource.
+
+[ADR-0012](../contributing/adr/0012-user-installed-fonts.md) decides the first
+exception — installing a font the user chose — and the constraints below are
+what keep it from becoming a general-purpose request forwarder. They are
+recorded here because they are trust-boundary properties, not implementation
+detail.
+
+- **A family NAME is the input, never a URL.** The daemon builds the request
+  from a pinned template, so the reachable hosts are a property of the code
+  rather than of a validator over attacker-influenced input.
+- **Only a user triggers it — it is not an MCP tool.** The daemon is driven by
+  AI agents, and agents act on instructions found in the documents they read.
+  A network primitive reachable from a tool call completes the chain
+  *malicious document → agent → request into the user's network*. Keeping the
+  trigger human removes it rather than bounding it. Exposing installation to
+  MCP later requires re-deciding this, not extending it.
+- **Redirects are not followed**, since an allowed host answering `302` would
+  otherwise reach anywhere.
+- **The stored filename is derived by the daemon**, never taken from the URL or
+  a `Content-Disposition` header — the same rule as the export/upload paths
+  above.
+- **Size cap and timeout** bound a hostile or broken response.
+- **The bytes must parse as a font before anything is written.** A file that
+  `opentype.js` cannot parse never reaches the data directory.
+
 ## Browser-dependent operations
 
 No current MCP tool requires a connected browser client — canvas editing

--- a/packages/mcp-server/src/server/export/headless-renderer.test.ts
+++ b/packages/mcp-server/src/server/export/headless-renderer.test.ts
@@ -257,11 +257,14 @@ describe('headless-renderer', () => {
     vi.doMock('./measure-text.js', () => ({
       createOpentypeMeasureText: buildSpy,
       _resetExportMeasureTextCacheForTests: vi.fn(),
-      // `headless-renderer` asks this what the export face cannot draw. These
-      // mocks replace the module wholesale, so an export it omits is a runtime
-      // failure rather than a type error. `null` is the documented "no parsed
-      // face" answer and keeps these tests about the singleton, not fonts.
+      // These mocks replace the module WHOLESALE, so every export
+      // `headless-renderer` reaches for has to be answered here — an omission
+      // is a runtime failure rather than a type error, and adding an export to
+      // `measure-text.ts` has now broken this file twice. The empty/`null`
+      // answers are the documented "no parsed face" case, which keeps these
+      // tests about the singleton rather than about fonts.
       loadExportFont: vi.fn().mockResolvedValue(null),
+      loadExportFonts: vi.fn().mockResolvedValue([]),
     }))
     try {
       const { renderSpatialCanvasToSvg } = await importRenderer()
@@ -286,11 +289,14 @@ describe('headless-renderer', () => {
         .mockRejectedValueOnce(new Error('boom'))
         .mockResolvedValue(() => ({ advanceWidth: 0, ascent: 0, descent: 0, lineGap: 0 })),
       _resetExportMeasureTextCacheForTests: vi.fn(),
-      // `headless-renderer` asks this what the export face cannot draw. These
-      // mocks replace the module wholesale, so an export it omits is a runtime
-      // failure rather than a type error. `null` is the documented "no parsed
-      // face" answer and keeps these tests about the singleton, not fonts.
+      // These mocks replace the module WHOLESALE, so every export
+      // `headless-renderer` reaches for has to be answered here — an omission
+      // is a runtime failure rather than a type error, and adding an export to
+      // `measure-text.ts` has now broken this file twice. The empty/`null`
+      // answers are the documented "no parsed face" case, which keeps these
+      // tests about the singleton rather than about fonts.
       loadExportFont: vi.fn().mockResolvedValue(null),
+      loadExportFonts: vi.fn().mockResolvedValue([]),
     }))
     const { renderSpatialCanvasToSvg } = await importRenderer()
     await expect(renderSpatialCanvasToSvg(rectCanvas())).rejects.toThrow('boom')
@@ -304,11 +310,14 @@ describe('headless-renderer', () => {
     vi.doMock('./measure-text.js', () => ({
       createOpentypeMeasureText: vi.fn().mockRejectedValue(new Error('font load failed')),
       _resetExportMeasureTextCacheForTests: vi.fn(),
-      // `headless-renderer` asks this what the export face cannot draw. These
-      // mocks replace the module wholesale, so an export it omits is a runtime
-      // failure rather than a type error. `null` is the documented "no parsed
-      // face" answer and keeps these tests about the singleton, not fonts.
+      // These mocks replace the module WHOLESALE, so every export
+      // `headless-renderer` reaches for has to be answered here — an omission
+      // is a runtime failure rather than a type error, and adding an export to
+      // `measure-text.ts` has now broken this file twice. The empty/`null`
+      // answers are the documented "no parsed face" case, which keeps these
+      // tests about the singleton rather than about fonts.
       loadExportFont: vi.fn().mockResolvedValue(null),
+      loadExportFonts: vi.fn().mockResolvedValue([]),
     }))
     // `captureLogsForTests` must come from the SAME fresh module instance
     // `headless-renderer.js` resolves its own `getLogger` through — both

--- a/packages/mcp-server/src/server/export/headless-renderer.ts
+++ b/packages/mcp-server/src/server/export/headless-renderer.ts
@@ -38,6 +38,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 
 import { getLogger } from '../log.js'
 import { EXPORT_FONT_FAMILY, resolveExportFontFaces } from './export-font.js'
+import { installedFontFiles } from './installed-fonts.js'
 import { createOpentypeMeasureText } from './measure-text.js'
 import { undrawableCharacters } from './undrawable-characters.js'
 
@@ -197,6 +198,9 @@ async function buildExporter(): Promise<HeadlessExporter> {
   // appears in the SVG canvas-render produces. All four faces register:
   // resvg selects among them by the font-weight/font-style the SVG
   // declares, and it does NOT synthesize a face it was not given.
+  // The vendored faces plus whatever the user installed. Resolved per render
+  // rather than once with the exporter singleton: installing a font must take
+  // effect on the next export, not on the next daemon restart.
   const fontFiles = [faces.regular, faces.bold, faces.italic, faces.boldItalic].filter(
     (path): path is string => path !== null,
   )
@@ -215,9 +219,10 @@ async function buildExporter(): Promise<HeadlessExporter> {
         Number.isFinite(scale) && scale > 0 && scale !== 1
           ? ({ mode: 'zoom', value: scale } as const)
           : ({ mode: 'original' } as const)
+      const installed = await installedFontFiles()
       const resvg = new Resvg(svg, {
         background: themeBackground(options),
-        font: fontOption,
+        font: { ...fontOption, fontFiles: [...(fontOption.fontFiles ?? []), ...installed] },
         fitTo,
       })
       const png = resvg.render()

--- a/packages/mcp-server/src/server/export/installed-fonts.test.ts
+++ b/packages/mcp-server/src/server/export/installed-fonts.test.ts
@@ -1,0 +1,114 @@
+// ADR-0011 decided fonts beyond the Latin default are installed rather than
+// bundled; ADR-0012 decided the daemon keeps them as files. This is the read
+// side of both: whatever is in the data directory participates in export.
+//
+// Deliberately a plain directory rather than a manifest. A user who drops a
+// TTF in has installed a font, and a mechanism that only recognises its own
+// downloads would refuse the simplest way to answer "my exports are tofu".
+
+import { existsSync, mkdtempSync } from 'node:fs'
+import { copyFile, mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { resetDataDirForTests, setDataDirForTests } from '../../shared/data-dir-secure.js'
+import { installedFontDir, installedFontFiles } from './installed-fonts.js'
+
+let dataDir: string
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), 'wb-fonts-'))
+  setDataDirForTests(dataDir)
+})
+
+afterEach(() => {
+  resetDataDirForTests()
+})
+
+describe('installedFontFiles', () => {
+  it('is empty when nothing has been installed', async () => {
+    expect(await installedFontFiles()).toEqual([])
+  })
+
+  it('is empty when the directory does not exist at all', async () => {
+    setDataDirForTests(join(dataDir, 'nope'))
+
+    // A daemon that has never installed a font must export exactly as before,
+    // not fail because a directory is missing.
+    expect(await installedFontFiles()).toEqual([])
+  })
+
+  it('finds font files a user dropped in, sorted for reproducibility', async () => {
+    await mkdir(installedFontDir(), { recursive: true })
+    for (const name of ['zeta.ttf', 'alpha.otf', 'beta.ttc']) {
+      await writeFile(join(installedFontDir(), name), 'not really a font')
+    }
+
+    expect(await installedFontFiles()).toEqual([
+      join(installedFontDir(), 'alpha.otf'),
+      join(installedFontDir(), 'beta.ttc'),
+      join(installedFontDir(), 'zeta.ttf'),
+    ])
+  })
+
+  it('ignores anything that is not a font file', async () => {
+    await mkdir(installedFontDir(), { recursive: true })
+    await writeFile(join(installedFontDir(), 'notes.txt'), 'x')
+    await writeFile(join(installedFontDir(), '.DS_Store'), 'x')
+    await writeFile(join(installedFontDir(), 'real.ttf'), 'x')
+
+    expect(await installedFontFiles()).toEqual([join(installedFontDir(), 'real.ttf')])
+  })
+})
+
+/**
+ * The report and the render have to read the same set, or the report is about
+ * a picture nobody produced. This is ADR-0011 decision 4 at the one place it
+ * can actually be checked: install a face that covers the text, and both the
+ * pixels and the `undrawable` answer must change together.
+ */
+describe('an installed font reaches both the renderer and the report', () => {
+  // Any CJK-capable face on the machine; the point is coverage, not identity.
+  const SYSTEM_CJK = [
+    '/usr/share/fonts/truetype/droid/DroidSansFallbackFull.ttf',
+    '/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc',
+  ].find((path) => existsSync(path))
+
+  const CANVAS = {
+    nodes: [
+      { id: 'n', type: 'text' as const, x: 0, y: 0, width: 300, height: 60, text: 'こんにちは' },
+    ],
+    edges: [],
+  }
+
+  it.skipIf(SYSTEM_CJK === undefined)('stops reporting characters it can now draw', async () => {
+    const { undrawableCharacters } = await import('./undrawable-characters.js')
+    expect(await undrawableCharacters(CANVAS)).toEqual(['こ', 'ん', 'に', 'ち', 'は'])
+
+    await mkdir(installedFontDir(), { recursive: true })
+    await copyFile(SYSTEM_CJK as string, join(installedFontDir(), 'cjk.ttf'))
+
+    expect(await undrawableCharacters(CANVAS)).toEqual([])
+  })
+
+  // The report changing is NOT evidence the picture did: they are wired
+  // separately, and a version that fixed only the report passed the test
+  // above unchanged. resvg is the half a user actually sees, so it gets its
+  // own assertion — on the PIXELS, since that is the only place the answer
+  // exists.
+  it.skipIf(SYSTEM_CJK === undefined)('renders glyphs the vendored face lacks', async () => {
+    const { renderSpatialCanvasToPng } = await import('./headless-renderer.js')
+    const tofu = await renderSpatialCanvasToPng(CANVAS, { theme: 'light' })
+
+    await mkdir(installedFontDir(), { recursive: true })
+    await copyFile(SYSTEM_CJK as string, join(installedFontDir(), 'cjk.ttf'))
+    const drawn = await renderSpatialCanvasToPng(CANVAS, { theme: 'light' })
+
+    // Same canvas, same size, different ink. Byte equality would mean resvg
+    // painted the identical tofu boxes — which is exactly what happens when
+    // the installed files never reach `fontFiles`.
+    expect(drawn.width).toBe(tofu.width)
+    expect(drawn.height).toBe(tofu.height)
+    expect(drawn.png.equals(tofu.png)).toBe(false)
+  })
+})

--- a/packages/mcp-server/src/server/export/installed-fonts.test.ts
+++ b/packages/mcp-server/src/server/export/installed-fonts.test.ts
@@ -6,8 +6,8 @@
 // TTF in has installed a font, and a mechanism that only recognises its own
 // downloads would refuse the simplest way to answer "my exports are tofu".
 
-import { existsSync, mkdtempSync } from 'node:fs'
-import { copyFile, mkdir, writeFile } from 'node:fs/promises'
+import { mkdtempSync } from 'node:fs'
+import { mkdir, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -66,27 +66,60 @@ describe('installedFontFiles', () => {
  * a picture nobody produced. This is ADR-0011 decision 4 at the one place it
  * can actually be checked: install a face that covers the text, and both the
  * pixels and the `undrawable` answer must change together.
+ *
+ * The face is SYNTHESISED rather than copied from the machine. An earlier
+ * version read `/usr/share/fonts/...` and skipped when absent — which on CI is
+ * always, since no job installs a CJK font. Both assertions below were
+ * therefore green and had never run. A test that needs a glyph can make one.
  */
 describe('an installed font reaches both the renderer and the report', () => {
-  // Any CJK-capable face on the machine; the point is coverage, not identity.
-  const SYSTEM_CJK = [
-    '/usr/share/fonts/truetype/droid/DroidSansFallbackFull.ttf',
-    '/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc',
-  ].find((path) => existsSync(path))
+  const COVERED = 'こ'
+
+  /** A one-glyph font covering `COVERED`, drawn as a filled square so it leaves ink. */
+  async function writeSyntheticFont(path: string): Promise<void> {
+    const opentype = await import('opentype.js')
+    const square = new opentype.Path()
+    square.moveTo(100, 0)
+    square.lineTo(100, 700)
+    square.lineTo(800, 700)
+    square.lineTo(800, 0)
+    square.close()
+    const font = new opentype.Font({
+      familyName: 'WhiteboardTestCJK',
+      styleName: 'Regular',
+      unitsPerEm: 1000,
+      ascender: 800,
+      descender: -200,
+      glyphs: [
+        // Index 0 must be `.notdef` — a font without it is not loadable.
+        new opentype.Glyph({
+          name: '.notdef',
+          unicode: 0,
+          advanceWidth: 1000,
+          path: new opentype.Path(),
+        }),
+        new opentype.Glyph({
+          name: 'covered',
+          unicode: COVERED.codePointAt(0),
+          advanceWidth: 1000,
+          path: square,
+        }),
+      ],
+    })
+    await writeFile(path, Buffer.from(font.toArrayBuffer()))
+  }
 
   const CANVAS = {
-    nodes: [
-      { id: 'n', type: 'text' as const, x: 0, y: 0, width: 300, height: 60, text: 'こんにちは' },
-    ],
+    nodes: [{ id: 'n', type: 'text' as const, x: 0, y: 0, width: 300, height: 60, text: COVERED }],
     edges: [],
   }
 
-  it.skipIf(SYSTEM_CJK === undefined)('stops reporting characters it can now draw', async () => {
+  it('stops reporting characters it can now draw', async () => {
     const { undrawableCharacters } = await import('./undrawable-characters.js')
-    expect(await undrawableCharacters(CANVAS)).toEqual(['こ', 'ん', 'に', 'ち', 'は'])
+    expect(await undrawableCharacters(CANVAS)).toEqual([COVERED])
 
     await mkdir(installedFontDir(), { recursive: true })
-    await copyFile(SYSTEM_CJK as string, join(installedFontDir(), 'cjk.ttf'))
+    await writeSyntheticFont(join(installedFontDir(), 'covered.ttf'))
 
     expect(await undrawableCharacters(CANVAS)).toEqual([])
   })
@@ -96,17 +129,17 @@ describe('an installed font reaches both the renderer and the report', () => {
   // above unchanged. resvg is the half a user actually sees, so it gets its
   // own assertion — on the PIXELS, since that is the only place the answer
   // exists.
-  it.skipIf(SYSTEM_CJK === undefined)('renders glyphs the vendored face lacks', async () => {
+  it('renders glyphs the vendored face lacks', async () => {
     const { renderSpatialCanvasToPng } = await import('./headless-renderer.js')
     const tofu = await renderSpatialCanvasToPng(CANVAS, { theme: 'light' })
 
     await mkdir(installedFontDir(), { recursive: true })
-    await copyFile(SYSTEM_CJK as string, join(installedFontDir(), 'cjk.ttf'))
+    await writeSyntheticFont(join(installedFontDir(), 'covered.ttf'))
     const drawn = await renderSpatialCanvasToPng(CANVAS, { theme: 'light' })
 
     // Same canvas, same size, different ink. Byte equality would mean resvg
-    // painted the identical tofu boxes — which is exactly what happens when
-    // the installed files never reach `fontFiles`.
+    // painted the identical tofu box — which is exactly what happens when the
+    // installed files never reach `fontFiles`.
     expect(drawn.width).toBe(tofu.width)
     expect(drawn.height).toBe(tofu.height)
     expect(drawn.png.equals(tofu.png)).toBe(false)

--- a/packages/mcp-server/src/server/export/installed-fonts.ts
+++ b/packages/mcp-server/src/server/export/installed-fonts.ts
@@ -1,0 +1,51 @@
+import { readdir } from 'node:fs/promises'
+import { extname, join } from 'node:path'
+import { getDataDir } from '../../shared/data-dir-secure.js'
+
+/**
+ * Where a font the user installed lives.
+ *
+ * A plain directory rather than a manifest, deliberately. Dropping a TTF in is
+ * the simplest possible answer to "my exports are tofu", and a mechanism that
+ * recognised only its own downloads would refuse it. The download path
+ * (ADR-0012) writes here; it does not own the directory.
+ */
+export function installedFontDir(): string {
+  return join(getDataDir(), 'fonts')
+}
+
+/**
+ * `.ttc` is a collection rather than a single face; both resvg's fontdb and
+ * opentype.js read one, so it is admitted alongside the single-face formats.
+ *
+ * `.woff2` is NOT here. resvg's font database does not decode it, so accepting
+ * one would put a file in the directory that silently never renders — worse
+ * than refusing it. What the browser loads and what the exporter loads are
+ * allowed to differ in FORMAT; they must not differ in which glyphs exist.
+ */
+const FONT_EXTENSIONS = new Set(['.ttf', '.otf', '.ttc'])
+
+/**
+ * Absolute paths of every installed font, sorted.
+ *
+ * Sorted because this list reaches resvg's `fontFiles`, and family resolution
+ * among faces that declare the same name depends on registration order —
+ * directory order is not stable across filesystems, and an export that changes
+ * with it would break the byte-identical guarantee for no visible reason.
+ *
+ * A missing directory is the normal state of a daemon that has installed
+ * nothing, so it answers `[]` rather than throwing.
+ */
+export async function installedFontFiles(): Promise<readonly string[]> {
+  const dir = installedFontDir()
+  let entries: string[]
+  try {
+    entries = await readdir(dir)
+  } catch {
+    return []
+  }
+  return entries
+    .filter((name) => FONT_EXTENSIONS.has(extname(name).toLowerCase()))
+    .sort()
+    .map((name) => join(dir, name))
+}

--- a/packages/mcp-server/src/server/export/measure-text.ts
+++ b/packages/mcp-server/src/server/export/measure-text.ts
@@ -10,6 +10,7 @@ import * as opentype from 'opentype.js'
 
 import { getLogger } from '../log.js'
 import { EXPORT_FONT_FAMILY, type ExportFontFace, resolveExportFontFaces } from './export-font.js'
+import { installedFontFiles } from './installed-fonts.js'
 
 const log = getLogger('export-measure-text')
 
@@ -180,6 +181,35 @@ export async function loadExportFont(
   } catch {
     return null
   }
+}
+
+/**
+ * Every face the export path draws with: the vendored Regular plus whatever
+ * the user installed.
+ *
+ * This is the set `undrawableCharacters` has to ask, not just the vendored
+ * one. A report built from a narrower set than the renderer uses answers about
+ * a picture nobody produced — it would keep naming characters an installed
+ * font now draws perfectly.
+ *
+ * A face that fails to parse is skipped rather than fatal: it cannot draw
+ * anything, so it contributes nothing to the question being asked, and a
+ * corrupt file in the directory must not take the export down with it.
+ */
+export async function loadExportFonts(
+  resolveFontFiles: () => Promise<Record<ExportFontFace, string | null>> = resolveExportFontFaces,
+): Promise<readonly opentype.Font[]> {
+  const paths = [(await resolveFontFiles()).regular, ...(await installedFontFiles())]
+  const fonts: opentype.Font[] = []
+  for (const path of paths) {
+    try {
+      const font = await parseFace(path)
+      if (font !== null) fonts.push(font)
+    } catch {
+      // Skipped on purpose — see above.
+    }
+  }
+  return fonts
 }
 
 async function loadRealMeasurer(

--- a/packages/mcp-server/src/server/export/undrawable-characters.ts
+++ b/packages/mcp-server/src/server/export/undrawable-characters.ts
@@ -1,14 +1,14 @@
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
-import { loadExportFont } from './measure-text.js'
+import { loadExportFonts } from './measure-text.js'
 
 /**
  * The characters this renderer's own fonts have no glyph for.
  *
- * The export path draws with the vendored Roboto and nothing else
- * (`loadSystemFonts: false` in `headless-renderer.ts` — a deliberate choice,
- * since the system-font scan dominates first-call latency). resvg does not
- * substitute a face it was not given, so a code point Roboto lacks is painted
- * as a tofu box.
+ * The export path draws with the vendored Roboto plus whatever the user
+ * installed, and nothing else (`loadSystemFonts: false` in
+ * `headless-renderer.ts` — a deliberate choice, since the system-font scan
+ * dominates first-call latency). resvg does not substitute a face it was not
+ * given, so a code point NONE of those faces carries is painted as a tofu box.
  *
  * It is worth reporting because of HOW it fails. Measurement is correct
  * (`createOpentypeMeasureText` falls back to the estimator per code point), so
@@ -23,11 +23,11 @@ import { loadExportFont } from './measure-text.js'
  * report this should say which of the two they mean.
  */
 export async function undrawableCharacters(canvas: SpatialCanvas): Promise<readonly string[]> {
-  const font = await loadExportFont()
-  // No parsed face means the whole render already degraded to system fonts,
-  // which is logged where it happens. Claiming every character is undrawable
-  // there would be a second, louder, and wrong report.
-  if (font === null) return []
+  const fonts = await loadExportFonts()
+  // No parsed face at all means the whole render already degraded to system
+  // fonts, which is logged where it happens. Claiming every character is
+  // undrawable there would be a second, louder, and wrong report.
+  if (fonts.length === 0) return []
 
   const seen = new Set<string>()
   const missing: string[] = []
@@ -38,7 +38,7 @@ export async function undrawableCharacters(canvas: SpatialCanvas): Promise<reado
       seen.add(char)
       // Whitespace and control characters have no glyph to miss.
       if (char.trim() === '') continue
-      if (font.charToGlyphIndex(char) === 0) missing.push(char)
+      if (fonts.every((font) => font.charToGlyphIndex(char) === 0)) missing.push(char)
     }
   }
 


### PR DESCRIPTION
The first slice of [ADR-0011](docs/contributing/adr/0011-font-distribution.md) / [ADR-0012](docs/contributing/adr/0012-user-installed-fonts.md), and the one that makes a Japanese PNG legible. Includes ADR-0012 itself, which this implements the read side of.

## Before / after

Same canvas. The only difference is one CJK face copied into `<dataDir>/fonts/`:

![install-before.png](https://github.com/user-attachments/assets/66f04bd1-c8e4-4e2c-88d2-29d31e9a871e)

![install-after.png](https://github.com/user-attachments/assets/f8760600-eb44-48c6-aed5-e8fe3a393421)

```
before  undrawable: ["こ","ん","に","ち","は","世","界"]
after   undrawable: []
```

## What it does

Anything in `<dataDir>/fonts/` reaches **both** halves of the export — resvg's `fontFiles` so the glyphs are painted, and `undrawableCharacters` so the report stops naming characters an installed font now draws. Both, or neither is worth having: a report built from a narrower set than the renderer uses answers about a picture nobody produced.

A **plain directory, not a manifest**. Dropping a TTF in is the simplest possible answer to "my exports are tofu", and a mechanism that recognised only its own downloads would refuse it. The download path ADR-0012 describes will write here; it does not own the directory.

## The test that mattered, and why it exists

My first version asserted only on `undrawable`. Cutting resvg's wiring entirely left it **green** — the report and the render are wired separately, so fixing one proves nothing about the other, and I had confirmed the pixels only by eye.

The pixel assertion exists because of that. The two mutations now redden one test each:

| mutation | red |
|---|---|
| installed files never reach `fontFiles` | `renders glyphs the vendored face lacks` |
| report reads only the first face | `stops reporting characters it can now draw` |

## Two smaller decisions

- **`.woff2` is deliberately rejected.** resvg's font database cannot decode it, so admitting one would put a file in the directory that silently never renders — worse than refusing it. The browser and the exporter may differ in font *format*; they must not differ in which glyphs exist.
- **The whole-font fallback branch now also receives installed files.** A deployment missing its vendored Roboto but carrying an installed face should use it rather than going straight to system fonts. That is a behaviour change to ADR-0012 decision 5's branch, made deliberately.

## Not in this slice

The download itself. This is the read side; ADR-0012's fetch — family name in, Google Fonts out, user-triggered and not an MCP tool — is the next one. Until then a user or a deployment installs by copying a file, which is the mechanism ADR-0011 asked for.

Verified: `mcp-node` + `server-core-node` + `arch-lint-node` **334 files / 3947 passed**, `pnpm -r typecheck` clean, `pnpm knip` clean, `pnpm smoke:e2e` ALL OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9ztKagj84t3AJDYFtXqXJ