### PR TITLE
refactor(mcp-server): let the document store stop knowing about compaction

### DIFF
--- a/packages/mcp-server/src/server/routes/document.ts
+++ b/packages/mcp-server/src/server/routes/document.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { scheduleAutoCompact, setAutoCompactTrigger } from '../store/document-store.js'
+import { installAutoCompact } from '../store/auto-compact.js'
 import { FileVersionStore, type VersionStore } from '../store/version-store.js'
 import { setBroadcastFn } from './document/_shared.js'
 import { AUTO_VERSION_INTERVAL_MS, createAutoVersionTrigger } from './document/auto-version.js'
@@ -48,12 +48,9 @@ export function createDocumentRouter(options: DocumentRouterOptions = {}) {
   // Auto-compact debounce: every successful saveDocument reschedules a per-
   // canvas compaction. The 30s default lets active editing sessions burst
   // without thrashing the op-log; once the user pauses, the shallow-snapshot
-  // runs in the background. Tests can override the trigger via
-  // setAutoCompactTrigger(null) before assertions if they want to isolate
-  // the save path from the compact path.
-  setAutoCompactTrigger((workspaceId, path) => {
-    scheduleAutoCompact(workspaceId, path, versionStore)
-  })
+  // runs in the background. A test that wants the save path isolated from the
+  // compact path calls `uninstallAutoCompact()`.
+  installAutoCompact(versionStore)
 
   app.route('/', createWorkspacesRouter())
   app.route('/', createDocumentMetadataRouter())

--- a/packages/mcp-server/src/server/store/auto-compact.ts
+++ b/packages/mcp-server/src/server/store/auto-compact.ts
@@ -1,0 +1,178 @@
+/**
+ * The debounced auto-compaction scheduler.
+ *
+ * Lifted out of `document-store.ts`, which is about reading and writing
+ * documents. This is a different thing wearing the same file: a background
+ * scheduler with its own timers, its own in-flight tracking, its own disposal
+ * protocol and its own two test seams. The store announces a save; this module subscribes.
+ * The dependency runs one way — which was NOT true before the split, and is
+ * what made the split more than a file move.
+ *
+ * That direction is why the DB dispose hook is registered HERE. It used to run
+ * whenever `document-store.ts` loaded, which was early and often; it now runs
+ * when this module loads — which is exactly when a compaction could first be
+ * scheduled, since nothing can schedule one without importing this file.
+ */
+
+import { getLogger } from '../log.js'
+import { registerDbDisposeHook } from './db/index.js'
+import { compactDocument, setDocumentSavedListener } from './document-store.js'
+import type { VersionStore } from './version-store.js'
+
+// ── auto-compact debouncer ────────────────────────────────────────────
+// saveDocument calls a registered trigger after every write. The route layer
+// wires that trigger to scheduleAutoCompact below; tests can register a spy
+// instead to verify call ordering. Per-canvas timers coalesce a burst of
+// edits into a single compaction once the editing pause exceeds debounceMs.
+
+// Shared by uninstallAutoCompact() and disposeAutoCompact() so the two
+// cancellation paths can never drift out of sync with each other.
+function clearAllAutoCompactTimers(): void {
+  for (const t of autoCompactTimers.values()) clearTimeout(t)
+  autoCompactTimers.clear()
+}
+
+/**
+ * Subscribe to saves and debounce a compaction after each one.
+ *
+ * The `versionStore` is taken here rather than reached for inside, which is
+ * why the store never had to know the concrete version-store type — that
+ * indirection was the original reason for a registered trigger, and it
+ * survives the split intact.
+ */
+export function installAutoCompact(versionStore: VersionStore): void {
+  setDocumentSavedListener((workspaceId, path) => {
+    scheduleAutoCompact(workspaceId, path, versionStore)
+  })
+}
+
+/**
+ * Stop compacting, and drain the timers that were already ticking.
+ *
+ * Synchronous by contract: it cancels timers that have not fired yet and
+ * deliberately does NOT await in-flight compactions — `disposeAutoCompact` is
+ * the superset that does. Uninstalling without clearing would leave a pending
+ * timer to fire against a test's removed tempDir.
+ */
+export function uninstallAutoCompact(): void {
+  setDocumentSavedListener(null)
+  clearAllAutoCompactTimers()
+}
+
+const AUTO_COMPACT_DEBOUNCE_MS = 30_000
+const autoCompactTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+// Tracks compactDocument() calls that have already fired but not yet settled.
+// A Set of the promises themselves (not a Map keyed by workspaceId/path) is
+// required: two overlapping compactions for the same key must both stay
+// tracked until they individually settle, since a keyed map with an
+// unconditional delete-on-settle would let a still-in-flight entry get
+// dropped by an unrelated compaction for the same key finishing first.
+const inFlightAutoCompacts = new Set<Promise<unknown>>()
+
+// True only for the duration of a disposeAutoCompact() call. An in-flight
+// compaction's loadDocument() can run legacy migration, which calls
+// saveDocument(), which re-invokes the registered auto-compact trigger and
+// tries to schedule a fresh timer for the same key — see disposeAutoCompact's
+// loop comment below. Without this guard, that reschedule's timer and
+// disposeAutoCompact's next clear-and-recheck pass race each other: whichever
+// one is scheduled first on the event loop wins, and under load the timer
+// can fire (starting a real compaction) before the loop gets back around to
+// cancel it. disposeAutoCompact's own loop still correctly waits for a
+// compaction that wins that race, so this was never a leak, but the outcome
+// was nondeterministic. Refusing new timers for the whole disposal removes
+// the race instead of relying on winning it.
+// A counter rather than a boolean: overlapping disposeAutoCompact() calls
+// (parallel DB dispose hooks, test teardown racing an explicit call) must not
+// let the first finisher drop the guard while another disposal is still
+// draining.
+let disposingAutoCompactCount = 0
+
+export function scheduleAutoCompact(
+  workspaceId: string,
+  path: string,
+  versionStore: VersionStore,
+  options: { debounceMs?: number } = {},
+): void {
+  if (disposingAutoCompactCount > 0) return
+  const key = `${workspaceId}/${path}`
+  const existing = autoCompactTimers.get(key)
+  if (existing) clearTimeout(existing)
+  const timer = setTimeout(() => {
+    autoCompactTimers.delete(key)
+    const compaction = compactDocument(workspaceId, path, versionStore)
+      .then((result) => {
+        if (result.compacted) {
+          getLogger('auto-compact').info(
+            {
+              workspaceId,
+              path,
+              beforeBytes: result.beforeBytes,
+              afterBytes: result.afterBytes,
+            },
+            'compacted',
+          )
+        }
+      })
+      .catch((err) => {
+        getLogger('auto-compact').warning({ workspaceId, path, err }, 'failed')
+      })
+      .finally(() => {
+        inFlightAutoCompacts.delete(compaction)
+      })
+    inFlightAutoCompacts.add(compaction)
+  }, options.debounceMs ?? AUTO_COMPACT_DEBOUNCE_MS)
+  // Do not keep the event loop alive just for this debounce. Node will
+  // still flush the compaction if anything else (HTTP, WS) holds the
+  // loop open; in tests we explicitly wait for the timeout.
+  if (typeof timer === 'object' && 'unref' in timer && typeof timer.unref === 'function') {
+    timer.unref()
+  }
+  autoCompactTimers.set(key, timer)
+}
+
+// Awaitable superset of uninstallAutoCompact(): cancels every pending
+// timer AND waits for every already-fired compaction to settle, so a caller
+// that awaits this is guaranteed no compactDocument call can still reach the
+// DB driver afterward. Registered as a DB dispose hook (below) so disposing
+// a store's DB always drains this state first, without every dispose call
+// site having to remember to call it manually. Idempotent: calling it with
+// nothing pending simply resolves immediately, and scheduleAutoCompact works
+// again afterward (a fresh call re-populates both trackers).
+export async function disposeAutoCompact(): Promise<void> {
+  disposingAutoCompactCount++
+  try {
+    // A single clear-then-await pass is not enough: an in-flight compaction's
+    // loadDocument() can run legacy migration, which calls saveDocument(), which
+    // re-invokes the registered auto-compact trigger *while we are still
+    // awaiting the first batch*. scheduleAutoCompact refuses that reschedule
+    // outright (the guard counter is non-zero for this whole call), so this
+    // loop's job is just to drain whatever was already in flight or already
+    // timer-scheduled before disposal began.
+    for (;;) {
+      clearAllAutoCompactTimers()
+      const inFlight = Array.from(inFlightAutoCompacts)
+      if (inFlight.length === 0) break
+      await Promise.allSettled(inFlight)
+    }
+  } finally {
+    disposingAutoCompactCount--
+  }
+}
+
+// Test-only introspection, matching the `_destinationCountForTests` pattern
+// in log.ts: lets tests poll for "a compaction has fired and is mid-flight"
+// without a bespoke gate inside compactDocument itself.
+export function _inFlightAutoCompactCountForTests(): number {
+  return inFlightAutoCompacts.size
+}
+
+// Test-only introspection: lets a test deterministically wait until
+// disposeAutoCompact() has begun (and is therefore refusing reschedules)
+// before triggering a reschedule attempt, instead of racing a wall-clock
+// delay against dispose's await window.
+export function _isDisposingAutoCompactForTests(): boolean {
+  return disposingAutoCompactCount > 0
+}
+
+registerDbDisposeHook(disposeAutoCompact)

--- a/packages/mcp-server/src/server/store/document-store.test.ts
+++ b/packages/mcp-server/src/server/store/document-store.test.ts
@@ -27,13 +27,16 @@ const {
   deleteDocument,
   renameDocumentPath,
   ConflictError,
-  scheduleAutoCompact,
-  setAutoCompactTrigger,
-  disposeAutoCompact,
   getDocumentKind,
+  setDocumentSavedListener,
+} = await import('./document-store.js')
+const {
+  scheduleAutoCompact,
+  uninstallAutoCompact,
+  disposeAutoCompact,
   _inFlightAutoCompactCountForTests,
   _isDisposingAutoCompactForTests,
-} = await import('./document-store.js')
+} = await import('./auto-compact.js')
 const { captureLogsForTests } = await import('../log.js')
 const { FileVersionStore } = await import('./version-store.js')
 const { createIsolatedDb } = await import('./db/test-helpers.js')
