### PR TITLE
feat(canvas-render): type the SVG element table and brand navigation hrefs

### DIFF
--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -16,17 +16,10 @@ import type {
   TextRunNode,
 } from '../scene-graph.js'
 import { collectDefs } from './defs.js'
-import { formatCoord, sanitizeHref } from './format.js'
+import type { PaintAttrs, SvgBoxAttrs, TextEmphasisAttrs } from './elements.js'
+import { formatCoord, sanitizeHref, trustedHref } from './format.js'
 import { serializeSvg } from './serialize.js'
-import {
-  el,
-  rawXml,
-  type SvgAttrs,
-  type SvgAttrValue,
-  type SvgChild,
-  type SvgDef,
-  withDefs,
-} from './vnode.js'
+import { el, rawXml, type SvgChild, type SvgDef, withDefs } from './vnode.js'
 
 /**
  * Decorative/presentational elements (backgrounds, dividers, group
@@ -36,7 +29,7 @@ import {
  */
 const PRESENTATION = 'presentation'
 
-function rectAttrs(bbox: BoundingBox): SvgAttrs {
+function rectAttrs(bbox: BoundingBox): SvgBoxAttrs {
   // Fixed declaration order: x, y, width, height.
   return { x: bbox.x, y: bbox.y, width: bbox.w, height: bbox.h }
 }
@@ -65,9 +58,9 @@ function isPositiveLength(value: number | undefined): value is number {
  * or unusable field is omitted rather than defaulted — see the
  * `Appearance` doc comment for why the backend never invents a value.
  */
-function appearanceAttrs(appearance?: Appearance): SvgAttrs {
+function appearanceAttrs(appearance?: Appearance): PaintAttrs {
   if (!appearance) return {}
-  const attrs: Record<string, SvgAttrValue> = {}
+  const attrs: PaintAttrs = {}
   if (isNonEmptyString(appearance.fill)) attrs.fill = appearance.fill
   if (isNonEmptyString(appearance.stroke)) attrs.stroke = appearance.stroke
   if (isNonNegativeLength(appearance.strokeWidth)) attrs['stroke-width'] = appearance.strokeWidth
@@ -115,8 +108,8 @@ const TEXT_HALO_PAD_PX = 2
 const BACKDROP_RADIUS_PX = 6
 
 /** Inline emphasis the layout measured for — painted, or the flags are lies. */
-function emphasisAttrs(run: TextRunNode): SvgAttrs {
-  const attrs: Record<string, SvgAttrValue> = {}
+function emphasisAttrs(run: TextRunNode): TextEmphasisAttrs {
+  const attrs: TextEmphasisAttrs = {}
   if (run.strong === true) attrs['font-weight'] = '700'
   if (run.emphasis === true) attrs['font-style'] = 'italic'
   // A link is underlined rather than recolored because this backend is never
@@ -226,7 +219,8 @@ function renderTextRun(run: TextRunNode): SvgChild {
   // pill.
   const content: SvgChild = [renderBackdrop(run), underlay, text]
   if (!run.link) return content
-  const href = run.link.kind === 'link' ? sanitizeHref(run.link.href) : run.link.documentId
+  const href =
+    run.link.kind === 'link' ? sanitizeHref(run.link.href) : trustedHref(run.link.documentId)
   return el('a', { href }, [content])
 }
 
@@ -452,7 +446,7 @@ function renderNode(node: SceneNode): SvgChild {
       // preceding block. The node carries no measured ascent (it is not a
       // text run), so the baseline is derived from the box: 0.8 matches the
       // ascent ratio the measurer contract documents for body text.
-      return el('a', { href: `#${node.documentId}` }, [
+      return el('a', { href: trustedHref(`#${node.documentId}`) }, [
         el('text', { x: node.bbox.x, y: node.bbox.y + node.bbox.h * 0.8 }, [node.title]),
       ])
     case 'embedResolved':

--- a/packages/canvas-render/src/svg/defs.test.ts
+++ b/packages/canvas-render/src/svg/defs.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { collectDefs } from './defs.js'
+import { trustedHref } from './format.js'
 import { el, rawXml, type SvgDef, withDefs } from './vnode.js'
 
 const gradient: SvgDef = { id: 'grad', node: el('linearGradient', { id: 'grad' }) }
@@ -7,11 +8,16 @@ const mask: SvgDef = { id: 'mask', node: el('mask', { id: 'mask' }) }
 
 describe('collectDefs', () => {
   it('returns nothing for a tree with no declarations', () => {
-    expect(collectDefs([el('g', undefined, [el('rect', { x: 0 }), 'text'])])).toEqual([])
+    const rect = el('rect', { x: 0, y: 0, width: 1, height: 1 })
+    expect(collectDefs([el('g', undefined, [rect, 'text'])])).toEqual([])
   })
 
   it('collects a declaration from a deeply nested element', () => {
-    const tree = [el('g', undefined, [el('a', { href: '#x' }, [withDefs(el('text'), [gradient])])])]
+    const tree = [
+      el('g', undefined, [
+        el('a', { href: trustedHref('#x') }, [withDefs(el('text', { x: 0, y: 0 }), [gradient])]),
+      ]),
+    ]
     expect(collectDefs(tree)).toEqual([gradient])
   })
 

--- a/packages/canvas-render/src/svg/elements.ts
+++ b/packages/canvas-render/src/svg/elements.ts
@@ -1,0 +1,87 @@
+/**
+ * The element/attribute table of the SVG this backend actually emits —
+ * deliberately NARROW, not a general SVG typing. Every element and every
+ * attribute here exists because a renderer emits it; extending the output
+ * vocabulary means extending this table, which is where the canonical-
+ * serialization review happens. Type aliases (not interfaces) throughout,
+ * so each shape stays assignable to the serializer's loose attr storage.
+ *
+ * Conventions encoded as types rather than review rules:
+ * - Coordinates and lengths are `number` — the serializer routes them
+ *   through `formatCoord`, so a pre-formatted (locale-dependent) string
+ *   cannot reach the output.
+ * - Presence-only: an optional attribute set to `undefined` is omitted.
+ * - `<a href>` takes a `SafeHref` (sanitizeHref/trustedHref), never a raw
+ *   string, so an executable scheme cannot bypass the sanitizer. `<image
+ *   href>` stays a plain string by decision #9 (emitted verbatim: data:/
+ *   blob:/app URLs the composition root already owns).
+ * - Stroked line elements declare `fill` explicitly — SVG's initial black
+ *   fill painting a wedge across a bent edge is the shipped defect this
+ *   requirement pins.
+ */
+
+import type { SafeHref } from './format.js'
+
+export type SvgRole = 'presentation'
+
+export type SvgBoxAttrs = {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export type PaintAttrs = {
+  fill?: string
+  stroke?: string
+  'stroke-width'?: number
+  'font-family'?: string
+  'font-size'?: number
+  'fill-opacity'?: number
+  'stroke-opacity'?: number
+}
+
+export type TextEmphasisAttrs = {
+  'font-weight'?: string
+  'font-style'?: string
+  'text-decoration'?: string
+}
+
+export type SvgElements = {
+  svg: {
+    xmlns?: string
+    x?: number
+    y?: number
+    width?: number
+    height?: number
+    viewBox?: string
+    overflow?: 'visible'
+    fill?: string
+    role?: SvgRole
+  }
+  g: PaintAttrs & { transform?: string; role?: SvgRole }
+  rect: SvgBoxAttrs & PaintAttrs & { rx?: number; role?: SvgRole }
+  // width/height appear on <text> only through the legacy codeBlock/rawHtml
+  // box-placement path (rectAttrs spread); x/y are the baseline contract.
+  text: PaintAttrs &
+    TextEmphasisAttrs & {
+      x: number
+      y: number
+      width?: number
+      height?: number
+      mask?: string
+      'xml:space'?: 'preserve'
+    }
+  a: { href: SafeHref }
+  polyline: PaintAttrs & { points: string; fill: string; role?: SvgRole }
+  path: PaintAttrs & { d: string; fill: string; role?: SvgRole }
+  polygon: { points: string; fill: string; role?: SvgRole }
+  image: SvgBoxAttrs & { href: string; preserveAspectRatio: string; role?: SvgRole }
+  title: Record<string, never>
+  defs: Record<string, never>
+  linearGradient: { id: string; x1?: number; y1?: number; x2?: number; y2?: number }
+  stop: { offset: number; 'stop-color': string }
+  mask: { id: string; maskContentUnits?: 'objectBoundingBox' }
+}
+
+export type SvgTagName = keyof SvgElements

--- a/packages/canvas-render/src/svg/elements.type-safety.test.ts
+++ b/packages/canvas-render/src/svg/elements.type-safety.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeHref } from './format.js'
+import { el } from './vnode.js'
+
+/**
+ * Compile-time contract of the typed element table (elements.ts). The
+ * `@ts-expect-error` lines are verified by `tsc --noEmit` (typecheck), not
+ * by vitest — an annotation with no error under it FAILS the typecheck, so
+ * a loosened element type is caught even though every runtime assertion
+ * here stays green.
+ */
+describe('typed SVG element table', () => {
+  it('accepts the shapes the backend actually emits', () => {
+    expect(el('rect', { x: 0, y: 0, width: 1, height: 1, rx: 2, fill: '#fff' }).tag).toBe('rect')
+    expect(el('text', { x: 0, y: 0, 'xml:space': 'preserve' }, ['hi']).tag).toBe('text')
+    expect(el('g', { transform: 'translate(1,0)' }, []).tag).toBe('g')
+    expect(el('a', { href: sanitizeHref('https://example.com') }, []).tag).toBe('a')
+  })
+
+  it('rejects what the canonical serialization rules forbid', () => {
+    // @ts-expect-error unknown element name
+    el('rectt', {})
+    // @ts-expect-error typo'd attribute name
+    el('rect', { x: 0, y: 0, width: 1, heigth: 1 })
+    // @ts-expect-error a coordinate must be a number (formatCoord input), not a pre-formatted string
+    el('rect', { x: '0', y: 0, width: 1, height: 1 })
+    // @ts-expect-error an edge path must declare its fill (SVG's initial black fill must never leak)
+    el('polyline', { points: '0,0 1,1' })
+    // @ts-expect-error xml:space accepts only the one value the backend uses
+    el('text', { x: 0, y: 0, 'xml:space': 'default' })
+    // @ts-expect-error an <a href> takes a SafeHref (sanitizeHref/trustedHref), never a raw string
+    el('a', { href: 'javascript:alert(1)' }, [])
+  })
+})

--- a/packages/canvas-render/src/svg/format.ts
+++ b/packages/canvas-render/src/svg/format.ts
@@ -113,13 +113,36 @@ function normalizeHrefForSchemeCheck(href: string): string {
   return href.replace(ASCII_TAB_OR_NEWLINE, '').replace(LEADING_C0_OR_SPACE, '')
 }
 
+declare const safeHrefBrand: unique symbol
+
+/**
+ * A navigation href that has passed `sanitizeHref`, or that this package
+ * composed itself from a value the host resolves (`trustedHref`). The
+ * `<a href>` attribute accepts only this brand, so a caller cannot hand a
+ * raw markdown URL to the serializer without the scheme check — the
+ * compile-time form of the invariant `sanitizeHref`'s doc comment states.
+ */
+export type SafeHref = string & { readonly [safeHrefBrand]: true }
+
 /**
  * Returns `href` unchanged when it has no scheme (relative/hash link) or an
  * allow-listed scheme, otherwise `#` — never throws, degrades to a safe
  * same-page anchor rather than rejecting the whole render.
  */
-export function sanitizeHref(href: string): string {
+export function sanitizeHref(href: string): SafeHref {
   const match = URL_SCHEME_PATTERN.exec(normalizeHrefForSchemeCheck(href))
-  if (!match) return href
-  return SAFE_URL_SCHEMES.has(match[1].toLowerCase()) ? href : '#'
+  if (!match) return href as SafeHref
+  return (SAFE_URL_SCHEMES.has(match[1].toLowerCase()) ? href : '#') as SafeHref
+}
+
+/**
+ * Brands an href this package COMPOSES itself rather than receives from
+ * markdown: a `#fragment` built from a document id, or a wiki-link's
+ * document reference. Those are resolved by the host application, not the
+ * browser's URL parser, so the scheme allow-list does not apply — the
+ * XML-escaping in the serializer still does. Never pass caller-supplied
+ * link URLs here; those go through `sanitizeHref`.
+ */
+export function trustedHref(href: string): SafeHref {
+  return href as SafeHref
 }

--- a/packages/canvas-render/src/svg/serialize.test.ts
+++ b/packages/canvas-render/src/svg/serialize.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
+import { sanitizeHref } from './format.js'
 import { serializeSvg, serializeSvgChunks } from './serialize.js'
 import { el, rawXml } from './vnode.js'
+
+const box = { y: 0, width: 1, height: 1 }
 
 describe('serializeSvg', () => {
   it('emits attributes in insertion order with number values through formatCoord', () => {
@@ -9,12 +12,12 @@ describe('serializeSvg', () => {
   })
 
   it('omits attributes whose value is undefined (presence-only)', () => {
-    const node = el('rect', { x: 0, rx: undefined, fill: undefined })
-    expect(serializeSvg(node)).toBe('<rect x="0"/>')
+    const node = el('rect', { x: 0, ...box, rx: undefined, fill: undefined })
+    expect(serializeSvg(node)).toBe('<rect x="0" y="0" width="1" height="1"/>')
   })
 
   it('escapes string attribute values including quotes', () => {
-    const node = el('a', { href: 'https://e.com/?a=1&b="x"<y>' }, [])
+    const node = el('a', { href: sanitizeHref('https://e.com/?a=1&b="x"<y>') }, [])
     expect(serializeSvg(node)).toBe(
       '<a href="https://e.com/?a=1&amp;b=&quot;x&quot;&lt;y&gt;"></a>',
     )
@@ -33,15 +36,17 @@ describe('serializeSvg', () => {
   it('self-closes when children are absent but pairs tags when children are an empty array', () => {
     expect(serializeSvg(el('g', { role: 'presentation' }))).toBe('<g role="presentation"/>')
     expect(serializeSvg(el('g', undefined, []))).toBe('<g></g>')
-    expect(serializeSvg(el('image', { x: 0 }, []))).toBe('<image x="0"></image>')
+    expect(serializeSvg(el('title', undefined, []))).toBe('<title></title>')
   })
 
   it('flattens nested child arrays in document order', () => {
     const node = el('g', undefined, [
-      [el('rect', { x: 1 }), [el('rect', { x: 2 })]],
-      el('rect', { x: 3 }),
+      [el('rect', { x: 1, ...box }), [el('rect', { x: 2, ...box })]],
+      el('rect', { x: 3, ...box }),
     ])
-    expect(serializeSvg(node)).toBe('<g><rect x="1"/><rect x="2"/><rect x="3"/></g>')
+    expect(serializeSvg(node)).toBe(
+      '<g><rect x="1" y="0" width="1" height="1"/><rect x="2" y="0" width="1" height="1"/><rect x="3" y="0" width="1" height="1"/></g>',
+    )
   })
 
   it('recurses into element children', () => {
@@ -54,11 +59,11 @@ describe('serializeSvg', () => {
   })
 
   it('joins to the same bytes the chunk generator yields', () => {
-    const node = el('svg', { xmlns: 'x' }, [el('rect', { x: 1 }), 'txt', rawXml('<g/>')])
+    const node = el('svg', { xmlns: 'x' }, [el('rect', { x: 1, ...box }), 'txt', rawXml('<g/>')])
     expect([...serializeSvgChunks(node)].join('')).toBe(serializeSvg(node))
   })
 
   it('throws on a non-finite number attribute (formatCoord contract: a layout bug, not a serializer one)', () => {
-    expect(() => serializeSvg(el('rect', { x: Number.NaN }))).toThrow(RangeError)
+    expect(() => serializeSvg(el('rect', { x: Number.NaN, ...box }))).toThrow(RangeError)
   })
 })

--- a/packages/canvas-render/src/svg/vnode.ts
+++ b/packages/canvas-render/src/svg/vnode.ts
@@ -6,6 +6,8 @@
  * attribute ordering cannot diverge per call site.
  */
 
+import type { SvgElements, SvgTagName } from './elements.js'
+
 /**
  * `undefined` means the attribute is omitted — the presence-only rule
  * (an absent field is never defaulted) expressed as a type. Numbers are
@@ -70,6 +72,18 @@ export function withDefs(node: SvgVNode, defs: ReadonlyArray<SvgDef>): SvgVNode 
   return { ...node, defs }
 }
 
+/**
+ * Builds one element VNode. The public signature is constrained by the
+ * typed element table (elements.ts): only emitted element names, only
+ * their declared attributes, numbers where `formatCoord` is the contract.
+ * The VNode itself stores attrs loosely — the table is a construction-time
+ * gate, not a runtime shape.
+ */
+export function el<T extends SvgTagName>(
+  tag: T,
+  attrs?: SvgElements[T],
+  children?: ReadonlyArray<SvgChild>,
+): SvgVNode
 export function el(tag: string, attrs?: SvgAttrs, children?: ReadonlyArray<SvgChild>): SvgVNode {
   return {
     tag,


### PR DESCRIPTION
## Summary

- `svg/elements.ts` declares the **narrow** element/attribute table this backend actually emits (not a general SVG typing), and `el()`'s public signature is constrained by it: an unknown element name, a typo'd attribute, a pre-formatted coordinate string, or a stroked line element without an explicit `fill` (the black-wedge defect class) now **fails to compile**.
- `sanitizeHref` returns the branded `SafeHref`, and `<a href>` accepts only that brand — `trustedHref` covers the two package-composed cases (`#fragment` ids, wiki-link document references). The sanitizer path is now compiler-checked instead of a convention. `<image href>` deliberately stays a plain string (decision #9: emitted verbatim).
- The JSX-runtime layer originally scoped here is **deliberately deferred**, with the reason recorded in the commit: `xml:space` is not a legal JSX attribute name, so a JSX form would need a camelCase→XML name-mapping table — a second producer of attribute names beside the serializer — plus jsx config across four toolchains, for author ergonomics the typed builder already covers.

Stack layer 3/3 (top) — base is `claude/svg-generation-improvement-uigd90-2` (PR #927). **This is the PR to merge when the stack lands** (single squash; then close #926/#927 whose commits it contains).

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — `svg/elements.type-safety.test.ts`: `@ts-expect-error` contract pins verified by `tsc --noEmit` (written red-first: 6 unused-directive errors before the table existed), plus runtime accepts-cases
- [x] `pnpm test` passes locally — `canvas-render-node`: 755 passed; typecheck exit 0; knip clean
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable — not applicable: compile-time-only change, bytes unchanged

Manual verification: output bytes untouched — goldens and the full suite pass unchanged; the type table is a construction-time gate only (VNode storage stays loose).

## Visual evidence

Invisible change — compile-time only, output byte-identical.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — internal package surface only
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kn5gTK3WGQcNrahPppzvHg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn5gTK3WGQcNrahPppzvHg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safer handling for SVG navigation links, including validation of external URLs and support for trusted internal links.
  - Added typed support for supported SVG elements and attributes, helping prevent invalid markup during rendering.

- **Bug Fixes**
  - Improved protection against unsafe link schemes in generated SVG content.
  - Ensured SVG dimensions, paint settings, text attributes, and element properties are validated consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->