### PR TITLE
perf(canvas-render): take the two CPU costs decision #10 named, after re-measuring which they are

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -492,14 +492,35 @@ paths:
       sequential search does in 0.6s. No production router found (libavoid,
       ELK, yFiles, Excalidraw) parallelises this step; the comparable one
       (Excalidraw's elbow arrows) shrank the routing search space instead.
-      The experiments are preserved unmerged on branches
-      `batch-side-choice` and `webgpu-pair-scorer`. Do not re-propose GPU
-      or batch search for SPEED; what batch still offers is QUALITY on large
-      canvases (345-edge clustered: violations 183 -> 138, interior ink
-      -22%) at 4x the time, which is a separate trade. The speed work goes
-      into the CPU-side costs the profile named: unmeasured `selfPenalty`,
-      per-trial full `computeAnchorsFor`, allocation in `addCost`/`lessCost`,
-      and `routeEdge` rebuilding obstacle lists it was already given.
+      Both experiments were left on local branches (`batch-side-choice`,
+      `webgpu-pair-scorer`) that were never pushed and are not reachable
+      from this repository — so the paragraph above, not a branch, is what
+      has to carry the conclusion. Enough to rebuild either: the batch form
+      is the one described under the 2026-08-14 measurement (best candidate
+      per edge scored against ONE base configuration, adopted where old and
+      new bounding boxes are both disjoint, merged configuration
+      re-evaluated), and the kernel is one WGSL compute shader over
+      `scoreQuantizedSegmentPair`'s integer narrow phase — which is exactly
+      why that function was made integer-only and is documented as
+      reproducible by a second implementation.
+      Do not re-propose GPU or batch search for SPEED; what batch still
+      offers is QUALITY on large canvases (345-edge clustered: violations
+      183 -> 138, interior ink -22%) at 4x the time, which is a separate
+      trade. The speed work goes
+      into the CPU-side costs the profile named. Two of the four are done:
+      `addCost`/`lessCost` allocation (the trial sums into one scratch
+      array) and `routeEdge`'s repeated `deriveDefaultSides` scan.
+      `computeAnchorsFor` gave up its layout-invariant half (node index,
+      rects, centers, hoisted into an `AnchorContext` built once per
+      search); what remains of it is the grouping and fan-out, which a
+      trial genuinely changes, and recovering that needs a per-group
+      incremental recompute — only the (nodeId, side) groups an edge leaves
+      and joins can differ, at most four per re-sided edge, though the
+      aligned run's slide reads group SIZES and so has to be re-checked for
+      every edge touching a resized group. `selfPenalty` was measured
+      rather than assumed and the answer moved the target: its cost is
+      overlap-and-intrusion (10.9% of layout), not border-tracing (3.1%),
+      and that term now rejects by axis before measuring.
     - **Facet-driven rendering rides the injected-resolver pattern.**
       Shipped as the `facets` field of `ResolvedReference`
       (`layout/spatial-canvas.ts`) — synchronous, optional, caller-supplied,

--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -510,14 +510,16 @@ paths:
       into the CPU-side costs the profile named. Two of the four are done:
       `addCost`/`lessCost` allocation (the trial sums into one scratch
       array) and `routeEdge`'s repeated `deriveDefaultSides` scan.
-      `computeAnchorsFor` gave up its layout-invariant half (node index,
-      rects, centers, hoisted into an `AnchorContext` built once per
-      search); what remains of it is the grouping and fan-out, which a
-      trial genuinely changes, and recovering that needs a per-group
-      incremental recompute — only the (nodeId, side) groups an edge leaves
-      and joins can differ, at most four per re-sided edge, though the
-      aligned run's slide reads group SIZES and so has to be re-checked for
-      every edge touching a resized group. `selfPenalty` was measured
+      `computeAnchorsFor` is done: it gave up its layout-invariant half
+      (node index, rects, centers, hoisted into an `AnchorContext` built
+      once per search), and its partition is now patched per trial rather
+      than rebuilt (`patchAnchorGroups`). Timing its three phases is what
+      made the second half tractable — grouping 15.4ms, placement 27.2ms,
+      alignment 3.8ms of 46.4ms on the 200-edge bench — because it showed
+      alignment could stay a FULL pass. That is the part worth remembering:
+      the hard question was which edges' alignment a re-side can flip
+      (the aligned run's slide reads group SIZES), and at 8% of the
+      function it never had to be answered. `selfPenalty` was measured
       rather than assumed and the answer moved the target: its cost is
       overlap-and-intrusion (10.9% of layout), not border-tracing (3.1%),
       and that term now rejects by axis before measuring.

--- a/packages/canvas-render/src/layout/anchor-groups.properties.test.ts
+++ b/packages/canvas-render/src/layout/anchor-groups.properties.test.ts
@@ -1,0 +1,108 @@
+// The parity this package's one-producer rule requires. `buildAnchorGroups`
+// derives the anchor partition from scratch; `patchAnchorGroups` derives the
+// same partition for a one-edge re-side by reusing the incumbent's. Every
+// trial the side-choice search evaluates takes the second path, so the two
+// have to agree exactly — not approximately, and not only on the shapes
+// somebody thought to write an example for.
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-model'
+import { describe, expect } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import {
+  type AnchorGroups,
+  anchorContext,
+  buildAnchorGroups,
+  patchAnchorGroups,
+} from './spatial-edges.js'
+
+const SIDES = ['top', 'right', 'bottom', 'left'] as const
+type Side = (typeof SIDES)[number]
+
+const layout = fc
+  .record({
+    nodeCount: fc.integer({ min: 2, max: 6 }),
+    boxes: fc.array(
+      fc.record({
+        x: fc.integer({ min: -400, max: 400 }),
+        y: fc.integer({ min: -400, max: 400 }),
+        w: fc.integer({ min: 20, max: 200 }),
+        h: fc.integer({ min: 20, max: 200 }),
+      }),
+      { minLength: 6, maxLength: 6 },
+    ),
+    // Deliberately dense: with few nodes and many edges, sides collide, so
+    // groups hold several ends and a re-side actually changes fan-out
+    // fractions instead of moving a lone end between empty sides.
+    links: fc.array(
+      fc.record({
+        from: fc.integer({ min: 0, max: 5 }),
+        to: fc.integer({ min: 0, max: 5 }),
+        fromSide: fc.constantFrom(...SIDES),
+        toSide: fc.constantFrom(...SIDES),
+      }),
+      { minLength: 1, maxLength: 12 },
+    ),
+    reSide: fc.record({
+      index: fc.nat(),
+      fromSide: fc.constantFrom(...SIDES),
+      toSide: fc.constantFrom(...SIDES),
+    }),
+  })
+  .map(({ nodeCount, boxes, links, reSide }) => {
+    const nodes: SpatialNode[] = boxes.slice(0, nodeCount).map((b, i) => ({
+      id: `n${i}`,
+      type: 'text',
+      x: b.x,
+      y: b.y,
+      width: b.w,
+      height: b.h,
+      text: `n${i}`,
+    }))
+    const edges: CanvasEdge[] = links.map((l, i) => ({
+      id: `e${i}`,
+      fromNode: `n${l.from % nodeCount}`,
+      toNode: `n${l.to % nodeCount}`,
+    }))
+    const sides = new Map<string, { fromSide: Side; toSide: Side }>(
+      links.map((l, i) => [`e${i}`, { fromSide: l.fromSide, toSide: l.toSide }]),
+    )
+    return { nodes, edges, sides, target: reSide.index % edges.length, next: reSide }
+  })
+
+/** Group membership as a comparable value: the alignment pass reads sizes,
+ *  and placement reads the members themselves. */
+const shapeOf = (g: AnchorGroups) => ({
+  entries: [...g.entries.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),
+  sizes: [...g.groups.entries()]
+    .map(([k, v]) => [k, v.length] as const)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),
+})
+
+describe('patchAnchorGroups agrees with a full rebuild', () => {
+  fcTest.prop([layout], withDefaults())(
+    'a one-edge re-side lands the same partition either way',
+    ({ nodes, edges, sides, target, next }) => {
+      const ctx = anchorContext(nodes, edges)
+      const base = buildAnchorGroups(ctx, sides)
+      const edge = edges[target]
+      if (edge === undefined) return
+      const trial = new Map(sides)
+      trial.set(edge.id, { fromSide: next.fromSide, toSide: next.toSide })
+
+      const patched = patchAnchorGroups(ctx, base, trial, target)
+      const rebuilt = buildAnchorGroups(ctx, trial)
+      expect(shapeOf(patched)).toEqual(shapeOf(rebuilt))
+    },
+  )
+
+  fcTest.prop([layout], withDefaults())(
+    're-siding to the sides it already has is the identity',
+    ({ nodes, edges, sides, target }) => {
+      const ctx = anchorContext(nodes, edges)
+      const base = buildAnchorGroups(ctx, sides)
+      const edge = edges[target]
+      if (edge === undefined) return
+      const patched = patchAnchorGroups(ctx, base, sides, target)
+      expect(shapeOf(patched)).toEqual(shapeOf(base))
+    },
+  )
+})

--- a/packages/canvas-render/src/layout/edge-rules.test.ts
+++ b/packages/canvas-render/src/layout/edge-rules.test.ts
@@ -315,6 +315,75 @@ describe('overlap-and-intrusion', () => {
     const rect: Rect = { x: 0, y: 0, w: 100, h: 100 }
     expect(selfPenalty(path, [rect])).toEqual(zeroPenalty())
   })
+
+  // The four cases below pin the branches the term takes BEFORE it measures
+  // anything: which axis a segment runs along, and whether it runs along one
+  // at all. The scoreboard prices them in aggregate, which says a rewrite
+  // changed nothing overall but not which case a future one breaks.
+  it('self term: a VERTICAL segment through a foreign rect interior is scored like the horizontal one', () => {
+    const path = [
+      { x: 50, y: -10 },
+      { x: 50, y: 110 },
+    ]
+    const rect: Rect = { x: 0, y: 0, w: 100, h: 100 }
+    expect(selfPenalty(path, [rect])).toEqual(costAt('overlap-and-intrusion', 100 * COST_QUANTUM))
+  })
+
+  it('self term: a vertical segment on the rect LEFT border grazes, exactly as a horizontal one does on the top', () => {
+    const path = [
+      { x: 0, y: -10 },
+      { x: 0, y: 110 },
+    ]
+    const rect: Rect = { x: 0, y: 0, w: 100, h: 100 }
+    expect(selfPenalty(path, [rect])).toEqual(zeroPenalty())
+  })
+
+  it('self term: a diagonal segment tunnels through nothing — only an axis-aligned one can', () => {
+    // The start x sits STRICTLY inside the rect on purpose. A diagonal
+    // starting outside it scores zero either way — the vertical branch would
+    // reject it on the same coordinate test — so such a case cannot tell
+    // whether the skip is there at all (mutation-checked: it is not). This
+    // one would be charged 90px of intrusion without it.
+    const path = [
+      { x: 10, y: -10 },
+      { x: 110, y: 90 },
+    ]
+    const rect: Rect = { x: 0, y: 0, w: 100, h: 100 }
+    expect(selfPenalty(path, [rect])).toEqual(zeroPenalty())
+  })
+
+  it('self term: a zero-length segment inside a rect contributes nothing', () => {
+    // Both axes read as equal, so the segment answers to neither branch —
+    // and an intrusion of zero length is what it actually is.
+    const path = [
+      { x: 50, y: 50 },
+      { x: 50, y: 50 },
+    ]
+    const rect: Rect = { x: 0, y: 0, w: 100, h: 100 }
+    expect(selfPenalty(path, [rect])).toEqual(zeroPenalty())
+  })
+
+  it('self term: a vertical retrace is charged its quantized length, mirroring the horizontal case', () => {
+    const path = [
+      { x: 0, y: 0 },
+      { x: 0, y: 20 },
+      { x: 0, y: 5 },
+    ]
+    expect(selfPenalty(path, [])).toEqual([15 * COST_QUANTUM, 0, 0, 0, 0, 1, 1])
+  })
+
+  it('self term: a retrace shorter than one quantum is not ink, though the turn is still a bend', () => {
+    // 0.4 of a quantum out and back: the overlap rounds to nothing, while
+    // realized-bends counts the direction change off the raw geometry. The
+    // two tiers reading the same path at different resolutions is the point
+    // — quantization is the ink terms' own rule, not the path's.
+    const path = [
+      { x: 0, y: 0 },
+      { x: 0.1, y: 0 },
+      { x: 0, y: 0 },
+    ]
+    expect(selfPenalty(path, [])).toEqual(costAt('realized-bends', 1))
+  })
 })
 
 describe('illegibility', () => {

--- a/packages/canvas-render/src/layout/edge-rules.ts
+++ b/packages/canvas-render/src/layout/edge-rules.ts
@@ -452,6 +452,16 @@ export function fullyContains(outer: Rect, inner: Rect): boolean {
 }
 
 /**
+ * The one COST_QUANTUM rounding every ink term measures in. Sub-quantum
+ * differences are rounding wobble, not geometry: anchors land on fractions
+ * (a slid anchor can sit at 233.333...px), so terms that compare or subtract
+ * coordinates must agree on where the grid is.
+ */
+function quantize(n: number): number {
+  return Math.round(n * COST_QUANTUM)
+}
+
+/**
  * Quantized length of an axis-aligned path's ink lying along `rects`, in the
  * COST_QUANTUM-quantized integer space every ink-length term is measured in
  * (so the term is integral by construction). `qualifies` is the ONE thing
@@ -467,7 +477,7 @@ function inkAlongRects(
   rects: readonly Rect[],
   qualifies: (fixed: number, near: number, far: number) => boolean,
 ): number {
-  const q = (n: number) => Math.round(n * COST_QUANTUM)
+  const q = quantize
   let total = 0
   for (let i = 1; i < path.length; i++) {
     const a = path[i - 1] as Point
@@ -503,40 +513,61 @@ const overlapAndIntrusion: PenaltyRule = {
   tier: 0,
   pairTerm: (triple) => triple[0],
   selfTerm: (path, foreignBodies) => {
-    const q = (n: number) => Math.round(n * COST_QUANTUM)
     let overlap = 0
+    // Quantized once per POINT rather than per comparison: the retrace loop
+    // below is quadratic in the segment count and re-derived the same six
+    // values for every pair. `quantize` is pure, so the sums are unchanged.
+    const qx: number[] = []
+    const qy: number[] = []
+    for (const p of path) {
+      qx.push(quantize(p.x))
+      qy.push(quantize(p.y))
+    }
     for (let i = 1; i < path.length; i++) {
       const a = path[i - 1] as Point
       const b = path[i] as Point
+      // Only an axis-aligned segment can tunnel, and only through a body
+      // whose OTHER axis strictly contains it — the same reject the router
+      // and the grid search already apply. A diagonal or zero-length
+      // segment scores nothing against any body, so it skips the loop
+      // entirely rather than computing four bounds per obstacle to find
+      // that out. Boundary grazing stays excluded: an anchor ON a
+      // neighbour's border or a segment riding the margin band is
+      // bestCandidate's business, not a tunnel.
+      const horizontal = a.y === b.y && a.x !== b.x
+      const vertical = a.x === b.x && a.y !== b.y
+      if (!horizontal && !vertical) continue
       for (const r of foreignBodies) {
-        // Axis-aligned intrusion length, boundary grazing excluded: an
-        // anchor ON a neighbour's border or a segment riding the margin
-        // band is bestCandidate's business, not a tunnel.
-        const minX = Math.max(Math.min(a.x, b.x), r.x)
-        const maxX = Math.min(Math.max(a.x, b.x), r.x + r.w)
-        const minY = Math.max(Math.min(a.y, b.y), r.y)
-        const maxY = Math.min(Math.max(a.y, b.y), r.y + r.h)
-        if (maxX <= minX && maxY <= minY) continue
-        if (a.y === b.y && a.y > r.y && a.y < r.y + r.h && maxX > minX) {
-          overlap += q(maxX - minX)
-        } else if (a.x === b.x && a.x > r.x && a.x < r.x + r.w && maxY > minY) {
-          overlap += q(maxY - minY)
+        if (horizontal) {
+          if (a.y <= r.y || a.y >= r.y + r.h) continue
+          const minX = Math.max(Math.min(a.x, b.x), r.x)
+          const maxX = Math.min(Math.max(a.x, b.x), r.x + r.w)
+          if (maxX > minX) overlap += quantize(maxX - minX)
+        } else {
+          if (a.x <= r.x || a.x >= r.x + r.w) continue
+          const minY = Math.max(Math.min(a.y, b.y), r.y)
+          const maxY = Math.min(Math.max(a.y, b.y), r.y + r.h)
+          if (maxY > minY) overlap += quantize(maxY - minY)
         }
       }
     }
     for (let i = 1; i < path.length; i++) {
       for (let j = i + 1; j < path.length; j++) {
-        const a1 = path[i - 1] as Point
-        const a2 = path[i] as Point
-        const b1 = path[j - 1] as Point
-        const b2 = path[j] as Point
-        if (q(a1.x) === q(a2.x) && q(b1.x) === q(b2.x) && q(a1.x) === q(b1.x)) {
-          const lo = Math.max(q(Math.min(a1.y, a2.y)), q(Math.min(b1.y, b2.y)))
-          const hi = Math.min(q(Math.max(a1.y, a2.y)), q(Math.max(b1.y, b2.y)))
+        const ax1 = qx[i - 1] as number
+        const ay1 = qy[i - 1] as number
+        const ax2 = qx[i] as number
+        const ay2 = qy[i] as number
+        const bx1 = qx[j - 1] as number
+        const by1 = qy[j - 1] as number
+        const bx2 = qx[j] as number
+        const by2 = qy[j] as number
+        if (ax1 === ax2 && bx1 === bx2 && ax1 === bx1) {
+          const lo = Math.max(Math.min(ay1, ay2), Math.min(by1, by2))
+          const hi = Math.min(Math.max(ay1, ay2), Math.max(by1, by2))
           if (hi > lo) overlap += hi - lo
-        } else if (q(a1.y) === q(a2.y) && q(b1.y) === q(b2.y) && q(a1.y) === q(b1.y)) {
-          const lo = Math.max(q(Math.min(a1.x, a2.x)), q(Math.min(b1.x, b2.x)))
-          const hi = Math.min(q(Math.max(a1.x, a2.x)), q(Math.max(b1.x, b2.x)))
+        } else if (ay1 === ay2 && by1 === by2 && ay1 === by1) {
+          const lo = Math.max(Math.min(ax1, ax2), Math.min(bx1, bx2))
+          const hi = Math.min(Math.max(ax1, ax2), Math.max(bx1, bx2))
           if (hi > lo) overlap += hi - lo
         }
       }
@@ -678,7 +709,7 @@ export const endpointBodyInk: PenaltyRule = {
  * anchor can land at e.g. 233.333...px), so a raw `Math.sign` would read a
  * sub-quarter-pixel rounding wobble as a reversal. */
 function quantizedSign(a: number, b: number): number {
-  return Math.sign(Math.round(b * COST_QUANTUM) - Math.round(a * COST_QUANTUM))
+  return Math.sign(quantize(b) - quantize(a))
 }
 
 /** Direction reversals per axis along a polyline: a segment whose sign on

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -338,10 +338,47 @@ function initialSideChoices(
   return choices
 }
 
+/**
+ * The layout-invariant half of `computeAnchorsFor`'s inputs, built ONCE per
+ * search and reused by every trial: nodes do not move while sides are being
+ * chosen, so their index, rects and centers are identical on every call. The
+ * search runs that function hundreds of times per layout (measured: 252 calls
+ * on the 200-edge bench, 463 on the 345-edge one), and rebuilding these per
+ * call was 15% of layout time.
+ *
+ * Carrying `edges` alongside them is what makes the reuse safe: `ends` is
+ * indexed by edge position, so a context cannot be paired with an edge list
+ * it was not derived from.
+ */
+interface AnchorContext {
+  readonly edges: readonly CanvasEdge[]
+  /** Per edge index; `undefined` when either endpoint node is missing. */
+  readonly ends: ReadonlyArray<AnchorEnds | undefined>
+}
+
+interface AnchorEnds {
+  readonly fromRect: Rect
+  readonly toRect: Rect
+  readonly fromCenter: Point
+  readonly toCenter: Point
+}
+
+function anchorContext(nodes: readonly SpatialNode[], edges: readonly CanvasEdge[]): AnchorContext {
+  const byId = new Map(nodes.map((n) => [n.id, n]))
+  const ends = edges.map((edge) => {
+    const fromNode = byId.get(edge.fromNode)
+    const toNode = byId.get(edge.toNode)
+    if (fromNode === undefined || toNode === undefined) return undefined
+    const fromRect = rectOf(fromNode)
+    const toRect = rectOf(toNode)
+    return { fromRect, toRect, fromCenter: centerOf(fromRect), toCenter: centerOf(toRect) }
+  })
+  return { edges, ends }
+}
+
 /** Grouping, anchor fan-out and lane depths for a FIXED side configuration. */
 function computeAnchorsFor(
-  nodes: readonly SpatialNode[],
-  edges: readonly CanvasEdge[],
+  ctx: AnchorContext,
   sides: ReadonlyMap<string, SidePair>,
   // Alignment never varies WITHIN one optimizer run: sliding anchors
   // mid-optimization changes trial costs, which shifts side-choice
@@ -358,7 +395,7 @@ function computeAnchorsFor(
   // point/depth is the committed one — a stationary edge never moves.
   pins?: ReadonlyMap<string, EdgeAnchorOverride>,
 ): ReadonlyMap<string, EdgeAnchorPair> {
-  const byId = new Map(nodes.map((n) => [n.id, n]))
+  const { edges, ends: edgeEnds } = ctx
   type End = {
     readonly edgeId: string
     readonly edgeIndex: number
@@ -369,12 +406,10 @@ function computeAnchorsFor(
   }
   const groups = new Map<string, End[]>()
   edges.forEach((edge, edgeIndex) => {
-    const fromNode = byId.get(edge.fromNode)
-    const toNode = byId.get(edge.toNode)
+    const geom = edgeEnds[edgeIndex]
     const chosen = sides.get(edge.id)
-    if (fromNode === undefined || toNode === undefined || chosen === undefined) return
-    const fromRect = rectOf(fromNode)
-    const toRect = rectOf(toNode)
+    if (geom === undefined || chosen === undefined) return
+    const { fromRect, toRect } = geom
     const ends: End[] = [
       {
         edgeId: edge.id,
@@ -382,7 +417,7 @@ function computeAnchorsFor(
         role: 'from',
         rect: fromRect,
         side: chosen.fromSide,
-        farCenter: centerOf(toRect),
+        farCenter: geom.toCenter,
       },
       {
         edgeId: edge.id,
@@ -390,7 +425,7 @@ function computeAnchorsFor(
         role: 'to',
         rect: toRect,
         side: chosen.toSide,
-        farCenter: centerOf(fromRect),
+        farCenter: geom.fromCenter,
       },
     ]
     for (const end of ends) {
@@ -474,20 +509,19 @@ function computeAnchorsFor(
   // per-side fraction placement above only delivers when the two side
   // midpoints happen to align. Multi-edge sides keep their fan-out
   // fractions: collapsing two corridors onto one lane is worse than a jog.
-  for (const edge of edges) {
+  for (let edgeIndex = 0; edgeIndex < edges.length; edgeIndex++) {
+    const edge = edges[edgeIndex] as CanvasEdge
     // A pinned edge holds its committed anchors; alignment must not move it.
     if (pins?.get(edge.id)?.from !== undefined || pins?.get(edge.id)?.to !== undefined) continue
     const chosen = sides.get(edge.id)
     const entry = anchors.get(edge.id)
     if (chosen === undefined || entry?.from === undefined || entry.to === undefined) continue
     if (chosen.toSide !== oppositeSide(chosen.fromSide)) continue
-    const fromNode = byId.get(edge.fromNode)
-    const toNode = byId.get(edge.toNode)
-    if (fromNode === undefined || toNode === undefined) continue
+    const geom = edgeEnds[edgeIndex]
+    if (geom === undefined) continue
     if ((groups.get(`${edge.fromNode} ${chosen.fromSide}`)?.length ?? 0) > 1) continue
     if ((groups.get(`${edge.toNode} ${chosen.toSide}`)?.length ?? 0) > 1) continue
-    const fromRect = rectOf(fromNode)
-    const toRect = rectOf(toNode)
+    const { fromRect, toRect } = geom
     const axis = chosen.fromSide === 'left' || chosen.fromSide === 'right' ? 'h' : 'v'
     // Interpenetrating boxes (authored sides can force them) have no
     // forward-facing lane to slide into.
@@ -735,8 +769,9 @@ function optimizeSideChoices(
     a.y - COST_QUANTUM <= b.y + b.h &&
     b.y - COST_QUANTUM <= a.y + a.h
 
+  const ctx = anchorContext(nodes, edges)
   let current = new Map(initial)
-  let anchors = computeAnchorsFor(nodes, edges, current, align, pins)
+  let anchors = computeAnchorsFor(ctx, current, align, pins)
   let paths: (readonly Point[])[] = edges.map((e, i) => routeCached(e, i, anchors.get(e.id)))
   let bounds: Rect[] = paths.map(boundsOf)
   const pairKey = (i: number, j: number) => i * edges.length + j
@@ -796,7 +831,7 @@ function optimizeSideChoices(
     updates: Map<number, ConfigCost>
     selfUpdates: Map<number, ConfigCost>
   } => {
-    const trialAnchors = computeAnchorsFor(nodes, edges, trialSides, align, pins)
+    const trialAnchors = computeAnchorsFor(ctx, trialSides, align, pins)
     const touched: number[] = []
     for (let i = 0; i < edges.length; i++) {
       if (!sameAnchor(anchors.get(edges[i]!.id), trialAnchors.get(edges[i]!.id))) touched.push(i)
@@ -992,7 +1027,8 @@ function anchorsWithoutCoincidentEnds(
     const a = anchors.get(id)
     return a?.from !== undefined && a.to !== undefined && a.from.x === a.to.x && a.from.y === a.to.y
   }
-  const anchors = computeAnchorsFor(nodes, edges, sides, align, pins)
+  const ctx = anchorContext(nodes, edges)
+  const anchors = computeAnchorsFor(ctx, sides, align, pins)
   const collided = edges.filter(
     (edge) =>
       edge.fromNode !== edge.toNode &&
@@ -1037,7 +1073,7 @@ function anchorsWithoutCoincidentEnds(
       }
       const trial = new Map(repaired)
       trial.set(edge.id, sided)
-      const trialAnchors = computeAnchorsFor(nodes, edges, trial, align, pins)
+      const trialAnchors = computeAnchorsFor(ctx, trial, align, pins)
       if (coincides(trialAnchors, edge.id)) continue
       const { path } = routeEdge(nodes, edge, style, trialAnchors.get(edge.id))
       // The arrowhead is drawn ON the final segment; a shorter one paints an
@@ -1071,7 +1107,7 @@ function anchorsWithoutCoincidentEnds(
     // draws the shared point rather than a spike, so the worst case is an
     // invisible edge, never a wrong one.
   }
-  return computeAnchorsFor(nodes, edges, repaired, align, pins)
+  return computeAnchorsFor(ctx, repaired, align, pins)
 }
 
 /**

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -350,7 +350,7 @@ function initialSideChoices(
  * indexed by edge position, so a context cannot be paired with an edge list
  * it was not derived from.
  */
-interface AnchorContext {
+export interface AnchorContext {
   readonly edges: readonly CanvasEdge[]
   /** Per edge index; `undefined` when either endpoint node is missing. */
   readonly ends: ReadonlyArray<AnchorEnds | undefined>
@@ -363,7 +363,10 @@ interface AnchorEnds {
   readonly toCenter: Point
 }
 
-function anchorContext(nodes: readonly SpatialNode[], edges: readonly CanvasEdge[]): AnchorContext {
+export function anchorContext(
+  nodes: readonly SpatialNode[],
+  edges: readonly CanvasEdge[],
+): AnchorContext {
   const byId = new Map(nodes.map((n) => [n.id, n]))
   const ends = edges.map((edge) => {
     const fromNode = byId.get(edge.fromNode)
@@ -374,6 +377,208 @@ function anchorContext(nodes: readonly SpatialNode[], edges: readonly CanvasEdge
     return { fromRect, toRect, fromCenter: centerOf(fromRect), toCenter: centerOf(toRect) }
   })
   return { edges, ends }
+}
+
+/**
+ * One end of one edge, as the fan-out sees it. Ends are partitioned by
+ * `(nodeId, side)`: a group's placement is a function of its own members and
+ * nothing else, which is what lets a trial re-place only the groups it
+ * disturbs (`patchAnchorGroups`).
+ */
+interface AnchorEnd {
+  readonly edgeId: string
+  readonly edgeIndex: number
+  readonly role: 'from' | 'to'
+  readonly rect: Rect
+  readonly side: Side
+  readonly farCenter: Point
+}
+
+/** Pre-alignment anchor entry: what the fan-out writes, before the aligned
+ *  run slides facing pairs and before pins are applied. */
+interface AnchorEntry {
+  from?: Point
+  to?: Point
+  fromLaneDepth?: number
+  toLaneDepth?: number
+  fromSide?: Side
+  toSide?: Side
+}
+
+/**
+ * The partition plus the entries placed from it. Held across a search so a
+ * one-edge trial can rebuild the two groups that edge leaves and the two it
+ * joins, instead of re-deriving all of them: measured on the 200-edge bench,
+ * grouping and placement are 92% of `computeAnchorsFor` (15.4ms + 27.2ms of
+ * 46.4ms) and alignment only 8%, so alignment stays a full pass and only
+ * this half is made incremental.
+ *
+ * This type and the two functions producing it are exported for one reason:
+ * the incremental path is a SECOND producer of a partition the full path
+ * also produces, and this package's one-producer rule admits that only with
+ * a parity test pinning their agreement — see
+ * `anchor-groups.properties.test.ts`.
+ */
+export interface AnchorGroups {
+  readonly groups: Map<string, AnchorEnd[]>
+  readonly entries: Map<string, AnchorEntry>
+}
+
+const groupKeyFor = (edge: CanvasEdge, role: 'from' | 'to', side: Side): string =>
+  `${role === 'from' ? edge.fromNode : edge.toNode} ${side}`
+
+function endsOfEdge(
+  ctx: AnchorContext,
+  edgeIndex: number,
+  sides: ReadonlyMap<string, SidePair>,
+): readonly [AnchorEnd, AnchorEnd] | undefined {
+  const edge = ctx.edges[edgeIndex]
+  const geom = ctx.ends[edgeIndex]
+  if (edge === undefined || geom === undefined) return undefined
+  const chosen = sides.get(edge.id)
+  if (chosen === undefined) return undefined
+  return [
+    {
+      edgeId: edge.id,
+      edgeIndex,
+      role: 'from',
+      rect: geom.fromRect,
+      side: chosen.fromSide,
+      farCenter: geom.toCenter,
+    },
+    {
+      edgeId: edge.id,
+      edgeIndex,
+      role: 'to',
+      rect: geom.toRect,
+      side: chosen.toSide,
+      farCenter: geom.fromCenter,
+    },
+  ]
+}
+
+/**
+ * Fan-out and lane depth for ONE group, written into `entries`. Each end
+ * writes only its own half (`from*` or `to*`), so re-placing a group never
+ * disturbs the other end of an edge that reaches into it.
+ */
+function placeAnchorGroup(group: readonly AnchorEnd[], entries: Map<string, AnchorEntry>): void {
+  const ordered = [...group].sort(
+    (a, b) =>
+      tangentCoordinate(a.side, a.farCenter) - tangentCoordinate(b.side, b.farCenter) ||
+      a.edgeIndex - b.edgeIndex ||
+      (a.role === b.role ? 0 : a.role === 'from' ? -1 : 1),
+  )
+  const placed = ordered.map((end, i) => ({
+    end,
+    point: sidePointAt(end.rect, end.side, (i + 1) / (ordered.length + 1)),
+    t: tangentCoordinate(end.side, sidePointAt(end.rect, end.side, (i + 1) / (ordered.length + 1))),
+  }))
+  for (const member of placed) {
+    // Depth by SWEEP RANK, not list index: a corridor travelling toward
+    // its far endpoint passes every anchor between its own and that
+    // direction, and must run deeper than all of their exit segments —
+    // an index-ordered ladder gives a sweeping corridor a shallow lane
+    // and forces a crossing right at the node that the connections
+    // themselves never required. Ends that sweep past nothing share the
+    // base depth; their corridors occupy disjoint tangent ranges.
+    const dir = Math.sign(tangentCoordinate(member.end.side, member.end.farCenter) - member.t)
+    const rank =
+      dir === 0
+        ? 0
+        : placed.filter((other) => (dir > 0 ? other.t > member.t : other.t < member.t)).length
+    const depth = ORTHOGONAL_STUB_PX + rank * STUB_LANE_STEP_PX
+    const entry = entries.get(member.end.edgeId) ?? {}
+    entries.set(
+      member.end.edgeId,
+      member.end.role === 'from'
+        ? { ...entry, from: member.point, fromLaneDepth: depth, fromSide: member.end.side }
+        : { ...entry, to: member.point, toLaneDepth: depth, toSide: member.end.side },
+    )
+  }
+}
+
+/** The whole partition, placed. */
+export function buildAnchorGroups(
+  ctx: AnchorContext,
+  sides: ReadonlyMap<string, SidePair>,
+): AnchorGroups {
+  const groups = new Map<string, AnchorEnd[]>()
+  ctx.edges.forEach((edge, edgeIndex) => {
+    const ends = endsOfEdge(ctx, edgeIndex, sides)
+    if (ends === undefined) return
+    for (const end of ends) {
+      const key = groupKeyFor(edge, end.role, end.side)
+      const group = groups.get(key)
+      if (group === undefined) groups.set(key, [end])
+      else group.push(end)
+    }
+  })
+  const entries = new Map<string, AnchorEntry>()
+  for (const group of groups.values()) placeAnchorGroup(group, entries)
+  return { groups, entries }
+}
+
+/**
+ * The same partition with ONE edge re-sided. Every trial the side-choice
+ * search evaluates is exactly this shape (`new Map(current)` plus one
+ * `set`), and only the two groups that edge leaves and the two it joins can
+ * differ — every other group keeps the members, and therefore the fan-out,
+ * it already had. `base` is left untouched.
+ */
+export function patchAnchorGroups(
+  ctx: AnchorContext,
+  base: AnchorGroups,
+  sides: ReadonlyMap<string, SidePair>,
+  edgeIndex: number,
+): AnchorGroups {
+  const edge = ctx.edges[edgeIndex]
+  const next = endsOfEdge(ctx, edgeIndex, sides)
+  if (edge === undefined || next === undefined) return base
+  const groups = new Map(base.groups)
+  const touched = new Set<string>()
+  const replace = (key: string, mutate: (members: AnchorEnd[]) => AnchorEnd[]): void => {
+    const members = mutate([...(groups.get(key) ?? [])])
+    // A side an edge has just left may hold nothing now. `buildAnchorGroups`
+    // never creates an empty group, so keeping one here would leave the two
+    // partitions unequal — harmlessly for the alignment pass, which reads a
+    // missing key and an empty one alike, but the parity property compares
+    // the partitions themselves and an emptied key would also accumulate
+    // across a search.
+    if (members.length === 0) groups.delete(key)
+    else groups.set(key, members)
+    touched.add(key)
+  }
+  // Leave the old groups. The edge's previous sides are read off the base
+  // entry rather than a second side map: they are what placed it there.
+  const previous = base.entries.get(edge.id)
+  for (const [role, side] of [
+    ['from', previous?.fromSide],
+    ['to', previous?.toSide],
+  ] as const) {
+    if (side === undefined) continue
+    replace(groupKeyFor(edge, role, side), (members) =>
+      members.filter((m) => !(m.edgeId === edge.id && m.role === role)),
+    )
+  }
+  // Join the new ones.
+  for (const end of next) {
+    replace(groupKeyFor(edge, end.role, end.side), (members) => [...members, end])
+  }
+  // Re-place only what moved. A member of a touched group keeps the half it
+  // owns in another, untouched group, because `placeAnchorGroup` writes one
+  // half per end onto whatever entry is already there.
+  const entries = new Map(base.entries)
+  // The re-sided edge needs no clearing first: both of its new groups are
+  // touched by construction, and each end overwrites its own half of the
+  // entry, so nothing of the old sides survives. (Clearing it anyway was
+  // written here and removed — the parity property showed it changed
+  // nothing.)
+  for (const key of touched) {
+    const group = groups.get(key)
+    if (group !== undefined) placeAnchorGroup(group, entries)
+  }
+  return { groups, entries }
 }
 
 /** Grouping, anchor fan-out and lane depths for a FIXED side configuration. */
@@ -394,94 +599,13 @@ function computeAnchorsFor(
   // carried newcomer lands on a distinct lane, but their own placed
   // point/depth is the committed one — a stationary edge never moves.
   pins?: ReadonlyMap<string, EdgeAnchorOverride>,
+  // A partition already placed for exactly these sides, when the caller has
+  // one (a trial patched from the incumbent). Absent, it is built here.
+  placement?: AnchorGroups,
 ): ReadonlyMap<string, EdgeAnchorPair> {
   const { edges, ends: edgeEnds } = ctx
-  type End = {
-    readonly edgeId: string
-    readonly edgeIndex: number
-    readonly role: 'from' | 'to'
-    readonly rect: Rect
-    readonly side: Side
-    readonly farCenter: Point
-  }
-  const groups = new Map<string, End[]>()
-  edges.forEach((edge, edgeIndex) => {
-    const geom = edgeEnds[edgeIndex]
-    const chosen = sides.get(edge.id)
-    if (geom === undefined || chosen === undefined) return
-    const { fromRect, toRect } = geom
-    const ends: End[] = [
-      {
-        edgeId: edge.id,
-        edgeIndex,
-        role: 'from',
-        rect: fromRect,
-        side: chosen.fromSide,
-        farCenter: geom.toCenter,
-      },
-      {
-        edgeId: edge.id,
-        edgeIndex,
-        role: 'to',
-        rect: toRect,
-        side: chosen.toSide,
-        farCenter: geom.fromCenter,
-      },
-    ]
-    for (const end of ends) {
-      const key = `${end.role === 'from' ? edge.fromNode : edge.toNode} ${end.side}`
-      const group = groups.get(key)
-      if (group === undefined) groups.set(key, [end])
-      else group.push(end)
-    }
-  })
-
-  const anchors = new Map<
-    string,
-    {
-      from?: Point
-      to?: Point
-      fromLaneDepth?: number
-      toLaneDepth?: number
-      fromSide?: Side
-      toSide?: Side
-    }
-  >()
-  for (const group of groups.values()) {
-    group.sort(
-      (a, b) =>
-        tangentCoordinate(a.side, a.farCenter) - tangentCoordinate(b.side, b.farCenter) ||
-        a.edgeIndex - b.edgeIndex ||
-        (a.role === b.role ? 0 : a.role === 'from' ? -1 : 1),
-    )
-    const placed = group.map((end, i) => ({
-      end,
-      point: sidePointAt(end.rect, end.side, (i + 1) / (group.length + 1)),
-      t: tangentCoordinate(end.side, sidePointAt(end.rect, end.side, (i + 1) / (group.length + 1))),
-    }))
-    for (const member of placed) {
-      // Depth by SWEEP RANK, not list index: a corridor travelling toward
-      // its far endpoint passes every anchor between its own and that
-      // direction, and must run deeper than all of their exit segments —
-      // an index-ordered ladder gives a sweeping corridor a shallow lane
-      // and forces a crossing right at the node that the connections
-      // themselves never required. Ends that sweep past nothing share the
-      // base depth; their corridors occupy disjoint tangent ranges.
-      const dir = Math.sign(tangentCoordinate(member.end.side, member.end.farCenter) - member.t)
-      const rank =
-        dir === 0
-          ? 0
-          : placed.filter((other) => (dir > 0 ? other.t > member.t : other.t < member.t)).length
-      const depth = ORTHOGONAL_STUB_PX + rank * STUB_LANE_STEP_PX
-      const entry = anchors.get(member.end.edgeId) ?? {}
-      anchors.set(
-        member.end.edgeId,
-        member.end.role === 'from'
-          ? { ...entry, from: member.point, fromLaneDepth: depth, fromSide: member.end.side }
-          : { ...entry, to: member.point, toLaneDepth: depth, toSide: member.end.side },
-      )
-    }
-  }
+  const { groups, entries } = placement ?? buildAnchorGroups(ctx, sides)
+  const anchors = new Map<string, AnchorEntry>(entries)
 
   const applyPins = (): void => {
     if (pins === undefined) return
@@ -771,7 +895,12 @@ function optimizeSideChoices(
 
   const ctx = anchorContext(nodes, edges)
   let current = new Map(initial)
-  let anchors = computeAnchorsFor(ctx, current, align, pins)
+  // The incumbent's partition, carried so a trial can patch it rather than
+  // re-derive it. Replaced only when a trial is adopted, so it always
+  // describes exactly `current`.
+  let placement = buildAnchorGroups(ctx, current)
+  const edgeIndexById = new Map(edges.map((e, i) => [e.id, i]))
+  let anchors = computeAnchorsFor(ctx, current, align, pins, placement)
   let paths: (readonly Point[])[] = edges.map((e, i) => routeCached(e, i, anchors.get(e.id)))
   let bounds: Rect[] = paths.map(boundsOf)
   const pairKey = (i: number, j: number) => i * edges.length + j
@@ -822,16 +951,22 @@ function optimizeSideChoices(
 
   const evaluateTrial = (
     trialSides: ReadonlyMap<string, SidePair>,
+    // Which edge `trialSides` re-sided. Every trial here differs from the
+    // incumbent in exactly one edge, which is what makes the partition
+    // patchable instead of rebuilt.
+    reSidedIndex: number,
   ): {
     cost: ConfigCost
     anchors: ReadonlyMap<string, EdgeAnchorPair>
+    placement: AnchorGroups
     paths: (readonly Point[])[]
     bounds: Rect[]
     touched: number[]
     updates: Map<number, ConfigCost>
     selfUpdates: Map<number, ConfigCost>
   } => {
-    const trialAnchors = computeAnchorsFor(ctx, trialSides, align, pins)
+    const trialPlacement = patchAnchorGroups(ctx, placement, trialSides, reSidedIndex)
+    const trialAnchors = computeAnchorsFor(ctx, trialSides, align, pins, trialPlacement)
     const touched: number[] = []
     for (let i = 0; i < edges.length; i++) {
       if (!sameAnchor(anchors.get(edges[i]!.id), trialAnchors.get(edges[i]!.id))) touched.push(i)
@@ -888,6 +1023,7 @@ function optimizeSideChoices(
     return {
       cost,
       anchors: trialAnchors,
+      placement: trialPlacement,
       paths: trialPaths,
       bounds: trialBounds,
       touched,
@@ -976,13 +1112,14 @@ function optimizeSideChoices(
         if (candidate.fromSide === chosen.fromSide && candidate.toSide === chosen.toSide) continue
         const trial = new Map(current)
         trial.set(edge.id, candidate)
-        const evaluated = evaluateTrial(trial)
+        const evaluated = evaluateTrial(trial, edgeIndexById.get(edge.id) ?? -1)
         // incumbent-wins-ties: adopt only on a strict decrease (edge-rules.ts),
         // so a tie never triggers churn and the lexicographic loop cannot oscillate.
         if (shouldAdoptCandidate(evaluated.cost, currentCost, lessCost)) {
           current = trial
           currentCost = evaluated.cost
           anchors = evaluated.anchors
+          placement = evaluated.placement
           paths = evaluated.paths
           bounds = evaluated.bounds
           for (const [key, score] of evaluated.updates) matrix.set(key, score)


### PR DESCRIPTION
## Summary

The CPU-side worklist decision #10 left behind when the WebGPU/batch case was rejected, taken one item at a time. Each change was measured before it was written, each is behaviour-preserving, and the measurement redirected the work twice — once onto a different penalty rule than the note guessed, and once away from an "obvious" optimization that turned out not to pay.

- **`f55f7de`** — `computeAnchorsFor` rebuilt the node index, endpoint rects and far centers on every call, from data that cannot change while sides are being chosen. An `AnchorContext` carries that invariant half, built once per search.
- **`7b61877`** — `overlap-and-intrusion` (tier 0) computed four bounds for every (segment, body) pair before asking whether the segment could tunnel at all. It rejects by axis first now, and its quadratic retrace loop quantizes each point once.
- **`0d13b59`** — a trial patches the anchor partition instead of rebuilding it: at most the two groups a re-sided edge leaves and the two it joins can differ, and a fast-check parity property pins the patched partition equal to a rebuilt one.
- **`f28fd1b` / `52c3097`** — decision #10 pointed at two branches to justify "do not re-propose GPU or batch search", and neither is reachable from this repository. The record carries its own reproduction now, and its worklist reflects what actually landed.

## What the measurement changed

Instrumentation first, per `measured-change` — temporary, removed, tree verified clean each time. The CPU profiler was not usable: tsx's transform collapses the module to one line, so every anonymous frame symbolizes as `(anon L2)` and 36% of package self-time was unattributable. Direct timing answered it instead, and corrected three things:

**1. The `selfPenalty` cost was not where it looked.** `border-tracing` scans every node border on every call, so it was the obvious suspect. Per-rule timing said otherwise, and the change went to tier 0 instead:

| rule | share of layout (345-edge) |
|---|---|
| overlap-and-intrusion (tier 0) | **10.9%** |
| border-tracing (tier 4) | 3.1% |
| endpoint-body-ink (tier 3) | 0.4% |
| every other `selfTerm` | ≤ 0.2% |

**2. Phase timing made the hard half of the anchor work unnecessary.** Splitting `computeAnchorsFor` into its three phases (200-edge bench, 46.4ms total) gave grouping 15.4ms, placement 27.2ms, **alignment 3.8ms**. Alignment is where the difficult question lives — the aligned run's slide reads group *sizes*, so a re-side can flip the alignment of edges it never touched — and at 8% of the function it simply stays a full pass. Only the partition is incremental.

**3. One optimization was written, measured and reverted.** Removing the placement loop's redundant `sidePointAt` call, its per-member `filter` allocation and its per-comparison `tangentCoordinate` recomputation looked free. Measured against the function itself (min of 5 in-process reps, 3 interleaved rounds) it was neutral-to-negative: dense 43.9/44.8/42.0ms → 39.6/44.5/41.1ms, clustered 66.7/69.2/71.4ms → 70.9/72.9/71.7ms. Group sizes are small enough that the quadratic never bites, and the wrapper objects the caching needed cost more than the arithmetic they saved. Not in this PR; recorded here so it is not retried on the same reasoning.

## Results

Interleaved pairs, same sitting, alternating, min of N runs each:

| | 200-edge grid | 345-edge clustered |
|---|---|---|
| anchor context (`f55f7de`) | 391/380 → 349/366ms | 735/678 → 686/654ms |
| tier-0 reject (`7b61877`) | 369/351 → 361/326ms | 691/683 → 639/654ms |
| incremental partition (`0d13b59`) | 354/369/362 → 338/339/327ms | 685/707/626 → 589/586/592ms |

The first two are modest and consistent in direction; the third is the clearest, improving in all six comparisons. All three are behaviour-preserving by construction, and the routing scoreboard's exact pins are the executable statement of that.

## Test plan

- [x] New property test — `anchor-groups.properties.test.ts`, the parity this package's one-producer rule requires for the second partition producer
- [x] `pnpm test` for `canvas-render`: 880 passed / 90 files, routing scoreboard pins unchanged
- [x] `pnpm -r typecheck`, `biome ci` (exit 0), root `pnpm knip` — clean
- [x] `pnpm test --project mcp-node`: 3668 passed; the 4 failures are the known root-container EACCES set (a root user can read `chmod 000` fixtures), unrelated to this diff
- [x] **Mutation checks.** On the tier-0 change: relaxing the strict-containment reject (`<=` → `<`) turns the scoreboard red (`own-endpoint` 12 and `foreign` 15 both move). On the parity property: dropping one of the two joined ends turns it red.
- [ ] Manual verification in the running editor — not applicable: nothing user-visible changes, and "unchanged" is what the scoreboard asserts

## The property earned its place twice

It found a real divergence before the change landed: a **self-loop**, where both ends of an edge share one group, left an emptied group key in the patched partition that a rebuild never creates. Harmless to the alignment pass, which reads a missing key and an empty one alike — but it would have accumulated across a search, and the two partitions have to be *equal*, not merely equivalent.

Then mutation-checking it found the opposite problem: a line clearing the re-sided edge's entry changed nothing, because both of its new groups are touched by construction and each end overwrites its own half. Dead code that looked load-bearing. Removed.

## Visual evidence

None: the scoreboard's exact pins are the evidence. A change that moved a pixel would have moved a number.

## Notes for the reviewer

- `AnchorContext` bundles the edge list with the derived ends deliberately — `ends` is indexed by edge position, so carrying them together makes it structurally impossible to pair a context with an edge list it was not derived from.
- The incremental partition is a *second producer*. This package's one-producer rule admits that only with a parity test, which is why `buildAnchorGroups` / `patchAnchorGroups` / `anchorContext` are exported and why the property compares entries **and** group sizes rather than just the final anchors.
- The repair path (`repairCollidedAnchors`) still rebuilds per trial. It is a rarer path and was left alone rather than widened into this diff.
- The doc commits do not try to recover the missing experiment branches. If they still exist on the machine that ran them, pushing them is worth doing — but the conclusion no longer depends on it.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated — decision #10 is updated in the same increments as the work it describes
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kn5gTK3WGQcNrahPppzvHg