### PR TITLE
test(web): trim HistoryCluster.browser assertions duplicated from VersionTimeline.browser

### DIFF
--- a/apps/web/src/components/history-cluster/HistoryCluster.browser.test.tsx
+++ b/apps/web/src/components/history-cluster/HistoryCluster.browser.test.tsx
@@ -92,12 +92,8 @@ describe('HistoryCluster version panel (real browser)', () => {
       cluster.getBoundingClientRect().top + 1,
     )
 
-    const viewport = container.querySelector('[data-slot="scroll-area-viewport"]')
-    expect(viewport).toBeInstanceOf(HTMLDivElement)
-    await waitFor(() => {
-      expect(viewport!.clientHeight).toBeGreaterThan(0)
-      expect(viewport!.scrollHeight).toBeGreaterThan(viewport!.clientHeight)
-    })
+    // Scrollability of the list itself is VersionTimeline.browser's case —
+    // this file only owns what the CLUSTER adds around the shared panel.
 
     // Outside-click closes it.
     fireEvent.mouseDown(document.body)
@@ -120,23 +116,5 @@ describe('HistoryCluster version panel (real browser)', () => {
 
     expect(screen.getByTestId('history-version-panel')).toBeTruthy()
     expect(screen.getByText('Restore this version?')).toBeTruthy()
-  })
-
-  it('opens the restore dialog from a real history row and posts restore on confirm', async () => {
-    renderCluster()
-
-    await page.getByRole('button', { name: 'Version history' }).click()
-    await page.getByText(/^Version 1$/).click()
-
-    await expect.element(page.getByText('Restore this version?')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Restore' }))
-
-    await waitFor(() => {
-      const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
-      expect(fetchMock).toHaveBeenCalledWith(
-        expect.stringContaining('/versions/v-0/restore'),
-        expect.objectContaining({ method: 'POST' }),
-      )
-    })
   })
 })


### PR DESCRIPTION
Test-stability audit item 18.

`HistoryCluster` → `VersionPanel` → `VersionTimeline` (verified component chain), so two things asserted in `HistoryCluster.browser.test.tsx` were re-tests of `VersionTimeline.browser.test.tsx`'s own cases:

- the scroll-viewport `scrollHeight > clientHeight` assertion (VersionTimeline: "keeps the history list scrollable inside the fixed-height popover")
- the restore-confirm POST case (VersionTimeline: "closes the dialog and notifies the caller after a real click through a successful restore")

Both dropped. The file keeps the cluster-specific coverage: upward panel geometry, outside-click close, and mousedown-inside-portaled-dialog staying open — the last of which still drives the real row → restore-dialog wiring, so the cluster's prop plumbing remains exercised.

Verification: trimmed file 2/2 green in real browser mode; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s25uzvSqVGyadYkmAoVFK