### PR TITLE
fix(web): give the browser test page focus back, and say when it lacks it

### DIFF
--- a/apps/web/src/test-utils/focus-editable.browser.test.tsx
+++ b/apps/web/src/test-utils/focus-editable.browser.test.tsx
@@ -1,0 +1,60 @@
+// `focusEditable` is what eleven browser tests depend on to receive a
+// keystroke at all, so when it fails it has to say WHY. It failed across a
+// whole file in CI with `expected <body>… to be <div spellcheck=…>`, which
+// names the symptom and none of the three things that produce it.
+import { afterEach, describe, expect, it } from 'vitest'
+import { focusEditable } from './focus-editable.js'
+
+afterEach(() => {
+  for (const el of document.querySelectorAll('[data-focus-fixture]')) el.remove()
+})
+
+function editable(): HTMLElement {
+  const el = document.createElement('div')
+  el.contentEditable = 'true'
+  el.setAttribute('data-focus-fixture', '')
+  document.body.append(el)
+  return el
+}
+
+describe('focusEditable', () => {
+  it('focuses a live editable', async () => {
+    const el = editable()
+    await focusEditable(el)
+    expect(document.activeElement).toBe(el)
+  })
+
+  it('names the detached case instead of timing out on a dead node', async () => {
+    // The shape this repo has now hit three times: a reference held across a
+    // re-render. A detached node cannot take focus and never will, so waiting
+    // is the one thing that cannot help — say so rather than spend the budget.
+    const el = editable()
+    el.remove()
+    await expect(focusEditable(el)).rejects.toThrow(/no longer in the document/i)
+  })
+
+  it('recovers when something else takes focus first', async () => {
+    // Focus is retried on every attempt rather than called once before the
+    // wait: a neighbour's leftover keystrokes can steal it after the call and
+    // before it settles, and waiting alone never gets it back.
+    const el = editable()
+    const thief = editable()
+    // Steals on `focusin`, so the theft is guaranteed to land exactly when
+    // focus arrives rather than racing a timer the retry can outrun.
+    let steals = 0
+    const steal = () => {
+      if (steals < 2) {
+        steals += 1
+        thief.focus()
+      }
+    }
+    el.addEventListener('focusin', steal)
+    try {
+      await focusEditable(el)
+    } finally {
+      el.removeEventListener('focusin', steal)
+    }
+    expect(steals).toBe(2)
+    expect(document.activeElement).toBe(el)
+  })
+})

--- a/apps/web/src/test-utils/focus-editable.ts
+++ b/apps/web/src/test-utils/focus-editable.ts
@@ -20,10 +20,33 @@ import { expect, vi } from 'vitest'
  * specific `.cm-line` also places the caret at that position, and replacing it
  * with `focus()` would move the caret to wherever CodeMirror last had it — a
  * different test.
+ *
+ * `focus()` is re-issued on EVERY attempt rather than once before the wait.
+ * Focus is shared mutable state across a whole browser project: a neighbour's
+ * leftover keystrokes, or its still-settling layout, can take it back after
+ * the call and before it settles, and waiting alone never gets it back. And a
+ * detached node is reported by name — it can never take focus, so waiting is
+ * the one thing that cannot help, and "activeElement is <body>" says nothing
+ * about which of the two happened. That message is what a whole file of
+ * failures looked like in CI, eleven times, with no way to tell them apart.
  */
 export async function focusEditable(element: Element): Promise<void> {
-  ;(element as HTMLElement).focus()
   await vi.waitFor(() => {
-    expect(document.activeElement).toBe(element)
+    if (!element.isConnected) {
+      throw new Error(
+        'focusEditable: the editable is no longer in the document — it was replaced between ' +
+          'being queried and being focused. Re-query it inside the step that focuses it.',
+      )
+    }
+    ;(element as HTMLElement).focus()
+    expect(
+      document.activeElement,
+      `focusEditable: focus did not land. document.hasFocus()=${document.hasFocus()}, ` +
+        `activeElement=<${document.activeElement?.tagName.toLowerCase() ?? 'none'}${
+          document.activeElement instanceof HTMLElement && document.activeElement.className !== ''
+            ? ` class="${document.activeElement.className}"`
+            : ''
+        }>`,
+    ).toBe(element)
   })
 }

--- a/apps/web/src/test-utils/focus-editable.ts
+++ b/apps/web/src/test-utils/focus-editable.ts
@@ -52,6 +52,12 @@ export async function focusEditable(element: Element): Promise<void> {
           'being queried and being focused. Re-query it inside the step that focuses it.',
       )
     }
+    // The window first: measured in CI, the failing case is
+    // `document.hasFocus()=false`, and an element in an unfocused document
+    // cannot become its activeElement however many times focus() is called.
+    // Several browser pages run in parallel and only one can hold focus, so
+    // this asks for it back rather than assuming the frame still has it.
+    window.focus()
     ;(element as HTMLElement).focus()
     // The message carries what DID have focus, and whether the document had
     // any: three different causes reached this line in CI and none of them was

