### PR TITLE
docs(test): size the browser testTimeout on a fresh measurement; record the held-ref guard decision

### DIFF
--- a/.claude/rules/integrator-flow.md
+++ b/.claude/rules/integrator-flow.md
@@ -83,7 +83,12 @@ When a preview contradicts a green test, suspect the cache before suspecting the
     breaks it, so a reproduction has to get that order right (the first attempt
     here did not, and its mutation check passed against the unfixed code).
 - **A third shape: `await import()` of a heavy module INSIDE a test body.** It charges the transform-and-load of that whole module graph to the per-test timeout (10s in `mcp-node`), which is ample on an idle machine and the first thing to blow once the full suite runs every project in parallel — aggregate import time there is measured in minutes. It reads as a mysterious load-dependent failure and the message names the test, not the import. Hoist it to a static top-level `import`, where the cost lands in the collection phase that no per-test timeout bounds. A dynamic import is only necessary when the file mocks what it imports (`vi.mock` + top-level `await import` is a different, legitimate shape), so **an in-body `await import()` with no `vi.mock` in the file is the tell**.
-- **A sixth shape: an element reference held across an action that remounts it.** A query
+- **A sixth shape: an element reference held across an action that remounts it.**
+  (Deliberately NOT scan-guarded: a textual rule for "held reference crosses a
+  remounting action" flags ~90% false positives — most held references never
+  cross one. Reader judgement in review, plus `focusEditable`-style
+  resolver-taking helpers where a site genuinely crosses a remount, is the
+  standing decision — audit-triage 2026-08-21.) A query
   resolves, the page swaps, and the assertion reads a node that is no longer in the document —
   reporting the value it had when it was detached. Measured at one such failure:
   `held.isConnected=false held.value='' live.value='Fast switch'`. The typing was always fine;

--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -100,6 +100,15 @@ export default defineConfig({
     // one run, so the budget's real job is narrower than it looked — it
     // bounds a genuinely hung test, and nothing else.
     //
+    // Sized on a measurement, not a guess. Post-focus-fix, with the ten
+    // IndexedDB-only suites migrated to jsdom (2026-08-21, 124 files / 716
+    // tests, full parallel run): slowest test 27.0s (the markdown page's
+    // pre-unification body case), p99 9.4s, p95 5.5s, median 0.85s. 60s is
+    // ~2.2x that slowest test, leaving headroom for slower CI hardware while
+    // still bounding the keystroke-leakage collateral below. Re-measure
+    // before changing it; do not tighten toward p99 — the max is the binding
+    // number, and it is one test, not an outlier family.
+    //
     // What makes the overrun expensive is the collateral: vitest abandons the
     // test but its in-flight `userEvent.keyboard` keeps typing, so the NEXT
     // test in the file receives the leftover keystrokes interleaved with its


### PR DESCRIPTION
Test-stability audit closeout — items 15 and 14 (both docs/comment-only).

## Item 15 — testTimeout sized on a measurement

Full `web-browser` run on merged main after the migrations (#959/#961) and hoists (#962): **124 files / 716 tests, all passing**. Slowest-test distribution under full parallel load:

| metric | value |
|---|---|
| max | 27.0s (markdown page's pre-unification body case) |
| p99 | 9.4s |
| p95 | 5.5s |
| median | 0.85s |

The 60s budget stays: it is ~2.2× the measured max, leaving headroom for CI-class hardware while still bounding the shape-8 keystroke-leakage collateral. The config comment now carries these numbers and warns against tightening toward p99 — the max is the binding number and it is one known test, not an outlier family.

## Item 14 — held-DOM-reference shape: no scan guard, recorded

`integrator-flow.md`'s sixth flake shape now records the standing decision: a textual guard for "held reference crosses a remounting action" is ~90% false positives, so the enforcement stays reader judgement plus resolver-taking helpers (`focusEditable`'s contract) where a site genuinely crosses a remount. The audit's named conversion site (create-delete-node) migrated to jsdom in #961, where the remount-race class doesn't apply.

This closes the 2026-08-21 test-stability audit: 19 findings → 13 DONE, 2 deliberately deferred with recorded rationale (items 19, and 9 pending #952), plus the audit's own two measured answers (suite is not over-tested; the browser project is now 124 files after retiring ~12%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s25uzvSqVGyadYkmAoVFK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded CI troubleshooting guidance with an additional pattern for stale element references after UI remounts.
  * Added browser test timeout performance measurements and rationale for retaining the current timeout setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->