### PR TITLE
feat(mcp-server): say which font families an export declared but could not get

### DIFF
--- a/packages/mcp-server/src/server/export/headless-renderer.test.ts
+++ b/packages/mcp-server/src/server/export/headless-renderer.test.ts
@@ -42,7 +42,7 @@ async function importRenderer() {
 
 import { renderSceneToSvg } from '@kamiazya/whiteboard-canvas-render'
 import { buildSpatialScene } from './headless-renderer.js'
-import { createOpentypeMeasureText } from './measure-text.js'
+import { createOpentypeMeasureText, loadExportFonts } from './measure-text.js'
 
 describe('emphasis survives the whole export pipeline', () => {
   it('a real PNG render selects the vendored bold/italic faces — styled pixels differ from plain', async () => {
@@ -366,5 +366,47 @@ describe('headless-renderer', () => {
   afterEach(() => {
     vi.doUnmock('./measure-text.js')
     vi.doUnmock('./export-font.js')
+  })
+})
+
+describe('an export says which declared families it could not provide', () => {
+  // The case that exists today, end to end: a fenced code block declares the
+  // markdown theme's mono chain, and the export has the vendored Latin face
+  // and nothing else. Every character is drawn — in the wrong face — so
+  // `undrawable` is empty and only this answer says anything happened.
+  const CODE_CANVAS: SpatialCanvas = {
+    nodes: [
+      {
+        id: 'n1',
+        type: 'text',
+        x: 0,
+        y: 0,
+        width: 320,
+        height: 200,
+        text: '```ts\nconst x = 1\n```',
+      },
+    ],
+    edges: [],
+  }
+
+  it('reports the mono chain a fenced block declares, while undrawable stays empty', async () => {
+    const { renderSpatialCanvasToSvg } = await importRenderer()
+    const result = await renderSpatialCanvasToSvg(CODE_CANVAS, {})
+    expect(result.undrawable).toEqual([])
+    expect(result.unresolvedFamilies.join(' ')).toContain('ui-monospace')
+  })
+
+  it('says nothing for a canvas whose text declares only the export family', async () => {
+    // Guards the vacuous pass: with no face loaded, `unresolvedFamilies`
+    // answers `[]` for EVERY canvas by design, so this assertion would hold
+    // while the report was inert. The mono case above is what proves the
+    // machinery runs; this proves it can also stay quiet.
+    expect((await loadExportFonts()).length).toBeGreaterThan(0)
+    const { renderSpatialCanvasToSvg } = await importRenderer()
+    const plain: SpatialCanvas = {
+      nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 320, height: 120, text: 'plain prose' }],
+      edges: [],
+    }
+    expect((await renderSpatialCanvasToSvg(plain, {})).unresolvedFamilies).toEqual([])
   })
 })

--- a/packages/mcp-server/src/server/export/headless-renderer.ts
+++ b/packages/mcp-server/src/server/export/headless-renderer.ts
@@ -39,8 +39,9 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { getLogger } from '../log.js'
 import { EXPORT_FONT_FAMILY, resolveExportFontFaces } from './export-font.js'
 import { installedFontFiles } from './installed-fonts.js'
-import { createOpentypeMeasureText } from './measure-text.js'
+import { createOpentypeMeasureText, loadExportFonts } from './measure-text.js'
 import { undrawableCharacters } from './undrawable-characters.js'
+import { unresolvedFamilies } from './unresolved-families.js'
 
 // Export never has its own theme switch (the composition root always
 // exports light, see package-canvas-render.md decision #8), so this
@@ -97,6 +98,13 @@ export interface HeadlessExportResult {
    * logged where it happens.
    */
   undrawable: readonly string[]
+  /**
+   * Font families this render DECLARED that no loaded face provides, so
+   * resvg drew them in the fallback. Distinct from `undrawable`, which is
+   * family-blind: every character can be present and still be painted in the
+   * wrong face, which is a silent loss rather than a visible one.
+   */
+  unresolvedFamilies: readonly string[]
 }
 
 export interface HeadlessSvgExportResult {
@@ -108,6 +116,8 @@ export interface HeadlessSvgExportResult {
    * the PNG of the same canvas would lose.
    */
   undrawable: readonly string[]
+  /** Same question as `HeadlessExportResult.unresolvedFamilies`. */
+  unresolvedFamilies: readonly string[]
 }
 
 interface HeadlessExporter {
@@ -164,22 +174,54 @@ export function buildSpatialScene(
   })
 }
 
+/**
+ * The SVG and the scene it came from. The scene is returned rather than
+ * rebuilt because the caller needs it to report which declared font families
+ * this render could not resolve, and laying the canvas out twice to answer
+ * that would cost the whole of layout for a report.
+ */
 function buildSvg(
   canvas: SpatialCanvas,
   options: HeadlessExportOptions,
   measure: MeasureText,
-): string {
+): { svg: string; scene: Scene } {
   // `theme` is an explicit per-request argument — the invariant that a
   // user's ambient UI theme never changes exported bytes is untouched.
   const mode: ExportThemeMode = options.theme === 'dark' ? 'dark' : 'light'
   const scene = buildSpatialScene(canvas, measure, mode)
-  return renderSceneToSvgString(scene, {
+  const svg = renderSceneToSvgString(scene, {
     padding: options.padding ?? DEFAULT_PADDING_PX,
     background: themeBackground(options),
     // Dark node chrome uses transparent fills, so body runs sit directly on
     // the dark background — the root-level inheritable fill is what keeps
     // them legible. Light stays byte-identical (no root fill).
     ...(mode === 'dark' ? { textFill: SPATIAL_DARK_PALETTE.labelFill } : {}),
+  })
+  return { svg, scene }
+}
+
+/**
+ * The families the loaded faces actually provide, for `unresolvedFamilies`.
+ *
+ * The name lives under a PLATFORM record, and which one a face carries is not
+ * fixed — the vendored Roboto has `windows` and nothing else, while
+ * opentype.js's typings advertise a flat `names.fontFamily` that is undefined
+ * there. Reading only the typed path returned no families at all, which made
+ * every declaration resolve against an empty set and the report silently
+ * empty. All three shapes are read, and the English entry preferred because
+ * that is what a `font-family` declaration is written against.
+ */
+async function availableFamilies(): Promise<readonly string[]> {
+  const fonts = await loadExportFonts()
+  return fonts.flatMap((font) => {
+    const names = font.names as unknown as Record<string, Record<string, unknown> | undefined>
+    for (const record of [names.windows, names.macintosh, names]) {
+      const family = record?.fontFamily as Record<string, string> | string | undefined
+      const name =
+        typeof family === 'string' ? family : (family?.en ?? Object.values(family ?? {})[0])
+      if (typeof name === 'string' && name !== '') return [name]
+    }
+    return []
   })
 }
 
@@ -210,7 +252,7 @@ async function buildExporter(): Promise<HeadlessExporter> {
 
   return {
     async render(canvas, options) {
-      const svg = buildSvg(canvas, options, measure)
+      const { svg, scene } = buildSvg(canvas, options, measure)
       const scale = options.scale ?? 1
       // A non-finite, zero, or negative scale is not a valid zoom factor for
       // resvg (it throws on a zero/negative target size) — degrade to an
@@ -232,10 +274,16 @@ async function buildExporter(): Promise<HeadlessExporter> {
         width: png.width,
         height: png.height,
         undrawable,
+        unresolvedFamilies: await reportUnresolvedFamilies(scene),
       }
     },
     async renderSvg(canvas, options) {
-      return { svg: buildSvg(canvas, options, measure), undrawable: await reportUndrawable(canvas) }
+      const { svg, scene } = buildSvg(canvas, options, measure)
+      return {
+        svg,
+        undrawable: await reportUndrawable(canvas),
+        unresolvedFamilies: await reportUnresolvedFamilies(scene),
+      }
     },
   }
 }
@@ -247,6 +295,17 @@ async function buildExporter(): Promise<HeadlessExporter> {
  * per-character case, and it is logged per render because it depends on the
  * canvas rather than on the install.
  */
+async function reportUnresolvedFamilies(scene: Scene): Promise<readonly string[]> {
+  const families = unresolvedFamilies(scene, await availableFamilies())
+  if (families.length > 0) {
+    log.warning(
+      { families },
+      'export declared font families no loaded face provides; drawn in the fallback',
+    )
+  }
+  return families
+}
+
 async function reportUndrawable(canvas: SpatialCanvas): Promise<readonly string[]> {
   const undrawable = await undrawableCharacters(canvas)
   if (undrawable.length > 0) {

--- a/packages/mcp-server/src/server/export/unresolved-families.test.ts
+++ b/packages/mcp-server/src/server/export/unresolved-families.test.ts
@@ -1,0 +1,67 @@
+import type { Scene } from '@kamiazya/whiteboard-canvas-render'
+import { describe, expect, it } from 'vitest'
+import { unresolvedFamilies } from './unresolved-families.js'
+
+const run = (fontFamily: string) => ({
+  kind: 'textRun' as const,
+  bbox: { x: 0, y: 0, w: 10, h: 10 },
+  baseline: 8,
+  text: 'x',
+  appearance: { fontFamily },
+})
+const scene = (...families: string[]): Scene => ({ nodes: families.map(run) }) as unknown as Scene
+
+describe('the families a render declared but could not resolve', () => {
+  it('says nothing when every declared family is loaded', () => {
+    expect(unresolvedFamilies(scene('Roboto'), ['Roboto'])).toEqual([])
+  })
+
+  it('names a family no loaded face provides', () => {
+    expect(unresolvedFamilies(scene('Roboto', 'Comic Sans'), ['Roboto'])).toEqual(['Comic Sans'])
+  })
+
+  it('accepts a CSS chain when ANY name in it is loaded, as resvg does', () => {
+    expect(unresolvedFamilies(scene('Menlo, Roboto, monospace'), ['Roboto'])).toEqual([])
+  })
+
+  // The case that exists today: a fenced code run declares the mono chain the
+  // markdown theme carries, and the export has only the vendored Latin face.
+  it('reports the markdown mono chain against a Roboto-only export', () => {
+    const mono =
+      'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace'
+    expect(unresolvedFamilies(scene('Roboto', mono), ['Roboto'])).toEqual([mono])
+  })
+
+  it('does not count a generic keyword as a resolution, because no face backs it', () => {
+    expect(unresolvedFamilies(scene('monospace'), ['Roboto'])).toEqual(['monospace'])
+  })
+
+  it('strips quotes and matches case-insensitively', () => {
+    expect(unresolvedFamilies(scene('"Roboto Mono"'), ['roboto mono'])).toEqual([])
+  })
+
+  it('reports each distinct declaration once, in first-seen order', () => {
+    const s = scene('A', 'B', 'A')
+    expect(unresolvedFamilies(s, ['Roboto'])).toEqual(['A', 'B'])
+  })
+
+  it('walks nested runs, which is where code and table text live', () => {
+    const nested = {
+      nodes: [
+        { kind: 'codeBlock', bbox: { x: 0, y: 0, w: 1, h: 1 }, runs: [run('Mono')] },
+        {
+          kind: 'table',
+          bbox: { x: 0, y: 0, w: 1, h: 1 },
+          rows: [{ cells: [{ runs: [run('Cell')] }] }],
+        },
+      ],
+    } as unknown as Scene
+    expect(unresolvedFamilies(nested, ['Roboto'])).toEqual(['Mono', 'Cell'])
+  })
+
+  it('says nothing when no face was loaded at all, matching undrawable', () => {
+    // No parsed face means the render already degraded to system fonts, which
+    // is logged where it happens; a second, louder report there would be wrong.
+    expect(unresolvedFamilies(scene('Roboto'), [])).toEqual([])
+  })
+})

--- a/packages/mcp-server/src/server/export/unresolved-families.ts
+++ b/packages/mcp-server/src/server/export/unresolved-families.ts
@@ -1,0 +1,71 @@
+import type { Scene, SceneNode } from '@kamiazya/whiteboard-canvas-render'
+
+/**
+ * The font families this render DECLARED and the renderer could not provide.
+ *
+ * `undrawableCharacters` answers the other half of ADR-0011 decision 3 — "the
+ * resolved font set is part of the render contract, and is reported" — and it
+ * is family-blind by construction: it asks whether ANY loaded face has a
+ * glyph, never whether the face a run NAMED was among them. So a run declaring
+ * a family nobody installed reports nothing, renders in the fallback, and
+ * looks correct: every character present, the wrong face, and silence.
+ *
+ * That is exactly the "silent variation by ambient state" the ADR calls the
+ * failure class this repo keeps paying for, arriving through the one door its
+ * report could not see. It costs something today: a fenced code block declares
+ * the markdown theme's mono chain, and a Roboto-only export resolves none of
+ * it.
+ *
+ * Deliberately about DECLARATIONS, not about what a reader loses. A missing
+ * family still draws readable text in the fallback face, which is why this is
+ * a separate answer from `undrawable` rather than folded into it.
+ */
+export function unresolvedFamilies(
+  scene: Scene,
+  availableFamilies: readonly string[],
+): readonly string[] {
+  // No face at all means the render already degraded to system fonts, which is
+  // logged where it happens. Every declaration would be "unresolved" there,
+  // which is a louder and less true answer than saying nothing — the same rule
+  // `undrawableCharacters` follows.
+  if (availableFamilies.length === 0) return []
+  const available = new Set(availableFamilies.map(normalize))
+  const seen = new Set<string>()
+  const unresolved: string[] = []
+  const visit = (node: unknown): void => {
+    if (node === null || typeof node !== 'object') return
+    const entry = node as SceneNode & {
+      appearance?: { fontFamily?: string }
+      runs?: unknown[]
+      children?: unknown[]
+      items?: unknown[]
+      cells?: unknown[]
+      rows?: unknown[]
+    }
+    const declared = entry.appearance?.fontFamily
+    if (declared !== undefined && declared !== '' && !seen.has(declared)) {
+      seen.add(declared)
+      // A CSS chain is a preference list, and resvg takes the first name it
+      // has — so the declaration is resolved if ANY name in it is loaded. A
+      // generic keyword is not a resolution: nothing here backs `monospace`
+      // with a real face, which is the whole point of reporting this.
+      if (!splitFamilies(declared).some((name) => available.has(name))) unresolved.push(declared)
+    }
+    for (const key of ['runs', 'children', 'items', 'cells', 'rows'] as const) {
+      for (const child of entry[key] ?? []) visit(child)
+    }
+  }
+  for (const node of scene.nodes) visit(node)
+  return unresolved
+}
+
+function splitFamilies(declared: string): string[] {
+  return declared.split(',').map(normalize)
+}
+
+function normalize(name: string): string {
+  return name
+    .trim()
+    .replace(/^["']|["']$/g, '')
+    .toLowerCase()
+}

--- a/packages/mcp-server/src/server/routes/document/export-svg.test.ts
+++ b/packages/mcp-server/src/server/routes/document/export-svg.test.ts
@@ -31,7 +31,11 @@ const mockExportCanvasHeadlessSvg =
       workspaceId: string
       path: string
       options?: { padding?: number; frameId?: string; theme?: 'light' | 'dark' }
-    }) => Promise<{ svg: string; undrawable: readonly string[] }>
+    }) => Promise<{
+      svg: string
+      undrawable: readonly string[]
+      unresolvedFamilies: readonly string[]
+    }>
   >()
 vi.mock('../../export/headless-export.js', () => ({
   exportCanvasHeadlessSvg: (args: {
@@ -55,7 +59,11 @@ describe('POST /api/w/:workspaceId/document/:path/export-svg', () => {
     mockExportCanvasHeadlessSvg.mockReset()
     mockDocumentExists.mockReset()
     mockDocumentExists.mockResolvedValue(true)
-    mockExportCanvasHeadlessSvg.mockResolvedValue({ svg: '<svg><rect/></svg>', undrawable: [] })
+    mockExportCanvasHeadlessSvg.mockResolvedValue({
+      svg: '<svg><rect/></svg>',
+      undrawable: [],
+      unresolvedFamilies: [],
+    })
   })
 
   afterEach(async () => {
@@ -100,6 +108,7 @@ describe('POST /api/w/:workspaceId/document/:path/export-svg', () => {
     mockExportCanvasHeadlessSvg.mockResolvedValue({
       svg: '<svg><rect/></svg>',
       undrawable: ['日'],
+      unresolvedFamilies: [],
     })
 
     const res = await makeApp().request('/api/w/s1/document/canvas-a/export-svg', {

--- a/packages/mcp-server/src/server/routes/document/export-svg.ts
+++ b/packages/mcp-server/src/server/routes/document/export-svg.ts
@@ -89,6 +89,7 @@ export function createDocumentSvgExportRouter() {
 
       let svg: string
       let undrawable: readonly string[]
+      let unresolvedFamilies: readonly string[]
       try {
         const result = await exportCanvasHeadlessSvg({
           workspaceId,
@@ -97,6 +98,7 @@ export function createDocumentSvgExportRouter() {
         })
         svg = result.svg
         undrawable = result.undrawable
+        unresolvedFamilies = result.unresolvedFamilies
       } catch (err) {
         const errBody: ExportErrorBody = {
           error: 'headless_export_failed',
@@ -111,7 +113,11 @@ export function createDocumentSvgExportRouter() {
       // Typed rather than a bare literal so the contract, not this handler,
       // decides what an export answers with — the PNG route and this one had
       // already drifted into two different response shapes.
-      const response: ExportResponse = { filePath, undrawable: [...undrawable] }
+      const response: ExportResponse = {
+        filePath,
+        undrawable: [...undrawable],
+        unresolvedFamilies: [...unresolvedFamilies],
+      }
       return c.json(response)
     },
     bodyLimit({

--- a/packages/mcp-server/src/server/routes/export.test.ts
+++ b/packages/mcp-server/src/server/routes/export.test.ts
@@ -47,6 +47,7 @@ const mockExportCanvasHeadless =
       width: number
       height: number
       undrawable: readonly string[]
+      unresolvedFamilies: readonly string[]
     }>
   >()
 
@@ -109,6 +110,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       width: 100,
       height: 50,
       undrawable: [],
+      unresolvedFamilies: [],
     })
     const app = makeApp()
 
@@ -133,6 +135,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       width: 100,
       height: 50,
       undrawable: [],
+      unresolvedFamilies: [],
     })
 
     mockGetClientCount.mockReturnValue(0)
@@ -163,6 +166,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       width: 100,
       height: 50,
       undrawable: [],
+      unresolvedFamilies: [],
     })
     const app = makeApp()
     vi.useFakeTimers()
@@ -215,7 +219,14 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       () =>
         new Promise((resolve) => {
           setTimeout(
-            () => resolve({ png: Buffer.from('slow-png'), width: 10, height: 10, undrawable: [] }),
+            () =>
+              resolve({
+                png: Buffer.from('slow-png'),
+                width: 10,
+                height: 10,
+                undrawable: [],
+                unresolvedFamilies: [],
+              }),
             50,
           )
         }),
@@ -231,6 +242,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       width: 100,
       height: 50,
       undrawable: [],
+      unresolvedFamilies: [],
     })
     const app = makeApp()
 
@@ -251,6 +263,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       width: 100,
       height: 50,
       undrawable: [],
+      unresolvedFamilies: [],
     })
     const app = makeApp()
 
@@ -276,6 +289,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       width: 100,
       height: 50,
       undrawable: [],
+      unresolvedFamilies: [],
     })
     const app = makeApp()
 
@@ -325,6 +339,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       width: 100,
       height: 50,
       undrawable: [],
+      unresolvedFamilies: [],
     })
     const app = makeApp()
 
@@ -347,6 +362,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       width: 1,
       height: 1,
       undrawable: [],
+      unresolvedFamilies: [],
     })
     const app = makeApp()
 
@@ -365,6 +381,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       width: 1,
       height: 1,
       undrawable: ['日', '本'],
+      unresolvedFamilies: [],
     })
 
     const res = await makeApp().request('/api/w/s1/document/canvas-a/export', { method: 'POST' })
@@ -380,6 +397,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       width: 1,
       height: 1,
       undrawable: [],
+      unresolvedFamilies: [],
     })
 
     const res = await makeApp().request('/api/w/s1/document/canvas-a/export', { method: 'POST' })
@@ -399,12 +417,19 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
     vi.mocked(nanoid).mockReturnValueOnce('aaaaaa').mockReturnValueOnce('aaaaaa')
 
     mockExportCanvasHeadless
-      .mockResolvedValueOnce({ png: Buffer.from('first-png'), width: 1, height: 1, undrawable: [] })
+      .mockResolvedValueOnce({
+        png: Buffer.from('first-png'),
+        width: 1,
+        height: 1,
+        undrawable: [],
+        unresolvedFamilies: [],
+      })
       .mockResolvedValueOnce({
         png: Buffer.from('second-png'),
         width: 1,
         height: 1,
         undrawable: [],
+        unresolvedFamilies: [],
       })
     const app = makeApp()
     vi.useFakeTimers()
@@ -432,6 +457,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       width: 1,
       height: 1,
       undrawable: [],
+      unresolvedFamilies: [],
     })
     const app = makeApp()
 
