### PR TITLE
refactor(web)!: facet UI rides contribution points — plugins get a displayName, core surfaces stop naming domains

### DIFF
--- a/.claude/rules/package-facet-engine.md
+++ b/.claude/rules/package-facet-engine.md
@@ -15,18 +15,29 @@ paths:
   read-side compat resolution (`resolveFacetPayload`, decision 7 — stepwise
   chain, drop-not-fail, newer-than-registered preserved).
 - The bundled `visual` plugin and its facet schemas, plus resolvers
-  (`resolveCanvasEdgeStyle`: facet first, legacy `x-whiteboard.edgeRouting`
-  fallback). WIRING STATUS: foundation — canvas-render's layout and the
-  editor still read the legacy key directly; the visual.edges UI rewiring
-  increment adopts this resolver and is what makes the facet user-reachable.
+  (`resolveCanvasEdgeStyle`, `resolveNodeShape`: facet first, legacy
+  fallback where one exists). Both are adopted by canvas-render's layout
+  defaults and the editor — user-reachable, no longer foundation-only.
+- The contribution RESOLUTION layer (`contributions.ts`): the closed
+  `ContributionPoint` set, and `resolveFacetContributions` answering "what
+  facet UI does this point carry" as namespace groups derived mechanically
+  from facet `targets` — ordered by plugin ID (never `displayName`, which
+  may be reworded/localized), headed by `displayName`. Ownership is
+  two-level: the POINT (core surface) owns the point set, the namespace
+  containers, their order and caps; a PLUGIN owns only the inside of its
+  own container. The VESSEL half (actual React rendering, widget lookup by
+  facet key) lives in each surface's composition root — today
+  `apps/web/src/components/spatial-editor/facet-widgets/`, guarded by
+  `facet-wiring-guard.test.ts` so point-owning surfaces never name a
+  domain.
 
 ## What does NOT belong here
 
 - Facet KEY grammar and the `facets` bucket schemas — those are model's
   (`extensionFacetsSchema`); this package constructs keys and a test
   cross-checks them against model's grammar.
-- Storage, rendering, transport, UI, contribution-point machinery (later
-  increments), Inversify.
+- Storage, rendering, transport, UI vessels (React widgets — those live in
+  the composition roots), Inversify.
 
 ## Dependency rules
 
@@ -45,6 +56,11 @@ paths:
   add a cross-version converter that skips a step.
 - The bundled plugin is ordinary (no privileged namespace, no special
   ordering); anything that would special-case it belongs nowhere.
+- `displayName` is required and human-facing only — UI containers show it;
+  the id stays machine-only (key grammar, storage, ordering).
+- Adding a `ContributionPoint` is a core increment, like adding a widget
+  kind: a plugin can neither mint a point nor place itself outside its
+  container.
 - Result types are discriminated unions (`resolved`/`dropped`/`preserved`/
   `passthrough`, `ok` true/false) — never sentinel nulls.
 

--- a/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
@@ -6,7 +6,7 @@ import {
   SPATIAL_LIGHT_PALETTE,
   tidyNodes,
 } from '@kamiazya/whiteboard-canvas-render'
