### PR TITLE
feat(web): [[ inline completion in the markdown editor

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "license": "Apache-2.0",
-  "description": "Hosted browser app for whiteboard \u2014 Cloudflare Pages deploy target",
+  "description": "Hosted browser app for whiteboard — Cloudflare Pages deploy target",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -21,6 +21,7 @@
     "smoke:pwa-precache": "node scripts/check-pwa-precache.mjs"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^6.20.3",
     "@codemirror/commands": "^6.10.4",
     "@codemirror/lang-markdown": "^6.5.1",
     "@codemirror/language": "^6.11.4",

--- a/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
@@ -1,3 +1,4 @@
+import { autocompletion } from '@codemirror/autocomplete'
 import type { Extension } from '@codemirror/state'
 import type { MdastLayoutOptions, MeasureText } from '@kamiazya/whiteboard-canvas-render'
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
@@ -39,6 +40,7 @@ import { SourcePane, type SourcePaneApi } from './SourcePane.js'
 import { setHeadingLevel } from './set-heading-level.js'
 import { toggleTaskCheckbox } from './toggle-task-checkbox.js'
 import { useDebouncedValue } from './use-debounced-value.js'
+import { wikiLinkCompletionSource } from './wiki-link-completion.js'
 
 export interface MarkdownEditorProps {
   value: string
@@ -262,6 +264,18 @@ export function MarkdownEditor({
   sourceExtensions,
 }: MarkdownEditorProps) {
   const resolvedMeasure = useMemo(() => measure ?? createBrowserMeasureText(), [measure])
+  // [[ completion reads targets through a ref: the source is installed once
+  // at view creation, while the document list keeps refreshing under it.
+  const linkTargetsRef = useRef<readonly LinkTarget[]>(linkTargets ?? [])
+  linkTargetsRef.current = linkTargets ?? []
+  const completionExtension = useMemo(
+    () => autocompletion({ override: [wikiLinkCompletionSource(() => linkTargetsRef.current)] }),
+    [],
+  )
+  const paneExtensions = useMemo(
+    () => [completionExtension, ...(sourceExtensions ?? [])],
+    [completionExtension, sourceExtensions],
+  )
   const debouncedValue = useDebouncedValue(value, previewDebounceMs)
   // Watches the DEBOUNCED value: fragment sources only exist once the
   // preview would draw them, and rendering per raw keystroke would race
@@ -677,7 +691,7 @@ export function MarkdownEditor({
             apiRef={sourceApiRef}
             placeholderText="Write in Markdown…"
             className="markdown-editor-source"
-            extensions={sourceExtensions}
+            extensions={paneExtensions}
             // A CRDT binding owns editor<->document sync; the controlled
             // reconcile path would race it (see SourcePane).
             reconcileExternalValue={sourceExtensions === undefined}

--- a/apps/web/src/components/markdown-editor/wiki-link-completion.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/wiki-link-completion.browser.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { MarkdownEditor } from './MarkdownEditor.js'
+
+// Real-keyboard regression for the [[ completion: CodeMirror's completion
+// popup opens from real input events, and accepting with Enter routes
+// through its keymap — neither is representable in jsdom.
+
+afterEach(() => {
+  cleanup()
+  window.localStorage.removeItem('whiteboard.markdown-view-mode')
+})
+
+const TARGETS = [
+  { id: '01ARZ3NDEKTSV4RRFFQ69G5FAV', name: 'Release plan' },
+  { id: '01BX5ZZKBKACTAV9WEVGEMMVRZ', name: 'Retro notes' },
+]
+
+describe('wiki link completion (real browser)', () => {
+  it('typing [[Re offers documents and Enter inserts the readable link', async () => {
+    let value = ''
+    const onChange = (next: string) => {
+      value = next
+    }
+    const { getByTestId } = render(
+      <MarkdownEditor initialViewMode="write" value="" onChange={onChange} linkTargets={TARGETS} />,
+    )
+    const editable = getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]')
+    if (!editable) throw new Error('expected a contenteditable CodeMirror host')
+    ;(editable as HTMLElement).focus()
+    await vi.waitFor(() => {
+      expect(document.activeElement).toBe(editable)
+    })
+
+    // user-event treats [[ as an escaped literal [ — four brackets type two.
+    await userEvent.keyboard('see [[[[Re')
+    // The completion tooltip lists both matches, best first.
+    await vi.waitFor(() => {
+      const options = document.querySelectorAll('.cm-tooltip-autocomplete li')
+      expect(options.length).toBeGreaterThanOrEqual(1)
+      expect(options[0]?.textContent).toContain('Release plan')
+    })
+
+    await userEvent.keyboard('{Enter}')
+    await vi.waitFor(() => {
+      expect(value).toBe('see [[Release plan]]')
+    })
+    // Accepting closed the popup rather than leaving it over the text.
+    expect(document.querySelector('.cm-tooltip-autocomplete')).toBeNull()
+  })
+
+  it('plain prose never opens the popup', async () => {
+    const { getByTestId } = render(
+      <MarkdownEditor initialViewMode="write" value="" onChange={() => {}} linkTargets={TARGETS} />,
+    )
+    const editable = getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]')
+    if (!editable) throw new Error('expected a contenteditable CodeMirror host')
+    ;(editable as HTMLElement).focus()
+    await vi.waitFor(() => {
+      expect(document.activeElement).toBe(editable)
+    })
+    await userEvent.keyboard('Release plan is due')
+    // Give any (wrong) async popup a beat to appear before asserting absence.
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    expect(document.querySelector('.cm-tooltip-autocomplete')).toBeNull()
+  })
+})

--- a/apps/web/src/components/markdown-editor/wiki-link-completion.test.ts
+++ b/apps/web/src/components/markdown-editor/wiki-link-completion.test.ts
@@ -1,0 +1,88 @@
+import { CompletionContext } from '@codemirror/autocomplete'
+import { EditorState } from '@codemirror/state'
+import { scanReferences } from '@kamiazya/whiteboard-codec'
+import { describe, expect, it } from 'vitest'
+import type { LinkTarget } from './link-target.js'
+import { wikiLinkCompletionSource } from './wiki-link-completion.js'
+
+const ID_A = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+const ID_B = '01BX5ZZKBKACTAV9WEVGEMMVRZ'
+const ID_C = '01CX5ZZKBKACTAV9WEVGEMMVRA'
+const TARGETS: readonly LinkTarget[] = [
+  { id: ID_A, name: 'Release plan' },
+  { id: ID_B, name: 'Retro 8月' },
+  { id: ID_C, name: 'Dup' },
+  { id: '01DX5ZZKBKACTAV9WEVGEMMVRB', name: 'Dup' },
+]
+
+function complete(doc: string, pos: number, explicit = false) {
+  const state = EditorState.create({ doc })
+  const context = new CompletionContext(state, pos, explicit)
+  return wikiLinkCompletionSource(() => TARGETS)(context)
+}
+
+describe('wikiLinkCompletionSource', () => {
+  it('offers ranked candidates inside [[ and inserts the readable markup', () => {
+    const doc = '詳細は [[Re'
+    const result = complete(doc, doc.length)
+    expect(result).not.toBeNull()
+    // Replacement starts at the [[, so accepting rewrites the whole reference.
+    expect(result?.from).toBe(doc.length - '[[Re'.length)
+    const labels = result?.options.map((o) => o.label)
+    expect(labels?.[0]).toBe('Release plan')
+    expect(labels).toContain('Retro 8月')
+    // Load-bearing: the plugin's default filter re-matches labels against
+    // the text from `from`, which begins with the [[ no name contains —
+    // leaving this true silently discards every result in the real editor.
+    expect(result?.filter).toBe(false)
+
+    const state = EditorState.create({ doc })
+    const applied = applyOption(state, result!, 0)
+    expect(applied).toBe('詳細は [[Release plan]]')
+  })
+
+  it('keeps a preceding ! so an embed stays an embed', () => {
+    const doc = '![[Re'
+    const result = complete(doc, doc.length)
+    expect(result?.from).toBe(1) // after the !, at the [[
+    const applied = applyOption(EditorState.create({ doc }), result!, 0)
+    expect(applied).toBe('![[Release plan]]')
+  })
+
+  it('falls back to the id form for a duplicated name', () => {
+    const doc = '[[Du'
+    const result = complete(doc, doc.length)
+    const dup = result?.options.find((o) => o.label === 'Dup')
+    expect(dup).toBeDefined()
+    const applied = applyOption(EditorState.create({ doc }), result!, result!.options.indexOf(dup!))
+    expect(applied).toBe(`[[${ID_C}|Dup]]`)
+  })
+
+  it('stays silent outside a [[ context and across a line break', () => {
+    expect(complete('plain text', 10)).toBeNull()
+    const doc = '[[\nRe'
+    expect(complete(doc, doc.length)).toBeNull()
+  })
+
+  it('every accepted candidate parses back to exactly one reference to the picked target', () => {
+    for (let i = 0; i < TARGETS.length; i++) {
+      const result = complete('[[', 2)
+      expect(result).not.toBeNull()
+      const inserted = applyOption(EditorState.create({ doc: '[[' }), result!, i)
+      const refs = scanReferences(inserted)
+      expect(refs, inserted).toHaveLength(1)
+    }
+  })
+})
+
+/** Applies option `index` the way CodeMirror would: replace [from, pos) with its apply string. */
+function applyOption(
+  state: EditorState,
+  result: { from: number; options: readonly { apply?: unknown; label: string }[] },
+  index: number,
+): string {
+  const option = result.options[index]
+  if (option === undefined) throw new Error(`no option at ${index}`)
+  const insert = typeof option.apply === 'string' ? option.apply : option.label
+  return state.doc.sliceString(0, result.from) + insert
+}

--- a/apps/web/src/components/markdown-editor/wiki-link-completion.ts
+++ b/apps/web/src/components/markdown-editor/wiki-link-completion.ts
@@ -1,0 +1,43 @@
+import type { CompletionContext, CompletionResult } from '@codemirror/autocomplete'
+import { type LinkTarget, linkMarkupFor, rankLinkTargets } from './link-target.js'
+
+/**
+ * `[[` completion for document references. The list is the same ranking the
+ * Link verb's picker shows (`rankLinkTargets`), and accepting a candidate
+ * writes the same markup the picker would (`linkMarkupFor`) — readable
+ * `[[Name]]` when unique, `[[<id>|Name]]` otherwise — so the two entry
+ * points cannot teach different link spellings.
+ *
+ * Targets arrive through a getter rather than being captured: the document
+ * list refreshes while the editor lives, and a completion source is built
+ * once at view creation.
+ */
+export function wikiLinkCompletionSource(getTargets: () => readonly LinkTarget[]) {
+  return (context: CompletionContext): CompletionResult | null => {
+    // The open [[ with whatever partial query follows it. `matchBefore` only
+    // looks at the current line, so a reference cannot span a line break —
+    // the same rule the codec scanner enforces on read.
+    const match = context.matchBefore(/\[\[[^\][|]*$/)
+    if (match === null) return null
+    const targets = getTargets()
+    if (targets.length === 0) return null
+    const ranked = rankLinkTargets(targets, match.text.slice(2))
+    if (ranked.length === 0) return null
+    return {
+      from: match.from,
+      options: ranked.map((target) => ({
+        label: target.name,
+        type: 'text',
+        apply: linkMarkupFor(target, targets),
+      })),
+      // OUR ranking is the ranking (the picker's, so both entry points
+      // agree). filter:false is load-bearing, not an optimisation: the
+      // plugin's default filter re-matches label against the text from
+      // `from` — which starts at `[[`, a string no document name contains —
+      // so every option scores zero and the result is silently discarded.
+      // Without validFor the source re-runs per keystroke; targets are a
+      // workspace's document list, so that is cheap.
+      filter: false,
+    }
+  }
+}

--- a/docs/how-to/link-documents.md
+++ b/docs/how-to/link-documents.md
@@ -5,8 +5,10 @@ side. Works against a daemon-backed workspace.
 
 ## Write a link
 
-In a **markdown document**, use the editor toolbar's Link action (or type
-`[[` brackets yourself). A reference can name its target three ways:
+In a **markdown document**, type `[[` — a completion list of the
+workspace's documents opens as you type, ranked by match; Enter inserts the
+link. The toolbar's Link action offers the same list as a dialog (and also
+handles external URLs). A reference can name its target three ways:
 
 - `[[<document id>]]` — survives renames and moves; what the link picker
   inserts when names are ambiguous.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@codemirror/autocomplete':
+        specifier: ^6.20.3
+        version: 6.20.3
       '@codemirror/commands':
         specifier: ^6.10.4
         version: 6.10.4


### PR DESCRIPTION
## What

Connections UX P2 — the authoring half of the linking loop. Typing `[[` (or `![[`) in the markdown source pane opens a completion list of the workspace's documents; Enter inserts the link without leaving the keyboard.

- Ranking and markup are **shared with the Link picker** (`rankLinkTargets` / `linkMarkupFor`): readable `[[Name]]` when the name is unique, `[[<id>|Name]]` otherwise — the two entry points cannot teach different link spellings, and every inserted link is one P1's backlinks index resolves.
- `@codemirror/autocomplete` moves transitive (already shipped via `lang-markdown`) → direct. Zero new install weight.
- Targets reach the completion source through a ref, so the document list keeps refreshing under an editor that is created once.

## The bug the browser test exists for

The plugin's default filter re-matches option labels against the text from `result.from` — which starts at the `[[` no document name contains — so **every option scored zero and the result was silently discarded in the real editor while jsdom unit tests stayed green** (the popup never appeared; `completionStatus` went `pending → null`). `filter: false` is therefore load-bearing: the unit test pins the flag, the browser test pins the end-to-end flow (type `[[Re` → popup → Enter → `see [[Release plan]]`).

Found by isolating with a bare-CodeMirror probe after the wired editor showed the source returning options that never surfaced.

## Visual evidence

Real editor in vitest browser mode (real Chromium + app stylesheet), popup open after typing `[[R`:

![wiki-link-completion.png](https://github.com/user-attachments/assets/f62eea77-2760-45bf-a2b8-d6a1b4085d71)

## Verification

- apps/web jsdom 2647 + node 77, browser projects 760 — all green
- red-first at both layers; the filter regression was watched failing live before the fix

## Docs

`docs/how-to/link-documents.md` now leads with the typed-`[[` flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmbb1zNhiZitB7tn9LQ5f3