### PR TITLE
refactor(web): name the editor's command surface, which was 36 flat props

### DIFF
--- a/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
@@ -84,84 +84,105 @@ export type DocumentPickerState =
   | { readonly mode: 'create'; readonly point?: Point }
   | { readonly mode: 'retarget'; readonly nodeId: string }
 
+/**
+ * Everything the menu can DO, as one object.
+ *
+ * The menu is a command surface: thirty-six flat props made it read as a
+ * component with thirty-six concerns, when twenty of them were the same
+ * concern — verbs the editor exposes, the set the keyboard shortcuts invoke
+ * too. Dialog-opening setters are included deliberately: from the menu's side
+ * "edit this label" and "add a link" are commands, and that they happen to be
+ * implemented as state setters is the editor's business.
+ *
+ * Data, predicates, and the image-insertion refs stay flat: they answer what
+ * the menu SHOWS, not what it does.
+ */
+export interface CanvasCommands {
+  readonly applyResult: (result: GestureResult) => void
+  readonly applyBoxMoves: (moves: readonly BoxMove[]) => boolean
+  readonly copySelection: () => ClipboardFragment | null
+  /** Cut-flavoured copy: also records the cut surface for paste to reconnect. */
+  readonly cutSelection: () => ClipboardFragment | null
+  readonly pasteClipboard: (at?: Point) => boolean
+  readonly duplicateSelection: () => boolean
+  readonly reorderSelection: (placement: 'forward' | 'backward' | 'front' | 'back') => void
+  readonly groupSelection: (memberIds: readonly string[]) => void
+  readonly createNodeAt: (point: Point) => void
+  readonly createGroupAtViewportCenter: (at?: Point) => void
+  readonly openLinkNode: (node: Extract<SpatialNode, { type: 'link' }>) => void
+  readonly onOpenFileRef?: (file: string, subpath?: string) => void
+  readonly onAddImage?: (file: File) => Promise<string | undefined>
+  readonly onToggleNodeLock?: (nodeId: string, locked: boolean) => void
+  readonly onToggleEdgeLock?: (edgeId: string, locked: boolean) => void
+  readonly setEdgeLabelEditId: (id: string | null) => void
+  readonly setGroupLabelEditId: (id: string | null) => void
+  readonly setSelectedEdgeId: (id: string | null) => void
+  readonly setLinkDialog: (state: LinkDialogState | null) => void
+  readonly setDocumentPicker: (state: DocumentPickerState | null) => void
+}
+
 export interface CanvasContextMenuProps {
+  readonly commands: CanvasCommands
   readonly contextMenu: ContextMenuTarget
   readonly setContextMenu: (target: ContextMenuTarget | null) => void
   readonly canvas: SpatialCanvas
   readonly canvasRef: MutableRefObject<SpatialCanvas>
   readonly theme: ResolvedTheme
   readonly gestureState: GestureState
-  readonly applyResult: (result: GestureResult) => void
   readonly isEdgeLocked: (edgeId: string) => boolean
-  readonly onToggleEdgeLock?: (edgeId: string, locked: boolean) => void
-  readonly setEdgeLabelEditId: (id: string | null) => void
-  readonly setSelectedEdgeId: (id: string | null) => void
-  readonly setGroupLabelEditId: (id: string | null) => void
-  readonly pasteClipboard: (at?: Point) => boolean
-  readonly createNodeAt: (point: Point) => void
-  readonly createGroupAtViewportCenter: (at?: Point) => void
-  readonly setLinkDialog: (state: LinkDialogState | null) => void
   readonly fileRefOptions?: readonly FileRefOption[]
-  readonly setDocumentPicker: (state: DocumentPickerState | null) => void
-  readonly onAddImage?: (file: File) => Promise<string | undefined>
   readonly pendingImagePointRef: MutableRefObject<Point | null>
   readonly imageInputRef: MutableRefObject<HTMLInputElement | null>
   readonly pendingBackgroundGroupIdRef: MutableRefObject<string | null>
   readonly isLocked: (nodeId: string) => boolean
-  readonly onToggleNodeLock?: (nodeId: string, locked: boolean) => void
-  readonly applyBoxMoves: (moves: readonly BoxMove[]) => boolean
   readonly extraIds: ReadonlySet<string>
   readonly selectedId: string | null
-  readonly groupSelection: (memberIds: readonly string[]) => void
   readonly isImageFileRef?: (file: string) => boolean
   readonly missingFileRef?: (file: string) => boolean
-  readonly onOpenFileRef?: (file: string, subpath?: string) => void
-  readonly openLinkNode: (node: Extract<SpatialNode, { type: 'link' }>) => void
-  readonly copySelection: () => ClipboardFragment | null
-  /** Cut-flavoured copy: also records the cut surface for paste to reconnect. */
-  readonly cutSelection: () => ClipboardFragment | null
-  readonly duplicateSelection: () => boolean
-  readonly reorderSelection: (placement: 'forward' | 'backward' | 'front' | 'back') => void
 }
 
 export function CanvasContextMenu({
+  commands,
   contextMenu,
   setContextMenu,
   canvas,
   canvasRef,
   theme,
   gestureState,
-  applyResult,
   isEdgeLocked,
-  onToggleEdgeLock,
-  setEdgeLabelEditId,
-  setSelectedEdgeId,
-  setGroupLabelEditId,
-  pasteClipboard,
-  createNodeAt,
-  createGroupAtViewportCenter,
-  setLinkDialog,
   fileRefOptions,
-  setDocumentPicker,
-  onAddImage,
   pendingImagePointRef,
   imageInputRef,
   pendingBackgroundGroupIdRef,
   isLocked,
-  onToggleNodeLock,
-  applyBoxMoves,
   extraIds,
   selectedId,
-  groupSelection,
   isImageFileRef,
   missingFileRef,
-  onOpenFileRef,
-  openLinkNode,
-  copySelection,
-  cutSelection,
-  duplicateSelection,
-  reorderSelection,
 }: CanvasContextMenuProps) {
+  const {
+    applyResult,
+    applyBoxMoves,
+    copySelection,
+    cutSelection,
+    pasteClipboard,
+    duplicateSelection,
+    reorderSelection,
+    groupSelection,
+    createNodeAt,
+    createGroupAtViewportCenter,
+    openLinkNode,
+    onOpenFileRef,
+    onAddImage,
+    onToggleNodeLock,
+    onToggleEdgeLock,
+    setEdgeLabelEditId,
+    setGroupLabelEditId,
+    setSelectedEdgeId,
+    setLinkDialog,
+    setDocumentPicker,
+  } = commands
+
   // Both derive from whether the host wired the matching toggle callback —
   // without one, the menu has nothing to call, so the affordance stays
   // hidden rather than offering a lock that can never be released.

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -3223,42 +3223,44 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         )}
         {contextMenu !== null && (
           <CanvasContextMenu
+            commands={{
+              applyResult,
+              applyBoxMoves,
+              copySelection,
+              cutSelection,
+              pasteClipboard,
+              duplicateSelection,
+              reorderSelection,
+              groupSelection,
+              createNodeAt,
+              createGroupAtViewportCenter,
+              openLinkNode,
+              onOpenFileRef,
+              onAddImage,
+              onToggleNodeLock,
+              onToggleEdgeLock,
+              setEdgeLabelEditId,
+              setGroupLabelEditId,
+              setSelectedEdgeId,
+              setLinkDialog,
+              setDocumentPicker,
+            }}
             contextMenu={contextMenu}
             setContextMenu={setContextMenu}
             canvas={canvas}
             canvasRef={canvasRef}
             theme={theme}
             gestureState={gestureState}
-            applyResult={applyResult}
             isEdgeLocked={isEdgeLocked}
-            onToggleEdgeLock={onToggleEdgeLock}
-            setEdgeLabelEditId={setEdgeLabelEditId}
-            setSelectedEdgeId={setSelectedEdgeId}
-            setGroupLabelEditId={setGroupLabelEditId}
-            pasteClipboard={pasteClipboard}
-            createNodeAt={createNodeAt}
-            createGroupAtViewportCenter={createGroupAtViewportCenter}
-            setLinkDialog={setLinkDialog}
             fileRefOptions={fileRefOptions}
-            setDocumentPicker={setDocumentPicker}
-            onAddImage={onAddImage}
             pendingImagePointRef={pendingImagePointRef}
             imageInputRef={imageInputRef}
             pendingBackgroundGroupIdRef={pendingBackgroundGroupIdRef}
             isLocked={isLocked}
-            onToggleNodeLock={onToggleNodeLock}
-            applyBoxMoves={applyBoxMoves}
             extraIds={extraIds}
             selectedId={selectedId}
-            groupSelection={groupSelection}
             isImageFileRef={isImageFileRef}
             missingFileRef={missingFileRef}
-            onOpenFileRef={onOpenFileRef}
-            openLinkNode={openLinkNode}
-            copySelection={copySelection}
-            cutSelection={cutSelection}
-            duplicateSelection={duplicateSelection}
-            reorderSelection={reorderSelection}
           />
         )}
         {canvasPicker !== null && fileRefOptions !== undefined && (


### PR DESCRIPTION
`CanvasContextMenu` took **36 props** while every other component `SpatialEditor` renders takes 1–6. This PR names the concept those props were hiding.

## Why not Context (measured, not argued)

The question that started this was "would a Context work here?" — so it was measured first:

| what Context solves | what the file actually has |
|---|---|
| props drilled through intermediate layers | **none** — all 14 children are direct |
| one value read by many consumers | `canvas` ×5, `viewport` ×3, everything else ≤2 |

And it would cost something real: `viewport` and `gestureState` change **per frame** during a drag or pan, and the file's comments state the design goal of keeping per-frame cost isolated in small layers. A Context carrying those values re-renders every consumer per frame — it fights the architecture rather than serving it.

## What the 36 props actually were

One unnamed concept plus its inputs. **Twenty are verbs** — copy, cut, paste, duplicate, reorder, group, create node/group, open link/file, toggle locks, dispatch a gesture command, and open the label/link/document editors — the same set the keyboard shortcuts invoke. They are now one prop:

```tsx
<CanvasContextMenu commands={{ copySelection, cutSelection, … }} … />   // 36 → 17
```

Dialog-opening setters are in `commands` deliberately: from the menu's side *"edit this label"* is a command, and that it is implemented as a state setter is the editor's business. Data, predicates, and the image-insertion refs stay flat — they answer what the menu **shows**, not what it does.

Context stays rejected until a third consumer appears somewhere props cannot reach; today both consumers of the verb set (menu, keyboard) live in one component.

## Verification

- Full jsdom (**2615**) + node-config (**77**) + all three browser projects (**711**) pass unchanged.
- **Mutation:** disconnecting one verb inside the new object (`duplicateSelection: () => false`) reddens the duplicate browser test — the wiring is load-bearing, not decorative.
- No test touches the menu directly (all 101 files in the directory drive it through `SpatialEditor`), which is why the change surface is exactly two files. No test weakened.
- lint / knip / typecheck clean.