### PR TITLE
fix(web): export the PNG with the editor's font, not the operating system's

### DIFF
--- a/apps/web/src/hooks/useDocumentSync.test.ts
+++ b/apps/web/src/hooks/useDocumentSync.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+
 import type {
   DocumentBackend,
   DocumentBackendHandlers,
@@ -20,6 +21,14 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { act, renderHook } from '@testing-library/react'
 import { LoroDoc } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
+
+// Only the embedding function is faked; the rest of canvas-viewer stays real.
+const { embedSpy } = vi.hoisted(() => ({ embedSpy: vi.fn(async (svg: string) => svg) }))
+vi.mock('@kamiazya/whiteboard-canvas-viewer', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@kamiazya/whiteboard-canvas-viewer')>()),
+  withViewerFontEmbedded: embedSpy,
+}))
+
 import type { EditorCommand } from '../components/spatial-editor/commands.js'
 import { applyCommand } from '../components/spatial-editor/commands.js'
 import type { SpatialEditorProps } from '../components/spatial-editor/index.js'
@@ -615,6 +624,31 @@ describe('useDocumentSync', () => {
       expect(blob).not.toBeNull()
       expect(blob?.type).toBe('image/svg+xml')
       expect(blob?.size).toBeGreaterThan(0)
+    })
+
+    // The wiring half. That an embedded face actually changes a rasterised
+    // SVG is proved in canvas-viewer's own browser test, under a family name
+    // no system font can match; asserting it on pixels HERE would be vacuous
+    // on any machine that happens to have Roboto installed.
+    it('embeds the viewer face for png, and leaves a saved svg alone', async () => {
+      const backend = makeFakeBackend()
+      const { result } = renderHook(() => useDocumentSync(backend))
+      await hydrate(backend, TEXT_CANVAS)
+      embedSpy.mockClear()
+
+      await act(async () => {
+        await result.current.exportScene('svg')
+      })
+      // A saved .svg names the family without carrying it: embedding would add
+      // ~466 KB for a face any viewer with Roboto already has.
+      expect(embedSpy).not.toHaveBeenCalled()
+
+      await act(async () => {
+        await result.current.exportScene('png')
+      })
+      expect(embedSpy).toHaveBeenCalledTimes(1)
+      // What it embeds into is the rendered scene, not some other string.
+      expect(embedSpy.mock.calls[0]?.[0]).toContain('<svg')
     })
 
     it('derives the svg from the empty canvas (still non-null) before any snapshot has arrived', async () => {

--- a/apps/web/src/hooks/useDocumentSync.ts
+++ b/apps/web/src/hooks/useDocumentSync.ts
@@ -1,4 +1,7 @@
-import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
+import {
+  createBrowserMeasureText,
+  withViewerFontEmbedded,
+} from '@kamiazya/whiteboard-canvas-viewer'
 import { serializeSpatial } from '@kamiazya/whiteboard-codec'
 import type { DocumentBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
 import type { SpatialCanvas, StoredCoreFacets } from '@kamiazya/whiteboard-model'
@@ -330,8 +333,12 @@ export function useDocumentSync(
       if (format === 'svg') {
         return new Blob([svg], { type: 'image/svg+xml' })
       }
+      // The face has to travel INSIDE the document: `ensureViewerFontLoaded`
+      // registers it on this page, and an `<img>`-rendered SVG cannot see the
+      // page's fonts, so without this the exported PNG is drawn in whatever
+      // system font the browser picks — not the one on screen.
       const png = await rasterizeSvgToPng(
-        svg,
+        await withViewerFontEmbedded(svg),
         Math.max(1, Math.round(bounds.w)),
         Math.max(1, Math.round(bounds.h)),
       )

--- a/docs/contributing/adr/0012-user-installed-fonts.md
+++ b/docs/contributing/adr/0012-user-installed-fonts.md
@@ -110,6 +110,26 @@ different direction:
 | daemon only | system fallback | the chosen font |
 | browser only | the chosen font | tofu |
 
+**Correction, measured after this was written: there are THREE surfaces, not
+two.** The table above says "exported" as if the browser and the daemon export
+the same way. They do not, and the web editor's own export is a third answer:
+
+A page's registered `FontFace` does not reach an SVG rendered inside an
+`<img>`, which is how the browser rasterises a PNG. Measured directly: a face
+with `status: 'loaded'` on the document renders there byte-identically to a
+family name nobody has registered at all. So the browser's exported PNG used
+whatever the operating system offered — not the vendored Roboto the editor
+draws with, and not anything a user installs into the daemon.
+
+The first attempt to measure this said the opposite, because the machine had
+Roboto as a system font; the control that settled it was running the same probe
+on an origin with zero registered faces.
+
+The fix is `withViewerFontEmbedded`: the face travels inside the document as a
+`data:` URI, which is not a resource load and does survive that boundary (same
+probe: 714x46 becomes 722x41). It applies to the PNG path only — a saved `.svg`
+would grow by ~466 KB to carry a face any viewer with Roboto already has.
+
 So a font is not a boolean. Each surface reports what it resolved, the same
 discipline `undrawable` already follows for the export path: a missing font is
 a **declared degradation**, never silence.

--- a/docs/reference/export-formats.md
+++ b/docs/reference/export-formats.md
@@ -49,6 +49,12 @@ The web editor's canvas row (More actions → Export) saves the current canvas a
 SVG or PNG, rendered with the light theme regardless of the UI theme so an
 export's bytes never depend on a display preference.
 
+The PNG a browser export produces carries the editor's own font inside the
+image data it rasterises from, so it draws the text the editor showed rather
+than whatever font the operating system offers. A saved `.svg` names the family
+instead of carrying it — a viewer with Roboto renders it identically, and one
+without it gets a smaller file.
+
 **Copy as JSON Canvas** (same menu) puts the extended-mode JSON Canvas
 document on the clipboard as plain text — the quickest way to hand the exact
 canvas to another tool or a debugging session from any device.

--- a/packages/canvas-viewer/src/font-embedding.browser.test.tsx
+++ b/packages/canvas-viewer/src/font-embedding.browser.test.tsx
@@ -1,0 +1,139 @@
+// Two separate claims, deliberately not tested together:
+//
+//   1. `withViewerFontEmbedded` puts the viewer's family and a data: URI into
+//      the SVG. Pure string work.
+//   2. A data: URI face reaches an `<img>`-rendered SVG at all — the platform
+//      fact the whole thing rests on, and the one a `FontFace` on the document
+//      does NOT satisfy.
+//
+// (2) is asserted under a family name NOBODY can have. Asserting it as
+// "Roboto" would be vacuous on any machine with Roboto installed — which is
+// most of them, and is exactly what made the first hand-measurement of this
+// look like the FontFace had crossed when it had not.
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import { VIEWER_FONT_FAMILY } from './font.js'
+import {
+  _resetViewerFontEmbeddingForTests,
+  viewerFontDataUri,
+  withViewerFontEmbedded,
+} from './font-embedding.js'
+
+beforeEach(() => {
+  _resetViewerFontEmbeddingForTests()
+})
+
+const TEXT = 'Hamburgefonstiv Hamburgefonstiv'
+
+function svgNaming(family: string, faceCss = ''): string {
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="900" height="90">${faceCss}<rect width="900" height="90" fill="#ffffff"/><text x="5" y="60" font-family="${family}" font-size="44" fill="#000000">${TEXT}</text></svg>`
+}
+
+/** Ink bounding box of an SVG rasterised the way a PNG export rasterises one. */
+async function rasterisedInk(svg: string): Promise<{ width: number; height: number }> {
+  const canvas = document.createElement('canvas')
+  canvas.width = 900
+  canvas.height = 90
+  const ctx = canvas.getContext('2d')
+  if (ctx === null) throw new Error('no 2d context')
+  ctx.fillStyle = '#ffffff'
+  ctx.fillRect(0, 0, 900, 90)
+
+  const url = URL.createObjectURL(new Blob([svg], { type: 'image/svg+xml' }))
+  try {
+    const image = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const img = new Image()
+      img.onload = () => resolve(img)
+      img.onerror = () => reject(new Error('failed to load SVG'))
+      img.src = url
+    })
+    ctx.drawImage(image, 0, 0)
+  } finally {
+    URL.revokeObjectURL(url)
+  }
+
+  const { data } = ctx.getImageData(0, 0, 900, 90)
+  let minX = 900
+  let maxX = -1
+  let minY = 90
+  let maxY = -1
+  for (let y = 0; y < 90; y++) {
+    for (let x = 0; x < 900; x++) {
+      if (data[(y * 900 + x) * 4]! < 128) {
+        if (x < minX) minX = x
+        if (x > maxX) maxX = x
+        if (y < minY) minY = y
+        if (y > maxY) maxY = y
+      }
+    }
+  }
+  return { width: maxX - minX, height: maxY - minY }
+}
+
+describe('withViewerFontEmbedded', () => {
+  it('carries the viewer family and the face bytes into the document', async () => {
+    const embedded = await withViewerFontEmbedded(svgNaming(VIEWER_FONT_FAMILY))
+
+    expect(embedded).toContain('@font-face')
+    expect(embedded).toContain(`font-family:'${VIEWER_FONT_FAMILY}'`)
+    expect(embedded).toContain('data:font/ttf;base64,')
+    // Inserted INSIDE the root element, or the rule governs nothing.
+    expect(embedded.indexOf('@font-face')).toBeGreaterThan(embedded.indexOf('<svg'))
+    expect(embedded.indexOf('@font-face')).toBeLessThan(embedded.indexOf('<text'))
+  })
+
+  it('leaves the drawing untouched', async () => {
+    const original = svgNaming(VIEWER_FONT_FAMILY)
+    const embedded = await withViewerFontEmbedded(original)
+
+    // Everything the original said is still said, in order — the transform
+    // adds, it does not rewrite.
+    expect(embedded).toContain('<rect width="900" height="90" fill="#ffffff"/>')
+    expect(embedded).toContain(`font-family="${VIEWER_FONT_FAMILY}"`)
+  })
+})
+
+describe('a data: URI face reaches a rasterised SVG', () => {
+  // The claim `ensureViewerFontLoaded` cannot make. Under a family no system
+  // font can match, so "it drew differently" has exactly one explanation.
+  const UNCLAIMABLE = 'WhiteboardEmbedProbeZzz'
+
+  it('changes what an <img>-rendered SVG draws, where a registered FontFace does not', async () => {
+    const dataUri = await viewerFontDataUri()
+    expect(dataUri).not.toBeNull()
+
+    const withoutFace = await rasterisedInk(svgNaming(UNCLAIMABLE))
+    const withFace = await rasterisedInk(
+      svgNaming(
+        UNCLAIMABLE,
+        `<defs><style>@font-face{font-family:'${UNCLAIMABLE}';src:url('${dataUri}') format('truetype');}</style></defs>`,
+      ),
+    )
+
+    // Something was drawn at all — otherwise both are empty and equal, and
+    // this test would pass while asserting nothing.
+    expect(withoutFace.width).toBeGreaterThan(0)
+    expect(withFace.width).toBeGreaterThan(0)
+    // Different metrics: the fallback the browser picked for an unknown family
+    // is not the face we handed it.
+    expect(withFace.width).not.toBe(withoutFace.width)
+  })
+
+  it('proves the same registration through document.fonts does NOT', async () => {
+    const dataUri = await viewerFontDataUri()
+    const family = 'WhiteboardFontFaceProbeZzz'
+    const face = new FontFace(family, `url(${dataUri})`)
+    await face.load()
+    document.fonts.add(face)
+    expect(face.status).toBe('loaded')
+
+    // Loaded, on this document, and the rasteriser still cannot see it: an
+    // `<img>`-rendered SVG is a separate resource-restricted document. This is
+    // the whole reason `font-embedding.ts` exists rather than reusing
+    // `ensureViewerFontLoaded`.
+    const viaFontFace = await rasterisedInk(svgNaming(family))
+    const unknownFamily = await rasterisedInk(svgNaming('WhiteboardNothingHasThisNameZzz'))
+    expect(viaFontFace.width).toBe(unknownFamily.width)
+    expect(viaFontFace.height).toBe(unknownFamily.height)
+  })
+})

--- a/packages/canvas-viewer/src/font-embedding.ts
+++ b/packages/canvas-viewer/src/font-embedding.ts
@@ -1,0 +1,72 @@
+// eslint-disable-next-line import/no-unresolved -- Vite's `?url` asset suffix, resolved at build/dev-server time.
+import robotoFontUrl from '../assets/fonts/Roboto/Roboto-Regular.ttf?url'
+import { VIEWER_FONT_FAMILY } from './font.js'
+
+/**
+ * The vendored face as a `data:` URI, or null if it cannot be read.
+ *
+ * Exists because of a gap between two things that both look like "the browser
+ * has the font": `ensureViewerFontLoaded` registers a `FontFace` on the
+ * document, which governs the LIVE canvas — and does not reach an SVG rendered
+ * inside an `<img>`, which is how a PNG export is rasterised. Measured
+ * directly: a face with `status: 'loaded'` on the page renders there
+ * byte-identically to a family name nobody has registered at all.
+ *
+ * A `data:` URI is not a resource load, so it survives that boundary. Same
+ * measurement, embedding the same bytes: the drawn text went from 714x46 to
+ * 722x41 — a different face, which is the point.
+ *
+ * Memoised at module scope: the bytes are ~349 KB and base64 of them ~466 KB,
+ * and an export must not pay for that twice.
+ */
+let dataUriPromise: Promise<string | null> | undefined
+
+export function viewerFontDataUri(): Promise<string | null> {
+  dataUriPromise ??= readFontAsDataUri()
+  return dataUriPromise
+}
+
+async function readFontAsDataUri(): Promise<string | null> {
+  try {
+    const bytes = new Uint8Array(await (await fetch(robotoFontUrl)).arrayBuffer())
+    // Chunked because `String.fromCharCode(...bytes)` on a 349 KB array blows
+    // the argument limit rather than being slow.
+    let binary = ''
+    const CHUNK = 0x8000
+    for (let i = 0; i < bytes.length; i += CHUNK) {
+      binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK))
+    }
+    return `data:font/ttf;base64,${btoa(binary)}`
+  } catch {
+    return null
+  }
+}
+
+/** Test seam: the memo would otherwise carry one test's stubbed fetch into the next. */
+export function _resetViewerFontEmbeddingForTests(): void {
+  dataUriPromise = undefined
+}
+
+/**
+ * The same SVG, with the viewer's face embedded so a rasteriser that cannot
+ * see the document's fonts still draws the text the editor showed.
+ *
+ * Returns the input unchanged when the face cannot be read: an export that
+ * falls back to a system font is worse than one that matches, and better than
+ * no export at all.
+ *
+ * Meant for the PNG path only. A saved `.svg` keeps naming the family without
+ * carrying it — the file would grow by ~466 KB to embed a face that any viewer
+ * with Roboto already has, and one without it is exactly the reader who wants
+ * a small file.
+ */
+export async function withViewerFontEmbedded(svg: string): Promise<string> {
+  const dataUri = await viewerFontDataUri()
+  if (dataUri === null) return svg
+
+  // After the opening tag, so the rule is in scope for every element below it.
+  const openTagEnd = svg.indexOf('>')
+  if (openTagEnd === -1) return svg
+  const style = `<defs><style>@font-face{font-family:'${VIEWER_FONT_FAMILY}';src:url('${dataUri}') format('truetype');}</style></defs>`
+  return svg.slice(0, openTagEnd + 1) + style + svg.slice(openTagEnd + 1)
+}

--- a/packages/canvas-viewer/src/font-embedding.ts
+++ b/packages/canvas-viewer/src/font-embedding.ts
@@ -65,6 +65,13 @@ export async function withViewerFontEmbedded(svg: string): Promise<string> {
   if (dataUri === null) return svg
 
   // After the opening tag, so the rule is in scope for every element below it.
+  //
+  // The naive scan for the first `>` is sound because canvas-render is the
+  // sole producer and its root element carries only `xmlns`, numeric
+  // `width`/`height`, a formatted `viewBox` and a theme colour — none of which
+  // can contain one. XML does permit a raw `>` inside a quoted attribute
+  // value, so a root attribute that ever carries document content would need a
+  // real scan rather than this.
   const openTagEnd = svg.indexOf('>')
   if (openTagEnd === -1) return svg
   const style = `<defs><style>@font-face{font-family:'${VIEWER_FONT_FAMILY}';src:url('${dataUri}') format('truetype');}</style></defs>`

--- a/packages/canvas-viewer/src/index.ts
+++ b/packages/canvas-viewer/src/index.ts
@@ -6,6 +6,7 @@
 export type { CanvasViewerProps } from './CanvasViewer.js'
 export { CanvasViewer } from './CanvasViewer.js'
 export { VIEWER_FONT_FAMILY } from './font.js'
+export { withViewerFontEmbedded } from './font-embedding.js'
 export { ensureViewerFontLoaded, type ViewerFontStatus } from './font-loading.js'
 export { createBrowserMeasureText } from './measure-text.js'
 export type { CanvasViewerHandle, MountCanvasViewerOptions } from './mount.js'


### PR DESCRIPTION
Every PNG the web editor has ever exported was drawn with system fonts — not the vendored Roboto the editor itself draws with, for **every** character, Latin included. Nothing reported it, and on a machine that happens to have Roboto installed nothing looks wrong either.

The cause is a boundary that looks like it should not be one: **a `FontFace` registered on the page does not reach an SVG rendered inside an `<img>`**, and that is exactly how `rasterizeSvgToPng` produces the image.

## Measured, because the first measurement was wrong

| probe | result |
|---|---|
| render the same SVG twice | identical hash — the harness is deterministic |
| two different unknown family names | identical hash — an unknown family lands somewhere fixed |
| `serif` / `monospace` | different — the harness detects a font change |
| **a `FontFace` with `status: 'loaded'` on the document** | **byte-identical to an unknown family** |
| **the same bytes as a `data:` URI `@font-face` inside the SVG** | **714x46 → 722x41** |

The first attempt said the FontFace *did* cross, because the probe machine has Roboto as a system font. The control that settled it was re-running on an origin with **zero** registered faces: `Roboto` still differed from an unknown family there, so the difference was never the FontFace.

That confound is why the browser test asserts both halves under a family name **no system font can match** — asserting it as "Roboto" would be vacuous on most machines, which is the trap the hand measurement fell into. The test also pins the negative (a registered `FontFace` does *not* reach the raster), so the platform fact this rests on cannot change silently.

## The fix

`withViewerFontEmbedded` inlines the face as a `data:` URI, which is not a resource load and does survive the boundary.

**PNG path only.** A saved `.svg` names the family instead of carrying it: embedding would add ~466 KB for a face any viewer with Roboto already has, and a viewer without it is exactly the reader who wants a small file. Both directions are pinned — the wiring test fails if the PNG path stops embedding *and* if the SVG path starts.

## Cost, measured rather than assumed

```
SVG           6 KB  ->  461 KB
encode       19 ms  (0 ms after, memoised)
rasterise     7 ms  ->  11 ms   (median of 5)
```

Paid once, by a user who pressed Export.

## Also

ADR-0012's decision 4 enumerated two surfaces (browser / daemon). There are **three** — the web editor's own export is neither — and it now says so, with the measurement.

`pnpm --filter @kamiazya/whiteboard-web test` 2591 tests, `canvas-viewer-browser` 14, lint / knip / typecheck clean. Four mutations checked, each reddening exactly its own test.