### PR TITLE
refactor(ports): make the in-memory index answer to the shared path-tree rules

### DIFF
--- a/packages/ports/src/test-utils/in-memory-document-index.ts
+++ b/packages/ports/src/test-utils/in-memory-document-index.ts
@@ -1,4 +1,5 @@
 import { generateDocumentId } from '@kamiazya/whiteboard-model'
+import { findDescendantPath, isSelfOrDescendant, planSubtreeMove } from '../document-path-tree.js'
 import type {
   CreateDocumentInput,
   CreateWorkspaceInput,
@@ -19,16 +20,6 @@ import {
   DocumentPathTakenError,
   WorkspaceNotFoundError,
 } from '../index.js'
-
-/** Whether `path` is `ancestor` itself or sits below it. */
-function isSelfOrDescendant(path: string, ancestor: string): boolean {
-  return path === ancestor || path.startsWith(`${ancestor}/`)
-}
-
-/** How many segments a path has. */
-function depth(path: string): number {
-  return path.split('/').length
-}
 
 /**
  * `DocumentIndex` with no persistence, for the DI module the tests compose
@@ -138,33 +129,26 @@ export class InMemoryDocumentIndex implements DocumentIndex {
       throw new DocumentMoveIntoSelfError(from, to)
     }
     const documents = this.#inWorkspace(workspaceId)
-    const moving = [...documents.values()].filter((entry) => isSelfOrDescendant(entry.path, from))
-    if (moving.length === 0) {
-      throw new DocumentNotFoundError(workspaceId, from)
+    const rows = [...documents.values()].map((entry) => ({ id: entry.path, path: entry.path }))
+    const plan = planSubtreeMove(rows, from, to)
+    if (!plan.ok) {
+      if (plan.reason === 'not-found') throw new DocumentNotFoundError(workspaceId, from)
+      throw new DocumentPathTakenError(workspaceId, plan.path)
     }
-    const vacating = new Set(moving.map((entry) => entry.path))
-    const rewritten = moving.map((entry) => ({
-      entry,
-      path: `${to}${entry.path.slice(from.length)}`,
-    }))
-    for (const { path } of rewritten) {
-      if (documents.has(path) && !vacating.has(path)) {
-        throw new DocumentPathTakenError(workspaceId, path)
-      }
-    }
-    // Shallowest source first, for the same reason the sqlite store sorts:
-    // moving up into one's own ancestor namespace sends a deeper row onto a
-    // path a shallower one is still vacating.
-    rewritten.sort((left, right) => depth(left.entry.path) - depth(right.entry.path))
-    for (const { entry, path } of rewritten) {
-      documents.delete(entry.path)
-      documents.set(path, { ...entry, path })
+    for (const move of plan.moves) {
+      const entry = documents.get(move.from)
+      if (entry === undefined) continue
+      documents.delete(move.from)
+      documents.set(move.path, { ...entry, path: move.path })
     }
   }
 
   async deleteDocument({ workspaceId, path }: DeleteDocumentInput): Promise<void> {
     const documents = this.#inWorkspace(workspaceId)
-    const descendant = [...documents.keys()].find((candidate) => candidate.startsWith(`${path}/`))
+    const descendant = findDescendantPath(
+      [...documents.keys()].map((key) => ({ id: key, path: key })),
+      path,
+    )
     if (descendant !== undefined) {
       throw new DocumentHasDescendantsError(
         path,


### PR DESCRIPTION
Test-stability audit item 5 — the self-checking double.

`InMemoryDocumentIndex` privately re-derived the path-tree rules (`isSelfOrDescendant`, depth-ordered subtree moves, descendant-blocked deletes) that `document-path-tree.ts` exists to own. That made its conformance run circular: the double satisfied the suite by construction, not by agreeing with the shared semantics.

**Measured before the change**: reversing `planSubtreeMove`'s depth sort in the shared module left the in-memory conformance suite fully green (22/22).

`moveDocument` now delegates to `planSubtreeMove` and `deleteDocument` to `findDescendantPath` — the same imports the sqlite, HTTP, and IndexedDB stores already use. Net −16 lines.

**Mutation check after**: the same reversed sort now fails exactly the two depth-ordering conformance cases (`allows a subtree to move up into a path it is itself vacating`, `orders a self-vacating move by depth, not by path order`); shared module restored after.

Verification: ports-node 134/134, `pnpm -r typecheck` clean, knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s25uzvSqVGyadYkmAoVFK