### PR TITLE
feat(web): the Connections panel surfaces unlinked mentions

### DIFF
--- a/apps/web/src/components/connections/ConnectionsChip.test.tsx
+++ b/apps/web/src/components/connections/ConnectionsChip.test.tsx
@@ -33,6 +33,39 @@ describe('ConnectionsChip', () => {
     expect(panel.textContent).toContain('日程を確定する')
   })
 
+  it('shows unlinked mentions as their own section, and navigates on click', () => {
+    const onOpen = vi.fn()
+    render(
+      <ConnectionsChip
+        backlinks={TWO}
+        mentions={[
+          {
+            documentId: '01CX5ZZKBKACTAV9WEVGEMMVRA',
+            path: 'standup',
+            name: 'Standup memo',
+            kind: 'markdown' as const,
+            contexts: ['…昨日の議論で Release plan の前提が変わった…'],
+          },
+        ]}
+        onOpen={onOpen}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /connections/i }))
+    const panel = screen.getByRole('region', { name: /connections/i })
+    expect(panel.textContent).toContain('Mentioned, not linked')
+    expect(panel.textContent).toContain('Standup memo')
+    fireEvent.click(screen.getByRole('button', { name: /standup memo/i }))
+    expect(onOpen).toHaveBeenCalledWith(expect.objectContaining({ path: 'standup' }))
+  })
+
+  it('hides the mentions section when there are none', () => {
+    render(<ConnectionsChip backlinks={TWO} mentions={[]} onOpen={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: /connections/i }))
+    expect(screen.getByRole('region', { name: /connections/i }).textContent).not.toContain(
+      'Mentioned, not linked',
+    )
+  })
+
   it('navigates to the source document when its row is clicked', () => {
     const onOpen = vi.fn()
     render(<ConnectionsChip backlinks={TWO} onOpen={onOpen} />)

--- a/apps/web/src/components/connections/ConnectionsChip.tsx
+++ b/apps/web/src/components/connections/ConnectionsChip.tsx
@@ -8,6 +8,11 @@ export type ConnectionsBacklink = DocumentBacklinksResponse['backlinks'][number]
 export interface ConnectionsChipProps {
   /** `null` while the fetch is in flight or unavailable — the chip waits. */
   readonly backlinks: readonly ConnectionsBacklink[] | null
+  /**
+   * Sources naming this document in prose without a link — the panel's
+   * seeding section. Absent hides it (a backend that answers no mentions).
+   */
+  readonly mentions?: readonly ConnectionsBacklink[]
   /** The whole entry: the daemon page navigates by `path`, others may not. */
   readonly onOpen: (backlink: ConnectionsBacklink) => void
 }
@@ -22,7 +27,7 @@ export interface ConnectionsChipProps {
  * links land somewhere, which is the reason to write one; hiding it until
  * content exists would hide the loop exactly where it needs starting.
  */
-export function ConnectionsChip({ backlinks, onOpen }: ConnectionsChipProps) {
+export function ConnectionsChip({ backlinks, mentions, onOpen }: ConnectionsChipProps) {
   const [open, setOpen] = useState(false)
   const panelId = useId()
   const loaded = backlinks !== null
@@ -60,37 +65,66 @@ export function ConnectionsChip({ backlinks, onOpen }: ConnectionsChipProps) {
               No links yet — a [[link]] written in any document lands here.
             </p>
           ) : (
-            <ul className="flex flex-col">
-              {backlinks.map((entry) => (
-                <li key={entry.documentId}>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setOpen(false)
-                      onOpen(entry)
-                    }}
-                    className="hover:bg-muted flex w-full flex-col gap-0.5 rounded px-2 py-1.5 text-left"
-                  >
-                    <span className="flex items-center gap-1.5 text-sm font-medium">
-                      {entry.kind === 'spatial' ? (
-                        <LayoutDashboard aria-hidden="true" className="size-3.5 shrink-0" />
-                      ) : (
-                        <FileText aria-hidden="true" className="size-3.5 shrink-0" />
-                      )}
-                      {entry.name ?? entry.path}
-                    </span>
-                    {entry.contexts.slice(0, 2).map((context) => (
-                      <span key={context} className="text-muted-foreground truncate text-xs">
-                        {context}
-                      </span>
-                    ))}
-                  </button>
-                </li>
-              ))}
-            </ul>
+            <SourceList
+              entries={backlinks}
+              onPick={(entry) => {
+                setOpen(false)
+                onOpen(entry)
+              }}
+            />
+          )}
+          {(mentions?.length ?? 0) > 0 && (
+            <>
+              <p className="text-muted-foreground mb-1 mt-3 text-[11px] font-semibold uppercase tracking-wide">
+                Mentioned, not linked {mentions?.length}
+              </p>
+              <SourceList
+                entries={mentions ?? []}
+                onPick={(entry) => {
+                  setOpen(false)
+                  onOpen(entry)
+                }}
+              />
+            </>
           )}
         </section>
       )}
     </>
