### PR TITLE
refactor(canvas-render): rebuild the SVG backend on a VNode IR and canonical serializer

### DIFF
--- a/packages/canvas-render/src/scene-bounds.test.ts
+++ b/packages/canvas-render/src/scene-bounds.test.ts
@@ -348,15 +348,22 @@ describe('sceneBounds', () => {
     )['./svg/backend.ts']
 
     // A renderer emits a transform by writing a `transform:` attribute onto
-    // its VNode; ownership is the nearest preceding `function renderX(`
-    // declaration. Comments discussing transforms don't match the attribute
-    // spelling, so they cannot produce false positives.
-    const functionStarts = [...backendSource.matchAll(/function (render\w+)\(/g)].map((m) => ({
-      name: m[1],
-      index: m.index ?? 0,
-    }))
-    const translating = [...backendSource.matchAll(/transform: `translate\(/g)].map(
-      (m) => functionStarts.filter((f) => f.index < (m.index ?? 0)).at(-1)?.name,
+    // its VNode; ownership is the nearest preceding renderer declaration
+    // (`function renderX(` or `const renderX = `). Comments discussing
+    // transforms don't match the attribute spelling, so they cannot produce
+    // false positives. The occurrence COUNT is pinned first and separately:
+    // attribution by nearest-preceding-declaration could credit a new
+    // emitter to a renderer already in the expected set (e.g. an arrow
+    // function the declaration regex missed, defined right after one of the
+    // two), and the count catches that case regardless of attribution.
+    const occurrences = [...backendSource.matchAll(/transform: `translate\(/g)]
+    expect(occurrences).toHaveLength(2)
+
+    const declarationStarts = [
+      ...backendSource.matchAll(/(?:function|const)\s+(render\w+)\s*[=(]/g),
+    ].map((m) => ({ name: m[1], index: m.index ?? 0 }))
+    const translating = occurrences.map(
+      (m) => declarationStarts.filter((f) => f.index < (m.index ?? 0)).at(-1)?.name,
     )
 
     expect(new Set(translating)).toEqual(new Set(['renderListItem', 'renderTableCell']))

--- a/packages/canvas-render/src/scene-bounds.test.ts
+++ b/packages/canvas-render/src/scene-bounds.test.ts
@@ -347,11 +347,17 @@ describe('sceneBounds', () => {
       }) as Record<string, string>
     )['./svg/backend.ts']
 
-    const translating = [
-      ...backendSource.matchAll(/function (render\w+)\([^)]*\)[^{]*\{([^}]*)\}/g),
-    ]
-      .filter(([, , body]) => body.includes('transform="translate('))
-      .map(([, name]) => name)
+    // A renderer emits a transform by writing a `transform:` attribute onto
+    // its VNode; ownership is the nearest preceding `function renderX(`
+    // declaration. Comments discussing transforms don't match the attribute
+    // spelling, so they cannot produce false positives.
+    const functionStarts = [...backendSource.matchAll(/function (render\w+)\(/g)].map((m) => ({
+      name: m[1],
+      index: m.index ?? 0,
+    }))
+    const translating = [...backendSource.matchAll(/transform: `translate\(/g)].map(
+      (m) => functionStarts.filter((f) => f.index < (m.index ?? 0)).at(-1)?.name,
+    )
 
     expect(new Set(translating)).toEqual(new Set(['renderListItem', 'renderTableCell']))
   })

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -15,7 +15,9 @@ import type {
   TableRowSceneNode,
   TextRunNode,
 } from '../scene-graph.js'
-import { escapeXmlAttr, escapeXmlText, formatCoord, sanitizeHref } from './format.js'
+import { formatCoord, sanitizeHref } from './format.js'
+import { serializeSvg } from './serialize.js'
+import { el, rawXml, type SvgAttrs, type SvgAttrValue, type SvgChild } from './vnode.js'
 
 /**
  * Decorative/presentational elements (backgrounds, dividers, group
@@ -23,11 +25,11 @@ import { escapeXmlAttr, escapeXmlText, formatCoord, sanitizeHref } from './forma
  * `role="presentation"` so a screen reader does not announce them; text
  * runs and links keep their natural implicit role.
  */
-const PRESENTATION_ATTR = 'role="presentation"'
+const PRESENTATION = 'presentation'
 
-function rectAttrs(bbox: BoundingBox): string {
+function rectAttrs(bbox: BoundingBox): SvgAttrs {
   // Fixed declaration order: x, y, width, height.
-  return `x="${formatCoord(bbox.x)}" y="${formatCoord(bbox.y)}" width="${formatCoord(bbox.w)}" height="${formatCoord(bbox.h)}"`
+  return { x: bbox.x, y: bbox.y, width: bbox.w, height: bbox.h }
 }
 
 function isFiniteBox(box: BoundingBox): boolean {
@@ -48,32 +50,20 @@ function isPositiveLength(value: number | undefined): value is number {
   return isNonNegativeLength(value) && value > 0
 }
 
-function withLeadingSpace(attrs: string): string {
-  return attrs === '' ? '' : ` ${attrs}`
-}
-
 /**
  * Presence-only presentation attributes for a shape/text-run/edge, in the
  * fixed order `fill stroke stroke-width font-family font-size`. An absent
  * or unusable field is omitted rather than defaulted — see the
  * `Appearance` doc comment for why the backend never invents a value.
  */
-function appearanceAttrs(appearance?: Appearance): string {
-  if (!appearance) return ''
-  const parts: string[] = []
-  if (isNonEmptyString(appearance.fill)) parts.push(`fill="${escapeXmlAttr(appearance.fill)}"`)
-  if (isNonEmptyString(appearance.stroke)) {
-    parts.push(`stroke="${escapeXmlAttr(appearance.stroke)}"`)
-  }
-  if (isNonNegativeLength(appearance.strokeWidth)) {
-    parts.push(`stroke-width="${formatCoord(appearance.strokeWidth)}"`)
-  }
-  if (isNonEmptyString(appearance.fontFamily)) {
-    parts.push(`font-family="${escapeXmlAttr(appearance.fontFamily)}"`)
-  }
-  if (isNonNegativeLength(appearance.fontSize)) {
-    parts.push(`font-size="${formatCoord(appearance.fontSize)}"`)
-  }
+function appearanceAttrs(appearance?: Appearance): SvgAttrs {
+  if (!appearance) return {}
+  const attrs: Record<string, SvgAttrValue> = {}
+  if (isNonEmptyString(appearance.fill)) attrs.fill = appearance.fill
+  if (isNonEmptyString(appearance.stroke)) attrs.stroke = appearance.stroke
+  if (isNonNegativeLength(appearance.strokeWidth)) attrs['stroke-width'] = appearance.strokeWidth
+  if (isNonEmptyString(appearance.fontFamily)) attrs['font-family'] = appearance.fontFamily
+  if (isNonNegativeLength(appearance.fontSize)) attrs['font-size'] = appearance.fontSize
   // Emitted after `fill` so the pair reads together; `1` is the SVG initial
   // value, so it is omitted to keep an opacity-free scene byte-identical.
   if (
@@ -81,16 +71,16 @@ function appearanceAttrs(appearance?: Appearance): string {
     Number.isFinite(appearance.fillOpacity) &&
     appearance.fillOpacity !== 1
   ) {
-    parts.push(`fill-opacity="${formatCoord(appearance.fillOpacity)}"`)
+    attrs['fill-opacity'] = appearance.fillOpacity
   }
   if (
     typeof appearance.strokeOpacity === 'number' &&
     Number.isFinite(appearance.strokeOpacity) &&
     appearance.strokeOpacity !== 1
   ) {
-    parts.push(`stroke-opacity="${formatCoord(appearance.strokeOpacity)}"`)
+    attrs['stroke-opacity'] = appearance.strokeOpacity
   }
-  return parts.join(' ')
+  return attrs
 }
 
 /**
@@ -116,10 +106,10 @@ const TEXT_HALO_PAD_PX = 2
 const BACKDROP_RADIUS_PX = 6
 
 /** Inline emphasis the layout measured for — painted, or the flags are lies. */
-function emphasisAttrs(run: TextRunNode): string {
-  const parts: string[] = []
-  if (run.strong === true) parts.push('font-weight="700"')
-  if (run.emphasis === true) parts.push('font-style="italic"')
+function emphasisAttrs(run: TextRunNode): SvgAttrs {
+  const attrs: Record<string, SvgAttrValue> = {}
+  if (run.strong === true) attrs['font-weight'] = '700'
+  if (run.emphasis === true) attrs['font-style'] = 'italic'
   // A link is underlined rather than recolored because this backend is never
   // handed a palette: a run's fill is INHERITED from whatever host group the
   // SVG is dropped into, which is what lets one scene render on the editor's
@@ -129,8 +119,8 @@ function emphasisAttrs(run: TextRunNode): string {
     ...(run.deleted === true ? ['line-through'] : []),
     ...(run.link ? ['underline'] : []),
   ]
-  if (decorations.length > 0) parts.push(`text-decoration="${decorations.join(' ')}"`)
-  return parts.length > 0 ? ` ${parts.join(' ')}` : ''
+  if (decorations.length > 0) attrs['text-decoration'] = decorations.join(' ')
+  return attrs
 }
 
 /**
@@ -148,12 +138,15 @@ const FADE_MASK_ID = 'wb-truncation-fade'
  * honoured by resvg (the PNG export path) as well as browsers — a fully black
  * mask renders byte-identically to an empty canvas there.
  */
-const FADE_DEFS =
-  `<defs><linearGradient id="${FADE_MASK_ID}-gradient" x1="0" y1="0" x2="1" y2="0">` +
-  '<stop offset="0.75" stop-color="#ffffff"/><stop offset="1" stop-color="#000000"/>' +
-  `</linearGradient><mask id="${FADE_MASK_ID}" maskContentUnits="objectBoundingBox">` +
-  `<rect x="0" y="0" width="1" height="1" fill="url(#${FADE_MASK_ID}-gradient)"/>` +
-  '</mask></defs>'
+const FADE_DEFS = el('defs', undefined, [
+  el('linearGradient', { id: `${FADE_MASK_ID}-gradient`, x1: 0, y1: 0, x2: 1, y2: 0 }, [
+    el('stop', { offset: 0.75, 'stop-color': '#ffffff' }),
+    el('stop', { offset: 1, 'stop-color': '#000000' }),
+  ]),
+  el('mask', { id: FADE_MASK_ID, maskContentUnits: 'objectBoundingBox' }, [
+    el('rect', { x: 0, y: 0, width: 1, height: 1, fill: `url(#${FADE_MASK_ID}-gradient)` }),
+  ]),
+])
 
 /** Whether anything in the scene needs `FADE_DEFS`; nothing is emitted if not. */
 function hasTruncatedRun(nodes: readonly SceneNode[]): boolean {
@@ -175,79 +168,106 @@ function hasTruncatedRun(nodes: readonly SceneNode[]): boolean {
  * the line above. A non-finite bbox renders as nothing rather than reaching
  * `formatCoord`, which throws by contract.
  */
-function renderBackdrop(run: TextRunNode): string {
-  if (run.backdrop === undefined || !isFiniteBox(run.bbox)) return ''
+function renderBackdrop(run: TextRunNode): SvgChild {
+  if (run.backdrop === undefined || !isFiniteBox(run.bbox)) return []
   const pad = isNonNegativeLength(run.backdropPadXPx) ? run.backdropPadXPx : 0
-  const appearance = withLeadingSpace(appearanceAttrs(run.backdrop))
   const box = {
     x: run.bbox.x - pad,
     y: run.bbox.y,
     w: run.bbox.w + 2 * pad,
     h: run.bbox.h,
   }
-  return `<rect ${rectAttrs(box)} rx="${formatCoord(BACKDROP_RADIUS_PX)}"${appearance}/>`
+  return el('rect', {
+    ...rectAttrs(box),
+    rx: BACKDROP_RADIUS_PX,
+    ...appearanceAttrs(run.backdrop),
+  })
 }
 
-function renderTextRun(run: TextRunNode): string {
-  const appearance =
-    withLeadingSpace(appearanceAttrs(run.appearance)) +
-    emphasisAttrs(run) +
-    (run.truncated === true ? ` mask="url(#${FADE_MASK_ID})"` : '')
-  const position = `x="${formatCoord(run.bbox.x)}" y="${formatCoord(textBaselineY(run))}"`
-  const body = escapeXmlText(run.text)
+function renderTextRun(run: TextRunNode): SvgChild {
   const halo = run.appearance?.halo
   // A surface-colored pill under the whole text box (a glyph-outline halo
   // leaves the crossed line peeking through word spaces), so a label
   // sitting ON an edge stays readable end to end.
-  const underlay =
+  const underlay: SvgChild =
     halo !== undefined && halo.length > 0
-      ? `<rect x="${formatCoord(run.bbox.x - TEXT_HALO_PAD_PX)}" y="${formatCoord(run.bbox.y - TEXT_HALO_PAD_PX)}" width="${formatCoord(run.bbox.w + 2 * TEXT_HALO_PAD_PX)}" height="${formatCoord(run.bbox.h + 2 * TEXT_HALO_PAD_PX)}" rx="${formatCoord(TEXT_HALO_PAD_PX)}" fill="${escapeXmlAttr(halo)}"/>`
-      : ''
-  // Painted before the halo underlay so a run can carry both without the
-  // panel hiding the halo; inline code uses this for its tinted pill.
-  const backdrop = renderBackdrop(run)
-  // A code run's whitespace is CONTENT: XML collapses it otherwise, and a
-  // fenced line loses the indentation that says what nests inside what.
-  const space = run.code === true ? ' xml:space="preserve"' : ''
-  const text = `${backdrop}${underlay}<text ${position}${appearance}${space}>${body}</text>`
-  if (!run.link) return text
+      ? el('rect', {
+          x: run.bbox.x - TEXT_HALO_PAD_PX,
+          y: run.bbox.y - TEXT_HALO_PAD_PX,
+          width: run.bbox.w + 2 * TEXT_HALO_PAD_PX,
+          height: run.bbox.h + 2 * TEXT_HALO_PAD_PX,
+          rx: TEXT_HALO_PAD_PX,
+          fill: halo,
+        })
+      : []
+  const text = el(
+    'text',
+    {
+      x: run.bbox.x,
+      y: textBaselineY(run),
+      ...appearanceAttrs(run.appearance),
+      ...emphasisAttrs(run),
+      mask: run.truncated === true ? `url(#${FADE_MASK_ID})` : undefined,
+      // A code run's whitespace is CONTENT: XML collapses it otherwise, and a
+      // fenced line loses the indentation that says what nests inside what.
+      'xml:space': run.code === true ? 'preserve' : undefined,
+    },
+    [run.text],
+  )
+  // The backdrop is painted before the halo underlay so a run can carry both
+  // without the panel hiding the halo; inline code uses this for its tinted
+  // pill.
+  const content: SvgChild = [renderBackdrop(run), underlay, text]
+  if (!run.link) return content
   const href = run.link.kind === 'link' ? sanitizeHref(run.link.href) : run.link.documentId
-  return `<a href="${escapeXmlAttr(href)}">${text}</a>`
+  return el('a', { href }, [content])
 }
 
 /**
  * The box chrome of a spatial canvas node. A non-finite bbox field is a
- * layout bug this package must not crash on — it renders as the empty
- * string rather than reaching `formatCoord`, which throws by contract.
+ * layout bug this package must not crash on — it renders as nothing rather
+ * than reaching `formatCoord`, which throws by contract.
  */
-function renderShape(node: ShapeSceneNode): string {
-  if (!isFiniteBox(node.bbox)) return ''
-  const rx = isPositiveLength(node.radius) ? ` rx="${formatCoord(node.radius)}"` : ''
-  const appearance = withLeadingSpace(appearanceAttrs(node.appearance))
-  return `<rect ${rectAttrs(node.bbox)}${rx}${appearance}/>`
+function renderShape(node: ShapeSceneNode): SvgChild {
+  if (!isFiniteBox(node.bbox)) return []
+  return el('rect', {
+    ...rectAttrs(node.bbox),
+    rx: isPositiveLength(node.radius) ? node.radius : undefined,
+    ...appearanceAttrs(node.appearance),
+  })
 }
 
-function renderListItem(item: ListItemNode): string {
+function renderListItem(item: ListItemNode): SvgChild {
   const tx = item.bbox.x
-  const transform = tx !== 0 ? ` transform="translate(${formatCoord(tx)},0)"` : ''
-  return `<g${transform}>${item.children.map(renderNode).join('')}</g>`
+  return el(
+    'g',
+    tx !== 0 ? { transform: `translate(${formatCoord(tx)},0)` } : undefined,
+    item.children.map(renderNode),
+  )
 }
 
-function renderTableCell(cell: TableCellSceneNode): string {
+function renderTableCell(cell: TableCellSceneNode): SvgChild {
   const tx = cell.bbox.x
-  const transform = tx !== 0 ? ` transform="translate(${formatCoord(tx)},0)"` : ''
-  return `<g${transform}>${cell.runs.map(renderTextRun).join('')}</g>`
+  return el(
+    'g',
+    tx !== 0 ? { transform: `translate(${formatCoord(tx)},0)` } : undefined,
+    cell.runs.map(renderTextRun),
+  )
 }
 
-function renderTableRow(row: TableRowSceneNode): string {
+function renderTableRow(row: TableRowSceneNode): SvgChild {
   // A hairline on the row's bottom edge is the whole of a table's chrome —
   // no cell grid, no zebra wash. Drawn at the row's own y so it separates
   // this row from the next rather than boxing either.
-  const separator =
+  const separator: SvgChild =
     row.appearance !== undefined && isFiniteBox(row.bbox)
-      ? `<rect ${rectAttrs({ x: row.bbox.x, y: row.bbox.y + row.bbox.h - 1, w: row.bbox.w, h: 1 })}${withLeadingSpace(appearanceAttrs(row.appearance))} ${PRESENTATION_ATTR}/>`
-      : ''
-  return `<g>${separator}${row.cells.map(renderTableCell).join('')}</g>`
+      ? el('rect', {
+          ...rectAttrs({ x: row.bbox.x, y: row.bbox.y + row.bbox.h - 1, w: row.bbox.w, h: 1 }),
+          ...appearanceAttrs(row.appearance),
+          role: PRESENTATION,
+        })
+      : []
+  return el('g', undefined, [separator, row.cells.map(renderTableCell)])
 }
 
 /**
@@ -260,15 +280,20 @@ function renderTableRow(row: TableRowSceneNode): string {
  * before layout carried them, which still renders through the old path
  * rather than nothing.
  */
-function renderCodeBlock(node: CodeBlockNode): string {
-  const panel =
+function renderCodeBlock(node: CodeBlockNode): SvgChild {
+  const panel: SvgChild =
     node.appearance !== undefined && isFiniteBox(node.bbox)
-      ? `<rect ${rectAttrs(node.bbox)}${isPositiveLength(node.radius) ? ` rx="${formatCoord(node.radius)}"` : ''}${withLeadingSpace(appearanceAttrs(node.appearance))} ${PRESENTATION_ATTR}/>`
-      : ''
+      ? el('rect', {
+          ...rectAttrs(node.bbox),
+          rx: isPositiveLength(node.radius) ? node.radius : undefined,
+          ...appearanceAttrs(node.appearance),
+          role: PRESENTATION,
+        })
+      : []
   if (node.runs === undefined) {
-    return `${panel}<text ${rectAttrs(node.bbox)} xml:space="preserve">${escapeXmlText(node.value)}</text>`
+    return [panel, el('text', { ...rectAttrs(node.bbox), 'xml:space': 'preserve' }, [node.value])]
   }
-  return `${panel}${node.runs.map(renderTextRun).join('')}`
+  return [panel, node.runs.map(renderTextRun)]
 }
 
 type EdgePoint = { readonly x: number; readonly y: number }
@@ -350,16 +375,20 @@ function roundedPathData(path: readonly EdgePoint[], jumps: readonly EdgeJump[] 
   return parts.join(' ')
 }
 
-function renderNode(node: SceneNode): string {
+function pointsAttr(points: readonly EdgePoint[]): string {
+  return points.map((p) => `${formatCoord(p.x)},${formatCoord(p.y)}`).join(' ')
+}
+
+function renderNode(node: SceneNode): SvgChild {
   switch (node.kind) {
     case 'textRun':
       return renderTextRun(node)
     case 'heading':
-      return `<g>${node.runs.map(renderTextRun).join('')}</g>`
+      return el('g', undefined, node.runs.map(renderTextRun))
     case 'paragraph':
-      return `<g>${node.runs.map(renderTextRun).join('')}</g>`
+      return el('g', undefined, node.runs.map(renderTextRun))
     case 'list':
-      return `<g>${node.items.map(renderListItem).join('')}</g>`
+      return el('g', undefined, node.items.map(renderListItem))
     case 'codeBlock':
       return renderCodeBlock(node)
     case 'blockquote':
@@ -368,20 +397,28 @@ function renderNode(node: SceneNode): string {
       // colour that would be wrong in one of the two host themes. The bar
       // child sets its own value, and a descendant's own presentation
       // attribute wins over the inherited one (it does not multiply).
-      return `<g${withLeadingSpace(appearanceAttrs(node.appearance))} ${PRESENTATION_ATTR}>${node.children.map(renderNode).join('')}</g>`
+      return el(
+        'g',
+        { ...appearanceAttrs(node.appearance), role: PRESENTATION },
+        node.children.map(renderNode),
+      )
     case 'group':
-      return `<g ${PRESENTATION_ATTR}>${node.children.map(renderNode).join('')}</g>`
+      return el('g', { role: PRESENTATION }, node.children.map(renderNode))
     case 'thematicBreak':
-      return `<rect ${rectAttrs(node.bbox)}${withLeadingSpace(appearanceAttrs(node.appearance))} ${PRESENTATION_ATTR}/>`
+      return el('rect', {
+        ...rectAttrs(node.bbox),
+        ...appearanceAttrs(node.appearance),
+        role: PRESENTATION,
+      })
     case 'table':
-      return `<g>${node.rows.map(renderTableRow).join('')}</g>`
+      return el('g', undefined, node.rows.map(renderTableRow))
     case 'rawHtml':
       // Raw HTML has no independently-verifiable well-formedness guarantee
       // (it is caller-supplied Markdown-embedded HTML), so it is escaped as
       // text rather than injected verbatim like a trusted SVG fragment.
-      return `<text ${rectAttrs(node.bbox)}>${escapeXmlText(node.value)}</text>`
+      return el('text', rectAttrs(node.bbox), [node.value])
     case 'unresolvedReference':
-      return `<g ${PRESENTATION_ATTR}/>`
+      return el('g', { role: PRESENTATION })
     case 'svgFragment': {
       // Precondition: the caller has already validated `svg` is well-formed
       // XML before constructing this node — emitted verbatim, not escaped.
@@ -396,15 +433,11 @@ function renderNode(node: SceneNode): string {
       const { x, y, w, h } = node.bbox
       const positioned =
         Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(w) && Number.isFinite(h)
+      const role = node.role === 'presentation' ? PRESENTATION : undefined
       if (!positioned) {
-        return node.role === 'presentation'
-          ? `<g ${PRESENTATION_ATTR}>${node.svg}</g>`
-          : `<g>${node.svg}</g>`
+        return el('g', role === undefined ? undefined : { role }, [rawXml(node.svg)])
       }
-      const attrs = `x="${formatCoord(x)}" y="${formatCoord(y)}" width="${formatCoord(w)}" height="${formatCoord(h)}" overflow="visible"`
-      return node.role === 'presentation'
-        ? `<svg ${attrs} ${PRESENTATION_ATTR}>${node.svg}</svg>`
-        : `<svg ${attrs}>${node.svg}</svg>`
+      return el('svg', { x, y, width: w, height: h, overflow: 'visible', role }, [rawXml(node.svg)])
     }
     case 'embedPlaceholder':
       // SVG <text> y is the BASELINE, so the box TOP would paint the title
@@ -412,25 +445,43 @@ function renderNode(node: SceneNode): string {
       // preceding block. The node carries no measured ascent (it is not a
       // text run), so the baseline is derived from the box: 0.8 matches the
       // ascent ratio the measurer contract documents for body text.
-      return `<a href="#${escapeXmlAttr(node.documentId)}"><text x="${formatCoord(node.bbox.x)}" y="${formatCoord(node.bbox.y + node.bbox.h * 0.8)}">${escapeXmlText(node.title)}</text></a>`
+      return el('a', { href: `#${node.documentId}` }, [
+        el('text', { x: node.bbox.x, y: node.bbox.y + node.bbox.h * 0.8 }, [node.title]),
+      ])
     case 'embedResolved':
-      return `<g>${node.children.map(renderNode).join('')}</g>`
+      return el('g', undefined, node.children.map(renderNode))
     case 'edge': {
-      const points = node.path.map((p) => `${formatCoord(p.x)},${formatCoord(p.y)}`).join(' ')
-      const appearance = withLeadingSpace(appearanceAttrs(node.appearance))
+      const appearance = appearanceAttrs(node.appearance)
       // `fill="none"` is not decoration. SVG's initial fill is black and a
       // <polyline> fills the region its points enclose, so a bent edge would
       // paint a solid wedge across its own corner in whatever fill the
       // surrounding document inherits — invisible while every path had two
       // points, glaring the moment routing started bending them. A <path>
-      // needs it for exactly the same reason.
+      // needs it for exactly the same reason. It is declared before the
+      // appearance spread, matching the string backend's emission order (an
+      // edge appearance never carries a fill of its own).
       const jumps = node.jumps ?? []
       const polyline =
         node.rounded === true
-          ? `<path d="${roundedPathData(node.path, jumps)}" fill="none"${appearance} ${PRESENTATION_ATTR}/>`
+          ? el('path', {
+              d: roundedPathData(node.path, jumps),
+              fill: 'none',
+              ...appearance,
+              role: PRESENTATION,
+            })
           : jumps.length > 0
-            ? `<path d="${jumpedPathData(node.path, jumps)}" fill="none"${appearance} ${PRESENTATION_ATTR}/>`
-            : `<polyline points="${points}" fill="none"${appearance} ${PRESENTATION_ATTR}/>`
+            ? el('path', {
+                d: jumpedPathData(node.path, jumps),
+                fill: 'none',
+                ...appearance,
+                role: PRESENTATION,
+              })
+            : el('polyline', {
+                points: pointsAttr(node.path),
+                fill: 'none',
+                ...appearance,
+                role: PRESENTATION,
+              })
       // Arrowheads are filled triangles in the edge's stroke color, drawn
       // after (over) the polyline. Geometry comes from the shared helper so
       // sceneBounds always agrees on how far the wings reach.
@@ -438,19 +489,11 @@ function renderNode(node: SceneNode): string {
       // No stroke means the polyline itself is invisible (SVG's default
       // stroke is none) — the arrow must match it, not fall back to the
       // polygon's default black fill and float detached.
-      const arrowFill =
-        typeof stroke === 'string' && stroke.length > 0
-          ? ` fill="${escapeXmlAttr(stroke)}"`
-          : ' fill="none"'
-      const arrows = edgeArrowPolygons(node)
-        .map((arrow) => {
-          const arrowPoints = arrow.points
-            .map((p) => `${formatCoord(p.x)},${formatCoord(p.y)}`)
-            .join(' ')
-          return `<polygon points="${arrowPoints}"${arrowFill} ${PRESENTATION_ATTR}/>`
-        })
-        .join('')
-      return `${polyline}${arrows}`
+      const arrowFill = typeof stroke === 'string' && stroke.length > 0 ? stroke : 'none'
+      const arrows = edgeArrowPolygons(node).map((arrow) =>
+        el('polygon', { points: pointsAttr(arrow.points), fill: arrowFill, role: PRESENTATION }),
+      )
+      return [polyline, arrows]
     }
     case 'shape':
       return renderShape(node)
@@ -459,12 +502,17 @@ function renderNode(node: SceneNode): string {
       // per this package's canonical-serialization rule. Aspect is always
       // preserved; alt renders as a <title> child (the SVG accessible-name
       // mechanism), absence marks the image as presentation.
-      const title =
-        node.alt !== undefined && node.alt.length > 0
-          ? `<title>${escapeXmlText(node.alt)}</title>`
-          : ''
-      const roleAttr = title === '' ? ` ${PRESENTATION_ATTR}` : ''
-      return `<image ${rectAttrs(node.bbox)} href="${escapeXmlAttr(node.href)}" preserveAspectRatio="xMidYMid ${node.fit === 'cover' ? 'slice' : 'meet'}"${roleAttr}>${title}</image>`
+      const hasAlt = node.alt !== undefined && node.alt.length > 0
+      return el(
+        'image',
+        {
+          ...rectAttrs(node.bbox),
+          href: node.href,
+          preserveAspectRatio: `xMidYMid ${node.fit === 'cover' ? 'slice' : 'meet'}`,
+          role: hasAlt ? undefined : PRESENTATION,
+        },
+        hasAlt ? [el('title', undefined, [node.alt as string])] : [],
+      )
     }
   }
 }
@@ -540,9 +588,11 @@ function resolveDimension(explicit: number | undefined, fallback: number): numbe
   return explicit !== undefined && Number.isFinite(explicit) && explicit >= 0 ? explicit : fallback
 }
 
-function renderBackgroundRect(box: BoundingBox, background: string): string {
-  return `<rect ${rectAttrs(box)} fill="${escapeXmlAttr(background)}" ${PRESENTATION_ATTR}/>`
+function renderBackgroundRect(box: BoundingBox, background: string): SvgChild {
+  return el('rect', { ...rectAttrs(box), fill: background, role: PRESENTATION })
 }
+
+const SVG_XMLNS = 'http://www.w3.org/2000/svg'
 
 /**
  * Serializes a decorated scene to an SVG string. Pure, no DOM — the same
@@ -561,26 +611,37 @@ function renderBackgroundRect(box: BoundingBox, background: string): string {
  * no-visual-attributes rule) when `background` is set.
  */
 export function renderSceneToSvg(scene: Scene, options?: SvgDocumentOptions): string {
-  const body = scene.nodes.map(renderNode).join('')
+  const body = scene.nodes.map(renderNode)
   // Presence-only, exactly like an absent appearance attribute: a scene with
   // nothing truncated emits the same bytes it always has.
-  const defs = hasTruncatedRun(scene.nodes) ? FADE_DEFS : ''
+  const defs: SvgChild = hasTruncatedRun(scene.nodes) ? FADE_DEFS : []
 
   if (!hasEnvelopeOptions(options)) {
-    return `<svg xmlns="http://www.w3.org/2000/svg">${defs}${body}</svg>`
+    return serializeSvg(el('svg', { xmlns: SVG_XMLNS }, [defs, body]))
   }
 
   const viewBox = resolveViewBox(scene, options)
   const width = resolveDimension(options.width, viewBox.w)
   const height = resolveDimension(options.height, viewBox.h)
   const viewBoxAttr = `${formatCoord(viewBox.x)} ${formatCoord(viewBox.y)} ${formatCoord(viewBox.w)} ${formatCoord(viewBox.h)}`
-  const background =
-    options.background !== undefined ? renderBackgroundRect(viewBox, options.background) : ''
-  // Fixed root-attribute order: xmlns width height viewBox fill.
-  const textFillAttr =
-    typeof options.textFill === 'string' && options.textFill.length > 0
-      ? ` fill="${escapeXmlAttr(options.textFill)}"`
-      : ''
+  const background: SvgChild =
+    options.background !== undefined ? renderBackgroundRect(viewBox, options.background) : []
 
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="${formatCoord(width)}" height="${formatCoord(height)}" viewBox="${viewBoxAttr}"${textFillAttr}>${defs}${background}${body}</svg>`
+  // Fixed root-attribute order: xmlns width height viewBox fill.
+  return serializeSvg(
+    el(
+      'svg',
+      {
+        xmlns: SVG_XMLNS,
+        width,
+        height,
+        viewBox: viewBoxAttr,
+        fill:
+          typeof options.textFill === 'string' && options.textFill.length > 0
+            ? options.textFill
+            : undefined,
+      },
+      [defs, background, body],
+    ),
+  )
 }

--- a/packages/canvas-render/src/svg/serialize.test.ts
+++ b/packages/canvas-render/src/svg/serialize.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { serializeSvg, serializeSvgChunks } from './serialize.js'
+import { el, rawXml } from './vnode.js'
+
+describe('serializeSvg', () => {
+  it('emits attributes in insertion order with number values through formatCoord', () => {
+    const node = el('rect', { x: 1.5, y: -0, width: 10.125, height: 0 })
+    expect(serializeSvg(node)).toBe('<rect x="1.5" y="0" width="10.125" height="0"/>')
+  })
+
+  it('omits attributes whose value is undefined (presence-only)', () => {
+    const node = el('rect', { x: 0, rx: undefined, fill: undefined })
+    expect(serializeSvg(node)).toBe('<rect x="0"/>')
+  })
+
+  it('escapes string attribute values including quotes', () => {
+    const node = el('a', { href: 'https://e.com/?a=1&b="x"<y>' }, [])
+    expect(serializeSvg(node)).toBe(
+      '<a href="https://e.com/?a=1&amp;b=&quot;x&quot;&lt;y&gt;"></a>',
+    )
+  })
+
+  it('escapes plain-string children as text content', () => {
+    const node = el('text', { x: 0, y: 0 }, ['a < b & c > d'])
+    expect(serializeSvg(node)).toBe('<text x="0" y="0">a &lt; b &amp; c &gt; d</text>')
+  })
+
+  it('emits rawXml children verbatim, unescaped', () => {
+    const node = el('g', undefined, [rawXml('<circle r="1"/>')])
+    expect(serializeSvg(node)).toBe('<g><circle r="1"/></g>')
+  })
+
+  it('self-closes when children are absent but pairs tags when children are an empty array', () => {
+    expect(serializeSvg(el('g', { role: 'presentation' }))).toBe('<g role="presentation"/>')
+    expect(serializeSvg(el('g', undefined, []))).toBe('<g></g>')
+    expect(serializeSvg(el('image', { x: 0 }, []))).toBe('<image x="0"></image>')
+  })
+
+  it('flattens nested child arrays in document order', () => {
+    const node = el('g', undefined, [
+      [el('rect', { x: 1 }), [el('rect', { x: 2 })]],
+      el('rect', { x: 3 }),
+    ])
+    expect(serializeSvg(node)).toBe('<g><rect x="1"/><rect x="2"/><rect x="3"/></g>')
+  })
+
+  it('recurses into element children', () => {
+    const node = el('svg', { xmlns: 'http://www.w3.org/2000/svg' }, [
+      el('g', undefined, [el('text', { x: 4, y: 8 }, ['hi'])]),
+    ])
+    expect(serializeSvg(node)).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg"><g><text x="4" y="8">hi</text></g></svg>',
+    )
+  })
+
+  it('joins to the same bytes the chunk generator yields', () => {
+    const node = el('svg', { xmlns: 'x' }, [el('rect', { x: 1 }), 'txt', rawXml('<g/>')])
+    expect([...serializeSvgChunks(node)].join('')).toBe(serializeSvg(node))
+  })
+
+  it('throws on a non-finite number attribute (formatCoord contract: a layout bug, not a serializer one)', () => {
+    expect(() => serializeSvg(el('rect', { x: Number.NaN }))).toThrow(RangeError)
+  })
+})

--- a/packages/canvas-render/src/svg/serialize.ts
+++ b/packages/canvas-render/src/svg/serialize.ts
@@ -1,0 +1,63 @@
+/**
+ * The one place an `SvgVNode` tree becomes serialized SVG text. Everything
+ * byte-visible is decided here — attribute order (insertion order of the
+ * attrs object), number formatting (`formatCoord`), escaping
+ * (`escapeXmlAttr`/`escapeXmlText`), self-closing — so the canonical
+ * serialization rules live in one function instead of per renderer.
+ *
+ * The generator is the core and the string API its aggregation: chunk
+ * boundaries fall on element opens/closes, which is what a future
+ * streaming or per-group patching consumer would consume.
+ */
+
+import { escapeXmlAttr, escapeXmlText, formatCoord } from './format.js'
+import type { RawXmlChild, SvgChild, SvgVNode } from './vnode.js'
+
+function isRawXml(child: SvgChild): child is RawXmlChild {
+  return typeof child === 'object' && child !== null && 'raw' in child
+}
+
+function isVNode(child: SvgChild): child is SvgVNode {
+  return typeof child === 'object' && child !== null && 'tag' in child
+}
+
+function openTag(node: SvgVNode, selfClose: boolean): string {
+  let out = `<${node.tag}`
+  if (node.attrs !== undefined) {
+    for (const [name, value] of Object.entries(node.attrs)) {
+      if (value === undefined) continue
+      out += ` ${name}="${typeof value === 'number' ? formatCoord(value) : escapeXmlAttr(value)}"`
+    }
+  }
+  return selfClose ? `${out}/>` : `${out}>`
+}
+
+function* serializeChildren(children: ReadonlyArray<SvgChild>): Generator<string> {
+  for (const child of children) {
+    if (typeof child === 'string') {
+      yield escapeXmlText(child)
+    } else if (Array.isArray(child)) {
+      yield* serializeChildren(child)
+    } else if (isRawXml(child)) {
+      yield child.raw
+    } else if (isVNode(child)) {
+      yield* serializeSvgChunks(child)
+    }
+  }
+}
+
+export function* serializeSvgChunks(node: SvgVNode): Generator<string> {
+  if (node.children === undefined) {
+    yield openTag(node, true)
+    return
+  }
+  yield openTag(node, false)
+  yield* serializeChildren(node.children)
+  yield `</${node.tag}>`
+}
+
+export function serializeSvg(node: SvgVNode): string {
+  let out = ''
+  for (const chunk of serializeSvgChunks(node)) out += chunk
+  return out
+}

--- a/packages/canvas-render/src/svg/vnode.ts
+++ b/packages/canvas-render/src/svg/vnode.ts
@@ -1,0 +1,59 @@
+/**
+ * The SVG backend's intermediate representation: plain data between the
+ * scene-graph renderers and the canonical serializer. Renderers describe
+ * WHAT to emit as a tree of `SvgVNode`s; `serialize.ts` is the only code
+ * that turns that tree into bytes, so escaping, number formatting and
+ * attribute ordering cannot diverge per call site.
+ */
+
+/**
+ * `undefined` means the attribute is omitted — the presence-only rule
+ * (an absent field is never defaulted) expressed as a type. Numbers are
+ * formatted by the serializer through `formatCoord`, strings through
+ * `escapeXmlAttr`; a call site never pre-formats either.
+ */
+export type SvgAttrValue = string | number | undefined
+
+export type SvgAttrs = Readonly<Record<string, SvgAttrValue>>
+
+/**
+ * A child emitted verbatim, bypassing text escaping. The only legitimate
+ * producers are trusted, already-well-formed fragments (the `svgFragment`
+ * scene node's payload, whose well-formedness is the CALLER's documented
+ * precondition). A runtime wrapper rather than a branded string because
+ * the serializer must distinguish it from escapable text at runtime.
+ */
+export interface RawXmlChild {
+  readonly raw: string
+}
+
+export function rawXml(xml: string): RawXmlChild {
+  return { raw: xml }
+}
+
+/**
+ * Nested arrays are flattened in document order, so a renderer that
+ * produces a fragment (several siblings, possibly none) composes without
+ * wrapper elements — the empty array is the VNode spelling of the string
+ * backend's `''` degradation.
+ */
+export type SvgChild = SvgVNode | string | RawXmlChild | ReadonlyArray<SvgChild>
+
+export interface SvgVNode {
+  readonly tag: string
+  readonly attrs?: SvgAttrs
+  /**
+   * Absent children self-close the element (`<g/>`); a present-but-empty
+   * array keeps the paired form (`<g></g>`). The distinction is
+   * load-bearing for byte-identical output, not cosmetic.
+   */
+  readonly children?: ReadonlyArray<SvgChild>
+}
+
+export function el(tag: string, attrs?: SvgAttrs, children?: ReadonlyArray<SvgChild>): SvgVNode {
+  return {
+    tag,
+    ...(attrs === undefined ? {} : { attrs }),
+    ...(children === undefined ? {} : { children }),
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces the string-concatenation SVG backend with a zero-dependency VNode intermediate representation (`svg/vnode.ts`) and ONE canonical serializer (`svg/serialize.ts`): escaping, `formatCoord` number formatting, attribute ordering (insertion order) and self-closing decisions now live in a single function instead of per renderer.
- The serializer core is a `Generator<string>` with the string API as its aggregation — chunk boundaries fall on element opens/closes, which is the seam a future streaming or per-group DOM-patching consumer would consume (deliberately NOT wired yet, per `userReach`).
- `rawXml` is the one explicit escape hatch (runtime wrapper, used only for the trusted `svgFragment` payload); plain string children are always escaped, so escaping-by-convention becomes escaping-by-construction.

**Byte-identical by proof**: every existing golden (`DETERMINISM_GOLDEN_SVG` and friends), the XML well-formedness properties, and the full `canvas-render-node` suite pass **unchanged** (747 tests), plus the browser-mode determinism golden in real Chromium. No golden was regenerated — that is this PR's acceptance criterion.

This is the bottom of a 3-PR stack (design note: VNode IR → defs collection → typed element table). **Stack landing plan**: review each layer, then land by merging the top PR once and closing the lower ones — this environment cannot run `gh stack init`, and hand-chained PRs must not be squash-merged one at a time (see `dev-flow.md`).

Note: CodeRabbit auto-review only runs on PRs whose base is the default branch, so on this stack only this bottom PR gets AI review automatically.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — `svg/serialize.test.ts` (10 cases, written red-first)
- [x] `pnpm test` passes locally — `canvas-render-node`: 747 passed; `pnpm --filter @kamiazya/whiteboard-canvas-render typecheck` and `pnpm knip` clean. (The 4 pre-existing `mcp-node` chmod/EACCES-simulation failures reproduce identically on `origin/main` in this root-user container — environment artifact, verified against a pristine main worktree.)
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable — not applicable: output bytes are unchanged, existing goldens are the regression net

Manual verification: browser-mode determinism golden (`svg/determinism.browser.test.ts`, real Chromium) passes on the refactor — same bytes on Node and in the browser. The `scene-bounds` transform-boundary tripwire's source matcher was updated to the VNode attribute spelling and **mutation-checked**: injecting a third `transform:`-emitting renderer turns it red.

## Visual evidence

Invisible refactor — output is byte-identical (test evidence above stands in per AGENTS.md).

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — no user-visible/contract change
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kn5gTK3WGQcNrahPppzvHg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn5gTK3WGQcNrahPppzvHg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SVG rendering reliability while preserving existing visual output and formatting.
  * Continued safe handling of special characters, optional attributes, embedded content, and unusual geometry values.
  * Maintained consistent rendering for diagrams, shapes, text, tables, code blocks, images, backgrounds, and fades.

* **Refactor**
  * Updated the rendering pipeline to improve consistency and maintainability without changing the end-user appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->