### PR TITLE
fix(web): [[ completion no longer races acceptCompletion's interaction guard

### DIFF
--- a/apps/web/src/components/markdown-editor/wiki-link-completion.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/wiki-link-completion.browser.test.tsx
@@ -36,12 +36,21 @@ describe('wiki link completion (real browser)', () => {
     // user-event treats [[ as an escaped literal [ — four brackets type two.
     await userEvent.keyboard('see [[[[Re')
     // The completion tooltip lists both matches, best first.
+    // Selection, not mere presence: the tooltip keeps rendering through a
+    // re-query, but only an ACTIVE result marks an option selected — and
+    // only then does Enter accept instead of inserting a newline. This is
+    // what the user sees before pressing Enter, so it is what the test
+    // waits for.
     await vi.waitFor(() => {
-      const options = document.querySelectorAll('.cm-tooltip-autocomplete li')
-      expect(options.length).toBeGreaterThanOrEqual(1)
-      expect(options[0]?.textContent).toContain('Release plan')
+      const selected = document.querySelector('.cm-tooltip-autocomplete li[aria-selected="true"]')
+      expect(selected?.textContent).toContain('Release plan')
     })
 
+    // acceptCompletion deliberately ignores an Enter within interactionDelay
+    // (75ms) of the result opening — an accident guard a human never races.
+    // The wait keeps this test on the human side of that guard; under load
+    // it only grows, so the guard can never re-flake this.
+    await new Promise((resolve) => setTimeout(resolve, 120))
     await userEvent.keyboard('{Enter}')
     await vi.waitFor(() => {
       expect(value).toBe('see [[Release plan]]')

--- a/apps/web/src/components/markdown-editor/wiki-link-completion.test.ts
+++ b/apps/web/src/components/markdown-editor/wiki-link-completion.test.ts
@@ -1,61 +1,73 @@
 import { CompletionContext } from '@codemirror/autocomplete'
 import { EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
 import { scanReferences } from '@kamiazya/whiteboard-codec'
 import { describe, expect, it } from 'vitest'
 import type { LinkTarget } from './link-target.js'
 import { wikiLinkCompletionSource } from './wiki-link-completion.js'
 
 const ID_A = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
-const ID_B = '01BX5ZZKBKACTAV9WEVGEMMVRZ'
 const ID_C = '01CX5ZZKBKACTAV9WEVGEMMVRA'
 const TARGETS: readonly LinkTarget[] = [
   { id: ID_A, name: 'Release plan' },
-  { id: ID_B, name: 'Retro 8月' },
+  { id: '01BX5ZZKBKACTAV9WEVGEMMVRZ', name: 'Retro 8月' },
   { id: ID_C, name: 'Dup' },
   { id: '01DX5ZZKBKACTAV9WEVGEMMVRB', name: 'Dup' },
 ]
 
-function complete(doc: string, pos: number, explicit = false) {
+function complete(doc: string, pos: number) {
   const state = EditorState.create({ doc })
-  const context = new CompletionContext(state, pos, explicit)
-  return wikiLinkCompletionSource(() => TARGETS)(context)
+  return wikiLinkCompletionSource(() => TARGETS)(new CompletionContext(state, pos, false))
+}
+
+/** Accepts option `index` the way the plugin would: run its apply function. */
+function accept(
+  doc: string,
+  result: NonNullable<ReturnType<ReturnType<typeof wikiLinkCompletionSource>>>,
+  index: number,
+): string {
+  const option = result.options[index]
+  if (option === undefined || typeof option.apply !== 'function')
+    throw new Error('expected an apply function')
+  const view = new EditorView({ state: EditorState.create({ doc }) })
+  option.apply(view, option, result.from, doc.length)
+  const text = view.state.doc.toString()
+  view.destroy()
+  return text
 }
 
 describe('wikiLinkCompletionSource', () => {
-  it('offers ranked candidates inside [[ and inserts the readable markup', () => {
+  it('offers ranked candidates AFTER the brackets so the default filter can match, and keeps the result while a plain query grows', () => {
     const doc = '詳細は [[Re'
     const result = complete(doc, doc.length)
     expect(result).not.toBeNull()
-    // Replacement starts at the [[, so accepting rewrites the whole reference.
-    expect(result?.from).toBe(doc.length - '[[Re'.length)
-    const labels = result?.options.map((o) => o.label)
-    expect(labels?.[0]).toBe('Release plan')
-    expect(labels).toContain('Retro 8月')
-    // Load-bearing: the plugin's default filter re-matches labels against
-    // the text from `from`, which begins with the [[ no name contains —
-    // leaving this true silently discards every result in the real editor.
-    expect(result?.filter).toBe(false)
+    // Load-bearing: `from` at the brackets makes the plugin's label filter
+    // score every option zero and silently discard the result; and without
+    // validFor every keystroke re-queries, opening the pending window where
+    // Enter inserts a newline instead of accepting.
+    expect(result?.from).toBe(doc.length - 'Re'.length)
+    expect(result?.validFor).toBeDefined()
+    expect(result?.options.map((o) => o.label)[0]).toBe('Release plan')
+  })
 
-    const state = EditorState.create({ doc })
-    const applied = applyOption(state, result!, 0)
-    expect(applied).toBe('詳細は [[Release plan]]')
+  it('accepting replaces the whole reference, brackets included', () => {
+    const doc = '詳細は [[Re'
+    const result = complete(doc, doc.length)
+    expect(accept(doc, result!, 0)).toBe('詳細は [[Release plan]]')
   })
 
   it('keeps a preceding ! so an embed stays an embed', () => {
     const doc = '![[Re'
     const result = complete(doc, doc.length)
-    expect(result?.from).toBe(1) // after the !, at the [[
-    const applied = applyOption(EditorState.create({ doc }), result!, 0)
-    expect(applied).toBe('![[Release plan]]')
+    expect(accept(doc, result!, 0)).toBe('![[Release plan]]')
   })
 
   it('falls back to the id form for a duplicated name', () => {
     const doc = '[[Du'
     const result = complete(doc, doc.length)
-    const dup = result?.options.find((o) => o.label === 'Dup')
-    expect(dup).toBeDefined()
-    const applied = applyOption(EditorState.create({ doc }), result!, result!.options.indexOf(dup!))
-    expect(applied).toBe(`[[${ID_C}|Dup]]`)
+    const index = result!.options.findIndex((o) => o.label === 'Dup')
+    expect(index).toBeGreaterThanOrEqual(0)
+    expect(accept(doc, result!, index)).toBe(`[[${ID_C}|Dup]]`)
   })
 
   it('stays silent outside a [[ context and across a line break', () => {
@@ -64,25 +76,11 @@ describe('wikiLinkCompletionSource', () => {
     expect(complete(doc, doc.length)).toBeNull()
   })
 
-  it('every accepted candidate parses back to exactly one reference to the picked target', () => {
+  it('every accepted candidate parses back to exactly one reference', () => {
     for (let i = 0; i < TARGETS.length; i++) {
       const result = complete('[[', 2)
-      expect(result).not.toBeNull()
-      const inserted = applyOption(EditorState.create({ doc: '[[' }), result!, i)
-      const refs = scanReferences(inserted)
-      expect(refs, inserted).toHaveLength(1)
+      const inserted = accept('[[', result!, i)
+      expect(scanReferences(inserted), inserted).toHaveLength(1)
     }
   })
 })
-
-/** Applies option `index` the way CodeMirror would: replace [from, pos) with its apply string. */
-function applyOption(
-  state: EditorState,
-  result: { from: number; options: readonly { apply?: unknown; label: string }[] },
-  index: number,
-): string {
-  const option = result.options[index]
-  if (option === undefined) throw new Error(`no option at ${index}`)
-  const insert = typeof option.apply === 'string' ? option.apply : option.label
-  return state.doc.sliceString(0, result.from) + insert
-}

--- a/apps/web/src/components/markdown-editor/wiki-link-completion.ts
+++ b/apps/web/src/components/markdown-editor/wiki-link-completion.ts
@@ -1,12 +1,25 @@
-import type { CompletionContext, CompletionResult } from '@codemirror/autocomplete'
+import type { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete'
+import type { EditorView } from '@codemirror/view'
 import { type LinkTarget, linkMarkupFor, rankLinkTargets } from './link-target.js'
 
 /**
- * `[[` completion for document references. The list is the same ranking the
- * Link verb's picker shows (`rankLinkTargets`), and accepting a candidate
- * writes the same markup the picker would (`linkMarkupFor`) — readable
- * `[[Name]]` when unique, `[[<id>|Name]]` otherwise — so the two entry
- * points cannot teach different link spellings.
+ * `[[` completion for document references. Accepting a candidate writes the
+ * same markup the Link picker would (`linkMarkupFor`) — readable `[[Name]]`
+ * when unique, `[[<id>|Name]]` otherwise — so the two entry points cannot
+ * teach different link spellings.
+ *
+ * `from` points AFTER the `[[`, at the query, and each option's `apply` is a
+ * function that replaces the brackets too. That split is load-bearing, twice
+ * over: the plugin's default filter matches labels against the text from
+ * `from` (a `from` at the brackets scored every option zero and silently
+ * discarded the result), and `validFor` keeps ONE result alive while the
+ * query grows. The earlier shape — `filter: false`, no `validFor` — re-ran
+ * the source on every keystroke, and each re-query re-stamped the open
+ * result, so acceptCompletion's interactionDelay guard (Enter within 75ms
+ * of the result opening is treated as an accident and falls through to a
+ * newline) could reject a fast Enter indefinitely. With validFor the stamp
+ * is set once when `[[` opens the list and fast typing cannot push it
+ * forward.
  *
  * Targets arrive through a getter rather than being captured: the document
  * list refreshes while the editor lives, and a completion source is built
@@ -21,23 +34,28 @@ export function wikiLinkCompletionSource(getTargets: () => readonly LinkTarget[]
     if (match === null) return null
     const targets = getTargets()
     if (targets.length === 0) return null
+    const bracketsFrom = match.from
     const ranked = rankLinkTargets(targets, match.text.slice(2))
     if (ranked.length === 0) return null
     return {
-      from: match.from,
-      options: ranked.map((target) => ({
-        label: target.name,
-        type: 'text',
-        apply: linkMarkupFor(target, targets),
-      })),
-      // OUR ranking is the ranking (the picker's, so both entry points
-      // agree). filter:false is load-bearing, not an optimisation: the
-      // plugin's default filter re-matches label against the text from
-      // `from` — which starts at `[[`, a string no document name contains —
-      // so every option scores zero and the result is silently discarded.
-      // Without validFor the source re-runs per keystroke; targets are a
-      // workspace's document list, so that is cheap.
-      filter: false,
+      from: bracketsFrom + 2,
+      options: ranked.map(
+        (target): Completion => ({
+          label: target.name,
+          type: 'text',
+          apply: (view: EditorView, _completion, _from, to) => {
+            const insert = linkMarkupFor(target, targets)
+            view.dispatch({
+              changes: { from: bracketsFrom, to, insert },
+              selection: { anchor: bracketsFrom + insert.length },
+              userEvent: 'input.complete',
+            })
+          },
+        }),
+      ),
+      // A growing plain query keeps this result (the plugin narrows it);
+      // a ] or | changes the grammar and re-asks the source.
+      validFor: /^[^\][|]*$/,
     }
   }
 }


### PR DESCRIPTION
## What / why main went red

`test-browser` on main failed on the P2 feature's own test: **Enter sometimes inserted a newline instead of accepting the completion**.

Root cause: CodeMirror's `interactionDelay` guard — `acceptCompletion` deliberately ignores an Enter within **75ms of the result opening** (accident prevention). The previous source shape (`filter: false`, no `validFor`) re-ran the source on every keystroke and **re-stamped the open result each time**, so a fast Enter could be rejected indefinitely; under CI timing this landed 7/8 locally once reproduced.

## Fix

- `from` now points after the `[[` so the plugin's default label filter works (instead of being disabled), with an `apply` **function** replacing the brackets too.
- `validFor` keeps one result alive while the query grows — the interaction stamp is set once when `[[` opens the list, and fast typing can no longer push it forward.
- The browser test waits out the guard the way a human does (with the reasoning inline); the selection wait now checks `li[aria-selected]` (active result), not mere tooltip presence.

## Verification

- Stressed the browser test **10/10 green** where the previous shape failed 7/8 on the same machine.
- Editor suites: jsdom 172 + browser 64 — green. Unit tests updated to pin `from` placement and `validFor` as load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmbb1zNhiZitB7tn9LQ5f3