### PR TITLE
fix(mcp-server): stop exports serving a document from before the agent edited it

### DIFF
--- a/packages/mcp-server/src/server/export/headless-export.cache.test.ts
+++ b/packages/mcp-server/src/server/export/headless-export.cache.test.ts
@@ -1,0 +1,141 @@
+// The export path reads documents through a `(workspaceId, path)`-keyed LRU
+// of live LoroDoc instances. The MCP tool surface writes them by documentId,
+// with a fresh LoroDoc per call, and nothing on that path touches the cache —
+// so an export can serve bytes from before an agent's edit.
+//
+// It fails in the worst available shape: both loaders answer "nothing found"
+// with an EMPTY document rather than an error, so a stale or missed read is
+// indistinguishable from a canvas that really is empty. The route returns 200
+// and a file path for a picture of nothing.
+//
+// Deliberately not mocking the store. The existing `headless-export.test.ts`
+// calls `clearCache()` in beforeEach AND afterEach, which designs this defect
+// out of every case in the file; this one exists to keep the cache in play.
+
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { chunkSnapshot } from '@kamiazya/whiteboard-ports'
+import { LoroDoc } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let tempDir: string
+
+vi.mock('../config.js', () => ({
+  get DATA_DIR() {
+    return tempDir
+  },
+  getDataDir: () => tempDir,
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+  REPO_ROOT: '/tmp',
+}))
+
+const { exportCanvasHeadlessSvg } = await import('./headless-export.js')
+const { saveDocument, getDoc } = await import('../store/document-store.js')
+const { clearCache } = await import('../store/doc-cache.js')
+const { getDb } = await import('../store/db/index.js')
+const { LibsqlDocumentStore } = await import('../store/libsql/libsql-document-store.js')
+const { getDocumentIdByPath } = await import('../store/db/upsert-workspace.js')
+
+const WORKSPACE = 'ws_cache'
+const PATH = 'design'
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-export-cache-test-'))
+  clearCache()
+})
+
+afterEach(async () => {
+  clearCache()
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+function textDoc(text: string): LoroDoc {
+  const doc = new LoroDoc()
+  doc
+    .getMap('nodes')
+    .set('n1', { id: 'n1', type: 'text', x: 0, y: 0, width: 300, height: 80, text })
+  doc.commit()
+  return doc
+}
+
+/**
+ * The MCP tool surface's write, reproduced exactly: resolve the documentId,
+ * build a FRESH LoroDoc, and save it against `document:<id>`. That freshness
+ * is the whole point — a caller mutating the cached instance in place leaves
+ * the cache correct by identity, and every tool call does the opposite.
+ */
+async function writeThroughToolPath(text: string): Promise<void> {
+  const db = await getDb(tempDir)
+  const documentId = await getDocumentIdByPath(db, WORKSPACE, PATH)
+  if (documentId === undefined || documentId === null) throw new Error('no documentId for path')
+  const doc = textDoc(text)
+  const { manifest, chunks } = chunkSnapshot(doc.export({ mode: 'snapshot' }), 1024 * 1024)
+  await new LibsqlDocumentStore(db).saveSnapshot({
+    docRef: { kind: 'document', documentId },
+    manifest,
+    chunks,
+    // The tools' own value (`document-io.ts`). It is what tells a reader the
+    // stored bytes are ahead of anything it is holding.
+    frontier: doc.oplogVersion().encode() as Uint8Array<ArrayBuffer>,
+  })
+}
+
+describe('an export after an agent edit', () => {
+  it('renders what the tool wrote, not what was cached before it', async () => {
+    await saveDocument(WORKSPACE, PATH, new LoroDoc())
+
+    // Stands in for anything that opens the document BY PATH between the
+    // create and the edit — a browser tab's WS connect, a snapshot GET, a
+    // version read. Each populates this cache; none is unusual.
+    await getDoc(WORKSPACE, PATH)
+
+    await writeThroughToolPath('日本語のテキスト')
+
+    const { svg } = await exportCanvasHeadlessSvg({ workspaceId: WORKSPACE, path: PATH })
+
+    expect(svg).toContain('日本語のテキスト')
+  })
+
+  // Two writers, neither a prefix of the other: an open editor holding the
+  // cached document while an agent writes the same one. The frontier
+  // comparison answers `undefined` here rather than "behind", and treating
+  // that as up-to-date would drop the agent's node while looking correct —
+  // the editor's own edit is still there, so the export is not obviously
+  // wrong.
+  it('merges a diverged history instead of preferring the copy it holds', async () => {
+    await saveDocument(WORKSPACE, PATH, new LoroDoc())
+    const cached = await getDoc(WORKSPACE, PATH)
+    cached.getMap('nodes').set('editor', {
+      id: 'editor',
+      type: 'text',
+      x: 0,
+      y: 200,
+      width: 300,
+      height: 80,
+      text: 'from the editor',
+    })
+    cached.commit()
+
+    await writeThroughToolPath('from the agent')
+
+    const { svg } = await exportCanvasHeadlessSvg({ workspaceId: WORKSPACE, path: PATH })
+
+    expect(svg).toContain('from the editor')
+    expect(svg).toContain('from the agent')
+  })
+
+  it('is not merely a smaller picture — the empty case is a valid-looking export', async () => {
+    await saveDocument(WORKSPACE, PATH, new LoroDoc())
+    await getDoc(WORKSPACE, PATH)
+    await writeThroughToolPath('hello')
+
+    const { svg } = await exportCanvasHeadlessSvg({ workspaceId: WORKSPACE, path: PATH })
+
+    // The observed failure was `<svg width="21" height="21" …><rect/></svg>`:
+    // a well-formed 200 that a caller cannot tell from an empty canvas. Pin
+    // the dimension so a regression cannot hide behind "the text assertion is
+    // just about fonts".
+    expect(svg).not.toMatch(/width="21" height="21"/)
+  })
+})

--- a/packages/mcp-server/src/server/routes/document/export-svg.test.ts
+++ b/packages/mcp-server/src/server/routes/document/export-svg.test.ts
@@ -16,6 +16,15 @@ vi.mock('../../config.js', () => ({
   REPO_ROOT: '/tmp',
 }))
 
+// The route now refuses a path that does not exist, so the metadata lookup is
+// stubbed true for every case; the not-found case overrides it.
+const mockDocumentExists = vi.fn<(workspaceId: string, path: string) => Promise<boolean>>(
+  async () => true,
+)
+vi.mock('../../store/document-store.js', () => ({
+  documentExists: (workspaceId: string, path: string) => mockDocumentExists(workspaceId, path),
+}))
+
 const mockExportCanvasHeadlessSvg =
   vi.fn<
     (args: {
@@ -44,6 +53,8 @@ describe('POST /api/w/:workspaceId/document/:path/export-svg', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-export-svg-test-'))
     mockExportCanvasHeadlessSvg.mockReset()
+    mockDocumentExists.mockReset()
+    mockDocumentExists.mockResolvedValue(true)
     mockExportCanvasHeadlessSvg.mockResolvedValue({ svg: '<svg><rect/></svg>', undrawable: [] })
   })
 
@@ -71,6 +82,20 @@ describe('POST /api/w/:workspaceId/document/:path/export-svg', () => {
   // characters as `<text>`, so a viewer whose system has the face reads them
   // — only rasterising is lossy. A caller relaying this to a person owes them
   // that distinction.
+  it('answers 404 for a path that does not exist, rather than an empty SVG', async () => {
+    mockDocumentExists.mockResolvedValue(false)
+
+    const res = await makeApp().request('/api/w/s1/document/no-such-canvas/export-svg', {
+      method: 'POST',
+    })
+
+    // Without the guard this is a 200 and a well-formed SVG of nothing, which
+    // a caller cannot tell from a canvas that is genuinely empty.
+    expect(res.status).toBe(404)
+    expect(await res.json()).toMatchObject({ error: 'canvas_not_found' })
+    expect(mockExportCanvasHeadlessSvg).not.toHaveBeenCalled()
+  })
+
   it('reports the characters the export renderer had no glyph for', async () => {
     mockExportCanvasHeadlessSvg.mockResolvedValue({
       svg: '<svg><rect/></svg>',

--- a/packages/mcp-server/src/server/routes/document/export-svg.ts
+++ b/packages/mcp-server/src/server/routes/document/export-svg.ts
@@ -11,6 +11,7 @@ import {
 import { getDataDir } from '../../config.js'
 import { exportCanvasHeadlessSvg } from '../../export/headless-export.js'
 import { OutputPathError, validateOutputPath } from '../../output-path.js'
+import { documentExists } from '../../store/document-store.js'
 import { toDocumentOutputPathErrorBody } from '../document-output-path-error.js'
 import { onDocumentAction } from './path-route.js'
 
@@ -35,6 +36,18 @@ export function createDocumentSvgExportRouter() {
     'post',
     'export-svg',
     async (c, workspaceId, path) => {
+      // The same guard the PNG route carries, and for the same reason: the
+      // headless path answers a missing document with an EMPTY one, so a
+      // typoed path would otherwise return 200 and a valid-looking SVG of
+      // nothing. Its absence here was the asymmetry, not a decision.
+      if (!(await documentExists(workspaceId, path))) {
+        const errBody: ExportErrorBody = {
+          error: 'canvas_not_found',
+          message: `Canvas not found: ${workspaceId}/${path}`,
+        }
+        return c.json(errBody, 404)
+      }
+
       const rawText = await c.req.text()
       let body: ExportSvgRequest = {}
       if (rawText.length > 0) {

--- a/packages/mcp-server/src/server/store/document-store.ts
+++ b/packages/mcp-server/src/server/store/document-store.ts
@@ -47,7 +47,7 @@ import {
 import { getDb, registerDbDisposeHook } from './db/index.js'
 import { prepareDataDir } from './db/prepare.js'
 import { getDocumentIdByPath, upsertWorkspaceRow } from './db/upsert-workspace.js'
-import { evictDoc, getOrLoad } from './doc-cache.js'
+import { evictDoc, getOrLoad, peekDoc } from './doc-cache.js'
 import { LibsqlDocumentStore } from './libsql/libsql-document-store.js'
 import type { VersionStore } from './version-store.js'
 import { thumbnailPath } from './version-store.js'
@@ -151,6 +151,36 @@ async function saveSnapshotLocked(
 // doc was the last writer. A stored snapshot that fails to import falls
 // back to plain overwrite — the pre-flip semantics for an unreadable
 // snapshot — with a warning.
+/**
+ * Brings `doc` up to the stored bytes when it is behind them, and does
+ * nothing when it is not.
+ *
+ * Used on BOTH sides, and for the same reason from opposite directions: a
+ * writer must not overwrite work it never saw, and a reader must not serve
+ * a cached document someone else has since written past. The read side is
+ * what makes the resident LRU self-correcting — every write would otherwise
+ * have to remember to evict, and the MCP tools cannot: they address
+ * documents by id and have no idea what path a document is cached under.
+ *
+ * Throws rather than logging, so each caller can say what its own failure
+ * costs — an overwrite on the write side, stale bytes on the read side.
+ */
+async function importStoredIfBehind(
+  documentStore: LibsqlDocumentStore,
+  documentId: string,
+  doc: LoroDoc,
+): Promise<void> {
+  const docRef = { kind: 'document' as const, documentId }
+  const stored = await documentStore.readFrontier({ docRef })
+  if (stored === null) return
+  const comparison = doc.oplogVersion().compare(VersionVector.decode(stored.frontier))
+  // `undefined` means the two histories diverged — neither is a prefix of the
+  // other — which is still a reason to merge, not to ignore.
+  if (comparison !== undefined && comparison >= 0) return
+  const existing = await documentStore.loadSnapshot({ docRef })
+  if (existing !== null) doc.import(reassembleSnapshot(existing.manifest, existing.chunks))
+}
+
 async function mergeAndSaveSnapshotLocked(
   documentStore: LibsqlDocumentStore,
   workspaceId: string,
@@ -159,22 +189,13 @@ async function mergeAndSaveSnapshotLocked(
 ): Promise<number> {
   const docRef = { kind: 'document' as const, documentId }
   return withDocumentWriteLock(documentId, async () => {
-    const stored = await documentStore.readFrontier({ docRef })
-    if (stored !== null) {
-      const comparison = doc.oplogVersion().compare(VersionVector.decode(stored.frontier))
-      if (comparison === undefined || comparison < 0) {
-        try {
-          const existing = await documentStore.loadSnapshot({ docRef })
-          if (existing !== null) {
-            doc.import(reassembleSnapshot(existing.manifest, existing.chunks))
-          }
-        } catch (err) {
-          getLogger('document').warning(
-            { workspaceId, documentId, err: err as Error },
-            'stored snapshot failed to merge before save; overwriting',
-          )
-        }
-      }
+    try {
+      await importStoredIfBehind(documentStore, documentId, doc)
+    } catch (err) {
+      getLogger('document').warning(
+        { workspaceId, documentId, err: err as Error },
+        'stored snapshot failed to merge before save; overwriting',
+      )
     }
     const snapshot = doc.export({ mode: 'snapshot' })
     const { manifest, chunks } = chunkSnapshot(snapshot, SNAPSHOT_MAX_CHUNK_BYTES)
@@ -367,6 +388,27 @@ export async function loadDocument(workspaceId: string, path: string): Promise<L
  * only when a *fresh* instance is the point.
  */
 export async function getDoc(workspaceId: string, path: string): Promise<LoroDoc> {
+  // Only a HIT can be stale; a miss is about to load the stored bytes anyway.
+  // Paying the two small indexed reads here rather than on every call keeps
+  // the common path unchanged.
+  const cached = peekDoc(workspaceId, path)
+  if (cached !== undefined) {
+    try {
+      const db = await dbReady()
+      const documentId = await getDocumentIdByPath(db, workspaceId, path)
+      if (documentId) {
+        await importStoredIfBehind(await documentStoreReady(), documentId, cached)
+      }
+    } catch (err) {
+      // Serving the cached document is the honest fallback: it is what this
+      // process last knew, and refusing to answer would turn a stale read
+      // into a failed one.
+      getLogger('document').warning(
+        { workspaceId, path, err: err as Error },
+        'could not refresh cached document from the store; serving cached bytes',
+      )
+    }
+  }
   return getOrLoad(workspaceId, path, () => loadDocument(workspaceId, path))
 }
 


### PR DESCRIPTION
An agent that edits a canvas and then exports it over HTTP gets a **blank image, silently** — `200`, a file path, and `<svg width="21" height="21"><rect/></svg>`. Observed on a live daemon, one document, the same minute:

```
wb_canvas_snapshot   node present
wb_document_get      stored content has the node
wb_scene_render      300x80 SVG containing 日本語のテキスト
POST …/export        93-byte PNG
POST …/export-svg    <svg width="21" height="21"><rect/></svg>
```

## Not the store split — the cache

That split existed and was closed by #855; both sides now read the same rows. What is still split is the **cache**: the export path reads through a `(workspaceId, path)`-keyed LRU of live `LoroDoc`s, while the MCP tools write **by documentId, with a fresh `LoroDoc` per call**.

Nothing on that write path *can* evict — `server-core` addresses documents by id and has no idea what path one is cached under. So the export served whatever the last path-keyed reader left behind. A browser tab's WS connect between the create and the edit is enough to poison it.

And it fails in the worst available shape: **both loaders answer "not found" with an empty document rather than an error**, so stale, missed, and genuinely-empty are one indistinguishable result.

## Fixed on the read side, not by asking writers to remember

`getDoc` now verifies a cache **hit** against the stored frontier and merges when behind, reusing the comparison the write path already performed — extracted as `importStoredIfBehind` so both directions of one invariant share an implementation. A miss is untouched: it is about to load the stored bytes anyway.

Eviction-on-write was the alternative and is fragile in exactly the way this bug demonstrates: it works until someone adds a writer that forgets.

## Reproduced first

The new test keeps the cache in play, which the existing `headless-export.test.ts` structurally cannot — it calls `clearCache()` in **both** `beforeEach` and `afterEach`, designing this defect out of every case in the file. That is why 3600 green tests never saw it.

Three mutations, each reddening exactly its own test:

| mutation | test that goes red |
|---|---|
| skip the cache-hit check | renders what the tool wrote |
| treat a **diverged** history as up to date | merges a diverged history |
| drop the new 404 | answers 404 for a path that does not exist |

The diverged case is the real multi-writer one — an open editor holding the cached document while an agent writes the same one, neither history a prefix of the other. The frontier comparison answers `undefined` there, and calling that "up to date" would drop the agent's node while *looking* right, because the editor's own edit is still present.

## Cost, measured

Interleaved A/B, 2000 cached calls each:

```
cached getDoc   0.000 ms  ->  0.116 ms
```

Two small indexed reads where there had been a `Map` lookup. At 60 frames a second that is 0.7% of wall time, and it buys a cache that corrects itself for **every** reader rather than one that trusts its last writer.

## Also

The SVG route gets the `documentExists` guard the PNG route has carried all along. Its absence was an asymmetry, not a decision — a typoed path answered 200 and a valid-looking picture of nothing. Adding it turned every existing test in that file red until they stubbed the lookup, which is the guard being real.

`pnpm test --project mcp-node` 299 files / 3616 tests, lint / knip / typecheck clean.