### PR TITLE
fix(web): stop BrowserLocalDocumentPage jsdom suites racing the lazy WorkspaceTopBar chunk

### DIFF
--- a/apps/web/src/pages/BrowserLocalDocumentPage.multi-document.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.multi-document.test.tsx
@@ -41,6 +41,10 @@ import {
 import { waitForMenuClosed } from '../test-utils/menu.js'
 import '../index.css'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+// The lazy WorkspaceTopBar chunk, transformed in the collection phase so a
+// findBy* on its controls never pays the load (integrator-flow.md's
+// lazy()-vs-findBy* family; see BrowserLocalDocumentPage.test.tsx).
+import '../components/WorkspaceTopBar.js'
 
 claimIsolatedWhiteboardDb('browserlocaldocumentpage-multi-document')
 

--- a/apps/web/src/pages/BrowserLocalDocumentPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.test.tsx
@@ -11,6 +11,15 @@ import { Loro } from 'loro-crdt'
 import type { ReactElement } from 'react'
 import { createMemoryRouter, MemoryRouter, RouterProvider } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+// Statically imported so the chunk's transform-and-load happens in the
+// collection phase, not inside a findBy* retry budget: the page renders
+// WorkspaceTopBar through React.lazy, and under a full parallel suite the
+// transform alone can outlast testing-library's 1000ms — the delete-confirm
+// helper's `More actions` query failed exactly that way in 2/2 full-suite
+// runs while every apps/web-only run passed (the lazy()-vs-findBy* family in
+// integrator-flow.md; same fix as App.test.tsx's precedent). The import is
+// unused by name on purpose — being in the module graph is the fix.
+import '../components/WorkspaceTopBar.js'
 import type { LoroLoadResult } from '../lib/loro-store.js'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
 import { LocalStoreDouble } from '../test-utils/local-index.js'


### PR DESCRIPTION
## What

Root-cause fix for the full-suite flake filed after two P1-era `pnpm test` runs: `BrowserLocalDocumentPage.test.tsx > renders cleanup-completed view after delete button click and confirm` — `findByRole('More actions')` timing out with the WorkspaceTopBar slot still an empty `h-12` placeholder.

**Family**: integrator-flow.md's *lazy() dynamic import racing a findBy\* query*. Under 902 parallel test files the lazy chunk's transform outlasts testing-library's 1000ms retry budget; every apps/web-only run passes, which is exactly why this shape hides.

**Fix** (the family's documented one, same as `App.test.tsx`): a static side-effect import of `WorkspaceTopBar` in the test file moves the transform into the collection phase.

Notably, `BrowserLocalDocumentPage.fullscreen.test.tsx` **already carried this import** — the failing sibling suites had missed it, the same one-file-drift that motivated `App.lazy-coverage.test.ts`. Extending that guard to page-level suites is left as open judgement per the audit-triage 2026-08-21 decision (the textual scan for this shape is ~90% false positives).

## Verification

- All three suites green (44 tests); typecheck/biome clean.
- The flake reproduces only under full-suite load; the next scheduled full runs are the ongoing evidence. Resolves the whiteboard issue `flake-lazy-topbar-browser-local-delete` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmbb1zNhiZitB7tn9LQ5f3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved browser document test reliability by ensuring workspace controls load consistently during test execution.
  * Reduced timing-related failures when locating asynchronous interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->