### PR TITLE
feat(canvas-render): hoist shared inherited paint attributes onto their group

### DIFF
--- a/packages/canvas-render/src/svg/backend.test.ts
+++ b/packages/canvas-render/src/svg/backend.test.ts
@@ -494,8 +494,11 @@ describe('renderSceneToSvg — appearance on textRun and edge', () => {
       ],
     }
     const svg = renderSceneToSvg(scene)
+    // The run's appearance rides the enclosing group via SVG inheritance
+    // (attribute hoisting); the non-inherited text-decoration stays on the
+    // <text>, and the link wrapper still wraps.
     expect(svg).toContain(
-      '<a href="https://example.com"><text x="0" y="0" fill="#111" font-family="Inter" font-size="14" text-decoration="underline">styled link</text></a>',
+      '<g fill="#111" font-family="Inter" font-size="14"><a href="https://example.com"><text x="0" y="0" text-decoration="underline">styled link</text></a></g>',
     )
   })
 

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -16,9 +16,9 @@ import type {
   TextRunNode,
 } from '../scene-graph.js'
 import { collectDefs } from './defs.js'
-import { hoistInheritedAttrs } from './hoist.js'
 import type { PaintAttrs, SvgBoxAttrs, TextEmphasisAttrs } from './elements.js'
 import { formatCoord, sanitizeHref, trustedHref } from './format.js'
+import { hoistInheritedAttrs } from './hoist.js'
 import { serializeSvg } from './serialize.js'
 import { el, rawXml, type SvgChild, type SvgDef, withDefs } from './vnode.js'
 

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -16,6 +16,7 @@ import type {
   TextRunNode,
 } from '../scene-graph.js'
 import { collectDefs } from './defs.js'
+import { hoistInheritedAttrs } from './hoist.js'
 import type { PaintAttrs, SvgBoxAttrs, TextEmphasisAttrs } from './elements.js'
 import { formatCoord, sanitizeHref, trustedHref } from './format.js'
 import { serializeSvg } from './serialize.js'