--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -79,15 +79,26 @@ export default defineConfig({
     // A timeout costs nothing while tests pass; it only decides how long a
     // genuinely hung test takes to report.
     //
-    // 30s was not enough either, and the measurements say the budget is the
-    // only lever that works. The costliest test here (a markdown embed that
-    // types into real CodeMirror and lays the preview out through the render
-    // pipeline) takes 1.5s with its file alone and 1.6s with the twelve
+    // 30s was not enough either. The costliest test here (a markdown embed
+    // that types into real CodeMirror and lays the preview out through the
+    // render pipeline) takes 1.5s with its file alone and 1.6s with the twelve
     // IndexedDB-heavy page files running together — but 30–39s once all 115
-    // browser files are in flight. Neither of the obvious causes survives
-    // contact: cutting `--maxWorkers` to 4 made it WORSE (33–39s, and 40%
-    // more wall clock), and the IndexedDB-contention theory is refuted by
-    // the 1.6s twelve-file run.
+    // browser files are in flight. Cutting `--maxWorkers` to 4 made it WORSE
+    // (33–39s, and 40% more wall clock), and the IndexedDB-contention theory
+    // is refuted by the 1.6s twelve-file run.
+    //
+    // This comment used to conclude from that that the budget is the only
+    // lever that works. It is not, and the reasoning was wrong in a way worth
+    // recording: those numbers are not machine time at all. `focusEditable`'s
+    // diagnostic reported `document.hasFocus()=false` on its first CI run —
+    // several browser pages run in parallel and only ONE can hold focus, so a
+    // test in an unfocused page waits out its whole budget on a condition
+    // nothing can satisfy. That single fact explains every observation above:
+    // why the victim rotates, why every one passes in isolation, and why
+    // FEWER workers made it worse rather than better (same contention, longer
+    // run). Asking for focus back removed ten of eleven browser failures in
+    // one run, so the budget's real job is narrower than it looked — it
+    // bounds a genuinely hung test, and nothing else.
     //
     // What makes the overrun expensive is the collateral: vitest abandons the
     // test but its in-flight `userEvent.keyboard` keeps typing, so the NEXT


### PR DESCRIPTION
## Summary

**Scope correction.** This PR originally added two things: re-issuing `focus()` inside the retry, and reporting *why* focus did not land. While it sat in review, `main` landed the retry independently (#929's follow-up), with a better-grounded explanation than mine — CodeMirror's contentDOM is not focusable until the view has finished mounting, so a `focus()` before then is a silent no-op and waiting alone can never recover.

That half is now `main`'s. What is left here is the half that is still missing: **when focus does not land, say which of the three causes it was.**

## What this adds

`focusEditable` is what eleven browser tests depend on to receive a keystroke at all. When it fails it reports:

```
expected <body><div>…</div></body> to be <div spellcheck="true" …>
```

Three different situations reach that line and none is distinguishable from the others:

1. the view has not finished mounting (what `main`'s retry now handles),
2. **the element was detached** between being queried and being focused — a reference held across a re-render, the shape this repo has hit three times,
3. something else took focus and kept it.

**(2) is now called out by name** rather than waited on: a detached node can never take focus, so the retry is the one thing that cannot help it, and the message says to re-query inside the step that focuses — which is the fix, at the call site rather than here.

**The remaining assertion carries `document.hasFocus()` and what did have focus**, so (1) and (3) separate on sight.

Both behaviours are pinned by tests that fail against the pre-#929 implementation. The thief test steals focus on `focusin`, not on a timer: a timer-based thief is outrun by the retry and proves nothing — the first version of that test passed either way.

## The diagnostic answered its own question, and the answer changed the diagnosis

First CI run after adding it:

```
focusEditable: focus did not land. document.hasFocus()=false, activeElement=<body>
```

**The document does not have focus.** An element in an unfocused document cannot become that document's `activeElement` however many times `focus()` is called on it — so the retry cannot help, and neither can a longer budget. Several browser pages run in parallel and only one can hold focus at a time.

That single fact explains every observation the suite has accumulated:

| observation | explanation |
|---|---|
| the victim rotates every run | whichever test needed focus while its page did not have it |
| every victim passes in isolation | one page, and it has focus |
| cutting `--maxWorkers` made it **worse** | same contention, longer run |
| the IndexedDB-contention theory failed | the contention was over focus |
| failures burn the whole 60s budget | waiting on a condition nothing can satisfy — stalled, not slow |

So `window.focus()` now asks for it back rather than assuming the frame still has it. **Measured, same PR, one run apart:**

| | before | after |
|---|---|---|
| test-browser failures | **11** (1 typing + 10 focus) | **1** |
| `focusEditable` diagnostics | every one `hasFocus()=false` | **none** |

`vitest.browser.config.ts` carried the old conclusion — *"the measurements say the budget is the only lever that works"*. The measurements were right and the conclusion was wrong; the comment now says so, and says why, rather than being quietly replaced.

## What is still red, and is not this

Neither is caused by this PR, and **`main` fails `test-browser` too** on its latest run:

- **test-browser, 1 test**: `expected '# Hello from an agent - edi…'` — a dropped character while typing. `integrator-flow.md` already records this shape (a character with no keycode is synthesised separately and is the one that goes missing under load). Its own lane.
- **test-jsdom, 1 test**: `SettingsPage.test.tsx` — a confetti `celebrate` spy not called. Nothing in this PR is reachable from jsdom; `focus-editable.browser.test.tsx` is excluded from that project by pattern.

Keeping them out is deliberate: the focus fix has a measured effect, and folding two unrelated failures in would make it impossible to say which change did what.

## Test plan
- [x] 3 tests in `focus-editable.browser.test.tsx`; mutation-checked.
- [x] `source-pane-keymap` + `loro-binding` (the 11 dependents): 13 passed.
- [x] Full browser project: 130 files / 713 passed.
- [x] `pnpm -r typecheck` clean after merging current `main`; `pnpm lint` 1 pre-existing warning.

## Checklist

- [x] Commit message follows Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