+  )
+}
+
+function SourceList({
+  entries,
+  onPick,
+}: {
+  readonly entries: readonly ConnectionsBacklink[]
+  readonly onPick: (entry: ConnectionsBacklink) => void
+}) {
+  return (
+    <ul className="flex flex-col">
+      {entries.map((entry) => (
+        <li key={entry.documentId}>
+          <button
+            type="button"
+            onClick={() => onPick(entry)}
+            className="hover:bg-muted flex w-full flex-col gap-0.5 rounded px-2 py-1.5 text-left"
+          >
+            <span className="flex items-center gap-1.5 text-sm font-medium">
+              {entry.kind === 'spatial' ? (
+                <LayoutDashboard aria-hidden="true" className="size-3.5 shrink-0" />
+              ) : (
+                <FileText aria-hidden="true" className="size-3.5 shrink-0" />
+              )}
+              {entry.name ?? entry.path}
+            </span>
+            {entry.contexts.slice(0, 2).map((context) => (
+              <span key={context} className="text-muted-foreground truncate text-xs">
+                {context}
+              </span>
+            ))}
+          </button>
+        </li>
+      ))}
+    </ul>
   )
 }

--- a/apps/web/src/pages/DaemonDocumentPage.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.test.tsx
@@ -134,7 +134,7 @@ describe('DaemonDocumentPage', () => {
         { path: 'second', id: 'id-second', updatedAt: '2026-01-02', kind: 'spatial' },
       ],
     })
