### PR TITLE
feat(web): the document browser's icon controls reveal their names

### DIFF
--- a/.claude/rules/integrator-flow.md
+++ b/.claude/rules/integrator-flow.md
@@ -124,6 +124,16 @@ When a preview contradicts a green test, suspect the cache before suspecting the
   Two obvious causes were refuted by measurement rather than argument: cutting
   `--maxWorkers` to 4 made it WORSE (33–39s, 40% more wall clock), and the
   shared-IndexedDB theory died on the twelve-file run.
+- **A ninth: a test's own teardown wiping the DOM out from under React.**
+  `afterEach(() => { document.body.innerHTML = '' })` leaves React roots
+  mounted on detached nodes; the NEXT render's reconciler then throws
+  unhandled `NotFoundError: removeChild ... not a child` — and vitest
+  reports every test in the file as PASSED while the file exits 1
+  ("Unhandled Errors"). Measured on CI: `Tests 3 passed (3)`, `Errors 4
+  errors`, job red. Always unmount through testing-library's `cleanup()`;
+  a raw DOM wipe also races the shared setup's own cleanup, so in
+  isolation it reproduces only intermittently (1 in 17 reruns) while CI
+  load makes it reliable.
 - **A seventh: clicking a trigger whose menu is still dismissing.** The click is consumed and
   the menu stays shut, so the failure reads as "the list does not contain this item" when no
   list was ever opened — and raising the query's timeout only buys a slower identical failure.

--- a/apps/web/src/components/workspace-files/SearchResults.tsx
+++ b/apps/web/src/components/workspace-files/SearchResults.tsx
@@ -15,6 +15,7 @@
 
 import { LayoutGrid, List } from 'lucide-react'
 import { type ReactNode, useState } from 'react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '../../lib/utils.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
 
@@ -89,24 +90,34 @@ export function SearchResults({
     <div className={className}>
       <div className="mb-1 flex justify-end">
         <div className="flex items-center gap-0.5 rounded-md border p-0.5">
-          <button
-            type="button"
-            aria-label="List results"
-            aria-pressed={layout === 'list'}
-            onClick={() => setLayout('list')}
-            className="text-muted-foreground aria-pressed:bg-accent aria-pressed:text-foreground rounded p-1"
-          >
-            <List className="size-4" />
-          </button>
-          <button
-            type="button"
-            aria-label="Grid results"
-            aria-pressed={layout === 'grid'}
-            onClick={() => setLayout('grid')}
-            className="text-muted-foreground aria-pressed:bg-accent aria-pressed:text-foreground rounded p-1"
-          >
-            <LayoutGrid className="size-4" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="List results"
+                aria-pressed={layout === 'list'}
+                onClick={() => setLayout('list')}
+                className="text-muted-foreground aria-pressed:bg-accent aria-pressed:text-foreground rounded p-1"
+              >
+                <List className="size-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>List results</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="Grid results"
+                aria-pressed={layout === 'grid'}
+                onClick={() => setLayout('grid')}
+                className="text-muted-foreground aria-pressed:bg-accent aria-pressed:text-foreground rounded p-1"
+              >
+                <LayoutGrid className="size-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Grid results</TooltipContent>
+          </Tooltip>
         </div>
       </div>
       {layout === 'list' ? (

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -1,6 +1,7 @@
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import { Columns2, FilePlus2, LayoutGrid, List, Search } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useThemeMode } from '../../hooks/useThemeMode.js'
 import { DocumentMinimap } from './DocumentMinimap.js'
 import { DocumentPreview } from './DocumentPreview.js'
@@ -284,45 +285,65 @@ export function WorkspaceFilesPanel({
           />
         </div>
         <div className="flex shrink-0 items-center gap-1">
-          <button
-            type="button"
-            aria-label="New markdown document"
-            disabled={creating}
-            onClick={() => void createHere('markdown').catch(() => setCreateError('markdown'))}
-            className="text-muted-foreground hover:text-foreground rounded border p-1.5"
-          >
-            <FilePlus2 className="size-4" />
-          </button>
-          <button
-            type="button"
-            aria-label="New canvas"
-            disabled={creating}
-            onClick={() => void createHere('spatial').catch(() => setCreateError('spatial'))}
-            className="text-muted-foreground hover:text-foreground rounded border p-1.5"
-          >
-            <LayoutGrid className="size-4" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="New markdown document"
+                disabled={creating}
+                onClick={() => void createHere('markdown').catch(() => setCreateError('markdown'))}
+                className="text-muted-foreground hover:text-foreground rounded border p-1.5"
+              >
+                <FilePlus2 className="size-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>New markdown document</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="New canvas"
+                disabled={creating}
+                onClick={() => void createHere('spatial').catch(() => setCreateError('spatial'))}
+                className="text-muted-foreground hover:text-foreground rounded border p-1.5"
+              >
+                <LayoutGrid className="size-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>New canvas</TooltipContent>
+          </Tooltip>
         </div>
         <fieldset className="flex shrink-0 items-center gap-0.5 rounded border p-0.5">
           <legend className="sr-only">Column layout</legend>
-          <button
-            type="button"
-            aria-label="One column"
-            aria-pressed={columns === 'one'}
-            onClick={() => setColumns('one')}
-            className="text-muted-foreground aria-pressed:bg-accent aria-pressed:text-foreground rounded p-1"
-          >
-            <List className="size-4" />
-          </button>
-          <button
-            type="button"
-            aria-label="Two columns"
-            aria-pressed={columns === 'two'}
-            onClick={() => setColumns('two')}
-            className="text-muted-foreground aria-pressed:bg-accent aria-pressed:text-foreground rounded p-1"
-          >
-            <Columns2 className="size-4" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="One column"
+                aria-pressed={columns === 'one'}
+                onClick={() => setColumns('one')}
+                className="text-muted-foreground aria-pressed:bg-accent aria-pressed:text-foreground rounded p-1"
+              >
+                <List className="size-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>One column</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="Two columns"
+                aria-pressed={columns === 'two'}
+                onClick={() => setColumns('two')}
+                className="text-muted-foreground aria-pressed:bg-accent aria-pressed:text-foreground rounded p-1"
+              >
+                <Columns2 className="size-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Two columns</TooltipContent>
+          </Tooltip>
         </fieldset>
       </div>
 

--- a/apps/web/src/components/workspace-files/panel-tooltips.browser.test.tsx
+++ b/apps/web/src/components/workspace-files/panel-tooltips.browser.test.tsx
@@ -65,12 +65,20 @@ describe('document browser toolbar tooltips (real browser)', () => {
   })
 
   it('keyboard focus reveals the name too', async () => {
+    // Trusted keyboard input, never a programmatic focus(): reaching the
+    // tooltip through :focus-visible is the behavior under test, and the
+    // live app demonstrably does NOT open it for element.focus() — a
+    // programmatic call here would pass on a UA heuristic the product
+    // never relies on.
     renderPanel()
     await vi.waitFor(() => {
       expect(document.querySelector('button[aria-label="New canvas"]')).not.toBeNull()
     })
     const button = document.querySelector('button[aria-label="New canvas"]') as HTMLElement
-    button.focus()
+    for (let hops = 0; hops < 12 && document.activeElement !== button; hops++) {
+      await userEvent.tab()
+    }
+    expect(document.activeElement).toBe(button)
     await vi.waitFor(() => {
       const tips = [...document.querySelectorAll('[data-slot="tooltip-content"], [role="tooltip"]')]
       expect(tips.some((t) => t.textContent?.includes('New canvas'))).toBe(true)

--- a/apps/web/src/components/workspace-files/panel-tooltips.browser.test.tsx
+++ b/apps/web/src/components/workspace-files/panel-tooltips.browser.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { cleanup, render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
 import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
@@ -9,11 +9,11 @@ import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
 // with it — this pins their return on the panel. Real browser because
 // jsdom cannot be trusted to portal-render Radix tooltip content.
 
-afterEach(() => {
-  // Radix leaves no timers behind, but the portal root may linger between
-  // tests; a fresh body keeps the queries honest.
-  document.body.innerHTML = ''
-})
+// testing-library's cleanup, never a bare innerHTML wipe: React must
+// unmount its own roots, or its later teardown removeChild()s nodes that
+// are no longer in the document and the file fails with unhandled
+// NotFoundErrors (measured on CI).
+afterEach(cleanup)
 
 function renderPanel() {
   const source = fakeFilesSource({

--- a/apps/web/src/components/workspace-files/panel-tooltips.browser.test.tsx
+++ b/apps/web/src/components/workspace-files/panel-tooltips.browser.test.tsx
@@ -1,0 +1,79 @@
+import { render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
+import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
+
+// The document browser's toolbar is icon-only; ADR-0006 point 4 says an
+// icon-only control reveals its name. The grid's Radix tooltips retired
+// with it — this pins their return on the panel. Real browser because
+// jsdom cannot be trusted to portal-render Radix tooltip content.
+
+afterEach(() => {
+  // Radix leaves no timers behind, but the portal root may linger between
+  // tests; a fresh body keeps the queries honest.
+  document.body.innerHTML = ''
+})
+
+function renderPanel() {
+  const source = fakeFilesSource({
+    listDocuments: () =>
+      Promise.resolve([{ documentId: 'd1', path: 'seed', kind: 'markdown' as const }]),
+  })
+  return render(<WorkspaceFilesPanel source={source} />)
+}
+
+async function expectTooltip(label: string) {
+  const button = document.querySelector(`button[aria-label="${label}"]`) as HTMLElement | null
+  if (!button) throw new Error(`no button labeled ${label}`)
+  await userEvent.hover(button)
+  await vi.waitFor(() => {
+    const tips = [...document.querySelectorAll('[data-slot="tooltip-content"], [role="tooltip"]')]
+    // The visible name matches the accessible one, so the two cannot drift.
+    expect(tips.some((t) => t.textContent?.includes(label))).toBe(true)
+  })
+  await userEvent.unhover(button)
+}
+
+describe('document browser toolbar tooltips (real browser)', () => {
+  it('every icon-only control reveals its name on hover', async () => {
+    renderPanel()
+    await vi.waitFor(() => {
+      expect(document.querySelector('button[aria-label="New canvas"]')).not.toBeNull()
+    })
+    for (const label of ['New markdown document', 'New canvas', 'One column', 'Two columns']) {
+      await expectTooltip(label)
+    }
+  })
+
+  it('the search layout toggles reveal their names too', async () => {
+    const { rerender: _r } = renderPanel()
+    await vi.waitFor(() => {
+      expect(document.querySelector('input[aria-label="Search documents"]')).not.toBeNull()
+    })
+    const search = document.querySelector(
+      'input[aria-label="Search documents"]',
+    ) as HTMLInputElement
+    search.focus()
+    await userEvent.fill(search, 'seed')
+    await vi.waitFor(() => {
+      expect(document.querySelector('button[aria-label="List results"]')).not.toBeNull()
+    })
+    for (const label of ['List results', 'Grid results']) {
+      await expectTooltip(label)
+    }
+  })
+
+  it('keyboard focus reveals the name too', async () => {
+    renderPanel()
+    await vi.waitFor(() => {
+      expect(document.querySelector('button[aria-label="New canvas"]')).not.toBeNull()
+    })
+    const button = document.querySelector('button[aria-label="New canvas"]') as HTMLElement
+    button.focus()
+    await vi.waitFor(() => {
+      const tips = [...document.querySelectorAll('[data-slot="tooltip-content"], [role="tooltip"]')]
+      expect(tips.some((t) => t.textContent?.includes('New canvas'))).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
Increment C of the **Document First** direction (A = #971, B = #978). The grid's retirement (#969) took its Radix tooltips with it, leaving the panel's toolbar icon-only with aria-labels alone — ADR-0006 point 4 says an icon-only control reveals its name.

- Six controls gain tooltips: **New markdown document**, **New canvas**, **One column**, **Two columns**, and the search results' **List results** / **Grid results** toggles.
- The tooltip text IS the aria-label, and the browser test asserts the tooltip content contains the label — so the visible name and the accessible one cannot drift.
- Real-browser test (red first) pins reveal on **hover** and on **keyboard focus** — jsdom cannot be trusted to portal Radix tooltip content, which is exactly why the retired grid's tooltip test was browser-mode too.

Verification: apps/web jsdom 2670 + node 77; workspace-files browser files + flow test 6/6 + the new 3; lint / knip clean. Preview hover check follows as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoaNgqWUKbYJxk2azmRQKY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added descriptive tooltips to workspace file controls, including document creation, layout switching, and search layout actions.
  * Tooltips appear when controls are hovered or focused with the keyboard, improving discoverability and accessibility.

* **Tests**
  * Added browser coverage to verify tooltip behavior across workspace file panel controls and layouts.

* **Documentation**
  * Documented guidance for preventing intermittent CI failures caused by improper test cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->