### PR TITLE
feat(model)!: facet keys become {namespace}.{name}/v{n} (ADR-0013)

### DIFF
--- a/.claude/rules/package-model.md
+++ b/.claude/rules/package-model.md
@@ -22,7 +22,7 @@ paths:
 ## Conventions
 
 - Every exported type is `z.infer`-derived. Sole exception: mutually-recursive mdast category types use the documented explicit `z.ZodType<T>` annotation, guarded by a compile-time assignability test.
-- Facet buckets are disjoint by construction: extension facets live only under the reserved `facets` key (`{domain}/{version}` keys; malformed keys are rejected, not dropped). Unknown ROOT-level frontmatter keys belong to `facetsRaw`, never to extension facets.
+- Facet buckets are disjoint by construction: extension facets live only under the reserved `facets` key (`{namespace}.{name}/v{n}` keys per ADR-0013; malformed keys are rejected, not dropped). Unknown ROOT-level frontmatter keys belong to `facetsRaw`, never to extension facets.
 - mdast schemas follow the mdast spec content-model hierarchy (flow / phrasing / list / table / row content). Do not widen a parent's `children` back to the flat node union.
 - IDs: canvas ID = canonical ULID (first char `[0-7]`); node ID = nanoid (charset deliberately unenforced — documented looseness).
 - JSON Canvas geometry is integer, with no extension carve-out: `x-whiteboard` carries no geometry of its own.

--- a/.claude/rules/vocabulary.md
+++ b/.claude/rules/vocabulary.md
@@ -10,7 +10,7 @@ this rule is how it converges without anyone scheduling a big-bang rename.
 |---|---|---|
 | **Workspace** | the tree that holds documents; owns placement (`segment`, derived `alias`) and naming (display name) | anything about a document's content |
 | **Document** | the unit a workspace contains. Has a kind | a canvas |
-| **Facet** | OKF frontmatter (`type`, `tags`, extension `{domain}/{version}` buckets) | metadata on a JSON Canvas document — that concept does not exist yet |
+| **Facet** | a namespaced, versioned, schema'd attribute group attached to an object — key grammar `{namespace}.{name}/v{n}`, registered by a plugin at distribution time ([ADR-0013](../../docs/contributing/adr/0013-facet-system.md)). OKF core frontmatter (`type`, `tags`) stays a markdown-document concern | a runtime-definable schema, or anything with a privileged "core" namespace — no facet is core; only the engine is |
 | **Body** | an OKF document's markdown body | a spatial document's content |
 | **Node** / **Edge** | JSON Canvas elements | anything in an OKF document |
 | **Canvas** | the spatial surface, and the JSON Canvas format | the container a workspace holds — that is a Document |