@@ -612,7 +613,9 @@ const SVG_XMLNS = 'http://www.w3.org/2000/svg'
  * no-visual-attributes rule) when `background` is set.
  */
 export function renderSceneToSvg(scene: Scene, options?: SvgDocumentOptions): string {
-  const body = scene.nodes.map(renderNode)
+  // Hoisting runs before defs collection only by convention — it preserves
+  // `defs` declarations on rebuilt nodes, so the order is not load-bearing.
+  const body = scene.nodes.map(renderNode).map(hoistInheritedAttrs)
   // Presence-only, exactly like an absent appearance attribute: a scene
   // declaring no definitions emits the same bytes it always has.
   const collected = collectDefs(body)

--- a/packages/canvas-render/src/svg/hoist.test.ts
+++ b/packages/canvas-render/src/svg/hoist.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { hoistInheritedAttrs } from './hoist.js'
+import { serializeSvg } from './serialize.js'
+import type { SvgAttrs, SvgAttrValue, SvgChild, SvgVNode } from './vnode.js'
+import { rawXml } from './vnode.js'
+
+// Built as plain literals (not `el`) so tests and generators can compose
+// arbitrary attr combinations without satisfying the per-element table.
+const node = (tag: string, attrs?: SvgAttrs, children?: readonly SvgChild[]): SvgVNode => ({
+  tag,
+  ...(attrs === undefined ? {} : { attrs }),
+  ...(children === undefined ? {} : { children }),
+})
+
+const asSvg = (child: SvgChild): string => serializeSvg(node('svg', undefined, [child]))
+
+describe('hoistInheritedAttrs', () => {
+  it('hoists paint attrs shared by every direct child onto the group, in canonical order', () => {
+    const g = node('g', undefined, [
+      node('text', { x: 0, y: 0, fill: '#404040', 'font-family': 'Roboto', 'font-size': 16 }, [
+        'a',
+      ]),
+      node('text', { x: 0, y: 20, fill: '#404040', 'font-family': 'Roboto', 'font-size': 16 }, [
+        'b',
+      ]),
+    ])
+    expect(asSvg(hoistInheritedAttrs(g))).toBe(
+      '<svg><g fill="#404040" font-family="Roboto" font-size="16"><text x="0" y="0">a</text><text x="0" y="20">b</text></g></svg>',
+    )
+  })
+
+  it('does not hoist an attr some child lacks — that child would start inheriting it', () => {
+    const g = node('g', undefined, [
+      node('text', { x: 0, y: 0, fill: '#404040' }, ['a']),
+      node('rect', { x: 0, y: 0, width: 1, height: 1 }),
+    ])
+    expect(asSvg(hoistInheritedAttrs(g))).toBe(asSvg(g))
+  })
+
+  it('does not hoist when values differ', () => {
+    const g = node('g', undefined, [
+      node('text', { x: 0, y: 0, fill: '#111111' }, ['a']),
+      node('text', { x: 0, y: 20, fill: '#222222' }, ['b']),
+    ])
+    expect(asSvg(hoistInheritedAttrs(g))).toBe(asSvg(g))
+  })
+
+  it('keeps role as the last attribute on the receiving group', () => {
+    const g = node('g', { role: 'presentation' }, [
+      node('text', { x: 0, y: 0, fill: '#404040' }, ['a']),
+      node('text', { x: 0, y: 20, fill: '#404040' }, ['b']),
+    ])
+    expect(asSvg(hoistInheritedAttrs(g))).toBe(
+      '<svg><g fill="#404040" role="presentation"><text x="0" y="0">a</text><text x="0" y="20">b</text></g></svg>',
+    )
+  })
+
+  it('strips children matching a value the parent already declares, and leaves a differing parent value alone', () => {
+    const matching = node('g', { fill: '#404040' }, [
+      node('text', { x: 0, y: 0, fill: '#404040' }, ['a']),
+    ])
+    expect(asSvg(hoistInheritedAttrs(matching))).toBe(
+      '<svg><g fill="#404040"><text x="0" y="0">a</text></g></svg>',
+    )
+    const differing = node('g', { fill: '#111111' }, [
+      node('text', { x: 0, y: 0, fill: '#404040' }, ['a']),
+    ])
+    expect(asSvg(hoistInheritedAttrs(differing))).toBe(asSvg(differing))
+  })
+
+  it('composes bottom-up through nested containers (a inside g)', () => {
+    const g = node('g', undefined, [
+      node('a', { href: '#x' }, [node('text', { x: 0, y: 0, fill: '#404040' }, ['a'])]),
+      node('text', { x: 0, y: 20, fill: '#404040' }, ['b']),
+    ])
+    expect(asSvg(hoistInheritedAttrs(g))).toBe(
+      '<svg><g fill="#404040"><a href="#x"><text x="0" y="0">a</text></a><text x="0" y="20">b</text></g></svg>',
+    )
+  })
+
+  it('a rawXml child blocks hoisting — its computed style cannot be inspected', () => {
+    const g = node('g', undefined, [
+      node('text', { x: 0, y: 0, fill: '#404040' }, ['a']),
+      rawXml('<circle r="1"/>'),
+    ])
+    expect(asSvg(hoistInheritedAttrs(g))).toBe(asSvg(g))
+  })
+
+  it('preserves defs declarations on rebuilt nodes', () => {
+    const def = { id: 'd', node: node('mask', { id: 'd' }) }
+    const g = node('g', undefined, [
+      { ...node('text', { x: 0, y: 0, fill: '#404040' }, ['a']), defs: [def] },
+      node('text', { x: 0, y: 20, fill: '#404040' }, ['b']),
+    ])
+    const hoisted = hoistInheritedAttrs(g) as SvgVNode
+    const [first] = hoisted.children ?? []
+    expect((first as SvgVNode).defs).toEqual([def])
+  })
+})
+
+// --- property: hoisting never changes any element's computed paint ---
+
+const HOISTABLE = [
+  'fill',
+  'stroke',
+  'stroke-width',
+  'font-family',
+  'font-size',
+  'fill-opacity',
+  'stroke-opacity',
+] as const
+
+type Resolved = {
+  readonly tag: string
+  /** Computed paint — recorded only for PAINTING elements. A container's
+   * own computed paint legitimately changes when it receives a hoisted
+   * attribute (a `g`/`a` paints nothing itself); what must be invariant is
+   * what its descendants resolve to. */
+  readonly paint: Readonly<Record<string, SvgAttrValue>> | undefined
+  readonly rest: Readonly<Record<string, SvgAttrValue>>
+  readonly text: string
+}
+
+const CONTAINER_TAGS = new Set(['g', 'a'])
+
+/** Independent oracle: expands inheritance the way SVG does (nearest ancestor wins). */
+function resolvePaint(
+  child: SvgChild,
+  inherited: Readonly<Record<string, SvgAttrValue>>,
+  out: Resolved[],
+): void {
+  if (typeof child === 'string') return
+  // Array.isArray does not narrow a readonly-array union member away in its
+  // false branch, so the element case needs its own guard.
+  if (Array.isArray(child)) {
+    for (const inner of child as ReadonlyArray<SvgChild>) resolvePaint(inner, inherited, out)
+    return
+  }
+  if (!('tag' in child)) return
+  const attrs = child.attrs ?? {}
+  const paint: Record<string, SvgAttrValue> = { ...inherited }
+  const rest: Record<string, SvgAttrValue> = {}
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value === undefined) continue
+    if ((HOISTABLE as readonly string[]).includes(key)) paint[key] = value
+    else rest[key] = value
+  }
+  const text = (child.children ?? []).filter((c): c is string => typeof c === 'string').join('')
+  out.push({ tag: child.tag, paint: CONTAINER_TAGS.has(child.tag) ? undefined : paint, rest, text })
+  for (const inner of child.children ?? []) resolvePaint(inner, paint, out)
+}
+
+const paintArb = fc.record(
+  {
+    fill: fc.constantFrom('#111111', '#404040'),
+    'font-family': fc.constantFrom('Roboto', 'serif'),
+    'font-size': fc.constantFrom(14, 16),
+    'stroke-width': fc.constantFrom(1, 2),
+  },
+  { requiredKeys: [] },
+)
+
+const leafArb: fc.Arbitrary<SvgVNode> = fc.oneof(
+  paintArb.map((paint) => node('text', { x: 0, y: 0, ...paint }, ['t'])),
+  paintArb.map((paint) => node('rect', { x: 0, y: 0, width: 1, height: 1, ...paint })),
+)
+
+const treeArb: fc.Arbitrary<SvgVNode> = fc.letrec<{ tree: SvgVNode }>((tie) => ({
+  tree: fc.oneof(
+    { maxDepth: 3, withCrossShrink: true },
+    leafArb,
+    fc
+      .tuple(
+        fc.constantFrom('g', 'a'),
+        paintArb,
+        fc.option(fc.constant('presentation' as const), { nil: undefined }),
+        fc.array(tie('tree'), { maxLength: 4 }),
+      )
+      .map(([tag, paint, role, children]) =>
+        node(tag, { ...paint, ...(role === undefined ? {} : { role }) }, children),
+      ),
+  ),
+})).tree
+
+describe('hoistInheritedAttrs (PBT)', () => {
+  fcTest.prop([treeArb], withDefaults())(
+    'preserves every element sequence, computed paint, and non-paint attrs',
+    (tree) => {
+      const before: Resolved[] = []
+      const after: Resolved[] = []
+      resolvePaint(tree, {}, before)
+      resolvePaint(hoistInheritedAttrs(tree), {}, after)
+      expect(after).toEqual(before)
+    },
+  )
+
+  fcTest.prop([treeArb], withDefaults())('is idempotent', (tree) => {
+    const once = hoistInheritedAttrs(tree)
+    expect(hoistInheritedAttrs(once)).toEqual(once)
+  })
+})

