### PR TITLE
docs(arch-lint): say that a portable dependency may be added, which the list denies

### DIFF
--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -2,7 +2,7 @@
 
 Package boundaries are cut by **runtime requirements**, not by feature. The shared layer must run unchanged on Node, the browser, and Cloudflare Workers.
 
-| Package | Role | May depend on |
+| Package | Role | Checked dependencies |
 |---|---|---|
 | `packages/model` | Zod schemas for the whiteboard document model (single source of truth) | zod only |
 | `packages/codec` | OKF Markdown / JSON Canvas serialize+parse, remark pipeline | model, remark |
@@ -13,6 +13,25 @@ Package boundaries are cut by **runtime requirements**, not by feature. The shar
 | `packages/canvas-viewer` | Read-only spatial-canvas scene viewer UI (renders canvas-render SVG), shared between `apps/web` and the MCP Apps widget | model, codec, render, `@modelcontextprotocol/ext-apps`, react, zod |
 | `packages/mcp-server` | Node composition root: CLI, stdio, local store impls, resvg, Inversify container | server-core + port impls |
 | `apps/web` | Browser composition root: Canvas API backend, IndexedDB store impls, read-write spatial canvas editor, markdown editor | loro-adapter, model, codec, render, canvas-viewer, ports, `@kamiazya/whiteboard-mcp`'s browser-safe client subpaths (`/api-client`, `/api-contracts`, `/browser-contract`) + port impls |
+
+**A third-party dependency is judged by that criterion, not by a quota.** The
+`allowedThirdParty` lists in `architecture-map.ts` are a RECORD of what has
+been checked against it — not a cap, and not a statement that the shared layer
+is closed. A package that runs unchanged on all three runtimes and does not
+break the published build may be added; say in the entry what you checked, the
+way `css-line-break`'s does ("Pure and DOM-free, so it holds in Node, the
+browser and a worker alike — verified before adopting").
+
+What the criterion actually rejects is worth reading, because it is not
+weight: BudouX is *vendored* rather than depended on because depending on it
+drags in linkedom and the native canvas package and breaks the published
+build. Nothing here has ever been refused for being one dependency too many.
+
+This is worded explicitly because the list-shaped enforcement teaches the
+opposite. Faced with adding a highlighter that three packages needed, one
+session read the list as a wall and seriously considered writing the same
+scope-to-role table out three times instead — the dependency was pure JS with
+no DOM and no `node:*`, and met the criterion on sight.
 
 Absolute rules:
 

