### PR TITLE
fix(lint): enforce noDangerouslySetInnerHtml, which was never actually on

### DIFF
--- a/apps/web/src/components/markdown-editor/MinimapRail.tsx
+++ b/apps/web/src/components/markdown-editor/MinimapRail.tsx
@@ -72,8 +72,10 @@ export function MinimapRail({ blocks, viewport, onSeek, className }: MinimapRail
   }
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: the rail duplicates scrolling, which the panes themselves already expose to the keyboard; it is a pointer shortcut, not the only route
-    // biome-ignore lint/a11y/useKeyWithClickEvents: same rationale — no keyboard-only user depends on this element
+    // Pointer-only on purpose, and `aria-hidden`: the rail duplicates
+    // scrolling that the panes themselves already expose to the keyboard, so
+    // it is a shortcut rather than the only route. No keyboard-only user
+    // depends on it.
     <div
       ref={railRef}
       data-testid="markdown-minimap-rail"

--- a/apps/web/src/components/markdown-editor/PreviewPane.tsx
+++ b/apps/web/src/components/markdown-editor/PreviewPane.tsx
@@ -101,6 +101,7 @@ export function PreviewPane({
       // (var() included) — `inherit` is ignored, so inheritance alone leaves
       // a visited wikiLink near-invisible.
       style={{ overflow: 'auto', fill, '--preview-fill': fill } as CSSProperties}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: canvas-render's SVG serializer is the sole producer of this string and escapes text and attribute values (svg/format.ts)
       dangerouslySetInnerHTML={{ __html: svg }}
     />
   )

--- a/apps/web/src/components/spatial-editor/DragPreviewLayer.tsx
+++ b/apps/web/src/components/spatial-editor/DragPreviewLayer.tsx
@@ -47,6 +47,7 @@ export function DragPreviewLayer({ preview, zoom, contentSvg }: DragPreviewLayer
         // Same trusted producer as the committed scene: canvas-render's
         // serializer is the sole source of this string (see CanvasViewer's
         // documented reasoning for dangerouslySetInnerHTML).
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: same trusted producer as the committed scene — canvas-render's escaping serializer
         dangerouslySetInnerHTML={{ __html: contentSvg.svg }}
       />
     )

--- a/apps/web/src/components/spatial-editor/MarkdownNodeEditor.tsx
+++ b/apps/web/src/components/spatial-editor/MarkdownNodeEditor.tsx
@@ -155,7 +155,6 @@ export function MarkdownNodeEditor({
     }
     // Mount-once by design: initialText is the seed, later parent renders
     // must not reset the document under the caret.
-    // biome-ignore lint/correctness/useExhaustiveDependencies: see above
   }, [])
 
   return (

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -3348,6 +3348,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             // canvas-render's SVG serializer is the SOLE producer of this
             // string and escapes text/attrs (see svg/format.ts) — the same
             // already-reviewed reasoning as CanvasViewer.tsx's identical sink.
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: canvas-render's serializer is the SOLE producer and escapes text/attrs (svg/format.ts)
             dangerouslySetInnerHTML={{ __html: dragStatic?.svg ?? svg }}
           />
           {liveEdges !== undefined && (
@@ -3362,6 +3363,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               }}
               // Same trusted producer as the committed scene (canvas-render's
               // escaping serializer).
+              // biome-ignore lint/security/noDangerouslySetInnerHtml: same trusted producer as the committed scene
               dangerouslySetInnerHTML={{ __html: liveEdges.svg }}
             />
           )}
@@ -3377,6 +3379,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               }}
               // Same trusted producer as the committed scene (canvas-render's
               // escaping serializer).
+              // biome-ignore lint/security/noDangerouslySetInnerHtml: same trusted producer as the committed scene
               dangerouslySetInnerHTML={{ __html: liveNode.svg }}
             />
           )}

