### PR TITLE
test: hoist in-body await imports and guard the flake shape executably

### DIFF
--- a/apps/web/src/components/spatial-editor/live-drag.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/live-drag.browser.test.tsx
@@ -3,6 +3,7 @@
 // scene hides what the ghost layer is already drawing — no duplicate node
 // left behind at the start position. Real pointer input, assertions taken
 // MID-drag before any pointerup.
+import { assignEdgeAnchors } from '@kamiazya/whiteboard-canvas-render'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
@@ -357,7 +358,6 @@ it('keeps bystander pins frozen when a layout-worker reply lands mid-gesture', a
     expect(pathsBefore.length).toBeGreaterThan(0)
 
     const lastId = FakeWorker.instances.flatMap((w) => w.requests).at(-1)?.id ?? 1
-    const { assignEdgeAnchors } = await import('@kamiazya/whiteboard-canvas-render')
     FakeWorker.respond({
       type: 'laid-out',
       id: lastId,

--- a/apps/web/src/lib/browser-idb-migration.browser.test.tsx
+++ b/apps/web/src/lib/browser-idb-migration.browser.test.tsx
@@ -26,6 +26,7 @@ import {
   loadLocalDocument,
 } from './local-document-summary.js'
 import { LoroStore } from './loro-store.js'
+import { purgeLegacyReconnectCredentials } from './purge-legacy-reconnect-credentials.js'
 
 /**
  * This file's own database.
@@ -446,9 +447,6 @@ describe('IndexedDB v5 -> v6 (removes reconnectKeypairs)', () => {
     // at app boot in main.tsx; this test verifies the IndexedDB-side and
     // localStorage-side erasure are BOTH complete once a real app boot would
     // have run.
-    const { purgeLegacyReconnectCredentials } = await import(
-      './purge-legacy-reconnect-credentials.js'
-    )
     purgeLegacyReconnectCredentials()
     expect(localStorage.getItem(LEGACY_RECONNECT_SECRET_KEY)).toBeNull()
   })

--- a/apps/web/src/lib/layout-worker-pool.test.ts
+++ b/apps/web/src/lib/layout-worker-pool.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { createLayoutWorkerPool, type PoolWorker } from './layout-worker-pool.js'
+import { createLayoutWorkerPool, defaultPoolSize, type PoolWorker } from './layout-worker-pool.js'
 
 /**
  * A worker whose replies the test releases by hand, so "how many ran at
@@ -384,7 +384,6 @@ describe('createLayoutWorkerPool', () => {
 
 describe('pool sizing', () => {
   it('leaves a core for the main thread and caps the fleet', async () => {
-    const { defaultPoolSize } = await import('./layout-worker-pool.js')
     // A thumbnail list is not worth every core: the editor's own worker and
     // the main thread still have to run while it fills.
     expect(defaultPoolSize(1)).toBe(1)

--- a/apps/web/src/lib/webmcp/use-browser-tool-registry.test.tsx
+++ b/apps/web/src/lib/webmcp/use-browser-tool-registry.test.tsx
@@ -1,6 +1,8 @@
 import { render } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
+import { createWhiteboardCommands } from '../commands/create-commands.js'
 import type { WhiteboardCommands } from '../commands/index.js'
+import { BROWSER_LOCAL_CAPABILITIES } from '../provider.js'
 import { webMcpTools } from './tool-definitions.js'
 import type { ModelContext, WebMcpToolDescriptor } from './use-browser-tool-registry.js'
 import { useBrowserToolRegistry } from './use-browser-tool-registry.js'
@@ -255,8 +257,6 @@ describe('useBrowserToolRegistry', () => {
     // Real commands.getAppContext validates via its Zod input schema
     // (assertValidInput) and rejects extra keys — exercised here with the
     // real command layer via fakeCommands()'s sibling, createWhiteboardCommands.
-    const { createWhiteboardCommands } = await import('../commands/create-commands.js')
-    const { BROWSER_LOCAL_CAPABILITIES } = await import('../provider.js')
     const realCommands = createWhiteboardCommands({
       current: {
         provider: { kind: 'browser-local', capabilities: BROWSER_LOCAL_CAPABILITIES },

--- a/packages/loro-adapter/src/loro-bridge.property.test.ts
+++ b/packages/loro-adapter/src/loro-bridge.property.test.ts
@@ -2,7 +2,7 @@ import {
   extensionFacetsArbitrary,
   spatialCanvasArbitrary,
 } from '@kamiazya/whiteboard-model/test-utils'
-import { LoroDoc } from 'loro-crdt'
+import { LoroDoc, UndoManager } from 'loro-crdt'
 import { describe, expect } from 'vitest'
 import {
   deleteSpatialEdge,
@@ -86,7 +86,6 @@ describe('withSpatialBatch equivalence property', () => {
   )(
     'one batch ≡ sequential helpers on state, and at most one undo step',
     async (canvas, opSpecs) => {
-      const { UndoManager } = await import('loro-crdt')
       const ops: BatchOp[] = opSpecs
       const apply = {
         writeNode: (index: number) => canvas.nodes[index % Math.max(1, canvas.nodes.length)],

--- a/packages/loro-adapter/src/loro-bridge.test.ts
+++ b/packages/loro-adapter/src/loro-bridge.test.ts
@@ -5,7 +5,7 @@ import type {
   SpatialNode,
   StoredCoreFacets,
 } from '@kamiazya/whiteboard-model'
-import { LoroDoc } from 'loro-crdt'
+import { LoroDoc, UndoManager } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
 import {
   deleteSpatialEdge,
@@ -346,7 +346,6 @@ describe('loro-bridge', () => {
   })
 
   test('deleteSpatialNode is a single commit: one UndoManager step restores node and edges together', async () => {
-    const { UndoManager } = await import('loro-crdt')
     const doc = makeDoc()
     writeSpatialCanvas(doc, { nodes: [TEXT_NODE, FILE_NODE], edges: [EDGE] })
     const undoManager = new UndoManager(doc, {})
@@ -666,7 +665,6 @@ describe('withSpatialBatch', () => {
   })
 
   test('deleting an ABSENT id inside a batch preserves the helper no-op: no ops, no undo step', async () => {
-    const { UndoManager } = await import('loro-crdt')
     const doc = seeded()
     const undoManager = new UndoManager(doc, { mergeInterval: 0 })
     expect(undoManager.canUndo()).toBe(false)
@@ -679,7 +677,6 @@ describe('withSpatialBatch', () => {
   })
 
   test('one batch of N writes = exactly one undo step (mergeInterval 0 so timing cannot mask it)', async () => {
-    const { UndoManager } = await import('loro-crdt')
     const doc = seeded()
     const before = readSpatialCanvas(doc)
     const undoManager = new UndoManager(doc, { mergeInterval: 0 })
@@ -700,7 +697,6 @@ describe('withSpatialBatch', () => {
   })
 
   test('error contract: a mid-batch throw commits NOTHING; the partial ops stay pending until a later committing write converges the doc', async () => {
-    const { UndoManager } = await import('loro-crdt')
     const doc = seeded()
     const undoManager = new UndoManager(doc, { mergeInterval: 0 })
     expect(() =>
@@ -793,7 +789,6 @@ describe('node lock sidecar', () => {
   })
 
   test('setNodeLock to its current value writes nothing (no empty undo step)', async () => {
-    const { UndoManager } = await import('loro-crdt')
     const doc = seeded()
     setNodeLock(doc, TEXT_NODE.id, true)
     const undoManager = new UndoManager(doc, { mergeInterval: 0 })
@@ -873,7 +868,6 @@ describe('edge lock sidecar', () => {
   })
 
   test('setEdgeLock to its current value writes nothing (no empty undo step)', async () => {
-    const { UndoManager } = await import('loro-crdt')
     const doc = seeded()
     setEdgeLock(doc, EDGE.id, true)
     const undoManager = new UndoManager(doc, { mergeInterval: 0 })

--- a/packages/mcp-server/src/cli/daemon-logs.test.ts
+++ b/packages/mcp-server/src/cli/daemon-logs.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { DaemonRecordParseResult } from '../daemon/daemon-record.js'
 import { daemonLogEntrySchema } from '../shared/diagnostics/log-jsonl.js'
 import { runDaemonLogs } from './daemon-logs.js'
+import { main } from './dispatcher.js'
 
 function parseJsonLines(stream: string): unknown[] {
   if (stream === '') return []
@@ -259,7 +260,6 @@ describe('CLI dispatcher: whiteboard daemon logs --json', () => {
   }
 
   it('drives the real main(): `daemon logs --json --data-dir=<empty>` writes JSONL to stdout exactly once with no array wrapper, no stderr', async () => {
-    const { main } = await import('./dispatcher.js')
     const dataDir = '/this/path/does/not/exist-cli-logs-test'
 
     const {
@@ -281,7 +281,6 @@ describe('CLI dispatcher: whiteboard daemon logs --json', () => {
   })
 
   it('drives the real main() twice: concatenated stdout is valid multi-entry JSONL, NOT a single JSON document', async () => {
-    const { main } = await import('./dispatcher.js')
     const dataDir = '/this/path/does/not/exist-cli-logs-test'
 
     const { stdout } = await captureStdio(async () => {
@@ -306,7 +305,6 @@ describe('CLI dispatcher: whiteboard daemon logs --json', () => {
     // gate. We pass a deliberately-unknown subcommand to confirm the
     // dispatcher's exit-64 path is what would catch a `logs`-removal
     // mutation.
-    const { main } = await import('./dispatcher.js')
     const {
       result: exitCode,
       stdout,

--- a/packages/mcp-server/src/cli/daemon-support-bundle.test.ts
+++ b/packages/mcp-server/src/cli/daemon-support-bundle.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { runDaemonSupportBundle } from './daemon-support-bundle.js'
+import { main } from './dispatcher.js'
 
 let root: string
 
@@ -148,7 +149,6 @@ describe('runDaemonSupportBundle helper', () => {
 
 describe('CLI dispatcher: whiteboard daemon support-bundle --json', () => {
   it('drives main(): writes one JSON object to stdout, no stderr, files on disk', async () => {
-    const { main } = await import('./dispatcher.js')
     const dataDir = join(root, 'cli-data')
     const outputDir = join(root, 'cli-out')
 
@@ -183,7 +183,6 @@ describe('CLI dispatcher: whiteboard daemon support-bundle --json', () => {
   })
 
   it('missing --output-dir: exit 64, stdout empty, stderr usage error', async () => {
-    const { main } = await import('./dispatcher.js')
     const {
       result: exitCode,
       stdout,
@@ -195,7 +194,6 @@ describe('CLI dispatcher: whiteboard daemon support-bundle --json', () => {
   })
 
   it('usage block lists support-bundle for unknown subcommand', async () => {
-    const { main } = await import('./dispatcher.js')
     const {
       result: exitCode,
       stdout,

--- a/packages/mcp-server/src/di/container.test.ts
+++ b/packages/mcp-server/src/di/container.test.ts
@@ -72,6 +72,9 @@ describe('resolveServerDeps', () => {
 
 describe('ports TOKENS identity', () => {
   it('is the same Symbol across separate imports (global registry)', async () => {
+    // lazy-import: a second import of the same specifier IS the subject —
+    // the test proves TOKENS symbols survive separate imports via the global
+    // symbol registry.
     const reimported = await import('@kamiazya/whiteboard-ports')
     expect(reimported.TOKENS.DocumentStore).toBe(TOKENS.DocumentStore)
     expect(typeof TOKENS.DocumentStore).toBe('symbol')

--- a/packages/mcp-server/src/server/export/installed-fonts.test.ts
+++ b/packages/mcp-server/src/server/export/installed-fonts.test.ts
@@ -13,7 +13,9 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { resetDataDirForTests, setDataDirForTests } from '../../shared/data-dir-secure.js'
 import { syntheticFont } from '../../shared/test-utils/synthetic-font.js'
+import { renderSpatialCanvasToPng } from './headless-renderer.js'
 import { installedFontDir, installedFontFiles } from './installed-fonts.js'
+import { undrawableCharacters } from './undrawable-characters.js'
 
 let dataDir: string
 
@@ -85,7 +87,6 @@ describe('an installed font reaches both the renderer and the report', () => {
   }
 
   it('stops reporting characters it can now draw', async () => {
-    const { undrawableCharacters } = await import('./undrawable-characters.js')
     expect(await undrawableCharacters(CANVAS)).toEqual([COVERED])
 
     await mkdir(installedFontDir(), { recursive: true })
@@ -100,7 +101,6 @@ describe('an installed font reaches both the renderer and the report', () => {
   // own assertion — on the PIXELS, since that is the only place the answer
   // exists.
   it('renders glyphs the vendored face lacks', async () => {
-    const { renderSpatialCanvasToPng } = await import('./headless-renderer.js')
     const tofu = await renderSpatialCanvasToPng(CANVAS, { theme: 'light' })
 
     await mkdir(installedFontDir(), { recursive: true })

--- a/packages/mcp-server/src/server/mcp/logging.test.ts
+++ b/packages/mcp-server/src/server/mcp/logging.test.ts
@@ -1,6 +1,11 @@
 import { McpServer } from '@modelcontextprotocol/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { type CapturedLogsHandle, captureLogsForTests, getLogger } from '../log.js'
+import {
+  _destinationCountForTests,
+  type CapturedLogsHandle,
+  captureLogsForTests,
+  getLogger,
+} from '../log.js'
 import { wireMcpLogging } from './logging.js'
 
 function makeServer() {
@@ -90,7 +95,6 @@ describe('wireMcpLogging', () => {
     // createMcpServer, so the destination has to come back
     // automatically when the server closes — otherwise every per-request
     // server permanently grows the destination set.
-    const { _destinationCountForTests } = await import('../log.js')
     const baseline = _destinationCountForTests()
 
     for (let i = 0; i < 20; i++) {

--- a/packages/mcp-server/src/server/store/data-dir-seam.test.ts
+++ b/packages/mcp-server/src/server/store/data-dir-seam.test.ts
@@ -20,7 +20,8 @@ process.env.WHITEBOARD_DATA_DIR = importBaseDir
 
 const { overrideDataDir, resetDataDirForTests } = await import('../../shared/data-dir-secure.js')
 const { saveDocument } = await import('./document-store.js')
-const { closeDb } = await import('./db/index.js')
+const { closeDb, getDb } = await import('./db/index.js')
+const { getDocumentIdByPath } = await import('./db/upsert-workspace.js')
 
 describe('storage layer follows the effective data dir seam', () => {
   let overrideDir: string
@@ -50,8 +51,6 @@ describe('storage layer follows the effective data dir seam', () => {
     // Canvas content lives in the sqlite db's Libsql snapshot tables now,
     // not a separate blob tree — confirm the row landed under the override
     // dir's db, keyed to the document just saved.
-    const { getDb } = await import('./db/index.js')
-    const { getDocumentIdByPath } = await import('./db/upsert-workspace.js')
     const db = await getDb(overrideDir)
     const documentId = await getDocumentIdByPath(db, 'ws-seam-test', 'seam-canvas')
     expect(documentId).not.toBeNull()

--- a/packages/mcp-server/src/server/store/db/test-helpers.test.ts
+++ b/packages/mcp-server/src/server/store/db/test-helpers.test.ts
@@ -3,7 +3,7 @@
 // of the URL trick (or the cache injection) cannot silently break every store
 // suite at once.
 
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { sql } from 'kysely'
@@ -98,9 +98,7 @@ describe('createIsolatedDb (file fallback)', () => {
         .insertInto('workspaces')
         .values({ id: 's', createdAt: 1, updatedAt: 1 })
         .execute()
-      const fs = await import('node:fs/promises')
-      const exists = await fs
-        .stat(join(scratch, 'whiteboard.db'))
+      const exists = await stat(join(scratch, 'whiteboard.db'))
         .then(() => true)
         .catch(() => false)
       expect(exists).toBe(true)

--- a/packages/mcp-server/src/shared/api-client.test.ts
+++ b/packages/mcp-server/src/shared/api-client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { readRuntimeConfig, runtimeConfigSchema } from './api-client.js'
+import { apiFetch, readRuntimeConfig, runtimeConfigSchema } from './api-client.js'
 import { resetTokenStoreForTests } from './token-store.js'
 
 describe('runtimeConfigSchema', () => {
@@ -94,7 +94,6 @@ describe('apiFetch auth header (TokenStore-sourced)', () => {
   })
 
   it('attaches Authorization from the TokenStore token, ignoring any daemonToken on the runtime-config global', async () => {
-    const { apiFetch } = await import('./api-client.js')
     let capturedHeaders: Headers | undefined
     const fakeWindow = {
       location: { origin: 'http://localhost' },

--- a/packages/mcp-server/src/shared/daemon-backend.close-codes.test.ts
+++ b/packages/mcp-server/src/shared/daemon-backend.close-codes.test.ts
@@ -6,6 +6,7 @@
 // (Policy Violation) — the client must treat it as terminal rather than
 // entering its exponential-backoff reconnect loop.
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { DaemonBackend } from './daemon-backend.js'
 
 class FakeWebSocket {
   static instances: FakeWebSocket[] = []
@@ -51,7 +52,6 @@ describe('DaemonBackend close-code policy', () => {
   })
 
   it('treats close code 1003 as terminal: no reconnect timer scheduled, onAuthError called', async () => {
-    const { DaemonBackend } = await import('./daemon-backend.js')
     const backend = new DaemonBackend('ws-id', 'path', 'http://localhost/')
     const onAuthError = () => {
       authErrorCalled = true
@@ -82,7 +82,6 @@ describe('DaemonBackend close-code policy', () => {
   })
 
   it('code 1006 still reconnects with backoff (unchanged behavior)', async () => {
-    const { DaemonBackend } = await import('./daemon-backend.js')
     const backend = new DaemonBackend('ws-id', 'path', 'http://localhost/')
     let scheduledDelay: number | null = null
     const setTimeoutSpy = ((_fn: () => void, delay: number) => {
@@ -111,7 +110,6 @@ describe('DaemonBackend close-code policy', () => {
   })
 
   it('reconnects after 1011: the server closes with 1011 when it fails to persist a canvas update, which is a server-side state problem, not a client protocol violation, so the client must retry rather than treat it as terminal', async () => {
-    const { DaemonBackend } = await import('./daemon-backend.js')
     const backend = new DaemonBackend('ws-id', 'path', 'http://localhost/')
     let scheduledDelay: number | null = null
     const setTimeoutSpy = ((_fn: () => void, delay: number) => {

--- a/packages/mcp-server/src/shared/daemon-backend.ws-token.test.ts
+++ b/packages/mcp-server/src/shared/daemon-backend.ws-token.test.ts
@@ -8,6 +8,7 @@
 // all and was rejected 401, silently losing every edit. These tests pin
 // that the transport's wsToken reaches the upgrade offer.
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { DaemonBackend } from './daemon-backend.js'
 import { resetTokenStoreForTests } from './token-store.js'
 
 class FakeWebSocket {
@@ -65,7 +66,6 @@ describe('DaemonBackend WS credential selection', () => {
   })
 
   it('offers the transport wsToken via the daemon-token subprotocol when no bootstrap global is seeded', async () => {
-    const { DaemonBackend } = await import('./daemon-backend.js')
     const backend = new DaemonBackend('ws1', 'main', 'http://127.0.0.1:3099/', {
       fetch: globalThis.fetch,
       wsToken: () => 'pairing-session-token',
@@ -82,7 +82,6 @@ describe('DaemonBackend WS credential selection', () => {
       location: { origin: 'http://localhost' },
       __WHITEBOARD_DAEMON_TOKEN__: 'bootstrap-token',
     }
-    const { DaemonBackend } = await import('./daemon-backend.js')
     const backend = new DaemonBackend('ws1', 'main', 'http://127.0.0.1:3099/', {
       fetch: globalThis.fetch,
       wsToken: () => 'pairing-session-token',
@@ -95,7 +94,6 @@ describe('DaemonBackend WS credential selection', () => {
   })
 
   it('re-reads a rotated wsToken on every socket attempt', async () => {
-    const { DaemonBackend } = await import('./daemon-backend.js')
     let current = 'first-token'
     const backend = new DaemonBackend('ws1', 'main', 'http://127.0.0.1:3099/', {
       fetch: globalThis.fetch,
@@ -112,7 +110,6 @@ describe('DaemonBackend WS credential selection', () => {
   })
 
   it('keeps the credential-less offer when neither source provides a token', async () => {
-    const { DaemonBackend } = await import('./daemon-backend.js')
     const backend = new DaemonBackend('ws1', 'main', 'http://127.0.0.1:3099/', {
       fetch: globalThis.fetch,
     })

--- a/packages/mcp-server/src/shared/data-dir-contract.test.ts
+++ b/packages/mcp-server/src/shared/data-dir-contract.test.ts
@@ -16,9 +16,11 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { resolveDefaultDataDir } from '../daemon/data-dir.js'
+import * as dataDirSecureModule from './data-dir-secure.js'
 import {
   DATA_DIR,
   getDataDir,
+  parentIsWritable,
   resetDataDirForTests,
   resolveDataDir,
   setDataDirForTests,
@@ -223,7 +225,6 @@ describe('DATA_DIR does not create directories at import time', () => {
       await rm(homeWhiteboard, { recursive: true, force: true })
 
       // resolveDataDir with parentIsWritable (used by DATA_DIR) does NOT create the dir
-      const { parentIsWritable } = await import('./data-dir-secure.js')
       const result = resolveDataDir({}, { homeDir: tempHome, isWritableDir: parentIsWritable })
       expect(result).toBe(homeWhiteboard)
       expect(existsSync(homeWhiteboard)).toBe(false)
@@ -239,7 +240,6 @@ describe('shared/data-dir-secure.ts module boundary', () => {
     // the HTTP server's static-file middleware. Daemon and CLI code imports
     // this shared module and must not transitively pull in a
     // server-specific path constant.
-    const mod = await import('./data-dir-secure.js')
-    expect('DIST_WEB_APP_DIR' in mod).toBe(false)
+    expect('DIST_WEB_APP_DIR' in dataDirSecureModule).toBe(false)
   })
 })

--- a/packages/mcp-server/src/shared/token-redaction.test.ts
+++ b/packages/mcp-server/src/shared/token-redaction.test.ts
@@ -7,6 +7,8 @@
 // in a record's message or structured fields.
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { captureLogsForTests } from '../server/log.js'
+import { apiFetch } from './api-client.js'
+import { DaemonBackend } from './daemon-backend.js'
 import { readDaemonTokenOnce, resetTokenStoreForTests } from './token-store.js'
 
 const SENTINEL_TOKEN = 'sentinel-do-not-log-9f3c2a'
@@ -79,7 +81,6 @@ describe('token redaction: sentinel never reaches a log record', () => {
   it('apiFetch auth-header attachment does not log the sentinel', async () => {
     const capture = captureLogsForTests()
     try {
-      const { apiFetch } = await import('./api-client.js')
       await apiFetch('http://localhost/api/workspaces')
       expect(recordsContainSentinel(capture.records)).toBe(false)
     } finally {
@@ -90,7 +91,6 @@ describe('token redaction: sentinel never reaches a log record', () => {
   it('DaemonBackend.openSocket (incl. simulated auth failure) does not log the sentinel', async () => {
     const capture = captureLogsForTests()
     try {
-      const { DaemonBackend } = await import('./daemon-backend.js')
       const backend = new DaemonBackend('ws-id', 'path', 'http://localhost/')
       backend.connect({
         onSnapshot: () => {},

--- a/packages/ports/src/smoke.test.ts
+++ b/packages/ports/src/smoke.test.ts
@@ -15,6 +15,8 @@ describe('ports package smoke', () => {
   // reports as a timeout on a test whose subject is resolvability, not
   // latency. The generous budget belongs to this test, not to the project.
   it('imports the barrel via its package specifier and exercises a full round-trip', async () => {
+    // lazy-import: resolving the barrel through package `exports` is the
+    // subject; the budget comment above prices exactly this cold resolve.
     const pkg = await import('@kamiazya/whiteboard-ports')
 
     const bytes = new Uint8Array([10, 20, 30, 40, 50])

--- a/packages/server-core/src/tools/document-io.test.ts
+++ b/packages/server-core/src/tools/document-io.test.ts
@@ -1,5 +1,6 @@
 import { writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { chunkSnapshot } from '@kamiazya/whiteboard-ports'
 import { LoroDoc } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
 import { FakeDocumentStore, seedDoc } from '../test-utils/fake-document-store.js'
@@ -55,9 +56,6 @@ describe('document-io', () => {
     }
 
     // Seed the store directly (bypassing the tool under test).
-    const { LoroDoc } = await import('loro-crdt')
-    const { writeSpatialCanvas } = await import('@kamiazya/whiteboard-loro-adapter')
-    const { chunkSnapshot } = await import('@kamiazya/whiteboard-ports')
     const seedDoc = new LoroDoc()
     writeSpatialCanvas(seedDoc, canvas)
     const { manifest, chunks } = chunkSnapshot(seedDoc.export({ mode: 'snapshot' }), 1_000_000)

--- a/packages/server-core/src/tools/version.test.ts
+++ b/packages/server-core/src/tools/version.test.ts
@@ -1,5 +1,5 @@
 import { readSpatialCanvas, writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
-import { reassembleSnapshot } from '@kamiazya/whiteboard-ports'
+import { chunkSnapshot, reassembleSnapshot } from '@kamiazya/whiteboard-ports'
 import { LoroDoc } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import {
@@ -97,7 +97,6 @@ describe('wb_version_list tool', () => {
     const doc = await loadDoc(store, DOCUMENT_ID)
     doc.getMap('versions').set('corrupt-version', JSON.stringify({ label: 'bad', frontier: 123 }))
     doc.commit()
-    const { chunkSnapshot } = await import('@kamiazya/whiteboard-ports')
     const { manifest, chunks } = chunkSnapshot(doc.export({ mode: 'snapshot' }), 1_000_000)
     await store.saveSnapshot({
       docRef: { kind: 'document', documentId: DOCUMENT_ID },
@@ -136,7 +135,6 @@ describe('wb_version_restore tool', () => {
       edges: [],
     })
     doc.commit()
-    const { chunkSnapshot } = await import('@kamiazya/whiteboard-ports')
     const { manifest, chunks } = chunkSnapshot(doc.export({ mode: 'snapshot' }), 1_000_000)
     await store.saveSnapshot({
       docRef: { kind: 'document', documentId: DOCUMENT_ID },

--- a/tools/arch-lint/src/test-lazy-import-check.test.ts
+++ b/tools/arch-lint/src/test-lazy-import-check.test.ts
@@ -1,0 +1,126 @@
+/**
+ * An `await import()` INSIDE a test body charges that module graph's
+ * transform-and-load to the per-test timeout — ample on an idle machine,
+ * and the first thing to blow once the full suite runs every project in
+ * parallel (aggregate import time there is measured in minutes). The
+ * failure names the test, not the import, and reads as a mysterious
+ * load-dependent flake. Hoisted to a static top-level import, the cost
+ * lands in the collection phase no per-test timeout bounds.
+ *
+ * A dynamic import is legitimate when the file mocks what it imports
+ * (`vi.mock`/`vi.doMock`/`vi.resetModules` make evaluation order the point)
+ * or when the specifier is computed (`pathToFileURL(...)` — the release
+ * suites loading .mjs scripts by path). Those are recognised structurally.
+ * Anything else deliberate carries a `lazy-import: <reason>` comment on the
+ * line above, the same shape as an EXEMPT_FILES entry: visible, reasoned,
+ * and greppable.
+ */
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..', '..')
+
+const SCAN_DIRS = [
+  'apps/web/src',
+  'packages/model/src',
+  'packages/codec/src',
+  'packages/canvas-render/src',
+  'packages/ports/src',
+  'packages/loro-adapter/src',
+  'packages/server-core/src',
+  'packages/canvas-viewer/src',
+  'packages/mcp-server/src',
+  'tools/arch-lint/src',
+] as const
+
+/** Files whose `await import(` lives inside STRING FIXTURES, not code. */
+const EXEMPT_FILES: Record<string, string> = {
+  'tools/arch-lint/src/scanner.test.ts': 'the dynamic import is a scanner fixture string',
+  'tools/arch-lint/src/cycle-check.test.ts': 'the dynamic import is a cycle-check fixture string',
+  'tools/arch-lint/src/test-lazy-import-check.test.ts': 'this guard names the pattern it hunts',
+}
+
+/** Module-mock machinery that makes evaluation order the test's point. */
+const MOCK_MACHINERY = /vi\.(mock|doMock|resetModules|unmock)\(/
+
+/** An INDENTED await import of a LITERAL specifier — the flake shape. */
+const IN_BODY_LITERAL_IMPORT = /^\s+.*await import\(\s*(?:\/\*.*\*\/\s*)?['"`]/
+
+const MARKER = 'lazy-import:'
+
+function listTestFiles(dir: string): string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules') continue
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...listTestFiles(full))
+      continue
+    }
+    if (/\.test\.(ts|tsx)$/.test(entry.name)) files.push(full)
+  }
+  return files
+}
+
+function offendingLines(source: string): Array<{ line: number; text: string }> {
+  if (MOCK_MACHINERY.test(source)) return []
+  const lines = source.split('\n')
+  const hits: Array<{ line: number; text: string }> = []
+  for (const [index, line] of lines.entries()) {
+    if (!IN_BODY_LITERAL_IMPORT.test(line)) continue
+    if (line.includes(MARKER)) continue
+    const preceding = lines.slice(Math.max(0, index - 4), index).join('\n')
+    if (preceding.includes(MARKER)) continue
+    hits.push({ line: index + 1, text: line.trim() })
+  }
+  return hits
+}
+
+describe('in-body await import in test files', () => {
+  it('scans a real population', () => {
+    const all = SCAN_DIRS.flatMap((dir) => listTestFiles(join(REPO_ROOT, dir)))
+    expect(all.length).toBeGreaterThan(300)
+  })
+
+  it('detects the shape, and honors mocks, markers, and computed paths (self-test)', () => {
+    expect(
+      offendingLines(`it('x', async () => {\n  const { y } = await import('./y.js')\n})`),
+    ).toHaveLength(1)
+    expect(
+      offendingLines(
+        `vi.mock('./y.js')\nit('x', async () => {\n  const { y } = await import('./y.js')\n})`,
+      ),
+    ).toHaveLength(0)
+    expect(
+      offendingLines(
+        `it('x', async () => {\n  // lazy-import: identity is the subject\n  const { y } = await import('./y.js')\n})`,
+      ),
+    ).toHaveLength(0)
+    expect(
+      offendingLines(`it('x', async () => {\n  const m = await import(pathToFileURL(p).href)\n})`),
+    ).toHaveLength(0)
+  })
+
+  it('every in-body literal await import is mocked, marked, or hoisted', () => {
+    const offenders: string[] = []
+    for (const dir of SCAN_DIRS) {
+      for (const file of listTestFiles(join(REPO_ROOT, dir))) {
+        const relativePath = relative(REPO_ROOT, file).split(sep).join('/')
+        if (relativePath in EXEMPT_FILES) continue
+        for (const hit of offendingLines(readFileSync(file, 'utf-8'))) {
+          offenders.push(`${relativePath}:${hit.line}: ${hit.text}`)
+        }
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+
+  it('EXEMPT_FILES entries still exist and still contain the pattern they excuse', () => {
+    for (const relativePath of Object.keys(EXEMPT_FILES)) {
+      if (relativePath.endsWith('test-lazy-import-check.test.ts')) continue
+      const source = readFileSync(join(REPO_ROOT, relativePath), 'utf-8')
+      expect(source, relativePath).toMatch(/await import\(/)
+    }
+  })
+})


### PR DESCRIPTION
Test-stability audit item 10 — the in-body `await import()` flake shape, prose-only until now.

## The rule, made executable

`tools/arch-lint/src/test-lazy-import-check.test.ts` scans every `*.test.ts(x)` under the workspaces for an **indented, literal-specifier** `await import(` and fails unless one of three legitimizers holds:

- the file uses module-mock machinery (`vi.mock`/`doMock`/`resetModules`/`unmock`) — evaluation order is the point there
- the specifier is computed (`pathToFileURL(...)` — the release suites loading `.mjs` scripts by path) — recognised structurally, no name-list needed
- the line carries a `lazy-import: <reason>` marker (same visible-reason shape as `EXEMPT_FILES`)

Self-test covers all four branches; population assertion (>300 test files) keeps the glob honest; `EXEMPT_FILES` carries the two arch-lint fixture files whose `await import(` lives inside scanner fixture STRINGS. **Observed red against three real offenders mid-work** (data-dir-seam's second import, data-dir-contract ×2) before going green — the guard finds what the hand-scan missed.

## The hoists (17 files)

Everywhere the dynamic import bought nothing — verified per file that the module binds globals at call time (daemon-backend reads `globalThis.WebSocket` per-instance, api-client reads `window` lazily) or was already imported statically in the same file. Two files keep a deliberate dynamic import under a marker: `di/container.test.ts` (a second import of the same specifier IS the subject — symbol-registry identity) and `ports/smoke.test.ts` (the cold barrel resolve is the subject, with its own budget comment).

## Verification

- Guard + full arch-lint project: 83/83
- All touched suites re-run green: mcp-node 78, loro-adapter/server-core/ports 83, apps/web jsdom 32, browser 34
- `pnpm -r typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s25uzvSqVGyadYkmAoVFK