### PR TITLE
feat(web)!: edge display settings live in the visual.edges facet

### DIFF
--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -6,14 +6,14 @@ Package boundaries are cut by **runtime requirements**, not by feature. The shar
 |---|---|---|
 | `packages/model` | Zod schemas for the whiteboard document model (single source of truth) | zod only |
 | `packages/codec` | OKF Markdown / JSON Canvas serialize+parse, remark pipeline | model, remark |
-| `packages/canvas-render` | scene graph, layout, SVG backend, sceneDigest | model, codec, zod, css-line-break, lowlight |
+| `packages/canvas-render` | scene graph, layout, SVG backend, sceneDigest | model, codec, facet-engine, zod, css-line-break, lowlight |
 | `packages/ports` | store/sync port contracts + Symbol `TOKENS` | model, zod |
 | `packages/facet-engine` | the facet engine (ADR-0013): definePlugin/defineFacet, registry, write validation, compat resolution, bundled `visual` plugin | model, zod |
 | `packages/loro-adapter` | LoroDoc<->model bridge | model, ports, loro-crdt |
 | `packages/server-core` | `/api/v1` Hono routes + MCP tool definitions, exposed as `createServer(deps)` | crdt, render, facet-engine, hono, zod, loro-crdt |
 | `packages/canvas-viewer` | Read-only spatial-canvas scene viewer UI (renders canvas-render SVG), shared between `apps/web` and the MCP Apps widget | model, codec, render, `@modelcontextprotocol/ext-apps`, react, zod |
 | `packages/mcp-server` | Node composition root: CLI, stdio, local store impls, resvg, Inversify container | server-core + port impls |
-| `apps/web` | Browser composition root: Canvas API backend, IndexedDB store impls, read-write spatial canvas editor, markdown editor | loro-adapter, model, codec, render, canvas-viewer, ports, `@kamiazya/whiteboard-mcp`'s browser-safe client subpaths (`/api-client`, `/api-contracts`, `/browser-contract`) + port impls |
+| `apps/web` | Browser composition root: Canvas API backend, IndexedDB store impls, read-write spatial canvas editor, markdown editor | loro-adapter, model, codec, render, canvas-viewer, ports, facet-engine, `@kamiazya/whiteboard-mcp`'s browser-safe client subpaths (`/api-client`, `/api-contracts`, `/browser-contract`) + port impls |
 
 **A third-party dependency is judged by that criterion, not by a quota.** The
 `allowedThirdParty` lists in `architecture-map.ts` are a RECORD of what has

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "license": "Apache-2.0",
-  "description": "Hosted browser app for whiteboard — Cloudflare Pages deploy target",
+  "description": "Hosted browser app for whiteboard \u2014 Cloudflare Pages deploy target",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -29,6 +29,7 @@
     "@kamiazya/whiteboard-canvas-render": "workspace:*",
     "@kamiazya/whiteboard-canvas-viewer": "workspace:*",
     "@kamiazya/whiteboard-codec": "workspace:*",
+    "@kamiazya/whiteboard-facet-engine": "workspace:*",
     "@kamiazya/whiteboard-loro-adapter": "workspace:*",
     "@kamiazya/whiteboard-mcp": "workspace:*",
     "@kamiazya/whiteboard-model": "workspace:*",

--- a/apps/web/src/components/spatial-editor/CanvasDisplaySettings.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasDisplaySettings.tsx
@@ -9,6 +9,7 @@
  * Radix owns dismissal (outside click, Escape) and returns focus to the
  * gear, so a keyboard user never falls to <body>.
  */
