### PR TITLE
fix(web): say a document is unreadable instead of opening it empty

### DIFF
--- a/apps/web/src/hooks/useDocumentSync.test.ts
+++ b/apps/web/src/hooks/useDocumentSync.test.ts
@@ -165,6 +165,35 @@ describe('useDocumentSync', () => {
     expect(result.current.syncStatus).toBe('connected')
   })
 
+  it('reports WHY the backend failed, not only that it did', () => {
+    const backend = makeFakeBackend()
+    const { result } = renderHook(() => useDocumentSync(backend))
+
+    act(() => {
+      backend._ctrl.handlers!.onError?.('unsupported-version')
+    })
+
+    expect(result.current.backendError).toBe('unsupported-version')
+  })
+
+  it('drops the reason when the backend changes, so it cannot outlive its document', () => {
+    // The reason describes ONE document. Carried across a switch it turns the
+    // next document — which may be perfectly readable — into an error screen,
+    // and the page has no way to tell the difference.
+    const broken = makeFakeBackend()
+    const { result, rerender } = renderHook(({ backend }) => useDocumentSync(backend), {
+      initialProps: { backend: broken },
+    })
+    act(() => {
+      broken._ctrl.handlers!.onError?.('unsupported-version')
+    })
+    expect(result.current.backendError).toBe('unsupported-version')
+
+    rerender({ backend: makeFakeBackend() })
+
+    expect(result.current.backendError).toBeNull()
+  })
+
   it('sets syncStatus to "error" when onError fires', () => {
     const backend = makeFakeBackend()
     const { result } = renderHook(() => useDocumentSync(backend))

--- a/apps/web/src/hooks/useDocumentSync.ts
+++ b/apps/web/src/hooks/useDocumentSync.ts
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type { EditorCommand } from '../components/spatial-editor/commands.js'
 import { renderCanvasToSvg } from '../components/spatial-editor/scene-render.js'
 import {
+  type BackendErrorReason,
   createDocumentSyncSession,
   createGenerationCounters,
   type DocumentSyncSession,
@@ -29,6 +30,7 @@ export type SceneExportFormat = 'png' | 'svg'
 
 export interface UseDocumentSyncResult {
   syncStatus: SyncStatus
+  backendError: BackendErrorReason | null
   /**
    * True once the backend has published this canvas's document at least
    * once. The document arrives AFTER mount, so anything deriving a decision
@@ -182,6 +184,15 @@ export function useDocumentSync(
   const generationsRef = useRef(createGenerationCounters())
 
   const [syncStatus, setSyncStatus] = useState<SyncStatus>('idle')
+  /**
+   * Why the last backend failure happened, or null.
+   *
+   * Kept beside `syncStatus` rather than folded into it: 'error' answers
+   * whether the editor is live, and this answers what to tell the user about
+   * their document — which for an unreadable one is the opposite of "it is
+   * empty".
+   */
+  const [backendError, setBackendError] = useState<BackendErrorReason | null>(null)
   const [canvas, setCanvas] = useState<SpatialCanvas>(EMPTY_CANVAS)
   const [loaded, setLoaded] = useState(false)
   const [externalVersion, setExternalVersion] = useState(0)
@@ -233,6 +244,7 @@ export function useDocumentSync(
     const session = createDocumentSyncSession(backend, {
       getOptions: () => optionsRef.current,
       onStatusChange: setSyncStatus,
+      onBackendError: setBackendError,
       onRestoreChange: (inProgress, label) => {
         setRestoreInProgress(inProgress)
         setRestoreLabel(label)
@@ -391,6 +403,7 @@ export function useDocumentSync(
 
   return {
     syncStatus,
+    backendError,
     loaded,
     canvas,
     onChange,

--- a/apps/web/src/hooks/useDocumentSync.ts
+++ b/apps/web/src/hooks/useDocumentSync.ts
@@ -228,6 +228,11 @@ export function useDocumentSync(
     // do — left standing it would render against whatever document is next.
     setMarkdownBodyState('')
     setCoreFacetsState(undefined)
+    // And the failure reason, for the same reason and with a sharper
+    // consequence: it describes ONE document, and carried across a switch it
+    // turns the next one — which may be perfectly readable — into an error
+    // screen the page cannot distinguish from a real failure.
+    setBackendError(null)
 
     if (backend === null) {
       sessionRef.current = null

--- a/apps/web/src/lib/document-read-failure.ts
+++ b/apps/web/src/lib/document-read-failure.ts
@@ -1,0 +1,36 @@
+/**
+ * What to tell someone whose document is stored but this build cannot read it.
+ *
+ * The EDITOR's wording. The import panel says its own thing about the same
+ * three cases, and deliberately so: it is answering "why was this skipped",
+ * where this is answering "why can I not open it". Unifying the two was tried
+ * and reverted — the sentences are about different actions, and a shared one
+ * ends up vague about both.
+ *
+ * What they do share is the classification, which is the part that must not
+ * drift. Every sentence here is about the STORAGE, never about the document
+ * being empty or missing: the bytes are there, and telling their owner
+ * otherwise is the one thing this must not do.
+ */
+export type DocumentReadFailure = 'unsupported-version' | 'corrupt-snapshot' | 'corrupt-delta'
+
+const MESSAGES: Record<DocumentReadFailure, string> = {
+  'unsupported-version': 'This canvas was saved by a newer version of the app. Update to open it.',
+  'corrupt-snapshot': 'This canvas’s data could not be read.',
+  'corrupt-delta': 'This canvas’s edit history could not be read.',
+}
+
+export function documentReadFailureMessage(kind: DocumentReadFailure): string {
+  return MESSAGES[kind]
+}
+
+/**
+ * Whether a backend failure means "the stored document cannot be read".
+ *
+ * `storage-failure` is deliberately NOT one: that is a write that did not land,
+ * which the header's save status already reports, and it says nothing about
+ * whether the stored document is readable.
+ */
+export function isDocumentReadFailure(reason: string | null): reason is DocumentReadFailure {
+  return reason !== null && reason in MESSAGES
+}

--- a/apps/web/src/lib/document-sync-session.test.ts
+++ b/apps/web/src/lib/document-sync-session.test.ts
@@ -108,6 +108,7 @@ function makeDeps(overrides: Partial<SessionDeps> = {}): SessionDeps {
   return {
     getOptions: () => ({}),
     onStatusChange: vi.fn(),
+    onBackendError: vi.fn(),
     onRestoreChange: vi.fn(),
     dispatchIdentityEvent: vi.fn(),
     generations: createGenerationCounters(),

--- a/apps/web/src/lib/document-sync-session.ts
+++ b/apps/web/src/lib/document-sync-session.ts
@@ -15,7 +15,14 @@ import {
   writeSpatialEdge,
   writeSpatialNode,
 } from '@kamiazya/whiteboard-loro-adapter'
-import type { DocumentBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
+import type {
+  DocumentBackend,
+  DocumentBackendHandlers,
+} from '@kamiazya/whiteboard-mcp/browser-contract'
+
+/** Why a backend read or write failed. The published contract's own union. */
+export type BackendErrorReason = Parameters<NonNullable<DocumentBackendHandlers['onError']>>[0]
+
 import { exportResponseMessageSchema } from '@kamiazya/whiteboard-mcp/browser-shared'
 import type { SpatialCanvas, StoredCoreFacets } from '@kamiazya/whiteboard-model'
 import { LoroDoc, UndoManager } from 'loro-crdt'
@@ -116,6 +123,16 @@ export interface SessionDeps {
   // the session having to be recreated.
   getOptions: () => UseDocumentSyncOptions
   onStatusChange: (status: SyncStatus) => void
+  /**
+   * WHY the backend failed, not just that it did.
+   *
+   * `onStatusChange('error')` is the whole story for a transport that dropped;
+   * it is not for a document that is intact and unreadable by THIS build.
+   * Collapsing those into one status is how a user with a future-version
+   * document gets shown an empty canvas — which says their work is gone when
+   * it is sitting on disk.
+   */
+  onBackendError: (reason: BackendErrorReason) => void
   onRestoreChange: (inProgress: boolean, label: string | null) => void
   dispatchIdentityEvent: (eventName: string, identity: UseDocumentSyncOptions['identity']) => void
   generations: GenerationCounters
@@ -697,8 +714,9 @@ export function createDocumentSyncSession(
         }
       },
 
-      onError: () => {
+      onError: (reason) => {
         if (isStale()) return
+        deps.onBackendError(reason)
         deps.onStatusChange('error')
       },
     })

--- a/apps/web/src/pages/BrowserLocalDocumentPage.fullscreen.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.fullscreen.test.tsx
@@ -2,17 +2,25 @@
 // top layer — workspace switcher, rename, menus — which is 48px of chrome
 // nobody entered fullscreen to see. It now steps aside, leaving the canvas
 // and the dock, with one floating way back out.
+// jsdom has no IndexedDB, and the page's backend reads content from a real
+// one. Without this every content read fails — which the page now reports as
+// an unreadable document instead of silently drawing an editor over it, so a
+// suite about fullscreen chrome would otherwise be testing the error screen.
+import 'fake-indexeddb/auto'
 import { act, cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
 import type { ReactElement } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, expect, it, vi } from 'vitest'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { LocalStoreDouble } from '../test-utils/local-index.js'
 import { BrowserLocalDocumentPage } from './BrowserLocalDocumentPage.js'
 // The top bar is React.lazy in the page; loading it in the collection phase
 // keeps its chunk cost out of findBy*'s 1000ms retry budget (the lazy-race
 // flake shape integrator-flow.md documents).
 import '../components/WorkspaceTopBar.js'
+
+claimIsolatedWhiteboardDb('browserlocaldocumentpage-fullscreen')
 
 beforeEach(() => {
   // jsdom has no fullscreen at all; start each test explicitly OUT of it.

--- a/apps/web/src/pages/BrowserLocalDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.tsx
@@ -48,6 +48,7 @@ import { browserLocalDocumentPath, parseBrowserLocalRoute } from '../lib/app-rou
 import { BrowserLocalBackend } from '../lib/browser-local-backend.js'
 import { useWhiteboardCommands } from '../lib/commands/index.js'
 import { BROWSER_LOCAL_FILE_ADAPTER } from '../lib/document-embed-content.js'
+import { isDocumentReadFailure } from '../lib/document-read-failure.js'
 import { browserLocalFaviconStatus, type FaviconStyle } from '../lib/favicon.js'
 import { readLastTool, resolveInitialTool } from '../lib/initial-tool.js'
 import type { ContentClock, DefaultDocumentPointer } from '../lib/local-document-summary.js'
@@ -57,7 +58,7 @@ import { createUserSettingsStore } from '../lib/user-settings-store.js'
 import { cn } from '../lib/utils.js'
 import { useBrowserToolRegistry } from '../lib/webmcp/use-browser-tool-registry.js'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
-import { derivePageState } from './browser-local-page-state.js'
+import { derivePageState, refineForContentReadFailure } from './browser-local-page-state.js'
 import {
   type LoroStoreLike,
   useBrowserLocalDocumentController,
@@ -472,7 +473,16 @@ export function BrowserLocalDocumentPage({
     setNodeLock,
     lockedEdgeIds,
     setEdgeLock,
+    backendError,
   } = useDocumentSync(backend)
+
+  // The second phase of the page state. `pageState` above is derived from what
+  // the INDEX knows; this is what reading the CONTENT said, which can only
+  // arrive after the id it needed came out of that first phase.
+  const renderState = refineForContentReadFailure(
+    pageState,
+    isDocumentReadFailure(backendError) ? backendError : null,
+  )
 
   const nodeInEditor = useNodeInEditor(canvas, onChange)
 
@@ -567,14 +577,14 @@ export function BrowserLocalDocumentPage({
   // schedule another refresh. The snapshot is this canvas's live truth; the
   // list is only the copy the switcher reads for the OTHER documents.
 
-  if (pageState.kind === 'load-degraded') {
+  if (renderState.kind === 'load-degraded') {
     return (
       <div
         role="alert"
         aria-live="assertive"
         className="flex h-full flex-col items-center justify-center gap-4 p-6 text-center"
       >
-        <p className="max-w-md text-sm text-destructive">{pageState.message}</p>
+        <p className="max-w-md text-sm text-destructive">{renderState.message}</p>
         <button
           type="button"
           onClick={() => void startFresh()}
@@ -586,7 +596,7 @@ export function BrowserLocalDocumentPage({
     )
   }
 
-  if (pageState.kind === 'cleanup-completed') {
+  if (renderState.kind === 'cleanup-completed') {
     return (
       <div
         data-testid="cleanup-completed"
@@ -604,7 +614,7 @@ export function BrowserLocalDocumentPage({
     )
   }
 
-  if (pageState.kind === 'loading') {
+  if (renderState.kind === 'loading') {
     return <DocumentPageSkeleton label="Loading canvas" />
   }
 
@@ -733,7 +743,7 @@ export function BrowserLocalDocumentPage({
         <DocumentProperties
           inline
           key={documentId ?? 'no-canvas'}
-          status={<SaveStatusChip state={pageState.persistence} />}
+          status={<SaveStatusChip state={renderState.persistence} />}
           actions={canvasRowActions}
           title={titleOf(documentName, documentPath)}
           onTitleChange={onTitleChange}
@@ -750,7 +760,7 @@ export function BrowserLocalDocumentPage({
       <DocumentProperties
         inline
         key={documentId ?? 'no-canvas'}
-        status={<SaveStatusChip state={pageState.persistence} />}
+        status={<SaveStatusChip state={renderState.persistence} />}
         settings={<CanvasDisplaySettings canvas={canvas} onChange={onChange} />}
         actions={canvasRowActions}
         title={titleOf(documentName, documentPath)}
@@ -776,7 +786,7 @@ export function BrowserLocalDocumentPage({
         {/* Visually-hidden heading landmark: WorkspaceTopBar's canvas switcher
           is the visible title control, but the page keeps a real <h1> for
           accessibility trees. */}
-        <h1 className="sr-only">{pageState.snapshot.name}</h1>
+        <h1 className="sr-only">{renderState.snapshot.name}</h1>
         {/* Fullscreen means the CANVAS, maximised: the whole top-bar row —
             switcher, rename, menus — steps aside. The floating control below
             replaces its exit path, Escape still works natively, and the dock
@@ -808,7 +818,7 @@ export function BrowserLocalDocumentPage({
               }
               dataMode="local"
               workspaceId="local"
-              path={pageState.snapshot.path}
+              path={renderState.snapshot.path}
               documents={switcherOptions.map((c) => ({
                 path: c.path,
                 name: c.name,

--- a/apps/web/src/pages/BrowserLocalDocumentPage.unreadable-content.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.unreadable-content.test.tsx
@@ -23,7 +23,11 @@ import { BrowserLocalDocumentPage } from './BrowserLocalDocumentPage.js'
 const DB = claimIsolatedWhiteboardDb('browserlocaldocumentpage-unreadable-content')
 
 vi.mock('../components/spatial-editor/index.js', () => ({
-  SpatialEditor: () => null,
+  // Renders a marker rather than null: "the editor did not render" is the
+  // guarantee this file exists for — an unreadable document must not be
+  // editable, because the next save would overwrite bytes that are intact —
+  // and a null mock makes that unassertable.
+  SpatialEditor: () => <div data-testid="mock-spatial-editor" />,
 }))
 
 function render(ui: ReactElement): ReturnType<typeof rtlRender> {
@@ -61,6 +65,9 @@ describe('a document this build cannot read', () => {
     await waitFor(() => {
       expect(screen.getByRole('alert').textContent).toMatch(/saved by a newer version/i)
     })
+    // The half that protects the document: no editor, so nothing can save
+    // over it.
+    expect(screen.queryByTestId('mock-spatial-editor')).toBeNull()
   })
 
   it('says the data is corrupt when the bytes are not Loro', async () => {
@@ -74,5 +81,39 @@ describe('a document this build cannot read', () => {
     await waitFor(() => {
       expect(screen.getByRole('alert').textContent).toMatch(/could not be read/i)
     })
+    expect(screen.queryByTestId('mock-spatial-editor')).toBeNull()
+  })
+
+  it('stops reporting the failure once a readable document is opened', async () => {
+    // The reason is state, and state that nothing clears outlives what it was
+    // about. A switch from an unreadable document to a sound one would carry
+    // the first one's failure across and turn the second into an error screen.
+    const index = new IdbDocumentIndex()
+    await ensureLocalWorkspace(index)
+    const broken = await index.createDocument({
+      workspaceId: 'local',
+      path: 'broken',
+      name: 'Broken',
+      kind: 'spatial',
+    })
+    await seedSyncDocument(broken.documentId, { raw: { v: 99 } }, DB)
+    const sound = await index.createDocument({
+      workspaceId: 'local',
+      path: 'sound',
+      name: 'Sound',
+      kind: 'spatial',
+    })
+    await new IdbDefaultDocumentPointer(DB).set(broken.documentId)
+
+    const view = render(<BrowserLocalDocumentPage store={new IdbDocumentIndex()} />)
+    await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy())
+
+    // Reopen at the sound document's path, the way the switcher does.
+    view.unmount()
+    await new IdbDefaultDocumentPointer(DB).set(sound.documentId)
+    render(<BrowserLocalDocumentPage store={new IdbDocumentIndex()} />)
+
+    await waitFor(() => expect(screen.getByTestId('mock-spatial-editor')).toBeTruthy())
+    expect(screen.queryByRole('alert')).toBeNull()
   })
 })

--- a/apps/web/src/pages/BrowserLocalDocumentPage.unreadable-content.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.unreadable-content.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * A document whose stored content this build cannot read must SAY so.
+ *
+ * `LoroStore.load` classifies it — `unsupported-version` for an envelope from
+ * a newer build, `corrupt-snapshot` for bytes that will not import — and the
+ * backend forwards the classification. What this file pins is the last leg:
+ * that it reaches the screen. Without it a user whose document is intact but
+ * unreadable by THIS build is shown an empty canvas, which says their work is
+ * gone.
+ */
+import 'fake-indexeddb/auto'
+import { cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { IdbDocumentIndex } from '../lib/idb-document-index.js'
+import { ensureLocalWorkspace, IdbDefaultDocumentPointer } from '../lib/local-document-summary.js'
+import { clearWhiteboardDb } from '../test-utils/browser-local-document.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { seedSyncDocument } from '../test-utils/seed-sync-document.js'
+import { BrowserLocalDocumentPage } from './BrowserLocalDocumentPage.js'
+
+const DB = claimIsolatedWhiteboardDb('browserlocaldocumentpage-unreadable-content')
+
+vi.mock('../components/spatial-editor/index.js', () => ({
+  SpatialEditor: () => null,
+}))
+
+function render(ui: ReactElement): ReturnType<typeof rtlRender> {
+  return rtlRender(
+    <div style={{ height: '100vh' }}>
+      <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
+    </div>,
+  )
+}
+
+async function seedDocumentWithContent(
+  content: { raw: unknown } | { snapshot: Uint8Array },
+): Promise<void> {
+  const index = new IdbDocumentIndex()
+  await ensureLocalWorkspace(index)
+  const entry = await index.createDocument({
+    workspaceId: 'local',
+    path: 'unreadable',
+    name: 'Unreadable',
+    kind: 'spatial',
+  })
+  await seedSyncDocument(entry.documentId, content, DB)
+  await new IdbDefaultDocumentPointer(DB).set(entry.documentId)
+}
+
+describe('a document this build cannot read', () => {
+  beforeEach(clearWhiteboardDb)
+  afterEach(cleanup)
+
+  it('says the storage version is unsupported rather than showing an empty canvas', async () => {
+    await seedDocumentWithContent({ raw: { v: 99, writtenByANewerBuild: true } })
+
+    render(<BrowserLocalDocumentPage store={new IdbDocumentIndex()} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toMatch(/saved by a newer version/i)
+    })
+  })
+
+  it('says the data is corrupt when the bytes are not Loro', async () => {
+    // A well-formed record carrying bytes Loro will not import — distinct
+    // from `{snapshot: null}`, which is a legitimate document that simply has
+    // no snapshot yet.
+    await seedDocumentWithContent({ snapshot: new Uint8Array([0xff, 0xfe, 0x00, 0x01]) })
+
+    render(<BrowserLocalDocumentPage store={new IdbDocumentIndex()} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toMatch(/could not be read/i)
+    })
+  })
+})

--- a/apps/web/src/pages/browser-local-page-state.ts
+++ b/apps/web/src/pages/browser-local-page-state.ts
@@ -21,6 +21,10 @@
 // invariants grep-friendly and lets the helper be tested in isolation
 // (no React renderer required).
 
+import {
+  type DocumentReadFailure,
+  documentReadFailureMessage,
+} from '../lib/document-read-failure.js'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
 import type { BrowserLocalPersistenceState } from './use-browser-local-document-controller.js'
 
@@ -66,4 +70,25 @@ export function derivePageState(input: BrowserLocalPageStateInput): BrowserLocal
     return { kind: 'loading' }
   }
   return { kind: 'editing', snapshot: input.snapshot, persistence: input.persistence }
+}
+
+/**
+ * Second phase: what the CONTENT read said, once it has said anything.
+ *
+ * Separate from `derivePageState` because the data flow is genuinely two-step
+ * and pretending otherwise would be circular — the page needs a documentId to
+ * open the content at all, and it gets that from the first phase's `editing`
+ * state. The failure can only arrive after.
+ *
+ * It has to be a page-level state rather than a banner over the editor.
+ * Rendering the editor for a document whose bytes are intact but unreadable
+ * shows an empty canvas, and the next save overwrites them — so a user whose
+ * app is merely out of date would LOSE the document by opening it.
+ */
+export function refineForContentReadFailure(
+  state: BrowserLocalPageState,
+  failure: DocumentReadFailure | null,
+): BrowserLocalPageState {
+  if (failure === null || state.kind !== 'editing') return state
+  return { kind: 'load-degraded', message: documentReadFailureMessage(failure) }
 }


### PR DESCRIPTION
A document stored by a **newer build**, or one whose bytes will not import, opened as an **empty canvas with no message**.

Found while verifying #948 on the preview: `LoroStore.load` classified it correctly and the backend forwarded the classification — the chain was broken twice after that.

| link | state |
|---|---|
| `LoroStore.load` classifies | ✅ |
| backend forwards the kind | ✅ |
| `document-sync-session` | ❌ collapsed every failure into `onStatusChange('error')`, discarding **why** |
| `BrowserLocalDocumentPage` | ❌ did not read the sync status at all |

## This is not only a messaging bug

The page rendered an editor over a document whose bytes were **intact**, and the next save would overwrite them. A user whose app was merely out of date would **lose the document by opening it**.

That is why it is a page-level screen — with the recovery action the degraded path already has — rather than a banner over a live editor. A banner would leave the editor writable.

## Two phases, because the data flow is two phases

`derivePageState` answers from what the **index** knows, which is where the `documentId` comes from. `refineForContentReadFailure` answers from what reading the **content** said, which can only arrive after that id exists. Folding them into one call would have been circular, and the second helper says so.

`storage-failure` is deliberately not treated as a read failure: it is a write that did not land, already reported by the header's save status, and it says nothing about whether the stored document is readable.

## One thing tried and reverted

Sharing the wording with the import panel. The two surfaces answer different questions — *"why can I not open it"* vs *"why was this skipped"* — and one sentence for both is vague about each. Its test caught the regression; the classification is what they share, not the prose.

## A test that had been passing for the wrong reason

`BrowserLocalDocumentPage.fullscreen.test.tsx` needed `fake-indexeddb`. jsdom has none, so **every** content read there failed — and the suite passed only because the failure was swallowed. That it broke under this change is the fix working; an A/B with `git stash` confirmed it passes without the change and times out with it, before the environment was fixed.

## Verification

Both new links mutation-checked: invert the refine, or drop the reason in the session, and the tests go red; restore and they go green. (The first attempt at that check produced no output — a grep that did not match vitest's `Tests 2 failed (2)` line — and was redone rather than counted.)

| suite | result |
|---|---|
| whole root suite | **8938 passed**, 6 skipped |
| `apps/web` jsdom + node | 2621 + 77 |
| `typecheck` / `lint` / `knip` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoaNgqWUKbYJxk2azmRQKY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Browser-local documents that cannot be read now show specific, helpful error messages instead of an empty canvas.
  - Unsupported versions and corrupted document data are identified separately.
  - Document loading and page status now accurately reflect content-read failures.
  - Backend synchronization errors are surfaced distinctly from general sync status.

- **Tests**
  - Added coverage for unreadable documents and backend error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->