-import { resolveNodeShape, type VisualShapeFacet } from '@kamiazya/whiteboard-facet-engine'
+import { bundledFacetRegistry, type FacetRegistry } from '@kamiazya/whiteboard-facet-engine'
 import type {
   CanvasColor,
   ClipboardFragment,
@@ -25,16 +25,12 @@ import {
   BringToFront,
   ChevronDown,
   ChevronUp,
-  Circle,
   ClipboardPaste,
   Copy as CopyIcon,
   CopyPlus,
-  Cylinder,
-  Diamond,
   ExternalLink,
   FileBox,
   Frame,
-  Hexagon,
   Image as ImageIcon,
   ImageOff,
   Link,
@@ -48,13 +44,12 @@ import {
   Scissors,
   SendToBack,
   Sparkles,
-  Square,
   SquareDashed,
   StickyNote,
   Tag,
   Trash2,
 } from 'lucide-react'
-import type { MutableRefObject, ReactNode } from 'react'
+import type { MutableRefObject } from 'react'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
 import { hasClipboardFragment } from '../../lib/clipboard-store.js'
 import type { BoxMove } from './align.js'
@@ -63,6 +58,7 @@ import { ContextMenu, type ContextMenuItem } from './ContextMenu.js'
 import type { EditorCommand } from './commands.js'
 import { CREATION_LABELS } from './creation-labels.js'
 import type { FileRefOption } from './DocumentPickerDialog.js'
+import { nodePropertyItems } from './facet-widgets/index.js'
 import { type GestureResult, type GestureState, reduceGesture } from './gestures.js'
 import type { Point } from './viewport.js'
 
@@ -144,6 +140,8 @@ export interface CanvasContextMenuProps {
   readonly extraIds: ReadonlySet<string>
   readonly selectedId: string | null
   readonly isImageFileRef?: (file: string) => boolean
+  /** Contribution source; a test seam — production uses the bundled registry. */
+  readonly facetRegistry?: FacetRegistry
   readonly missingFileRef?: (file: string) => boolean
 }
 
@@ -165,6 +163,7 @@ export function CanvasContextMenu({
   selectedId,
   isImageFileRef,
   missingFileRef,
+  facetRegistry = bundledFacetRegistry,
 }: CanvasContextMenuProps) {
   const {
     applyResult,
@@ -641,64 +640,20 @@ export function CanvasContextMenu({
             })
           }),
         )
-        // The silhouette row: writes the visual.shape/v0 facet through the
-        // same selection semantics as Color (a multi-selection reshapes
-        // every member). `rect` is the historic default and deliberately
-        // unrepresentable as a value — choosing it removes the facet.
+        // Facet quick bands ride the contribution seam: this surface asks the
+        // registry what the point carries and looks widgets up by key — it
+        // never names a plugin or facet itself (facet-wiring-guard.test.ts
+        // keeps it that way). Bands apply to the whole selection, the same
+        // semantics as Color.
         {
-          const currentShape = resolveNodeShape(node)
-          const applyShape = (shape: VisualShapeFacet['kind'] | undefined) => {
+          const applyToSelection = (
+            commandsFor: (targetIds: readonly string[]) => readonly EditorCommand[],
+          ) => {
             const members = new Set(selectedId !== null ? [selectedId, ...extraIds] : [])
             const nodeTargets = members.has(node.id) ? [...members] : [node.id]
-            applyResult({
-              state: { kind: 'idle' },
-              commands: nodeTargets.map((id) => ({ kind: 'set-node-shape' as const, id, shape })),
-            })
+            applyResult({ state: { kind: 'idle' }, commands: [...commandsFor(nodeTargets)] })
           }
-          const shapeOption = (
-            shape: VisualShapeFacet['kind'],
-            ariaLabel: string,
-            icon: ReactNode,
-          ) => ({
-            label: shape,
-            ariaLabel,
-            icon,
-            selected: currentShape === shape,
-            onSelect: () => applyShape(shape),
-          })
-          properties.push({
-            kind: 'options' as const,
-            label: 'Shape',
-            options: [
-              {
-                label: 'rect',
-                ariaLabel: 'Rectangle',
-                icon: <Square />,
-                selected: currentShape === undefined,
-                onSelect: () => applyShape(undefined),
-              },
-              shapeOption('ellipse', 'Ellipse', <Circle />),
-              shapeOption('diamond', 'Diamond', <Diamond />),
-              shapeOption('hexagon', 'Hexagon', <Hexagon />),
-              shapeOption(
-                'parallelogram',
-                'Parallelogram',
-                // No lucide glyph for a parallelogram; drawn in the same
-                // 24-grid stroke style so the row reads as one set.
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinejoin="round"
-                  aria-hidden="true"
-                >
-                  <path d="M7 5h14l-4 14H3Z" />
-                </svg>,
-              ),
-              shapeOption('cylinder', 'Cylinder', <Cylinder />),
-            ],
-          })
+          properties.push(...nodePropertyItems(facetRegistry, { node, applyToSelection }))
         }
         // Z-order as one-tap options — the touch path to the [ / ]
         // keyboard shortcuts (see shortcuts.ts). Not a picker: no

--- a/apps/web/src/components/spatial-editor/CanvasDisplaySettings.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasDisplaySettings.tsx
@@ -1,39 +1,51 @@
 /**
- * Canvas-wide display settings (edge routing style, line jumps) as a gear
- * popover for the canvas header row. Standalone from SpatialEditor so the
- * PAGE places it with the other canvas-level chrome; it speaks the same
- * (canvas, onChange) command contract the editor does.
+ * Canvas-wide display settings as a gear popover for the canvas header row.
+ * Standalone from SpatialEditor so the PAGE places it with the other
+ * canvas-level chrome; it speaks the same (canvas, onChange) command
+ * contract the editor does.
+ *
+ * This surface OWNS the `canvasSettings` contribution point and knows no
+ * facet domain (facet-wiring-guard.test.ts): panels come from the registry,
+ * grouped per plugin namespace. With one contributing namespace the panel
+ * renders bare; a second namespace introduces a tab strip headed by each
+ * plugin's displayName (ordering stays namespace-id lexicographic — a
+ * display name may be reworded or localized and must not move the order).
  *
  * Picks apply immediately and keep the popover open — these are property
  * pickers, and closing per pick would force a reopen for every adjustment.
  * Radix owns dismissal (outside click, Escape) and returns focus to the
  * gear, so a keyboard user never falls to <body>.
  */
-import { resolveCanvasEdgeStyle } from '@kamiazya/whiteboard-facet-engine'
-import type { EdgeRoutingStyle, SpatialCanvas } from '@kamiazya/whiteboard-model'
+import {
+  bundledFacetRegistry,
+  type FacetRegistry,
+  resolveFacetContributions,
+} from '@kamiazya/whiteboard-facet-engine'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { SlidersHorizontal } from 'lucide-react'
-import { useEffect, useRef } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover.js'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js'
 import type { EditorCommand } from './commands.js'
 import { applyCommand } from './commands.js'
+import { CANVAS_SETTINGS_WIDGETS, type CanvasSettingsWidget } from './facet-widgets/index.js'
 
 export interface CanvasDisplaySettingsProps {
   readonly canvas: SpatialCanvas
   readonly onChange: (next: SpatialCanvas, command: EditorCommand) => void
+  /** Contribution source; a test seam — production uses the bundled registry. */
+  readonly facetRegistry?: FacetRegistry
+  /** Widget lookup; a test seam — production uses the registered widgets. */
+  readonly widgets?: Readonly<Record<string, CanvasSettingsWidget>>
 }
 
-const EDGE_ROUTING_CHOICES: readonly { style: EdgeRoutingStyle; label: string }[] = [
-  { style: 'straight', label: 'Straight' },
-  { style: 'orthogonal', label: 'Orthogonal' },
-  { style: 'curved', label: 'Curved' },
-]
-
-const OPTION_CLASS =
-  'flex h-7 min-w-7 items-center justify-center rounded px-2 text-xs transition-colors duration-(--motion-duration-fast) ease-(--motion-ease-out) hover:bg-accent focus-visible:bg-accent focus-visible:outline-none'
-
-export function CanvasDisplaySettings({ canvas, onChange }: CanvasDisplaySettingsProps) {
+export function CanvasDisplaySettings({
+  canvas,
+  onChange,
+  facetRegistry = bundledFacetRegistry,
+  widgets = CANVAS_SETTINGS_WIDGETS,
+}: CanvasDisplaySettingsProps) {
   // Eager command chaining: two picks from the same open popover can land
   // before a slow parent commits the first, and the second must build on
   // the first's result, not the stale prop. The ref follows the prop only
@@ -48,12 +60,18 @@ export function CanvasDisplaySettings({ canvas, onChange }: CanvasDisplaySetting
     onChange(running, command)
   }
 
-  // Facet-first (visual.edges/v0), legacy edgeRouting fallback — the same
-  // resolution the renderer defaults to, so the checked segment always
-  // matches what the canvas draws.
-  const current = resolveCanvasEdgeStyle(canvas)
-  const currentRouting = current.style ?? 'straight'
-  const currentJumps = current.lineJumps ?? 'none'
+  const groups = resolveFacetContributions(facetRegistry, 'canvasSettings')
+    .map((group) => ({
+      group,
+      widgets: group.facets.flatMap((facet) => {
+        const widget = widgets[facet.key]
+        return widget === undefined ? [] : [{ key: facet.key, widget }]
+      }),
+    }))
+    .filter((entry) => entry.widgets.length > 0)
+
+  const [activeNamespace, setActiveNamespace] = useState<string | null>(null)
+  const active = groups.find((entry) => entry.group.namespace === activeNamespace) ?? groups[0]
 
   return (
     <Popover>
@@ -73,55 +91,30 @@ export function CanvasDisplaySettings({ canvas, onChange }: CanvasDisplaySetting
         <TooltipContent>Display settings</TooltipContent>
       </Tooltip>
       <PopoverContent data-testid="canvas-settings-menu" className="w-auto min-w-52 p-2">
-        <div className="flex flex-col gap-1">
-          <div className="flex items-center justify-between gap-3">
-            <span className="text-xs text-muted-foreground">Edge routing</span>
-            <span className="flex items-center gap-0.5">
-              {EDGE_ROUTING_CHOICES.map(({ style, label }) => (
-                <button
-                  key={style}
-                  type="button"
-                  aria-pressed={currentRouting === style}
-                  onClick={() => run({ kind: 'set-edge-routing', style })}
-                  className={cn(
-                    OPTION_CLASS,
-                    currentRouting === style
-                      ? 'bg-accent font-medium text-foreground'
-                      : 'text-muted-foreground',
-                  )}
-                >
-                  {label}
-                </button>
-              ))}
-            </span>
+        {groups.length >= 2 && (
+          <div role="tablist" className="mb-2 flex items-center gap-1 border-b border-border">
+            {groups.map(({ group }) => (
+              <button
+                key={group.namespace}
+                type="button"
+                role="tab"
+                aria-selected={group.namespace === active?.group.namespace}
+                onClick={() => setActiveNamespace(group.namespace)}
+                className={cn(
+                  'rounded-t px-2 py-1 text-xs',
+                  group.namespace === active?.group.namespace
+                    ? 'bg-accent font-medium text-foreground'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                {group.displayName}
+              </button>
+            ))}
           </div>
-          <div className="flex items-center justify-between gap-3">
-            <span className="text-xs text-muted-foreground">Line jumps</span>
-            <span className="flex items-center gap-0.5">
-              {(
-                [
-                  { lineJumps: 'none', label: 'Off' },
-                  { lineJumps: 'arc', label: 'On' },
-                ] as const
-              ).map(({ lineJumps, label }) => (
-                <button
-                  key={lineJumps}
-                  type="button"
-                  aria-pressed={currentJumps === lineJumps}
-                  onClick={() => run({ kind: 'set-line-jumps', lineJumps })}
-                  className={cn(
-                    OPTION_CLASS,
-                    currentJumps === lineJumps
-                      ? 'bg-accent font-medium text-foreground'
-                      : 'text-muted-foreground',
-                  )}
-                >
-                  {label}
-                </button>
-              ))}
-            </span>
-          </div>
-        </div>
+        )}
+        {active?.widgets.map(({ key, widget }) => (
+          <Fragment key={key}>{widget({ canvas, run })}</Fragment>
+        ))}
       </PopoverContent>
     </Popover>
   )

--- a/apps/web/src/components/spatial-editor/ContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/ContextMenu.tsx
@@ -70,7 +70,20 @@ export interface ContextMenuSeparator {
   readonly kind: 'separator'
 }
 
-export type ContextMenuItem = ContextMenuActionItem | ContextMenuOptionsItem | ContextMenuSeparator
+/**
+ * A namespace-container heading over contributed property bands — shown only
+ * once a second plugin contributes, so a single-namespace menu stays clean.
+ */
+export interface ContextMenuHeadingItem {
+  readonly kind: 'heading'
+  readonly label: string
+}
+
+export type ContextMenuItem =
+  | ContextMenuActionItem
+  | ContextMenuOptionsItem
+  | ContextMenuSeparator
+  | ContextMenuHeadingItem
 
 export interface ContextMenuProps {
   /** Screen position relative to the editor root. */
@@ -280,6 +293,14 @@ export function ContextMenu({ x, y, items, onClose, variant = 'list' }: ContextM
   function renderCatalogItem(item: ContextMenuItem, index: number) {
     return item.kind === 'separator' ? (
       <hr key={`separator-${index}`} className="my-1 border-border" />
+    ) : item.kind === 'heading' ? (
+      <div
+        key={`heading-${item.label}`}
+        role="presentation"
+        className="px-3 pt-1.5 pb-0.5 text-[0.65rem] font-medium tracking-wide text-muted-foreground"
+      >
+        {item.label}
+      </div>
     ) : item.kind === 'options' ? (
       <Fragment key={item.label}>
         <fieldset

--- a/apps/web/src/components/spatial-editor/canvas-settings.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/canvas-settings.browser.test.tsx
@@ -2,12 +2,20 @@
 // pick applies the canvas-wide command immediately and keeps it open for
 // the next tweak, consecutive picks chain under a deferred parent, and
 // dismissal returns focus to the gear.
-import type { VisualEdgesFacet } from '@kamiazya/whiteboard-facet-engine'
+import {
+  bundledPlugins,
+  createFacetRegistry,
+  defineFacet,
+  definePlugin,
+  type VisualEdgesFacet,
+} from '@kamiazya/whiteboard-facet-engine'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
+import { z } from 'zod'
 import { CanvasDisplaySettings } from './CanvasDisplaySettings.js'
+import { CANVAS_SETTINGS_WIDGETS } from './facet-widgets/index.js'
 
 const edgesFacetOf = (canvas: SpatialCanvas) =>
   canvas['x-whiteboard']?.facets?.['visual.edges/v0'] as VisualEdgesFacet | undefined
@@ -115,4 +123,48 @@ it('Escape closes and hands focus back to the gear', async () => {
   // Radix hands focus back to the trigger, so a keyboard user keeps their
   // place instead of falling to <body>.
   await vi.waitFor(() => expect(document.activeElement).toBe(trigger))
+})
+
+it('a second contributing namespace introduces displayName tabs; one namespace stays bare', async () => {
+  const planning = definePlugin({
+    id: 'planning',
+    displayName: 'Planning',
+    facets: [
+      defineFacet({ name: 'board', version: 'v0', targets: ['canvas'], schema: z.object({}) }),
+    ],
+  })
+  const registry = createFacetRegistry([...bundledPlugins, planning])
+  function Host() {
+    const [canvas, setCanvas] = useState(initial)
+    return (
+      <CanvasDisplaySettings
+        canvas={canvas}
+        onChange={(next) => setCanvas(next)}
+        facetRegistry={registry}
+        widgets={{
+          ...CANVAS_SETTINGS_WIDGETS,
+          'planning.board/v0': () => <div>Board options</div>,
+        }}
+      />
+    )
+  }
+  const { container } = render(<Host />)
+  fireEvent.click(gear(container))
+  await vi.waitFor(() => expect(menu()).toBeTruthy())
+
+  const tabs = [...(menu()?.querySelectorAll('[role="tab"]') ?? [])]
+  expect(tabs.map((t) => t.textContent)).toEqual(['Planning', 'Visual style'])
+  // First namespace by id is active: planning's panel shows, visual's not.
+  expect(menu()?.textContent).toContain('Board options')
+  expect(menu()?.textContent).not.toContain('Edge routing')
+  fireEvent.click(tabs[1] as HTMLElement)
+  await vi.waitFor(() => expect(menu()?.textContent).toContain('Edge routing'))
+
+  cleanup()
+  // The bundled registry alone (one namespace) shows no tablist.
+  const { Host: BareHost } = makeHost()
+  const { container: bare } = render(<BareHost />)
+  fireEvent.click(gear(bare))
+  await vi.waitFor(() => expect(menu()).toBeTruthy())
+  expect(menu()?.querySelector('[role="tab"]')).toBeNull()
 })

--- a/apps/web/src/components/spatial-editor/facet-widgets/index.test.tsx
+++ b/apps/web/src/components/spatial-editor/facet-widgets/index.test.tsx
@@ -1,0 +1,51 @@
+// The namespace-container rule for the node context menu: one contributing
+// namespace renders bare bands; a second namespace introduces displayName
+// headings, in namespace-ID order regardless of the display wording.
+import { createFacetRegistry, defineFacet, definePlugin } from '@kamiazya/whiteboard-facet-engine'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { type NodePropertiesWidget, nodePropertyItems } from './index.js'
+
+const node = { id: 'n1', type: 'text' as const, x: 0, y: 0, width: 10, height: 10, text: '' }
+const ctx = { node, applyToSelection: () => {} }
+
+const nodeFacet = (name: string) =>
+  defineFacet({ name, version: 'v0', targets: ['node' as const], schema: z.object({}) })
+
+const band =
+  (label: string): NodePropertiesWidget =>
+  () => [{ kind: 'options' as const, label, options: [] }]
+
+// zeta before apple by DISPLAY name — id order must win.
+const zeta = definePlugin({
+  id: 'aaa-zeta',
+  displayName: 'Zeta styling',
+  facets: [nodeFacet('one')],
+})
+const apple = definePlugin({
+  id: 'zzz-apple',
+  displayName: 'Apple tools',
+  facets: [nodeFacet('two')],
+})
+
+describe('nodePropertyItems', () => {
+  it('two namespaces get displayName headings, ordered by namespace id', () => {
+    const registry = createFacetRegistry([zeta, apple])
+    const widgets = { 'aaa-zeta.one/v0': band('One'), 'zzz-apple.two/v0': band('Two') }
+    const items = nodePropertyItems(registry, ctx, widgets)
+    expect(items.map((i) => (i.kind === 'heading' ? `#${i.label}` : i.kind))).toEqual([
+      '#Zeta styling',
+      'options',
+      '#Apple tools',
+      'options',
+    ])
+  })
+
+  it('a single contributing namespace renders bare bands — no heading', () => {
+    const registry = createFacetRegistry([zeta, apple])
+    // apple has no widget registered, so only zeta actually contributes.
+    const widgets = { 'aaa-zeta.one/v0': band('One') }
+    const items = nodePropertyItems(registry, ctx, widgets)
+    expect(items.map((i) => i.kind)).toEqual(['options'])
+  })
+})

--- a/apps/web/src/components/spatial-editor/facet-widgets/index.tsx
+++ b/apps/web/src/components/spatial-editor/facet-widgets/index.tsx
@@ -1,0 +1,200 @@
+/**
+ * The EXTENSION side of the facet-UI seam: quick-edit widgets keyed by facet
+ * key, one registration per contribution point. This module is the ONE place
+ * on the web side allowed to name a facet domain — the point-owning surfaces
+ * (CanvasContextMenu, CanvasDisplaySettings) iterate contribution groups and
+ * look widgets up here, and `facet-wiring-guard.test.ts` keeps them that way.
+ *
+ * A facet with no widget registered simply contributes nothing yet — the
+ * later editor-spec tier derives a default form instead of failing here.
+ */
+import {
+  type FacetRegistry,
+  resolveCanvasEdgeStyle,
+  resolveFacetContributions,
+  resolveNodeShape,
+  type VisualShapeFacet,
+} from '@kamiazya/whiteboard-facet-engine'
+import type { EdgeRoutingStyle, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
+import { Circle, Cylinder, Diamond, Hexagon, Square } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+import type { ContextMenuItem } from '../ContextMenu.js'
+import type { EditorCommand } from '../commands.js'
+
+/** `contextMenu.node.properties`: what a node quick-band widget receives. */
+export interface NodePropertiesContext {
+  readonly node: SpatialNode
+  /** Applies per-target commands with the menu's selection semantics. */
+  readonly applyToSelection: (
+    commandsFor: (targetIds: readonly string[]) => readonly EditorCommand[],
+  ) => void
+}
+
+export type NodePropertiesWidget = (ctx: NodePropertiesContext) => readonly ContextMenuItem[]
+
+/** `canvasSettings`: what a canvas-settings panel widget receives. */
+export interface CanvasSettingsContext {
+  readonly canvas: SpatialCanvas
+  readonly run: (command: EditorCommand) => void
+}
+
+export type CanvasSettingsWidget = (ctx: CanvasSettingsContext) => ReactNode
+
+// --- visual.shape/v0 -------------------------------------------------------
+
+const visualShapeBand: NodePropertiesWidget = ({ node, applyToSelection }) => {
+  const currentShape = resolveNodeShape(node)
+  const applyShape = (shape: VisualShapeFacet['kind'] | undefined) => {
+    applyToSelection((ids) => ids.map((id) => ({ kind: 'set-node-shape' as const, id, shape })))
+  }
+  const shapeOption = (shape: VisualShapeFacet['kind'], ariaLabel: string, icon: ReactNode) => ({
+    label: shape,
+    ariaLabel,
+    icon,
+    selected: currentShape === shape,
+    onSelect: () => applyShape(shape),
+  })
+  return [
+    {
+      kind: 'options' as const,
+      label: 'Shape',
+      options: [
+        // `rect` is the historic default and deliberately unrepresentable
+        // as a value — choosing it removes the facet.
+        {
+          label: 'rect',
+          ariaLabel: 'Rectangle',
+          icon: <Square />,
+          selected: currentShape === undefined,
+          onSelect: () => applyShape(undefined),
+        },
+        shapeOption('ellipse', 'Ellipse', <Circle />),
+        shapeOption('diamond', 'Diamond', <Diamond />),
+        shapeOption('hexagon', 'Hexagon', <Hexagon />),
+        shapeOption(
+          'parallelogram',
+          'Parallelogram',
+          // No lucide glyph for a parallelogram; drawn in the same 24-grid
+          // stroke style so the row reads as one set.
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M7 5h14l-4 14H3Z" />
+          </svg>,
+        ),
+        shapeOption('cylinder', 'Cylinder', <Cylinder />),
+      ],
+    },
+  ]
+}
+
+// --- visual.edges/v0 -------------------------------------------------------
+
+const EDGE_ROUTING_CHOICES: readonly { style: EdgeRoutingStyle; label: string }[] = [
+  { style: 'straight', label: 'Straight' },
+  { style: 'orthogonal', label: 'Orthogonal' },
+  { style: 'curved', label: 'Curved' },
+]
+
+const OPTION_CLASS =
+  'flex h-7 min-w-7 items-center justify-center rounded px-2 text-xs transition-colors duration-(--motion-duration-fast) ease-(--motion-ease-out) hover:bg-accent focus-visible:bg-accent focus-visible:outline-none'
+
+const visualEdgesPanel: CanvasSettingsWidget = ({ canvas, run }) => {
+  // Facet-first (visual.edges/v0), legacy edgeRouting fallback — the same
+  // resolution the renderer defaults to, so the checked segment always
+  // matches what the canvas draws.
+  const current = resolveCanvasEdgeStyle(canvas)
+  const currentRouting = current.style ?? 'straight'
+  const currentJumps = current.lineJumps ?? 'none'
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs text-muted-foreground">Edge routing</span>
+        <span className="flex items-center gap-0.5">
+          {EDGE_ROUTING_CHOICES.map(({ style, label }) => (
+            <button
+              key={style}
+              type="button"
+              aria-pressed={currentRouting === style}
+              onClick={() => run({ kind: 'set-edge-routing', style })}
+              className={cn(
+                OPTION_CLASS,
+                currentRouting === style
+                  ? 'bg-accent font-medium text-foreground'
+                  : 'text-muted-foreground',
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </span>
+      </div>
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs text-muted-foreground">Line jumps</span>
+        <span className="flex items-center gap-0.5">
+          {(
+            [
+              { lineJumps: 'none', label: 'Off' },
+              { lineJumps: 'arc', label: 'On' },
+            ] as const
+          ).map(({ lineJumps, label }) => (
+            <button
+              key={lineJumps}
+              type="button"
+              aria-pressed={currentJumps === lineJumps}
+              onClick={() => run({ kind: 'set-line-jumps', lineJumps })}
+              className={cn(
+                OPTION_CLASS,
+                currentJumps === lineJumps
+                  ? 'bg-accent font-medium text-foreground'
+                  : 'text-muted-foreground',
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The `contextMenu.node.properties` point resolved to menu items: bands per
+ * contributing namespace, headed by the plugin's displayName only once a
+ * SECOND namespace contributes (one namespace stays unlabeled). Group order
+ * is namespace-id lexicographic — display wording never moves it.
+ */
+export function nodePropertyItems(
+  registry: FacetRegistry,
+  ctx: NodePropertiesContext,
+  widgets: Readonly<Record<string, NodePropertiesWidget>> = NODE_PROPERTIES_WIDGETS,
+): readonly ContextMenuItem[] {
+  const contributed = resolveFacetContributions(registry, 'contextMenu.node.properties')
+    .map((group) => ({
+      group,
+      bands: group.facets.flatMap((facet) => widgets[facet.key]?.(ctx) ?? []),
+    }))
+    .filter((entry) => entry.bands.length > 0)
+  return contributed.flatMap(({ group, bands }) =>
+    contributed.length >= 2
+      ? [{ kind: 'heading' as const, label: group.displayName }, ...bands]
+      : bands,
+  )
+}
+
+// --- registrations ---------------------------------------------------------
+
+export const NODE_PROPERTIES_WIDGETS: Readonly<Record<string, NodePropertiesWidget>> = {
+  'visual.shape/v0': visualShapeBand,
+}
+
+export const CANVAS_SETTINGS_WIDGETS: Readonly<Record<string, CanvasSettingsWidget>> = {
+  'visual.edges/v0': visualEdgesPanel,
+}

--- a/apps/web/src/components/spatial-editor/facet-wiring-guard.test.ts
+++ b/apps/web/src/components/spatial-editor/facet-wiring-guard.test.ts
@@ -1,0 +1,34 @@
+// Core surfaces publish contribution points and know NO facet domain — the
+// agreed governance line (spec: "facetのUIを既存面に手で書き足す線形拡張は
+// しない"). Two increments shipped hand-wired facet UI anyway, so the rule
+// gets an executable rung: the point-owning surfaces must not name a plugin
+// namespace, a facet key, or a facet-specific resolver. Domain knowledge is
+// allowed exactly one home on this side: the facet-widgets registration
+// modules, which ARE the extension side of the seam.
+
+import { describe, expect, it } from 'vitest'
+import contextMenuSource from './CanvasContextMenu.tsx?raw'
+import displaySettingsSource from './CanvasDisplaySettings.tsx?raw'
+
+const CORE_SURFACES = [
+  ['CanvasContextMenu.tsx', contextMenuSource],
+  ['CanvasDisplaySettings.tsx', displaySettingsSource],
+] as const
+
+const DOMAIN_MARKS = [
+  /'visual\./, // a facet key literal
+  /resolveNodeShape/,
+  /resolveCanvasEdgeStyle/,
+  /VisualShapeFacet/,
+  /VISUAL_[A-Z_]*KEY/,
+]
+
+describe('facet wiring guard', () => {
+  for (const [name, source] of CORE_SURFACES) {
+    it(`${name} names no facet domain`, () => {
+      for (const mark of DOMAIN_MARKS) {
+        expect(mark.test(source), `${name} matches ${mark}`).toBe(false)
+      }
+    })
+  }
+})

--- a/packages/facet-engine/src/compat.property.test.ts
+++ b/packages/facet-engine/src/compat.property.test.ts
@@ -10,6 +10,7 @@ import { createFacetRegistry, defineFacet, definePlugin } from './registry.js'
 const registry = createFacetRegistry([
   definePlugin({
     id: 'chain',
+    displayName: 'Chain',
     facets: [
       defineFacet({
         name: 'thing',

--- a/packages/facet-engine/src/contributions.test.ts
+++ b/packages/facet-engine/src/contributions.test.ts
@@ -41,10 +41,6 @@ describe('resolveFacetContributions', () => {
     const canvas = resolveFacetContributions(registry, 'canvasSettings')
     expect(canvas.map((g) => g.namespace)).toEqual(['visual'])
     expect(canvas[0]?.facets.map((f) => f.key)).toEqual(['visual.edges/v0'])
-
-    const document = resolveFacetContributions(registry, 'documentProperties')
-    expect(document.map((g) => g.namespace)).toEqual(['planning'])
-    expect(document[0]?.facets.map((f) => f.key)).toEqual(['planning.due/v0'])
   })
 
   it('a plugin contributing nothing to a point produces no empty group', () => {

--- a/packages/facet-engine/src/contributions.test.ts
+++ b/packages/facet-engine/src/contributions.test.ts
@@ -1,0 +1,73 @@
+// The contribution resolution layer: core surfaces ask "what does this
+// point carry" and get namespace groups derived mechanically from facet
+// targets — no surface ever names a plugin or facet key itself.
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { resolveFacetContributions } from './contributions.js'
+import { createFacetRegistry, defineFacet, definePlugin } from './registry.js'
+import { visualPlugin } from './visual.js'
+
+const planning = definePlugin({
+  id: 'planning',
+  displayName: 'Planning',
+  facets: [
+    defineFacet({
+      name: 'due',
+      version: 'v0',
+      targets: ['node', 'document'],
+      schema: z.object({ date: z.string() }),
+    }),
+    defineFacet({
+      name: 'assignee',
+      version: 'v0',
+      targets: ['node'],
+      schema: z.object({ member: z.string() }),
+    }),
+  ],
+})
+
+const registry = createFacetRegistry([visualPlugin, planning])
+
+describe('resolveFacetContributions', () => {
+  it('groups a point by namespace in id order, facets in name order, headed by displayName', () => {
+    const groups = resolveFacetContributions(registry, 'contextMenu.node.properties')
+    expect(groups.map((g) => g.namespace)).toEqual(['planning', 'visual'])
+    expect(groups.map((g) => g.displayName)).toEqual(['Planning', 'Visual style'])
+    expect(groups[0]?.facets.map((f) => f.key)).toEqual(['planning.assignee/v0', 'planning.due/v0'])
+    expect(groups[1]?.facets.map((f) => f.key)).toEqual(['visual.shape/v0'])
+  })
+
+  it('a point only carries facets whose targets include its object', () => {
+    const canvas = resolveFacetContributions(registry, 'canvasSettings')
+    expect(canvas.map((g) => g.namespace)).toEqual(['visual'])
+    expect(canvas[0]?.facets.map((f) => f.key)).toEqual(['visual.edges/v0'])
+
+    const document = resolveFacetContributions(registry, 'documentProperties')
+    expect(document.map((g) => g.namespace)).toEqual(['planning'])
+    expect(document[0]?.facets.map((f) => f.key)).toEqual(['planning.due/v0'])
+  })
+
+  it('a plugin contributing nothing to a point produces no empty group', () => {
+    const canvas = resolveFacetContributions(registry, 'canvasSettings')
+    expect(canvas.some((g) => g.namespace === 'planning')).toBe(false)
+  })
+
+  it('each contribution carries its definition, so a vessel can read targets and schema', () => {
+    const groups = resolveFacetContributions(registry, 'contextMenu.node.properties')
+    const shape = groups.find((g) => g.namespace === 'visual')?.facets[0]
+    expect(shape?.definition.name).toBe('shape')
+    expect(shape?.definition.targets).toContain('node')
+  })
+})
+
+describe('plugin displayName', () => {
+  it('definePlugin rejects a blank displayName', () => {
+    expect(() => definePlugin({ id: 'blank', displayName: '  ', facets: [] })).toThrow(
+      /displayName/,
+    )
+  })
+
+  it('the bundled visual plugin names itself for humans', () => {
+    expect(visualPlugin.displayName).toBe('Visual style')
+  })
+})

--- a/packages/facet-engine/src/contributions.ts
+++ b/packages/facet-engine/src/contributions.ts
@@ -1,0 +1,65 @@
+/**
+ * The contribution resolution layer: which facet UI a core surface carries,
+ * answered as DATA so no surface ever names a plugin or facet key itself.
+ *
+ * Ownership is two-level. The POINT (core) owns the closed set of points,
+ * the namespace containers and their order, and any per-point caps; the
+ * PLUGIN owns only the inside of its own container. Ordering is by plugin
+ * ID, never displayName — a display name may be reworded or localized, and
+ * deterministic order must not move when it does.
+ */
+
+import type { FacetDefinition, FacetRegistry } from './registry.js'
+
+/**
+ * The closed set of places facet UI can appear. Adding a point is a core
+ * increment, exactly like adding a widget kind — a plugin can neither mint
+ * a point nor place itself outside its container.
+ */
+export type ContributionPoint =
+  | 'contextMenu.node.properties'
+  | 'canvasSettings'
+  | 'documentProperties'
+
+const POINT_TARGET = {
+  'contextMenu.node.properties': 'node',
+  canvasSettings: 'canvas',
+  documentProperties: 'document',
+} as const
+
+export interface FacetContribution {
+  /** The facet's current storage key, `{namespace}.{name}/v{n}`. */
+  readonly key: string
+  readonly definition: FacetDefinition
+}
+
+export interface NamespaceContributions {
+  readonly namespace: string
+  /** The plugin's human-facing name — what a container heading shows. */
+  readonly displayName: string
+  readonly facets: readonly FacetContribution[]
+}
+
+/**
+ * Derived mechanically from facet targets: a plugin never declares where it
+ * appears. Plugins contributing nothing to a point produce no group.
+ */
+export function resolveFacetContributions(
+  registry: FacetRegistry,
+  point: ContributionPoint,
+): readonly NamespaceContributions[] {
+  const target = POINT_TARGET[point]
+  return [...registry.plugins]
+    .sort((a, b) => (a.id < b.id ? -1 : 1))
+    .flatMap((plugin) => {
+      const facets = plugin.facets
+        .filter((definition) => definition.targets.includes(target))
+        .sort((a, b) => (a.name < b.name ? -1 : 1))
+        .map((definition) => ({
+          key: `${plugin.id}.${definition.name}/${definition.version}`,
+          definition,
+        }))
+      if (facets.length === 0) return []
+      return [{ namespace: plugin.id, displayName: plugin.displayName, facets }]
+    })
+}

--- a/packages/facet-engine/src/contributions.ts
+++ b/packages/facet-engine/src/contributions.ts
@@ -14,17 +14,16 @@ import type { FacetDefinition, FacetRegistry } from './registry.js'
 /**
  * The closed set of places facet UI can appear. Adding a point is a core
  * increment, exactly like adding a widget kind — a plugin can neither mint
- * a point nor place itself outside its container.
+ * a point nor place itself outside its container. A point exists only once
+ * its vessel does: `documentProperties` (the DocumentProperties disclosure)
+ * joins together with the surface that consumes it, in the facet editor
+ * increment.
  */
-export type ContributionPoint =
-  | 'contextMenu.node.properties'
-  | 'canvasSettings'
-  | 'documentProperties'
+export type ContributionPoint = 'contextMenu.node.properties' | 'canvasSettings'
 
 const POINT_TARGET = {
   'contextMenu.node.properties': 'node',
   canvasSettings: 'canvas',
-  documentProperties: 'document',
 } as const
 
 export interface FacetContribution {

--- a/packages/facet-engine/src/index.ts
+++ b/packages/facet-engine/src/index.ts
@@ -1,2 +1,3 @@
+export * from './contributions.js'
 export * from './registry.js'
 export * from './visual.js'

--- a/packages/facet-engine/src/registry.test.ts
+++ b/packages/facet-engine/src/registry.test.ts
@@ -4,6 +4,7 @@ import { createFacetRegistry, defineFacet, definePlugin } from './registry.js'
 
 const samplePlugin = definePlugin({
   id: 'example',
+  displayName: 'Example',
   facets: [
     defineFacet({
       name: 'sample',
@@ -39,7 +40,7 @@ describe('defineFacet / definePlugin', () => {
   })
 
   it('rejects an invalid plugin id segment', () => {
-    expect(() => definePlugin({ id: 'Not OK', facets: [] })).toThrow(/id/)
+    expect(() => definePlugin({ id: 'Not OK', displayName: 'Not OK', facets: [] })).toThrow(/id/)
   })
 
   it('rejects two facets with the same name inside one plugin', () => {
@@ -49,7 +50,9 @@ describe('defineFacet / definePlugin', () => {
       targets: ['document'],
       schema: z.object({}),
     })
-    expect(() => definePlugin({ id: 'example', facets: [twice, twice] })).toThrow(/duplicate/)
+    expect(() =>
+      definePlugin({ id: 'example', displayName: 'Example', facets: [twice, twice] }),
+    ).toThrow(/duplicate/)
   })
 })
 
@@ -99,6 +102,7 @@ describe('resolveFacetPayload', () => {
   // A three-version facet: v0 {a:number} -> v1 {b:string} -> v2 {c:string}.
   const chained = definePlugin({
     id: 'chain',
+    displayName: 'Chain',
     facets: [
       defineFacet({
         name: 'thing',
@@ -148,6 +152,7 @@ describe('resolveFacetPayload', () => {
     const gapped = createFacetRegistry([
       definePlugin({
         id: 'gap',
+        displayName: 'Gap',
         facets: [
           defineFacet({
             name: 'thing',

--- a/packages/facet-engine/src/registry.ts
+++ b/packages/facet-engine/src/registry.ts
@@ -39,6 +39,12 @@ export interface FacetDefinition<S extends z.ZodTypeAny = z.ZodTypeAny> {
 export interface FacetPlugin {
   /** The plugin's id doubles as the facet-key namespace. */
   readonly id: string
+  /**
+   * The plugin's human-facing name — what UI containers (namespace
+   * sections, submenus, tabs) show. The id stays machine-only: key
+   * grammar, storage, and deterministic ordering.
+   */
+  readonly displayName: string
   readonly facets: readonly FacetDefinition[]
 }
 
@@ -68,6 +74,9 @@ export function definePlugin(plugin: FacetPlugin): FacetPlugin {
   if (!SEGMENT_PATTERN.test(plugin.id)) {
     throw new Error(`plugin id "${plugin.id}" must match ${SEGMENT_PATTERN}`)
   }
+  if (plugin.displayName.trim() === '') {
+    throw new Error(`plugin "${plugin.id}" needs a non-blank displayName`)
+  }
   const seen = new Set<string>()
   for (const facet of plugin.facets) {
     if (seen.has(facet.name)) {
@@ -93,6 +102,8 @@ export type FacetResolution =
   | { readonly kind: 'passthrough'; readonly payload: unknown }
 
 export interface FacetRegistry {
+  /** The source plugin list, in registration order (contributions sort by id). */
+  readonly plugins: readonly FacetPlugin[]
   readonly targetsOf: (key: string) => readonly FacetTarget[] | undefined
   readonly validateFacetWrite: (key: string, payload: unknown) => FacetWriteResult
   readonly resolveFacetPayload: (key: string, payload: unknown) => FacetResolution
@@ -124,6 +135,7 @@ export function createFacetRegistry(plugins: readonly FacetPlugin[]): FacetRegis
     `${namespace}.${definition.name}/${definition.version}`
 
   return {
+    plugins,
     targetsOf(key) {
       const parsed = parseKey(key)
       if (parsed === null) return undefined

--- a/packages/facet-engine/src/visual.ts
+++ b/packages/facet-engine/src/visual.ts
@@ -45,6 +45,7 @@ export const VISUAL_SHAPE_KEY = 'visual.shape/v0'
  */
 export const visualPlugin = definePlugin({
   id: 'visual',
+  displayName: 'Visual style',
   facets: [
     defineFacet({
       name: 'edges',

--- a/packages/server-core/src/tools/facet-set.test.ts
+++ b/packages/server-core/src/tools/facet-set.test.ts
@@ -197,6 +197,7 @@ describe('facets belong to OKF (ADR-0009 decision 3)', () => {
 describe('registered-facet validation (ADR-0013 decision 6)', () => {
   const documentTicket = definePlugin({
     id: 'ticket',
+    displayName: 'Ticket',
     facets: [
       defineFacet({
         name: 'sample',


### PR DESCRIPTION
## Summary

Increment 5a of the facet system: the **contribution-point mechanism**, plus repayment of the governance deviation the last two increments shipped ([decision record](https://claude.ai/code/artifact/6c1794ea-f809-4ca0-a007-79c64f911db0)). The agreed design says core surfaces publish named points and know no facet domain — the bundled `visual` plugin goes through the same pipeline as any third-party plugin. #968 and #974 hand-wired their facet UI instead; this PR builds the seam and re-wires both through it.

- **facet-engine**: `FacetPlugin` gains a required human-facing `displayName` (UI containers show it; the id stays machine-only — key grammar, storage, ordering). `contributions.ts` adds the closed `ContributionPoint` set (`contextMenu.node.properties`, `canvasSettings` — a point exists only once its vessel does) and `resolveFacetContributions`: namespace groups derived mechanically from facet `targets`, ordered by plugin **id** (never displayName, which may be reworded or localized), facets by name, no empty groups. Ownership is two-level: the point owns the containers and their order; a plugin owns only its own container's inside.
- **apps/web**: `facet-widgets/` is now the ONLY module allowed to name a facet domain — the Shape band and the edges settings panel moved there verbatim. The point-owning surfaces iterate contributions and look widgets up by key, and **`facet-wiring-guard.test.ts`** (source scan) is the executable rung that fails if a domain mark ever returns to them — mutation-checked (reintroducing a `resolveNodeShape` import turns it red).
- **Namespace containers materialise only at ≥2 contributing plugins**: the context menu gains `displayName` headings, the settings popover a `displayName` tab strip — both pinned with a two-namespace test registry, both invisible today, so with the bundled registry the rendered UI is **byte-identical to before** (every existing jsdom and browser test passes unmodified).

## Behavior-preserving proof

No visual evidence per the skip rule: with one contributing namespace nothing on screen changes. The proof is the unchanged test surface — spatial-editor jsdom 400, browser regression locks (shape menu, context menu, edge routing, canvas settings) all green without edits — plus the new mechanism tests (heading rule ×2, tab strip ×1, resolution layer ×5).

## Verification

- Full root suite 9134 passed (2 fails were load-flakes in files outside the diff — both 3× green in isolation, same verdict from the review gate's independent QA lane), apps/web CI-style 2679+77, facet-engine 53, server-core 306, typecheck/lint/knip clean.
- Review gate: 1 confirmed finding (MEDIUM — `documentProperties` point added with no vessel: a silently foundation-only addition), fixed by removing the point until its vessel increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013avJozs9SoCuDzZJGuTcqH