--- a/tools/arch-lint/src/allowed-deps-check.ts
+++ b/tools/arch-lint/src/allowed-deps-check.ts
@@ -12,6 +12,14 @@ export interface AllowedDepsViolation {
  * the remaining, non-internal entries of a `package.json` "dependencies"
  * object against the package's declared `allowedThirdParty` list.
  * `devDependencies` are never inspected.
+ *
+ * The list is a RECORD of what has been checked against the shared layer's
+ * criterion (runs unchanged on Node, the browser and Workers; does not break
+ * the published build), not a quota. This check exists so a dependency
+ * arrives with that reasoning written down, not so the count stays low — see
+ * architecture-map.md. Answering a violation by adding the entry IS the
+ * intended fix when the dependency meets the criterion; the failure message
+ * says so, because the check's shape otherwise reads as a refusal.
  */
 export function checkAllowedDependencies(manifest: PackageManifest): AllowedDepsViolation[] {
   const violations: AllowedDepsViolation[] = []

--- a/tools/arch-lint/src/repo-coverage.test.ts
+++ b/tools/arch-lint/src/repo-coverage.test.ts
@@ -108,12 +108,27 @@ describe('shared-layer boundary lint (real source coverage)', () => {
       expect(violations).toHaveLength(0)
     })
 
-    it(`${packageDir}/package.json has no unlisted third-party dependency`, () => {
+    it(`${packageDir}/package.json declares every third-party dependency it uses`, () => {
       const manifest = JSON.parse(
         readFileSync(join(REPO_ROOT, packageDir, 'package.json'), 'utf-8'),
       )
       const violations = checkAllowedDependencies(manifest)
-      expect(violations).toHaveLength(0)
+      // The message names the criterion and the fix. Read as a bare
+      // "unlisted dependency" this check teaches that the shared layer is
+      // closed, which it is not — the bar is that a dependency runs unchanged
+      // on Node, the browser and Workers and does not break the published
+      // build, and the list records the ones checked against it.
+      expect(
+        violations,
+        violations.length === 0
+          ? ''
+          : `${violations.map((v) => v.dependencyName).join(', ')} is not recorded in ` +
+              `allowedThirdParty for ${manifest.name}. If it runs unchanged on Node, the ` +
+              'browser and Workers and does not break the published build, add it to ' +
+              'architecture-map.ts with a note saying what you checked — that is the fix, ' +
+              'not a workaround. If it does not (BudouX drags in linkedom and the native ' +
+              'canvas package), vendor it or keep it out of the shared layer.',
+      ).toHaveLength(0)
     })
   }
 })


### PR DESCRIPTION
## Summary

The shared layer's criterion is stated once, at the top of `architecture-map.md`:

> The shared layer must run unchanged on Node, the browser, and Cloudflare Workers.

Everything that **enforces** it is a name allowlist — a "May depend on" column, an `allowedThirdParty` array, and a test called *"has no unlisted third-party dependency"*. All three read as *"the shared layer is closed"*.

Those are not the same statement, and the gap is not academic.

## The evidence that it mis-teaches

Faced with a highlighter that three packages needed, a session read the list as a wall and seriously considered **writing the same scope-to-role table out three times** rather than add a dependency that was pure JS, DOM-free, no `node:*` — meeting the criterion on sight. It ended up asking a human to authorise something the stated rule already permits.

The rule's own comments have always said the right thing case by case:

- `css-line-break`: *"Pure and DOM-free, so it holds in Node, the browser and a worker alike — **verified before adopting**"*
- BudouX is **vendored** rather than depended on because *"depending on it drags in linkedom and the native canvas package and breaks the published build"*

So the criterion rejects **non-portability**, not weight. Nothing in this repo has ever been refused for being one dependency too many. Only the shape of the enforcement suggested otherwise.

## What changed

Prose and one test message. No behaviour, no dependency, no package boundary moves.

- `architecture-map.md` states the criterion where the list is, says the lists are a **record of what has been checked** rather than a cap, and records what the criterion actually rejects (with BudouX as the worked example). The table column is renamed `May depend on` → **`Checked dependencies`**.
- `allowed-deps-check.ts`'s doc comment says the check exists so a dependency arrives *with its reasoning written down*, and that adding the entry **is** the intended fix when the criterion is met.
- The `repo-coverage` test is renamed from *"has no unlisted third-party dependency"* to *"declares every third-party dependency it uses"*, and its failure now names the criterion and the fix.

## The message was read from a real failure, not assumed

A message nobody sees is not a fix, so it was fired on purpose by adding `left-pad` to `packages/ports`:

```
AssertionError: left-pad is not recorded in allowedThirdParty for
@kamiazya/whiteboard-ports. If it runs unchanged on Node, the browser and
Workers and does not break the published build, add it to architecture-map.ts
with a note saying what you checked — that is the fix, not a workaround. If it
does not (BudouX drags in linkedom and the native canvas package), vendor it or
keep it out of the shared layer.
```

Reverted immediately; `arch-lint-node` is **79 passed** on the branch.

## Deliberately not in this PR

The other half of the same conversation — that four independent `layoutSpatialCanvas` composition sites let a new seam be wired at one and silently missed at the others (`textFill`, `highlightCode`, theme mode, three times) — is a **type change** that will produce compile errors at four call sites. It gets its own review rather than riding along with a prose edit.

## Checklist

- [x] Commit message follows Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema
