### PR TITLE
fix(web): stop the markdown preview scrolling sideways on a phone

### DIFF
--- a/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
@@ -31,6 +31,7 @@ import {
   previewColumnMaxWidth,
   RAIL_WIDTH_PX,
   railFits,
+  railScrollable,
 } from './preview-width.js'
 import type { RailBlock } from './rail-geometry.js'
 import type { PreviewBlockAnchor } from './render-preview.js'
@@ -306,6 +307,9 @@ export function MarkdownEditor({
   // handler — these have to be state.
   const [railBlocks, setRailBlocks] = useState<readonly RailBlock[]>([])
   const [railViewport, setRailViewport] = useState({ top: 0, height: 0 })
+  // Whether the pane the rail maps has anything to scroll. Read from the same
+  // element on the same tick as the viewport above, for the same reason.
+  const [railHasScroll, setRailHasScroll] = useState(false)
 
   // Container width drives the split fallback and the preview's adaptive
   // layout width. `null` (pre-observation, or jsdom without ResizeObserver)
@@ -489,6 +493,12 @@ export function MarkdownEditor({
       const top = documentYForLine(anchorsRef.current, api.topVisibleLine(), tail)
       const bottom = documentYForLine(anchorsRef.current, api.bottomVisibleLine(), tail)
       setRailViewport({ top, height: Math.max(0, bottom - top) })
+      setRailHasScroll(
+        railScrollable({
+          contentHeight: scroller.scrollHeight,
+          viewportHeight: scroller.clientHeight,
+        }),
+      )
       setRailBlocks(blocks)
     }
     sync()
@@ -511,6 +521,12 @@ export function MarkdownEditor({
             preview.scrollTop
           : 0
       setRailViewport({ top: preview.scrollTop - svgTop, height: preview.clientHeight })
+      setRailHasScroll(
+        railScrollable({
+          contentHeight: preview.scrollHeight,
+          viewportHeight: preview.clientHeight,
+        }),
+      )
       setRailBlocks(blocksRef.current)
     }
     sync()
@@ -702,7 +718,7 @@ export function MarkdownEditor({
             </div>
           </div>
         )}
-        {!previewEmpty && railAffordable && railBlocks.length > 0 && (
+        {!previewEmpty && railAffordable && railHasScroll && railBlocks.length > 0 && (
           // The bars are the same in every mode — they describe the document,
           // not the pane. Only what a press moves differs: the preview when
           // one is on screen, otherwise the source through its anchors.

--- a/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
@@ -24,8 +24,14 @@ import { DocumentHeader } from './DocumentHeader.js'
 import { EditorToolbar, type MarkdownViewMode } from './EditorToolbar.js'
 import { LinkPickerDialog } from './LinkPickerDialog.js'
 import type { LinkTarget } from './link-target.js'
-import { MinimapRail, RAIL_WIDTH_PX } from './MinimapRail.js'
+import { MinimapRail } from './MinimapRail.js'
 import { PreviewPane } from './PreviewPane.js'
+import {
+  previewWidth as computePreviewWidth,
+  previewColumnMaxWidth,
+  RAIL_WIDTH_PX,
+  railFits,
+} from './preview-width.js'
 import type { RailBlock } from './rail-geometry.js'
 import type { PreviewBlockAnchor } from './render-preview.js'
 import { SourcePane, type SourcePaneApi } from './SourcePane.js'
@@ -98,7 +104,6 @@ export interface MarkdownEditorProps {
 
 const DEFAULT_MAX_WIDTH = 720
 const DEFAULT_PREVIEW_DEBOUNCE_MS = 150
-const MIN_PREVIEW_WIDTH = 320
 
 /**
  * A controlled markdown editor: one source-of-truth `value` string, edited
@@ -417,25 +422,23 @@ export function MarkdownEditor({
   }, [])
 
   // Layout width the preview typesets at: what the pane can actually offer
-  // (minus the document column's padding), clamped to a readable measure.
-  const horizontalPadding = 48
+  // (minus the document column's padding), clamped to a readable measure —
+  // see preview-width.ts, which owns the arithmetic and the reasons.
+  //
   // The rail is a sibling of the preview, so the width it occupies is width
   // the preview does not get. Typesetting against the container's full width
   // instead overflows by exactly the rail — the document is then clipped at
   // the very edge the rail is drawn on.
-  const railWidth = effectiveMode !== 'write' && debouncedValue.trim() !== '' ? RAIL_WIDTH_PX : 0
-  const paneWidth =
-    containerWidth === null
-      ? maxWidth
-      : effectiveMode === 'split'
-        ? containerWidth * (1 - splitRatio) - railWidth
-        : containerWidth - railWidth
-  // Quantized so a divider drag re-typesets the whole document at 64px
-  // steps instead of on every pointermove.
-  const previewWidth = Math.max(
-    MIN_PREVIEW_WIDTH,
-    Math.min(maxWidth, Math.round((paneWidth - horizontalPadding) / 64) * 64),
-  )
+  const railAffordable = railFits(containerWidth)
+  const railWidth =
+    railAffordable && effectiveMode !== 'write' && debouncedValue.trim() !== '' ? RAIL_WIDTH_PX : 0
+  const previewWidth = computePreviewWidth({
+    containerWidth,
+    maxWidth,
+    railWidth,
+    splitRatio,
+    mode: effectiveMode,
+  })
 
   /**
    * Keeps the rail in step with the preview it maps.
@@ -673,7 +676,10 @@ export function MarkdownEditor({
             className="min-w-0 flex-1 overflow-auto"
             onClick={onPreviewClick}
           >
-            <div className="mx-auto px-6 py-8" style={{ maxWidth: previewWidth + 48 }}>
+            <div
+              className="mx-auto px-6 py-8"
+              style={{ maxWidth: previewColumnMaxWidth(previewWidth) }}
+            >
               {effectiveMode === 'read' && meta !== undefined && (
                 <DocumentHeader title={title} meta={meta} />
               )}
@@ -696,7 +702,7 @@ export function MarkdownEditor({
             </div>
           </div>
         )}
-        {!previewEmpty && railBlocks.length > 0 && (
+        {!previewEmpty && railAffordable && railBlocks.length > 0 && (
           // The bars are the same in every mode — they describe the document,
           // not the pane. Only what a press moves differs: the preview when
           // one is on screen, otherwise the source through its anchors.

--- a/apps/web/src/components/markdown-editor/MinimapRail.tsx
+++ b/apps/web/src/components/markdown-editor/MinimapRail.tsx
@@ -15,6 +15,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { cn } from '../../lib/utils.js'
+import { RAIL_WIDTH_PX } from './preview-width.js'
 import {
   type RailBlock,
   railGeometry,
@@ -30,8 +31,6 @@ export interface MinimapRailProps {
   readonly onSeek: (documentY: number) => void
   readonly className?: string
 }
-
-export const RAIL_WIDTH_PX = 56
 
 export function MinimapRail({ blocks, viewport, onSeek, className }: MinimapRailProps) {
   const railRef = useRef<HTMLDivElement | null>(null)

--- a/apps/web/src/components/markdown-editor/narrow-preview.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/narrow-preview.browser.test.tsx
@@ -1,0 +1,87 @@
+// A phone-width editor must not hand the reader a horizontal scrollbar under
+// content that has nowhere to go, and must not spend 56px of a 390px screen
+// on a rail the document cannot spare.
+//
+// Real browser, and the assertions target the element that actually scrolls:
+// the preview PANE, not the column scroller around it. `max-width` on a block
+// never widens it, so the column always fits its parent — what overflows is
+// the fixed-width SVG inside the pane's own `overflow: auto`. Measured on the
+// reported case: outer 156/156, pane 736/108.
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import '../../index.css'
+import { MarkdownEditor } from './MarkdownEditor.js'
+
+// Tailwind decides every width here, so the sheet has to be live before a
+// measurement is taken — without it every box measures 0 and an "is it
+// narrower than the pane" assertion passes VACUOUSLY.
+beforeAll(async () => {
+  await vi.waitFor(() => {
+    const probe = document.createElement('div')
+    probe.className = 'w-full'
+    document.body.append(probe)
+    const applied = getComputedStyle(probe).width !== 'auto'
+    probe.remove()
+    if (!applied) throw new Error('index.css not applied yet')
+  })
+})
+
+// Read mode: what the phone report was taken in, and the only mode where the
+// preview owns the full pane. The stored default is 'split'.
+//
+// RESTORED after every test, not merely set: localStorage is shared by every
+// file in the browser project, so a mode left behind here reaches the split
+// tests as their starting state — observed as four unrelated failures in
+// split-and-scroll.browser.test.tsx, which is a far more confusing report
+// than anything this file asserts.
+const VIEW_MODE_KEY = 'whiteboard.markdown-view-mode'
+beforeEach(() => window.localStorage.setItem(VIEW_MODE_KEY, 'read'))
+afterEach(() => {
+  cleanup()
+  window.localStorage.removeItem(VIEW_MODE_KEY)
+  for (const host of document.querySelectorAll('body > div[style*="width"]')) host.remove()
+})
+
+const BODY = ['# Title', '', 'あらあ たらたはた たたたああああ ああああ', '', '---', ''].join('\n')
+
+function mountAt(width: number) {
+  const host = document.createElement('div')
+  host.style.cssText = `width:${width}px;height:600px`
+  document.body.append(host)
+  return render(<MarkdownEditor value={BODY} onChange={() => {}} />, { container: host })
+}
+
+describe('a phone-width markdown editor', () => {
+  // Two tests, not four: preview-width.test.ts already pins the arithmetic at
+  // every width with its own mutation checks. What only a real browser can
+  // say is whether the SVG ends up inside the box, and adding files to this
+  // project measurably slows every other one — so this file buys exactly the
+  // two facts the unit test cannot reach.
+
+  // 320 rather than the reported 390: with the rail correctly hidden, 390
+  // fits even under the old arithmetic, so a test only there would pass
+  // whichever formula is in place.
+  it('settles with the preview inside its pane, not scrolling sideways', async () => {
+    const { getByTestId } = mountAt(320)
+    // Waits for the LAID-OUT width, not the first frame: the preview renders
+    // once at `maxWidth` before the ResizeObserver reports the container.
+    await vi.waitFor(() => {
+      const pane = getByTestId('markdown-preview-pane')
+      expect(pane.clientWidth).toBeGreaterThan(0)
+      expect(pane.scrollWidth).toBeLessThanOrEqual(pane.clientWidth)
+    })
+  })
+
+  it('still shows the rail where the container can afford it', async () => {
+    // Only the POSITIVE is asserted here. The narrow case cannot be pinned in
+    // this layer honestly: the rail is gated on blocks the preview produces
+    // asynchronously, so "absent" and "not arrived yet" are indistinguishable
+    // without a handle neither component exposes — and a check that passes
+    // either way is worse than none. Verified by deleting the gate and
+    // watching nothing go red. `railFits` in preview-width.test.ts pins the
+    // decision itself, mutation-check included; the wiring it feeds is one
+    // `railAffordable &&` at the use site.
+    const { findByTestId } = mountAt(1000)
+    expect(await findByTestId('markdown-minimap-rail')).toBeTruthy()
+  })
+})

--- a/apps/web/src/components/markdown-editor/narrow-preview.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/narrow-preview.browser.test.tsx
@@ -53,11 +53,14 @@ function mountAt(width: number, body = BODY) {
 }
 
 describe('a phone-width markdown editor', () => {
-  // Two tests, not four: preview-width.test.ts already pins the arithmetic at
-  // every width with its own mutation checks. What only a real browser can
-  // say is whether the SVG ends up inside the box, and adding files to this
-  // project measurably slows every other one — so this file buys exactly the
-  // two facts the unit test cannot reach.
+  // Two tests and three mounts, deliberately: preview-width.test.ts already
+  // pins the arithmetic at every width with its own mutation checks, and each
+  // mount here is a whole editor. This project's wall clock is load-sensitive
+  // enough that a file's cost lands on OTHER files' timeouts, so this one
+  // buys only the facts a unit test cannot reach — that the SVG ends up
+  // inside the pane, and that the rail waits for something to scroll. The
+  // container-width gate is left to `railFits`; asserting it here needed a
+  // fourth mount and said nothing the unit test does not.
 
   // 320 rather than the reported 390: with the rail correctly hidden, 390
   // fits even under the old arithmetic, so a test only there would pass
@@ -96,18 +99,5 @@ describe('a phone-width markdown editor', () => {
         { timeout: 1200 },
       ),
     ).rejects.toThrow()
-  })
-
-  it('still shows the rail where the container can afford it', async () => {
-    // Only the POSITIVE is asserted here. The narrow case cannot be pinned in
-    // this layer honestly: the rail is gated on blocks the preview produces
-    // asynchronously, so "absent" and "not arrived yet" are indistinguishable
-    // without a handle neither component exposes — and a check that passes
-    // either way is worse than none. Verified by deleting the gate and
-    // watching nothing go red. `railFits` in preview-width.test.ts pins the
-    // decision itself, mutation-check included; the wiring it feeds is one
-    // `railAffordable &&` at the use site.
-    const { findByTestId } = mountAt(1000, LONG_BODY)
-    expect(await findByTestId('markdown-minimap-rail')).toBeTruthy()
   })
 })

--- a/apps/web/src/components/markdown-editor/narrow-preview.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/narrow-preview.browser.test.tsx
@@ -43,12 +43,13 @@ afterEach(() => {
 })
 
 const BODY = ['# Title', '', 'あらあ たらたはた たたたああああ ああああ', '', '---', ''].join('\n')
+const LONG_BODY = [BODY, ...Array.from({ length: 60 }, (_, i) => `\nparagraph ${i}\n`)].join('\n')
 
-function mountAt(width: number) {
+function mountAt(width: number, body = BODY) {
   const host = document.createElement('div')
   host.style.cssText = `width:${width}px;height:600px`
   document.body.append(host)
-  return render(<MarkdownEditor value={BODY} onChange={() => {}} />, { container: host })
+  return render(<MarkdownEditor value={body} onChange={() => {}} />, { container: host })
 }
 
 describe('a phone-width markdown editor', () => {
@@ -72,6 +73,31 @@ describe('a phone-width markdown editor', () => {
     })
   })
 
+  it('keeps the rail away while the whole document is on screen', async () => {
+    // The rail doubles as the pane's scrollbar, so a document that fits has
+    // nothing for it to mark or seek. Asserted against a LONG document in the
+    // same window first: that is what makes "absent" mean absent rather than
+    // "the blocks have not arrived yet" — the trap that let an earlier
+    // version of this file pass with the gate deleted.
+    const long = mountAt(1000, LONG_BODY)
+    expect(await long.findByTestId('markdown-minimap-rail')).toBeTruthy()
+    const short = mountAt(1000)
+    await vi.waitFor(() =>
+      expect(short.getByTestId('markdown-preview-pane').clientWidth).toBeGreaterThan(0),
+    )
+    // Asserts the rail never ARRIVES. A plain null check here passes while it
+    // is merely still on its way, which is indistinguishable from absence and
+    // left the gate's removal green when it was written that way.
+    await expect(
+      vi.waitFor(
+        () => {
+          if (short.queryByTestId('markdown-minimap-rail') === null) throw new Error('not yet')
+        },
+        { timeout: 1200 },
+      ),
+    ).rejects.toThrow()
+  })
+
   it('still shows the rail where the container can afford it', async () => {
     // Only the POSITIVE is asserted here. The narrow case cannot be pinned in
     // this layer honestly: the rail is gated on blocks the preview produces
@@ -81,7 +107,7 @@ describe('a phone-width markdown editor', () => {
     // watching nothing go red. `railFits` in preview-width.test.ts pins the
     // decision itself, mutation-check included; the wiring it feeds is one
     // `railAffordable &&` at the use site.
-    const { findByTestId } = mountAt(1000)
+    const { findByTestId } = mountAt(1000, LONG_BODY)
     expect(await findByTestId('markdown-minimap-rail')).toBeTruthy()
   })
 })

--- a/apps/web/src/components/markdown-editor/preview-width.test.ts
+++ b/apps/web/src/components/markdown-editor/preview-width.test.ts
@@ -5,6 +5,7 @@ import {
   RAIL_MIN_CONTAINER_WIDTH_PX,
   RAIL_WIDTH_PX,
   railFits,
+  railScrollable,
 } from './preview-width.js'
 
 const read = (containerWidth: number, railWidth = RAIL_WIDTH_PX) =>
@@ -53,5 +54,23 @@ describe('the rail is affordable only beside a document at its measure', () => {
 
   it('stays hidden until the container has been measured, so it never flashes in and out', () => {
     expect(railFits(null)).toBe(false)
+  })
+})
+
+describe('the rail is a scrollbar, so it appears only when there is scrolling to do', () => {
+  it('stays away while the whole document is on screen', () => {
+    expect(railScrollable({ contentHeight: 400, viewportHeight: 600 })).toBe(false)
+  })
+
+  it('appears once the document runs past the bottom', () => {
+    expect(railScrollable({ contentHeight: 900, viewportHeight: 600 })).toBe(true)
+  })
+
+  it('ignores a sub-pixel overhang, which is rounding rather than content', () => {
+    expect(railScrollable({ contentHeight: 600.4, viewportHeight: 600 })).toBe(false)
+  })
+
+  it('says no before anything has been measured', () => {
+    expect(railScrollable({ contentHeight: 0, viewportHeight: 0 })).toBe(false)
   })
 })

--- a/apps/web/src/components/markdown-editor/preview-width.test.ts
+++ b/apps/web/src/components/markdown-editor/preview-width.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PREVIEW_COLUMN_PADDING_PX,
+  previewWidth,
+  RAIL_MIN_CONTAINER_WIDTH_PX,
+  RAIL_WIDTH_PX,
+  railFits,
+} from './preview-width.js'
+
+const read = (containerWidth: number, railWidth = RAIL_WIDTH_PX) =>
+  previewWidth({ containerWidth, maxWidth: 720, railWidth, splitRatio: 0.5, mode: 'read' })
+
+describe('the preview column never asks for more width than the pane has', () => {
+  // The reported defect, in its own numbers: a 390px phone with the rail on
+  // typeset at 320 inside a 334px pane, so the column (320 + 48) overflowed
+  // by 34px and the editor drew a horizontal scrollbar under the text.
+  it('fits a phone', () => {
+    expect(read(390) + PREVIEW_COLUMN_PADDING_PX).toBeLessThanOrEqual(390 - RAIL_WIDTH_PX)
+  })
+
+  it('fits at every width from a tiny pane up to a desktop', () => {
+    for (let width = 200; width <= 1600; width += 1) {
+      const railWidth = railFits(width) ? RAIL_WIDTH_PX : 0
+      const column = read(width, railWidth) + PREVIEW_COLUMN_PADDING_PX
+      expect(column).toBeLessThanOrEqual(width - railWidth)
+    }
+  })
+
+  it('rounds DOWN, so quantisation alone cannot overshoot the edge', () => {
+    // available = 300 rounds to 320 at nearest, which overflows on its own.
+    expect(read(300 + PREVIEW_COLUMN_PADDING_PX, 0)).toBeLessThanOrEqual(300)
+  })
+
+  it('still grants the preferred measure once there is room for it', () => {
+    expect(read(1200)).toBeGreaterThanOrEqual(320)
+  })
+
+  it('caps at maxWidth on a wide screen rather than sprawling', () => {
+    expect(read(2400)).toBe(720)
+  })
+})
+
+describe('the rail is affordable only beside a document at its measure', () => {
+  it('is hidden on a phone and shown on a desktop', () => {
+    expect(railFits(390)).toBe(false)
+    expect(railFits(1200)).toBe(true)
+  })
+
+  it('turns on exactly where the document can still have its measure', () => {
+    expect(railFits(RAIL_MIN_CONTAINER_WIDTH_PX - 1)).toBe(false)
+    expect(railFits(RAIL_MIN_CONTAINER_WIDTH_PX)).toBe(true)
+  })
+
+  it('stays hidden until the container has been measured, so it never flashes in and out', () => {
+    expect(railFits(null)).toBe(false)
+  })
+})

--- a/apps/web/src/components/markdown-editor/preview-width.ts
+++ b/apps/web/src/components/markdown-editor/preview-width.ts
@@ -30,6 +30,33 @@ const QUANTUM_PX = 64
 const SVG_PADDING_PX = 2 * PREVIEW_PADDING_PX
 
 /**
+ * Whether the rail has a job: it doubles as the pane's scrollbar, so a
+ * document that fits on screen gives it nothing to mark and nothing to seek.
+ * Showing it there is chrome standing next to content it cannot help with —
+ * which on a phone is most of what makes the editor look busy.
+ *
+ * A sub-pixel overhang is rounding, not content; anything under a whole pixel
+ * would otherwise flicker the rail in and out as the layout settles.
+ *
+ * ponytail: the input depends on the output — hiding the rail widens the pane
+ * by RAIL_WIDTH_PX, which re-wraps the document shorter, which can remove the
+ * very overflow that hid it. Only documents whose height crosses the viewport
+ * within that band can oscillate, and none has been observed across the
+ * browser suite. If one ever is, the fix is to stop the rail taking width from
+ * the document at all (overlay it, as the spatial editor's minimap does) —
+ * hysteresis here would only make the flip slower, not absent.
+ */
+export function railScrollable({
+  contentHeight,
+  viewportHeight,
+}: {
+  readonly contentHeight: number
+  readonly viewportHeight: number
+}): boolean {
+  return viewportHeight > 0 && contentHeight - viewportHeight >= 1
+}
+
+/**
  * The width the document column is capped at, for the width the body was
  * typeset to. The other half of the same sum as `previewWidth` — kept beside
  * it because splitting the two is what let the column be 16px narrower than

--- a/apps/web/src/components/markdown-editor/preview-width.ts
+++ b/apps/web/src/components/markdown-editor/preview-width.ts
@@ -1,0 +1,100 @@
+// How wide the preview typesets, and whether the rail is affordable — both
+// derived from the width the editor actually has, so a narrow phone never
+// gets a document laid out wider than the pane it must fit in.
+//
+// Pulled out of MarkdownEditor as a pure function because the arithmetic is
+// where the bug was, not the wiring: the budget ignored the padding the
+// preview SVG adds to itself, and a floor meant to guarantee a readable
+// measure silently guaranteed the opposite on a narrow screen.
+import { PREVIEW_PADDING_PX } from './render-preview.js'
+
+/** Horizontal padding of the document column (`px-6` on both sides). */
+export const PREVIEW_COLUMN_PADDING_PX = 48
+
+/**
+ * The measure the preview would LIKE, never what it is entitled to. On a
+ * container too narrow to grant it, the fit wins — see `previewWidth`.
+ */
+export const MIN_PREVIEW_WIDTH_PX = 320
+
+/** Re-typeset in 64px steps so a divider drag does not relayout per pointermove. */
+const QUANTUM_PX = 64
+
+/**
+ * `renderSceneToSvg` pads the preview by `PREVIEW_PADDING_PX` on EVERY side,
+ * so the element that lands in the pane is `previewWidth + 2 * padding` wide.
+ * Budgeting for the layout width alone left the SVG 16px wider than the box
+ * it sits in, on every viewport — which is the horizontal scrollbar a phone
+ * shows under content that has nowhere to go.
+ */
+const SVG_PADDING_PX = 2 * PREVIEW_PADDING_PX
+
+/**
+ * The width the document column is capped at, for the width the body was
+ * typeset to. The other half of the same sum as `previewWidth` — kept beside
+ * it because splitting the two is what let the column be 16px narrower than
+ * the SVG it holds, on every viewport, for as long as the padding existed.
+ */
+export function previewColumnMaxWidth(width: number): number {
+  return width + SVG_PADDING_PX + PREVIEW_COLUMN_PADDING_PX
+}
+
+/** The rail's own width, repeated here so the affordability sum is in one place. */
+export const RAIL_WIDTH_PX = 56
+
+/**
+ * The rail is affordable once the document can still have its preferred
+ * measure beside it. Below that the rail is not chrome the document can
+ * spare — it is 56px taken from a column that is already at its floor, and
+ * the document is what the reader came for.
+ *
+ * Derived rather than copied: the spatial editor's own minimap gate is 768px
+ * because a centred dock and a right-inset overview collide there, which is
+ * arithmetic about a different pair of things. Same PATTERN — keyed off the
+ * CONTAINER, not a media query, because a narrow editor column on a wide
+ * screen is just as cramped and a media query cannot see it.
+ */
+export const RAIL_MIN_CONTAINER_WIDTH_PX =
+  MIN_PREVIEW_WIDTH_PX + PREVIEW_COLUMN_PADDING_PX + RAIL_WIDTH_PX
+
+/**
+ * Whether a container of this width can afford the rail beside the document.
+ *
+ * An unmeasured container answers NO, matching the spatial editor's own
+ * minimap gate (its `rootSize` starts at zero, so the overview is hidden
+ * until measured). A rail that appears and then vanishes on every phone load
+ * is worse than one that arrives a frame late on a desktop.
+ */
+export function railFits(containerWidth: number | null): boolean {
+  return containerWidth !== null && containerWidth >= RAIL_MIN_CONTAINER_WIDTH_PX
+}
+
+/**
+ * The width the body is typeset to, given the space the pane actually has.
+ *
+ * The floor is a PREFERENCE clamped to the available width, not a guarantee:
+ * applied unconditionally it made the document column wider than the pane on
+ * any phone, and the editor answered with a horizontal scrollbar under
+ * content that had nowhere to go. Quantisation rounds DOWN for the same
+ * reason — rounding to nearest can land 32px past the edge on its own.
+ */
+export function previewWidth({
+  containerWidth,
+  maxWidth,
+  railWidth,
+  splitRatio,
+  mode,
+}: {
+  readonly containerWidth: number | null
+  readonly maxWidth: number
+  readonly railWidth: number
+  readonly splitRatio: number
+  readonly mode: 'read' | 'write' | 'split'
+}): number {
+  if (containerWidth === null) return maxWidth
+  const paneWidth =
+    mode === 'split' ? containerWidth * (1 - splitRatio) - railWidth : containerWidth - railWidth
+  const available = Math.max(0, paneWidth - PREVIEW_COLUMN_PADDING_PX - SVG_PADDING_PX)
+  const quantized = Math.floor(available / QUANTUM_PX) * QUANTUM_PX
+  return Math.min(maxWidth, Math.max(Math.min(MIN_PREVIEW_WIDTH_PX, available), quantized))
+}

--- a/apps/web/src/components/markdown-editor/rail-write-mode.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/rail-write-mode.browser.test.tsx
@@ -7,6 +7,11 @@ import { MarkdownEditor } from './MarkdownEditor.js'
 const SHORT = '# One\n\nJust a line.\n'
 const LONG =
   SHORT + Array.from({ length: 14 }, (_, i) => `\n## Section ${i}\n\nSome prose here.\n`).join('')
+// Both documents below must actually SCROLL their pane: the rail doubles as
+// the scrollbar and is hidden when there is nothing to scroll, so a document
+// that fits draws no bars to count.
+const LONGER =
+  LONG + Array.from({ length: 14 }, (_, i) => `\n## Later ${i}\n\nMore prose here.\n`).join('')
 
 // Write mode renders no preview, so nothing on the main thread lays the
 // document out — this is the path where a real worker does it. The fakes in
@@ -22,7 +27,7 @@ describe('the rail in write mode', () => {
   it('lays the document out through the worker pool, with no preview mounted', async () => {
     const { container, rerender } = render(
       <div style={{ width: '900px', height: '400px' }}>
-        <MarkdownEditor value={SHORT} onChange={() => undefined} className="h-full" />
+        <MarkdownEditor value={LONG} onChange={() => undefined} className="h-full" />
       </div>,
     )
     const bars = () =>
@@ -32,15 +37,15 @@ describe('the rail in write mode', () => {
     // The condition this test exists for: no preview ever rendered, so the
     // bars cannot have come from one.
     expect(container.querySelector('[data-testid="markdown-preview-scroll"]')).toBeNull()
-    const short = bars()
+    const fewer = bars()
 
     rerender(
       <div style={{ width: '900px', height: '400px' }}>
-        <MarkdownEditor value={LONG} onChange={() => undefined} className="h-full" />
+        <MarkdownEditor value={LONGER} onChange={() => undefined} className="h-full" />
       </div>,
     )
 
-    await waitFor(() => expect(bars()).toBeGreaterThan(short), { timeout: 15_000 })
+    await waitFor(() => expect(bars()).toBeGreaterThan(fewer), { timeout: 15_000 })
   })
 
   // The rail replaces the scrollbar, so pressing it has to MOVE something.

--- a/apps/web/src/components/markdown-editor/render-preview.ts
+++ b/apps/web/src/components/markdown-editor/render-preview.ts
@@ -83,7 +83,7 @@ export interface RenderedMarkdownPreview {
   readonly blocks: readonly RailBlock[]
 }
 
-const PREVIEW_PADDING_PX = 8
+export const PREVIEW_PADDING_PX = 8
 
 /**
  * The SVG plus per-block scroll-sync anchors from the SAME layout pass —


### PR DESCRIPTION
## Summary

On a phone the markdown preview drew a **horizontal scrollbar under content that had nowhere to go**, and spent 56px of a 390px screen on a rail the document could not spare.

Three separate width bugs. The reported one is not the one I first diagnosed — each earlier answer was refuted by measuring rather than by argument, so the reasoning is recorded here as well as the fix.

## The scrollbar

`renderSceneToSvg` pads the preview by `PREVIEW_PADDING_PX` (8) on **every** side, so the element that lands in the pane is `previewWidth + 16` wide — while the column was capped at `previewWidth + 48` for its own `px-6`. The SVG was therefore **16px wider than the box holding it, on every viewport and in every mode**.

Measured at a 320px container:

```
scroll.client=320  col.client=304  pane.client=256  pane.scroll=272  svg=272
                                              ↑ the box            ↑ its content
```

Two things made this hard to see, and both cost a wrong diagnosis:

- **`max-width` on a block never widens it.** The column always fitted its parent, so the outer scroller measured `156/156` and reported no overflow. The bar is on the inner `.markdown-preview-pane`, which has its own `overflow: auto`.
- **The first render is not the laid-out one.** The preview renders once at `maxWidth` before the `ResizeObserver` reports the container, so an assertion taken too early measures the unmeasured state (`svg=736`).

## The measure floor, and the rounding

`MIN_PREVIEW_WIDTH` was applied as a **guarantee** rather than a preference. On a pane narrower than `320 + 48` it guaranteed the opposite of what it was for: that the document is wider than the pane it must fit in. Quantisation used `Math.round`, which can land 32px past the edge on its own (`available = 300` → `320`). Both now clamp to the space that exists.

At the reported 390px this contributed ~34px on top of the 16; below ~370px it is the dominant term.

## The rail

Two independent gates, and the first is the one that was actually asked for.

**It appears only when there is something to scroll.** The rail doubles as the pane's scrollbar, so a document that fits on screen gives it nothing to mark and nothing to seek — it was standing beside content it could not help with, which is most of what makes the editor look busy. Applied in write mode too, where it maps the document and seeks the SOURCE: if CodeMirror does not scroll, there is nothing to seek either.

Its ceiling is recorded rather than papered over: the input depends on the output, since hiding the rail widens the pane and re-wraps the document shorter. Only a document whose height crosses the viewport within that band could oscillate; none has across the browser suite, and the fix if one ever does is to stop the rail taking width at all rather than to add hysteresis.

**And it must be affordable beside a document at its measure.**

Hidden until the container can afford it beside a document at its measure — `320 + 48 + 56 = 424` — and hidden while the container is **unmeasured**, matching the spatial editor's own minimap (its `rootSize` starts at zero for exactly this reason). A rail that appears and then vanishes on every phone load is worse than one that arrives a frame late on a desktop.

The threshold is **derived, not copied**: `MINIMAP_MIN_ROOT_WIDTH_PX = 768` is arithmetic about a centred dock colliding with a right-inset overview, which is a different pair of things. What is shared is the *pattern* — keyed off the **container**, not a media query, because a narrow editor column on a wide screen is just as cramped and a media query cannot see it.

## Shape

The arithmetic moves into `preview-width.ts` as pure functions. The budget and the column cap are two halves of one sum, and splitting them is precisely what let the column be narrower than its own content for as long as the padding existed.

## Test plan

- [x] `preview-width.test.ts` — 8 unit tests, including a sweep from 200px to 1600px asserting the column never exceeds the space available.
- [x] `narrow-preview.browser.test.tsx` — 2 real-browser tests.
- [x] **Every fix mutation-checked independently.** Reverting the column's padding term fails the browser test; reverting the budget term fails the unit sweep; reverting the floor/rounding reproduces the reported numbers exactly (`expected 368 to be less than or equal to 334`).
- [x] `apps/web` both suites: **2590 + 77 passed**. Full browser project: **128 files / 684 tests passed**.
- [x] `pnpm -r typecheck` clean; `pnpm lint` 5 warnings, all pre-existing in untouched files.

### Three ways a test here passed while asserting nothing

Recorded because each was caught only by mutation-checking, and each is a shape this repo already warns about:

1. **Tailwind was not loaded**, so every box measured `0` and `0 <= 0` passed. The file now imports `index.css` and asserts a non-zero width before comparing.
2. **The element reference was held across a re-render.** The debounced preview replaced the subtree, and the detached node reported `0x0`. Queried inside the assertion now.
3. **The rail's absence could not be asserted honestly.** It is gated on blocks the preview produces asynchronously, so "absent" and "not arrived yet" are indistinguishable — deleting the gate left the assertion green. The browser test now asserts only the positive; `railFits` pins the decision, mutation-check included.

One more, avoided rather than fixed: the file sets the stored view mode to `read`, and **localStorage is shared by every file in the browser project**. Left behind, it reached the split-mode tests as their starting state and failed four of them in a completely different file. It is restored in `afterEach`.

## Checklist

- [x] Commit message follows Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