+import { resolveCanvasEdgeStyle } from '@kamiazya/whiteboard-facet-engine'
 import type { EdgeRoutingStyle, SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { SlidersHorizontal } from 'lucide-react'
 import { useEffect, useRef } from 'react'
@@ -47,8 +48,12 @@ export function CanvasDisplaySettings({ canvas, onChange }: CanvasDisplaySetting
     onChange(running, command)
   }
 
-  const currentRouting = canvas['x-whiteboard']?.edgeRouting?.style ?? 'straight'
-  const currentJumps = canvas['x-whiteboard']?.edgeRouting?.lineJumps ?? 'none'
+  // Facet-first (visual.edges/v0), legacy edgeRouting fallback — the same
+  // resolution the renderer defaults to, so the checked segment always
+  // matches what the canvas draws.
+  const current = resolveCanvasEdgeStyle(canvas)
+  const currentRouting = current.style ?? 'straight'
+  const currentJumps = current.lineJumps ?? 'none'
 
   return (
     <Popover>

--- a/apps/web/src/components/spatial-editor/canvas-settings.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/canvas-settings.browser.test.tsx
@@ -2,11 +2,15 @@
 // pick applies the canvas-wide command immediately and keeps it open for
 // the next tweak, consecutive picks chain under a deferred parent, and
 // dismissal returns focus to the gear.
+import type { VisualEdgesFacet } from '@kamiazya/whiteboard-facet-engine'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { CanvasDisplaySettings } from './CanvasDisplaySettings.js'
+
+const edgesFacetOf = (canvas: SpatialCanvas) =>
+  canvas['x-whiteboard']?.facets?.['visual.edges/v0'] as VisualEdgesFacet | undefined
 
 afterEach(cleanup)
 
@@ -56,14 +60,14 @@ it('a pick applies canvas-wide and keeps the popover open; current values are ma
   fireEvent.click(option('Curved') as HTMLElement)
 
   await vi.waitFor(() => {
-    expect(latest.canvas['x-whiteboard']?.edgeRouting?.style).toBe('curved')
+    expect(edgesFacetOf(latest.canvas)?.routing).toBe('curved')
   })
   expect(menu()).toBeTruthy()
   expect(option('Curved')?.getAttribute('aria-pressed')).toBe('true')
 
   fireEvent.click(option('On') as HTMLElement)
   await vi.waitFor(() => {
-    expect(latest.canvas['x-whiteboard']?.edgeRouting?.lineJumps).toBe('arc')
+    expect(edgesFacetOf(latest.canvas)?.lineJumps).toBe('arc')
   })
 })
 
@@ -91,8 +95,8 @@ it('consecutive picks both survive a deferred parent', async () => {
   fireEvent.click(option('On') as HTMLElement)
 
   await vi.waitFor(() => {
-    expect(latest.canvas['x-whiteboard']?.edgeRouting).toEqual({
-      style: 'orthogonal',
+    expect(edgesFacetOf(latest.canvas)).toEqual({
+      routing: 'orthogonal',
       lineJumps: 'arc',
     })
   })

--- a/apps/web/src/components/spatial-editor/commands.test.ts
+++ b/apps/web/src/components/spatial-editor/commands.test.ts
@@ -641,14 +641,17 @@ describe('create-edge', () => {
 })
 
 // The routing style belongs to the canvas, so the command that sets it names
-// no node. It is the first command that edits the canvas ENVELOPE rather than
-// its contents.
+// no node. Stored as the visual.edges/v0 facet (ADR-0013); writing it also
+// removes the legacy edgeRouting preference — the write is where the
+// migration persists.
 describe('set-edge-routing', () => {
   const empty: SpatialCanvas = { nodes: [], edges: [] }
+  const edgesFacet = (canvas: SpatialCanvas) => canvas['x-whiteboard']?.facets?.['visual.edges/v0']
 
-  it('records the style on the canvas', () => {
+  it('records the style as the visual.edges facet', () => {
     const next = applyCommand(empty, { kind: 'set-edge-routing', style: 'orthogonal' })
-    expect(next['x-whiteboard']?.edgeRouting?.style).toBe('orthogonal')
+    expect(edgesFacet(next)).toEqual({ routing: 'orthogonal' })
+    expect(next['x-whiteboard']).not.toHaveProperty('edgeRouting')
   })
 
   it('leaves nodes and edges untouched', () => {
@@ -671,18 +674,32 @@ describe('set-edge-routing', () => {
     expect(reverted).not.toHaveProperty('x-whiteboard')
   })
 
-  it('keeps any other canvas-level extension it does not own', () => {
+  // The write is where the legacy preference migrates: the resolved current
+  // value seeds the merge, the facet takes over, and the legacy key goes.
+  it('migrates a legacy edgeRouting canvas on first write, keeping the other field', () => {
+    const legacy: SpatialCanvas = {
+      ...empty,
+      'x-whiteboard': { edgeRouting: { style: 'curved', lineJumps: 'arc' } },
+    }
+    const next = applyCommand(legacy, { kind: 'set-edge-routing', style: 'orthogonal' })
+
+    expect(edgesFacet(next)).toEqual({ routing: 'orthogonal', lineJumps: 'arc' })
+    expect(next['x-whiteboard']).not.toHaveProperty('edgeRouting')
+  })
+
+  it('keeps facets it does not own', () => {
     const withOther: SpatialCanvas = {
       ...empty,
-      'x-whiteboard': { edgeRouting: { style: 'curved' } },
+      'x-whiteboard': { facets: { 'someone.else/v1': { keep: true } } },
     }
     const next = applyCommand(withOther, { kind: 'set-edge-routing', style: 'orthogonal' })
 
-    expect(next['x-whiteboard']?.edgeRouting?.style).toBe('orthogonal')
+    expect(next['x-whiteboard']?.facets?.['someone.else/v1']).toEqual({ keep: true })
+    expect(edgesFacet(next)).toEqual({ routing: 'orthogonal' })
   })
 
-  // Style and jumps live in the same edgeRouting object but are independent
-  // settings — reverting one must never erase the other.
+  // Routing and jumps are fields of one facet but independent settings —
+  // reverting one must never erase the other.
   it('reverting the style to straight keeps the line-jumps setting', () => {
     const withJumps = applyCommand(
       applyCommand(empty, { kind: 'set-edge-routing', style: 'orthogonal' }),
@@ -690,25 +707,26 @@ describe('set-edge-routing', () => {
     )
     const reverted = applyCommand(withJumps, { kind: 'set-edge-routing', style: 'straight' })
 
-    expect(reverted['x-whiteboard']?.edgeRouting).toEqual({ lineJumps: 'arc' })
+    expect(edgesFacet(reverted)).toEqual({ lineJumps: 'arc' })
   })
 })
 
 describe('set-line-jumps', () => {
   const empty: SpatialCanvas = { nodes: [], edges: [] }
+  const edgesFacet = (canvas: SpatialCanvas) => canvas['x-whiteboard']?.facets?.['visual.edges/v0']
 
-  it('records arc on the canvas and keeps the routing style', () => {
+  it('records arc on the facet and keeps the routing style', () => {
     const styled = applyCommand(empty, { kind: 'set-edge-routing', style: 'curved' })
     const jumped = applyCommand(styled, { kind: 'set-line-jumps', lineJumps: 'arc' })
 
-    expect(jumped['x-whiteboard']?.edgeRouting).toEqual({ style: 'curved', lineJumps: 'arc' })
+    expect(edgesFacet(jumped)).toEqual({ routing: 'curved', lineJumps: 'arc' })
   })
 
   // Same no-trace rule as the routing style: default settings serialize as
   // if never touched.
   it('turning jumps off leaves no trace', () => {
     const jumped = applyCommand(empty, { kind: 'set-line-jumps', lineJumps: 'arc' })
-    expect(jumped['x-whiteboard']?.edgeRouting).toEqual({ lineJumps: 'arc' })
+    expect(edgesFacet(jumped)).toEqual({ lineJumps: 'arc' })
 
     const off = applyCommand(jumped, { kind: 'set-line-jumps', lineJumps: 'none' })
     expect(off).not.toHaveProperty('x-whiteboard')
@@ -720,7 +738,8 @@ describe('set-line-jumps', () => {
       lineJumps: 'arc',
     })
     const off = applyCommand(both, { kind: 'set-line-jumps', lineJumps: 'none' })
-    expect(off['x-whiteboard']?.edgeRouting).toEqual({ style: 'curved' })
+
+    expect(edgesFacet(off)).toEqual({ routing: 'curved' })
   })
 })
 

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -18,6 +18,7 @@
  * `toNode` referenced the removed node, so no command sequence can ever
  * produce a canvas with a dangling edge endpoint.
  */
+import { resolveCanvasEdgeStyle, VISUAL_EDGES_KEY } from '@kamiazya/whiteboard-facet-engine'
 import type {
   CanvasColor,
   CanvasEdge,
@@ -308,37 +309,56 @@ function setEdgeEnds(
  * opened the menu on would carry a redundant extension forever.
  */
 /**
- * Rebuilds the canvas envelope from the CANONICAL form of its edgeRouting:
- * default values (style straight, jumps none) are omitted, an empty
- * edgeRouting is dropped, and an empty x-whiteboard disappears — so a
- * canvas that chose a setting and reverted serializes identically to one
- * that never touched it. Style and jumps are independent fields of the
- * same object; writing one must never erase the other.
+ * Rebuilds the canvas envelope from the CANONICAL form of the visual.edges
+ * facet: default values (routing straight, jumps none) are omitted, an
+ * empty payload drops the facet key, an empty facets bucket disappears,
+ * and an empty x-whiteboard disappears — so a canvas that chose a setting
+ * and reverted serializes identically to one that never touched it.
+ * Routing and jumps are independent fields of the same facet; writing one
+ * must never erase the other.
  */
-function withEdgeRouting(
+function withEdgeStyle(
   canvas: SpatialCanvas,
-  patch: { style?: EdgeRoutingStyle; lineJumps?: LineJumps },
+  patch: { routing?: EdgeRoutingStyle; lineJumps?: LineJumps },
 ): SpatialCanvas {
   const { 'x-whiteboard': extension, ...rest } = canvas
-  const merged = { ...extension?.edgeRouting, ...patch }
+  // Seed the merge from the RESOLVED current value (facet first, legacy
+  // fallback), so the first write on a legacy canvas carries its setting
+  // into the facet — the write is where the migration persists.
+  const current = resolveCanvasEdgeStyle(canvas)
+  const merged = {
+    routing: patch.routing ?? current.style,
+    lineJumps: patch.lineJumps ?? current.lineJumps,
+  }
   const canonical = {
-    ...(merged.style !== undefined && merged.style !== 'straight' ? { style: merged.style } : {}),
+    ...(merged.routing !== undefined && merged.routing !== 'straight'
+      ? { routing: merged.routing }
+      : {}),
     ...(merged.lineJumps !== undefined && merged.lineJumps !== 'none'
       ? { lineJumps: merged.lineJumps }
       : {}),
   }
-  const { edgeRouting: _removed, ...others } = extension ?? {}
-  const nextExtension =
-    Object.keys(canonical).length === 0 ? others : { ...others, edgeRouting: canonical }
+  // The legacy edgeRouting key is absorbed above and removed here — one
+  // facet, one version, no second place for the same answer to live.
+  const { edgeRouting: _legacy, facets, ...others } = extension ?? {}
+  const { [VISUAL_EDGES_KEY]: _previous, ...otherFacets } = facets ?? {}
+  const nextFacets =
+    Object.keys(canonical).length === 0
+      ? otherFacets
+      : { ...otherFacets, [VISUAL_EDGES_KEY]: canonical }
+  const nextExtension = {
+    ...others,
+    ...(Object.keys(nextFacets).length === 0 ? {} : { facets: nextFacets }),
+  }
   return Object.keys(nextExtension).length === 0 ? rest : { ...rest, 'x-whiteboard': nextExtension }
 }
 
 function setEdgeRouting(canvas: SpatialCanvas, style: EdgeRoutingStyle): SpatialCanvas {
-  return withEdgeRouting(canvas, { style })
+  return withEdgeStyle(canvas, { routing: style })
 }
 
 function setLineJumps(canvas: SpatialCanvas, lineJumps: LineJumps): SpatialCanvas {
-  return withEdgeRouting(canvas, { lineJumps })
+  return withEdgeStyle(canvas, { lineJumps })
 }
 
 function setNodeColor(

--- a/apps/web/src/components/spatial-editor/drag-preview.ts
+++ b/apps/web/src/components/spatial-editor/drag-preview.ts
@@ -22,6 +22,7 @@ import {
   flattenDrawnEdgePath,
   routeEdge,
 } from '@kamiazya/whiteboard-canvas-render'
+import { resolveCanvasEdgeStyle } from '@kamiazya/whiteboard-facet-engine'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import type { Box, NodeBox } from './geometry.js'
 import { hitTest, resizeBoxByDelta } from './geometry.js'
@@ -151,18 +152,14 @@ export function computeDragPreview(
         fromNode: gestureState.fromNodeId,
         toNode: targetId,
       }
+      const routingStyle = resolveCanvasEdgeStyle(canvas).style
       const anchors = assignEdgeAnchors(
         nodes,
         [...canvas.edges, tentative],
-        canvas['x-whiteboard']?.edgeRouting?.style,
+        routingStyle,
         connect.frozenEdgeSides,
       )
-      const routed = routeEdge(
-        nodes,
-        tentative,
-        canvas['x-whiteboard']?.edgeRouting?.style,
-        anchors.get(tentative.id),
-      )
+      const routed = routeEdge(nodes, tentative, routingStyle, anchors.get(tentative.id))
       // The preview shows the DRAWN line the drop will produce: rounded
       // corners flattened and the committed arrowheads, from the same
       // producers the editor's committed render uses.

--- a/apps/web/src/components/spatial-editor/edge-routing-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-routing-menu.browser.test.tsx
@@ -5,12 +5,16 @@
 // host composes the popover and the editor over one canvas state, exactly
 // as the page does; the popover's own wiring is pinned in
 // canvas-settings.browser.test.tsx.
+import type { VisualEdgesFacet } from '@kamiazya/whiteboard-facet-engine'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { CanvasDisplaySettings } from './CanvasDisplaySettings.js'
 import { SpatialEditor } from './SpatialEditor.js'
+
+const edgesFacetOf = (canvas: SpatialCanvas) =>
+  canvas['x-whiteboard']?.facets?.['visual.edges/v0'] as VisualEdgesFacet | undefined
 
 afterEach(cleanup)
 
@@ -83,7 +87,7 @@ it('records the choice on the canvas and bends the edge', async () => {
   optionButton(container, 'Orthogonal')?.click()
 
   await vi.waitFor(() => {
-    expect(latest.canvas['x-whiteboard']?.edgeRouting?.style).toBe('orthogonal')
+    expect(edgesFacetOf(latest.canvas)?.routing).toBe('orthogonal')
   })
   // The scene follows: a bent edge has more than the two endpoint points.
   await vi.waitFor(() => {
@@ -101,9 +105,7 @@ it('drops the setting again when the style returns to straight', async () => {
   openSettings(container)
   await vi.waitFor(() => expect(optionButton(container, 'Orthogonal')).toBeDefined())
   optionButton(container, 'Orthogonal')?.click()
-  await vi.waitFor(() =>
-    expect(latest.canvas['x-whiteboard']?.edgeRouting?.style).toBe('orthogonal'),
-  )
+  await vi.waitFor(() => expect(edgesFacetOf(latest.canvas)?.routing).toBe('orthogonal'))
 
   // The popover stays open after a pick — flip straight from the same surface.
   await vi.waitFor(() => expect(optionButton(container, 'Straight')).toBeDefined())
@@ -126,7 +128,7 @@ it('draws a curve when the canvas asks for one', async () => {
   optionButton(container, 'Curved')?.click()
 
   await vi.waitFor(() => {
-    expect(latest.canvas['x-whiteboard']?.edgeRouting?.style).toBe('curved')
+    expect(edgesFacetOf(latest.canvas)?.routing).toBe('curved')
   })
   await vi.waitFor(() => {
     const path = container.querySelector('[data-testid="viewport-transform"] path')
@@ -173,7 +175,7 @@ it('toggles line jumps from the canvas menu and draws the hop arc', async () => 
   optionButton(container, 'On')?.click()
 
   await vi.waitFor(() => {
-    expect(latest.canvas['x-whiteboard']?.edgeRouting?.lineJumps).toBe('arc')
+    expect(edgesFacetOf(latest.canvas)?.lineJumps).toBe('arc')
   })
   // The crossing edge is now a path with a hop arc.
   await vi.waitFor(() => {
@@ -220,8 +222,8 @@ it('consecutive style + jumps picks both survive a deferred parent', async () =>
   optionButton(container, 'On')?.click()
 
   await vi.waitFor(() => {
-    expect(latest.canvas['x-whiteboard']?.edgeRouting).toEqual({
-      style: 'orthogonal',
+    expect(edgesFacetOf(latest.canvas)).toEqual({
+      routing: 'orthogonal',
       lineJumps: 'arc',
     })
   })

--- a/packages/canvas-render/package.json
+++ b/packages/canvas-render/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "license": "Apache-2.0",
-  "description": "Spatial-canvas scene graph, pure layout, SVG backend, and sceneDigest — shared-layer, runs unchanged on Node/browser/Workers.",
+  "description": "Spatial-canvas scene graph, pure layout, SVG backend, and sceneDigest \u2014 shared-layer, runs unchanged on Node/browser/Workers.",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@kamiazya/whiteboard-codec": "workspace:*",
+    "@kamiazya/whiteboard-facet-engine": "workspace:*",
     "@kamiazya/whiteboard-model": "workspace:*",
     "css-line-break": "catalog:",
     "highlight.js": "catalog:",

--- a/packages/canvas-render/src/layout/spatial-canvas.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.test.ts
@@ -168,6 +168,50 @@ describe('layoutSpatialCanvas', () => {
     expect(label?.appearance?.fill).toBe('#303030')
   })
 
+  it('routes by the visual.edges facet when the canvas carries one', () => {
+    // The facet is the successor of the legacy edgeRouting preference
+    // (ADR-0013); resolution is canvas-render's own default so every
+    // surface — editor, export, viewer, widget — reads the same answer.
+    const a = textNode({ id: 'a', x: 0, y: 0, width: 50, height: 50, text: 'a' })
+    const b = textNode({ id: 'b', x: 300, y: 200, width: 50, height: 50, text: 'b' })
+    const edge = { id: 'e1', fromNode: 'a', toNode: 'b' }
+    const scene = layoutSpatialCanvas(
+      {
+        ...canvas([a, b], [edge]),
+        'x-whiteboard': { facets: { 'visual.edges/v0': { routing: 'orthogonal' } } },
+      },
+      baseOptions(),
+    )
+    const routed = scene.nodes.find(
+      (n): n is import('../scene-graph.js').ResolvedEdgeNode => n.kind === 'edge',
+    )
+    expect(routed).toBeDefined()
+    // Diagonal neighbours under orthogonal routing draw an L, never a
+    // straight two-point segment.
+    expect(routed?.path.length).toBeGreaterThan(2)
+  })
+
+  it('the facet takes whole-value precedence over the legacy edgeRouting preference', () => {
+    const a = textNode({ id: 'a', x: 0, y: 0, width: 50, height: 50, text: 'a' })
+    const b = textNode({ id: 'b', x: 300, y: 200, width: 50, height: 50, text: 'b' })
+    const edge = { id: 'e1', fromNode: 'a', toNode: 'b' }
+    const scene = layoutSpatialCanvas(
+      {
+        ...canvas([a, b], [edge]),
+        'x-whiteboard': {
+          edgeRouting: { style: 'orthogonal' },
+          facets: { 'visual.edges/v0': { routing: 'straight' } },
+        },
+      },
+      baseOptions(),
+    )
+    const routed = scene.nodes.find(
+      (n): n is import('../scene-graph.js').ResolvedEdgeNode => n.kind === 'edge',
+    )
+    expect(routed).toBeDefined()
+    expect(routed?.path.length).toBe(2)
+  })
+
   it('centers a multi-segment edge label at the arc-length midpoint, not a corner vertex', () => {
     // Diagonal neighbours route as an L with unequal legs; the label must
     // sit halfway along the DRAWN line (the same anchor the editor's

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -24,8 +24,15 @@
 // reproducibility does not need a sort to hold: document order is already
 // a total function of a deterministic canvas, so the same canvas renders
 // the same SVG twice regardless.
+
 import { parseMarkdownBody } from '@kamiazya/whiteboard-codec'
-import type { CanvasEdge, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
+import { resolveCanvasEdgeStyle } from '@kamiazya/whiteboard-facet-engine'
+import type {
+  CanvasEdge,
+  EdgeRoutingStyle,
+  SpatialCanvas,
+  SpatialNode,
+} from '@kamiazya/whiteboard-model'
 import type { MdastFlowContent, MdastRoot } from '@kamiazya/whiteboard-model/mdast'
 import { highlightCode } from '../highlight/lowlight.js'
 import type { MeasureText } from '../measure.js'
@@ -912,6 +919,7 @@ function composeEdge(
   canvas: SpatialCanvas,
   edge: CanvasEdge,
   options: ResolvedLayoutOptions,
+  routingStyle: EdgeRoutingStyle | undefined,
   anchors: EdgeAnchorPair | undefined,
 ): ResolvedEdgeNode {
   // `routeEdge` already degrades a missing endpoint per canvas-render's own
@@ -921,7 +929,7 @@ function composeEdge(
   // so honouring it costs no new plumbing through the consumers: editor,
   // export and viewer all pass the canvas and get the same routes from it.
   const routed = pullEdgeOntoOutlines(
-    routeEdge(canvas.nodes, edge, canvas['x-whiteboard']?.edgeRouting?.style, anchors),
+    routeEdge(canvas.nodes, edge, routingStyle, anchors),
     canvas,
     edge,
     options.nodeOutlines,
@@ -1117,18 +1125,23 @@ function composeEdgesAndLabels(
 ): { content: SceneNode[]; anchors: ReadonlyMap<string, EdgeAnchorPair> } {
   // One anchor pass for the whole edge set: fan-out needs to see every end
   // sharing a side, which a per-edge route cannot.
+  // Facet-aware by DEFAULT (visual.edges/v0 first, legacy edgeRouting
+  // fallback): resolution lives here rather than at the call sites for the
+  // same reason the tokeniser default does — every surface that lays a
+  // canvas out wants it, and the one that forgets draws different routes.
+  const edgeStyle = resolveCanvasEdgeStyle(canvas)
   const anchors = assignEdgeAnchors(
     canvas.nodes,
     canvas.edges,
-    canvas['x-whiteboard']?.edgeRouting?.style,
+    edgeStyle.style,
     resolved.edgeSideOverrides,
   )
   const routedEdges = canvas.edges.map((edge) =>
-    composeEdge(canvas, edge, resolved, anchors.get(edge.id)),
+    composeEdge(canvas, edge, resolved, edgeStyle.style, anchors.get(edge.id)),
   )
   // Canvas-wide today; the same resolution is where a per-edge
   // x-whiteboard override slots in later without touching the pipeline.
-  const lineJumps = canvas['x-whiteboard']?.edgeRouting?.lineJumps ?? 'none'
+  const lineJumps = edgeStyle.lineJumps ?? 'none'
   const jumpsByEdge = lineJumps === 'arc' ? computeEdgeJumps(routedEdges) : undefined
   const edgeContent =
     jumpsByEdge === undefined

--- a/packages/facet-engine/src/visual.ts
+++ b/packages/facet-engine/src/visual.ts
@@ -61,7 +61,7 @@ export type EdgeRouting = z.infer<typeof edgeRoutingSchema>
  */
 export function resolveCanvasEdgeStyle(
   canvas: SpatialCanvas,
-  registry: FacetRegistry,
+  registry: FacetRegistry = bundledFacetRegistry,
 ): EdgeRouting {
   const extension = canvas['x-whiteboard']
   const stored = extension?.facets?.[VISUAL_EDGES_KEY]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       '@kamiazya/whiteboard-codec':
         specifier: workspace:*
         version: link:../../packages/codec
+      '@kamiazya/whiteboard-facet-engine':
+        specifier: workspace:*
+        version: link:../../packages/facet-engine
       '@kamiazya/whiteboard-loro-adapter':
         specifier: workspace:*
         version: link:../../packages/loro-adapter
@@ -315,6 +318,9 @@ importers:
       '@kamiazya/whiteboard-codec':
         specifier: workspace:*
         version: link:../codec
+      '@kamiazya/whiteboard-facet-engine':
+        specifier: workspace:*
+        version: link:../facet-engine
       '@kamiazya/whiteboard-model':
         specifier: workspace:*
         version: link:../model

--- a/tools/arch-lint/src/architecture-map.ts
+++ b/tools/arch-lint/src/architecture-map.ts
@@ -45,7 +45,15 @@ export const ARCHITECTURE_MAP: Readonly<Record<string, PackageArchEntry>> = {
     // codec: the mdast body parser this package DEFAULTS to. Every consumer
     // already bundles codec to pass it in, so the dependency adds nothing to
     // any bundle and removes the same line from seven call sites.
-    allowedInternalDeps: ['@kamiazya/whiteboard-model', '@kamiazya/whiteboard-codec'],
+    // facet-engine: resolveCanvasEdgeStyle is the DEFAULT read for edge
+    // style (facet first, legacy x-whiteboard.edgeRouting fallback) — the
+    // lowlight lesson again: an opt-in resolution step at four call sites
+    // is a step that gets missed, so the shared renderer owns the default.
+    allowedInternalDeps: [
+      '@kamiazya/whiteboard-model',
+      '@kamiazya/whiteboard-codec',
+      '@kamiazya/whiteboard-facet-engine',
+    ],
     // css-line-break: deciding WHERE a line may break is this package's own
     // job, and the answer is a Unicode standard (UAX #14 + CSS `line-break`,
     // which is where Japanese kinsoku lives), not something to hand-roll from
@@ -142,6 +150,7 @@ export const ARCHITECTURE_MAP: Readonly<Record<string, PackageArchEntry>> = {
       '@kamiazya/whiteboard-canvas-viewer',
       '@kamiazya/whiteboard-mcp',
       '@kamiazya/whiteboard-ports',
+      '@kamiazya/whiteboard-facet-engine',
     ],
     allowedThirdParty: [],
   },


### PR DESCRIPTION
## Summary

Increment 3 of ADR-0013 — the wiring that makes the facet engine user-reachable (closes the foundation gap #967 shipped):

- **canvas-render** resolves edge routing style + line jumps through `resolveCanvasEdgeStyle` **by default** (`visual.edges/v0` first, legacy `x-whiteboard.edgeRouting` fallback) — editor, export, `wb_scene_render`, widget and viewer all read the same answer (the lowlight lesson: an opt-in step at four call sites gets missed). Resolved once per layout, threaded into `composeEdge`.
- **apps/web** `set-edge-routing`/`set-line-jumps` write the `visual.edges/v0` facet and **remove the legacy key — the write is where the migration persists** (ADR-0013 decision 7). The merge seeds from the resolved current value, so a legacy canvas's first write carries its setting into the facet, keeping the untouched field. No-trace canonicalization and routing/jumps independence unchanged, re-pinned against the new shape; facets the command does not own survive.
- CanvasDisplaySettings + connect drag preview read through the same resolver, so checked segments and preview always match the drawn canvas.

## Verification

- Full suite **895 files / 9008 passed** (edge-routing quality scoreboard unmoved — legacy canvases resolve identically via fallback)
- Browser regressions re-pin the pick→store→bend round-trip against the facet shape in a real browser (canvas-settings, edge-routing-menu: 10 tests)
- `pnpm --filter @kamiazya/whiteboard-web test` (CI-equivalent): 2702 passed
- arch-lint green with canvas-render/apps-web → facet-engine deps registered; `pnpm -r typecheck` / lint / knip clean

Manual verification on the Cloudflare preview follows before merge (UI change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013avJozs9SoCuDzZJGuTcqH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Canvas edge routing and line-jump settings now use the latest visual edge configuration.
  - Existing legacy settings continue to work through automatic fallback and migration.
  - Rendering and drag previews now consistently honor configured edge styles.
  - Visual edge settings take precedence over older configuration when both are present.

- **Bug Fixes**
  - Preserved unrelated visual settings while updating routing options.
  - Improved handling of default routing and line-jump values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Visual repro

Same canvas rendered through the real pipeline (`composeCanvasScene` → `renderSceneToSvg` → resvg), before = no facet (legacy default, straight), after = `visual.edges/v0: { routing: "orthogonal" }`:

| before (straight) | after (visual.edges orthogonal) |
|---|---|
| ![before-legacy-straight.png](https://github.com/user-attachments/assets/8763b091-8bd1-45df-8867-a02ef53c9972) | ![after-visual-edges-orthogonal.png](https://github.com/user-attachments/assets/d4e76d4a-69a6-47eb-ac17-8d5e1eca4bde) |

## Manual verification (Cloudflare preview, real Chrome)

On `https://facet-edges-rewire.kamiazya-whiteboard.pages.dev` (browser-local mode): created two notes + an edge (polyline **2 points** = straight default) → opened the display-settings gear (resolver correctly showed Straight/Off) → picked **Orthogonal**: applied immediately, popover stayed open, edge re-routed to an L (**4 points**: `820,313 840,313 1150,313 1150,433`) → full page reload: edge still 4 points — the facet persisted to IndexedDB and the renderer re-resolved it on load.
