### PR TITLE
feat(canvas-render): add a VNode optimization-pass seam, marker arrowheads, and FLIP motion

### DIFF
--- a/apps/web/src/components/markdown-editor/PreviewPane.tsx
+++ b/apps/web/src/components/markdown-editor/PreviewPane.tsx
@@ -2,6 +2,7 @@ import type { MdastLayoutOptions, MeasureText } from '@kamiazya/whiteboard-canva
 import type { AliasResolver } from '@kamiazya/whiteboard-codec'
 import { type CSSProperties, type MutableRefObject, useEffect, useMemo } from 'react'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
+import { useKeyedSvg } from '../../lib/use-keyed-svg.js'
 import { editorTextFill } from '../spatial-editor/editor-appearance.js'
 import type { RailBlock } from './rail-geometry.js'
 import { type PreviewBlockAnchor, renderMarkdownPreview } from './render-preview.js'
@@ -37,20 +38,24 @@ export interface PreviewPaneProps {
 }
 
 /**
- * Renders `value` through the SVG string produced by
- * `renderMarkdownPreviewSvg` (codec -> canvas-render). Injecting that
- * string via `dangerouslySetInnerHTML` carries the same soundness rationale
- * as `packages/canvas-viewer/src/CanvasViewer.tsx`: canvas-render's
- * serializer is the SOLE producer of this string and escapes text content
- * (`&`/`<`/`>`) and attribute values (`"`/`'`) — there is no untrusted-HTML
- * injection path here. The one addition to that reasoning: `renderMath` /
- * `renderDiagram` fragments are emitted verbatim by the backend, so they
- * must come only from engines safe against untrusted document text —
- * MathJax typesets into its own glyph paths, and mermaid runs at
- * securityLevel 'strict' (see markdown-fragment-renderers.ts). Do not add
- * a sanitizer dependency; if this string ever stops being canvas-render's
- * own output plus those two engines' fragments, this reasoning no longer
- * holds and must be revisited.
+ * Renders `value` through the keyed SVG projection produced by
+ * `renderMarkdownPreview` (codec -> canvas-render), mounted once and DOM-
+ * patched per change (lib/keyed-svg-patcher.ts): a keystroke replaces only
+ * the edited block's group, so decoded images, running diagrams and
+ * animations in untouched blocks survive, and block moves glide (FLIP).
+ * Every byte the patcher injects is still canvas-render's serializer
+ * output, carrying the same soundness rationale as
+ * `packages/canvas-viewer/src/CanvasViewer.tsx`: the serializer is the
+ * SOLE producer and escapes text content (`&`/`<`/`>`) and attribute
+ * values (`"`/`'`) — there is no untrusted-HTML injection path here. The
+ * one addition to that reasoning: `renderMath` / `renderDiagram` fragments
+ * are emitted verbatim by the backend, so they must come only from engines
+ * safe against untrusted document text — MathJax typesets into its own
+ * glyph paths, and mermaid runs at securityLevel 'strict' (see
+ * markdown-fragment-renderers.ts). Do not add a sanitizer dependency; if
+ * these bytes ever stop being canvas-render's own output plus those two
+ * engines' fragments, this reasoning no longer holds and must be
+ * revisited.
  */
 export function PreviewPane({
   value,
@@ -65,7 +70,7 @@ export function PreviewPane({
   anchorsRef,
   blocksRef,
 }: PreviewPaneProps) {
-  const { svg, anchors, blocks } = useMemo(
+  const { keyed, anchors, blocks } = useMemo(
     () =>
       renderMarkdownPreview(value, {
         measure,
@@ -101,8 +106,7 @@ export function PreviewPane({
       // (var() included) — `inherit` is ignored, so inheritance alone leaves
       // a visited wikiLink near-invisible.
       style={{ overflow: 'auto', fill, '--preview-fill': fill } as CSSProperties}
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: canvas-render's SVG serializer is the sole producer of this string and escapes text and attribute values (svg/format.ts)
-      dangerouslySetInnerHTML={{ __html: svg }}
+      ref={useKeyedSvg(keyed)}
     />
   )
 }

--- a/apps/web/src/components/markdown-editor/preview-pane-keyed.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/preview-pane-keyed.browser.test.tsx
@@ -1,0 +1,28 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, expect, it } from 'vitest'
+import { PreviewPane } from './PreviewPane'
+
+afterEach(cleanup)
+
+const measure = (text: string) => ({
+  advanceWidth: text.length * 6,
+  ascent: 10,
+  descent: 3,
+  lineGap: 3,
+})
+
+it('editing one block patches only that block: the untouched group keeps its DOM element', async () => {
+  const { container, rerender } = render(
+    <PreviewPane value={'first paragraph\n\nsecond paragraph'} measure={measure} maxWidth={400} />,
+  )
+  const groups = () => [...container.querySelectorAll('[data-wb-key]')]
+  expect(groups().length).toBeGreaterThanOrEqual(2)
+  const [keptFirst] = groups()
+
+  rerender(
+    <PreviewPane value={'first paragraph\n\nsecond EDITED'} measure={measure} maxWidth={400} />,
+  )
+  const after = groups()
+  expect(after[0]).toBe(keptFirst)
+  expect(container.innerHTML).toContain('EDITED')
+})

--- a/apps/web/src/components/markdown-editor/render-preview.ts
+++ b/apps/web/src/components/markdown-editor/render-preview.ts
@@ -1,7 +1,8 @@
 import type { MdastLayoutOptions, MeasureText, Scene } from '@kamiazya/whiteboard-canvas-render'
 import {
+  type KeyedSvgRender,
   layoutMdastBlocks,
-  renderSceneToSvg,
+  renderSceneToKeyedSvg,
   SPATIAL_THEME_FONT_FAMILY,
   sceneBounds,
 } from '@kamiazya/whiteboard-canvas-render'
@@ -58,7 +59,7 @@ export function renderMarkdownPreviewSvg(
   value: string,
   options: RenderMarkdownPreviewOptions,
 ): string {
-  return renderMarkdownPreview(value, options).svg
+  return renderMarkdownPreview(value, options).keyed.svg
 }
 
 /**
@@ -73,7 +74,10 @@ export interface PreviewBlockAnchor {
 }
 
 export interface RenderedMarkdownPreview {
-  readonly svg: string
+  /** Keyed projection of the preview document: `keyed.svg` is the full
+   * byte-identical document for string consumers (the worker protocol,
+   * `renderMarkdownPreviewSvg`); the groups feed the pane's DOM patcher. */
+  readonly keyed: KeyedSvgRender
   readonly anchors: readonly PreviewBlockAnchor[]
   /**
    * Each top-level block's box, in the SVG's own pixel space — the same
@@ -114,8 +118,8 @@ export function renderMarkdownPreview(
     renderMath,
     renderDiagram,
   })
-  const svg = renderSceneToSvg(scene, { padding: PREVIEW_PADDING_PX, background })
-  return { svg, anchors: blockAnchors(value, scene), blocks: blockBoxes(scene) }
+  const keyed = renderSceneToKeyedSvg(scene, { padding: PREVIEW_PADDING_PX, background })
+  return { keyed, anchors: blockAnchors(value, scene), blocks: blockBoxes(scene) }
 }
 
 /**

--- a/apps/web/src/lib/keyed-svg-flip.browser.test.tsx
+++ b/apps/web/src/lib/keyed-svg-flip.browser.test.tsx
@@ -1,0 +1,96 @@
+import { renderSceneToKeyedSvg, type SceneNode } from '@kamiazya/whiteboard-canvas-render'
+import { afterEach, describe, expect, it } from 'vitest'
+import { mountKeyedSvg } from './keyed-svg-patcher'
+
+const shape = (id: string, x: number, fill = '#fff'): SceneNode => ({
+  kind: 'shape',
+  id,
+  bbox: { x, y: 0, w: 100, h: 60 },
+  appearance: { fill, stroke: '#333' },
+})
+
+const keyedOf = (nodes: SceneNode[]) =>
+  renderSceneToKeyedSvg({ nodes }, { padding: 4, viewBox: { x: 0, y: 0, w: 600, h: 400 } })
+
+let mounted: HTMLElement | null = null
+afterEach(() => {
+  mounted?.remove()
+  mounted = null
+})
+
+/** FLIP needs real layout, so the container must be in the document. */
+function mount(nodes: SceneNode[]) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  mounted = container
+  const patcher = mountKeyedSvg(container, keyedOf(nodes))
+  const byKey = (key: string) =>
+    container.querySelector(`[data-wb-key="${key}"]`) as SVGGElement | null
+  return { container, patcher, byKey }
+}
+
+describe('keyed patching animates moves (FLIP)', () => {
+  it('a replaced group animates from its old position; untouched groups do not', () => {
+    const { patcher, byKey } = mount([shape('a', 0), shape('b', 200)])
+    patcher.update(keyedOf([shape('a', 0), shape('b', 320)]))
+
+    const animations = byKey('b')?.getAnimations() ?? []
+    expect(animations).toHaveLength(1)
+    expect(byKey('a')?.getAnimations() ?? []).toHaveLength(0)
+  })
+
+  it('an INSERTED key appears without animation — a local drop commit must not fly in', () => {
+    // During a drag the static backdrop excludes the dragged node, so the
+    // commit on drop arrives as an insertion. Animating insertions would
+    // double-move exactly that case; only same-key replacements animate.
+    const { patcher, byKey } = mount([shape('a', 0)])
+    patcher.update(keyedOf([shape('a', 0), shape('b', 320)]))
+    expect(byKey('b')?.getAnimations() ?? []).toHaveLength(0)
+  })
+
+  it('a replaced group whose position did not move gets no animation', () => {
+    // Same key, changed bytes (fill), same geometry: an edit-in-place must
+    // not wiggle.
+    const { patcher, byKey } = mount([shape('a', 0)])
+    patcher.update(keyedOf([shape('a', 0, '#eee')]))
+    expect(byKey('a')?.getAnimations() ?? []).toHaveLength(0)
+  })
+
+  it('motion: false disables move animation entirely', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    mounted = container
+    const patcher = mountKeyedSvg(container, keyedOf([shape('a', 0)]), { motion: false })
+    patcher.update(keyedOf([shape('a', 240)]))
+    const group = container.querySelector('[data-wb-key="a"]') as SVGGElement
+    expect(group.getAnimations()).toHaveLength(0)
+  })
+
+  it('the move delta is measured in user units, so an editor zoom does not overshoot', () => {
+    // The editor scales the whole surface for zoom; screen-px deltas are
+    // divided back to SVG user units before the translate keyframe.
+    const parent = document.createElement('div')
+    parent.style.transform = 'scale(2)'
+    parent.style.transformOrigin = '0 0'
+    document.body.appendChild(parent)
+    mounted = parent
+    const container = document.createElement('div')
+    parent.appendChild(container)
+    const patcher = mountKeyedSvg(container, keyedOf([shape('a', 0)]))
+    patcher.update(keyedOf([shape('a', 240)]))
+    const group = container.querySelector('[data-wb-key="a"]') as SVGGElement
+    const [animation] = group.getAnimations()
+    const keyframes =
+      animation?.effect instanceof KeyframeEffect ? animation.effect.getKeyframes() : []
+    expect(keyframes[0]?.transform).toBe('translate(-240px, 0px)')
+  })
+
+  it('the animation ends at the natural position (no lingering transform)', async () => {
+    const { patcher, byKey } = mount([shape('a', 0)])
+    patcher.update(keyedOf([shape('a', 240)]))
+    const group = byKey('a') as SVGGElement
+    await Promise.all(group.getAnimations().map((animation) => animation.finished))
+    expect(group.getAnimations()).toHaveLength(0)
+    expect(group.getAttribute('style')).toBeNull()
+  })
+})

--- a/apps/web/src/lib/keyed-svg-patcher.ts
+++ b/apps/web/src/lib/keyed-svg-patcher.ts
@@ -25,6 +25,61 @@ export interface KeyedSvgPatcher {
   update(next: KeyedSvgRender): void
 }
 
+export interface KeyedSvgPatcherOptions {
+  /** `false` disables the FLIP move animation (default on, and always off
+   * under `prefers-reduced-motion`). */
+  readonly motion?: boolean
+}
+
+const MOVE_ANIMATION: KeyframeAnimationOptions = {
+  duration: 180,
+  easing: 'cubic-bezier(0.2, 0, 0, 1)',
+}
+/** Screen-px deltas below this are layout noise, not a move. */
+const MIN_MOVE_PX = 0.5
+
+function prefersReducedMotion(): boolean {
+  return typeof window.matchMedia === 'function'
+    ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    : false
+}
+
+/**
+ * Plays the FLIP "invert + play" half: each replaced element starts at a
+ * transform that puts it back where its predecessor sat, and animates to
+ * none. Deltas are measured in screen px and converted to the root's USER
+ * units, because a CSS translate on an SVG child applies in local
+ * coordinates while the editor scales the whole surface for zoom — a
+ * screen-px delta applied directly would overshoot by the zoom factor.
+ * WAAPI leaves no inline style behind, so the converged DOM stays byte-
+ * equal to a fresh mount.
+ */
+function playMoveAnimations(
+  root: SVGSVGElement,
+  elements: ReadonlyMap<string, Element>,
+  firstRects: ReadonlyMap<string, DOMRect>,
+): void {
+  const rootRect = root.getBoundingClientRect()
+  if (rootRect.width <= 0 || rootRect.height <= 0) return
+  const viewBox = root.viewBox.baseVal
+  const scaleX = viewBox !== null && viewBox.width > 0 ? rootRect.width / viewBox.width : 1
+  const scaleY = viewBox !== null && viewBox.height > 0 ? rootRect.height / viewBox.height : 1
+  for (const [key, first] of firstRects) {
+    const element = elements.get(key)
+    if (element === undefined || typeof element.animate !== 'function') continue
+    const last = element.getBoundingClientRect()
+    const dxPx = first.left - last.left
+    const dyPx = first.top - last.top
+    if (Math.abs(dxPx) < MIN_MOVE_PX && Math.abs(dyPx) < MIN_MOVE_PX) continue
+    const dx = dxPx / scaleX
+    const dy = dyPx / scaleY
+    element.animate(
+      [{ transform: `translate(${dx}px, ${dy}px)` }, { transform: 'none' }],
+      MOVE_ANIMATION,
+    )
+  }
+}
+
 /** Parses one group's serialized bytes into its single element. */
 function parseGroup(svg: string): Element {
   const host = document.createElementNS(SVG_NS, 'svg')
@@ -38,7 +93,11 @@ function parseGroup(svg: string): Element {
   return element
 }
 
-export function mountKeyedSvg(container: Element, initial: KeyedSvgRender): KeyedSvgPatcher {
+export function mountKeyedSvg(
+  container: Element,
+  initial: KeyedSvgRender,
+  options?: KeyedSvgPatcherOptions,
+): KeyedSvgPatcher {
   container.innerHTML = initial.svg
   const root = container.firstElementChild
   if (!(root instanceof SVGSVGElement)) {
@@ -67,6 +126,23 @@ export function mountKeyedSvg(container: Element, initial: KeyedSvgRender): Keye
 
     const prevSvgByKey = new Map(prev.groups.map((group) => [group.key, group.svg]))
     const nextElements = new Map<string, Element>()
+    // FLIP first-rects: a REPLACED key (same key, changed bytes) is the one
+    // continuity break worth animating — the element is swapped, so the
+    // move would otherwise be a hard jump. Insertions deliberately never
+    // animate: during a drag the static backdrop excludes the dragged
+    // node, so its drop commit arrives as an insertion, and animating that
+    // would double-move a node the user just placed. Rects are captured
+    // BEFORE the reconciliation loop displaces anything.
+    const animate = options?.motion !== false && !prefersReducedMotion()
+    const firstRects = animate ? new Map<string, DOMRect>() : undefined
+    if (firstRects !== undefined) {
+      for (const group of next.groups) {
+        const existing = elements.get(group.key)
+        if (existing !== undefined && prevSvgByKey.get(group.key) !== group.svg) {
+          firstRects.set(group.key, existing.getBoundingClientRect())
+        }
+      }
+    }
     next.groups.forEach((group, index) => {
       const existing = elements.get(group.key)
       const element =
@@ -83,6 +159,10 @@ export function mountKeyedSvg(container: Element, initial: KeyedSvgRender): Keye
 
     while (root.children.length > next.groups.length) {
       root.children[next.groups.length]?.remove()
+    }
+
+    if (firstRects !== undefined && firstRects.size > 0) {
+      playMoveAnimations(root, nextElements, firstRects)
     }
 
     elements.clear()

--- a/apps/web/src/lib/layout-worker-parity.browser.test.tsx
+++ b/apps/web/src/lib/layout-worker-parity.browser.test.tsx
@@ -212,7 +212,7 @@ it('the worker markdown SVG is the main-thread markdown SVG', async () => {
 
   expect(fromWorker.type).toBe('markdown-render-done')
   if (fromWorker.type !== 'markdown-render-done') return
-  expect(fromWorker.svg).toBe(onMain.svg)
+  expect(fromWorker.svg).toBe(onMain.keyed.svg)
   expect(fromWorker.bounds.w).toBeGreaterThan(0)
   expect(fromWorker.bounds.h).toBeGreaterThan(0)
 }, 60_000)

--- a/apps/web/src/lib/layout-worker.ts
+++ b/apps/web/src/lib/layout-worker.ts
@@ -87,7 +87,7 @@ self.onmessage = async (
         self.postMessage(failed)
         return
       }
-      const { svg, blocks } = renderMarkdownPreview(request.body, {
+      const { keyed, blocks } = renderMarkdownPreview(request.body, {
         measure,
         maxWidth: request.maxWidth,
       })
@@ -98,7 +98,7 @@ self.onmessage = async (
       const done: MarkdownRenderResponse = {
         type: 'markdown-render-done',
         id: request.id,
-        svg,
+        svg: keyed.svg,
         bounds: { x: 0, y: 0, w: right, h: bottom },
       }
       self.postMessage(done)

--- a/packages/canvas-render/src/edge-arrows.ts
+++ b/packages/canvas-render/src/edge-arrows.ts
@@ -41,6 +41,61 @@ function arrowAt(
 }
 
 /**
+ * Marker-local arrowhead geometry: the same triangle `arrowAt` places in
+ * canvas space, expressed in a marker viewport so the SVG backend can emit
+ * ONE `<marker>` definition per color instead of a polygon per edge end.
+ * Derived from the same constants, so the drawn ink is identical — the
+ * browser's `orient="auto"` rotation reproduces `arrowAt`'s unit-vector
+ * math (both take the direction of the path's terminal segment), which the
+ * arrowhead pixel goldens pin. Points are tip first, per the emission-
+ * order convention above. `refX`/`refY` place the tip ON the path
+ * endpoint, exactly where `arrowAt` puts it.
+ */
+export const ARROW_MARKER = {
+  width: ARROW_LENGTH,
+  height: ARROW_HALF_WIDTH * 2,
+  end: {
+    refX: ARROW_LENGTH,
+    refY: ARROW_HALF_WIDTH,
+    points: [
+      { x: ARROW_LENGTH, y: ARROW_HALF_WIDTH },
+      { x: 0, y: 0 },
+      { x: 0, y: ARROW_HALF_WIDTH * 2 },
+    ],
+  },
+  // A start arrow points AGAINST the outgoing segment (its tip sits on the
+  // first vertex), so the start marker's triangle points -x rather than
+  // relying on `orient="auto-start-reverse"`, which resvg support is not
+  // established for.
+  start: {
+    refX: 0,
+    refY: ARROW_HALF_WIDTH,
+    points: [
+      { x: 0, y: ARROW_HALF_WIDTH },
+      { x: ARROW_LENGTH, y: 0 },
+      { x: ARROW_LENGTH, y: ARROW_HALF_WIDTH * 2 },
+    ],
+  },
+} as const
+
+/**
+ * Which ends of this edge get an arrowhead — the SAME rule that decides
+ * whether `edgeArrowPolygons` yields a polygon for that end. The backend
+ * must consult this (not `fromEnd`/`toEnd` alone) before attaching a
+ * marker: an end with no usable direction draws nothing as a polygon,
+ * while a marker with `orient="auto"` on a degenerate segment would paint
+ * an arrow at angle 0.
+ */
+export function edgeArrowEnds(edge: ResolvedEdgeNode): { from: boolean; to: boolean } {
+  if (edge.path.length < 2) return { from: false, to: false }
+  const from = edge.fromEnd === 'arrow' && arrowAt(edge.path[0], edge.path[1]) !== null
+  const tip = edge.path[edge.path.length - 1]
+  const inward = edge.path[edge.path.length - 2]
+  const to = edge.toEnd === 'arrow' && arrowAt(tip, inward) !== null
+  return { from, to }
+}
+
+/**
  * The arrowhead polygons of an edge, source arrow first. Total: a
  * degenerate path (fewer than two points, or no finite direction at an
  * end) simply yields no polygon for that end.

--- a/packages/canvas-render/src/svg/backend.test.ts
+++ b/packages/canvas-render/src/svg/backend.test.ts
@@ -559,7 +559,7 @@ describe('renderSceneToSvg — appearance on textRun and edge', () => {
     )
   })
 
-  it('draws a filled destination arrowhead for toEnd=arrow, oriented along the last segment', () => {
+  it('a toEnd=arrow edge references the shared end marker (orientation is orient="auto")', () => {
     const scene: Scene = {
       nodes: [
         {
@@ -577,11 +577,11 @@ describe('renderSceneToSvg — appearance on textRun and edge', () => {
       ],
     }
     expect(renderSceneToSvg(scene)).toBe(
-      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 30,0" fill="none" role="presentation"/><polygon points="30,0 20,4 20,-4" fill="none" role="presentation"/></svg>',
+      '<svg xmlns="http://www.w3.org/2000/svg"><defs><marker id="wb-arrow-end-none" markerWidth="10" markerHeight="8" refX="10" refY="4" markerUnits="userSpaceOnUse" orient="auto"><polygon points="10,4 0,0 0,8" fill="none"/></marker></defs><polyline points="0,0 30,0" fill="none" marker-end="url(#wb-arrow-end-none)" role="presentation"/></svg>',
     )
   })
 
-  it('draws both arrowheads for fromEnd=arrow toEnd=arrow, source arrow first', () => {
+  it('references start and end markers for fromEnd=arrow toEnd=arrow, start defined first', () => {
     const scene: Scene = {
       nodes: [
         {
@@ -599,11 +599,11 @@ describe('renderSceneToSvg — appearance on textRun and edge', () => {
       ],
     }
     expect(renderSceneToSvg(scene)).toBe(
-      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 30,0" fill="none" role="presentation"/><polygon points="0,0 10,-4 10,4" fill="none" role="presentation"/><polygon points="30,0 20,4 20,-4" fill="none" role="presentation"/></svg>',
+      '<svg xmlns="http://www.w3.org/2000/svg"><defs><marker id="wb-arrow-start-none" markerWidth="10" markerHeight="8" refX="0" refY="4" markerUnits="userSpaceOnUse" orient="auto"><polygon points="0,4 10,0 10,8" fill="none"/></marker><marker id="wb-arrow-end-none" markerWidth="10" markerHeight="8" refX="10" refY="4" markerUnits="userSpaceOnUse" orient="auto"><polygon points="10,4 0,0 0,8" fill="none"/></marker></defs><polyline points="0,0 30,0" fill="none" marker-start="url(#wb-arrow-start-none)" marker-end="url(#wb-arrow-end-none)" role="presentation"/></svg>',
     )
   })
 
-  it('the arrowhead inherits the edge stroke color as its fill', () => {
+  it('the arrowhead marker inherits the edge stroke color as its fill', () => {
     const scene: Scene = {
       nodes: [
         {
@@ -622,7 +622,7 @@ describe('renderSceneToSvg — appearance on textRun and edge', () => {
       ],
     }
     expect(renderSceneToSvg(scene)).toBe(
-      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 30,0" fill="none" stroke="#888" role="presentation"/><polygon points="30,0 20,4 20,-4" fill="#888" role="presentation"/></svg>',
+      '<svg xmlns="http://www.w3.org/2000/svg"><defs><marker id="wb-arrow-end-_23888" markerWidth="10" markerHeight="8" refX="10" refY="4" markerUnits="userSpaceOnUse" orient="auto"><polygon points="10,4 0,0 0,8" fill="#888"/></marker></defs><polyline points="0,0 30,0" fill="none" stroke="#888" marker-end="url(#wb-arrow-end-_23888)" role="presentation"/></svg>',
     )
   })
 

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -18,8 +18,8 @@ import type {
 import { collectDefs } from './defs.js'
 import type { PaintAttrs, SvgBoxAttrs, SvgElements, TextEmphasisAttrs } from './elements.js'
 import { formatCoord, sanitizeHref, trustedHref } from './format.js'
-import { hoistInheritedAttrs } from './hoist.js'
 import { serializeSvg } from './serialize.js'
+import { applyOptimizationPasses } from './transform.js'
 import { el, rawXml, type SvgChild, type SvgDef, withDefs } from './vnode.js'
 
 /**
@@ -632,9 +632,11 @@ export function buildSvgDocumentParts(
   scene: Scene,
   options?: SvgDocumentOptions,
 ): SvgDocumentParts {
-  // Hoisting runs before defs collection only by convention — it preserves
-  // `defs` declarations on rebuilt nodes, so the order is not load-bearing.
-  const body = scene.nodes.map(renderNode).map(hoistInheritedAttrs)
+  // Optimization passes run before defs collection only by convention —
+  // they preserve `defs` declarations on rebuilt nodes, so the order is not
+  // load-bearing. Applied per top-level node: passes are group-local by
+  // construction (see transform.ts).
+  const body = scene.nodes.map(renderNode).map((node) => applyOptimizationPasses(node))
   // Presence-only, exactly like an absent appearance attribute: a scene
   // declaring no definitions emits the same bytes it always has.
   const collected = collectDefs(body)

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -1,4 +1,4 @@
-import { edgeArrowPolygons } from '../edge-arrows.js'
+import { ARROW_MARKER, edgeArrowEnds } from '../edge-arrows.js'
 import { hopEndpoints, jumpsWithinSpan } from '../layout/edge-flatten.js'
 import { EDGE_JUMP_RADIUS_PX } from '../layout/edge-jumps.js'
 import { roundedEdgeCorners } from '../layout/edge-rounding.js'
@@ -381,6 +381,39 @@ function pointsAttr(points: readonly EdgePoint[]): string {
   return points.map((p) => `${formatCoord(p.x)},${formatCoord(p.y)}`).join(' ')
 }
 
+/**
+ * Content-derived id token: every character outside [A-Za-z0-9-] becomes
+ * `_` + its hex code point, so any authored color string yields a valid,
+ * collision-free XML id and the same color always derives the same id
+ * (which is what lets `collectDefs` share one definition per color).
+ */
+function idToken(value: string): string {
+  return [...value]
+    .map((ch) => (/[A-Za-z0-9-]/.test(ch) ? ch : `_${(ch.codePointAt(0) ?? 0).toString(16)}`))
+    .join('')
+}
+
+function arrowMarkerDef(direction: 'start' | 'end', fill: string): SvgDef {
+  const geometry = ARROW_MARKER[direction]
+  const id = `wb-arrow-${direction}-${idToken(fill)}`
+  return {
+    id,
+    node: el(
+      'marker',
+      {
+        id,
+        markerWidth: ARROW_MARKER.width,
+        markerHeight: ARROW_MARKER.height,
+        refX: geometry.refX,
+        refY: geometry.refY,
+        markerUnits: 'userSpaceOnUse',
+        orient: 'auto',
+      },
+      [el('polygon', { points: pointsAttr(geometry.points), fill })],
+    ),
+  }
+}
+
 function renderNode(node: SceneNode): SvgChild {
   switch (node.kind) {
     case 'textRun':
@@ -463,12 +496,34 @@ function renderNode(node: SceneNode): SvgChild {
       // appearance spread, matching the string backend's emission order (an
       // edge appearance never carries a fill of its own).
       const jumps = node.jumps ?? []
+      // Arrowheads are shared <marker> definitions in the edge's stroke
+      // color, referenced per end — one definition per (direction, color)
+      // instead of a polygon per edge end. Marker geometry derives from the
+      // same constants as `edgeArrowPolygons` (edge-arrows.ts), which
+      // sceneBounds keeps reading for the wings' reach; the arrowhead pixel
+      // goldens pin that the two stay the same ink. Which ends get one is
+      // `edgeArrowEnds` — the polygon renderer's own skip rule — because a
+      // marker on a direction-less end would paint at angle 0 where the
+      // polygon drew nothing.
+      const stroke = node.appearance?.stroke
+      // No stroke means the polyline itself is invisible (SVG's default
+      // stroke is none) — the arrow must match it, not fall back to the
+      // marker content's default black fill and float detached.
+      const arrowFill = typeof stroke === 'string' && stroke.length > 0 ? stroke : 'none'
+      const ends = edgeArrowEnds(node)
+      const startDef = ends.from ? arrowMarkerDef('start', arrowFill) : undefined
+      const endDef = ends.to ? arrowMarkerDef('end', arrowFill) : undefined
+      const markers = {
+        'marker-start': startDef === undefined ? undefined : `url(#${startDef.id})`,
+        'marker-end': endDef === undefined ? undefined : `url(#${endDef.id})`,
+      }
       const polyline =
         node.rounded === true
           ? el('path', {
               d: roundedPathData(node.path, jumps),
               fill: 'none',
               ...appearance,
+              ...markers,
               role: PRESENTATION,
             })
           : jumps.length > 0
@@ -476,26 +531,21 @@ function renderNode(node: SceneNode): SvgChild {
                 d: jumpedPathData(node.path, jumps),
                 fill: 'none',
                 ...appearance,
+                ...markers,
                 role: PRESENTATION,
               })
             : el('polyline', {
                 points: pointsAttr(node.path),
                 fill: 'none',
                 ...appearance,
+                ...markers,
                 role: PRESENTATION,
               })
-      // Arrowheads are filled triangles in the edge's stroke color, drawn
-      // after (over) the polyline. Geometry comes from the shared helper so
-      // sceneBounds always agrees on how far the wings reach.
-      const stroke = node.appearance?.stroke
-      // No stroke means the polyline itself is invisible (SVG's default
-      // stroke is none) — the arrow must match it, not fall back to the
-      // polygon's default black fill and float detached.
-      const arrowFill = typeof stroke === 'string' && stroke.length > 0 ? stroke : 'none'
-      const arrows = edgeArrowPolygons(node).map((arrow) =>
-        el('polygon', { points: pointsAttr(arrow.points), fill: arrowFill, role: PRESENTATION }),
-      )
-      return [polyline, arrows]
+      const defs = [
+        ...(startDef === undefined ? [] : [startDef]),
+        ...(endDef === undefined ? [] : [endDef]),
+      ]
+      return defs.length > 0 ? withDefs(polyline, defs) : polyline
     }
     case 'shape':
       return renderShape(node)

--- a/packages/canvas-render/src/svg/edge-marker.test.ts
+++ b/packages/canvas-render/src/svg/edge-marker.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import type { ResolvedEdgeNode } from '../scene-graph.js'
+import { renderSceneToSvg } from './backend.js'
+
+const edge = (overrides: Partial<ResolvedEdgeNode>): ResolvedEdgeNode => ({
+  kind: 'edge',
+  id: 'e1',
+  path: [
+    { x: 0, y: 0 },
+    { x: 100, y: 0 },
+  ],
+  fromSide: 'right',
+  toSide: 'left',
+  fromEnd: 'none',
+  toEnd: 'arrow',
+  appearance: { stroke: '#404040' },
+  ...overrides,
+})
+
+describe('edge arrowheads render as shared <marker> defs', () => {
+  it('a to-arrow edge references an end marker and emits no inline polygon', () => {
+    const svg = renderSceneToSvg({ nodes: [edge({})] })
+    // The only <polygon> left is the marker's own content INSIDE <defs>;
+    // the document body carries references, not per-edge triangles.
+    const body = svg.slice(svg.indexOf('</defs>'))
+    expect(body).not.toContain('<polygon')
+    expect(svg).toContain('marker-end="url(#wb-arrow-end-_23404040)"')
+    expect(svg).toContain(
+      '<defs><marker id="wb-arrow-end-_23404040" markerWidth="10" markerHeight="8" refX="10" refY="4" markerUnits="userSpaceOnUse" orient="auto"><polygon points="10,4 0,0 0,8" fill="#404040"/></marker></defs>',
+    )
+  })
+
+  it('a from-arrow edge references a start marker whose triangle points backwards', () => {
+    const svg = renderSceneToSvg({ nodes: [edge({ fromEnd: 'arrow', toEnd: 'none' })] })
+    expect(svg).toContain('marker-start="url(#wb-arrow-start-_23404040)"')
+    expect(svg).toContain(
+      '<marker id="wb-arrow-start-_23404040" markerWidth="10" markerHeight="8" refX="0" refY="4" markerUnits="userSpaceOnUse" orient="auto"><polygon points="0,4 10,0 10,8" fill="#404040"/></marker>',
+    )
+  })
+
+  it('two same-color arrowed edges share ONE marker definition', () => {
+    const svg = renderSceneToSvg({
+      nodes: [
+        edge({}),
+        edge({
+          path: [
+            { x: 0, y: 50 },
+            { x: 100, y: 50 },
+          ],
+        }),
+      ],
+    })
+    expect(svg.match(/<marker /g)).toHaveLength(1)
+    expect(svg.match(/marker-end=/g)).toHaveLength(2)
+  })
+
+  it('differently-colored arrows get separate content-derived definitions', () => {
+    const svg = renderSceneToSvg({
+      nodes: [edge({}), edge({ appearance: { stroke: '#111111' } })],
+    })
+    expect(svg).toContain('wb-arrow-end-_23404040')
+    expect(svg).toContain('wb-arrow-end-_23111111')
+    expect(svg.match(/<marker /g)).toHaveLength(2)
+  })
+
+  it('an end with no usable direction gets no marker reference, matching the skipped polygon', () => {
+    // A coincident final segment has no direction: the polygon renderer
+    // skipped the arrow, and a marker with orient="auto" would instead
+    // paint one at angle 0 — a visible difference this pins against.
+    const svg = renderSceneToSvg({
+      nodes: [
+        edge({
+          path: [
+            { x: 0, y: 0 },
+            { x: 100, y: 0 },
+            { x: 100, y: 0 },
+          ],
+        }),
+      ],
+    })
+    expect(svg).not.toContain('marker-end')
+    expect(svg).not.toContain('<marker ')
+  })
+
+  it('a stroke-less arrowed edge keeps fill="none" markers (invisible, like the polygon it replaces)', () => {
+    const svg = renderSceneToSvg({ nodes: [edge({ appearance: undefined })] })
+    expect(svg).toContain('fill="none"/></marker>')
+  })
+})

--- a/packages/canvas-render/src/svg/elements.ts
+++ b/packages/canvas-render/src/svg/elements.ts
@@ -75,9 +75,30 @@ export type SvgElements = {
       'xml:space'?: 'preserve'
     }
   a: { href: SafeHref }
-  polyline: PaintAttrs & { points: string; fill: string; role?: SvgRole }
-  path: PaintAttrs & { d: string; fill: string; role?: SvgRole }
+  polyline: PaintAttrs & {
+    points: string
+    fill: string
+    'marker-start'?: string
+    'marker-end'?: string
+    role?: SvgRole
+  }
+  path: PaintAttrs & {
+    d: string
+    fill: string
+    'marker-start'?: string
+    'marker-end'?: string
+    role?: SvgRole
+  }
   polygon: { points: string; fill: string; role?: SvgRole }
+  marker: {
+    id: string
+    markerWidth: number
+    markerHeight: number
+    refX: number
+    refY: number
+    markerUnits: 'userSpaceOnUse'
+    orient: 'auto'
+  }
   image: SvgBoxAttrs & { href: string; preserveAspectRatio: string; role?: SvgRole }
   title: Record<string, never>
   defs: Record<string, never>

--- a/packages/canvas-render/src/svg/hoist.test.ts
+++ b/packages/canvas-render/src/svg/hoist.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { svgPaintTreeArb } from '../test-utils/svg-vnode-arbitraries.js'
 import { hoistInheritedAttrs } from './hoist.js'
 import { serializeSvg } from './serialize.js'
 import type { SvgAttrs, SvgAttrValue, SvgChild, SvgVNode } from './vnode.js'
@@ -151,40 +152,8 @@ function resolvePaint(
   for (const inner of child.children ?? []) resolvePaint(inner, paint, out)
 }
 
-const paintArb = fc.record(
-  {
-    fill: fc.constantFrom('#111111', '#404040'),
-    'font-family': fc.constantFrom('Roboto', 'serif'),
-    'font-size': fc.constantFrom(14, 16),
-    'stroke-width': fc.constantFrom(1, 2),
-  },
-  { requiredKeys: [] },
-)
-
-const leafArb: fc.Arbitrary<SvgVNode> = fc.oneof(
-  paintArb.map((paint) => node('text', { x: 0, y: 0, ...paint }, ['t'])),
-  paintArb.map((paint) => node('rect', { x: 0, y: 0, width: 1, height: 1, ...paint })),
-)
-
-const treeArb: fc.Arbitrary<SvgVNode> = fc.letrec<{ tree: SvgVNode }>((tie) => ({
-  tree: fc.oneof(
-    { maxDepth: 3, withCrossShrink: true },
-    leafArb,
-    fc
-      .tuple(
-        fc.constantFrom('g', 'a'),
-        paintArb,
-        fc.option(fc.constant('presentation' as const), { nil: undefined }),
-        fc.array(tie('tree'), { maxLength: 4 }),
-      )
-      .map(([tag, paint, role, children]) =>
-        node(tag, { ...paint, ...(role === undefined ? {} : { role }) }, children),
-      ),
-  ),
-})).tree
-
 describe('hoistInheritedAttrs (PBT)', () => {
-  fcTest.prop([treeArb], withDefaults())(
+  fcTest.prop([svgPaintTreeArb], withDefaults())(
     'preserves every element sequence, computed paint, and non-paint attrs',
     (tree) => {
       const before: Resolved[] = []
@@ -195,7 +164,7 @@ describe('hoistInheritedAttrs (PBT)', () => {
     },
   )
 
-  fcTest.prop([treeArb], withDefaults())('is idempotent', (tree) => {
+  fcTest.prop([svgPaintTreeArb], withDefaults())('is idempotent', (tree) => {
     const once = hoistInheritedAttrs(tree)
     expect(hoistInheritedAttrs(once)).toEqual(once)
   })

--- a/packages/canvas-render/src/svg/transform.test.ts
+++ b/packages/canvas-render/src/svg/transform.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { svgPaintTreeArb, vnode } from '../test-utils/svg-vnode-arbitraries.js'
+import { hoistInheritedAttrs } from './hoist.js'
+import { serializeSvg } from './serialize.js'
+import { applyOptimizationPasses, OPTIMIZATION_PASSES, type SvgNodeTransform } from './transform.js'
+import type { SvgChild } from './vnode.js'
+
+describe('the optimization pass list', () => {
+  it('registers exactly the declared passes, in order', () => {
+    // Adding a pass is meant to be a visible one-entry diff HERE, alongside
+    // its own equivalence test — this pin is what makes an unregistered or
+    // silently reordered pass loud.
+    expect(OPTIMIZATION_PASSES).toEqual([hoistInheritedAttrs])
+  })
+
+  it('composes passes left-to-right in declared order', () => {
+    const appendAttr =
+      (name: string): SvgNodeTransform =>
+      (child) =>
+        typeof child === 'object' && 'tag' in child
+          ? { ...child, attrs: { ...child.attrs, [name]: Object.keys(child.attrs ?? {}).length } }
+          : child
+    // Pass order is observable: the second pass sees the first's output.
+    // With `first` applied first, `second` records 1 prior attr; reversed,
+    // `first` would record 1 instead.
+    const out = applyOptimizationPasses(vnode('g'), [
+      appendAttr('data-first'),
+      appendAttr('data-second'),
+    ])
+    expect(out).toEqual(vnode('g', { 'data-first': 0, 'data-second': 1 }))
+  })
+})
+
+describe('every registered pass honours the shared contract', () => {
+  // Render-equivalence is pass-specific (each pass ships its own oracle,
+  // e.g. hoist.test.ts's inheritance expansion); what is generic is that a
+  // pass must be deterministic, idempotent, total, and serializable — the
+  // properties the byte-identical guarantee and the keyed diff layer
+  // (string equality as change detection) rest on.
+  for (const [index, pass] of OPTIMIZATION_PASSES.entries()) {
+    fcTest.prop([svgPaintTreeArb], withDefaults())(`pass #${index} is deterministic`, (tree) => {
+      expect(pass(structuredClone(tree))).toEqual(pass(structuredClone(tree)))
+    })
+
+    fcTest.prop([svgPaintTreeArb], withDefaults())(`pass #${index} is idempotent`, (tree) => {
+      const once = pass(tree)
+      expect(pass(once)).toEqual(once)
+    })
+
+    fcTest.prop([svgPaintTreeArb], withDefaults())(
+      `pass #${index} output serializes without throwing`,
+      (tree) => {
+        const out: SvgChild = applyOptimizationPasses(tree)
+        expect(() => serializeSvg(vnode('svg', undefined, [out]))).not.toThrow()
+      },
+    )
+  }
+})

--- a/packages/canvas-render/src/svg/transform.ts
+++ b/packages/canvas-render/src/svg/transform.ts
@@ -1,0 +1,43 @@
+/**
+ * The VNode optimization-pass seam: byte-level rewrites applied between
+ * rendering (scene -> VNode) and canonical serialization (VNode -> bytes).
+ *
+ * A registered pass must honour four contracts, in addition to its own
+ * render-equivalence oracle (each pass ships one; see hoist.test.ts):
+ *
+ * - RENDER-EQUIVALENT: the output draws identically to the input. Passes
+ *   optimize the byte encoding, never the picture. Anything that decides
+ *   how something LOOKS (theme, style) belongs upstream in the scene
+ *   layer, which still has the semantic provenance a paint decision
+ *   needs — a VNode carries only tags and resolved values.
+ * - GROUP-LOCAL by construction: a pass receives ONE top-level scene
+ *   entry's subtree and never its siblings, because the keyed projection
+ *   (svg/keyed.ts) uses string equality as change detection — a pass
+ *   whose output for one entry depended on another would dirty unrelated
+ *   groups on every edit and destroy the patch layer's DOM reuse.
+ *   Cross-entry sharing goes through the defs mechanism (content-derived
+ *   ids) instead.
+ * - DETERMINISTIC and platform-free: byte-identical output on Node, the
+ *   browser, and Workers, per this package's headline guarantee.
+ * - TOTAL: never throws, on any tree including degenerate ones.
+ *
+ * transform.test.ts holds the generic half of this contract (determinism,
+ * idempotence, serializability) for every registered pass; registering a
+ * pass there is part of adding one.
+ */
+
+import { hoistInheritedAttrs } from './hoist.js'
+import type { SvgChild } from './vnode.js'
+
+export type SvgNodeTransform = (child: SvgChild) => SvgChild
+
+export const OPTIMIZATION_PASSES: readonly SvgNodeTransform[] = [hoistInheritedAttrs]
+
+export function applyOptimizationPasses(
+  child: SvgChild,
+  passes: readonly SvgNodeTransform[] = OPTIMIZATION_PASSES,
+): SvgChild {
+  let current = child
+  for (const pass of passes) current = pass(current)
+  return current
+}

--- a/packages/canvas-render/src/test-utils/golden-scene.ts
+++ b/packages/canvas-render/src/test-utils/golden-scene.ts
@@ -176,10 +176,14 @@ export function buildShapeAppearanceGoldenScene(): Scene {
  */
 export const SHAPE_APPEARANCE_GOLDEN_SVG =
   '<svg xmlns="http://www.w3.org/2000/svg">' +
+  '<defs>' +
+  '<marker id="wb-arrow-end-_23888" markerWidth="10" markerHeight="8" refX="10" refY="4" markerUnits="userSpaceOnUse" orient="auto">' +
+  '<polygon points="10,4 0,0 0,8" fill="#888"/>' +
+  '</marker>' +
+  '</defs>' +
   '<rect x="0" y="0" width="100" height="60" rx="8"/>' +
   '<rect x="120" y="0" width="100" height="60"/>' +
   '<rect x="240" y="0" width="100" height="60" rx="4" fill="#fff" stroke="#000" stroke-width="2"/>' +
   '<g fill="#111" font-family="Inter" font-size="14"><text x="0" y="80">Styled</text></g>' +
-  '<polyline points="0,120 100,120" fill="none" stroke="#888" stroke-width="1.5" role="presentation"/>' +
-  '<polygon points="100,120 90,124 90,116" fill="#888" role="presentation"/>' +
+  '<polyline points="0,120 100,120" fill="none" stroke="#888" stroke-width="1.5" marker-end="url(#wb-arrow-end-_23888)" role="presentation"/>' +
   '</svg>'

--- a/packages/canvas-render/src/test-utils/svg-vnode-arbitraries.ts
+++ b/packages/canvas-render/src/test-utils/svg-vnode-arbitraries.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared fast-check arbitraries over SVG VNode trees, for properties that
+ * must hold for EVERY registered optimization pass (svg/transform.ts) as
+ * well as for pass-specific oracles (svg/hoist.test.ts). Trees are built
+ * as plain literals (not `el`) so generators can compose arbitrary attr
+ * combinations without satisfying the per-element table.
+ */
+
+import type { SvgAttrs, SvgChild, SvgVNode } from '../svg/vnode.js'
+import { fc } from './fast-check.js'
+
+export const vnode = (tag: string, attrs?: SvgAttrs, children?: readonly SvgChild[]): SvgVNode => ({
+  tag,
+  ...(attrs === undefined ? {} : { attrs }),
+  ...(children === undefined ? {} : { children }),
+})
+
+const paintArb = fc.record(
+  {
+    fill: fc.constantFrom('#111111', '#404040'),
+    'font-family': fc.constantFrom('Roboto', 'serif'),
+    'font-size': fc.constantFrom(14, 16),
+    'stroke-width': fc.constantFrom(1, 2),
+  },
+  { requiredKeys: [] },
+)
+
+const leafArb: fc.Arbitrary<SvgVNode> = fc.oneof(
+  paintArb.map((paint) => vnode('text', { x: 0, y: 0, ...paint }, ['t'])),
+  paintArb.map((paint) => vnode('rect', { x: 0, y: 0, width: 1, height: 1, ...paint })),
+)
+
+/**
+ * A paint-attribute-bearing element tree with `g`/`a` containers — dense
+ * enough that hoisting opportunities (every-child-same-value) actually
+ * arise, which is what its mutation checks rely on.
+ */
+export const svgPaintTreeArb: fc.Arbitrary<SvgVNode> = fc.letrec<{ tree: SvgVNode }>((tie) => ({
+  tree: fc.oneof(
+    { maxDepth: 3, withCrossShrink: true },
+    leafArb,
+    fc
+      .tuple(
+        fc.constantFrom('g', 'a'),
+        paintArb,
+        fc.option(fc.constant('presentation' as const), { nil: undefined }),
+        fc.array(tie('tree'), { maxLength: 4 }),
+      )
+      .map(([tag, paint, role, children]) =>
+        vnode(tag, { ...paint, ...(role === undefined ? {} : { role }) }, children),
+      ),
+  ),
+})).tree


### PR DESCRIPTION
## Summary

Follow-up wave to the VNode/keyed-patching stack (#939, landed as c23871d) — four increments on one branch:

1. **VNode optimization-pass seam** (`svg/transform.ts`) — `backend.ts`'s direct `hoistInheritedAttrs` application becomes a declared pass list with a documented contract: render-equivalent, **group-local by construction** (a pass sees one top-level entry's subtree, never siblings — required so string-equality diffing keeps its 94–99 % DOM-reuse ceiling), deterministic, total. `transform.test.ts` enforces the generic half (determinism, idempotence, serializability) for every registered pass; the shared paint-tree arbitrary moved to `test-utils/svg-vnode-arbitraries.ts`. Byte-identical (goldens unchanged). Theme/style deliberately stay OUT of this pipeline per decision #8 — a VNode has no semantic provenance left to theme with.
2. **Arrowheads as shared `<marker>` defs** (reactivates deferred PR5) — one content-derived definition per (direction, stroke color) (`wb-arrow-end-_23888`-style ids) referenced via `marker-start`/`marker-end`, replacing an inline `<polygon>` per edge end. `edgeArrowEnds` gates references by the polygon renderer's own skip rule (a direction-less end still draws nothing); start markers point backwards instead of relying on `orient="auto-start-reverse"`. Deliberate byte change: the shape/appearance golden is regenerated.
3. **FLIP move animation** in the keyed patcher — a replaced group (same key, changed bytes) plays a 180 ms invert-and-play translate from its predecessor's position: remote edits, AI tidy-ups, and undo/redo glide. Insertions never animate — a drag's static backdrop excludes the dragged node, so its drop commit arrives as an insertion and would double-move if animated (no caller flag needed). Deltas convert screen px to SVG user units (zoom-safe, keyframe pinned under a scaled parent); sub-pixel deltas skip; off under `prefers-reduced-motion` / `motion: false`.
4. **Markdown preview pane on the keyed projection** — `renderMarkdownPreview` returns `keyed` (`keyed.svg` stays the byte-identical document for the worker protocol) and `PreviewPane` mounts through `useKeyedSvg`: a keystroke replaces only the edited block's group, so decoded images/diagrams in untouched blocks keep their DOM and block moves glide. `DocumentPreview`/`DocumentThumbnail` stay on innerHTML deliberately: they receive pre-rendered SVG strings (no scene in hand) and render once per card, so keyed patching buys them nothing.

## Measurements (marker change)

- Large canvas (258 edges, one document): raw **−18.7 %** (68,671 → 55,850 B), gzip **−39.6 %** (10,675 → 6,450 B) — marker refs repeat identically per edge where polygon coordinates were incompressible.
- Small-canvas corpus (105 docs, avg 3 edges): raw +4.9 %, gzip +15.9 % — the per-document `<defs>` overhead dominates below ~4–8 arrows/document, an absolute cost of ~200 B per tiny document. Recorded as the accepted trade; real canvases sit well above break-even.
- resvg (PNG export) parity probe at 4× supersampling: 0.015 % of raw pixel bytes differ (antialiasing at the triangle boundary), no geometry shift.

## Test plan

- [x] Red-first tests per increment: pass-list order/contract PBTs (mutation-checked: reversed composition and skipped-pass wiring both go red), `edge-marker.test.ts` (6 cases incl. the degenerate-direction skip), FLIP browser tests (insertion/no-move/zoom keyframe/reduced-motion pins, mutation-checked: dropped `MIN_MOVE_PX` guard and dropped zoom division both go red), `preview-pane-keyed.browser.test.tsx` (red confirmed against the pre-change implementation)
- [x] **Arrowhead pixel goldens pass UNCHANGED** in real Chromium — marker ink is the polygon ink, at every orientation and both ends
- [x] `canvas-render-node` 802/802, `canvas-render-browser` 7/7, `web-browser` markdown-editor+lib 188/188, apps/web CI-equivalent jsdom green apart from the 9 known environment-artifact daemon-fetch failures (verified identical on pristine `origin/main`), root `pnpm test` with no new failures, `pnpm -r typecheck`, root `pnpm knip` clean
- [x] Manual verification in the running editor (Playwright-driven real browser): live DOM shows `defs > marker#wb-arrow-end-_23737373` with the edge polyline referencing it and zero inline arrow polygons; drag+undo plays a `running` FLIP animation on the node's group while the drop commit itself does not animate
- [ ] Markdown preview pane manually driven in the running app — not reached through the UI flow this session; covered instead by the real-Chromium element-identity test plus the full markdown-editor browser suite

## Visual evidence

The marker change is pixel-identical by design — the unchanged committed arrowhead pixel-golden baselines are the before/after evidence. FLIP is motion; its evidence is the browser tests above plus the live `getAnimations()` observation. (This remote session has no `gh` CLI, so screenshots stay in `tmp/screenshots/` rather than uploaded attachments.)

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — internal rendering path; no published contract change
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kn5gTK3WGQcNrahPppzvHg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn5gTK3WGQcNrahPppzvHg)_