### PR TITLE
perf(canvas-render): search the route grid with A*, and pin its optimality against an independent Dijkstra

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -578,6 +578,48 @@ paths:
       carries that round's warm-up, and three rounds of a fixed order
       reproduce the artifact rather than test it. Alternate the order, not
       only the variant.
+      **`routeOnGrid` searches with A*, and finding that out took refuting the
+      obvious answer first.** The profile pointed at it (27% of layout on the
+      clustered canvas), and the plan was to cut the obstacle SET down
+      spatially, as the rejected prototype's post-mortem above suggested.
+      Measured inside the function, that was already done: its window filter
+      keeps 31 of 287 rects, and costs 0.3% of layout to do it. The time was
+      the search itself — 161k heap pops per layout, 331 per call over grids
+      averaging 422 cells — expanding the grid blind because the priority was
+      `g` alone. A Manhattan heuristic makes it A*: admissible (a step costs
+      its own Manhattan length plus a non-negative bend charge) and consistent
+      (the same inequality edge by edge), so the first pop of the goal stays
+      optimal. Worth 8-11% on the clustered canvas, five of five interleaved
+      comparisons in both orders; neutral on the grid canvas.
+      It is NOT free, and the price is a kind worth recognising. A* is fast
+      precisely because it does not expand the states a blind search does, so
+      among EQUAL-cost shortest paths it settles on a different member. Over
+      7419 generated cases the two never disagreed about what an optimal route
+      costs — never worse, never better — and disagreed about which one to
+      draw in 10-30% of them. On the 345-edge canvas exactly 2 of 345 edges
+      then settled on different sides, which is what moved that scoreboard's
+      violations 99 -> 100 and interior ink by 1.1%; the corpus-wide debt
+      metrics did not move at all.
+      That cost cannot be bought back inside the router, and the reason is
+      structural rather than a tuning failure: `routeOnGrid` is handed every
+      obstacle including the edge's own endpoints and avoids all their
+      interiors, so its path can never BE a violation — the difference arrives
+      through the side-choice search, which a per-edge routing cost cannot see.
+      Two attempts confirmed it: a lower-g heap tie-break (paths differing 394
+      -> 408, i.e. worse) and a canonical predecessor on equal-cost relaxations
+      (394 -> 363, i.e. barely moved). The second failure is the instructive
+      one — canonicalising among the alternatives requires having LOOKED at
+      them, which is the exact work A* skips.
+      The guard for all of this is `grid-route.optimality.properties.test.ts`,
+      an independent-oracle property: a plain Dijkstra written in the test from
+      the definition, asserting equal COST (never equal path — equal-cost
+      routes are the norm on a lattice). It exists because an inadmissible
+      heuristic fails silently: it returns a merely-good path, and every debt
+      metric the scoreboard pins stays put because a slightly-long detour still
+      avoids every body. Mutation-checked twice, and the second mutation is not
+      hypothetical — accumulating the successor's `g` from the popped `f` was
+      written during this change and caught by reading the push site, not by a
+      test. The property catches it now.
     - **Facet-driven rendering rides the injected-resolver pattern.**
       Shipped as the `facets` field of `ResolvedReference`
       (`layout/spatial-canvas.ts`) — synchronous, optional, caller-supplied,

--- a/packages/canvas-render/src/layout/edge-routing-quality.test.ts
+++ b/packages/canvas-render/src/layout/edge-routing-quality.test.ts
@@ -179,9 +179,9 @@ describe('routing quality across the synthetic corpus', () => {
       violations: { 'own-endpoint': 12, foreign: 15, degenerate: 0 },
       interiorInk: 2083,
       borderInk: 824,
-      bends: 8149,
-      crossings: 493,
-      length: 1340729,
+      bends: 8152,
+      crossings: 494,
+      length: 1341164,
       shortArrowRunway: 136,
     })
   })
