### PR TITLE
refactor(web): move the connection chip from the document header into the app shell

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -46,8 +46,8 @@ one it is not in yet, `spinner` that same ring while the doing is in flight.
   named set, and each member says what QUESTION it answers — two carriers
   that look alike but answer differently is the defect this naming exists to
   prevent:
-  - **connection chip** (`ConnectionStatus`) — is this document reaching its
-    backend? Filled dot.
+  - **connection chip** (`ConnectionStatus`) — is this browser reaching its
+    backend? Filled dot. It lives in the AppShell, not in a page.
   - **save-state chip** (`SaveStatusChip`) — did the last write to this
     browser's storage land? Filled dot. Browser-local only; on a daemon the
     connection chip is what answers "is my work safe", and a second dot
@@ -61,13 +61,25 @@ one it is not in yet, `spinner` that same ring while the doing is in flight.
 
   Anything else stateful in chrome needs this list amended first, and takes
   its paint from `StateDot` rather than a fresh literal.
-- **The AppShell owns brand and settings.** Every page mounts `AppShell`
-  (brand mark = home, the ALPHA honesty chip, the settings gear + attention
-  dot) and never renders its own brand or settings chrome. Context and
-  tools stay in the page's own surface, always visible — collapsing them
-  into menus is a narrow-viewport last resort, not a desktop pattern.
-  Where BRAND.md (identity, motion) and this file (app chrome) disagree
-  about chrome, this file wins and the exception gets documented here.
+- **The AppShell owns brand, connection and settings.** Every page mounts
+  `AppShell` (brand mark = home, the ALPHA honesty chip, the connection chip,
+  the settings gear + attention dot) and never renders its own brand,
+  connection or settings chrome. Context and tools stay in the page's own
+  surface, always visible — collapsing them into menus is a narrow-viewport
+  last resort, not a desktop pattern. Where BRAND.md (identity, motion) and
+  this file (app chrome) disagree about chrome, this file wins and the
+  exception gets documented here.
+- **What belongs in the shell is what does not change when you open a
+  different document.** Which daemon this browser talks to is one such fact,
+  so the connection chip is the shell's; the document's own title, actions
+  and history are the page's. The dividing question is not importance, it is
+  whether the answer survives navigation.
+- **The shell states a connection only while a page holds one.** Pages report
+  through `lib/shell-status-store`, and `null` — an index or settings page —
+  draws no chip at all. A daemon index page does talk to the daemon over
+  HTTP but runs no document sync, so neither "Synced" nor "Reconnecting" is
+  true there, and a chip that stayed behind from the last document would say
+  one of them anyway. Clear on unmount; never latch.
 - **Buttons**: use `components/ui/button.tsx` variants
   (`default`/`outline`/`ghost`/`destructive`, sizes `sm`/`icon`) instead of
   hand-rolled `rounded-md border px-*` buttons. Icon-only buttons MUST have

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { App, LazyPageFallback } from './App.js'
 import { errorBoundaryLog } from './components/ErrorBoundary.js'
 import type { DaemonConnectionResult } from './hooks/useDaemonConnection.js'
-import { resetShellStatusForTests, setShellDaemonAuthError } from './lib/shell-status-store.js'
+import { resetShellStatusForTests, setShellConnection } from './lib/shell-status-store.js'
 // App reaches every page through React.lazy(), so a page renders only once its
 // dynamic import resolves — and under a full-suite run that resolution can
 // outlast the 1000ms retry budget of the `findBy*` query waiting on it. The
@@ -30,7 +30,13 @@ import {
 } from './lib/provider.js'
 import { createUserSettingsStore, STORAGE_KEY } from './lib/user-settings-store.js'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  // File-wide: several tests publish a shell connection to drive the chip,
+  // and a leftover sync-off lights the settings nudge for whichever test
+  // runs next.
+  resetShellStatusForTests()
+})
 
 // Records the props BrowserLocalDocumentPage receives so tests can assert
 // capabilities actually flow from App down to the page, not just that the
@@ -597,7 +603,6 @@ describe('App local-daemon provider state', () => {
     expect(receivedDaemonPageProps?.path).toBe('main')
     expect(receivedDaemonPageProps?.capabilities).toEqual(LOCAL_DAEMON_STATE.capabilities)
     expect(receivedDaemonPageProps?.browserLocalStore).toBeDefined()
-    expect(receivedDaemonPageProps?.onContinueBrowserLocal).toBeInstanceOf(Function)
     expect(receivedDaemonPageProps?.onNavigateBack).toBeInstanceOf(Function)
   })
 
@@ -717,10 +722,14 @@ describe('App local-daemon provider state', () => {
       onOpenDocument('w1', 'main')
     })
     await screen.findByTestId('daemon-document-page')
-    const onContinueBrowserLocal = receivedDaemonPageProps?.onContinueBrowserLocal as () => void
+    // The escape is the shell's now: a rejected session publishes sync-off,
+    // and the chip's popover carries the way out. Driving it from here is
+    // what proves App still wires the branch switch behind it.
     act(() => {
-      onContinueBrowserLocal()
+      setShellConnection({ state: 'sync-off', daemonBaseUrl: 'http://127.0.0.1:3099' })
     })
+    fireEvent.click(await screen.findByTestId('connection-chip'))
+    fireEvent.click(await screen.findByRole('button', { name: /continue in browser-local/i }))
     expect(await screen.findByTestId('browser-local-index-page')).toBeTruthy()
     expect(screen.queryByTestId('daemon-document-page')).toBeNull()
     // Capabilities flow to the editor: open a canvas from the escaped list.
@@ -1004,9 +1013,12 @@ describe('App shell (single instance above the routed pages)', () => {
       await waitFor(() => expect(screen.queryByTestId('settings-nudge')).toBeNull())
 
       act(() => {
-        setShellDaemonAuthError(true)
+        setShellConnection({ state: 'sync-off', daemonBaseUrl: 'http://127.0.0.1:3099' })
       })
       expect(screen.getByTestId('settings-nudge')).toBeTruthy()
+      // The chip is the shell's now, so the state a page reports reaches the
+      // user here rather than inside the page's own top bar.
+      expect(screen.getByTestId('connection-chip').textContent).toMatch(/sync off/i)
     } finally {
       Object.defineProperty(navigator, 'storage', { value: undefined, configurable: true })
     }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -443,7 +443,10 @@ export function App({ providerState }: AppProps) {
         // boundary, which must be here to catch it.
         <ErrorBoundary>
           <div className="flex h-dvh flex-col">
-            <AppShellLazy daemon={true} />
+            <AppShellLazy
+              daemon={true}
+              onContinueBrowserLocal={() => setForcedBrowserLocal(true)}
+            />
             <div className="min-h-0 flex-1">
               <Suspense
                 fallback={<LazyPageFallback heightClass="h-full" message="Connecting to daemon…" />}
@@ -464,7 +467,6 @@ export function App({ providerState }: AppProps) {
                     workspaceId={daemonView.workspaceId}
                     path={daemonView.path}
                     token={pairedToken}
-                    onContinueBrowserLocal={() => setForcedBrowserLocal(true)}
                     browserLocalStore={browserLocalStore}
                     onNavigateBack={() =>
                       setDaemonView({ kind: 'index', workspaceId: daemonView.workspaceId })
@@ -530,7 +532,7 @@ export function App({ providerState }: AppProps) {
     return (
       <ErrorBoundary>
         <div className="flex h-dvh flex-col">
-          <AppShellLazy daemon={true} />
+          <AppShellLazy daemon={true} onContinueBrowserLocal={() => setForcedBrowserLocal(true)} />
           <div className="min-h-0 flex-1 overflow-hidden">
             <Suspense
               fallback={<LazyPageFallback heightClass="h-full" message="Connecting to daemon…" />}
@@ -553,7 +555,6 @@ export function App({ providerState }: AppProps) {
                   capabilities={effectiveState.capabilities}
                   token={daemonToken}
                   browserLocalStore={browserLocalStore}
-                  onContinueBrowserLocal={() => setForcedBrowserLocal(true)}
                   onNavigateBack={() =>
                     setDaemonView({ kind: 'index', workspaceId: daemonView.workspaceId })
                   }

--- a/apps/web/src/components/AppShell.test.tsx
+++ b/apps/web/src/components/AppShell.test.tsx
@@ -1,8 +1,9 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { resetInstallPromptForTests } from '@/lib/install-prompt-store'
-import { resetShellStatusForTests, setShellDaemonAuthError } from '@/lib/shell-status-store'
+import { resetShellStatusForTests, setShellConnection } from '@/lib/shell-status-store'
+import { createUserSettingsStore } from '@/lib/user-settings-store'
 import { resetSwStatusForTests } from '../pwa/sw-status-store.js'
 import { AppShell } from './AppShell.js'
 
@@ -18,14 +19,25 @@ afterEach(() => {
   Object.defineProperty(navigator, 'storage', { value: undefined, configurable: true })
 })
 
-function renderShell(daemonConnected: boolean, at = '/local/c1') {
+function renderShell(
+  daemonConnected: boolean,
+  at = '/local/c1',
+  onContinueBrowserLocal?: () => void,
+) {
   const router = createMemoryRouter(
-    [{ path: '*', element: <AppShell daemon={daemonConnected} /> }],
+    [
+      {
+        path: '*',
+        element: (
+          <AppShell daemon={daemonConnected} onContinueBrowserLocal={onContinueBrowserLocal} />
+        ),
+      },
+    ],
     {
       initialEntries: [at],
     },
   )
-  render(<RouterProvider router={router} />)
+  render(<RouterProvider router={router} />, { container: document.body })
   return router
 }
 
@@ -67,7 +79,9 @@ describe('AppShell', () => {
       value: { persisted: () => Promise.resolve(true) },
       configurable: true,
     })
-    setShellDaemonAuthError(true)
+    // Sync off IS the auth error: re-pairing is the only way out of it, so it
+    // counts as disconnected for the attention dot. Transient reconnects do not.
+    setShellConnection({ state: 'sync-off', daemonBaseUrl: 'http://127.0.0.1:3099' })
     renderShell(true)
     expect(await screen.findByTestId('settings-nudge')).toBeTruthy()
   })
@@ -81,5 +95,103 @@ describe('AppShell', () => {
     // allow the persistence query to settle
     await screen.findByRole('button', { name: 'Settings' })
     expect(screen.queryByTestId('settings-nudge')).toBeNull()
+  })
+})
+
+// The connection is an APP-level fact, not a document-level one: which daemon
+// this browser talks to does not change when you open a different document.
+// It lives beside the settings gear for the same reason the gear does — the
+// document's own surface is for the document.
+describe('AppShell — the connection chip', () => {
+  const CTA_TEXT =
+    'Connect a local daemon (MCP) to unlock version history, workspaces, variations, and combining changes'
+
+  it('shows no chip until a page publishes a live session', () => {
+    renderShell(true)
+    expect(screen.queryByTestId('connection-chip')).toBeNull()
+  })
+
+  it.each([
+    ['local', /local/i],
+    ['synced', /synced/i],
+    ['reconnecting', /reconnecting/i],
+    ['sync-off', /sync off/i],
+  ] as const)('renders the %s state the page published', async (state, label) => {
+    setShellConnection({ state, daemonBaseUrl: 'http://127.0.0.1:3099' })
+    renderShell(state !== 'local')
+    expect((await screen.findByTestId('connection-chip')).textContent).toMatch(label)
+  })
+
+  it('follows the page as its session changes, without a remount', async () => {
+    setShellConnection({ state: 'synced', daemonBaseUrl: 'http://127.0.0.1:3099' })
+    renderShell(true)
+    expect((await screen.findByTestId('connection-chip')).textContent).toMatch(/synced/i)
+
+    act(() => setShellConnection({ state: 'reconnecting', daemonBaseUrl: 'http://127.0.0.1:3099' }))
+    expect(screen.getByTestId('connection-chip').textContent).toMatch(/reconnecting/i)
+
+    // Leaving the document takes the claim with it: nothing on an index page
+    // is synced, and a latched chip would say otherwise.
+    act(() => setShellConnection(null))
+    expect(screen.queryByTestId('connection-chip')).toBeNull()
+  })
+
+  it('carries the capability CTA inside the Local popover, not in page chrome', async () => {
+    setShellConnection({ state: 'local' })
+    renderShell(false)
+    expect(screen.queryByText(CTA_TEXT)).toBeNull()
+
+    fireEvent.click(await screen.findByTestId('connection-chip'))
+    expect(await screen.findByText(CTA_TEXT)).toBeTruthy()
+  })
+
+  it('offers the browser-local escape from the sync-off popover', async () => {
+    const onContinueBrowserLocal = vi.fn()
+    setShellConnection({ state: 'sync-off', daemonBaseUrl: 'http://127.0.0.1:3099' })
+    renderShell(true, '/w/ws/document/a.canvas', onContinueBrowserLocal)
+
+    fireEvent.click(await screen.findByTestId('connection-chip'))
+    fireEvent.click(await screen.findByRole('button', { name: /continue in browser-local/i }))
+    expect(onContinueBrowserLocal).toHaveBeenCalledTimes(1)
+  })
+
+  it('disconnecting records the dismissal so discovery does not bring it straight back', async () => {
+    const daemonBaseUrl = 'http://127.0.0.1:3099'
+    const onContinueBrowserLocal = vi.fn()
+    // Seeded through the store, not by writing JSON: a hand-built payload that
+    // fails the store's own validation is silently replaced by defaults, and
+    // every assertion below would then pass without touching the real state.
+    createUserSettingsStore().update((current) => ({
+      ...current,
+      storage: {
+        ...current.storage,
+        localDaemonBaseUrl: daemonBaseUrl,
+        knownDaemonBaseUrls: [daemonBaseUrl],
+      },
+    }))
+    expect(createUserSettingsStore().load().storage.localDaemonBaseUrl).toBe(daemonBaseUrl)
+
+    setShellConnection({ state: 'synced', daemonBaseUrl })
+    renderShell(true, '/w/ws/document/a.canvas', onContinueBrowserLocal)
+
+    fireEvent.click(await screen.findByTestId('connection-chip'))
+    fireEvent.click(await screen.findByTestId('connection-disconnect'))
+
+    expect(onContinueBrowserLocal).toHaveBeenCalledTimes(1)
+    const storage = createUserSettingsStore().load().storage
+    expect(storage.dismissedDaemonBaseUrls).toContain(daemonBaseUrl)
+    expect(storage.knownDaemonBaseUrls ?? []).not.toContain(daemonBaseUrl)
+    // App.tsx reads localDaemonBaseUrl to decide a page is daemon-backed, so
+    // leaving it set reconnects on the next load — which makes the popover's
+    // "this browser stops using it" false the moment the user reloads.
+    expect(storage.localDaemonBaseUrl).toBeUndefined()
+  })
+
+  it('withholds the disconnect action where the app has no browser-local escape', async () => {
+    setShellConnection({ state: 'synced', daemonBaseUrl: 'http://127.0.0.1:3099' })
+    renderShell(true)
+    fireEvent.click(await screen.findByTestId('connection-chip'))
+    await waitFor(() => expect(screen.getByTestId('connection-popover')).toBeTruthy())
+    expect(screen.queryByTestId('connection-disconnect')).toBeNull()
   })
 })

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -1,28 +1,56 @@
 import { Settings } from 'lucide-react'
-import { useSyncExternalStore } from 'react'
+import { lazy, Suspense, useState, useSyncExternalStore } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { useSettingsNudge } from '@/hooks/useSettingsNudge'
 import { settingsPath } from '@/lib/app-routes'
-import { getShellDaemonAuthError, subscribeShellStatus } from '@/lib/shell-status-store'
+import { beginPairingGrant } from '@/lib/pairing-grant'
+import { getShellConnection, subscribeShellStatus } from '@/lib/shell-status-store'
+import { createUserSettingsStore } from '@/lib/user-settings-store'
 import HomeMark from '../brand/home-mark.svg?react'
+import { ConnectionStatus } from './connection/ConnectionStatus.js'
+
+// React.lazy for the same reason the browser-local page had it: the banner
+// pulls in daemon-probe.ts and its Zod parsing, and only the Local popover
+// ever opens it.
+const DaemonDetectedBanner = lazy(() =>
+  import('./migration/DaemonDetectedBanner.js').then((m) => ({
+    default: m.DaemonDetectedBanner,
+  })),
+)
+
+export interface AppShellProps {
+  readonly daemon: boolean
+  /**
+   * Switches the app to the browser-local flow. The App branch owns this, so
+   * a branch without the escape (settings, browser-local itself) leaves it
+   * unset and the chip drops the two actions that depend on it.
+   */
+  readonly onContinueBrowserLocal?: () => void
+}
 
 /**
  * The app-level chrome, deliberately minimal: brand (= go home) + the alpha
- * honesty chip on the left, the settings gear (+ attention dot) on the
- * right. Nothing else ever moves in here — context and tools stay in the
- * page's own surface, always visible (see DESIGN.md's shell rule). Pages
- * mount this shared component instead of owning any brand/settings chrome
- * themselves.
+ * honesty chip on the left, the connection chip and the settings gear (+
+ * attention dot) on the right. Nothing else ever moves in here — context and
+ * tools stay in the page's own surface, always visible (see DESIGN.md's shell
+ * rule). Pages mount this shared component instead of owning any brand,
+ * connection or settings chrome themselves.
  */
-export function AppShell({ daemon }: { daemon: boolean }) {
+export function AppShell({ daemon, onContinueBrowserLocal }: AppShellProps) {
   const navigate = useNavigate()
   const location = useLocation()
-  // A live auth error (reported by DaemonDocumentPage through the shell-status
-  // store) means the daemon needs the user's action, so it counts as
-  // disconnected for the attention dot.
-  const authError = useSyncExternalStore(subscribeShellStatus, getShellDaemonAuthError)
-  const nudge = useSettingsNudge(daemon && !authError)
+  // Read fresh rather than cached in state: the store is a thin localStorage
+  // accessor, and a cached snapshot would go stale behind the settings page.
+  const [settingsStore] = useState(() => createUserSettingsStore())
+  // Published by whichever page holds a live document session; `null` on an
+  // index or settings page, which has none to describe.
+  const connection = useSyncExternalStore(subscribeShellStatus, getShellConnection)
+  // Sync off means the daemon rejected the session and re-pairing is the only
+  // way out, so it counts as disconnected for the attention dot. A transient
+  // reconnect does not — it recovers on its own.
+  const nudge = useSettingsNudge(daemon && connection?.state !== 'sync-off')
+  const daemonBaseUrl = connection?.daemonBaseUrl
 
   return (
     <header className="flex h-10 shrink-0 items-center gap-2 border-b bg-background px-3">
@@ -58,6 +86,78 @@ export function AppShell({ daemon }: { daemon: boolean }) {
         </PopoverContent>
       </Popover>
       <span className="min-w-0 flex-1" />
+      {connection && (
+        // The ONE connection affordance: the chip signals the state and its
+        // popover carries the explanation and every recovery path. Re-pairing
+        // navigates top-level to the daemon's own /pair consent page, the
+        // same trust anchor first-time pairing uses.
+        <ConnectionStatus
+          state={connection.state}
+          daemonBaseUrl={daemonBaseUrl}
+          onRepair={
+            daemonBaseUrl === undefined
+              ? undefined
+              : () => {
+                  void beginPairingGrant({
+                    daemonBaseUrl,
+                    hostedOrigin: window.location.origin,
+                    sessionStorage: window.sessionStorage,
+                    navigate: (url) => window.location.assign(url),
+                  })
+                }
+          }
+          onContinueBrowserLocal={onContinueBrowserLocal}
+          onDisconnect={
+            onContinueBrowserLocal === undefined || daemonBaseUrl === undefined
+              ? undefined
+              : () => {
+                  // Recorded so discovery skips it next time: the default port
+                  // range is rescanned on every visit, so forgetting alone
+                  // would bring this daemon straight back and make the action
+                  // look like a no-op.
+                  settingsStore.update((current) => {
+                    const known = (current.storage.knownDaemonBaseUrls ?? []).filter(
+                      (entry) => entry !== daemonBaseUrl,
+                    )
+                    const dismissed = (current.storage.dismissedDaemonBaseUrls ?? []).filter(
+                      (entry) => entry !== daemonBaseUrl,
+                    )
+                    // Clearing the stored target is what makes this outlive
+                    // the page: App.tsx reads localDaemonBaseUrl to decide a
+                    // load is daemon-backed, so leaving it set reconnects on
+                    // the next visit and the popover's "this browser stops
+                    // using it" becomes false.
+                    const { localDaemonBaseUrl, ...storage } = current.storage
+                    return {
+                      ...current,
+                      storage: {
+                        ...storage,
+                        ...(localDaemonBaseUrl === daemonBaseUrl ? {} : { localDaemonBaseUrl }),
+                        knownDaemonBaseUrls: known,
+                        dismissedDaemonBaseUrls: [daemonBaseUrl, ...dismissed].slice(0, 5),
+                      },
+                    }
+                  })
+                  onContinueBrowserLocal()
+                }
+          }
+        >
+          {connection.state === 'local' && (
+            <>
+              <p className="text-muted-foreground">
+                Connect a local daemon (MCP) to unlock version history, workspaces, variations, and
+                combining changes
+              </p>
+              <Suspense fallback={null}>
+                <DaemonDetectedBanner
+                  settingsStore={settingsStore}
+                  fetch={window.fetch.bind(window)}
+                />
+              </Suspense>
+            </>
+          )}
+        </ConnectionStatus>
+      )}
       <button
         type="button"
         // The dot is the only thing on the shell that can read as an alarm.

--- a/apps/web/src/components/AppShellLazy.tsx
+++ b/apps/web/src/components/AppShellLazy.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense } from 'react'
+import type { AppShellProps } from './AppShell.js'
 
 const AppShell = lazy(() => import('./AppShell.js').then((m) => ({ default: m.AppShell })))
 
@@ -9,12 +10,12 @@ const AppShell = lazy(() => import('./AppShell.js').then((m) => ({ default: m.Ap
  * with it. The fallback reserves the shell's exact height so the swap-in
  * never shifts the page below.
  */
-export function AppShellLazy({ daemon }: { daemon: boolean }) {
+export function AppShellLazy(props: AppShellProps) {
   return (
     <Suspense
       fallback={<div aria-hidden="true" className="h-10 shrink-0 border-b bg-background" />}
     >
-      <AppShell daemon={daemon} />
+      <AppShell {...props} />
     </Suspense>
   )
 }

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -59,10 +59,6 @@ interface Props {
   // (another client, an MCP tool call) so the chip/timeline refetch without
   // waiting for their own poll interval.
   branchRefreshSignal?: number
-  // Right-side slot ahead of the secondary actions — the host page's
-  // connection-state chip mounts here so the one
-  // status affordance lives in the header instead of a banner row.
-  statusSlot?: ReactNode
   /**
    * The merged canvas row's flexible middle (title + properties triggers),
    * provided by the page — the header is one row, so pages inject their
@@ -100,7 +96,6 @@ export default function WorkspaceTopBar({
   dataMode = 'daemon',
   capabilities,
   branchRefreshSignal,
-  statusSlot,
   titleSlot,
 }: Props) {
   const isLocalMode = dataMode === 'local'
@@ -189,7 +184,6 @@ export default function WorkspaceTopBar({
         )}
       </div>
 
-      {statusSlot}
       <TopBarSecondaryActions onToggleFullscreen={onToggleFullscreen} isFullscreen={isFullscreen} />
     </header>
   )

--- a/apps/web/src/lib/shell-status-store.test.ts
+++ b/apps/web/src/lib/shell-status-store.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
-  getShellDaemonAuthError,
+  getShellConnection,
   resetShellStatusForTests,
-  setShellDaemonAuthError,
+  setShellConnection,
   subscribeShellStatus,
 } from './shell-status-store.js'
 
@@ -11,22 +11,41 @@ beforeEach(() => {
 })
 
 describe('shell-status-store', () => {
-  it('starts without an auth error', () => {
-    expect(getShellDaemonAuthError()).toBe(false)
+  it('starts with no live session, so the shell has nothing to claim', () => {
+    expect(getShellConnection()).toBeNull()
   })
 
-  it('setting the auth error notifies subscribers', () => {
+  it('publishing a connection notifies subscribers', () => {
     const listener = vi.fn()
     subscribeShellStatus(listener)
-    setShellDaemonAuthError(true)
-    expect(getShellDaemonAuthError()).toBe(true)
+    setShellConnection({ state: 'synced', daemonBaseUrl: 'http://127.0.0.1:3099' })
+    expect(getShellConnection()?.state).toBe('synced')
     expect(listener).toHaveBeenCalledTimes(1)
   })
 
-  it('setting the same value does not notify', () => {
+  // useSyncExternalStore reads a fresh object as a change, so an identity
+  // comparison here would re-render the shell on every page render.
+  it('re-publishing the same fields does not notify', () => {
+    setShellConnection({ state: 'synced', daemonBaseUrl: 'http://127.0.0.1:3099' })
     const listener = vi.fn()
     subscribeShellStatus(listener)
-    setShellDaemonAuthError(false)
+    setShellConnection({ state: 'synced', daemonBaseUrl: 'http://127.0.0.1:3099' })
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('clearing a published connection notifies', () => {
+    setShellConnection({ state: 'local' })
+    const listener = vi.fn()
+    subscribeShellStatus(listener)
+    setShellConnection(null)
+    expect(getShellConnection()).toBeNull()
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('clearing when nothing was published does not notify', () => {
+    const listener = vi.fn()
+    subscribeShellStatus(listener)
+    setShellConnection(null)
     expect(listener).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/lib/shell-status-store.ts
+++ b/apps/web/src/lib/shell-status-store.ts
@@ -1,8 +1,25 @@
-// The AppShell is mounted once per App branch, above the routed pages, so a
-// page that learns something shell-relevant (DaemonDocumentPage's live auth
-// error) cannot pass it as a prop. This module store is that one signal's
-// channel; keep it to shell concerns only.
-let daemonAuthError = false
+import type { ConnectionState } from '../components/connection/ConnectionStatus.js'
+
+/**
+ * What the page holding a live document session knows about its connection.
+ *
+ * The AppShell is mounted once per App branch, above the routed pages, so a
+ * page cannot pass this as a prop. This module store is that channel; keep it
+ * to shell concerns only.
+ */
+export interface ShellConnection {
+  readonly state: ConnectionState
+  /** Named in the synced popover, and the target of repair/disconnect. */
+  readonly daemonBaseUrl?: string
+}
+
+/**
+ * `null` means no page holds a live session, and the shell then shows no chip
+ * rather than inventing a state for one. A daemon INDEX page does talk to the
+ * daemon over HTTP, but it runs no document sync — so neither "Synced" nor
+ * "Reconnecting" is a true thing to say there.
+ */
+let connection: ShellConnection | null = null
 const listeners = new Set<() => void>()
 
 export function subscribeShellStatus(listener: () => void): () => void {
@@ -10,17 +27,20 @@ export function subscribeShellStatus(listener: () => void): () => void {
   return () => listeners.delete(listener)
 }
 
-export function getShellDaemonAuthError(): boolean {
-  return daemonAuthError
+export function getShellConnection(): ShellConnection | null {
+  return connection
 }
 
-export function setShellDaemonAuthError(next: boolean): void {
-  if (next === daemonAuthError) return
-  daemonAuthError = next
+export function setShellConnection(next: ShellConnection | null): void {
+  // Compared field by field, never by identity: useSyncExternalStore reads a
+  // fresh object as a change, so publishing from a render-scoped effect would
+  // otherwise re-render the shell on every page render.
+  if (next?.state === connection?.state && next?.daemonBaseUrl === connection?.daemonBaseUrl) return
+  connection = next
   for (const listener of listeners) listener()
 }
 
 export function resetShellStatusForTests(): void {
-  daemonAuthError = false
+  connection = null
   listeners.clear()
 }

--- a/apps/web/src/pages/BrowserLocalDocumentPage.shell-connection.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.shell-connection.browser.test.tsx
@@ -1,0 +1,97 @@
+import { cleanup, fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { AppShell } from '../components/AppShell.js'
+import { IdbDocumentIndex } from '../lib/idb-document-index.js'
+import { resetShellStatusForTests } from '../lib/shell-status-store.js'
+import { BrowserLocalDocumentPage } from './BrowserLocalDocumentPage.js'
+// Real app styles so the chip is laid out the way it ships.
+import '../index.css'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+
+const ISOLATED_DB = claimIsolatedWhiteboardDb('browserlocaldocumentpage-shell-connection')
+
+async function clearDb(): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase(ISOLATED_DB)
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+  })
+}
+
+// The composition main.tsx ships: the shell above the routed page, both in one
+// router. Neither half proves this on its own — the page publishes a state it
+// does not draw, and the shell draws a state it does not know.
+function renderApp() {
+  return rtlRender(
+    <div style={{ height: '100vh' }}>
+      <MemoryRouter initialEntries={['/local/c1']}>
+        <div className="flex h-dvh flex-col">
+          <AppShell daemon={false} />
+          <div className="min-h-0 flex-1">
+            <BrowserLocalDocumentPage store={new IdbDocumentIndex()} />
+          </div>
+        </div>
+      </MemoryRouter>
+    </div>,
+  )
+}
+
+describe('shell connection chip over a real browser-local document', () => {
+  beforeEach(async () => {
+    resetShellStatusForTests()
+    await clearDb()
+  })
+
+  afterEach(() => {
+    cleanup()
+    resetShellStatusForTests()
+  })
+
+  it('the open document lights the shell chip, whose popover carries the daemon CTA', async () => {
+    renderApp()
+    await waitFor(
+      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
+      {
+        timeout: 5000,
+      },
+    )
+
+    const chip = await waitFor(() => screen.getByTestId('connection-chip'), { timeout: 5000 })
+    expect(chip.textContent).toMatch(/local/i)
+    // The chip sits in the shell's own row, not inside the document's top bar
+    // — that separation is the whole point of the move, and a DOM assertion is
+    // the only thing that can tell the two rows apart.
+    expect(chip.closest('header')?.querySelector('[data-testid="shell-settings"]')).toBeTruthy()
+
+    // Sentence-length copy stays out of chrome: it appears only once opened.
+    expect(screen.queryByText(/only in this browser/i)).toBeNull()
+    fireEvent.click(chip)
+    expect(await screen.findByText(/only in this browser/i)).toBeInTheDocument()
+    expect(await screen.findByText(/unlock version history/i)).toBeInTheDocument()
+  })
+
+  it('leaving the document takes the claim with it', async () => {
+    renderApp()
+    await waitFor(
+      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
+      {
+        timeout: 5000,
+      },
+    )
+    await waitFor(() => expect(screen.getByTestId('connection-chip')).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+
+    // The shell outlives the page in production, so the page unmounting is
+    // exactly what must clear the chip — a latched one would keep telling an
+    // index page it is holding a session.
+    cleanup()
+    rtlRender(
+      <MemoryRouter initialEntries={['/']}>
+        <AppShell daemon={false} />
+      </MemoryRouter>,
+    )
+    expect(screen.queryByTestId('connection-chip')).toBeNull()
+  })
+})

--- a/apps/web/src/pages/BrowserLocalDocumentPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.test.tsx
@@ -21,6 +21,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // unused by name on purpose — being in the module graph is the fix.
 import '../components/WorkspaceTopBar.js'
 import type { LoroLoadResult } from '../lib/loro-store.js'
+import { getShellConnection, resetShellStatusForTests } from '../lib/shell-status-store.js'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
 import { LocalStoreDouble } from '../test-utils/local-index.js'
 import { assertNoSetStateInRenderWarning } from '../test-utils/no-setstate-in-render.js'
@@ -109,10 +110,14 @@ async function openDeleteConfirm() {
 }
 
 describe('BrowserLocalDocumentPage', () => {
-  beforeEach(() => vi.useFakeTimers())
+  beforeEach(() => {
+    vi.useFakeTimers()
+    resetShellStatusForTests()
+  })
   afterEach(() => {
     cleanup()
     vi.useRealTimers()
+    resetShellStatusForTests()
   })
 
   it('renders loading state before canvas is loaded', () => {
@@ -815,7 +820,7 @@ describe('BrowserLocalDocumentPage', () => {
     const CTA_TEXT =
       'Connect a local daemon (MCP) to unlock version history, workspaces, variations, and combining changes'
 
-    it('moves the capability CTA into the Local connection chip popover (D1: no standing copy)', async () => {
+    it('keeps the capability CTA out of page chrome and reports "local" to the shell', async () => {
       const store = new LocalStoreDouble()
       await store.setDefaultDocumentId('069CFJNRVY147ADGKPSWZ258BE')
       await store.save(snap)
@@ -829,19 +834,19 @@ describe('BrowserLocalDocumentPage', () => {
           />,
         )
       })
-      // No sentence-length CTA sits in the page chrome anymore...
+      // No sentence-length CTA sits in the page chrome...
       expect(screen.queryByText(CTA_TEXT)).toBeNull()
       for (const label of ['Version history', 'Workspaces', 'Branches', 'Merge']) {
         expect(screen.queryByRole('button', { name: label })).toBeNull()
       }
-      // ...it lives in the Local chip's popover, next to the storage note.
-      // (Synchronous assertions: this file runs under fake timers, so
-      // findBy*'s real-timer polling would hang.)
-      await act(async () => {
-        fireEvent.click(screen.getByTestId('connection-chip'))
-      })
-      expect(screen.getByText(/only in this browser/i)).toBeTruthy()
-      expect(screen.getByText(CTA_TEXT)).toBeTruthy()
+      // ...nor does the chip itself: the connection is app-level, so the
+      // App-mounted shell draws it (and hosts the CTA in its popover) from
+      // the state this page publishes.
+      expect(screen.queryByTestId('connection-chip')).toBeNull()
+      expect(getShellConnection()).toEqual({ state: 'local' })
+
+      cleanup()
+      expect(getShellConnection()).toBeNull()
     })
 
     it('does not render any mode-switch control — mode stays a read-only status', async () => {

--- a/apps/web/src/pages/BrowserLocalDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.tsx
@@ -6,7 +6,6 @@ import { LoroSyncPlugin } from 'loro-codemirror'
 import { Braces, Copy, Minimize2, Trash2 } from 'lucide-react'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
 import { DocumentPageSkeleton } from '../components/DocumentPageSkeleton.js'
 import { DocumentEditorSurface } from '../components/document-editor/DocumentEditorSurface.js'
 import { NodeTextEditorOverlay } from '../components/document-editor/NodeTextEditorOverlay.js'
@@ -53,6 +52,7 @@ import { kindNoun } from '../lib/kind-noun.js'
 import type { ContentClock, DefaultDocumentPointer } from '../lib/local-document-summary.js'
 import { ensurePersistentStorage } from '../lib/persistent-storage.js'
 import { BROWSER_LOCAL_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
+import { setShellConnection } from '../lib/shell-status-store.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
 import { cn } from '../lib/utils.js'
 import { useBrowserToolRegistry } from '../lib/webmcp/use-browser-tool-registry.js'
@@ -63,16 +63,6 @@ import {
   useBrowserLocalDocumentController,
 } from './use-browser-local-document-controller.js'
 import { useMarkdownDocument } from './use-markdown-document.js'
-
-// React.lazy: DaemonDetectedBanner pulls in daemon-probe.ts + Zod parsing
-// that would otherwise ship in the entry chunk, which is already close to
-// its gzip budget (apps/web/scripts/smoke-bundle-size.mjs). Deferred load
-// keeps first paint unaffected by a feature most sessions never render.
-const DaemonDetectedBanner = lazy(() =>
-  import('../components/migration/DaemonDetectedBanner.js').then((m) => ({
-    default: m.DaemonDetectedBanner,
-  })),
-)
 
 // WorkspaceTopBar statically imports Radix, lucide, HeaderSaveDot,
 // VersionTimeline, HeaderBranchChip, and the Zod-validated
@@ -155,9 +145,18 @@ export function BrowserLocalDocumentPage({
   const location = useLocation()
   const navigate = useNavigate()
 
-  // Stable across re-renders so DaemonDetectedBanner's dismissal state isn't
-  // re-read from localStorage on every render.
+  // Stable across re-renders so the settings payload isn't re-read from
+  // localStorage on every render.
   const [settingsStore] = useState(() => createUserSettingsStore())
+
+  // The connection is app-level, so the App-mounted shell draws it and this
+  // page only reports what it knows: while a browser-local document is open,
+  // the data lives in this browser and nowhere else. Cleared on unmount so an
+  // index page makes no claim of its own.
+  useEffect(() => {
+    setShellConnection({ state: 'local' })
+    return () => setShellConnection(null)
+  }, [])
 
   // duplicateDocument() rejects on failure (see the controller hook) rather
   // than carrying its own error/pending state, so this page owns both: a
@@ -792,20 +791,6 @@ export function BrowserLocalDocumentPage({
               // the daemon's `/names`, so the identity the bar offers is unused
               // here and `documentName`/`onTitleChange` stay the source.
               titleSlot={() => documentTitleSlot}
-              statusSlot={
-                <ConnectionStatus state="local">
-                  <p className="text-muted-foreground">
-                    Connect a local daemon (MCP) to unlock version history, workspaces, variations,
-                    and combining changes
-                  </p>
-                  <Suspense fallback={null}>
-                    <DaemonDetectedBanner
-                      settingsStore={settingsStore}
-                      fetch={window.fetch.bind(window)}
-                    />
-                  </Suspense>
-                </ConnectionStatus>
-              }
               dataMode="local"
               workspaceId="local"
               path={renderState.snapshot.path}

--- a/apps/web/src/pages/DaemonDocumentPage.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.test.tsx
@@ -16,8 +16,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as daemonApiClient from '../lib/daemon-api-client.js'
 import { LOCAL_WORKSPACE_ID } from '../lib/local-document-summary.js'
-import { getShellDaemonAuthError } from '../lib/shell-status-store.js'
-import { createUserSettingsStore } from '../lib/user-settings-store.js'
+import { getShellConnection } from '../lib/shell-status-store.js'
 import { LocalStoreDouble } from '../test-utils/local-index.js'
 import { DaemonDocumentPage } from './DaemonDocumentPage.js'
 
@@ -387,60 +386,10 @@ describe('DaemonDocumentPage', () => {
     expect(createdBackends[1]?.disconnectCount).toBe(0)
   })
 
-  it('records the daemon as dismissed when disconnecting, so discovery stops finding it', async () => {
-    // Forgetting alone is not enough: the default port range is rescanned on
-    // every visit, so a daemon on 3099 would come straight back and the
-    // action would read as a no-op the second time.
-    const onContinueBrowserLocal = vi.fn()
-    // The state a connected browser is actually in: App.tsx stores the daemon
-    // it connected to, and that is what puts the page in daemon mode on the
-    // next load. Without seeding it the assertion below passes vacuously.
-    // Seeded through the store, not by writing JSON: a hand-built payload that
-    // fails the store's own validation is silently replaced by defaults, and
-    // every assertion below then passes without touching the real state.
-    createUserSettingsStore().update((current) => ({
-      ...current,
-      storage: {
-        ...current.storage,
-        localDaemonBaseUrl: DAEMON_BASE_URL,
-        knownDaemonBaseUrls: [DAEMON_BASE_URL],
-      },
-    }))
-    await act(async () => {
-      render(
-        <DaemonDocumentPage
-          daemonBaseUrl={DAEMON_BASE_URL}
-          createBackend={makeCreateBackend()}
-          onContinueBrowserLocal={onContinueBrowserLocal}
-        />,
-        { container: document.body },
-      )
-    })
-    await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
-
-    // Precondition, asserted rather than assumed: if the seed did not survive
-    // the store's own validation, everything below would pass vacuously.
-    expect(createUserSettingsStore().load().storage.localDaemonBaseUrl).toBe(DAEMON_BASE_URL)
-
-    fireEvent.click(screen.getByTestId('connection-chip'))
-    fireEvent.click(screen.getByTestId('connection-disconnect'))
-
-    expect(onContinueBrowserLocal).toHaveBeenCalledTimes(1)
-    // Asserted as arrays, not as substrings of the whole store: the daemon's
-    // URL also appears under localDaemonBaseUrl, so a `toContain` on the
-    // serialized storage holds whether or not the dismissal was recorded.
-    const storage = createUserSettingsStore().load().storage
-    expect(storage.dismissedDaemonBaseUrls).toContain(DAEMON_BASE_URL)
-    expect(storage.knownDaemonBaseUrls ?? []).not.toContain(DAEMON_BASE_URL)
-    // App.tsx reads localDaemonBaseUrl to decide a page is daemon-backed, so
-    // leaving it set reconnects on the next load — which makes the popover's
-    // "this browser stops using it" false the moment the user reloads.
-    expect(createUserSettingsStore().load().storage.localDaemonBaseUrl).toBeUndefined()
-  })
-
-  it('flips the connection chip to "Reconnecting" while the transport is down', async () => {
+  it('reports "reconnecting" to the shell while the transport is down', async () => {
     // A chip that reads Synced while the transport is down tells the user
-    // remote edits are arriving when they are not.
+    // remote edits are arriving when they are not. The App-mounted shell
+    // draws the chip; this page's contract is the state it publishes.
     await act(async () => {
       render(
         <DaemonDocumentPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
@@ -448,22 +397,22 @@ describe('DaemonDocumentPage', () => {
       )
     })
     await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
-    expect(screen.getByTestId('connection-chip').textContent).toMatch(/synced/i)
+    expect(getShellConnection()).toEqual({ state: 'synced', daemonBaseUrl: DAEMON_BASE_URL })
 
     const backend = createdBackends[0]!
     await act(async () => {
       backend.handlers?.onDisconnected?.()
     })
-    expect(screen.getByTestId('connection-chip').textContent).toMatch(/reconnecting/i)
+    expect(getShellConnection()?.state).toBe('reconnecting')
 
     // …and back, so a recovered stream clears it rather than latching.
     await act(async () => {
       backend.handlers?.onConnected()
     })
-    expect(screen.getByTestId('connection-chip').textContent).toMatch(/synced/i)
+    expect(getShellConnection()?.state).toBe('synced')
   })
 
-  it('flips the connection chip to "Sync off" on WS auth failure (close 1008 -> onAuthError)', async () => {
+  it('reports "sync-off" on WS auth failure (close 1008 -> onAuthError) without replacing the page', async () => {
     await act(async () => {
       render(
         <DaemonDocumentPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
@@ -474,49 +423,20 @@ describe('DaemonDocumentPage', () => {
     // Hand (view-only) is the default tool; the host history cluster only
     // docks in Select mode, so tests exercising it switch first.
     fireEvent.click(await screen.findByTestId('select-tool-button'))
-    // Healthy session: the chip reads Synced.
-    expect(screen.getByTestId('connection-chip').textContent).toMatch(/synced/i)
+    // Healthy session.
+    expect(getShellConnection()?.state).toBe('synced')
 
     const backend = createdBackends[0]!
     await act(async () => {
       backend.handlers?.onAuthError?.()
     })
 
-    // D1: no standing role=alert banner — the chip carries the state and a
-    // polite live region announces it to assistive tech.
+    expect(getShellConnection()?.state).toBe('sync-off')
+    // D1: no standing role=alert banner anywhere on the page — the shell's
+    // chip carries the state and its own live region announces it.
     expect(screen.queryByRole('alert')).toBeNull()
-    expect(screen.getByTestId('connection-chip').textContent).toMatch(/sync off/i)
-    expect(screen.getByRole('status', { name: /live sync off/i })).toBeTruthy()
     // Editor chrome stays mounted — auth error never replaces the page.
     expect(screen.getByTestId('spatial-editor-container')).toBeTruthy()
-
-    // The popover is the recovery surface: both ways forward are offered.
-    fireEvent.click(screen.getByTestId('connection-chip'))
-    await waitFor(() => expect(screen.getByRole('button', { name: /re-pair/i })).toBeTruthy())
-    expect(screen.getByText(/edits stay in this browser/i)).toBeTruthy()
-  })
-
-  it('keeps the sr-only live region quiet until authError is true', async () => {
-    await act(async () => {
-      render(
-        <DaemonDocumentPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
-        { container: document.body },
-      )
-    })
-    await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
-    // Hand (view-only) is the default tool; the host history cluster only
-    // docks in Select mode, so tests exercising it switch first.
-    fireEvent.click(await screen.findByTestId('select-tool-button'))
-
-    expect(screen.queryByLabelText(/live sync off/i)).toBeNull()
-
-    await act(async () => {
-      createdBackends[0]?.handlers?.onAuthError?.()
-    })
-
-    const region = screen.getByLabelText(/live sync off/i)
-    expect(region.getAttribute('role')).toBe('status')
-    expect(screen.queryByRole('alert')).toBeNull()
   })
 
   it('reports a live auth error to the shell-status store (and clears on unmount)', async () => {
@@ -527,19 +447,22 @@ describe('DaemonDocumentPage', () => {
       )
     })
     await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
-    expect(getShellDaemonAuthError()).toBe(false)
+    expect(getShellConnection()?.state).toBe('synced')
 
     await act(async () => {
       createdBackends[0]?.handlers?.onAuthError?.()
     })
-    // The App-mounted shell reads this to light the gear's attention dot.
-    expect(getShellDaemonAuthError()).toBe(true)
+    // The App-mounted shell reads this to draw the chip and to light the
+    // gear's attention dot.
+    expect(getShellConnection()?.state).toBe('sync-off')
 
+    // Cleared on unmount: an index page holds no session, and a latched chip
+    // would keep claiming one.
     cleanup()
-    expect(getShellDaemonAuthError()).toBe(false)
+    expect(getShellConnection()).toBeNull()
   })
 
-  it('clears the auth-error banner when switching to a new canvas (new backend identity)', async () => {
+  it('clears the reported auth error when switching to a new canvas (new backend identity)', async () => {
     await act(async () => {
       render(
         <DaemonDocumentPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
@@ -554,64 +477,14 @@ describe('DaemonDocumentPage', () => {
     await act(async () => {
       createdBackends[0]?.handlers?.onAuthError?.()
     })
-    expect(screen.getByTestId('connection-chip').textContent).toMatch(/sync off/i)
-    expect(screen.getByLabelText(/live sync off/i)).toBeTruthy()
+    expect(getShellConnection()?.state).toBe('sync-off')
 
     await act(async () => {
       await switchDocumentViaConnections('Second board')
     })
 
     // The stale sync-off state must not outlive the backend that produced it.
-    expect(screen.getByTestId('connection-chip').textContent).toMatch(/synced/i)
-    expect(screen.queryByLabelText(/live sync off/i)).toBeNull()
-  })
-
-  it('offers the browser-local escape inside the chip popover and invokes the callback', async () => {
-    const onContinueBrowserLocal = vi.fn()
-    // The state a connected browser is actually in: App.tsx stores the daemon
-    // it connected to, and that is what puts the page in daemon mode on the
-    // next load. Without seeding it the assertion below passes vacuously.
-    // Seeded through the store, not by writing JSON: a hand-built payload that
-    // fails the store's own validation is silently replaced by defaults, and
-    // every assertion below then passes without touching the real state.
-    createUserSettingsStore().update((current) => ({
-      ...current,
-      storage: {
-        ...current.storage,
-        localDaemonBaseUrl: DAEMON_BASE_URL,
-        knownDaemonBaseUrls: [DAEMON_BASE_URL],
-      },
-    }))
-    await act(async () => {
-      render(
-        <DaemonDocumentPage
-          daemonBaseUrl={DAEMON_BASE_URL}
-          createBackend={makeCreateBackend()}
-          onContinueBrowserLocal={onContinueBrowserLocal}
-        />,
-        { container: document.body },
-      )
-    })
-    await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
-    // Hand (view-only) is the default tool; the host history cluster only
-    // docks in Select mode, so tests exercising it switch first.
-    fireEvent.click(await screen.findByTestId('select-tool-button'))
-
-    await act(async () => {
-      createdBackends[0]?.handlers?.onAuthError?.()
-    })
-
-    // D1: the escape lives in the chip's popover, not a banner.
-    await act(async () => {
-      screen.getByTestId('connection-chip').click()
-    })
-    const escapeButton = await screen.findByRole('button', {
-      name: /continue in browser-local/i,
-    })
-    await act(async () => {
-      escapeButton.click()
-    })
-    expect(onContinueBrowserLocal).toHaveBeenCalledTimes(1)
+    expect(getShellConnection()?.state).toBe('synced')
   })
 
   it('shows a structural skeleton while workspace/canvas resolution is pending', async () => {

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -9,7 +9,6 @@ import type { DocumentIndex } from '@kamiazya/whiteboard-ports'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { AgentPresenceChip } from '../components/AgentPresenceChip.js'
 import { CapabilityTeaser } from '../components/capability-teaser/CapabilityTeaser.js'
-import { ConnectionStatus } from '../components/connection/ConnectionStatus.js'
 import type { ConnectionsBacklink } from '../components/connections/ConnectionsChip.js'
 import { ConnectionsChip } from '../components/connections/ConnectionsChip.js'
 import { DocumentPageSkeleton } from '../components/DocumentPageSkeleton.js'
@@ -55,9 +54,8 @@ import { devTransportOverride } from '../lib/dev-transport-override.js'
 import { daemonFaviconStatus, type FaviconStyle } from '../lib/favicon.js'
 import { readLastTool, resolveInitialTool } from '../lib/initial-tool.js'
 import type { ContentClock } from '../lib/local-document-summary.js'
-import { beginPairingGrant } from '../lib/pairing-grant.js'
 import { LOCAL_DAEMON_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
-import { setShellDaemonAuthError } from '../lib/shell-status-store.js'
+import { setShellConnection } from '../lib/shell-status-store.js'
 import { createSharedSseStreamSource } from '../lib/sse-shared-stream-source.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
 import { applyViewportRequest } from '../lib/viewport-request.js'
@@ -86,10 +84,6 @@ export interface DaemonDocumentPageProps {
   // window.__WHITEBOARD_DAEMON_TOKEN__, that global wins for the WS.
   token?: string
   capabilities?: WhiteboardCapabilities
-  // Rendered as a "Continue in browser-local" escape next to the auth-error
-  // banner — without it a rejected session leaves the user stuck on a dead
-  // daemon page with no way back into the app.
-  onContinueBrowserLocal?: () => void
   // Injectable so tests can avoid real WebSocket networking; production
   // callers rely on the default DaemonBackend + createDaemonFetch wiring.
   createBackend?: (workspaceId: string, path: string, daemonFetch: typeof fetch) => DocumentBackend
@@ -111,7 +105,6 @@ export function DaemonDocumentPage({
   path,
   token,
   capabilities = LOCAL_DAEMON_CAPABILITIES,
-  onContinueBrowserLocal,
   createBackend,
   browserLocalStore,
   browserLocalClock,
@@ -188,14 +181,6 @@ export function DaemonDocumentPage({
       : null
 
   const [authError, setAuthError] = useState(false)
-  // Report the live auth error to the App-mounted shell: it means the daemon
-  // needs the user's action (re-pair lives under Settings -> Connections),
-  // so it counts as disconnected for the attention dot; transient reconnects
-  // don't.
-  useEffect(() => {
-    setShellDaemonAuthError(authError)
-    return () => setShellDaemonAuthError(false)
-  }, [authError])
   // Disables the empty-state "Create a canvas" control while a create is in
   // flight. `disabled` is the whole mechanism: an in-handler
   // `if (creating) return` reads the render closure, so it is stale in exactly
@@ -456,6 +441,21 @@ export function DaemonDocumentPage({
     rects: documentOutline,
   })
 
+  // The connection is app-level, so the App-mounted shell draws it and this
+  // page only reports what it knows. Synced is claimed only while the session
+  // is actually connected: an auth rejection outranks everything else because
+  // re-pairing is the only way out of it, and `idle` (not started yet) and
+  // `error` fold in with `reconnecting`, whose copy makes no claim about
+  // recovery timing. Cleared on unmount — an index page has no live session,
+  // and a latched chip would keep claiming one.
+  useEffect(() => {
+    setShellConnection({
+      state: authError ? 'sync-off' : syncStatus === 'connected' ? 'synced' : 'reconnecting',
+      daemonBaseUrl,
+    })
+    return () => setShellConnection(null)
+  }, [authError, syncStatus, daemonBaseUrl])
+
   // PNG, because the daemon's thumbnail endpoint validates a PNG signature
   // on upload and rejects anything else.
   const getThumbnailBlob = useCallback(() => exportScene('png'), [exportScene])
@@ -559,63 +559,6 @@ export function DaemonDocumentPage({
       </div>
     ) : null
 
-  // The ONE connection affordance: a header chip whose popover carries
-  // the explanation and the available recovery paths — re-pairing always,
-  // plus continue-in-browser-local when the host page provides that
-  // escape. Re-pairing navigates top-level to the daemon's own /pair
-  // consent page, the same trust anchor first-time pairing uses.
-  const connectionStatus = (
-    <ConnectionStatus
-      // Synced is claimed only while the session is actually connected. An
-      // auth rejection outranks everything else because re-pairing is the only
-      // way out of it; `idle` (not started yet) and `error` are folded in with
-      // `reconnecting`, whose copy makes no claim about recovery timing —
-      // reporting them as Synced is what this whole change exists to stop.
-      state={authError ? 'sync-off' : syncStatus === 'connected' ? 'synced' : 'reconnecting'}
-      daemonBaseUrl={daemonBaseUrl}
-      onRepair={() => {
-        void beginPairingGrant({
-          daemonBaseUrl,
-          hostedOrigin: window.location.origin,
-          sessionStorage: window.sessionStorage,
-          navigate: (url) => window.location.assign(url),
-        })
-      }}
-      onContinueBrowserLocal={onContinueBrowserLocal}
-      onDisconnect={
-        onContinueBrowserLocal &&
-        (() => {
-          // Recorded so discovery skips it next time: the default port range
-          // is rescanned on every visit, so forgetting alone would bring this
-          // daemon straight back and make the action look like a no-op.
-          settingsStore.update((current) => {
-            const known = (current.storage.knownDaemonBaseUrls ?? []).filter(
-              (entry) => entry !== daemonBaseUrl,
-            )
-            const dismissed = (current.storage.dismissedDaemonBaseUrls ?? []).filter(
-              (entry) => entry !== daemonBaseUrl,
-            )
-            // Clearing the stored target is what makes this outlive the page:
-            // App.tsx reads localDaemonBaseUrl to decide a load is
-            // daemon-backed, so leaving it set reconnects on the next visit
-            // and the popover's "this browser stops using it" becomes false.
-            const { localDaemonBaseUrl, ...storage } = current.storage
-            return {
-              ...current,
-              storage: {
-                ...storage,
-                ...(localDaemonBaseUrl === daemonBaseUrl ? {} : { localDaemonBaseUrl }),
-                knownDaemonBaseUrls: known,
-                dismissedDaemonBaseUrls: [daemonBaseUrl, ...dismissed].slice(0, 5),
-              },
-            }
-          })
-          onContinueBrowserLocal()
-        })
-      }
-    />
-  )
-
   return (
     <DaemonApiContext.Provider value={daemonFetch}>
       {/* Two-row grid shell: everything header-shaped stacks inside the
@@ -634,17 +577,8 @@ export function DaemonDocumentPage({
               <span className="text-xs text-destructive">{controller.switchError}</span>
             </div>
           )}
-          {/* Rendered at the page level when WorkspaceTopBar has nowhere to
-            mount (no-canvas/empty-workspace view) so the degraded state
-            never disappears with the canvas-gated chrome. */}
-          {authError && !canvas && (
-            <div className="flex items-center border-b bg-background px-4 py-1.5">
-              {connectionStatus}
-            </div>
-          )}
           {canvas && (
             <WorkspaceTopBar
-              statusSlot={connectionStatus}
               // Document identity in the merged header row, mirroring the
               // browser-local page. The NAME is the workspace's — the top bar
               // hands it down from `/names`, the same surface the canvas


### PR DESCRIPTION
## Summary

- **The connection chip moves to the AppShell.** Which daemon this browser talks to does not change when you open a different document, so the chip was app-level state living in a document-level surface. It now sits beside the settings gear, and the document's top bar is left to the document.
- **One signal instead of two.** `lib/shell-status-store` widens from a boolean auth-error flag to the whole connection (`{ state, daemonBaseUrl } | null`). The old flag was derivable from the new one — `sync-off` *is* the auth error — so keeping both would have been two signals that can disagree. Pages report; the shell draws.
- **`null` is what keeps the relocation honest.** No page holding a live session means no chip. A daemon INDEX page talks to the daemon over HTTP but runs no document sync, so neither "Synced" nor "Reconnecting" is true there, and a chip latched from the last document would say one of them anyway. Both document pages clear on unmount.
- **The recovery actions move with it**, because every one was already app-level and only lived in the page because the chip did: re-pair, disconnect, continue-in-browser-local, and the browser-local capability CTA. `onContinueBrowserLocal` therefore leaves `DaemonDocumentPage`'s props and goes to `AppShellLazy`; `WorkspaceTopBar` loses its now-unused `statusSlot`.

Follows the same brief as #1004 and #1006: the header is re-cut so each surface answers one question.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [x] `pnpm test` passes locally
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable

Test moves follow the code: assertions about the chip's rendering and its actions are now `AppShell.test.tsx`'s, and the pages assert the state they publish. The composed surface — a real shell above a real page in real Chromium — is pinned by a new `web-browser` test, `BrowserLocalDocumentPage.shell-connection.browser.test.tsx`.

Mutation-checked, each confirmed red before the fix:

| guard | mutation | result |
|---|---|---|
| store's field-wise comparison | compare by identity | `re-publishing the same fields does not notify` ✗ |
| unmount clears the claim | drop the effect's cleanup | both new browser tests ✗ |
| page publishes at all | drop `setShellConnection({ state: 'local' })` | both new browser tests ✗ |

Suites run: `apps/web` jsdom + node (2662, the CI command), `pnpm test:browser` (748, all green), `pnpm -r typecheck`, `pnpm lint`, `pnpm knip` (clean).

Pre-existing failures on this machine, verified unchanged by an A/B against a clean tree and untouched by this diff: 9 `apps/web` objectURL/thumbnail tests (jsdom `createObjectURL`) and 4 `mcp-node` EACCES tests (chmod is a no-op for root). The pre-push gate was bypassed for those 4 alone.

**Manual verification** — the running app, driven through one pipeline before and after the change:

| | shell header | document top bar |
|---|---|---|
| before | `ALPHA` | `Title \| Local` |
| after | `ALPHA \| Local` | `Title` |

Also confirmed live: the index page shows no chip (0), the chip in the editor resolves inside the shell's `<header>` (the one holding `shell-settings`), its popover carries the storage note and the daemon CTA, and pressing "back to documents" clears the chip.

## Visual evidence

Before — the chip sat at the right end of the document's own row:

```
[~] [ALPHA]                                                    [⚙]
[<] [•] Untitled                             [⚙] [⋮] [• Local] [⛶]
```

After — it sits in the shell, and the document row carries only document things:

```
[~] [ALPHA]                                        [• Local] [⚙]
[<] [•] Untitled                                    [⚙] [⋮] [⛶]
```

Screenshots captured at `tmp/screenshots/shell-connection-{before,after,popover}.png`; the `gh image` extension is unavailable in this environment, so they could not be uploaded inline.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — `apps/web/DESIGN.md`'s shell rule now names the connection chip, states the dividing question ("does the answer survive navigation?"), and records why an index page draws no chip
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema


---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_