### PR TITLE
test(web): move two IndexedDB-only suites to jsdom via fake-indexeddb

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -70,6 +70,7 @@
     "@vitest/browser-playwright": "catalog:",
     "@vitest/web-worker": "^4.1.10",
     "decode-named-character-reference": "^1.3.0",
+    "fake-indexeddb": "^6.2.5",
     "fast-check": "^4.7.0",
     "msw": "^2.15.0",
     "playwright": "1.61.1",

--- a/apps/web/src/components/migration/ImportBrowserLocalPanel.idb.test.tsx
+++ b/apps/web/src/components/migration/ImportBrowserLocalPanel.idb.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Real-IndexedDB browser test: seeds the actual IdbDocumentIndex + LoroStore
+ * with two documents (one with deltas), imports both, and asserts copy-first
+ * — after import the source store's contents are byte-identical.
+ */
+
+// jsdom + fake-indexeddb: this file exercises the copy-first import flow over
+// IndexedDB persistence, not browser layout or input fidelity — the real-IDB
+// contract stays pinned by idb-document-index/loro-store/browser-local-backend/
+// browser-idb-migration in the browser project. (ImportBrowserLocalPanel.test.tsx
+// is the store-double suite; this one drives the real stores.)
+import 'fake-indexeddb/auto'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { Loro } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { IdbDocumentIndex } from '../../lib/idb-document-index.js'
+import { listLocalDocuments } from '../../lib/local-document-summary.js'
+import { LoroStore } from '../../lib/loro-store.js'
+import { createUserSettingsStore } from '../../lib/user-settings-store.js'
+import { claimIsolatedWhiteboardDb } from '../../test-utils/isolated-whiteboard-db.js'
+import { ImportBrowserLocalPanel } from './ImportBrowserLocalPanel.js'
+
+const ISOLATED_DB = claimIsolatedWhiteboardDb('importbrowserlocalpanel')
+
+async function clearDb(): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase(ISOLATED_DB)
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+  })
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('ImportBrowserLocalPanel (real IndexedDB)', () => {
+  beforeEach(async () => {
+    await clearDb()
+    localStorage.removeItem('whiteboard.markdown-view-mode')
+  })
+  afterEach(cleanup)
+
+  it('imports two seeded documents via daemonFetch without mutating the source IndexedDB store', async () => {
+    const browserLocalStore = new IdbDocumentIndex()
+    await browserLocalStore.createWorkspace({ workspaceId: 'local' })
+    const loroStore = new LoroStore()
+
+    const noDeltasId = (
+      await browserLocalStore.createDocument({
+        workspaceId: 'local',
+        path: 'no-deltas',
+        name: 'No Deltas',
+        kind: 'spatial',
+      })
+    ).documentId
+    const withDeltasId = (
+      await browserLocalStore.createDocument({
+        workspaceId: 'local',
+        path: 'with-deltas',
+        name: 'With Deltas',
+        kind: 'spatial',
+      })
+    ).documentId
+
+    const doc1 = new Loro()
+    doc1.getMovableList('elements').push('one')
+    doc1.commit()
+    await loroStore.save(noDeltasId, doc1.export({ mode: 'snapshot' }))
+
+    const doc2 = new Loro()
+    doc2.getMovableList('elements').push('two-a')
+    doc2.commit()
+    await loroStore.save(withDeltasId, doc2.export({ mode: 'snapshot' }))
+    const prevVV = doc2.version()
+    doc2.getMovableList('elements').push('two-b')
+    doc2.commit()
+    await loroStore.appendDelta(withDeltasId, doc2.export({ mode: 'update', from: prevVV }))
+
+    const documentsBefore = await listLocalDocuments(browserLocalStore)
+    const loro1Before = await loroStore.load(noDeltasId)
+    const loro2Before = await loroStore.load(withDeltasId)
+
+    const daemonFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/documents')) {
+        const { path } = JSON.parse(init?.body as string) as { path: string }
+        return jsonResponse({ path })
+      }
+      return jsonResponse({ ok: true })
+    })
+
+    render(
+      <ImportBrowserLocalPanel
+        workspaceId="ws1"
+        daemonFetch={daemonFetch}
+        browserLocalStore={browserLocalStore}
+        loroStore={loroStore}
+        settingsStore={createUserSettingsStore()}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: /import/i }))
+
+    await screen.findByText(/^imported as no-deltas$/i)
+    await screen.findByText(/^imported as with-deltas$/i)
+
+    const createCalls = daemonFetch.mock.calls.filter(([input]) =>
+      String(input).endsWith('/documents'),
+    )
+    const updateCalls = daemonFetch.mock.calls.filter(([input]) =>
+      String(input).includes('/update'),
+    )
+    expect(createCalls).toHaveLength(2)
+    expect(updateCalls).toHaveLength(2)
+
+    const documentsAfter = await listLocalDocuments(browserLocalStore)
+    const loro1After = await loroStore.load(noDeltasId)
+    const loro2After = await loroStore.load(withDeltasId)
+
+    await waitFor(() => {
+      expect(documentsAfter).toEqual(documentsBefore)
+    })
+    expect(loro1After).toEqual(loro1Before)
+    expect(loro2After).toEqual(loro2Before)
+  })
+})

--- a/apps/web/src/lib/browser-idb-migration.browser.test.tsx
+++ b/apps/web/src/lib/browser-idb-migration.browser.test.tsx
@@ -11,6 +11,10 @@
  * row must be stripped on upgrade without ever touching the Loro store.
  */
 
+// Stays in REAL-browser mode on purpose: this file is part of the real-IDB
+// fidelity contract (transaction/upgrade/abort semantics fake-indexeddb only
+// approximates). IndexedDB-only suites with no such stake run in jsdom via
+// fake-indexeddb instead — see e.g. local-document-summary.test.tsx.
 import { Loro } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { DB_VERSION, openWhiteboardDb } from './browser-idb.js'

--- a/apps/web/src/lib/browser-local-backend.browser.test.tsx
+++ b/apps/web/src/lib/browser-local-backend.browser.test.tsx
@@ -4,6 +4,10 @@
  * Real browser context required for IndexedDB + loro-crdt WASM.
  */
 
+// Stays in REAL-browser mode on purpose: this file is part of the real-IDB
+// fidelity contract (transaction/upgrade/abort semantics fake-indexeddb only
+// approximates). IndexedDB-only suites with no such stake run in jsdom via
+// fake-indexeddb instead — see e.g. local-document-summary.test.tsx.
 import type {
   BinaryFileDataLike,
   DocumentBackendHandlers,

--- a/apps/web/src/lib/idb-document-index.browser.test.tsx
+++ b/apps/web/src/lib/idb-document-index.browser.test.tsx
@@ -8,6 +8,10 @@
  * deleted afterwards, because the conformance cases assume an index that
  * starts empty.
  */
+// Stays in REAL-browser mode on purpose: this file is part of the real-IDB
+// fidelity contract (transaction/upgrade/abort semantics fake-indexeddb only
+// approximates). IndexedDB-only suites with no such stake run in jsdom via
+// fake-indexeddb instead — see e.g. local-document-summary.test.tsx.
 import { describeDocumentIndexConformance } from '@kamiazya/whiteboard-ports/test-utils'
 import { describe } from 'vitest'
 import { IdbDocumentIndex } from './idb-document-index.js'

--- a/apps/web/src/lib/local-document-summary.test.tsx
+++ b/apps/web/src/lib/local-document-summary.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * The summary layer: what `DocumentIndex` does not own.
+ *
+ * The port answers placement, identity, kind and name. Two things a
+ * browser-local user still needs are not in it and are not gaps in it — the
+ * pointer to the document a plain load resumes into, and when a document was
+ * last edited. Both are apps/web product concerns, so they live here rather
+ * than bending the contract around them.
+ */
+
+// jsdom + fake-indexeddb: this file exercises IndexedDB persistence logic,
+// not browser layout or input fidelity — the real-IDB contract stays pinned
+// by idb-document-index/loro-store/browser-local-backend/browser-idb-migration
+// in the browser project.
+import 'fake-indexeddb/auto'
+import { Loro } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { IdbDocumentIndex } from './idb-document-index.js'
+import {
+  IdbDefaultDocumentPointer,
+  idbContentClock,
+  LOCAL_WORKSPACE_ID,
+  listLocalDocuments,
+} from './local-document-summary.js'
+import { LoroStore } from './loro-store.js'
+
+const DB_NAME = 'whiteboard-summary-test'
+
+async function clearDb(): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase(DB_NAME)
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+  })
+}
+
+async function seedWorkspace(): Promise<IdbDocumentIndex> {
+  const index = new IdbDocumentIndex(DB_NAME)
+  await index.createWorkspace({ workspaceId: LOCAL_WORKSPACE_ID })
+  return index
+}
+
+async function writeContent(documentId: string): Promise<void> {
+  const doc = new Loro()
+  doc.getList('elements').push({ id: 'el' })
+  await new LoroStore(DB_NAME).save(documentId, doc.export({ mode: 'snapshot' }))
+}
+
+describe('local document summary', () => {
+  beforeEach(clearDb)
+  afterEach(clearDb)
+
+  it('carries the index entry plus the time its content was last written', async () => {
+    const index = await seedWorkspace()
+    const entry = await index.createDocument({
+      workspaceId: LOCAL_WORKSPACE_ID,
+      path: 'notes',
+      kind: 'markdown',
+      name: 'Notes',
+    })
+    await writeContent(entry.documentId)
+
+    const [row] = await listLocalDocuments(index, idbContentClock(DB_NAME))
+    expect(row?.documentId).toBe(entry.documentId)
+    expect(row?.path).toBe('notes')
+    expect(row?.name).toBe('Notes')
+    expect(row?.kind).toBe('markdown')
+    // A real ISO stamp from the content write, not a placeholder.
+    expect(Date.parse(row?.updatedAt ?? '')).toBeGreaterThan(0)
+  })
+
+  it('falls back to the path when a document has no name of its own', async () => {
+    // `DocumentEntry.name` is ABSENT rather than defaulted, on purpose: a
+    // listing that invents one reads as though somebody typed the path in as
+    // a title. Choosing the fallback is this layer's job, not the port's.
+    const index = await seedWorkspace()
+    const entry = await index.createDocument({
+      workspaceId: LOCAL_WORKSPACE_ID,
+      path: 'archive/untitled',
+      kind: 'spatial',
+    })
+    await writeContent(entry.documentId)
+
+    const [row] = await listLocalDocuments(index, idbContentClock(DB_NAME))
+    expect(row?.name).toBe('archive/untitled')
+  })
+
+  it('lists a document whose content was never written, rather than hiding it', async () => {
+    // Every create path seeds an empty content record, so this should not
+    // happen — but a listing that drops a row it cannot timestamp would hide
+    // stored data, which is the dishonest surface. It reports the epoch so
+    // the sort puts it last rather than first.
+    const index = await seedWorkspace()
+    await index.createDocument({
+      workspaceId: LOCAL_WORKSPACE_ID,
+      path: 'contentless',
+      kind: 'spatial',
+    })
+
+    const rows = await listLocalDocuments(index, idbContentClock(DB_NAME))
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.updatedAt).toBe(new Date(0).toISOString())
+  })
+
+  it('remembers, and forgets, which document a plain load resumes into', async () => {
+    const pointer = new IdbDefaultDocumentPointer(DB_NAME)
+    expect(await pointer.get()).toBeNull()
+
+    await pointer.set('01ARZ3NDEKTSV4RRFFQ69G5FAV')
+    expect(await pointer.get()).toBe('01ARZ3NDEKTSV4RRFFQ69G5FAV')
+
+    await pointer.clear()
+    expect(await pointer.get()).toBeNull()
+  })
+})

