### PR TITLE
feat(canvas-render): rebuild SVG rendering on a typed VNode IR with keyed DOM patching

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -99,8 +99,10 @@ import {
   recordReconnection,
   writeClipboardFragment,
 } from '../../lib/clipboard-store.js'
+import { createSpatialContentCache } from '../../lib/content-cache.js'
 import { hapticTick } from '../../lib/haptics.js'
 import { composeReferenceSeam } from '../../lib/layout-worker-protocol.js'
+import { useKeyedSvg } from '../../lib/use-keyed-svg.js'
 import type { BoxMove } from './align.js'
 import {
   CanvasContextMenu,
@@ -163,6 +165,7 @@ import {
 import { PendingCutChip } from './PendingCutChip.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
 import { renderCanvasToSvg, requiredTextNodeHeight } from './scene-render.js'
+import { renderedCanvasKeyed } from './scene-render-core.js'
 import {
   EMPTY_SELECTION,
   reduceSelection,
@@ -759,6 +762,17 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     // `resolveReferenceContent` rides along UNCOMPOSED so the worker gate can
     // still tell content (which cannot be serialized) from label/missing
     // (which already cross as data).
+    // One text-node body memo per measure+theme (the cache's validity
+    // contract); rides fileSeamOptions so every synchronous render path in
+    // this component — the committed fallback, the drag backdrop, the live
+    // resize node — shares it. It never crosses to the layout worker
+    // (LayoutRequest carries plain data only); the worker keeps its own.
+    const contentCache = useMemo(
+      () => createSpatialContentCache(),
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- theme and
+      // measure invalidate cached layout; nothing else does.
+      [resolvedMeasure, theme],
+    )
     const fileSeamOptions = useMemo(
       () => ({
         resolveReference: composeReferenceSeam({
@@ -768,21 +782,28 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         }),
         resolveReferenceContent: resolveReference,
         expandFileNode,
+        contentCache,
       }),
-      [resolveReference, fileRefLabelMap, missingRefSet, expandFileNode],
+      [resolveReference, fileRefLabelMap, missingRefSet, expandFileNode, contentCache],
     )
     // The COMMITTED scene, laid out in a worker when it can be. The drag
     // layers below keep their own synchronous paths: a gesture already has a
     // fast route through carried-side caching, and a round trip per frame
     // would be the wrong trade there. This is the path that blocks on every
     // node added and every drag dropped.
-    const { svg, bounds, scene, anchors } = useWorkerScene(
+    const { bounds, scene, anchors } = useWorkerScene(
       canvas,
       { measure: resolvedMeasure, theme },
       fileSeamOptions,
       fileRefOptions,
       missingFileRefs,
     )
+    // The committed surface's keyed projection, derived from the scene the
+    // worker (or sync path) delivered — ~3ms of stringify against the
+    // 66-125ms layout, so the worker protocol stays plain-data. The patch
+    // container below consumes it; the plain `svg` string is no longer
+    // read here.
+    const keyed = useMemo(() => renderedCanvasKeyed({ scene, bounds }), [scene, bounds])
     // Routed edge paths in canvas coordinates, for edge hit-testing and the
     // selection highlight. Edges have no area, so selection is a
     // distance-to-polyline test against a zoom-adjusted tolerance. The
@@ -996,7 +1017,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // which a fresh pass over a newer canvas is not.
       return {
         carried,
-        svg: rendered.svg,
+        keyed: renderedCanvasKeyed(rendered),
         bounds: rendered.bounds,
         measure,
         committedAnchors: gestureCommitted.anchors,
@@ -1013,6 +1034,10 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       theme,
       fileSeamOptions,
     ])
+    // The committed surface's mount-once container (see the JSX below):
+    // during a gesture it patches to the drag backdrop, on drop back to the
+    // committed render — both through the same keyed reconciliation.
+    const canvasContentRef = useKeyedSvg(dragStatic?.keyed ?? keyed)
 
     useImperativeHandle(
       forwardedRef,
@@ -3345,10 +3370,13 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               left: (dragStatic?.bounds ?? bounds).x,
               top: (dragStatic?.bounds ?? bounds).y,
             }}
-            // canvas-render's SVG serializer is the SOLE producer of this
-            // string and escapes text/attrs (see svg/format.ts) — the same
-            // already-reviewed reasoning as CanvasViewer.tsx's identical sink.
-            dangerouslySetInnerHTML={{ __html: dragStatic?.svg ?? svg }}
+            // Mount-once keyed patching (use-keyed-svg.ts): every byte that
+            // lands in this container is still canvas-render's serializer
+            // output — the patcher only decides WHICH groups to replace —
+            // so CanvasViewer.tsx's single-producer injection reasoning
+            // carries over unchanged, and untouched groups keep their DOM
+            // nodes across commits (selection, focus, animations survive).
+            ref={canvasContentRef}
           />
           {liveEdges !== undefined && (
             <div

--- a/apps/web/src/components/spatial-editor/purity-guard.test.ts
+++ b/apps/web/src/components/spatial-editor/purity-guard.test.ts
@@ -4,7 +4,12 @@ import { describe, expect, it } from 'vitest'
 // canvas-render's import-guard.test.ts does. A lazy glob makes each case
 // await a per-file transform, and scanning the whole directory serially
 // that way overran the 5s default under a saturated worker pool.
-const modules = import.meta.glob('./**/*.{ts,tsx}', {
+// `../../lib` joins the scan because the committed-scene sink moved there:
+// the keyed SVG patcher owns the mount/patch innerHTML writes that used to
+// be a dangerouslySetInnerHTML prop in SpatialEditor.tsx, and a guard that
+// stopped at this directory would have let a new raw-HTML sink land in lib
+// unscanned.
+const modules = import.meta.glob(['./**/*.{ts,tsx}', '../../lib/**/*.{ts,tsx}'], {
   query: '?raw',
   eager: true,
   import: 'default',
@@ -109,19 +114,25 @@ describe('file seams reach every render path', () => {
 })
 
 describe('single content path (S10 guardrail)', () => {
-  it('raw HTML injection exists ONLY at the two documented scene-svg sinks', () => {
+  it('raw HTML injection exists ONLY at the documented scene-svg sinks', () => {
     // String-level TRIPWIRE, not a syntax-aware proof: it catches the ways
     // raw markup realistically enters a React/DOM codebase
     // (dangerouslySetInnerHTML, innerHTML/outerHTML assignment,
     // insertAdjacentHTML). The escaping guarantee itself lives in
     // canvas-render's serializer tests — this test only pins that nothing
-    // BUT that serializer's two documented injection points exists here.
+    // BUT the serializer's documented injection points exists here.
     const allowed = new Map([
-      // Committed scene + the live-edges drag overlay + the live-node
-      // resize overlay, all fed solely by canvas-render's escaping
-      // serializer.
-      ['./SpatialEditor.tsx', 3],
+      // The live-edges drag overlay + the live-node resize overlay, both
+      // fed solely by canvas-render's escaping serializer.
+      ['./SpatialEditor.tsx', 2],
       ['./DragPreviewLayer.tsx', 1],
+      // The committed-scene sink: mount-once innerHTML write of the full
+      // keyed document, plus the per-group parse the patcher replaces
+      // changed groups through. Every byte both writes carry is
+      // serializer-produced (`renderSceneToKeyedSvg`'s group strings) —
+      // the patcher decides WHICH elements to swap, never how markup is
+      // spelled, so the single-producer argument is unchanged.
+      ['../../lib/keyed-svg-patcher.ts', 2],
     ])
     const sinkPattern =
       /dangerouslySetInnerHTML=|\.innerHTML\s*=|\.outerHTML\s*=|insertAdjacentHTML\(/g

--- a/apps/web/src/components/spatial-editor/scene-render-core.ts
+++ b/apps/web/src/components/spatial-editor/scene-render-core.ts
@@ -16,12 +16,16 @@
 import type {
   BoundingBox,
   EdgeAnchorPair,
+  KeyedSvgRender,
   MeasureText,
   ResolvedReference,
   Scene,
+  SpatialContentCache,
+  SvgDocumentOptions,
 } from '@kamiazya/whiteboard-canvas-render'
 import {
   layoutSpatialCanvasWithAnchors,
+  renderSceneToKeyedSvg,
   renderSceneToSvg,
   sceneBounds,
 } from '@kamiazya/whiteboard-canvas-render'
@@ -35,6 +39,14 @@ export interface RenderCanvasCoreOptions {
   readonly theme?: ResolvedTheme
   readonly resolveReference?: (ref: string) => ResolvedReference | undefined
   readonly expandFileNode?: (node: Extract<SpatialNode, { type: 'file' }>) => boolean
+  /**
+   * canvas-render's text-node body memo (see SpatialContentCache's caller
+   * contract: one cache per measure+theme, dropped when either changes).
+   * Never crosses to the layout worker — the worker keeps its own per-theme
+   * cache, sound because it refuses to lay out before its font is loaded,
+   * so its measurer is stable for its whole serving lifetime.
+   */
+  readonly contentCache?: SpatialContentCache
 }
 
 export interface RenderedCanvas {
@@ -59,9 +71,28 @@ export function renderCanvasToSvgWith(
     appearance: createEditorAppearance(options.theme ?? 'light'),
     resolveReference: options.resolveReference,
     expandFileNode: options.expandFileNode,
+    contentCache: options.contentCache,
     highlightCode,
   })
   const bounds = sceneBounds(scene)
-  const svg = renderSceneToSvg(scene, { width: bounds.w, height: bounds.h, viewBox: bounds })
+  const svg = renderSceneToSvg(scene, documentEnvelope(bounds))
   return { svg, bounds, scene, anchors }
+}
+
+/** The ONE producer of the editor surface's document-envelope options, so
+ * the plain string and the keyed projection below can never disagree. */
+function documentEnvelope(bounds: BoundingBox): SvgDocumentOptions {
+  return { width: bounds.w, height: bounds.h, viewBox: bounds }
+}
+
+/**
+ * The keyed projection of an already-rendered canvas, derived on the main
+ * thread from the scene the worker (or sync path) already delivered —
+ * stringification is ~3ms at 40 nodes against a 66-125ms layout, so the
+ * worker protocol stays untouched. Same envelope as `RenderedCanvas.svg`.
+ */
+export function renderedCanvasKeyed(
+  rendered: Pick<RenderedCanvas, 'scene' | 'bounds'>,
+): KeyedSvgRender {
+  return renderSceneToKeyedSvg(rendered.scene, documentEnvelope(rendered.bounds))
 }

--- a/apps/web/src/lib/content-cache.ts
+++ b/apps/web/src/lib/content-cache.ts
@@ -1,0 +1,24 @@
+/**
+ * A size-capped store for canvas-render's text-node body memo
+ * (`SpatialLayoutOptions.contentCache`). The cap is a memory backstop, not
+ * an eviction policy: a canvas re-render touches every live key, so by the
+ * time the cap trips the map is dominated by keys from deleted or edited
+ * nodes, and clearing costs one re-layout of content the next render
+ * rebuilds anyway. Validity is the CALLER's contract — one cache per
+ * measure+theme, dropped when either changes.
+ */
+
+import type { FittedBlocks, SpatialContentCache } from '@kamiazya/whiteboard-canvas-render'
+
+const DEFAULT_MAX_ENTRIES = 2000
+
+export function createSpatialContentCache(maxEntries = DEFAULT_MAX_ENTRIES): SpatialContentCache {
+  const store = new Map<string, FittedBlocks>()
+  return {
+    get: (key) => store.get(key),
+    set: (key, value) => {
+      if (store.size >= maxEntries) store.clear()
+      store.set(key, value)
+    },
+  }
+}

--- a/apps/web/src/lib/keyed-svg-patcher.browser.test.tsx
+++ b/apps/web/src/lib/keyed-svg-patcher.browser.test.tsx
@@ -1,0 +1,164 @@
+import {
+  type KeyedSvgRender,
+  renderSceneToKeyedSvg,
+  type Scene,
+  type SceneNode,
+  type SvgDocumentOptions,
+} from '@kamiazya/whiteboard-canvas-render'
+import { describe, expect, it } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check'
+import { mountKeyedSvg } from './keyed-svg-patcher'
+
+const shape = (id: string, x: number): SceneNode => ({
+  kind: 'shape',
+  id,
+  bbox: { x, y: 0, w: 100, h: 60 },
+  radius: 4,
+  appearance: { fill: '#fff', stroke: '#333' },
+})
+
+const paragraph = (x: number, text: string, truncated = false): SceneNode => ({
+  kind: 'paragraph',
+  bbox: { x, y: 8, w: 80, h: 16 },
+  runs: [
+    {
+      kind: 'textRun',
+      bbox: { x, y: 8, w: 40, h: 16 },
+      text,
+      ...(truncated ? { truncated: true as const } : {}),
+    },
+  ],
+})
+
+const edge = (id: string, fromX: number, toX: number): SceneNode => ({
+  kind: 'edge',
+  id,
+  path: [
+    { x: fromX, y: 30 },
+    { x: toX, y: 30 },
+  ],
+  fromSide: 'right',
+  toSide: 'left',
+  fromEnd: 'none',
+  toEnd: 'arrow',
+  appearance: { stroke: '#888' },
+})
+
+const rootOf = (container: Element): SVGSVGElement => {
+  const root = container.firstElementChild
+  if (!(root instanceof SVGSVGElement)) throw new Error('no mounted svg root')
+  return root
+}
+
+const attrMap = (el: Element): Record<string, string> =>
+  Object.fromEntries([...el.attributes].map((a) => [a.name, a.value]))
+
+/** The oracle: a from-scratch mount of the same render. */
+function expectConverged(container: Element, next: KeyedSvgRender): void {
+  const fresh = document.createElement('div')
+  mountKeyedSvg(fresh, next)
+  expect(rootOf(container).innerHTML).toBe(rootOf(fresh).innerHTML)
+  expect(attrMap(rootOf(container))).toEqual(attrMap(rootOf(fresh)))
+}
+
+describe('mountKeyedSvg', () => {
+  it('reuses untouched group elements and replaces only the changed one', () => {
+    const before = renderSceneToKeyedSvg(
+      { nodes: [shape('a', 0), shape('b', 200), edge('e', 100, 200)] },
+      { padding: 4 },
+    )
+    const container = document.createElement('div')
+    const patcher = mountKeyedSvg(container, before)
+    const root = rootOf(container)
+    const byKey = (key: string) => root.querySelector(`[data-wb-key="${key}"]`) as Element | null
+    const keptA = byKey('a')
+    const keptE = byKey('e')
+    const oldB = byKey('b')
+
+    const after = renderSceneToKeyedSvg(
+      { nodes: [shape('a', 0), shape('b', 220), edge('e', 100, 200)] },
+      { padding: 4 },
+    )
+    patcher.update(after)
+
+    expect(byKey('a')).toBe(keptA)
+    expect(byKey('e')).toBe(keptE)
+    expect(byKey('b')).not.toBe(oldB)
+    expectConverged(container, after)
+  })
+
+  it('converges across chrome transitions: background and defs appearing and disappearing', () => {
+    const container = document.createElement('div')
+    const first = renderSceneToKeyedSvg({ nodes: [shape('a', 0), paragraph(8, 'plain')] })
+    const patcher = mountKeyedSvg(container, first)
+
+    const withChrome = renderSceneToKeyedSvg(
+      { nodes: [shape('a', 0), paragraph(8, 'cut…', true)] },
+      { padding: 4, background: '#fff' },
+    )
+    patcher.update(withChrome)
+    expectConverged(container, withChrome)
+
+    patcher.update(first)
+    expectConverged(container, first)
+  })
+
+  it('converges across entry insertion, removal, and reorder', () => {
+    const container = document.createElement('div')
+    const a = shape('a', 0)
+    const b = shape('b', 200)
+    const c = shape('c', 400)
+    const patcher = mountKeyedSvg(
+      container,
+      renderSceneToKeyedSvg({ nodes: [a, b] }, { padding: 4 }),
+    )
+    for (const nodes of [[a, b, c], [c, a], [b, c, a], [b]] as const) {
+      const next = renderSceneToKeyedSvg({ nodes: [...nodes] }, { padding: 4 })
+      patcher.update(next)
+      expectConverged(container, next)
+    }
+  })
+})
+
+const entryArb: fc.Arbitrary<SceneNode> = fc.oneof(
+  fc
+    .record({ id: fc.constantFrom('a', 'b', 'c', 'd'), x: fc.integer({ min: 0, max: 500 }) })
+    .map(({ id, x }) => shape(id, x)),
+  fc
+    .record({
+      text: fc.constantFrom('one', 'two', 'three'),
+      x: fc.integer({ min: 0, max: 300 }),
+      truncated: fc.boolean(),
+    })
+    .map(({ text, x, truncated }) => paragraph(x, text, truncated)),
+  fc
+    .record({ id: fc.constantFrom('e1', 'e2'), toX: fc.integer({ min: 150, max: 400 }) })
+    .map(({ id, toX }) => edge(id, 100, toX)),
+)
+
+const sceneArb: fc.Arbitrary<Scene> = fc
+  .array(entryArb, { minLength: 0, maxLength: 5 })
+  .map((nodes) => ({ nodes }))
+
+const optionsArb: fc.Arbitrary<SvgDocumentOptions | undefined> = fc.oneof(
+  fc.constant(undefined),
+  fc.constant({ padding: 4 }),
+  fc.constant({ padding: 4, background: '#fff' }),
+)
+
+describe('mountKeyedSvg (PBT)', () => {
+  fcTest.prop(
+    [fc.array(fc.tuple(sceneArb, optionsArb), { minLength: 2, maxLength: 5 })],
+    withDefaults({ numRuns: 30 }),
+  )('any update sequence converges to the fresh mount of the last render', (steps) => {
+    const container = document.createElement('div')
+    const renders = steps.map(([scene, options]) => renderSceneToKeyedSvg(scene, options))
+    const first = renders[0]
+    if (first === undefined) return
+    const patcher = mountKeyedSvg(container, first)
+    for (const next of renders.slice(1)) {
+      patcher.update(next)
+      expectConverged(container, next)
+    }
+  })
+})

--- a/apps/web/src/lib/keyed-svg-patcher.ts
+++ b/apps/web/src/lib/keyed-svg-patcher.ts
@@ -1,0 +1,94 @@
+/**
+ * Mount-once, patch-forever consumer of canvas-render's keyed SVG
+ * projection. The first render lands as one innerHTML write; every later
+ * render is a keyed reconciliation that touches only the groups whose
+ * serialized bytes changed — string equality IS change detection, because
+ * the producer's serializer is canonical and deterministic.
+ *
+ * Every byte that reaches the DOM is serializer-produced (the group
+ * strings themselves): this layer decides only WHICH elements to replace,
+ * never how markup is spelled, so canvas-render stays the single producer
+ * the `dangerouslySetInnerHTML` safety argument rests on. What patching
+ * buys over innerHTML replacement is DOM continuity for the 94-99% of
+ * groups a typical edit leaves byte-identical (the scene-diff scoreboard's
+ * measured reuse ceiling): selection, focus, running CSS animations and
+ * decoded images on untouched groups survive an update.
+ */
+
+import type { KeyedSvgRender } from '@kamiazya/whiteboard-canvas-render'
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+export interface KeyedSvgPatcher {
+  /** The mounted `<svg>` root — stable for the patcher's whole lifetime. */
+  readonly root: SVGSVGElement
+  update(next: KeyedSvgRender): void
+}
+
+/** Parses one group's serialized bytes into its single element. */
+function parseGroup(svg: string): Element {
+  const host = document.createElementNS(SVG_NS, 'svg')
+  host.innerHTML = svg
+  const element = host.firstElementChild
+  if (element === null) {
+    // A group is one element by the producer's contract; an empty parse
+    // means the contract broke upstream, which must not fail silently.
+    throw new Error('keyed svg group parsed to no element')
+  }
+  return element
+}
+
+export function mountKeyedSvg(container: Element, initial: KeyedSvgRender): KeyedSvgPatcher {
+  container.innerHTML = initial.svg
+  const root = container.firstElementChild
+  if (!(root instanceof SVGSVGElement)) {
+    throw new Error('keyed svg document parsed to no <svg> root')
+  }
+
+  // The mounted document's children correspond 1:1, in order, to
+  // `groups` — the producer pins `svg === rootOpen + groups + close`.
+  let prev = initial
+  const elements = new Map<string, Element>()
+  initial.groups.forEach((group, index) => {
+    const child = root.children[index]
+    if (child !== undefined) elements.set(group.key, child)
+  })
+
+  const update = (next: KeyedSvgRender): void => {
+    // Root envelope: attribute maps are compared, not order — DOM
+    // attribute order is not semantically meaningful, and setAttribute
+    // keeps the existing position on value changes.
+    for (const [name, value] of Object.entries(next.rootAttrs)) {
+      if (prev.rootAttrs[name] !== value) root.setAttribute(name, value)
+    }
+    for (const name of Object.keys(prev.rootAttrs)) {
+      if (!(name in next.rootAttrs)) root.removeAttribute(name)
+    }
+
+    const prevSvgByKey = new Map(prev.groups.map((group) => [group.key, group.svg]))
+    const nextElements = new Map<string, Element>()
+    next.groups.forEach((group, index) => {
+      const existing = elements.get(group.key)
+      const element =
+        existing !== undefined && prevSvgByKey.get(group.key) === group.svg
+          ? existing
+          : parseGroup(group.svg)
+      nextElements.set(group.key, element)
+      // Anchor by position: insertBefore both inserts new elements and
+      // moves reused ones; a replaced key's stale element drifts toward
+      // the tail and is dropped by the cleanup below.
+      const anchor = root.children[index] ?? null
+      if (anchor !== element) root.insertBefore(element, anchor)
+    })
+
+    while (root.children.length > next.groups.length) {
+      root.children[next.groups.length]?.remove()
+    }
+
+    elements.clear()
+    for (const [key, element] of nextElements) elements.set(key, element)
+    prev = next
+  }
+
+  return { root, update }
+}

--- a/apps/web/src/lib/layout-worker.ts
+++ b/apps/web/src/lib/layout-worker.ts
@@ -27,6 +27,7 @@
 // `document` on evaluation, and a worker has none — importing it throws
 // `document is not defined` before a single message is handled.
 
+import type { SpatialContentCache } from '@kamiazya/whiteboard-canvas-render'
 import { ensureViewerFontLoaded } from '@kamiazya/whiteboard-canvas-viewer/font-loading'
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer/measure-text'
 import {
@@ -34,6 +35,8 @@ import {
   renderMarkdownPreview,
 } from '../components/markdown-editor/render-preview.js'
 import { renderCanvasToSvgWith } from '../components/spatial-editor/scene-render-core.js'
+import type { ResolvedTheme } from '../hooks/useThemeMode'
+import { createSpatialContentCache } from './content-cache'
 import {
   composeReferenceSeam,
   FONT_DEGRADED,
@@ -46,6 +49,19 @@ import {
 } from './layout-worker-protocol.js'
 
 const measure = createBrowserMeasureText()
+
+// One content cache per theme, for the worker's whole lifetime. Sound
+// because this worker REFUSES to lay out until its font face is loaded
+// (the FONT_DEGRADED gate below), so `measure` behaves identically for
+// every request it ever serves — theme is the only remaining cache axis.
+const contentCaches = new Map<ResolvedTheme, SpatialContentCache>()
+function contentCacheFor(theme: ResolvedTheme): SpatialContentCache {
+  const existing = contentCaches.get(theme)
+  if (existing !== undefined) return existing
+  const cache = createSpatialContentCache()
+  contentCaches.set(theme, cache)
+  return cache
+}
 
 // Registration is idempotent and memoized inside the loader, but the FIRST
 // request must wait for it: measuring before the face lands produces
@@ -150,6 +166,7 @@ self.onmessage = async (
       measure,
       theme: request.theme,
       resolveReference: composeReferenceSeam({ labels, missing: missingRefs }),
+      contentCache: contentCacheFor(request.theme),
     })
     const response: LayoutResponse = {
       type: 'laid-out',

--- a/apps/web/src/lib/use-keyed-svg.browser.test.tsx
+++ b/apps/web/src/lib/use-keyed-svg.browser.test.tsx
@@ -1,0 +1,55 @@
+import {
+  type KeyedSvgRender,
+  renderSceneToKeyedSvg,
+  type SceneNode,
+} from '@kamiazya/whiteboard-canvas-render'
+import { act, cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { useKeyedSvg } from './use-keyed-svg'
+
+afterEach(cleanup)
+
+const shape = (id: string, x: number): SceneNode => ({
+  kind: 'shape',
+  id,
+  bbox: { x, y: 0, w: 100, h: 60 },
+  appearance: { fill: '#fff', stroke: '#333' },
+})
+
+const keyedOf = (nodes: SceneNode[]): KeyedSvgRender =>
+  renderSceneToKeyedSvg({ nodes }, { padding: 4 })
+
+let setKeyed: (next: KeyedSvgRender) => void = () => {}
+let bumpUnrelated: () => void = () => {}
+
+function Host({ initial }: { readonly initial: KeyedSvgRender }) {
+  const [keyed, set] = useState(initial)
+  const [, bump] = useState(0)
+  setKeyed = set
+  bumpUnrelated = () => bump((n) => n + 1)
+  return <div data-testid="surface" ref={useKeyedSvg(keyed)} />
+}
+
+it('mounts once, and a keyed prop change patches only the changed group', () => {
+  const { container } = render(<Host initial={keyedOf([shape('a', 0), shape('b', 200)])} />)
+  const byKey = (key: string) => container.querySelector(`[data-wb-key="${key}"]`)
+  const keptA = byKey('a')
+  const oldB = byKey('b')
+  expect(keptA).not.toBeNull()
+
+  act(() => setKeyed(keyedOf([shape('a', 0), shape('b', 240)])))
+  expect(byKey('a')).toBe(keptA)
+  expect(byKey('b')).not.toBe(oldB)
+  expect(byKey('b')?.outerHTML).toContain('x="240"')
+})
+
+it('a parent re-render without a keyed change leaves the patched DOM untouched', () => {
+  const { container } = render(<Host initial={keyedOf([shape('a', 0)])} />)
+  const root = container.querySelector('svg')
+  const group = container.querySelector('[data-wb-key="a"]')
+
+  act(() => bumpUnrelated())
+  expect(container.querySelector('svg')).toBe(root)
+  expect(container.querySelector('[data-wb-key="a"]')).toBe(group)
+})

--- a/apps/web/src/lib/use-keyed-svg.ts
+++ b/apps/web/src/lib/use-keyed-svg.ts
@@ -1,0 +1,41 @@
+/**
+ * React seam for the keyed SVG patcher: a ref callback that mounts once
+ * and patches on every `keyed` change. React owns the CONTAINER element
+ * and nothing below it — the hook renders no children through React, so a
+ * parent re-render can never clobber a patched subtree the way a
+ * `dangerouslySetInnerHTML` prop swap would. This is the imperative-
+ * container pattern (the same shape as embedding a map library), chosen
+ * so the patcher's DOM continuity survives React's render cycle.
+ */
+
+import type { KeyedSvgRender } from '@kamiazya/whiteboard-canvas-render'
+import { useCallback, useLayoutEffect, useRef } from 'react'
+import { type KeyedSvgPatcher, mountKeyedSvg } from './keyed-svg-patcher'
+
+export function useKeyedSvg(keyed: KeyedSvgRender): (container: HTMLElement | null) => void {
+  const containerRef = useRef<HTMLElement | null>(null)
+  const patcherRef = useRef<KeyedSvgPatcher | null>(null)
+
+  // Layout-effect timing: the patch lands before paint, in the same frame
+  // as the React commit that carried the new render — the innerHTML swap
+  // this replaces had the same timing.
+  useLayoutEffect(() => {
+    const container = containerRef.current
+    if (container === null) return
+    if (patcherRef.current === null) {
+      patcherRef.current = mountKeyedSvg(container, keyed)
+    } else {
+      patcherRef.current.update(keyed)
+    }
+  }, [keyed])
+
+  return useCallback((container: HTMLElement | null) => {
+    if (container === containerRef.current) return
+    containerRef.current = container
+    // A detached or swapped container invalidates the mounted patcher; the
+    // next layout effect re-mounts into the new one. (StrictMode's dev
+    // double-mount re-runs the mount path idempotently.)
+    patcherRef.current = null
+    if (container !== null) container.replaceChildren()
+  }, [])
+}

--- a/packages/canvas-render/src/index.ts
+++ b/packages/canvas-render/src/index.ts
@@ -20,6 +20,7 @@ export type {
 export type {
   FacetCardData,
   ResolvedReference,
+  SpatialContentCache,
   SpatialLayoutDegradation,
   SpatialLayoutOptions,
 } from './layout/spatial-canvas.js'
@@ -42,6 +43,7 @@ export { clampAdvance, constantRatioMeasureText, isFullWidthCodePoint } from './
 export { MIN_SCENE_EXTENT_PX, sceneBounds } from './scene-bounds.js'
 export type { SceneDigest } from './scene-digest.js'
 export { sceneDigest, sceneDigestSchema } from './scene-digest.js'
+export { sceneEntryKeys } from './scene-entry-keys.js'
 export type {
   Appearance,
   BlockquoteNode,
@@ -72,6 +74,8 @@ export type {
 export type { SvgDocumentOptions } from './svg/backend.js'
 export { renderSceneToSvg } from './svg/backend.js'
 export { escapeXmlAttr, escapeXmlText, formatCoord } from './svg/format.js'
+export type { KeyedSvgGroup, KeyedSvgRender } from './svg/keyed.js'
+export { renderSceneToKeyedSvg } from './svg/keyed.js'
 export { SPATIAL_THEME_FONT_FAMILY } from './theme/font-family.js'
 export type { SpatialGeometry } from './theme/spatial-geometry.js'
 export { SPATIAL_THEME_GEOMETRY } from './theme/spatial-geometry.js'

--- a/packages/canvas-render/src/index.ts
+++ b/packages/canvas-render/src/index.ts
@@ -7,6 +7,7 @@ export type {
   CodeToken,
   CodeTokenLines,
   CodeTokenRole,
+  FittedBlocks,
   MdastLayoutOptions,
   RenderedSvgFragment,
 } from './layout/mdast-blocks.js'

--- a/packages/canvas-render/src/layout/spatial-canvas-content-cache.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas-content-cache.test.ts
@@ -1,0 +1,151 @@
+import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
+import { describe, expect, it, vi } from 'vitest'
+import type { MeasureText } from '../measure.js'
+import { createFakeMeasure } from '../test-utils/fake-measure.js'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { createSpatialTheme } from '../theme/spatial-theme.js'
+import type { FittedBlocks } from './mdast-blocks.js'
+import {
+  layoutSpatialCanvas,
+  type SpatialContentCache,
+  type SpatialLayoutOptions,
+} from './spatial-canvas.js'
+
+const textNode = (
+  id: string,
+  x: number,
+  y: number,
+  text: string,
+  size: { w?: number; h?: number } = {},
+): SpatialNode => ({
+  id,
+  type: 'text',
+  x,
+  y,
+  width: size.w ?? 240,
+  height: size.h ?? 140,
+  text,
+})
+
+function mapCache(): SpatialContentCache & { store: Map<string, FittedBlocks> } {
+  const store = new Map<string, FittedBlocks>()
+  return { store, get: (key) => store.get(key), set: (key, value) => store.set(key, value) }
+}
+
+function options(
+  overrides: Partial<SpatialLayoutOptions> = {},
+  measure: MeasureText = createFakeMeasure(),
+): SpatialLayoutOptions {
+  return { measure, appearance: createSpatialTheme({ mode: 'light' }), ...overrides }
+}
+
+function countingMeasure(): { measure: MeasureText; calls: () => number } {
+  const inner = createFakeMeasure()
+  let n = 0
+  return {
+    measure: (text, font) => {
+      n += 1
+      return inner(text, font)
+    },
+    calls: () => n,
+  }
+}
+
+const BODY = '# Title\n\nA paragraph long enough to wrap across a couple of lines in the box.'
+
+describe('layoutSpatialCanvas content cache', () => {
+  it('a warm cache reproduces the uncached scene exactly, including after a move', () => {
+    const canvas: SpatialCanvas = { nodes: [textNode('a', 40, 40, BODY)], edges: [] }
+    const cache = mapCache()
+    const cold = layoutSpatialCanvas(canvas, options({ contentCache: cache }))
+    expect(JSON.stringify(cold)).toBe(JSON.stringify(layoutSpatialCanvas(canvas, options())))
+
+    const moved: SpatialCanvas = { nodes: [textNode('a', 300, 500, BODY)], edges: [] }
+    const warm = layoutSpatialCanvas(moved, options({ contentCache: cache }))
+    expect(JSON.stringify(warm)).toBe(JSON.stringify(layoutSpatialCanvas(moved, options())))
+  })
+
+  it('a warm cache lays text-node content out without a single measure call', () => {
+    const canvas: SpatialCanvas = {
+      nodes: [textNode('a', 0, 0, BODY), textNode('b', 400, 0, `${BODY} And more.`)],
+      edges: [],
+    }
+    const cache = mapCache()
+    const cold = countingMeasure()
+    layoutSpatialCanvas(canvas, options({ contentCache: cache }, cold.measure))
+    expect(cold.calls()).toBeGreaterThan(0)
+
+    const warm = countingMeasure()
+    layoutSpatialCanvas(canvas, options({ contentCache: cache }, warm.measure))
+    expect(warm.calls()).toBe(0)
+  })
+
+  it('distinguishes text and box size in the key — a changed node recomputes', () => {
+    const cache = mapCache()
+    const base: SpatialCanvas = { nodes: [textNode('a', 0, 0, BODY)], edges: [] }
+    layoutSpatialCanvas(base, options({ contentCache: cache }))
+
+    for (const edited of [
+      { nodes: [textNode('a', 0, 0, `${BODY}!`)], edges: [] },
+      { nodes: [textNode('a', 0, 0, BODY, { w: 300 })], edges: [] },
+      { nodes: [textNode('a', 0, 0, BODY, { h: 80 })], edges: [] },
+    ] satisfies SpatialCanvas[]) {
+      const counting = countingMeasure()
+      layoutSpatialCanvas(edited, options({ contentCache: cache }, counting.measure))
+      expect(counting.calls()).toBeGreaterThan(0)
+    }
+  })
+
+  it('does not cache the parse-failure fallback, and reports the degradation every run', () => {
+    const cache = mapCache()
+    const parseBody = () => {
+      throw new Error('bad body')
+    }
+    const canvas: SpatialCanvas = { nodes: [textNode('a', 0, 0, 'x')], edges: [] }
+    const onDegrade = vi.fn()
+    layoutSpatialCanvas(canvas, options({ contentCache: cache, parseBody, onDegrade }))
+    layoutSpatialCanvas(canvas, options({ contentCache: cache, parseBody, onDegrade }))
+    expect(cache.store.size).toBe(0)
+    expect(onDegrade).toHaveBeenCalledTimes(2)
+  })
+})
+
+const bodyArb = fc.oneof(
+  fc.constant(''),
+  fc.string({ maxLength: 40 }),
+  fc
+    .array(fc.string({ minLength: 1, maxLength: 20 }), { minLength: 1, maxLength: 6 })
+    .map((words) => `# H\n\n${words.join(' ')}`),
+)
+
+const nodeArb = (id: string): fc.Arbitrary<SpatialNode> =>
+  fc
+    .record({
+      x: fc.integer({ min: -200, max: 600 }),
+      y: fc.integer({ min: -200, max: 600 }),
+      w: fc.integer({ min: 30, max: 320 }),
+      h: fc.integer({ min: 20, max: 200 }),
+      text: bodyArb,
+    })
+    .map(({ x, y, w, h, text }) => textNode(id, x, y, text, { w, h }))
+
+describe('layoutSpatialCanvas content cache (PBT)', () => {
+  fcTest.prop(
+    [fc.array(nodeArb('n'), { minLength: 1, maxLength: 3 }), nodeArb('n')],
+    withDefaults(),
+  )(
+    'a shared warm cache never changes any layout across a random edit sequence',
+    (nodes, edited) => {
+      const cache = mapCache()
+      const canvases: SpatialCanvas[] = [
+        { nodes: nodes.map((n, i) => ({ ...n, id: `n${i}` })), edges: [] },
+        { nodes: [{ ...edited, id: 'n0' }], edges: [] },
+      ]
+      for (const canvas of canvases) {
+        const withCache = layoutSpatialCanvas(canvas, options({ contentCache: cache }))
+        const fresh = layoutSpatialCanvas(canvas, options())
+        expect(JSON.stringify(withCache)).toBe(JSON.stringify(fresh))
+      }
+    },
+  )
+})

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -171,6 +171,39 @@ export interface SpatialLayoutOptions {
    * editor decides by on-screen size, export by intrinsic size.
    */
   readonly expandFileNode?: (node: Extract<SpatialNode, { type: 'file' }>) => boolean
+  /**
+   * Optional memo for a text node's laid-out body. Content is laid out in
+   * ORIGIN-RELATIVE coordinates and placed by `placeInNode`, so a cached
+   * value is position-independent by construction: keyed by the node's
+   * text and box size only. Everything else that shapes content —
+   * `measure`, the appearance resolver, `geometry`, `parseBody`, the mdast
+   * seams — is deliberately NOT in the key: the CALLER owns the cache's
+   * lifetime and must discard it when any of those change (in practice:
+   * one cache per document+theme, dropped on theme/font switches). Cached
+   * values are shared between scenes and must be treated as immutable,
+   * which scene nodes already are.
+   *
+   * Only the success path is cached. The parse-failure fallback recomputes
+   * every run so `onDegrade` keeps firing — a cache must change timings,
+   * never what the caller is told.
+   *
+   * Measured before building (the instrument-first rule): content layout
+   * is 15-18ms of a 66-125ms full layout on the scene-diff corpus with the
+   * arithmetic test measurer — edge routing dominates — so this memo buys
+   * roughly the content share, more under a real (Canvas/opentype)
+   * measurer whose per-call cost is far above the fake's.
+   */
+  readonly contentCache?: SpatialContentCache
+}
+
+/**
+ * The store behind `SpatialLayoutOptions.contentCache`. Deliberately a
+ * plain get/set pair rather than a Map subtype, so a caller can wrap an
+ * LRU, a WeakRef map, or a plain object without this package caring.
+ */
+export interface SpatialContentCache {
+  get(key: string): FittedBlocks | undefined
+  set(key: string, value: FittedBlocks): void
 }
 
 /**
@@ -428,13 +461,28 @@ function composeTextNode(
   options: ResolvedLayoutOptions,
 ): readonly SceneNode[] {
   const maxWidth = contentWidth(node.width, options)
+  // Position deliberately absent from the key: the cached value is
+  // origin-relative (see `contentCache`'s contract), so a moved node hits.
+  const cacheKey =
+    options.contentCache === undefined
+      ? undefined
+      : JSON.stringify([node.width, node.height, node.text])
+  const cached = cacheKey === undefined ? undefined : options.contentCache?.get(cacheKey)
   let body: FittedBlocks
-  try {
-    const laid = layoutMdastBlocks(options.parseBody(node.text), mdastOptionsFor(maxWidth, options))
-    body = fitTextBody(laid, node, options)
-  } catch (err) {
-    options.onDegrade?.({ kind: 'body-parse-failed', nodeId: node.id, err })
-    body = fitTextBody({ nodes: [labelRun(node.text, options, maxWidth)] }, node, options)
+  if (cached !== undefined) {
+    body = cached
+  } else {
+    try {
+      const laid = layoutMdastBlocks(
+        options.parseBody(node.text),
+        mdastOptionsFor(maxWidth, options),
+      )
+      body = fitTextBody(laid, node, options)
+      if (cacheKey !== undefined) options.contentCache?.set(cacheKey, body)
+    } catch (err) {
+      options.onDegrade?.({ kind: 'body-parse-failed', nodeId: node.id, err })
+      body = fitTextBody({ nodes: [labelRun(node.text, options, maxWidth)] }, node, options)
+    }
   }
   return [
     chromeWithFit(node, options, body.truncated),

--- a/packages/canvas-render/src/scene-bounds.test.ts
+++ b/packages/canvas-render/src/scene-bounds.test.ts
@@ -348,15 +348,22 @@ describe('sceneBounds', () => {
     )['./svg/backend.ts']
 
     // A renderer emits a transform by writing a `transform:` attribute onto
-    // its VNode; ownership is the nearest preceding `function renderX(`
-    // declaration. Comments discussing transforms don't match the attribute
-    // spelling, so they cannot produce false positives.
-    const functionStarts = [...backendSource.matchAll(/function (render\w+)\(/g)].map((m) => ({
-      name: m[1],
-      index: m.index ?? 0,
-    }))
-    const translating = [...backendSource.matchAll(/transform: `translate\(/g)].map(
-      (m) => functionStarts.filter((f) => f.index < (m.index ?? 0)).at(-1)?.name,
+    // its VNode; ownership is the nearest preceding renderer declaration
+    // (`function renderX(` or `const renderX = `). Comments discussing
+    // transforms don't match the attribute spelling, so they cannot produce
+    // false positives. The occurrence COUNT is pinned first and separately:
+    // attribution by nearest-preceding-declaration could credit a new
+    // emitter to a renderer already in the expected set (e.g. an arrow
+    // function the declaration regex missed, defined right after one of the
+    // two), and the count catches that case regardless of attribution.
+    const occurrences = [...backendSource.matchAll(/transform: `translate\(/g)]
+    expect(occurrences).toHaveLength(2)
+
+    const declarationStarts = [
+      ...backendSource.matchAll(/(?:function|const)\s+(render\w+)\s*[=(]/g),
+    ].map((m) => ({ name: m[1], index: m.index ?? 0 }))
+    const translating = occurrences.map(
+      (m) => declarationStarts.filter((f) => f.index < (m.index ?? 0)).at(-1)?.name,
     )
 
     expect(new Set(translating)).toEqual(new Set(['renderListItem', 'renderTableCell']))

--- a/packages/canvas-render/src/scene-bounds.test.ts
+++ b/packages/canvas-render/src/scene-bounds.test.ts
@@ -347,11 +347,17 @@ describe('sceneBounds', () => {
       }) as Record<string, string>
     )['./svg/backend.ts']
 
-    const translating = [
-      ...backendSource.matchAll(/function (render\w+)\([^)]*\)[^{]*\{([^}]*)\}/g),
-    ]
-      .filter(([, , body]) => body.includes('transform="translate('))
-      .map(([, name]) => name)
+    // A renderer emits a transform by writing a `transform:` attribute onto
+    // its VNode; ownership is the nearest preceding `function renderX(`
+    // declaration. Comments discussing transforms don't match the attribute
+    // spelling, so they cannot produce false positives.
+    const functionStarts = [...backendSource.matchAll(/function (render\w+)\(/g)].map((m) => ({
+      name: m[1],
+      index: m.index ?? 0,
+    }))
+    const translating = [...backendSource.matchAll(/transform: `translate\(/g)].map(
+      (m) => functionStarts.filter((f) => f.index < (m.index ?? 0)).at(-1)?.name,
+    )
 
     expect(new Set(translating)).toEqual(new Set(['renderListItem', 'renderTableCell']))
   })

--- a/packages/canvas-render/src/scene-diff-quality.test.ts
+++ b/packages/canvas-render/src/scene-diff-quality.test.ts
@@ -1,6 +1,7 @@
 import type { CanvasEdge, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
 import { describe, expect, it } from 'vitest'
 import { layoutSpatialCanvas } from './layout/spatial-canvas.js'
+import { sceneEntryKeys } from './scene-entry-keys.js'
 import type { Scene } from './scene-graph.js'
 import { createFakeMeasure } from './test-utils/fake-measure.js'
 import { createSpatialTheme } from './theme/spatial-theme.js'
@@ -65,28 +66,14 @@ const layout = (canvas: SpatialCanvas): Scene =>
     appearance: createSpatialTheme({ mode: 'light' }),
   })
 
-/**
- * Keys each top-level scene entry stably: identified entries (chrome
- * shapes, edges) by their id; the content entries a node's shape is
- * followed by inherit that owner id plus an ordinal, matching the
- * documented emission order (shape, then its content, then all edges).
- */
+/** Entries keyed by the shared producer the keyed SVG renderer patches by
+ * (scene-entry-keys.ts) — one keying, so this scoreboard's counts are
+ * exactly the group replacements a patch layer would perform. */
 function keyedEntries(scene: Scene): Map<string, string> {
-  const out = new Map<string, string>()
-  let owner = 'preamble'
-  let ordinal = 0
-  for (const node of scene.nodes) {
-    const id = 'id' in node && typeof node.id === 'string' ? node.id : undefined
-    if (id !== undefined) {
-      owner = id
-      ordinal = 0
-      out.set(id, JSON.stringify(node))
-    } else {
-      ordinal += 1
-      out.set(`${owner}#${ordinal}`, JSON.stringify(node))
-    }
-  }
-  return out
+  const keys = sceneEntryKeys(scene)
+  return new Map(
+    scene.nodes.map((node, index) => [keys[index] ?? `#${index}`, JSON.stringify(node)]),
+  )
 }
 
 function diffCount(base: Scene, edited: Scene): { changed: number; total: number } {

--- a/packages/canvas-render/src/scene-diff-quality.test.ts
+++ b/packages/canvas-render/src/scene-diff-quality.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest'
+import type { CanvasEdge, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
+import { layoutSpatialCanvas } from './layout/spatial-canvas.js'
+import type { Scene } from './scene-graph.js'
+import { createFakeMeasure } from './test-utils/fake-measure.js'
+import { createSpatialTheme } from './theme/spatial-theme.js'
+
+/**
+ * The SCENE-DIFF SCOREBOARD: how much of a laid-out scene actually changes
+ * under a typical single edit. This is the go/no-go number for keyed
+ * per-group DOM patching in the editor (an incremental-rendering layer can
+ * only reuse what layout left byte-identical), measured BEFORE building
+ * that layer — the instrument-first rule.
+ *
+ * Every count is pinned EXACTLY, not as a ceiling, so an improvement in
+ * layout stability (e.g. localized edge re-routing) is as loud as a
+ * regression. `changed` counts top-level scene entries whose JSON differs
+ * (or that appear/disappear) between the base layout and the layout of the
+ * edited canvas; rendering is a pure per-entry function of these entries,
+ * so a changed entry is exactly a changed emitted group.
+ *
+ * The corpus is one deterministic 40-node/54-edge grid document — the
+ * scale an AI-authored canvas reaches — with wrapping text, a hub node,
+ * and both grid-neighbour and long-range edges. Deterministic measurer
+ * (fake, monospace-like) and theme, so the numbers cannot drift with
+ * fonts or platforms.
+ */
+
+const COLS = 8
+const NODE_COUNT = 40
+
+function buildCanvas(): { canvas: SpatialCanvas; leafId: string; hubId: string } {
+  const nodes: SpatialNode[] = []
+  const edges: CanvasEdge[] = []
+  for (let i = 0; i < NODE_COUNT; i++) {
+    const col = i % COLS
+    const row = Math.floor(i / COLS)
+    nodes.push({
+      id: `n${i}`,
+      type: 'text',
+      x: col * 320,
+      y: row * 220,
+      width: 240,
+      height: 140,
+      text: `# Step ${i}\n\nThis node explains stage ${i} of the pipeline with a sentence long enough to wrap across lines.`,
+    })
+  }
+  for (let i = 0; i < NODE_COUNT; i++) {
+    if (i + 1 < NODE_COUNT) edges.push({ id: `e${i}a`, fromNode: `n${i}`, toNode: `n${i + 1}` })
+    if (i + COLS < NODE_COUNT && i % 2 === 0) {
+      edges.push({ id: `e${i}b`, fromNode: `n${i}`, toNode: `n${i + COLS}` })
+    }
+  }
+  // n0 is the hub every long-range edge below meets; n39 is the far corner
+  // leaf (edge-degree 1) whose move should be the most local edit there is.
+  for (const target of ['n13', 'n21', 'n34']) {
+    edges.push({ id: `hub-${target}`, fromNode: 'n0', toNode: target })
+  }
+  return { canvas: { nodes, edges }, leafId: 'n39', hubId: 'n0' }
+}
+
+const layout = (canvas: SpatialCanvas): Scene =>
+  layoutSpatialCanvas(canvas, {
+    measure: createFakeMeasure(),
+    appearance: createSpatialTheme({ mode: 'light' }),
+  })
+
+/**
+ * Keys each top-level scene entry stably: identified entries (chrome
+ * shapes, edges) by their id; the content entries a node's shape is
+ * followed by inherit that owner id plus an ordinal, matching the
+ * documented emission order (shape, then its content, then all edges).
+ */
+function keyedEntries(scene: Scene): Map<string, string> {
+  const out = new Map<string, string>()
+  let owner = 'preamble'
+  let ordinal = 0
+  for (const node of scene.nodes) {
+    const id = 'id' in node && typeof node.id === 'string' ? node.id : undefined
+    if (id !== undefined) {
+      owner = id
+      ordinal = 0
+      out.set(id, JSON.stringify(node))
+    } else {
+      ordinal += 1
+      out.set(`${owner}#${ordinal}`, JSON.stringify(node))
+    }
+  }
+  return out
+}
+
+function diffCount(base: Scene, edited: Scene): { changed: number; total: number } {
+  const before = keyedEntries(base)
+  const after = keyedEntries(edited)
+  let changed = 0
+  for (const [key, value] of after) {
+    if (before.get(key) !== value) changed += 1
+  }
+  for (const key of before.keys()) {
+    if (!after.has(key)) changed += 1
+  }
+  return { changed, total: after.size }
+}
+
+function editNode(
+  canvas: SpatialCanvas,
+  id: string,
+  patch: (node: SpatialNode) => SpatialNode,
+): SpatialCanvas {
+  return { ...canvas, nodes: canvas.nodes.map((n) => (n.id === id ? patch(n) : n)) }
+}
+
+describe('scene-diff scoreboard (single edit → fraction of the scene that changes)', () => {
+  const { canvas, leafId, hubId } = buildCanvas()
+  const base = layout(canvas)
+
+  it('is measured against a stable corpus size', () => {
+    // 40 shapes + ~2 content entries per node (heading, paragraph) + 57 edges.
+    expect(keyedEntries(base).size).toBe(178)
+  })
+
+  it('moving the far-corner leaf node re-lays only its own neighbourhood', () => {
+    const edited = layout(editNode(canvas, leafId, (n) => ({ ...n, x: (n.x ?? 0) + 10 })))
+    expect(diffCount(base, edited)).toEqual({ changed: 11, total: 178 })
+  })
+
+  it('moving the hub node reaches the edges it anchors, and no further', () => {
+    const edited = layout(editNode(canvas, hubId, (n) => ({ ...n, x: (n.x ?? 0) + 10 })))
+    expect(diffCount(base, edited)).toEqual({ changed: 8, total: 178 })
+  })
+
+  it('editing visible text touches that node content and nothing else', () => {
+    const edited = layout(
+      editNode(canvas, 'n18', (n) =>
+        n.type === 'text' ? { ...n, text: (n.text ?? '').replace('# Step 18', '# Step 18b') } : n,
+      ),
+    )
+    expect(diffCount(base, edited)).toEqual({ changed: 1, total: 178 })
+  })
+
+  it('an edit entirely past the truncation cut changes nothing — free reuse', () => {
+    // The corpus bodies overflow their 140px boxes, so appended text falls
+    // in the region fitBlocksToHeight already cut. The honest count is 0:
+    // an incremental renderer gets these edits for free, and a layout
+    // change that makes truncation leak into visible entries shows up here.
+    const edited = layout(
+      editNode(canvas, 'n18', (n) =>
+        n.type === 'text' ? { ...n, text: `${n.text} Appended past the cut.` } : n,
+      ),
+    )
+    expect(diffCount(base, edited)).toEqual({ changed: 0, total: 178 })
+  })
+
+  it('adding a disconnected node adds its own entries and disturbs nothing', () => {
+    const added: SpatialNode = {
+      id: 'n-new',
+      type: 'text',
+      x: 9 * 320,
+      y: 0,
+      width: 240,
+      height: 140,
+      text: 'New note',
+    }
+    const edited = layout({ ...canvas, nodes: [...canvas.nodes, added] })
+    expect(diffCount(base, edited)).toEqual({ changed: 2, total: 180 })
+  })
+
+  it('deleting one edge removes exactly its own entry — surviving routes are untouched', () => {
+    const edited = layout({ ...canvas, edges: canvas.edges.filter((e) => e.id !== 'e10a') })
+    expect(diffCount(base, edited)).toEqual({ changed: 1, total: 177 })
+  })
+})

--- a/packages/canvas-render/src/scene-diff-quality.test.ts
+++ b/packages/canvas-render/src/scene-diff-quality.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
 import type { CanvasEdge, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
+import { describe, expect, it } from 'vitest'
 import { layoutSpatialCanvas } from './layout/spatial-canvas.js'
 import type { Scene } from './scene-graph.js'
 import { createFakeMeasure } from './test-utils/fake-measure.js'

--- a/packages/canvas-render/src/scene-entry-keys.ts
+++ b/packages/canvas-render/src/scene-entry-keys.ts
@@ -1,0 +1,30 @@
+/**
+ * The ONE producer of stable top-level scene-entry keys, shared by the
+ * keyed SVG renderer (svg/keyed.ts) and the scene-diff scoreboard.
+ * Identified entries — chrome shapes, edges — key by their id; the content
+ * entries that follow a node's chrome inherit that owner id plus an
+ * ordinal, matching the documented emission order (shape, then its
+ * content, then all edges). Entries before any identified one fall under
+ * the `preamble` owner, so a hand-built scene with no ids still keys by
+ * position — the same last-resort naming `sceneDigest` uses.
+ */
+
+import type { Scene } from './scene-graph.js'
+
+export function sceneEntryKeys(scene: Scene): readonly string[] {
+  const keys: string[] = []
+  let owner = 'preamble'
+  let ordinal = 0
+  for (const node of scene.nodes) {
+    const id = 'id' in node && typeof node.id === 'string' ? node.id : undefined
+    if (id !== undefined) {
+      owner = id
+      ordinal = 0
+      keys.push(id)
+    } else {
+      ordinal += 1
+      keys.push(`${owner}#${ordinal}`)
+    }
+  }
+  return keys
+}

--- a/packages/canvas-render/src/svg/backend.test.ts
+++ b/packages/canvas-render/src/svg/backend.test.ts
@@ -494,8 +494,11 @@ describe('renderSceneToSvg — appearance on textRun and edge', () => {
       ],
     }
     const svg = renderSceneToSvg(scene)
+    // The run's appearance rides the enclosing group via SVG inheritance
+    // (attribute hoisting); the non-inherited text-decoration stays on the
+    // <text>, and the link wrapper still wraps.
     expect(svg).toContain(
-      '<a href="https://example.com"><text x="0" y="0" fill="#111" font-family="Inter" font-size="14" text-decoration="underline">styled link</text></a>',
+      '<g fill="#111" font-family="Inter" font-size="14"><a href="https://example.com"><text x="0" y="0" text-decoration="underline">styled link</text></a></g>',
     )
   })
 

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -16,9 +16,9 @@ import type {
   TextRunNode,
 } from '../scene-graph.js'
 import { collectDefs } from './defs.js'
-import { hoistInheritedAttrs } from './hoist.js'
 import type { PaintAttrs, SvgBoxAttrs, TextEmphasisAttrs } from './elements.js'
 import { formatCoord, sanitizeHref, trustedHref } from './format.js'
+import { hoistInheritedAttrs } from './hoist.js'
 import { serializeSvg } from './serialize.js'
 import { el, rawXml, type SvgChild, type SvgDef, withDefs } from './vnode.js'
 

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -16,7 +16,7 @@ import type {
   TextRunNode,
 } from '../scene-graph.js'
 import { collectDefs } from './defs.js'
-import type { PaintAttrs, SvgBoxAttrs, TextEmphasisAttrs } from './elements.js'
+import type { PaintAttrs, SvgBoxAttrs, SvgElements, TextEmphasisAttrs } from './elements.js'
 import { formatCoord, sanitizeHref, trustedHref } from './format.js'
 import { hoistInheritedAttrs } from './hoist.js'
 import { serializeSvg } from './serialize.js'
@@ -612,7 +612,26 @@ const SVG_XMLNS = 'http://www.w3.org/2000/svg'
  * per-node visual attribute — the one exemption to this package's
  * no-visual-attributes rule) when `background` is set.
  */
-export function renderSceneToSvg(scene: Scene, options?: SvgDocumentOptions): string {
+/**
+ * The document's assembled pieces, shared by `renderSceneToSvg` and the
+ * keyed renderer (svg/keyed.ts) so the two can never disagree on root
+ * attributes, defs, background, or per-entry bodies. `body` holds exactly
+ * one (possibly empty) child per top-level scene entry, hoisted, in
+ * document order — the unit the keyed renderer wraps and the scene-diff
+ * scoreboard counts.
+ */
+export interface SvgDocumentParts {
+  /** Fixed order: xmlns [width height viewBox fill] — the envelope rule. */
+  readonly rootAttrs: SvgElements['svg']
+  readonly defs: SvgChild
+  readonly background: SvgChild
+  readonly body: ReadonlyArray<SvgChild>
+}
+
+export function buildSvgDocumentParts(
+  scene: Scene,
+  options?: SvgDocumentOptions,
+): SvgDocumentParts {
   // Hoisting runs before defs collection only by convention — it preserves
   // `defs` declarations on rebuilt nodes, so the order is not load-bearing.
   const body = scene.nodes.map(renderNode).map(hoistInheritedAttrs)
@@ -629,7 +648,7 @@ export function renderSceneToSvg(scene: Scene, options?: SvgDocumentOptions): st
       : []
 
   if (!hasEnvelopeOptions(options)) {
-    return serializeSvg(el('svg', { xmlns: SVG_XMLNS }, [defs, body]))
+    return { rootAttrs: { xmlns: SVG_XMLNS }, defs, background: [], body }
   }
 
   const viewBox = resolveViewBox(scene, options)
@@ -639,21 +658,25 @@ export function renderSceneToSvg(scene: Scene, options?: SvgDocumentOptions): st
   const background: SvgChild =
     options.background !== undefined ? renderBackgroundRect(viewBox, options.background) : []
 
-  // Fixed root-attribute order: xmlns width height viewBox fill.
-  return serializeSvg(
-    el(
-      'svg',
-      {
-        xmlns: SVG_XMLNS,
-        width,
-        height,
-        viewBox: viewBoxAttr,
-        fill:
-          typeof options.textFill === 'string' && options.textFill.length > 0
-            ? options.textFill
-            : undefined,
-      },
-      [defs, background, body],
-    ),
-  )
+  return {
+    // Fixed root-attribute order: xmlns width height viewBox fill.
+    rootAttrs: {
+      xmlns: SVG_XMLNS,
+      width,
+      height,
+      viewBox: viewBoxAttr,
+      fill:
+        typeof options.textFill === 'string' && options.textFill.length > 0
+          ? options.textFill
+          : undefined,
+    },
+    defs,
+    background,
+    body,
+  }
+}
+
+export function renderSceneToSvg(scene: Scene, options?: SvgDocumentOptions): string {
+  const parts = buildSvgDocumentParts(scene, options)
+  return serializeSvg(el('svg', parts.rootAttrs, [parts.defs, parts.background, parts.body]))
 }

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -16,6 +16,7 @@ import type {
   TextRunNode,
 } from '../scene-graph.js'
 import { collectDefs } from './defs.js'
+import { hoistInheritedAttrs } from './hoist.js'
 import type { PaintAttrs, SvgBoxAttrs, TextEmphasisAttrs } from './elements.js'
 import { formatCoord, sanitizeHref, trustedHref } from './format.js'
 import { serializeSvg } from './serialize.js'
@@ -612,7 +613,9 @@ const SVG_XMLNS = 'http://www.w3.org/2000/svg'
  * no-visual-attributes rule) when `background` is set.
  */
 export function renderSceneToSvg(scene: Scene, options?: SvgDocumentOptions): string {
-  const body = scene.nodes.map(renderNode)
+  // Hoisting runs before defs collection only by convention — it preserves
+  // `defs` declarations on rebuilt nodes, so the order is not load-bearing.
+  const body = scene.nodes.map(renderNode).map(hoistInheritedAttrs)
   // Presence-only, exactly like an absent appearance attribute: a scene
   // declaring no definitions emits the same bytes it always has.
   const collected = collectDefs(body)

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -15,9 +15,18 @@ import type {
   TableRowSceneNode,
   TextRunNode,
 } from '../scene-graph.js'
+import { collectDefs } from './defs.js'
 import { formatCoord, sanitizeHref } from './format.js'
 import { serializeSvg } from './serialize.js'
-import { el, rawXml, type SvgAttrs, type SvgAttrValue, type SvgChild } from './vnode.js'
+import {
+  el,
+  rawXml,
+  type SvgAttrs,
+  type SvgAttrValue,
+  type SvgChild,
+  type SvgDef,
+  withDefs,
+} from './vnode.js'
 
 /**
  * Decorative/presentational elements (backgrounds, dividers, group
@@ -137,29 +146,26 @@ const FADE_MASK_ID = 'wb-truncation-fade'
  * it scales to each run rather than needing a definition per run. Verified
  * honoured by resvg (the PNG export path) as well as browsers — a fully black
  * mask renders byte-identically to an empty canvas there.
+ *
+ * Declared on each truncated run and hoisted by `collectDefs`, so the
+ * document's `<defs>` appears exactly when something references the mask —
+ * the presence-only rule as a mechanism instead of a bespoke scene walk.
  */
-const FADE_DEFS = el('defs', undefined, [
-  el('linearGradient', { id: `${FADE_MASK_ID}-gradient`, x1: 0, y1: 0, x2: 1, y2: 0 }, [
-    el('stop', { offset: 0.75, 'stop-color': '#ffffff' }),
-    el('stop', { offset: 1, 'stop-color': '#000000' }),
-  ]),
-  el('mask', { id: FADE_MASK_ID, maskContentUnits: 'objectBoundingBox' }, [
-    el('rect', { x: 0, y: 0, width: 1, height: 1, fill: `url(#${FADE_MASK_ID}-gradient)` }),
-  ]),
-])
-
-/** Whether anything in the scene needs `FADE_DEFS`; nothing is emitted if not. */
-function hasTruncatedRun(nodes: readonly SceneNode[]): boolean {
-  const stack: SceneNode[] = [...nodes]
-  for (let node = stack.pop(); node !== undefined; node = stack.pop()) {
-    if (node.kind === 'textRun' && node.truncated === true) return true
-    for (const key of ['runs', 'children', 'items', 'rows', 'cells'] as const) {
-      const children = (node as unknown as Record<string, unknown>)[key]
-      if (Array.isArray(children)) stack.push(...(children as SceneNode[]))
-    }
-  }
-  return false
-}
+const FADE_DEFS: ReadonlyArray<SvgDef> = [
+  {
+    id: `${FADE_MASK_ID}-gradient`,
+    node: el('linearGradient', { id: `${FADE_MASK_ID}-gradient`, x1: 0, y1: 0, x2: 1, y2: 0 }, [
+      el('stop', { offset: 0.75, 'stop-color': '#ffffff' }),
+      el('stop', { offset: 1, 'stop-color': '#000000' }),
+    ]),
+  },
+  {
+    id: FADE_MASK_ID,
+    node: el('mask', { id: FADE_MASK_ID, maskContentUnits: 'objectBoundingBox' }, [
+      el('rect', { x: 0, y: 0, width: 1, height: 1, fill: `url(#${FADE_MASK_ID}-gradient)` }),
+    ]),
+  },
+]
 
 /**
  * The tinted box behind a run (inline code today). Bleeds `backdropPadXPx`
@@ -200,7 +206,7 @@ function renderTextRun(run: TextRunNode): SvgChild {
           fill: halo,
         })
       : []
-  const text = el(
+  const textEl = el(
     'text',
     {
       x: run.bbox.x,
@@ -214,6 +220,7 @@ function renderTextRun(run: TextRunNode): SvgChild {
     },
     [run.text],
   )
+  const text = run.truncated === true ? withDefs(textEl, FADE_DEFS) : textEl
   // The backdrop is painted before the halo underlay so a run can carry both
   // without the panel hiding the halo; inline code uses this for its tinted
   // pill.
@@ -612,9 +619,17 @@ const SVG_XMLNS = 'http://www.w3.org/2000/svg'
  */
 export function renderSceneToSvg(scene: Scene, options?: SvgDocumentOptions): string {
   const body = scene.nodes.map(renderNode)
-  // Presence-only, exactly like an absent appearance attribute: a scene with
-  // nothing truncated emits the same bytes it always has.
-  const defs: SvgChild = hasTruncatedRun(scene.nodes) ? FADE_DEFS : []
+  // Presence-only, exactly like an absent appearance attribute: a scene
+  // declaring no definitions emits the same bytes it always has.
+  const collected = collectDefs(body)
+  const defs: SvgChild =
+    collected.length > 0
+      ? el(
+          'defs',
+          undefined,
+          collected.map((def) => def.node),
+        )
+      : []
 
   if (!hasEnvelopeOptions(options)) {
     return serializeSvg(el('svg', { xmlns: SVG_XMLNS }, [defs, body]))

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -16,17 +16,10 @@ import type {
   TextRunNode,
 } from '../scene-graph.js'
 import { collectDefs } from './defs.js'
-import { formatCoord, sanitizeHref } from './format.js'
+import type { PaintAttrs, SvgBoxAttrs, TextEmphasisAttrs } from './elements.js'
+import { formatCoord, sanitizeHref, trustedHref } from './format.js'
 import { serializeSvg } from './serialize.js'
-import {
-  el,
-  rawXml,
-  type SvgAttrs,
-  type SvgAttrValue,
-  type SvgChild,
-  type SvgDef,
-  withDefs,
-} from './vnode.js'
+import { el, rawXml, type SvgChild, type SvgDef, withDefs } from './vnode.js'
 
 /**
  * Decorative/presentational elements (backgrounds, dividers, group
@@ -36,7 +29,7 @@ import {
  */
 const PRESENTATION = 'presentation'
 
-function rectAttrs(bbox: BoundingBox): SvgAttrs {
+function rectAttrs(bbox: BoundingBox): SvgBoxAttrs {
   // Fixed declaration order: x, y, width, height.
   return { x: bbox.x, y: bbox.y, width: bbox.w, height: bbox.h }
 }
@@ -65,9 +58,9 @@ function isPositiveLength(value: number | undefined): value is number {
  * or unusable field is omitted rather than defaulted — see the
  * `Appearance` doc comment for why the backend never invents a value.
  */
-function appearanceAttrs(appearance?: Appearance): SvgAttrs {
+function appearanceAttrs(appearance?: Appearance): PaintAttrs {
   if (!appearance) return {}
-  const attrs: Record<string, SvgAttrValue> = {}
+  const attrs: PaintAttrs = {}
   if (isNonEmptyString(appearance.fill)) attrs.fill = appearance.fill
   if (isNonEmptyString(appearance.stroke)) attrs.stroke = appearance.stroke
   if (isNonNegativeLength(appearance.strokeWidth)) attrs['stroke-width'] = appearance.strokeWidth
@@ -115,8 +108,8 @@ const TEXT_HALO_PAD_PX = 2
 const BACKDROP_RADIUS_PX = 6
 
 /** Inline emphasis the layout measured for — painted, or the flags are lies. */
-function emphasisAttrs(run: TextRunNode): SvgAttrs {
-  const attrs: Record<string, SvgAttrValue> = {}
+function emphasisAttrs(run: TextRunNode): TextEmphasisAttrs {
+  const attrs: TextEmphasisAttrs = {}
   if (run.strong === true) attrs['font-weight'] = '700'
   if (run.emphasis === true) attrs['font-style'] = 'italic'
   // A link is underlined rather than recolored because this backend is never
@@ -226,7 +219,8 @@ function renderTextRun(run: TextRunNode): SvgChild {
   // pill.
   const content: SvgChild = [renderBackdrop(run), underlay, text]
   if (!run.link) return content
-  const href = run.link.kind === 'link' ? sanitizeHref(run.link.href) : run.link.documentId
+  const href =
+    run.link.kind === 'link' ? sanitizeHref(run.link.href) : trustedHref(run.link.documentId)
   return el('a', { href }, [content])
 }
 
@@ -452,7 +446,7 @@ function renderNode(node: SceneNode): SvgChild {
       // preceding block. The node carries no measured ascent (it is not a
       // text run), so the baseline is derived from the box: 0.8 matches the
       // ascent ratio the measurer contract documents for body text.
-      return el('a', { href: `#${node.documentId}` }, [
+      return el('a', { href: trustedHref(`#${node.documentId}`) }, [
         el('text', { x: node.bbox.x, y: node.bbox.y + node.bbox.h * 0.8 }, [node.title]),
       ])
     case 'embedResolved':

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -15,7 +15,9 @@ import type {
   TableRowSceneNode,
   TextRunNode,
 } from '../scene-graph.js'
-import { escapeXmlAttr, escapeXmlText, formatCoord, sanitizeHref } from './format.js'
+import { formatCoord, sanitizeHref } from './format.js'
+import { serializeSvg } from './serialize.js'
+import { el, rawXml, type SvgAttrs, type SvgAttrValue, type SvgChild } from './vnode.js'
 
 /**
  * Decorative/presentational elements (backgrounds, dividers, group
@@ -23,11 +25,11 @@ import { escapeXmlAttr, escapeXmlText, formatCoord, sanitizeHref } from './forma
  * `role="presentation"` so a screen reader does not announce them; text
  * runs and links keep their natural implicit role.
  */
-const PRESENTATION_ATTR = 'role="presentation"'
+const PRESENTATION = 'presentation'
 
-function rectAttrs(bbox: BoundingBox): string {
+function rectAttrs(bbox: BoundingBox): SvgAttrs {
   // Fixed declaration order: x, y, width, height.
-  return `x="${formatCoord(bbox.x)}" y="${formatCoord(bbox.y)}" width="${formatCoord(bbox.w)}" height="${formatCoord(bbox.h)}"`
+  return { x: bbox.x, y: bbox.y, width: bbox.w, height: bbox.h }
 }
 
 function isFiniteBox(box: BoundingBox): boolean {
@@ -48,32 +50,20 @@ function isPositiveLength(value: number | undefined): value is number {
   return isNonNegativeLength(value) && value > 0
 }
 
-function withLeadingSpace(attrs: string): string {
-  return attrs === '' ? '' : ` ${attrs}`
-}
-
 /**
  * Presence-only presentation attributes for a shape/text-run/edge, in the
  * fixed order `fill stroke stroke-width font-family font-size`. An absent
  * or unusable field is omitted rather than defaulted — see the
  * `Appearance` doc comment for why the backend never invents a value.
  */
-function appearanceAttrs(appearance?: Appearance): string {
-  if (!appearance) return ''
-  const parts: string[] = []
-  if (isNonEmptyString(appearance.fill)) parts.push(`fill="${escapeXmlAttr(appearance.fill)}"`)
-  if (isNonEmptyString(appearance.stroke)) {
-    parts.push(`stroke="${escapeXmlAttr(appearance.stroke)}"`)
-  }
-  if (isNonNegativeLength(appearance.strokeWidth)) {
-    parts.push(`stroke-width="${formatCoord(appearance.strokeWidth)}"`)
-  }
-  if (isNonEmptyString(appearance.fontFamily)) {
-    parts.push(`font-family="${escapeXmlAttr(appearance.fontFamily)}"`)
-  }
-  if (isNonNegativeLength(appearance.fontSize)) {
-    parts.push(`font-size="${formatCoord(appearance.fontSize)}"`)
-  }
+function appearanceAttrs(appearance?: Appearance): SvgAttrs {
+  if (!appearance) return {}
+  const attrs: Record<string, SvgAttrValue> = {}
+  if (isNonEmptyString(appearance.fill)) attrs.fill = appearance.fill
+  if (isNonEmptyString(appearance.stroke)) attrs.stroke = appearance.stroke
+  if (isNonNegativeLength(appearance.strokeWidth)) attrs['stroke-width'] = appearance.strokeWidth
+  if (isNonEmptyString(appearance.fontFamily)) attrs['font-family'] = appearance.fontFamily
+  if (isNonNegativeLength(appearance.fontSize)) attrs['font-size'] = appearance.fontSize
   // Emitted after `fill` so the pair reads together; `1` is the SVG initial
   // value, so it is omitted to keep an opacity-free scene byte-identical.
   if (
@@ -81,16 +71,16 @@ function appearanceAttrs(appearance?: Appearance): string {
     Number.isFinite(appearance.fillOpacity) &&
     appearance.fillOpacity !== 1
   ) {
-    parts.push(`fill-opacity="${formatCoord(appearance.fillOpacity)}"`)
+    attrs['fill-opacity'] = appearance.fillOpacity
   }
   if (
     typeof appearance.strokeOpacity === 'number' &&
     Number.isFinite(appearance.strokeOpacity) &&
     appearance.strokeOpacity !== 1
   ) {
-    parts.push(`stroke-opacity="${formatCoord(appearance.strokeOpacity)}"`)
+    attrs['stroke-opacity'] = appearance.strokeOpacity
   }
-  return parts.join(' ')
+  return attrs
 }
 
 /**
@@ -116,10 +106,10 @@ const TEXT_HALO_PAD_PX = 2
 const BACKDROP_RADIUS_PX = 6
 
 /** Inline emphasis the layout measured for — painted, or the flags are lies. */
-function emphasisAttrs(run: TextRunNode): string {
-  const parts: string[] = []
-  if (run.strong === true) parts.push('font-weight="700"')
-  if (run.emphasis === true) parts.push('font-style="italic"')
+function emphasisAttrs(run: TextRunNode): SvgAttrs {
+  const attrs: Record<string, SvgAttrValue> = {}
+  if (run.strong === true) attrs['font-weight'] = '700'
+  if (run.emphasis === true) attrs['font-style'] = 'italic'
   // A link is underlined rather than recolored because this backend is never
   // handed a palette: a run's fill is INHERITED from whatever host group the
   // SVG is dropped into, which is what lets one scene render on the editor's
@@ -129,8 +119,8 @@ function emphasisAttrs(run: TextRunNode): string {
     ...(run.deleted === true ? ['line-through'] : []),
     ...(run.link ? ['underline'] : []),
   ]
-  if (decorations.length > 0) parts.push(`text-decoration="${decorations.join(' ')}"`)
-  return parts.length > 0 ? ` ${parts.join(' ')}` : ''
+  if (decorations.length > 0) attrs['text-decoration'] = decorations.join(' ')
+  return attrs
 }
 
 /**
@@ -148,12 +138,15 @@ const FADE_MASK_ID = 'wb-truncation-fade'
  * honoured by resvg (the PNG export path) as well as browsers — a fully black
  * mask renders byte-identically to an empty canvas there.
  */
-const FADE_DEFS =
-  `<defs><linearGradient id="${FADE_MASK_ID}-gradient" x1="0" y1="0" x2="1" y2="0">` +
-  '<stop offset="0.75" stop-color="#ffffff"/><stop offset="1" stop-color="#000000"/>' +
-  `</linearGradient><mask id="${FADE_MASK_ID}" maskContentUnits="objectBoundingBox">` +
-  `<rect x="0" y="0" width="1" height="1" fill="url(#${FADE_MASK_ID}-gradient)"/>` +
-  '</mask></defs>'
+const FADE_DEFS = el('defs', undefined, [
+  el('linearGradient', { id: `${FADE_MASK_ID}-gradient`, x1: 0, y1: 0, x2: 1, y2: 0 }, [
+    el('stop', { offset: 0.75, 'stop-color': '#ffffff' }),
+    el('stop', { offset: 1, 'stop-color': '#000000' }),
+  ]),
+  el('mask', { id: FADE_MASK_ID, maskContentUnits: 'objectBoundingBox' }, [
+    el('rect', { x: 0, y: 0, width: 1, height: 1, fill: `url(#${FADE_MASK_ID}-gradient)` }),
+  ]),
+])
 
 /** Whether anything in the scene needs `FADE_DEFS`; nothing is emitted if not. */
 function hasTruncatedRun(nodes: readonly SceneNode[]): boolean {
@@ -175,79 +168,106 @@ function hasTruncatedRun(nodes: readonly SceneNode[]): boolean {
  * the line above. A non-finite bbox renders as nothing rather than reaching
  * `formatCoord`, which throws by contract.
  */
-function renderBackdrop(run: TextRunNode): string {
-  if (run.backdrop === undefined || !isFiniteBox(run.bbox)) return ''
+function renderBackdrop(run: TextRunNode): SvgChild {
+  if (run.backdrop === undefined || !isFiniteBox(run.bbox)) return []
   const pad = isNonNegativeLength(run.backdropPadXPx) ? run.backdropPadXPx : 0
-  const appearance = withLeadingSpace(appearanceAttrs(run.backdrop))
   const box = {
     x: run.bbox.x - pad,
     y: run.bbox.y,
     w: run.bbox.w + 2 * pad,
     h: run.bbox.h,
   }
-  return `<rect ${rectAttrs(box)} rx="${formatCoord(BACKDROP_RADIUS_PX)}"${appearance}/>`
+  return el('rect', {
+    ...rectAttrs(box),
+    rx: BACKDROP_RADIUS_PX,
+    ...appearanceAttrs(run.backdrop),
+  })
 }
 
-function renderTextRun(run: TextRunNode): string {
-  const appearance =
-    withLeadingSpace(appearanceAttrs(run.appearance)) +
-    emphasisAttrs(run) +
-    (run.truncated === true ? ` mask="url(#${FADE_MASK_ID})"` : '')
-  const position = `x="${formatCoord(run.bbox.x)}" y="${formatCoord(textBaselineY(run))}"`
-  const body = escapeXmlText(run.text)
+function renderTextRun(run: TextRunNode): SvgChild {
   const halo = run.appearance?.halo
   // A surface-colored pill under the whole text box (a glyph-outline halo
   // leaves the crossed line peeking through word spaces), so a label
   // sitting ON an edge stays readable end to end.
-  const underlay =
+  const underlay: SvgChild =
     halo !== undefined && halo.length > 0
-      ? `<rect x="${formatCoord(run.bbox.x - TEXT_HALO_PAD_PX)}" y="${formatCoord(run.bbox.y - TEXT_HALO_PAD_PX)}" width="${formatCoord(run.bbox.w + 2 * TEXT_HALO_PAD_PX)}" height="${formatCoord(run.bbox.h + 2 * TEXT_HALO_PAD_PX)}" rx="${formatCoord(TEXT_HALO_PAD_PX)}" fill="${escapeXmlAttr(halo)}"/>`
-      : ''
-  // Painted before the halo underlay so a run can carry both without the
-  // panel hiding the halo; inline code uses this for its tinted pill.
-  const backdrop = renderBackdrop(run)
-  // A code run's whitespace is CONTENT: XML collapses it otherwise, and a
-  // fenced line loses the indentation that says what nests inside what.
-  const space = run.code === true ? ' xml:space="preserve"' : ''
-  const text = `${backdrop}${underlay}<text ${position}${appearance}${space}>${body}</text>`
-  if (!run.link) return text
+      ? el('rect', {
+          x: run.bbox.x - TEXT_HALO_PAD_PX,
+          y: run.bbox.y - TEXT_HALO_PAD_PX,
+          width: run.bbox.w + 2 * TEXT_HALO_PAD_PX,
+          height: run.bbox.h + 2 * TEXT_HALO_PAD_PX,
+          rx: TEXT_HALO_PAD_PX,
+          fill: halo,
+        })
+      : []
+  const text = el(
+    'text',
+    {
+      x: run.bbox.x,
+      y: textBaselineY(run),
+      ...appearanceAttrs(run.appearance),
+      ...emphasisAttrs(run),
+      mask: run.truncated === true ? `url(#${FADE_MASK_ID})` : undefined,
+      // A code run's whitespace is CONTENT: XML collapses it otherwise, and a
+      // fenced line loses the indentation that says what nests inside what.
+      'xml:space': run.code === true ? 'preserve' : undefined,
+    },
+    [run.text],
+  )
+  // The backdrop is painted before the halo underlay so a run can carry both
+  // without the panel hiding the halo; inline code uses this for its tinted
+  // pill.
+  const content: SvgChild = [renderBackdrop(run), underlay, text]
+  if (!run.link) return content
   const href = run.link.kind === 'link' ? sanitizeHref(run.link.href) : run.link.documentId
-  return `<a href="${escapeXmlAttr(href)}">${text}</a>`
+  return el('a', { href }, [content])
 }
 
 /**
  * The box chrome of a spatial canvas node. A non-finite bbox field is a
- * layout bug this package must not crash on — it renders as the empty
- * string rather than reaching `formatCoord`, which throws by contract.
+ * layout bug this package must not crash on — it renders as nothing rather
+ * than reaching `formatCoord`, which throws by contract.
  */
-function renderShape(node: ShapeSceneNode): string {
-  if (!isFiniteBox(node.bbox)) return ''
-  const rx = isPositiveLength(node.radius) ? ` rx="${formatCoord(node.radius)}"` : ''
-  const appearance = withLeadingSpace(appearanceAttrs(node.appearance))
-  return `<rect ${rectAttrs(node.bbox)}${rx}${appearance}/>`
+function renderShape(node: ShapeSceneNode): SvgChild {
+  if (!isFiniteBox(node.bbox)) return []
+  return el('rect', {
+    ...rectAttrs(node.bbox),
+    rx: isPositiveLength(node.radius) ? node.radius : undefined,
+    ...appearanceAttrs(node.appearance),
+  })
 }
 
-function renderListItem(item: ListItemNode): string {
+function renderListItem(item: ListItemNode): SvgChild {
   const tx = item.bbox.x
-  const transform = tx !== 0 ? ` transform="translate(${formatCoord(tx)},0)"` : ''
-  return `<g${transform}>${item.children.map(renderNode).join('')}</g>`
+  return el(
+    'g',
+    tx !== 0 ? { transform: `translate(${formatCoord(tx)},0)` } : undefined,
+    item.children.map(renderNode),
+  )
 }
 
-function renderTableCell(cell: TableCellSceneNode): string {
+function renderTableCell(cell: TableCellSceneNode): SvgChild {
   const tx = cell.bbox.x
-  const transform = tx !== 0 ? ` transform="translate(${formatCoord(tx)},0)"` : ''
-  return `<g${transform}>${cell.runs.map(renderTextRun).join('')}</g>`
+  return el(
+    'g',
+    tx !== 0 ? { transform: `translate(${formatCoord(tx)},0)` } : undefined,
+    cell.runs.map(renderTextRun),
+  )
 }
 
-function renderTableRow(row: TableRowSceneNode): string {
+function renderTableRow(row: TableRowSceneNode): SvgChild {
   // A hairline on the row's bottom edge is the whole of a table's chrome —
   // no cell grid, no zebra wash. Drawn at the row's own y so it separates
   // this row from the next rather than boxing either.
-  const separator =
+  const separator: SvgChild =
     row.appearance !== undefined && isFiniteBox(row.bbox)
-      ? `<rect ${rectAttrs({ x: row.bbox.x, y: row.bbox.y + row.bbox.h - 1, w: row.bbox.w, h: 1 })}${withLeadingSpace(appearanceAttrs(row.appearance))} ${PRESENTATION_ATTR}/>`
-      : ''
-  return `<g>${separator}${row.cells.map(renderTableCell).join('')}</g>`
+      ? el('rect', {
+          ...rectAttrs({ x: row.bbox.x, y: row.bbox.y + row.bbox.h - 1, w: row.bbox.w, h: 1 }),
+          ...appearanceAttrs(row.appearance),
+          role: PRESENTATION,
+        })
+      : []
+  return el('g', undefined, [separator, row.cells.map(renderTableCell)])
 }
 
 /**
@@ -260,15 +280,20 @@ function renderTableRow(row: TableRowSceneNode): string {
  * before layout carried them, which still renders through the old path
  * rather than nothing.
  */
-function renderCodeBlock(node: CodeBlockNode): string {
-  const panel =
+function renderCodeBlock(node: CodeBlockNode): SvgChild {
+  const panel: SvgChild =
     node.appearance !== undefined && isFiniteBox(node.bbox)
-      ? `<rect ${rectAttrs(node.bbox)}${isPositiveLength(node.radius) ? ` rx="${formatCoord(node.radius)}"` : ''}${withLeadingSpace(appearanceAttrs(node.appearance))} ${PRESENTATION_ATTR}/>`
-      : ''
+      ? el('rect', {
+          ...rectAttrs(node.bbox),
+          rx: isPositiveLength(node.radius) ? node.radius : undefined,
+          ...appearanceAttrs(node.appearance),
+          role: PRESENTATION,
+        })
+      : []
   if (node.runs === undefined) {
-    return `${panel}<text ${rectAttrs(node.bbox)} xml:space="preserve">${escapeXmlText(node.value)}</text>`
+    return [panel, el('text', { ...rectAttrs(node.bbox), 'xml:space': 'preserve' }, [node.value])]
   }
-  return `${panel}${node.runs.map(renderTextRun).join('')}`
+  return [panel, node.runs.map(renderTextRun)]
 }
 
 type EdgePoint = { readonly x: number; readonly y: number }
@@ -350,16 +375,20 @@ function roundedPathData(path: readonly EdgePoint[], jumps: readonly EdgeJump[] 
   return parts.join(' ')
 }
 
-function renderNode(node: SceneNode): string {
+function pointsAttr(points: readonly EdgePoint[]): string {
+  return points.map((p) => `${formatCoord(p.x)},${formatCoord(p.y)}`).join(' ')
+}
+
+function renderNode(node: SceneNode): SvgChild {
   switch (node.kind) {
     case 'textRun':
       return renderTextRun(node)
     case 'heading':
-      return `<g>${node.runs.map(renderTextRun).join('')}</g>`
+      return el('g', undefined, node.runs.map(renderTextRun))
     case 'paragraph':
-      return `<g>${node.runs.map(renderTextRun).join('')}</g>`
+      return el('g', undefined, node.runs.map(renderTextRun))
     case 'list':
-      return `<g>${node.items.map(renderListItem).join('')}</g>`
+      return el('g', undefined, node.items.map(renderListItem))
     case 'codeBlock':
       return renderCodeBlock(node)
     case 'blockquote':
@@ -368,20 +397,28 @@ function renderNode(node: SceneNode): string {
       // colour that would be wrong in one of the two host themes. The bar
       // child sets its own value, and a descendant's own presentation
       // attribute wins over the inherited one (it does not multiply).
-      return `<g${withLeadingSpace(appearanceAttrs(node.appearance))} ${PRESENTATION_ATTR}>${node.children.map(renderNode).join('')}</g>`
+      return el(
+        'g',
+        { ...appearanceAttrs(node.appearance), role: PRESENTATION },
+        node.children.map(renderNode),
+      )
     case 'group':
-      return `<g ${PRESENTATION_ATTR}>${node.children.map(renderNode).join('')}</g>`
+      return el('g', { role: PRESENTATION }, node.children.map(renderNode))
     case 'thematicBreak':
-      return `<rect ${rectAttrs(node.bbox)}${withLeadingSpace(appearanceAttrs(node.appearance))} ${PRESENTATION_ATTR}/>`
+      return el('rect', {
+        ...rectAttrs(node.bbox),
+        ...appearanceAttrs(node.appearance),
+        role: PRESENTATION,
+      })
     case 'table':
-      return `<g>${node.rows.map(renderTableRow).join('')}</g>`
+      return el('g', undefined, node.rows.map(renderTableRow))
     case 'rawHtml':
       // Raw HTML has no independently-verifiable well-formedness guarantee
       // (it is caller-supplied Markdown-embedded HTML), so it is escaped as
       // text rather than injected verbatim like a trusted SVG fragment.
-      return `<text ${rectAttrs(node.bbox)}>${escapeXmlText(node.value)}</text>`
+      return el('text', rectAttrs(node.bbox), [node.value])
     case 'unresolvedReference':
-      return `<g ${PRESENTATION_ATTR}/>`
+      return el('g', { role: PRESENTATION })
     case 'svgFragment': {
       // Precondition: the caller has already validated `svg` is well-formed
       // XML before constructing this node — emitted verbatim, not escaped.
@@ -396,15 +433,11 @@ function renderNode(node: SceneNode): string {
       const { x, y, w, h } = node.bbox
       const positioned =
         Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(w) && Number.isFinite(h)
+      const role = node.role === 'presentation' ? PRESENTATION : undefined
       if (!positioned) {
-        return node.role === 'presentation'
-          ? `<g ${PRESENTATION_ATTR}>${node.svg}</g>`
-          : `<g>${node.svg}</g>`
+        return el('g', role === undefined ? undefined : { role }, [rawXml(node.svg)])
       }
-      const attrs = `x="${formatCoord(x)}" y="${formatCoord(y)}" width="${formatCoord(w)}" height="${formatCoord(h)}" overflow="visible"`
-      return node.role === 'presentation'
-        ? `<svg ${attrs} ${PRESENTATION_ATTR}>${node.svg}</svg>`
-        : `<svg ${attrs}>${node.svg}</svg>`
+      return el('svg', { x, y, width: w, height: h, overflow: 'visible', role }, [rawXml(node.svg)])
     }
     case 'embedPlaceholder':
       // SVG <text> y is the BASELINE, so the box TOP would paint the title
@@ -412,25 +445,43 @@ function renderNode(node: SceneNode): string {
       // preceding block. The node carries no measured ascent (it is not a
       // text run), so the baseline is derived from the box: 0.8 matches the
       // ascent ratio the measurer contract documents for body text.
-      return `<a href="#${escapeXmlAttr(node.documentId)}"><text x="${formatCoord(node.bbox.x)}" y="${formatCoord(node.bbox.y + node.bbox.h * 0.8)}">${escapeXmlText(node.title)}</text></a>`
+      return el('a', { href: `#${node.documentId}` }, [
+        el('text', { x: node.bbox.x, y: node.bbox.y + node.bbox.h * 0.8 }, [node.title]),
+      ])
     case 'embedResolved':
-      return `<g>${node.children.map(renderNode).join('')}</g>`
+      return el('g', undefined, node.children.map(renderNode))
     case 'edge': {
-      const points = node.path.map((p) => `${formatCoord(p.x)},${formatCoord(p.y)}`).join(' ')
-      const appearance = withLeadingSpace(appearanceAttrs(node.appearance))
+      const appearance = appearanceAttrs(node.appearance)
       // `fill="none"` is not decoration. SVG's initial fill is black and a
       // <polyline> fills the region its points enclose, so a bent edge would
       // paint a solid wedge across its own corner in whatever fill the
       // surrounding document inherits — invisible while every path had two
       // points, glaring the moment routing started bending them. A <path>
-      // needs it for exactly the same reason.
+      // needs it for exactly the same reason. It is declared before the
+      // appearance spread, matching the string backend's emission order (an
+      // edge appearance never carries a fill of its own).
       const jumps = node.jumps ?? []
       const polyline =
         node.rounded === true
-          ? `<path d="${roundedPathData(node.path, jumps)}" fill="none"${appearance} ${PRESENTATION_ATTR}/>`
+          ? el('path', {
+              d: roundedPathData(node.path, jumps),
+              fill: 'none',
+              ...appearance,
+              role: PRESENTATION,
+            })
           : jumps.length > 0
-            ? `<path d="${jumpedPathData(node.path, jumps)}" fill="none"${appearance} ${PRESENTATION_ATTR}/>`
-            : `<polyline points="${points}" fill="none"${appearance} ${PRESENTATION_ATTR}/>`
+            ? el('path', {
+                d: jumpedPathData(node.path, jumps),
+                fill: 'none',
+                ...appearance,
+                role: PRESENTATION,
+              })
+            : el('polyline', {
+                points: pointsAttr(node.path),
+                fill: 'none',
+                ...appearance,
+                role: PRESENTATION,
+              })
       // Arrowheads are filled triangles in the edge's stroke color, drawn
       // after (over) the polyline. Geometry comes from the shared helper so
       // sceneBounds always agrees on how far the wings reach.
@@ -438,19 +489,11 @@ function renderNode(node: SceneNode): string {
       // No stroke means the polyline itself is invisible (SVG's default
       // stroke is none) — the arrow must match it, not fall back to the
       // polygon's default black fill and float detached.
-      const arrowFill =
-        typeof stroke === 'string' && stroke.length > 0
-          ? ` fill="${escapeXmlAttr(stroke)}"`
-          : ' fill="none"'
-      const arrows = edgeArrowPolygons(node)
-        .map((arrow) => {
-          const arrowPoints = arrow.points
-            .map((p) => `${formatCoord(p.x)},${formatCoord(p.y)}`)
-            .join(' ')
-          return `<polygon points="${arrowPoints}"${arrowFill} ${PRESENTATION_ATTR}/>`
-        })
-        .join('')
-      return `${polyline}${arrows}`
+      const arrowFill = typeof stroke === 'string' && stroke.length > 0 ? stroke : 'none'
+      const arrows = edgeArrowPolygons(node).map((arrow) =>
+        el('polygon', { points: pointsAttr(arrow.points), fill: arrowFill, role: PRESENTATION }),
+      )
+      return [polyline, arrows]
     }
     case 'shape':
       return renderShape(node)
@@ -459,12 +502,17 @@ function renderNode(node: SceneNode): string {
       // per this package's canonical-serialization rule. Aspect is always
       // preserved; alt renders as a <title> child (the SVG accessible-name
       // mechanism), absence marks the image as presentation.
-      const title =
-        node.alt !== undefined && node.alt.length > 0
-          ? `<title>${escapeXmlText(node.alt)}</title>`
-          : ''
-      const roleAttr = title === '' ? ` ${PRESENTATION_ATTR}` : ''
-      return `<image ${rectAttrs(node.bbox)} href="${escapeXmlAttr(node.href)}" preserveAspectRatio="xMidYMid ${node.fit === 'cover' ? 'slice' : 'meet'}"${roleAttr}>${title}</image>`
+      const hasAlt = node.alt !== undefined && node.alt.length > 0
+      return el(
+        'image',
+        {
+          ...rectAttrs(node.bbox),
+          href: node.href,
+          preserveAspectRatio: `xMidYMid ${node.fit === 'cover' ? 'slice' : 'meet'}`,
+          role: hasAlt ? undefined : PRESENTATION,
+        },
+        hasAlt ? [el('title', undefined, [node.alt as string])] : [],
+      )
     }
   }
 }
@@ -540,9 +588,11 @@ function resolveDimension(explicit: number | undefined, fallback: number): numbe
   return explicit !== undefined && Number.isFinite(explicit) && explicit >= 0 ? explicit : fallback
 }
 
-function renderBackgroundRect(box: BoundingBox, background: string): string {
-  return `<rect ${rectAttrs(box)} fill="${escapeXmlAttr(background)}" ${PRESENTATION_ATTR}/>`
+function renderBackgroundRect(box: BoundingBox, background: string): SvgChild {
+  return el('rect', { ...rectAttrs(box), fill: background, role: PRESENTATION })
 }
+
+const SVG_XMLNS = 'http://www.w3.org/2000/svg'
 
 /**
  * Serializes a decorated scene to an SVG string. Pure, no DOM — the same
@@ -561,26 +611,37 @@ function renderBackgroundRect(box: BoundingBox, background: string): string {
  * no-visual-attributes rule) when `background` is set.
  */
 export function renderSceneToSvg(scene: Scene, options?: SvgDocumentOptions): string {
-  const body = scene.nodes.map(renderNode).join('')
+  const body = scene.nodes.map(renderNode)
   // Presence-only, exactly like an absent appearance attribute: a scene with
   // nothing truncated emits the same bytes it always has.
-  const defs = hasTruncatedRun(scene.nodes) ? FADE_DEFS : ''
+  const defs: SvgChild = hasTruncatedRun(scene.nodes) ? FADE_DEFS : []
 
   if (!hasEnvelopeOptions(options)) {
-    return `<svg xmlns="http://www.w3.org/2000/svg">${defs}${body}</svg>`
+    return serializeSvg(el('svg', { xmlns: SVG_XMLNS }, [defs, body]))
   }
 
   const viewBox = resolveViewBox(scene, options)
   const width = resolveDimension(options.width, viewBox.w)
   const height = resolveDimension(options.height, viewBox.h)
   const viewBoxAttr = `${formatCoord(viewBox.x)} ${formatCoord(viewBox.y)} ${formatCoord(viewBox.w)} ${formatCoord(viewBox.h)}`
-  const background =
-    options.background !== undefined ? renderBackgroundRect(viewBox, options.background) : ''
-  // Fixed root-attribute order: xmlns width height viewBox fill.
-  const textFillAttr =
-    typeof options.textFill === 'string' && options.textFill.length > 0
-      ? ` fill="${escapeXmlAttr(options.textFill)}"`
-      : ''
+  const background: SvgChild =
+    options.background !== undefined ? renderBackgroundRect(viewBox, options.background) : []
 
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="${formatCoord(width)}" height="${formatCoord(height)}" viewBox="${viewBoxAttr}"${textFillAttr}>${defs}${background}${body}</svg>`
+  // Fixed root-attribute order: xmlns width height viewBox fill.
+  return serializeSvg(
+    el(
+      'svg',
+      {
+        xmlns: SVG_XMLNS,
+        width,
+        height,
+        viewBox: viewBoxAttr,
+        fill:
+          typeof options.textFill === 'string' && options.textFill.length > 0
+            ? options.textFill
+            : undefined,
+      },
+      [defs, background, body],
+    ),
+  )
 }

--- a/packages/canvas-render/src/svg/defs.test.ts
+++ b/packages/canvas-render/src/svg/defs.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { collectDefs } from './defs.js'
+import { el, rawXml, type SvgDef, withDefs } from './vnode.js'
+
+const gradient: SvgDef = { id: 'grad', node: el('linearGradient', { id: 'grad' }) }
+const mask: SvgDef = { id: 'mask', node: el('mask', { id: 'mask' }) }
+
+describe('collectDefs', () => {
+  it('returns nothing for a tree with no declarations', () => {
+    expect(collectDefs([el('g', undefined, [el('rect', { x: 0 }), 'text'])])).toEqual([])
+  })
+
+  it('collects a declaration from a deeply nested element', () => {
+    const tree = [el('g', undefined, [el('a', { href: '#x' }, [withDefs(el('text'), [gradient])])])]
+    expect(collectDefs(tree)).toEqual([gradient])
+  })
+
+  it('keeps declaration order and dedupes by id, first occurrence winning', () => {
+    const other: SvgDef = { id: 'grad', node: el('linearGradient', { id: 'grad', x1: 1 }) }
+    const tree = [
+      withDefs(el('text'), [gradient, mask]),
+      withDefs(el('text'), [other]), // same id as `gradient` — dropped
+    ]
+    expect(collectDefs(tree)).toEqual([gradient, mask])
+  })
+
+  it('collects each of several distinct ids exactly once', () => {
+    const tree = [
+      withDefs(el('text'), [gradient]),
+      el('g', undefined, [withDefs(el('text'), [mask, gradient])]),
+      rawXml('<circle/>'), // opaque: cannot carry declarations
+    ]
+    expect(collectDefs(tree)).toEqual([gradient, mask])
+  })
+})

--- a/packages/canvas-render/src/svg/defs.test.ts
+++ b/packages/canvas-render/src/svg/defs.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { collectDefs } from './defs.js'
+import { trustedHref } from './format.js'
 import { el, rawXml, type SvgDef, withDefs } from './vnode.js'
 
 const gradient: SvgDef = { id: 'grad', node: el('linearGradient', { id: 'grad' }) }
@@ -7,11 +8,16 @@ const mask: SvgDef = { id: 'mask', node: el('mask', { id: 'mask' }) }
 
 describe('collectDefs', () => {
   it('returns nothing for a tree with no declarations', () => {
-    expect(collectDefs([el('g', undefined, [el('rect', { x: 0 }), 'text'])])).toEqual([])
+    const rect = el('rect', { x: 0, y: 0, width: 1, height: 1 })
+    expect(collectDefs([el('g', undefined, [rect, 'text'])])).toEqual([])
   })
 
   it('collects a declaration from a deeply nested element', () => {
-    const tree = [el('g', undefined, [el('a', { href: '#x' }, [withDefs(el('text'), [gradient])])])]
+    const tree = [
+      el('g', undefined, [
+        el('a', { href: trustedHref('#x') }, [withDefs(el('text', { x: 0, y: 0 }), [gradient])]),
+      ]),
+    ]
     expect(collectDefs(tree)).toEqual([gradient])
   })
 

--- a/packages/canvas-render/src/svg/defs.test.ts
+++ b/packages/canvas-render/src/svg/defs.test.ts
@@ -24,6 +24,28 @@ describe('collectDefs', () => {
     expect(collectDefs(tree)).toEqual([gradient, mask])
   })
 
+  it('collects a dependency declared on a definition node itself, dependency first', () => {
+    // A mask whose gradient dependency rides the mask definition's own node —
+    // the natural shape for a def with private dependencies. Dropping it
+    // leaves url(#dep-grad) unresolved in the emitted document.
+    const depGradient: SvgDef = { id: 'dep-grad', node: el('linearGradient', { id: 'dep-grad' }) }
+    const maskWithDep: SvgDef = {
+      id: 'dep-mask',
+      node: withDefs(el('mask', { id: 'dep-mask' }), [depGradient]),
+    }
+    const tree = [withDefs(el('text', { x: 0, y: 0 }), [maskWithDep])]
+    expect(collectDefs(tree)).toEqual([depGradient, maskWithDep])
+  })
+
+  it('terminates on mutually dependent definitions, keeping each once', () => {
+    const a: SvgDef = { id: 'a', node: el('mask', { id: 'a' }) }
+    const b: SvgDef = { id: 'b', node: withDefs(el('mask', { id: 'b' }), [a]) }
+    const aCyclic: SvgDef = { id: 'a', node: withDefs(el('mask', { id: 'a' }), [b]) }
+    const tree = [withDefs(el('text', { x: 0, y: 0 }), [aCyclic])]
+    const ids = collectDefs(tree).map((def) => def.id)
+    expect(ids.sort()).toEqual(['a', 'b'])
+  })
+
   it('collects each of several distinct ids exactly once', () => {
     const tree = [
       withDefs(el('text'), [gradient]),

--- a/packages/canvas-render/src/svg/defs.ts
+++ b/packages/canvas-render/src/svg/defs.ts
@@ -25,6 +25,11 @@ export function collectDefs(children: ReadonlyArray<SvgChild>): ReadonlyArray<Sv
     for (const def of child.defs ?? []) {
       if (seen.has(def.id)) continue
       seen.add(def.id)
+      // A definition's own node may declare the definitions IT depends on
+      // (a mask carrying its gradient). Visit it before pushing so a
+      // dependency is emitted ahead of its dependent; `seen` is marked
+      // first, so mutually dependent definitions terminate.
+      visit(def.node)
       collected.push(def)
     }
     for (const inner of child.children ?? []) visit(inner)

--- a/packages/canvas-render/src/svg/defs.ts
+++ b/packages/canvas-render/src/svg/defs.ts
@@ -1,0 +1,34 @@
+/**
+ * Hoists the `defs` declarations scattered through a VNode tree into one
+ * ordered, id-deduplicated list — the document assembly wraps the result in
+ * a single `<defs>` element as the root's first child, or emits nothing
+ * when the list is empty. First occurrence wins on an id collision, which
+ * is sound because ids are content-derived by contract (see `SvgVNode.defs`):
+ * two declarations sharing an id say the same thing in the same bytes.
+ */
+
+import type { SvgChild, SvgDef, SvgVNode } from './vnode.js'
+
+function isVNode(child: SvgChild): child is SvgVNode {
+  return typeof child === 'object' && child !== null && 'tag' in child
+}
+
+export function collectDefs(children: ReadonlyArray<SvgChild>): ReadonlyArray<SvgDef> {
+  const seen = new Set<string>()
+  const collected: SvgDef[] = []
+  const visit = (child: SvgChild): void => {
+    if (Array.isArray(child)) {
+      for (const inner of child) visit(inner)
+      return
+    }
+    if (!isVNode(child)) return
+    for (const def of child.defs ?? []) {
+      if (seen.has(def.id)) continue
+      seen.add(def.id)
+      collected.push(def)
+    }
+    for (const inner of child.children ?? []) visit(inner)
+  }
+  for (const child of children) visit(child)
+  return collected
+}

--- a/packages/canvas-render/src/svg/elements.ts
+++ b/packages/canvas-render/src/svg/elements.ts
@@ -59,7 +59,9 @@ export type SvgElements = {
     fill?: string
     role?: SvgRole
   }
-  g: PaintAttrs & { transform?: string; role?: SvgRole }
+  // data-wb-key is the keyed renderer's patch handle (svg/keyed.ts) —
+  // emitted only in keyed mode, never by the plain document renderer.
+  g: PaintAttrs & { transform?: string; role?: SvgRole; 'data-wb-key'?: string }
   rect: SvgBoxAttrs & PaintAttrs & { rx?: number; role?: SvgRole }
   // width/height appear on <text> only through the legacy codeBlock/rawHtml
   // box-placement path (rectAttrs spread); x/y are the baseline contract.

--- a/packages/canvas-render/src/svg/elements.ts
+++ b/packages/canvas-render/src/svg/elements.ts
@@ -1,0 +1,87 @@
+/**
+ * The element/attribute table of the SVG this backend actually emits —
+ * deliberately NARROW, not a general SVG typing. Every element and every
+ * attribute here exists because a renderer emits it; extending the output
+ * vocabulary means extending this table, which is where the canonical-
+ * serialization review happens. Type aliases (not interfaces) throughout,
+ * so each shape stays assignable to the serializer's loose attr storage.
+ *
+ * Conventions encoded as types rather than review rules:
+ * - Coordinates and lengths are `number` — the serializer routes them
+ *   through `formatCoord`, so a pre-formatted (locale-dependent) string
+ *   cannot reach the output.
+ * - Presence-only: an optional attribute set to `undefined` is omitted.
+ * - `<a href>` takes a `SafeHref` (sanitizeHref/trustedHref), never a raw
+ *   string, so an executable scheme cannot bypass the sanitizer. `<image
+ *   href>` stays a plain string by decision #9 (emitted verbatim: data:/
+ *   blob:/app URLs the composition root already owns).
+ * - Stroked line elements declare `fill` explicitly — SVG's initial black
+ *   fill painting a wedge across a bent edge is the shipped defect this
+ *   requirement pins.
+ */
+
+import type { SafeHref } from './format.js'
+
+export type SvgRole = 'presentation'
+
+export type SvgBoxAttrs = {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export type PaintAttrs = {
+  fill?: string
+  stroke?: string
+  'stroke-width'?: number
+  'font-family'?: string
+  'font-size'?: number
+  'fill-opacity'?: number
+  'stroke-opacity'?: number
+}
+
+export type TextEmphasisAttrs = {
+  'font-weight'?: string
+  'font-style'?: string
+  'text-decoration'?: string
+}
+
+export type SvgElements = {
+  svg: {
+    xmlns?: string
+    x?: number
+    y?: number
+    width?: number
+    height?: number
+    viewBox?: string
+    overflow?: 'visible'
+    fill?: string
+    role?: SvgRole
+  }
+  g: PaintAttrs & { transform?: string; role?: SvgRole }
+  rect: SvgBoxAttrs & PaintAttrs & { rx?: number; role?: SvgRole }
+  // width/height appear on <text> only through the legacy codeBlock/rawHtml
+  // box-placement path (rectAttrs spread); x/y are the baseline contract.
+  text: PaintAttrs &
+    TextEmphasisAttrs & {
+      x: number
+      y: number
+      width?: number
+      height?: number
+      mask?: string
+      'xml:space'?: 'preserve'
+    }
+  a: { href: SafeHref }
+  polyline: PaintAttrs & { points: string; fill: string; role?: SvgRole }
+  path: PaintAttrs & { d: string; fill: string; role?: SvgRole }
+  polygon: { points: string; fill: string; role?: SvgRole }
+  image: SvgBoxAttrs & { href: string; preserveAspectRatio: string; role?: SvgRole }
+  title: Record<string, never>
+  defs: Record<string, never>
+  linearGradient: { id: string; x1?: number; y1?: number; x2?: number; y2?: number }
+  stop: { offset: number; 'stop-color': string }
+  mask: { id: string; maskContentUnits?: 'objectBoundingBox' }
+}
+
+export type SvgTagName = keyof SvgElements

--- a/packages/canvas-render/src/svg/elements.type-safety.test.ts
+++ b/packages/canvas-render/src/svg/elements.type-safety.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeHref } from './format.js'
+import { el } from './vnode.js'
+
+/**
+ * Compile-time contract of the typed element table (elements.ts). The
+ * `@ts-expect-error` lines are verified by `tsc --noEmit` (typecheck), not
+ * by vitest — an annotation with no error under it FAILS the typecheck, so
+ * a loosened element type is caught even though every runtime assertion
+ * here stays green.
+ */
+describe('typed SVG element table', () => {
+  it('accepts the shapes the backend actually emits', () => {
+    expect(el('rect', { x: 0, y: 0, width: 1, height: 1, rx: 2, fill: '#fff' }).tag).toBe('rect')
+    expect(el('text', { x: 0, y: 0, 'xml:space': 'preserve' }, ['hi']).tag).toBe('text')
+    expect(el('g', { transform: 'translate(1,0)' }, []).tag).toBe('g')
+    expect(el('a', { href: sanitizeHref('https://example.com') }, []).tag).toBe('a')
+  })
+
+  it('rejects what the canonical serialization rules forbid', () => {
+    // @ts-expect-error unknown element name
+    el('rectt', {})
+    // @ts-expect-error typo'd attribute name
+    el('rect', { x: 0, y: 0, width: 1, heigth: 1 })
+    // @ts-expect-error a coordinate must be a number (formatCoord input), not a pre-formatted string
+    el('rect', { x: '0', y: 0, width: 1, height: 1 })
+    // @ts-expect-error an edge path must declare its fill (SVG's initial black fill must never leak)
+    el('polyline', { points: '0,0 1,1' })
+    // @ts-expect-error xml:space accepts only the one value the backend uses
+    el('text', { x: 0, y: 0, 'xml:space': 'default' })
+    // @ts-expect-error an <a href> takes a SafeHref (sanitizeHref/trustedHref), never a raw string
+    el('a', { href: 'javascript:alert(1)' }, [])
+  })
+})

--- a/packages/canvas-render/src/svg/format.ts
+++ b/packages/canvas-render/src/svg/format.ts
@@ -113,13 +113,36 @@ function normalizeHrefForSchemeCheck(href: string): string {
   return href.replace(ASCII_TAB_OR_NEWLINE, '').replace(LEADING_C0_OR_SPACE, '')
 }
 
+declare const safeHrefBrand: unique symbol
+
+/**
+ * A navigation href that has passed `sanitizeHref`, or that this package
+ * composed itself from a value the host resolves (`trustedHref`). The
+ * `<a href>` attribute accepts only this brand, so a caller cannot hand a
+ * raw markdown URL to the serializer without the scheme check — the
+ * compile-time form of the invariant `sanitizeHref`'s doc comment states.
+ */
+export type SafeHref = string & { readonly [safeHrefBrand]: true }
+
 /**
  * Returns `href` unchanged when it has no scheme (relative/hash link) or an
  * allow-listed scheme, otherwise `#` — never throws, degrades to a safe
  * same-page anchor rather than rejecting the whole render.
  */
-export function sanitizeHref(href: string): string {
+export function sanitizeHref(href: string): SafeHref {
   const match = URL_SCHEME_PATTERN.exec(normalizeHrefForSchemeCheck(href))
-  if (!match) return href
-  return SAFE_URL_SCHEMES.has(match[1].toLowerCase()) ? href : '#'
+  if (!match) return href as SafeHref
+  return (SAFE_URL_SCHEMES.has(match[1].toLowerCase()) ? href : '#') as SafeHref
+}
+
+/**
+ * Brands an href this package COMPOSES itself rather than receives from
+ * markdown: a `#fragment` built from a document id, or a wiki-link's
+ * document reference. Those are resolved by the host application, not the
+ * browser's URL parser, so the scheme allow-list does not apply — the
+ * XML-escaping in the serializer still does. Never pass caller-supplied
+ * link URLs here; those go through `sanitizeHref`.
+ */
+export function trustedHref(href: string): SafeHref {
+  return href as SafeHref
 }

--- a/packages/canvas-render/src/svg/hoist.test.ts
+++ b/packages/canvas-render/src/svg/hoist.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { hoistInheritedAttrs } from './hoist.js'
+import { serializeSvg } from './serialize.js'
+import type { SvgAttrs, SvgAttrValue, SvgChild, SvgVNode } from './vnode.js'
+import { rawXml } from './vnode.js'
+
+// Built as plain literals (not `el`) so tests and generators can compose
+// arbitrary attr combinations without satisfying the per-element table.
+const node = (tag: string, attrs?: SvgAttrs, children?: readonly SvgChild[]): SvgVNode => ({
+  tag,
+  ...(attrs === undefined ? {} : { attrs }),
+  ...(children === undefined ? {} : { children }),
+})
+
+const asSvg = (child: SvgChild): string => serializeSvg(node('svg', undefined, [child]))
+
+describe('hoistInheritedAttrs', () => {
+  it('hoists paint attrs shared by every direct child onto the group, in canonical order', () => {
+    const g = node('g', undefined, [
+      node('text', { x: 0, y: 0, fill: '#404040', 'font-family': 'Roboto', 'font-size': 16 }, [
+        'a',
+      ]),
+      node('text', { x: 0, y: 20, fill: '#404040', 'font-family': 'Roboto', 'font-size': 16 }, [
+        'b',
+      ]),
+    ])
+    expect(asSvg(hoistInheritedAttrs(g))).toBe(
+      '<svg><g fill="#404040" font-family="Roboto" font-size="16"><text x="0" y="0">a</text><text x="0" y="20">b</text></g></svg>',
+    )
+  })
+
+  it('does not hoist an attr some child lacks — that child would start inheriting it', () => {
+    const g = node('g', undefined, [
+      node('text', { x: 0, y: 0, fill: '#404040' }, ['a']),
+      node('rect', { x: 0, y: 0, width: 1, height: 1 }),
+    ])
+    expect(asSvg(hoistInheritedAttrs(g))).toBe(asSvg(g))
+  })
+
+  it('does not hoist when values differ', () => {
+    const g = node('g', undefined, [
+      node('text', { x: 0, y: 0, fill: '#111111' }, ['a']),
+      node('text', { x: 0, y: 20, fill: '#222222' }, ['b']),
+    ])
+    expect(asSvg(hoistInheritedAttrs(g))).toBe(asSvg(g))
+  })
+
+  it('keeps role as the last attribute on the receiving group', () => {
+    const g = node('g', { role: 'presentation' }, [
+      node('text', { x: 0, y: 0, fill: '#404040' }, ['a']),
+      node('text', { x: 0, y: 20, fill: '#404040' }, ['b']),
+    ])
+    expect(asSvg(hoistInheritedAttrs(g))).toBe(
+      '<svg><g fill="#404040" role="presentation"><text x="0" y="0">a</text><text x="0" y="20">b</text></g></svg>',
+    )
+  })
+
+  it('strips children matching a value the parent already declares, and leaves a differing parent value alone', () => {
+    const matching = node('g', { fill: '#404040' }, [
+      node('text', { x: 0, y: 0, fill: '#404040' }, ['a']),
+    ])
+    expect(asSvg(hoistInheritedAttrs(matching))).toBe(
+      '<svg><g fill="#404040"><text x="0" y="0">a</text></g></svg>',
+    )
+    const differing = node('g', { fill: '#111111' }, [
+      node('text', { x: 0, y: 0, fill: '#404040' }, ['a']),
+    ])
+    expect(asSvg(hoistInheritedAttrs(differing))).toBe(asSvg(differing))
+  })
+
+  it('composes bottom-up through nested containers (a inside g)', () => {
+    const g = node('g', undefined, [
+      node('a', { href: '#x' }, [node('text', { x: 0, y: 0, fill: '#404040' }, ['a'])]),
+      node('text', { x: 0, y: 20, fill: '#404040' }, ['b']),
+    ])
+    expect(asSvg(hoistInheritedAttrs(g))).toBe(
+      '<svg><g fill="#404040"><a href="#x"><text x="0" y="0">a</text></a><text x="0" y="20">b</text></g></svg>',
+    )
+  })
+
+  it('a rawXml child blocks hoisting — its computed style cannot be inspected', () => {
+    const g = node('g', undefined, [
+      node('text', { x: 0, y: 0, fill: '#404040' }, ['a']),
+      rawXml('<circle r="1"/>'),
+    ])
+    expect(asSvg(hoistInheritedAttrs(g))).toBe(asSvg(g))
+  })
+
+  it('preserves defs declarations on rebuilt nodes', () => {
+    const def = { id: 'd', node: node('mask', { id: 'd' }) }
+    const g = node('g', undefined, [
+      { ...node('text', { x: 0, y: 0, fill: '#404040' }, ['a']), defs: [def] },
+      node('text', { x: 0, y: 20, fill: '#404040' }, ['b']),
+    ])
+    const hoisted = hoistInheritedAttrs(g) as SvgVNode
+    const [first] = hoisted.children ?? []
+    expect((first as SvgVNode).defs).toEqual([def])
+  })
+})
+
+// --- property: hoisting never changes any element's computed paint ---
+
+const HOISTABLE = [
+  'fill',
+  'stroke',
+  'stroke-width',
+  'font-family',
+  'font-size',
+  'fill-opacity',
+  'stroke-opacity',
+] as const
+
+type Resolved = {
+  readonly tag: string
+  /** Computed paint — recorded only for PAINTING elements. A container's
+   * own computed paint legitimately changes when it receives a hoisted
+   * attribute (a `g`/`a` paints nothing itself); what must be invariant is
+   * what its descendants resolve to. */
+  readonly paint: Readonly<Record<string, SvgAttrValue>> | undefined
+  readonly rest: Readonly<Record<string, SvgAttrValue>>
+  readonly text: string
+}
+
+const CONTAINER_TAGS = new Set(['g', 'a'])
+
+/** Independent oracle: expands inheritance the way SVG does (nearest ancestor wins). */
+function resolvePaint(
+  child: SvgChild,
+  inherited: Readonly<Record<string, SvgAttrValue>>,
+  out: Resolved[],
+): void {
+  if (typeof child === 'string') return
+  // Array.isArray does not narrow a readonly-array union member away in its
+  // false branch, so the element case needs its own guard.
+  if (Array.isArray(child)) {
+    for (const inner of child as ReadonlyArray<SvgChild>) resolvePaint(inner, inherited, out)
+    return
+  }
+  if (!('tag' in child)) return
+  const attrs = child.attrs ?? {}
+  const paint: Record<string, SvgAttrValue> = { ...inherited }
+  const rest: Record<string, SvgAttrValue> = {}
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value === undefined) continue
+    if ((HOISTABLE as readonly string[]).includes(key)) paint[key] = value
+    else rest[key] = value
+  }
+  const text = (child.children ?? []).filter((c): c is string => typeof c === 'string').join('')
+  out.push({ tag: child.tag, paint: CONTAINER_TAGS.has(child.tag) ? undefined : paint, rest, text })
+  for (const inner of child.children ?? []) resolvePaint(inner, paint, out)
+}
+
+const paintArb = fc.record(
+  {
+    fill: fc.constantFrom('#111111', '#404040'),
+    'font-family': fc.constantFrom('Roboto', 'serif'),
+    'font-size': fc.constantFrom(14, 16),
+    'stroke-width': fc.constantFrom(1, 2),
+  },
+  { requiredKeys: [] },
+)
+
+const leafArb: fc.Arbitrary<SvgVNode> = fc.oneof(
+  paintArb.map((paint) => node('text', { x: 0, y: 0, ...paint }, ['t'])),
+  paintArb.map((paint) => node('rect', { x: 0, y: 0, width: 1, height: 1, ...paint })),
+)
+
+const treeArb: fc.Arbitrary<SvgVNode> = fc.letrec<{ tree: SvgVNode }>((tie) => ({
+  tree: fc.oneof(
+    { maxDepth: 3, withCrossShrink: true },
+    leafArb,
+    fc
+      .tuple(
+        fc.constantFrom('g', 'a'),
+        paintArb,
+        fc.option(fc.constant('presentation' as const), { nil: undefined }),
+        fc.array(tie('tree'), { maxLength: 4 }),
+      )
+      .map(([tag, paint, role, children]) =>
+        node(tag, { ...paint, ...(role === undefined ? {} : { role }) }, children),
+      ),
+  ),
+})).tree
+
+describe('hoistInheritedAttrs (PBT)', () => {
+  fcTest.prop([treeArb], withDefaults())(
+    'preserves every element sequence, computed paint, and non-paint attrs',
+    (tree) => {
+      const before: Resolved[] = []
+      const after: Resolved[] = []
+      resolvePaint(tree, {}, before)
+      resolvePaint(hoistInheritedAttrs(tree), {}, after)
+      expect(after).toEqual(before)
+    },
+  )
+
+  fcTest.prop([treeArb], withDefaults())('is idempotent', (tree) => {
+    const once = hoistInheritedAttrs(tree)
+    expect(hoistInheritedAttrs(once)).toEqual(once)
+  })
+})

--- a/packages/canvas-render/src/svg/hoist.ts
+++ b/packages/canvas-render/src/svg/hoist.ts
@@ -1,0 +1,159 @@
+/**
+ * Hoists inherited paint attributes shared by every child of a container
+ * (`<g>`/`<a>`) onto the container itself — the SVG-inheritance form of
+ * deduplication, measured at ~30-40% of a realistic document's raw bytes
+ * (96 identical `fill font-family font-size` clusters on one 40-node
+ * canvas). Pure VNode→VNode; painted output is provably unchanged (the
+ * computed-paint equivalence property in hoist.test.ts).
+ *
+ * The soundness rule: an attribute is lifted only when EVERY direct child
+ * is an element that declares it with the SAME value. A child lacking the
+ * attribute blocks the lift — it would otherwise start inheriting a value
+ * it never declared — and an opaque `rawXml` child blocks all lifting for
+ * its container, since its computed style cannot be inspected. Nearest-
+ * ancestor-wins keeps differing descendants untouched. Bottom-up
+ * application lets lifts compose through nested containers.
+ */
+
+import type { SvgAttrs, SvgAttrValue, SvgChild, SvgDef, SvgVNode } from './vnode.js'
+
+/** The SVG-inherited presentation attributes this backend emits. `role`,
+ * `mask`, and `xml:space` are deliberately absent: not inheritance-safe
+ * (`role`), not inherited (`mask`), or content semantics (`xml:space`). */
+const HOISTABLE = [
+  'fill',
+  'stroke',
+  'stroke-width',
+  'font-family',
+  'font-size',
+  'fill-opacity',
+  'stroke-opacity',
+] as const
+
+/** Containers legal to receive inherited paint and emitted by this backend. */
+const CONTAINERS = new Set(['g', 'a'])
+
+function isVNode(child: SvgChild): child is SvgVNode {
+  return typeof child === 'object' && child !== null && 'tag' in child
+}
+
+function rebuild(
+  node: SvgVNode,
+  attrs: SvgAttrs | undefined,
+  children: ReadonlyArray<SvgChild> | undefined,
+): SvgVNode {
+  const defs: { defs?: ReadonlyArray<SvgDef> } = node.defs === undefined ? {} : { defs: node.defs }
+  return {
+    tag: node.tag,
+    ...(attrs === undefined ? {} : { attrs }),
+    ...(children === undefined ? {} : { children }),
+    ...defs,
+  }
+}
+
+function withoutAttrs(node: SvgVNode, names: ReadonlySet<string>): SvgVNode {
+  if (node.attrs === undefined || names.size === 0) return node
+  const attrs = Object.fromEntries(Object.entries(node.attrs).filter(([name]) => !names.has(name)))
+  return rebuild(node, attrs, node.children)
+}
+
+/** `role` stays the last attribute — the canonical position it has always
+ * had on this backend's container elements. */
+function withHoisted(node: SvgVNode, hoisted: ReadonlyMap<string, SvgAttrValue>): SvgVNode {
+  if (hoisted.size === 0) return node
+  const existing = Object.entries(node.attrs ?? {})
+  const attrs: Record<string, SvgAttrValue> = Object.fromEntries(
+    existing.filter(([name]) => name !== 'role'),
+  )
+  for (const name of HOISTABLE) {
+    const value = hoisted.get(name)
+    if (value !== undefined) attrs[name] = value
+  }
+  const role = existing.find(([name]) => name === 'role')
+  if (role !== undefined) attrs.role = role[1]
+  return rebuild(node, attrs, node.children)
+}
+
+function flatten(children: ReadonlyArray<SvgChild>): SvgChild[] {
+  const out: SvgChild[] = []
+  for (const child of children) {
+    if (Array.isArray(child)) out.push(...flatten(child))
+    else out.push(child)
+  }
+  return out
+}
+
+type ChangeFlag = { changed: boolean }
+
+function hoistContainer(container: SvgVNode, flag: ChangeFlag): SvgVNode {
+  const children = flatten(container.children ?? [])
+  const elements = children.filter(isVNode)
+  // A non-element child (text, rawXml) cannot be inspected or is content —
+  // lifting anything past it is unsound, so the container is left alone.
+  if (elements.length === 0 || elements.length !== children.length) {
+    return rebuild(container, container.attrs, children)
+  }
+
+  const lift = new Map<string, SvgAttrValue>()
+  const strip = new Set<string>()
+  for (const name of HOISTABLE) {
+    const first = elements[0]?.attrs?.[name]
+    if (first === undefined) continue
+    if (!elements.every((element) => element.attrs?.[name] === first)) continue
+    const own = container.attrs?.[name]
+    if (own === undefined) {
+      lift.set(name, first)
+      strip.add(name)
+    } else if (own === first) {
+      // The parent already declares the same value: the copies are noise.
+      strip.add(name)
+    }
+  }
+  if (strip.size === 0) return rebuild(container, container.attrs, children)
+  flag.changed = true
+  return withHoisted(
+    rebuild(
+      container,
+      container.attrs,
+      children.map((child) => (isVNode(child) ? withoutAttrs(child, strip) : child)),
+    ),
+    lift,
+  )
+}
+
+function hoistOnce(child: SvgChild, flag: ChangeFlag): SvgChild {
+  if (typeof child === 'string') return child
+  if (Array.isArray(child)) return child.map((inner) => hoistOnce(inner, flag))
+  if (!isVNode(child)) return child
+  const node =
+    child.children === undefined
+      ? child
+      : rebuild(
+          child,
+          child.attrs,
+          child.children.map((inner) => hoistOnce(inner, flag)),
+        )
+  return CONTAINERS.has(node.tag) ? hoistContainer(node, flag) : node
+}
+
+/**
+ * Applies hoisting bottom-up through the whole tree, ITERATED TO A
+ * FIXPOINT. One bottom-up pass is not enough: stripping a nested
+ * container's attribute (because its parent lifted the same value) can
+ * make that container's own children newly uniform — an opportunity the
+ * pass already walked past. Verified by the shrunk counterexample
+ * `g[g{sw:1}[rect{sw:2}]]`, where a single pass is not idempotent. Each
+ * pass only moves attributes upward or deletes copies, so the iteration
+ * terminates; in practice it converges in one or two passes.
+ *
+ * Nested child arrays are flattened inside processed containers —
+ * byte-identical, since the serializer flattens them anyway.
+ */
+export function hoistInheritedAttrs(child: SvgChild): SvgChild {
+  let current = child
+  for (;;) {
+    const flag: ChangeFlag = { changed: false }
+    current = hoistOnce(current, flag)
+    if (!flag.changed) return current
+  }
+}

--- a/packages/canvas-render/src/svg/keyed.test.ts
+++ b/packages/canvas-render/src/svg/keyed.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import { sceneEntryKeys } from '../scene-entry-keys.js'
+import type { Scene } from '../scene-graph.js'
+import { renderSceneToSvg } from './backend.js'
+import { renderSceneToKeyedSvg } from './keyed.js'
+
+const scene: Scene = {
+  nodes: [
+    { kind: 'shape', id: 'node-a', bbox: { x: 0, y: 0, w: 100, h: 60 }, radius: 4 },
+    {
+      kind: 'paragraph',
+      bbox: { x: 8, y: 8, w: 80, h: 16 },
+      runs: [
+        {
+          kind: 'textRun',
+          bbox: { x: 8, y: 8, w: 40, h: 16 },
+          text: 'hello',
+          truncated: true,
+        },
+      ],
+    },
+    { kind: 'shape', id: 'node-b', bbox: { x: 200, y: 0, w: 100, h: 60 } },
+    {
+      kind: 'edge',
+      id: 'edge-1',
+      path: [
+        { x: 100, y: 30 },
+        { x: 200, y: 30 },
+      ],
+      fromSide: 'right',
+      toSide: 'left',
+      fromEnd: 'none',
+      toEnd: 'arrow',
+      appearance: { stroke: '#888' },
+    },
+  ],
+}
+
+describe('sceneEntryKeys', () => {
+  it('keys identified entries by id and content entries by owner and ordinal', () => {
+    expect(sceneEntryKeys(scene)).toEqual(['node-a', 'node-a#1', 'node-b', 'edge-1'])
+  })
+
+  it('keys leading unidentified entries under the preamble owner', () => {
+    const bare: Scene = {
+      nodes: [
+        { kind: 'paragraph', bbox: { x: 0, y: 0, w: 10, h: 10 }, runs: [] },
+        { kind: 'shape', id: 's', bbox: { x: 0, y: 0, w: 1, h: 1 } },
+      ],
+    }
+    expect(sceneEntryKeys(bare)).toEqual(['preamble#1', 's'])
+  })
+})
+
+describe('renderSceneToKeyedSvg', () => {
+  it('emits one keyed group per scene entry, plus the defs pseudo-group', () => {
+    const keyed = renderSceneToKeyedSvg(scene)
+    expect(keyed.groups.map((g) => g.key)).toEqual([
+      '#defs',
+      'node-a',
+      'node-a#1',
+      'node-b',
+      'edge-1',
+    ])
+    for (const group of keyed.groups) {
+      if (group.key.startsWith('#')) continue
+      expect(group.svg.startsWith(`<g data-wb-key="${group.key}">`)).toBe(true)
+      expect(group.svg.endsWith('</g>')).toBe(true)
+    }
+  })
+
+  it('assembles the document exactly from its parts', () => {
+    const keyed = renderSceneToKeyedSvg(scene, { padding: 4, background: '#fff' })
+    const body = keyed.groups.map((g) => g.svg).join('')
+    expect(keyed.svg).toBe(`${keyed.rootOpen}${body}</svg>`)
+    expect(keyed.groups.map((g) => g.key).slice(0, 2)).toEqual(['#defs', '#background'])
+  })
+
+  it('carries the root attributes the patch layer must keep in sync', () => {
+    const keyed = renderSceneToKeyedSvg(scene, { padding: 4 })
+    expect(keyed.rootAttrs.xmlns).toBe('http://www.w3.org/2000/svg')
+    expect(typeof keyed.rootAttrs.viewBox).toBe('string')
+  })
+
+  it('is byte-identical to renderSceneToSvg once the key wrappers are removed', () => {
+    for (const options of [undefined, { padding: 4, background: '#fff' }] as const) {
+      const keyed = renderSceneToKeyedSvg(scene, options)
+      // Exact reconstruction, no regex: a non-pseudo group is by contract
+      // `<g data-wb-key="KEY">` + inner + `</g>`; pseudo groups (#defs,
+      // #background) are emitted unwrapped in both forms.
+      const unwrapped = keyed.groups
+        .map((group) =>
+          group.key.startsWith('#')
+            ? group.svg
+            : group.svg.slice(`<g data-wb-key="${group.key}">`.length, -'</g>'.length),
+        )
+        .join('')
+      expect(`${keyed.rootOpen}${unwrapped}</svg>`).toBe(renderSceneToSvg(scene, options))
+    }
+  })
+
+  it('changes exactly the groups whose scene entries changed', () => {
+    const before = renderSceneToKeyedSvg(scene)
+    const movedB: Scene = {
+      nodes: scene.nodes.map((n) =>
+        'id' in n && n.id === 'node-b' && n.kind === 'shape'
+          ? { ...n, bbox: { ...n.bbox, x: 220 } }
+          : n,
+      ),
+    }
+    const after = renderSceneToKeyedSvg(movedB)
+    const beforeByKey = new Map(before.groups.map((g) => [g.key, g.svg]))
+    const changed = after.groups.filter((g) => beforeByKey.get(g.key) !== g.svg).map((g) => g.key)
+    expect(changed).toEqual(['node-b'])
+  })
+})

--- a/packages/canvas-render/src/svg/keyed.ts
+++ b/packages/canvas-render/src/svg/keyed.ts
@@ -1,0 +1,82 @@
+/**
+ * The keyed projection of the SVG document: the same bytes
+ * `renderSceneToSvg` emits, cut at the seams a DOM patch layer needs.
+ * Every top-level scene entry becomes one `<g data-wb-key="…">` group; the
+ * document-chrome pieces that live outside any entry — `<defs>` and the
+ * background rect — become the pseudo-groups `#defs` / `#background`. A
+ * consumer mounts `svg` once, then on the next render compares each
+ * group's string against what it holds and replaces only the ones that
+ * differ — string equality IS change detection, because the serializer is
+ * canonical and deterministic.
+ *
+ * Two invariants the tests pin:
+ * - Removing the wrappers reproduces `renderSceneToSvg` byte-for-byte
+ *   (both share `buildSvgDocumentParts`, so they cannot drift).
+ * - `svg` equals `rootOpen` + the groups' strings + `</svg>`, so the
+ *   mounted document and the patch units are the same bytes by
+ *   construction.
+ *
+ * The wrappers are an EDITOR-MODE projection: exports and the MCP render
+ * tool keep calling `renderSceneToSvg`, whose bytes carry no keys.
+ */
+
+import { sceneEntryKeys } from '../scene-entry-keys.js'
+import type { Scene } from '../scene-graph.js'
+import { buildSvgDocumentParts, type SvgDocumentOptions } from './backend.js'
+import { formatCoord } from './format.js'
+import { serializeSvg, serializeSvgChild, serializeSvgChunks } from './serialize.js'
+import { el, type SvgChild } from './vnode.js'
+
+export interface KeyedSvgGroup {
+  readonly key: string
+  /** The group's exact document bytes: `<g data-wb-key="KEY">…</g>` for a
+   * scene entry, the bare element for a pseudo-group. */
+  readonly svg: string
+}
+
+export interface KeyedSvgRender {
+  /** The full document — identical bytes to mounting the groups yourself. */
+  readonly svg: string
+  /** The root `<svg …>` open tag, exactly as it appears in `svg`. */
+  readonly rootOpen: string
+  /** Root attributes as raw (unescaped) strings, for `setAttribute` when a
+   * patch keeps the mounted root element and only its attributes moved. */
+  readonly rootAttrs: Readonly<Record<string, string>>
+  readonly groups: ReadonlyArray<KeyedSvgGroup>
+}
+
+function isEmptyChild(child: SvgChild): boolean {
+  return Array.isArray(child) && child.length === 0
+}
+
+export function renderSceneToKeyedSvg(scene: Scene, options?: SvgDocumentOptions): KeyedSvgRender {
+  const parts = buildSvgDocumentParts(scene, options)
+  const keys = sceneEntryKeys(scene)
+
+  const groups: KeyedSvgGroup[] = []
+  if (!isEmptyChild(parts.defs)) groups.push({ key: '#defs', svg: serializeSvgChild(parts.defs) })
+  if (!isEmptyChild(parts.background)) {
+    groups.push({ key: '#background', svg: serializeSvgChild(parts.background) })
+  }
+  parts.body.forEach((child, index) => {
+    const key = keys[index] ?? `preamble#${index}`
+    groups.push({ key, svg: serializeSvg(el('g', { 'data-wb-key': key }, [child])) })
+  })
+
+  const [rootOpen] = serializeSvgChunks(el('svg', parts.rootAttrs, []))
+  const rootAttrs = Object.fromEntries(
+    Object.entries(parts.rootAttrs)
+      .filter(([, value]) => value !== undefined)
+      .map(([name, value]) => [
+        name,
+        typeof value === 'number' ? formatCoord(value) : String(value),
+      ]),
+  )
+
+  return {
+    svg: `${rootOpen}${groups.map((group) => group.svg).join('')}</svg>`,
+    rootOpen: rootOpen ?? '<svg>',
+    rootAttrs,
+    groups,
+  }
+}

--- a/packages/canvas-render/src/svg/serialize.test.ts
+++ b/packages/canvas-render/src/svg/serialize.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { serializeSvg, serializeSvgChunks } from './serialize.js'
+import { el, rawXml } from './vnode.js'
+
+describe('serializeSvg', () => {
+  it('emits attributes in insertion order with number values through formatCoord', () => {
+    const node = el('rect', { x: 1.5, y: -0, width: 10.125, height: 0 })
+    expect(serializeSvg(node)).toBe('<rect x="1.5" y="0" width="10.125" height="0"/>')
+  })
+
+  it('omits attributes whose value is undefined (presence-only)', () => {
+    const node = el('rect', { x: 0, rx: undefined, fill: undefined })
+    expect(serializeSvg(node)).toBe('<rect x="0"/>')
+  })
+
+  it('escapes string attribute values including quotes', () => {
+    const node = el('a', { href: 'https://e.com/?a=1&b="x"<y>' }, [])
+    expect(serializeSvg(node)).toBe(
+      '<a href="https://e.com/?a=1&amp;b=&quot;x&quot;&lt;y&gt;"></a>',
+    )
+  })
+
+  it('escapes plain-string children as text content', () => {
+    const node = el('text', { x: 0, y: 0 }, ['a < b & c > d'])
+    expect(serializeSvg(node)).toBe('<text x="0" y="0">a &lt; b &amp; c &gt; d</text>')
+  })
+
+  it('emits rawXml children verbatim, unescaped', () => {
+    const node = el('g', undefined, [rawXml('<circle r="1"/>')])
+    expect(serializeSvg(node)).toBe('<g><circle r="1"/></g>')
+  })
+
+  it('self-closes when children are absent but pairs tags when children are an empty array', () => {
+    expect(serializeSvg(el('g', { role: 'presentation' }))).toBe('<g role="presentation"/>')
+    expect(serializeSvg(el('g', undefined, []))).toBe('<g></g>')
+    expect(serializeSvg(el('image', { x: 0 }, []))).toBe('<image x="0"></image>')
+  })
+
+  it('flattens nested child arrays in document order', () => {
+    const node = el('g', undefined, [
+      [el('rect', { x: 1 }), [el('rect', { x: 2 })]],
+      el('rect', { x: 3 }),
+    ])
+    expect(serializeSvg(node)).toBe('<g><rect x="1"/><rect x="2"/><rect x="3"/></g>')
+  })
+
+  it('recurses into element children', () => {
+    const node = el('svg', { xmlns: 'http://www.w3.org/2000/svg' }, [
+      el('g', undefined, [el('text', { x: 4, y: 8 }, ['hi'])]),
+    ])
+    expect(serializeSvg(node)).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg"><g><text x="4" y="8">hi</text></g></svg>',
+    )
+  })
+
+  it('joins to the same bytes the chunk generator yields', () => {
+    const node = el('svg', { xmlns: 'x' }, [el('rect', { x: 1 }), 'txt', rawXml('<g/>')])
+    expect([...serializeSvgChunks(node)].join('')).toBe(serializeSvg(node))
+  })
+
+  it('throws on a non-finite number attribute (formatCoord contract: a layout bug, not a serializer one)', () => {
+    expect(() => serializeSvg(el('rect', { x: Number.NaN }))).toThrow(RangeError)
+  })
+})

--- a/packages/canvas-render/src/svg/serialize.test.ts
+++ b/packages/canvas-render/src/svg/serialize.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
+import { sanitizeHref } from './format.js'
 import { serializeSvg, serializeSvgChunks } from './serialize.js'
 import { el, rawXml } from './vnode.js'
+
+const box = { y: 0, width: 1, height: 1 }
 
 describe('serializeSvg', () => {
   it('emits attributes in insertion order with number values through formatCoord', () => {
@@ -9,12 +12,12 @@ describe('serializeSvg', () => {
   })
 
   it('omits attributes whose value is undefined (presence-only)', () => {
-    const node = el('rect', { x: 0, rx: undefined, fill: undefined })
-    expect(serializeSvg(node)).toBe('<rect x="0"/>')
+    const node = el('rect', { x: 0, ...box, rx: undefined, fill: undefined })
+    expect(serializeSvg(node)).toBe('<rect x="0" y="0" width="1" height="1"/>')
   })
 
   it('escapes string attribute values including quotes', () => {
-    const node = el('a', { href: 'https://e.com/?a=1&b="x"<y>' }, [])
+    const node = el('a', { href: sanitizeHref('https://e.com/?a=1&b="x"<y>') }, [])
     expect(serializeSvg(node)).toBe(
       '<a href="https://e.com/?a=1&amp;b=&quot;x&quot;&lt;y&gt;"></a>',
     )
@@ -33,15 +36,17 @@ describe('serializeSvg', () => {
   it('self-closes when children are absent but pairs tags when children are an empty array', () => {
     expect(serializeSvg(el('g', { role: 'presentation' }))).toBe('<g role="presentation"/>')
     expect(serializeSvg(el('g', undefined, []))).toBe('<g></g>')
-    expect(serializeSvg(el('image', { x: 0 }, []))).toBe('<image x="0"></image>')
+    expect(serializeSvg(el('title', undefined, []))).toBe('<title></title>')
   })
 
   it('flattens nested child arrays in document order', () => {
     const node = el('g', undefined, [
-      [el('rect', { x: 1 }), [el('rect', { x: 2 })]],
-      el('rect', { x: 3 }),
+      [el('rect', { x: 1, ...box }), [el('rect', { x: 2, ...box })]],
+      el('rect', { x: 3, ...box }),
     ])
-    expect(serializeSvg(node)).toBe('<g><rect x="1"/><rect x="2"/><rect x="3"/></g>')
+    expect(serializeSvg(node)).toBe(
+      '<g><rect x="1" y="0" width="1" height="1"/><rect x="2" y="0" width="1" height="1"/><rect x="3" y="0" width="1" height="1"/></g>',
+    )
   })
 
   it('recurses into element children', () => {
@@ -54,11 +59,11 @@ describe('serializeSvg', () => {
   })
 
   it('joins to the same bytes the chunk generator yields', () => {
-    const node = el('svg', { xmlns: 'x' }, [el('rect', { x: 1 }), 'txt', rawXml('<g/>')])
+    const node = el('svg', { xmlns: 'x' }, [el('rect', { x: 1, ...box }), 'txt', rawXml('<g/>')])
     expect([...serializeSvgChunks(node)].join('')).toBe(serializeSvg(node))
   })
 
   it('throws on a non-finite number attribute (formatCoord contract: a layout bug, not a serializer one)', () => {
-    expect(() => serializeSvg(el('rect', { x: Number.NaN }))).toThrow(RangeError)
+    expect(() => serializeSvg(el('rect', { x: Number.NaN, ...box }))).toThrow(RangeError)
   })
 })

--- a/packages/canvas-render/src/svg/serialize.ts
+++ b/packages/canvas-render/src/svg/serialize.ts
@@ -56,6 +56,14 @@ export function* serializeSvgChunks(node: SvgVNode): Generator<string> {
   yield `</${node.tag}>`
 }
 
+/** Serializes any child form — element, text, rawXml, nested arrays — to
+ * its exact document bytes; the keyed renderer's per-part serializer. */
+export function serializeSvgChild(child: SvgChild): string {
+  let out = ''
+  for (const chunk of serializeChildren([child])) out += chunk
+  return out
+}
+
 export function serializeSvg(node: SvgVNode): string {
   let out = ''
   for (const chunk of serializeSvgChunks(node)) out += chunk

--- a/packages/canvas-render/src/svg/serialize.ts
+++ b/packages/canvas-render/src/svg/serialize.ts
@@ -1,0 +1,63 @@
+/**
+ * The one place an `SvgVNode` tree becomes serialized SVG text. Everything
+ * byte-visible is decided here — attribute order (insertion order of the
+ * attrs object), number formatting (`formatCoord`), escaping
+ * (`escapeXmlAttr`/`escapeXmlText`), self-closing — so the canonical
+ * serialization rules live in one function instead of per renderer.
+ *
+ * The generator is the core and the string API its aggregation: chunk
+ * boundaries fall on element opens/closes, which is what a future
+ * streaming or per-group patching consumer would consume.
+ */
+
+import { escapeXmlAttr, escapeXmlText, formatCoord } from './format.js'
+import type { RawXmlChild, SvgChild, SvgVNode } from './vnode.js'
+
+function isRawXml(child: SvgChild): child is RawXmlChild {
+  return typeof child === 'object' && child !== null && 'raw' in child
+}
+
+function isVNode(child: SvgChild): child is SvgVNode {
+  return typeof child === 'object' && child !== null && 'tag' in child
+}
+
+function openTag(node: SvgVNode, selfClose: boolean): string {
+  let out = `<${node.tag}`
+  if (node.attrs !== undefined) {
+    for (const [name, value] of Object.entries(node.attrs)) {
+      if (value === undefined) continue
+      out += ` ${name}="${typeof value === 'number' ? formatCoord(value) : escapeXmlAttr(value)}"`
+    }
+  }
+  return selfClose ? `${out}/>` : `${out}>`
+}
+
+function* serializeChildren(children: ReadonlyArray<SvgChild>): Generator<string> {
+  for (const child of children) {
+    if (typeof child === 'string') {
+      yield escapeXmlText(child)
+    } else if (Array.isArray(child)) {
+      yield* serializeChildren(child)
+    } else if (isRawXml(child)) {
+      yield child.raw
+    } else if (isVNode(child)) {
+      yield* serializeSvgChunks(child)
+    }
+  }
+}
+
+export function* serializeSvgChunks(node: SvgVNode): Generator<string> {
+  if (node.children === undefined) {
+    yield openTag(node, true)
+    return
+  }
+  yield openTag(node, false)
+  yield* serializeChildren(node.children)
+  yield `</${node.tag}>`
+}
+
+export function serializeSvg(node: SvgVNode): string {
+  let out = ''
+  for (const chunk of serializeSvgChunks(node)) out += chunk
+  return out
+}

--- a/packages/canvas-render/src/svg/vnode.ts
+++ b/packages/canvas-render/src/svg/vnode.ts
@@ -1,0 +1,59 @@
+/**
+ * The SVG backend's intermediate representation: plain data between the
+ * scene-graph renderers and the canonical serializer. Renderers describe
+ * WHAT to emit as a tree of `SvgVNode`s; `serialize.ts` is the only code
+ * that turns that tree into bytes, so escaping, number formatting and
+ * attribute ordering cannot diverge per call site.
+ */
+
+/**
+ * `undefined` means the attribute is omitted — the presence-only rule
+ * (an absent field is never defaulted) expressed as a type. Numbers are
+ * formatted by the serializer through `formatCoord`, strings through
+ * `escapeXmlAttr`; a call site never pre-formats either.
+ */
+export type SvgAttrValue = string | number | undefined
+
+export type SvgAttrs = Readonly<Record<string, SvgAttrValue>>
+
+/**
+ * A child emitted verbatim, bypassing text escaping. The only legitimate
+ * producers are trusted, already-well-formed fragments (the `svgFragment`
+ * scene node's payload, whose well-formedness is the CALLER's documented
+ * precondition). A runtime wrapper rather than a branded string because
+ * the serializer must distinguish it from escapable text at runtime.
+ */
+export interface RawXmlChild {
+  readonly raw: string
+}
+
+export function rawXml(xml: string): RawXmlChild {
+  return { raw: xml }
+}
+
+/**
+ * Nested arrays are flattened in document order, so a renderer that
+ * produces a fragment (several siblings, possibly none) composes without
+ * wrapper elements — the empty array is the VNode spelling of the string
+ * backend's `''` degradation.
+ */
+export type SvgChild = SvgVNode | string | RawXmlChild | ReadonlyArray<SvgChild>
+
+export interface SvgVNode {
+  readonly tag: string
+  readonly attrs?: SvgAttrs
+  /**
+   * Absent children self-close the element (`<g/>`); a present-but-empty
+   * array keeps the paired form (`<g></g>`). The distinction is
+   * load-bearing for byte-identical output, not cosmetic.
+   */
+  readonly children?: ReadonlyArray<SvgChild>
+}
+
+export function el(tag: string, attrs?: SvgAttrs, children?: ReadonlyArray<SvgChild>): SvgVNode {
+  return {
+    tag,
+    ...(attrs === undefined ? {} : { attrs }),
+    ...(children === undefined ? {} : { children }),
+  }
+}

--- a/packages/canvas-render/src/svg/vnode.ts
+++ b/packages/canvas-render/src/svg/vnode.ts
@@ -6,6 +6,8 @@
  * attribute ordering cannot diverge per call site.
  */
 
+import type { SvgElements, SvgTagName } from './elements.js'
+
 /**
  * `undefined` means the attribute is omitted — the presence-only rule
  * (an absent field is never defaulted) expressed as a type. Numbers are
@@ -70,6 +72,18 @@ export function withDefs(node: SvgVNode, defs: ReadonlyArray<SvgDef>): SvgVNode 
   return { ...node, defs }
 }
 
+/**
+ * Builds one element VNode. The public signature is constrained by the
+ * typed element table (elements.ts): only emitted element names, only
+ * their declared attributes, numbers where `formatCoord` is the contract.
+ * The VNode itself stores attrs loosely — the table is a construction-time
+ * gate, not a runtime shape.
+ */
+export function el<T extends SvgTagName>(
+  tag: T,
+  attrs?: SvgElements[T],
+  children?: ReadonlyArray<SvgChild>,
+): SvgVNode
 export function el(tag: string, attrs?: SvgAttrs, children?: ReadonlyArray<SvgChild>): SvgVNode {
   return {
     tag,

--- a/packages/canvas-render/src/svg/vnode.ts
+++ b/packages/canvas-render/src/svg/vnode.ts
@@ -48,6 +48,26 @@ export interface SvgVNode {
    * load-bearing for byte-identical output, not cosmetic.
    */
   readonly children?: ReadonlyArray<SvgChild>
+  /**
+   * Shared definitions this element depends on (`<mask>`, `<linearGradient>`,
+   * …). Declared where the dependency arises; `collectDefs` (defs.ts) hoists
+   * them into the document's single `<defs>` element, deduplicated by `id` —
+   * so a definition is emitted only when something in the tree actually
+   * references it (presence-only, mechanized). Ids must be derived from the
+   * definition's CONTENT (never a counter or randomness): same id ⇒ same
+   * bytes is what makes a repeated id across several inline-injected SVGs
+   * harmless, and what keeps first-occurrence-wins deduplication sound.
+   */
+  readonly defs?: ReadonlyArray<SvgDef>
+}
+
+export interface SvgDef {
+  readonly id: string
+  readonly node: SvgVNode
+}
+
+export function withDefs(node: SvgVNode, defs: ReadonlyArray<SvgDef>): SvgVNode {
+  return { ...node, defs }
 }
 
 export function el(tag: string, attrs?: SvgAttrs, children?: ReadonlyArray<SvgChild>): SvgVNode {

--- a/packages/canvas-render/src/test-utils/golden-scene.ts
+++ b/packages/canvas-render/src/test-utils/golden-scene.ts
@@ -179,7 +179,7 @@ export const SHAPE_APPEARANCE_GOLDEN_SVG =
   '<rect x="0" y="0" width="100" height="60" rx="8"/>' +
   '<rect x="120" y="0" width="100" height="60"/>' +
   '<rect x="240" y="0" width="100" height="60" rx="4" fill="#fff" stroke="#000" stroke-width="2"/>' +
-  '<g><text x="0" y="80" fill="#111" font-family="Inter" font-size="14">Styled</text></g>' +
+  '<g fill="#111" font-family="Inter" font-size="14"><text x="0" y="80">Styled</text></g>' +
   '<polyline points="0,120 100,120" fill="none" stroke="#888" stroke-width="1.5" role="presentation"/>' +
   '<polygon points="100,120 90,124 90,116" fill="#888" role="presentation"/>' +
   '</svg>'


### PR DESCRIPTION
## Summary

- **`lib/keyed-svg-patcher.ts`** — mount-once, patch-forever consumer of `renderSceneToKeyedSvg` (PR #935): the first render lands as one `innerHTML` write; every later render is a keyed reconciliation that replaces only the groups whose serialized bytes changed (string equality IS change detection, because the serializer is canonical). All DOM bytes remain serializer-produced — this layer decides only *which* elements to replace, never how markup is spelled, so canvas-render stays the single producer the injection-safety argument rests on. What patching buys over an innerHTML swap is DOM continuity for the 94–99 % of groups a typical edit leaves byte-identical (PR #933's measured reuse ceiling): selection, focus, running CSS animations, and decoded images on untouched groups survive an update.
- **`lib/use-keyed-svg.ts`** — the React seam: an imperative-container hook (ref callback + `useLayoutEffect`) where React owns the container element and nothing below it, so a parent re-render can never clobber the patched subtree.
- **`SpatialEditor.tsx`** — the committed-scene and drag-static surfaces swap `dangerouslySetInnerHTML` for the keyed container. The keyed render is derived on the main thread from the scene the worker already ships (~3 ms), so the worker protocol is untouched. The two gesture overlays (live edges / live node) keep their existing innerHTML sinks — they are transient whole-replacements with nothing to patch.
- **`purity-guard.test.ts`** — the S10 raw-HTML-sink tripwire now scans `src/lib` too and pins the patcher's two `innerHTML` writes as the documented serializer-only sinks that replaced the removed prop (it went red on this change before the sink list was updated — the guard fires).
- **Per-theme layout content cache** — `createSpatialContentCache` (size-capped) memoizes origin-relative text-node content layout on `(width, height, text)` via canvas-render's `SpatialLayoutOptions.contentCache` (PR #934). Validity is the caller's contract (one cache per measure+theme): the layout worker keys one cache per theme — sound because it refuses layout before fonts load — and the editor memoizes on `(resolvedMeasure, theme)`, threading it through the shared `fileSeamOptions` so every sync render path shares it.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — `keyed-svg-patcher.browser.test.tsx` + `use-keyed-svg.browser.test.tsx` (convergence-vs-fresh-mount oracle plus a fast-check property over update sequences), purity-guard sink pin updated red-first
- [x] `pnpm test` passes locally — full `web-browser` project 126 files / 695 tests green with the keyed container live; apps/web CI-equivalent jsdom suite green apart from the 9 known environment-artifact daemon-fetch/objectURL failures (verified identical on pristine `origin/main`)
- [x] Manual verification completed — editing in the running editor patches only changed groups (element identity of untouched groups verified stable across edits)
- [ ] E2E coverage added or extended where applicable — the browser-project tests exercise the real DOM path; no route/persistence surface changed

## Visual evidence

No pixel change by construction: the mounted document is byte-identical to the `renderSceneToSvg` output (`svg === rootOpen + groups + '</svg>'`, pinned in PR #935). The user-visible effect is DOM continuity, which the browser tests assert by element identity rather than pixels.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — no user-visible behavior or published contract changes (internal rendering path)
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---

Stacked PR **8/8** (top of stack) on #935. The whole stack lands as a single squash once review completes; see #926 for the series overview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kn5gTK3WGQcNrahPppzvHg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn5gTK3WGQcNrahPppzvHg)_