### PR TITLE
feat(canvas-render): add an injectable content cache for text-node bodies

### DIFF
--- a/packages/canvas-render/src/layout/spatial-canvas-content-cache.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas-content-cache.test.ts
@@ -1,0 +1,151 @@
+import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
+import { describe, expect, it, vi } from 'vitest'
+import type { MeasureText } from '../measure.js'
+import { createFakeMeasure } from '../test-utils/fake-measure.js'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { createSpatialTheme } from '../theme/spatial-theme.js'
+import type { FittedBlocks } from './mdast-blocks.js'
+import {
+  layoutSpatialCanvas,
+  type SpatialContentCache,
+  type SpatialLayoutOptions,
+} from './spatial-canvas.js'
+
+const textNode = (
+  id: string,
+  x: number,
+  y: number,
+  text: string,
+  size: { w?: number; h?: number } = {},
+): SpatialNode => ({
+  id,
+  type: 'text',
+  x,
+  y,
+  width: size.w ?? 240,
+  height: size.h ?? 140,
+  text,
+})
+
+function mapCache(): SpatialContentCache & { store: Map<string, FittedBlocks> } {
+  const store = new Map<string, FittedBlocks>()
+  return { store, get: (key) => store.get(key), set: (key, value) => store.set(key, value) }
+}
+
+function options(
+  overrides: Partial<SpatialLayoutOptions> = {},
+  measure: MeasureText = createFakeMeasure(),
+): SpatialLayoutOptions {
+  return { measure, appearance: createSpatialTheme({ mode: 'light' }), ...overrides }
+}
+
+function countingMeasure(): { measure: MeasureText; calls: () => number } {
+  const inner = createFakeMeasure()
+  let n = 0
+  return {
+    measure: (text, font) => {
+      n += 1
+      return inner(text, font)
+    },
+    calls: () => n,
+  }
+}
+
+const BODY = '# Title\n\nA paragraph long enough to wrap across a couple of lines in the box.'
+
+describe('layoutSpatialCanvas content cache', () => {
+  it('a warm cache reproduces the uncached scene exactly, including after a move', () => {
+    const canvas: SpatialCanvas = { nodes: [textNode('a', 40, 40, BODY)], edges: [] }
+    const cache = mapCache()
+    const cold = layoutSpatialCanvas(canvas, options({ contentCache: cache }))
+    expect(JSON.stringify(cold)).toBe(JSON.stringify(layoutSpatialCanvas(canvas, options())))
+
+    const moved: SpatialCanvas = { nodes: [textNode('a', 300, 500, BODY)], edges: [] }
+    const warm = layoutSpatialCanvas(moved, options({ contentCache: cache }))
+    expect(JSON.stringify(warm)).toBe(JSON.stringify(layoutSpatialCanvas(moved, options())))
+  })
+
+  it('a warm cache lays text-node content out without a single measure call', () => {
+    const canvas: SpatialCanvas = {
+      nodes: [textNode('a', 0, 0, BODY), textNode('b', 400, 0, `${BODY} And more.`)],
+      edges: [],
+    }
+    const cache = mapCache()
+    const cold = countingMeasure()
+    layoutSpatialCanvas(canvas, options({ contentCache: cache }, cold.measure))
+    expect(cold.calls()).toBeGreaterThan(0)
+
+    const warm = countingMeasure()
+    layoutSpatialCanvas(canvas, options({ contentCache: cache }, warm.measure))
+    expect(warm.calls()).toBe(0)
+  })
+
+  it('distinguishes text and box size in the key — a changed node recomputes', () => {
+    const cache = mapCache()
+    const base: SpatialCanvas = { nodes: [textNode('a', 0, 0, BODY)], edges: [] }
+    layoutSpatialCanvas(base, options({ contentCache: cache }))
+
+    for (const edited of [
+      { nodes: [textNode('a', 0, 0, `${BODY}!`)], edges: [] },
+      { nodes: [textNode('a', 0, 0, BODY, { w: 300 })], edges: [] },
+      { nodes: [textNode('a', 0, 0, BODY, { h: 80 })], edges: [] },
+    ] satisfies SpatialCanvas[]) {
+      const counting = countingMeasure()
+      layoutSpatialCanvas(edited, options({ contentCache: cache }, counting.measure))
+      expect(counting.calls()).toBeGreaterThan(0)
+    }
+  })
+
+  it('does not cache the parse-failure fallback, and reports the degradation every run', () => {
+    const cache = mapCache()
+    const parseBody = () => {
+      throw new Error('bad body')
+    }
+    const canvas: SpatialCanvas = { nodes: [textNode('a', 0, 0, 'x')], edges: [] }
+    const onDegrade = vi.fn()
+    layoutSpatialCanvas(canvas, options({ contentCache: cache, parseBody, onDegrade }))
+    layoutSpatialCanvas(canvas, options({ contentCache: cache, parseBody, onDegrade }))
+    expect(cache.store.size).toBe(0)
+    expect(onDegrade).toHaveBeenCalledTimes(2)
+  })
+})
+
+const bodyArb = fc.oneof(
+  fc.constant(''),
+  fc.string({ maxLength: 40 }),
+  fc
+    .array(fc.string({ minLength: 1, maxLength: 20 }), { minLength: 1, maxLength: 6 })
+    .map((words) => `# H\n\n${words.join(' ')}`),
+)
+
+const nodeArb = (id: string): fc.Arbitrary<SpatialNode> =>
+  fc
+    .record({
+      x: fc.integer({ min: -200, max: 600 }),
+      y: fc.integer({ min: -200, max: 600 }),
+      w: fc.integer({ min: 30, max: 320 }),
+      h: fc.integer({ min: 20, max: 200 }),
+      text: bodyArb,
+    })
+    .map(({ x, y, w, h, text }) => textNode(id, x, y, text, { w, h }))
+
+describe('layoutSpatialCanvas content cache (PBT)', () => {
+  fcTest.prop(
+    [fc.array(nodeArb('n'), { minLength: 1, maxLength: 3 }), nodeArb('n')],
+    withDefaults(),
+  )(
+    'a shared warm cache never changes any layout across a random edit sequence',
+    (nodes, edited) => {
+      const cache = mapCache()
+      const canvases: SpatialCanvas[] = [
+        { nodes: nodes.map((n, i) => ({ ...n, id: `n${i}` })), edges: [] },
+        { nodes: [{ ...edited, id: 'n0' }], edges: [] },
+      ]
+      for (const canvas of canvases) {
+        const withCache = layoutSpatialCanvas(canvas, options({ contentCache: cache }))
+        const fresh = layoutSpatialCanvas(canvas, options())
+        expect(JSON.stringify(withCache)).toBe(JSON.stringify(fresh))
+      }
+    },
+  )
+})

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -171,6 +171,39 @@ export interface SpatialLayoutOptions {
    * editor decides by on-screen size, export by intrinsic size.
    */
   readonly expandFileNode?: (node: Extract<SpatialNode, { type: 'file' }>) => boolean
+  /**
+   * Optional memo for a text node's laid-out body. Content is laid out in
+   * ORIGIN-RELATIVE coordinates and placed by `placeInNode`, so a cached
+   * value is position-independent by construction: keyed by the node's
+   * text and box size only. Everything else that shapes content —
+   * `measure`, the appearance resolver, `geometry`, `parseBody`, the mdast
+   * seams — is deliberately NOT in the key: the CALLER owns the cache's
+   * lifetime and must discard it when any of those change (in practice:
+   * one cache per document+theme, dropped on theme/font switches). Cached
+   * values are shared between scenes and must be treated as immutable,
+   * which scene nodes already are.
+   *
+   * Only the success path is cached. The parse-failure fallback recomputes
+   * every run so `onDegrade` keeps firing — a cache must change timings,
+   * never what the caller is told.
+   *
+   * Measured before building (the instrument-first rule): content layout
+   * is 15-18ms of a 66-125ms full layout on the scene-diff corpus with the
+   * arithmetic test measurer — edge routing dominates — so this memo buys
+   * roughly the content share, more under a real (Canvas/opentype)
+   * measurer whose per-call cost is far above the fake's.
+   */
+  readonly contentCache?: SpatialContentCache
+}
+
+/**
+ * The store behind `SpatialLayoutOptions.contentCache`. Deliberately a
+ * plain get/set pair rather than a Map subtype, so a caller can wrap an
+ * LRU, a WeakRef map, or a plain object without this package caring.
+ */
+export interface SpatialContentCache {
+  get(key: string): FittedBlocks | undefined
+  set(key: string, value: FittedBlocks): void
 }
 
 /**
@@ -428,13 +461,28 @@ function composeTextNode(
   options: ResolvedLayoutOptions,
 ): readonly SceneNode[] {
   const maxWidth = contentWidth(node.width, options)
+  // Position deliberately absent from the key: the cached value is
+  // origin-relative (see `contentCache`'s contract), so a moved node hits.
+  const cacheKey =
+    options.contentCache === undefined
+      ? undefined
+      : JSON.stringify([node.width, node.height, node.text])
+  const cached = cacheKey === undefined ? undefined : options.contentCache?.get(cacheKey)
   let body: FittedBlocks
-  try {
-    const laid = layoutMdastBlocks(options.parseBody(node.text), mdastOptionsFor(maxWidth, options))
-    body = fitTextBody(laid, node, options)
-  } catch (err) {
-    options.onDegrade?.({ kind: 'body-parse-failed', nodeId: node.id, err })
-    body = fitTextBody({ nodes: [labelRun(node.text, options, maxWidth)] }, node, options)
+  if (cached !== undefined) {
+    body = cached
+  } else {
+    try {
+      const laid = layoutMdastBlocks(
+        options.parseBody(node.text),
+        mdastOptionsFor(maxWidth, options),
+      )
+      body = fitTextBody(laid, node, options)
+      if (cacheKey !== undefined) options.contentCache?.set(cacheKey, body)
+    } catch (err) {
+      options.onDegrade?.({ kind: 'body-parse-failed', nodeId: node.id, err })
+      body = fitTextBody({ nodes: [labelRun(node.text, options, maxWidth)] }, node, options)
+    }
   }
   return [
     chromeWithFit(node, options, body.truncated),


### PR DESCRIPTION
## Summary

- `SpatialLayoutOptions.contentCache` memoizes a text node's laid-out body (parse + wrap + fit). Content is laid out **origin-relative** and placed by `placeInNode`, so a cached value is position-independent by construction — the key is only `(width, height, text)`. Validity for everything else (`measure`, theme, `geometry`, `parseBody`, mdast seams) is the caller's documented contract: one cache per document+theme, dropped on theme/font switches.
- Only the success path is cached: the parse-failure fallback recomputes every run so `onDegrade` keeps firing — a cache changes timings, never what the caller is told.
- **Instrument-first, and honest about the ceiling**: on the scene-diff corpus with the arithmetic test measurer, edge routing is **77–86%** of full layout time, which a content memo cannot touch. Measured interleaved (40-node corpus): content-only layout **13.9ms → 0.3ms warm (−98%)**; full layout **53.3ms → 38.1ms (−29%)**. Under a real Canvas/opentype measurer the content share — and the win — is larger. Routing incrementality is recorded as the bigger lever, deferred alongside decision #10's parallel-executor seam.
- `userReach: foundation` — wired by the editor DOM-patch layer (the next stack layer), which owns the per-document cache lifetime (including the layout worker's per-theme map).

Stack layer 6 — base `claude/svg-generation-improvement-uigd90-5` (#933). Landing: top-PR-only merge, see #926.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — `layout/spatial-canvas-content-cache.test.ts` (red-first): byte-equal scenes cold vs warm **including after a move**; zero `measure` calls on a warm run; key sensitivity to text/width/height (**mutation-checked**: dropping `height` from the key turns it red); degraded path uncached with `onDegrade` still firing per run; plus a fast-check property that a shared warm cache never changes any layout
- [x] `pnpm test` passes locally — canvas-render-node **778 passed** (full project), typecheck 0, knip 0, biome clean
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable — not applicable: opt-in seam, no caller wired yet by design

Manual verification: interleaved timing runs (cold/warm/cold/warm) on the 40-node corpus, numbers above; the no-cache path is bit-for-bit the previous code path (option absent → `cacheKey` undefined → identical control flow).

## Visual evidence

No pixels move — scene equality cold-vs-warm is property-tested; existing goldens unchanged.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — internal package surface; behavior unchanged
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kn5gTK3WGQcNrahPppzvHg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn5gTK3WGQcNrahPppzvHg)_