-    mockGetDocumentBacklinks.mockResolvedValue({ backlinks: [] })
+    mockGetDocumentBacklinks.mockResolvedValue({ backlinks: [], unlinkedMentions: [] })
   })
 
   afterEach(() => {
@@ -208,6 +208,7 @@ describe('DaemonDocumentPage', () => {
           contexts: ['embedded on this canvas'],
         },
       ],
+      unlinkedMentions: [],
     })
     await act(async () => {
       render(

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -364,14 +364,17 @@ export function DaemonDocumentPage({
   // an older daemon's id-less listing leaves it undefined and the chip
   // disabled rather than querying with a path the route would reject.
   const currentDocumentId = controller.documents.find((d) => d.path === controller.path)?.id
-  const [backlinks, setBacklinks] = useState<readonly ConnectionsBacklink[] | null>(null)
+  const [connections, setConnections] = useState<{
+    readonly backlinks: readonly ConnectionsBacklink[]
+    readonly unlinkedMentions: readonly ConnectionsBacklink[]
+  } | null>(null)
   useEffect(() => {
-    setBacklinks(null)
+    setConnections(null)
     if (currentDocumentId === undefined || controller.workspaceId === null) return
     let cancelled = false
     getDocumentBacklinks(daemonFetch, daemonBaseUrl, controller.workspaceId, currentDocumentId)
       .then((response) => {
-        if (!cancelled) setBacklinks(response.backlinks)
+        if (!cancelled) setConnections(response)
       })
       .catch(() => {
         // The chip simply stays disabled; connections are never worth an
@@ -640,7 +643,8 @@ export function DaemonDocumentPage({
                     onFacetsChange={setCoreFacets}
                   />
                   <ConnectionsChip
-                    backlinks={backlinks}
+                    backlinks={connections === null ? null : connections.backlinks}
+                    mentions={connections?.unlinkedMentions}
                     onOpen={(entry) => controller.switchDocument(entry.path)}
                   />
                 </>

--- a/docs/how-to/link-documents.md
+++ b/docs/how-to/link-documents.md
@@ -31,6 +31,11 @@ reference (or the canvas relationship). Click an entry to jump to it.
 The chip shows `0` on a document nothing links to yet; links written
 anywhere in the workspace land here automatically.
 
+Below the linked-from list, **Mentioned, not linked** surfaces documents
+whose prose contains this document's display name without linking to it —
+candidates for a link the author never wrote. Click one to open it and
+decide; the system never links on its own (a link is the author's claim).
+
 ## Rules worth knowing
 
 - A link that does not resolve for the *reader* (an ambiguous name, an

--- a/packages/server-core/src/references/extract.ts
+++ b/packages/server-core/src/references/extract.ts
@@ -18,6 +18,16 @@ function textReferences(value: string): RawReference[] {
   }))
 }
 
+function spatialTexts(canvas: SpatialCanvas): string[] {
+  const texts: string[] = []
+  for (const node of canvas.nodes) {
+    if (node.type === 'text') texts.push(node.text)
+    if (node.type === 'group' && node.label !== undefined) texts.push(node.label)
+  }
+  for (const edge of canvas.edges) if (edge.label !== undefined) texts.push(edge.label)
+  return texts
+}
+
 function spatialReferences(canvas: SpatialCanvas): RawReference[] {
   const refs: RawReference[] = []
   for (const node of canvas.nodes) {
@@ -47,14 +57,16 @@ function spatialReferences(canvas: SpatialCanvas): RawReference[] {
  */
 export function extractReferenceFacts(entry: DocumentEntry, doc: LoroDoc): DocumentReferenceFacts {
   const kind = entry.kind ?? readDocumentKind(doc)
-  const refs =
-    kind === 'markdown'
-      ? textReferences(readMarkdownBody(doc))
-      : spatialReferences(readSpatialCanvas(doc))
+  const markdown = kind === 'markdown'
+  const canvas = markdown ? undefined : readSpatialCanvas(doc)
   return {
     path: entry.path,
     ...(entry.name === undefined ? {} : { name: entry.name }),
     ...(entry.kind === undefined ? {} : { kind: entry.kind }),
-    refs,
+    refs: markdown
+      ? textReferences(readMarkdownBody(doc))
+      : spatialReferences(canvas as SpatialCanvas),
+    // The prose itself, for mention detection against other documents' names.
+    texts: markdown ? [readMarkdownBody(doc)] : spatialTexts(canvas as SpatialCanvas),
   }
 }

--- a/packages/server-core/src/references/reference-aggregate.property.test.ts
+++ b/packages/server-core/src/references/reference-aggregate.property.test.ts
@@ -27,6 +27,7 @@ const factsArb: fc.Arbitrary<DocumentReferenceFacts> = fc.record(
   {
     path: fc.constantFrom<string>(...PATHS),
     name: fc.option(fc.constantFrom('Plan', 'Note'), { nil: undefined }),
+    texts: fc.array(fc.constantFrom('Plan の話', 'plain prose'), { maxLength: 2 }),
     refs: fc.array(
       fc.record({
         target: fc.constantFrom<string>(...IDS, ...PATHS, 'Plan'),

--- a/packages/server-core/src/references/reference-aggregate.ts
+++ b/packages/server-core/src/references/reference-aggregate.ts
@@ -1,4 +1,4 @@
-import { createUniqueNameResolver } from '@kamiazya/whiteboard-codec'
+import { createUniqueNameResolver, scanReferences } from '@kamiazya/whiteboard-codec'
 import {
   documentIdSchema,
   documentKindSchema,
@@ -6,6 +6,7 @@ import {
 } from '@kamiazya/whiteboard-model'
 import { compareDocumentPaths } from '@kamiazya/whiteboard-ports'
 import { z } from 'zod'
+import { snippetAround } from '../search/snippet.js'
 
 /**
  * The reference aggregation layer, designed around the Loro document
@@ -58,6 +59,12 @@ const documentReferenceFactsSchema = z
     name: z.string().min(1).optional(),
     kind: documentKindSchema.optional(),
     refs: z.array(rawReferenceSchema),
+    /**
+     * The document's raw prose — body and canvas text — kept alongside the
+     * extracted refs because MENTION detection is a join against another
+     * document's NAME, which extraction cannot know per-document.
+     */
+    texts: z.array(z.string()),
   })
   .strict()
 export type DocumentReferenceFacts = z.infer<typeof documentReferenceFactsSchema>
@@ -153,6 +160,51 @@ export class ReferenceAggregate {
     )
     return backlinks
   }
+}
+
+/**
+ * Sources whose TEXT names `documentId`'s display name without a resolving
+ * reference — the seeding half of the linking loop: the system finds the
+ * candidate, a human confirms (a link is the author's claim, never a
+ * statistic). Occurrences inside any `[[...]]` span are excluded whole —
+ * target and alias halves alike — so an already-linking document surfaces
+ * only its EXTRA prose mentions.
+ */
+export function mentionsOfIn(
+  target: { readonly documentId: string; readonly name: string },
+  sources: ReadonlyMap<string, DocumentReferenceFacts>,
+): BacklinkEntry[] {
+  const mentions: BacklinkEntry[] = []
+  for (const [sourceId, facts] of sources) {
+    if (sourceId === target.documentId) continue
+    const contexts: string[] = []
+    for (const text of facts.texts) {
+      const spans = scanReferences(text).map(
+        (match) => [match.index, match.index + match.full.length] as const,
+      )
+      let cursor = 0
+      for (;;) {
+        const at = text.indexOf(target.name, cursor)
+        if (at === -1) break
+        cursor = at + target.name.length
+        if (spans.some(([from, to]) => at >= from && at < to)) continue
+        contexts.push(snippetAround(text, at, target.name.length))
+        if (contexts.length >= 3) break
+      }
+      if (contexts.length >= 3) break
+    }
+    if (contexts.length === 0) continue
+    mentions.push({
+      documentId: sourceId,
+      path: facts.path,
+      ...(facts.name === undefined ? {} : { name: facts.name }),
+      ...(facts.kind === undefined ? {} : { kind: facts.kind }),
+      contexts,
+    })
+  }
+  return mentions.sort(
+    (a, b) => compareDocumentPaths(a.path, b.path) || a.documentId.localeCompare(b.documentId),
+  )
 }
 
 function resolvesTo(

--- a/packages/server-core/src/tools/backlinks.test.ts
+++ b/packages/server-core/src/tools/backlinks.test.ts
@@ -134,6 +134,45 @@ describe('GET /backlinks', () => {
     expect((await backlinksOf(deps, other.documentId)).backlinks).toHaveLength(0)
   })
 
+  it('reports unlinked mentions: the name in prose, never inside a reference', async () => {
+    const deps = makeDeps()
+    const { create, writeBody } = await seed(deps)
+    // seed() created the target named 'Release plan' at path 'target'.
+    const [plain, linked, aliasOnly] = [
+      await create('plain-mention', 'markdown', 'Plain'),
+      await create('linked-too', 'markdown', 'Linked'),
+      await create('alias-only', 'markdown', 'Alias'),
+    ]
+    const targetId = (await deps.documentIndex.resolveDocument({ workspaceId: WS, path: 'target' }))
+      ?.documentId
+    if (targetId === undefined) throw new Error('target missing')
+    await writeBody(plain.documentId, '会議で Release plan の前提が変わった。')
+    // A document that LINKS and also mentions in prose sits in both lists.
+    await writeBody(
+      linked.documentId,
+      'see [[Release plan]] — and later, Release plan again in prose.',
+    )
+    // The name only as an alias inside a reference: no mention.
+    await writeBody(aliasOnly.documentId, `see [[${targetId}|Release plan]]`)
+
+    const out = await backlinksOf(deps, targetId)
+    expect(out.backlinks.map((b) => b.path).sort()).toEqual(['alias-only', 'linked-too'])
+    expect(out.unlinkedMentions.map((m) => m.path).sort()).toEqual(['linked-too', 'plain-mention'])
+    expect(out.unlinkedMentions.find((m) => m.path === 'plain-mention')?.contexts[0]).toContain(
+      '前提が変わった',
+    )
+  })
+
+  it('an unnamed document accrues no mentions — a path is an address, not prose', async () => {
+    const deps = makeDeps()
+    const { create, writeBody } = await seed(deps)
+    const unnamed = await create('nameless', 'markdown')
+    const src = await create('src', 'markdown')
+    await writeBody(src.documentId, 'the word nameless appears here in prose')
+    const out = await backlinksOf(deps, unnamed.documentId)
+    expect(out.unlinkedMentions).toEqual([])
+  })
+
   it('excludes self-references and answers 404 for an unknown document', async () => {
     const deps = makeDeps()
     const { target, writeBody } = await seed(deps)

--- a/packages/server-core/src/tools/backlinks.ts
+++ b/packages/server-core/src/tools/backlinks.ts
@@ -1,7 +1,11 @@
 import { documentIdSchema, workspaceIdSchema } from '@kamiazya/whiteboard-model'
 import { z } from 'zod'
 import { extractReferenceFacts } from '../references/extract.js'
-import { backlinkEntrySchema, ReferenceAggregate } from '../references/reference-aggregate.js'
+import {
+  backlinkEntrySchema,
+  mentionsOfIn,
+  ReferenceAggregate,
+} from '../references/reference-aggregate.js'
 import type { ServerDeps } from '../server-deps.js'
 import { WorkspaceDocumentNotFoundError } from './document-crud.errors.js'
 import { loadDocument } from './document-io.js'
@@ -11,7 +15,13 @@ export const backlinksInputSchema = z
   .strict()
 export type BacklinksInput = z.infer<typeof backlinksInputSchema>
 
-export const backlinksOutputSchema = z.object({ backlinks: z.array(backlinkEntrySchema) }).strict()
+export const backlinksOutputSchema = z
+  .object({
+    backlinks: z.array(backlinkEntrySchema),
+    /** Sources naming this document in prose without a resolving link. */
+    unlinkedMentions: z.array(backlinkEntrySchema),
+  })
+  .strict()
 export type BacklinksOutput = z.infer<typeof backlinksOutputSchema>
 
 /**
@@ -49,10 +59,17 @@ export async function computeBacklinks(
         ...(entry.name === undefined ? {} : { name: entry.name }),
         ...(entry.kind === undefined ? {} : { kind: entry.kind }),
         refs: [],
+        texts: [],
       })
       continue
     }
     aggregate.upsert(entry.documentId, 0, extractReferenceFacts(entry, doc))
   }
-  return { backlinks: aggregate.backlinksOf(input.documentId) }
+  const alive = aggregate.entries()
+  const name = alive.get(input.documentId)?.name
+  return {
+    backlinks: aggregate.backlinksOf(input.documentId),
+    unlinkedMentions:
+      name === undefined ? [] : mentionsOfIn({ documentId: input.documentId, name }, alive),
+  }
 }


### PR DESCRIPTION
## What — P3 of the Connections design (detection slice)

Documents whose prose contains the open document's **display name without a resolving link** now appear in the Connections panel under **Mentioned, not linked**, with context snippets; clicking one opens the mentioning document. The seeding half of the linking loop from the design artifact: the system finds the candidate, the human decides — the panel never links on its own (a link is the author's claim, not a statistic).

Semantics pinned red-first:

- name inside any `[[...]]` span — target **or alias half** — never counts; an already-linking document surfaces only its *extra* prose mentions (sits in both lists)
- an unnamed document accrues no mentions (a path is an address, not prose someone types)
- canvas text participates like markdown bodies

**Where it lives**: `DocumentReferenceFacts` gains the raw `texts` — extraction cannot precompute mentions, they join against *another* document's name — and `mentionsOfIn` answers from the aggregate's held facts, so ADR-0014's future event-fed mode inherits mentions for free. The backlinks response widens additively; one fetch feeds the whole panel.

**Deliberately out (named follow-up)**: one-click linkify. Editing another live CRDT document belongs in an atomic server-side operation, not client-side offset patching — the exact stale-offset class #980 fixed.

## Verification

- server-core 322 green (incl. new red-first cases; convergence property suite extended with the texts field)
- apps/web jsdom 2672 + node 77 green; panel section + navigation pinned
- Real dev daemon: Japanese mention (「昨日の会議で設計メモの前提が変わった」 naming 「設計メモ」 unlinked) detected with correct snippet, no false backlink
- `origin/main` (with #985) merged in; overlap files green on the merge result

## Docs

`docs/how-to/link-documents.md` gains the Mentioned-not-linked paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmbb1zNhiZitB7tn9LQ5f3