### PR TITLE
fix(web): empty-doc caret lands at the line start; link targets exclude the open document

### DIFF
--- a/apps/web/src/components/markdown-editor/SourcePane.tsx
+++ b/apps/web/src/components/markdown-editor/SourcePane.tsx
@@ -279,6 +279,13 @@ export function SourcePane({
             caretColor: 'var(--foreground)',
           },
           '.cm-line': { padding: '0 24px' },
+          // Out of the line's flow: upstream renders the placeholder as an
+          // inline-block INSIDE the first line, and Android places the
+          // native caret (and its selection handle) after that span — the
+          // cursor appears mid-line on an empty document. Absolute takes
+          // the span out of caret geometry; the <br> CodeMirror keeps in an
+          // empty line preserves the line's height.
+          '.cm-placeholder': { position: 'absolute' },
         }),
         EditorView.updateListener.of((update) => {
           if (update.docChanged) {

--- a/apps/web/src/components/markdown-editor/placeholder-caret.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/placeholder-caret.browser.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MarkdownEditor } from './MarkdownEditor.js'
+
+afterEach(() => {
+  cleanup()
+  window.localStorage.removeItem('whiteboard.markdown-view-mode')
+})
+
+describe('empty-document caret', () => {
+  it('the native caret sits at the line start, not after the placeholder text', async () => {
+    // On Android the OS draws its selection handle at the NATIVE caret. The
+    // placeholder is an inline-block span inside the first line, so a caret
+    // that lands after it renders mid-line — the "cursor appears in a weird
+    // place" report on an empty document. The caret must sit where typing
+    // will put the first character: the line start.
+    const { getByTestId } = render(
+      <MarkdownEditor initialViewMode="write" value="" onChange={() => {}} />,
+    )
+    const editable = getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]')
+    if (!editable) throw new Error('expected a contenteditable CodeMirror host')
+    ;(editable as HTMLElement).focus()
+    await vi.waitFor(() => {
+      expect(document.activeElement).toBe(editable)
+    })
+
+    const placeholder = editable.querySelector('.cm-placeholder')
+    expect(placeholder).not.toBeNull()
+    const line = editable.querySelector('.cm-line')
+    expect(line).not.toBeNull()
+
+    // The mechanism, not only the symptom: the placeholder must sit outside
+    // the line's flow (desktop Chromium puts the caret at line start either
+    // way, so only this guards the Android handle placement), while the
+    // empty line keeps a real height for it to overlay.
+    expect(getComputedStyle(placeholder as Element).position).toBe('absolute')
+    expect((line as HTMLElement).getBoundingClientRect().height).toBeGreaterThan(10)
+
+    await vi.waitFor(() => {
+      const selection = window.getSelection()
+      expect(selection?.rangeCount).toBeGreaterThan(0)
+      const caret = selection!.getRangeAt(0).getBoundingClientRect()
+      const lineRect = (line as HTMLElement).getBoundingClientRect()
+      // Within a character's width of the line start — never past the
+      // placeholder's span.
+      expect(caret.left - lineRect.left).toBeLessThan(10)
+    })
+  })
+})

--- a/apps/web/src/lib/daemon-link-entries.test.ts
+++ b/apps/web/src/lib/daemon-link-entries.test.ts
@@ -67,3 +67,16 @@ describe('daemonLinkTargets', () => {
     ])
   })
 })
+
+describe('self-reference exclusion', () => {
+  it('daemonLinkTargets leaves the open document out of its own link targets', () => {
+    const documents = [
+      { path: 'self', id: 'id-self', updatedAt: 't', displayName: 'Self' },
+      { path: 'other', id: 'id-other', updatedAt: 't', displayName: 'Other' },
+    ]
+    const targets = daemonLinkTargets(documents, { excludeDocumentId: 'id-self' })
+    expect(targets.map((t) => t.id)).toEqual(['id-other'])
+    // Without the exclusion everything stays listed (existing callers).
+    expect(daemonLinkTargets(documents).map((t) => t.id)).toEqual(['id-self', 'id-other'])
+  })
+})

--- a/apps/web/src/lib/daemon-link-entries.ts
+++ b/apps/web/src/lib/daemon-link-entries.ts
@@ -39,10 +39,25 @@ export function daemonLinkEntries(
  * known by. Unlike the resolver above this is a list a human reads, so a
  * document appearing twice would be noise rather than tolerance.
  */
-export function daemonLinkTargets(documents: readonly DocumentSummary[]): readonly LinkTarget[] {
-  return documents.map((entry) => ({
-    id: documentId(entry),
-    name: entry.displayName ?? entry.path,
-    ...(entry.kind ? { kind: entry.kind } : {}),
-  }))
+/**
+ * `excludeDocumentId` is the OPEN document: a link's whole job is to reach
+ * some other document, and offering the one being edited invites the
+ * self-reference the Connections surface would then have to explain away
+ * (backlinks already skip self, so a self-link is invisible everywhere).
+ */
+export function daemonLinkTargets(
+  documents: readonly DocumentSummary[],
+  { excludeDocumentId }: { excludeDocumentId?: string } = {},
+): readonly LinkTarget[] {
+  return documents.flatMap((entry) => {
+    const id = documentId(entry)
+    if (id === excludeDocumentId) return []
+    return [
+      {
+        id,
+        name: entry.displayName ?? entry.path,
+        ...(entry.kind ? { kind: entry.kind } : {}),
+      },
+    ]
+  })
 }

--- a/apps/web/src/pages/BrowserLocalDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.tsx
@@ -326,12 +326,16 @@ export function BrowserLocalDocumentPage({
 
   const linkTargets = useMemo(
     () =>
-      switcherOptions.map((entry) => ({
-        id: entry.documentId,
-        name: entry.name,
-        kind: entry.kind,
-      })),
-    [switcherOptions],
+      switcherOptions
+        // Never the open document itself: a link's whole job is to reach
+        // some OTHER document, and backlinks skip self-references anyway.
+        .filter((entry) => entry.documentId !== documentId)
+        .map((entry) => ({
+          id: entry.documentId,
+          name: entry.name,
+          kind: entry.kind,
+        })),
+    [switcherOptions, documentId],
   )
   // ![[embed]] bodies, pre-fetched so the layout's sync seam has content.
   const resolveEmbed = useMarkdownEmbedContent({

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -358,7 +358,13 @@ export function DaemonDocumentPage({
   )
   // The same list, one row per document, carried with ids so the picker can
   // fall back to one when a name is ambiguous.
-  const linkTargets = useMemo(() => daemonLinkTargets(controller.documents), [controller.documents])
+  const linkTargets = useMemo(
+    () =>
+      daemonLinkTargets(controller.documents, {
+        excludeDocumentId: controller.documents.find((d) => d.path === controller.path)?.id,
+      }),
+    [controller.documents, controller.path],
+  )
 
   // Backlinks for the Connections chip. Keyed on the CURRENT document's id —
   // an older daemon's id-less listing leaves it undefined and the chip


### PR DESCRIPTION
## What — two small dogfood findings, fixed before moving on

### 1. 空のマークダウンでカーソルが変な位置に出る (Android)

Upstream renders the placeholder ("Write in Markdown…") as an **inline-block span inside the first line**, and Android places the native caret — and its blue selection handle — *after* that span, mid-line (the screenshot's floating drop). The placeholder is now absolutely positioned in SourcePane's theme, taking it out of caret geometry entirely; the `<br>` CodeMirror keeps in an empty line preserves its height. Desktop Chromium puts the caret at line start either way, so the browser test guards the **mechanism** (computed `position: absolute` + line keeps height) alongside the caret-at-line-start symptom.

### 2. ドキュメントリンクの自己参照

Both pages offered the open document among its own link targets — `[[` completion and the Link picker would happily link a document to itself, producing a reference the Connections surface then *skips* as a self-link (invisible everywhere: worst of both). `daemonLinkTargets` takes `excludeDocumentId`, and both the daemon and browser-local pages pass the open document's id. Red-first at the helper.

## Verification

- apps/web jsdom 1433 + editor browser 68 — green; typecheck/biome/knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmbb1zNhiZitB7tn9LQ5f3