### PR TITLE
feat(web): Escape restores the name the title field held before the edit

### DIFF
--- a/apps/web/src/components/document-properties/DocumentProperties.test.tsx
+++ b/apps/web/src/components/document-properties/DocumentProperties.test.tsx
@@ -192,6 +192,36 @@ describe('DocumentProperties title typing (controlled-input round trip)', () => 
     expect(current).toBe('Release plan')
   })
 
+  // Escape can arrive in the SAME tick as the keystroke before it — a paste
+  // followed by Escape, or any driver that dispatches both without yielding.
+  // React batches across them, so the draft state the handler would read is
+  // still the previous render's. Reading it there decides "nothing changed"
+  // and leaves the abandoned name standing, which is the failure mode this
+  // pins: no await between the change and the Escape.
+  it('restores the previous name even when Escape lands in the same tick as the edit', () => {
+    let current = 'Release plan'
+    const onTitleChange = vi.fn((next: string) => {
+      current = next
+    })
+    const view = () => (
+      <DocumentProperties
+        {...titleProps({ title: current, onTitleChange })}
+        facets={meta()}
+        onFacetsChange={vi.fn()}
+      />
+    )
+    render(view())
+
+    const box = screen.getByRole('textbox', { name: /title/i })
+    fireEvent.focus(box)
+    // No rerender between the two: the component never sees the draft state
+    // land before the Escape handler runs.
+    fireEvent.change(box, { target: { value: 'Release pl' } })
+    fireEvent.keyDown(box, { key: 'Escape' })
+
+    expect(current).toBe('Release plan')
+  })
+
   // The spatial editor guards its own bindings with isTextEntryEvent, but a
   // Delete typed into the title must not reach a canvas selection by any
   // route — this field is always mounted, right beside the canvas.

--- a/apps/web/src/components/document-properties/DocumentProperties.tsx
+++ b/apps/web/src/components/document-properties/DocumentProperties.tsx
@@ -1,7 +1,7 @@
 import type { StoredCoreFacets } from '@kamiazya/whiteboard-model'
 import { Info, X } from 'lucide-react'
 import type { ReactNode } from 'react'
-import { useId, useState } from 'react'
+import { useId, useRef, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js'
 
 export interface DocumentPropertiesProps {
@@ -86,6 +86,11 @@ export function DocumentProperties({
   // it: the next character lands flush against the previous word, and
   // "Release plan" typed one key at a time arrives as "Releaseplan".
   const [draftTitle, setDraftTitle] = useState<string | null>(null)
+  // The name this field held when the current edit began. Every keystroke is
+  // already committed (there is no Save button), so Escape has nothing to
+  // discard — it has to put the previous name BACK. Without it, "type, change
+  // your mind, Escape" silently keeps the half-typed name.
+  const editBaselineRef = useRef(title)
   const suggestionsId = useId()
 
   return (
@@ -110,12 +115,28 @@ export function DocumentProperties({
             onTitleChange(event.target.value)
           }}
           readOnly={onTitleChange === undefined}
-          // The editor binds its shortcuts on its own root and guards them
-          // with isTextEntryEvent, so this is belt-and-braces rather than
-          // load-bearing — but a stray Delete reaching a canvas selection from
-          // the title box is the kind of defect nobody reports as a keyboard
-          // bug. Window-capture bindings (Cmd+S) are unaffected by this.
-          onKeyDown={(event) => event.stopPropagation()}
+          onFocus={() => {
+            editBaselineRef.current = title
+          }}
+          // stopPropagation is belt-and-braces: the editor binds its shortcuts
+          // on its own root and guards them with isTextEntryEvent, but a stray
+          // Delete reaching a canvas selection from the title box is the kind
+          // of defect nobody reports as a keyboard bug. Window-capture
+          // bindings (Cmd+S) are unaffected by it.
+          onKeyDown={(event) => {
+            event.stopPropagation()
+            if (event.key !== 'Escape' || onTitleChange === undefined) return
+            event.preventDefault()
+            setDraftTitle(null)
+            // Compared against what the BOX holds, never against `title`: the
+            // commit is async, so `title` can still be the old name here and a
+            // comparison to it would decide "nothing changed" while a rename
+            // to the typed value is already in flight.
+            if ((draftTitle ?? title) !== editBaselineRef.current) {
+              onTitleChange(editBaselineRef.current)
+            }
+            event.currentTarget.blur()
+          }}
           onKeyUp={(event) => event.stopPropagation()}
           // Dropping the draft is the whole tidy-up: the box falls back to the
           // canonical name, which is already trimmed.

--- a/apps/web/src/pages/BrowserLocalDocumentPage.rename.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.rename.browser.test.tsx
@@ -116,6 +116,27 @@ describe('BrowserLocalDocumentPage rename (real IndexedDB)', () => {
     }
   })
 
+  // The field commits per keystroke, so Escape puts the previous name back
+  // rather than discarding a draft. Real IndexedDB and real timing here: the
+  // failure this pins is the ABANDONED name landing after the restore, which
+  // an assertion that stops at the first match sails straight past.
+  it('Escape restores the previous name and the abandoned one never lands', async () => {
+    await renderLoaded()
+    const titleInput = await titleField()
+    titleInput.focus()
+    fireEvent.change(titleInput, { target: { value: 'Should not persist' } })
+    fireEvent.keyDown(titleInput, { key: 'Escape' })
+    await waitForTitle('untitled')
+
+    // Settle everything still in flight before believing the restore held.
+    await new Promise((resolve) => setTimeout(resolve, 400))
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('untitled')
+
+    cleanup()
+    render(<BrowserLocalDocumentPage store={new IdbDocumentIndex()} />)
+    await waitForTitle('untitled')
+  })
+
   it("whitespace-only commit persists 'untitled' and restores it on remount", async () => {
     await renderLoaded()
     // Commit a real name first so the remount assertion below can distinguish

--- a/apps/web/src/pages/BrowserLocalDocumentPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.test.tsx
@@ -640,6 +640,45 @@ describe('BrowserLocalDocumentPage', () => {
     expect((await store.load('069CFJNRVY147ADGKPSWZ258BE'))?.name).toBe('Renamed canvas')
   })
 
+  // The field commits per keystroke, so Escape cannot discard a draft — it has
+  // to put the previous name BACK. Two renames land in quick succession, and
+  // the one asked for LAST must be the one that survives: settling on the old
+  // name and then being overwritten by the half-typed one is the failure this
+  // pins, and it is invisible to an assertion that stops at the first match.
+  it('Escape restores the previous name, and the abandoned one does not land afterwards', async () => {
+    vi.useRealTimers()
+    const store = new LocalStoreDouble()
+    await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
+    await store.save(snap)
+    await act(async () => {
+      render(
+        <BrowserLocalDocumentPage
+          loro={store.loro}
+          store={store.index}
+          pointer={store.pointer}
+          clock={store.clock}
+        />,
+      )
+    })
+    const heading = () => screen.getByRole('heading', { level: 1 }).textContent
+
+    const titleInput = await screen.findByRole('textbox', { name: /^title$/i })
+    fireEvent.focus(titleInput)
+    fireEvent.change(titleInput, { target: { value: 'Half typed' } })
+    await waitFor(() => expect(heading()).toBe('Half typed'))
+
+    fireEvent.keyDown(titleInput, { key: 'Escape' })
+    await waitFor(() => expect(heading()).toBe('untitled'))
+
+    // Settle everything still in flight before believing it: the defect is a
+    // LATER write winning, which a first-match assertion sails straight past.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    })
+    expect(heading()).toBe('untitled')
+    expect((await store.load('069CFJNRVY147ADGKPSWZ258BE'))?.name).toBe('untitled')
+  })
+
   it('does not render an "Add rectangle" button — scene writes flow through SpatialEditor gestures', async () => {
     const store = new LocalStoreDouble()
     await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')

--- a/apps/web/src/pages/use-browser-local-document-controller.test.ts
+++ b/apps/web/src/pages/use-browser-local-document-controller.test.ts
@@ -625,6 +625,52 @@ describe('useBrowserLocalDocumentController', () => {
     expect(result.current.persistence.kind).toBe('saved')
   })
 
+  // Typing commits per keystroke, so "type, change your mind, put the old
+  // name back" is two renames in quick succession with the first one's write
+  // possibly still in flight. Whichever was asked for LAST has to be the one
+  // that survives, in the snapshot the header reads and in the store.
+  it('the later of two overlapping renames wins, in state and in the store', async () => {
+    const store = new LocalStoreDouble()
+    await store.setDefaultDocumentId(C1)
+    await store.save(snap)
+
+    // Hold the first write open so the second rename is issued while it is
+    // still in flight — the ordering this guards only exists then.
+    const realSet = store.index.setDocumentName.bind(store.index)
+    let releaseFirst!: () => void
+    const firstHeld = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    let calls = 0
+    store.index.setDocumentName = async (args) => {
+      calls += 1
+      if (calls === 1) await firstHeld
+      return realSet(args)
+    }
+
+    const { result } = renderHook(() =>
+      useBrowserLocalDocumentController(store.index, {
+        loro: store.loro,
+        pointer: store.pointer,
+        clock: store.clock,
+      }),
+    )
+    await act(async () => {})
+
+    await act(async () => {
+      void result.current.renameDocument('Half-typed name')
+      void result.current.renameDocument('Restored name')
+      releaseFirst()
+    })
+
+    expect(result.current.snapshot?.name).toBe('Restored name')
+    const stored = await store.index.resolveDocumentById({
+      workspaceId: LOCAL_WORKSPACE_ID,
+      documentId: C1,
+    })
+    expect(stored?.name).toBe('Restored name')
+  })
+
   // The shape change is only real if the controller MINTS the new fields.
   // Converting the fixtures made 44 tests compile again while asserting
   // nothing about workspace or path — both mutations below stayed green


### PR DESCRIPTION
## Summary

- The title field commits per keystroke, so **Escape has nothing to discard — it has to put the previous name BACK**. That capability lived on the retired pencil's input, whose Enter/blur commit meant Escape could simply drop a draft. It went with the pencil in #1004; this restores it on the field that replaced it.
- **Root-causes the failure that made me withdraw a first attempt.** The guard compared the field's content against the `title` **prop**, which lags — the commit is async, so when Escape arrives in the same tick as the keystroke before it, `title` is still the old name, the comparison decides "nothing changed", and the abandoned name stands. Comparing against what the **box** holds fixes it.
- Two things the earlier follow-up note asserted, now measured instead of assumed — **both were wrong**:
  - It does **not** need controller-level supersede support. `use-browser-local-document-controller` already resolves overlapping renames last-write-wins, in state *and* in the store, even with the first write held open mid-flight. That is now pinned by a test rather than left assumed either way.
  - The page layer is not implicated either: the same flow settles correctly in jsdom and in a real browser, including after everything in flight has drained and across a remount against real IndexedDB.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [x] `pnpm test` passes locally
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable

Four new tests, one per layer the diagnosis had to rule in or out:

| layer | test | what it pins |
|---|---|---|
| controller | `use-browser-local-document-controller.test.ts` | two overlapping renames, the first write held open — the later one wins in state and in the store |
| component | `DocumentProperties.test.tsx` | Escape restores the baseline, **and** does so when Escape lands in the same tick as the edit |
| page (jsdom) | `BrowserLocalDocumentPage.test.tsx` | the restore holds after everything in flight drains — the abandoned name must not land afterwards |
| page (browser) | `BrowserLocalDocumentPage.rename.browser.test.tsx` | same, against real IndexedDB, plus a remount |

**The same-tick test is the one that catches the bug.** The other Escape test rerenders between the two events and sails straight past it — which is exactly why the defect shipped the first time. Mutation-checked by restoring the `title` comparison: only the same-tick test turns red.

The jsdom and browser page tests deliberately do not stop at the first match. The failure mode is a **later** write winning, and an assertion that settles as soon as it sees the right value cannot see it — so both settle everything in flight and re-assert.

Results: `apps/web` jsdom+node **2644 passed / 9 failed** — the 9 are pre-existing thumbnail objectURL failures this machine reproduces on an unmodified tree. The full `web-browser` project was run **twice** (131 files, 748 tests, green both times): that is the layer where the original failure appeared, so a single isolated green would not have been evidence. `pnpm -r typecheck`, `pnpm knip` and `biome check` are clean.

## Visual evidence

No pixels move. The change is behavioural: pressing Escape while editing the document title now writes the pre-edit name back instead of leaving the half-typed one committed.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_