### PR TITLE
feat(mcp-server): report the characters an export could not draw

### DIFF
--- a/docs/how-to/install-fonts-for-export.md
+++ b/docs/how-to/install-fonts-for-export.md
@@ -8,6 +8,12 @@ This is a property of the daemon, not of your canvas or your browser: the text i
 SVG export still carries it as text that any viewer with the font can read. Only the rasterised
 formats (PNG) bake in what the daemon could draw.
 
+It is specifically the **daemon's** exports — the ones an AI agent produces over MCP or HTTP.
+The web editor's own Export menu renders in your browser with your browser's fonts, so it can
+look fine while an agent exporting the same canvas gets boxes. The daemon's export routes say
+which characters they lost, in an `undrawable` field; see
+[export-formats](../reference/export-formats.md#characters-the-exporter-cannot-draw).
+
 ## Install one
 
 1. Connect the web app to a local daemon (see

--- a/docs/reference/export-formats.md
+++ b/docs/reference/export-formats.md
@@ -43,6 +43,38 @@ What may appear inside `x-whiteboard` is machine-readable:
 draft 2020-12) is generated from the same Zod schemas the code validates
 with, so it cannot drift from the implementation.
 
+## Characters the exporter cannot draw
+
+The daemon rasterises with the fonts **it** has — a vendored Latin face plus
+whatever has been installed into its data directory, and deliberately nothing
+from the operating system. A character no such face carries is painted as an
+empty box.
+
+It is worth reporting because of how it fails. Measurement is correct, so the
+text wraps in the right places and every box is the right size; the only thing
+wrong is that a reader cannot read it. The daemon's HTTP export routes
+therefore answer with the characters they could not draw:
+
+```json
+{ "filePath": "…/canvas-a-8f3.png", "undrawable": ["日", "本"] }
+```
+
+Empty is the normal answer. What the report means differs by format:
+
+| Format | What was lost |
+| --- | --- |
+| PNG | The characters are gone from the image. |
+| SVG | Nothing yet — the file still carries them as `<text>`, and any viewer whose own system has the face renders them correctly. The report is what a PNG of this file would lose. |
+
+Fix it by installing a font for the script:
+[install-fonts-for-export](../how-to/install-fonts-for-export.md).
+
+**The web editor's own exports are a separate question.** They are rendered in
+the browser, not by the daemon, so they use the browser's fonts and the report
+above does not describe them. A daemon with no Japanese face and a browser with
+one disagree about the same canvas — which is why installing a font is worth
+doing even when the on-screen canvas looks fine.
+
 ## Web app exports
 
 The web editor's canvas row (More actions → Export) saves the current canvas as

--- a/packages/mcp-server/src/server/routes/document/export-svg.test.ts
+++ b/packages/mcp-server/src/server/routes/document/export-svg.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Hono } from 'hono'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { exportResponseSchema } from '../../../shared/api-contracts/export.js'
 
 let tempDir: string
 
@@ -21,7 +22,7 @@ const mockExportCanvasHeadlessSvg =
       workspaceId: string
       path: string
       options?: { padding?: number; frameId?: string; theme?: 'light' | 'dark' }
