### PR TITLE
perf(canvas-render): share one routed-path cache across a region's two search runs

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -535,17 +535,28 @@ paths:
       now disagree about where the time is, and a change judged on one of
       them has not been judged.
       One cost off that profile is taken: the routed-path cache is owned by
-      `assignEdgeAnchors` rather than by each `optimizeSideChoices`, which
-      is what lets it span regions and both runs. 1021 of 1900 routings on
-      the clustered canvas repeat a key already seen in the layout; the
-      per-search caches caught 567. Worth 15-17% there, within noise on the
-      grid canvas (which sits at the region gate, so it shares only across
-      one region's two runs, whose aligned anchors mostly key differently).
-      Sound because `nodes`, `style` and an edge's obstacle list are fixed
-      for a whole layout, leaving the anchor pair as the only variable —
-      and `routeCacheKey` covers it field by field, pinned one case per
-      field, because a field the key misses is a wrong path rather than a
-      slow one.
+      the REGION rather than by each `optimizeSideChoices`, so it spans a
+      region's unaligned and aligned runs. That pairing is where the repeats
+      are — 1021 of 1900 routings on the clustered canvas repeat a key the
+      other run of their own region already saw, against 567 caught by the
+      per-search caches. Worth 15-19% there in six of six interleaved
+      comparisons, within noise on the grid canvas. Sound because `nodes`,
+      `style` and an edge's obstacle list are fixed across those two runs,
+      leaving the anchor pair as the only variable — and `routeCacheKey`
+      covers it field by field, pinned one case per field, because a field
+      the key misses is a wrong path rather than a slow one.
+      **It was first written one scope too wide, and the reason is worth
+      keeping.** A cache owned by `assignEdgeAnchors` measured exactly the
+      same, so nothing flagged it: regions PARTITION the edge list, an edge
+      is routed in only the region that holds it, and `routeCacheKey` starts
+      with `edge.id` — so a later region can never hit an earlier one's
+      entry. Measured 0 cross-region hits on canvases of one, two and four
+      regions. The wider scope bought nothing and held every completed
+      region's paths until the layout finished. The gap in the reasoning was
+      specific: soundness was checked (may these searches share?) and
+      usefulness was not (do they ever have anything to share?). A sharing
+      change needs both, and the cheap way to get the second is to attribute
+      the hits, not to count them.
       **The obstacle preparation was tried and rejected**, the second
       measurement in this series to refuse a change that argued well.
       `routeEdge` rebuilds two 286-element arrays per call — the

--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -523,6 +523,50 @@ paths:
       rather than assumed and the answer moved the target: its cost is
       overlap-and-intrusion (10.9% of layout), not border-tracing (3.1%),
       and that term now rejects by axis before measuring.
+      **All four are landed, and re-profiling afterwards moved the target
+      off that list entirely.** On the 345-edge clustered canvas — the size
+      an AI-authored document reaches — `routeEdge` is now 60% of layout,
+      and inside it the fallback chain is nearly all of that: the grid
+      search `routeOnGrid` 27%, `bestCandidate` 8%, the detour `region`
+      union 5%. The elbow shortcut, which the code is written around as the
+      common case, is taken on only 292 of 1215 routings there; the grid
+      search runs on 719 of them. On the 200-edge grid canvas none of this
+      shows (routing is 13%, pair scoring 22%) — so the two bench shapes
+      now disagree about where the time is, and a change judged on one of
+      them has not been judged.
+      One cost off that profile is taken: the routed-path cache is owned by
+      `assignEdgeAnchors` rather than by each `optimizeSideChoices`, which
+      is what lets it span regions and both runs. 1021 of 1900 routings on
+      the clustered canvas repeat a key already seen in the layout; the
+      per-search caches caught 567. Worth 15-17% there, within noise on the
+      grid canvas (which sits at the region gate, so it shares only across
+      one region's two runs, whose aligned anchors mostly key differently).
+      Sound because `nodes`, `style` and an edge's obstacle list are fixed
+      for a whole layout, leaving the anchor pair as the only variable —
+      and `routeCacheKey` covers it field by field, pinned one case per
+      field, because a field the key misses is a wrong path rather than a
+      slow one.
+      **The obstacle preparation was tried and rejected**, the second
+      measurement in this series to refuse a change that argued well.
+      `routeEdge` rebuilds two 286-element arrays per call — the
+      endpoint-containment filter and the margin-inflated copy — 1333 times
+      per clustered layout, and only 421 of those filters drop anything.
+      Memoizing the inflated array and returning the shared one untouched
+      when nothing is dropped measured neutral-to-negative (clustered
+      494/502/491 against 508/470/485ms, rounds disagreeing in sign; grid
+      slightly worse in all three). The 11% the phase profile attributes to
+      those two lines is the SCAN, not the allocation: 1333 calls x 286
+      rects x two `containsPoint` tests is 760k tests, and the prototype
+      keeps every one of them. Nothing here gets cheaper without cutting
+      the obstacle SET down spatially, which changes what is tested rather
+      than how fast it is tested.
+      A note on method, because it cost a wrong conclusion before it was
+      caught: the first interleaved run said the grid canvas regressed 3-4%
+      consistently, in all three rounds. Running the same pairs with the
+      ORDER FLIPPED said neutral. Whichever variant runs first in a round
+      carries that round's warm-up, and three rounds of a fixed order
+      reproduce the artifact rather than test it. Alternate the order, not
+      only the variant.
     - **Facet-driven rendering rides the injected-resolver pattern.**
       Shipped as the `facets` field of `ResolvedReference`
       (`layout/spatial-canvas.ts`) — synchronous, optional, caller-supplied,

--- a/packages/canvas-render/src/layout/route-cache-key.test.ts
+++ b/packages/canvas-render/src/layout/route-cache-key.test.ts
@@ -1,0 +1,55 @@
+import type { CanvasEdge } from '@kamiazya/whiteboard-model'
+import { describe, expect, it } from 'vitest'
+import { type EdgeAnchorPair, routeCacheKey } from './spatial-edges.js'
+
+/**
+ * The route cache is scoped to one `assignEdgeAnchors` call, spanning every
+ * region and both runs of the side-choice search. That is sound only because
+ * the key names every input `routeEdge` actually varies on: `nodes` and
+ * `style` are fixed for the whole call, an edge is the same object in every
+ * region, and its obstacle list is derived from those two — leaving the
+ * anchor pair as the only thing that moves.
+ *
+ * So the key has to cover the anchor pair COMPLETELY. A field `routeEdge`
+ * reads but the key omits is not a slow path, it is a wrong path: two
+ * genuinely different routes collapse onto one cache entry and the search
+ * scores geometry it never drew. This pins each field individually.
+ */
+const edge: CanvasEdge = { id: 'e1', fromNode: 'a', toNode: 'b' }
+const base: EdgeAnchorPair = {
+  from: { x: 10, y: 20 },
+  to: { x: 30, y: 40 },
+  fromSide: 'right',
+  toSide: 'left',
+  fromLaneDepth: 20,
+  toLaneDepth: 20,
+}
+
+describe('routeCacheKey — complete over everything routeEdge reads', () => {
+  it('equal anchors key equally, whatever the object identity', () => {
+    expect(routeCacheKey(edge, { ...base, from: { ...base.from! }, to: { ...base.to! } })).toBe(
+      routeCacheKey(edge, base),
+    )
+  })
+
+  it('a different edge keys differently even with identical anchors', () => {
+    expect(routeCacheKey({ ...edge, id: 'e2' }, base)).not.toBe(routeCacheKey(edge, base))
+  })
+
+  it.each([
+    ['from.x', { ...base, from: { x: 11, y: 20 } }],
+    ['from.y', { ...base, from: { x: 10, y: 21 } }],
+    ['to.x', { ...base, to: { x: 31, y: 40 } }],
+    ['to.y', { ...base, to: { x: 30, y: 41 } }],
+    ['fromSide', { ...base, fromSide: 'top' as const }],
+    ['toSide', { ...base, toSide: 'bottom' as const }],
+    ['fromLaneDepth', { ...base, fromLaneDepth: 21 }],
+    ['toLaneDepth', { ...base, toLaneDepth: 21 }],
+  ])('changing %s changes the key', (_field, changed) => {
+    expect(routeCacheKey(edge, changed)).not.toBe(routeCacheKey(edge, base))
+  })
+
+  it('an absent anchor pair keys distinctly from any present one', () => {
+    expect(routeCacheKey(edge, undefined)).not.toBe(routeCacheKey(edge, base))
+  })
+})

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -859,18 +859,19 @@ function optimizeSideChoices(
   // measured at 60 nodes / 200 edges, 296 of 854 routings were repeats of an
   // identical call, one combination recurring nine times.
   //
-  // The caller supplies the cache, so it spans every region and BOTH runs of
-  // one `assignEdgeAnchors` rather than one search: measured on a 288-node /
-  // 345-edge clustered canvas, 1021 of 1900 routings repeated a key already
-  // seen in that layout while a per-search cache caught only 567 of them.
-  // Sound because everything the key omits is fixed for the whole layout —
+  // The caller supplies the cache, so it spans BOTH runs of a region rather
+  // than one search. That pairing is where the repeats are: measured on a
+  // 288-node / 345-edge clustered canvas, 1021 of 1900 routings repeated a
+  // key already seen by the other run of their own region, while a
+  // per-search cache caught only 567 of them.
+  // Sound because everything the key omits is fixed across those two runs —
   // `nodes` and `style` are passed down unchanged, an edge is the SAME
-  // object in every region, and its obstacle list is derived from those
-  // two. What is left is the anchor pair, and `routeCacheKey` covers it
-  // field by field (`route-cache-key.test.ts` pins that, one case per
-  // field, because a field the key misses is a wrong path rather than a
-  // slow one). A cache never outlives its `assignEdgeAnchors` call, so a
-  // later layout of a moved canvas cannot see a stale path.
+  // object in both, and its obstacle list is derived from those two. What
+  // is left is the anchor pair, and `routeCacheKey` covers it field by
+  // field (`route-cache-key.test.ts` pins that, one case per field, because
+  // a field the key misses is a wrong path rather than a slow one). A cache
+  // never outlives its region, so a later layout of a moved canvas cannot
+  // see a stale path.
   const cache = routeCache ?? new Map<string, readonly Point[]>()
   const routeCached = (
     edge: CanvasEdge,
@@ -1302,14 +1303,19 @@ function optimizeAcrossRegions(
   locked?: ReadonlySet<string>,
   pins?: ReadonlyMap<string, EdgeAnchorOverride>,
 ): ReadonlyMap<string, SidePair> {
-  // One cache for the whole layout: regions partition the same edge list and
-  // every run is handed the same `nodes` and `style`, so a path routed for
-  // one region's search is the path any other would compute.
-  const routeCache = new Map<string, readonly Point[]>()
   const bothRuns = (
     regionEdges: readonly CanvasEdge[],
     seed: ReadonlyMap<string, SidePair>,
   ): ReadonlyMap<string, SidePair> => {
+    // One cache per region, shared by its unaligned and aligned runs — the
+    // pairing the per-search cache could not see. NOT one cache for the whole
+    // layout: regions partition the edge list, so an edge is routed in
+    // exactly one of them, and `routeCacheKey` starts with `edge.id` — a
+    // later region cannot hit an earlier region's entry. Measured 0
+    // cross-region hits on canvases of one, two and four regions. A
+    // layout-wide map would therefore buy nothing and hold every completed
+    // region's paths until the layout finished.
+    const routeCache = new Map<string, readonly Point[]>()
     const unaligned = optimizeSideChoices(
       nodes,
       regionEdges,

--- a/packages/canvas-render/src/layout/spatial-edges.ts
+++ b/packages/canvas-render/src/layout/spatial-edges.ts
@@ -787,6 +787,15 @@ const FULL_OPT_MAX_EDGES = 40
 const TRIAL_BUDGET_EDGES = 16
 
 /**
+ * The route cache's key: an edge plus every field of the anchor pair that
+ * `routeEdge` reads. Exported so the completeness of that list is pinned by
+ * a test rather than by a reader remembering to check it.
+ */
+export function routeCacheKey(edge: CanvasEdge, a: EdgeAnchorPair | undefined): string {
+  return `${edge.id}|${a?.fromSide}|${a?.toSide}|${a?.from?.x},${a?.from?.y}|${a?.to?.x},${a?.to?.y}|${a?.fromLaneDepth}|${a?.toLaneDepth}`
+}
+
+/**
  * Bounded global improvement over per-edge side choices: iterate edges in
  * document order; adopt an alternative ranked pair only when the WHOLE
  * configuration's cost strictly decreases (lexicographic integer compare —
@@ -819,6 +828,10 @@ function optimizeSideChoices(
   // equilibrium can oscillate.
   align = false,
   pins?: ReadonlyMap<string, EdgeAnchorOverride>,
+  // Routed paths shared across every search in one `assignEdgeAnchors`; see
+  // the comment on `routeCached` for why one layout may share one cache.
+  // Omitted, this search keeps a cache of its own.
+  routeCache?: Map<string, readonly Point[]>,
 ): ReadonlyMap<string, SidePair> {
   const byId = new Map(nodes.map((n) => [n.id, n]))
   const othersFor = edges.map((e) =>
@@ -844,23 +857,31 @@ function optimizeSideChoices(
   // ONE edge, but that recomputes the anchor groups it leaves and joins, so
   // the same (edge, anchor) combination comes back around repeatedly:
   // measured at 60 nodes / 200 edges, 296 of 854 routings were repeats of an
-  // identical call, one combination recurring nine times. `nodes` and
-  // `style` are fixed for the whole call, so they are not part of the key —
-  // and the cache lives only as long as this call, so a later layout of a
-  // moved canvas never sees a stale path.
-  const routeCache = new Map<string, readonly Point[]>()
-  const anchorKey = (edge: CanvasEdge, a: EdgeAnchorPair | undefined) =>
-    `${edge.id}|${a?.fromSide}|${a?.toSide}|${a?.from?.x},${a?.from?.y}|${a?.to?.x},${a?.to?.y}|${a?.fromLaneDepth}|${a?.toLaneDepth}`
+  // identical call, one combination recurring nine times.
+  //
+  // The caller supplies the cache, so it spans every region and BOTH runs of
+  // one `assignEdgeAnchors` rather than one search: measured on a 288-node /
+  // 345-edge clustered canvas, 1021 of 1900 routings repeated a key already
+  // seen in that layout while a per-search cache caught only 567 of them.
+  // Sound because everything the key omits is fixed for the whole layout —
+  // `nodes` and `style` are passed down unchanged, an edge is the SAME
+  // object in every region, and its obstacle list is derived from those
+  // two. What is left is the anchor pair, and `routeCacheKey` covers it
+  // field by field (`route-cache-key.test.ts` pins that, one case per
+  // field, because a field the key misses is a wrong path rather than a
+  // slow one). A cache never outlives its `assignEdgeAnchors` call, so a
+  // later layout of a moved canvas cannot see a stale path.
+  const cache = routeCache ?? new Map<string, readonly Point[]>()
   const routeCached = (
     edge: CanvasEdge,
     i: number,
     a: EdgeAnchorPair | undefined,
   ): readonly Point[] => {
-    const key = anchorKey(edge, a)
-    const hit = routeCache.get(key)
+    const key = routeCacheKey(edge, a)
+    const hit = cache.get(key)
     if (hit !== undefined) return hit
     const path = routeEdge(nodes, edge, style, a, othersFor[i]).path
-    routeCache.set(key, path)
+    cache.set(key, path)
     return path
   }
 
@@ -1281,12 +1302,25 @@ function optimizeAcrossRegions(
   locked?: ReadonlySet<string>,
   pins?: ReadonlyMap<string, EdgeAnchorOverride>,
 ): ReadonlyMap<string, SidePair> {
+  // One cache for the whole layout: regions partition the same edge list and
+  // every run is handed the same `nodes` and `style`, so a path routed for
+  // one region's search is the path any other would compute.
+  const routeCache = new Map<string, readonly Point[]>()
   const bothRuns = (
     regionEdges: readonly CanvasEdge[],
     seed: ReadonlyMap<string, SidePair>,
   ): ReadonlyMap<string, SidePair> => {
-    const unaligned = optimizeSideChoices(nodes, regionEdges, style, seed, locked)
-    return optimizeSideChoices(nodes, regionEdges, style, unaligned, locked, true, pins)
+    const unaligned = optimizeSideChoices(
+      nodes,
+      regionEdges,
+      style,
+      seed,
+      locked,
+      false,
+      undefined,
+      routeCache,
+    )
+    return optimizeSideChoices(nodes, regionEdges, style, unaligned, locked, true, pins, routeCache)
   }
 
   if (edges.length <= CROSSING_OPT_MAX_EDGES) return bothRuns(edges, initial)


### PR DESCRIPTION
## Summary

Decision #10's CPU worklist is finished, so this starts from a fresh profile rather than from the list — and the profile no longer points where the list did.

- **`581649b` + `2f621be`** — the routed-path cache was created inside `optimizeSideChoices`, so it never spanned the two runs (unaligned search, then aligned repair) that a region makes. It is owned by the region now. Measured on a 288-node / 345-edge clustered canvas, **1021 of 1900 routings repeat a key the other run of their own region already saw; the per-search caches caught 567**.
- **`7f0e822` + `2f621be`** — records the new profile, the prototype that was measured and rejected, and two method notes that each cost a wrong conclusion before being caught.

## The profile moved off the list

After all four named costs landed, on the **345-edge clustered** canvas — the size an AI-authored document reaches — `routeEdge` is **60%** of layout, and its fallback chain is nearly all of it:

| | share of layout |
|---|---|
| `routeOnGrid` | **26.9%** |
| `bestCandidate` | 8.3% |
| detour `region` union | 5.2% |
| obstacle prep (filter + inflate) | 11.1% |

The elbow shortcut the code is written around as the common case is taken on only **292 of 1215** routings there; the grid search runs on **719**. On the 200-edge grid canvas none of this shows — routing is 13%, pair scoring 22%. **The two bench shapes now disagree about where the time is**, which is worth stating: a change judged on one of them has not been judged.

## Why sharing across the two runs is sound

`bothRuns` hands both searches the same `nodes` and the same `style`, and an edge is the same object in each, so its obstacle list is derived from those two. The anchor pair is the only thing left that varies.

So the whole correctness argument is *the key covers the anchor pair completely* — and that is pinned rather than argued. `route-cache-key.test.ts` asserts one case per field, because a field the key misses is not a slow path: it collapses two different routes onto one entry and the search scores geometry it never drew.

## Results

Interleaved pairs against `origin/main`, alternating, min of 7 runs each, **in both orders**:

| | scoped-first | main-first |
|---|---|---|
| clustered 288n/345e | 497/530/488 → vs 573/603/565ms | 479/478/481 vs 591/588/608ms |
| dense grid 60n/200e | within noise | within noise |

**Six of six comparisons favour the change, 15–19%.** Dense sits at the region gate and is one region, so it gets the same cross-run sharing — its aligned anchors simply key differently more often, and the opportunity is smaller.

## Two method notes, each from a wrong conclusion caught

**Order is a variable.** The first interleaved run said the grid canvas regressed 3–4% *consistently, in all three rounds*. Flipping the order said neutral. Whichever variant runs first in a round carries that round's warm-up, and three rounds of a fixed order reproduce the artifact rather than test it.

**Soundness is not usefulness.** This shipped one scope too wide — a cache owned by `assignEdgeAnchors`. It measured *identically*, so nothing flagged it. Regions partition the edge list, so an edge is routed in exactly one of them, and `routeCacheKey` starts with `edge.id`: a later region can never hit an earlier one's entry. Tagging each entry with its creating search and attributing every hit gives **0 cross-region hits** on canvases of one, two and four regions. The wider map bought nothing and held every completed region's paths until the layout finished. Caught by CodeRabbit; verified before acting on it, and fixed in `2f621be`.

The gap was specific: I checked whether the searches *may* share a cache and never whether they ever *have* anything to share. Both notes are in decision #10.

## One change measured and rejected

`routeEdge` rebuilds two 286-element arrays per call — the endpoint-containment filter and the margin-inflated copy — 1333 times per clustered layout, and **only 421 of those filters drop anything**. Memoizing the inflated array and returning the shared one untouched when nothing is dropped is the obvious fix. Measured: clustered 494/502/491 against 508/470/485ms with rounds disagreeing in sign, grid slightly worse in all three. Reverted.

The 11% the phase profile attributes to those two lines is the **scan**, not the allocation: 1333 calls × 286 rects × two `containsPoint` tests is 760k tests, and the prototype keeps every one of them. Nothing there gets cheaper without cutting the obstacle set down spatially, which changes *what* is tested rather than how fast. Recorded so it is not retried on the same reasoning.

## Test plan

- [x] New test — `route-cache-key.test.ts`, one case per anchor field plus edge identity and the absent-anchor case
- [x] `pnpm test --project canvas-render-node`: 897 passed / 91 files, **routing scoreboard pins unchanged** (the executable statement that this is behaviour-preserving)
- [x] `pnpm -r typecheck`, `biome ci` (exit 0), `pnpm knip` — clean
- [x] `pnpm test --project mcp-node`: 3668 passed; the 4 failures are the known root-container EACCES set (a root user can read `chmod 000` fixtures), all in migration/prepare fixtures, none in canvas-render
- [x] **Mutation check.** Dropping `fromLaneDepth`, `to.y` or `toSide` from the key each turns exactly one case red — the guard is precise, not merely present
- [ ] Manual verification in the running editor — not applicable: nothing user-visible changes, and "unchanged" is what the scoreboard asserts

## Visual evidence

None: the scoreboard's exact pins are the evidence. A change that moved a pixel would have moved a number.

## Notes for the reviewer

- `optimizeSideChoices` is up to eight positional parameters now. It is module-private and the additions follow the existing shape, but if it grows again it wants an options object.
- Cache retention is now bounded by a region rather than by the layout — ~880 entries at most on the 345-edge canvas, released when the region finishes.
- `routeCacheKey` is exported only so the test can reach it; it is not in the package's public `index.ts`.
- The next target is `routeOnGrid` at 27%, which is a larger piece of work than anything in this PR and is not started.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated — decision #10 is updated in the same increment as the work it describes
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kn5gTK3WGQcNrahPppzvHg