### PR TITLE
test(model): facet-value arbitrary normalizes -0, which no JSON-text codec can round-trip

### DIFF
--- a/packages/model/src/test-utils/arbitraries.ts
+++ b/packages/model/src/test-utils/arbitraries.ts
@@ -56,6 +56,12 @@ const extensionFacetKeyArbitrary: fc.Arbitrary<string> = fc
  */
 function stripProtoKeys(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(stripProtoKeys)
+  // Negative zero is legal JS but not a JSON-text value: JSON.stringify(-0)
+  // emits "0" and JSON.parse never yields -0, so a facet value holding one
+  // cannot round-trip through ANY JSON-text codec. Normalize at generation
+  // — the same call as the __proto__ strip below (narrow the generator,
+  // never teach a parser to reproduce the unreachable value).
+  if (typeof value === 'number') return Object.is(value, -0) ? 0 : value
   if (value === null || typeof value !== 'object') return value
   const out: Record<string, unknown> = {}
   for (const [key, child] of Object.entries(value)) {


### PR DESCRIPTION
## Summary

Fixes the red `test-unit (1)` on main (`canvas-viewer-node` `scene.property.test.ts`, seed 355253463): after #974's arbitraries started generating node facets, the extended-mode round-trip property could draw a facet payload containing **`-0`** — which no JSON-text codec can preserve (`JSON.stringify(-0)` emits `'0'`; `JSON.parse` never yields `-0`). The PR run passed only by seed luck.

Per the repo's PBT discipline this is an inherent representational limit, so the fix narrows the **generator** (normalize `-0 → 0` in the same walk as the `__proto__` strip, with the class commented) rather than teaching a parser to reproduce an unreachable value.

## Verification

- Reproduced red with the CI seed pinned locally, green with the same seed after the fix, seed unpinned again (never committed).
- model / codec / canvas-viewer projects: 313 tests green; scene property file 3 further random-seed runs green; `pnpm -r typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013avJozs9SoCuDzZJGuTcqH