--- a/apps/web/src/lib/loro-record-envelope.ts
+++ b/apps/web/src/lib/loro-record-envelope.ts
@@ -19,7 +19,13 @@ import { z } from 'zod'
  */
 // z.custom pins the inferred type to Uint8Array<ArrayBuffer> (matching lib:ES2020+DOM),
 // which is narrower than the z.instanceof(Uint8Array) result (Uint8Array<ArrayBufferLike>).
-const uint8ArraySchema = z.custom<Uint8Array>((v) => v instanceof Uint8Array)
+// Judged by tag rather than `instanceof`: a structured clone can hand back a
+// Uint8Array built by another realm's constructor (fake-indexeddb under the
+// jsdom test project does; an `instanceof` check silently rejects the record
+// and the read reports the epoch instead of the stored stamp).
+const uint8ArraySchema = z.custom<Uint8Array>(
+  (v) => ArrayBuffer.isView(v) && Object.prototype.toString.call(v) === '[object Uint8Array]',
+)
 
 export const loroRecordEnvelopeSchema = z.object({
   v: z.literal(1),

--- a/apps/web/src/lib/loro-store.browser.test.tsx
+++ b/apps/web/src/lib/loro-store.browser.test.tsx
@@ -4,6 +4,10 @@
  * Real browser tests because IndexedDB requires a browser environment.
  */
 
+// Stays in REAL-browser mode on purpose: this file is part of the real-IDB
+// fidelity contract (transaction/upgrade/abort semantics fake-indexeddb only
+// approximates). IndexedDB-only suites with no such stake run in jsdom via
+// fake-indexeddb instead — see e.g. local-document-summary.test.tsx.
 import { Loro } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,9 @@ importers:
       decode-named-character-reference:
         specifier: ^1.3.0
         version: 1.3.0
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       fast-check:
         specifier: ^4.7.0
         version: 4.8.0
@@ -5227,6 +5230,10 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fast-check@4.8.0:
     resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
@@ -12623,6 +12630,8 @@ snapshots:
       - supports-color
 
   extend@3.0.2: {}
+
+  fake-indexeddb@6.2.5: {}
 
   fast-check@4.8.0:
     dependencies:


### PR DESCRIPTION
Test-stability audit item 12, wave 1 of the browser→jsdom migration (the two lib-level files; the 8 SpatialEditor-mocking page files follow separately).

## What moved

- `local-document-summary.browser.test.tsx` → `local-document-summary.test.tsx` (jsdom + `fake-indexeddb/auto`)
- `ImportBrowserLocalPanel.browser.test.tsx` → `ImportBrowserLocalPanel.idb.test.tsx` — a jsdom `ImportBrowserLocalPanel.test.tsx` (store-double suite) already existed, so the real-store import-flow suite keeps a distinct name

Neither file used any browser API beyond IndexedDB (no `vitest/browser` imports at all), so the migration is the rename + the fake-indexeddb import.

## What it caught (production fix)

fake-indexeddb's structured clone hands back a `Uint8Array` constructed by another realm, and `loroRecordEnvelopeSchema`'s `v instanceof Uint8Array` check silently rejected the parsed record — `updatedAt` then read as the epoch instead of the stored stamp. The byte-field check is now tag-based (`ArrayBuffer.isView(v) && toString === '[object Uint8Array]'`), which is identical in behavior for same-realm values and correct across realms.

**Mutation check**: reverting the schema to `instanceof` fails the migrated jsdom summary test (`expected 0 to be greater than 0` on the parsed stamp); restored green.

## Keepers

`idb-document-index` / `loro-store` / `browser-local-backend` / `browser-idb-migration` `.browser` suites stay in real-browser mode as the real-IDB fidelity contract (transaction/upgrade/abort semantics fake-indexeddb only approximates) — each now says so in a header comment.

## Verification

- Migrated suites green in jsdom; the four keeper suites green in real browser (82 tests)
- Full apps/web: jsdom 2604 + node 77, typecheck clean, knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s25uzvSqVGyadYkmAoVFK