### PR TITLE
feat(web): one Rename dialog for a document's name and its path

### DIFF
--- a/apps/web/src/components/workspace-files/DocumentPreview.test.tsx
+++ b/apps/web/src/components/workspace-files/DocumentPreview.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { DocumentPreview } from './DocumentPreview.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
@@ -118,68 +118,22 @@ describe('DocumentPreview', () => {
     )
   })
 
-  // The path is where a document LIVES, and until now the only way to change
-  // it was an HTTP route with no caller. This is that caller.
-  describe('moving a document', () => {
-    async function open() {
-      const onMove = vi.fn(async () => undefined)
-      render(<DocumentPreview document={doc} loadRender={async () => drawn} onMove={onMove} />)
+  // The path is where a document LIVES. Editing it — and the display name
+  // beside it — belongs to the Rename dialog, which is the one surface that
+  // explains how the two differ; this pane only opens it.
+  describe('renaming a document', () => {
+    it('asks the caller to open the rename dialog for THIS document', async () => {
+      const onRename = vi.fn()
+      render(<DocumentPreview document={doc} loadRender={async () => drawn} onRename={onRename} />)
       await act(async () => {})
-      fireEvent.click(screen.getByRole('button', { name: /Move/ }))
-      return onMove
-    }
-
-    it('offers the current path as the starting point', async () => {
-      await open()
-      expect(screen.getByRole('textbox', { name: /path/i })).toHaveProperty('value', 'design/login')
+      fireEvent.click(screen.getByRole('button', { name: /Rename/ }))
+      expect(onRename).toHaveBeenCalledWith(doc)
     })
 
-    it('moves the document to the typed path', async () => {
-      const onMove = await open()
-      fireEvent.change(screen.getByRole('textbox', { name: /path/i }), {
-        target: { value: 'archive/login' },
-      })
-      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
-      await waitFor(() => expect(onMove).toHaveBeenCalledWith(doc, 'archive/login'))
-    })
-
-    // Saving the path it already has is not a move — it is a round trip that
-    // can only fail (the destination is occupied by the document itself).
-    it('does nothing when the path was not changed', async () => {
-      const onMove = await open()
-      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
-      await act(async () => {})
-      expect(onMove).not.toHaveBeenCalled()
-    })
-
-    // The server names the PRODUCED path that collided, which on a subtree
-    // move is often not the one that was typed. Showing our own sentence
-    // would send someone to retry the one thing that was never the problem.
-    it('shows the server’s own refusal, not a rebuilt one', async () => {
-      render(
-        <DocumentPreview
-          document={doc}
-          loadRender={async () => drawn}
-          onMove={async () => {
-            throw new Error('Path "archive/login/notes" already exists')
-          }}
-        />,
-      )
-      await act(async () => {})
-      fireEvent.click(screen.getByRole('button', { name: /Move/ }))
-      fireEvent.change(screen.getByRole('textbox', { name: /path/i }), {
-        target: { value: 'archive/login' },
-      })
-      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
-
-      const alert = await screen.findByRole('alert')
-      expect(alert.textContent).toContain('archive/login/notes')
-    })
-
-    it('has no move affordance when the caller supplies no way to move', async () => {
+    it('has no rename affordance when the caller supplies no way to rename', async () => {
       render(<DocumentPreview document={doc} loadRender={async () => drawn} />)
       await act(async () => {})
-      expect(screen.queryByRole('button', { name: /Move/ })).toBeNull()
+      expect(screen.queryByRole('button', { name: /Rename/ })).toBeNull()
     })
   })
 
@@ -187,7 +141,7 @@ describe('DocumentPreview', () => {
   // carry them or retiring the grid loses them. They live on the SELECTED
   // document, which is the one the pane is already about.
   describe('acting on the selected document', () => {
-    it('duplicates, and does not open or move anything', async () => {
+    it('duplicates, and does not open or rename anything', async () => {
       const onDuplicate = vi.fn()
       const onOpen = vi.fn()
       render(

--- a/apps/web/src/components/workspace-files/DocumentPreview.tsx
+++ b/apps/web/src/components/workspace-files/DocumentPreview.tsx
@@ -12,7 +12,7 @@
  * keep throwing you into an editor.
  */
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { cn } from '../../lib/utils.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
 import { fitSvgToBox } from './fit-svg.js'
@@ -28,7 +28,8 @@ export interface DocumentPreviewProps {
    * Move the document, and everything under it, to a new path. Absent means
    * the pane shows no way to move — reading still works.
    */
-  readonly onMove?: (document: WorkspaceDocumentEntry, newPath: string) => Promise<void>
+  /** Opens the shared Rename dialog (name + path together). */
+  readonly onRename?: (document: WorkspaceDocumentEntry) => void
   /** Copy it. Absent means the pane offers no copy. */
   readonly onDuplicate?: (document: WorkspaceDocumentEntry) => void
   /**
@@ -38,12 +39,6 @@ export interface DocumentPreviewProps {
    */
   readonly onDelete?: (document: WorkspaceDocumentEntry) => void
   readonly className?: string
-  /**
-   * Bumped by the panel when a context menu's Move… targets the (already
-   * selected) document: the move form opens without a second click on the
-   * preview's own Move… link. Absent or unchanged means untouched.
-   */
-  readonly startMoveToken?: number
 }
 
 type State =
@@ -56,15 +51,12 @@ export function DocumentPreview({
   document,
   loadRender,
   onOpen,
-  onMove,
+  onRename,
   onDuplicate,
   onDelete,
   className,
-  startMoveToken,
 }: DocumentPreviewProps) {
   const [state, setState] = useState<State>({ kind: 'idle' })
-  const [editing, setEditing] = useState<string | null>(null)
-  const [moveError, setMoveError] = useState<string | null>(null)
 
   useEffect(() => {
     if (document === null) {
@@ -72,8 +64,6 @@ export function DocumentPreview({
       return
     }
     let live = true
-    setEditing(null)
-    setMoveError(null)
     setState({ kind: 'loading', path: document.path })
     loadRender(document)
       .then((render) => {
@@ -93,20 +83,6 @@ export function DocumentPreview({
       live = false
     }
   }, [document, loadRender])
-
-  // Context-menu Move…: each bump opens the form for whatever document the
-  // panel has just selected. Defined AFTER the selection-change effect above,
-  // whose editing reset would otherwise run second and undo this in the very
-  // commit where selection and token change together. Skipped on mount so
-  // plain selection never starts an edit.
-  const lastMoveToken = useRef(startMoveToken)
-  useEffect(() => {
-    if (startMoveToken === undefined || startMoveToken === lastMoveToken.current) return
-    lastMoveToken.current = startMoveToken
-    if (document === null || onMove === undefined) return
-    setMoveError(null)
-    setEditing(document.path)
-  }, [startMoveToken, document, onMove])
 
   if (document === null) {
     return (
@@ -140,80 +116,21 @@ export function DocumentPreview({
           {document.name ?? document.path.split('/').at(-1)}
         </h2>
         {/* The path is the address, not the name — so it goes here, quietly,
-            where someone who needs it can read it, and where the one control
-            that changes it lives. */}
-        {editing === null ? (
-          <div className="flex min-w-0 items-center gap-2">
-            <p className="text-muted-foreground truncate font-mono text-xs">{document.path}</p>
-            {onMove !== undefined && (
-              <button
-                type="button"
-                onClick={() => {
-                  setMoveError(null)
-                  setEditing(document.path)
-                }}
-                className="text-muted-foreground hover:text-foreground shrink-0 text-xs underline"
-              >
-                Move…
-              </button>
-            )}
-          </div>
-        ) : (
-          <form
-            className="flex min-w-0 flex-col gap-1"
-            onSubmit={(event) => {
-              event.preventDefault()
-              const next = editing.trim()
-              // Saving the path it already has is not a move: it is a round
-              // trip whose only possible answer is that the destination is
-              // occupied — by this very document.
-              if (next === '' || next === document.path) {
-                setEditing(null)
-                return
-              }
-              setMoveError(null)
-              void onMove?.(document, next)
-                .then(() => setEditing(null))
-                // The server names the PRODUCED path that collided, which on
-                // a subtree move is often not the one typed here. Rebuilding
-                // a sentence around `next` would send someone to retry the
-                // one thing that was never the problem.
-                .catch((err: unknown) =>
-                  setMoveError(err instanceof Error ? err.message : 'Could not move it.'),
-                )
-            }}
-          >
-            <label className="text-muted-foreground text-xs" htmlFor="document-path">
-              Path
-            </label>
-            <input
-              id="document-path"
-              value={editing}
-              onChange={(event) => setEditing(event.target.value)}
-              className="w-full rounded border px-2 py-1 font-mono text-xs"
-            />
-            <div className="flex gap-2">
-              <button
-                type="submit"
-                className="bg-primary text-primary-foreground rounded px-2.5 py-1 text-xs"
-              >
-                Save
-              </button>
-              <button
-                type="button"
-                onClick={() => setEditing(null)}
-                className="text-muted-foreground rounded border px-2.5 py-1 text-xs"
-              >
-                Cancel
-              </button>
-            </div>
-            {moveError !== null && (
-              <p role="alert" className="text-destructive text-xs">
-                {moveError}
-              </p>
-            )}
-          </form>
-        )}
+            where someone who needs it can read it. BOTH are edited in the
+            Rename dialog, which is the one place that explains how they
+            differ. */}
+        <div className="flex min-w-0 items-center gap-2">
+          <p className="text-muted-foreground truncate font-mono text-xs">{document.path}</p>
+          {onRename !== undefined && (
+            <button
+              type="button"
+              onClick={() => onRename(document)}
+              className="text-muted-foreground hover:text-foreground shrink-0 text-xs underline"
+            >
+              Rename…
+            </button>
+          )}
+        </div>
         <dl className="text-muted-foreground grid grid-cols-[auto_1fr] gap-x-3 text-xs">
           <dt>Kind</dt>
           <dd className="text-foreground">{document.kind ?? 'markdown'}</dd>

--- a/apps/web/src/components/workspace-files/RenameDocumentDialog.tsx
+++ b/apps/web/src/components/workspace-files/RenameDocumentDialog.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import type { WorkspaceDocumentEntry } from './document-entry.js'
+
+/**
+ * The one place a document's two addresses are edited together, each field
+ * saying what it is — the answer to "why are there two names?" is given
+ * where the question arises, not in a doc nobody opens.
+ *
+ * The model stays untouched underneath: the name lives in the workspace and
+ * may be empty (readers fall back to the path's last segment), the path is
+ * placement and moving it takes everything under it. Neither field derives
+ * the other (ADR-0008: a path is never invented from a name).
+ */
+export function RenameDocumentDialog({
+  document,
+  busy,
+  error,
+  onCancel,
+  onSubmit,
+}: {
+  /** The document being renamed, or null when the dialog is closed. */
+  document: WorkspaceDocumentEntry | null
+  busy: boolean
+  /** Shown verbatim — the server names the path that actually collided. */
+  error: string | null
+  onCancel: () => void
+  /** An empty trimmed name arrives as undefined: "clear it". */
+  onSubmit: (name: string | undefined, newPath: string) => void
+}) {
+  const [name, setName] = useState('')
+  const [path, setPath] = useState('')
+
+  // Re-prime the fields for each newly targeted document; edits in a
+  // cancelled dialog must not leak into the next one.
+  useEffect(() => {
+    setName(document?.name ?? '')
+    setPath(document?.path ?? '')
+  }, [document])
+
+  return (
+    <Dialog open={document !== null} onOpenChange={(open) => (open ? undefined : onCancel())}>
+      <DialogContent className="sm:max-w-md">
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            const trimmedName = name.trim()
+            const trimmedPath = path.trim()
+            if (trimmedPath === '') return
+            onSubmit(trimmedName === '' ? undefined : trimmedName, trimmedPath)
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>Rename</DialogTitle>
+            <DialogDescription>
+              A document has a name and an address; change either here.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-4 py-4">
+            <label className="flex flex-col gap-1">
+              <span className="text-sm font-medium">Name</span>
+              <input
+                type="text"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder={path.split('/').at(-1) ?? ''}
+                className="rounded-md border bg-background px-2 py-1.5 text-sm"
+              />
+              <span className="text-muted-foreground text-xs">
+                What it is called, everywhere it appears. Leave empty to show the last part of the
+                path instead.
+              </span>
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-sm font-medium">Path</span>
+              <input
+                type="text"
+                value={path}
+                onChange={(event) => setPath(event.target.value)}
+                className="rounded-md border bg-background px-2 py-1.5 font-mono text-sm"
+              />
+              <span className="text-muted-foreground text-xs">
+                Where it lives in the workspace. Moving it takes everything under it along.
+              </span>
+            </label>
+            {error !== null && (
+              <p role="alert" className="text-destructive text-sm">
+                {error}
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <button
+              type="button"
+              onClick={onCancel}
+              className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={busy}
+              className="bg-primary text-primary-foreground rounded-md px-3 py-1.5 text-sm disabled:opacity-50"
+            >
+              Save
+            </button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -14,6 +14,7 @@ import { type WorkspaceFilesSource, WorkspaceMissingError } from './files-source
 import { createRowOutlineLoader } from './load-row-outline.js'
 import { createRowRenderLoader } from './load-row-render.js'
 import { newDocumentPathIn } from './new-document-path.js'
+import { RenameDocumentDialog } from './RenameDocumentDialog.js'
 import { SearchResults } from './SearchResults.js'
 import { searchDocuments } from './search-documents.js'
 import { WorkspaceFileTree } from './WorkspaceFileTree.js'
@@ -100,9 +101,11 @@ export function WorkspaceFilesPanel({
     x: number
     y: number
   } | null>(null)
-  // Bumped when the menu's Move… fires, so the preview opens its move form
-  // for the selection the same gesture just made.
-  const [startMoveToken, setStartMoveToken] = useState(0)
+  // The rename dialog's target, plus the in-flight/refusal state its form
+  // shows. Null means closed.
+  const [renaming, setRenaming] = useState<WorkspaceDocumentEntry | null>(null)
+  const [renameBusy, setRenameBusy] = useState(false)
+  const [renameError, setRenameError] = useState<string | null>(null)
   const rootRef = useRef<HTMLDivElement | null>(null)
   // Every tag in the workspace, each once, in reading order. The strip is
   // derived — deleting the last carrier of a tag removes its chip with it.
@@ -240,6 +243,40 @@ export function WorkspaceFilesPanel({
     [query, folder],
   )
 
+  /**
+   * Apply whatever the rename dialog changed: the name through the source's
+   * workspace-side setter, the path through the same move the panel already
+   * performs. Both, in that order, when both changed — a failed move then
+   * leaves the new name applied, which is honest: the dialog stays open on
+   * the server's refusal and the field still shows what was typed.
+   */
+  const submitRename = useCallback(
+    async (entry: WorkspaceDocumentEntry, name: string | undefined, newPath: string) => {
+      setRenameBusy(true)
+      setRenameError(null)
+      try {
+        if ((entry.name ?? undefined) !== name) {
+          await source.setDocumentName(entry, name)
+        }
+        if (newPath !== entry.path) {
+          await moveDocumentRef.current(entry, newPath)
+        } else {
+          const entries = await readList()
+          setDocuments(entries)
+          setSelected(entries.find((row) => row.path === entry.path) ?? null)
+        }
+        setRenaming(null)
+      } catch (err) {
+        // The server names the PRODUCED path that collided, which on a
+        // subtree move is often not the one typed here.
+        setRenameError(err instanceof Error ? err.message : 'Could not rename it.')
+      } finally {
+        setRenameBusy(false)
+      }
+    },
+    [source, readList],
+  )
+
   const moveDocument = useCallback(
     async (entry: WorkspaceDocumentEntry, newPath: string) => {
       await source.renameDocumentPath(entry.path, newPath)
@@ -250,6 +287,12 @@ export function WorkspaceFilesPanel({
     },
     [source, readList],
   )
+  // submitRename is declared above moveDocument (it reads better beside the
+  // dialog state) and calls it through a ref rather than being reordered:
+  // both are hooks, so their ORDER is load-bearing and a reader should not
+  // have to verify it twice.
+  const moveDocumentRef = useRef(moveDocument)
+  moveDocumentRef.current = moveDocument
 
   /**
    * Moving the contents pane always empties the preview.
@@ -304,10 +347,11 @@ export function WorkspaceFilesPanel({
             ? []
             : [{ label: 'Duplicate', onSelect: () => onDuplicateDocument(cardMenu.entry.path) }]),
           {
-            label: 'Move…',
+            label: 'Rename…',
             onSelect: () => {
               setSelected(cardMenu.entry)
-              setStartMoveToken((token) => token + 1)
+              setRenameError(null)
+              setRenaming(cardMenu.entry)
             },
           },
           ...(onRequestDelete === undefined
@@ -525,11 +569,13 @@ export function WorkspaceFilesPanel({
           <DocumentPreview
             document={selected}
             loadRender={loadRender}
-            startMoveToken={startMoveToken}
             {...(onOpenDocument === undefined
               ? {}
               : { onOpen: (entry: WorkspaceDocumentEntry) => onOpenDocument(entry.path) })}
-            onMove={moveDocument}
+            onRename={(entry: WorkspaceDocumentEntry) => {
+              setRenameError(null)
+              setRenaming(entry)
+            }}
             {...(onDuplicateDocument === undefined
               ? {}
               : {
@@ -545,6 +591,19 @@ export function WorkspaceFilesPanel({
           />
         </div>
       </div>
+      <RenameDocumentDialog
+        document={renaming}
+        busy={renameBusy}
+        error={renameError}
+        onCancel={() => {
+          setRenaming(null)
+          setRenameError(null)
+        }}
+        onSubmit={(name, newPath) => {
+          if (renaming === null) return
+          void submitRename(renaming, name, newPath)
+        }}
+      />
       {cardMenu !== null && (
         <ContextMenu
           x={cardMenu.x}

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -270,6 +270,18 @@ export function WorkspaceFilesPanel({
         // The server names the PRODUCED path that collided, which on a
         // subtree move is often not the one typed here.
         setRenameError(err instanceof Error ? err.message : 'Could not rename it.')
+        // A rename applies two writes; the first may have landed before the
+        // second was refused. Re-reading here is what stops the panel from
+        // showing a name the store no longer holds — the refusal is about
+        // the path, and the rest of the screen must still be true.
+        try {
+          const entries = await readList()
+          setDocuments(entries)
+          setSelected(entries.find((row) => row.path === entry.path) ?? null)
+        } catch {
+          // The list read failing on top of a failed rename leaves what is
+          // already on screen; the dialog's own message is the report.
+        }
       } finally {
         setRenameBusy(false)
       }

--- a/apps/web/src/components/workspace-files/card-context-menu.test.tsx
+++ b/apps/web/src/components/workspace-files/card-context-menu.test.tsx
@@ -43,7 +43,7 @@ describe('document card context menu', () => {
     renderPanel({ onOpenDocument, onDuplicateDocument, onRequestDelete: () => {} })
 
     const menu = await contextMenuOnCard('Meeting notes')
-    for (const label of ['Open', 'Duplicate', 'Move…', 'Delete']) {
+    for (const label of ['Open', 'Duplicate', 'Rename…', 'Delete']) {
       expect(within(menu).getByRole('menuitem', { name: label })).toBeTruthy()
     }
     fireEvent.click(within(menu).getByRole('menuitem', { name: 'Open' }))
@@ -76,9 +76,8 @@ describe('document card context menu', () => {
     expect(within(menu).getByRole('menuitem', { name: 'Open' })).toBeTruthy()
   })
 
-  it('plain selection never opens the move form', async () => {
-    // The startMoveToken guard: only a Move… bump starts an edit —
-    // clicking a card to select it must not.
+  it('plain selection never opens the rename dialog', async () => {
+    // Selecting shows the document; only Rename… asks to change it.
     renderPanel({ onOpenDocument: () => {} })
     await waitFor(() => {
       expect(
@@ -88,16 +87,16 @@ describe('document card context menu', () => {
     const el = screen.getAllByTestId('card-title').find((n) => n.textContent === 'Meeting notes')
     fireEvent.click(el?.closest('button') as HTMLElement)
     await screen.findByTestId('okf-preview')
-    expect(screen.queryByLabelText('Path')).toBeNull()
+    expect(screen.queryByRole('dialog')).toBeNull()
   })
 
-  it('Move… selects the document and opens the move form', async () => {
+  it('Rename… opens the dialog for exactly this document', async () => {
     renderPanel({ onOpenDocument: () => {} })
     const menu = await contextMenuOnCard('Meeting notes')
-    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Move…' }))
-    // The preview's path form appears for exactly this document, ready to edit.
-    const input = await screen.findByLabelText('Path')
-    expect((input as HTMLInputElement).value).toBe('meeting-notes')
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Rename…' }))
+    const dialog = await screen.findByRole('dialog')
+    expect((within(dialog).getByLabelText(/^Path/) as HTMLInputElement).value).toBe('meeting-notes')
+    expect((within(dialog).getByLabelText(/^Name/) as HTMLInputElement).value).toBe('Meeting notes')
   })
 
   it('a search result row opens the same menu, and Escape closes it', async () => {

--- a/apps/web/src/components/workspace-files/files-source.ts
+++ b/apps/web/src/components/workspace-files/files-source.ts
@@ -21,6 +21,16 @@ export interface WorkspaceFilesSource {
   /** Move a document — and everything under it — to a new path. */
   renameDocumentPath(path: string, newPath: string): Promise<void>
   /**
+   * Set what the document is called, or clear it (undefined) so readers
+   * fall back to the path's last segment. The name lives in the WORKSPACE
+   * (vocabulary.md), which is why this sits on the source and not on the
+   * document's content.
+   */
+  setDocumentName(
+    entry: Pick<WorkspaceDocumentEntry, 'documentId' | 'path'>,
+    name: string | undefined,
+  ): Promise<void>
+  /**
    * The OKF markdown of a markdown document, for row thumbnails and the
    * preview pane. Empty string when the document has no body yet.
    */

--- a/apps/web/src/components/workspace-files/rename-document-dialog.test.tsx
+++ b/apps/web/src/components/workspace-files/rename-document-dialog.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
+import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
+
+// One dialog for a document's two addresses. The name lives in the
+// workspace and may be empty (readers fall back to the path's last
+// segment); the path is placement. Neither derives the other (ADR-0008).
+
+afterEach(cleanup)
+
+const entry = {
+  documentId: 'd1',
+  path: 'design/login',
+  name: 'Login flow',
+  kind: 'spatial' as const,
+}
+
+function renderPanel(overrides: Parameters<typeof fakeFilesSource>[0] = {}) {
+  const source = fakeFilesSource({ listDocuments: async () => [entry], ...overrides })
+  render(<WorkspaceFilesPanel source={source} onOpenDocument={() => {}} />)
+  return source
+}
+
+// The fixture lives one folder down, which is the interesting case: the
+// dialog's Path field must show the FULL path, not the segment.
+async function selectCard() {
+  fireEvent.click((await screen.findAllByRole('button', { name: 'Open folder design' }))[0]!)
+  await waitFor(() => {
+    expect(
+      screen.queryAllByTestId('card-title').some((el) => el.textContent === 'Login flow'),
+    ).toBe(true)
+  })
+  const card = screen.getAllByTestId('card-title').find((n) => n.textContent === 'Login flow')
+  fireEvent.click(card?.closest('button') as HTMLElement)
+}
+
+async function openDialog() {
+  await selectCard()
+  fireEvent.click(await screen.findByRole('button', { name: /Rename/ }))
+  return screen.findByRole('dialog')
+}
+
+describe('rename dialog', () => {
+  it('opens prefilled with both addresses and explains each', async () => {
+    renderPanel()
+    const dialog = await openDialog()
+    expect((within(dialog).getByLabelText(/^Name/) as HTMLInputElement).value).toBe('Login flow')
+    expect((within(dialog).getByLabelText(/^Path/) as HTMLInputElement).value).toBe('design/login')
+    // Each field says what it is — the answer to "why two?" lives here.
+    expect(within(dialog).getByText(/What it is called/)).toBeTruthy()
+    expect(within(dialog).getByText(/Where it lives in the workspace/)).toBeTruthy()
+  })
+
+  it('renames without moving when only the name changed', async () => {
+    const source = renderPanel()
+    const dialog = await openDialog()
+    fireEvent.change(within(dialog).getByLabelText(/^Name/), { target: { value: 'Sign-in flow' } })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }))
+    await waitFor(() =>
+      expect(source.setDocumentName).toHaveBeenCalledWith(
+        expect.objectContaining({ path: 'design/login' }),
+        'Sign-in flow',
+      ),
+    )
+    expect(source.renameDocumentPath).not.toHaveBeenCalled()
+  })
+
+  it('clears the name as absence, so readers fall back to the segment', async () => {
+    const source = renderPanel()
+    const dialog = await openDialog()
+    fireEvent.change(within(dialog).getByLabelText(/^Name/), { target: { value: '  ' } })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }))
+    await waitFor(() =>
+      expect(source.setDocumentName).toHaveBeenCalledWith(expect.anything(), undefined),
+    )
+  })
+
+  it('moves without touching the name when only the path changed', async () => {
+    const source = renderPanel()
+    const dialog = await openDialog()
+    fireEvent.change(within(dialog).getByLabelText(/^Path/), {
+      target: { value: 'archive/login' },
+    })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }))
+    await waitFor(() =>
+      expect(source.renameDocumentPath).toHaveBeenCalledWith('design/login', 'archive/login'),
+    )
+    expect(source.setDocumentName).not.toHaveBeenCalled()
+  })
+
+  it('applies both when both changed', async () => {
+    const source = renderPanel()
+    const dialog = await openDialog()
+    fireEvent.change(within(dialog).getByLabelText(/^Name/), { target: { value: 'Archived' } })
+    fireEvent.change(within(dialog).getByLabelText(/^Path/), { target: { value: 'archive/login' } })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }))
+    await waitFor(() =>
+      expect(source.setDocumentName).toHaveBeenCalledWith(expect.anything(), 'Archived'),
+    )
+    await waitFor(() =>
+      expect(source.renameDocumentPath).toHaveBeenCalledWith('design/login', 'archive/login'),
+    )
+  })
+
+  // The server names the PRODUCED path that collided, which on a subtree
+  // move is often not the one typed here.
+  it("shows the server's own refusal and stays open", async () => {
+    renderPanel({
+      renameDocumentPath: async () => {
+        throw new Error('Path "archive/login/notes" already exists')
+      },
+    })
+    const dialog = await openDialog()
+    fireEvent.change(within(dialog).getByLabelText(/^Path/), { target: { value: 'archive/login' } })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }))
+    const alert = await within(dialog).findByRole('alert')
+    expect(alert.textContent).toContain('archive/login/notes')
+    expect(screen.getByRole('dialog')).toBeTruthy()
+  })
+
+  it('the card context menu opens the same dialog', async () => {
+    renderPanel()
+    fireEvent.click((await screen.findAllByRole('button', { name: 'Open folder design' }))[0]!)
+    await waitFor(() => {
+      expect(
+        screen.queryAllByTestId('card-title').some((el) => el.textContent === 'Login flow'),
+      ).toBe(true)
+    })
+    const card = screen
+      .getAllByTestId('card-title')
+      .find((n) => n.textContent === 'Login flow')
+      ?.closest('button') as HTMLElement
+    fireEvent.contextMenu(card, { clientX: 20, clientY: 20 })
+    const menu = await screen.findByRole('menu', { name: 'Document actions' })
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Rename…' }))
+    const dialog = await screen.findByRole('dialog')
+    expect((within(dialog).getByLabelText(/^Path/) as HTMLInputElement).value).toBe('design/login')
+  })
+
+  it('cancelling leaves both addresses untouched', async () => {
+    const source = renderPanel()
+    const dialog = await openDialog()
+    fireEvent.change(within(dialog).getByLabelText(/^Name/), { target: { value: 'Nope' } })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    expect(source.setDocumentName).not.toHaveBeenCalled()
+    expect(source.renameDocumentPath).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/workspace-files/rename-document-dialog.test.tsx
+++ b/apps/web/src/components/workspace-files/rename-document-dialog.test.tsx
@@ -120,6 +120,39 @@ describe('rename dialog', () => {
     expect(screen.getByRole('dialog')).toBeTruthy()
   })
 
+  // A name that reached the store but not the screen is the worst of both:
+  // the refusal is about the PATH, and the panel behind the dialog must not
+  // keep showing a name the store no longer holds.
+  it('shows the name that landed even when the move that followed was refused', async () => {
+    let storedName: string | undefined = entry.name
+    const source = fakeFilesSource({
+      listDocuments: async () => [
+        // The stored name, absent once cleared — the entry type omits the
+        // key rather than carrying undefined.
+        { ...entry, ...(storedName === undefined ? {} : { name: storedName }) },
+      ],
+      setDocumentName: async (_entry, name) => {
+        storedName = name
+      },
+      renameDocumentPath: async () => {
+        throw new Error('Path "archive/login" already exists')
+      },
+    })
+    render(<WorkspaceFilesPanel source={source} onOpenDocument={() => {}} />)
+
+    const dialog = await openDialog()
+    fireEvent.change(within(dialog).getByLabelText(/^Name/), { target: { value: 'Archived' } })
+    fireEvent.change(within(dialog).getByLabelText(/^Path/), { target: { value: 'archive/login' } })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }))
+
+    expect((await within(dialog).findByRole('alert')).textContent).toContain('already exists')
+    await waitFor(() => {
+      expect(
+        screen.queryAllByTestId('card-title').some((el) => el.textContent === 'Archived'),
+      ).toBe(true)
+    })
+  })
+
   it('the card context menu opens the same dialog', async () => {
     renderPanel()
     fireEvent.click((await screen.findAllByRole('button', { name: 'Open folder design' }))[0]!)

--- a/apps/web/src/components/workspace-files/row-render.browser.test.tsx
+++ b/apps/web/src/components/workspace-files/row-render.browser.test.tsx
@@ -35,6 +35,7 @@ it('renders a spatial document from its snapshot bytes through the pool', async 
       listDocuments: async () => [],
       createDocument: async () => {},
       renameDocumentPath: async () => {},
+      setDocumentName: async () => {},
       loadSpatialSnapshot: async () => bytes,
       loadMarkdown: async () => {
         throw new Error('a spatial document must not be read as OKF')

--- a/apps/web/src/lib/daemon-files-source.test.ts
+++ b/apps/web/src/lib/daemon-files-source.test.ts
@@ -26,6 +26,35 @@ function fetchStub(handlers: {
   }) as unknown as typeof globalThis.fetch
 }
 
+describe('createDaemonFilesSource setDocumentName', () => {
+  function nameFetchStub(calls: Array<{ url: string; body: unknown }>): typeof globalThis.fetch {
+    return vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.endsWith('/name') && init?.method === 'PUT') {
+        calls.push({ url, body: JSON.parse(String(init.body)) })
+        return Promise.resolve(jsonResponse({ documents: {}, pinned: [] }))
+      }
+      return Promise.resolve(jsonResponse({ message: 'unexpected' }, 500))
+    }) as unknown as typeof globalThis.fetch
+  }
+
+  it('PUTs the new display name for the entry path', async () => {
+    const calls: Array<{ url: string; body: unknown }> = []
+    const source = createDaemonFilesSource(nameFetchStub(calls), BASE, 'ws')
+    await source.setDocumentName({ documentId: 'id1', path: 'plans/roadmap' }, 'Roadmap')
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.url).toContain('roadmap')
+    expect(calls[0]?.body).toEqual({ name: 'Roadmap' })
+  })
+
+  it("clears with the API's delete spelling: an empty string", async () => {
+    const calls: Array<{ url: string; body: unknown }> = []
+    const source = createDaemonFilesSource(nameFetchStub(calls), BASE, 'ws')
+    await source.setDocumentName({ documentId: 'id1', path: 'plans/roadmap' }, undefined)
+    expect(calls[0]?.body).toEqual({ name: '' })
+  })
+})
+
 describe('createDaemonFilesSource pinned mapping', () => {
   it('marks entries pinned from the names response, in pin order', async () => {
     const source = createDaemonFilesSource(

--- a/apps/web/src/lib/daemon-files-source.ts
+++ b/apps/web/src/lib/daemon-files-source.ts
@@ -13,6 +13,7 @@ import {
   getWorkspaceNames,
   listDocuments,
   renameDocumentPath,
+  setDocumentDisplayName,
 } from './daemon-api-client.js'
 
 /**
@@ -73,6 +74,11 @@ export function createDaemonFilesSource(
 
     async renameDocumentPath(path: string, newPath: string): Promise<void> {
       await renameDocumentPath(daemonFetch, daemonBaseUrl, workspaceId, path, newPath)
+    },
+
+    async setDocumentName(entry, name): Promise<void> {
+      // The API spells "clear" as an empty string (PUT name deletes on '').
+      await setDocumentDisplayName(daemonFetch, daemonBaseUrl, workspaceId, entry.path, name ?? '')
     },
 
     async loadMarkdown(entry: WorkspaceDocumentEntry): Promise<string> {

--- a/apps/web/src/lib/local-files-source.test.ts
+++ b/apps/web/src/lib/local-files-source.test.ts
@@ -67,6 +67,29 @@ describe('createLocalFilesSource', () => {
     expect(paths).toEqual(['roadmap', 'roadmap/sub'])
   })
 
+  it('names a document by its ID, and clears the name by absence', async () => {
+    // The daemon sibling keys the same call on PATH; both are plain strings,
+    // so a swap typechecks and silently renames nothing. The fixture makes
+    // the two addresses differ (a nested path never equals an id) so only
+    // the id can produce this result.
+    const source = createLocalFilesSource()
+    const index = new IdbDocumentIndex()
+    await ensureLocalWorkspace(index)
+    const created = await index.createDocument({
+      workspaceId: 'local',
+      path: 'plans/roadmap',
+      kind: 'markdown',
+    })
+
+    await source.setDocumentName({ documentId: created.documentId, path: created.path }, 'Roadmap')
+    expect((await source.listDocuments())[0]?.name).toBe('Roadmap')
+
+    // Clearing is ABSENCE for the port (the daemon spells it as an empty
+    // string) — a reader then falls back to the path's last segment.
+    await source.setDocumentName({ documentId: created.documentId, path: created.path }, undefined)
+    expect((await source.listDocuments())[0]?.name).toBeUndefined()
+  })
+
   it('reads a markdown document body back', async () => {
     const source = createLocalFilesSource()
     const index = new IdbDocumentIndex()

--- a/apps/web/src/lib/local-files-source.ts
+++ b/apps/web/src/lib/local-files-source.ts
@@ -125,6 +125,15 @@ export function createLocalFilesSource(
       await index.moveDocument({ workspaceId: LOCAL_WORKSPACE_ID, from: path, to: newPath })
     },
 
+    async setDocumentName(entry, name): Promise<void> {
+      await index.setDocumentName({
+        workspaceId: LOCAL_WORKSPACE_ID,
+        documentId: entry.documentId,
+        // The port spells "clear" as absence, not empty string.
+        ...(name === undefined ? {} : { name }),
+      })
+    },
+
     async loadMarkdown(entry: WorkspaceDocumentEntry): Promise<string> {
       // The BODY, not an OKF serialization: the reads behind this method feed
       // the thumbnail and preview renderers, which draw markdown — a

--- a/apps/web/src/pages/DaemonIndexPage.files-tab.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.files-tab.test.tsx
@@ -221,7 +221,7 @@ describe('DaemonIndexPage tree view', () => {
   })
 
   // The move route has existed since #888 with no caller at all. This is it.
-  it('moves a document, and the panes follow it', async () => {
+  it('renames a document to a new path, and the panes follow it', async () => {
     // The daemon's own semantics, in miniature: a move takes the subtree.
     let docs = [
       { id: 'a', path: 'notes', updatedAt: '2026-05-01T12:00:00.000Z', kind: 'markdown' },
@@ -262,11 +262,12 @@ describe('DaemonIndexPage tree view', () => {
     )
     await screen.findByTestId('okf-preview')
 
-    fireEvent.click(screen.getByRole('button', { name: /Move/ }))
-    fireEvent.change(screen.getByRole('textbox', { name: /path/i }), {
+    fireEvent.click(screen.getByRole('button', { name: /Rename/ }))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.change(within(dialog).getByLabelText(/^Path/), {
       target: { value: 'archive/design' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }))
 
     // The selection follows the document, and the panes move with it —
     // otherwise the preview goes blank exactly when someone wants to see
@@ -278,7 +279,7 @@ describe('DaemonIndexPage tree view', () => {
     expect(screen.queryByRole('alert')).toBeNull()
   })
 
-  it('shows the server’s refusal when a move collides', async () => {
+  it('shows the server’s refusal when the new path collides', async () => {
     const base = installFetchMock()
     vi.stubGlobal(
       'fetch',
@@ -303,15 +304,16 @@ describe('DaemonIndexPage tree view', () => {
     )
     await screen.findByTestId('okf-preview')
 
-    fireEvent.click(screen.getByRole('button', { name: /Move/ }))
-    fireEvent.change(screen.getByRole('textbox', { name: /path/i }), {
+    fireEvent.click(screen.getByRole('button', { name: /Rename/ }))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.change(within(dialog).getByLabelText(/^Path/), {
       target: { value: 'archive/design' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }))
 
     // The server named a path the caller never typed — that is the point of
     // forwarding its words instead of building a sentence around the input.
-    const alert = await screen.findByRole('alert')
+    const alert = await within(screen.getByRole('dialog')).findByRole('alert')
     expect(alert.textContent).toContain('archive/design/x')
   })
 

--- a/apps/web/src/test-utils/fake-files-source.ts
+++ b/apps/web/src/test-utils/fake-files-source.ts
@@ -7,6 +7,7 @@ export interface FakeFilesSource extends WorkspaceFilesSource {
   listDocuments: ReturnType<typeof vi.fn<() => Promise<readonly WorkspaceDocumentEntry[]>>>
   createDocument: ReturnType<typeof vi.fn<WorkspaceFilesSource['createDocument']>>
   renameDocumentPath: ReturnType<typeof vi.fn<WorkspaceFilesSource['renameDocumentPath']>>
+  setDocumentName: ReturnType<typeof vi.fn<WorkspaceFilesSource['setDocumentName']>>
   loadMarkdown: ReturnType<typeof vi.fn<WorkspaceFilesSource['loadMarkdown']>>
   loadSpatialSnapshot: ReturnType<typeof vi.fn<WorkspaceFilesSource['loadSpatialSnapshot']>>
 }
@@ -21,6 +22,7 @@ export function fakeFilesSource(overrides: Partial<WorkspaceFilesSource> = {}): 
     listDocuments: vi.fn(overrides.listDocuments ?? (async () => [])),
     createDocument: vi.fn(overrides.createDocument ?? (async () => {})),
     renameDocumentPath: vi.fn(overrides.renameDocumentPath ?? (async () => {})),
+    setDocumentName: vi.fn(overrides.setDocumentName ?? (async () => {})),
     loadMarkdown: vi.fn(overrides.loadMarkdown ?? (async () => '')),
     loadSpatialSnapshot: vi.fn(overrides.loadSpatialSnapshot ?? (async () => new Uint8Array())),
   } as FakeFilesSource


### PR DESCRIPTION
Increment E of the **Document First** direction (A #971, B #978, C #982, D #989), per the **Q4 decision: one dialog** rather than explaining a split.

A document has a **name** (what it is called; optional — readers fall back to the path's last segment) and a **path** (where it lives; moving takes the subtree). Both were editable, in two different places, with nothing on screen saying how they differ. **Rename…** now opens one dialog carrying both fields, each with a line explaining its role:

> **Name** — What it is called, everywhere it appears. Leave empty to show the last part of the path instead.
> **Path** — Where it lives in the workspace. Moving it takes everything under it along.

## The model underneath is unchanged

- The name still lives in the **workspace**: the seam gains `setDocumentName`, mapping to the daemon's `PUT …/name` (whose "clear" spelling is the empty string) and to `DocumentIndex.setDocumentName` by id (whose clear is *absence*). Both spellings are pinned by adapter tests.
- The path still moves through the existing `renameDocumentPath`.
- **Neither field derives the other** (ADR-0008).
- Saving applies **only what changed**; a collision shows the server's own message, because it names the PRODUCED path — on a subtree move often not the one typed.

## What this retires

The preview pane's inline move form and the context menu's `Move…`-plus-bump-token plumbing both go; each now opens this dialog. The token's ordering hazard from #989 (an effect that had to be declared *after* the selection reset or the edit was undone in the same commit) disappears with it.

## Tests

Eight new dialog tests (prefill + both explanations, name-only, clear-as-absence, path-only, both, server refusal keeps the dialog open, context-menu parity, cancel touches nothing), preview tests migrated to the Rename… affordance, `files-tab` move tests re-pointed at the dialog, adapter tests for both clear spellings.

Verification: apps/web jsdom 2697 + node 77, workspace-files browser + flow 6/6, lint / knip / typecheck clean. Live preview walk-through follows as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoaNgqWUKbYJxk2azmRQKY