### PR TITLE
refactor(canvas-render): generalize defs emission into a declared-and-collected pass

### DIFF
--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -15,9 +15,18 @@ import type {
   TableRowSceneNode,
   TextRunNode,
 } from '../scene-graph.js'
+import { collectDefs } from './defs.js'
 import { formatCoord, sanitizeHref } from './format.js'
 import { serializeSvg } from './serialize.js'
-import { el, rawXml, type SvgAttrs, type SvgAttrValue, type SvgChild } from './vnode.js'
+import {
+  el,
+  rawXml,
+  type SvgAttrs,
+  type SvgAttrValue,
+  type SvgChild,
+  type SvgDef,
+  withDefs,
+} from './vnode.js'
 
 /**
  * Decorative/presentational elements (backgrounds, dividers, group
@@ -137,29 +146,26 @@ const FADE_MASK_ID = 'wb-truncation-fade'
  * it scales to each run rather than needing a definition per run. Verified
  * honoured by resvg (the PNG export path) as well as browsers — a fully black
  * mask renders byte-identically to an empty canvas there.
+ *
+ * Declared on each truncated run and hoisted by `collectDefs`, so the
+ * document's `<defs>` appears exactly when something references the mask —
+ * the presence-only rule as a mechanism instead of a bespoke scene walk.
  */
