### PR TITLE
test(web): move six SpatialEditor-mocked page suites to jsdom via fake-indexeddb

### DIFF
--- a/apps/web/src/pages/BrowserLocalDocumentPage.create-delete-node.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.create-delete-node.test.tsx
@@ -9,6 +9,11 @@
  * command shape a real create/delete gesture would report.
  */
 
+// jsdom + fake-indexeddb: this suite drives page wiring over IndexedDB
+// persistence with the spatial editor mocked — no browser layout or input
+// fidelity at stake. The real-IDB contract stays pinned by the four
+// browser-mode keeper suites (see loro-store.browser.test.tsx).
+import 'fake-indexeddb/auto'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { act, cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
 import type { ReactElement, ReactNode } from 'react'
@@ -77,10 +82,9 @@ describe('BrowserLocalDocumentPage create/delete-node persistence (real IndexedD
     // The mobile path: no keyboard exists, so the cluster button must drive
     // the same Loro UndoManager the Cmd/Ctrl+Z shortcut does.
     render(<BrowserLocalDocumentPage store={new IdbDocumentIndex()} />)
-    await waitFor(
-      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
-      { timeout: 5000 },
-    )
+    await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy(), {
+      timeout: 5000,
+    })
     await waitFor(() => expect(latestOnChange).not.toBeNull(), { timeout: 5000 })
 
     const created = textNodeCanvas('undo-probe-node', 20, 20)
@@ -131,10 +135,9 @@ describe('BrowserLocalDocumentPage create/delete-node persistence (real IndexedD
 
   it('a created node survives remount, and a deleted one stays gone', async () => {
     render(<BrowserLocalDocumentPage store={new IdbDocumentIndex()} />)
-    await waitFor(
-      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
-      { timeout: 5000 },
-    )
+    await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy(), {
+      timeout: 5000,
+    })
     await waitFor(() => expect(latestOnChange).not.toBeNull(), { timeout: 5000 })
 
     const created = textNodeCanvas('created-node', 20, 20)
@@ -161,10 +164,9 @@ describe('BrowserLocalDocumentPage create/delete-node persistence (real IndexedD
     cleanup()
     latestMountedCanvases = []
     render(<BrowserLocalDocumentPage store={new IdbDocumentIndex()} />)
-    await waitFor(
-      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
-      { timeout: 5000 },
-    )
+    await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy(), {
+      timeout: 5000,
+    })
     await waitFor(
       () => {
         const restoredIds = latestMountedCanvases.flatMap((canvas) => canvas.nodes.map((n) => n.id))
@@ -190,10 +192,9 @@ describe('BrowserLocalDocumentPage create/delete-node persistence (real IndexedD
     cleanup()
     latestMountedCanvases = []
     render(<BrowserLocalDocumentPage store={new IdbDocumentIndex()} />)
-    await waitFor(
-      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
-      { timeout: 5000 },
-    )
+    await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy(), {
+      timeout: 5000,
+    })
     await waitFor(
       () => {
         const restoredIds = latestMountedCanvases.flatMap((canvas) => canvas.nodes.map((n) => n.id))

--- a/apps/web/src/pages/BrowserLocalDocumentPage.history-nav.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.history-nav.test.tsx
@@ -10,6 +10,11 @@
  * input.
  */
 
+// jsdom + fake-indexeddb: this suite drives page wiring over IndexedDB
+// persistence with the spatial editor mocked — no browser layout or input
+// fidelity at stake. The real-IDB contract stays pinned by the four
+// browser-mode keeper suites (see loro-store.browser.test.tsx).
+import 'fake-indexeddb/auto'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import {
   act,
@@ -94,12 +99,9 @@ describe('BrowserLocalDocumentPage browser Back/Forward (browser — real Indexe
       </div>,
     )
 
-    await waitFor(
-      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
-      {
-        timeout: 5000,
-      },
-    )
+    await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy(), {
+      timeout: 5000,
+    })
     await waitFor(() => expect(latestOnChange).not.toBeNull(), { timeout: 5000 })
 
     const idA = await waitFor(
@@ -173,7 +175,7 @@ describe('BrowserLocalDocumentPage browser Back/Forward (browser — real Indexe
       },
       { timeout: 5000 },
     )
-    await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1 })).toBeTruthy())
     // The editor must actually be showing canvas A now — the assertions above
     // only establish that the navigation and the store agree about which
     // canvas is current.

--- a/apps/web/src/pages/BrowserLocalDocumentPage.multi-document.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.multi-document.test.tsx
@@ -10,6 +10,11 @@
  * this suite's subject is the backend/IndexedDB sync layer, not gesture input.
  */
 
+// jsdom + fake-indexeddb: this suite drives page wiring over IndexedDB
+// persistence with the spatial editor mocked — no browser layout or input
+// fidelity at stake. The real-IDB contract stays pinned by the four
+// browser-mode keeper suites (see loro-store.browser.test.tsx).
+import 'fake-indexeddb/auto'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import {
   act,
@@ -87,12 +92,9 @@ describe('BrowserLocalDocumentPage multi-canvas UI (real IndexedDB)', () => {
   it('edits A, New switches to empty B, switching back to A restores the edited node', async () => {
     const store = new IdbDocumentIndex()
     render(<BrowserLocalDocumentPage store={store} />)
-    await waitFor(
-      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
-      {
-        timeout: 5000,
-      },
-    )
+    await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy(), {
+      timeout: 5000,
+    })
     await waitFor(() => expect(latestOnChange).not.toBeNull(), { timeout: 5000 })
 
     const idA = await waitFor(
@@ -187,12 +189,9 @@ describe('BrowserLocalDocumentPage multi-canvas UI (real IndexedDB)', () => {
   it('persists an edit made inside the 300ms debounce before switching canvas', async () => {
     const store = new IdbDocumentIndex()
     render(<BrowserLocalDocumentPage store={store} />)
-    await waitFor(
-      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
-      {
-        timeout: 5000,
-      },
-    )
+    await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy(), {
+      timeout: 5000,
+    })
     await waitFor(() => expect(latestOnChange).not.toBeNull(), { timeout: 5000 })
 
     const idA = await waitFor(

--- a/apps/web/src/pages/BrowserLocalDocumentPage.node-lock.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.node-lock.test.tsx
@@ -10,6 +10,11 @@
  * `onToggleNodeLock` without synthesising pointer input.
  */
 
+// jsdom + fake-indexeddb: this suite drives page wiring over IndexedDB
+// persistence with the spatial editor mocked — no browser layout or input
+// fidelity at stake. The real-IDB contract stays pinned by the four
+// browser-mode keeper suites (see loro-store.browser.test.tsx).
+import 'fake-indexeddb/auto'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { act, cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
 import type { ReactElement, ReactNode } from 'react'
@@ -61,7 +66,7 @@ const { BrowserLocalDocumentPage } = await import('./BrowserLocalDocumentPage.js
 
 async function mountPage(): Promise<void> {
   render(<BrowserLocalDocumentPage store={new IdbDocumentIndex()} />)
-  await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(), {
+  await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy(), {
     timeout: 5000,
   })
   await waitFor(() => expect(latestOnChange).not.toBeNull(), { timeout: 5000 })

--- a/apps/web/src/pages/BrowserLocalDocumentPage.open-in-editor.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.open-in-editor.test.tsx
@@ -2,6 +2,11 @@
 // the surface, and the edit has to land back in the canvas. Each part has its
 // own test; only the page can answer whether they are connected.
 
+// jsdom + fake-indexeddb: this suite drives page wiring over IndexedDB
+// persistence with the spatial editor mocked — no browser layout or input
+// fidelity at stake. The real-IDB contract stays pinned by the four
+// browser-mode keeper suites (see loro-store.browser.test.tsx).
+import 'fake-indexeddb/auto'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'

--- a/apps/web/src/pages/BrowserLocalDocumentPage.reload-elements.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.reload-elements.test.tsx
@@ -15,6 +15,11 @@
  * backend/IndexedDB sync layer underneath, which remains real.
  */
 
+// jsdom + fake-indexeddb: this suite drives page wiring over IndexedDB
+// persistence with the spatial editor mocked — no browser layout or input
+// fidelity at stake. The real-IDB contract stays pinned by the four
+// browser-mode keeper suites (see loro-store.browser.test.tsx).
+import 'fake-indexeddb/auto'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { act, cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
 import type { ReactElement } from 'react'
@@ -74,12 +79,9 @@ describe('BrowserLocalDocumentPage reload persistence (browser — real IndexedD
 
   it('persists a node across remount and never writes a __placeholder__ row', async () => {
     render(<BrowserLocalDocumentPage store={new IdbDocumentIndex()} />)
-    await waitFor(
-      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
-      {
-        timeout: 5000,
-      },
-    )
+    await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy(), {
+      timeout: 5000,
+    })
     await waitFor(() => expect(latestOnChange).not.toBeNull(), { timeout: 5000 })
 
     const next = textNodeCanvas('reload-regression-node', 10, 10)
@@ -112,12 +114,9 @@ describe('BrowserLocalDocumentPage reload persistence (browser — real IndexedD
     cleanup()
     latestMountedCanvases = []
     render(<BrowserLocalDocumentPage store={new IdbDocumentIndex()} />)
-    await waitFor(
-      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
-      {
-        timeout: 5000,
-      },
-    )
+    await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy(), {
+      timeout: 5000,
+    })
 
     // The restored scene must include the node written before remount.
     await waitFor(


### PR DESCRIPTION
Test-stability audit item 12, wave 2 (follows #959).

The six `BrowserLocalDocumentPage` suites here all mock `SpatialEditor` and drive scene changes through `onChange` — their subject is the backend/IndexedDB sync layer, not layout or input. Measured before migrating: **none imported a single `vitest/browser` API** (no `page.*`, no browser `userEvent`). The migration per file is the rename, the `fake-indexeddb/auto` import, and swapping `toBeInTheDocument` — a browser-mode-only matcher; the jsdom project deliberately loads no jest-dom — for `.toBeTruthy()` on `getBy*` results, which already throw when the element is absent.

- create-delete-node, history-nav, multi-document, node-lock, reload-elements: pure page-wiring + IDB persistence
- open-in-editor: keeps its CodeMirror assertions — display-only, and MarkdownEditor mounts fine in jsdom

**Item 12 closes with this PR.** The remaining two files the audit tentatively listed — `BrowserLocalDocumentPage.markdown` and `BrowserLocalIndexPage.flow` — STAY in browser mode deliberately: both type into real CodeMirror (`userEvent.keyboard`/`fill` through the real input path), the exact fidelity the repo's "do not rely on jsdom for browser interaction bugs" rule protects. Net: 10 of the browser project's files retired across the two waves (~12% of file count).

## Verification

- The six migrated suites: 9/9 green in jsdom (re-run after rebasing onto merged #959)
- Full apps/web on the pre-rebase tree: jsdom 2613 + node 77, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s25uzvSqVGyadYkmAoVFK