### PR TITLE
feat(canvas-render): add the keyed SVG projection for per-group DOM patching

### DIFF
--- a/packages/canvas-render/src/scene-diff-quality.test.ts
+++ b/packages/canvas-render/src/scene-diff-quality.test.ts
@@ -1,6 +1,7 @@
 import type { CanvasEdge, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
 import { describe, expect, it } from 'vitest'
 import { layoutSpatialCanvas } from './layout/spatial-canvas.js'
+import { sceneEntryKeys } from './scene-entry-keys.js'
 import type { Scene } from './scene-graph.js'
 import { createFakeMeasure } from './test-utils/fake-measure.js'
 import { createSpatialTheme } from './theme/spatial-theme.js'
@@ -65,28 +66,14 @@ const layout = (canvas: SpatialCanvas): Scene =>
     appearance: createSpatialTheme({ mode: 'light' }),
   })
 
-/**
- * Keys each top-level scene entry stably: identified entries (chrome
- * shapes, edges) by their id; the content entries a node's shape is
- * followed by inherit that owner id plus an ordinal, matching the
- * documented emission order (shape, then its content, then all edges).
- */
+/** Entries keyed by the shared producer the keyed SVG renderer patches by
+ * (scene-entry-keys.ts) — one keying, so this scoreboard's counts are
+ * exactly the group replacements a patch layer would perform. */
 function keyedEntries(scene: Scene): Map<string, string> {
-  const out = new Map<string, string>()
-  let owner = 'preamble'
-  let ordinal = 0
-  for (const node of scene.nodes) {
-    const id = 'id' in node && typeof node.id === 'string' ? node.id : undefined
-    if (id !== undefined) {
-      owner = id
-      ordinal = 0
-      out.set(id, JSON.stringify(node))
-    } else {
-      ordinal += 1
-      out.set(`${owner}#${ordinal}`, JSON.stringify(node))
-    }
-  }
-  return out
+  const keys = sceneEntryKeys(scene)
+  return new Map(
+    scene.nodes.map((node, index) => [keys[index] ?? `#${index}`, JSON.stringify(node)]),
+  )
 }
 
 function diffCount(base: Scene, edited: Scene): { changed: number; total: number } {

--- a/packages/canvas-render/src/scene-entry-keys.ts
+++ b/packages/canvas-render/src/scene-entry-keys.ts
@@ -1,0 +1,30 @@
+/**
+ * The ONE producer of stable top-level scene-entry keys, shared by the
+ * keyed SVG renderer (svg/keyed.ts) and the scene-diff scoreboard.
+ * Identified entries — chrome shapes, edges — key by their id; the content
+ * entries that follow a node's chrome inherit that owner id plus an
+ * ordinal, matching the documented emission order (shape, then its
+ * content, then all edges). Entries before any identified one fall under
+ * the `preamble` owner, so a hand-built scene with no ids still keys by
+ * position — the same last-resort naming `sceneDigest` uses.
+ */
+
+import type { Scene } from './scene-graph.js'
+
+export function sceneEntryKeys(scene: Scene): readonly string[] {
+  const keys: string[] = []
+  let owner = 'preamble'
+  let ordinal = 0
+  for (const node of scene.nodes) {
+    const id = 'id' in node && typeof node.id === 'string' ? node.id : undefined
+    if (id !== undefined) {
+      owner = id
+      ordinal = 0
+      keys.push(id)
+    } else {
+      ordinal += 1
+      keys.push(`${owner}#${ordinal}`)
+    }
+  }
+  return keys
+}

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -16,7 +16,7 @@ import type {
   TextRunNode,
 } from '../scene-graph.js'
 import { collectDefs } from './defs.js'
-import type { PaintAttrs, SvgBoxAttrs, TextEmphasisAttrs } from './elements.js'
+import type { PaintAttrs, SvgBoxAttrs, SvgElements, TextEmphasisAttrs } from './elements.js'
 import { formatCoord, sanitizeHref, trustedHref } from './format.js'
 import { hoistInheritedAttrs } from './hoist.js'
 import { serializeSvg } from './serialize.js'
@@ -612,7 +612,26 @@ const SVG_XMLNS = 'http://www.w3.org/2000/svg'
  * per-node visual attribute — the one exemption to this package's
  * no-visual-attributes rule) when `background` is set.
  */