@@ -1740,15 +1743,15 @@ describe('auto-compact', () => {
   })
 
   afterEach(async () => {
-    setAutoCompactTrigger(null)
+    uninstallAutoCompact()
     await disposeAutoCompact()
     await teardownIsolatedDb()
     await rm(tempDir, { recursive: true, force: true })
   })
 
-  it('saveDocument invokes the registered auto-compact trigger', async () => {
+  it('saveDocument notifies the registered document-saved listener', async () => {
     const trigger = vi.fn<(workspaceId: string, path: string) => void>()
-    setAutoCompactTrigger(trigger)
+    setDocumentSavedListener(trigger)
     await saveDocument('session1', 'foo', new LoroDoc())
     expect(trigger).toHaveBeenCalledTimes(1)
     expect(trigger).toHaveBeenCalledWith('session1', 'foo')
@@ -1880,7 +1883,7 @@ describe('auto-compact disposal', () => {
   })
 
   afterEach(async () => {
-    setAutoCompactTrigger(null)
+    uninstallAutoCompact()
     await disposeAutoCompact()
     if (!disposedDb) {
       await teardownIsolatedDb()
@@ -1937,7 +1940,7 @@ describe('auto-compact disposal', () => {
     const store = await buildCompactableCanvas('big')
     const logs = captureLogsForTests('warning')
 
-    // Do NOT call setAutoCompactTrigger(null) here — the point of this test
+    // Do NOT call uninstallAutoCompact() here — the point of this test
     // is that DB disposal alone (without that manual call) must cancel the
     // pending timer.
     scheduleAutoCompact('session1', 'big', store, { debounceMs: 20 })
@@ -2120,7 +2123,7 @@ describe('auto-compact disposal', () => {
     )
   })
 
-  it('composes with setAutoCompactTrigger(null) in either order without dropping in-flight work', async () => {
+  it('composes with uninstallAutoCompact() in either order without dropping in-flight work', async () => {
     const store = await buildCompactableCanvas('composed')
     const { getDb } = await import('./db/index.js')
 
@@ -2145,9 +2148,9 @@ describe('auto-compact disposal', () => {
       { timeout: 2000 },
     )
 
-    // setAutoCompactTrigger(null) stays synchronous and timer-only: it must
+    // uninstallAutoCompact() stays synchronous and timer-only: it must
     // not swallow the in-flight compaction that is already running.
-    setAutoCompactTrigger(null)
+    uninstallAutoCompact()
     await disposeAutoCompact()
 
     expect(await readLastCompactedAt()).not.toBeNull()

--- a/packages/mcp-server/src/server/store/document-store.ts
+++ b/packages/mcp-server/src/server/store/document-store.ts
@@ -214,6 +214,34 @@ async function mergeAndSaveSnapshotLocked(
 // overwrite defaults to false so canvas_create does not destroy existing
 // data by mistake. Normal incremental saves (WS updates, live-doc and
 // restore writes, compactDocument) must pass overwrite: true.
+/**
+ * Called after every successful `saveDocument`.
+ *
+ * A plain notification, not a compaction hook. This module used to name the
+ * subscriber it happened to have — the auto-compact debouncer — which is how
+ * the store came to know about compaction at all. It does not need to: what it
+ * has to say is "this document changed", and who cares is not its business.
+ *
+ * A subscriber that throws is logged and swallowed. A save that already
+ * succeeded must not be reported as failed because a listener misbehaved.
+ */
+export type DocumentSavedListener = (workspaceId: string, path: string) => void
+
+let documentSavedListener: DocumentSavedListener | null = null
+
+export function setDocumentSavedListener(listener: DocumentSavedListener | null): void {
+  documentSavedListener = listener
+}
+
+function notifyDocumentSaved(workspaceId: string, path: string): void {
+  if (documentSavedListener === null) return
+  try {
+    documentSavedListener(workspaceId, path)
+  } catch (err) {
+    getLogger('document-store').warning({ workspaceId, path, err }, 'document-saved listener threw')
+  }
+}
+
 export async function saveDocument(
   workspaceId: string,
   path: string,
@@ -302,16 +330,7 @@ export async function saveDocument(
         )
       }
     }
-    // Hand off to the auto-compact debouncer when one is registered. Wired
-    // by the route layer (where versionStore is in scope) so this module
-    // does not depend on the version-store concrete type.
-    if (autoCompactTrigger) {
-      try {
-        autoCompactTrigger(workspaceId, path)
-      } catch (err) {
-        getLogger('document-store').warning({ workspaceId, path, err }, 'autoCompactTrigger threw')
-      }
-    }
+    notifyDocumentSaved(workspaceId, path)
   })
 }
 
@@ -680,151 +699,6 @@ export async function readLatestCompactedAt(): Promise<number | null> {
   const value = row?.maxAt ?? null
   return value === null || typeof value !== 'number' ? null : value
 }
-
-// ── auto-compact debouncer ────────────────────────────────────────────
-// saveDocument calls a registered trigger after every write. The route layer
-// wires that trigger to scheduleAutoCompact below; tests can register a spy
-// instead to verify call ordering. Per-canvas timers coalesce a burst of
-// edits into a single compaction once the editing pause exceeds debounceMs.
-type AutoCompactTrigger = (workspaceId: string, path: string) => void
-let autoCompactTrigger: AutoCompactTrigger | null = null
-
-// Shared by setAutoCompactTrigger(null) and disposeAutoCompact() so the two
-// cancellation paths can never drift out of sync with each other.
-function clearAllAutoCompactTimers(): void {
-  for (const t of autoCompactTimers.values()) clearTimeout(t)
-  autoCompactTimers.clear()
-}
-
-// Resetting the trigger to null also drains any pending debounced timers so
-// a subsequent test's tempDir is not surprised by a stray compactDocument
-// firing on a removed directory. This stays synchronous by contract — it
-// cancels only timers that have not fired yet, and deliberately does not
-// await in-flight compactions (see disposeAutoCompact for that superset).
-export function setAutoCompactTrigger(fn: AutoCompactTrigger | null): void {
-  if (fn === null) {
-    clearAllAutoCompactTimers()
-  }
-  autoCompactTrigger = fn
-}
-
-const AUTO_COMPACT_DEBOUNCE_MS = 30_000
-const autoCompactTimers = new Map<string, ReturnType<typeof setTimeout>>()
-
-// Tracks compactDocument() calls that have already fired but not yet settled.
-// A Set of the promises themselves (not a Map keyed by workspaceId/path) is
-// required: two overlapping compactions for the same key must both stay
-// tracked until they individually settle, since a keyed map with an
-// unconditional delete-on-settle would let a still-in-flight entry get
-// dropped by an unrelated compaction for the same key finishing first.
-const inFlightAutoCompacts = new Set<Promise<unknown>>()
-
-// True only for the duration of a disposeAutoCompact() call. An in-flight
-// compaction's loadDocument() can run legacy migration, which calls
-// saveDocument(), which re-invokes the registered auto-compact trigger and
-// tries to schedule a fresh timer for the same key — see disposeAutoCompact's
-// loop comment below. Without this guard, that reschedule's timer and
-// disposeAutoCompact's next clear-and-recheck pass race each other: whichever
-// one is scheduled first on the event loop wins, and under load the timer
-// can fire (starting a real compaction) before the loop gets back around to
-// cancel it. disposeAutoCompact's own loop still correctly waits for a
-// compaction that wins that race, so this was never a leak, but the outcome
-// was nondeterministic. Refusing new timers for the whole disposal removes
-// the race instead of relying on winning it.
-// A counter rather than a boolean: overlapping disposeAutoCompact() calls
-// (parallel DB dispose hooks, test teardown racing an explicit call) must not
-// let the first finisher drop the guard while another disposal is still
-// draining.
-let disposingAutoCompactCount = 0
-
-export function scheduleAutoCompact(
-  workspaceId: string,
-  path: string,
-  versionStore: VersionStore,
-  options: { debounceMs?: number } = {},
-): void {
-  if (disposingAutoCompactCount > 0) return
-  const key = `${workspaceId}/${path}`
-  const existing = autoCompactTimers.get(key)
-  if (existing) clearTimeout(existing)
-  const timer = setTimeout(() => {
-    autoCompactTimers.delete(key)
-    const compaction = compactDocument(workspaceId, path, versionStore)
-      .then((result) => {
-        if (result.compacted) {
-          getLogger('auto-compact').info(
-            {
-              workspaceId,
-              path,
-              beforeBytes: result.beforeBytes,
-              afterBytes: result.afterBytes,
-            },
-            'compacted',
-          )
-        }
-      })
-      .catch((err) => {
-        getLogger('auto-compact').warning({ workspaceId, path, err }, 'failed')
-      })
-      .finally(() => {
-        inFlightAutoCompacts.delete(compaction)
-      })
-    inFlightAutoCompacts.add(compaction)
-  }, options.debounceMs ?? AUTO_COMPACT_DEBOUNCE_MS)
-  // Do not keep the event loop alive just for this debounce. Node will
-  // still flush the compaction if anything else (HTTP, WS) holds the
-  // loop open; in tests we explicitly wait for the timeout.
-  if (typeof timer === 'object' && 'unref' in timer && typeof timer.unref === 'function') {
-    timer.unref()
-  }
-  autoCompactTimers.set(key, timer)
-}
-
-// Awaitable superset of setAutoCompactTrigger(null): cancels every pending
-// timer AND waits for every already-fired compaction to settle, so a caller
-// that awaits this is guaranteed no compactDocument call can still reach the
-// DB driver afterward. Registered as a DB dispose hook (below) so disposing
-// a store's DB always drains this state first, without every dispose call
-// site having to remember to call it manually. Idempotent: calling it with
-// nothing pending simply resolves immediately, and scheduleAutoCompact works
-// again afterward (a fresh call re-populates both trackers).
-export async function disposeAutoCompact(): Promise<void> {
-  disposingAutoCompactCount++
-  try {
-    // A single clear-then-await pass is not enough: an in-flight compaction's
-    // loadDocument() can run legacy migration, which calls saveDocument(), which
-    // re-invokes the registered auto-compact trigger *while we are still
-    // awaiting the first batch*. scheduleAutoCompact refuses that reschedule
-    // outright (the guard counter is non-zero for this whole call), so this
-    // loop's job is just to drain whatever was already in flight or already
-    // timer-scheduled before disposal began.
-    for (;;) {
-      clearAllAutoCompactTimers()
-      const inFlight = Array.from(inFlightAutoCompacts)
-      if (inFlight.length === 0) break
-      await Promise.allSettled(inFlight)
-    }
-  } finally {
-    disposingAutoCompactCount--
-  }
-}
-
-// Test-only introspection, matching the `_destinationCountForTests` pattern
-// in log.ts: lets tests poll for "a compaction has fired and is mid-flight"
-// without a bespoke gate inside compactDocument itself.
-export function _inFlightAutoCompactCountForTests(): number {
-  return inFlightAutoCompacts.size
-}
-
-// Test-only introspection: lets a test deterministically wait until
-// disposeAutoCompact() has begun (and is therefore refusing reschedules)
-// before triggering a reschedule attempt, instead of racing a wall-clock
-// delay against dispose's await window.
-export function _isDisposingAutoCompactForTests(): boolean {
-  return disposingAutoCompactCount > 0
-}
-
-registerDbDisposeHook(disposeAutoCompact)
 
 // ── list workspaces from the workspaces table ──
 export async function listWorkspaces(): Promise<{ workspaceId: string }[]> {


### PR DESCRIPTION
`document-store.ts` held two things. One is what its name says — reading and writing documents. The other is a background scheduler: per-document debounce timers, an in-flight promise set, a disposal protocol with its own counter, and two test-only introspection hooks. That moves to `auto-compact.ts`.

## The move alone does not work, and why is the actual change

Lifting the block left `saveDocument` calling `autoCompactTrigger` — a variable that had gone with it. `ReferenceError: autoCompactTrigger is not defined`.

**The dependency ran both ways.** The store called the scheduler and the scheduler called the store, which is why the two had never come apart, and why my first commit message's claim that "it calls the store; the store does not call it" was simply wrong.

The seam was misnamed rather than misplaced. What `saveDocument` has to say is *"this document changed"*; who cares is not its business.

```
before   saveDocument -> autoCompactTrigger   (a hook named for its only subscriber)
after    saveDocument -> documentSavedListener
                         auto-compact subscribes via installAutoCompact(versionStore)
```

The store now knows nothing about compaction. The version-store type stays out of it exactly as before — that indirection was the original reason for a registered trigger, and it survives intact.

`setAutoCompactTrigger(null)` becomes `uninstallAutoCompact()`, which is what it always did: drop the listener **and** clear the timers. The old name described the first half while the behaviour did both.

The DB dispose hook moves with the scheduler. It used to register whenever `document-store.ts` loaded — early and often — and now registers when `auto-compact.ts` does, which is precisely when a compaction first becomes possible, since nothing can schedule one without importing that file.

## Behaviour-preserving, and checked as such

```
document-store tests   112 before  ->  112 after   (no test weakened)
arch-lint cycle check  passes on the new one-way edge
928 lines              ->  802 + 178
```

One test was renamed to describe the seam instead of its old subscriber: `saveDocument invokes the registered auto-compact trigger` → `saveDocument notifies the registered document-saved listener`.

**No tests were moved.** Splitting the 2155-line test file along the same line is a separate increment — doing it here would mean duplicating the file's mock/temp-dir preamble, which is exactly how a case goes quiet during a move.

`pnpm test --project mcp-node --project arch-lint-node` 307 files / 3695 tests, lint / knip / typecheck clean.

Footnote: the type error that caught my wrong `VersionStore` import was legible only because `document-backend-contract.test.ts` was fixed earlier today to print tsc's stdout — it reports diagnostics there, and the test used to show stderr alone.