### PR TITLE
fix(server-core): facts cache scopes eviction per workspace and stamps the kind

### DIFF
--- a/packages/server-core/src/references/content-facts-cache.test.ts
+++ b/packages/server-core/src/references/content-facts-cache.test.ts
@@ -35,6 +35,54 @@ async function seedTwo(deps: ReturnType<typeof makeDeps>) {
 }
 
 describe('ContentFactsCache', () => {
+  it('alternating workspaces never evict each other (regression: cross-workspace thrash)', async () => {
+    const deps = makeDeps()
+    await seedTwo(deps) // ws-1
+    const OTHER = 'ws-2'
+    const c = await wbDocumentCreate(deps, {
+      workspaceId: OTHER,
+      path: 'c',
+      kind: 'markdown',
+      createWorkspace: true,
+      name: 'Gamma',
+    })
+    await createDocumentSetTool(deps).execute({
+      workspaceId: OTHER,
+      documentId: c.documentId,
+      markdown: '---\ntype: note\n---\ngamma body',
+    })
+    const cache = new ContentFactsCache()
+    const ws1 = await deps.documentIndex.listDocuments({ workspaceId: WS })
+    const ws2 = await deps.documentIndex.listDocuments({ workspaceId: OTHER })
+    await cache.factsFor(deps, WS, ws1)
+    await cache.factsFor(deps, OTHER, ws2)
+
+    const loads = vi.spyOn(deps.documentStore, 'loadSnapshot')
+    await cache.factsFor(deps, WS, ws1)
+    await cache.factsFor(deps, OTHER, ws2)
+    await cache.factsFor(deps, WS, ws1)
+    expect(loads).not.toHaveBeenCalled()
+  })
+
+  it('a kind flip without a content change re-extracts (the kind is part of the stamp)', async () => {
+    const deps = makeDeps()
+    const { a } = await seedTwo(deps)
+    const cache = new ContentFactsCache()
+    const entries = await deps.documentIndex.listDocuments({ workspaceId: WS })
+    const first = await cache.factsFor(deps, WS, entries)
+    expect(first.get(a.documentId)?.texts[0]).toContain('alpha body')
+
+    // No listing-only kind mutation exists today; hand a re-kinded entry to
+    // pin the latent trap: extraction branches on entry.kind, so cached
+    // facts are only valid FOR the kind they were extracted under.
+    const flipped = entries.map((entry) =>
+      entry.documentId === a.documentId ? { ...entry, kind: 'spatial' as const } : entry,
+    )
+    const second = await cache.factsFor(deps, WS, flipped)
+    // A markdown doc read as spatial has no text nodes: facts must change.
+    expect(second.get(a.documentId)?.texts).toEqual([])
+  })
+
   it('loads every document once, then nothing while frontiers stand still', async () => {
     const deps = makeDeps()
     await seedTwo(deps)
@@ -42,12 +90,12 @@ describe('ContentFactsCache', () => {
     const cache = new ContentFactsCache()
 
     const entries = await deps.documentIndex.listDocuments({ workspaceId: WS })
-    const first = await cache.factsFor(deps, entries)
+    const first = await cache.factsFor(deps, WS, entries)
     expect(first.size).toBe(2)
     expect(loads).toHaveBeenCalledTimes(2)
 
     loads.mockClear()
-    const second = await cache.factsFor(deps, entries)
+    const second = await cache.factsFor(deps, WS, entries)
     expect(second.get(entries[0]?.documentId ?? '')?.texts[0]).toContain('alpha body one')
     expect(loads).not.toHaveBeenCalled()
   })
@@ -57,11 +105,11 @@ describe('ContentFactsCache', () => {
     const { b, write } = await seedTwo(deps)
     const cache = new ContentFactsCache()
     const entries = await deps.documentIndex.listDocuments({ workspaceId: WS })
-    await cache.factsFor(deps, entries)
+    await cache.factsFor(deps, WS, entries)
 
     await write(b.documentId, 'beta body two')
     const loads = vi.spyOn(deps.documentStore, 'loadSnapshot')
-    const facts = await cache.factsFor(deps, entries)
+    const facts = await cache.factsFor(deps, WS, entries)
     expect(loads).toHaveBeenCalledTimes(1)
     expect(facts.get(b.documentId)?.texts[0]).toContain('beta body two')
   })
@@ -80,7 +128,7 @@ describe('ContentFactsCache', () => {
     const cache = new ContentFactsCache()
     const loads = vi.spyOn(deps.documentStore, 'loadSnapshot')
     const all = await deps.documentIndex.listDocuments({ workspaceId: WS })
-    const facts = await cache.factsFor(deps, all)
+    const facts = await cache.factsFor(deps, WS, all)
     expect(facts.get(empty.documentId)).toEqual({ refs: [], texts: [], tags: undefined })
     // Two seeded documents loaded; the snapshotless one never was.
     expect(loads).toHaveBeenCalledTimes(2)
@@ -88,6 +136,7 @@ describe('ContentFactsCache', () => {
     await deps.documentIndex.deleteDocument({ workspaceId: WS, path: 'a' })
     const after = await cache.factsFor(
       deps,
+      WS,
       await deps.documentIndex.listDocuments({ workspaceId: WS }),
     )
     expect(after.has(a.documentId)).toBe(false)
@@ -109,6 +158,7 @@ describe('ContentFactsCache', () => {
     const cache = new ContentFactsCache()
     const facts = await cache.factsFor(
       deps,
+      WS,
       await deps.documentIndex.listDocuments({ workspaceId: WS }),
     )
     expect(facts.get(doc.documentId)?.tags).toEqual(['release'])

--- a/packages/server-core/src/references/content-facts-cache.ts
+++ b/packages/server-core/src/references/content-facts-cache.ts
@@ -22,20 +22,28 @@ const EMPTY_FACTS: ContentFacts = { refs: [], texts: [], tags: undefined }
  * read fresh from the listing per request — a rename needs no invalidation.
  */
 export class ContentFactsCache {
-  private readonly held = new Map<string, { stamp: string; facts: ContentFacts }>()
+  /** workspaceId -> documentId -> stamped facts. Scoped so alternating
+   *  requests across workspaces cannot evict each other's entries. */
+  private readonly held = new Map<string, Map<string, { stamp: string; facts: ContentFacts }>>()
 
   /**
-   * Facts for exactly `entries`, loading only documents whose frontier
-   * moved (or were never seen) and evicting ids the listing no longer
-   * contains. A document with no snapshot yet (frontier null) is empty
-   * facts without a load.
+   * Facts for exactly `entries` of one workspace, loading only documents
+   * whose stamp moved (or were never seen) and evicting ids that
+   * workspace's listing no longer contains. A document with no snapshot
+   * yet (frontier null) is empty facts without a load.
    */
   async factsFor(
     deps: ServerDeps,
+    workspaceId: string,
     entries: readonly DocumentEntry[],
   ): Promise<ReadonlyMap<string, ContentFacts>> {
+    let held = this.held.get(workspaceId)
+    if (held === undefined) {
+      held = new Map()
+      this.held.set(workspaceId, held)
+    }
     const wanted = new Set(entries.map((entry) => entry.documentId))
-    for (const id of this.held.keys()) if (!wanted.has(id)) this.held.delete(id)
+    for (const id of held.keys()) if (!wanted.has(id)) held.delete(id)
 
     const result = new Map<string, ContentFacts>()
     for (const entry of entries) {
@@ -43,19 +51,23 @@ export class ContentFactsCache {
         docRef: { kind: 'document', documentId: entry.documentId },
       })
       if (frontier === null) {
-        this.held.delete(entry.documentId)
+        held.delete(entry.documentId)
         result.set(entry.documentId, EMPTY_FACTS)
         continue
       }
-      const stamp = stampOf(frontier.frontier)
-      const cached = this.held.get(entry.documentId)
+      // The kind is part of the stamp: extraction branches on it, so facts
+      // are only valid FOR the kind they were extracted under. No
+      // listing-only kind mutation exists today — this closes the latent
+      // trap rather than a reachable bug.
+      const stamp = `${entry.kind ?? '?'}:${stampOf(frontier.frontier)}`
+      const cached = held.get(entry.documentId)
       if (cached !== undefined && cached.stamp === stamp) {
         result.set(entry.documentId, cached.facts)
         continue
       }
       const { doc } = await loadDocument(deps, entry.documentId)
       const facts = extractContentFacts(entry, doc)
-      this.held.set(entry.documentId, { stamp, facts })
+      held.set(entry.documentId, { stamp, facts })
       result.set(entry.documentId, facts)
     }
     return result

--- a/packages/server-core/src/tools/backlinks.ts
+++ b/packages/server-core/src/tools/backlinks.ts
@@ -44,7 +44,7 @@ export async function computeBacklinks(
     throw new WorkspaceDocumentNotFoundError(input.workspaceId, input.documentId)
   }
 
-  const content = await cache.factsFor(deps, entries)
+  const content = await cache.factsFor(deps, input.workspaceId, entries)
   const aggregate = new ReferenceAggregate()
   for (const entry of entries) {
     const facts = content.get(entry.documentId)

--- a/packages/server-core/src/tools/document-search.ts
+++ b/packages/server-core/src/tools/document-search.ts
@@ -66,7 +66,7 @@ export function createDocumentSearchTool(
     async execute(input: DocumentSearchInput): Promise<DocumentSearchOutput> {
       const parsed = documentSearchInputSchema.parse(input)
       const entries = await deps.documentIndex.listDocuments({ workspaceId: parsed.workspaceId })
-      const content = await cache.factsFor(deps, entries)
+      const content = await cache.factsFor(deps, parsed.workspaceId, entries)
 
       const searchable: (SearchableDocument & { kind?: 'markdown' | 'spatial' })[] = []
       for (const entry of entries) {

--- a/packages/server-core/src/tools/document-tags.ts
+++ b/packages/server-core/src/tools/document-tags.ts
@@ -34,7 +34,7 @@ export async function computeDocumentTags(
   cache: ContentFactsCache = new ContentFactsCache(),
 ): Promise<DocumentTagsOutput> {
   const entries = await deps.documentIndex.listDocuments({ workspaceId: input.workspaceId })
-  const content = await cache.factsFor(deps, entries)
+  const content = await cache.factsFor(deps, input.workspaceId, entries)
   const documents: DocumentTagsOutput['documents'] = []
   for (const entry of entries) {
     const tags = content.get(entry.documentId)?.tags


### PR DESCRIPTION
## What — fix-forward for CodeRabbit's two findings on #991

Both verified against the code before acting (per the merge-gate rubric), both fixed red-first:

1. **Cross-workspace thrash** (real, performance): `factsFor`'s eviction treated *"not in this request's listing"* as *"deleted"* — a daemon serving two workspaces evicted each other's entries on every alternation and reloaded whole workspaces. Entries are now scoped `workspaceId → documentId`. Regression test: alternate two workspaces, assert **zero** snapshot loads.

2. **Kind missing from the stamp** (latent, integrity): extraction branches on `entry.kind` while the cache compared only the frontier, so a listing-only kind change would serve facts extracted under the prior kind. Verified **unreachable today** (every kind-recording path also moves content, hence the frontier) — the kind now rides the stamp anyway, closing the trap; pinned with a hand-flipped entry.

Process note: #991 was merged before these inline comments were read — the sweep happened, but after the merge instead of before. This PR is the correction; both PR-comment threads get replies pointing here.

## Verification

server-core 332 green (330 + 2 new red-first); typecheck/biome/knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmbb1zNhiZitB7tn9LQ5f3