### PR TITLE
feat(web): user copy names the object — note, canvas, or document, never the container "canvas"

### DIFF
--- a/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
@@ -447,7 +447,7 @@ describe('WorkspaceTopBar browser mode', () => {
 
     renderTopBar()
 
-    await page.getByRole('button', { name: 'Canvas actions' }).click()
+    await page.getByRole('button', { name: 'Document actions' }).click()
     await page.getByText('Copy canvas URL').click()
 
     const alert = await screen.findByRole('alert')
@@ -534,7 +534,7 @@ describe('WorkspaceTopBar browser mode', () => {
     const backButton = screen.getByRole('button', { name: 'Back to documents' })
     expect(backButton.getAttribute('aria-hidden')).toBeNull()
 
-    await page.getByRole('button', { name: 'Canvas actions' }).click()
+    await page.getByRole('button', { name: 'Document actions' }).click()
     await screen.findByRole('menu')
     await userEvent.keyboard('{Escape}')
     await waitFor(() => expect(screen.queryByRole('menu')).toBeNull())

--- a/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
@@ -404,7 +404,7 @@ describe('WorkspaceTopBar browser mode', () => {
 
     // The left-side group (back button + canvas switcher + Pencil kebab +
     // HeaderBranchChip) still renders without overflow or wrapping.
-    expect(isDisplayNone(screen.getByRole('button', { name: /back to canvas list/i }))).toBe(false)
+    expect(isDisplayNone(screen.getByRole('button', { name: /back to documents/i }))).toBe(false)
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /^Workspace:/i })).toBeTruthy()
     })
@@ -531,7 +531,7 @@ describe('WorkspaceTopBar browser mode', () => {
   it('does not leave sibling top-bar controls aria-hidden after the Canvas actions menu closes', async () => {
     renderTopBar()
 
-    const backButton = screen.getByRole('button', { name: 'Back to canvas list' })
+    const backButton = screen.getByRole('button', { name: 'Back to documents' })
     expect(backButton.getAttribute('aria-hidden')).toBeNull()
 
     await page.getByRole('button', { name: 'Canvas actions' }).click()

--- a/apps/web/src/components/WorkspaceTopBar.scopes.browser.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.scopes.browser.test.tsx
@@ -58,7 +58,7 @@ describe('top bar scopes', () => {
     // canvas-name resolution lifted out of this component, which the
     // identity-model work owns. Rename is the part that duplicated row two.
     expect(screen.queryByRole('menuitem', { name: /rename/i })).toBeNull()
-    expect(screen.queryByLabelText('Canvas title')).toBeNull()
+    expect(screen.queryByLabelText('Document title')).toBeNull()
   })
 
   it('toggles fullscreen rather than only entering it', async () => {

--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -461,7 +461,7 @@ describe('WorkspaceTopBar — daemon-context-aware fetch, remaining call sites (
   it('commits a canvas rename through the injected daemon fetch', async () => {
     const daemonFetch = renderBarWithDaemonFetch()
 
-    const canvasActions = screen.getByLabelText('Canvas actions')
+    const canvasActions = screen.getByLabelText('Document actions')
     fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
     const renameItem = await screen.findByText('Rename canvas')
     fireEvent.pointerUp(renameItem)
@@ -513,7 +513,7 @@ describe('WorkspaceTopBar — daemon-context-aware fetch, remaining call sites (
 
 describe('WorkspaceTopBar — export affordance (RED-first)', () => {
   async function openDocumentActions() {
-    const canvasActions = screen.getByLabelText('Canvas actions')
+    const canvasActions = screen.getByLabelText('Document actions')
     fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
     await screen.findByText('Rename canvas')
   }
@@ -526,7 +526,7 @@ describe('WorkspaceTopBar — export affordance (RED-first)', () => {
     expect(screen.queryByText('Export as SVG')).toBeNull()
   })
 
-  it('invokes onExport with "png" from the Canvas actions menu and triggers a download', async () => {
+  it('invokes onExport with "png" from the Document actions menu and triggers a download', async () => {
     const blob = new Blob(['fake-png'], { type: 'image/png' })
     const onExport = vi.fn().mockResolvedValue(blob)
     const createObjectURL = vi.fn(() => 'blob:mock-url')
@@ -557,7 +557,7 @@ describe('WorkspaceTopBar — export affordance (RED-first)', () => {
     vi.unstubAllGlobals()
   })
 
-  it('invokes onExport with "svg" from the Canvas actions menu', async () => {
+  it('invokes onExport with "svg" from the Document actions menu', async () => {
     const blob = new Blob(['<svg></svg>'], { type: 'image/svg+xml' })
     const onExport = vi.fn().mockResolvedValue(blob)
     vi.stubGlobal('URL', {
@@ -880,7 +880,7 @@ describe('WorkspaceTopBar — workspaceId URL encoding', () => {
 
 describe('WorkspaceTopBar — copy canvas URL feedback (RED-first)', () => {
   function openDocumentActionsMenu() {
-    const canvasActions = screen.getByLabelText('Canvas actions')
+    const canvasActions = screen.getByLabelText('Document actions')
     fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
     return screen.findByText('Copy canvas URL')
   }
@@ -1063,7 +1063,7 @@ describe('WorkspaceTopBar — dataMode="local"', () => {
       { container: document.body },
     )
 
-    const canvasActions = screen.getByLabelText('Canvas actions')
+    const canvasActions = screen.getByLabelText('Document actions')
     fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
     const renameItem = await screen.findByText('Rename canvas')
     fireEvent.pointerUp(renameItem)
@@ -1097,7 +1097,7 @@ describe('WorkspaceTopBar — dataMode="local"', () => {
       { container: document.body },
     )
 
-    const canvasActions = screen.getByLabelText('Canvas actions')
+    const canvasActions = screen.getByLabelText('Document actions')
     fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
     const renameItem = await screen.findByText('Rename canvas')
     fireEvent.pointerUp(renameItem)
@@ -1156,7 +1156,7 @@ describe('WorkspaceTopBar — dataMode="local"', () => {
       { container: document.body },
     )
 
-    const canvasActions = screen.getByLabelText('Canvas actions')
+    const canvasActions = screen.getByLabelText('Document actions')
     fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
     const renameItem = await screen.findByText('Rename canvas')
     fireEvent.pointerUp(renameItem)
@@ -1316,7 +1316,7 @@ describe('WorkspaceTopBar — mountedRef survives StrictMode dev double-invoke',
       { container: document.body },
     )
 
-    const actionsButton = screen.getByRole('button', { name: 'Canvas actions' })
+    const actionsButton = screen.getByRole('button', { name: 'Document actions' })
     fireEvent.pointerDown(actionsButton, { button: 0, ctrlKey: false })
     const renameItem = await screen.findByText('Rename canvas')
     fireEvent.pointerUp(renameItem)

--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -463,7 +463,7 @@ describe('WorkspaceTopBar — daemon-context-aware fetch, remaining call sites (
 
     const canvasActions = screen.getByLabelText('Document actions')
     fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
-    const renameItem = await screen.findByText('Rename canvas')
+    const renameItem = await screen.findByText('Rename')
     fireEvent.pointerUp(renameItem)
     const input = await screen.findByPlaceholderText('canvas-a')
     fireEvent.change(input, { target: { value: 'renamed' } })
@@ -515,7 +515,7 @@ describe('WorkspaceTopBar — export affordance (RED-first)', () => {
   async function openDocumentActions() {
     const canvasActions = screen.getByLabelText('Document actions')
     fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
-    await screen.findByText('Rename canvas')
+    await screen.findByText('Rename')
   }
 
   it('does not render export menu items when onExport is not provided', async () => {
@@ -1065,7 +1065,7 @@ describe('WorkspaceTopBar — dataMode="local"', () => {
 
     const canvasActions = screen.getByLabelText('Document actions')
     fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
-    const renameItem = await screen.findByText('Rename canvas')
+    const renameItem = await screen.findByText('Rename')
     fireEvent.pointerUp(renameItem)
     // Query and edit synchronously in the same tick as the pointerUp that
     // mounts this input (no intervening `await`) — Radix asynchronously
@@ -1099,7 +1099,7 @@ describe('WorkspaceTopBar — dataMode="local"', () => {
 
     const canvasActions = screen.getByLabelText('Document actions')
     fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
-    const renameItem = await screen.findByText('Rename canvas')
+    const renameItem = await screen.findByText('Rename')
     fireEvent.pointerUp(renameItem)
     // See the comment in the success-path test above: edit synchronously,
     // in the same tick, to avoid Radix's async focus-return-to-trigger
@@ -1158,7 +1158,7 @@ describe('WorkspaceTopBar — dataMode="local"', () => {
 
     const canvasActions = screen.getByLabelText('Document actions')
     fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
-    const renameItem = await screen.findByText('Rename canvas')
+    const renameItem = await screen.findByText('Rename')
     fireEvent.pointerUp(renameItem)
 
     const input = screen.getByRole('textbox', { name: 'Document title' })
@@ -1318,7 +1318,7 @@ describe('WorkspaceTopBar — mountedRef survives StrictMode dev double-invoke',
 
     const actionsButton = screen.getByRole('button', { name: 'Document actions' })
     fireEvent.pointerDown(actionsButton, { button: 0, ctrlKey: false })
-    const renameItem = await screen.findByText('Rename canvas')
+    const renameItem = await screen.findByText('Rename')
     fireEvent.pointerUp(renameItem)
 
     const input = await screen.findByLabelText('Document title')

--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -168,7 +168,7 @@ describe('WorkspaceTopBar — router-free navigation callbacks', () => {
     const onNavigateBack = vi.fn()
     renderBar({ onNavigateBack })
 
-    fireEvent.click(screen.getByRole('button', { name: /back to canvas list/i }))
+    fireEvent.click(screen.getByRole('button', { name: /back to documents/i }))
 
     expect(onNavigateBack).toHaveBeenCalledTimes(1)
   })
@@ -765,7 +765,7 @@ describe('WorkspaceTopBar — optional daemon-context props (RED-first)', () => 
       />,
       { container: document.body },
     )
-    expect(screen.queryByLabelText('Back to canvas list')).toBeNull()
+    expect(screen.queryByLabelText('Back to documents')).toBeNull()
   })
 
   it('hides the fullscreen button when onToggleFullscreen is omitted', () => {
@@ -1161,7 +1161,7 @@ describe('WorkspaceTopBar — dataMode="local"', () => {
     const renameItem = await screen.findByText('Rename canvas')
     fireEvent.pointerUp(renameItem)
 
-    const input = screen.getByRole('textbox', { name: 'Canvas title' })
+    const input = screen.getByRole('textbox', { name: 'Document title' })
 
     const docKeydown = vi.fn()
     const docKeyup = vi.fn()
@@ -1321,7 +1321,7 @@ describe('WorkspaceTopBar — mountedRef survives StrictMode dev double-invoke',
     const renameItem = await screen.findByText('Rename canvas')
     fireEvent.pointerUp(renameItem)
 
-    const input = await screen.findByLabelText('Canvas title')
+    const input = await screen.findByLabelText('Document title')
     fireEvent.change(input, { target: { value: 'Renamed Canvas' } })
     fireEvent.keyDown(input, { key: 'Enter' })
 
@@ -1330,7 +1330,7 @@ describe('WorkspaceTopBar — mountedRef survives StrictMode dev double-invoke',
     // false, so the rename completion path (gated on mountedRef.current)
     // would never close the input.
     await waitFor(() => {
-      expect(screen.queryByLabelText('Canvas title')).toBeNull()
+      expect(screen.queryByLabelText('Document title')).toBeNull()
     })
   })
 })

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -249,13 +249,13 @@ export default function WorkspaceTopBar({
               <button
                 type="button"
                 onClick={onNavigateBack}
-                aria-label="Back to canvas list"
+                aria-label="Back to documents"
                 className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
               >
                 <ChevronLeft className="size-4" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Back to canvas list</TooltipContent>
+            <TooltipContent>Back to documents</TooltipContent>
           </Tooltip>
         )}
 
@@ -292,7 +292,7 @@ export default function WorkspaceTopBar({
           <div className="flex min-w-0 flex-col gap-0.5">
             <Input
               autoFocus
-              aria-label="Canvas title"
+              aria-label="Document title"
               value={draft}
               onChange={(e) => setDraft(e.target.value)}
               onBlur={commitDocumentName}

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -33,7 +33,7 @@ export interface WorkspaceFilesPanelProps {
    * the same destructive act.
    */
   onDuplicateDocument?: (path: string) => void
-  onRequestDelete?: (path: string, displayName: string) => void
+  onRequestDelete?: (path: string, displayName: string, kind?: DocumentKind) => void
   /**
    * Any value that changes when the workspace's documents may have changed
    * behind this panel's back.
@@ -443,7 +443,7 @@ export function WorkspaceFilesPanel({
               ? {}
               : {
                   onDelete: (entry: WorkspaceDocumentEntry) =>
-                    onRequestDelete(entry.path, entry.name ?? entry.path),
+                    onRequestDelete(entry.path, entry.name ?? entry.path, entry.kind),
                 })}
             className="h-full"
           />

--- a/apps/web/src/components/workspace-top-bar/DocumentActionsMenu.tsx
+++ b/apps/web/src/components/workspace-top-bar/DocumentActionsMenu.tsx
@@ -50,7 +50,7 @@ export function DocumentActionsMenu({
           <button
             type="button"
             className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-            aria-label="Canvas actions"
+            aria-label="Document actions"
           >
             <Pencil className="size-3.5" />
           </button>

--- a/apps/web/src/components/workspace-top-bar/DocumentActionsMenu.tsx
+++ b/apps/web/src/components/workspace-top-bar/DocumentActionsMenu.tsx
@@ -58,7 +58,7 @@ export function DocumentActionsMenu({
         <DropdownMenuContent align="start">
           <DropdownMenuItem onSelect={onStartRename} className="gap-2">
             <Pencil className="size-3.5" />
-            Rename canvas
+            Rename
           </DropdownMenuItem>
           <DropdownMenuItem
             onSelect={(e) => {

--- a/apps/web/src/lib/kind-noun.test.ts
+++ b/apps/web/src/lib/kind-noun.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { kindNoun } from './kind-noun.js'
+
+describe('kindNoun', () => {
+  it('names each kind, and the honest generic when none is recorded', () => {
+    expect(kindNoun('spatial')).toBe('canvas')
+    expect(kindNoun('markdown')).toBe('note')
+    // Pre-kind documents have no recorded kind; calling one "canvas" is
+    // exactly the guess this helper exists to retire.
+    expect(kindNoun(undefined)).toBe('document')
+  })
+})

--- a/apps/web/src/lib/kind-noun.ts
+++ b/apps/web/src/lib/kind-noun.ts
@@ -1,0 +1,12 @@
+import type { DocumentKind } from '@kamiazya/whiteboard-model'
+
+/**
+ * What user-visible copy calls a document of this kind. "canvas" is correct
+ * ONLY when the kind is known to be spatial (vocabulary.md: the container
+ * sense of the word is retired); an unrecorded kind gets the honest generic.
+ */
+export function kindNoun(kind: DocumentKind | undefined): 'canvas' | 'note' | 'document' {
+  if (kind === 'spatial') return 'canvas'
+  if (kind === 'markdown') return 'note'
+  return 'document'
+}

--- a/apps/web/src/pages/BrowserLocalDocumentPage.delete-confirm.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.delete-confirm.browser.test.tsx
@@ -156,7 +156,7 @@ describe('BrowserLocalDocumentPage delete confirmation (browser — real Indexed
     // Put the header persistence state into "pending" by renaming, then
     // immediately open+confirm the delete dialog before the debounce fires.
     //
-    // In real-browser mode, opening WorkspaceTopBar's "Canvas actions" menu
+    // In real-browser mode, opening WorkspaceTopBar's "Document actions" menu
     // for the first time after several prior AlertDialogs have opened and
     // closed in this file occasionally does not register on the first
     // pointerdown — a Radix dismissable-layer/testing-tooling quirk (never
@@ -172,7 +172,7 @@ describe('BrowserLocalDocumentPage delete confirmation (browser — real Indexed
       // cleanup+remount; querying "all" and taking the most-recently-mounted
       // match sidesteps a transient multiple-elements error instead of
       // failing the whole retry loop on it.
-      const allCanvasActions = await waitFor(() => screen.getAllByLabelText('Canvas actions'), {
+      const allCanvasActions = await waitFor(() => screen.getAllByLabelText('Document actions'), {
         timeout: 5000,
       })
       const canvasActions = allCanvasActions[allCanvasActions.length - 1]!
@@ -186,7 +186,7 @@ describe('BrowserLocalDocumentPage delete confirmation (browser — real Indexed
         // retry with a fresh remount
       }
     }
-    if (!renameItem) throw new Error('Canvas actions dropdown never opened after retries')
+    if (!renameItem) throw new Error('Document actions dropdown never opened after retries')
     fireEvent.pointerUp(renameItem)
     const titleInput = await screen.findByRole(
       'textbox',

--- a/apps/web/src/pages/BrowserLocalDocumentPage.delete-confirm.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.delete-confirm.browser.test.tsx
@@ -15,6 +15,7 @@ import { BrowserLocalDocumentPage } from './BrowserLocalDocumentPage.js'
 // Real app styles so a11y/focus assertions run against the shipped geometry.
 import '../index.css'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { seedIdbDocument } from '../test-utils/seed-idb-document.js'
 
 const ISOLATED_DB = claimIsolatedWhiteboardDb('browserlocaldocumentpage-delete-confirm')
 
@@ -67,6 +68,24 @@ describe('BrowserLocalDocumentPage delete confirmation (browser — real Indexed
 
   afterEach(() => {
     cleanup()
+  })
+
+  it('a markdown note names itself in the dialog: note, not canvas', async () => {
+    // The kind-aware copy's whole point on this page — the markdown branch
+    // must not inherit the spatial wording.
+    const store = new IdbDocumentIndex()
+    await seedIdbDocument(store, {
+      path: 'meeting-notes',
+      name: 'Meeting notes',
+      kind: 'markdown',
+      makeDefault: true,
+    })
+    render(<BrowserLocalDocumentPage store={store} />)
+    await screen.findByRole('button', { name: 'More actions' }, { timeout: 5000 })
+
+    const dialog = await openDeleteDialog()
+    expect(dialog).toHaveAccessibleName('Delete this note?')
+    expect(dialog).toHaveAccessibleDescription(/permanently removes the note/i)
   })
 
   it('opening the delete dialog does not delete the canvas yet', async () => {
@@ -178,7 +197,7 @@ describe('BrowserLocalDocumentPage delete confirmation (browser — real Indexed
       const canvasActions = allCanvasActions[allCanvasActions.length - 1]!
       fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
       try {
-        const allRenameItems = await waitFor(() => screen.getAllByText('Rename canvas'), {
+        const allRenameItems = await waitFor(() => screen.getAllByText('Rename'), {
           timeout: 1500,
         })
         renameItem = allRenameItems[allRenameItems.length - 1]!

--- a/apps/web/src/pages/BrowserLocalDocumentPage.delete-confirm.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.delete-confirm.browser.test.tsx
@@ -190,7 +190,7 @@ describe('BrowserLocalDocumentPage delete confirmation (browser — real Indexed
     fireEvent.pointerUp(renameItem)
     const titleInput = await screen.findByRole(
       'textbox',
-      { name: /canvas title/i },
+      { name: /document title/i },
       { timeout: 3000 },
     )
     titleInput.focus()

--- a/apps/web/src/pages/BrowserLocalDocumentPage.rename.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.rename.browser.test.tsx
@@ -77,7 +77,7 @@ async function openRenameInput(): Promise<HTMLElement> {
   if (!renameItem) throw new Error('Canvas actions dropdown never opened after retries')
   fireEvent.pointerUp(renameItem)
   const allTitleInputs = await waitFor(
-    () => screen.getAllByRole('textbox', { name: /canvas title/i }),
+    () => screen.getAllByRole('textbox', { name: /document title/i }),
     { timeout: 3000 },
   )
   return allTitleInputs[allTitleInputs.length - 1]!

--- a/apps/web/src/pages/BrowserLocalDocumentPage.rename.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.rename.browser.test.tsx
@@ -44,7 +44,7 @@ async function waitForTitle(expected: string): Promise<void> {
   )
 }
 
-// The rename input lives behind WorkspaceTopBar's "Canvas actions" menu
+// The rename input lives behind WorkspaceTopBar's "Document actions" menu
 // rather than being always-mounted, so each edit starts by opening it.
 //
 // In real-browser mode, the first time this specific trigger is opened in a
@@ -60,7 +60,7 @@ async function openRenameInput(): Promise<HTMLElement> {
       cleanup()
       await renderLoaded()
     }
-    const allCanvasActions = await waitFor(() => screen.getAllByLabelText('Canvas actions'), {
+    const allCanvasActions = await waitFor(() => screen.getAllByLabelText('Document actions'), {
       timeout: 5000,
     })
     const canvasActions = allCanvasActions[allCanvasActions.length - 1]!

--- a/apps/web/src/pages/BrowserLocalDocumentPage.rename.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.rename.browser.test.tsx
@@ -66,7 +66,7 @@ async function openRenameInput(): Promise<HTMLElement> {
     const canvasActions = allCanvasActions[allCanvasActions.length - 1]!
     fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
     try {
-      const allRenameItems = await waitFor(() => screen.getAllByText('Rename canvas'), {
+      const allRenameItems = await waitFor(() => screen.getAllByText('Rename'), {
         timeout: 1500,
       })
       renameItem = allRenameItems[allRenameItems.length - 1]!

--- a/apps/web/src/pages/BrowserLocalDocumentPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.test.tsx
@@ -630,7 +630,7 @@ describe('BrowserLocalDocumentPage', () => {
     fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
     const renameItem = await screen.findByText('Rename canvas')
     fireEvent.pointerUp(renameItem)
-    const titleInput = screen.getByRole('textbox', { name: /canvas title/i })
+    const titleInput = screen.getByRole('textbox', { name: /document title/i })
     fireEvent.change(titleInput, { target: { value: 'Renamed canvas' } })
     fireEvent.keyDown(titleInput, { key: 'Enter' })
     await waitFor(() => {
@@ -1009,7 +1009,7 @@ describe('BrowserLocalDocumentPage', () => {
     const canvasActions = await screen.findByLabelText('Canvas actions')
     fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
     fireEvent.pointerUp(await screen.findByText('Rename canvas'))
-    const titleInput = screen.getByRole('textbox', { name: /canvas title/i })
+    const titleInput = screen.getByRole('textbox', { name: /document title/i })
     const refreshesBeforeRename = resolvers.length
     fireEvent.change(titleInput, { target: { value: 'Renamed canvas' } })
     fireEvent.keyDown(titleInput, { key: 'Enter' })

--- a/apps/web/src/pages/BrowserLocalDocumentPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.test.tsx
@@ -438,7 +438,7 @@ describe('BrowserLocalDocumentPage', () => {
 
     // The top bar's Canvas actions menu keeps rename/copy-URL only on this
     // page (daemon mode, which has no canvas row, keeps its export there).
-    const topTrigger = await screen.findByLabelText('Canvas actions')
+    const topTrigger = await screen.findByLabelText('Document actions')
     fireEvent.pointerDown(topTrigger, { button: 0, ctrlKey: false })
     const topMenu = await screen.findByRole('menu')
     expect(topMenu.textContent).not.toContain('Export')
@@ -606,7 +606,7 @@ describe('BrowserLocalDocumentPage', () => {
     const heading = screen.getByRole('heading', { level: 1 })
     expect(heading.textContent).toBe('untitled')
     // WorkspaceTopBar mounts through a lazy chunk; wait for it to resolve.
-    expect(await screen.findByLabelText('Canvas actions')).toBeTruthy()
+    expect(await screen.findByLabelText('Document actions')).toBeTruthy()
     // Distinct from the canvas row's operations kebab.
     expect(screen.getByRole('button', { name: 'More actions' })).toBeTruthy()
   })
@@ -626,7 +626,7 @@ describe('BrowserLocalDocumentPage', () => {
         />,
       )
     })
-    const canvasActions = await screen.findByLabelText('Canvas actions')
+    const canvasActions = await screen.findByLabelText('Document actions')
     fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
     const renameItem = await screen.findByText('Rename canvas')
     fireEvent.pointerUp(renameItem)
@@ -683,7 +683,7 @@ describe('BrowserLocalDocumentPage', () => {
     // Accessible names must not collide with the operations kebab or the
     // top bar's canvas actions control.
     expect(screen.getByRole('button', { name: 'More actions' })).toBeTruthy()
-    expect(screen.getByLabelText('Canvas actions')).toBeTruthy()
+    expect(screen.getByLabelText('Document actions')).toBeTruthy()
     fireEvent.pointerDown(switcher, { button: 0, ctrlKey: false })
     await screen.findByText('Other canvas')
   })
@@ -905,7 +905,7 @@ describe('BrowserLocalDocumentPage', () => {
         />,
       )
     })
-    await screen.findByLabelText('Canvas actions')
+    await screen.findByLabelText('Document actions')
     // Resolve the initial mount's list refresh (generation 1) with both
     // documents, so the switcher has real options to switch between.
     await act(async () => {
@@ -1006,7 +1006,7 @@ describe('BrowserLocalDocumentPage', () => {
       resolvers[0]!([snap])
     })
 
-    const canvasActions = await screen.findByLabelText('Canvas actions')
+    const canvasActions = await screen.findByLabelText('Document actions')
     fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
     fireEvent.pointerUp(await screen.findByText('Rename canvas'))
     const titleInput = screen.getByRole('textbox', { name: /document title/i })
@@ -1157,7 +1157,7 @@ describe('BrowserLocalDocumentPage', () => {
         )
       })
       expect(screen.getByRole('button', { name: 'More actions' })).toBeTruthy()
-      expect(screen.getByLabelText('Canvas actions')).toBeTruthy()
+      expect(screen.getByLabelText('Document actions')).toBeTruthy()
     })
   })
 

--- a/apps/web/src/pages/BrowserLocalDocumentPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.test.tsx
@@ -628,7 +628,7 @@ describe('BrowserLocalDocumentPage', () => {
     })
     const canvasActions = await screen.findByLabelText('Document actions')
     fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
-    const renameItem = await screen.findByText('Rename canvas')
+    const renameItem = await screen.findByText('Rename')
     fireEvent.pointerUp(renameItem)
     const titleInput = screen.getByRole('textbox', { name: /document title/i })
     fireEvent.change(titleInput, { target: { value: 'Renamed canvas' } })
@@ -1008,7 +1008,7 @@ describe('BrowserLocalDocumentPage', () => {
 
     const canvasActions = await screen.findByLabelText('Document actions')
     fireEvent.pointerDown(canvasActions, { button: 0, ctrlKey: false })
-    fireEvent.pointerUp(await screen.findByText('Rename canvas'))
+    fireEvent.pointerUp(await screen.findByText('Rename'))
     const titleInput = screen.getByRole('textbox', { name: /document title/i })
     const refreshesBeforeRename = resolvers.length
     fireEvent.change(titleInput, { target: { value: 'Renamed canvas' } })

--- a/apps/web/src/pages/BrowserLocalDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.tsx
@@ -50,6 +50,7 @@ import { BROWSER_LOCAL_FILE_ADAPTER } from '../lib/document-embed-content.js'
 import { isDocumentReadFailure } from '../lib/document-read-failure.js'
 import { browserLocalFaviconStatus, type FaviconStyle } from '../lib/favicon.js'
 import { readLastTool, resolveInitialTool } from '../lib/initial-tool.js'
+import { kindNoun } from '../lib/kind-noun.js'
 import type { ContentClock, DefaultDocumentPointer } from '../lib/local-document-summary.js'
 import { ensurePersistentStorage } from '../lib/persistent-storage.js'
 import { BROWSER_LOCAL_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
@@ -174,7 +175,9 @@ export function BrowserLocalDocumentPage({
     try {
       await duplicateDocument()
     } catch (err) {
-      setDuplicateError(err instanceof Error ? err.message : 'Failed to duplicate canvas.')
+      setDuplicateError(
+        err instanceof Error ? err.message : `Failed to duplicate ${kindNoun(documentKind)}.`,
+      )
     } finally {
       setIsDuplicating(false)
     }
@@ -701,10 +704,10 @@ export function BrowserLocalDocumentPage({
           }}
         >
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete this canvas?</AlertDialogTitle>
+            <AlertDialogTitle>Delete this {kindNoun(documentKind)}?</AlertDialogTitle>
             <AlertDialogDescription>
-              This permanently removes the canvas and its drawing data from this browser. This
-              action cannot be undone.
+              This permanently removes the {kindNoun(documentKind)} and its content from this
+              browser. This action cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/apps/web/src/pages/BrowserLocalIndexPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalIndexPage.test.tsx
@@ -199,6 +199,42 @@ describe('BrowserLocalIndexPage', () => {
     await waitFor(() => expect(button.hasAttribute('disabled')).toBe(false))
   })
 
+  it('the delete dialog names the kind: note for markdown, canvas for spatial', async () => {
+    // The dialog copy names the OBJECT being destroyed. Calling a markdown
+    // note "the canvas" is the retired container sense of the word.
+    const store = await seededStore([
+      {
+        documentId: '0CFJNRVY147ADGKPSWZ258BEHM',
+        workspaceId: 'local',
+        path: 'meeting-notes',
+        name: 'Meeting notes',
+        updatedAt: '2026-08-01T00:00:00Z',
+        kind: 'markdown',
+      },
+      {
+        documentId: '0KPSWZ258BEHMQTX0369CFJNRV',
+        workspaceId: 'local',
+        path: 'trip-plan',
+        name: 'Trip plan',
+        updatedAt: '2026-08-02T00:00:00Z',
+        kind: 'spatial',
+      },
+    ])
+    renderPage(store)
+
+    await selectCard('Meeting notes')
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }))
+    let dialog = await screen.findByRole('alertdialog')
+    expect(within(dialog).getByText(/removes the note from this browser/)).toBeTruthy()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+
+    await selectCard('Trip plan')
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }))
+    dialog = await screen.findByRole('alertdialog')
+    expect(within(dialog).getByText(/removes the canvas from this browser/)).toBeTruthy()
+  })
+
   it('Delete opens a dialog naming the canvas; Cancel removes nothing', async () => {
     const store = await seededStore([
       {
@@ -295,7 +331,7 @@ describe('BrowserLocalIndexPage', () => {
 
     // Fixed copy — never the raw error text — and the dialog stays open.
     expect(
-      await within(dialog).findByText('Failed to delete the canvas from this browser.'),
+      await within(dialog).findByText('Failed to delete the document from this browser.'),
     ).toBeTruthy()
     expect(within(dialog).queryByText(/quota exceeded/)).toBeNull()
 

--- a/apps/web/src/pages/BrowserLocalIndexPage.tsx
+++ b/apps/web/src/pages/BrowserLocalIndexPage.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { DeleteDocumentDialog } from '../components/document-list/DeleteDocumentDialog.js'
 import { EmptyWorkspaceState } from '../components/workspace-files/EmptyWorkspaceState.js'
 import { WorkspaceFilesPanel } from '../components/workspace-files/WorkspaceFilesPanel.js'
+import { kindNoun } from '../lib/kind-noun.js'
 import {
   type ContentClock,
   type DefaultDocumentPointer,
@@ -94,6 +95,7 @@ export function BrowserLocalIndexPage({
   const [pendingDelete, setPendingDelete] = useState<{
     path: string
     displayName: string
+    kind?: DocumentKind
   } | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [deleteError, setDeleteError] = useState<string | null>(null)
@@ -124,7 +126,7 @@ export function BrowserLocalIndexPage({
       setFilesRevision((revision) => revision + 1)
       setPendingDelete(null)
     } catch {
-      setDeleteError('Failed to delete the canvas from this browser.')
+      setDeleteError('Failed to delete the document from this browser.')
     } finally {
       setDeleting(false)
     }
@@ -150,7 +152,7 @@ export function BrowserLocalIndexPage({
         await pointer.set(created.documentId)
         onOpenDocument(created.path)
       } catch {
-        setError('Failed to create a canvas in this browser.')
+        setError(`Failed to create a ${kindNoun(kind)} in this browser.`)
       } finally {
         setCreating(false)
       }
@@ -160,7 +162,7 @@ export function BrowserLocalIndexPage({
 
   return (
     <div className="flex h-full flex-col overflow-y-auto p-4">
-      <h1 className="sr-only">Canvases</h1>
+      <h1 className="sr-only">Documents</h1>
       {error && (
         <div role="alert" className="mb-2 text-sm text-destructive">
           {error}
@@ -191,7 +193,9 @@ export function BrowserLocalIndexPage({
         <WorkspaceFilesPanel
           source={filesSource}
           onOpenDocument={onOpenDocument}
-          onRequestDelete={(path, displayName) => setPendingDelete({ path, displayName })}
+          onRequestDelete={(path, displayName, kind) =>
+            setPendingDelete({ path, displayName, kind })
+          }
           revision={filesRevision}
         />
       ) : (
@@ -212,7 +216,7 @@ export function BrowserLocalIndexPage({
         pending={pendingDelete}
         busy={deleting}
         error={deleteError}
-        description="This permanently removes the canvas from this browser. There is no undo."
+        description={`This permanently removes the ${kindNoun(pendingDelete?.kind)} from this browser. There is no undo.`}
         onCancel={() => {
           setPendingDelete(null)
           setDeleteError(null)

--- a/apps/web/src/pages/DaemonDocumentPage.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.test.tsx
@@ -1902,7 +1902,7 @@ describe('DaemonDocumentPage', () => {
   })
 
   describe('WorkspaceTopBar chrome adoption', () => {
-    it('does not render a "Back to canvas list" button (onNavigateBack omitted)', async () => {
+    it('does not render a "Back to documents" button (onNavigateBack omitted)', async () => {
       await act(async () => {
         render(
           <DaemonDocumentPage
@@ -1917,10 +1917,10 @@ describe('DaemonDocumentPage', () => {
       // docks in Select mode, so tests exercising it switch first.
       fireEvent.click(await screen.findByTestId('select-tool-button'))
 
-      expect(screen.queryByRole('button', { name: 'Back to canvas list' })).toBeNull()
+      expect(screen.queryByRole('button', { name: 'Back to documents' })).toBeNull()
     })
 
-    it('renders "Back to canvas list" and invokes onNavigateBack when provided', async () => {
+    it('renders "Back to documents" and invokes onNavigateBack when provided', async () => {
       const onNavigateBack = vi.fn()
       await act(async () => {
         render(
@@ -1937,12 +1937,12 @@ describe('DaemonDocumentPage', () => {
       // docks in Select mode, so tests exercising it switch first.
       fireEvent.click(await screen.findByTestId('select-tool-button'))
 
-      const button = screen.getByRole('button', { name: 'Back to canvas list' })
+      const button = screen.getByRole('button', { name: 'Back to documents' })
       fireEvent.click(button)
       expect(onNavigateBack).toHaveBeenCalledTimes(1)
     })
 
-    it('renders "Back to canvas list" in the zero-documents branch, where WorkspaceTopBar does not mount', async () => {
+    it('renders "Back to documents" in the zero-documents branch, where WorkspaceTopBar does not mount', async () => {
       mockListDocuments.mockResolvedValue({ documents: [] })
       const onNavigateBack = vi.fn()
 
@@ -1961,7 +1961,7 @@ describe('DaemonDocumentPage', () => {
         expect(screen.getByText('This workspace has no documents yet.')).toBeTruthy(),
       )
 
-      const button = screen.getByRole('button', { name: 'Back to canvas list' })
+      const button = screen.getByRole('button', { name: 'Back to documents' })
       fireEvent.click(button)
       expect(onNavigateBack).toHaveBeenCalledTimes(1)
     })

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -91,7 +91,7 @@ export interface DaemonDocumentPageProps {
   // daemon workspace. Absent in tests/embedders that don't need the flow.
   browserLocalStore?: DocumentIndex
   browserLocalClock?: ContentClock
-  // Wired to WorkspaceTopBar's own "Back to canvas list" button. Absent
+  // Wired to WorkspaceTopBar's own "Back to documents" button. Absent
   // (the default) hides that button — callers that own an index view (the
   // daemon gallery) pass this to return there.
   onNavigateBack?: () => void
@@ -768,7 +768,7 @@ export function DaemonDocumentPage({
                 onClick={onNavigateBack}
                 className="self-start rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
               >
-                <span aria-hidden="true">← </span>Back to canvas list
+                <span aria-hidden="true">← </span>Back to documents
               </button>
             )}
             <p className="text-sm text-muted-foreground">This workspace has no documents yet.</p>

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -882,6 +882,45 @@ describe('DaemonIndexPage', () => {
     expect(onOpenDocument).not.toHaveBeenCalled()
   })
 
+  it('the delete dialog names the kind: note for markdown, canvas for spatial', async () => {
+    // Hardcoding "canvas" back into this page's dialog must go red here —
+    // the local page has the same pin, and the daemon page is not exempt.
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      documentsByWorkspace: {
+        'ws-a': [
+          {
+            path: 'meeting-notes',
+            displayName: 'Meeting notes',
+            updatedAt: '2026-08-01T00:00:00Z',
+            kind: 'markdown',
+          },
+          {
+            path: 'trip-plan',
+            displayName: 'Trip plan',
+            updatedAt: '2026-08-02T00:00:00Z',
+            kind: 'spatial',
+          },
+        ],
+      },
+    })
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenDocument={vi.fn()} />, {
+      container: document.body,
+    })
+
+    await selectCard('Meeting notes')
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    let dialog = await screen.findByRole('alertdialog')
+    expect(within(dialog).getByText(/removes the note, including its versions/)).toBeTruthy()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+
+    await selectCard('Trip plan')
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    dialog = await screen.findByRole('alertdialog')
+    expect(within(dialog).getByText(/removes the canvas, including its versions/)).toBeTruthy()
+  })
+
   it('Delete opens an AlertDialog naming the canvas; Cancel sends no DELETE', async () => {
     const deleted: string[] = []
     installFetchMock({

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -20,6 +20,7 @@ import { createDaemonFilesSource } from '../lib/daemon-files-source.js'
 import { deriveCopyName } from '../lib/derive-copy-name.js'
 import { deriveCopyPath } from '../lib/derive-copy-path.js'
 import { deriveNewDocumentPath } from '../lib/derive-new-document-path.js'
+import { kindNoun } from '../lib/kind-noun.js'
 import type { WhiteboardCapabilities } from '../lib/provider.js'
 
 // The document browser for a connected daemon, scoped to ONE workspace at a
@@ -208,7 +209,7 @@ export function DaemonIndexPage({
       } catch (err) {
         // daemon-api-client errors are already sanitized (Problem Details
         // title or a generic status message) — safe to surface directly.
-        setCreateError(err instanceof Error ? err.message : 'Failed to create canvas.')
+        setCreateError(err instanceof Error ? err.message : `Failed to create ${kindNoun(kind)}.`)
         // The path is derived from `rows`, so a failure caused by a name this list has not seen
         // (another tab, a lost race) would otherwise re-derive the SAME path on every retry and
         // collide forever. Re-read the list so the next derive skips what is actually taken.
@@ -264,7 +265,7 @@ export function DaemonIndexPage({
         await loadWorkspace(workspaceAtStart, isStale)
       } catch (err) {
         if (selectedWorkspaceRef.current !== workspaceAtStart) return
-        setDuplicateError(err instanceof Error ? err.message : 'Failed to duplicate canvas.')
+        setDuplicateError(err instanceof Error ? err.message : 'Failed to duplicate document.')
       } finally {
         setDuplicatingPath((current) => (current === sourcePath ? null : current))
       }
@@ -275,6 +276,7 @@ export function DaemonIndexPage({
   const [pendingDelete, setPendingDelete] = useState<{
     path: string
     displayName: string
+    kind?: DocumentKind
   } | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [deleteError, setDeleteError] = useState<string | null>(null)
@@ -304,7 +306,7 @@ export function DaemonIndexPage({
     } catch (err) {
       // daemon-api-client errors are already sanitized (problem-details
       // title or a generic status message) — safe to surface directly.
-      setDeleteError(err instanceof Error ? err.message : 'Failed to delete canvas.')
+      setDeleteError(err instanceof Error ? err.message : 'Failed to delete document.')
     } finally {
       setDeleting(false)
     }
@@ -313,7 +315,7 @@ export function DaemonIndexPage({
   return (
     <DaemonApiContext.Provider value={daemonFetch}>
       <div className="flex h-full flex-col overflow-y-auto p-4">
-        <h1 className="sr-only">Canvases</h1>
+        <h1 className="sr-only">Documents</h1>
         <div className="mb-4 flex flex-wrap items-center gap-2 border-b pb-2">
           {workspaces.length > 1 && (
             <select
@@ -393,7 +395,9 @@ export function DaemonIndexPage({
               source={filesSource}
               onOpenDocument={(path) => onOpenDocument(selectedWorkspace, path)}
               onDuplicateDocument={(path) => void handleDuplicate(path)}
-              onRequestDelete={(path, displayName) => setPendingDelete({ path, displayName })}
+              onRequestDelete={(path, displayName, kind) =>
+                setPendingDelete({ path, displayName, kind })
+              }
               // A new array on every successful read, which is exactly the
               // signal the panel needs: the page reloads this list after a
               // duplicate and after a delete, both of which it performs on
@@ -408,7 +412,7 @@ export function DaemonIndexPage({
           pending={pendingDelete}
           busy={deleting}
           error={deleteError}
-          description="This permanently removes the canvas, including its versions and branches. There is no undo."
+          description={`This permanently removes the ${kindNoun(pendingDelete?.kind)}, including its versions and branches. There is no undo.`}
           onCancel={closeDeleteDialog}
           onConfirm={() => void handleConfirmDelete()}
         />


### PR DESCRIPTION
Increment B of the **Document First** direction (A = #971). The retired container sense of "canvas" survived only in user-visible copy; every string now names the OBJECT, kind-aware where it is at hand.

| before | after |
|---|---|
| Delete dialog: "This permanently removes the **canvas**…" (even for a markdown note) | "…the **note** / the **canvas** / the **document**…" chosen from the deleted document's kind (`kindNoun`, one rule for all sites; the panel's `onRequestDelete` now carries the entry's kind) |
| "Back to canvas list" (aria + tooltip + visible label) | "Back to documents" |
| "Canvas title" (the field also edits note titles) | "Document title" |
| sr-only h1 "Canvases" | "Documents" |
| "Failed to create/duplicate/delete canvas." | kind where the call site knows it (create), "document" where it does not |

**Deliberately untouched (kind-certain, correct usage)**: the top bar's spatial-only create ("New canvas", "Creating canvas…", its error), the spatial editor's "Canvas actions", Settings' minimap description.

New red-first test pins the kind-aware wording (delete a note → "removes the note", a canvas → "removes the canvas"). All existing copy assertions re-pointed across 9 test files.

Verification: apps/web jsdom 2662 + node 77 green; affected browser files 32/32; lint / knip / typecheck clean. ## Live verification (Pages preview, fresh origin, SW uncontrolled)

Driven through the real UI and read from the live DOM (the browser tab was backgrounded on the verification machine, so the evidence is the rendered text rather than pixels):

- deleting the markdown note: `Delete "untitled"? This permanently removes the **note** from this browser. There is no undo.`
- deleting the spatial canvas: `Delete "untitled-2"? This permanently removes the **canvas** from this browser. There is no undo.`
- `h1.sr-only` reads `Documents`; the old `Back to canvas list` aria-label is gone.

The live pass also caught one site the grep sweep had misclassified: the top bar's actions menu (rename/copy/delete — any kind) was labeled **"Canvas actions"** while open on a markdown note. Renamed to **"Document actions"** in a follow-up commit; the spatial editor's own `ContextMenu` keeps "Canvas actions", where the word means the surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoaNgqWUKbYJxk2azmRQKY
