### PR TITLE
feat(web): a document card's actions open at the card — right-click context menu

### DIFF
--- a/apps/web/src/components/spatial-editor/ContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/ContextMenu.tsx
@@ -73,6 +73,11 @@ export interface ContextMenuSeparator {
 export type ContextMenuItem = ContextMenuActionItem | ContextMenuOptionsItem | ContextMenuSeparator
 
 export interface ContextMenuProps {
+  /**
+   * Accessible name of the menu. The default names the spatial surface;
+   * object menus (a document card's) pass their own.
+   */
+  readonly label?: string
   /** Screen position relative to the editor root. */
   readonly x: number
   readonly y: number
@@ -151,7 +156,14 @@ function CustomColorPanel({
   )
 }
 
-export function ContextMenu({ x, y, items, onClose, variant = 'list' }: ContextMenuProps) {
+export function ContextMenu({
+  x,
+  y,
+  items,
+  onClose,
+  variant = 'list',
+  label = 'Canvas actions',
+}: ContextMenuProps) {
   const menuRef = useRef<HTMLDivElement | null>(null)
   // A menu opened near the editor's right/bottom edge would clip outside it,
   // so the requested position is nudged back inside once the real menu size
@@ -202,7 +214,7 @@ export function ContextMenu({ x, y, items, onClose, variant = 'list' }: ContextM
       data-testid="context-menu"
       data-variant={variant}
       role="menu"
-      aria-label="Canvas actions"
+      aria-label={label}
       tabIndex={-1}
       className={
         sheet

--- a/apps/web/src/components/workspace-files/DocumentPreview.tsx
+++ b/apps/web/src/components/workspace-files/DocumentPreview.tsx
@@ -12,7 +12,7 @@
  * keep throwing you into an editor.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { cn } from '../../lib/utils.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
 import { fitSvgToBox } from './fit-svg.js'
@@ -38,6 +38,12 @@ export interface DocumentPreviewProps {
    */
   readonly onDelete?: (document: WorkspaceDocumentEntry) => void
   readonly className?: string
+  /**
+   * Bumped by the panel when a context menu's Move… targets the (already
+   * selected) document: the move form opens without a second click on the
+   * preview's own Move… link. Absent or unchanged means untouched.
+   */
+  readonly startMoveToken?: number
 }
 
 type State =
@@ -54,6 +60,7 @@ export function DocumentPreview({
   onDuplicate,
   onDelete,
   className,
+  startMoveToken,
 }: DocumentPreviewProps) {
   const [state, setState] = useState<State>({ kind: 'idle' })
   const [editing, setEditing] = useState<string | null>(null)
@@ -86,6 +93,20 @@ export function DocumentPreview({
       live = false
     }
   }, [document, loadRender])
+
+  // Context-menu Move…: each bump opens the form for whatever document the
+  // panel has just selected. Defined AFTER the selection-change effect above,
+  // whose editing reset would otherwise run second and undo this in the very
+  // commit where selection and token change together. Skipped on mount so
+  // plain selection never starts an edit.
+  const lastMoveToken = useRef(startMoveToken)
+  useEffect(() => {
+    if (startMoveToken === undefined || startMoveToken === lastMoveToken.current) return
+    lastMoveToken.current = startMoveToken
+    if (document === null || onMove === undefined) return
+    setMoveError(null)
+    setEditing(document.path)
+  }, [startMoveToken, document, onMove])
 
   if (document === null) {
     return (

--- a/apps/web/src/components/workspace-files/FolderContentsList.tsx
+++ b/apps/web/src/components/workspace-files/FolderContentsList.tsx
@@ -20,6 +20,8 @@ export interface FolderContentsListProps {
   /** The folder being looked inside. `''` is the workspace root. */
   folder: string
   onOpen: (target: FolderContentsOpen) => void
+  /** Right-click on a document card — the object-action menu hook. */
+  onDocumentContextMenu?: (entry: WorkspaceDocumentEntry, x: number, y: number) => void
   /** The document the preview is showing, so the two panes agree. */
   selectedPath?: string
   /**
@@ -41,6 +43,7 @@ export function FolderContentsList({
   documents,
   folder,
   onOpen,
+  onDocumentContextMenu,
   selectedPath,
   renderThumbnail,
   className,
@@ -89,6 +92,14 @@ export function FolderContentsList({
             type="button"
             aria-current={entry.path === selectedPath ? 'true' : undefined}
             onClick={() => onOpen({ kind: 'document', document: entry })}
+            onContextMenu={
+              onDocumentContextMenu === undefined
+                ? undefined
+                : (event) => {
+                    event.preventDefault()
+                    onDocumentContextMenu(entry, event.clientX, event.clientY)
+                  }
+            }
             className="hover:bg-accent/40 aria-[current]:border-primary aria-[current]:ring-primary/40 flex w-full flex-col overflow-hidden rounded-md border text-left aria-[current]:ring-1"
           >
             <span className="bg-muted/40 flex h-16 w-full items-center justify-center overflow-hidden">

--- a/apps/web/src/components/workspace-files/SearchResults.tsx
+++ b/apps/web/src/components/workspace-files/SearchResults.tsx
@@ -25,6 +25,8 @@ export interface SearchResultsProps {
   query: string
   selectedPath?: string
   onSelect: (document: WorkspaceDocumentEntry) => void
+  /** Right-click on a result row — the object-action menu hook. */
+  onDocumentContextMenu?: (entry: WorkspaceDocumentEntry, x: number, y: number) => void
   renderThumbnail?: (document: WorkspaceDocumentEntry) => ReactNode
   className?: string
 }
@@ -59,6 +61,7 @@ export function SearchResults({
   query,
   selectedPath,
   onSelect,
+  onDocumentContextMenu,
   renderThumbnail,
   className,
 }: SearchResultsProps) {
@@ -128,6 +131,14 @@ export function SearchResults({
                 type="button"
                 aria-current={entry.path === selectedPath ? 'true' : undefined}
                 onClick={() => onSelect(entry)}
+                onContextMenu={
+                  onDocumentContextMenu === undefined
+                    ? undefined
+                    : (event) => {
+                        event.preventDefault()
+                        onDocumentContextMenu(entry, event.clientX, event.clientY)
+                      }
+                }
                 className="hover:bg-accent/40 aria-[current]:border-primary aria-[current]:ring-primary/40 flex w-full min-w-0 items-center gap-2 rounded-md border p-1.5 text-left aria-[current]:ring-1"
               >
                 {/* 80x44, not smaller: measured on a real document, a faithful
@@ -166,6 +177,14 @@ export function SearchResults({
                 type="button"
                 aria-current={entry.path === selectedPath ? 'true' : undefined}
                 onClick={() => onSelect(entry)}
+                onContextMenu={
+                  onDocumentContextMenu === undefined
+                    ? undefined
+                    : (event) => {
+                        event.preventDefault()
+                        onDocumentContextMenu(entry, event.clientX, event.clientY)
+                      }
+                }
                 className="hover:bg-accent/40 aria-[current]:border-primary aria-[current]:ring-primary/40 flex w-full min-w-0 flex-col gap-1.5 rounded-md border p-2 text-left aria-[current]:ring-1"
               >
                 {thumbnail(entry, 'aspect-[16/9] w-full')}

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -3,6 +3,7 @@ import { Columns2, FilePlus2, LayoutGrid, List, Search } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useThemeMode } from '../../hooks/useThemeMode.js'
+import { ContextMenu } from '../spatial-editor/ContextMenu.js'
 import { DocumentMinimap } from './DocumentMinimap.js'
 import { DocumentPreview } from './DocumentPreview.js'
 import { DocumentThumbnail } from './DocumentThumbnail.js'
@@ -93,6 +94,15 @@ export function WorkspaceFilesPanel({
   // same-tick case it exists to catch.
   const [creating, setCreating] = useState(false)
   const [query, setQuery] = useState('')
+  // The object-action menu: which document was right-clicked, and where.
+  const [cardMenu, setCardMenu] = useState<{
+    entry: WorkspaceDocumentEntry
+    x: number
+    y: number
+  } | null>(null)
+  // Bumped when the menu's Move… fires, so the preview opens its move form
+  // for the selection the same gesture just made.
+  const [startMoveToken, setStartMoveToken] = useState(0)
   // Every tag in the workspace, each once, in reading order. The strip is
   // derived — deleting the last carrier of a tag removes its chip with it.
   const workspaceTags = useMemo(() => {
@@ -258,6 +268,45 @@ export function WorkspaceFilesPanel({
     return <p className="text-muted-foreground text-sm">Loading files…</p>
   }
 
+  // Plain function, deliberately not a hook: this sits below the early
+  // returns, where a hook would change the count between renders.
+  const openCardMenu = (entry: WorkspaceDocumentEntry, x: number, y: number) => {
+    setCardMenu({ entry, x, y })
+  }
+
+  const cardMenuItems =
+    cardMenu === null
+      ? []
+      : [
+          ...(onOpenDocument === undefined
+            ? []
+            : [{ label: 'Open', onSelect: () => onOpenDocument(cardMenu.entry.path) }]),
+          ...(onDuplicateDocument === undefined
+            ? []
+            : [{ label: 'Duplicate', onSelect: () => onDuplicateDocument(cardMenu.entry.path) }]),
+          {
+            label: 'Move…',
+            onSelect: () => {
+              setSelected(cardMenu.entry)
+              setStartMoveToken((token) => token + 1)
+            },
+          },
+          ...(onRequestDelete === undefined
+            ? []
+            : [
+                {
+                  label: 'Delete',
+                  danger: true,
+                  onSelect: () =>
+                    onRequestDelete(
+                      cardMenu.entry.path,
+                      cardMenu.entry.name ?? cardMenu.entry.path,
+                      cardMenu.entry.kind,
+                    ),
+                },
+              ]),
+        ]
+
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-2" data-testid="workspace-files-panel">
       <div className="flex items-center gap-2">
@@ -385,6 +434,7 @@ export function WorkspaceFilesPanel({
                 query={query}
                 selectedPath={selected?.path}
                 onSelect={setSelected}
+                onDocumentContextMenu={openCardMenu}
                 renderThumbnail={(entry) => (
                   <DocumentThumbnail
                     key={entry.documentId}
@@ -434,6 +484,7 @@ export function WorkspaceFilesPanel({
                       ? selectFolder(target.path)
                       : setSelected(target.document)
                   }
+                  onDocumentContextMenu={openCardMenu}
                   renderThumbnail={(entry) => (
                     <DocumentThumbnail
                       key={entry.documentId}
@@ -451,6 +502,7 @@ export function WorkspaceFilesPanel({
           <DocumentPreview
             document={selected}
             loadRender={loadRender}
+            startMoveToken={startMoveToken}
             {...(onOpenDocument === undefined
               ? {}
               : { onOpen: (entry: WorkspaceDocumentEntry) => onOpenDocument(entry.path) })}
@@ -470,6 +522,15 @@ export function WorkspaceFilesPanel({
           />
         </div>
       </div>
+      {cardMenu !== null && (
+        <ContextMenu
+          x={cardMenu.x}
+          y={cardMenu.y}
+          label="Document actions"
+          items={cardMenuItems}
+          onClose={() => setCardMenu(null)}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -1,6 +1,6 @@
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import { Columns2, FilePlus2, LayoutGrid, List, Search } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useThemeMode } from '../../hooks/useThemeMode.js'
 import { ContextMenu } from '../spatial-editor/ContextMenu.js'
@@ -103,6 +103,7 @@ export function WorkspaceFilesPanel({
   // Bumped when the menu's Move… fires, so the preview opens its move form
   // for the selection the same gesture just made.
   const [startMoveToken, setStartMoveToken] = useState(0)
+  const rootRef = useRef<HTMLDivElement | null>(null)
   // Every tag in the workspace, each once, in reading order. The strip is
   // derived — deleting the last carrier of a tag removes its chip with it.
   const workspaceTags = useMemo(() => {
@@ -159,6 +160,15 @@ export function WorkspaceFilesPanel({
         setSelected((current) =>
           current === null ? null : (entries.find((row) => row.path === current.path) ?? null),
         )
+        // An open context menu is a captured snapshot; a refresh behind the
+        // panel's back (the whole reason `revision` exists) re-resolves it
+        // the same way, and a menu whose document is GONE closes rather
+        // than offering verbs for a target that no longer exists.
+        setCardMenu((current) => {
+          if (current === null) return null
+          const entry = entries.find((row) => row.path === current.entry.path)
+          return entry === undefined ? null : { ...current, entry }
+        })
       })
       .catch(() => undefined)
     return () => {
@@ -270,8 +280,17 @@ export function WorkspaceFilesPanel({
 
   // Plain function, deliberately not a hook: this sits below the early
   // returns, where a hook would change the count between renders.
-  const openCardMenu = (entry: WorkspaceDocumentEntry, x: number, y: number) => {
-    setCardMenu({ entry, x, y })
+  // ContextMenu's x/y contract is ROOT-local (its absolute box resolves
+  // against the nearest positioned ancestor — the panel root below), so the
+  // viewport coordinates the click carries are converted here instead of
+  // leaning on the app shell never scrolling the window.
+  const openCardMenu = (entry: WorkspaceDocumentEntry, clientX: number, clientY: number) => {
+    const rect = rootRef.current?.getBoundingClientRect()
+    setCardMenu({
+      entry,
+      x: clientX - (rect?.left ?? 0),
+      y: clientY - (rect?.top ?? 0),
+    })
   }
 
   const cardMenuItems =
@@ -308,7 +327,11 @@ export function WorkspaceFilesPanel({
         ]
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-2" data-testid="workspace-files-panel">
+    <div
+      ref={rootRef}
+      className="relative flex min-h-0 flex-1 flex-col gap-2"
+      data-testid="workspace-files-panel"
+    >
       <div className="flex items-center gap-2">
         <div className="min-w-0 flex-1">
           {/* The trail belongs to whatever narrows the view. In one-column

--- a/apps/web/src/components/workspace-files/card-context-menu.test.tsx
+++ b/apps/web/src/components/workspace-files/card-context-menu.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
+import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
+
+// OOUI: the object's actions are reachable FROM the object. Right-click a
+// document card and the same verbs the preview pane offers appear at the
+// cursor — no trip across the panel required.
+
+afterEach(cleanup)
+
+const entries = [
+  { documentId: 'd1', path: 'meeting-notes', name: 'Meeting notes', kind: 'markdown' as const },
+  { documentId: 'd2', path: 'plans/roadmap', name: 'Roadmap', kind: 'spatial' as const },
+]
+
+function renderPanel(
+  overrides: {
+    onOpenDocument?: (path: string) => void
+    onDuplicateDocument?: (path: string) => void
+    onRequestDelete?: (path: string, displayName: string, kind?: 'spatial' | 'markdown') => void
+  } = {},
+) {
+  const source = fakeFilesSource({ listDocuments: () => Promise.resolve(entries) })
+  render(<WorkspaceFilesPanel source={source} {...overrides} />)
+  return source
+}
+
+async function contextMenuOnCard(title: string) {
+  await waitFor(() => {
+    expect(screen.getAllByTestId('card-title').some((el) => el.textContent === title)).toBe(true)
+  })
+  const el = screen.getAllByTestId('card-title').find((n) => n.textContent === title)
+  fireEvent.contextMenu(el?.closest('button') as HTMLElement, { clientX: 40, clientY: 40 })
+  return screen.findByRole('menu', { name: 'Document actions' })
+}
+
+describe('document card context menu', () => {
+  it('offers the object verbs and Open fires the open handler', async () => {
+    const onOpenDocument = vi.fn()
+    const onDuplicateDocument = vi.fn()
+    renderPanel({ onOpenDocument, onDuplicateDocument, onRequestDelete: () => {} })
+
+    const menu = await contextMenuOnCard('Meeting notes')
+    for (const label of ['Open', 'Duplicate', 'Move…', 'Delete']) {
+      expect(within(menu).getByRole('menuitem', { name: label })).toBeTruthy()
+    }
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Open' }))
+    expect(onOpenDocument).toHaveBeenCalledWith('meeting-notes')
+    await waitFor(() => expect(screen.queryByRole('menu', { name: 'Document actions' })).toBeNull())
+  })
+
+  it('Delete carries the kind the dialog copy needs', async () => {
+    const onRequestDelete = vi.fn()
+    renderPanel({ onRequestDelete })
+    const menu = await contextMenuOnCard('Meeting notes')
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Delete' }))
+    expect(onRequestDelete).toHaveBeenCalledWith('meeting-notes', 'Meeting notes', 'markdown')
+  })
+
+  it('omits Duplicate when the page does not provide it', async () => {
+    renderPanel({ onRequestDelete: () => {} })
+    const menu = await contextMenuOnCard('Meeting notes')
+    expect(within(menu).queryByRole('menuitem', { name: 'Duplicate' })).toBeNull()
+  })
+
+  it('Move… selects the document and opens the move form', async () => {
+    renderPanel({ onOpenDocument: () => {} })
+    const menu = await contextMenuOnCard('Meeting notes')
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Move…' }))
+    // The preview's path form appears for exactly this document, ready to edit.
+    const input = await screen.findByLabelText('Path')
+    expect((input as HTMLInputElement).value).toBe('meeting-notes')
+  })
+
+  it('a search result row opens the same menu, and Escape closes it', async () => {
+    renderPanel({ onOpenDocument: () => {} })
+    await waitFor(() => expect(screen.getAllByTestId('card-title').length).toBeGreaterThan(0))
+    fireEvent.change(screen.getByLabelText('Search documents'), { target: { value: 'road' } })
+    const row = await screen.findByTestId('result-title')
+    fireEvent.contextMenu(row.closest('button') as HTMLElement, { clientX: 30, clientY: 30 })
+    const menu = await screen.findByRole('menu', { name: 'Document actions' })
+    fireEvent.keyDown(menu, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByRole('menu', { name: 'Document actions' })).toBeNull())
+  })
+
+  it('a folder card opens no menu', async () => {
+    renderPanel({ onOpenDocument: () => {} })
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Open folder plans' }).length).toBeGreaterThan(0)
+    })
+    fireEvent.contextMenu(screen.getAllByRole('button', { name: 'Open folder plans' })[0]!, {
+      clientX: 30,
+      clientY: 30,
+    })
+    expect(screen.queryByRole('menu', { name: 'Document actions' })).toBeNull()
+  })
+})

--- a/apps/web/src/components/workspace-files/card-context-menu.test.tsx
+++ b/apps/web/src/components/workspace-files/card-context-menu.test.tsx
@@ -59,10 +59,36 @@ describe('document card context menu', () => {
     expect(onRequestDelete).toHaveBeenCalledWith('meeting-notes', 'Meeting notes', 'markdown')
   })
 
-  it('omits Duplicate when the page does not provide it', async () => {
+  it('omits every verb whose handler the page does not provide', async () => {
+    // Only Delete is wired here: Open, Duplicate must both be absent —
+    // making any spread unconditional goes red.
     renderPanel({ onRequestDelete: () => {} })
     const menu = await contextMenuOnCard('Meeting notes')
     expect(within(menu).queryByRole('menuitem', { name: 'Duplicate' })).toBeNull()
+    expect(within(menu).queryByRole('menuitem', { name: 'Open' })).toBeNull()
+    expect(within(menu).getByRole('menuitem', { name: 'Delete' })).toBeTruthy()
+  })
+
+  it('omits Delete when only opening is wired', async () => {
+    renderPanel({ onOpenDocument: () => {} })
+    const menu = await contextMenuOnCard('Meeting notes')
+    expect(within(menu).queryByRole('menuitem', { name: 'Delete' })).toBeNull()
+    expect(within(menu).getByRole('menuitem', { name: 'Open' })).toBeTruthy()
+  })
+
+  it('plain selection never opens the move form', async () => {
+    // The startMoveToken guard: only a Move… bump starts an edit —
+    // clicking a card to select it must not.
+    renderPanel({ onOpenDocument: () => {} })
+    await waitFor(() => {
+      expect(
+        screen.getAllByTestId('card-title').some((el) => el.textContent === 'Meeting notes'),
+      ).toBe(true)
+    })
+    const el = screen.getAllByTestId('card-title').find((n) => n.textContent === 'Meeting notes')
+    fireEvent.click(el?.closest('button') as HTMLElement)
+    await screen.findByTestId('okf-preview')
+    expect(screen.queryByLabelText('Path')).toBeNull()
   })
 
   it('Move… selects the document and opens the move form', async () => {
@@ -83,6 +109,17 @@ describe('document card context menu', () => {
     const menu = await screen.findByRole('menu', { name: 'Document actions' })
     fireEvent.keyDown(menu, { key: 'Escape' })
     await waitFor(() => expect(screen.queryByRole('menu', { name: 'Document actions' })).toBeNull())
+  })
+
+  it('the grid layout of search results carries the menu too', async () => {
+    renderPanel({ onOpenDocument: () => {} })
+    await waitFor(() => expect(screen.getAllByTestId('card-title').length).toBeGreaterThan(0))
+    fireEvent.change(screen.getByLabelText('Search documents'), { target: { value: 'road' } })
+    await screen.findByTestId('search-results-list')
+    fireEvent.click(screen.getByRole('button', { name: 'Grid results' }))
+    const row = await screen.findByTestId('result-title')
+    fireEvent.contextMenu(row.closest('button') as HTMLElement, { clientX: 30, clientY: 30 })
+    expect(await screen.findByRole('menu', { name: 'Document actions' })).toBeTruthy()
   })
 
   it('a folder card opens no menu', async () => {


### PR DESCRIPTION
Increment D of the **Document First** direction (A = #971, B = #978, C = #982): OOUI's noun-then-verb, at the object. Right-clicking a document card (folder pane) or a search result row opens **Open / Duplicate / Move… / Delete** at the cursor.

- Every item fires the **same handler the preview pane uses** — no second set of rules. Duplicate appears only when the page provides it; Delete carries the kind so the dialog says note/canvas correctly (#978's contract).
- **Move…** selects the document and opens the preview's move form in one gesture. The bump-token effect is deliberately defined AFTER the preview's selection-change reset — defined earlier, the reset ran second and undid the edit in the very commit where selection and token change together (caught red in the new test).
- The menu is the existing `ContextMenu` (role=menu, Escape handling, focus-on-open — already shared: MarkdownEditor imports it too) with its hardcoded aria-label made a prop: **"Document actions"** here, the spatial surface's "Canvas actions" default untouched.
- Folders and empty space open no menu (native browser menu preserved).

Six red-first jsdom tests pin: the verb set, Open/Delete dispatch (kind included), Duplicate omission, Move-opens-the-form, search-row parity + Escape close, folder-no-menu.

Verification: apps/web jsdom 2679 + node 77 green (one earlier run had a single load-dependent failure in an untouched file; full rerun clean), workspace-files browser files + flow + spatial context-menu browser test 8/8, lint / knip clean. Live preview verb-by-verb check follows as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoaNgqWUKbYJxk2azmRQKY