### PR TITLE
fix(web): [[ completion accepts at the mapped position and dresses like the app

### DIFF
--- a/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
@@ -42,7 +42,7 @@ import { SourcePane, type SourcePaneApi } from './SourcePane.js'
 import { setHeadingLevel } from './set-heading-level.js'
 import { toggleTaskCheckbox } from './toggle-task-checkbox.js'
 import { useDebouncedValue } from './use-debounced-value.js'
-import { wikiLinkCompletionSource } from './wiki-link-completion.js'
+import { wikiLinkCompletionSource, wikiLinkCompletionTheme } from './wiki-link-completion.js'
 
 export interface MarkdownEditorProps {
   value: string
@@ -298,6 +298,7 @@ export function MarkdownEditor({
           },
         ]),
       ),
+      wikiLinkCompletionTheme,
     ],
     [],
   )

--- a/apps/web/src/components/markdown-editor/wiki-link-completion.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/wiki-link-completion.browser.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
 import { MarkdownEditor } from './MarkdownEditor.js'
@@ -57,6 +58,76 @@ describe('wiki link completion (real browser)', () => {
     })
     // Accepting closed the popup rather than leaving it over the text.
     expect(document.querySelector('.cm-tooltip-autocomplete')).toBeNull()
+  })
+
+  it('tapping an option accepts it — the touch path, not only Enter', async () => {
+    let value = ''
+    const { getByTestId } = render(
+      <MarkdownEditor
+        initialViewMode="write"
+        value=""
+        onChange={(next) => {
+          value = next
+        }}
+        linkTargets={TARGETS}
+      />,
+    )
+    const editable = getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]')
+    if (!editable) throw new Error('expected a contenteditable CodeMirror host')
+    ;(editable as HTMLElement).focus()
+    await vi.waitFor(() => {
+      expect(document.activeElement).toBe(editable)
+    })
+    await userEvent.keyboard('see [[[[Ret')
+    const option = await vi.waitFor(() => {
+      const el = [...document.querySelectorAll('.cm-tooltip-autocomplete li')].find((li) =>
+        li.textContent?.includes('Retro notes'),
+      )
+      expect(el).toBeDefined()
+      return el as HTMLElement
+    })
+    await userEvent.click(option)
+    await vi.waitFor(() => {
+      expect(value).toBe('see [[Retro notes]]')
+    })
+  })
+
+  it('the preview catches up with an accepted completion once the debounce settles', async () => {
+    // The dogfood report: on a phone, accepting a completion left the
+    // preview disagreeing with the source. The controlled round-trip is
+    // value -> onChange -> value -> debounced preview; this pins that an
+    // accept (a programmatic dispatch, not typing) travels the whole way.
+    function Harness() {
+      const [value, setValue] = useState('')
+      return (
+        <MarkdownEditor
+          initialViewMode="split"
+          previewDebounceMs={30}
+          value={value}
+          onChange={setValue}
+          linkTargets={TARGETS}
+        />
+      )
+    }
+    const { getByTestId } = render(<Harness />)
+    const editable = getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]')
+    if (!editable) throw new Error('expected a contenteditable CodeMirror host')
+    ;(editable as HTMLElement).focus()
+    await vi.waitFor(() => {
+      expect(document.activeElement).toBe(editable)
+    })
+    await userEvent.keyboard('see [[[[Re')
+    await vi.waitFor(() => {
+      expect(
+        document.querySelector('.cm-tooltip-autocomplete li[aria-selected="true"]'),
+      ).toBeTruthy()
+    })
+    await new Promise((resolve) => setTimeout(resolve, 120))
+    await userEvent.keyboard('{Enter}')
+    await vi.waitFor(() => {
+      const preview = getByTestId('markdown-preview-pane')
+      expect(preview.textContent).toContain('Release plan')
+    })
   })
 
   it('plain prose never opens the popup', async () => {

--- a/apps/web/src/components/markdown-editor/wiki-link-completion.test.ts
+++ b/apps/web/src/components/markdown-editor/wiki-link-completion.test.ts
@@ -70,6 +70,32 @@ describe('wikiLinkCompletionSource', () => {
     expect(accept(doc, result!, index)).toBe(`[[${ID_C}|Dup]]`)
   })
 
+  it('inserts at the CURRENT bracket position even after the document changed above it', () => {
+    // The mobile desync shape: the result opens, then the document shifts
+    // under it before the user accepts — an autocorrect elsewhere, a CRDT
+    // remote echo, another tab. CodeMirror maps the from/to it hands to
+    // apply through those changes; an offset captured when the source RAN
+    // does not move with them, and the markup lands mid-word at the stale
+    // position, silently corrupting the body.
+    const before = '詳細は [[Re'
+    const result = complete(before, before.length)
+    expect(result).not.toBeNull()
+    const option = result?.options[0]
+    if (option === undefined || typeof option.apply !== 'function')
+      throw new Error('expected apply fn')
+
+    const view = new EditorView({ state: EditorState.create({ doc: before }) })
+    const PREFIX = '先頭に挿入された行。\n'
+    view.dispatch({ changes: { from: 0, to: 0, insert: PREFIX } })
+    // What the plugin would pass: the ORIGINAL positions mapped through the
+    // concurrent change.
+    const mappedFrom = PREFIX.length + before.length - 'Re'.length
+    const mappedTo = PREFIX.length + before.length
+    option.apply(view, option, mappedFrom, mappedTo)
+    expect(view.state.doc.toString()).toBe(`${PREFIX}詳細は [[Release plan]]`)
+    view.destroy()
+  })
+
   it('stays silent outside a [[ context and across a line break', () => {
     expect(complete('plain text', 10)).toBeNull()
     const doc = '[[\nRe'

--- a/apps/web/src/components/markdown-editor/wiki-link-completion.ts
+++ b/apps/web/src/components/markdown-editor/wiki-link-completion.ts
@@ -1,6 +1,47 @@
 import type { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete'
-import type { EditorView } from '@codemirror/view'
+import { EditorView } from '@codemirror/view'
 import { type LinkTarget, linkMarkupFor, rankLinkTargets } from './link-target.js'
+
+/**
+ * The popup in the app's popover clothes. An EditorView.theme rather than
+ * index.css on purpose: the app stylesheet lives inside CSS @layer blocks,
+ * and CodeMirror injects its own UNLAYERED style element at view creation —
+ * which beats any layered rule regardless of specificity, so an index.css
+ * override silently loses. A theme extension compiles to CodeMirror's own
+ * generated classes and wins by the same mechanism the defaults do. CSS
+ * custom properties resolve at runtime, so the popover tokens (and theme
+ * switches) keep covering this surface.
+ */
+export const wikiLinkCompletionTheme = EditorView.theme({
+  '.cm-tooltip.cm-tooltip-autocomplete': {
+    backgroundColor: 'var(--popover)',
+    color: 'var(--popover-foreground)',
+    border: '1px solid var(--border)',
+    borderRadius: 'var(--radius-md)',
+    boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
+    overflow: 'hidden',
+  },
+  '.cm-tooltip.cm-tooltip-autocomplete > ul': {
+    fontFamily: 'inherit',
+    fontSize: '0.875rem',
+    maxHeight: '16rem',
+    padding: '0.25rem',
+  },
+  '.cm-tooltip.cm-tooltip-autocomplete > ul > li': {
+    borderRadius: 'var(--radius-sm)',
+    padding: '0.25rem 0.5rem',
+    lineHeight: '1.4',
+  },
+  '.cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected]': {
+    backgroundColor: 'var(--accent)',
+    color: 'var(--accent-foreground)',
+  },
+  // The generic "text" kind icon says nothing a document list needs said,
+  // and eats a monospace-width gutter.
+  '.cm-tooltip.cm-tooltip-autocomplete .cm-completionIcon': {
+    display: 'none',
+  },
+})
 
 /**
  * `[[` completion for document references. Accepting a candidate writes the
@@ -34,16 +75,24 @@ export function wikiLinkCompletionSource(getTargets: () => readonly LinkTarget[]
     if (match === null) return null
     const targets = getTargets()
     if (targets.length === 0) return null
-    const bracketsFrom = match.from
     const ranked = rankLinkTargets(targets, match.text.slice(2))
     if (ranked.length === 0) return null
     return {
-      from: bracketsFrom + 2,
+      from: match.from + 2,
       options: ranked.map(
         (target): Completion => ({
           label: target.name,
           type: 'text',
-          apply: (view: EditorView, _completion, _from, to) => {
+          apply: (view: EditorView, _completion, from, to) => {
+            // The brackets sit two characters before the QUERY start — and
+            // it must be the `from` the plugin passes, never a position
+            // captured when the source ran: the document may have changed in
+            // between (mobile autocorrect elsewhere, a CRDT remote echo,
+            // another tab), and the plugin maps from/to through those
+            // changes while a captured offset stays behind and writes the
+            // markup mid-word, corrupting the body.
+            const bracketsFrom = from - 2
+            if (view.state.sliceDoc(bracketsFrom, from) !== '[[') return
             const insert = linkMarkupFor(target, targets)
             view.dispatch({
               changes: { from: bracketsFrom, to, insert },


### PR DESCRIPTION
## What — two dogfood findings from phone use

### 1. Source/preview desync → reproduced as body corruption

The completion's `apply` captured the brackets' offset **when the source ran**, while the plugin maps the `from`/`to` it passes through every document change since — a mobile autocorrect elsewhere, a CRDT remote echo, another tab. Reproduced red-first:

```
'先頭に挿入された行。\n詳細は [[Re' + accept
→ '先頭に挿[[Release plan]]'   // markup at the STALE offset, text eaten
```

`apply` now derives the brackets from the **mapped** `from` and refuses when the two characters there are no longer `[[`. Also pinned in real Chromium: **tap-accept** (the touch path, not only Enter) and the accept → preview round-trip.

### 2. Popup styled like a foreign widget

CodeMirror's system-blue monospace default → the app's popover look. Notably **index.css cannot do this**: the app stylesheet lives in `@layer` blocks and CodeMirror injects *unlayered* styles at view creation, which beat any layered rule regardless of specificity — the first attempt rendered pixel-identical, which is how this constraint was found. `EditorView.theme` compiles into CodeMirror's own generated classes and wins by the same mechanism the defaults do; popover tokens resolve at runtime so theme switches keep covering it.

## Visual evidence

![completion-restyled.png](https://github.com/user-attachments/assets/adc01679-fb3c-4007-bcd2-b6415e87cd26)

## Verification

- Unit: stale-offset repro red → green; 7 unit + 4 browser tests on the completion, editor suites jsdom 173 / browser 66 all green
- The preview round-trip test pins value → onChange → debounced preview after a programmatic accept

回線の再確認のお願い: スマホでの乖離がこの stale-offset 破壊と同一物か、修正後も別の乖離が残るか — 再現したら「何を打って何が出たか」を一言もらえると特定が速いです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmbb1zNhiZitB7tn9LQ5f3