### PR TITLE
feat(web): Link it — one server-side operation turns a mention into a real link

### DIFF
--- a/apps/web/src/components/connections/ConnectionsChip.test.tsx
+++ b/apps/web/src/components/connections/ConnectionsChip.test.tsx
@@ -58,6 +58,33 @@ describe('ConnectionsChip', () => {
     expect(onOpen).toHaveBeenCalledWith(expect.objectContaining({ path: 'standup' }))
   })
 
+  it('mention rows offer Link it when a handler is given, and only then', () => {
+    const onLinkify = vi.fn()
+    const mention = {
+      documentId: '01CX5ZZKBKACTAV9WEVGEMMVRA',
+      path: 'standup',
+      name: 'Standup memo',
+      kind: 'markdown' as const,
+      contexts: ['…Release plan の前提が…'],
+    }
+    const { unmount } = render(
+      <ConnectionsChip
+        backlinks={TWO}
+        mentions={[mention]}
+        onOpen={() => {}}
+        onLinkify={onLinkify}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /connections/i }))
+    fireEvent.click(screen.getByRole('button', { name: /link it/i }))
+    expect(onLinkify).toHaveBeenCalledWith(expect.objectContaining({ path: 'standup' }))
+    unmount()
+
+    render(<ConnectionsChip backlinks={TWO} mentions={[mention]} onOpen={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: /connections/i }))
+    expect(screen.queryByRole('button', { name: /link it/i })).toBeNull()
+  })
+
   it('hides the mentions section when there are none', () => {
     render(<ConnectionsChip backlinks={TWO} mentions={[]} onOpen={() => {}} />)
     fireEvent.click(screen.getByRole('button', { name: /connections/i }))

--- a/apps/web/src/components/connections/ConnectionsChip.tsx
+++ b/apps/web/src/components/connections/ConnectionsChip.tsx
@@ -15,6 +15,12 @@ export interface ConnectionsChipProps {
   readonly mentions?: readonly ConnectionsBacklink[]
   /** The whole entry: the daemon page navigates by `path`, others may not. */
   readonly onOpen: (backlink: ConnectionsBacklink) => void
+  /**
+   * Converts a mention row's occurrences into real links (the server-side
+   * linkify operation). Absent hides the button — a backend without the
+   * route offers navigation only.
+   */
+  readonly onLinkify?: (mention: ConnectionsBacklink) => void
 }
 
 /**
@@ -27,7 +33,7 @@ export interface ConnectionsChipProps {
  * links land somewhere, which is the reason to write one; hiding it until
  * content exists would hide the loop exactly where it needs starting.
  */
-export function ConnectionsChip({ backlinks, mentions, onOpen }: ConnectionsChipProps) {
+export function ConnectionsChip({ backlinks, mentions, onOpen, onLinkify }: ConnectionsChipProps) {
   const [open, setOpen] = useState(false)
   const panelId = useId()
   const loaded = backlinks !== null
@@ -84,6 +90,11 @@ export function ConnectionsChip({ backlinks, mentions, onOpen }: ConnectionsChip
                   setOpen(false)
                   onOpen(entry)
                 }}
+                action={
+                  onLinkify === undefined
+                    ? undefined
+                    : { label: 'Link it', onPick: (entry) => onLinkify(entry) }
+                }
               />
             </>
           )}
@@ -96,18 +107,20 @@ export function ConnectionsChip({ backlinks, mentions, onOpen }: ConnectionsChip
 function SourceList({
   entries,
   onPick,
+  action,
 }: {
   readonly entries: readonly ConnectionsBacklink[]
   readonly onPick: (entry: ConnectionsBacklink) => void
+  readonly action?: { label: string; onPick: (entry: ConnectionsBacklink) => void }
 }) {
   return (
     <ul className="flex flex-col">
       {entries.map((entry) => (
-        <li key={entry.documentId}>
+        <li key={entry.documentId} className="flex items-start gap-1">
           <button
             type="button"
             onClick={() => onPick(entry)}
-            className="hover:bg-muted flex w-full flex-col gap-0.5 rounded px-2 py-1.5 text-left"
+            className="hover:bg-muted flex min-w-0 flex-1 flex-col gap-0.5 rounded px-2 py-1.5 text-left"
           >
             <span className="flex items-center gap-1.5 text-sm font-medium">
               {entry.kind === 'spatial' ? (
@@ -123,6 +136,15 @@ function SourceList({
               </span>
             ))}
           </button>
+          {action !== undefined && (
+            <button
+              type="button"
+              onClick={() => action.onPick(entry)}
+              className="text-primary hover:bg-accent mt-1.5 shrink-0 rounded border px-2 py-0.5 text-xs font-medium"
+            >
+              {action.label}
+            </button>
+          )}
         </li>
       ))}
     </ul>

--- a/apps/web/src/lib/daemon-api-client.ts
+++ b/apps/web/src/lib/daemon-api-client.ts
@@ -13,9 +13,11 @@ import {
   documentsApiUrl,
   type InstallFontResponse,
   installFontResponseSchema,
+  type LinkifyMentionsResponse,
   type ListDocumentsResponse,
   type ListFontsResponse,
   type ListWorkspacesResponse,
+  linkifyMentionsResponseSchema,
   listDocumentsResponseSchema,
   listFontsResponseSchema,
   listWorkspacesResponseSchema,
@@ -250,6 +252,26 @@ export function getWorkspaceDocumentTags(
     fetchImpl,
     `${daemonBaseUrl}/api/v1/workspaces/${encodeURIComponent(workspaceId)}/document-tags`,
     workspaceDocumentTagsResponseSchema,
+  )
+}
+
+/** Convert a source document's unlinked mentions of the target into [[...]] links. */
+export function linkifyDocumentMentions(
+  fetchImpl: typeof fetch,
+  daemonBaseUrl: string,
+  workspaceId: string,
+  sourceDocumentId: string,
+  targetDocumentId: string,
+): Promise<LinkifyMentionsResponse> {
+  return fetchAndParse(
+    fetchImpl,
+    `${daemonBaseUrl}/api/v1/workspaces/${encodeURIComponent(workspaceId)}/documents/${encodeURIComponent(sourceDocumentId)}/linkify-mentions`,
+    linkifyMentionsResponseSchema,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ targetDocumentId }),
+    },
   )
 }
 

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -39,7 +39,11 @@ import { useFavicon } from '../hooks/useFavicon.js'
 import { useThemeMode } from '../hooks/useThemeMode.js'
 import { getAppLogger } from '../lib/app-logger.js'
 import { useWhiteboardCommands } from '../lib/commands/index.js'
-import { createDaemonFetch, getDocumentBacklinks } from '../lib/daemon-api-client.js'
+import {
+  createDaemonFetch,
+  getDocumentBacklinks,
+  linkifyDocumentMentions,
+} from '../lib/daemon-api-client.js'
 import { createDaemonFileAdapter } from '../lib/daemon-file-adapter.js'
 import { daemonLinkEntries, daemonLinkTargets } from '../lib/daemon-link-entries.js'
 import { deriveNewDocumentPath } from '../lib/derive-new-document-path.js'
@@ -374,6 +378,7 @@ export function DaemonDocumentPage({
     readonly backlinks: readonly ConnectionsBacklink[]
     readonly unlinkedMentions: readonly ConnectionsBacklink[]
   } | null>(null)
+  const [connectionsRefresh, setConnectionsRefresh] = useState(0)
   useEffect(() => {
     setConnections(null)
     if (currentDocumentId === undefined || controller.workspaceId === null) return
@@ -389,7 +394,7 @@ export function DaemonDocumentPage({
     return () => {
       cancelled = true
     }
-  }, [daemonFetch, daemonBaseUrl, controller.workspaceId, currentDocumentId])
+  }, [daemonFetch, daemonBaseUrl, controller.workspaceId, currentDocumentId, connectionsRefresh])
   const loadEmbedSource = useCallback<MarkdownEmbedLoader>(
     async (documentId) => {
       const target = await fileAdapter.loadDocument(documentId)
@@ -652,6 +657,21 @@ export function DaemonDocumentPage({
                     backlinks={connections === null ? null : connections.backlinks}
                     mentions={connections?.unlinkedMentions}
                     onOpen={(entry) => controller.switchDocument(entry.path)}
+                    onLinkify={(mention) => {
+                      if (controller.workspaceId === null || currentDocumentId === undefined) return
+                      void linkifyDocumentMentions(
+                        daemonFetch,
+                        daemonBaseUrl,
+                        controller.workspaceId,
+                        mention.documentId,
+                        currentDocumentId,
+                      )
+                        .then(() => setConnectionsRefresh((n) => n + 1))
+                        .catch(() => {
+                          // The panel simply keeps showing the mention; the
+                          // next open retries.
+                        })
+                    }}
                   />
                 </>
               )}

--- a/docs/how-to/link-documents.md
+++ b/docs/how-to/link-documents.md
@@ -33,8 +33,13 @@ anywhere in the workspace land here automatically.
 
 Below the linked-from list, **Mentioned, not linked** surfaces documents
 whose prose contains this document's display name without linking to it —
-candidates for a link the author never wrote. Click one to open it and
-decide; the system never links on its own (a link is the author's claim).
+candidates for a link the author never wrote. Click a row to open it and
+decide, or **Link it** to convert that document's mentions into real
+`[[...]]` links in one server-side operation — the readable `[[Name]]`
+when the name is unique, `[[<id>|Name]]` otherwise. Mentions inside canvas
+labels are listed but never rewritten (a link in a label would render as
+literal brackets). The system still never links without a click — a link
+is the author's claim.
 
 ## Rules worth knowing
 

--- a/packages/mcp-server/src/shared/api-contracts/index.ts
+++ b/packages/mcp-server/src/shared/api-contracts/index.ts
@@ -18,6 +18,7 @@ export {
   backlinksOutputSchema as documentBacklinksResponseSchema,
   documentTagsOutputSchema as workspaceDocumentTagsResponseSchema,
   exportOkfOutputSchema as documentOkfV1ResponseSchema,
+  linkifyMentionsOutputSchema as linkifyMentionsResponseSchema,
   wbDocumentListOutputSchema as listDocumentsV1ResponseSchema,
 } from '@kamiazya/whiteboard-server-core'
 export * from './branches.js'
@@ -40,11 +41,13 @@ export { daemonPingResponseSchema, runtimeVerifyResponseSchema } from './runtime
 import type {
   exportOkfOutputSchema as _canvasOkfV1ResponseSchema,
   backlinksOutputSchema as _documentBacklinksResponseSchema,
+  linkifyMentionsOutputSchema as _linkifyMentionsResponseSchema,
   wbDocumentListOutputSchema as _listDocumentsV1ResponseSchema,
   documentTagsOutputSchema as _workspaceDocumentTagsResponseSchema,
 } from '@kamiazya/whiteboard-server-core'
 import type { z as _z } from 'zod'
 export type DocumentBacklinksResponse = _z.infer<typeof _documentBacklinksResponseSchema>
 export type WorkspaceDocumentTagsResponse = _z.infer<typeof _workspaceDocumentTagsResponseSchema>
+export type LinkifyMentionsResponse = _z.infer<typeof _linkifyMentionsResponseSchema>
 export type DocumentOkfV1Response = _z.infer<typeof _canvasOkfV1ResponseSchema>
 export type ListDocumentsV1Response = _z.infer<typeof _listDocumentsV1ResponseSchema>

--- a/packages/server-core/src/create-server.ts
+++ b/packages/server-core/src/create-server.ts
@@ -34,6 +34,11 @@ import { createDocumentSetTool } from './tools/document-set.js'
 import { computeDocumentTags, documentTagsInputSchema } from './tools/document-tags.js'
 import { exportOkf, exportOkfInputSchema } from './tools/export-okf.js'
 import { createFacetSetTool } from './tools/facet-set.js'
+import {
+  linkifyMentions,
+  linkifyMentionsInputSchema,
+  NamelessLinkifyTargetError,
+} from './tools/linkify-mentions.js'
 import { createVersionListTool } from './tools/version-list.js'
 import { createVersionRestoreTool } from './tools/version-restore.js'
 import { createVersionSaveTool } from './tools/version-save.js'
@@ -136,6 +141,26 @@ export function createServer(deps: ServerDeps) {
     try {
       return c.json(await computeDocumentTags(deps, parsed.data))
     } catch (err) {
+      return mapDocumentError(c, err)
+    }
+  })
+
+  app.post('/api/v1/workspaces/:workspaceId/documents/:documentId/linkify-mentions', async (c) => {
+    const body = await c.req.json().catch(() => ({}))
+    const parsed = linkifyMentionsInputSchema.safeParse({
+      workspaceId: c.req.param('workspaceId'),
+      documentId: c.req.param('documentId'),
+      ...body,
+    })
+    if (!parsed.success) {
+      return c.json({ error: 'invalid input', issues: parsed.error.issues }, 400)
+    }
+    try {
+      return c.json(await linkifyMentions(deps, parsed.data))
+    } catch (err) {
+      if (err instanceof NamelessLinkifyTargetError) {
+        return c.json({ error: err.message }, 400)
+      }
       return mapDocumentError(c, err)
     }
   })

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -96,6 +96,13 @@ export {
 } from './tools/export-okf.js'
 export type { FacetSetInput, FacetSetOutput } from './tools/facet-set.js'
 export { createFacetSetTool, facetSetInputSchema, facetSetOutputSchema } from './tools/facet-set.js'
+export type { LinkifyMentionsInput, LinkifyMentionsOutput } from './tools/linkify-mentions.js'
+export {
+  linkifyMentions,
+  linkifyMentionsInputSchema,
+  linkifyMentionsOutputSchema,
+  NamelessLinkifyTargetError,
+} from './tools/linkify-mentions.js'
 export type { VersionListInput, VersionListOutput } from './tools/version-list.js'
 export {
   createVersionListTool,

--- a/packages/server-core/src/references/reference-aggregate.ts
+++ b/packages/server-core/src/references/reference-aggregate.ts
@@ -163,6 +163,29 @@ export class ReferenceAggregate {
 }
 
 /**
+ * Where `name` occurs in `text` OUTSIDE any `[[...]]` span — the ONE rule
+ * both mention detection and linkify apply, so what the panel lists is
+ * exactly what the linkify operation will rewrite.
+ */
+export function unlinkedNameSpans(
+  text: string,
+  name: string,
+): readonly { index: number; length: number }[] {
+  const refs = scanReferences(text).map(
+    (match) => [match.index, match.index + match.full.length] as const,
+  )
+  const spans: { index: number; length: number }[] = []
+  let cursor = 0
+  for (;;) {
+    const at = text.indexOf(name, cursor)
+    if (at === -1) return spans
+    cursor = at + name.length
+    if (refs.some(([from, to]) => at >= from && at < to)) continue
+    spans.push({ index: at, length: name.length })
+  }
+}
+
+/**
  * Sources whose TEXT names `documentId`'s display name without a resolving
  * reference — the seeding half of the linking loop: the system finds the
  * candidate, a human confirms (a link is the author's claim, never a
@@ -179,16 +202,8 @@ export function mentionsOfIn(
     if (sourceId === target.documentId) continue
     const contexts: string[] = []
     for (const text of facts.texts) {
-      const spans = scanReferences(text).map(
-        (match) => [match.index, match.index + match.full.length] as const,
-      )
-      let cursor = 0
-      for (;;) {
-        const at = text.indexOf(target.name, cursor)
-        if (at === -1) break
-        cursor = at + target.name.length
-        if (spans.some(([from, to]) => at >= from && at < to)) continue
-        contexts.push(snippetAround(text, at, target.name.length))
+      for (const span of unlinkedNameSpans(text, target.name)) {
+        contexts.push(snippetAround(text, span.index, span.length))
         if (contexts.length >= 3) break
       }
       if (contexts.length >= 3) break

--- a/packages/server-core/src/tools/linkify-mentions.test.ts
+++ b/packages/server-core/src/tools/linkify-mentions.test.ts
@@ -1,0 +1,136 @@
+import { InMemoryDocumentIndex } from '@kamiazya/whiteboard-ports/test-utils'
+import { describe, expect, it } from 'vitest'
+import { createServer } from '../create-server.js'
+import { createInMemoryDocumentStore } from '../test-utils/in-memory-document-store.js'
+import { backlinksOutputSchema } from './backlinks.js'
+import { createCanvasEditTool } from './canvas-edit.js'
+import { wbDocumentCreate } from './document-crud.js'
+import { createDocumentGetTool } from './document-get.js'
+import { createDocumentSetTool } from './document-set.js'
+import { linkifyMentionsOutputSchema } from './linkify-mentions.js'
+
+const WS = 'ws-1'
+
+function makeDeps() {
+  return {
+    documentStore: createInMemoryDocumentStore(),
+    blobStore: {} as never,
+    documentIndex: new InMemoryDocumentIndex(),
+  }
+}
+
+function harness(deps: ReturnType<typeof makeDeps>) {
+  const app = createServer(deps).app
+  const create = (path: string, kind: 'markdown' | 'spatial', name?: string) =>
+    wbDocumentCreate(deps, {
+      workspaceId: WS,
+      path,
+      kind,
+      createWorkspace: true,
+      ...(name === undefined ? {} : { name }),
+    })
+  const set = createDocumentSetTool(deps)
+  const writeBody = (documentId: string, body: string) =>
+    set.execute({ workspaceId: WS, documentId, markdown: `---\ntype: note\n---\n${body}` })
+  const readBody = async (documentId: string) => {
+    const out = await createDocumentGetTool(deps).execute({ workspaceId: WS, documentId })
+    return out.content.split('---\n').slice(2).join('---\n')
+  }
+  const linkify = async (sourceId: string, targetDocumentId: string) => {
+    const res = await app.request(
+      `/api/v1/workspaces/${WS}/documents/${sourceId}/linkify-mentions`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ targetDocumentId }),
+      },
+    )
+    return {
+      status: res.status,
+      body:
+        res.status === 200 ? linkifyMentionsOutputSchema.parse(await res.json()) : await res.json(),
+    }
+  }
+  const backlinksOf = async (documentId: string) => {
+    const res = await app.request(`/api/v1/workspaces/${WS}/documents/${documentId}/backlinks`)
+    return backlinksOutputSchema.parse(await res.json())
+  }
+  return { app, create, writeBody, readBody, linkify, backlinksOf }
+}
+
+describe('POST /linkify-mentions', () => {
+  it('wraps every prose occurrence, skips existing references, and the mention disappears', async () => {
+    const deps = makeDeps()
+    const h = harness(deps)
+    const target = await h.create('target', 'markdown', '設計メモ')
+    const src = await h.create('src', 'markdown', '日報')
+    await h.writeBody(
+      src.documentId,
+      '会議で設計メモの前提が変わった。既存の [[設計メモ]] は触らない。末尾にも設計メモ。',
+    )
+
+    const out = await h.linkify(src.documentId, target.documentId)
+    expect(out.status).toBe(200)
+    expect(out.body).toEqual({ linked: 2 })
+    expect(await h.readBody(src.documentId)).toBe(
+      '会議で[[設計メモ]]の前提が変わった。既存の [[設計メモ]] は触らない。末尾にも[[設計メモ]]。',
+    )
+
+    // Detection and linkify share one span rule: nothing left to mention.
+    const after = await h.backlinksOf(target.documentId)
+    expect(after.unlinkedMentions).toEqual([])
+    expect(after.backlinks.map((b) => b.path)).toEqual(['src'])
+
+    // Idempotent: nothing found, nothing written.
+    expect((await h.linkify(src.documentId, target.documentId)).body).toEqual({ linked: 0 })
+  })
+
+  it('an ambiguous name links by id with the name as alias', async () => {
+    const deps = makeDeps()
+    const h = harness(deps)
+    const target = await h.create('target', 'markdown', 'Dup')
+    await h.create('rival', 'markdown', 'Dup')
+    const src = await h.create('src', 'markdown')
+    await h.writeBody(src.documentId, 'about Dup here')
+    expect((await h.linkify(src.documentId, target.documentId)).body).toEqual({ linked: 1 })
+    expect(await h.readBody(src.documentId)).toBe(`about [[${target.documentId}|Dup]] here`)
+  })
+
+  it('rewrites canvas text nodes but never labels', async () => {
+    const deps = makeDeps()
+    const h = harness(deps)
+    const target = await h.create('target', 'markdown', 'Redis')
+    const board = await h.create('board', 'spatial')
+    const edit = createCanvasEditTool(deps)
+    await edit.execute({
+      workspaceId: WS,
+      documentId: board.documentId,
+      ops: [
+        { op: 'node.add', node: { id: 'a', type: 'text', text: 'we depend on Redis heavily' } },
+        { op: 'node.add', node: { id: 'b', type: 'text', text: 'B' } },
+        { op: 'edge.add', edge: { id: 'e', fromNode: 'a', toNode: 'b', label: 'Redis link' } },
+      ],
+    })
+    expect((await h.linkify(board.documentId, target.documentId)).body).toEqual({ linked: 1 })
+    const canvas = await createDocumentGetTool(deps).execute({
+      workspaceId: WS,
+      documentId: board.documentId,
+    })
+    const parsed = JSON.parse(canvas.content)
+    expect(parsed.nodes.find((n: { id: string }) => n.id === 'a').text).toBe(
+      'we depend on [[Redis]] heavily',
+    )
+    // A [[link]] in a label would render as literal brackets, so labels are
+    // mention-detected but never rewritten.
+    expect(parsed.edges[0].label).toBe('Redis link')
+  })
+
+  it('refuses a nameless target and unknown documents', async () => {
+    const deps = makeDeps()
+    const h = harness(deps)
+    const nameless = await h.create('nameless', 'markdown')
+    const src = await h.create('src', 'markdown')
+    expect((await h.linkify(src.documentId, nameless.documentId)).status).toBe(400)
+    expect((await h.linkify(src.documentId, '01ARZ3NDEKTSV4RRFFQ69G5FAV')).status).toBe(404)
+  })
+})

--- a/packages/server-core/src/tools/linkify-mentions.ts
+++ b/packages/server-core/src/tools/linkify-mentions.ts
@@ -1,0 +1,126 @@
+import { createUniqueNameResolver } from '@kamiazya/whiteboard-codec'
+import {
+  MARKDOWN_BODY_KEY,
+  readDocumentKind,
+  readSpatialCanvas,
+} from '@kamiazya/whiteboard-loro-adapter'
+import {
+  documentIdSchema,
+  spatialCanvasSchema,
+  workspaceIdSchema,
+} from '@kamiazya/whiteboard-model'
+import { z } from 'zod'
+import { unlinkedNameSpans } from '../references/reference-aggregate.js'
+import type { ServerDeps } from '../server-deps.js'
+import { WorkspaceDocumentNotFoundError } from './document-crud.errors.js'
+import { loadDocument, saveDocumentBodySnapshot, saveDocumentSnapshot } from './document-io.js'
+
+export const linkifyMentionsInputSchema = z
+  .object({
+    workspaceId: workspaceIdSchema,
+    /** The SOURCE — the document whose prose gets rewritten. */
+    documentId: documentIdSchema,
+    /** The document the mentions name. */
+    targetDocumentId: documentIdSchema,
+  })
+  .strict()
+export type LinkifyMentionsInput = z.infer<typeof linkifyMentionsInputSchema>
+
+export const linkifyMentionsOutputSchema = z
+  .object({ linked: z.number().int().nonnegative() })
+  .strict()
+export type LinkifyMentionsOutput = z.infer<typeof linkifyMentionsOutputSchema>
+
+/** The target carries no display name, so there is no prose to find. */
+export class NamelessLinkifyTargetError extends Error {
+  constructor(readonly targetDocumentId: string) {
+    super(
+      `Document ${targetDocumentId} has no display name — nothing names it in prose, so there is nothing to linkify.`,
+    )
+    this.name = 'NamelessLinkifyTargetError'
+  }
+}
+
+function rewrite(text: string, name: string, markup: string): { text: string; count: number } {
+  const spans = unlinkedNameSpans(text, name)
+  let out = text
+  // Reverse order so earlier spans' offsets stay valid while later ones are
+  // spliced.
+  for (const span of [...spans].reverse()) {
+    out = out.slice(0, span.index) + markup + out.slice(span.index + span.length)
+  }
+  return { text: out, count: spans.length }
+}
+
+/**
+ * Convert a source document's unlinked mentions of `targetDocumentId` into
+ * `[[...]]` references, as ONE server-side load-modify-save — the panel's
+ * Link-it action. Client-side offset patching of another live CRDT document
+ * is exactly the stale-offset class the completion once shipped, which is
+ * why this lives here.
+ *
+ * Markdown bodies are edited by targeted Loro text splices (reverse order,
+ * one commit), so a concurrent edit elsewhere in the body merges instead of
+ * being clobbered by a whole-body replace. Canvas TEXT NODES go through the
+ * schema-validated canvas save; labels are mention-DETECTED but never
+ * rewritten — a `[[link]]` in a label renders as literal brackets.
+ */
+export async function linkifyMentions(
+  deps: ServerDeps,
+  input: LinkifyMentionsInput,
+): Promise<LinkifyMentionsOutput> {
+  const entries = await deps.documentIndex.listDocuments({ workspaceId: input.workspaceId })
+  const byId = new Map(entries.map((entry) => [entry.documentId, entry]))
+  const source = byId.get(input.documentId)
+  if (source === undefined) {
+    throw new WorkspaceDocumentNotFoundError(input.workspaceId, input.documentId)
+  }
+  const target = byId.get(input.targetDocumentId)
+  if (target === undefined) {
+    throw new WorkspaceDocumentNotFoundError(input.workspaceId, input.targetDocumentId)
+  }
+  if (target.name === undefined) throw new NamelessLinkifyTargetError(input.targetDocumentId)
+  const name = target.name
+
+  // The reader's rule decides the spelling: the readable [[Name]] only when
+  // resolution would land on the target, the explicit [[<id>|Name]] form
+  // otherwise — the same trade the link picker makes.
+  const resolve = createUniqueNameResolver(
+    entries.flatMap((entry) => [
+      { id: entry.documentId, name: entry.path },
+      ...(entry.name === undefined ? [] : [{ id: entry.documentId, name: entry.name }]),
+    ]),
+  )
+  const markup =
+    resolve(name) === input.targetDocumentId
+      ? `[[${name}]]`
+      : `[[${input.targetDocumentId}|${name}]]`
+
+  const { doc, canvas } = await loadDocument(deps, input.documentId)
+  const kind = source.kind ?? readDocumentKind(doc)
+
+  if (kind === 'markdown') {
+    const text = doc.getText(MARKDOWN_BODY_KEY)
+    const spans = unlinkedNameSpans(text.toString(), name)
+    for (const span of [...spans].reverse()) {
+      text.delete(span.index, span.length)
+      text.insert(span.index, markup)
+    }
+    if (spans.length === 0) return { linked: 0 }
+    doc.commit()
+    await saveDocumentSnapshot(deps, input.documentId, doc)
+    return { linked: spans.length }
+  }
+
+  let linked = 0
+  const nodes = readSpatialCanvas(doc).nodes.map((node) => {
+    if (node.type !== 'text') return node
+    const result = rewrite(node.text, name, markup)
+    linked += result.count
+    return result.count === 0 ? node : { ...node, text: result.text }
+  })
+  if (linked === 0) return { linked: 0 }
+  const candidate = spatialCanvasSchema.parse({ nodes, edges: canvas.edges })
+  await saveDocumentBodySnapshot(deps, input.documentId, doc, candidate)
+  return { linked }
+}


### PR DESCRIPTION
## What — the P3 follow-up (backlog item 1)

Mention rows in the Connections panel gain a **Link it** button: every unlinked occurrence of the open document's name in that source becomes `[[...]]` markup, in one atomic server-side operation (`POST /documents/:sourceId/linkify-mentions`).

Design points:

- **One rule, both sides**: `unlinkedNameSpans` is extracted from `mentionsOfIn` and shared with the rewrite — mutation-checked (disabling the `[[...]]`-span exclusion turns the mention tests *and* the linkify tests red together), so the panel can never list a mention the operation would not rewrite.
- **CRDT-respecting edits**: markdown bodies are edited by *targeted Loro text splices* (reverse order, one commit) — a concurrent edit elsewhere in the body merges instead of being clobbered by a whole-body replace. Canvas **text nodes** go through the schema-validated canvas save; **labels are detected but never rewritten** (a `[[link]]` in a label renders as literal brackets).
- **Reader-rule spelling**: `[[Name]]` only when resolution lands on the target, `[[<id>|Name]]` otherwise (pinned with a duplicate-name case).
- **Idempotent**: a second call finds no spans and writes nothing (`{linked: 0}`).
- The panel refetches after success — the row visibly moves from *Mentioned, not linked* to *Linked from*.

## Verification

- Red-first server tests: replace-all-outside-spans with byte-exact bodies, ambiguous-name form, canvas node vs label, idempotence, nameless-target 400 / unknown 404 — server-core 326 green
- apps/web jsdom 2674 + node 77 green; button presence/absence and callback pinned
- **Real-daemon end-to-end**: Japanese mention → `{"linked":1}` → body reads `会議で[[設計メモ]]の前提が変わった。` → backlinks `['lk-src']`, mentions `[]`

## Docs

`docs/how-to/link-documents.md` — Link it paragraph, label caveat included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmbb1zNhiZitB7tn9LQ5f3