--- a/packages/canvas-render/src/svg/hoist.ts
+++ b/packages/canvas-render/src/svg/hoist.ts
@@ -1,0 +1,159 @@
+/**
+ * Hoists inherited paint attributes shared by every child of a container
+ * (`<g>`/`<a>`) onto the container itself — the SVG-inheritance form of
+ * deduplication, measured at ~30-40% of a realistic document's raw bytes
+ * (96 identical `fill font-family font-size` clusters on one 40-node
+ * canvas). Pure VNode→VNode; painted output is provably unchanged (the
+ * computed-paint equivalence property in hoist.test.ts).
+ *
+ * The soundness rule: an attribute is lifted only when EVERY direct child
+ * is an element that declares it with the SAME value. A child lacking the
+ * attribute blocks the lift — it would otherwise start inheriting a value
+ * it never declared — and an opaque `rawXml` child blocks all lifting for
+ * its container, since its computed style cannot be inspected. Nearest-
+ * ancestor-wins keeps differing descendants untouched. Bottom-up
+ * application lets lifts compose through nested containers.
+ */
+
+import type { SvgAttrs, SvgAttrValue, SvgChild, SvgDef, SvgVNode } from './vnode.js'
+
+/** The SVG-inherited presentation attributes this backend emits. `role`,
+ * `mask`, and `xml:space` are deliberately absent: not inheritance-safe
+ * (`role`), not inherited (`mask`), or content semantics (`xml:space`). */
+const HOISTABLE = [
+  'fill',
+  'stroke',
+  'stroke-width',
+  'font-family',
+  'font-size',
+  'fill-opacity',
+  'stroke-opacity',
+] as const
+
+/** Containers legal to receive inherited paint and emitted by this backend. */
+const CONTAINERS = new Set(['g', 'a'])
+
+function isVNode(child: SvgChild): child is SvgVNode {
+  return typeof child === 'object' && child !== null && 'tag' in child
+}
+
+function rebuild(
+  node: SvgVNode,
+  attrs: SvgAttrs | undefined,
+  children: ReadonlyArray<SvgChild> | undefined,
+): SvgVNode {
+  const defs: { defs?: ReadonlyArray<SvgDef> } = node.defs === undefined ? {} : { defs: node.defs }
+  return {
+    tag: node.tag,
+    ...(attrs === undefined ? {} : { attrs }),
+    ...(children === undefined ? {} : { children }),
+    ...defs,
+  }
+}
+
+function withoutAttrs(node: SvgVNode, names: ReadonlySet<string>): SvgVNode {
+  if (node.attrs === undefined || names.size === 0) return node
+  const attrs = Object.fromEntries(Object.entries(node.attrs).filter(([name]) => !names.has(name)))
+  return rebuild(node, attrs, node.children)
+}
+
+/** `role` stays the last attribute — the canonical position it has always
+ * had on this backend's container elements. */
+function withHoisted(node: SvgVNode, hoisted: ReadonlyMap<string, SvgAttrValue>): SvgVNode {
+  if (hoisted.size === 0) return node
+  const existing = Object.entries(node.attrs ?? {})
+  const attrs: Record<string, SvgAttrValue> = Object.fromEntries(
+    existing.filter(([name]) => name !== 'role'),
+  )
+  for (const name of HOISTABLE) {
+    const value = hoisted.get(name)
+    if (value !== undefined) attrs[name] = value
+  }
+  const role = existing.find(([name]) => name === 'role')
+  if (role !== undefined) attrs.role = role[1]
+  return rebuild(node, attrs, node.children)
+}
+
+function flatten(children: ReadonlyArray<SvgChild>): SvgChild[] {
+  const out: SvgChild[] = []
+  for (const child of children) {
+    if (Array.isArray(child)) out.push(...flatten(child))
+    else out.push(child)
+  }
+  return out
+}
+
+type ChangeFlag = { changed: boolean }
+
+function hoistContainer(container: SvgVNode, flag: ChangeFlag): SvgVNode {
+  const children = flatten(container.children ?? [])
+  const elements = children.filter(isVNode)
+  // A non-element child (text, rawXml) cannot be inspected or is content —
+  // lifting anything past it is unsound, so the container is left alone.
+  if (elements.length === 0 || elements.length !== children.length) {
+    return rebuild(container, container.attrs, children)
+  }
+
+  const lift = new Map<string, SvgAttrValue>()
+  const strip = new Set<string>()
+  for (const name of HOISTABLE) {
+    const first = elements[0]?.attrs?.[name]
+    if (first === undefined) continue
+    if (!elements.every((element) => element.attrs?.[name] === first)) continue
+    const own = container.attrs?.[name]
+    if (own === undefined) {
+      lift.set(name, first)
+      strip.add(name)
+    } else if (own === first) {
+      // The parent already declares the same value: the copies are noise.
+      strip.add(name)
+    }
+  }
+  if (strip.size === 0) return rebuild(container, container.attrs, children)
+  flag.changed = true
+  return withHoisted(
+    rebuild(
+      container,
+      container.attrs,
+      children.map((child) => (isVNode(child) ? withoutAttrs(child, strip) : child)),
+    ),
+    lift,
+  )
+}
+
+function hoistOnce(child: SvgChild, flag: ChangeFlag): SvgChild {
+  if (typeof child === 'string') return child
+  if (Array.isArray(child)) return child.map((inner) => hoistOnce(inner, flag))
+  if (!isVNode(child)) return child
+  const node =
+    child.children === undefined
+      ? child
+      : rebuild(
+          child,
+          child.attrs,
+          child.children.map((inner) => hoistOnce(inner, flag)),
+        )
+  return CONTAINERS.has(node.tag) ? hoistContainer(node, flag) : node
+}
+
+/**
+ * Applies hoisting bottom-up through the whole tree, ITERATED TO A
+ * FIXPOINT. One bottom-up pass is not enough: stripping a nested
+ * container's attribute (because its parent lifted the same value) can
+ * make that container's own children newly uniform — an opportunity the
+ * pass already walked past. Verified by the shrunk counterexample
+ * `g[g{sw:1}[rect{sw:2}]]`, where a single pass is not idempotent. Each
+ * pass only moves attributes upward or deletes copies, so the iteration
+ * terminates; in practice it converges in one or two passes.
+ *
+ * Nested child arrays are flattened inside processed containers —
+ * byte-identical, since the serializer flattens them anyway.
+ */
+export function hoistInheritedAttrs(child: SvgChild): SvgChild {
+  let current = child
+  for (;;) {
+    const flag: ChangeFlag = { changed: false }
+    current = hoistOnce(current, flag)
+    if (!flag.changed) return current
+  }
+}

--- a/packages/canvas-render/src/test-utils/golden-scene.ts
+++ b/packages/canvas-render/src/test-utils/golden-scene.ts
@@ -179,7 +179,7 @@ export const SHAPE_APPEARANCE_GOLDEN_SVG =
   '<rect x="0" y="0" width="100" height="60" rx="8"/>' +
   '<rect x="120" y="0" width="100" height="60"/>' +
   '<rect x="240" y="0" width="100" height="60" rx="4" fill="#fff" stroke="#000" stroke-width="2"/>' +
-  '<g><text x="0" y="80" fill="#111" font-family="Inter" font-size="14">Styled</text></g>' +
+  '<g fill="#111" font-family="Inter" font-size="14"><text x="0" y="80">Styled</text></g>' +
   '<polyline points="0,120 100,120" fill="none" stroke="#888" stroke-width="1.5" role="presentation"/>' +
   '<polygon points="100,120 90,124 90,116" fill="#888" role="presentation"/>' +
   '</svg>'


### PR DESCRIPTION
## Summary

- `hoistInheritedAttrs` (`svg/hoist.ts`): a pure VNode→VNode pass, iterated to a fixpoint, lifting an inherited paint attribute onto a `<g>`/`<a>` container **only when every direct child declares it with the same value** — a child lacking the attribute blocks the lift (it would otherwise start inheriting a value it never declared), `rawXml` children block their container entirely, nearest-ancestor-wins keeps differing descendants untouched, `role` stays the container's last attribute, and `defs` declarations survive the rebuild.
- The fixpoint iteration is not decoration: one bottom-up pass is **not idempotent** — fast-check found and shrank `g[g{sw:1}[rect{sw:2}]]`, where stripping the inner container's value opens a hoisting opportunity the pass already walked past. The counterexample is recorded in the code.
- **Deliberate serializer-format change** (this stack's first bytes-changing layer): `SHAPE_APPEARANCE_GOLDEN_SVG` regenerated (a single-run paragraph's appearance now rides the `<g>`), and one `backend.test.ts` expectation follows.