@@ -465,6 +491,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       width: 1,
       height: 1,
       undrawable: [],
+      unresolvedFamilies: [],
     })
     const app = makeApp()
     const outputPath = join(tempDir, 's1', 'exports', 'subdir', 'custom.excalidraw.png')
@@ -571,6 +598,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       width: 1,
       height: 1,
       undrawable: [],
+      unresolvedFamilies: [],
     })
     const app = makeApp()
     const outputPath = join(tempDir, 's1', 'exports', 'pre-existing.png')
@@ -594,6 +622,7 @@ describe('POST /api/w/:workspaceId/document/:path/export - error handling', () =
       width: 1,
       height: 1,
       undrawable: [],
+      unresolvedFamilies: [],
     })
     const app = makeApp()
     const outputPath = join(tempDir, 's1', 'exports', 'replace.png')

--- a/packages/mcp-server/src/server/routes/export.ts
+++ b/packages/mcp-server/src/server/routes/export.ts
@@ -91,8 +91,13 @@ export function createExportRouter() {
 
       let pngBuffer: Buffer
       let undrawable: readonly string[]
+      let unresolvedFamilies: readonly string[]
       try {
-        ;({ png: pngBuffer, undrawable } = await renderHeadless(workspaceId, path, body))
+        ;({
+          png: pngBuffer,
+          undrawable,
+          unresolvedFamilies,
+        } = await renderHeadless(workspaceId, path, body))
       } catch (err) {
         const errBody: ExportErrorBody = {
           error: 'headless_export_failed',
@@ -105,7 +110,11 @@ export function createExportRouter() {
         outputPath !== undefined
           ? await writeExplicitOutput(outputPath, pngBuffer)
           : await writeDefaultOutput(workspaceId, path, pngBuffer)
-      const response: ExportResponse = { filePath, undrawable: [...undrawable] }
+      const response: ExportResponse = {
+        filePath,
+        undrawable: [...undrawable],
+        unresolvedFamilies: [...unresolvedFamilies],
+      }
       return c.json(response)
     },
     bodyLimit({
@@ -128,7 +137,11 @@ async function renderHeadless(
   workspaceId: string,
   path: string,
   body: z.infer<typeof exportRequestSchema>,
-): Promise<{ png: Buffer; undrawable: readonly string[] }> {
+): Promise<{
+  png: Buffer
+  undrawable: readonly string[]
+  unresolvedFamilies: readonly string[]
+}> {
   const result = await exportCanvasHeadless({
     workspaceId,
     path,
@@ -140,7 +153,11 @@ async function renderHeadless(
       theme: body.theme,
     },
   })
-  return { png: result.png, undrawable: result.undrawable }
+  return {
+    png: result.png,
+    undrawable: result.undrawable,
+    unresolvedFamilies: result.unresolvedFamilies,
+  }
 }
 
 // A plain PNG: the headless renderer no longer embeds scene JSON, so a

--- a/packages/mcp-server/src/shared/api-contracts/export.ts
+++ b/packages/mcp-server/src/shared/api-contracts/export.ts
@@ -37,6 +37,21 @@ export const exportResponseSchema = z.object({
    * `POST /api/fonts/:id/install` (ADR-0012).
    */
   undrawable: z.array(z.string()),
+  /**
+   * Font families this render DECLARED that no loaded face provides. resvg
+   * drew them in the fallback, so unlike `undrawable` nothing is missing on
+   * the page — the text is legible and in the wrong face, which is why it
+   * needs saying rather than showing.
+   *
+   * The other half of ADR-0011 decision 3: the resolved font set is part of
+   * the render contract. `undrawable` is family-blind by construction — it
+   * asks whether ANY loaded face has a glyph, never whether the face a run
+   * named was among them — so this is the door that report cannot see
+   * through. Empty is the normal answer.
+   *
+   * Install a family with `POST /api/fonts/:id/install` (ADR-0012).
+   */
+  unresolvedFamilies: z.array(z.string()),
 })
 
 // Shared error body. The route emits this for invalid_request /


### PR DESCRIPTION
## Summary

ADR-0011 decision 3 makes the resolved font set part of the render contract and requires it be reported. `undrawableCharacters` answers half of that, and is **family-blind by construction**: it asks whether ANY loaded face has a glyph, never whether the face a run *named* was among them.

So a run declaring a family nobody installed reports nothing and renders in the fallback — every character present, the wrong face, and silence. That is the ADR's own *"silent variation by ambient state"*, arriving through the one door its report cannot see through.

**It costs something today, not hypothetically.** A fenced code block declares the markdown theme's mono chain, and a Roboto-only export resolves none of it — so every exported code block is proportional and nothing says so:

```
undrawable          []
unresolvedFamilies  ['ui-monospace, SFMono-Regular, "SF Mono", Menlo, …, monospace']
```

## Design notes

- **A CSS chain is a preference list**, and resvg takes the first name it has — so a declaration counts as resolved when ANY name in it is loaded.
- **A generic keyword is not a resolution.** Nothing here backs `monospace` with a real face, which is the whole point of the report.
- **A render with no parsed face at all answers `[]`**, the same rule `undrawableCharacters` follows: everything would be "unresolved" there, which is louder and less true than silence.
- **`undrawable` is not extended, and this is not folded into it.** A missing family still draws readable text; a missing glyph does not. Two different losses deserve two answers.
- `buildSvg` returns the scene it built rather than only the string — answering this by laying the canvas out a second time would cost the whole of layout for a report.

## Two things the first attempt got wrong

Both found by printing values rather than by reading code, and both would have shipped a feature that was **silently inert**:

1. **The family name is not at opentype's typed `names.fontFamily`.** The vendored Roboto carries it under `names.windows`, and the typed path is `undefined` there. Reading only it returned no families at all, so every declaration resolved against an empty set and the report came back empty — measured as `fonts=1 families=` while the declaration was sitting right there.
2. **The quiet-case test passed for that same reason.** With no families loaded the function returns `[]` for every canvas by design, so "says nothing for plain prose" held while the machinery was dead. It now asserts a face was actually loaded before claiming the report *chose* to stay quiet.

## Test plan

- [x] `unresolved-families.test.ts` — 9 unit tests; mutation-checked (forcing `[]` fails 5, removing chain-splitting fails 1).
- [x] End-to-end through the real exporter: the mono chain is reported while `undrawable` stays empty; mutation-checked (forcing `[]` fails it).
- [x] `mcp-node` **3628 passed**. `pnpm -r typecheck` clean, `pnpm knip` clean, `pnpm lint` 5 warnings all pre-existing in untouched files.
- [x] The response contract is extended once in Zod and flows to both routes — the type checker caught the SVG route, which is the guard working.

Two unrelated tests failed once under full-suite load (`startup.smoke-impl`, and a blob-chunking migration test that takes 8.5s alone and timed out at 13.1s). Both pass in isolation and the suite is green on re-run.

## Follow-up this makes visible rather than fixes

The mono chain should be **one family name**, per ADR-0011 decision 1 — the theme names a family, a font package provides the faces. Changing it needs a face to name (`Roboto Mono` inherits decision 6's licensing precedent exactly), because naming one nobody has would regress the browser, where the chain currently resolves. This PR is the instrument that makes that change measurable.

## Checklist

- [x] Commit message follows Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema
