### PR TITLE
test(web): stop browser test files sharing one database and wiping one storage

### DIFF
--- a/apps/web/src/components/WorkspaceTopBar.scopes.browser.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.scopes.browser.test.tsx
@@ -80,9 +80,11 @@ describe('top bar scopes', () => {
 describe('fullscreen ground', () => {
   it('paints the fullscreen target itself, not just the body behind it', async () => {
     // In memory, and ALL FOUR of them: every browser test file shares one
-    // origin, so a sibling file's `indexedDB.deleteDatabase('whiteboard')`
-    // lands mid-load here and the page never leaves its loading state. The
-    // assertion is about a CSS ground, so the storage backend is incidental.
+    // origin, and a sibling deleting the shared database used to land
+    // mid-load here, leaving the page stuck loading. Files now claim private
+    // databases (claimIsolatedWhiteboardDb) and a scan bars the shared name,
+    // but in-memory stays right regardless: the assertion is about a CSS
+    // ground, so the storage backend is incidental.
     //
     // All four, not just the index: the page's `loro`, `pointer` and `clock`
     // each default to real IndexedDB, so an in-memory index beside three real

--- a/apps/web/src/components/markdown-editor/editor-catalog.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/editor-catalog.browser.test.tsx
@@ -10,7 +10,7 @@ import { MarkdownEditor } from './MarkdownEditor.js'
 
 afterEach(() => {
   cleanup()
-  window.localStorage.clear()
+  window.localStorage.removeItem('whiteboard.markdown-view-mode')
 })
 
 async function caretInto(container: HTMLElement, right: number): Promise<void> {

--- a/apps/web/src/components/markdown-editor/link-picker.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/link-picker.browser.test.tsx
@@ -10,7 +10,7 @@ import { MarkdownEditor } from './MarkdownEditor.js'
 
 afterEach(() => {
   cleanup()
-  window.localStorage.clear()
+  window.localStorage.removeItem('whiteboard.markdown-view-mode')
 })
 
 const targets: readonly LinkTarget[] = [

--- a/apps/web/src/components/markdown-editor/markdown-editor.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/markdown-editor.browser.test.tsx
@@ -9,7 +9,7 @@ import { MarkdownEditor } from './MarkdownEditor.js'
 
 afterEach(() => {
   cleanup()
-  window.localStorage.clear()
+  window.localStorage.removeItem('whiteboard.markdown-view-mode')
 })
 
 describe('MarkdownEditor (real browser)', () => {

--- a/apps/web/src/components/markdown-editor/rail-write-mode.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/rail-write-mode.browser.test.tsx
@@ -19,7 +19,7 @@ const LONGER =
 // under real postMessage ordering is exactly what stranded this once.
 describe('the rail in write mode', () => {
   afterEach(() => {
-    window.localStorage.clear()
+    window.localStorage.removeItem('whiteboard.markdown-view-mode')
     cleanup()
   })
 

--- a/apps/web/src/components/markdown-editor/view-mode-isolation.test.ts
+++ b/apps/web/src/components/markdown-editor/view-mode-isolation.test.ts
@@ -46,6 +46,16 @@ function offendingFiles(entries: Record<string, string>): string[] {
     .sort()
 }
 
+/** A blanket wipe of either origin-shared storage, however the object is reached. */
+const WIPES_STORAGE = /(?:local|session)Storage\s*\.\s*clear\s*\(/
+
+function storageWipers(entries: Record<string, string>): string[] {
+  return Object.entries(entries)
+    .filter(([, source]) => WIPES_STORAGE.test(source))
+    .map(([path]) => path)
+    .sort()
+}
+
 describe('the shared markdown view-mode preference', () => {
   it('scans a real population, so an empty result cannot mean the glob matched nothing', () => {
     expect(Object.keys(sources).length).toBeGreaterThan(20)
@@ -84,6 +94,28 @@ describe('the shared markdown view-mode preference', () => {
         'x.browser.test.tsx':
           "expect(localStorage.getItem('whiteboard.markdown-view-mode')).toBe('split')",
       }),
+    ).toEqual([])
+  })
+})
+
+describe('origin-shared storage', () => {
+  // Nine files used to localStorage.clear() in their hooks — wiping theme,
+  // settings, and the view-mode preference out from under every concurrently
+  // running file, not just their own. removeItem of the keys the file's
+  // subject actually reads is the whole discipline.
+  it('is never blanket-cleared by a browser test', () => {
+    expect(storageWipers(sources)).toEqual([])
+  })
+
+  it('detects both storages, so clean means clean rather than blind', () => {
+    expect(storageWipers({ 'x.browser.test.tsx': 'window.localStorage.clear()' })).toEqual([
+      'x.browser.test.tsx',
+    ])
+    expect(storageWipers({ 'x.browser.test.tsx': 'sessionStorage.clear()' })).toEqual([
+      'x.browser.test.tsx',
+    ])
+    expect(
+      storageWipers({ 'x.browser.test.tsx': "localStorage.removeItem('wb.lastTool')" }),
     ).toEqual([])
   })
 })

--- a/apps/web/src/components/migration/ImportBrowserLocalPanel.browser.test.tsx
+++ b/apps/web/src/components/migration/ImportBrowserLocalPanel.browser.test.tsx
@@ -11,11 +11,14 @@ import { IdbDocumentIndex } from '../../lib/idb-document-index.js'
 import { listLocalDocuments } from '../../lib/local-document-summary.js'
 import { LoroStore } from '../../lib/loro-store.js'
 import { createUserSettingsStore } from '../../lib/user-settings-store.js'
+import { claimIsolatedWhiteboardDb } from '../../test-utils/isolated-whiteboard-db.js'
 import { ImportBrowserLocalPanel } from './ImportBrowserLocalPanel.js'
+
+const ISOLATED_DB = claimIsolatedWhiteboardDb('importbrowserlocalpanel')
 
 async function clearDb(): Promise<void> {
   return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase('whiteboard')
+    const req = indexedDB.deleteDatabase(ISOLATED_DB)
     req.onsuccess = () => resolve()
     req.onerror = () => resolve()
   })
@@ -31,7 +34,7 @@ function jsonResponse(body: unknown, status = 200): Response {
 describe('ImportBrowserLocalPanel (real IndexedDB)', () => {
   beforeEach(async () => {
     await clearDb()
-    localStorage.clear()
+    localStorage.removeItem('whiteboard.markdown-view-mode')
   })
   afterEach(cleanup)
 

--- a/apps/web/src/lib/browser-idb.ts
+++ b/apps/web/src/lib/browser-idb.ts
@@ -9,6 +9,30 @@
  */
 const DB_NAME = 'whiteboard'
 
+// The name every opener below resolves when its caller passes none. Module
+// state, not a parameter, because page-level browser tests mount whole pages
+// that construct their stores internally — no argument can reach them.
+// Browser test files each run in their own page with their own module graph,
+// so setting this in one file cannot leak into another; what IS shared across
+// files is the origin's IndexedDB itself, which is exactly why every file
+// must claim its own name instead of deleting the shared one out from under
+// its neighbours.
+let activeDbName = DB_NAME
+
+/**
+ * Point this page's openers at a private database. Test seam, same shape as
+ * `openWhiteboardDb(dbName?)`: production never calls it. See
+ * `test-utils/isolated-whiteboard-db.ts` for the helper tests actually use.
+ */
+export function setWhiteboardDbNameForTests(name: string): void {
+  activeDbName = name
+}
+
+/** The database name this page's openers currently resolve. */
+export function whiteboardDbName(): string {
+  return activeDbName
+}
+
 /**
  * The database name is a parameter so a test can have one of its own. Browser
  * tests share an origin, so two FILES touching `whiteboard` interleave: a
@@ -245,7 +269,7 @@ function renameMetaKey(tx: IDBTransaction, from: string, to: string): void {
   }
 }
 
-export function openWhiteboardDb(dbName: string = DB_NAME): Promise<IDBDatabase> {
+export function openWhiteboardDb(dbName: string = activeDbName): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const req = indexedDB.open(dbName, DB_VERSION)
     req.onupgradeneeded = () => {

--- a/apps/web/src/lib/browser-local-backend.browser.test.tsx
+++ b/apps/web/src/lib/browser-local-backend.browser.test.tsx
@@ -10,8 +10,11 @@ import type {
 } from '@kamiazya/whiteboard-mcp/browser-contract'
 import { Loro } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { DB_VERSION } from './browser-idb.js'
 import { BrowserLocalBackend } from './browser-local-backend.js'
+
+const ISOLATED_DB = claimIsolatedWhiteboardDb('browser-local-backend')
 
 // Generous timeout: async IDB reads under CI load can take well over the
 // 200ms fixed sleeps this file used to rely on. Waiting on the concrete
@@ -21,7 +24,7 @@ const WAIT_TIMEOUT = 10_000
 
 async function clearDb(): Promise<void> {
   return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase('whiteboard')
+    const req = indexedDB.deleteDatabase(ISOLATED_DB)
     req.onsuccess = () => resolve()
     req.onerror = () => resolve()
   })
@@ -460,7 +463,7 @@ describe('BrowserLocalBackend', () => {
 
 async function forceInvalidLoroRecord(documentId: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open('whiteboard', DB_VERSION)
+    const req = indexedDB.open(ISOLATED_DB, DB_VERSION)
     req.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result
       if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
@@ -494,7 +497,7 @@ async function forceInvalidLoroRecord(documentId: string): Promise<void> {
 
 async function forceRecordWithBadDelta(documentId: string, snapshot: Uint8Array): Promise<void> {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open('whiteboard', DB_VERSION)
+    const req = indexedDB.open(ISOLATED_DB, DB_VERSION)
     req.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result
       if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
@@ -529,7 +532,7 @@ async function forceRecordWithBadDelta(documentId: string, snapshot: Uint8Array)
 
 async function forceCorruptFileRecord(_canvasId: string, fileId: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open('whiteboard', DB_VERSION)
+    const req = indexedDB.open(ISOLATED_DB, DB_VERSION)
     req.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result
       if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
@@ -557,7 +560,7 @@ async function forceCorruptFileRecord(_canvasId: string, fileId: string): Promis
 
 async function forceCorruptRecord(documentId: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open('whiteboard', DB_VERSION)
+    const req = indexedDB.open(ISOLATED_DB, DB_VERSION)
     req.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result
       if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')

--- a/apps/web/src/lib/document-file-store.browser.test.tsx
+++ b/apps/web/src/lib/document-file-store.browser.test.tsx
@@ -4,8 +4,11 @@
  * Real browser context required for IndexedDB.
  */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { openWhiteboardDb } from './browser-idb.js'
 import { DocumentFileStore, documentFileRecordSchema } from './document-file-store.js'
+
+const ISOLATED_DB = claimIsolatedWhiteboardDb('document-file-store')
 
 // Rejects on failure: silently keeping stale fixed-key records would let
 // these persistence tests pass without exercising the current write.
@@ -16,7 +19,7 @@ import { DocumentFileStore, documentFileRecordSchema } from './document-file-sto
 // surfaces as a loud test timeout.
 async function clearDb(): Promise<void> {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.deleteDatabase('whiteboard')
+    const req = indexedDB.deleteDatabase(ISOLATED_DB)
     req.onsuccess = () => resolve()
     req.onerror = () => reject(req.error ?? new Error('whiteboard database deletion failed'))
     req.onblocked = () => {

--- a/apps/web/src/lib/loro-store.browser.test.tsx
+++ b/apps/web/src/lib/loro-store.browser.test.tsx
@@ -6,13 +6,16 @@
 
 import { Loro } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { DB_VERSION } from './browser-idb.js'
 import { loroRecordEnvelopeSchema } from './loro-record-envelope.js'
 import { LoroStore } from './loro-store.js'
 
+const ISOLATED_DB = claimIsolatedWhiteboardDb('loro-store')
+
 async function clearDb(): Promise<void> {
   return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase('whiteboard')
+    const req = indexedDB.deleteDatabase(ISOLATED_DB)
     req.onsuccess = () => resolve()
     req.onerror = () => resolve()
   })
@@ -220,7 +223,7 @@ describe('LoroStore (real IndexedDB)', () => {
 function openLoroDb(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     // Open at the CURRENT DB_VERSION so upgrade runs if needed
-    const req = indexedDB.open('whiteboard', DB_VERSION)
+    const req = indexedDB.open(ISOLATED_DB, DB_VERSION)
     req.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result
       if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')

--- a/apps/web/src/lib/shared-idb-version-games.test.ts
+++ b/apps/web/src/lib/shared-idb-version-games.test.ts
@@ -55,6 +55,17 @@ function offendingFiles(entries: Record<string, string>): string[] {
     .sort()
 }
 
+/** Touching the SHARED database by its literal name, in either destructive form. */
+const DELETES_SHARED = /deleteDatabase\(\s*['"]whiteboard['"]\s*\)/
+const OPENS_SHARED = /indexedDB\s*\.\s*open\(\s*['"]whiteboard['"]/
+
+function sharedDbTouchers(entries: Record<string, string>): string[] {
+  return Object.entries(entries)
+    .filter(([, source]) => DELETES_SHARED.test(source) || OPENS_SHARED.test(source))
+    .map(([path]) => path)
+    .sort()
+}
+
 describe('a test that parks IndexedDB at an old version', () => {
   it('is compared against a real current version', () => {
     expect(DB_VERSION).toBeGreaterThan(0)
@@ -76,6 +87,31 @@ describe('a test that parks IndexedDB at an old version', () => {
     ).toEqual(['x.test.ts'])
     expect(
       offendingFiles({ 'x.test.ts': "const NAME = 'whiteboard-mine'\nindexedDB.open(NAME, 7)" }),
+    ).toEqual([])
+  })
+})
+
+describe('the shared whiteboard database, by name', () => {
+  // Ten files used to deleteDatabase('whiteboard') in beforeEach — each one
+  // destroying whatever a concurrently-running neighbour had just seeded,
+  // with the failure surfacing in the neighbour. The seam is
+  // claimIsolatedWhiteboardDb(fileTag): the file's whole module graph (page
+  // stores included) resolves a private name, and its deletes hit that name.
+  it('is never opened or deleted by literal name in a browser test', () => {
+    expect(sharedDbTouchers(sources)).toEqual([])
+  })
+
+  it('detects both destructive forms, so clean means clean rather than blind', () => {
+    expect(
+      sharedDbTouchers({ 'x.browser.test.tsx': "indexedDB.deleteDatabase('whiteboard')" }),
+    ).toEqual(['x.browser.test.tsx'])
+    expect(
+      sharedDbTouchers({ 'x.browser.test.tsx': "indexedDB.open('whiteboard', DB_VERSION)" }),
+    ).toEqual(['x.browser.test.tsx'])
+    // The PNG iTXt keyword is also the literal 'whiteboard' — a keyword
+    // argument, not a database touch, and must stay legal.
+    expect(
+      sharedDbTouchers({ 'x.browser.test.tsx': "extractTextFromPng(bytes, 'whiteboard')" }),
     ).toEqual([])
   })
 })

--- a/apps/web/src/pages/BrowserLocalDocumentPage.backend-identity.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.backend-identity.browser.test.tsx
@@ -16,6 +16,9 @@ import { afterEach, beforeEach, expect, it, vi } from 'vitest'
 import { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { clearWhiteboardDb } from '../test-utils/browser-local-document.js'
 import '../index.css'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+
+claimIsolatedWhiteboardDb('browserlocaldocumentpage-backend-identity')
 
 const constructedFor: string[] = []
 const connectedFor: string[] = []

--- a/apps/web/src/pages/BrowserLocalDocumentPage.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.browser.test.tsx
@@ -13,6 +13,9 @@ import { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { BrowserLocalDocumentPage } from './BrowserLocalDocumentPage.js'
 // Real app styles so layout assertions measure the shipped geometry.
 import '../index.css'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+
+const ISOLATED_DB = claimIsolatedWhiteboardDb('browserlocaldocumentpage')
 
 // The page reads/writes the canvas id through the router, so it needs a router
 // in scope exactly as it has one in main.tsx.
@@ -28,7 +31,7 @@ function render(ui: ReactElement) {
 
 async function clearDb(): Promise<void> {
   return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase('whiteboard')
+    const req = indexedDB.deleteDatabase(ISOLATED_DB)
     req.onsuccess = () => resolve()
     req.onerror = () => resolve()
   })

--- a/apps/web/src/pages/BrowserLocalDocumentPage.create-delete-node.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.create-delete-node.browser.test.tsx
@@ -25,6 +25,9 @@ import {
   textNodeCanvas,
 } from '../test-utils/browser-local-document.js'
 import '../index.css'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+
+claimIsolatedWhiteboardDb('browserlocaldocumentpage-create-delete-node')
 
 function render(ui: ReactElement) {
   return rtlRender(

--- a/apps/web/src/pages/BrowserLocalDocumentPage.delete-confirm.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.delete-confirm.browser.test.tsx
@@ -14,6 +14,9 @@ import { listLocalDocuments } from '../lib/local-document-summary.js'
 import { BrowserLocalDocumentPage } from './BrowserLocalDocumentPage.js'
 // Real app styles so a11y/focus assertions run against the shipped geometry.
 import '../index.css'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+
+const ISOLATED_DB = claimIsolatedWhiteboardDb('browserlocaldocumentpage-delete-confirm')
 
 // The page reads/writes the canvas id through the router, so it needs a router
 // in scope exactly as it has one in main.tsx.
@@ -29,7 +32,7 @@ function render(ui: ReactElement) {
 
 async function clearDb(): Promise<void> {
   return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase('whiteboard')
+    const req = indexedDB.deleteDatabase(ISOLATED_DB)
     req.onsuccess = () => resolve()
     req.onerror = () => resolve()
   })

--- a/apps/web/src/pages/BrowserLocalDocumentPage.export.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.export.browser.test.tsx
@@ -6,6 +6,9 @@ import { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { extractTextFromPng } from '../lib/png-embed.js'
 import { BrowserLocalDocumentPage } from './BrowserLocalDocumentPage.js'
 import '../index.css'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+
+const ISOLATED_DB = claimIsolatedWhiteboardDb('browserlocaldocumentpage-export')
 
 function render(ui: ReactElement) {
   return rtlRender(
@@ -19,7 +22,7 @@ function render(ui: ReactElement) {
 
 async function clearDb(): Promise<void> {
   return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase('whiteboard')
+    const req = indexedDB.deleteDatabase(ISOLATED_DB)
     req.onsuccess = () => resolve()
     req.onerror = () => resolve()
   })

--- a/apps/web/src/pages/BrowserLocalDocumentPage.history-nav.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.history-nav.browser.test.tsx
@@ -31,6 +31,9 @@ import {
   textNodeCanvas,
 } from '../test-utils/browser-local-document.js'
 import '../index.css'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+
+claimIsolatedWhiteboardDb('browserlocaldocumentpage-history-nav')
 
 type OnChange = (next: SpatialCanvas, command: EditorCommand) => void
 

--- a/apps/web/src/pages/BrowserLocalDocumentPage.initial-tool.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.initial-tool.browser.test.tsx
@@ -6,6 +6,9 @@ import { userEvent } from 'vitest/browser'
 import { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { BrowserLocalDocumentPage } from './BrowserLocalDocumentPage.js'
 import '../index.css'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+
+const ISOLATED_DB = claimIsolatedWhiteboardDb('browserlocaldocumentpage-initial-tool')
 
 // Real browser + real IndexedDB: the canvas's node count comes from the Loro
 // document the backend actually loads, which is exactly the input the initial
@@ -20,7 +23,7 @@ function render(ui: ReactElement) {
 
 async function clearDb(): Promise<void> {
   return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase('whiteboard')
+    const req = indexedDB.deleteDatabase(ISOLATED_DB)
     req.onsuccess = () => resolve()
     req.onerror = () => resolve()
   })
@@ -38,7 +41,9 @@ function pressed(name: string): string | null {
 }
 
 beforeEach(async () => {
-  sessionStorage.clear()
+  // Only the key this suite is about: storages are origin-shared across
+  // parallel test files, and clear() wipes the neighbours' state too.
+  sessionStorage.removeItem('wb.lastTool')
   await clearDb()
 })
 

--- a/apps/web/src/pages/BrowserLocalDocumentPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.markdown.browser.test.tsx
@@ -25,6 +25,9 @@ import { clearWhiteboardDb } from '../test-utils/browser-local-document.js'
 import { waitForMenuClosed } from '../test-utils/menu.js'
 import '../index.css'
 import { focusEditable } from '../test-utils/focus-editable.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+
+claimIsolatedWhiteboardDb('browserlocaldocumentpage-markdown')
 
 function render(ui: ReactElement) {
   return rtlRender(

--- a/apps/web/src/pages/BrowserLocalDocumentPage.multi-document.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.multi-document.browser.test.tsx
@@ -34,6 +34,9 @@ import {
 } from '../test-utils/browser-local-document.js'
 import { waitForMenuClosed } from '../test-utils/menu.js'
 import '../index.css'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+
+claimIsolatedWhiteboardDb('browserlocaldocumentpage-multi-document')
 
 // The page reads/writes the canvas id through the router, so it needs a router
 // in scope exactly as it has one in main.tsx.

--- a/apps/web/src/pages/BrowserLocalDocumentPage.node-lock.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.node-lock.browser.test.tsx
@@ -23,6 +23,9 @@ import {
   textNodeCanvas,
 } from '../test-utils/browser-local-document.js'
 import '../index.css'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+
+claimIsolatedWhiteboardDb('browserlocaldocumentpage-node-lock')
 
 function render(ui: ReactElement) {
   return rtlRender(

--- a/apps/web/src/pages/BrowserLocalDocumentPage.open-in-editor.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.open-in-editor.browser.test.tsx
@@ -8,7 +8,10 @@ import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { clearWhiteboardDb } from '../test-utils/browser-local-document.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { seedIdbDocument } from '../test-utils/seed-idb-document.js'
+
+claimIsolatedWhiteboardDb('browserlocaldocumentpage-open-in-editor')
 
 type OnChange = (next: SpatialCanvas, command: unknown) => void
 type OpenInEditor = (nodeId: string, text: string) => void
@@ -38,7 +41,7 @@ describe('open in editor (page seam)', () => {
   })
 
   afterEach(() => {
-    window.localStorage.clear()
+    window.localStorage.removeItem('whiteboard.markdown-view-mode')
   })
 
   it("opens the page's editing surface on the node body the canvas hands over", async () => {

--- a/apps/web/src/pages/BrowserLocalDocumentPage.reload-elements.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.reload-elements.browser.test.tsx
@@ -30,6 +30,9 @@ import {
   textNodeCanvas,
 } from '../test-utils/browser-local-document.js'
 import '../index.css'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+
+claimIsolatedWhiteboardDb('browserlocaldocumentpage-reload-elements')
 
 // The page reads/writes the canvas id through the router, so it needs a router
 // in scope exactly as it has one in main.tsx.

--- a/apps/web/src/pages/BrowserLocalDocumentPage.rename.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.rename.browser.test.tsx
@@ -6,6 +6,9 @@ import { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { BrowserLocalDocumentPage } from './BrowserLocalDocumentPage.js'
 // Real app styles so layout assertions measure the shipped geometry.
 import '../index.css'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+
+const ISOLATED_DB = claimIsolatedWhiteboardDb('browserlocaldocumentpage-rename')
 
 // The page reads/writes the canvas id through the router, so it needs a router
 // in scope exactly as it has one in main.tsx.
@@ -21,7 +24,7 @@ function render(ui: ReactElement) {
 
 async function clearDb(): Promise<void> {
   return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase('whiteboard')
+    const req = indexedDB.deleteDatabase(ISOLATED_DB)
     req.onsuccess = () => resolve()
     req.onerror = () => resolve()
   })

--- a/apps/web/src/pages/BrowserLocalIndexPage.defaults.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalIndexPage.defaults.browser.test.tsx
@@ -12,7 +12,10 @@ import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { clearWhiteboardDb } from '../test-utils/browser-local-document.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { BrowserLocalIndexPage } from './BrowserLocalIndexPage.js'
+
+claimIsolatedWhiteboardDb('browserlocalindexpage-defaults')
 
 describe('list page, production wiring', () => {
   beforeEach(clearWhiteboardDb)

--- a/apps/web/src/pages/BrowserLocalIndexPage.flow.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalIndexPage.flow.browser.test.tsx
@@ -14,6 +14,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
 import { clearWhiteboardDb } from '../test-utils/browser-local-document.js'
 import '../index.css'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+
+claimIsolatedWhiteboardDb('browserlocalindexpage-flow')
 
 vi.mock('../components/spatial-editor/index.js', () => ({
   SpatialEditor: (_props: { canvas: SpatialCanvas }) => <div data-testid="mock-spatial-editor" />,
@@ -38,7 +41,10 @@ function renderApp() {
 describe('browser-local list landing (browser — real IndexedDB)', () => {
   beforeEach(async () => {
     await clearWhiteboardDb()
-    localStorage.clear()
+    // Only the keys this page reads — storages are origin-shared across
+    // parallel test files.
+    localStorage.removeItem('whiteboard.markdown-view-mode')
+    sessionStorage.removeItem('wb.lastTool')
   })
 
   afterEach(() => {

--- a/apps/web/src/pages/DaemonDocumentPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.markdown.browser.test.tsx
@@ -100,7 +100,9 @@ const DAEMON_BASE_URL = 'http://127.0.0.1:3099'
 
 describe('DaemonDocumentPage markdown editing', () => {
   beforeEach(() => {
-    window.localStorage.clear()
+    // Only the keys this page reads: clear() would wipe origin-shared
+    // state out from under concurrently-running files.
+    window.localStorage.removeItem('whiteboard.markdown-view-mode')
     mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
     mockListDocuments.mockResolvedValue({
       documents: [{ path: 'agent-note', id: 'id-note', updatedAt: '2026-01-01', kind: 'markdown' }],
@@ -108,7 +110,9 @@ describe('DaemonDocumentPage markdown editing', () => {
   })
   afterEach(() => {
     cleanup()
-    window.localStorage.clear()
+    // Only the keys this page reads: clear() would wipe origin-shared
+    // state out from under concurrently-running files.
+    window.localStorage.removeItem('whiteboard.markdown-view-mode')
     vi.clearAllMocks()
   })
 

--- a/apps/web/src/pages/use-browser-local-document-controller.multi-document.browser.test.tsx
+++ b/apps/web/src/pages/use-browser-local-document-controller.multi-document.browser.test.tsx
@@ -10,11 +10,16 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { IdbDefaultDocumentPointer } from '../lib/local-document-summary.js'
 import { LoroStore } from '../lib/loro-store.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { useBrowserLocalDocumentController } from './use-browser-local-document-controller.js'
+
+const ISOLATED_DB = claimIsolatedWhiteboardDb(
+  'use-browser-local-document-controller-multi-document',
+)
 
 async function clearDb(): Promise<void> {
   return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase('whiteboard')
+    const req = indexedDB.deleteDatabase(ISOLATED_DB)
     req.onsuccess = () => resolve()
     req.onerror = () => resolve()
   })

--- a/apps/web/src/test-utils/browser-local-document.ts
+++ b/apps/web/src/test-utils/browser-local-document.ts
@@ -11,8 +11,8 @@
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { Loro } from 'loro-crdt'
 import type { EditorCommand } from '../components/spatial-editor/commands.js'
+import { whiteboardDbName } from '../lib/browser-idb.js'
 
-const DB_NAME = 'whiteboard'
 const DOCUMENT_STORE = 'loroDocuments'
 
 type DocumentEnvelope = { snapshot: Uint8Array; deltas?: Uint8Array[] }
@@ -20,7 +20,7 @@ type DocumentEnvelope = { snapshot: Uint8Array; deltas?: Uint8Array[] }
 /** Deletes the app's IndexedDB database. */
 export async function clearWhiteboardDb(): Promise<void> {
   return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(DB_NAME)
+    const req = indexedDB.deleteDatabase(whiteboardDbName())
     req.onsuccess = () => resolve()
     req.onerror = () => resolve()
     // If a prior connection isn't fully closed, deleteDatabase fires onblocked
@@ -33,7 +33,7 @@ export async function clearWhiteboardDb(): Promise<void> {
 /** Runs `read` against the canvas object store of the real IndexedDB database. */
 async function withDocumentStore<T>(read: (store: IDBObjectStore) => IDBRequest): Promise<T> {
   return new Promise((resolve, reject) => {
-    const openReq = indexedDB.open(DB_NAME)
+    const openReq = indexedDB.open(whiteboardDbName())
     openReq.onerror = () => reject(openReq.error)
     openReq.onsuccess = () => {
       const db = openReq.result

--- a/apps/web/src/test-utils/isolated-whiteboard-db.ts
+++ b/apps/web/src/test-utils/isolated-whiteboard-db.ts
@@ -1,0 +1,22 @@
+import { setWhiteboardDbNameForTests } from '../lib/browser-idb.js'
+
+/**
+ * Claim a private IndexedDB for this test FILE, and return its name.
+ *
+ * Browser test files share one origin and run in parallel pages, so the
+ * `whiteboard` database is a single global across all of them — and ten files
+ * used to `deleteDatabase('whiteboard')` in `beforeEach`, each one destroying
+ * whatever a concurrently-running neighbour had just seeded. The failure then
+ * surfaces in the neighbour, which did nothing wrong (the same class as the
+ * version-pinning and view-mode incidents, one API over).
+ *
+ * Call once at module scope. Every opener in this page's module graph — the
+ * stores pages construct internally included — resolves the claimed name from
+ * then on, so page-level suites are covered without threading a parameter.
+ * `clearWhiteboardDb()` clears the claimed database, not the shared one.
+ */
+export function claimIsolatedWhiteboardDb(fileTag: string): string {
+  const name = `whiteboard-${fileTag}`
+  setWhiteboardDbNameForTests(name)
+  return name
+}


### PR DESCRIPTION
The three flakes root-caused this week — a fixture connection blocking an IndexedDB upgrade (#930), a parallel page stealing focus (#937), a view-mode write hiding a neighbour's source pane (#938) — were all the same sentence: **browser test files share one origin and run in parallel, and each file behaved as if it owned the origin.** This closes the remaining two ways that sentence was still true.

Items 2 + 11 of today's test-stability audit (`tmp/issues/00-test-stability-audit-index.md`).

## The shared database, claimed per file

Ten files did `indexedDB.deleteDatabase('whiteboard')` in their hooks — each destroying whatever a concurrently-running neighbour had just seeded, with the failure surfacing in the neighbour. **Twenty files** (those ten plus the ten driving the shared read/clear helper) now claim a private database:

```ts
claimIsolatedWhiteboardDb('loro-store')   // one line, module scope
```

The seam is **module state** in `browser-idb.ts` rather than a constructor parameter, for a measured reason: page-level suites mount whole pages that construct their stores internally — no argument can reach them. A browser test file's module graph is its own page, so the setting cannot leak between files; what is shared is the origin's IndexedDB itself, which is exactly why every file needs its own *name*.

## The shared storage, no longer wiped

Nine files called `localStorage.clear()` — taking the neighbours' theme, settings and view-mode with it (`sessionStorage` is shared the same way between same-tab testers). Each wipe is now `removeItem` of the keys that file's subject actually reads. The key population was **enumerated** (six app keys) rather than guessed.

## Guards, both mutation-checked by reintroducing an offender

| scan | red on |
|---|---|
| `deleteDatabase('whiteboard')` / `indexedDB.open('whiteboard'` in a browser test | the file, by name |
| `localStorage.clear()` / `sessionStorage.clear()` in a browser test | the file, by name |

The database scan **caught a real straggler on its first run** — a stale comment narrating the exact hazard this PR closes (now updated to describe the closed state). The PNG iTXt keyword, also spelled `'whiteboard'`, stays legal and is pinned as such.

## Verification

Merged current main (#943's content-addressed blobs landed mid-flight and conflicted on one of the twenty files; resolved as the union, and the pre-PR hook is what caught the staleness). Browser **752** across all three projects on the merge result, jsdom 2594 + 77, lint / knip / typecheck clean.

With this, all five shared-origin globals the audit enumerated are closed or guarded: IndexedDB version-pinning (#930), destructive deletes (here), view-mode writes (#938), blanket storage wipes (here), page focus (#937).