-const FADE_DEFS = el('defs', undefined, [
-  el('linearGradient', { id: `${FADE_MASK_ID}-gradient`, x1: 0, y1: 0, x2: 1, y2: 0 }, [
-    el('stop', { offset: 0.75, 'stop-color': '#ffffff' }),
-    el('stop', { offset: 1, 'stop-color': '#000000' }),
-  ]),
-  el('mask', { id: FADE_MASK_ID, maskContentUnits: 'objectBoundingBox' }, [
-    el('rect', { x: 0, y: 0, width: 1, height: 1, fill: `url(#${FADE_MASK_ID}-gradient)` }),
-  ]),
-])
-
-/** Whether anything in the scene needs `FADE_DEFS`; nothing is emitted if not. */
-function hasTruncatedRun(nodes: readonly SceneNode[]): boolean {
-  const stack: SceneNode[] = [...nodes]
-  for (let node = stack.pop(); node !== undefined; node = stack.pop()) {
-    if (node.kind === 'textRun' && node.truncated === true) return true
-    for (const key of ['runs', 'children', 'items', 'rows', 'cells'] as const) {
-      const children = (node as unknown as Record<string, unknown>)[key]
-      if (Array.isArray(children)) stack.push(...(children as SceneNode[]))
-    }
-  }
-  return false
-}
+const FADE_DEFS: ReadonlyArray<SvgDef> = [
+  {
+    id: `${FADE_MASK_ID}-gradient`,
+    node: el('linearGradient', { id: `${FADE_MASK_ID}-gradient`, x1: 0, y1: 0, x2: 1, y2: 0 }, [
+      el('stop', { offset: 0.75, 'stop-color': '#ffffff' }),
+      el('stop', { offset: 1, 'stop-color': '#000000' }),
+    ]),
+  },
+  {
+    id: FADE_MASK_ID,
+    node: el('mask', { id: FADE_MASK_ID, maskContentUnits: 'objectBoundingBox' }, [
+      el('rect', { x: 0, y: 0, width: 1, height: 1, fill: `url(#${FADE_MASK_ID}-gradient)` }),
+    ]),
+  },
+]
 
 /**
  * The tinted box behind a run (inline code today). Bleeds `backdropPadXPx`
@@ -200,7 +206,7 @@ function renderTextRun(run: TextRunNode): SvgChild {
           fill: halo,
         })
       : []
-  const text = el(
+  const textEl = el(
     'text',
     {
       x: run.bbox.x,
@@ -214,6 +220,7 @@ function renderTextRun(run: TextRunNode): SvgChild {
     },
     [run.text],
   )
+  const text = run.truncated === true ? withDefs(textEl, FADE_DEFS) : textEl
   // The backdrop is painted before the halo underlay so a run can carry both
   // without the panel hiding the halo; inline code uses this for its tinted
   // pill.
@@ -612,9 +619,17 @@ const SVG_XMLNS = 'http://www.w3.org/2000/svg'
  */
 export function renderSceneToSvg(scene: Scene, options?: SvgDocumentOptions): string {
   const body = scene.nodes.map(renderNode)
-  // Presence-only, exactly like an absent appearance attribute: a scene with
-  // nothing truncated emits the same bytes it always has.
-  const defs: SvgChild = hasTruncatedRun(scene.nodes) ? FADE_DEFS : []
+  // Presence-only, exactly like an absent appearance attribute: a scene
+  // declaring no definitions emits the same bytes it always has.
+  const collected = collectDefs(body)
+  const defs: SvgChild =
+    collected.length > 0
+      ? el(
+          'defs',
+          undefined,
+          collected.map((def) => def.node),
+        )
+      : []
 
   if (!hasEnvelopeOptions(options)) {
     return serializeSvg(el('svg', { xmlns: SVG_XMLNS }, [defs, body]))

--- a/packages/canvas-render/src/svg/defs.test.ts
+++ b/packages/canvas-render/src/svg/defs.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { collectDefs } from './defs.js'
+import { el, rawXml, type SvgDef, withDefs } from './vnode.js'
+
+const gradient: SvgDef = { id: 'grad', node: el('linearGradient', { id: 'grad' }) }
+const mask: SvgDef = { id: 'mask', node: el('mask', { id: 'mask' }) }
+
+describe('collectDefs', () => {
+  it('returns nothing for a tree with no declarations', () => {
+    expect(collectDefs([el('g', undefined, [el('rect', { x: 0 }), 'text'])])).toEqual([])
+  })
+
+  it('collects a declaration from a deeply nested element', () => {
+    const tree = [el('g', undefined, [el('a', { href: '#x' }, [withDefs(el('text'), [gradient])])])]
+    expect(collectDefs(tree)).toEqual([gradient])
+  })
+
+  it('keeps declaration order and dedupes by id, first occurrence winning', () => {
+    const other: SvgDef = { id: 'grad', node: el('linearGradient', { id: 'grad', x1: 1 }) }
+    const tree = [
+      withDefs(el('text'), [gradient, mask]),
+      withDefs(el('text'), [other]), // same id as `gradient` — dropped
+    ]
+    expect(collectDefs(tree)).toEqual([gradient, mask])
+  })
+
+  it('collects each of several distinct ids exactly once', () => {
+    const tree = [
+      withDefs(el('text'), [gradient]),
+      el('g', undefined, [withDefs(el('text'), [mask, gradient])]),
+      rawXml('<circle/>'), // opaque: cannot carry declarations
+    ]
+    expect(collectDefs(tree)).toEqual([gradient, mask])
+  })
+})

--- a/packages/canvas-render/src/svg/defs.test.ts
+++ b/packages/canvas-render/src/svg/defs.test.ts
@@ -24,6 +24,28 @@ describe('collectDefs', () => {
     expect(collectDefs(tree)).toEqual([gradient, mask])
   })
 
+  it('collects a dependency declared on a definition node itself, dependency first', () => {
+    // A mask whose gradient dependency rides the mask definition's own node —
+    // the natural shape for a def with private dependencies. Dropping it
+    // leaves url(#dep-grad) unresolved in the emitted document.
+    const depGradient: SvgDef = { id: 'dep-grad', node: el('linearGradient', { id: 'dep-grad' }) }
+    const maskWithDep: SvgDef = {
+      id: 'dep-mask',
+      node: withDefs(el('mask', { id: 'dep-mask' }), [depGradient]),
+    }
+    const tree = [withDefs(el('text', { x: 0, y: 0 }), [maskWithDep])]
+    expect(collectDefs(tree)).toEqual([depGradient, maskWithDep])
+  })
+
+  it('terminates on mutually dependent definitions, keeping each once', () => {
+    const a: SvgDef = { id: 'a', node: el('mask', { id: 'a' }) }
+    const b: SvgDef = { id: 'b', node: withDefs(el('mask', { id: 'b' }), [a]) }
+    const aCyclic: SvgDef = { id: 'a', node: withDefs(el('mask', { id: 'a' }), [b]) }
+    const tree = [withDefs(el('text', { x: 0, y: 0 }), [aCyclic])]
+    const ids = collectDefs(tree).map((def) => def.id)
+    expect(ids.sort()).toEqual(['a', 'b'])
+  })
+
   it('collects each of several distinct ids exactly once', () => {
     const tree = [
       withDefs(el('text'), [gradient]),

--- a/packages/canvas-render/src/svg/defs.ts
+++ b/packages/canvas-render/src/svg/defs.ts
@@ -25,6 +25,11 @@ export function collectDefs(children: ReadonlyArray<SvgChild>): ReadonlyArray<Sv
     for (const def of child.defs ?? []) {
       if (seen.has(def.id)) continue
       seen.add(def.id)
+      // A definition's own node may declare the definitions IT depends on
+      // (a mask carrying its gradient). Visit it before pushing so a
+      // dependency is emitted ahead of its dependent; `seen` is marked
+      // first, so mutually dependent definitions terminate.
+      visit(def.node)
       collected.push(def)
     }
     for (const inner of child.children ?? []) visit(inner)

--- a/packages/canvas-render/src/svg/defs.ts
+++ b/packages/canvas-render/src/svg/defs.ts
@@ -1,0 +1,34 @@
+/**
+ * Hoists the `defs` declarations scattered through a VNode tree into one
+ * ordered, id-deduplicated list — the document assembly wraps the result in
+ * a single `<defs>` element as the root's first child, or emits nothing
+ * when the list is empty. First occurrence wins on an id collision, which
+ * is sound because ids are content-derived by contract (see `SvgVNode.defs`):
+ * two declarations sharing an id say the same thing in the same bytes.
+ */
+
+import type { SvgChild, SvgDef, SvgVNode } from './vnode.js'
+
+function isVNode(child: SvgChild): child is SvgVNode {
+  return typeof child === 'object' && child !== null && 'tag' in child
+}
+
+export function collectDefs(children: ReadonlyArray<SvgChild>): ReadonlyArray<SvgDef> {
+  const seen = new Set<string>()
+  const collected: SvgDef[] = []
+  const visit = (child: SvgChild): void => {
+    if (Array.isArray(child)) {
+      for (const inner of child) visit(inner)
+      return
+    }
+    if (!isVNode(child)) return
+    for (const def of child.defs ?? []) {
+      if (seen.has(def.id)) continue
+      seen.add(def.id)
+      collected.push(def)
+    }
+    for (const inner of child.children ?? []) visit(inner)
+  }
+  for (const child of children) visit(child)
+  return collected
+}

--- a/packages/canvas-render/src/svg/vnode.ts
+++ b/packages/canvas-render/src/svg/vnode.ts
@@ -48,6 +48,26 @@ export interface SvgVNode {
    * load-bearing for byte-identical output, not cosmetic.
    */
   readonly children?: ReadonlyArray<SvgChild>
+  /**
+   * Shared definitions this element depends on (`<mask>`, `<linearGradient>`,
+   * …). Declared where the dependency arises; `collectDefs` (defs.ts) hoists
+   * them into the document's single `<defs>` element, deduplicated by `id` —
+   * so a definition is emitted only when something in the tree actually
+   * references it (presence-only, mechanized). Ids must be derived from the
+   * definition's CONTENT (never a counter or randomness): same id ⇒ same
+   * bytes is what makes a repeated id across several inline-injected SVGs
+   * harmless, and what keeps first-occurrence-wins deduplication sound.
+   */
+  readonly defs?: ReadonlyArray<SvgDef>
+}
+
+export interface SvgDef {
+  readonly id: string
+  readonly node: SvgVNode
+}
+
+export function withDefs(node: SvgVNode, defs: ReadonlyArray<SvgDef>): SvgVNode {
+  return { ...node, defs }
 }
 
 export function el(tag: string, attrs?: SvgAttrs, children?: ReadonlyArray<SvgChild>): SvgVNode {


### PR DESCRIPTION
## Summary

- A VNode can now declare the shared definitions it depends on (`SvgVNode.defs`); `collectDefs` (`svg/defs.ts`) hoists them in document order into the document's single `<defs>` element, deduplicated by **content-derived id** (first occurrence wins — sound because equal ids mean equal bytes by contract, the generalization of the existing `FADE_MASK_ID` "byte-identical copies make id collisions harmless" rule).
- The truncation-fade mask becomes the first resident: each truncated text run declares it, and the bespoke `hasTruncatedRun` scene walk is deleted. Presence-only (`no reference → no <defs>`) is now a mechanism, not a per-feature scan.
- This is the seam later `<marker>` / `<pattern>` / `<symbol>` definitions (render-style seam, decision #10) ride for free.

Stack layer 2/3 — base is `claude/svg-generation-improvement-uigd90` (PR #926). Landing: top-PR-only merge, see #926.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — `svg/defs.test.ts` (collection, order, first-wins dedupe; written red-first)
- [x] `pnpm test` passes locally — `canvas-render-node`: 752 passed unchanged (goldens + fade tests prove byte-identity); typecheck + knip clean
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable — not applicable: bytes unchanged

Manual verification: existing fade tests assert the emitted `<defs>` bytes; they pass without modification, i.e. the collected emission is byte-identical to the old constant emission, including absence when nothing is truncated.

## Visual evidence

Invisible refactor — output is byte-identical.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — no user-visible/contract change
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kn5gTK3WGQcNrahPppzvHg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn5gTK3WGQcNrahPppzvHg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SVG rendering for truncated text, including more reliable fade effects.
  - Prevented duplicate SVG definitions from being emitted.
  - Ensured referenced SVG definitions are included only when needed.

- **Rendering Improvements**
  - Improved handling of nested SVG content and shared definitions.
  - Preserved definition ordering for more consistent rendered output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->