### PR TITLE
test(web): give the IndexedDB migration test a database of its own

### DIFF
--- a/apps/web/src/lib/browser-idb-migration.browser.test.tsx
+++ b/apps/web/src/lib/browser-idb-migration.browser.test.tsx
@@ -17,9 +17,22 @@ import { DB_VERSION, openWhiteboardDb } from './browser-idb.js'
 import { IndexedDBStore } from './browser-local-store.js'
 import { LoroStore } from './loro-store.js'
 
+/**
+ * This file's own database.
+ *
+ * Twelve browser test files touch the shared `whiteboard` database, and they
+ * share an origin — so IndexedDB is one global object across all of them. Only
+ * this file deliberately parks that database at OLD versions to exercise the
+ * upgrades, which makes it the one file whose fixtures can block another's
+ * open (and be blocked by it) with `another tab has this app open at an older
+ * version`. The name is a parameter precisely so this file can stop
+ * participating; nothing was passing it.
+ */
+const MIGRATION_DB = 'whiteboard-migration-test'
+
 async function clearDb(): Promise<void> {
   return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase('whiteboard')
+    const req = indexedDB.deleteDatabase(MIGRATION_DB)
     req.onsuccess = () => resolve()
     req.onerror = () => resolve()
   })
@@ -28,7 +41,7 @@ async function clearDb(): Promise<void> {
 /** Seed a pre-v3 ("v2 shape") fixture DB via raw IDB, bypassing the app's opener/schema. */
 async function seedV2Fixture(documentId: string, loroSnapshot: Uint8Array): Promise<void> {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open('whiteboard', 2)
+    const req = indexedDB.open(MIGRATION_DB, 2)
     req.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result
       if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
@@ -72,7 +85,7 @@ async function seedV2Fixture(documentId: string, loroSnapshot: Uint8Array): Prom
 /** Reads a 'documents' row directly via raw IDB, bypassing documentSnapshotSchema. */
 async function readRawDocumentsRow(documentId: string): Promise<unknown> {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open('whiteboard')
+    const req = indexedDB.open(MIGRATION_DB)
     req.onsuccess = () => {
       const db = req.result
       const tx = db.transaction('documents', 'readonly')
@@ -88,7 +101,7 @@ async function readRawDocumentsRow(documentId: string): Promise<unknown> {
 /** Seed a pre-v4 ("v3 shape") fixture DB via raw IDB, bypassing the app's opener/schema. */
 async function seedV3Fixture(documentId: string, loroSnapshot: Uint8Array): Promise<void> {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open('whiteboard', 3)
+    const req = indexedDB.open(MIGRATION_DB, 3)
     req.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result
       if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
@@ -123,7 +136,7 @@ async function seedV3Fixture(documentId: string, loroSnapshot: Uint8Array): Prom
 /** Seed a pre-v5 ("v4 shape") fixture DB via raw IDB, bypassing the app's opener/schema. */
 async function seedV4Fixture(documentId: string, loroSnapshot: Uint8Array): Promise<void> {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open('whiteboard', 4)
+    const req = indexedDB.open(MIGRATION_DB, 4)
     req.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result
       if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
@@ -160,7 +173,7 @@ async function seedV4Fixture(documentId: string, loroSnapshot: Uint8Array): Prom
 /** Seed a pre-v6 ("v5 shape") fixture DB via raw IDB, bypassing the app's opener/schema. */
 async function seedV5Fixture(documentId: string, loroSnapshot: Uint8Array): Promise<void> {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open('whiteboard', 5)
+    const req = indexedDB.open(MIGRATION_DB, 5)
     req.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result
       if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
@@ -208,7 +221,7 @@ async function seedV5Fixture(documentId: string, loroSnapshot: Uint8Array): Prom
 /** Seed a pre-v7 ("v6 shape") fixture DB via raw IDB, bypassing the app's opener/schema. */
 async function seedV6Fixture(documentId: string, loroSnapshot: Uint8Array): Promise<void> {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open('whiteboard', 6)
+    const req = indexedDB.open(MIGRATION_DB, 6)
     req.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result
       if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
@@ -243,7 +256,7 @@ async function seedV6Fixture(documentId: string, loroSnapshot: Uint8Array): Prom
 }
 
 async function metaKeys(): Promise<string[]> {
-  const db = await openWhiteboardDb()
+  const db = await openWhiteboardDb(MIGRATION_DB)
   return new Promise((resolve, reject) => {
     const tx = db.transaction('meta', 'readonly')
     const req = tx.objectStore('meta').getAllKeys()
@@ -267,7 +280,7 @@ describe('whiteboard IndexedDB v6 -> v7 upgrade (renames the container stores)',
     doc.getList('elements').push({ id: 'canonical-el' })
     await seedV6Fixture(documentId, doc.export({ mode: 'snapshot' }))
 
-    const db = await openWhiteboardDb()
+    const db = await openWhiteboardDb(MIGRATION_DB)
     // Read before asserting, and assert after: a failed expect() between the
     // open and the close would leak the connection, and every later test in
     // this file would then meet a database clearDb cannot delete.
@@ -298,7 +311,7 @@ describe('whiteboard IndexedDB v6 -> v7 upgrade (renames the container stores)',
     // them alone. A copy that lost its key or its value fails the count above
     // even though the store-name assertion passed.
 
-    const metaStore = new IndexedDBStore()
+    const metaStore = new IndexedDBStore(MIGRATION_DB)
     // The row does not survive: v8 DISCARDS a document with no workspace and
     // no path, because there is nothing to migrate it to without inventing an
     // address, and an invented one is indistinguishable from a chosen one.
@@ -308,7 +321,7 @@ describe('whiteboard IndexedDB v6 -> v7 upgrade (renames the container stores)',
     expect((await metaStore.load(documentId)).kind).toBe('not-found')
     expect(await metaStore.listDocuments()).toEqual([])
     // The bytes go with it rather than lingering as storage nothing names.
-    expect((await new LoroStore().load(documentId)).kind).toBe('not-found')
+    expect((await new LoroStore(MIGRATION_DB).load(documentId)).kind).toBe('not-found')
   })
 
   it('renames the meta pointer key, then clears it because v8 discarded its target', async () => {
@@ -321,11 +334,11 @@ describe('whiteboard IndexedDB v6 -> v7 upgrade (renames the container stores)',
     // document it named is gone — a pointer at a discarded document would
     // resume the editor into nothing.
     expect(await metaKeys()).toEqual([])
-    expect(await new IndexedDBStore().getDefaultDocumentId()).toBeNull()
+    expect(await new IndexedDBStore(MIGRATION_DB).getDefaultDocumentId()).toBeNull()
   })
 
   it('is a no-op for a fresh install, which never had the old stores', async () => {
-    const db = await openWhiteboardDb()
+    const db = await openWhiteboardDb(MIGRATION_DB)
     expect([...db.objectStoreNames].sort()).toEqual([
       'documentFiles',
       'documentIndex',
@@ -362,7 +375,7 @@ describe('IndexedDB v5 -> v6 (removes reconnectKeypairs)', () => {
       JSON.stringify({ origin: 'http://localhost:3099', secret: 'stale-secret' }),
     )
 
-    const db = await openWhiteboardDb()
+    const db = await openWhiteboardDb(MIGRATION_DB)
     // Erasure invariant: the credential surface is gone by construction —
     // no reader can reach it because there is no longer anywhere to read it
     // from.
@@ -378,9 +391,9 @@ describe('IndexedDB v5 -> v6 (removes reconnectKeypairs)', () => {
     expect(fileCount).toBe(1)
 
     // Discarded with its document — see the note below.
-    expect((await new LoroStore().load(documentId)).kind).toBe('not-found')
+    expect((await new LoroStore(MIGRATION_DB).load(documentId)).kind).toBe('not-found')
 
-    const metaStore = new IndexedDBStore()
+    const metaStore = new IndexedDBStore(MIGRATION_DB)
     // The row does not survive: v8 DISCARDS a document with no workspace and
     // no path, because there is nothing to migrate it to without inventing an
     // address, and an invented one is indistinguishable from a chosen one.
@@ -403,7 +416,7 @@ describe('IndexedDB v5 -> v6 (removes reconnectKeypairs)', () => {
   })
 
   it('a fresh install at the current version never creates reconnectKeypairs', async () => {
-    const db = await openWhiteboardDb()
+    const db = await openWhiteboardDb(MIGRATION_DB)
     expect(db.objectStoreNames.contains('reconnectKeypairs')).toBe(false)
     expect([...db.objectStoreNames].sort()).toEqual([
       'documentFiles',
@@ -432,7 +445,7 @@ describe('IndexedDB v4 -> v5', () => {
     const loroSnapshot = doc.export({ mode: 'snapshot' })
     await seedV4Fixture(documentId, loroSnapshot)
 
-    const db = await openWhiteboardDb()
+    const db = await openWhiteboardDb(MIGRATION_DB)
     // v4 -> current spans the v4->v5 store creation AND the v5->v6 removal
     // in one upgrade transaction (a multi-version jump fires
     // onupgradeneeded once, not once per intermediate version), so the net
@@ -449,9 +462,9 @@ describe('IndexedDB v4 -> v5', () => {
     expect(fileCount).toBe(1)
 
     // Discarded with its document — see the note below.
-    expect((await new LoroStore().load(documentId)).kind).toBe('not-found')
+    expect((await new LoroStore(MIGRATION_DB).load(documentId)).kind).toBe('not-found')
 
-    const metaStore = new IndexedDBStore()
+    const metaStore = new IndexedDBStore(MIGRATION_DB)
     // The row does not survive: v8 DISCARDS a document with no workspace and
     // no path, because there is nothing to migrate it to without inventing an
     // address, and an invented one is indistinguishable from a chosen one.
@@ -478,14 +491,14 @@ describe('whiteboard IndexedDB v3 -> v4 upgrade', () => {
     const loroSnapshot = doc.export({ mode: 'snapshot' })
     await seedV3Fixture(documentId, loroSnapshot)
 
-    const db = await openWhiteboardDb()
+    const db = await openWhiteboardDb(MIGRATION_DB)
     expect(db.objectStoreNames.contains('documentFiles')).toBe(true)
     db.close()
 
     // Discarded with its document — see the note below.
-    expect((await new LoroStore().load(documentId)).kind).toBe('not-found')
+    expect((await new LoroStore(MIGRATION_DB).load(documentId)).kind).toBe('not-found')
 
-    const metaStore = new IndexedDBStore()
+    const metaStore = new IndexedDBStore(MIGRATION_DB)
     // The row does not survive: v8 DISCARDS a document with no workspace and
     // no path, because there is nothing to migrate it to without inventing an
     // address, and an invented one is indistinguishable from a chosen one.
@@ -515,7 +528,7 @@ describe('whiteboard IndexedDB v2 -> v3 upgrade', () => {
     // current DB_VERSION. This half is the durable one: every version bump
     // since has had to keep it true, and a VersionError here is a bricked app
     // for anyone who has not opened the tab in a while.
-    const db = await openWhiteboardDb()
+    const db = await openWhiteboardDb(MIGRATION_DB)
     db.close()
 
     // (b) Nothing else survives. A v2 row carries no workspace and no path —
@@ -523,11 +536,11 @@ describe('whiteboard IndexedDB v2 -> v3 upgrade', () => {
     // Loro record. What the pre-v3 `scene` strip did to this row on the way
     // through is no longer observable; the guard that it must not THROW on a
     // corrupt row still is, and is the next test.
-    const metaStore = new IndexedDBStore()
+    const metaStore = new IndexedDBStore(MIGRATION_DB)
     expect(await readRawDocumentsRow(documentId)).toBeUndefined()
     expect((await metaStore.load(documentId)).kind).toBe('not-found')
     expect(await metaStore.listDocuments()).toEqual([])
-    expect((await new LoroStore().load(documentId)).kind).toBe('not-found')
+    expect((await new LoroStore(MIGRATION_DB).load(documentId)).kind).toBe('not-found')
     expect(await metaStore.getDefaultDocumentId()).toBeNull()
   })
 
@@ -536,7 +549,7 @@ describe('whiteboard IndexedDB v2 -> v3 upgrade', () => {
     // inside the upgrade cursor — that would abort the transaction and brick the
     // DB open for the user.
     await new Promise<void>((resolve, reject) => {
-      const req = indexedDB.open('whiteboard', 2)
+      const req = indexedDB.open(MIGRATION_DB, 2)
       req.onupgradeneeded = (event) => {
         const db = (event.target as IDBOpenDBRequest).result
         if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
@@ -565,7 +578,7 @@ describe('whiteboard IndexedDB v2 -> v3 upgrade', () => {
 
     // Opening through the shared opener at v3 must complete (guard prevents the
     // `in` TypeError from aborting the upgrade).
-    const db = await openWhiteboardDb()
+    const db = await openWhiteboardDb(MIGRATION_DB)
     expect(db.version).toBe(DB_VERSION)
     db.close()
   })
@@ -583,7 +596,7 @@ describe('whiteboard IndexedDB v2 -> v3 upgrade', () => {
     // Opening at the (hypothetically reverted) old version 2 does not run
     // onupgradeneeded at all, so the legacy 'scene' field is still present.
     const rawDb = await new Promise<IDBDatabase>((resolve, reject) => {
-      const req = indexedDB.open('whiteboard', 2)
+      const req = indexedDB.open(MIGRATION_DB, 2)
       req.onsuccess = () => resolve(req.result)
       req.onerror = () => reject(req.error)
     })
@@ -605,7 +618,7 @@ async function seedV7Fixture(rows: {
   defaultDocumentId?: string
 }): Promise<void> {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open('whiteboard', 7)
+    const req = indexedDB.open(MIGRATION_DB, 7)
     req.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result
       for (const name of ['meta', 'documents', 'loroDocuments', 'documentFiles']) {
@@ -639,7 +652,7 @@ async function seedV7Fixture(rows: {
 }
 
 async function storeKeys(name: string): Promise<string[]> {
-  const db = await openWhiteboardDb()
+  const db = await openWhiteboardDb(MIGRATION_DB)
   return new Promise((resolve, reject) => {
     const tx = db.transaction(name, 'readonly')
     const req = tx.objectStore(name).getAllKeys()
@@ -694,7 +707,7 @@ describe('whiteboard IndexedDB v7 -> v8 upgrade (discards pre-path documents)', 
 
     expect(await readRawDocumentsRow(POST_PATH_ID)).toEqual(row)
     expect(await storeKeys('loroDocuments')).toEqual([POST_PATH_ID])
-    expect(await new IndexedDBStore().getDefaultDocumentId()).toBe(POST_PATH_ID)
+    expect(await new IndexedDBStore(MIGRATION_DB).getDefaultDocumentId()).toBe(POST_PATH_ID)
   })
 
   it('discards only the pre-path rows when a store holds both', async () => {
@@ -719,7 +732,7 @@ describe('whiteboard IndexedDB v7 -> v8 upgrade (discards pre-path documents)', 
 
     expect(await storeKeys('documents')).toEqual([POST_PATH_ID])
     expect(await storeKeys('loroDocuments')).toEqual([POST_PATH_ID])
-    expect(await new IndexedDBStore().getDefaultDocumentId()).toBe(POST_PATH_ID)
+    expect(await new IndexedDBStore(MIGRATION_DB).getDefaultDocumentId()).toBe(POST_PATH_ID)
   })
 
   it('survives a corrupt (non-object) row rather than aborting the whole upgrade', async () => {
@@ -757,11 +770,11 @@ describe('cross-tab upgrades', () => {
     // its own version and the upgrade below never fires — the request sits in
     // `blocked` forever, which in the app is an editor that never loads and
     // no error to explain why.
-    const idle = await openWhiteboardDb()
+    const idle = await openWhiteboardDb(MIGRATION_DB)
 
     let blocked = false
     const upgraded = await new Promise<boolean>((resolve) => {
-      const req = indexedDB.open('whiteboard', DB_VERSION + 1)
+      const req = indexedDB.open(MIGRATION_DB, DB_VERSION + 1)
       req.onblocked = () => {
         blocked = true
       }
@@ -789,7 +802,7 @@ describe('cross-tab upgrades', () => {
     // file store — awaits a promise that has no outcome, which in the app is an
     // editor that never loads with nothing on screen to explain why.
     const stubborn = await new Promise<IDBDatabase>((resolve, reject) => {
-      const req = indexedDB.open('whiteboard', DB_VERSION - 1)
+      const req = indexedDB.open(MIGRATION_DB, DB_VERSION - 1)
       req.onsuccess = () => resolve(req.result)
       req.onerror = () => reject(req.error)
     })
@@ -800,7 +813,7 @@ describe('cross-tab upgrades', () => {
       // whole per-test timeout (measured: 120s) reporting the same thing this
       // says in three.
       const outcome = await Promise.race([
-        openWhiteboardDb().then(
+        openWhiteboardDb(MIGRATION_DB).then(
           (db) => {
             db.close()
             return 'resolved'

--- a/apps/web/src/lib/browser-local-store.ts
+++ b/apps/web/src/lib/browser-local-store.ts
@@ -102,8 +102,15 @@ export class MemoryStore implements BrowserLocalStore {
 }
 
 export class IndexedDBStore implements BrowserLocalStore {
+  /**
+   * Which database to talk to. Production never passes it; a browser test
+   * does, so its fixtures cannot collide with another test FILE's — they
+   * share an origin, and therefore one `whiteboard` database.
+   */
+  constructor(private readonly dbName?: string) {}
+
   async getDefaultDocumentId(): Promise<string | null> {
-    const db = await openWhiteboardDb()
+    const db = await openWhiteboardDb(this.dbName)
     return new Promise((resolve, reject) => {
       const tx = db.transaction('meta', 'readonly')
       const req = tx.objectStore('meta').get('defaultDocumentId')
@@ -114,7 +121,7 @@ export class IndexedDBStore implements BrowserLocalStore {
   }
 
   async setDefaultDocumentId(id: string): Promise<void> {
-    const db = await openWhiteboardDb()
+    const db = await openWhiteboardDb(this.dbName)
     return new Promise((resolve, reject) => {
       const tx = db.transaction('meta', 'readwrite')
       tx.objectStore('meta').put(id, 'defaultDocumentId')
@@ -133,7 +140,7 @@ export class IndexedDBStore implements BrowserLocalStore {
   }
 
   async load(id: string): Promise<LoadResult> {
-    const db = await openWhiteboardDb()
+    const db = await openWhiteboardDb(this.dbName)
     return new Promise((resolve) => {
       const tx = db.transaction('documents', 'readonly')
       const req = tx.objectStore('documents').get(id)
@@ -151,7 +158,7 @@ export class IndexedDBStore implements BrowserLocalStore {
   }
 
   async save(snapshot: DocumentSnapshot): Promise<void> {
-    const db = await openWhiteboardDb()
+    const db = await openWhiteboardDb(this.dbName)
     return new Promise((resolve, reject) => {
       const tx = db.transaction('documents', 'readwrite')
       const store = tx.objectStore('documents')
@@ -194,7 +201,7 @@ export class IndexedDBStore implements BrowserLocalStore {
   }
 
   async del(expectedId: string): Promise<DeleteResult> {
-    const db = await openWhiteboardDb()
+    const db = await openWhiteboardDb(this.dbName)
     return new Promise((resolve, reject) => {
       const tx = db.transaction(['meta', 'documents'], 'readwrite')
       const metaStore = tx.objectStore('meta')
@@ -236,7 +243,7 @@ export class IndexedDBStore implements BrowserLocalStore {
   }
 
   async removeDocument(id: string): Promise<void> {
-    const db = await openWhiteboardDb()
+    const db = await openWhiteboardDb(this.dbName)
     return new Promise((resolve, reject) => {
       const tx = db.transaction('documents', 'readwrite')
       tx.objectStore('documents').delete(id)
@@ -260,7 +267,7 @@ export class IndexedDBStore implements BrowserLocalStore {
   }
 
   async listDocuments(): Promise<DocumentSnapshot[]> {
-    const db = await openWhiteboardDb()
+    const db = await openWhiteboardDb(this.dbName)
     return new Promise((resolve, reject) => {
       const tx = db.transaction('documents', 'readonly')
       const cursorReq = tx.objectStore('documents').openCursor()

--- a/apps/web/src/lib/loro-store.ts
+++ b/apps/web/src/lib/loro-store.ts
@@ -73,6 +73,13 @@ function foldDeltas(snapshot: Uint8Array, deltas: readonly Uint8Array[]): Uint8A
  */
 export class LoroStore {
   /**
+   * Which database to talk to. Production never passes it; a browser test
+   * does, so its fixtures cannot collide with another test FILE's — they
+   * share an origin, and therefore one `whiteboard` database.
+   */
+  constructor(private readonly dbName?: string) {}
+
+  /**
    * Bytes for a brand-new, empty Loro document snapshot. Callers that only
    * need to seed a fresh canvas (e.g. the page-layer create-canvas flow) use
    * this instead of importing `loro-crdt` themselves, keeping CRDT-library
@@ -83,7 +90,7 @@ export class LoroStore {
   }
 
   async load(documentId: string): Promise<LoroLoadResult> {
-    const db = await openWhiteboardDb()
+    const db = await openWhiteboardDb(this.dbName)
     return new Promise((resolve) => {
       const tx = db.transaction('loroDocuments', 'readonly')
       const req = tx.objectStore('loroDocuments').get(documentId)
@@ -149,7 +156,7 @@ export class LoroStore {
   }
 
   async save(documentId: string, snapshot: Uint8Array): Promise<void> {
-    const db = await openWhiteboardDb()
+    const db = await openWhiteboardDb(this.dbName)
     return new Promise((resolve, reject) => {
       const envelope: LoroRecordEnvelope = {
         v: 1,
@@ -182,7 +189,7 @@ export class LoroStore {
    * If no record exists yet, this is a no-op (snapshot must be saved first).
    */
   async appendDelta(documentId: string, delta: Uint8Array): Promise<void> {
-    const db = await openWhiteboardDb()
+    const db = await openWhiteboardDb(this.dbName)
     return new Promise((resolve, reject) => {
       const tx = db.transaction('loroDocuments', 'readwrite')
       const store = tx.objectStore('loroDocuments')

--- a/apps/web/src/lib/shared-idb-version-games.test.ts
+++ b/apps/web/src/lib/shared-idb-version-games.test.ts
@@ -1,0 +1,81 @@
+/**
+ * A test that parks an IndexedDB at an OLD version must own that database.
+ *
+ * IndexedDB is one object per origin and browser test files share an origin,
+ * so `whiteboard` is global across every one of them. Opening it at the
+ * current `DB_VERSION` is harmless — every file is asking for the same thing.
+ * Opening it at a LOWER version is not: it holds the database there, and any
+ * other file whose open triggers an upgrade meanwhile fails with `another tab
+ * has this app open at an older version`, in whichever file happens to be
+ * running. The report then names a test that did nothing wrong.
+ *
+ * `openWhiteboardDb(name)` and both stores take a database name for exactly
+ * this reason, and for a long time nothing passed one.
+ *
+ * The rule is stated as "no version games ON THE SHARED NAME" rather than "no
+ * literal `'whiteboard'` next to a version": a file that names its database in
+ * a `const` — which is how one ends up written — defeats the literal form
+ * entirely. That version of this guard passed while the file it was written
+ * for sat on the shared database.
+ *
+ * Read as text via Vite's `?raw` glob, the same shape as
+ * `App.lazy-coverage.test.ts`: apps/web is browser-only and has no `node:fs`.
+ */
+import { describe, expect, it } from 'vitest'
+import { DB_VERSION } from './browser-idb.js'
+
+const sources = import.meta.glob('../**/*.{test,browser.test}.{ts,tsx}', {
+  query: '?raw',
+  eager: true,
+  import: 'default',
+}) as Record<string, string>
+
+/** `indexedDB.open(<anything>, <version>)` — a version-pinned open, however the name is spelled. */
+const VERSION_PINNED_OPEN = /indexedDB\.open\([^,)]+,\s*([^)]+)\)/g
+
+/** The shared database's name as a standalone literal, not a prefix of another one. */
+const SHARED_NAME_LITERAL = /'whiteboard'/
+
+function pinnedVersions(source: string): string[] {
+  return (
+    [...source.matchAll(VERSION_PINNED_OPEN)]
+      .map((match) => (match[1] ?? '').trim())
+      // Everyone agreeing on the current version can block nobody. Anything
+      // else — a literal, or `DB_VERSION ± n` — can.
+      .filter((version) => version !== 'DB_VERSION')
+  )
+}
+
+/** Files that hold a database at some other version AND name the shared one. */
+function offendingFiles(entries: Record<string, string>): string[] {
+  return Object.entries(entries)
+    .filter(([, source]) => pinnedVersions(source).length > 0)
+    .filter(([, source]) => SHARED_NAME_LITERAL.test(source))
+    .map(([path]) => path)
+    .sort()
+}
+
+describe('a test that parks IndexedDB at an old version', () => {
+  it('is compared against a real current version', () => {
+    expect(DB_VERSION).toBeGreaterThan(0)
+  })
+
+  it('never does it to the database every other browser test shares', () => {
+    expect(offendingFiles(sources)).toEqual([])
+  })
+
+  it('is actually detected — an empty result means clean, not blind', () => {
+    // Both halves, because either one silently passing makes the guard useless:
+    // the version scan surviving a formatter, and the name check seeing a
+    // database named in a const rather than inline.
+    expect(pinnedVersions('indexedDB.open(NAME, 7)')).toEqual(['7'])
+    expect(pinnedVersions('indexedDB.open(NAME, DB_VERSION)')).toEqual([])
+    expect(pinnedVersions('indexedDB.open(NAME, DB_VERSION - 1)')).toEqual(['DB_VERSION - 1'])
+    expect(
+      offendingFiles({ 'x.test.ts': "const NAME = 'whiteboard'\nindexedDB.open(NAME, 7)" }),
+    ).toEqual(['x.test.ts'])
+    expect(
+      offendingFiles({ 'x.test.ts': "const NAME = 'whiteboard-mine'\nindexedDB.open(NAME, 7)" }),
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
`browser-idb-migration.browser.test.tsx` failed CI on #920 — a PR that changed only `mcp-server` routes and docs — with the app's own copy for a blocked `versionchange`:

> another tab has this app open at an older version; close it and reload

IndexedDB is **one object per origin**, and browser test files share an origin. Twelve files touch `whiteboard`; eleven open it at the current `DB_VERSION`, which can block nobody. This one parks it at versions **2 through 7 on purpose** — that is what a migration test is — so it is the single file whose fixtures can hold the database below what another file's open needs, and be held below what it needs in return. The failure then lands in whichever file happened to be running.

`openWhiteboardDb(name)` has taken a database name **for exactly this reason**, with a comment saying so, and nothing ever passed one. Both stores now take one too, and this file uses it throughout.

## What is and is not demonstrated

**I could not reproduce the CI failure locally.** Three isolated runs, the whole `web-browser` project, and all three browser projects together were green every time. So this fixes the **class** the code's own comment already names — it is not a demonstrated root cause for that one instance, and I would rather say so than dress it up.

What *is* demonstrated: the fixtures still reach the migrations under the new name. Neutering the v7→v8 discard reddens **eight** of this file's tests, so the rename did not quietly disconnect them — which is the failure mode a rename like this actually risks.

## The guard, and its first version being useless

`shared-idb-version-games.test.ts` keeps the class closed.

Its first version scanned for `indexedDB.open('whiteboard', <version>)` — and **passed while this very file sat on the shared database**. A file that names its database in a `const`, which is how one ends up written, defeats a literal scan entirely. The guard was vacuous against the one file it was written for, and only the mutation check said so.

The rule is now *"a file that pins a version must not name the shared database at all"*. Putting `MIGRATION_DB` back to `'whiteboard'` reddens it **by file name**:

```
+   "./browser-idb-migration.browser.test.tsx",
```

It also carries its own detection test, because an empty result from a source scan is indistinguishable from a scan that stopped matching.

`pnpm --filter @kamiazya/whiteboard-web test` 2601 + 77, `web-browser` 687, lint / knip / typecheck clean.