Measured on a 40-node/55-edge canvas: **33,774 → 29,694 bytes (−12.1% raw, −2.6% gzip)**; render step 2.6ms → 3.5ms (layout at this scale is ~78ms, so ~1% of a committed change; the drag path's static layer is not re-rendered per frame).

Stack layer 4 — base is `claude/svg-generation-improvement-uigd90-3` (#928). Landing: top-PR-only merge, see #926.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — `svg/hoist.test.ts` (8 example cases red-first, plus two fast-check properties: paint-equivalence against an independent inheritance-expanding oracle, and idempotence — the pair that caught the fixpoint bug before it shipped)
- [x] `pnpm test` passes locally — canvas-render-node 766 passed; canvas-viewer node+jsdom 109 passed; mcp-node 3613 passed (its 4 failures are the known root-container chmod/EACCES simulations, byte-identical set to `origin/main` in this environment); apps/web jsdom 2605 passed (its 9 failures are daemon-fetch/objectURL environment artifacts, reproduced identically on a pristine `origin/main` worktree — CI's `test-jsdom` is green on this stack)
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable — not applicable; goldens + properties + pixel goldens are the regression net

Manual verification: full `canvas-render-browser` project in real Chromium — the determinism goldens match the regenerated strings, and the **pixel goldens pass unchanged**, which is the direct visual proof that bytes moved and pixels did not.

## Visual evidence

Pixel-invariant by construction and by test: `svg/pixel-golden.browser.test.ts` baselines are **untouched and green** in real Chromium. The paint-equivalence fast-check property is the same statement at the computed-style level.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — output SVG stays semantically identical; no documented contract names attribute placement
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kn5gTK3WGQcNrahPppzvHg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn5gTK3WGQcNrahPppzvHg)_