### PR TITLE
feat: a facet declares its editor instead of shipping one

### DIFF
--- a/.claude/rules/package-facet-engine.md
+++ b/.claude/rules/package-facet-engine.md
@@ -41,6 +41,19 @@ paths:
   writes there go back through `validateFacetWrite`, so a panel can never
   store what `wb_facet_set` would refuse.
 
+- TIER 2, in the same module: an optional `editor` spec on a facet
+  definition, declaring per-field widget/label/quick-band from a CLOSED
+  vocabulary (`text`/`number`/`toggle`/`choice`/`segmented`, glyphs from
+  `FACET_GLYPHS`). `deriveFacetForm(schema, editor)` merges it over the
+  derived form; `assertEditorSpecFits` rejects at definition time a spec
+  naming a field the schema does not declare, or one on a schema with no
+  derivable form. A segmented option's `value: null` means the facet's
+  ABSENCE — some defaults are unrepresentable as a stored value (a rect
+  node stores no shape facet), and a picker with no way to say that
+  cannot express them. The bundled `visual.shape` declares its band this
+  way and ships NO hand-written widget, which is how the mechanism is
+  proved by the plugin that ships with the engine.
+
 ## What does NOT belong here
 
 - Facet KEY grammar and the `facets` bucket schemas — those are model's

--- a/apps/web/src/components/spatial-editor/facet-panel.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/facet-panel.browser.test.tsx
@@ -47,11 +47,12 @@ it('the Facets entry opens the panel, and a pick there stores and draws', () => 
   // canvas behind it.
   expect(panel.contains(document.activeElement)).toBe(true)
 
-  // visual.shape's derived form: a choice control over the five silhouettes.
-  const select = panel.querySelector(
-    'select[aria-label="Visual style shape kind"]',
-  ) as HTMLSelectElement
-  fireEvent.change(select, { target: { value: 'hexagon' } })
+  // visual.shape DECLARES its editor, so the panel shows the segmented
+  // control the spec names — including Rectangle, which is the facet's
+  // ABSENCE rather than a stored value.
+  const hexagon = panel.querySelector('input[aria-label="Hexagon"]') as HTMLInputElement
+  expect(hexagon).not.toBeNull()
+  fireEvent.click(hexagon)
   const save = [...panel.querySelectorAll('button')].find((b) =>
     b.textContent?.startsWith('Save Visual style shape'),
   ) as HTMLElement

--- a/apps/web/src/components/spatial-editor/facet-widgets/FacetFormPanel.test.tsx
+++ b/apps/web/src/components/spatial-editor/facet-widgets/FacetFormPanel.test.tsx
@@ -143,6 +143,26 @@ describe("the panel honours a facet's declared editor", () => {
   })
 })
 
+describe('the absence segment clears the facet, like the band does', () => {
+  it('picking the absence option removes the facet instead of failing validation', () => {
+    const onWrite = vi.fn()
+    render(
+      <FacetFormPanel
+        node={node({ 'visual.shape/v0': { kind: 'hexagon' } })}
+        registry={registry}
+        onWrite={onWrite}
+      />,
+    )
+    // `Rectangle` carries value: null — the facet's ABSENCE. Staging it in
+    // the draft and saving would validate `{}` against a schema whose
+    // `kind` is required, so the pick must clear, exactly as the quick
+    // band and the Clear button already do.
+    fireEvent.click(screen.getByLabelText('Rectangle'))
+    expect(onWrite).toHaveBeenCalledWith('visual.shape/v0', undefined)
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})
+
 describe('a draft never outlives what it was seeded from', () => {
   it('clearing a facet empties the form, so a later Save cannot restore it', () => {
     const onWrite = vi.fn()

--- a/apps/web/src/components/spatial-editor/facet-widgets/FacetFormPanel.test.tsx
+++ b/apps/web/src/components/spatial-editor/facet-widgets/FacetFormPanel.test.tsx
@@ -132,6 +132,17 @@ describe('control kinds the derived form emits', () => {
   })
 })
 
+describe("the panel honours a facet's declared editor", () => {
+  it("uses the spec's label and its segmented options, not the derived defaults", () => {
+    render(<FacetFormPanel node={node()} registry={registry} onWrite={() => {}} />)
+    // visual.shape declares label 'Shape' and a segmented control; without
+    // the spec the panel would show a select labelled 'kind'.
+    const control = screen.getByLabelText('Visual style shape Shape')
+    expect(control).not.toBeNull()
+    expect(control.getAttribute('role')).toBe('radiogroup')
+  })
+})
+
 describe('a draft never outlives what it was seeded from', () => {
   it('clearing a facet empties the form, so a later Save cannot restore it', () => {
     const onWrite = vi.fn()

--- a/apps/web/src/components/spatial-editor/facet-widgets/FacetFormPanel.tsx
+++ b/apps/web/src/components/spatial-editor/facet-widgets/FacetFormPanel.tsx
@@ -74,6 +74,26 @@ function FieldInput({
       />
     )
   }
+  if (field.control.kind === 'segmented') {
+    return (
+      <span id={id} role="radiogroup" aria-label={name} className="flex items-center gap-0.5">
+        {/* Real radios rather than buttons wearing the role: the keyboard
+            behaviour a segmented control needs comes free with the element. */}
+        {field.control.options.map((option) => (
+          <label key={option.label} className={cn(common, 'flex items-center gap-1 px-1.5')}>
+            <input
+              type="radio"
+              name={id}
+              aria-label={option.label}
+              checked={option.value === null ? value === undefined : value === option.value}
+              onChange={() => onChange(option.value ?? undefined)}
+            />
+            {option.label}
+          </label>
+        ))}
+      </span>
+    )
+  }
   if (field.control.kind === 'choice') {
     return (
       <select
@@ -278,7 +298,7 @@ export function FacetFormPanel({ node, registry, onWrite, onClose }: FacetFormPa
               key={`${node.id}:${facet.key}`}
               facetKey={facet.key}
               title={`${group.displayName} ${facet.definition.name}`}
-              form={deriveFacetForm(facet.definition.schema)}
+              form={deriveFacetForm(facet.definition.schema, facet.definition.editor)}
               stored={stored[facet.key]}
               registry={registry}
               onWrite={onWrite}

--- a/apps/web/src/components/spatial-editor/facet-widgets/FacetFormPanel.tsx
+++ b/apps/web/src/components/spatial-editor/facet-widgets/FacetFormPanel.tsx
@@ -48,6 +48,7 @@ function FieldInput({
   field,
   value,
   onChange,
+  onClear,
 }: {
   readonly facetKey: string
   /** Facet title, so the accessible name says WHICH facet's field this is. */
@@ -55,6 +56,13 @@ function FieldInput({
   readonly field: FacetFormField
   readonly value: unknown
   readonly onChange: (next: unknown) => void
+  /**
+   * A segmented option carrying `value: null` means the facet should not
+   * exist — a whole-facet statement, not a field value. Staging it in the
+   * draft would submit a payload missing a required field, so it takes the
+   * same immediate path the Clear button beside it already takes.
+   */
+  readonly onClear: () => void
 }) {
   // Scoped by facet: two facets may declare the same field name, and a
   // duplicate id would point every label at the first input. The
@@ -86,7 +94,7 @@ function FieldInput({
               name={id}
               aria-label={option.label}
               checked={option.value === null ? value === undefined : value === option.value}
-              onChange={() => onChange(option.value ?? undefined)}
+              onChange={() => (option.value === null ? onClear() : onChange(option.value))}
             />
             {option.label}
           </label>
@@ -242,6 +250,7 @@ function FacetEditor({
             field={field}
             value={draft[field.name]}
             onChange={(next) => set(field.name, next)}
+            onClear={() => onWrite(facetKey, undefined)}
           />
         </label>
       ))}

--- a/apps/web/src/components/spatial-editor/facet-widgets/index.tsx
+++ b/apps/web/src/components/spatial-editor/facet-widgets/index.tsx
@@ -14,14 +14,14 @@ import {
   LUCIDE_VIEWBOX,
 } from '@kamiazya/whiteboard-canvas-render'
 import {
+  deriveFacetForm,
+  type FacetDefinition,
+  type FacetGlyph,
   type FacetRegistry,
   resolveCanvasEdgeStyle,
   resolveFacetContributions,
-  resolveNodeShape,
   resolveNodeSymbol,
-  VISUAL_SHAPE_KEY,
   VISUAL_SYMBOL_KEY,
-  type VisualShapeFacet,
   type VisualSymbolFacet,
 } from '@kamiazya/whiteboard-facet-engine'
 import type { EdgeRoutingStyle, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
@@ -52,62 +52,42 @@ export type CanvasSettingsWidget = (ctx: CanvasSettingsContext) => ReactNode
 
 // --- visual.shape/v0 -------------------------------------------------------
 
-const visualShapeBand: NodePropertiesWidget = ({ node, applyToSelection }) => {
-  const currentShape = resolveNodeShape(node)
-  const applyShape = (shape: VisualShapeFacet['kind'] | undefined) => {
-    applyToSelection((ids) =>
-      ids.map((id) => ({
-        kind: 'set-node-facet' as const,
-        id,
-        key: VISUAL_SHAPE_KEY,
-        payload: shape === undefined ? undefined : { kind: shape },
-      })),
-    )
+/**
+ * The core's glyph vocabulary rendered: a spec NAMES a glyph, this maps the
+ * name to a drawing. Keeping the map here (not in the engine) is the same
+ * split as everywhere else — the engine owns what may be said, the vessel
+ * owns how it looks.
+ */
+function FacetGlyphIcon({ glyph }: { readonly glyph?: FacetGlyph }) {
+  switch (glyph) {
+    case 'square':
+      return <Square />
+    case 'circle':
+      return <Circle />
+    case 'diamond':
+      return <Diamond />
+    case 'hexagon':
+      return <Hexagon />
+    case 'parallelogram':
+      // No lucide glyph for a parallelogram; drawn in the same 24-grid
+      // stroke style so a row of these reads as one set.
+      return (
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M7 5h14l-4 14H3Z" />
+        </svg>
+      )
+    case 'cylinder':
+      return <Cylinder />
+    default:
+      return undefined
   }
-  const shapeOption = (shape: VisualShapeFacet['kind'], ariaLabel: string, icon: ReactNode) => ({
-    label: shape,
-    ariaLabel,
-    icon,
-    selected: currentShape === shape,
-    onSelect: () => applyShape(shape),
-  })
-  return [
-    {
-      kind: 'options' as const,
-      label: 'Shape',
-      options: [
-        // `rect` is the historic default and deliberately unrepresentable
-        // as a value — choosing it removes the facet.
-        {
-          label: 'rect',
-          ariaLabel: 'Rectangle',
-          icon: <Square />,
-          selected: currentShape === undefined,
-          onSelect: () => applyShape(undefined),
-        },
-        shapeOption('ellipse', 'Ellipse', <Circle />),
-        shapeOption('diamond', 'Diamond', <Diamond />),
-        shapeOption('hexagon', 'Hexagon', <Hexagon />),
-        shapeOption(
-          'parallelogram',
-          'Parallelogram',
-          // No lucide glyph for a parallelogram; drawn in the same 24-grid
-          // stroke style so the row reads as one set.
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M7 5h14l-4 14H3Z" />
-          </svg>,
-        ),
-        shapeOption('cylinder', 'Cylinder', <Cylinder />),
-      ],
-    },
-  ]
 }
 
 // --- visual.symbol/v0 ------------------------------------------------------
@@ -259,6 +239,51 @@ const visualEdgesPanel: CanvasSettingsWidget = ({ canvas, run }) => {
  * SECOND namespace contributes (one namespace stays unlabeled). Group order
  * is namespace-id lexicographic — display wording never moves it.
  */
+/**
+ * Tier 2: a facet that DECLARES its editor gets its quick band rendered
+ * from the declaration — no per-facet React. The glyph vocabulary is the
+ * core's (a plugin names one, it cannot ship one), which is what keeps a
+ * declared editor a declaration rather than third-party UI code.
+ */
+function declaredBands(
+  facetKey: string,
+  definition: FacetDefinition,
+  ctx: NodePropertiesContext,
+): readonly ContextMenuItem[] {
+  if (definition.editor === undefined) return []
+  const form = deriveFacetForm(definition.schema, definition.editor)
+  if (form.kind !== 'fields') return []
+  const stored = ctx.node['x-whiteboard']?.facets?.[facetKey] as Record<string, unknown> | undefined
+  return form.fields.flatMap((field) => {
+    if (!field.quick || field.control.kind !== 'segmented') return []
+    const current = stored?.[field.name]
+    return [
+      {
+        kind: 'options' as const,
+        label: field.label,
+        options: field.control.options.map((option) => ({
+          label: option.value ?? 'none',
+          ariaLabel: option.label,
+          icon: <FacetGlyphIcon glyph={option.glyph} />,
+          // A null option means the facet's ABSENCE, which is why the
+          // comparison is against undefined rather than the value.
+          selected: option.value === null ? stored === undefined : current === option.value,
+          onSelect: () => {
+            ctx.applyToSelection((ids) =>
+              ids.map((id) => ({
+                kind: 'set-node-facet' as const,
+                id,
+                key: facetKey,
+                payload: option.value === null ? undefined : { [field.name]: option.value },
+              })),
+            )
+          },
+        })),
+      },
+    ]
+  })
+}
+
 export function nodePropertyItems(
   registry: FacetRegistry,
   ctx: NodePropertiesContext,
@@ -267,7 +292,12 @@ export function nodePropertyItems(
   const contributed = resolveFacetContributions(registry, 'contextMenu.node.properties')
     .map((group) => ({
       group,
-      bands: group.facets.flatMap((facet) => widgets[facet.key]?.(ctx) ?? []),
+      // A hand-written widget still wins where one is registered (tier 2
+      // is a ladder, not a replacement): a picker the catalog cannot yet
+      // express keeps its code.
+      bands: group.facets.flatMap(
+        (facet) => widgets[facet.key]?.(ctx) ?? declaredBands(facet.key, facet.definition, ctx),
+      ),
     }))
     .filter((entry) => entry.bands.length > 0)
   return contributed.flatMap(({ group, bands }) =>
@@ -280,7 +310,9 @@ export function nodePropertyItems(
 // --- registrations ---------------------------------------------------------
 
 export const NODE_PROPERTIES_WIDGETS: Readonly<Record<string, NodePropertiesWidget>> = {
-  'visual.shape/v0': visualShapeBand,
+  // visual.shape is NOT here: it declares its band (see visual.ts's editor
+  // spec) and is rendered from that declaration — the acceptance test for
+  // tier 2 being usable by the plugin that ships with the engine.
   'visual.symbol/v0': visualSymbolBand,
 }
 

--- a/packages/facet-engine/src/form.test.ts
+++ b/packages/facet-engine/src/form.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 import { deriveFacetForm } from './form.js'
+import { defineFacet } from './registry.js'
 import { visualShapeFacetSchema, visualSymbolFacetSchema } from './visual.js'
 
 describe('deriveFacetForm', () => {
@@ -19,9 +20,15 @@ describe('deriveFacetForm', () => {
     expect(form).toEqual({
       kind: 'fields',
       fields: [
-        { name: 'title', label: 'title', control: { kind: 'text' }, required: true },
-        { name: 'count', label: 'count', control: { kind: 'number' }, required: true },
-        { name: 'done', label: 'done', control: { kind: 'toggle' }, required: true },
+        { name: 'title', label: 'title', control: { kind: 'text' }, required: true, quick: false },
+        {
+          name: 'count',
+          label: 'count',
+          control: { kind: 'number' },
+          required: true,
+          quick: false,
+        },
+        { name: 'done', label: 'done', control: { kind: 'toggle' }, required: true, quick: false },
       ],
     })
   })
@@ -46,6 +53,7 @@ describe('deriveFacetForm', () => {
       label: 'note',
       control: { kind: 'text' },
       required: false,
+      quick: false,
     })
   })
 
@@ -131,5 +139,89 @@ describe('deriveFacetForm', () => {
     )
     expect(deriveFacetForm(z.string()).kind).toBe('unsupported')
     expect(deriveFacetForm(z.array(z.string())).kind).toBe('unsupported')
+  })
+})
+
+describe('an editor spec refines the derived form', () => {
+  const schema = z.object({
+    kind: z.enum(['ellipse', 'diamond']),
+    label: z.string().optional(),
+  })
+
+  it('a field may declare a richer control from the catalog, with per-option glyphs', () => {
+    const form = deriveFacetForm(schema, {
+      fields: {
+        kind: {
+          widget: 'segmented',
+          label: 'Shape',
+          quick: true,
+          options: [
+            { value: 'ellipse', label: 'Ellipse', glyph: 'circle' },
+            { value: 'diamond', label: 'Diamond', glyph: 'diamond' },
+          ],
+        },
+      },
+    })
+    if (form.kind !== 'fields') throw new Error('unreachable')
+    const [first, second] = form.fields
+    expect(first).toEqual({
+      name: 'kind',
+      label: 'Shape',
+      quick: true,
+      control: {
+        kind: 'segmented',
+        options: [
+          { value: 'ellipse', label: 'Ellipse', glyph: 'circle' },
+          { value: 'diamond', label: 'Diamond', glyph: 'diamond' },
+        ],
+      },
+      required: true,
+    })
+    // A field the spec says nothing about keeps its derived control.
+    expect(second?.control).toEqual({ kind: 'text' })
+    expect(second?.quick).toBe(false)
+  })
+
+  it('a spec may add an ABSENCE option, since some defaults are unrepresentable', () => {
+    // `visual.shape` has no 'rect' value — rect IS the absent facet — so a
+    // picker needs a way to say "clear this".
+    const form = deriveFacetForm(schema, {
+      fields: {
+        kind: {
+          widget: 'segmented',
+          options: [
+            { value: null, label: 'Rectangle', glyph: 'square' },
+            { value: 'ellipse', label: 'Ellipse', glyph: 'circle' },
+          ],
+        },
+      },
+    })
+    if (form.kind !== 'fields') throw new Error('unreachable')
+    const control = form.fields[0]?.control
+    expect(control?.kind === 'segmented' && control.options[0]?.value).toBeNull()
+  })
+
+  it('a spec naming a field the schema does not have is rejected at definition time', () => {
+    expect(() =>
+      defineFacet({
+        name: 'sample',
+        version: 'v0',
+        targets: ['node'],
+        schema,
+        editor: { fields: { nope: { widget: 'segmented', options: [] } } },
+      }),
+    ).toThrow(/nope/)
+  })
+
+  it('a spec on a schema with no derivable form is rejected too', () => {
+    expect(() =>
+      defineFacet({
+        name: 'sample',
+        version: 'v0',
+        targets: ['node'],
+        schema: z.string(),
+        editor: { fields: { kind: { widget: 'text' } } },
+      }),
+    ).toThrow(/form/)
   })
 })

--- a/packages/facet-engine/src/form.ts
+++ b/packages/facet-engine/src/form.ts
@@ -12,18 +12,68 @@
 
 import { z } from 'zod'
 
+/**
+ * The glyph vocabulary a spec may name — CLOSED, and owned by the core the
+ * way contribution points are. A plugin picks from it; it cannot ship an
+ * image or a component, which is what keeps a declared editor a
+ * declaration rather than third-party UI code (the catalog-as-sandbox
+ * principle of ADR-0013).
+ */
+export const FACET_GLYPHS = [
+  'square',
+  'circle',
+  'diamond',
+  'hexagon',
+  'parallelogram',
+  'cylinder',
+  'none',
+] as const
+export type FacetGlyph = (typeof FACET_GLYPHS)[number]
+
+export interface FacetSegmentedOption {
+  /**
+   * The value this segment writes. `null` CLEARS the facet — some defaults
+   * are the absence of a value (a rect node stores no shape facet), and a
+   * picker with no way to say that cannot express them.
+   */
+  readonly value: string | null
+  readonly label: string
+  readonly glyph?: FacetGlyph
+}
+
 export type FacetFormControl =
   | { readonly kind: 'text' }
   | { readonly kind: 'number' }
   | { readonly kind: 'toggle' }
   | { readonly kind: 'choice'; readonly options: readonly string[] }
+  | { readonly kind: 'segmented'; readonly options: readonly FacetSegmentedOption[] }
 
 export interface FacetFormField {
   readonly name: string
-  /** Human-facing; the field name until a definition can carry a label. */
+  /** Human-facing: the spec's label, else the field name. */
   readonly label: string
   readonly control: FacetFormControl
   readonly required: boolean
+  /**
+   * Whether this field belongs in a one-tap quick band (a context-menu
+   * row) as well as the full editor. Only a spec can say so — a derived
+   * field defaults to false, because a surface with room for one row
+   * should not guess which of five fields deserves it.
+   */
+  readonly quick: boolean
+}
+
+/** What a plugin may declare about ONE field. Widget names are closed. */
+export interface FacetFieldSpec {
+  readonly widget: 'text' | 'number' | 'toggle' | 'choice' | 'segmented'
+  readonly label?: string
+  readonly quick?: boolean
+  /** Required by `segmented`; ignored by the other widgets. */
+  readonly options?: readonly FacetSegmentedOption[]
+}
+
+export interface FacetEditorSpec {
+  readonly fields: Readonly<Record<string, FacetFieldSpec>>
 }
 
 export interface FacetFormVariant {
@@ -67,17 +117,35 @@ function controlOf(schema: z.ZodTypeAny): FacetFormControl | undefined {
   return undefined
 }
 
+/** The spec's control for a field, when it declares a richer one. */
+function specControl(spec: FacetFieldSpec | undefined): FacetFormControl | undefined {
+  if (spec === undefined) return undefined
+  if (spec.widget === 'segmented') {
+    return { kind: 'segmented', options: spec.options ?? [] }
+  }
+  if (spec.widget === 'choice') return undefined
+  return { kind: spec.widget }
+}
+
 function fieldsOf(
   shape: Record<string, z.ZodTypeAny>,
   skip?: string,
+  editor?: FacetEditorSpec,
 ): readonly FacetFormField[] | undefined {
   const fields: FacetFormField[] = []
   for (const [name, member] of Object.entries(shape)) {
     if (name === skip) continue
     const { inner, required } = unwrap(member)
-    const control = controlOf(inner)
-    if (control === undefined) return undefined
-    fields.push({ name, label: name, control, required })
+    const derived = controlOf(inner)
+    if (derived === undefined) return undefined
+    const spec = editor?.fields[name]
+    fields.push({
+      name,
+      label: spec?.label ?? name,
+      control: specControl(spec) ?? derived,
+      required,
+      quick: spec?.quick ?? false,
+    })
   }
   return fields
 }
@@ -93,9 +161,9 @@ function discriminantOf(shape: Record<string, z.ZodTypeAny>): [string, string] |
   return undefined
 }
 
-export function deriveFacetForm(schema: z.ZodTypeAny): FacetForm {
+export function deriveFacetForm(schema: z.ZodTypeAny, editor?: FacetEditorSpec): FacetForm {
   if (schema instanceof z.ZodObject) {
-    const fields = fieldsOf(schema.shape as Record<string, z.ZodTypeAny>)
+    const fields = fieldsOf(schema.shape as Record<string, z.ZodTypeAny>, undefined, editor)
     return fields === undefined ? UNSUPPORTED : { kind: 'fields', fields }
   }
   if (schema instanceof z.ZodUnion) {
@@ -120,4 +188,35 @@ export function deriveFacetForm(schema: z.ZodTypeAny): FacetForm {
     return discriminant === undefined ? UNSUPPORTED : { kind: 'variants', discriminant, variants }
   }
   return UNSUPPORTED
+}
+
+/**
+ * Definition-time check for an editor spec, kept HERE because this module
+ * owns what a form can express: a spec that names a field the schema does
+ * not declare, or sits on a schema with no derivable form, is a
+ * programmer error and throws like the rest of `defineFacet`'s grammar
+ * checks.
+ *
+ * Lives in this module rather than the registry so the dependency stays
+ * one-way — the registry may read the form layer, never the reverse.
+ */
+export function assertEditorSpecFits(
+  facetName: string,
+  schema: z.ZodTypeAny,
+  editor: FacetEditorSpec,
+): void {
+  const form = deriveFacetForm(schema)
+  if (form.kind !== 'fields') {
+    throw new Error(
+      `facet "${facetName}" declares an editor spec, but its schema has no derivable form`,
+    )
+  }
+  const known = new Set(form.fields.map((field) => field.name))
+  for (const name of Object.keys(editor.fields)) {
+    if (!known.has(name)) {
+      throw new Error(
+        `facet "${facetName}" editor names field "${name}", which its schema does not declare`,
+      )
+    }
+  }
 }

--- a/packages/facet-engine/src/registry.ts
+++ b/packages/facet-engine/src/registry.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod'
+import { assertEditorSpecFits, type FacetEditorSpec } from './form.js'
 
 /**
  * The facet engine's definition + registry machinery (ADR-0013 decisions 3,
@@ -34,6 +35,14 @@ export interface FacetDefinition<S extends z.ZodTypeAny = z.ZodTypeAny> {
    * so no N² converters ever exist.
    */
   readonly compat?: Readonly<Record<string, FacetCompatEntry>>
+  /**
+   * Tier 2 of the editor ladder: how this facet's fields should be
+   * presented, declared from a closed widget/glyph vocabulary rather than
+   * shipped as UI code. Absent, every field falls back to the control
+   * `deriveFacetForm` reads off the schema. Checked at definition time
+   * against the schema, so a spec cannot name a field that does not exist.
+   */
+  readonly editor?: FacetEditorSpec
 }
 
 export interface FacetPlugin {
@@ -59,6 +68,9 @@ export function defineFacet<S extends z.ZodTypeAny>(
   }
   if (definition.targets.length === 0) {
     throw new Error(`facet "${definition.name}" declares no targets`)
+  }
+  if (definition.editor !== undefined) {
+    assertEditorSpecFits(definition.name, definition.schema, definition.editor)
   }
   for (const tag of Object.keys(definition.compat ?? {})) {
     if (!VERSION_PATTERN.test(tag)) {

--- a/packages/facet-engine/src/visual.ts
+++ b/packages/facet-engine/src/visual.ts
@@ -94,6 +94,27 @@ export const visualPlugin = definePlugin({
       version: 'v0',
       targets: ['node'],
       schema: visualShapeFacetSchema,
+      // Declared, not hand-written: the bundled plugin goes through the
+      // same tier-2 catalog a third-party plugin would, so the mechanism
+      // is exercised by its first customer. `null` is the Rectangle
+      // segment — rect is the ABSENT facet, not a stored value.
+      editor: {
+        fields: {
+          kind: {
+            widget: 'segmented',
+            label: 'Shape',
+            quick: true,
+            options: [
+              { value: null, label: 'Rectangle', glyph: 'square' },
+              { value: 'ellipse', label: 'Ellipse', glyph: 'circle' },
+              { value: 'diamond', label: 'Diamond', glyph: 'diamond' },
+              { value: 'hexagon', label: 'Hexagon', glyph: 'hexagon' },
+              { value: 'parallelogram', label: 'Parallelogram', glyph: 'parallelogram' },
+              { value: 'cylinder', label: 'Cylinder', glyph: 'cylinder' },
+            ],
+          },
+        },
+      },
     }),
     defineFacet({
       name: 'symbol',


### PR DESCRIPTION
## Summary

Increment 6c: **tier 2 of the editor ladder** — a facet *declares* its editor instead of shipping UI code.

- **facet-engine**: an optional `editor` spec on a facet definition names, per field, a widget and a glyph from a **closed vocabulary the core owns** (`text`/`number`/`toggle`/`choice`/`segmented`; `FACET_GLYPHS`). A plugin picks from it — it cannot ship a component or an image, which is what keeps a declared editor a declaration rather than third-party UI code. `deriveFacetForm(schema, editor)` merges the spec over the derived form; `assertEditorSpecFits` rejects at **definition time** a spec naming a field the schema does not declare, or one on a schema with no derivable form. It lives in `form.ts` so the dependency stays one-way (the registry may read the form layer, never the reverse).
- **The absence option**: a segmented option may carry `value: null`, meaning the facet should *not exist*. Rect is not a stored shape, it is **no** shape — a picker with no way to say that cannot express the default.
- **apps/web**: a generic renderer builds the quick band from the declaration; the glyph vocabulary is mapped to drawings here (engine owns what may be said, the vessel owns how it looks). Segmented renders as **real radios**, not buttons wearing the role.

## The acceptance test

The same shape as #990 and #998: the bundled plugin is the mechanism's first customer. **`visual.shape`'s hand-written React widget is deleted** and its band is now declared — and `node-shape-menu.browser.test.tsx` passes **unchanged**. `visual.symbol` keeps its widget: tier 2 is a ladder, not a replacement, and a picker the catalog cannot yet express keeps its code.

## The defect the review caught

The absence option was broken in the **panel** (the band was fine): picking Rectangle staged `undefined`, `prune` dropped the key, and Save validated `{}` against a schema whose field is required — surfacing `kind: Invalid option` instead of removing the facet. Root cause was one line: `onClear` was added to `FieldInput`'s prop **type** but not to its destructuring, so the handler closed over nothing. TypeScript cannot see that — an unused parameter is legal — which is why the test had to reach the real click path. Fixed, and pinned by a test that picks the option and asserts both the write and the absence of an error.

## Verification

Root suite **9252 passed, 0 failed** (943 files) before the fix; after it, apps/web spatial-editor jsdom 414 and browser 395 both green, plus lint / `pnpm -r typecheck` / knip clean. No visual evidence: the rendered band is byte-identical to what #974 already illustrated — that identity *is* the claim, and the unchanged browser regression is its proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013avJozs9SoCuDzZJGuTcqH
