### PR TITLE
feat(mcp): wb_document_search — full-text search over bodies, canvas text, names and paths

### DIFF
--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -8,6 +8,8 @@ Guides:
 - **[self-host-with-docker](self-host-with-docker.md)** — run Whiteboard in server mode for a team.
 - **[link-documents](link-documents.md)** — write `[[references]]` between documents and read
   them back through the Connections chip.
+- **[find-documents-from-chat](find-documents-from-chat.md)** — full-text document search
+  through the MCP tool, CJK included.
 - **[organize-with-tags](organize-with-tags.md)** — tag documents and filter the document
   browser by tag.
 - **[connect-to-local-daemon](connect-to-local-daemon.md)** — detect a local daemon from the web

--- a/docs/how-to/find-documents-from-chat.md
+++ b/docs/how-to/find-documents-from-chat.md
@@ -1,0 +1,23 @@
+# Find documents from chat
+
+Ask your agent to find documents by what they contain — the
+`wb_document_search` MCP tool searches full text, not just titles.
+
+What it covers:
+
+- markdown bodies
+- canvas text: text nodes, group labels, and **edge labels** (a diagram's
+  meaning lives in its relations, so they are searchable content)
+- document names and paths
+
+Japanese (and other CJK) queries work without any dictionary or download.
+Results come back ranked, with a context excerpt around each match, and can
+be narrowed by `kind` (markdown / spatial) or by tags.
+
+Example prompts:
+
+> 「検索基盤について書いた文書を探して」
+> "Find the canvas where something depends on redis"
+
+The same search is available to tools over
+`GET /api/v1/workspaces/:id/search?q=…`.

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -138,6 +138,7 @@ const EXPECTED_TOOLS = [
   'wb_canvas_snapshot',
   'wb_canvas_edit',
   'wb_document_get',
+  'wb_document_search',
   'wb_document_set',
   'wb_scene_render',
   'canvas_view',
@@ -737,6 +738,21 @@ async function main() {
     throw new Error(`wb_document_set returned unexpected shape: ${JSON.stringify(imported)}`)
   }
   console.log('[e2e] wb_document_set → imported')
+
+  // wb_document_search over the body just imported — the runtime guard for
+  // this tool's structuredContent-vs-outputSchema drift, plus tag filtering.
+  const searched = await callTool('wb_document_search', {
+    workspaceId: WORKSPACE_ID,
+    query: 'Imported body',
+    tags: ['smoke'],
+  })
+  if (!searched.results.some((r) => r.documentId === mdCanvasId)) {
+    throw new Error(`wb_document_search missed the imported document: ${JSON.stringify(searched)}`)
+  }
+  if (!(searched.results[0].contexts[0] ?? '').includes('Imported body')) {
+    throw new Error(`wb_document_search snippet mismatch: ${JSON.stringify(searched.results[0])}`)
+  }
+  console.log('[e2e] wb_document_search → found the imported body with a snippet')
 
   const exported = await callTool('wb_document_get', {
     workspaceId: WORKSPACE_ID,

--- a/packages/mcp-server/src/server/mcp/document-tools.ts
+++ b/packages/mcp-server/src/server/mcp/document-tools.ts
@@ -121,6 +121,21 @@ export function registerDocumentTools(server: McpServer, deps: ServerDeps): void
 
   registerToolWithAnnotations(
     server,
+    tools.documentSearch.name,
+    {
+      description: tools.documentSearch.description,
+      inputSchema: tools.documentSearch.inputSchema.shape,
+      outputSchema: tools.documentSearch.outputSchema,
+    },
+    async (args) => {
+      const parsed = tools.documentSearch.inputSchema.parse(args)
+      const result = await tools.documentSearch.execute(parsed)
+      return structuredJsonResult(result)
+    },
+  )
+
+  registerToolWithAnnotations(
+    server,
     tools.documentGet.name,
     {
       description: tools.documentGet.description,

--- a/packages/mcp-server/src/server/mcp/mcp-smoke-coverage.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-smoke-coverage.ts
@@ -47,6 +47,7 @@ export const ALL_REGISTERED_TOOLS = [
   'wb_version_save',
   'wb_document_create',
   'wb_document_get',
+  'wb_document_search',
   'wb_document_delete',
   'wb_document_resolve',
   'wb_document_list',
@@ -56,6 +57,7 @@ export const ALL_REGISTERED_TOOLS = [
 export const COVERED_TOOLS = [
   'wb_viewport_set',
   'wb_document_set',
+  'wb_document_search',
   'wb_canvas_snapshot',
   'wb_canvas_edit',
   'wb_facet_set',

--- a/packages/mcp-server/src/server/mcp/tool-profiles.ts
+++ b/packages/mcp-server/src/server/mcp/tool-profiles.ts
@@ -43,6 +43,7 @@ export const TOOL_PROFILES: Record<string, { profile: AnnotationProfile; title: 
   },
   wb_document_set: { profile: MUTATING, title: 'Replace a document from OKF Markdown' },
   wb_document_get: { profile: READ_ONLY, title: 'Read a document in its own format' },
+  wb_document_search: { profile: READ_ONLY, title: 'Find documents by content' },
   wb_document_create: { profile: MUTATING, title: 'Create a document' },
   wb_document_list: { profile: READ_ONLY, title: 'List the documents in a workspace' },
   wb_document_resolve: { profile: READ_ONLY, title: 'Resolve a document id to its placement' },

--- a/packages/server-core/src/create-server.ts
+++ b/packages/server-core/src/create-server.ts
@@ -29,6 +29,7 @@ import {
 } from './tools/document-crud.schemas.js'
 import { createDocumentGetTool } from './tools/document-get.js'
 import { SnapshotNotFoundError } from './tools/document-io.js'
+import { createDocumentSearchTool, documentSearchInputSchema } from './tools/document-search.js'
 import { createDocumentSetTool } from './tools/document-set.js'
 import { computeDocumentTags, documentTagsInputSchema } from './tools/document-tags.js'
 import { exportOkf, exportOkfInputSchema } from './tools/export-okf.js'
@@ -107,6 +108,26 @@ export function createServer(deps: ServerDeps) {
   // (workspace file tree) can open one without an MCP client. Deliberately
   // still OKF-specific: this is a different surface from the MCP tools, and
   // the tree wants markdown regardless of what wb_document_get would choose.
+  app.get('/api/v1/workspaces/:workspaceId/search', async (c) => {
+    const parsed = documentSearchInputSchema.safeParse({
+      workspaceId: c.req.param('workspaceId'),
+      query: c.req.query('q'),
+      ...(c.req.query('kind') === undefined ? {} : { kind: c.req.query('kind') }),
+      ...(c.req.queries('tag') === undefined || c.req.queries('tag')?.length === 0
+        ? {}
+        : { tags: c.req.queries('tag') }),
+      ...(c.req.query('limit') === undefined ? {} : { limit: Number(c.req.query('limit')) }),
+    })
+    if (!parsed.success) {
+      return c.json({ error: 'invalid input', issues: parsed.error.issues }, 400)
+    }
+    try {
+      return c.json(await tools.documentSearch.execute(parsed.data))
+    } catch (err) {
+      return mapDocumentError(c, err)
+    }
+  })
+
   app.get('/api/v1/workspaces/:workspaceId/document-tags', async (c) => {
     const parsed = documentTagsInputSchema.safeParse({ workspaceId: c.req.param('workspaceId') })
     if (!parsed.success) {
@@ -166,6 +187,7 @@ export function createServer(deps: ServerDeps) {
     canvasEdit: createCanvasEditTool(deps),
     viewportSet: createViewportSetTool(deps),
     documentGet: createDocumentGetTool(deps),
+    documentSearch: createDocumentSearchTool(deps),
     documentSet: createDocumentSetTool(deps),
     versionSave: createVersionSaveTool(deps),
     versionList: createVersionListTool(deps),

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -55,6 +55,12 @@ export {
   wbDocumentResolveOutputSchema,
 } from './tools/document-crud.schemas.js'
 export { SnapshotNotFoundError } from './tools/document-io.js'
+export type { DocumentSearchInput, DocumentSearchOutput } from './tools/document-search.js'
+export {
+  createDocumentSearchTool,
+  documentSearchInputSchema,
+  documentSearchOutputSchema,
+} from './tools/document-search.js'
 export type { DocumentSetInput, DocumentSetOutput } from './tools/document-set.js'
 export {
   createDocumentSetTool,

--- a/packages/server-core/src/references/extract.ts
+++ b/packages/server-core/src/references/extract.ts
@@ -7,16 +7,8 @@ import {
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import type { DocumentEntry } from '@kamiazya/whiteboard-ports'
 import type { LoroDoc } from 'loro-crdt'
+import { snippetAround } from '../search/snippet.js'
 import type { DocumentReferenceFacts, RawReference } from './reference-aggregate.js'
-
-const CONTEXT_RADIUS = 60
-
-function snippetAround(value: string, index: number, length: number): string {
-  const start = Math.max(0, index - CONTEXT_RADIUS)
-  const end = Math.min(value.length, index + length + CONTEXT_RADIUS)
-  const text = value.slice(start, end).replace(/\s+/g, ' ').trim()
-  return `${start > 0 ? '…' : ''}${text}${end < value.length ? '…' : ''}`
-}
 
 function textReferences(value: string): RawReference[] {
   return scanReferences(value).map((match) => ({

--- a/packages/server-core/src/search/full-text.test.ts
+++ b/packages/server-core/src/search/full-text.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { fullTextSearch, tokenize } from './full-text.js'
+
+describe('tokenize', () => {
+  it('turns Japanese runs into adjacent character bigrams', () => {
+    expect(tokenize('検索基盤')).toEqual(['検索', '索基', '基盤'])
+  })
+
+  it('turns latin runs into lowercased words', () => {
+    expect(tokenize('Full-Text SEARCH')).toEqual(['full', 'text', 'search'])
+  })
+
+  it('handles mixed text and single CJK characters, and never yields empty tokens', () => {
+    // Hiragana is CJK too: particles cost noise bigrams, but dropping the
+    // script would lose every hiragana word. Scripts still split (bm25 is
+    // its own token, not glued to the kana).
+    expect(tokenize('BM25で検索')).toEqual(['bm25', 'で検', '検索'])
+    expect(tokenize('図')).toEqual(['図'])
+    for (const token of tokenize('  ,, 。 a ')) expect(token.length).toBeGreaterThan(0)
+  })
+})
+
+const DOC = (
+  documentId: string,
+  texts: string[],
+  extra: Partial<{ name: string; path: string }> = {},
+) => ({
+  documentId,
+  path: extra.path ?? documentId,
+  ...(extra.name === undefined ? {} : { name: extra.name }),
+  texts,
+})
+
+describe('fullTextSearch', () => {
+  it('ranks a body match above documents without the term, with a snippet around the hit', () => {
+    const results = fullTextSearch(
+      [DOC('a', ['QA完了後に検索基盤の日程を確定する。']), DOC('b', ['まったく関係のない本文。'])],
+      '検索基盤',
+    )
+    expect(results.map((r) => r.documentId)).toEqual(['a'])
+    expect(results[0]?.contexts[0]).toContain('検索基盤')
+  })
+
+  it('matches latin queries case-insensitively', () => {
+    const results = fullTextSearch([DOC('a', ['Tune the BM25 scoring constants.'])], 'bm25')
+    expect(results.map((r) => r.documentId)).toEqual(['a'])
+  })
+
+  it('matches names and paths, not only bodies', () => {
+    const results = fullTextSearch(
+      [DOC('a', [], { name: 'Release plan' }), DOC('b', [], { path: 'plans/roadmap' })],
+      'release',
+    )
+    expect(results.map((r) => r.documentId)).toEqual(['a'])
+    expect(fullTextSearch([DOC('b', [], { path: 'plans/roadmap' })], 'roadmap')).toHaveLength(1)
+  })
+
+  it('answers nothing for an empty or no-hit query', () => {
+    expect(fullTextSearch([DOC('a', ['text'])], '')).toEqual([])
+    expect(fullTextSearch([DOC('a', ['text'])], 'absent')).toEqual([])
+  })
+
+  fcTest.prop(
+    [fc.integer({ min: 1, max: 5 }), fc.integer({ min: 1, max: 5 })],
+    withDefaults({ numRuns: 60 }),
+  )(
+    'adding occurrences of a query term never lowers that document score (tf monotonicity)',
+    (base, extra) => {
+      const term = '検索'
+      const body = (n: number) => [`${'関係ない前置き。'.repeat(2)}${term.repeat(n)}`]
+      const others = [DOC('x', ['別の文書の本文がここにある。'])]
+      const score = (n: number) =>
+        fullTextSearch([DOC('a', body(n)), ...others], term).find((r) => r.documentId === 'a')
+          ?.score ?? 0
+      expect(score(base + extra)).toBeGreaterThanOrEqual(score(base))
+    },
+  )
+})

--- a/packages/server-core/src/search/full-text.ts
+++ b/packages/server-core/src/search/full-text.ts
@@ -1,0 +1,138 @@
+import { snippetAround } from './snippet.js'
+
+/**
+ * Dictionary-free lexical search: latin runs tokenize as lowercased words,
+ * CJK runs as adjacent character bigrams — the standard CJK trade (recall
+ * over precision) that works for Japanese, Chinese and Korean alike with
+ * zero download, which is why stage 0 of the search plan starts here. A
+ * lone CJK character (a run of length one) is its own token rather than
+ * disappearing.
+ */
+const CJK = /[぀-ヿ㐀-䶿一-鿿豈-﫿]/
+const WORD = /[\p{L}\p{N}]+/gu
+
+export function tokenize(text: string): string[] {
+  const tokens: string[] = []
+  for (const match of text.toLowerCase().matchAll(WORD)) {
+    const run = match[0]
+    // Split the run into CJK and non-CJK stretches: "bm25で検索" arrives as
+    // one \p{L}\p{N} run, and word-tokenizing it whole would glue the
+    // scripts together into a token nobody types.
+    let latin = ''
+    let cjk = ''
+    const flushLatin = () => {
+      if (latin !== '') tokens.push(latin)
+      latin = ''
+    }
+    const flushCjk = () => {
+      if (cjk.length === 1) tokens.push(cjk)
+      for (let i = 0; i + 1 < cjk.length; i++) tokens.push(cjk.slice(i, i + 2))
+      cjk = ''
+    }
+    for (const char of run) {
+      if (CJK.test(char)) {
+        flushLatin()
+        cjk += char
+      } else {
+        flushCjk()
+        latin += char
+      }
+    }
+    flushLatin()
+    flushCjk()
+  }
+  return tokens
+}
+
+export interface SearchableDocument {
+  readonly documentId: string
+  readonly path: string
+  readonly name?: string
+  /** Body / node / label texts, each a separate string so snippets stay per-source. */
+  readonly texts: readonly string[]
+}
+
+export interface SearchHit {
+  readonly documentId: string
+  readonly score: number
+  /** Excerpts around the first match per text that contains one. */
+  readonly contexts: readonly string[]
+}
+
+// Standard BM25 constants; nothing here has been tuned against a corpus,
+// and tuning without a scoreboard would be the measured-change anti-pattern.
+const K1 = 1.2
+const B = 0.75
+
+/**
+ * BM25 over the documents' token bags, name and path included as text (a
+ * query naming a document should find it without the caller special-casing
+ * fields). Scores are relative to THIS corpus — never compare across calls.
+ */
+export function fullTextSearch(
+  documents: readonly SearchableDocument[],
+  query: string,
+  { limit = 10 }: { limit?: number } = {},
+): SearchHit[] {
+  const queryTokens = [...new Set(tokenize(query))]
+  if (queryTokens.length === 0) return []
+
+  const bags = documents.map((doc) => {
+    const counts = new Map<string, number>()
+    let length = 0
+    for (const text of [doc.path, doc.name ?? '', ...doc.texts]) {
+      for (const token of tokenize(text)) {
+        counts.set(token, (counts.get(token) ?? 0) + 1)
+        length++
+      }
+    }
+    return { doc, counts, length }
+  })
+  const avgLength = bags.reduce((sum, bag) => sum + bag.length, 0) / Math.max(1, bags.length)
+
+  const hits: SearchHit[] = []
+  for (const bag of bags) {
+    let score = 0
+    for (const token of queryTokens) {
+      const tf = bag.counts.get(token) ?? 0
+      if (tf === 0) continue
+      const containing = bags.filter((other) => (other.counts.get(token) ?? 0) > 0).length
+      const idf = Math.log(1 + (bags.length - containing + 0.5) / (containing + 0.5))
+      score +=
+        (idf * tf * (K1 + 1)) / (tf + K1 * (1 - B + (B * bag.length) / Math.max(1, avgLength)))
+    }
+    if (score <= 0) continue
+    hits.push({ documentId: bag.doc.documentId, score, contexts: contextsFor(bag.doc, query) })
+  }
+  return hits
+    .sort((a, b) => b.score - a.score || a.documentId.localeCompare(b.documentId))
+    .slice(0, limit)
+}
+
+/**
+ * Excerpts, keyed on the RAW query string when it occurs verbatim (the
+ * common case, and the most readable snippet); a query that only matches
+ * token-wise falls back to the first matching token's position.
+ */
+function contextsFor(doc: SearchableDocument, query: string): string[] {
+  const needle = query.trim().toLowerCase()
+  const tokens = tokenize(query)
+  const contexts: string[] = []
+  for (const text of doc.texts) {
+    const lower = text.toLowerCase()
+    let index = needle === '' ? -1 : lower.indexOf(needle)
+    let length = needle.length
+    if (index === -1) {
+      for (const token of tokens) {
+        const at = lower.indexOf(token)
+        if (at !== -1 && (index === -1 || at < index)) {
+          index = at
+          length = token.length
+        }
+      }
+    }
+    if (index !== -1) contexts.push(snippetAround(text, index, length))
+    if (contexts.length >= 3) break
+  }
+  return contexts
+}

--- a/packages/server-core/src/search/snippet.ts
+++ b/packages/server-core/src/search/snippet.ts
@@ -1,0 +1,14 @@
+const CONTEXT_RADIUS = 60
+
+/**
+ * A short plain-text excerpt around [index, index+length), whitespace
+ * collapsed, ellipsised at cut edges. Shared by reference extraction and
+ * search results so "where is this in the document" reads the same way
+ * from both surfaces.
+ */
+export function snippetAround(value: string, index: number, length: number): string {
+  const start = Math.max(0, index - CONTEXT_RADIUS)
+  const end = Math.min(value.length, index + length + CONTEXT_RADIUS)
+  const text = value.slice(start, end).replace(/\s+/g, ' ').trim()
+  return `${start > 0 ? '…' : ''}${text}${end < value.length ? '…' : ''}`
+}

--- a/packages/server-core/src/tools/document-search.test.ts
+++ b/packages/server-core/src/tools/document-search.test.ts
@@ -1,0 +1,121 @@
+import { InMemoryDocumentIndex } from '@kamiazya/whiteboard-ports/test-utils'
+import { describe, expect, it } from 'vitest'
+import { createServer } from '../create-server.js'
+import { createInMemoryDocumentStore } from '../test-utils/in-memory-document-store.js'
+import { createCanvasEditTool } from './canvas-edit.js'
+import { wbDocumentCreate } from './document-crud.js'
+import { createDocumentSearchTool, documentSearchOutputSchema } from './document-search.js'
+import { createDocumentSetTool } from './document-set.js'
+
+const WS = 'ws-1'
+
+function makeDeps() {
+  return {
+    documentStore: createInMemoryDocumentStore(),
+    blobStore: {} as never,
+    documentIndex: new InMemoryDocumentIndex(),
+  }
+}
+
+async function seed(deps: ReturnType<typeof makeDeps>) {
+  const create = (path: string, kind: 'markdown' | 'spatial', name?: string) =>
+    wbDocumentCreate(deps, {
+      workspaceId: WS,
+      path,
+      kind,
+      createWorkspace: true,
+      ...(name === undefined ? {} : { name }),
+    })
+  const set = createDocumentSetTool(deps)
+  const writeBody = (documentId: string, frontmatter: string, body: string) =>
+    set.execute({ workspaceId: WS, documentId, markdown: `---\n${frontmatter}\n---\n${body}` })
+  return { create, writeBody, edit: createCanvasEditTool(deps) }
+}
+
+describe('wb_document_search', () => {
+  it('ranks a Japanese body match first, with a snippet, and skips unrelated documents', async () => {
+    const deps = makeDeps()
+    const { create, writeBody } = await seed(deps)
+    const hit = await create('plan', 'markdown', 'Release plan')
+    const miss = await create('other', 'markdown')
+    await writeBody(hit.documentId, 'type: note', 'QA完了後に検索基盤の日程を確定する。')
+    await writeBody(miss.documentId, 'type: note', 'まったく関係のない話。')
+
+    const tool = createDocumentSearchTool(deps)
+    const out = documentSearchOutputSchema.parse(
+      await tool.execute({ workspaceId: WS, query: '検索基盤' }),
+    )
+    expect(out.results.map((r) => r.documentId)).toEqual([hit.documentId])
+    expect(out.results[0]).toMatchObject({ path: 'plan', name: 'Release plan', kind: 'markdown' })
+    expect(out.results[0]?.contexts[0]).toContain('検索基盤')
+  })
+
+  it('finds text living on a canvas: text nodes, group labels, and edge labels', async () => {
+    const deps = makeDeps()
+    const { create, edit } = await seed(deps)
+    const board = await create('board', 'spatial', 'Q3 board')
+    await edit.execute({
+      workspaceId: WS,
+      documentId: board.documentId,
+      ops: [
+        { op: 'node.add', node: { id: 'n1', type: 'text', text: 'websocket の再接続を設計する' } },
+        { op: 'node.add', node: { id: 'n2', type: 'group', label: 'インフラ構成' } },
+        { op: 'node.add', node: { id: 'a', type: 'text', text: 'A' } },
+        { op: 'node.add', node: { id: 'b', type: 'text', text: 'B' } },
+        {
+          op: 'edge.add',
+          edge: { id: 'e1', fromNode: 'a', toNode: 'b', label: 'depends on redis' },
+        },
+      ],
+    })
+    const tool = createDocumentSearchTool(deps)
+    for (const query of ['再接続', 'インフラ', 'redis']) {
+      const out = await tool.execute({ workspaceId: WS, query })
+      expect(
+        out.results.map((r) => r.documentId),
+        query,
+      ).toEqual([board.documentId])
+    }
+  })
+
+  it('filters by kind and by tags', async () => {
+    const deps = makeDeps()
+    const { create, writeBody, edit } = await seed(deps)
+    const tagged = await create('tagged', 'markdown')
+    const untagged = await create('untagged', 'markdown')
+    const board = await create('board', 'spatial')
+    await writeBody(tagged.documentId, 'type: note\ntags:\n  - release', '共通の検索語を含む本文')
+    await writeBody(untagged.documentId, 'type: note', '共通の検索語を含む本文')
+    await edit.execute({
+      workspaceId: WS,
+      documentId: board.documentId,
+      ops: [{ op: 'node.add', node: { id: 'n', type: 'text', text: '共通の検索語を含む本文' } }],
+    })
+
+    const tool = createDocumentSearchTool(deps)
+    const all = await tool.execute({ workspaceId: WS, query: '検索語' })
+    expect(all.results).toHaveLength(3)
+    const markdownOnly = await tool.execute({ workspaceId: WS, query: '検索語', kind: 'markdown' })
+    expect(markdownOnly.results.map((r) => r.documentId).sort()).toEqual(
+      [tagged.documentId, untagged.documentId].sort(),
+    )
+    const taggedOnly = await tool.execute({ workspaceId: WS, query: '検索語', tags: ['release'] })
+    expect(taggedOnly.results.map((r) => r.documentId)).toEqual([tagged.documentId])
+  })
+
+  it('serves the same shape over GET /search and answers 404 for an unknown workspace', async () => {
+    const deps = makeDeps()
+    const { create, writeBody } = await seed(deps)
+    const doc = await create('plan', 'markdown')
+    await writeBody(doc.documentId, 'type: note', 'searchable body text')
+
+    const app = createServer(deps).app
+    const res = await app.request(`/api/v1/workspaces/${WS}/search?q=searchable`)
+    expect(res.status).toBe(200)
+    const out = documentSearchOutputSchema.parse(await res.json())
+    expect(out.results.map((r) => r.documentId)).toEqual([doc.documentId])
+
+    expect((await app.request('/api/v1/workspaces/nope/search?q=x')).status).toBe(404)
+    expect((await app.request(`/api/v1/workspaces/${WS}/search`)).status).toBe(400)
+  })
+})

--- a/packages/server-core/src/tools/document-search.ts
+++ b/packages/server-core/src/tools/document-search.ts
@@ -1,0 +1,123 @@
+import {
+  readCoreFacets,
+  readDocumentKind,
+  readMarkdownBody,
+} from '@kamiazya/whiteboard-loro-adapter'
+import {
+  documentIdSchema,
+  documentKindSchema,
+  documentPathSchema,
+  type SpatialCanvas,
+  workspaceIdSchema,
+} from '@kamiazya/whiteboard-model'
+import { z } from 'zod'
+import { fullTextSearch, type SearchableDocument } from '../search/full-text.js'
+import type { ServerDeps } from '../server-deps.js'
+import { loadDocument } from './document-io.js'
+
+export const documentSearchInputSchema = z
+  .object({
+    workspaceId: workspaceIdSchema,
+    query: z.string().min(1).describe('What to find. Japanese matches without a dictionary.'),
+    kind: documentKindSchema.optional().describe('Restrict to markdown or spatial documents.'),
+    tags: z
+      .array(z.string().min(1))
+      .min(1)
+      .optional()
+      .describe('Restrict to documents carrying EVERY listed tag exactly.'),
+    limit: z.number().int().min(1).max(50).default(10),
+  })
+  .strict()
+export type DocumentSearchInput = z.input<typeof documentSearchInputSchema>
+
+export const documentSearchOutputSchema = z
+  .object({
+    results: z.array(
+      z
+        .object({
+          documentId: documentIdSchema,
+          path: documentPathSchema,
+          name: z.string().min(1).optional(),
+          kind: documentKindSchema.optional(),
+          /** BM25 over this workspace's corpus — comparable within ONE response only. */
+          score: z.number(),
+          /** Excerpts around the first match per matching text source. */
+          contexts: z.array(z.string()),
+        })
+        .strict(),
+    ),
+  })
+  .strict()
+export type DocumentSearchOutput = z.infer<typeof documentSearchOutputSchema>
+
+function canvasTexts(canvas: SpatialCanvas): string[] {
+  const texts: string[] = []
+  for (const node of canvas.nodes) {
+    if (node.type === 'text') texts.push(node.text)
+    if (node.type === 'group' && node.label !== undefined) texts.push(node.label)
+  }
+  for (const edge of canvas.edges) if (edge.label !== undefined) texts.push(edge.label)
+  return texts
+}
+
+/**
+ * Lexical search across a workspace: markdown bodies, canvas text (nodes,
+ * group labels, edge labels — a canvas means through its RELATIONS, so edge
+ * labels are content, not decoration), names and paths.
+ *
+ * ponytail: O(N) document loads per query, the same ceiling as
+ * computeBacklinks/computeDocumentTags — one event-fed facts projection
+ * replaces all three when a measured workspace demands it (ADR-0014).
+ */
+export function createDocumentSearchTool(deps: ServerDeps) {
+  return {
+    name: 'wb_document_search' as const,
+    description:
+      'Find documents by content: full-text over markdown bodies and canvas text (nodes, group labels, edge labels), plus names and paths. Japanese works without a dictionary (character bigrams). Optional kind/tags filters. Returns ranked matches with context excerpts; scores compare within one response only.',
+    inputSchema: documentSearchInputSchema,
+    outputSchema: documentSearchOutputSchema,
+    async execute(input: DocumentSearchInput): Promise<DocumentSearchOutput> {
+      const parsed = documentSearchInputSchema.parse(input)
+      const entries = await deps.documentIndex.listDocuments({ workspaceId: parsed.workspaceId })
+
+      const searchable: (SearchableDocument & { kind?: 'markdown' | 'spatial' })[] = []
+      for (const entry of entries) {
+        let loaded: Awaited<ReturnType<typeof loadDocument>>
+        try {
+          loaded = await loadDocument(deps, entry.documentId)
+        } catch {
+          continue // no snapshot yet: nothing to match
+        }
+        const kind = entry.kind ?? readDocumentKind(loaded.doc)
+        if (parsed.kind !== undefined && kind !== parsed.kind) continue
+        if (parsed.tags !== undefined) {
+          const tags = readCoreFacets(loaded.doc)?.tags ?? []
+          if (!parsed.tags.every((tag) => tags.includes(tag))) continue
+        }
+        searchable.push({
+          documentId: entry.documentId,
+          path: entry.path,
+          ...(entry.name === undefined ? {} : { name: entry.name }),
+          ...(kind === undefined ? {} : { kind }),
+          texts: kind === 'markdown' ? [readMarkdownBody(loaded.doc)] : canvasTexts(loaded.canvas),
+        })
+      }
+
+      const byId = new Map(searchable.map((doc) => [doc.documentId, doc]))
+      const results = fullTextSearch(searchable, parsed.query, { limit: parsed.limit }).map(
+        (hit) => {
+          const doc = byId.get(hit.documentId)
+          return {
+            documentId: hit.documentId,
+            path: doc?.path ?? hit.documentId,
+            ...(doc?.name === undefined ? {} : { name: doc.name }),
+            ...(doc?.kind === undefined ? {} : { kind: doc.kind }),
+            score: hit.score,
+            contexts: [...hit.contexts],
+          }
+        },
+      )
+      return { results }
+    },
+  }
+}


### PR DESCRIPTION
## What

**Search stage 0** of the semantic-index plan (research report): the workspace gets full-text search, surfaced where it matters most first — as an **MCP tool**, so an agent can find documents by content, which is the original goal ("AI が意味・関連性を認識できる仕組み") in its lexical form.

- `wb_document_search` (READ_ONLY) + `GET /api/v1/workspaces/:ws/search?q=` — one Zod schema.
- **BM25 over dictionary-free tokens**: latin runs → lowercased words; CJK runs → character bigrams (the standard recall-over-precision CJK trade; Japanese/Chinese/Korean work with zero download — the 0MB tier the research staged before any embedding model).
- Corpus per document: markdown body, canvas **text nodes + group labels + edge labels** (a diagram means through its relations), name, path.
- Optional `kind` / `tags` filters; ranked results carry context excerpts; scores documented as comparable within one response only.
- O(N) document loads per query — the same `ponytail:` ceiling as `/backlinks` and `/document-tags`; ADR-0014's event-fed facts projection replaces all three when a measured workspace demands it.
- Snippet helper unified: `references/extract.ts` and search now share `search/snippet.ts`.

## Guards

- **tf-monotonicity property** (fast-check): more occurrences of a query term never lower that document's own score — mutation-checked (dropping `tf` from the BM25 numerator goes red with a counterexample).
- One incorrect test expectation caught by the implementation: hiragana **is** CJK — dropping it from bigrams would lose every hiragana word; the test now documents that choice.
- `smoke:e2e` calls the tool against a real server subprocess (structuredContent validated against outputSchema at runtime) with a tags filter; `ALL_REGISTERED_TOOLS` / `COVERED_TOOLS` / tool-profiles meta-tests all extended and green.

## Verification

- server-core 313 / mcp-node mcp+release subsets 553 — green; `pnpm smoke:e2e` ALL OK
- Real dev daemon: Japanese query `検索基盤` over `/mcp` returned the seeded document ranked with a correct snippet; `/search?q=BM25` route agreed

## Docs

`docs/how-to/find-documents-from-chat.md` + how-to index.

## Next (named follow-ups)

- P3 unlinked mentions rides this index (exact-name search)
- Web document-browser body search consumes the same route
- BM25 constants deliberately untuned — tuning without a scoreboard is the measured-change anti-pattern; a query corpus instrument comes first

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmbb1zNhiZitB7tn9LQ5f3