### PR TITLE
perf(canvas-render): cut side-choice search time 24-32% by removing work it repeated per trial

### DIFF
--- a/packages/canvas-render/src/layout/edge-crossing-sweep.ts
+++ b/packages/canvas-render/src/layout/edge-crossing-sweep.ts
@@ -46,38 +46,89 @@ export function scoreSegmentPair(
   b2: Point,
 ): readonly [number, number, number] {
   const q = (n: number) => Math.round(n * COST_QUANTUM)
-  const clearance = EDGE_JUMP_RADIUS_PX + 1
+  return scoreQuantizedSegmentPair(
+    q(a1.x),
+    q(a1.y),
+    q(a2.x),
+    q(a2.y),
+    q(b1.x),
+    q(b1.y),
+    q(b2.x),
+    q(b2.y),
+  )
+}
+
+/** `EDGE_JUMP_RADIUS_PX + 1`, in COST_QUANTUM units. */
+const CLEARANCE_Q = (EDGE_JUMP_RADIUS_PX + 1) * COST_QUANTUM
+
+/**
+ * The narrow phase on ALREADY-QUANTIZED integer coordinates — pure integer
+ * arithmetic from here on, so a second implementation of it (a WGSL
+ * kernel, a worker) can be held to bit-identical output. Quantizing first,
+ * rather than only for the collinear branch, is what makes that true: the
+ * crossing test used to run on raw floats, and two endpoints a
+ * sub-quantum apart could count as a crossing here while scoring equal
+ * everywhere else. `t`/`u` stay exact because every comparison is done on
+ * the cross-multiplied integers, never on the quotient.
+ */
+export function scoreQuantizedSegmentPair(
+  ax1: number,
+  ay1: number,
+  ax2: number,
+  ay2: number,
+  bx1: number,
+  by1: number,
+  bx2: number,
+  by2: number,
+): readonly [number, number, number] {
   // Collinear axis-aligned overlap.
-  if (q(a1.y) === q(a2.y) && q(b1.y) === q(b2.y) && q(a1.y) === q(b1.y)) {
-    const lo = Math.max(q(Math.min(a1.x, a2.x)), q(Math.min(b1.x, b2.x)))
-    const hi = Math.min(q(Math.max(a1.x, a2.x)), q(Math.max(b1.x, b2.x)))
+  if (ay1 === ay2 && by1 === by2 && ay1 === by1) {
+    const lo = Math.max(Math.min(ax1, ax2), Math.min(bx1, bx2))
+    const hi = Math.min(Math.max(ax1, ax2), Math.max(bx1, bx2))
     return [hi > lo ? hi - lo : 0, 0, 0]
   }
-  if (q(a1.x) === q(a2.x) && q(b1.x) === q(b2.x) && q(a1.x) === q(b1.x)) {
-    const lo = Math.max(q(Math.min(a1.y, a2.y)), q(Math.min(b1.y, b2.y)))
-    const hi = Math.min(q(Math.max(a1.y, a2.y)), q(Math.max(b1.y, b2.y)))
+  if (ax1 === ax2 && bx1 === bx2 && ax1 === bx1) {
+    const lo = Math.max(Math.min(ay1, ay2), Math.min(by1, by2))
+    const hi = Math.min(Math.max(ay1, ay2), Math.max(by1, by2))
     return [hi > lo ? hi - lo : 0, 0, 0]
   }
-  // Proper transversal crossing.
-  const dax = a2.x - a1.x
-  const day = a2.y - a1.y
-  const dbx = b2.x - b1.x
-  const dby = b2.y - b1.y
-  const denom = dax * dby - day * dbx
+  // Proper transversal crossing: t = tn/denom, u = un/denom, both strictly
+  // inside (0, 1). Signs are normalized so the open-interval test is a
+  // plain integer comparison.
+  const dax = ax2 - ax1
+  const day = ay2 - ay1
+  const dbx = bx2 - bx1
+  const dby = by2 - by1
+  let denom = dax * dby - day * dbx
   if (denom === 0) return [0, 0, 0]
-  const t = ((b1.x - a1.x) * dby - (b1.y - a1.y) * dbx) / denom
-  const u = ((b1.x - a1.x) * day - (b1.y - a1.y) * dax) / denom
-  if (t <= 0 || t >= 1 || u <= 0 || u >= 1) return [0, 0, 0]
-  const lenA = Math.hypot(dax, day)
-  const lenB = Math.hypot(dbx, dby)
+  let tn = (bx1 - ax1) * dby - (by1 - ay1) * dbx
+  let un = (bx1 - ax1) * day - (by1 - ay1) * dax
+  if (denom < 0) {
+    denom = -denom
+    tn = -tn
+    un = -un
+  }
+  if (tn <= 0 || tn >= denom || un <= 0 || un >= denom) return [0, 0, 0]
+  // Distance from each segment end to the crossing, compared against the
+  // clearance without dividing: t * |A| < c  <=>  tn * |A| < c * denom.
+  // |A| is exact for an axis-aligned segment; a diagonal one rounds its
+  // hypot, which is the one remaining float in this function.
+  const lenA = axisLength(dax, day)
+  const lenB = axisLength(dbx, dby)
   const illegible =
-    t * lenA < clearance ||
-    (1 - t) * lenA < clearance ||
-    u * lenB < clearance ||
-    (1 - u) * lenB < clearance
+    tn * lenA < CLEARANCE_Q * denom ||
+    (denom - tn) * lenA < CLEARANCE_Q * denom ||
+    un * lenB < CLEARANCE_Q * denom ||
+    (denom - un) * lenB < CLEARANCE_Q * denom
       ? 1
       : 0
   return [0, illegible, 1]
+}
+
+function axisLength(dx: number, dy: number): number {
+  if (dx === 0) return Math.abs(dy)
+  if (dy === 0) return Math.abs(dx)
+  return Math.round(Math.hypot(dx, dy))
 }
 
 interface SweepSegment {

--- a/packages/canvas-render/src/layout/edge-routing-quality.test.ts
+++ b/packages/canvas-render/src/layout/edge-routing-quality.test.ts
@@ -176,12 +176,12 @@ describe('routing quality across the synthetic corpus', () => {
       length: Math.round(length),
       shortArrowRunway: shortRunway,
     }).toEqual({
-      violations: { 'own-endpoint': 14, foreign: 16, degenerate: 0 },
-      interiorInk: 2203,
+      violations: { 'own-endpoint': 13, foreign: 16, degenerate: 0 },
+      interiorInk: 2164,
       borderInk: 824,
-      bends: 8150,
-      crossings: 498,
-      length: 1340155,
+      bends: 8153,
+      crossings: 497,
+      length: 1340228,
       shortArrowRunway: 137,
     })
   })

--- a/packages/canvas-render/src/layout/grid-route.ts
+++ b/packages/canvas-render/src/layout/grid-route.ts
@@ -78,8 +78,6 @@ function borderOverlap(a: Point, b: Point, rect: Rect): number {
   return 0
 }
 
-const uniqueSorted = (values: readonly number[]) => [...new Set(values)].sort((a, b) => a - b)
-
 /**
  * The cheapest rectilinear path from `start` to `end` whose interior avoids
  * every rect in `obstacles`, or undefined when there is none (or the grid is
@@ -92,17 +90,21 @@ export function routeOnGrid(
   obstacles: readonly Rect[],
   clearance: number,
 ): Point[] | undefined {
-  const xs = uniqueSorted([
-    start.x,
-    end.x,
-    ...obstacles.flatMap((r) => [r.x - clearance, r.x + r.w + clearance]),
-  ])
-  const ys = uniqueSorted([
-    start.y,
-    end.y,
-    ...obstacles.flatMap((r) => [r.y - clearance, r.y + r.h + clearance]),
-  ])
-  if (xs.length * ys.length > MAX_GRID_CELLS) return undefined
+  // Distinct coordinates first, sorting only once the grid is known to fit:
+  // on a canvas past the cap every call used to build and sort both axes
+  // just to abandon them (measured: every one of 705 calls on a 345-edge
+  // canvas, a quarter of its routing time).
+  const xSet = new Set<number>([start.x, end.x])
+  const ySet = new Set<number>([start.y, end.y])
+  for (const r of obstacles) {
+    xSet.add(r.x - clearance)
+    xSet.add(r.x + r.w + clearance)
+    ySet.add(r.y - clearance)
+    ySet.add(r.y + r.h + clearance)
+  }
+  if (xSet.size * ySet.size > MAX_GRID_CELLS) return undefined
+  const xs = [...xSet].sort((a, b) => a - b)
+  const ys = [...ySet].sort((a, b) => a - b)
 
   const si = xs.indexOf(start.x)
   const sj = ys.indexOf(start.y)

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -662,6 +662,9 @@ function optimizeSideChoices(
   pins?: ReadonlyMap<string, EdgeAnchorOverride>,
 ): ReadonlyMap<string, SidePair> {
   const byId = new Map(nodes.map((n) => [n.id, n]))
+  const othersFor = edges.map((e) =>
+    nodes.filter((n) => n.id !== e.fromNode && n.id !== e.toNode).map(rectOf),
+  )
   const sameAnchor = (a: EdgeAnchorPair | undefined, b: EdgeAnchorPair | undefined): boolean =>
     a?.from?.x === b?.from?.x &&
     a?.from?.y === b?.from?.y &&
@@ -689,11 +692,15 @@ function optimizeSideChoices(
   const routeCache = new Map<string, readonly Point[]>()
   const anchorKey = (edge: CanvasEdge, a: EdgeAnchorPair | undefined) =>
     `${edge.id}|${a?.fromSide}|${a?.toSide}|${a?.from?.x},${a?.from?.y}|${a?.to?.x},${a?.to?.y}|${a?.fromLaneDepth}|${a?.toLaneDepth}`
-  const routeCached = (edge: CanvasEdge, a: EdgeAnchorPair | undefined): readonly Point[] => {
+  const routeCached = (
+    edge: CanvasEdge,
+    i: number,
+    a: EdgeAnchorPair | undefined,
+  ): readonly Point[] => {
     const key = anchorKey(edge, a)
     const hit = routeCache.get(key)
     if (hit !== undefined) return hit
-    const path = routeEdge(nodes, edge, style, a).path
+    const path = routeEdge(nodes, edge, style, a, othersFor[i]).path
     routeCache.set(key, path)
     return path
   }
@@ -729,7 +736,7 @@ function optimizeSideChoices(
 
   let current = new Map(initial)
   let anchors = computeAnchorsFor(nodes, edges, current, align, pins)
-  let paths: (readonly Point[])[] = edges.map((e) => routeCached(e, anchors.get(e.id)))
+  let paths: (readonly Point[])[] = edges.map((e, i) => routeCached(e, i, anchors.get(e.id)))
   let bounds: Rect[] = paths.map(boundsOf)
   const pairKey = (i: number, j: number) => i * edges.length + j
   const matrix = new Map<number, ConfigCost>()
@@ -739,14 +746,11 @@ function optimizeSideChoices(
   // always excluded them; the SEARCH did not, so it priced ink the router
   // could not avoid and could be talked into a detour to "save" it — the
   // same predicate `deriveDefaultSides`'s occlusion filter already uses.
-  const foreignBodiesFor = edges.map((e) => {
+  const foreignBodiesFor = edges.map((e, i) => {
     const endpoints = [byId.get(e.fromNode), byId.get(e.toNode)]
       .filter((n): n is SpatialNode => n !== undefined)
       .map(rectOf)
-    return nodes
-      .filter((n) => n.id !== e.fromNode && n.id !== e.toNode)
-      .map(rectOf)
-      .filter((r) => !endpoints.some((endpoint) => fullyContains(r, endpoint)))
+    return othersFor[i]!.filter((r) => !endpoints.some((endpoint) => fullyContains(r, endpoint)))
   })
   // Every node's border, INCLUDING an edge's own endpoints — border-tracing
   // prices ink on a node's own outline, unlike foreignBodiesFor's tunnel
@@ -799,7 +803,7 @@ function optimizeSideChoices(
     const trialPaths = paths.slice()
     const trialBounds = bounds.slice()
     for (const i of touched) {
-      trialPaths[i] = routeCached(edges[i]!, trialAnchors.get(edges[i]!.id))
+      trialPaths[i] = routeCached(edges[i]!, i, trialAnchors.get(edges[i]!.id))
       trialBounds[i] = boundsOf(trialPaths[i]!)
     }
     const touchedSet = new Set(touched)
@@ -1730,6 +1734,10 @@ export function routeEdge(
   // Endpoint override from `assignEdgeAnchors`'s fan-out pass; an absent
   // field keeps the side midpoint, so single callers stay unchanged.
   anchors?: EdgeAnchorPair,
+  // Every node's rect except the two endpoints', when the caller already
+  // has them: the side-choice search routes each edge many times per
+  // layout and this is the one O(nodes) list it can hand over intact.
+  others?: readonly Rect[],
 ): ResolvedEdgeNode {
   const fromNode = nodes.find((n) => n.id === edge.fromNode)
   const toNode = nodes.find((n) => n.id === edge.toNode)
@@ -1797,10 +1805,9 @@ export function routeEdge(
   // anchor is boxed inside a neighbour's margin band, `bestCandidate`'s
   // second tier accepts a band crossing to escape rather than tunnelling
   // through the node itself.
-  const rawObstacles = nodes
-    .filter((n) => n.id !== edge.fromNode && n.id !== edge.toNode)
-    .map(rectOf)
-    .filter((rect) => !containsPoint(rect, start) && !containsPoint(rect, end))
+  const rawObstacles = (
+    others ?? nodes.filter((n) => n.id !== edge.fromNode && n.id !== edge.toNode).map(rectOf)
+  ).filter((rect) => !containsPoint(rect, start) && !containsPoint(rect, end))
   const obstacles = rawObstacles.map((rect) => ({
     x: rect.x - ROUTE_MARGIN_PX,
     y: rect.y - ROUTE_MARGIN_PX,

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -1721,11 +1721,15 @@ export function routeEdge(
     }
   }
 
-  const derived = deriveDefaultSides(nodes, edge, fromRect, toRect)
   // The anchor pass resolves sides with whole-edge-set crowding knowledge a
   // single call lacks; when it spoke, follow it (authored sides still win).
-  const fromSide = edge.fromSide ?? anchors?.fromSide ?? derived.fromSide
-  const toSide = edge.toSide ?? anchors?.toSide ?? derived.toSide
+  // Deriving is an occlusion scan over every node, and the search calls this
+  // a thousand times per layout with both sides already decided, so it only
+  // runs when a side is actually missing.
+  let derived: SidePair | undefined
+  const derive = () => (derived ??= deriveDefaultSides(nodes, edge, fromRect, toRect))
+  const fromSide = edge.fromSide ?? anchors?.fromSide ?? derive().fromSide
+  const toSide = edge.toSide ?? anchors?.toSide ?? derive().toSide
 
   const start = anchors?.from ?? sidePoint(fromRect, fromSide)
   const end = anchors?.to ?? sidePoint(toRect, toSide)

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -1,6 +1,6 @@
 import type { CanvasEdge, EdgeRoutingStyle, SpatialNode } from '@kamiazya/whiteboard-model'
 import type { ResolvedEdgeNode } from '../scene-graph.js'
-import { buildPairwiseScores, scoreSegmentPair } from './edge-crossing-sweep.js'
+import { buildPairwiseScores, scoreQuantizedSegmentPair } from './edge-crossing-sweep.js'
 import {
   addCost,
   bendCount,
@@ -539,18 +539,71 @@ type ConfigCost = readonly number[]
  * the declared tiers.
  */
 function pairScore(a: readonly Point[], b: readonly Point[]): ConfigCost {
+  const qa = quantizedSegments(a)
+  const qb = quantizedSegments(b)
   let overlap = 0
   let illegible = 0
   let crossings = 0
-  for (let ai = 1; ai < a.length; ai++) {
-    for (let bi = 1; bi < b.length; bi++) {
-      const [o, il, c] = scoreSegmentPair(a[ai - 1]!, a[ai]!, b[bi - 1]!, b[bi]!)
+  for (let ai = 0; ai < qa.length; ai += 8) {
+    for (let bi = 0; bi < qb.length; bi += 8) {
+      // Segment-level broad phase, the same inflated-bbox test the sweep
+      // applies (edge-crossing-sweep.ts): a pair whose boxes miss by more
+      // than a quantum cannot overlap, cross, or sit illegibly close.
+      if (
+        qa[ai + 4]! > qb[bi + 6]! ||
+        qb[bi + 4]! > qa[ai + 6]! ||
+        qa[ai + 5]! > qb[bi + 7]! ||
+        qb[bi + 5]! > qa[ai + 7]!
+      ) {
+        continue
+      }
+      const [o, il, c] = scoreQuantizedSegmentPair(
+        qa[ai]!,
+        qa[ai + 1]!,
+        qa[ai + 2]!,
+        qa[ai + 3]!,
+        qb[bi]!,
+        qb[bi + 1]!,
+        qb[bi + 2]!,
+        qb[bi + 3]!,
+      )
       overlap += o
       illegible += il
       crossings += c
     }
   }
   return pairPenalty([overlap, illegible, crossings])
+}
+
+/**
+ * A path's segments in COST_QUANTUM units, eight ints each: x1 y1 x2 y2,
+ * then the bbox (minX minY maxX maxY) inflated by one quantum for the
+ * broad phase. Keyed by path identity: the search routes through a cache,
+ * so the same path object is scored against hundreds of others and paid
+ * for its quantization once.
+ */
+const quantizedCache = new WeakMap<readonly Point[], Int32Array>()
+function quantizedSegments(path: readonly Point[]): Int32Array {
+  const hit = quantizedCache.get(path)
+  if (hit !== undefined) return hit
+  const out = new Int32Array(Math.max(0, path.length - 1) * 8)
+  for (let i = 1; i < path.length; i++) {
+    const x1 = Math.round(path[i - 1]!.x * COST_QUANTUM)
+    const y1 = Math.round(path[i - 1]!.y * COST_QUANTUM)
+    const x2 = Math.round(path[i]!.x * COST_QUANTUM)
+    const y2 = Math.round(path[i]!.y * COST_QUANTUM)
+    const o = (i - 1) * 8
+    out[o] = x1
+    out[o + 1] = y1
+    out[o + 2] = x2
+    out[o + 3] = y2
+    out[o + 4] = Math.min(x1, x2) - 1
+    out[o + 5] = Math.min(y1, y2) - 1
+    out[o + 6] = Math.max(x1, x2) + 1
+    out[o + 7] = Math.max(y1, y2) + 1
+  }
+  quantizedCache.set(path, out)
+  return out
 }
 
 /**


### PR DESCRIPTION
## Summary

Four commits, each profiled first and judged by the scoreboard + interleaved `pnpm bench`. The side-choice search (`optimizeSideChoices`) is the layout hot spot; profiling the sequential search showed its cost was mostly work repeated on every trial, not the scoring itself:

1. **`deriveDefaultSides` made lazy** — `routeEdge` ran an occlusion scan over every node on each call and discarded it whenever anchors already carried both sides (every search call). 131ms of 602ms routing on the 345-edge bench.
2. **Quantize-first narrow phase** (`scoreQuantizedSegmentPair`) — the transversal crossing test ran on raw floats while the collinear branch was quantized; now one integer scorer. *This is the one deliberate scoreboard move:* violations 30→29, interiorInk 2203→2164, crossings 498→497, bends 8150→8153, length +73. Debt metrics improve; one price metric (bends) +3.
3. **Int32 segment fast path with broad-phase gate** in `pairScore` — paths are cached objects scored hundreds of times; quantized once (WeakMap by identity), segment bboxes skip pairs that cannot contribute (same lemma as the sweep). Scoreboard unchanged.
4. **Obstacle list handed to `routeEdge`; Hanan grid sized before building** — the search rebuilt the other-nodes rect list per call (100ms), and `routeOnGrid` deduped+sorted both axes before checking the cell cap — every one of 705 calls on the 345-edge bench was abandoned right after (158ms). Scoreboard unchanged.

## Measured (interleaved `pnpm bench`, 3 paired rounds, min ms, load avg < 4)

| bench | before | after |
|---|---|---|
| 60 nodes / 200 edges | 449 / 382 / 410 | 272 / 270 / 280 (−32%) |
| clustered 144 / 165 edges | 196 / 207 / 190 | 135 / 134 / 131 (−31%) |
| clustered 288 / 345 edges | 621 / 624 / 632 | 484 / 467 / 488 (−24%) |

Faster in every paired round. `pnpm test` for canvas-render-node, arch-lint-node, canvas-viewer-*, server-core-node, mcp-node (two load-dependent flakes, green in isolation) and the apps/web jsdom suite (2666) pass; `pnpm knip` clean; `pnpm -r typecheck` clean.

`routeEdge` gains an optional trailing `others?: readonly Rect[]` parameter; all existing callers are unchanged.

Context: this replaces the WebGPU/batch plan, which was measured and refuted (#983).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsowZaXiyxZFpBhWykbPRv