### PR TITLE
feat: install fonts from the app, so exports stop rendering as empty boxes

### DIFF
--- a/apps/web/src/components/FontsCard.test.tsx
+++ b/apps/web/src/components/FontsCard.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
-import { FontsCard } from './FontsCard.js'
+import { FontsCard, formatSize } from './FontsCard.js'
 
 afterEach(cleanup)
 
@@ -40,6 +40,17 @@ function renderCard(fetchImpl: (url: string, init?: RequestInit) => Promise<Resp
   )
   return fetchFn
 }
+
+describe('formatSize', () => {
+  // Whole megabytes suit the CJK faces this list exists for and print "0 MB"
+  // for the small ones. A size shown before a download must not round away.
+  it('never rounds a real file down to nothing', () => {
+    expect(formatSize(112_640)).toBe('113 KB')
+    expect(formatSize(218_652)).toBe('219 KB')
+    expect(formatSize(9_589_900)).toBe('10 MB')
+    expect(formatSize(17_772_300)).toBe('18 MB')
+  })
+})
 
 describe('FontsCard', () => {
   it('lists the catalogue, and offers Install only for what the daemon lacks', async () => {

--- a/apps/web/src/components/FontsCard.test.tsx
+++ b/apps/web/src/components/FontsCard.test.tsx
@@ -1,0 +1,96 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
+import { FontsCard } from './FontsCard.js'
+
+afterEach(cleanup)
+
+const FONTS = [
+  {
+    id: 'noto-sans-jp',
+    family: 'Noto Sans JP',
+    scripts: ['Japanese'],
+    license: 'OFL-1.1' as const,
+    approxBytes: 9_589_900,
+    installed: false,
+  },
+  {
+    id: 'noto-sans-kr',
+    family: 'Noto Sans KR',
+    scripts: ['Korean'],
+    license: 'OFL-1.1' as const,
+    approxBytes: 10_414_588,
+    installed: true,
+  },
+]
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function renderCard(fetchImpl: (url: string, init?: RequestInit) => Promise<Response>) {
+  const fetchFn = vi.fn(fetchImpl)
+  render(
+    <DaemonApiContext.Provider value={fetchFn as unknown as typeof globalThis.fetch}>
+      <FontsCard />
+    </DaemonApiContext.Provider>,
+  )
+  return fetchFn
+}
+
+describe('FontsCard', () => {
+  it('lists the catalogue, and offers Install only for what the daemon lacks', async () => {
+    renderCard(async () => jsonResponse({ fonts: FONTS }))
+
+    await screen.findByText('Noto Sans JP')
+    expect(screen.getByRole('button', { name: 'Install Noto Sans JP' })).not.toBeNull()
+    // The already-installed one has nothing to press.
+    expect(screen.queryByRole('button', { name: 'Install Noto Sans KR' })).toBeNull()
+    expect(screen.getByText(/Japanese · 10 MB · OFL-1.1/)).not.toBeNull()
+  })
+
+  it('installs by id and marks the row without a refetch', async () => {
+    const fetchFn = renderCard(async (url, init) => {
+      if (init?.method === 'POST') {
+        return jsonResponse({ id: 'noto-sans-jp', family: 'Noto Sans JP', bytes: 9_589_900 })
+      }
+      expect(url).toBe('/api/fonts')
+      return jsonResponse({ fonts: FONTS })
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Install Noto Sans JP' }))
+
+    // The id, in the path, and no URL anywhere near the request — the whole
+    // reason the daemon accepts a catalogue id.
+    await waitFor(() => {
+      expect(fetchFn).toHaveBeenCalledWith('/api/fonts/noto-sans-jp/install', { method: 'POST' })
+    })
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Install Noto Sans JP' })).toBeNull()
+    })
+  })
+
+  it('leaves the row installable and says why when the download fails', async () => {
+    renderCard(async (_url, init) =>
+      init?.method === 'POST'
+        ? jsonResponse({ error: 'unreachable', message: 'Could not download Noto Sans JP.' }, 502)
+        : jsonResponse({ fonts: FONTS }),
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Install Noto Sans JP' }))
+
+    // The daemon-authored reason, not a generic failure: "the source is down"
+    // and "that font does not exist" are different problems for the user.
+    await screen.findByText('Could not download Noto Sans JP.')
+    expect(screen.getByRole('button', { name: 'Install Noto Sans JP' })).not.toBeNull()
+  })
+
+  it('reports a catalogue it could not load at all', async () => {
+    renderCard(async () => jsonResponse({ error: 'nope', message: 'Daemon unavailable.' }, 500))
+
+    await screen.findByText('Daemon unavailable.')
+  })
+})

--- a/apps/web/src/components/FontsCard.tsx
+++ b/apps/web/src/components/FontsCard.tsx
@@ -1,0 +1,159 @@
+import type { FontCatalogueItem } from '@kamiazya/whiteboard-mcp/api-contracts'
+import { Check, Download, Loader2 } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useDaemonApi } from '../contexts/DaemonApiContext.js'
+import { installFont, listFonts } from '../lib/daemon-api-client.js'
+import { Button } from './ui/button.js'
+
+// Relative, because `createDaemonFetch` prefixes the daemon origin — the same
+// convention the other daemon-backed settings cards use.
+const RELATIVE = ''
+
+type ListState =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'loaded'; fonts: readonly FontCatalogueItem[] }
+
+function formatSize(bytes: number): string {
+  return `${Math.round(bytes / 1_000_000)} MB`
+}
+
+/**
+ * Pick a font, and the daemon keeps it (ADR-0012).
+ *
+ * The catalogue is the daemon's, not this component's: the browser sends an
+ * id it was given and never a URL, so nothing here — and nothing that talks to
+ * this app — can choose where the daemon reaches.
+ *
+ * What it reports is deliberately one-sided. `installed` means the DAEMON has
+ * the face, which is what decides whether an EXPORT renders the text or a row
+ * of tofu boxes. Whether this browser can also draw it on screen is a separate
+ * question with a separate answer, and calling both "installed" would hide the
+ * mismatch that matters.
+ */
+export function FontsCard() {
+  const fetchApi = useDaemonApi()
+  const [state, setState] = useState<ListState>({ kind: 'loading' })
+  const [busyId, setBusyId] = useState<string | null>(null)
+  const [failures, setFailures] = useState<Readonly<Record<string, string>>>({})
+  const mounted = useRef(true)
+
+  useEffect(() => {
+    mounted.current = true
+    return () => {
+      mounted.current = false
+    }
+  }, [])
+
+  const refresh = useCallback(async () => {
+    try {
+      const { fonts } = await listFonts(fetchApi, RELATIVE)
+      if (mounted.current) setState({ kind: 'loaded', fonts })
+    } catch (err) {
+      if (mounted.current) {
+        setState({ kind: 'error', message: err instanceof Error ? err.message : 'Request failed.' })
+      }
+    }
+  }, [fetchApi])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const install = useCallback(
+    async (font: FontCatalogueItem) => {
+      setBusyId(font.id)
+      setFailures((prev) => {
+        const { [font.id]: _dropped, ...rest } = prev
+        return rest
+      })
+      try {
+        await installFont(fetchApi, RELATIVE, font.id)
+        if (!mounted.current) return
+        setState((prev) =>
+          prev.kind === 'loaded'
+            ? {
+                kind: 'loaded',
+                fonts: prev.fonts.map((item) =>
+                  item.id === font.id ? { ...item, installed: true } : item,
+                ),
+              }
+            : prev,
+        )
+      } catch (err) {
+        if (!mounted.current) return
+        setFailures((prev) => ({
+          ...prev,
+          [font.id]: err instanceof Error ? err.message : 'Install failed.',
+        }))
+      } finally {
+        if (mounted.current) setBusyId(null)
+      }
+    },
+    [fetchApi],
+  )
+
+  return (
+    <div>
+      <h3 className="text-sm font-medium">Fonts</h3>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Exports are drawn with the fonts this daemon has. Without a face covering the script you
+        write in, those characters export as empty boxes. Fonts are downloaded from Google Fonts and
+        licensed under the SIL Open Font License.
+      </p>
+
+      {/* Mounted unconditionally and emptied rather than removed: a polite
+          live region inserted already carrying its text is announced
+          unreliably. `empty:mt-0` keeps it in the accessibility tree while
+          costing no layout — `hidden` would prune it from that tree, which is
+          the same bug wearing different clothes. */}
+      <p className="mt-3 text-xs text-muted-foreground empty:mt-0" role="status">
+        {state.kind === 'loading' ? 'Loading fonts…' : ''}
+      </p>
+      {state.kind === 'error' && (
+        <div className="mt-3 text-xs text-destructive">{state.message}</div>
+      )}
+      {state.kind === 'loaded' && (
+        <ul className="mt-3 divide-y rounded-md border">
+          {state.fonts.map((font) => (
+            <li key={font.id} className="px-3 py-2" data-font-row={font.id}>
+              <div className="flex items-center gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium">{font.family}</div>
+                  <div className="truncate text-[11px] text-muted-foreground">
+                    {font.scripts.join(', ')} · {formatSize(font.approxBytes)} · {font.license}
+                  </div>
+                </div>
+                {font.installed ? (
+                  <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <Check className="size-3.5" />
+                    Installed
+                  </span>
+                ) : (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 gap-1.5"
+                    disabled={busyId !== null}
+                    onClick={() => void install(font)}
+                    aria-label={`Install ${font.family}`}
+                  >
+                    {busyId === font.id ? (
+                      <Loader2 className="size-3.5 animate-spin" />
+                    ) : (
+                      <Download className="size-3.5" />
+                    )}
+                    <span className="text-xs">Install</span>
+                  </Button>
+                )}
+              </div>
+              {failures[font.id] !== undefined && (
+                <div className="mt-1 text-[11px] text-destructive">{failures[font.id]}</div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/FontsCard.tsx
+++ b/apps/web/src/components/FontsCard.tsx
@@ -14,8 +14,16 @@ type ListState =
   | { kind: 'error'; message: string }
   | { kind: 'loaded'; fonts: readonly FontCatalogueItem[] }
 
-function formatSize(bytes: number): string {
-  return `${Math.round(bytes / 1_000_000)} MB`
+/**
+ * Rounding to whole megabytes is right for the CJK faces this list exists for
+ * (9–18 MB) and prints "0 MB" for the small ones — the catalogue's Hebrew face
+ * is 113 KB. A size the user reads before committing to a download must never
+ * round to nothing.
+ */
+export function formatSize(bytes: number): string {
+  return bytes < 1_000_000
+    ? `${Math.round(bytes / 1_000)} KB`
+    : `${Math.round(bytes / 1_000_000)} MB`
 }
 
 /**

--- a/apps/web/src/lib/app-routes.ts
+++ b/apps/web/src/lib/app-routes.ts
@@ -93,9 +93,9 @@ export function parseBrowserLocalRoute(pathname: string): { path: string } | nul
   return { path: segments.join('/') }
 }
 
-export type SettingsSection = 'general' | 'data' | 'connections'
+export type SettingsSection = 'general' | 'data' | 'fonts' | 'connections'
 
-const SETTINGS_SECTIONS: readonly SettingsSection[] = ['general', 'data', 'connections']
+const SETTINGS_SECTIONS: readonly SettingsSection[] = ['general', 'data', 'fonts', 'connections']
 
 export function settingsPath(section?: SettingsSection): string {
   return section === undefined ? '/settings' : `/settings/${section}`

--- a/apps/web/src/lib/daemon-api-client.ts
+++ b/apps/web/src/lib/daemon-api-client.ts
@@ -8,9 +8,13 @@ import {
   documentApiUrl,
   documentOkfV1ResponseSchema,
   documentsApiUrl,
+  type InstallFontResponse,
+  installFontResponseSchema,
   type ListDocumentsResponse,
+  type ListFontsResponse,
   type ListWorkspacesResponse,
   listDocumentsResponseSchema,
+  listFontsResponseSchema,
   listWorkspacesResponseSchema,
   type RenameDocumentPathRequest,
   type RenameDocumentPathResponse,
@@ -215,6 +219,35 @@ export function getDocumentOkfV1(
     fetchFn,
     `${daemonBaseUrl}/api/v1/workspaces/${encodeURIComponent(workspaceId)}/documents/${encodeURIComponent(documentId)}/okf`,
     documentOkfV1ResponseSchema,
+  )
+}
+
+// ---- fonts (ADR-0012: the daemon keeps what it renders with) ----
+
+export function listFonts(
+  fetchFn: typeof globalThis.fetch,
+  daemonBaseUrl: string,
+): Promise<ListFontsResponse> {
+  return fetchAndParse(fetchFn, `${daemonBaseUrl}/api/fonts`, listFontsResponseSchema)
+}
+
+/**
+ * Install one catalogued font.
+ *
+ * The argument is a catalogue id and there is deliberately no URL variant:
+ * the daemon builds the request from a pinned template, so no caller — this
+ * one, or an agent that talked one into it — can choose where it reaches.
+ */
+export function installFont(
+  fetchFn: typeof globalThis.fetch,
+  daemonBaseUrl: string,
+  fontId: string,
+): Promise<InstallFontResponse> {
+  return fetchAndParse(
+    fetchFn,
+    `${daemonBaseUrl}/api/fonts/${encodeURIComponent(fontId)}/install`,
+    installFontResponseSchema,
+    { method: 'POST' },
   )
 }
 

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -335,6 +335,42 @@ describe('SettingsPage — Connections', () => {
     expect(within(mobile).getByText(/not connected/i)).toBeTruthy()
   })
 
+  // Fonts are the daemon's, not this browser's: it is the daemon that
+  // rasterises an export, so an empty list would be the wrong answer here.
+  it('/settings/fonts says a daemon is needed before it offers any font', () => {
+    renderAt('/settings/fonts')
+    const mobile = screen.getByTestId('settings-mobile')
+    expect(within(mobile).getByText(/not connected/i)).toBeTruthy()
+    expect(within(mobile).queryByRole('button', { name: /^Install / })).toBeNull()
+  })
+
+  it('/settings/fonts lists the daemon catalogue when one is connected', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString()
+        if (url.includes('/api/fonts')) {
+          return jsonResponse({
+            fonts: [
+              {
+                id: 'noto-sans-jp',
+                family: 'Noto Sans JP',
+                scripts: ['Japanese'],
+                license: 'OFL-1.1',
+                approxBytes: 9_589_900,
+                installed: false,
+              },
+            ],
+          })
+        }
+        return jsonResponse({}, 404)
+      }),
+    )
+    renderAt('/settings/fonts', { baseUrl: 'http://127.0.0.1:9999', token: 'tok' })
+    const mobile = screen.getByTestId('settings-mobile')
+    expect(await within(mobile).findByRole('button', { name: 'Install Noto Sans JP' })).toBeTruthy()
+  })
+
   it('renders the paired-origins and storage cards when a daemon is provided', async () => {
     vi.stubGlobal(
       'fetch',

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -7,6 +7,7 @@ import {
   Moon,
   Palette,
   Sun,
+  Type,
   Waves,
 } from 'lucide-react'
 import { useCallback, useEffect, useId, useRef, useState, useSyncExternalStore } from 'react'
@@ -23,6 +24,7 @@ import type { FaviconStyle } from '@/lib/favicon'
 import { getInstallState, promptInstall, subscribeInstallState } from '@/lib/install-prompt-store'
 import { ensurePersistentStorage, queryPersistentStorage } from '@/lib/persistent-storage'
 import { createUserSettingsStore } from '@/lib/user-settings-store'
+import { FontsCard } from '../components/FontsCard.js'
 import { PairedOriginsCard } from '../components/PairedOriginsCard.js'
 import { StorageReportCard } from '../components/StorageReportCard.js'
 
@@ -48,6 +50,7 @@ const FAVICON_OPTIONS: Array<{ value: FaviconStyle; label: string; icon: typeof 
 const NAV_ITEMS: Array<{ section: SettingsSection; label: string; icon: typeof Palette }> = [
   { section: 'general', label: 'General', icon: Palette },
   { section: 'data', label: 'Data & app', icon: Database },
+  { section: 'fonts', label: 'Fonts', icon: Type },
   { section: 'connections', label: 'Connections', icon: Cable },
 ]
 
@@ -205,6 +208,33 @@ function ConnectionsSection({ daemon }: { daemon?: { baseUrl: string; token: str
   )
 }
 
+/**
+ * Fonts belong to the DAEMON, not to this browser: it is the daemon that
+ * rasterises an export, so a font the browser alone has still exports as
+ * tofu (ADR-0012 decision 4). Without one there is nothing to install into,
+ * and saying so beats an empty list.
+ */
+function FontsSection({ daemon }: { daemon?: { baseUrl: string; token: string | null } }) {
+  if (!daemon) {
+    return (
+      <section>
+        <p className="text-sm">Fonts — Not connected</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Installed fonts live on a local daemon, which renders exports. Connect one to choose fonts
+          for the scripts you write in.
+        </p>
+      </section>
+    )
+  }
+  return (
+    <DaemonApiContext.Provider value={createDaemonFetch(daemon.baseUrl, daemon.token ?? undefined)}>
+      <section aria-label="Fonts">
+        <FontsCard />
+      </section>
+    </DaemonApiContext.Provider>
+  )
+}
+
 function sectionContent(
   section: SettingsSection,
   props: {
@@ -251,6 +281,8 @@ function sectionContent(
           </div>
         </div>
       )
+    case 'fonts':
+      return <FontsSection daemon={props.daemon} />
     case 'connections':
       return <ConnectionsSection daemon={props.daemon} />
   }
@@ -259,6 +291,7 @@ function sectionContent(
 const SECTION_TITLE: Record<SettingsSection, string> = {
   general: 'General',
   data: 'Data & app',
+  fonts: 'Fonts',
   connections: 'Connections',
 }
 

--- a/docs/contributing/adr/0012-user-installed-fonts.md
+++ b/docs/contributing/adr/0012-user-installed-fonts.md
@@ -1,6 +1,6 @@
 # ADR-0012: A user installs a font by naming it, and the daemon keeps it
 
-**Status:** Accepted — not yet implemented
+**Status:** Accepted — implemented (daemon route + settings picker)
 
 ## Context
 
@@ -42,6 +42,15 @@ read it as a file.**
 
 Google Fonts is the source. It is the one the user knows, and picking a single
 well-known catalogue keeps the first version legible.
+
+Concretely, the pinned template resolves against **`google/fonts` on
+`raw.githubusercontent.com`** — the Google Fonts catalogue's own repository —
+because that serves the real `.ttf` in ONE hop. Decided while implementing;
+the two alternatives both fail on this ADR's own terms. `fonts.googleapis.com`
+is the two-hop shape decision 1 rejects, and it only offers `woff2`, which
+resvg's font database cannot decode. `fonts.gstatic.com` addresses files by a
+version-and-hash path that cannot be derived from a family name, so a template
+built on it would not be a template.
 
 ### 1. The input is a family NAME, never a URL
 

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -8,6 +8,8 @@ Guides:
 - **[self-host-with-docker](self-host-with-docker.md)** — run Whiteboard in server mode for a team.
 - **[connect-to-local-daemon](connect-to-local-daemon.md)** — detect a local daemon from the web
   app and copy browser-local canvases onto it.
+- **[install-fonts-for-export](install-fonts-for-export.md)** — stop exports rendering Japanese,
+  Chinese, Korean and other scripts as empty boxes.
 - **[view-canvas-in-chat](view-canvas-in-chat.md)** — render an interactive read-only canvas
   view inline in an MCP Apps-compatible AI chat client (currently unavailable — see the page's
   notice).

--- a/docs/how-to/install-fonts-for-export.md
+++ b/docs/how-to/install-fonts-for-export.md
@@ -1,0 +1,60 @@
+# Install fonts so exports are not empty boxes
+
+Your canvas reads fine on screen but exports as rows of `□□□`? The daemon draws exports with the
+fonts **it** has, and it ships with a Latin face only. Any script it has no glyph for — Japanese,
+Chinese, Korean, Thai, Devanagari, Arabic, Hebrew — is painted as an empty box.
+
+This is a property of the daemon, not of your canvas or your browser: the text is intact, and an
+SVG export still carries it as text that any viewer with the font can read. Only the rasterised
+formats (PNG) bake in what the daemon could draw.
+
+## Install one
+
+1. Connect the web app to a local daemon (see
+   [connect-to-local-daemon](connect-to-local-daemon.md)). Fonts live on the daemon, so this
+   screen has nothing to offer without one.
+2. Open **Settings → Fonts**.
+3. Press **Install** next to the font covering the script you write in.
+
+The daemon downloads it, checks it really is a font, and keeps it. Every later export uses it —
+no restart, no configuration.
+
+| Script | Font |
+|---|---|
+| Japanese | Noto Sans JP |
+| Chinese (Simplified / Traditional) | Noto Sans SC / TC |
+| Korean | Noto Sans KR |
+| Thai, Devanagari, Arabic, Hebrew | Noto Sans Thai / Devanagari / Arabic / Hebrew |
+
+A CJK font is 9–18 MB, because it carries thousands of glyphs. The others are under 1 MB.
+
+All of them come from [Google Fonts](https://fonts.google.com/) and are licensed under the
+[SIL Open Font License 1.1](https://openfontlicense.org/). Whiteboard does not redistribute
+them; your daemon fetches them when you ask it to.
+
+## Install one that is not listed
+
+Any font already on your machine works. Copy the `.ttf`, `.otf`, or `.ttc` into the daemon's
+`fonts` directory and it participates in the next export:
+
+```
+~/.whiteboard/fonts/
+```
+
+That is the location on every platform. If you set `WHITEBOARD_DATA_DIR`, it is
+`$WHITEBOARD_DATA_DIR/fonts/` instead. (Where the home directory is not writable — some
+sandboxes — the daemon falls back to `<temp>/.whiteboard`.)
+
+`.woff2` is deliberately **not** accepted: the export renderer cannot decode it, so a file
+dropped in that format would sit there and never draw anything.
+
+## Why the app does not just download the font it needs
+
+Installing reaches the network, and the daemon is also driven by AI agents that act on
+instructions found in the documents they read. Making this an agent-callable action would let a
+malicious canvas talk an agent into making the daemon fetch things. So it is a button a person
+presses, and the only thing it accepts is a name from the list above — never a URL, not even
+yours. The reasoning is recorded in
+[ADR-0012](../contributing/adr/0012-user-installed-fonts.md).
+
+← Back to [How-to guides](README.md)

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -36,6 +36,7 @@ import { createDebugRouter } from './routes/debug.js'
 import { createDocumentRouter } from './routes/document.js'
 import { createExportRouter } from './routes/export.js'
 import { createFilesRouter } from './routes/files.js'
+import { createFontsRouter } from './routes/fonts.js'
 import {
   createOAuthAuthzRouter,
   OAUTH_AUTHZ_CORS_PATHS,
@@ -415,6 +416,7 @@ export function createApp(options: AppOptions) {
   const sharedVersionStore = new FileVersionStore()
   app.route('/', createFilesRouter({ versionStore: sharedVersionStore }))
   app.route('/', createExportRouter())
+  app.route('/', createFontsRouter())
   app.route('/', createViewportRouter())
   app.route('/', createSyncSseRouter())
   app.route('/', createDebugRouter({ token }))

--- a/packages/mcp-server/src/server/export/font-catalogue.ts
+++ b/packages/mcp-server/src/server/export/font-catalogue.ts
@@ -1,0 +1,133 @@
+import { z } from 'zod'
+import { fontCatalogueItemSchema } from '../../shared/api-contracts/fonts.js'
+
+/**
+ * The one host the font installer will ever talk to.
+ *
+ * ADR-0012 decided the daemon takes a family ID and builds the request itself,
+ * rather than accepting a URL and validating it. That is why this is a
+ * constant and not configuration: "where can this reach" is a property of the
+ * code, not of a validator someone has to keep correct.
+ *
+ * `google/fonts` is the Google Fonts catalogue's own repository, and serving
+ * from it keeps the download to ONE hop. The `fonts.googleapis.com` CSS API is
+ * two — it answers with a stylesheet naming files on `fonts.gstatic.com` — and
+ * a fetch whose destination comes from a response body is the thing worth not
+ * building. It also only offers `woff2`, which resvg's font database cannot
+ * decode.
+ */
+export const FONT_SOURCE_ORIGIN = 'https://raw.githubusercontent.com'
+
+const FONT_SOURCE_BASE = `${FONT_SOURCE_ORIGIN}/google/fonts/main/`
+
+/**
+ * The published item plus the one field the browser has no business seeing.
+ *
+ * Extended from the HTTP contract rather than declared beside it: the two
+ * would otherwise drift, which is the exact failure the Zod-single-source rule
+ * exists to prevent. `installed` is omitted because it is per-daemon state
+ * answered at request time, not a property of the catalogue.
+ */
+export const fontCatalogueEntrySchema = fontCatalogueItemSchema.omit({ installed: true }).extend({
+  /** Path within the source repository. Joined onto the pinned base. */
+  path: z.string().min(1),
+})
+
+export type FontCatalogueEntry = z.infer<typeof fontCatalogueEntrySchema>
+
+/**
+ * Every font a user can install, as data.
+ *
+ * One face per script rather than a style choice: this list exists to stop
+ * exports rendering as tofu, and a second weight of a script already covered
+ * fixes nothing. Noto because it is the family with systematic script
+ * coverage, and all of it is OFL-1.1.
+ */
+export const FONT_CATALOGUE: readonly FontCatalogueEntry[] = [
+  {
+    id: 'noto-sans-jp',
+    family: 'Noto Sans JP',
+    scripts: ['Japanese'],
+    license: 'OFL-1.1',
+    approxBytes: 9_589_900,
+    path: 'ofl/notosansjp/NotoSansJP[wght].ttf',
+  },
+  {
+    id: 'noto-sans-sc',
+    family: 'Noto Sans SC',
+    scripts: ['Chinese (Simplified)'],
+    license: 'OFL-1.1',
+    approxBytes: 17_772_300,
+    path: 'ofl/notosanssc/NotoSansSC[wght].ttf',
+  },
+  {
+    id: 'noto-sans-tc',
+    family: 'Noto Sans TC',
+    scripts: ['Chinese (Traditional)'],
+    license: 'OFL-1.1',
+    approxBytes: 11_941_968,
+    path: 'ofl/notosanstc/NotoSansTC[wght].ttf',
+  },
+  {
+    id: 'noto-sans-kr',
+    family: 'Noto Sans KR',
+    scripts: ['Korean'],
+    license: 'OFL-1.1',
+    approxBytes: 10_414_588,
+    path: 'ofl/notosanskr/NotoSansKR[wght].ttf',
+  },
+  {
+    id: 'noto-sans-thai',
+    family: 'Noto Sans Thai',
+    scripts: ['Thai'],
+    license: 'OFL-1.1',
+    approxBytes: 218_652,
+    path: 'ofl/notosansthai/NotoSansThai[wdth,wght].ttf',
+  },
+  {
+    id: 'noto-sans-devanagari',
+    family: 'Noto Sans Devanagari',
+    scripts: ['Devanagari'],
+    license: 'OFL-1.1',
+    approxBytes: 647_144,
+    path: 'ofl/notosansdevanagari/NotoSansDevanagari[wdth,wght].ttf',
+  },
+  {
+    id: 'noto-sans-arabic',
+    family: 'Noto Sans Arabic',
+    scripts: ['Arabic'],
+    license: 'OFL-1.1',
+    approxBytes: 844_676,
+    path: 'ofl/notosansarabic/NotoSansArabic[wdth,wght].ttf',
+  },
+  {
+    id: 'noto-sans-hebrew',
+    family: 'Noto Sans Hebrew',
+    scripts: ['Hebrew'],
+    license: 'OFL-1.1',
+    approxBytes: 112_640,
+    path: 'ofl/notosanshebrew/NotoSansHebrew[wdth,wght].ttf',
+  },
+]
+
+export function fontCatalogueEntry(id: string): FontCatalogueEntry | undefined {
+  return FONT_CATALOGUE.find((entry) => entry.id === id)
+}
+
+/**
+ * The single URL the installer may request for this entry.
+ *
+ * `new URL` percent-encodes the `[wght]` in Google's variable-font file names,
+ * which is what the source expects. It also resolves a `path` that starts with
+ * `/` or `//` against the *authority* rather than the base path, so an entry
+ * spelled `//example.com/x` would silently retarget the download — hence the
+ * origin is re-checked here rather than only in a test, which only covers the
+ * entries that exist today.
+ */
+export function fontDownloadUrl(entry: FontCatalogueEntry): string {
+  const url = new URL(entry.path, FONT_SOURCE_BASE)
+  if (url.origin !== FONT_SOURCE_ORIGIN) {
+    throw new Error(`Font catalogue entry ${entry.id} resolves outside ${FONT_SOURCE_ORIGIN}.`)
+  }
+  return url.toString()
+}

--- a/packages/mcp-server/src/server/export/install-font.test.ts
+++ b/packages/mcp-server/src/server/export/install-font.test.ts
@@ -1,0 +1,187 @@
+// ADR-0012's write side. The read side (`installed-fonts.ts`) already exports
+// with whatever is in the directory; this is how something legitimately gets
+// there without the user hunting down a TTF by hand.
+//
+// The security shape is the point, not the download. The daemon is driven by
+// AI agents that act on instructions found in documents, so the input is a
+// catalogue ID and never a URL, and the request is built from a pinned
+// template. Most of what is asserted below is that property holding.
+
+import { mkdtempSync } from 'node:fs'
+import { readdir } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { extname, join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { resetDataDirForTests, setDataDirForTests } from '../../shared/data-dir-secure.js'
+import { syntheticFont } from '../../shared/test-utils/synthetic-font.js'
+import {
+  FONT_CATALOGUE,
+  FONT_SOURCE_ORIGIN,
+  fontCatalogueEntry,
+  fontDownloadUrl,
+} from './font-catalogue.js'
+import { FontInstallError, installFont, MAX_FONT_BYTES } from './install-font.js'
+import { FONT_EXTENSIONS, installedFontDir, installedFontFiles } from './installed-fonts.js'
+
+const COVERED = 'こ'
+
+beforeEach(() => {
+  setDataDirForTests(mkdtempSync(join(tmpdir(), 'wb-font-install-')))
+})
+
+afterEach(() => {
+  resetDataDirForTests()
+})
+
+/** Records what the installer asked for, and answers with `body`. */
+function recordingFetch(body: BodyInit | null, init?: ResponseInit) {
+  const calls: { url: string; init: RequestInit | undefined }[] = []
+  const impl = (async (input, requestInit) => {
+    calls.push({ url: String(input), init: requestInit })
+    return new Response(body, { status: 200, ...init })
+  }) as typeof fetch
+  return { impl, calls }
+}
+
+async function installedNames(): Promise<string[]> {
+  return (await installedFontFiles()).map((path) => path.split('/').at(-1) ?? '')
+}
+
+describe('the catalogue', () => {
+  it('is not empty, and every id is safe to use as a file name', () => {
+    expect(FONT_CATALOGUE.length).toBeGreaterThan(0)
+    for (const entry of FONT_CATALOGUE) {
+      // The id becomes a path segment under the data directory. Anything that
+      // could contain a separator or `..` would let the catalogue — not a
+      // user, but still — write outside it.
+      expect(entry.id).toMatch(/^[a-z0-9-]+$/)
+    }
+  })
+
+  it('has unique ids', () => {
+    const ids = FONT_CATALOGUE.map((entry) => entry.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('builds every download URL on the pinned origin', () => {
+    for (const entry of FONT_CATALOGUE) {
+      expect(new URL(fontDownloadUrl(entry)).origin).toBe(FONT_SOURCE_ORIGIN)
+    }
+  })
+
+  // A cap below the largest thing we offer would make that entry permanently
+  // uninstallable, and the failure would look like a network fault.
+  it('offers nothing larger than the size cap', () => {
+    for (const entry of FONT_CATALOGUE) {
+      expect(entry.approxBytes).toBeLessThan(MAX_FONT_BYTES)
+    }
+  })
+
+  it('does not resolve an unknown id', () => {
+    expect(fontCatalogueEntry('no-such-font')).toBeUndefined()
+  })
+
+  // An entry the reader ignores would download, report success, and render
+  // exactly the tofu it was installed to fix.
+  it('offers only extensions the export path reads back', () => {
+    for (const entry of FONT_CATALOGUE) {
+      expect(FONT_EXTENSIONS).toContain(extname(entry.path))
+    }
+  })
+
+  // `new URL` resolves an authority-relative path against the host, not the
+  // base path, so this is the one way a catalogue edit could retarget a
+  // download without looking wrong.
+  it('refuses to build a URL for an entry that escapes the pinned origin', () => {
+    expect(() =>
+      fontDownloadUrl({ ...FONT_CATALOGUE[0]!, path: '//example.com/evil.ttf' }),
+    ).toThrow(/outside/)
+  })
+})
+
+describe('installFont', () => {
+  const known = () => FONT_CATALOGUE[0]!
+
+  it('writes the font where the exporter reads it', async () => {
+    const font = syntheticFont(COVERED)
+    const { impl, calls } = recordingFetch(font)
+
+    const installed = await installFont(known().id, { fetchImpl: impl })
+
+    expect(installed.id).toBe(known().id)
+    expect(installed.family).toBe(known().family)
+    expect(installed.bytes).toBe(font.byteLength)
+    expect(installed.path).toBe(join(installedFontDir(), `${known().id}.ttf`))
+    // The whole point: the read side finds it without being told.
+    expect(await installedFontFiles()).toContain(installed.path)
+    expect(calls).toHaveLength(1)
+  })
+
+  it('requests exactly the pinned URL, refusing redirects and bounding the wait', async () => {
+    const { impl, calls } = recordingFetch(syntheticFont(COVERED))
+
+    await installFont(known().id, { fetchImpl: impl })
+
+    expect(calls[0]?.url).toBe(fontDownloadUrl(known()))
+    // A host that answers 302 could otherwise send the daemon anywhere, which
+    // is the whole reason the input is an id rather than a URL.
+    expect(calls[0]?.init?.redirect).toBe('error')
+    expect(calls[0]?.init?.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('refuses an id that is not in the catalogue, without fetching anything', async () => {
+    const { impl, calls } = recordingFetch(syntheticFont(COVERED))
+
+    await expect(installFont('../../etc/passwd', { fetchImpl: impl })).rejects.toThrow(
+      FontInstallError,
+    )
+    expect(calls).toHaveLength(0)
+    expect(await installedFontFiles()).toEqual([])
+  })
+
+  it('keeps nothing that does not parse as a font', async () => {
+    const { impl } = recordingFetch('<!doctype html><title>Not Found</title>')
+
+    await expect(installFont(known().id, { fetchImpl: impl })).rejects.toMatchObject({
+      reason: 'not-a-font',
+    })
+    // Not merely "no .ttf": a leftover temp file would be an unbounded litter
+    // of failed downloads in the user's data directory.
+    expect(await readdir(installedFontDir()).catch(() => [])).toEqual([])
+  })
+
+  it('keeps nothing when the source answers an error status', async () => {
+    const { impl } = recordingFetch('nope', { status: 404 })
+
+    await expect(installFont(known().id, { fetchImpl: impl })).rejects.toMatchObject({
+      reason: 'unreachable',
+    })
+    expect(await installedNames()).toEqual([])
+  })
+
+  it('stops reading past the size cap even when Content-Length understates it', async () => {
+    const chunk = new Uint8Array(1024)
+    const body = new ReadableStream({
+      start(controller) {
+        for (let i = 0; i < 16; i++) controller.enqueue(chunk)
+        controller.close()
+      },
+    })
+    // A lying header is the reason the cap is enforced on the stream rather
+    // than on the declared length.
+    const { impl } = recordingFetch(body, { headers: { 'content-length': '10' } })
+
+    await expect(
+      installFont(known().id, { fetchImpl: impl, maxBytes: 4 * 1024 }),
+    ).rejects.toMatchObject({ reason: 'too-large' })
+    expect(await installedNames()).toEqual([])
+  })
+
+  it('replaces an earlier install of the same font rather than accumulating files', async () => {
+    const { impl } = recordingFetch(syntheticFont(COVERED))
+    await installFont(known().id, { fetchImpl: impl })
+    await installFont(known().id, { fetchImpl: recordingFetch(syntheticFont(COVERED)).impl })
+
+    expect(await installedNames()).toEqual([`${known().id}.ttf`])
+  })
+})

--- a/packages/mcp-server/src/server/export/install-font.ts
+++ b/packages/mcp-server/src/server/export/install-font.ts
@@ -1,0 +1,169 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir, rename, rm, writeFile } from 'node:fs/promises'
+import { extname, join } from 'node:path'
+import { z } from 'zod'
+import { opentypeApi } from '../../shared/opentype.js'
+import { getLogger } from '../log.js'
+import { type FontCatalogueEntry, fontCatalogueEntry, fontDownloadUrl } from './font-catalogue.js'
+import { installedFontDir } from './installed-fonts.js'
+
+const log = getLogger('font-install')
+
+/**
+ * The largest download that will be kept. Comfortably above the biggest
+ * catalogue entry (a CJK face is ~18 MB); `install-font.test.ts` fails if an
+ * entry is ever added above it, since that entry could never install and the
+ * failure would read as a network fault.
+ */
+export const MAX_FONT_BYTES = 32 * 1024 * 1024
+
+/**
+ * Bounds the whole request including the body read. Generous because the
+ * largest face is ~18 MB on whatever connection the user has; the point is
+ * that a stalled response cannot hold the daemon open indefinitely.
+ */
+const FETCH_TIMEOUT_MS = 5 * 60 * 1000
+
+export const fontInstallFailureSchema = z.enum([
+  /** No catalogue entry has this id. The only failure that is the caller's fault. */
+  'unknown-font',
+  'unreachable',
+  'too-large',
+  'not-a-font',
+])
+
+export type FontInstallFailure = z.infer<typeof fontInstallFailureSchema>
+
+export class FontInstallError extends Error {
+  readonly reason: FontInstallFailure
+
+  constructor(reason: FontInstallFailure, message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'FontInstallError'
+    this.reason = reason
+  }
+}
+
+export interface InstallFontOptions {
+  /** Injected so tests never reach the network. */
+  readonly fetchImpl?: typeof fetch
+  readonly maxBytes?: number
+}
+
+export interface InstalledFont {
+  readonly id: string
+  readonly family: string
+  readonly path: string
+  readonly bytes: number
+}
+
+/**
+ * Download one catalogued font and keep it where the export path reads fonts.
+ *
+ * The input is a catalogue id, never a URL: the daemon is driven by AI agents
+ * that act on instructions found in the documents they read, so a URL
+ * parameter here would complete a prompt-injection-to-SSRF chain. This is also
+ * why ADR-0012 keeps the trigger human — nothing in the MCP surface calls it.
+ *
+ * Everything the response says about itself is treated as hostile: redirects
+ * are refused, the length is counted rather than believed, and the bytes must
+ * parse as a font before anything is written. The file name comes from the
+ * catalogue, never from the URL or a `Content-Disposition` header.
+ */
+export async function installFont(
+  id: string,
+  options: InstallFontOptions = {},
+): Promise<InstalledFont> {
+  const entry = fontCatalogueEntry(id)
+  if (entry === undefined) {
+    throw new FontInstallError('unknown-font', `No font in the catalogue is called ${id}.`)
+  }
+
+  const bytes = await download(entry, options)
+
+  try {
+    const font = opentypeApi.parse(
+      bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+    )
+    // A parse that succeeds on a file with no glyphs would install something
+    // that renders exactly the tofu it was meant to fix.
+    if (font.numGlyphs <= 0) throw new Error('the file declares no glyphs')
+  } catch (err) {
+    throw new FontInstallError(
+      'not-a-font',
+      `What ${entry.family} downloaded is not a usable font file.`,
+      { cause: err },
+    )
+  }
+
+  const dir = installedFontDir()
+  await mkdir(dir, { recursive: true })
+  const path = join(dir, `${entry.id}${extname(entry.path)}`)
+  // Written beside the target and renamed, because a render running
+  // concurrently would otherwise hand resvg a half-written file. The name is
+  // unique per call so two installs of the same font cannot interleave into
+  // one another's buffer; `installedFontFiles` ignores the extension either
+  // way.
+  const partial = `${path}.${randomUUID()}.partial`
+  try {
+    await writeFile(partial, bytes)
+    await rename(partial, path)
+  } catch (err) {
+    await rm(partial, { force: true })
+    throw err
+  }
+
+  log.notice({ id: entry.id, family: entry.family, bytes: bytes.byteLength }, 'installed font')
+  return { id: entry.id, family: entry.family, path, bytes: bytes.byteLength }
+}
+
+async function download(entry: FontCatalogueEntry, options: InstallFontOptions): Promise<Buffer> {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const maxBytes = options.maxBytes ?? MAX_FONT_BYTES
+
+  let response: Response
+  try {
+    response = await fetchImpl(fontDownloadUrl(entry), {
+      // The control that makes "the daemon builds the URL" mean anything: a
+      // source answering 302 could otherwise redirect it anywhere.
+      redirect: 'error',
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    })
+  } catch (err) {
+    throw new FontInstallError('unreachable', `Could not download ${entry.family}.`, { cause: err })
+  }
+
+  if (!response.ok) {
+    throw new FontInstallError(
+      'unreachable',
+      `Downloading ${entry.family} answered HTTP ${response.status}.`,
+    )
+  }
+  if (response.body === null) {
+    throw new FontInstallError('unreachable', `Downloading ${entry.family} returned no body.`)
+  }
+
+  // Counted rather than read from Content-Length, which a hostile or broken
+  // source is free to understate.
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let total = 0
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      total += value.byteLength
+      if (total > maxBytes) {
+        throw new FontInstallError(
+          'too-large',
+          `${entry.family} is larger than the ${maxBytes} byte limit.`,
+        )
+      }
+      chunks.push(value)
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined)
+  }
+
+  return Buffer.concat(chunks)
+}

--- a/packages/mcp-server/src/server/export/installed-fonts.test.ts
+++ b/packages/mcp-server/src/server/export/installed-fonts.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { resetDataDirForTests, setDataDirForTests } from '../../shared/data-dir-secure.js'
+import { syntheticFont } from '../../shared/test-utils/synthetic-font.js'
 import { installedFontDir, installedFontFiles } from './installed-fonts.js'
 
 let dataDir: string
@@ -75,39 +76,8 @@ describe('installedFontFiles', () => {
 describe('an installed font reaches both the renderer and the report', () => {
   const COVERED = 'こ'
 
-  /** A one-glyph font covering `COVERED`, drawn as a filled square so it leaves ink. */
-  async function writeSyntheticFont(path: string): Promise<void> {
-    const opentype = await import('opentype.js')
-    const square = new opentype.Path()
-    square.moveTo(100, 0)
-    square.lineTo(100, 700)
-    square.lineTo(800, 700)
-    square.lineTo(800, 0)
-    square.close()
-    const font = new opentype.Font({
-      familyName: 'WhiteboardTestCJK',
-      styleName: 'Regular',
-      unitsPerEm: 1000,
-      ascender: 800,
-      descender: -200,
-      glyphs: [
-        // Index 0 must be `.notdef` — a font without it is not loadable.
-        new opentype.Glyph({
-          name: '.notdef',
-          unicode: 0,
-          advanceWidth: 1000,
-          path: new opentype.Path(),
-        }),
-        new opentype.Glyph({
-          name: 'covered',
-          unicode: COVERED.codePointAt(0),
-          advanceWidth: 1000,
-          path: square,
-        }),
-      ],
-    })
-    await writeFile(path, Buffer.from(font.toArrayBuffer()))
-  }
+  const writeSyntheticFont = (path: string): Promise<void> =>
+    writeFile(path, syntheticFont(COVERED))
 
   const CANVAS = {
     nodes: [{ id: 'n', type: 'text' as const, x: 0, y: 0, width: 300, height: 60, text: COVERED }],

--- a/packages/mcp-server/src/server/export/installed-fonts.ts
+++ b/packages/mcp-server/src/server/export/installed-fonts.ts
@@ -23,7 +23,7 @@ export function installedFontDir(): string {
  * than refusing it. What the browser loads and what the exporter loads are
  * allowed to differ in FORMAT; they must not differ in which glyphs exist.
  */
-const FONT_EXTENSIONS = new Set(['.ttf', '.otf', '.ttc'])
+export const FONT_EXTENSIONS: ReadonlySet<string> = new Set(['.ttf', '.otf', '.ttc'])
 
 /**
  * Absolute paths of every installed font, sorted.

--- a/packages/mcp-server/src/server/export/measure-text.ts
+++ b/packages/mcp-server/src/server/export/measure-text.ts
@@ -6,22 +6,14 @@
 import { readFile } from 'node:fs/promises'
 import type { FontDescriptor, MeasureText, TextMetrics } from '@kamiazya/whiteboard-canvas-render'
 import { constantRatioMeasureText } from '@kamiazya/whiteboard-canvas-render'
-import * as opentype from 'opentype.js'
+import type * as opentype from 'opentype.js'
 
+import { opentypeApi } from '../../shared/opentype.js'
 import { getLogger } from '../log.js'
 import { EXPORT_FONT_FAMILY, type ExportFontFace, resolveExportFontFaces } from './export-font.js'
 import { installedFontFiles } from './installed-fonts.js'
 
 const log = getLogger('export-measure-text')
-
-// opentype.js is CommonJS. Running from source (tsx) its exports land on the
-// namespace root, but tsup's ESM interop nests them under `default` in the
-// bundled dist. Reading only one of the two shapes throws
-// "opentype.parse is not a function" in exactly one environment — the
-// published package — where the fallback measurer then silently absorbs it
-// and every export loses the real font metrics. Resolve whichever object
-// actually carries the API.
-const opentypeApi = (opentype as unknown as { default?: typeof opentype }).default ?? opentype
 
 function clampNonNegative(value: number): number {
   return Number.isFinite(value) && value >= 0 ? value : 0

--- a/packages/mcp-server/src/server/release/api-contracts-barrel.test.ts
+++ b/packages/mcp-server/src/server/release/api-contracts-barrel.test.ts
@@ -42,6 +42,10 @@ describe('api-contracts barrel scope', () => {
       // exported so every client error surface reads through the same
       // parser instead of hand-rolled per-file field checks.
       './errors.js',
+      // fonts: the installable-font catalogue, exported so the settings
+      // picker sends an id the daemon gave it. Publishing the contract is
+      // what keeps a URL out of the request (ADR-0012).
+      './fonts.js',
       './pairing.js',
       './runtime.js',
     ])

--- a/packages/mcp-server/src/server/routes/fonts.test.ts
+++ b/packages/mcp-server/src/server/routes/fonts.test.ts
@@ -1,0 +1,124 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { Hono } from 'hono'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  installFontResponseSchema,
+  listFontsResponseSchema,
+} from '../../shared/api-contracts/fonts.js'
+import { resetDataDirForTests, setDataDirForTests } from '../../shared/data-dir-secure.js'
+import { FONT_CATALOGUE } from '../export/font-catalogue.js'
+import { FontInstallError } from '../export/install-font.js'
+import { installedFontDir } from '../export/installed-fonts.js'
+import { withTempDataDir } from './_test-helpers.js'
+import { createFontsRouter } from './fonts.js'
+
+const temp = withTempDataDir('wb-fonts-route-')
+
+beforeEach(() => {
+  setDataDirForTests(temp.dir)
+})
+
+afterEach(() => {
+  resetDataDirForTests()
+})
+
+function serve(install?: Parameters<typeof createFontsRouter>[0]) {
+  const app = new Hono()
+  app.route('/', createFontsRouter(install))
+  return app
+}
+
+describe('GET /api/fonts', () => {
+  it('answers the catalogue, and never leaks the source path', async () => {
+    const res = await serve().request('/api/fonts')
+
+    expect(res.status).toBe(200)
+    const body = listFontsResponseSchema.parse(await res.json())
+    expect(body.fonts).toHaveLength(FONT_CATALOGUE.length)
+    // The repository path is an implementation detail of where the daemon
+    // fetches from; publishing it would invite a client to build its own URL,
+    // which is the shape ADR-0012 exists to avoid.
+    for (const font of body.fonts) expect(font).not.toHaveProperty('path')
+  })
+
+  it('reports nothing as installed on a fresh daemon', async () => {
+    const body = listFontsResponseSchema.parse(await (await serve().request('/api/fonts')).json())
+
+    expect(body.fonts.every((font) => font.installed === false)).toBe(true)
+  })
+
+  it('reports a font as installed once its file is on disk', async () => {
+    const target = FONT_CATALOGUE[0]!
+    await mkdir(installedFontDir(), { recursive: true })
+    await writeFile(join(installedFontDir(), `${target.id}.ttf`), 'x')
+
+    const body = listFontsResponseSchema.parse(await (await serve().request('/api/fonts')).json())
+
+    expect(body.fonts.find((font) => font.id === target.id)?.installed).toBe(true)
+    expect(body.fonts.filter((font) => font.installed)).toHaveLength(1)
+  })
+})
+
+describe('POST /api/fonts/:id/install', () => {
+  const target = () => FONT_CATALOGUE[0]!
+
+  it('installs the requested font and answers what it kept', async () => {
+    const install = vi
+      .fn()
+      .mockResolvedValue({ id: target().id, family: target().family, path: '/x.ttf', bytes: 42 })
+
+    const res = await serve({ install }).request(`/api/fonts/${target().id}/install`, {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(200)
+    expect(installFontResponseSchema.parse(await res.json())).toEqual({
+      id: target().id,
+      family: target().family,
+      bytes: 42,
+    })
+    expect(install).toHaveBeenCalledWith(target().id)
+  })
+
+  it('answers 404 for an id the catalogue does not have', async () => {
+    const install = vi
+      .fn()
+      .mockRejectedValue(new FontInstallError('unknown-font', 'No font in the catalogue.'))
+
+    const res = await serve({ install }).request('/api/fonts/not-a-font/install', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(404)
+    expect(await res.json()).toMatchObject({ error: 'unknown-font' })
+  })
+
+  // A source that is down is not the caller's fault, and the picker has to be
+  // able to tell "you asked for something that does not exist" from "try
+  // again later".
+  it.each([
+    'unreachable',
+    'too-large',
+    'not-a-font',
+  ] as const)('answers 502 when the download fails with %s', async (reason) => {
+    const install = vi.fn().mockRejectedValue(new FontInstallError(reason, 'nope'))
+
+    const res = await serve({ install }).request(`/api/fonts/${target().id}/install`, {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(502)
+    expect(await res.json()).toMatchObject({ error: reason, message: 'nope' })
+  })
+
+  it('does not swallow an unexpected error as a font problem', async () => {
+    const install = vi.fn().mockRejectedValue(new Error('disk on fire'))
+
+    const res = await serve({ install }).request(`/api/fonts/${target().id}/install`, {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(500)
+  })
+})

--- a/packages/mcp-server/src/server/routes/fonts.ts
+++ b/packages/mcp-server/src/server/routes/fonts.ts
@@ -1,0 +1,58 @@
+import { basename, extname } from 'node:path'
+import { Hono } from 'hono'
+import type { ApiErrorBody } from '../../shared/api-contracts/errors.js'
+import type { InstallFontResponse, ListFontsResponse } from '../../shared/api-contracts/fonts.js'
+import { FONT_CATALOGUE } from '../export/font-catalogue.js'
+import { FontInstallError, installFont } from '../export/install-font.js'
+import { installedFontFiles } from '../export/installed-fonts.js'
+
+/**
+ * The font picker's daemon surface.
+ *
+ * ADR-0012 keeps the trigger human: this is reachable from the browser UI and
+ * from nothing else. It is deliberately NOT an MCP tool — the daemon is driven
+ * by agents that act on instructions found in the documents they read, and a
+ * tool that fetches would complete a prompt-injection-to-SSRF chain. Adding
+ * one later is a decision that has to re-examine that sentence, not a natural
+ * extension of this router.
+ */
+export interface FontsRouterDeps {
+  /** Injected so a route test never reaches the network. */
+  readonly install?: typeof installFont
+}
+
+export function createFontsRouter({ install = installFont }: FontsRouterDeps = {}) {
+  const app = new Hono()
+
+  app.get('/api/fonts', async (c) => {
+    const stems = new Set((await installedFontFiles()).map((path) => basename(path, extname(path))))
+    const response: ListFontsResponse = {
+      fonts: FONT_CATALOGUE.map(({ path: _sourcePath, ...item }) => ({
+        ...item,
+        installed: stems.has(item.id),
+      })),
+    }
+    return c.json(response)
+  })
+
+  app.post('/api/fonts/:id/install', async (c) => {
+    try {
+      const { id, family, bytes } = await install(c.req.param('id'))
+      return c.json({ id, family, bytes } satisfies InstallFontResponse)
+    } catch (err) {
+      if (!(err instanceof FontInstallError)) throw err
+      // The reason is the machine-readable half and the message is what the
+      // picker shows; `apiErrorReason` only forwards a message that arrives
+      // alongside an `error` code.
+      return c.json(
+        { error: err.reason, message: err.message } satisfies ApiErrorBody,
+        // Only an unknown id is the caller's mistake. Everything else is the
+        // upstream source failing, which is not this daemon's fault and not
+        // something a retry of the same request will fix differently.
+        err.reason === 'unknown-font' ? 404 : 502,
+      )
+    }
+  })
+
+  return app
+}

--- a/packages/mcp-server/src/server/security/route-scope-registry.ts
+++ b/packages/mcp-server/src/server/security/route-scope-registry.ts
@@ -153,6 +153,15 @@ export function resolveApiRouteScope(method: string, path: string): RouteScopeDe
     return { kind: 'scoped', scopes: ['runtime:admin'] }
   }
 
+  // Fonts (ADR-0012). Installing one makes the daemon issue an outbound
+  // request and write to its own data directory, changing what every later
+  // export renders — daemon-level configuration, so it sits at the same admin
+  // tier as the other routes that mutate daemon state, not at canvas:write.
+  // Reading the catalogue is harmless and answers a picker.
+  if (path === '/api/fonts' || path.startsWith('/api/fonts/')) {
+    return { kind: 'scoped', scopes: [isWrite ? 'runtime:admin' : 'runtime:read'] }
+  }
+
   // POST /api/ws-ticket (ADR-0005): mints a WS connection ticket bound to
   // the caller's own OAuth grant scopes. canvas:read is the floor any live
   // grant is assumed to hold — the minted ticket never carries more than

--- a/packages/mcp-server/src/shared/api-contracts/fonts.ts
+++ b/packages/mcp-server/src/shared/api-contracts/fonts.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod'
+
+/**
+ * A catalogue id, and the stem of the file the daemon writes.
+ *
+ * Constrained to a pattern with no path separator and no `.`: the id reaches
+ * `join(dataDir, 'fonts', id + ext)`, and this is what stops anything shaped
+ * like `../..` from naming a file outside that directory. The daemon takes an
+ * id, never a URL — see ADR-0012.
+ */
+export const fontIdSchema = z.string().regex(/^[a-z0-9-]+$/)
+
+export const fontCatalogueItemSchema = z.object({
+  id: fontIdSchema,
+  /** What the user picks, and what an SVG `font-family` can then name. */
+  family: z.string().min(1),
+  /** Human-readable coverage, for the picker. Not used for font matching. */
+  scripts: z.array(z.string().min(1)).min(1),
+  license: z.literal('OFL-1.1'),
+  /** Size as measured upstream, so the picker can warn before a download. */
+  approxBytes: z.number().int().positive(),
+  /**
+   * Whether the DAEMON has this font. The browser's own `FontFace` state is a
+   * separate question with its own answer: ADR-0012 decision 4 — a font is not
+   * a boolean, because either surface can have it without the other.
+   */
+  installed: z.boolean(),
+})
+
+export type FontCatalogueItem = z.infer<typeof fontCatalogueItemSchema>
+
+export const listFontsResponseSchema = z.object({
+  fonts: z.array(fontCatalogueItemSchema),
+})
+
+export type ListFontsResponse = z.infer<typeof listFontsResponseSchema>
+
+export const installFontResponseSchema = z.object({
+  id: fontIdSchema,
+  family: z.string().min(1),
+  bytes: z.number().int().positive(),
+})
+
+export type InstallFontResponse = z.infer<typeof installFontResponseSchema>

--- a/packages/mcp-server/src/shared/api-contracts/index.ts
+++ b/packages/mcp-server/src/shared/api-contracts/index.ts
@@ -22,6 +22,7 @@ export * from './branches.js'
 export * from './document.js'
 export * from './document-url.js'
 export * from './errors.js'
+export * from './fonts.js'
 export type { ListGrantsResponse, PairingTokenResponse } from './pairing.js'
 export {
   listGrantsResponseSchema,

--- a/packages/mcp-server/src/shared/opentype.ts
+++ b/packages/mcp-server/src/shared/opentype.ts
@@ -1,0 +1,11 @@
+import * as opentype from 'opentype.js'
+
+// opentype.js is CommonJS. Running from source (tsx) its exports land on the
+// namespace root, but tsup's ESM interop nests them under `default` in the
+// bundled dist. Reading only one of the two shapes throws
+// "opentype.parse is not a function" in exactly one environment — the
+// published package — where the fallback measurer then silently absorbs it
+// and every export loses the real font metrics. Resolve whichever object
+// actually carries the API.
+export const opentypeApi =
+  (opentype as unknown as { default?: typeof opentype }).default ?? opentype

--- a/packages/mcp-server/src/shared/test-utils/synthetic-font.ts
+++ b/packages/mcp-server/src/shared/test-utils/synthetic-font.ts
@@ -1,0 +1,48 @@
+import { opentypeApi } from '../opentype.js'
+
+/**
+ * A minimal real font covering exactly `covered`, as bytes.
+ *
+ * Font tests need a glyph the vendored Latin face does not have. Reading one
+ * off the machine is not an option: no CI job installs a CJK font, so a test
+ * guarded by `skipIf(<font missing>)` is green everywhere and has run nowhere.
+ * `opentype.js` builds fonts as well as parsing them, so the fixture can make
+ * its own — no system dependency, no committed binary, no license question.
+ *
+ * The glyph is a filled square rather than an empty path so that a rendered
+ * result differs in PIXELS, which is the only place "did resvg actually use
+ * this face" can be observed.
+ */
+export function syntheticFont(covered: string, familyName = 'WhiteboardTestFont'): Buffer {
+  const square = new opentypeApi.Path()
+  square.moveTo(100, 0)
+  square.lineTo(100, 700)
+  square.lineTo(800, 700)
+  square.lineTo(800, 0)
+  square.close()
+
+  const font = new opentypeApi.Font({
+    familyName,
+    styleName: 'Regular',
+    unitsPerEm: 1000,
+    ascender: 800,
+    descender: -200,
+    glyphs: [
+      // Index 0 must be `.notdef` — a font without it is not loadable.
+      new opentypeApi.Glyph({
+        name: '.notdef',
+        unicode: 0,
+        advanceWidth: 1000,
+        path: new opentypeApi.Path(),
+      }),
+      new opentypeApi.Glyph({
+        name: 'covered',
+        unicode: covered.codePointAt(0),
+        advanceWidth: 1000,
+        path: square,
+      }),
+    ],
+  })
+
+  return Buffer.from(font.toArrayBuffer())
+}


### PR DESCRIPTION
Japanese, Chinese, Korean and every other non-Latin script currently exports as `□□□`. The daemon rasterises exports with the fonts **it** has, and it ships a Latin face only.

[#911](https://github.com/kamiazya/whiteboard/pull/911) made that failure *visible* (`undrawable`), and [#915](https://github.com/kamiazya/whiteboard/pull/915) made a hand-installed font *work*. This makes it **fixable from the app**: Settings → Fonts → Install.

Implements [ADR-0012](https://github.com/kamiazya/whiteboard/blob/main/docs/contributing/adr/0012-user-installed-fonts.md), which is now marked implemented.

## Visual repro

Same canvas, same render pipeline, before and after one install. Not a screenshot of a screen — both PNGs come from `renderSpatialCanvasToPng` over the identical input.

| before | after |
|---|---|
| ![font-before.png](https://github.com/user-attachments/assets/4cd85b70-ab01-4412-845c-2861cc78dd4f) | ![font-after.png](https://github.com/user-attachments/assets/a95a58b7-7c89-4292-8ac1-199a56174f60) |

`undrawable`: 40 characters → **0**.

## The security shape is the design

Font installation is the daemon's first outbound request ever, so the trigger and the destination were the decisions, not the download.

- **The input is a catalogue ID, never a URL.** The daemon builds the request from a pinned template, so *which hosts this can reach* is a property of our code rather than of a validator someone has to keep correct. A domain allowlist — the obvious control — is the weaker form of the same idea, and survives as the host-pinning inside that template.
- **No MCP tool.** The daemon is driven by agents that act on instructions found in the documents they read; a tool that fetches would complete a prompt-injection → SSRF chain. This is a button a person presses. Exposing it to MCP later has to re-argue that paragraph.
- **One hop.** `google/fonts` on raw.githubusercontent.com is the Google Fonts catalogue's own repository and serves the real `.ttf` directly. The CSS API is two hops — it answers with a stylesheet naming files on another host — and a fetch whose destination comes from a response body is the thing worth not building. It also only serves woff2, which resvg's font database cannot decode.
- Redirects refused; length **counted**, not believed; wait bounded; bytes must parse as a font with ≥1 glyph before anything is written; the on-disk name comes from the catalogue.

## Verification

Real daemon, real network — not mocks:

```
GET  /api/fonts                        401 unauthenticated
GET  /api/fonts                        200, 8 fonts, installed:false
POST /api/fonts/no-such-font/install   404 {"error":"unknown-font", …}
POST /api/fonts/noto-sans-jp/install   200 {"bytes":9589900}  (1.3s)
GET  /api/fonts                        noto-sans-jp installed:true
ls   ~/.whiteboard/fonts/              noto-sans-jp.ttf  9589900
```

Every guard is mutation-checked, each reddening exactly the one test that names it: the redirect policy, the streaming size cap, the font parse, the unknown id, the origin re-check, the route's scope declaration, and the four component branches. The full list is in the commit messages.

`pnpm test` 853 files / 8609 tests, `pnpm lint` clean, `pnpm knip` clean, typecheck clean.

## Also here

- 8 Noto faces (JP / SC / TC / KR / Thai / Devanagari / Arabic / Hebrew), OFL-1.1, surfaced with size and license in the picker.
- `docs/how-to/install-fonts-for-export.md`, including the directory to drop your own font into. That path was read off `resolveDataDir` rather than assumed — the first draft published XDG and Application Support paths that do not exist.
- Three copies of the opentype.js CommonJS-interop workaround folded into one module, and the synthetic-font test fixture moved to `test-utils`.

## Known-flake note

`typing into the daemon markdown editor pushes the edit to the backend` failed once in a full-suite run and passes in isolation and on re-run. It is the keystroke-overrun family already tracked, and touches nothing this PR changes.


## Also verified on the deployed preview

Real browser, real build, [the Cloudflare Pages preview for this PR](https://font-install.kamiazya-whiteboard.pages.dev/settings/fonts) — which runs in browser-local mode, so it exercises the branch with no daemon:

```
nav:  General · Data & app · Fonts · Connections
page: "Fonts — Not connected"
      "Installed fonts live on a local daemon, which renders exports. …"
```

`/settings/fonts` resolves as a route rather than falling through to not-found, and the no-daemon branch explains itself instead of showing an empty list.

Sub-megabyte sizes are also fixed here: the picker rounded 113 KB and 219 KB to **"0 MB"**, two of eight rows advertising a download of nothing. Found by printing every catalogue row through the formatter — the component tests used the two CJK rows, which round correctly.