--- a/apps/web/src/components/workspace-files/DocumentPreview.tsx
+++ b/apps/web/src/components/workspace-files/DocumentPreview.tsx
@@ -101,10 +101,10 @@ export function DocumentPreview({
         {state.kind === 'drawn' ? (
           // The same injection the editor's preview pane uses: the SVG comes
           // from this app's own renderer, over the document's own content.
-          // biome-ignore lint/security/noDangerouslySetInnerHtml: same-origin render output, as the markdown preview pane does
           <div
             data-testid="preview-render"
             className="size-full [&>svg]:size-full"
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: same-origin render output from canvas-render, as the markdown preview pane does
             dangerouslySetInnerHTML={{ __html: fitSvgToBox(state.svg) }}
           />
         ) : (

--- a/apps/web/src/components/workspace-files/DocumentThumbnail.tsx
+++ b/apps/web/src/components/workspace-files/DocumentThumbnail.tsx
@@ -66,15 +66,14 @@ export function DocumentThumbnail({ document, loadRender, className }: DocumentT
           />
         )
       ) : (
-        // eslint-disable-next-line react/no-danger -- the SVG is produced by
-        // this app's own renderer from the document's own content, never by a
-        // remote party; it is the same injection the editor's preview uses.
-        // biome-ignore lint/security/noDangerouslySetInnerHtml: same-origin render output, as the markdown preview pane does
+        // The SVG is produced by this app's own renderer from the document's
+        // own content, never by a remote party.
         // The rule lives on the span that actually PARENTS the svg. jsdom has
         // no layout, so a selector aimed one level too high still passes every
         // test and draws a 2000px canvas inside a 24px row in a real browser.
         <span
           className="size-full [&>svg]:size-full"
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: same-origin render output from canvas-render, as the markdown preview pane does
           dangerouslySetInnerHTML={{ __html: fitSvgToBox(drawn.svg) }}
         />
       )}

--- a/biome.json
+++ b/biome.json
@@ -50,6 +50,9 @@
         "noArrayIndexKey": "off",
         "useBiomeIgnoreFolder": "off"
       },
+      "security": {
+        "noDangerouslySetInnerHtml": "error"
+      },
       "style": {
         "noNonNullAssertion": "off",
         "useImportType": "warn"

--- a/packages/canvas-viewer/src/CanvasViewer.tsx
+++ b/packages/canvas-viewer/src/CanvasViewer.tsx
@@ -116,6 +116,7 @@ export function CanvasViewer({
         overflow: 'hidden',
         margin: 0,
       }}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: canvas-render's serializer is the SOLE producer and escapes &/</> in text and quotes in attributes (see this file's doc comment)
       dangerouslySetInnerHTML={{ __html: svg }}
     />
   )


### PR DESCRIPTION
Two files carried `biome-ignore lint/security/noDangerouslySetInnerHtml`, and Biome reported both suppressions **unused**. The reason is not that the code stopped needing them.

**The rule is not in Biome's `recommended` preset.** `preset: "recommended"` never turned it on, so the codebase has been declaring a deliberate exception to a guard that has never run — and 6 of the 8 injection sites never even claimed one.

Enabling it makes all eight visible. That is the point: a **new** `dangerouslySetInnerHTML` now has to argue for itself instead of arriving silently.

## No new judgement was needed

Every site is canvas-render's SVG serializer output, and six already carried that reasoning as a plain comment. Each was read and checked before signing off, not pattern-matched:

| site | source |
|---|---|
| `CanvasViewer.tsx` | `svg` — documented in the file's own doc comment |
| `SpatialEditor.tsx` ×3 | committed scene, live edges, live node |
| `DragPreviewLayer.tsx` | `contentSvg.svg` |
| `PreviewPane.tsx` | `svg` |
| `DocumentPreview.tsx` / `DocumentThumbnail.tsx` | `fitSvgToBox(…svg)` |

The suppressions now **carry** that reasoning, so there is one explanation per site rather than a comment sitting beside an ignore line saying something slightly different.

## Also clears the five standing warnings

`pnpm lint` had drifted back above zero after d85d8318 deliberately took it there:

- **MinimapRail** ×2 — the a11y ignores cannot fire: the element has no `onClick` and is `aria-hidden`. The reasoning survives as prose, because *why* it is pointer-only is worth knowing.
- **MarkdownNodeEditor** — `useExhaustiveDependencies` is `"off"` in `biome.json`, so that ignore could never fire. The two lines above it already say mount-once is deliberate.
- **DocumentThumbnail** — an `eslint-disable-next-line react/no-danger`, for a linter this repo does not run.

## Mutation-checked in both directions

```
remove any one suppression        -> lint fails, naming that exact site
add a fresh unguarded injection   -> lint fails
```

`pnpm lint` exits 0 with **zero** warnings; typecheck clean; `apps/web` 2611 + 77, `canvas-viewer` 123.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Quality**
  * Strengthened linting for potentially unsafe HTML injection.
  * Added documentation around trusted, sanitized SVG rendering paths.
  * Improved accessibility annotations for pointer-only minimap interactions.
  * Removed outdated lint suppressions and updated existing security annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->