### PR TITLE
feat(web): one document browser for both modes, with match highlighting

### DIFF
--- a/apps/web/src/components/workspace-files/SearchResults.test.tsx
+++ b/apps/web/src/components/workspace-files/SearchResults.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * What a search result row must carry: the match, made visible.
+ *
+ * Prior-art survey (Finder, Explorer, VS Code, Obsidian, Dropbox, Notion,
+ * Slack): highlighting the matched substring is near-universal in mature
+ * search UIs, and the two surveyed apps WITHOUT per-row location context
+ * (Finder, Figma) both have standing user complaints about it. This file pins
+ * the two things that make a flat cross-workspace result list legible: the
+ * highlighted match and the path on every row — plus the list/grid toggle.
+ */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { WorkspaceDocumentEntry } from './document-entry.js'
+import { SearchResults } from './SearchResults.js'
+
+afterEach(cleanup)
+
+const entries: WorkspaceDocumentEntry[] = [
+  { documentId: 'd1', path: 'plans/roadmap', name: 'Road map', kind: 'markdown' },
+  { documentId: 'd2', path: 'sketches/map-of-rome', kind: 'spatial' },
+]
+
+describe('SearchResults', () => {
+  it('highlights the matched substring in the title', () => {
+    render(<SearchResults results={entries} query="road" onSelect={vi.fn()} />)
+    const marks = screen.getAllByTestId('search-match')
+    // Case-insensitive, and in the TITLE — the visible answer to "why is
+    // this row here".
+    expect(marks.some((m) => m.textContent === 'Road')).toBe(true)
+  })
+
+  it('highlights a match that only the path has', () => {
+    render(<SearchResults results={entries} query="rome" onSelect={vi.fn()} />)
+    const marks = screen.getAllByTestId('search-match')
+    expect(marks.some((m) => m.textContent === 'rome')).toBe(true)
+  })
+
+  it('offers a list/grid toggle and switches the layout', () => {
+    render(<SearchResults results={entries} query="map" onSelect={vi.fn()} />)
+    // List first: the row carries the path inline, which is the location
+    // context a flat cross-workspace list owes every result.
+    expect(screen.getByTestId('search-results-list')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Grid results' }))
+    expect(screen.getByTestId('search-results-grid')).toBeTruthy()
+    expect(screen.queryByTestId('search-results-list')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'List results' }))
+    expect(screen.getByTestId('search-results-list')).toBeTruthy()
+  })
+
+  it('keeps the path visible on grid cards too', () => {
+    // The Finder/Figma gap: flattening hierarchy without restoring location
+    // per row is the documented complaint in both. The grid does not get to
+    // reintroduce it.
+    render(<SearchResults results={entries} query="map" onSelect={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Grid results' }))
+    // By textContent, because the highlight splits the string across a
+    // <mark> — which is itself the behaviour under test one case up.
+    const grid = screen.getByTestId('search-results-grid')
+    expect(grid.textContent).toContain('plans/roadmap')
+  })
+})

--- a/apps/web/src/components/workspace-files/SearchResults.tsx
+++ b/apps/web/src/components/workspace-files/SearchResults.tsx
@@ -4,66 +4,168 @@
  * Every row carries its full path, which the folder view deliberately does
  * not: there, the path is the pane you are standing in and repeating it on
  * every card would be noise. Here it is the only thing that says where the
- * document actually is, and the reason someone searched.
+ * document actually is, and the reason someone searched. (The two surveyed
+ * apps that flatten hierarchy WITHOUT restoring location per row — Finder and
+ * Figma — both carry standing user complaints about exactly that.)
+ *
+ * The matched substring is marked in place, in the title and in the path:
+ * a result list that will not say why a row is present makes the reader
+ * re-run the search with their eyes.
  */
 
-import type { ReactNode } from 'react'
+import { LayoutGrid, List } from 'lucide-react'
+import { type ReactNode, useState } from 'react'
 import { cn } from '../../lib/utils.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
 
 export interface SearchResultsProps {
   results: readonly WorkspaceDocumentEntry[]
+  /** The query the results answer, so the match can be shown, not implied. */
+  query: string
   selectedPath?: string
   onSelect: (document: WorkspaceDocumentEntry) => void
   renderThumbnail?: (document: WorkspaceDocumentEntry) => ReactNode
   className?: string
 }
 
+/**
+ * The text with its first case-insensitive match marked. First only: one
+ * highlight answers "why is this row here", and a title that matches four
+ * times painted four times reads as damage rather than emphasis.
+ */
+function Highlighted({ text, query }: { text: string; query: string }) {
+  const q = query.trim().toLowerCase()
+  if (q === '') return <>{text}</>
+  const at = text.toLowerCase().indexOf(q)
+  if (at === -1) return <>{text}</>
+  return (
+    <>
+      {text.slice(0, at)}
+      <mark data-testid="search-match" className="rounded-sm bg-primary/20 text-inherit">
+        {text.slice(at, at + q.length)}
+      </mark>
+      {text.slice(at + q.length)}
+    </>
+  )
+}
+
+function titleOf(entry: WorkspaceDocumentEntry): string {
+  return entry.name ?? entry.path.split('/').at(-1) ?? entry.path
+}
+
 export function SearchResults({
   results,
+  query,
   selectedPath,
   onSelect,
   renderThumbnail,
   className,
 }: SearchResultsProps) {
+  // List first: the row form carries the path inline beside the title, which
+  // is the stronger answer to "where is this" — the grid trades that density
+  // for a bigger picture, the way Finder's icon view does.
+  const [layout, setLayout] = useState<'list' | 'grid'>('list')
+
   if (results.length === 0) {
     return <p className={cn('text-muted-foreground text-sm', className)}>Nothing matches.</p>
   }
 
+  const thumbnail = (entry: WorkspaceDocumentEntry, sizeClass: string) => (
+    <span
+      className={cn(
+        'bg-muted/40 flex shrink-0 items-center justify-center overflow-hidden rounded',
+        sizeClass,
+      )}
+    >
+      {renderThumbnail?.(entry) ?? (
+        <span data-kind={entry.kind ?? 'markdown'} className="text-muted-foreground text-xs">
+          {entry.kind ?? 'markdown'}
+        </span>
+      )}
+    </span>
+  )
+
   return (
-    <ul className={cn('space-y-1 p-0.5', className)}>
-      {results.map((entry) => (
-        <li key={entry.documentId}>
+    <div className={className}>
+      <div className="mb-1 flex justify-end">
+        <div className="flex items-center gap-0.5 rounded-md border p-0.5">
           <button
             type="button"
-            aria-current={entry.path === selectedPath ? 'true' : undefined}
-            onClick={() => onSelect(entry)}
-            className="hover:bg-accent/40 aria-[current]:border-primary aria-[current]:ring-primary/40 flex w-full min-w-0 items-center gap-2 rounded-md border p-1.5 text-left aria-[current]:ring-1"
+            aria-label="List results"
+            aria-pressed={layout === 'list'}
+            onClick={() => setLayout('list')}
+            className="text-muted-foreground aria-pressed:bg-accent aria-pressed:text-foreground rounded p-1"
           >
-            {/* 80x44, not smaller: measured on a real document, a faithful
-                render is a smear below roughly this and only here do the
-                heading and the blocks separate. Recognising the document is
-                the whole job of a search result, so this is the one list that
-                pays for the height. */}
-            <span className="bg-muted/40 flex h-11 w-20 shrink-0 items-center justify-center overflow-hidden rounded">
-              {renderThumbnail?.(entry) ?? (
-                <span
-                  data-kind={entry.kind ?? 'markdown'}
-                  className="text-muted-foreground text-xs"
-                >
-                  {entry.kind ?? 'markdown'}
-                </span>
-              )}
-            </span>
-            <span className="flex min-w-0 flex-col">
-              <span data-testid="result-title" className="truncate text-sm">
-                {entry.name ?? entry.path.split('/').at(-1)}
-              </span>
-              <span className="text-muted-foreground truncate font-mono text-xs">{entry.path}</span>
-            </span>
+            <List className="size-4" />
           </button>
-        </li>
-      ))}
-    </ul>
+          <button
+            type="button"
+            aria-label="Grid results"
+            aria-pressed={layout === 'grid'}
+            onClick={() => setLayout('grid')}
+            className="text-muted-foreground aria-pressed:bg-accent aria-pressed:text-foreground rounded p-1"
+          >
+            <LayoutGrid className="size-4" />
+          </button>
+        </div>
+      </div>
+      {layout === 'list' ? (
+        <ul data-testid="search-results-list" className="space-y-1 p-0.5">
+          {results.map((entry) => (
+            <li key={entry.documentId}>
+              <button
+                type="button"
+                aria-current={entry.path === selectedPath ? 'true' : undefined}
+                onClick={() => onSelect(entry)}
+                className="hover:bg-accent/40 aria-[current]:border-primary aria-[current]:ring-primary/40 flex w-full min-w-0 items-center gap-2 rounded-md border p-1.5 text-left aria-[current]:ring-1"
+              >
+                {/* 80x44, not smaller: measured on a real document, a faithful
+                    render is a smear below roughly this and only here do the
+                    heading and the blocks separate. Recognising the document is
+                    the whole job of a search result, so this is the one list that
+                    pays for the height. */}
+                {thumbnail(entry, 'h-11 w-20')}
+                <span className="flex min-w-0 flex-col">
+                  <span data-testid="result-title" className="truncate text-sm">
+                    <Highlighted text={titleOf(entry)} query={query} />
+                  </span>
+                  <span className="text-muted-foreground truncate font-mono text-xs">
+                    <Highlighted text={entry.path} query={query} />
+                  </span>
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <ul
+          data-testid="search-results-grid"
+          className="grid grid-cols-2 gap-2 p-0.5 md:grid-cols-3"
+        >
+          {results.map((entry) => (
+            <li key={entry.documentId}>
+              <button
+                type="button"
+                aria-current={entry.path === selectedPath ? 'true' : undefined}
+                onClick={() => onSelect(entry)}
+                className="hover:bg-accent/40 aria-[current]:border-primary aria-[current]:ring-primary/40 flex w-full min-w-0 flex-col gap-1.5 rounded-md border p-2 text-left aria-[current]:ring-1"
+              >
+                {thumbnail(entry, 'aspect-[16/9] w-full')}
+                <span className="flex min-w-0 flex-col">
+                  <span data-testid="result-title" className="truncate text-sm">
+                    <Highlighted text={titleOf(entry)} query={query} />
+                  </span>
+                  {/* The path stays on the card. Dropping it here would
+                      reintroduce the Finder/Figma gap the list avoids. */}
+                  <span className="text-muted-foreground truncate font-mono text-xs">
+                    <Highlighted text={entry.path} query={query} />
+                  </span>
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   )
 }

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -2,20 +2,13 @@ import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import { Columns2, FilePlus2, LayoutGrid, List, Search } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useThemeMode } from '../../hooks/useThemeMode.js'
-import {
-  createDocument,
-  DaemonApiError,
-  getDocumentOkfV1,
-  getDocumentSnapshot,
-  listDocuments,
-  renameDocumentPath,
-} from '../../lib/daemon-api-client.js'
 import { DocumentMinimap } from './DocumentMinimap.js'
 import { DocumentPreview } from './DocumentPreview.js'
 import { DocumentThumbnail } from './DocumentThumbnail.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
 import { FolderBreadcrumb } from './FolderBreadcrumb.js'
 import { FolderContentsList } from './FolderContentsList.js'
+import { type WorkspaceFilesSource, WorkspaceMissingError } from './files-source.js'
 import { createRowOutlineLoader } from './load-row-outline.js'
 import { createRowRenderLoader } from './load-row-render.js'
 import { newDocumentPathIn } from './new-document-path.js'
@@ -25,9 +18,12 @@ import { WorkspaceFileTree } from './WorkspaceFileTree.js'
 import { WorkspaceFolderTree } from './WorkspaceFolderTree.js'
 
 export interface WorkspaceFilesPanelProps {
-  daemonFetch: typeof globalThis.fetch
-  daemonBaseUrl: string
-  workspaceId: string
+  /**
+   * Where the documents live. The panel itself no longer knows which mode it
+   * is in — the daemon and the browser-local store each supply one of these,
+   * which is what lets one browser serve both.
+   */
+  source: WorkspaceFilesSource
   /** Absent means the preview shows no way in — looking still works. */
   onOpenDocument?: (path: string) => void
   /**
@@ -74,16 +70,14 @@ export type BrowserColumns = 'one' | 'two'
  * of what the preview shows.
  */
 export function WorkspaceFilesPanel({
-  daemonFetch,
-  daemonBaseUrl,
-  workspaceId,
+  source,
   onOpenDocument,
   onDuplicateDocument,
   onRequestDelete,
   revision,
 }: WorkspaceFilesPanelProps) {
   const { resolvedTheme } = useThemeMode()
-  const [documents, setDocuments] = useState<WorkspaceDocumentEntry[] | null>(null)
+  const [documents, setDocuments] = useState<readonly WorkspaceDocumentEntry[] | null>(null)
   // 'not-found' is a workspace with no v1 tree yet — a calm empty state, not
   // a failure. 'error' is a genuine fetch/schema failure and keeps the alert.
   const [listStatus, setListStatus] = useState<'ok' | 'not-found' | 'error'>('ok')
@@ -97,51 +91,16 @@ export function WorkspaceFilesPanel({
   // One loader for the whole panel, so a re-render does not hand every card
   // a new function and re-trigger its render.
   const loadRender = useMemo(
-    () =>
-      createRowRenderLoader({
-        daemonFetch,
-        daemonBaseUrl,
-        workspaceId,
-        theme: resolvedTheme,
-        getSnapshot: getDocumentSnapshot,
-        getOkf: getDocumentOkfV1,
-      }),
-    [daemonFetch, daemonBaseUrl, workspaceId, resolvedTheme],
+    () => createRowRenderLoader({ source, theme: resolvedTheme }),
+    [source, resolvedTheme],
   )
 
   // The row-size rendition. Separate from `loadRender` on purpose: it asks
   // the worker for block geometry rather than a serialized SVG, which is
   // both cheaper and the only thing legible at 24px (see DocumentMinimap).
-  const loadOutline = useMemo(
-    () =>
-      createRowOutlineLoader({
-        daemonFetch,
-        daemonBaseUrl,
-        workspaceId,
-        getSnapshot: getDocumentSnapshot,
-        getOkf: getDocumentOkfV1,
-      }),
-    [daemonFetch, daemonBaseUrl, workspaceId],
-  )
+  const loadOutline = useMemo(() => createRowOutlineLoader({ source }), [source])
 
-  // The RICH list, not /api/v1's: that one carries only {documentId, path},
-  // so a row could be labelled by nothing but its path segment and there was
-  // no way to know a document's kind. Both are things the browser shows.
-  const readList = useCallback(
-    () =>
-      listDocuments(daemonFetch, daemonBaseUrl, workspaceId).then((res) =>
-        res.documents.map((entry) => ({
-          // An older daemon omits the id; the path stands in, as it does
-          // everywhere else that reads this list.
-          documentId: entry.id ?? entry.path,
-          path: entry.path,
-          ...(entry.displayName === undefined ? {} : { name: entry.displayName }),
-          ...(entry.kind === undefined ? {} : { kind: entry.kind }),
-          ...(entry.updatedAt === undefined ? {} : { updatedAt: entry.updatedAt }),
-        })),
-      ),
-    [daemonFetch, daemonBaseUrl, workspaceId],
-  )
+  const readList = useCallback(() => source.listDocuments(), [source])
 
   useEffect(() => {
     let cancelled = false
@@ -155,7 +114,7 @@ export function WorkspaceFilesPanel({
       })
       .catch((err) => {
         if (cancelled) return
-        setListStatus(err instanceof DaemonApiError && err.status === 404 ? 'not-found' : 'error')
+        setListStatus(err instanceof WorkspaceMissingError ? 'not-found' : 'error')
       })
     return () => {
       cancelled = true
@@ -210,12 +169,12 @@ export function WorkspaceFilesPanel({
         folder,
         (documents ?? []).map((row) => row.path),
       )
-      await createDocument(daemonFetch, daemonBaseUrl, workspaceId, path, kind)
+      await source.createDocument(path, kind)
       const entries = await readList()
       setDocuments(entries)
       setSelected(entries.find((row) => row.path === path) ?? null)
     },
-    [daemonFetch, daemonBaseUrl, workspaceId, readList, folder, documents],
+    [source, readList, folder, documents],
   )
 
   /**
@@ -244,13 +203,13 @@ export function WorkspaceFilesPanel({
 
   const moveDocument = useCallback(
     async (entry: WorkspaceDocumentEntry, newPath: string) => {
-      await renameDocumentPath(daemonFetch, daemonBaseUrl, workspaceId, entry.path, newPath)
+      await source.renameDocumentPath(entry.path, newPath)
       const entries = await readList()
       setDocuments(entries)
       setSelected(entries.find((row) => row.path === newPath) ?? null)
       setFolder(newPath.includes('/') ? newPath.slice(0, newPath.lastIndexOf('/')) : '')
     },
-    [daemonFetch, daemonBaseUrl, workspaceId, readList],
+    [source, readList],
   )
 
   /**
@@ -363,6 +322,7 @@ export function WorkspaceFilesPanel({
             <div data-testid="search-results">
               <SearchResults
                 results={searchDocuments(documents, query)}
+                query={query}
                 selectedPath={selected?.path}
                 onSelect={setSelected}
                 renderThumbnail={(entry) => (

--- a/apps/web/src/components/workspace-files/files-source.ts
+++ b/apps/web/src/components/workspace-files/files-source.ts
@@ -1,0 +1,48 @@
+import type { DocumentKind } from '@kamiazya/whiteboard-model'
+import type { WorkspaceDocumentEntry } from './document-entry.js'
+
+/**
+ * Everything `WorkspaceFilesPanel` asks of the world, as one seam.
+ *
+ * The panel used to call the daemon's client functions directly, which made
+ * the three-pane browser daemon-only — the single obstacle the
+ * one-browser-both-modes ticket names. These five operations are the panel's
+ * whole data surface, measured from its imports rather than assumed: list,
+ * create, rename, and the two content reads its thumbnails and preview need.
+ *
+ * Duplicate and delete are deliberately NOT here. Both stay with the page
+ * (`onDuplicateDocument` / `onRequestDelete`), which owns the confirmation
+ * dialog and the copy semantics — a second home for either would be a second
+ * set of rules for the same destructive act.
+ */
+export interface WorkspaceFilesSource {
+  listDocuments(): Promise<readonly WorkspaceDocumentEntry[]>
+  createDocument(path: string, kind: DocumentKind): Promise<void>
+  /** Move a document — and everything under it — to a new path. */
+  renameDocumentPath(path: string, newPath: string): Promise<void>
+  /**
+   * The OKF markdown of a markdown document, for row thumbnails and the
+   * preview pane. Empty string when the document has no body yet.
+   */
+  loadMarkdown(entry: WorkspaceDocumentEntry): Promise<string>
+  /**
+   * The CURRENT Loro bytes of a spatial document — snapshot plus any delta
+   * log folded in, because a thumbnail of the last snapshot is a thumbnail
+   * of a document the user is not looking at.
+   */
+  loadSpatialSnapshot(entry: WorkspaceDocumentEntry): Promise<Uint8Array>
+}
+
+/**
+ * The workspace this source points at does not exist.
+ *
+ * Named here so the panel can show its not-found state without knowing which
+ * implementation it is talking to: the daemon adapter maps its 404 onto this,
+ * the local adapter maps the port's `WorkspaceNotFoundError`.
+ */
+export class WorkspaceMissingError extends Error {
+  constructor(workspaceId: string) {
+    super(`Workspace not found: "${workspaceId}"`)
+    this.name = 'WorkspaceMissingError'
+  }
+}

--- a/apps/web/src/components/workspace-files/load-row-outline.test.ts
+++ b/apps/web/src/components/workspace-files/load-row-outline.test.ts
@@ -1,13 +1,9 @@
 import { writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
 import { LoroDoc } from 'loro-crdt'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
+import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
 import { createRowOutlineLoader } from './load-row-outline.js'
 
-const base = {
-  daemonFetch: globalThis.fetch,
-  daemonBaseUrl: 'http://127.0.0.1:3099',
-  workspaceId: 'ws',
-}
 const spatial = { documentId: 'c1', path: 'a/b', kind: 'spatial' as const }
 const markdown = { documentId: 'c2', path: 'notes', kind: 'markdown' as const }
 
@@ -15,39 +11,31 @@ describe('createRowOutlineLoader', () => {
   // Kind decides where the shape comes from, and reading the wrong endpoint
   // would either 404 or answer with a shape of the wrong thing.
   it('reads a spatial document’s snapshot, not its OKF', async () => {
-    const getSnapshot = vi.fn(async () => new Uint8Array())
-    const getOkf = vi.fn(async () => ({ markdown: '' }))
-    await createRowOutlineLoader({ ...base, getSnapshot, getOkf })(spatial)
-    expect(getSnapshot).toHaveBeenCalledOnce()
-    expect(getOkf).not.toHaveBeenCalled()
+    const source = fakeFilesSource()
+    await createRowOutlineLoader({ source })(spatial)
+    expect(source.loadSpatialSnapshot).toHaveBeenCalledOnce()
+    expect(source.loadMarkdown).not.toHaveBeenCalled()
   })
 
   it('reads a markdown document’s OKF, not its snapshot', async () => {
-    const getSnapshot = vi.fn(async () => new Uint8Array())
-    const getOkf = vi.fn(async () => ({ markdown: '' }))
-    await createRowOutlineLoader({ ...base, getSnapshot, getOkf })(markdown)
-    expect(getOkf).toHaveBeenCalledOnce()
-    expect(getSnapshot).not.toHaveBeenCalled()
+    const source = fakeFilesSource()
+    await createRowOutlineLoader({ source })(markdown)
+    expect(source.loadMarkdown).toHaveBeenCalledOnce()
+    expect(source.loadSpatialSnapshot).not.toHaveBeenCalled()
   })
 
-  it('addresses a spatial document by path and a markdown one by id', async () => {
-    const seen: string[] = []
-    const load = createRowOutlineLoader({
-      ...base,
-      getSnapshot: async (_f, _u, _w, path) => {
-        seen.push(`snapshot:${path}`)
-        return new Uint8Array()
-      },
-      getOkf: async (_f, _u, _w, documentId) => {
-        seen.push(`okf:${documentId}`)
-        return { markdown: '' }
-      },
-    })
+  it('hands each read the whole entry, so the source can address either way', async () => {
+    // The daemon serves a snapshot at the PATH and OKF by the ID; the local
+    // store keys everything by id. Passing the entry — not one field chosen
+    // here — is what lets each source pick its own address, which is the
+    // decision this loader used to make for them and got to be daemon-only by
+    // making.
+    const source = fakeFilesSource()
+    const load = createRowOutlineLoader({ source })
     await load(spatial)
     await load(markdown)
-    // The path is the address a snapshot is served at; the id is what the
-    // OKF read takes. Swapping them 404s.
-    expect(seen).toEqual(['snapshot:a/b', 'okf:c2'])
+    expect(source.loadSpatialSnapshot).toHaveBeenCalledWith(spatial)
+    expect(source.loadMarkdown).toHaveBeenCalledWith(markdown)
   })
 
   // The branch that actually produces a miniature. Every other test here
@@ -64,9 +52,7 @@ describe('createRowOutlineLoader', () => {
       return blocks
     }
     const load = createRowOutlineLoader({
-      ...base,
-      getSnapshot: async () => new Uint8Array(),
-      getOkf: async () => ({ markdown: '# Title\n\nProse.\n' }),
+      source: fakeFilesSource({ loadMarkdown: async () => '# Title\n\nProse.\n' }),
       layoutMarkdown,
     })
 
@@ -78,9 +64,7 @@ describe('createRowOutlineLoader', () => {
 
   it('answers null when the layout refuses', async () => {
     const load = createRowOutlineLoader({
-      ...base,
-      getSnapshot: async () => new Uint8Array(),
-      getOkf: async () => ({ markdown: '# Title\n' }),
+      source: fakeFilesSource({ loadMarkdown: async () => '# Title\n' }),
       layoutMarkdown: async () => null,
     })
     await expect(load(markdown)).resolves.toBeNull()
@@ -100,9 +84,7 @@ describe('createRowOutlineLoader', () => {
     const snapshot = doc.export({ mode: 'snapshot' })
 
     const load = createRowOutlineLoader({
-      ...base,
-      getSnapshot: async () => snapshot,
-      getOkf: async () => ({ markdown: '' }),
+      source: fakeFilesSource({ loadSpatialSnapshot: async () => snapshot }),
     })
 
     const rects = await load(spatial)
@@ -114,29 +96,25 @@ describe('createRowOutlineLoader', () => {
   // the whole tree down with it.
   it('answers null rather than throwing when the read fails', async () => {
     const load = createRowOutlineLoader({
-      ...base,
-      getSnapshot: async () => {
-        throw new Error('offline')
-      },
-      getOkf: async () => ({ markdown: '' }),
+      source: fakeFilesSource({
+        loadSpatialSnapshot: async () => {
+          throw new Error('offline')
+        },
+      }),
     })
     await expect(load(spatial)).resolves.toBeNull()
   })
 
   it('answers null rather than laying out an empty markdown document', async () => {
     const load = createRowOutlineLoader({
-      ...base,
-      getSnapshot: async () => new Uint8Array(),
-      getOkf: async () => ({ markdown: '   \n' }),
+      source: fakeFilesSource({ loadMarkdown: async () => '   \n' }),
     })
     await expect(load(markdown)).resolves.toBeNull()
   })
 
   it('answers null for a snapshot that is not a document', async () => {
     const load = createRowOutlineLoader({
-      ...base,
-      getSnapshot: async () => new Uint8Array([1, 2, 3]),
-      getOkf: async () => ({ markdown: '' }),
+      source: fakeFilesSource({ loadMarkdown: async () => '' }),
     })
     await expect(load(spatial)).resolves.toBeNull()
   })

--- a/apps/web/src/components/workspace-files/load-row-outline.ts
+++ b/apps/web/src/components/workspace-files/load-row-outline.ts
@@ -18,6 +18,7 @@ import type { FaviconRect } from '../../lib/favicon.js'
 import { nextLayoutRequestId, sharedLayoutWorkerPool } from '../../lib/layout-worker-pool.js'
 import type { MarkdownRailResponse } from '../../lib/layout-worker-protocol.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
+import type { WorkspaceFilesSource } from './files-source.js'
 
 /**
  * Width a row's markdown is laid out at. Fixed rather than measured: an icon
@@ -27,21 +28,7 @@ import type { WorkspaceDocumentEntry } from './document-entry.js'
 const ROW_LAYOUT_WIDTH = 640
 
 export interface RowOutlineDeps {
-  readonly daemonFetch: typeof globalThis.fetch
-  readonly daemonBaseUrl: string
-  readonly workspaceId: string
-  readonly getSnapshot: (
-    fetchFn: typeof globalThis.fetch,
-    baseUrl: string,
-    workspaceId: string,
-    path: string,
-  ) => Promise<Uint8Array>
-  readonly getOkf: (
-    fetchFn: typeof globalThis.fetch,
-    baseUrl: string,
-    workspaceId: string,
-    documentId: string,
-  ) => Promise<{ markdown: string }>
+  readonly source: WorkspaceFilesSource
   /**
    * Lays a markdown body out. Injected like the two reads above so the
    * success path is assertable without mocking a module — the branch that
@@ -69,22 +56,12 @@ export function createRowOutlineLoader(deps: RowOutlineDeps) {
   return async (document: WorkspaceDocumentEntry): Promise<readonly FaviconRect[] | null> => {
     try {
       if (document.kind === 'markdown') {
-        const { markdown } = await deps.getOkf(
-          deps.daemonFetch,
-          deps.daemonBaseUrl,
-          deps.workspaceId,
-          document.documentId,
-        )
+        const markdown = await deps.source.loadMarkdown(document)
         if (markdown.trim() === '') return null
         return await (deps.layoutMarkdown ?? layoutInSharedPool)(markdown, ROW_LAYOUT_WIDTH)
       }
 
-      const bytes = await deps.getSnapshot(
-        deps.daemonFetch,
-        deps.daemonBaseUrl,
-        deps.workspaceId,
-        document.path,
-      )
+      const bytes = await deps.source.loadSpatialSnapshot(document)
       const doc = new LoroDoc()
       doc.import(bytes)
       return outlineFromSpatial(readSpatialCanvas(doc))

--- a/apps/web/src/components/workspace-files/load-row-render.test.ts
+++ b/apps/web/src/components/workspace-files/load-row-render.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
 import { createRowRenderLoader, type RowRenderDeps } from './load-row-render.js'
 
 const SVG = '<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>'
@@ -6,12 +7,8 @@ const BOUNDS = { x: 0, y: 0, w: 640, h: 200 }
 
 function deps(over: Partial<RowRenderDeps> = {}): RowRenderDeps {
   return {
-    daemonFetch: vi.fn() as unknown as typeof globalThis.fetch,
-    daemonBaseUrl: 'http://d',
-    workspaceId: 'default',
+    source: fakeFilesSource({ loadMarkdown: vi.fn(async () => '# Hi') }),
     theme: 'light',
-    getSnapshot: vi.fn(async () => new Uint8Array()),
-    getOkf: vi.fn(async () => ({ markdown: '# Hi' })),
     renderMarkdown: vi.fn(async () => ({ svg: SVG, bounds: BOUNDS })),
     renderSpatial: vi.fn(async () => ({ svg: SVG, bounds: BOUNDS })),
     readCanvas: vi.fn(() => ({ nodes: [], edges: [] })),
@@ -32,14 +29,14 @@ describe('createRowRenderLoader', () => {
       svg: SVG,
       bounds: BOUNDS,
     })
-    expect(d.getOkf).toHaveBeenCalledWith(d.daemonFetch, 'http://d', 'default', 'd1')
+    expect(d.source.loadMarkdown).toHaveBeenCalledWith(
+      expect.objectContaining({ documentId: 'd1' }),
+    )
     expect(d.renderMarkdown).toHaveBeenCalledWith('# Hi', expect.any(Number))
-    expect(d.getSnapshot).not.toHaveBeenCalled()
+    expect(d.source.loadSpatialSnapshot).not.toHaveBeenCalled()
   })
 
-  // Spatial reads by PATH and markdown by id — two different routes, and
-  // sending either one the other's key is a 404 that reads as "no picture".
-  it('renders a spatial document from its snapshot, by path', async () => {
+  it('renders a spatial document from its snapshot', async () => {
     const d = deps()
     const load = createRowRenderLoader(d)
 
@@ -47,9 +44,13 @@ describe('createRowRenderLoader', () => {
       svg: SVG,
       bounds: BOUNDS,
     })
-    expect(d.getSnapshot).toHaveBeenCalledWith(d.daemonFetch, 'http://d', 'default', 'deep/one')
+    // The whole entry, so the source addresses it its own way — the daemon
+    // by path, the local store by id.
+    expect(d.source.loadSpatialSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({ path: 'deep/one' }),
+    )
     expect(d.renderSpatial).toHaveBeenCalledWith({ nodes: [], edges: [] }, 'light')
-    expect(d.getOkf).not.toHaveBeenCalled()
+    expect(d.source.loadMarkdown).not.toHaveBeenCalled()
   })
 
   it('carries the theme, so a dark row is not drawn in light ink', async () => {
@@ -61,7 +62,7 @@ describe('createRowRenderLoader', () => {
   // An empty body lays out to nothing; asking the pool for it spends a slot
   // to produce a blank picture.
   it('answers null for an empty body without touching the pool', async () => {
-    const d = deps({ getOkf: vi.fn(async () => ({ markdown: '   \n  ' })) })
+    const d = deps({ source: fakeFilesSource({ loadMarkdown: async () => '   \n  ' }) })
     expect(
       await createRowRenderLoader(d)({ documentId: 'd1', path: 'a', kind: 'markdown' }),
     ).toBeNull()
@@ -72,8 +73,10 @@ describe('createRowRenderLoader', () => {
   // list of forty rows must not be brought down by one unreadable document.
   it('answers null when the read throws', async () => {
     const d = deps({
-      getOkf: vi.fn(async () => {
-        throw new Error('403')
+      source: fakeFilesSource({
+        loadMarkdown: async () => {
+          throw new Error('403')
+        },
       }),
     })
     expect(

--- a/apps/web/src/components/workspace-files/load-row-render.ts
+++ b/apps/web/src/components/workspace-files/load-row-render.ts
@@ -26,6 +26,7 @@ import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
 import { nextLayoutRequestId, sharedLayoutWorkerPool } from '../../lib/layout-worker-pool.js'
 import type { LayoutResponse, MarkdownRenderResponse } from '../../lib/layout-worker-protocol.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
+import type { WorkspaceFilesSource } from './files-source.js'
 
 export interface DocumentRender {
   readonly svg: string
@@ -41,23 +42,9 @@ export interface DocumentRender {
 const ROW_LAYOUT_WIDTH = 640
 
 export interface RowRenderDeps {
-  readonly daemonFetch: typeof globalThis.fetch
-  readonly daemonBaseUrl: string
-  readonly workspaceId: string
+  readonly source: WorkspaceFilesSource
   /** Spatial rendering resolves its palette from this; markdown takes its ink from CSS. */
   readonly theme: ResolvedTheme
-  readonly getSnapshot: (
-    fetchFn: typeof globalThis.fetch,
-    baseUrl: string,
-    workspaceId: string,
-    path: string,
-  ) => Promise<Uint8Array>
-  readonly getOkf: (
-    fetchFn: typeof globalThis.fetch,
-    baseUrl: string,
-    workspaceId: string,
-    documentId: string,
-  ) => Promise<{ markdown: string }>
   /**
    * The two renders and the snapshot decode are injected like the reads
    * above, so the branch that actually produces a picture is assertable
@@ -103,22 +90,12 @@ export function createRowRenderLoader(deps: RowRenderDeps) {
   return async (document: WorkspaceDocumentEntry): Promise<DocumentRender | null> => {
     try {
       if (document.kind === 'markdown') {
-        const { markdown } = await deps.getOkf(
-          deps.daemonFetch,
-          deps.daemonBaseUrl,
-          deps.workspaceId,
-          document.documentId,
-        )
+        const markdown = await deps.source.loadMarkdown(document)
         if (markdown.trim() === '') return null
         return await (deps.renderMarkdown ?? renderMarkdownInPool)(markdown, ROW_LAYOUT_WIDTH)
       }
 
-      const bytes = await deps.getSnapshot(
-        deps.daemonFetch,
-        deps.daemonBaseUrl,
-        deps.workspaceId,
-        document.path,
-      )
+      const bytes = await deps.source.loadSpatialSnapshot(document)
       const canvas = (deps.readCanvas ?? decodeCanvas)(bytes)
       return await (deps.renderSpatial ?? renderSpatialInPool)(canvas, deps.theme)
     } catch {

--- a/apps/web/src/components/workspace-files/row-render.browser.test.tsx
+++ b/apps/web/src/components/workspace-files/row-render.browser.test.tsx
@@ -30,13 +30,15 @@ function snapshotBytes(): Uint8Array {
 it('renders a spatial document from its snapshot bytes through the pool', async () => {
   const bytes = snapshotBytes()
   const load = createRowRenderLoader({
-    daemonFetch: globalThis.fetch,
-    daemonBaseUrl: 'http://unused',
-    workspaceId: 'default',
     theme: 'light',
-    getSnapshot: async () => bytes,
-    getOkf: async () => {
-      throw new Error('a spatial document must not be read as OKF')
+    source: {
+      listDocuments: async () => [],
+      createDocument: async () => {},
+      renameDocumentPath: async () => {},
+      loadSpatialSnapshot: async () => bytes,
+      loadMarkdown: async () => {
+        throw new Error('a spatial document must not be read as OKF')
+      },
     },
   })
 

--- a/apps/web/src/lib/daemon-files-source.ts
+++ b/apps/web/src/lib/daemon-files-source.ts
@@ -1,0 +1,68 @@
+import type { DocumentKind } from '@kamiazya/whiteboard-model'
+import type { WorkspaceDocumentEntry } from '../components/workspace-files/document-entry.js'
+import {
+  type WorkspaceFilesSource,
+  WorkspaceMissingError,
+} from '../components/workspace-files/files-source.js'
+import {
+  createDocument,
+  DaemonApiError,
+  getDocumentOkfV1,
+  getDocumentSnapshot,
+  listDocuments,
+  renameDocumentPath,
+} from './daemon-api-client.js'
+
+/**
+ * `WorkspaceFilesSource` over the daemon's HTTP API — the same five client
+ * calls `WorkspaceFilesPanel` used to make itself, moved behind the seam so
+ * the panel stops being daemon-only.
+ *
+ * The one piece of translation is the 404: the panel's not-found state is
+ * mode-independent, so the daemon's `DaemonApiError(404)` becomes the seam's
+ * `WorkspaceMissingError` here rather than leaking into the panel.
+ */
+export function createDaemonFilesSource(
+  daemonFetch: typeof globalThis.fetch,
+  daemonBaseUrl: string,
+  workspaceId: string,
+): WorkspaceFilesSource {
+  return {
+    async listDocuments(): Promise<readonly WorkspaceDocumentEntry[]> {
+      try {
+        const res = await listDocuments(daemonFetch, daemonBaseUrl, workspaceId)
+        return res.documents.map((entry) => ({
+          // An older daemon omits the id; the path stands in, as it does
+          // everywhere else that reads this list.
+          documentId: entry.id ?? entry.path,
+          path: entry.path,
+          ...(entry.displayName === undefined ? {} : { name: entry.displayName }),
+          ...(entry.kind === undefined ? {} : { kind: entry.kind }),
+          ...(entry.updatedAt === undefined ? {} : { updatedAt: entry.updatedAt }),
+        }))
+      } catch (err) {
+        if (err instanceof DaemonApiError && err.status === 404) {
+          throw new WorkspaceMissingError(workspaceId)
+        }
+        throw err
+      }
+    },
+
+    async createDocument(path: string, kind: DocumentKind): Promise<void> {
+      await createDocument(daemonFetch, daemonBaseUrl, workspaceId, path, kind)
+    },
+
+    async renameDocumentPath(path: string, newPath: string): Promise<void> {
+      await renameDocumentPath(daemonFetch, daemonBaseUrl, workspaceId, path, newPath)
+    },
+
+    async loadMarkdown(entry: WorkspaceDocumentEntry): Promise<string> {
+      return (await getDocumentOkfV1(daemonFetch, daemonBaseUrl, workspaceId, entry.documentId))
+        .markdown
+    },
+
+    loadSpatialSnapshot(entry: WorkspaceDocumentEntry): Promise<Uint8Array> {
+      return getDocumentSnapshot(daemonFetch, daemonBaseUrl, workspaceId, entry.path)
+    },
+  }
+}

--- a/apps/web/src/lib/local-files-source.test.ts
+++ b/apps/web/src/lib/local-files-source.test.ts
@@ -1,0 +1,104 @@
+/**
+ * The browser-local `WorkspaceFilesSource` — the adapter that lets the
+ * three-pane browser serve local mode, which is the whole point of the seam.
+ */
+import 'fake-indexeddb/auto'
+import { Loro } from 'loro-crdt'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { clearWhiteboardDb } from '../test-utils/browser-local-document.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { IdbDocumentIndex } from './idb-document-index.js'
+import { ensureLocalWorkspace } from './local-document-summary.js'
+import { createLocalFilesSource } from './local-files-source.js'
+import { LoroStore } from './loro-store.js'
+
+claimIsolatedWhiteboardDb('local-files-source')
+
+describe('createLocalFilesSource', () => {
+  beforeEach(clearWhiteboardDb)
+
+  it('lists a fresh database as empty, not as missing', async () => {
+    // Written as the missing-workspace case first, and the test refuted its
+    // own premise: the v8+ IndexedDB upgrade seeds the `local` workspace row
+    // unconditionally, so a fresh database HAS the workspace before anything
+    // else touches it. The `WorkspaceMissingError` mapping in the source
+    // stays — it guards a state a hand-edited store can still reach — but the
+    // reachable first-run behaviour is an empty list.
+    await expect(createLocalFilesSource().listDocuments()).resolves.toEqual([])
+  })
+
+  it('lists what the index holds', async () => {
+    const index = new IdbDocumentIndex()
+    await ensureLocalWorkspace(index)
+    await index.createDocument({ workspaceId: 'local', path: 'a', kind: 'spatial', name: 'A' })
+
+    const entries = await createLocalFilesSource().listDocuments()
+    expect(entries.map((e) => ({ path: e.path, name: e.name, kind: e.kind }))).toEqual([
+      { path: 'a', name: 'A', kind: 'spatial' },
+    ])
+  })
+
+  it('creates a document with seeded content, like every other local create', async () => {
+    const source = createLocalFilesSource()
+    const index = new IdbDocumentIndex()
+    await ensureLocalWorkspace(index)
+
+    await source.createDocument('notes/plan', 'markdown')
+
+    const entries = await source.listDocuments()
+    expect(entries.map((e) => e.path)).toEqual(['notes/plan'])
+    // Content record seeded: a document created without one has no
+    // last-edited time and nothing to open.
+    const loaded = await new LoroStore().load(entries[0]?.documentId ?? '')
+    expect(loaded.kind).toBe('ok')
+  })
+
+  it('renames through the index, so the subtree moves with it', async () => {
+    const source = createLocalFilesSource()
+    const index = new IdbDocumentIndex()
+    await ensureLocalWorkspace(index)
+    await index.createDocument({ workspaceId: 'local', path: 'plan', kind: 'markdown' })
+    await index.createDocument({ workspaceId: 'local', path: 'plan/sub', kind: 'markdown' })
+
+    await source.renameDocumentPath('plan', 'roadmap')
+
+    const paths = (await source.listDocuments()).map((e) => e.path).sort()
+    expect(paths).toEqual(['roadmap', 'roadmap/sub'])
+  })
+
+  it('reads a markdown document body back', async () => {
+    const source = createLocalFilesSource()
+    const index = new IdbDocumentIndex()
+    await ensureLocalWorkspace(index)
+    const entry = await index.createDocument({ workspaceId: 'local', path: 'n', kind: 'markdown' })
+    const doc = new Loro()
+    doc.getText('body').insert(0, '# Hello from local')
+    await new LoroStore().save(entry.documentId, doc.export({ mode: 'snapshot' }))
+
+    const markdown = await source.loadMarkdown({ ...entry, kind: 'markdown' })
+    expect(markdown).toContain('Hello from local')
+  })
+
+  it('answers the CURRENT spatial bytes, deltas folded in', async () => {
+    const source = createLocalFilesSource()
+    const index = new IdbDocumentIndex()
+    await ensureLocalWorkspace(index)
+    const entry = await index.createDocument({ workspaceId: 'local', path: 's', kind: 'spatial' })
+    const doc = new Loro()
+    doc.getList('elements').push({ id: 'a' })
+    doc.commit()
+    const store = new LoroStore()
+    await store.save(entry.documentId, doc.export({ mode: 'snapshot' }))
+    const before = doc.version()
+    doc.getList('elements').push({ id: 'b' })
+    doc.commit()
+    await store.appendDelta(entry.documentId, doc.export({ mode: 'update', from: before }))
+
+    const bytes = await source.loadSpatialSnapshot({ ...entry, kind: 'spatial' })
+    const fresh = new Loro()
+    fresh.import(bytes)
+    // Both elements: a thumbnail of the last snapshot alone would show a
+    // document the user is not looking at.
+    expect(fresh.getList('elements').toJSON()).toHaveLength(2)
+  })
+})

--- a/apps/web/src/lib/local-files-source.ts
+++ b/apps/web/src/lib/local-files-source.ts
@@ -1,0 +1,106 @@
+import { readMarkdownBody } from '@kamiazya/whiteboard-loro-adapter'
+import type { DocumentKind } from '@kamiazya/whiteboard-model'
+import { WorkspaceNotFoundError } from '@kamiazya/whiteboard-ports'
+import { Loro } from 'loro-crdt'
+import type { WorkspaceDocumentEntry } from '../components/workspace-files/document-entry.js'
+import {
+  type WorkspaceFilesSource,
+  WorkspaceMissingError,
+} from '../components/workspace-files/files-source.js'
+import { IdbDocumentIndex } from './idb-document-index.js'
+import {
+  ensureLocalWorkspace,
+  idbContentClock,
+  LOCAL_WORKSPACE_ID,
+} from './local-document-summary.js'
+import { LoroStore } from './loro-store.js'
+
+/**
+ * `WorkspaceFilesSource` over the browser-local stores — the adapter that
+ * lets the three-pane document browser serve local mode, which is what the
+ * seam exists for.
+ *
+ * Reads go through the same `DocumentIndex`/`LoroStore` pair the editor
+ * uses, so the browser and the editor cannot disagree about what exists or
+ * what it currently says.
+ */
+export function createLocalFilesSource(): WorkspaceFilesSource {
+  const index = new IdbDocumentIndex()
+  const loro = new LoroStore()
+  const clock = idbContentClock()
+
+  async function loadCurrentDoc(entry: WorkspaceDocumentEntry): Promise<Loro> {
+    const loaded = await loro.load(entry.documentId)
+    if (loaded.kind !== 'ok') {
+      throw new Error(`document ${entry.documentId} is not readable: ${loaded.kind}`)
+    }
+    const doc = new Loro()
+    doc.import(loaded.snapshot)
+    // The log too: a thumbnail of the last snapshot alone is a picture of a
+    // document the user is not looking at.
+    for (const delta of loaded.deltas ?? []) doc.import(delta)
+    return doc
+  }
+
+  return {
+    async listDocuments(): Promise<readonly WorkspaceDocumentEntry[]> {
+      let entries: Awaited<ReturnType<IdbDocumentIndex['listDocuments']>>
+      try {
+        entries = await index.listDocuments({ workspaceId: LOCAL_WORKSPACE_ID })
+      } catch (err) {
+        // The panel's not-found state is mode-independent: this is the local
+        // spelling of the daemon's 404.
+        if (err instanceof WorkspaceNotFoundError) {
+          throw new WorkspaceMissingError(LOCAL_WORKSPACE_ID)
+        }
+        throw err
+      }
+      if (entries.length === 0) return []
+      const stamps = await clock(entries.map((entry) => entry.documentId))
+      return entries.map((entry) => ({
+        documentId: entry.documentId,
+        path: entry.path,
+        ...(entry.name === undefined ? {} : { name: entry.name }),
+        ...(entry.kind === undefined ? {} : { kind: entry.kind }),
+        ...(stamps.has(entry.documentId)
+          ? { updatedAt: stamps.get(entry.documentId) as string }
+          : {}),
+      }))
+    },
+
+    async createDocument(path: string, kind: DocumentKind): Promise<void> {
+      await ensureLocalWorkspace(index)
+      const entry = await index.createDocument({ workspaceId: LOCAL_WORKSPACE_ID, path, kind })
+      // Seeded like every other local create: a document with no content
+      // record has no last-edited time and nothing to open. Rolled back if
+      // the seed fails, so a failed create never leaves a row with nothing
+      // behind it.
+      try {
+        await loro.save(entry.documentId, loro.createEmptySnapshot())
+      } catch (err) {
+        try {
+          await index.deleteDocument({ workspaceId: LOCAL_WORKSPACE_ID, path: entry.path })
+        } catch {
+          // Best-effort: a stray index row is harmless next to reporting a
+          // create that did not happen.
+        }
+        throw err
+      }
+    },
+
+    async renameDocumentPath(path: string, newPath: string): Promise<void> {
+      await index.moveDocument({ workspaceId: LOCAL_WORKSPACE_ID, from: path, to: newPath })
+    },
+
+    async loadMarkdown(entry: WorkspaceDocumentEntry): Promise<string> {
+      // The BODY, not an OKF serialization: the reads behind this method feed
+      // the thumbnail and preview renderers, which draw markdown — a
+      // frontmatter block would be drawn as text on every card.
+      return readMarkdownBody(await loadCurrentDoc(entry))
+    },
+
+    async loadSpatialSnapshot(entry: WorkspaceDocumentEntry): Promise<Uint8Array> {
+      return (await loadCurrentDoc(entry)).export({ mode: 'snapshot' })
+    },
+  }
+}

--- a/apps/web/src/pages/BrowserLocalIndexPage.tree-view.test.tsx
+++ b/apps/web/src/pages/BrowserLocalIndexPage.tree-view.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * The three-pane document browser, in LOCAL mode.
+ *
+ * One browser for both modes: the daemon page has had the tree view since
+ * #902; this pins that the local page offers the same one, backed by the
+ * local source, with the same grid/tree toggle.
+ */
+import 'fake-indexeddb/auto'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { IdbDocumentIndex } from '../lib/idb-document-index.js'
+import { ensureLocalWorkspace } from '../lib/local-document-summary.js'
+import { clearWhiteboardDb } from '../test-utils/browser-local-document.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { seedIdbDocument } from '../test-utils/seed-idb-document.js'
+import { BrowserLocalIndexPage } from './BrowserLocalIndexPage.js'
+
+claimIsolatedWhiteboardDb('browserlocalindexpage-tree-view')
+
+function renderPage() {
+  const onOpenDocument = vi.fn()
+  render(
+    <MemoryRouter initialEntries={['/']}>
+      <BrowserLocalIndexPage index={new IdbDocumentIndex()} onOpenDocument={onOpenDocument} />
+    </MemoryRouter>,
+    { container: document.body },
+  )
+  return onOpenDocument
+}
+
+describe('browser-local tree view', () => {
+  beforeEach(async () => {
+    await clearWhiteboardDb()
+  })
+  afterEach(cleanup)
+
+  it('offers the grid/tree toggle and shows the three-pane browser', async () => {
+    const index = new IdbDocumentIndex()
+    await ensureLocalWorkspace(index)
+    await seedIdbDocument(index, { path: 'roadmap', name: 'Roadmap', kind: 'markdown' })
+
+    renderPage()
+
+    // The same toggle the daemon page carries — one browser, both modes.
+    const treeButton = await screen.findByRole('button', { name: 'Tree view' })
+    fireEvent.click(treeButton)
+
+    // The panel's search box is the tree view's distinctive chrome.
+    await screen.findByLabelText('Search documents')
+    // And the seeded document is reachable in it.
+    await waitFor(() => {
+      expect(screen.getAllByText('Roadmap').length).toBeGreaterThan(0)
+    })
+  })
+
+  it('opens a document from the tree view through the same navigation', async () => {
+    const index = new IdbDocumentIndex()
+    await ensureLocalWorkspace(index)
+    await seedIdbDocument(index, { path: 'roadmap', name: 'Roadmap', kind: 'markdown' })
+
+    const onOpenDocument = renderPage()
+    fireEvent.click(await screen.findByRole('button', { name: 'Tree view' }))
+    fireEvent.click((await screen.findAllByText('Roadmap'))[0] as HTMLElement)
+
+    // Selecting shows the preview; its open affordance drives navigation.
+    // Several affordances say "open"; the preview pane's is the one under
+    // test, and its label names the document.
+    const opens = await screen.findAllByRole('button', { name: /open/i })
+    fireEvent.click(opens[opens.length - 1] as HTMLElement)
+    await waitFor(() => {
+      expect(onOpenDocument).toHaveBeenCalledWith('roadmap')
+    })
+  })
+})

--- a/apps/web/src/pages/BrowserLocalIndexPage.tsx
+++ b/apps/web/src/pages/BrowserLocalIndexPage.tsx
@@ -1,8 +1,10 @@
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import type { DocumentIndex } from '@kamiazya/whiteboard-ports'
+import { LayoutGrid, ListTree } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { DeleteDocumentDialog } from '../components/document-list/DeleteDocumentDialog.js'
 import { DocumentListView } from '../components/document-list/DocumentListView.js'
+import { WorkspaceFilesPanel } from '../components/workspace-files/WorkspaceFilesPanel.js'
 import {
   type ContentClock,
   type DefaultDocumentPointer,
@@ -12,6 +14,7 @@ import {
   LOCAL_WORKSPACE_ID,
   listLocalDocuments,
 } from '../lib/local-document-summary.js'
+import { createLocalFilesSource } from '../lib/local-files-source.js'
 import { LoroStore } from '../lib/loro-store.js'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
 import {
@@ -56,6 +59,14 @@ export function BrowserLocalIndexPage({
   // and a handler-side `if (creating) return` reads a stale closure in
   // exactly the same-tick case it would have to catch.
   const [creating, setCreating] = useState(false)
+  // The same two projections the daemon page offers, so the browser is one
+  // surface across both modes rather than a grid here and a tree there.
+  const [view, setView] = useState<'grid' | 'tree'>('grid')
+  const filesSource = useMemo(() => createLocalFilesSource(), [])
+  // Deletions happen in this page's dialog, behind the panel's back — the
+  // panel re-reads whenever this identity changes, exactly as on the daemon
+  // page.
+  const [filesRevision, setFilesRevision] = useState(0)
 
   useEffect(() => {
     let cancelled = false
@@ -123,6 +134,9 @@ export function BrowserLocalIndexPage({
         await pointer.clear()
       }
       setSnapshots(await listLocalDocuments(index, clock))
+      // The tree view holds its own copy of the list; this identity change is
+      // its signal to re-read, same contract as the daemon page's `revision`.
+      setFilesRevision((revision) => revision + 1)
       setPendingDelete(null)
     } catch {
       setDeleteError('Failed to delete the canvas from this browser.')
@@ -162,12 +176,41 @@ export function BrowserLocalIndexPage({
   return (
     <div className="flex h-full flex-col overflow-y-auto p-4">
       <h1 className="sr-only">Canvases</h1>
+      <div className="mb-2 flex items-center">
+        <div className="ml-auto flex items-center gap-0.5 rounded-md border p-0.5">
+          <button
+            type="button"
+            aria-label="Grid view"
+            aria-pressed={view === 'grid'}
+            onClick={() => setView('grid')}
+            className="rounded p-1.5 text-muted-foreground aria-pressed:bg-accent aria-pressed:text-foreground"
+          >
+            <LayoutGrid className="size-4" />
+          </button>
+          <button
+            type="button"
+            aria-label="Tree view"
+            aria-pressed={view === 'tree'}
+            onClick={() => setView('tree')}
+            className="rounded p-1.5 text-muted-foreground aria-pressed:bg-accent aria-pressed:text-foreground"
+          >
+            <ListTree className="size-4" />
+          </button>
+        </div>
+      </div>
       {error && (
         <div role="alert" className="mb-2 text-sm text-destructive">
           {error}
         </div>
       )}
-      {snapshots === null && !error ? (
+      {view === 'tree' ? (
+        <WorkspaceFilesPanel
+          source={filesSource}
+          onOpenDocument={onOpenDocument}
+          onRequestDelete={(path, displayName) => setPendingDelete({ path, displayName })}
+          revision={filesRevision}
+        />
+      ) : snapshots === null && !error ? (
         <div
           role="status"
           aria-label="Loading documents"

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -18,6 +18,7 @@ import {
   setDocumentDisplayName,
   updateDocument,
 } from '../lib/daemon-api-client.js'
+import { createDaemonFilesSource } from '../lib/daemon-files-source.js'
 import { deriveCopyName } from '../lib/derive-copy-name.js'
 import { deriveCopyPath } from '../lib/derive-copy-path.js'
 import { deriveNewDocumentPath } from '../lib/derive-new-document-path.js'
@@ -96,6 +97,16 @@ export function DaemonIndexPage({
   const [view, setView] = useState<ViewKey>('grid')
   const [workspaces, setWorkspaces] = useState<string[]>([])
   const [selectedWorkspace, setSelectedWorkspace] = useState<string | null>(null)
+  // One source per (fetch, base, workspace): the panel re-reads whenever the
+  // source identity changes, so this memo is also what scopes it to the
+  // selected workspace.
+  const filesSource = useMemo(
+    () =>
+      selectedWorkspace
+        ? createDaemonFilesSource(daemonFetch, daemonBaseUrl, selectedWorkspace)
+        : null,
+    [daemonFetch, daemonBaseUrl, selectedWorkspace],
+  )
   const [rows, setRows] = useState<DocumentRow[]>([])
   // False from the moment a workspace switch clears rows until its documents
   // fetch settles — rows=[] alone cannot distinguish "still loading" from
@@ -378,15 +389,13 @@ export function DaemonIndexPage({
         )}
 
         {view === 'tree' ? (
-          selectedWorkspace ? (
+          selectedWorkspace && filesSource ? (
             // The wrapper remounts on every grid/tree toggle, so the fade
             // re-runs and the view switch reads as one continuous surface
             // changing shape rather than an instant swap.
             <div className="animate-in fade-in-0 duration-(--motion-duration-normal) ease-(--motion-ease-out)">
               <WorkspaceFilesPanel
-                daemonFetch={daemonFetch}
-                daemonBaseUrl={daemonBaseUrl}
-                workspaceId={selectedWorkspace}
+                source={filesSource}
                 onOpenDocument={(path) => onOpenDocument(selectedWorkspace, path)}
                 onDuplicateDocument={(path) => void handleDuplicate(path)}
                 onRequestDelete={(path, displayName) => setPendingDelete({ path, displayName })}

--- a/apps/web/src/test-utils/fake-files-source.ts
+++ b/apps/web/src/test-utils/fake-files-source.ts
@@ -1,0 +1,27 @@
+import { vi } from 'vitest'
+import type { WorkspaceDocumentEntry } from '../components/workspace-files/document-entry.js'
+import type { WorkspaceFilesSource } from '../components/workspace-files/files-source.js'
+
+/** Every method a `vi.fn`, so call assertions need no casts. */
+export interface FakeFilesSource extends WorkspaceFilesSource {
+  listDocuments: ReturnType<typeof vi.fn<() => Promise<readonly WorkspaceDocumentEntry[]>>>
+  createDocument: ReturnType<typeof vi.fn<WorkspaceFilesSource['createDocument']>>
+  renameDocumentPath: ReturnType<typeof vi.fn<WorkspaceFilesSource['renameDocumentPath']>>
+  loadMarkdown: ReturnType<typeof vi.fn<WorkspaceFilesSource['loadMarkdown']>>
+  loadSpatialSnapshot: ReturnType<typeof vi.fn<WorkspaceFilesSource['loadSpatialSnapshot']>>
+}
+
+/**
+ * A `WorkspaceFilesSource` whose every method is a spy, prefilled with the
+ * quietest possible answers. Override per test with plain async functions —
+ * they are wrapped in `vi.fn` here so call assertions work either way.
+ */
+export function fakeFilesSource(overrides: Partial<WorkspaceFilesSource> = {}): FakeFilesSource {
+  return {
+    listDocuments: vi.fn(overrides.listDocuments ?? (async () => [])),
+    createDocument: vi.fn(overrides.createDocument ?? (async () => {})),
+    renameDocumentPath: vi.fn(overrides.renameDocumentPath ?? (async () => {})),
+    loadMarkdown: vi.fn(overrides.loadMarkdown ?? (async () => '')),
+    loadSpatialSnapshot: vi.fn(overrides.loadSpatialSnapshot ?? (async () => new Uint8Array())),
+  } as FakeFilesSource
+}


### PR DESCRIPTION
The three-pane document browser (tree / folder contents / preview) was **daemon-only** because `WorkspaceFilesPanel` called the daemon's client functions directly — the single obstacle the one-browser-both-modes ticket named, cleared by the ports work. This PR puts the seam in and wires both sides, and upgrades the search results per the design review.

## The seam: `WorkspaceFilesSource`

Five operations, measured from the panel's imports rather than assumed: list, create, rename, and the two content reads its thumbnails and preview need. Duplicate and delete stay with the page, which owns the confirmation dialog.

| adapter | backing |
|---|---|
| `createDaemonFilesSource` | the same client calls the panel used to make; its 404 becomes the seam's `WorkspaceMissingError` |
| `createLocalFilesSource` | the same `DocumentIndex`/`LoroStore` pair the editor uses — browser and editor cannot disagree about what exists |

The content reads take the whole **entry**, not a field chosen by the loader: the daemon addresses a snapshot by path and OKF by id, the local store keys everything by id. Choosing the field in the loader is exactly the decision that made it daemon-only.

## Local mode gets the tree

`BrowserLocalIndexPage` gains the same grid/tree toggle the daemon page has had since #902. Phase 2 (retiring the grid + migrating its 38 tests) stays its own increment, per the standing ticket — it needs no further design input now that search has one.

## Search results: highlight + list/grid, per the ten-app survey

Design reviewed against Finder, Explorer, VS Code, Obsidian, Notion, Drive, Dropbox, Figma, Linear and Slack (full survey in the session):

- **Match highlighting** — near-universal in mature search UIs. First case-insensitive match marked in the title *and* the path; first only, because four highlights in one title read as damage.
- **The path stays on every row in BOTH layouts.** The two surveyed apps that flatten hierarchy without per-row location context — Finder and Figma — both carry standing user complaints about it. The grid does not get to reintroduce that gap.
- **List first**, grid as the toggle: the row form carries the path inline, the grid trades density for a bigger picture, Finder-icon-view style.
- Cross-workspace scope unchanged and deliberate (`search-documents.ts` documents why). Body search and a scope toggle are filed separately — full-text needs an **index**, not a UI.

## A test premise refuted while writing it

The local source's missing-workspace case cannot be reached on a fresh database: the v8+ upgrade seeds the `local` workspace row unconditionally. The test pins the reachable behaviour instead (fresh database lists empty), and the `WorkspaceMissingError` mapping stays as a guard for hand-edited stores.

## Verification

| suite | result |
|---|---|
| `apps/web` jsdom + node | 2640 + 77 |
| `web-browser` | 736 passed (1 isolated-green typing flake from the documented family, zero reachability to this diff) |
| workspace-files component suites | 104 |
| `typecheck` / `knip` | clean |

Daemon-mode behaviour is preserving-by-construction (the adapter wraps the same calls) and held by `DaemonIndexPage.test.tsx`'s 38 tests. Local-mode manual verification on the Pages preview is below — daemon mode is origin-locked off previews.

## Visual repro (local mode, Pages preview)

Verified live on the branch preview (fresh origin, service worker uncontrolled). The whole loop was driven through the new seam: create → move to `plans/roadmap` → edit in the real editor → browse → search → delete-with-refresh.

**The three-pane browser now serves local mode** — tree, folder contents with real markdown thumbnails, preview rendering the document body, and Move/Open/Delete:

![local-three-pane.jpg](https://github.com/user-attachments/assets/6cb56b66-6525-4640-8582-ddeac3f55a06)

**Search replaces the pane with a flat cross-folder list and marks the match** — `marketing-plan` matches in the title, `plans/roadmap` only in the path, and both say so:

![search-list-highlight.jpg](https://github.com/user-attachments/assets/f00d4dfa-275f-4837-a5e3-bce764b2ecf7)

**The grid layout trades density for the picture and keeps the path on the card** (the Finder/Figma gap stays closed):

![search-grid.jpg](https://github.com/user-attachments/assets/879ddf17-cb77-4a6d-aeeb-54fbf7619c08)

Also exercised, not pictured: rename to a nested path grows the tree a `plans` folder; deleting a document from a search result closes the dialog and drops the row without a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoaNgqWUKbYJxk2azmRQKY
