### PR TITLE
fix(web): a tap on a completion option commits it

### DIFF
--- a/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
@@ -42,7 +42,11 @@ import { SourcePane, type SourcePaneApi } from './SourcePane.js'
 import { setHeadingLevel } from './set-heading-level.js'
 import { toggleTaskCheckbox } from './toggle-task-checkbox.js'
 import { useDebouncedValue } from './use-debounced-value.js'
-import { wikiLinkCompletionSource, wikiLinkCompletionTheme } from './wiki-link-completion.js'
+import {
+  wikiLinkCompletionSource,
+  wikiLinkCompletionTheme,
+  wikiLinkTouchAccept,
+} from './wiki-link-completion.js'
 
 export interface MarkdownEditorProps {
   value: string
@@ -299,6 +303,7 @@ export function MarkdownEditor({
         ]),
       ),
       wikiLinkCompletionTheme,
+      wikiLinkTouchAccept,
     ],
     [],
   )

--- a/apps/web/src/components/markdown-editor/wiki-link-completion.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/wiki-link-completion.browser.test.tsx
@@ -130,6 +130,87 @@ describe('wiki link completion (real browser)', () => {
     })
   })
 
+  it('a real touch tap on an option commits it — no synthesized mouse events required', async () => {
+    // The phone report: an option looks selected but nothing commits.
+    // Upstream accepts on the synthesized mousedown and closes on the
+    // contenteditable blur + 10ms — an ordering a touch can lose, and one a
+    // synthetic TouchEvent (which synthesizes no mouse events at all)
+    // reproduces deterministically.
+    let value = ''
+    const { getByTestId } = render(
+      <MarkdownEditor
+        initialViewMode="write"
+        value=""
+        onChange={(next) => {
+          value = next
+        }}
+        linkTargets={TARGETS}
+      />,
+    )
+    const editable = getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]')
+    if (!editable) throw new Error('expected a contenteditable CodeMirror host')
+    ;(editable as HTMLElement).focus()
+    await vi.waitFor(() => {
+      expect(document.activeElement).toBe(editable)
+    })
+    await userEvent.keyboard('see [[[[Ret')
+    const option = await vi.waitFor(() => {
+      const el = [...document.querySelectorAll('.cm-tooltip-autocomplete li')].find((li) =>
+        li.textContent?.includes('Retro notes'),
+      )
+      expect(el).toBeDefined()
+      return el as HTMLElement
+    })
+    const rect = option.getBoundingClientRect()
+    const touch = (type: string, y: number) =>
+      option.dispatchEvent(
+        new TouchEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          changedTouches: [
+            new Touch({ identifier: 1, target: option, clientX: rect.x + 4, clientY: y }),
+          ],
+        }),
+      )
+    touch('touchstart', rect.y + 4)
+    touch('touchend', rect.y + 4)
+    await vi.waitFor(() => {
+      expect(value).toBe('see [[Retro notes]]')
+    })
+
+    // And a scroll gesture over the list must NOT commit: same events, but
+    // the finger travelled.
+    await userEvent.keyboard(' and [[[[Rel')
+    const second = await vi.waitFor(() => {
+      const el = [...document.querySelectorAll('.cm-tooltip-autocomplete li')].find((li) =>
+        li.textContent?.includes('Release plan'),
+      )
+      expect(el).toBeDefined()
+      return el as HTMLElement
+    })
+    const r2 = second.getBoundingClientRect()
+    second.dispatchEvent(
+      new TouchEvent('touchstart', {
+        bubbles: true,
+        cancelable: true,
+        changedTouches: [
+          new Touch({ identifier: 2, target: second, clientX: r2.x + 4, clientY: r2.y + 4 }),
+        ],
+      }),
+    )
+    second.dispatchEvent(
+      new TouchEvent('touchend', {
+        bubbles: true,
+        cancelable: true,
+        changedTouches: [
+          new Touch({ identifier: 2, target: second, clientX: r2.x + 4, clientY: r2.y + 60 }),
+        ],
+      }),
+    )
+    await new Promise((resolve) => setTimeout(resolve, 200))
+    expect(value).toBe('see [[Retro notes]] and [[Rel')
+  })
+
   it('plain prose never opens the popup', async () => {
     const { getByTestId } = render(
       <MarkdownEditor initialViewMode="write" value="" onChange={() => {}} linkTargets={TARGETS} />,

--- a/apps/web/src/components/markdown-editor/wiki-link-completion.ts
+++ b/apps/web/src/components/markdown-editor/wiki-link-completion.ts
@@ -1,5 +1,11 @@
-import type { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete'
-import { EditorView } from '@codemirror/view'
+import {
+  acceptCompletion,
+  type Completion,
+  type CompletionContext,
+  type CompletionResult,
+  setSelectedCompletion,
+} from '@codemirror/autocomplete'
+import { EditorView, ViewPlugin } from '@codemirror/view'
 import { type LinkTarget, linkMarkupFor, rankLinkTargets } from './link-target.js'
 
 /**
@@ -12,6 +18,50 @@ import { type LinkTarget, linkMarkupFor, rankLinkTargets } from './link-target.j
  * custom properties resolve at runtime, so the popover tokens (and theme
  * switches) keep covering this surface.
  */
+/**
+ * Deterministic tap-commit for the completion popup. Upstream accepts on
+ * the SYNTHESIZED mousedown and separately closes the popup when the
+ * contenteditable blurs (with a 10ms grace) — on touch devices the tap
+ * that should accept is also the tap that blurs the editor, and whether
+ * the synthesized mousedown beats the blur is a per-platform ordering the
+ * user experienced losing: the option highlights, nothing commits.
+ * touchend precedes both, so accepting there removes the race; a moved
+ * finger (a scroll over the option list) stays a scroll.
+ */
+const TAP_SLOP_PX = 12
+
+export const wikiLinkTouchAccept = ViewPlugin.define((view) => {
+  let startY: number | null = null
+  const optionAt = (target: EventTarget | null): HTMLElement | null => {
+    const li = target instanceof Element ? target.closest('.cm-tooltip-autocomplete li') : null
+    return li instanceof HTMLElement && view.dom.contains(li) ? li : null
+  }
+  const onTouchStart = (event: TouchEvent) => {
+    startY = optionAt(event.target) === null ? null : (event.changedTouches[0]?.clientY ?? null)
+  }
+  const onTouchEnd = (event: TouchEvent) => {
+    const li = optionAt(event.target)
+    const endY = event.changedTouches[0]?.clientY
+    if (li === null || startY === null || endY === undefined) return
+    if (Math.abs(endY - startY) > TAP_SLOP_PX) return
+    const match = /-(\d+)$/.exec(li.id)
+    if (match === null) return
+    // No synthesized mouse events after this tap: upstream must not accept
+    // a second time, and the blur that would close the popup never fires.
+    event.preventDefault()
+    view.dispatch({ effects: setSelectedCompletion(Number(match[1])) })
+    acceptCompletion(view)
+  }
+  view.dom.addEventListener('touchstart', onTouchStart, { passive: true })
+  view.dom.addEventListener('touchend', onTouchEnd, { passive: false })
+  return {
+    destroy() {
+      view.dom.removeEventListener('touchstart', onTouchStart)
+      view.dom.removeEventListener('touchend', onTouchEnd)
+    },
+  }
+})
+
 export const wikiLinkCompletionTheme = EditorView.theme({
   '.cm-tooltip.cm-tooltip-autocomplete': {
     backgroundColor: 'var(--popover)',


### PR DESCRIPTION
## What — the third phone finding

「候補を選択して表示されるように見えてもエンターを押さないと確定にならない」— an option highlights, nothing commits, and the only working commit path was the keyboard's Enter (labelled 改行 on a phone).

**Mechanism**: upstream accepts on the *synthesized* `mousedown` and separately closes the popup when the contenteditable blurs (+10ms grace). On touch, the tap that should accept **is also the tap that blurs the editor** — whether the synthesized mousedown beats the blur is per-platform event ordering, and the phone lost it. A synthetic `TouchEvent` (which synthesizes no mouse events at all) reproduces the loss deterministically and is the red test.

**Fix**: a view plugin accepts on `touchend` over an option — before both racers — with a 12px slop so a scroll gesture over the option list stays a scroll, and `preventDefault` so upstream cannot double-accept. Enter keeps working; desktop click path untouched.

A hint footer ("tap/Enter to insert") was considered and skipped: with tap actually committing, the confusion it would have papered over is gone.

## Verification

- Red-first: synthetic touch tap → no commit (reproduces the report) → green after the plugin; scroll-gesture negative case pinned
- Completion browser suite 5, editor suites jsdom 173 / browser 67 — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmbb1zNhiZitB7tn9LQ5f3