--- a/.claude/skills/ticketing/SKILL.md
+++ b/.claude/skills/ticketing/SKILL.md
@@ -51,7 +51,7 @@ wb_document_set   → { workspaceId: "default", canvasId, markdown: "<updated OK
 ### Updating facets only
 
 ```
-wb_facet_set → { workspaceId: "default", canvasId, facets: { "<domain>/1": { … } } }
+wb_facet_set → { workspaceId: "default", canvasId, facets: { "<namespace>.<name>/v0": { … } }  # key grammar per ADR-0013 }
 ```
 
 ### Resolving / deleting

--- a/apps/web/src/hooks/use-document-file-seams.test.tsx
+++ b/apps/web/src/hooks/use-document-file-seams.test.tsx
@@ -185,7 +185,11 @@ describe('toFacetCard', () => {
     // preserved by the model but have no agreed presentation.
     // `readCoreFacets` returns core facets PLUS `facetsRaw`, so the extra key
     // really does arrive at runtime even though the parameter narrows it away.
-    const facets = { type: 'note', view: 'kanban/1', facetsRaw: { owner: 'x' } } as CoreFacets
+    const facets = {
+      type: 'note',
+      view: 'example.kanban/v1',
+      facetsRaw: { owner: 'x' },
+    } as CoreFacets
     const card = toFacetCard('spec-a1b2c3', facets)
     expect(card?.rows).toEqual([{ label: 'type', value: 'note' }])
   })

--- a/docs/contributing/adr/0009-mcp-tool-naming.md
+++ b/docs/contributing/adr/0009-mcp-tool-naming.md
@@ -29,6 +29,17 @@
 > for a spatial document's lost `type`/`tags` — workspace-level metadata —
 > remains unbuilt.
 
+> **Addendum (2026-08-22): decision 3 is superseded by
+> [ADR-0013](0013-facet-system.md).** The alternative this ADR rejected —
+> facets as format-agnostic metadata — is adopted there *with* the safeguard
+> whose absence justified the rejection here: facet schemas are registered at
+> distribution time, so the format-agnostic bucket can no longer breed
+> accidental conventions (the `issue/1` failure). OKF core frontmatter
+> (`type`/`tags`) stays a markdown-document concern exactly as decided here;
+> what ADR-0013 widens is where *extension* facets may attach (documents,
+> the canvas, nodes), under a `{namespace}.{name}/v{n}` key grammar. The
+> reasoning below is kept as written — a decision record is history.
+
 ## Context
 
 This started as a tidy-up of MCP tool names and turned into a model

--- a/docs/contributing/adr/0013-facet-system.md
+++ b/docs/contributing/adr/0013-facet-system.md
@@ -1,0 +1,259 @@
+# ADR-0013: The facet system — plugins, versioned facet keys, and the meaning/display split
+
+**Status:** Accepted
+
+## Context
+
+ADR-0009 decision 3 confined facets to OKF frontmatter ("`Facet` belongs to
+OKF") and paid an explicit cost: a spatial document lost `type`/`tags`, and
+metadata on a diagram was deferred to an unbuilt workspace-level capability.
+Its Consequences named the question this ADR answers: *what OKF frontmatter
+this project standardises on* — and, wider, what a facet is at all.
+
+Since then, three things changed the ground:
+
+1. **The `issue/1` retirement taught the failure mode.** An extension facet
+   convention was implemented without an agreed schema; because extension
+   payloads round-trip unvalidated, whatever someone writes becomes the
+   convention by accident. The retirement left a standing rule — "agree the
+   schema first" — and this ADR is that agreement's structural form: a place
+   where facet schemas are *registered*, so a convention cannot arise by
+   accident again.
+2. **The product direction asks for more than frontmatter.** The facet idea
+   here is borrowed from OpenLineage: freely defined, named, versioned
+   attribute groups attached to entities. The concrete wants are metadata on
+   canvas *nodes* (shapes, symbols, cloud-provider icons for infrastructure
+   diagrams), on the *canvas* itself (themes aligned to official design
+   guidelines, hand-drawn style), and eventually ticketing fields on markdown
+   documents — with visual rendering, editing UI, and chat-side (MCP Apps)
+   access. SaaS and self-host deployments are planned, so extension
+   governance and security are first-class constraints, not afterthoughts.
+3. **The display substrate already landed.** canvas-render now draws
+   non-rect node silhouettes from a shape *kind*, icon scene nodes from a
+   vendored lucide subset, and outline-aware edge ends — written so an
+   unsupported runtime shape value (a future stored facet payload) degrades
+   instead of throwing. What remains is the data half this ADR specifies.
+
+## Decision
+
+### 1. A facet is a namespaced, versioned, schema'd attribute group attached to an object
+
+This supersedes ADR-0009 decision 3 and adopts the alternative it rejected —
+"facets as format-agnostic document metadata" — *with the safeguard whose
+absence was the reason for rejecting it*: facet schemas are registered at
+distribution time (decision 3 below), so the format-agnostic bucket can no
+longer breed accidental conventions. OKF core frontmatter (`type`, `tags`)
+is unchanged and remains a markdown-document concern; what widens is where
+*extension* facets may attach.
+
+The design judgment rule for growing the system: **a new question gets a new
+facet; a new answer to an existing question extends that facet's value
+space** (e.g. emoji is a new answer to "what symbolises this object", so it
+is a union member of `visual.symbol`, not a new facet). Facets stay
+independent dimensions (the library-science sense): one facet's value never
+constrains another facet's options.
+
+### 2. Facet keys are `{namespace}.{name}/v{n}`
+
+Pattern: `/^[a-z][a-z0-9-]*\.[a-z][a-z0-9-]*\/v[0-9]+$/`, e.g.
+`visual.shape/v0`, `ticketing.ticket/v0`.
+
+- The **namespace** is the owning plugin's id. There is no unnamespaced key
+  and no privileged core namespace: Kubernetes' unprefixed legacy API group
+  is acknowledged debt there, and copying it would copy the debt.
+- **`v0` is unstable**: breaking payload changes are allowed without a bump.
+  Old payloads that no longer parse are dropped on read (the existing
+  drop-not-fail storage rule absorbs them). **`v1`+ bumps only on breaking
+  change**; additive optional fields land in the same version.
+- The previous `{domain}/{version}` numeric grammar (`kanban/1`) is removed
+  without compatibility — there are no real stored facets under it, and a
+  stored old-grammar key is dropped on read like any other malformed key.
+
+### 3. Plugins are the unit of registration, distribution, and governance
+
+A plugin bundles facet definitions with everything that gives them meaning:
+
+- **Data layer** — `facets`: name, version, `targets`, Zod payload schema,
+  and `compat` (decision 7).
+- **View layer** — `views`: declarative view specs that name a *kind* from
+  the engine's catalog and declare which facets they read (`reads`,
+  same-plugin only; cross-plugin reads are coupling smuggled across a
+  package boundary).
+- **Editor layer** — `editors`: declarative editing specs built from the
+  engine's widget catalog.
+- **Assets** — symbol sets, themes, fonts; resolvable in both composition
+  roots so `wb_scene_render`/PNG export draw what the editor draws.
+
+Registration happens at **distribution time only** (a Vite-config-like
+mechanism; SaaS deployments swap plugin configuration per tenant). There is
+no runtime user-defined facet — the governance and security blast radius of
+runtime extension is wider than it looks, and the ticketing case shows the
+escape valve: runtime-variable *vocabulary* (a workspace's status set) is
+payload of a workspace-target facet, not a runtime schema. Load-time
+collision checking is per plugin id; no central registry (OpenLineage's own
+registry is still an unadopted proposal years in).
+
+The bundled plugin (`visual`: `shape`, `symbol`, `theme`, and the
+edge-style facet that replaces the ad-hoc `x-whiteboard.edgeRouting`
+preference) goes through this same pipeline with **no privileged wiring** —
+it is ordinary, disable-able, and sorts lexicographically with everyone
+else. "Core" names only the engine: the kind catalog, widget catalog,
+contribution points, token contract, targets vocabulary, key grammar,
+validation and migration machinery — closed sets the engine owns. No facet
+is core.
+
+### 4. Targets are declared by the definition, along two dimensions
+
+The engine allows attachment to any object kind; each facet declares where
+it may attach (`targets`) — the same inversion OpenLineage uses. The
+vocabulary has two dimensions:
+
+- **Container targets** (format-agnostic): `document`; `workspace` reserved.
+- **Content-structure targets** (contributed by a format): the spatial
+  format contributes `canvas` and `node`; `edge` reserved. A future format
+  contributes its own structure targets. `document` and `canvas` are
+  different concepts and must not be conflated — one is the workspace unit,
+  the other is the spatial format's surface.
+
+### 5. Storage slots
+
+- `document` → the existing `facets` bucket (one CRDT key per facet, so
+  concurrent writes to different facets both survive; within a facet,
+  replace-whole-payload, matching OpenLineage's re-emit-replaces rule).
+  Projected to the OKF `facets:` block on export.
+- `canvas` → the JSON Canvas root `x-whiteboard.facets` object.
+- `node` → the node's `x-whiteboard.facets` object (payload only, so the
+  node-level content-only rule holds).
+
+The canvas-level `x-whiteboard` rule is amended from "rendering preferences
+only" to also carry the `facets` bucket; the existing rendering preferences
+are re-modelled as canvas-target facets in a follow-up increment, after
+which the bucket is all that remains. A document-target facet on a spatial
+document is container-layer information and is not projected into the JSON
+Canvas export (it would collide with canvas-target facets there).
+
+### 6. Four validation layers
+
+| boundary | rule |
+|---|---|
+| schema boundary (keys) | reject, not drop — a malformed key fails the parse |
+| write, registered facet | payload validated against the registered Zod schema; invalid writes rejected |
+| write, unknown facet | passes through unvalidated (round-trip safety for other tools and future plugins) |
+| storage read | drop, not fail — a malformed key or unreadable payload is skipped |
+
+### 7. Per-facet compatibility migrations live in the definition
+
+A definition carries `compat`: for each older version, the retained old
+schema and a pure migration function to the next version; the registry
+composes the chain (`v0→v1→v2` — the linear-history form of hub-and-spoke,
+no N² converters). Reads are lazy (parse old → migrate → parse current;
+any failure drops per layer 4; storage is not rewritten). Persistence
+happens on the next write, which writes the current-version key and removes
+older-version keys — one version per facet per object is an invariant. A
+key *newer* than the registered version is preserved untouched and not
+rendered, like an unknown facet: forward data is never destroyed.
+
+### 8. Meaning, display, and display state are three layers
+
+- **Payload** (meaning) is the only stored layer: validated, exported,
+  CRDT-merged, queryable.
+- **View specs** (display) live in the plugin definition, not in documents.
+  The engine resolves payload × view spec × theme tokens into
+  medium-neutral resolved values; renderers consume those. A view is a
+  candidate on an object exactly when every facet it `reads` is present.
+  Each display **slot** (outline, badge, body, canvas theme, …) has one
+  active view; resolution order is session override → the persisted default
+  (the `view` core field, value `{namespace}.{viewId}`) → namespace/view-id
+  lexicographic order. Session overrides live in memory only.
+- **Kinds are medium-exclusive.** Canvas kinds (`node-shape`, `icon-badge`,
+  `node-figure`, `canvas-theme`, …) render as SVG inside canvas-render —
+  which is itself a requirement, since anything rendered as an HTML overlay
+  would vanish from `wb_scene_render`, PNG export, the widget and the
+  viewer. Chrome kinds (`header-chip`, `list-adornment`, …) render as
+  HTML/React per surface. No write-once widget abstraction spans the two —
+  only resolved *values* and SVG assets cross the medium boundary.
+
+Themes resolve the official-palette question without breaking the
+colors-are-engine-tokens rule: a payload never carries raw styles; it
+references a registered theme asset, which supplies token values (palette,
+fonts, stroke style, edge and group styles).
+
+### 9. Facet UI arrives only through contribution points
+
+Existing surfaces expose named contribution points (`contextMenu.node.*`,
+`canvasSettings`, `documentProperties`, …) and know no facet names.
+Contributions are derived mechanically from definitions (targets + editor
+spec + views); a definition cannot choose its placement. Layout policy —
+native rows first, then facet rows in pure namespace order, per-point caps
+with overflow folding into a "Facets…" entry — belongs to the point. Adding
+a plugin changes zero UI files.
+
+### 10. Editing is declarative, with the write path as the security boundary
+
+Two tiers: an automatic form derived from the Zod schema (every facet is
+editable with zero effort), and an optional declarative editor spec built
+from the engine's widget catalog. Neither runs plugin code, so neither
+needs an iframe sandbox — the enforcement point is the write path
+(`wb_facet_set` + layer-4 validation), which every UI goes through. A
+future editor that genuinely needs code reuses the existing MCP Apps
+(ext-apps) sandboxed-iframe machinery rather than growing a second sandbox.
+Registered definitions are also exposed over MCP so agents can construct
+valid payloads; the MCP Apps widget stays read-only until the standing
+"should the widget mutate documents at all" question is settled.
+
+## This increment
+
+This ADR lands together with decision 2's mechanical half only: the key
+grammar in `extensionFacetsSchema` (and every fixture that spoke the old
+grammar). The rest lands in order: the plugin registry, four-layer
+validation, compat chains, the canvas slot and the `visual` edge-style
+migration; then `visual.shape/v0` (first node-target facet, resolving to
+the already-landed silhouettes); then `visual.symbol/v0`; then the editor
+tiers and contribution surfaces.
+
+## Consequences
+
+- Extension metadata has a governed growth path: schemas are agreed by
+  being registered, the `issue/1` accident class is structurally closed,
+  and SaaS tenants get uniform per-plugin enable/disable — including the
+  bundled plugin.
+- The key itself carries provenance; nothing can pose as built-in, and
+  ordering/collision rules have no special cases.
+- Migration is a day-one capability, not a future invention: bumping a
+  facet version means writing one function, and the read path already
+  knows what to do with old data.
+- Any document stored with old-grammar keys silently loses those facets on
+  read. Accepted: the old grammar had no registered consumers and no known
+  real data (its one convention was already retired).
+- The engine's closed catalogs (kinds, widgets, points, tokens, targets)
+  are the extension contract; growing any of them is an engine increment.
+  That is deliberate friction — it is what keeps arbitrary code, arbitrary
+  colors, and arbitrary placement out of other people's deployments.
+- `readCoreFacets`'s spatial guard and `wb_facet_set`'s spatial refusal
+  become target checks when the canvas/node slots land — the invariant
+  "core facets never live on a spatial document" stays; the blanket "no
+  facets on spatial" does not.
+
+## Alternatives considered
+
+- **Format-agnostic facets without registration** — rejected by ADR-0009,
+  and the rejection held: unvalidated freedom is how `issue/1` happened.
+  Adopted now only because distribution-time registration supplies the
+  missing safeguard.
+- **An unprefixed namespace for bundled facets** (`shape/v0`) — mirrors
+  Kubernetes' core group, which Kubernetes itself treats as legacy; it
+  would also re-create a privileged "core facet" class this design just
+  removed.
+- **Runtime user-defined facets** — the original wish, declined for
+  governance: in SaaS/self-host the blast radius of runtime extension
+  exceeds what a user can see. Runtime-variable vocabulary lives in
+  payloads instead (workspace-target facets).
+- **A write-once widget/component abstraction across SVG and HTML** —
+  leaks structurally (canvas-render already needs its own text layout
+  because SVG has no CSS layout); only resolved values cross the boundary.
+- **Sandboxed iframes for the default editor tiers** — isolates trusted
+  engine code from itself, breaks popover/focus UX, and misplaces the
+  boundary: validation on the write path is what actually constrains a
+  hostile editor.
+- **Per-pair version converters** — N² growth; the stepwise compat chain
+  is hub-and-spoke's linear special case.

--- a/docs/contributing/adr/README.md
+++ b/docs/contributing/adr/README.md
@@ -45,3 +45,4 @@ See [template.md](template.md) for the standard structure (MADR-lite: Title, Sta
 | [ADR-0010](0010-canvas-edit-batch-tool.md) | One batch tool for spatial editing, and why it is not `apply` | Accepted |
 | [ADR-0011](0011-font-distribution.md) | Fonts are installed by whoever needs them, not bundled | Accepted — provider registry not built yet |
 | [ADR-0012](0012-user-installed-fonts.md) | A user installs a font by naming it, and the daemon keeps it | Accepted — not yet implemented; extends ADR-0011 |
+| [ADR-0013](0013-facet-system.md) | The facet system — plugins, versioned facet keys, and the meaning/display split | Accepted — key grammar landed; supersedes ADR-0009 decision 3 |

--- a/packages/codec/src/okf/serialize.test.ts
+++ b/packages/codec/src/okf/serialize.test.ts
@@ -8,21 +8,21 @@ describe('serializeOkf', () => {
       frontmatter: {
         type: 'note',
         facets: {
-          'zeta/1': { z: 1 },
-          'alpha/2': { a: 1 },
-          'mu/1': { m: 1 },
+          'zeta.z/v1': { z: 1 },
+          'alpha.a/v2': { a: 1 },
+          'mu.m/v1': { m: 1 },
         },
       },
       body: 'hello',
     })
 
     const facetsBlock = text.slice(text.indexOf('facets:'), text.indexOf('body:') || undefined)
-    const firstKeyIndex = ['alpha/2', 'mu/1', 'zeta/1']
+    const firstKeyIndex = ['alpha.a/v2', 'mu.m/v1', 'zeta.z/v1']
       .map((key) => facetsBlock.indexOf(key))
       .filter((index) => index !== -1)
     expect(firstKeyIndex).toEqual([...firstKeyIndex].sort((a, b) => a - b))
-    expect(facetsBlock.indexOf('alpha/2')).toBeLessThan(facetsBlock.indexOf('mu/1'))
-    expect(facetsBlock.indexOf('mu/1')).toBeLessThan(facetsBlock.indexOf('zeta/1'))
+    expect(facetsBlock.indexOf('alpha.a/v2')).toBeLessThan(facetsBlock.indexOf('mu.m/v1'))
+    expect(facetsBlock.indexOf('mu.m/v1')).toBeLessThan(facetsBlock.indexOf('zeta.z/v1'))
   })
 
   it('round-trips a minimal document through parseOkf', () => {
@@ -39,7 +39,7 @@ describe('serializeOkf', () => {
   it('surfaces a typed error instead of throwing when a facet value is not yaml-safe', () => {
     expect(() =>
       serializeOkf({
-        frontmatter: { type: 'note', facets: { 'x/1': { bad: Number.NaN } } },
+        frontmatter: { type: 'note', facets: { 'x.y/v1': { bad: Number.NaN } } },
         body: '',
       }),
     ).toThrow(/yaml-safe/)

--- a/packages/loro-adapter/src/loro-bridge.test.ts
+++ b/packages/loro-adapter/src/loro-bridge.test.ts
@@ -379,7 +379,7 @@ describe('facets bridge', () => {
 
   test('round-trips a single facet domain', () => {
     const doc = makeDoc()
-    const facets: ExtensionFacets = { 'kanban/1': { status: 'in-progress' } }
+    const facets: ExtensionFacets = { 'example.kanban/v1': { status: 'in-progress' } }
 
     writeFacets(doc, facets)
 
@@ -389,8 +389,8 @@ describe('facets bridge', () => {
   test('round-trips multiple facet domains', () => {
     const doc = makeDoc()
     const facets: ExtensionFacets = {
-      'kanban/1': { status: 'in-progress' },
-      'priority/1': { level: 'high' },
+      'example.kanban/v1': { status: 'in-progress' },
+      'example.priority/v1': { level: 'high' },
     }
 
     writeFacets(doc, facets)
@@ -401,15 +401,15 @@ describe('facets bridge', () => {
   test('merges new facet keys with existing ones on write', () => {
     const doc = makeDoc()
 
-    writeFacets(doc, { 'kanban/1': { status: 'todo' } })
+    writeFacets(doc, { 'example.kanban/v1': { status: 'todo' } })
     writeFacets(doc, {
-      'kanban/1': { status: 'done' },
-      'priority/1': { level: 'low' },
+      'example.kanban/v1': { status: 'done' },
+      'example.priority/v1': { level: 'low' },
     })
 
     expect(readFacets(doc)).toEqual({
-      'kanban/1': { status: 'done' },
-      'priority/1': { level: 'low' },
+      'example.kanban/v1': { status: 'done' },
+      'example.priority/v1': { level: 'low' },
     })
   })
 
@@ -417,26 +417,26 @@ describe('facets bridge', () => {
     const doc = makeDoc()
 
     writeFacets(doc, {
-      'kanban/1': { status: 'todo' },
-      'priority/1': { level: 'low' },
+      'example.kanban/v1': { status: 'todo' },
+      'example.priority/v1': { level: 'low' },
     })
-    writeFacets(doc, { 'kanban/1': { status: 'todo' } })
+    writeFacets(doc, { 'example.kanban/v1': { status: 'todo' } })
 
-    expect(readFacets(doc)).toEqual({ 'kanban/1': { status: 'todo' } })
+    expect(readFacets(doc)).toEqual({ 'example.kanban/v1': { status: 'todo' } })
   })
 
   test('CRDT merge: two docs add different facet domains', () => {
     const doc1 = new LoroDoc()
     const doc2 = new LoroDoc()
 
-    writeFacets(doc1, { 'kanban/1': { status: 'todo' } })
-    writeFacets(doc2, { 'priority/1': { level: 'high' } })
+    writeFacets(doc1, { 'example.kanban/v1': { status: 'todo' } })
+    writeFacets(doc2, { 'example.priority/v1': { level: 'high' } })
 
     doc1.import(doc2.export({ mode: 'snapshot' }))
 
     expect(readFacets(doc1)).toEqual({
-      'kanban/1': { status: 'todo' },
-      'priority/1': { level: 'high' },
+      'example.kanban/v1': { status: 'todo' },
+      'example.priority/v1': { level: 'high' },
     })
   })
 
@@ -525,7 +525,7 @@ describe('core facets bridge', () => {
     const meta: StoredCoreFacets = {
       type: 'note',
       tags: ['idea', 'browser'],
-      view: 'kanban/1',
+      view: 'example.kanban/v1',
       facetsRaw: { customKey: 'value' },
     }
 
@@ -546,7 +546,7 @@ describe('core facets bridge', () => {
   test('a later write replaces the whole document meta: an omitted optional field disappears', () => {
     const doc = makeDoc()
 
-    writeCoreFacets(doc, { type: 'note', view: 'kanban/1', tags: ['a'] })
+    writeCoreFacets(doc, { type: 'note', view: 'example.kanban/v1', tags: ['a'] })
     writeCoreFacets(doc, { type: 'note' })
 
     expect(readCoreFacets(doc)).toEqual({ type: 'note' })
@@ -554,20 +554,20 @@ describe('core facets bridge', () => {
 
   test('writing core meta never touches the extension facets bucket', () => {
     const doc = makeDoc()
-    writeFacets(doc, { 'kanban/1': { status: 'todo' } })
+    writeFacets(doc, { 'example.kanban/v1': { status: 'todo' } })
 
     writeCoreFacets(doc, { type: 'note', tags: ['untouched-adjacent'] })
 
-    expect(readFacets(doc)).toEqual({ 'kanban/1': { status: 'todo' } })
+    expect(readFacets(doc)).toEqual({ 'example.kanban/v1': { status: 'todo' } })
   })
 
   test('writing extension facets never touches the core meta bucket', () => {
     const doc = makeDoc()
-    writeCoreFacets(doc, { type: 'note', view: 'kanban/1' })
+    writeCoreFacets(doc, { type: 'note', view: 'example.kanban/v1' })
 
-    writeFacets(doc, { 'kanban/1': { status: 'todo' } })
+    writeFacets(doc, { 'example.kanban/v1': { status: 'todo' } })
 
-    expect(readCoreFacets(doc)).toEqual({ type: 'note', view: 'kanban/1' })
+    expect(readCoreFacets(doc)).toEqual({ type: 'note', view: 'example.kanban/v1' })
   })
 
   test('CRDT merge: two docs independently write different core-meta fields converge on both', () => {
@@ -590,11 +590,11 @@ describe('core facets bridge', () => {
   test('drops a single corrupt field but keeps the rest when type is still valid', () => {
     const doc = makeDoc()
     doc.getMap('core').set('type', 'note')
-    doc.getMap('core').set('view', 'kanban/1')
+    doc.getMap('core').set('view', 'example.kanban/v1')
     doc.getMap('core').set('tags', 'not-an-array')
     doc.commit()
 
-    expect(readCoreFacets(doc)).toEqual({ type: 'note', view: 'kanban/1' })
+    expect(readCoreFacets(doc)).toEqual({ type: 'note', view: 'example.kanban/v1' })
   })
 
   test('returns undefined when the required type field is missing or invalid', () => {

--- a/packages/loro-adapter/src/loro-bridge.ts
+++ b/packages/loro-adapter/src/loro-bridge.ts
@@ -395,7 +395,7 @@ function replaceBucket(doc: LoroDoc, mapKey: string, entries: Fields): void {
 }
 
 /**
- * Extension facets (the `{domain}/{version}` keyed bucket from
+ * Extension facets (the `{namespace}.{name}/v{n}` keyed bucket from
  * model's `extensionFacetsSchema`) are stored the same way as
  * nodes/edges above: a plain-object-valued `LoroMap` keyed by facet key, so
  * one domain's CRDT merge never overwrites another's.

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -225,7 +225,7 @@ async function main() {
   const facets = await callTool('wb_facet_set', {
     workspaceId: WORKSPACE_ID,
     documentId: named.documentId,
-    facets: { 'e2e/1': { note: 'before-save' } },
+    facets: { 'e2e.check/v1': { note: 'before-save' } },
   })
   if (facets.documentId !== named.documentId) {
     throw new Error(`wb_facet_set returned unexpected shape: ${JSON.stringify(facets)}`)
@@ -234,7 +234,7 @@ async function main() {
 
   await expectToolError(
     'wb_facet_set',
-    { workspaceId: WORKSPACE_ID, documentId, facets: { 'e2e/1': { note: 'nope' } } },
+    { workspaceId: WORKSPACE_ID, documentId, facets: { 'e2e.check/v1': { note: 'nope' } } },
     'on a spatial document',
     'Facets are OKF frontmatter',
   )
@@ -704,7 +704,7 @@ async function main() {
     '  - smoke',
     '  - e2e',
     'facets:',
-    '  issue/1:',
+    '  example.sample/v1:',
     '    status: open',
     '---',
     'Imported body.',
@@ -726,7 +726,7 @@ async function main() {
   if (!exported.content.includes('Imported body.')) {
     throw new Error(`canvas_export_okf body mismatch after import: ${exported.content}`)
   }
-  if (!exported.frontmatter.facets?.['issue/1']) {
+  if (!exported.frontmatter.facets?.['example.sample/v1']) {
     throw new Error(
       `canvas_export_okf facets missing after import: ${JSON.stringify(exported.frontmatter)}`,
     )

--- a/packages/mcp-server/src/server/mcp/mcp-e2e-checkpoint.smoke-impl.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-e2e-checkpoint.smoke-impl.ts
@@ -263,7 +263,7 @@ export async function runE2eCheckpointSmoke({
     const facets = await callTool('wb_facet_set', {
       workspaceId: WORKSPACE_ID,
       documentId,
-      facets: { 'e2e/1': { note: 'before-save' } },
+      facets: { 'e2e.check/v1': { note: 'before-save' } },
     })
     if (facets.documentId !== documentId) {
       throw new Error(`wb_facet_set returned unexpected shape: ${JSON.stringify(facets)}`)

--- a/packages/model/src/facets.test.ts
+++ b/packages/model/src/facets.test.ts
@@ -17,7 +17,7 @@ describe('coreFacetsSchema', () => {
       type: 'note',
       title: 'My note',
       tags: ['a', 'b'],
-      view: 'kanban/1',
+      view: 'example.board',
     })
     expect(result.success).toBe(true)
   })
@@ -37,22 +37,34 @@ describe('coreFacetsSchema', () => {
 })
 
 describe('extensionFacetsSchema', () => {
-  it('accepts a well-formed {domain}/{version} key and preserves the payload verbatim', () => {
-    const payload = { kanban: { columns: ['todo', 'done'] } }
-    const result = extensionFacetsSchema.safeParse({ 'kanban/1': payload.kanban })
+  it('accepts a well-formed {namespace}.{name}/v{n} key and preserves the payload verbatim', () => {
+    const payload = { shape: { kind: 'hexagon' } }
+    const result = extensionFacetsSchema.safeParse({ 'visual.shape/v0': payload.shape })
     expect(result.success).toBe(true)
     if (result.success) {
-      expect(result.data['kanban/1']).toEqual(payload.kanban)
+      expect(result.data['visual.shape/v0']).toEqual(payload.shape)
     }
+  })
+
+  it('accepts hyphenated namespace and name segments', () => {
+    const result = extensionFacetsSchema.safeParse({ 'my-plugin.edge-style/v12': {} })
+    expect(result.success).toBe(true)
   })
 
   it.each([
     'kanban',
     'kanban/',
-    'Kanban/1',
-    'kanban/v1',
-    '/1',
-    'kanban//1',
+    'kanban/1', // the pre-ADR-0013 unnamespaced numeric grammar
+    'shape/v0', // no namespace — every facet belongs to a plugin
+    'Visual.shape/v0',
+    'visual.Shape/v0',
+    'visual.shape/1',
+    'visual.shape/v',
+    'visual..shape/v0',
+    '.shape/v0',
+    'visual./v0',
+    'visual.shape.extra/v0',
+    '/v1',
   ])('rejects (not silently drops) a malformed key %s', (badKey) => {
     const result = extensionFacetsSchema.safeParse({ [badKey]: {} })
     expect(result.success).toBe(false)
@@ -121,7 +133,7 @@ describe('storedCoreFacetsSchema', () => {
       type: 'note',
       title: 'My note',
       tags: ['a', 'b'],
-      view: 'kanban/1',
+      view: 'example.board',
       facetsRaw: { someFutureKey: 'value' },
     })
     expect(result.success).toBe(true)

--- a/packages/model/src/facets.ts
+++ b/packages/model/src/facets.ts
@@ -11,13 +11,18 @@ export const coreFacetsSchema = z.object({
 
 export type CoreFacets = z.infer<typeof coreFacetsSchema>
 
-const EXTENSION_FACET_KEY_PATTERN = /^[a-z][a-z0-9-]*\/[0-9]+$/
+const EXTENSION_FACET_KEY_PATTERN = /^[a-z][a-z0-9-]*\.[a-z][a-z0-9-]*\/v[0-9]+$/
 
 /**
  * Extension facets live under the reserved root key `facets`, keyed by
- * `{domain}/{version}` (e.g. `kanban/1`). Values are intentionally
- * `z.unknown()` — an unknown domain's payload round-trips unvalidated so
- * this package doesn't need to know every extension ever registered.
+ * `{namespace}.{name}/v{n}` (e.g. `visual.shape/v0`) per ADR-0013. The
+ * namespace is the owning plugin's id — every facet belongs to a plugin,
+ * so an unnamespaced key is unrepresentable (there is no privileged core
+ * namespace; k8s's unprefixed legacy group is the debt this avoids).
+ * `v0` marks an unstable facet whose payload may still change shape;
+ * `v1`+ bumps only on breaking change. Values are intentionally
+ * `z.unknown()` — an unknown facet's payload round-trips unvalidated so
+ * this package doesn't need to know every plugin ever registered.
  *
  * A malformed key is rejected (via superRefine issuing a ZodError), not
  * silently dropped from the record: `z.record` with a validated key schema
@@ -30,7 +35,7 @@ export const extensionFacetsSchema = z.record(z.string(), z.unknown()).superRefi
     if (!EXTENSION_FACET_KEY_PATTERN.test(key)) {
       ctx.addIssue({
         code: 'custom',
-        message: `extension facet key "${key}" must match {domain}/{version}, e.g. "kanban/1"`,
+        message: `extension facet key "${key}" must match {namespace}.{name}/v{n}, e.g. "visual.shape/v0"`,
         path: [key],
       })
     }

--- a/packages/model/src/test-utils/arbitraries.ts
+++ b/packages/model/src/test-utils/arbitraries.ts
@@ -36,12 +36,13 @@ export const coreFacetsArbitrary = fc.record(
   { requiredKeys: ['type'] },
 )
 
-const domainArbitrary = fc.stringMatching(/^[a-z][a-z0-9-]{0,9}$/)
-const versionArbitrary = fc.integer({ min: 0, max: 99 }).map((n) => String(n))
+// Namespace = owning plugin id, name = the facet within it (ADR-0013).
+const facetSegmentArbitrary = fc.stringMatching(/^[a-z][a-z0-9-]{0,9}$/)
+const facetVersionArbitrary = fc.integer({ min: 0, max: 99 }).map((n) => `v${n}`)
 
 const extensionFacetKeyArbitrary: fc.Arbitrary<string> = fc
-  .tuple(domainArbitrary, versionArbitrary)
-  .map(([domain, version]) => `${domain}/${version}`)
+  .tuple(facetSegmentArbitrary, facetSegmentArbitrary, facetVersionArbitrary)
+  .map(([namespace, name, version]) => `${namespace}.${name}/${version}`)
 
 /**
  * `fc.jsonValue()` can place an own `__proto__` key inside a generated

--- a/packages/server-core/src/tools/document-set.test.ts
+++ b/packages/server-core/src/tools/document-set.test.ts
@@ -43,7 +43,7 @@ describe('wb_document_set tool', () => {
       '---',
       'type: issue',
       'facets:',
-      '  example/1:',
+      '  example.sample/v1:',
       '    status: open',
       '    priority: high',
       '---',
@@ -63,7 +63,7 @@ describe('wb_document_set tool', () => {
 
     const doc = await loadDoc(store, DOCUMENT_ID)
     const facets = readFacets(doc)
-    expect(facets).toEqual({ 'example/1': { status: 'open', priority: 'high' } })
+    expect(facets).toEqual({ 'example.sample/v1': { status: 'open', priority: 'high' } })
 
     expect(readMarkdownBody(doc)).toBe('# Bug report\n\nSomething is broken.')
     // And the document is NOT also a spatial canvas. The body used to be
@@ -97,15 +97,16 @@ describe('wb_document_set tool', () => {
     await registerDocumentInWorkspace(store, WORKSPACE_ID, DOCUMENT_ID)
     const tool = createDocumentSetTool(makeDeps(store))
 
-    const v1 = '---\ntype: issue\nfacets:\n  example/1:\n    status: open\n---\nFirst body.'
+    const v1 = '---\ntype: issue\nfacets:\n  example.sample/v1:\n    status: open\n---\nFirst body.'
     await tool.execute({ workspaceId: WORKSPACE_ID, documentId: DOCUMENT_ID, markdown: v1 })
 
-    const v2 = '---\ntype: issue\nfacets:\n  example/1:\n    status: closed\n---\nUpdated body.'
+    const v2 =
+      '---\ntype: issue\nfacets:\n  example.sample/v1:\n    status: closed\n---\nUpdated body.'
     await tool.execute({ workspaceId: WORKSPACE_ID, documentId: DOCUMENT_ID, markdown: v2 })
 
     const doc = await loadDoc(store, DOCUMENT_ID)
     const facets = readFacets(doc)
-    expect(facets['example/1']).toEqual({ status: 'closed' })
+    expect(facets['example.sample/v1']).toEqual({ status: 'closed' })
 
     // Overwritten, not appended: the second import replaces the body rather
     // than leaving the first one alongside it.

--- a/packages/server-core/src/tools/export-import-roundtrip.test.ts
+++ b/packages/server-core/src/tools/export-import-roundtrip.test.ts
@@ -61,9 +61,9 @@ describe('wb_document_set -> OKF export composed round-trip', () => {
       'tags:',
       '  - idea',
       '  - browser',
-      'view: kanban/1',
+      'view: example.kanban/v1',
       'facets:',
-      '  note/1:',
+      '  example.note/v1:',
       '    status: idea',
       '---',
       'Body text.',
@@ -77,8 +77,8 @@ describe('wb_document_set -> OKF export composed round-trip', () => {
       'Future: browser-extension auto-connect to the local daemon',
     )
     expect(result.frontmatter.tags).toEqual(['idea', 'browser'])
-    expect(result.frontmatter.view).toBe('kanban/1')
-    expect(result.frontmatter.facets).toEqual({ 'note/1': { status: 'idea' } })
+    expect(result.frontmatter.view).toBe('example.kanban/v1')
+    expect(result.frontmatter.facets).toEqual({ 'example.note/v1': { status: 'idea' } })
   })
 
   test('preserves facets with arbitrary domain keys through the LoroDoc persistence layer', async () => {
@@ -88,7 +88,7 @@ describe('wb_document_set -> OKF export composed round-trip', () => {
       '---',
       'type: issue',
       'facets:',
-      '  example/1:',
+      '  example.sample/v1:',
       '    status: open',
       '    priority: high',
       '---',
@@ -98,7 +98,9 @@ describe('wb_document_set -> OKF export composed round-trip', () => {
 
     const result = await exportOkf(deps, { workspaceId: WORKSPACE_ID, documentId: DOCUMENT_ID })
 
-    expect(result.frontmatter.facets).toEqual({ 'example/1': { status: 'open', priority: 'high' } })
+    expect(result.frontmatter.facets).toEqual({
+      'example.sample/v1': { status: 'open', priority: 'high' },
+    })
   })
 
   test('an empty (facets-only) body round-trips to an empty body', async () => {
@@ -118,7 +120,8 @@ describe('wb_document_set -> OKF export composed round-trip', () => {
   test('re-import after export is idempotent: the second import produces the same LoroDoc state', async () => {
     const { store, documentSet, deps } = await setupTools()
 
-    const markdown = '---\ntype: note\nfacets:\n  kanban/1:\n    status: todo\n---\nOriginal body.'
+    const markdown =
+      '---\ntype: note\nfacets:\n  example.kanban/v1:\n    status: todo\n---\nOriginal body.'
     await documentSet.execute({ workspaceId: WORKSPACE_ID, documentId: DOCUMENT_ID, markdown })
     const exported = await exportOkf(deps, { workspaceId: WORKSPACE_ID, documentId: DOCUMENT_ID })
 
@@ -129,7 +132,7 @@ describe('wb_document_set -> OKF export composed round-trip', () => {
     })
     const doc = await loadDoc(store, DOCUMENT_ID)
 
-    expect(readFacets(doc)).toEqual({ 'kanban/1': { status: 'todo' } })
+    expect(readFacets(doc)).toEqual({ 'example.kanban/v1': { status: 'todo' } })
     expect(readMarkdownBody(doc)).toBe('Original body.')
   })
 })
@@ -266,7 +269,7 @@ describe('error paths do not silently produce corrupt output', () => {
     // JS NaN, which has no round-trippable YAML representation) imports
     // successfully but must fail the composed export rather than silently
     // emitting corrupt YAML.
-    const markdown = '---\ntype: note\nfacets:\n  bad/1:\n    value: .nan\n---\nBody.'
+    const markdown = '---\ntype: note\nfacets:\n  example.bad/v1:\n    value: .nan\n---\nBody.'
     await documentSet.execute({ workspaceId: WORKSPACE_ID, documentId: DOCUMENT_ID, markdown })
 
     await expect(

--- a/packages/server-core/src/tools/export-okf.test.ts
+++ b/packages/server-core/src/tools/export-okf.test.ts
@@ -19,7 +19,7 @@ describe('exportOkf', () => {
         nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hello' }],
         edges: [],
       })
-      writeFacets(doc, { 'kanban/1': { status: 'todo' } })
+      writeFacets(doc, { 'example.kanban/v1': { status: 'todo' } })
     })
     const result = await exportOkf(makeDeps(store), {
       workspaceId: WORKSPACE_ID,
@@ -28,7 +28,7 @@ describe('exportOkf', () => {
 
     expect(result.markdown.startsWith('---\n')).toBe(true)
     expect(result.markdown).toContain('hello')
-    expect(result.frontmatter.facets).toEqual({ 'kanban/1': { status: 'todo' } })
+    expect(result.frontmatter.facets).toEqual({ 'example.kanban/v1': { status: 'todo' } })
   })
 
   test('falls back to an empty body when the canvas has no text node', async () => {

--- a/packages/server-core/src/tools/facet-set.test.ts
+++ b/packages/server-core/src/tools/facet-set.test.ts
@@ -31,12 +31,12 @@ describe('wb_facet_set tool', () => {
     const result = await tool.execute({
       workspaceId: WORKSPACE_ID,
       documentId: DOCUMENT_ID,
-      facets: { 'kanban/1': { status: 'todo' } },
+      facets: { 'example.kanban/v1': { status: 'todo' } },
     })
 
     expect(result).toEqual({
       documentId: DOCUMENT_ID,
-      facets: { 'kanban/1': { status: 'todo' } },
+      facets: { 'example.kanban/v1': { status: 'todo' } },
     })
   })
 
@@ -48,7 +48,7 @@ describe('wb_facet_set tool', () => {
     await tool.execute({
       workspaceId: WORKSPACE_ID,
       documentId: DOCUMENT_ID,
-      facets: { 'kanban/1': { status: 'todo' } },
+      facets: { 'example.kanban/v1': { status: 'todo' } },
     })
 
     const loaded = await store.loadSnapshot({
@@ -59,7 +59,7 @@ describe('wb_facet_set tool', () => {
     if (loaded !== null) {
       doc.import(reassembleSnapshot(loaded.manifest, loaded.chunks))
     }
-    expect(readFacets(doc)).toEqual({ 'kanban/1': { status: 'todo' } })
+    expect(readFacets(doc)).toEqual({ 'example.kanban/v1': { status: 'todo' } })
   })
 
   test('merges a new facet domain with an existing one instead of replacing it', async () => {
@@ -70,17 +70,17 @@ describe('wb_facet_set tool', () => {
     await tool.execute({
       workspaceId: WORKSPACE_ID,
       documentId: DOCUMENT_ID,
-      facets: { 'kanban/1': { status: 'todo' } },
+      facets: { 'example.kanban/v1': { status: 'todo' } },
     })
     const result = await tool.execute({
       workspaceId: WORKSPACE_ID,
       documentId: DOCUMENT_ID,
-      facets: { 'priority/1': { level: 'high' } },
+      facets: { 'example.priority/v1': { level: 'high' } },
     })
 
     expect(result.facets).toEqual({
-      'kanban/1': { status: 'todo' },
-      'priority/1': { level: 'high' },
+      'example.kanban/v1': { status: 'todo' },
+      'example.priority/v1': { level: 'high' },
     })
   })
 
@@ -92,15 +92,15 @@ describe('wb_facet_set tool', () => {
     await tool.execute({
       workspaceId: WORKSPACE_ID,
       documentId: DOCUMENT_ID,
-      facets: { 'kanban/1': { status: 'todo' } },
+      facets: { 'example.kanban/v1': { status: 'todo' } },
     })
     const result = await tool.execute({
       workspaceId: WORKSPACE_ID,
       documentId: DOCUMENT_ID,
-      facets: { 'kanban/1': { status: 'done' } },
+      facets: { 'example.kanban/v1': { status: 'done' } },
     })
 
-    expect(result.facets).toEqual({ 'kanban/1': { status: 'done' } })
+    expect(result.facets).toEqual({ 'example.kanban/v1': { status: 'done' } })
   })
 
   test('throws WorkspaceDocumentNotFoundError when workspaceId does not actually own documentId', async () => {
@@ -112,12 +112,12 @@ describe('wb_facet_set tool', () => {
       tool.execute({
         workspaceId: 'ws-other',
         documentId: DOCUMENT_ID,
-        facets: { 'kanban/1': { status: 'todo' } },
+        facets: { 'example.kanban/v1': { status: 'todo' } },
       }),
     ).rejects.toThrow(WorkspaceDocumentNotFoundError)
   })
 
-  test('rejects a facet key outside the {domain}/{version} pattern', () => {
+  test('rejects a facet key outside the {namespace}.{name}/v{n} pattern', () => {
     expect(() =>
       facetSetInputSchema.parse({
         workspaceId: WORKSPACE_ID,
@@ -147,7 +147,7 @@ describe('facets belong to OKF (ADR-0009 decision 3)', () => {
       createFacetSetTool(makeDeps(store)).execute({
         workspaceId: WORKSPACE_ID,
         documentId: DOCUMENT_ID,
-        facets: { 'example/1': { status: 'open' } },
+        facets: { 'example.sample/v1': { status: 'open' } },
       }),
     ).rejects.toThrow(DocumentKindMismatchError)
   })
@@ -161,7 +161,7 @@ describe('facets belong to OKF (ADR-0009 decision 3)', () => {
       createFacetSetTool(makeDeps(store)).execute({
         workspaceId: WORKSPACE_ID,
         documentId: DOCUMENT_ID,
-        facets: { 'example/1': { status: 'open' } },
+        facets: { 'example.sample/v1': { status: 'open' } },
       }),
     ).rejects.toThrow(DocumentKindMismatchError)
 
@@ -179,9 +179,9 @@ describe('facets belong to OKF (ADR-0009 decision 3)', () => {
     const result = await createFacetSetTool(makeDeps(store)).execute({
       workspaceId: WORKSPACE_ID,
       documentId: DOCUMENT_ID,
-      facets: { 'example/1': { status: 'open' } },
+      facets: { 'example.sample/v1': { status: 'open' } },
     })
 
-    expect(result.facets).toEqual({ 'example/1': { status: 'open' } })
+    expect(result.facets).toEqual({ 'example.sample/v1': { status: 'open' } })
   })
 })

--- a/packages/server-core/src/tools/facet-set.ts
+++ b/packages/server-core/src/tools/facet-set.ts
@@ -12,7 +12,7 @@ import { loadOrCreateDocument, saveDocumentSnapshot } from './document-io.js'
 import { DocumentKindMismatchError } from './errors.js'
 
 /**
- * `extensionFacetsSchema` already enforces the `{domain}/{version}` key
+ * `extensionFacetsSchema` already enforces the `{namespace}.{name}/v{n}` key
  * pattern (model's `EXTENSION_FACET_KEY_PATTERN`), so a caller can
  * never use this tool to set a core facet (`type`/`title`/`tags`/`view`) or
  * the raw `facets` root key itself — those don't match the pattern and are


### PR DESCRIPTION
## Summary

- **ADR-0013** records the facet-system decision set agreed in the design session: facets as plugin-registered, namespaced, versioned attribute groups attachable to objects (supersedes ADR-0009 decision 3 — with the distribution-time schema registration whose absence justified that rejection); targets in two dimensions; storage slots; four validation layers; per-facet compat migration chains; the meaning/display/display-state split with medium-exclusive view kinds; contribution points; two-tier declarative editing.
- **This increment implements the key grammar only**: `extensionFacetsSchema` moves from the unnamespaced numeric `{domain}/{version}` (`kanban/1`) to `{namespace}.{name}/v{n}` (`visual.shape/v0`). No compatibility for the old grammar (nothing registered ever consumed it; stored old keys drop on read via the existing drop-not-fail rule). All fixtures swept, including the e2e smoke's leftover `issue/1` block.
- ADR-0009 addendum, ADR README index, `vocabulary.md` Facet row, `package-model.md`, and the ticketing skill example follow the new definition.

## Verification

- `pnpm -r typecheck` — clean
- Full suite: **892 files / 8949 tests passed** (4 teardown-time unhandled rejections in `maintenance.test.ts` are an untouched mcp-server file, green in isolation — known load-dependent family)
- Review gate (correctness / contract / test-coverage / reachability + adversarial verify): **0 findings**
- QA smoke: `pnpm build` clean; `pnpm smoke:e2e` both suites `[e2e] ALL OK` — `wb_facet_set` with new-grammar keys round-trips through the real MCP daemon, spatial refusal intact
- `pnpm lint` (one pre-existing warning on main, untouched) and `pnpm knip` clean

Backend/schema + docs change — no visual surface (test output above is the evidence per the visual-evidence rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013avJozs9SoCuDzZJGuTcqH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced namespaced, versioned facet identifiers using the `{namespace}.{name}/v{n}` format.
  - Added documentation describing the plugin-based facet system, schema registration, storage, validation, compatibility, and display behavior.

- **Documentation**
  - Updated contributor guidance and examples to reflect the new facet-key convention.
  - Clarified that core frontmatter fields remain Markdown-specific.

- **Tests**
  - Updated fixtures, validation coverage, serialization, persistence, import/export, and smoke tests for the new identifiers.
  - Added coverage for payload preservation and hyphenated key segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->