### PR TITLE
refactor(mcp-server): share the pairing create-grant schemas via api-contracts

### DIFF
--- a/apps/web/src/lib/daemon-api-client.ts
+++ b/apps/web/src/lib/daemon-api-client.ts
@@ -2,6 +2,7 @@ import {
   apiErrorReason,
   type CreateDocumentResponse,
   createDocumentResponseSchema,
+  createGrantResponseSchema,
   type DeleteDocumentResponse,
   type DocumentOkfV1Response,
   deleteDocumentResponseSchema,
@@ -25,7 +26,7 @@ import {
   workspaceNamesSchema,
 } from '@kamiazya/whiteboard-mcp/api-contracts'
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
-import { z } from 'zod'
+import type { z } from 'zod'
 // Re-exported so existing callers keep one import site; the implementation
 // lives in its own module so a SharedWorker can use it without this file's
 // schema graph.
@@ -253,10 +254,7 @@ export function installFont(
 
 // ---- pairing-grant flow (daemon-origin consent page) ----
 
-const createPairingGrantResponseSchema = z
-  .object({ grantId: z.string(), origin: z.string(), code: z.string() })
-  .strict()
-export type CreatePairingGrantResponse = z.infer<typeof createPairingGrantResponseSchema>
+export type CreatePairingGrantResponse = z.infer<typeof createGrantResponseSchema>
 
 /** Same-origin call from the daemon-served /pair page; the daemon token is
  *  the R3-injected one. The credential goes through createDaemonFetch rather
@@ -278,5 +276,5 @@ export async function createPairingGrant(
   if (!res.ok) {
     throw new Error(`grant request failed (${res.status})`)
   }
-  return createPairingGrantResponseSchema.parse(await res.json())
+  return createGrantResponseSchema.parse(await res.json())
 }

--- a/packages/mcp-server/src/server/routes/pairing.ts
+++ b/packages/mcp-server/src/server/routes/pairing.ts
@@ -27,8 +27,9 @@
 //   access, so a forged cross-site POST yields the attacker nothing.
 import { createHash } from 'node:crypto'
 import { Hono } from 'hono'
-import { z } from 'zod'
 import {
+  type CreateGrantResponse,
+  createGrantRequestSchema,
   type ListGrantsResponse,
   listGrantsResponseSchema,
   type PairingTokenResponse,
@@ -38,22 +39,6 @@ import {
 import type { DaemonIdentity } from '../security/daemon-identity.js'
 import type { PairingGrantStore } from '../security/pairing-grant-store.js'
 import type { PairingCodeStore, PairingTokenStore } from '../security/pairing-session.js'
-
-const createGrantRequestSchema = z
-  .object({
-    origin: z.string().min(1),
-    codeChallenge: z.string().min(1),
-  })
-  .strict()
-
-const createGrantResponseSchema = z
-  .object({
-    grantId: z.string(),
-    origin: z.string(),
-    code: z.string(),
-  })
-  .strict()
-type CreateGrantResponse = z.infer<typeof createGrantResponseSchema>
 
 function signTokenResponse(
   identity: DaemonIdentity,

--- a/packages/mcp-server/src/shared/api-contracts/index.ts
+++ b/packages/mcp-server/src/shared/api-contracts/index.ts
@@ -23,8 +23,10 @@ export * from './document.js'
 export * from './document-url.js'
 export * from './errors.js'
 export * from './fonts.js'
-export type { ListGrantsResponse, PairingTokenResponse } from './pairing.js'
+export type { CreateGrantResponse, ListGrantsResponse, PairingTokenResponse } from './pairing.js'
 export {
+  createGrantRequestSchema,
+  createGrantResponseSchema,
   listGrantsResponseSchema,
   pairingTokenNonceSchema,
   pairingTokenRequestSchema,

--- a/packages/mcp-server/src/shared/api-contracts/pairing.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/pairing.test.ts
@@ -14,6 +14,9 @@
  */
 import { describe, expect, it } from 'vitest'
 import {
+  type CreateGrantResponse,
+  createGrantRequestSchema,
+  createGrantResponseSchema,
   type ListGrantsResponse,
   listGrantsResponseSchema,
   type PairingTokenResponse,
@@ -165,5 +168,34 @@ describe('pairingTokenNonceSchema bounds', () => {
 
   it('rejects a non-base64url string', () => {
     expect(pairingTokenNonceSchema.safeParse('not base64url!!!').success).toBe(false)
+  })
+})
+
+describe('createGrantRequestSchema / createGrantResponseSchema roundtrip', () => {
+  const request = { origin: 'https://app.example', codeChallenge: 'abc123' }
+  const response = { grantId: 'g1', origin: 'https://app.example', code: 'c0de' }
+
+  it('parses a well-formed request and survives the wire format', () => {
+    const parsed = createGrantRequestSchema.parse(JSON.parse(JSON.stringify(request)))
+    expect(parsed).toEqual(request)
+  })
+
+  it('parses a well-formed response and survives the wire format', () => {
+    const parsed: CreateGrantResponse = createGrantResponseSchema.parse(
+      JSON.parse(JSON.stringify(response)),
+    )
+    expect(parsed).toEqual(response)
+  })
+
+  it('rejects an empty origin or codeChallenge', () => {
+    expect(createGrantRequestSchema.safeParse({ ...request, origin: '' }).success).toBe(false)
+    expect(createGrantRequestSchema.safeParse({ ...request, codeChallenge: '' }).success).toBe(
+      false,
+    )
+  })
+
+  it('rejects an extra field on either side (strict)', () => {
+    expect(createGrantRequestSchema.safeParse({ ...request, extra: 1 }).success).toBe(false)
+    expect(createGrantResponseSchema.safeParse({ ...response, extra: 1 }).success).toBe(false)
   })
 })

--- a/packages/mcp-server/src/shared/api-contracts/pairing.ts
+++ b/packages/mcp-server/src/shared/api-contracts/pairing.ts
@@ -53,6 +53,27 @@ export const pairingTokenResponseSchema = z
 
 export type PairingTokenResponse = z.infer<typeof pairingTokenResponseSchema>
 
+// POST /api/pairing/grants — the consent page's grant + PKCE-code mint.
+// Shared for the same reason as the token schemas: the daemon route and the
+// browser consent page each parse this shape `.strict()`, so a field landing
+// on only one side is a runtime throw in the browser while CI stays green.
+export const createGrantRequestSchema = z
+  .object({
+    origin: z.string().min(1),
+    codeChallenge: z.string().min(1),
+  })
+  .strict()
+
+export const createGrantResponseSchema = z
+  .object({
+    grantId: z.string(),
+    origin: z.string(),
+    code: z.string(),
+  })
+  .strict()
+
+export type CreateGrantResponse = z.infer<typeof createGrantResponseSchema>
+
 // GET /api/pairing/grants response — shared so the daemon route and the
 // PairedOriginsCard settings UI can never drift apart: a server field
 // addition previously had to land in two independent `.strict()` copies at


### PR DESCRIPTION
Test-stability audit item 4 — the one pairing endpoint declared twice.

`POST /api/pairing/grants` had two independent `.strict()` schema copies: `createGrantRequestSchema`/`createGrantResponseSchema` in `routes/pairing.ts` and `createPairingGrantResponseSchema` in `apps/web`'s `daemon-api-client.ts`. A response-shape change on the daemon side would throw at runtime in the browser's strict parse while CI stayed fully green — the same drift class the list-grants and token schemas were already immunized against.

Both schemas now live in `shared/api-contracts/pairing.ts` (browser-safe, exported through the barrel), and the route + client import the one definition.

## Verification

- Red-first: roundtrip tests for both schemas added to `api-contracts/pairing.test.ts`, observed red (4 failed) before the move, 25/25 after.
- **Mutation check**: adding `extra: 1` to the route's response literal fails `pnpm --filter @kamiazya/whiteboard-mcp typecheck` with TS2353; restored and re-verified clean.
- `routes/pairing` tests 10/10, `daemon-api-client` jsdom tests 29/29, both typechecks pass, knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s25uzvSqVGyadYkmAoVFK