@@ -197,6 +197,20 @@ describe('routing quality across the synthetic corpus', () => {
 // Pinned exactly, like the aggregate above, and for the same reason: this
 // is a debt figure whose target is lower, and an improvement has to be as
 // loud as a regression.
+//
+// One movement in these numbers is NOT a routing change and is worth knowing
+// before chasing it: `routeOnGrid` searches with A*, which expands fewer
+// states than the Dijkstra it replaced and therefore settles on a different
+// member of the set of EQUAL-cost shortest paths. Measured over 7419
+// generated cases the two never disagreed about what an optimal route costs
+// and disagreed about which one to draw in 10-30% of them, and on this canvas
+// exactly 2 of 345 edges then settled on different sides. That is what moved
+// violations 99 -> 100 and interior ink 11451 -> 11578 here. The grid search
+// avoids every obstacle interior including the edge's own endpoints, so its
+// path cannot itself be a violation — the difference arrives through the
+// side-choice search, which no per-edge routing cost can see or target. Two
+// attempts to recover it (a lower-g heap tie-break, then a canonical
+// predecessor) were measured and neither moved it.
 describe('routing quality past the side-choice optimizer gate', () => {
   it('reports the drawing cost of a large clustered canvas', () => {
     const layout = clusteredLayout({ clusters: 24, nodesPerCluster: 12, edgesPerCluster: 16 })
@@ -223,12 +237,12 @@ describe('routing quality past the side-choice optimizer gate', () => {
       length: Math.round(length),
     }).toEqual({
       edges: 345,
-      violations: 99,
-      interiorInk: 11451,
+      violations: 100,
+      interiorInk: 11578,
       borderInk: 266,
-      bends: 756,
-      crossings: 848,
-      length: 275548,
+      bends: 760,
+      crossings: 855,
+      length: 275766,
     })
   }, 120_000)
 })

--- a/packages/canvas-render/src/layout/grid-route.optimality.properties.test.ts
+++ b/packages/canvas-render/src/layout/grid-route.optimality.properties.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { routeOnGrid } from './grid-route.js'
+
+/**
+ * `routeOnGrid` searches the Hanan grid with A*, so its speed comes precisely
+ * from NOT expanding states a plain Dijkstra would. That is sound only while
+ * the heuristic stays admissible — and an inadmissible one does not throw or
+ * return nothing, it quietly returns a path that is merely good. The routing
+ * scoreboard cannot catch that either: a slightly-long detour still avoids
+ * every body, so every debt metric it pins stays put.
+ *
+ * So the guard is an independent oracle. This test carries its own plain
+ * Dijkstra over the same grid and the same cost model, written from the
+ * definition rather than shared with the implementation, and asserts the two
+ * agree on COST. Not on the path: equal-cost routes are common on a lattice
+ * and which one a search finds is an artifact of its exploration order — the
+ * measured reason A* and Dijkstra disagree on ~10-30% of paths while never
+ * disagreeing on what an optimal route costs.
+ */
+
+const BEND_COST_PX = 80
+const CLEARANCE = 16
+
+type Rect = { x: number; y: number; w: number; h: number }
+type Point = { x: number; y: number }
+
+/**
+ * The reference: Dijkstra over the same Hanan grid, no heuristic, written
+ * straight from "cheapest rectilinear path whose interior avoids every rect".
+ * Deliberately naive — an O(V^2) scan for the minimum instead of a heap — so
+ * it shares no machinery with the thing it is checking.
+ */
+function referenceCost(
+  start: Point,
+  end: Point,
+  obstacles: readonly Rect[],
+  clearance: number,
+  windowPx: number,
+): number | undefined {
+  const minX = Math.min(start.x, end.x) - windowPx
+  const maxX = Math.max(start.x, end.x) + windowPx
+  const minY = Math.min(start.y, end.y) - windowPx
+  const maxY = Math.max(start.y, end.y) + windowPx
+  const near = obstacles.filter(
+    (r) =>
+      r.x - clearance <= maxX &&
+      r.x + r.w + clearance >= minX &&
+      r.y - clearance <= maxY &&
+      r.y + r.h + clearance >= minY,
+  )
+  const xSet = new Set<number>([start.x, end.x])
+  const ySet = new Set<number>([start.y, end.y])
+  for (const r of near) {
+    for (const x of [r.x - clearance, r.x + r.w + clearance])
+      if (x >= minX && x <= maxX) xSet.add(x)
+    for (const y of [r.y - clearance, r.y + r.h + clearance])
+      if (y >= minY && y <= maxY) ySet.add(y)
+  }
+  const xs = [...xSet].sort((a, b) => a - b)
+  const ys = [...ySet].sort((a, b) => a - b)
+  const si = xs.indexOf(start.x)
+  const sj = ys.indexOf(start.y)
+  const ei = xs.indexOf(end.x)
+  const ej = ys.indexOf(end.y)
+  if (si < 0 || sj < 0 || ei < 0 || ej < 0) return undefined
+
+  const stateOf = (i: number, j: number, axis: number) => (j * xs.length + i) * 2 + axis
+  const best = new Map<number, number>()
+  const done = new Set<number>()
+  for (const axis of [0, 1]) best.set(stateOf(si, sj, axis), 0)
+
+  for (;;) {
+    let cur = -1
+    let curCost = Number.POSITIVE_INFINITY
+    for (const [state, cost] of best) {
+      if (done.has(state)) continue
+      if (cost < curCost) {
+        curCost = cost
+        cur = state
+      }
+    }
+    if (cur < 0) break
+    done.add(cur)
+    const axis = cur % 2
+    const cell = (cur - axis) / 2
+    const i = cell % xs.length
+    const j = (cell - i) / xs.length
+    if (i === ei && j === ej) return curCost
+    for (const [di, dj, nextAxis] of [
+      [1, 0, 0],
+      [-1, 0, 0],
+      [0, 1, 1],
+      [0, -1, 1],
+    ] as const) {
+      const ni = i + di
+      const nj = j + dj
+      if (ni < 0 || nj < 0 || ni >= xs.length || nj >= ys.length) continue
+      const horizontal = dj === 0
+      const from = (horizontal ? xs[i] : ys[j]) as number
+      const to = (horizontal ? xs[ni] : ys[nj]) as number
+      const lo = Math.min(from, to)
+      const hi = Math.max(from, to)
+      const line = (horizontal ? ys[j] : xs[i]) as number
+      const lowOf = (r: Rect) => (horizontal ? r.y : r.x)
+      const sizeOf = (r: Rect) => (horizontal ? r.h : r.w)
+      const acrossLow = (r: Rect) => (horizontal ? r.x : r.y)
+      const acrossSize = (r: Rect) => (horizontal ? r.w : r.h)
+      // Clearance shapes the GRID COORDINATES and nothing else: blocking and
+      // border-tracing are both judged against the rect's raw bounds, because
+      // a route riding the offset line is already at the intended distance.
+      // Applying clearance twice is the obvious way to write this reference
+      // wrong, and it reports the implementation as broken rather than itself.
+      if (
+        near.some(
+          (r) =>
+            line > lowOf(r) &&
+            line < lowOf(r) + sizeOf(r) &&
+            lo < acrossLow(r) + acrossSize(r) &&
+            hi > acrossLow(r),
+        )
+      ) {
+        continue
+      }
+      let traced = 0
+      for (const r of near) {
+        if (line !== lowOf(r) && line !== lowOf(r) + sizeOf(r)) continue
+        const overlapLo = Math.max(lo, acrossLow(r))
+        const overlapHi = Math.min(hi, acrossLow(r) + acrossSize(r))
+        if (overlapHi > overlapLo) traced += overlapHi - overlapLo
+      }
+      const turn = (axis === 0) === (nextAxis === 0) ? 0 : BEND_COST_PX
+      const next = curCost + (hi - lo) + turn + traced
+      const nextState = stateOf(ni, nj, nextAxis)
+      if (next < (best.get(nextState) ?? Number.POSITIVE_INFINITY)) best.set(nextState, next)
+    }
+  }
+  return undefined
+}
+
+/** The router's own cost of a returned path, measured from the path alone. */
+function pathCost(path: readonly Point[], obstacles: readonly Rect[]): number {
+  let cost = 0
+  for (let i = 1; i < path.length; i++) {
+    const a = path[i - 1] as Point
+    const b = path[i] as Point
+    const horizontal = a.y === b.y
+    const lo = horizontal ? Math.min(a.x, b.x) : Math.min(a.y, b.y)
+    const hi = horizontal ? Math.max(a.x, b.x) : Math.max(a.y, b.y)
+    const line = horizontal ? a.y : a.x
+    cost += hi - lo
+    for (const r of obstacles) {
+      const lowOf = horizontal ? r.y : r.x
+      const sizeOf = horizontal ? r.h : r.w
+      if (line !== lowOf && line !== lowOf + sizeOf) continue
+      const acrossLow = horizontal ? r.x : r.y
+      const acrossSize = horizontal ? r.w : r.h
+      const overlapLo = Math.max(lo, acrossLow)
+      const overlapHi = Math.min(hi, acrossLow + acrossSize)
+      if (overlapHi > overlapLo) cost += overlapHi - overlapLo
+    }
+  }
+  // A collapsed path reports the bends its own turns imply.
+  for (let i = 2; i < path.length; i++) {
+    const a = path[i - 2] as Point
+    const b = path[i - 1] as Point
+    const c = path[i] as Point
+    if ((a.y === b.y) !== (b.y === c.y)) cost += BEND_COST_PX
+  }
+  return cost
+}
+
+// A LATTICE, not scattered rectangles: identical boxes on a regular pitch is
+// what makes equal-cost alternatives common, and a generator too sparse to
+// reach them would pass while proving nothing about the case that matters.
+const lattice = fc
+  .record({
+    pitchX: fc.integer({ min: 180, max: 300 }),
+    pitchY: fc.integer({ min: 140, max: 220 }),
+    w: fc.integer({ min: 80, max: 160 }),
+    h: fc.integer({ min: 60, max: 120 }),
+    cols: fc.integer({ min: 2, max: 4 }),
+    rows: fc.integer({ min: 2, max: 4 }),
+    present: fc.array(fc.boolean(), { minLength: 16, maxLength: 16 }),
+    startCell: fc.integer({ min: 0, max: 15 }),
+    endCell: fc.integer({ min: 0, max: 15 }),
+    startSide: fc.integer({ min: 0, max: 3 }),
+    endSide: fc.integer({ min: 0, max: 3 }),
+  })
+  .map((c) => {
+    const obstacles: Rect[] = []
+    for (let i = 0; i < c.cols; i++) {
+      for (let j = 0; j < c.rows; j++) {
+        if (c.present[j * c.cols + i] === false) continue
+        obstacles.push({ x: i * c.pitchX, y: j * c.pitchY, w: c.w, h: c.h })
+      }
+    }
+    const anchor = (cellIndex: number, side: number): Point => {
+      const i = cellIndex % c.cols
+      const j = Math.floor(cellIndex / c.cols) % c.rows
+      const bx = i * c.pitchX
+      const by = j * c.pitchY
+      return side === 0
+        ? { x: bx + c.w / 2, y: by }
+        : side === 1
+          ? { x: bx + c.w, y: by + c.h / 2 }
+          : side === 2
+            ? { x: bx + c.w / 2, y: by + c.h }
+            : { x: bx, y: by + c.h / 2 }
+    }
+    return {
+      obstacles,
+      start: anchor(c.startCell, c.startSide),
+      end: anchor(c.endCell, c.endSide),
+    }
+  })
+  .filter(
+    ({ obstacles, start, end }) => obstacles.length > 0 && (start.x !== end.x || start.y !== end.y),
+  )
+
+describe('routeOnGrid is optimal, not merely good', () => {
+  fcTest.prop({ layout: lattice }, withDefaults({ numRuns: 150 }))(
+    'a returned path costs exactly what an independent Dijkstra says it should',
+    ({ layout }) => {
+      const path = routeOnGrid(layout.start, layout.end, layout.obstacles, CLEARANCE)
+      if (path === undefined) return
+      const reference = referenceCost(
+        layout.start,
+        layout.end,
+        layout.obstacles,
+        CLEARANCE,
+        // The implementation's own window; a reference searching a wider one
+        // could find routes it is not asking for.
+        160,
+      )
+      expect(reference).toBeDefined()
+      expect(pathCost(path, layout.obstacles)).toBeCloseTo(reference as number, 6)
+    },
+  )
+})

--- a/packages/canvas-render/src/layout/grid-route.ts
+++ b/packages/canvas-render/src/layout/grid-route.ts
@@ -109,6 +109,20 @@ export function routeOnGrid(
   const ej = ys.indexOf(end.y)
   if (si < 0 || sj < 0 || ei < 0 || ej < 0) return undefined
 
+  // A* rather than Dijkstra: the priority is `g + h` with `h` the Manhattan
+  // distance to the goal. That is ADMISSIBLE (a step's cost is its own
+  // Manhattan length plus a non-negative bend charge, so no remaining route
+  // is ever cheaper than the straight-line remainder) and CONSISTENT (the
+  // same inequality applies edge by edge), which is what makes the first pop
+  // of the goal optimal — the guarantee plain Dijkstra was relying on, kept.
+  // Worth doing because this search is the expensive part of routing and it
+  // was expanding the grid blind: measured 161k pops per layout on a
+  // 345-edge clustered canvas, 331 per call over grids averaging 422 cells.
+  const goalX = xs[ei] as number
+  const goalY = ys[ej] as number
+  const heuristic = (i: number, j: number) =>
+    Math.abs((xs[i] as number) - goalX) + Math.abs((ys[j] as number) - goalY)
+
   const width = xs.length
   // Two states per cell — arrived horizontally or vertically — so a turn can
   // be charged. Collapsing them would make the first arrival win regardless
@@ -166,7 +180,7 @@ export function routeOnGrid(
 
   for (const axis of [0, 1] as const) {
     best[stateOf(si, sj, axis)] = 0
-    push(0, stateOf(si, sj, axis))
+    push(heuristic(si, sj), stateOf(si, sj, axis))
   }
 
   const steps: readonly (readonly [number, number, Axis])[] = [
@@ -207,11 +221,13 @@ export function routeOnGrid(
   let goal: number | undefined
   while (heap.length > 0) {
     const { cost, state } = pop()
-    if ((best[state] as number) < cost) continue
     const axis = (state % 2) as Axis
     const cell = (state - axis) / 2
     const i = cell % width
     const j = (cell - i) / width
+    // `best` holds g while the heap is ordered by f, so the stale test adds
+    // the same `h` back rather than comparing the two spaces directly.
+    if ((best[state] as number) + heuristic(i, j) < cost) continue
     if (i === ei && j === ej) {
       goal = state
       break
@@ -250,12 +266,15 @@ export function routeOnGrid(
         const overlapHi = Math.min(hi, near0(rect) + size0(rect))
         if (overlapHi > overlapLo) traced += overlapHi - overlapLo
       }
-      const next = cost + (hi - lo) + turn + traced
+      // `cost` is the popped f, so the successor's g accumulates from
+      // `best[state]` — adding to f instead would charge the heuristic once
+      // per step and stop being a shortest-path search at all.
+      const next = (best[state] as number) + (hi - lo) + turn + traced
       const nextState = stateOf(ni, nj, nextAxis)
       if (next >= (best[nextState] as number)) continue
       best[nextState] = next
       cameFrom[nextState] = state
-      push(next, nextState)
+      push(next + heuristic(ni, nj), nextState)
     }
   }
   if (goal === undefined) return undefined


### PR DESCRIPTION
## Summary

`routeOnGrid` was 27% of layout on a 345-edge clustered canvas. It searches with A* now — **8–11%, five of five interleaved comparisons in both orders**.

The interesting part is that the obvious plan was wrong, and that the win is not free.

## The obvious plan was refuted before it was built

The prior PR's post-mortem pointed here: "nothing gets cheaper without cutting the obstacle set down spatially." Measured *inside* the function, that was already done — its window filter **keeps 31 of 287 rects and costs 0.3% of layout**.

The time was the search itself, expanding the grid blind because the priority was `g` alone:

| | measured per layout, 345-edge clustered |
|---|---|
| heap pops | **161,294** |
| pops per call | 331, over grids averaging 422 cells |
| `near` filter | 0.3% of layout |
| coord build + sort | 1.1% |
| obstacle bucketing | 0.8% |
| **Dijkstra loop** | **31.3%** |

A Manhattan heuristic makes it A*: **admissible** (a step costs its own Manhattan length plus a non-negative bend charge) and **consistent** (the same inequality edge by edge), so the first pop of the goal is still optimal.

## Results

Interleaved against `origin/main`, min of 7 runs each, both orders:

| | astar-first | main-first |
|---|---|---|
| clustered 288n/345e | 457/477/464 vs 514/517/519ms | 497/469 vs 516/516ms |
| dense grid 60n/200e | within noise | within noise |

## The price, stated plainly

A* is fast **precisely because** it does not expand the states a blind search does — so among *equal-cost* shortest paths it settles on a different member.

Over **7419 generated cases** (random rectangles, plus a lattice generator built to make ties common) the two searches **never disagreed about what an optimal route costs — never worse, never better** — and disagreed about *which one to draw* in 10–30%.

On the large clustered canvas exactly **4 of 345 edges** end up routed differently and **2 of those settle on different sides**. Net effect on that scoreboard:

| | before | after |
|---|---|---|
| violations | 99 | **100** |
| interiorInk | 11451 | 11578 (+1.1%) |
| crossings | 848 | 855 |
| **corpus-wide debt** (foreign 15 / own-endpoint 12 / degenerate 0, interiorInk, borderInk, shortArrowRunway) | — | **unchanged** |

Pins updated, with the reason recorded beside them rather than in a commit message nobody will find.

**That net is a redistribution, not a uniform degradation** — worth knowing before reading `+1 violation` as "A* routes worse". Measuring one of the four changed edges, `e237`:

| e237 | interior ink through a foreign body | length | bends |
|---|---|---|---|
| before (Dijkstra) | **111px**, through `c16n0` in two places | 863 | 3 |
| after (A*) | **0px** | 909 | 2 |

Here A* is strictly better on the debt metric and on bends, for 46px more length. Somewhere else the opposite happened, and the aggregate is +1.

## Why the net cost cannot be bought back in the router

Structural, not a tuning failure: `routeOnGrid` is handed every obstacle **including the edge's own endpoints** and avoids all their interiors, so its own path can never *be* a violation. The difference arrives through the **side-choice search**, which a per-edge routing cost cannot see or target.

Two attempts confirmed that rather than assuming it:

- a **lower-g heap tie-break** (mimicking Dijkstra's exploration order) → paths differ *more*: 394 → 408
- a **canonical predecessor** on equal-cost relaxations → barely moved: 394 → 363

The second failure is the instructive one: canonicalising among the alternatives requires having **looked** at them, which is exactly the work A* skips.

## The guard, and why it had to be an independent oracle

An inadmissible heuristic **fails silently**. It returns a merely-good path, and every debt metric the scoreboard pins stays put — because a slightly-long detour still avoids every body. Neither the scoreboard nor the existing 6 example tests would notice.

So `grid-route.optimality.properties.test.ts` carries **a plain Dijkstra written in the test from the definition**, sharing no machinery with the implementation, asserting equal **cost**. Never equal *path* — equal-cost routes are the norm on a lattice, and pinning the path would pin a tie-break rather than the property that matters.

The generator is a **lattice**, not scattered rectangles: identical boxes on a regular pitch is what makes equal-cost alternatives common, and a generator too sparse to reach them would pass while proving nothing.

**Mutation-checked twice**, and the second one is not hypothetical:

| mutation | result |
|---|---|
| heuristic × 2 (inadmissible) | ❌ red, counterexample shrunk to 1 obstacle |
| successor's `g` accumulated from the popped `f` | ❌ red, counterexample shrunk to 1 obstacle |

That second mutation is a bug I actually wrote during this change — `const next = cost + …` where `cost` is now `f` — and caught by reading the push site, not by a test. The property catches it now.

## Visual repro

A side-by-side of `e237`'s neighbourhood (red is `e237`, grey is the surrounding traffic) is rendered and attached in the working session: **before** descends through `c16n0`'s body, **after** clears it to the right. The numbers in the table above are that same figure measured rather than eyeballed — the geometry is rendered straight from `routeEdge`, no measurer and no glyphs involved, so the fake-measure/real-font trap does not apply.

It is not embedded here because this environment has no `gh` CLI and so cannot upload to `user-attachments`; the PNG is at `tmp/screenshots/figure.png` and has been handed to the author.

## Test plan

- [x] New property test with an independent-Dijkstra oracle, mutation-checked twice
- [x] `pnpm test --project canvas-render-node`: **898 passed / 92 files**
- [x] Scoreboard re-pinned with the reason documented at the pin site
- [x] `pnpm -r typecheck`, `biome ci` (exit 0), `pnpm knip` — clean
- [x] `pnpm test --project mcp-node`: 3668 passed; the 4 failures are the known root-container EACCES set, all in migration/prepare fixtures
- [x] Visual repro of a changed route, selected by the metric rather than by eye
- [ ] Manual verification in the running editor — not done. Routes on canvases that reach the fallback search do change, so this is the one change in the series where the scoreboard is not a complete substitute. Flagging rather than claiming.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — decision #10 records the refuted hypothesis, the trade, and both failed recovery attempts
- [x] No `console.*` added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kn5gTK3WGQcNrahPppzvHg