-export function renderSceneToSvg(scene: Scene, options?: SvgDocumentOptions): string {
+/**
+ * The document's assembled pieces, shared by `renderSceneToSvg` and the
+ * keyed renderer (svg/keyed.ts) so the two can never disagree on root
+ * attributes, defs, background, or per-entry bodies. `body` holds exactly
+ * one (possibly empty) child per top-level scene entry, hoisted, in
+ * document order — the unit the keyed renderer wraps and the scene-diff
+ * scoreboard counts.
+ */
+export interface SvgDocumentParts {
+  /** Fixed order: xmlns [width height viewBox fill] — the envelope rule. */
+  readonly rootAttrs: SvgElements['svg']
+  readonly defs: SvgChild
+  readonly background: SvgChild
+  readonly body: ReadonlyArray<SvgChild>
+}
+
+export function buildSvgDocumentParts(
+  scene: Scene,
+  options?: SvgDocumentOptions,
+): SvgDocumentParts {
   // Hoisting runs before defs collection only by convention — it preserves
   // `defs` declarations on rebuilt nodes, so the order is not load-bearing.
   const body = scene.nodes.map(renderNode).map(hoistInheritedAttrs)
@@ -629,7 +648,7 @@ export function renderSceneToSvg(scene: Scene, options?: SvgDocumentOptions): st
       : []
 
   if (!hasEnvelopeOptions(options)) {
-    return serializeSvg(el('svg', { xmlns: SVG_XMLNS }, [defs, body]))
+    return { rootAttrs: { xmlns: SVG_XMLNS }, defs, background: [], body }
   }
 
   const viewBox = resolveViewBox(scene, options)
@@ -639,21 +658,25 @@ export function renderSceneToSvg(scene: Scene, options?: SvgDocumentOptions): st
   const background: SvgChild =
     options.background !== undefined ? renderBackgroundRect(viewBox, options.background) : []
 
-  // Fixed root-attribute order: xmlns width height viewBox fill.
-  return serializeSvg(
-    el(
-      'svg',
-      {
-        xmlns: SVG_XMLNS,
-        width,
-        height,
-        viewBox: viewBoxAttr,
-        fill:
-          typeof options.textFill === 'string' && options.textFill.length > 0
-            ? options.textFill
-            : undefined,
-      },
-      [defs, background, body],
-    ),
-  )
+  return {
+    // Fixed root-attribute order: xmlns width height viewBox fill.
+    rootAttrs: {
+      xmlns: SVG_XMLNS,
+      width,
+      height,
+      viewBox: viewBoxAttr,
+      fill:
+        typeof options.textFill === 'string' && options.textFill.length > 0
+          ? options.textFill
+          : undefined,
+    },
+    defs,
+    background,
+    body,
+  }
+}
+
+export function renderSceneToSvg(scene: Scene, options?: SvgDocumentOptions): string {
+  const parts = buildSvgDocumentParts(scene, options)
+  return serializeSvg(el('svg', parts.rootAttrs, [parts.defs, parts.background, parts.body]))
 }

--- a/packages/canvas-render/src/svg/elements.ts
+++ b/packages/canvas-render/src/svg/elements.ts
@@ -59,7 +59,9 @@ export type SvgElements = {
     fill?: string
     role?: SvgRole
   }
-  g: PaintAttrs & { transform?: string; role?: SvgRole }
+  // data-wb-key is the keyed renderer's patch handle (svg/keyed.ts) —
+  // emitted only in keyed mode, never by the plain document renderer.
+  g: PaintAttrs & { transform?: string; role?: SvgRole; 'data-wb-key'?: string }
   rect: SvgBoxAttrs & PaintAttrs & { rx?: number; role?: SvgRole }
   // width/height appear on <text> only through the legacy codeBlock/rawHtml
   // box-placement path (rectAttrs spread); x/y are the baseline contract.

--- a/packages/canvas-render/src/svg/keyed.test.ts
+++ b/packages/canvas-render/src/svg/keyed.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import { sceneEntryKeys } from '../scene-entry-keys.js'
+import type { Scene } from '../scene-graph.js'
+import { renderSceneToSvg } from './backend.js'
+import { renderSceneToKeyedSvg } from './keyed.js'
+
+const scene: Scene = {
+  nodes: [
+    { kind: 'shape', id: 'node-a', bbox: { x: 0, y: 0, w: 100, h: 60 }, radius: 4 },
+    {
+      kind: 'paragraph',
+      bbox: { x: 8, y: 8, w: 80, h: 16 },
+      runs: [
+        {
+          kind: 'textRun',
+          bbox: { x: 8, y: 8, w: 40, h: 16 },
+          text: 'hello',
+          truncated: true,
+        },
+      ],
+    },
+    { kind: 'shape', id: 'node-b', bbox: { x: 200, y: 0, w: 100, h: 60 } },
+    {
+      kind: 'edge',
+      id: 'edge-1',
+      path: [
+        { x: 100, y: 30 },
+        { x: 200, y: 30 },
+      ],
+      fromSide: 'right',
+      toSide: 'left',
+      fromEnd: 'none',
+      toEnd: 'arrow',
+      appearance: { stroke: '#888' },
+    },
+  ],
+}
+
+describe('sceneEntryKeys', () => {
+  it('keys identified entries by id and content entries by owner and ordinal', () => {
+    expect(sceneEntryKeys(scene)).toEqual(['node-a', 'node-a#1', 'node-b', 'edge-1'])
+  })
+
+  it('keys leading unidentified entries under the preamble owner', () => {
+    const bare: Scene = {
+      nodes: [
+        { kind: 'paragraph', bbox: { x: 0, y: 0, w: 10, h: 10 }, runs: [] },
+        { kind: 'shape', id: 's', bbox: { x: 0, y: 0, w: 1, h: 1 } },
+      ],
+    }
+    expect(sceneEntryKeys(bare)).toEqual(['preamble#1', 's'])
+  })
+})
+
+describe('renderSceneToKeyedSvg', () => {
+  it('emits one keyed group per scene entry, plus the defs pseudo-group', () => {
+    const keyed = renderSceneToKeyedSvg(scene)
+    expect(keyed.groups.map((g) => g.key)).toEqual([
+      '#defs',
+      'node-a',
+      'node-a#1',
+      'node-b',
+      'edge-1',
+    ])
+    for (const group of keyed.groups) {
+      if (group.key.startsWith('#')) continue
+      expect(group.svg.startsWith(`<g data-wb-key="${group.key}">`)).toBe(true)
+      expect(group.svg.endsWith('</g>')).toBe(true)
+    }
+  })
+
+  it('assembles the document exactly from its parts', () => {
+    const keyed = renderSceneToKeyedSvg(scene, { padding: 4, background: '#fff' })
+    const body = keyed.groups.map((g) => g.svg).join('')
+    expect(keyed.svg).toBe(`${keyed.rootOpen}${body}</svg>`)
+    expect(keyed.groups.map((g) => g.key).slice(0, 2)).toEqual(['#defs', '#background'])
+  })
+
+  it('carries the root attributes the patch layer must keep in sync', () => {
+    const keyed = renderSceneToKeyedSvg(scene, { padding: 4 })
+    expect(keyed.rootAttrs.xmlns).toBe('http://www.w3.org/2000/svg')
+    expect(typeof keyed.rootAttrs.viewBox).toBe('string')
+  })
+
+  it('is byte-identical to renderSceneToSvg once the key wrappers are removed', () => {
+    for (const options of [undefined, { padding: 4, background: '#fff' }] as const) {
+      const keyed = renderSceneToKeyedSvg(scene, options)
+      // Exact reconstruction, no regex: a non-pseudo group is by contract
+      // `<g data-wb-key="KEY">` + inner + `</g>`; pseudo groups (#defs,
+      // #background) are emitted unwrapped in both forms.
+      const unwrapped = keyed.groups
+        .map((group) =>
+          group.key.startsWith('#')
+            ? group.svg
+            : group.svg.slice(`<g data-wb-key="${group.key}">`.length, -'</g>'.length),
+        )
+        .join('')
+      expect(`${keyed.rootOpen}${unwrapped}</svg>`).toBe(renderSceneToSvg(scene, options))
+    }
+  })
+
+  it('changes exactly the groups whose scene entries changed', () => {
+    const before = renderSceneToKeyedSvg(scene)
+    const movedB: Scene = {
+      nodes: scene.nodes.map((n) =>
+        'id' in n && n.id === 'node-b' && n.kind === 'shape'
+          ? { ...n, bbox: { ...n.bbox, x: 220 } }
+          : n,
+      ),
+    }
+    const after = renderSceneToKeyedSvg(movedB)
+    const beforeByKey = new Map(before.groups.map((g) => [g.key, g.svg]))
+    const changed = after.groups.filter((g) => beforeByKey.get(g.key) !== g.svg).map((g) => g.key)
+    expect(changed).toEqual(['node-b'])
+  })
+})

--- a/packages/canvas-render/src/svg/keyed.ts
+++ b/packages/canvas-render/src/svg/keyed.ts
@@ -1,0 +1,82 @@
+/**
+ * The keyed projection of the SVG document: the same bytes
+ * `renderSceneToSvg` emits, cut at the seams a DOM patch layer needs.
+ * Every top-level scene entry becomes one `<g data-wb-key="…">` group; the
+ * document-chrome pieces that live outside any entry — `<defs>` and the
+ * background rect — become the pseudo-groups `#defs` / `#background`. A
+ * consumer mounts `svg` once, then on the next render compares each
+ * group's string against what it holds and replaces only the ones that
+ * differ — string equality IS change detection, because the serializer is
+ * canonical and deterministic.
+ *
+ * Two invariants the tests pin:
+ * - Removing the wrappers reproduces `renderSceneToSvg` byte-for-byte
+ *   (both share `buildSvgDocumentParts`, so they cannot drift).
+ * - `svg` equals `rootOpen` + the groups' strings + `</svg>`, so the
+ *   mounted document and the patch units are the same bytes by
+ *   construction.
+ *
+ * The wrappers are an EDITOR-MODE projection: exports and the MCP render
+ * tool keep calling `renderSceneToSvg`, whose bytes carry no keys.
+ */
+
+import { sceneEntryKeys } from '../scene-entry-keys.js'
+import type { Scene } from '../scene-graph.js'
+import { buildSvgDocumentParts, type SvgDocumentOptions } from './backend.js'
+import { formatCoord } from './format.js'
+import { serializeSvg, serializeSvgChild, serializeSvgChunks } from './serialize.js'
+import { el, type SvgChild } from './vnode.js'
+
+export interface KeyedSvgGroup {
+  readonly key: string
+  /** The group's exact document bytes: `<g data-wb-key="KEY">…</g>` for a
+   * scene entry, the bare element for a pseudo-group. */
+  readonly svg: string
+}
+
+export interface KeyedSvgRender {
+  /** The full document — identical bytes to mounting the groups yourself. */
+  readonly svg: string
+  /** The root `<svg …>` open tag, exactly as it appears in `svg`. */
+  readonly rootOpen: string
+  /** Root attributes as raw (unescaped) strings, for `setAttribute` when a
+   * patch keeps the mounted root element and only its attributes moved. */
+  readonly rootAttrs: Readonly<Record<string, string>>
+  readonly groups: ReadonlyArray<KeyedSvgGroup>
+}
+
+function isEmptyChild(child: SvgChild): boolean {
+  return Array.isArray(child) && child.length === 0
+}
+
+export function renderSceneToKeyedSvg(scene: Scene, options?: SvgDocumentOptions): KeyedSvgRender {
+  const parts = buildSvgDocumentParts(scene, options)
+  const keys = sceneEntryKeys(scene)
+
+  const groups: KeyedSvgGroup[] = []
+  if (!isEmptyChild(parts.defs)) groups.push({ key: '#defs', svg: serializeSvgChild(parts.defs) })
+  if (!isEmptyChild(parts.background)) {
+    groups.push({ key: '#background', svg: serializeSvgChild(parts.background) })
+  }
+  parts.body.forEach((child, index) => {
+    const key = keys[index] ?? `preamble#${index}`
+    groups.push({ key, svg: serializeSvg(el('g', { 'data-wb-key': key }, [child])) })
+  })
+
+  const [rootOpen] = serializeSvgChunks(el('svg', parts.rootAttrs, []))
+  const rootAttrs = Object.fromEntries(
+    Object.entries(parts.rootAttrs)
+      .filter(([, value]) => value !== undefined)
+      .map(([name, value]) => [
+        name,
+        typeof value === 'number' ? formatCoord(value) : String(value),
+      ]),
+  )
+
+  return {
+    svg: `${rootOpen}${groups.map((group) => group.svg).join('')}</svg>`,
+    rootOpen: rootOpen ?? '<svg>',
+    rootAttrs,
+    groups,
+  }
+}

--- a/packages/canvas-render/src/svg/serialize.ts
+++ b/packages/canvas-render/src/svg/serialize.ts
@@ -56,6 +56,14 @@ export function* serializeSvgChunks(node: SvgVNode): Generator<string> {
   yield `</${node.tag}>`
 }
 
+/** Serializes any child form — element, text, rawXml, nested arrays — to
+ * its exact document bytes; the keyed renderer's per-part serializer. */
+export function serializeSvgChild(child: SvgChild): string {
+  let out = ''
+  for (const chunk of serializeChildren([child])) out += chunk
+  return out
+}
+
 export function serializeSvg(node: SvgVNode): string {
   let out = ''
   for (const chunk of serializeSvgChunks(node)) out += chunk


### PR DESCRIPTION
## Summary

- `renderSceneToKeyedSvg` (`svg/keyed.ts`) emits **the same document** `renderSceneToSvg` does, cut at the seams a DOM patch layer needs: one `<g data-wb-key="…">` group per top-level scene entry, `#defs`/`#background` pseudo-groups for the chrome outside any entry, plus the root open tag and raw root attributes (for `setAttribute`-style envelope updates on a mounted root). **String equality is change detection** — the serializer is canonical and deterministic, so a patch layer compares group strings and replaces only what differs, with every byte that reaches the DOM still serializer-produced (single-producer preserved).
- Both renderers share the new `buildSvgDocumentParts`, so they cannot drift. Keys come from `scene-entry-keys.ts`, **promoted to production as the one key producer** — the scene-diff scoreboard (#933) now counts by exactly the keys the patch layer will patch by, and its pinned numbers are unchanged by the swap.
- Plain `renderSceneToSvg` output is untouched: the wrappers are an editor-mode projection; exports and the MCP render tool keep the keyless bytes.

Stack layer 7 — base `claude/svg-generation-improvement-uigd90-6` (#934). The next (final) layer mounts this in `apps/web`: mount-once ref container, per-group replacement, the patch≡full-render convergence property, and wiring of #934's content cache. Landing: top-PR-only merge, see #926.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — `svg/keyed.test.ts` (7 cases, red-first): shared-key shape incl. preamble fallback, per-entry wrapping, exact `rootOpen + groups + '</svg>'` assembly identity, **byte-identity to `renderSceneToSvg` with wrappers removed in both envelope modes** (exact reconstruction, no regex), root-attr carry, and single-group change under a single-entry edit
- [x] `pnpm test` passes locally — canvas-render-node **787 passed** (full project; scoreboard pins unchanged after the key-producer swap); typecheck 0; knip clean; biome clean
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable — the apps/web layer above carries the browser-mode convergence tests

Manual verification: the assembly-identity and strip-identity tests are constructive proofs over the real pipeline (shared `buildSvgDocumentParts`), not mocks.

## Visual evidence

Plain output byte-identical (full suite unchanged); keyed output is a new opt-in projection consumed by no surface yet.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — internal package surface, no behavior change
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kn5gTK3WGQcNrahPppzvHg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn5gTK3WGQcNrahPppzvHg)_