-    }) => Promise<{ svg: string }>
+    }) => Promise<{ svg: string; undrawable: readonly string[] }>
   >()
 vi.mock('../../export/headless-export.js', () => ({
   exportCanvasHeadlessSvg: (args: {
@@ -43,7 +44,7 @@ describe('POST /api/w/:workspaceId/document/:path/export-svg', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-export-svg-test-'))
     mockExportCanvasHeadlessSvg.mockReset()
-    mockExportCanvasHeadlessSvg.mockResolvedValue({ svg: '<svg><rect/></svg>' })
+    mockExportCanvasHeadlessSvg.mockResolvedValue({ svg: '<svg><rect/></svg>', undrawable: [] })
   })
 
   afterEach(async () => {
@@ -63,6 +64,25 @@ describe('POST /api/w/:workspaceId/document/:path/export-svg', () => {
     )
     const written = await readFile(body.filePath, 'utf-8')
     expect(written.trim().startsWith('<svg')).toBe(true)
+  })
+
+  // The same report as the PNG route, and deliberately the same field: what
+  // differs is the loss, not the finding. An SVG still carries these
+  // characters as `<text>`, so a viewer whose system has the face reads them
+  // — only rasterising is lossy. A caller relaying this to a person owes them
+  // that distinction.
+  it('reports the characters the export renderer had no glyph for', async () => {
+    mockExportCanvasHeadlessSvg.mockResolvedValue({
+      svg: '<svg><rect/></svg>',
+      undrawable: ['日'],
+    })
+
+    const res = await makeApp().request('/api/w/s1/document/canvas-a/export-svg', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(200)
+    expect(exportResponseSchema.parse(await res.json()).undrawable).toEqual(['日'])
   })
 
   it('generates distinct default filePaths for two exports in the same millisecond', async () => {

--- a/packages/mcp-server/src/server/routes/document/export-svg.ts
+++ b/packages/mcp-server/src/server/routes/document/export-svg.ts
@@ -3,7 +3,7 @@ import { dirname, join } from 'node:path'
 import { Hono } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
 import { nanoid } from 'nanoid'
-import type { ExportErrorBody } from '../../../shared/api-contracts/export.js'
+import type { ExportErrorBody, ExportResponse } from '../../../shared/api-contracts/export.js'
 import {
   type ExportSvgRequest,
   exportSvgRequestSchema,
@@ -75,6 +75,7 @@ export function createDocumentSvgExportRouter() {
       }
 
       let svg: string
+      let undrawable: readonly string[]
       try {
         const result = await exportCanvasHeadlessSvg({
           workspaceId,
@@ -82,6 +83,7 @@ export function createDocumentSvgExportRouter() {
           options: { padding: body.padding, frameId: body.frameId, theme: body.theme },
         })
         svg = result.svg
+        undrawable = result.undrawable
       } catch (err) {
         const errBody: ExportErrorBody = {
           error: 'headless_export_failed',
@@ -93,7 +95,11 @@ export function createDocumentSvgExportRouter() {
       const filePath = outputPath ?? defaultSvgExportPath(workspaceId, path)
       await mkdir(dirname(filePath), { recursive: true })
       await writeFile(filePath, svg, 'utf-8')
-      return c.json({ filePath })
+      // Typed rather than a bare literal so the contract, not this handler,
+      // decides what an export answers with — the PNG route and this one had
+      // already drifted into two different response shapes.
+      const response: ExportResponse = { filePath, undrawable: [...undrawable] }
+      return c.json(response)
     },
     bodyLimit({
       maxSize: EXPORT_OPTIONS_BODY_LIMIT_BYTES,

--- a/packages/mcp-server/src/server/routes/export.test.ts
+++ b/packages/mcp-server/src/server/routes/export.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Hono } from 'hono'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { exportResponseSchema } from '../../shared/api-contracts/export.js'
 
 let tempDir: string
 
@@ -40,7 +41,14 @@ type MockHeadlessArgs = {
   }
 }
 const mockExportCanvasHeadless =
-  vi.fn<(args: MockHeadlessArgs) => Promise<{ png: Buffer; width: number; height: number }>>()
+  vi.fn<
+    (args: MockHeadlessArgs) => Promise<{
+      png: Buffer
+      width: number
+      height: number
+      undrawable: readonly string[]
+    }>
+  >()
 
 vi.mock('../export/headless-export.js', () => ({
   exportCanvasHeadless: (args: MockHeadlessArgs) => mockExportCanvasHeadless(args),
@@ -96,7 +104,12 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
   it('is served by the headless renderer even when a WS client is connected', async () => {
     mockGetClientCount.mockReturnValue(2)
     const fakePng = Buffer.from('fake-png-bytes')
-    mockExportCanvasHeadless.mockResolvedValue({ png: fakePng, width: 100, height: 50 })
+    mockExportCanvasHeadless.mockResolvedValue({
+      png: fakePng,
+      width: 100,
+      height: 50,
+      undrawable: [],
+    })
     const app = makeApp()
 
     const res = await app.request('/api/w/s1/document/canvas-a/export', { method: 'POST' })
@@ -115,7 +128,12 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
   // Metamorphic: client count must not be an input to export behavior at all.
   it('produces identical status/body/headless-args regardless of WS client count', async () => {
     const fakePng = Buffer.from('fake-png-bytes')
-    mockExportCanvasHeadless.mockResolvedValue({ png: fakePng, width: 100, height: 50 })
+    mockExportCanvasHeadless.mockResolvedValue({
+      png: fakePng,
+      width: 100,
+      height: 50,
+      undrawable: [],
+    })
 
     mockGetClientCount.mockReturnValue(0)
     const resNoClient = await makeApp().request('/api/w/s1/document/canvas-a/export', {
@@ -144,6 +162,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       png: Buffer.from('fake-png-bytes'),
       width: 100,
       height: 50,
+      undrawable: [],
     })
     const app = makeApp()
     vi.useFakeTimers()
@@ -195,7 +214,10 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
     mockExportCanvasHeadless.mockImplementation(
       () =>
         new Promise((resolve) => {
-          setTimeout(() => resolve({ png: Buffer.from('slow-png'), width: 10, height: 10 }), 50)
+          setTimeout(
+            () => resolve({ png: Buffer.from('slow-png'), width: 10, height: 10, undrawable: [] }),
+            50,
+          )
         }),
     )
     const app = makeApp()
@@ -208,6 +230,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       png: Buffer.from('fake-png-bytes'),
       width: 100,
       height: 50,
+      undrawable: [],
     })
     const app = makeApp()
 
@@ -227,6 +250,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       png: Buffer.from('fake-png-bytes'),
       width: 100,
       height: 50,
+      undrawable: [],
     })
     const app = makeApp()
 
@@ -247,7 +271,12 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
   // so this only needs to assert the forwarding itself.
   it('forwards theme to the headless export', async () => {
     const fakePng = Buffer.from('fake-dark-png')
-    mockExportCanvasHeadless.mockResolvedValue({ png: fakePng, width: 100, height: 50 })
+    mockExportCanvasHeadless.mockResolvedValue({
+      png: fakePng,
+      width: 100,
+      height: 50,
+      undrawable: [],
+    })
     const app = makeApp()
 
     const res = await app.request('/api/w/s1/document/canvas-a/export', {
@@ -295,6 +324,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       png: Buffer.from('fake-png-bytes'),
       width: 100,
       height: 50,
+      undrawable: [],
     })
     const app = makeApp()
 
@@ -316,6 +346,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       png: Buffer.from(SAMPLE_PNG_BASE64, 'base64'),
       width: 1,
       height: 1,
+      undrawable: [],
     })
     const app = makeApp()
 
@@ -323,6 +354,39 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
     expect(res.status).toBe(200)
     const body = (await res.json()) as { filePath: string }
     expect(body.filePath).toMatch(/canvas-a-.*\.png$/)
+  })
+
+  // The renderer has always known which characters it could not draw; the
+  // route dropped the answer on the floor. This path's caller is an agent over
+  // HTTP, and a PNG it exported has already lost them.
+  it('reports the characters the export renderer had no glyph for', async () => {
+    mockExportCanvasHeadless.mockResolvedValue({
+      png: Buffer.from(SAMPLE_PNG_BASE64, 'base64'),
+      width: 1,
+      height: 1,
+      undrawable: ['日', '本'],
+    })
+
+    const res = await makeApp().request('/api/w/s1/document/canvas-a/export', { method: 'POST' })
+
+    expect(res.status).toBe(200)
+    // Parsed, not cast: the point is that the field survives the contract.
+    expect(exportResponseSchema.parse(await res.json()).undrawable).toEqual(['日', '本'])
+  })
+
+  it('reports an empty list when every character drew', async () => {
+    mockExportCanvasHeadless.mockResolvedValue({
+      png: Buffer.from(SAMPLE_PNG_BASE64, 'base64'),
+      width: 1,
+      height: 1,
+      undrawable: [],
+    })
+
+    const res = await makeApp().request('/api/w/s1/document/canvas-a/export', { method: 'POST' })
+
+    // Present and empty rather than absent: a caller must be able to tell
+    // "nothing was lost" from "this daemon does not report".
+    expect(exportResponseSchema.parse(await res.json()).undrawable).toEqual([])
   })
 
   // Nested canvas paths such as architecture/overview should create parent
@@ -335,8 +399,13 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
     vi.mocked(nanoid).mockReturnValueOnce('aaaaaa').mockReturnValueOnce('aaaaaa')
 
     mockExportCanvasHeadless
-      .mockResolvedValueOnce({ png: Buffer.from('first-png'), width: 1, height: 1 })
-      .mockResolvedValueOnce({ png: Buffer.from('second-png'), width: 1, height: 1 })
+      .mockResolvedValueOnce({ png: Buffer.from('first-png'), width: 1, height: 1, undrawable: [] })
+      .mockResolvedValueOnce({
+        png: Buffer.from('second-png'),
+        width: 1,
+        height: 1,
+        undrawable: [],
+      })
     const app = makeApp()
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'))
@@ -362,6 +431,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       png: Buffer.from(SAMPLE_PNG_BASE64, 'base64'),
       width: 1,
       height: 1,
+      undrawable: [],
     })
     const app = makeApp()
 
@@ -394,6 +464,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       png: Buffer.from(SAMPLE_PNG_BASE64, 'base64'),
       width: 1,
       height: 1,
+      undrawable: [],
     })
     const app = makeApp()
     const outputPath = join(tempDir, 's1', 'exports', 'subdir', 'custom.excalidraw.png')
@@ -499,6 +570,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       png: Buffer.from(SAMPLE_PNG_BASE64, 'base64'),
       width: 1,
       height: 1,
+      undrawable: [],
     })
     const app = makeApp()
     const outputPath = join(tempDir, 's1', 'exports', 'pre-existing.png')
@@ -521,6 +593,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       png: Buffer.from(SAMPLE_PNG_BASE64, 'base64'),
       width: 1,
       height: 1,
+      undrawable: [],
     })
     const app = makeApp()
     const outputPath = join(tempDir, 's1', 'exports', 'replace.png')

--- a/packages/mcp-server/src/server/routes/export.ts
+++ b/packages/mcp-server/src/server/routes/export.ts
@@ -90,8 +90,9 @@ export function createExportRouter() {
       }
 
       let pngBuffer: Buffer
+      let undrawable: readonly string[]
       try {
-        pngBuffer = await renderHeadless(workspaceId, path, body)
+        ;({ png: pngBuffer, undrawable } = await renderHeadless(workspaceId, path, body))
       } catch (err) {
         const errBody: ExportErrorBody = {
           error: 'headless_export_failed',
@@ -104,7 +105,7 @@ export function createExportRouter() {
         outputPath !== undefined
           ? await writeExplicitOutput(outputPath, pngBuffer)
           : await writeDefaultOutput(workspaceId, path, pngBuffer)
-      const response: ExportResponse = { filePath }
+      const response: ExportResponse = { filePath, undrawable: [...undrawable] }
       return c.json(response)
     },
     bodyLimit({
@@ -127,7 +128,7 @@ async function renderHeadless(
   workspaceId: string,
   path: string,
   body: z.infer<typeof exportRequestSchema>,
-): Promise<Buffer> {
+): Promise<{ png: Buffer; undrawable: readonly string[] }> {
   const result = await exportCanvasHeadless({
     workspaceId,
     path,
@@ -139,7 +140,7 @@ async function renderHeadless(
       theme: body.theme,
     },
   })
-  return result.png
+  return { png: result.png, undrawable: result.undrawable }
 }
 
 // A plain PNG: the headless renderer no longer embeds scene JSON, so a

--- a/packages/mcp-server/src/shared/api-contracts/export.ts
+++ b/packages/mcp-server/src/shared/api-contracts/export.ts
@@ -20,6 +20,23 @@ export const exportRequestSchema = z.object({
 
 export const exportResponseSchema = z.object({
   filePath: z.string(),
+  /**
+   * Characters this daemon's export fonts have no glyph for, in first-seen
+   * order — the vendored Latin face plus whatever the user installed, and
+   * nothing else (`loadSystemFonts: false`).
+   *
+   * Reported because of HOW it fails: measurement is correct, so the text
+   * wraps in the right places, the boxes are the right size, and every other
+   * signal says the render is fine. The only thing wrong is that a reader
+   * cannot read it. Empty is the normal answer.
+   *
+   * The loss is not the same on both formats, and a caller relaying this to a
+   * person should say which it means: a PNG has already lost these characters,
+   * while an SVG still carries them as `<text>` and renders correctly for any
+   * viewer whose own system has the face. Install one with
+   * `POST /api/fonts/:id/install` (ADR-0012).
+   */
+  undrawable: z.array(z.string()),
 })
 
 // Shared error body. The route emits this for invalid_request /


### PR DESCRIPTION
The renderer has always known which characters it had no glyph for. Both export routes threw the answer away one line after receiving it, so a caller got `200 {"filePath": "…"}` for an image whose text is a row of empty boxes, with nothing anywhere saying so.

```diff
-{ "filePath": "…/canvas-a.png" }
+{ "filePath": "…/canvas-a.png", "undrawable": ["日", "本"] }
```

`undrawable` is **required** in `exportResponseSchema`, not optional: a caller has to be able to tell *nothing was lost* from *this daemon does not report*. The SVG route's bare `c.json({ filePath })` is now typed as `ExportResponse` for the same reason — the two routes had drifted into two response shapes for one concept.

## The task I was given was wrong, and here is why

It said to surface this in the web UI. That cannot be done honestly: **`apps/web` never calls these routes.** Its PNG and SVG exports are both rendered in the browser (`useDocumentSync.exportScene` → client-side SVG → `<img>` + Canvas), and there is not one `fetch` to an export route anywhere under `apps/web/src`.

So the daemon's font coverage says nothing about a web export, and showing it after one would be reporting on a renderer the user did not use. The caller of this path is an **agent over HTTP**, and that is who now gets the answer. The docs state the split in both directions rather than leaving the next person to rediscover it.

## Verification, and its limit

Both mutations redden exactly their own test — dropping the field in the PNG route, dropping it in the SVG route. The SVG one **first came back green**: `vitest --project mcp-node routes/export` does not match `routes/document/export-svg.test.ts`, so that file had never run. Re-checked with a filter that reaches it.

Existing route tests could not stay green by accident either: making the field required turned every mock that omitted it into `TypeError: undrawable is not iterable`, which is how all 15 stale `mockResolvedValue` call sites were found.

**What is not verified end to end:** a non-empty value through the live route. Those routes render an *empty canvas* for a document the MCP tools render correctly — same daemon, same document, same minute:

```
wb_canvas_snapshot   node present
wb_document_get      stored content has the node
wb_scene_render      300x80 SVG containing 日本語のテキスト
POST …/export        93-byte PNG
POST …/export-svg    <svg width="21" height="21"><rect/></svg>
```

An agent that edits a canvas and then exports it over HTTP gets a blank image, silently. That is separate, pre-existing, and untouched here — filed with the evidence above. This PR only adds a field to the response.

`pnpm test --project mcp-node` 298 files / 3612 tests, lint / knip / typecheck clean.