### PR TITLE
feat: visual.text/v0 — text placement as a facet, contributed with no vessel change

### DIFF
--- a/.claude/rules/package-facet-engine.md
+++ b/.claude/rules/package-facet-engine.md
@@ -54,6 +54,12 @@ paths:
   way and ships NO hand-written widget, which is how the mechanism is
   proved by the plugin that ships with the engine.
 
+  `visual.text/v0` is the stronger proof, and the shape to copy for a new
+  node property: it was added to `visual.ts` alone, and reached the
+  context menu — row, segmented control, write path, clear — with zero
+  lines changed in `apps/web`. If a new facet needs a vessel edit to be
+  usable, the editor spec is the thing to extend, not the vessel.
+
 ## What does NOT belong here
 
 - Facet KEY grammar and the `facets` bucket schemas — those are model's

--- a/apps/web/src/components/spatial-editor/node-text-placement.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/node-text-placement.browser.test.tsx
@@ -1,0 +1,51 @@
+// visual.text/v0 reached the menu with NO apps/web change at all: it is a
+// facet definition carrying an editor spec, rendered by the tier-2 path.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const initial: SpatialCanvas = {
+  nodes: [{ id: 'a', type: 'text', x: 80, y: 80, width: 200, height: 100, text: 'A' }],
+  edges: [],
+}
+
+it('the Text row stores the facet and moves the drawn text', () => {
+  const latest: { canvas: SpatialCanvas } = { canvas: initial }
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
+    latest.canvas = canvas
+    return (
+      <div style={{ width: 800, height: 600 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const textY = () =>
+    Number(
+      (container.querySelector('[data-testid="spatial-editor"] svg text') as SVGTextElement | null)
+        ?.getAttribute('y') ?? '0',
+    )
+  const before = textY()
+
+  const r = root.getBoundingClientRect()
+  fireEvent.contextMenu(root, { clientX: r.left + 180, clientY: r.top + 130 })
+  const menu = container.querySelector('[data-testid="context-menu"]') as HTMLElement
+  fireEvent.click(menu.querySelector('[aria-label="Middle"]') as HTMLElement)
+
+  expect(latest.canvas.nodes[0]?.['x-whiteboard']?.facets?.['visual.text/v0']).toEqual({
+    align: 'center',
+  })
+  // Not merely stored: a rect's text moved down from the top.
+  expect(textY()).toBeGreaterThan(before)
+})

--- a/apps/web/src/components/spatial-editor/node-text-placement.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/node-text-placement.browser.test.tsx
@@ -33,8 +33,9 @@ it('the Text row stores the facet and moves the drawn text', () => {
   const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
   const textY = () =>
     Number(
-      (container.querySelector('[data-testid="spatial-editor"] svg text') as SVGTextElement | null)
-        ?.getAttribute('y') ?? '0',
+      (
+        container.querySelector('[data-testid="spatial-editor"] svg text') as SVGTextElement | null
+      )?.getAttribute('y') ?? '0',
     )
   const before = textY()
 

--- a/docs/contributing/adr/0013-facet-system.md
+++ b/docs/contributing/adr/0013-facet-system.md
@@ -209,7 +209,10 @@ grammar). The rest lands in order: the plugin registry, four-layer
 validation, compat chains, the canvas slot and the `visual` edge-style
 migration; then `visual.shape/v0` (first node-target facet, resolving to
 the already-landed silhouettes); then `visual.symbol/v0`; then the editor
-tiers and contribution surfaces.
+tiers and contribution surfaces. `visual.text/v0` (per-node text
+placement) landed after those and is the first facet to reach the editor
+with NO composition-root change at all — its whole UI comes from the
+tier-2 `editor` spec, which is the test of whether the tiers work.
 
 ## Consequences
 

--- a/packages/canvas-render/src/layout/spatial-canvas.test.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.test.ts
@@ -306,6 +306,33 @@ describe('layoutSpatialCanvas', () => {
     }
   })
 
+  it('visual.text overrides the placement a node would otherwise choose, both ways', () => {
+    // A plain RECT asked to centre: the default would top-align it.
+    const centredRect = {
+      ...textNode({ id: 'a', x: 0, y: 0, width: 200, height: 100, text: 'one line' }),
+      'x-whiteboard': { facets: { 'visual.text/v0': { align: 'center' as const } } },
+    }
+    const rectScene = layoutSpatialCanvas(canvas([centredRect]), baseOptions())
+    const rectBlock = rectScene.nodes.find((n) => n.kind === 'paragraph')
+    const rectCentre = (rectBlock?.bbox.y ?? 0) + (rectBlock?.bbox.h ?? 0) / 2
+    expect(Math.abs(rectCentre - 50)).toBeLessThan(6)
+
+    // A SHAPED node asked to start: the default would centre it.
+    const toppedShape = {
+      ...textNode({ id: 'b', x: 0, y: 0, width: 200, height: 100, text: 'one line' }),
+      'x-whiteboard': {
+        facets: {
+          'visual.shape/v0': { kind: 'ellipse' as const },
+          'visual.text/v0': { align: 'start' as const },
+        },
+      },
+    }
+    const shapeScene = layoutSpatialCanvas(canvas([toppedShape]), baseOptions())
+    const shapeBlock = shapeScene.nodes.find((n) => n.kind === 'paragraph')
+    // The inscribed box's top plus padding — well above the node's middle.
+    expect(shapeBlock?.bbox.y ?? 0).toBeLessThan(40)
+  })
+
   it('an explicit nodeOutlines option overrides the facet for that node', () => {
     const node = textNode({ id: 'a', x: 0, y: 0, width: 100, height: 60, text: 'a' })
     const shaped = {

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -30,6 +30,7 @@ import {
   resolveCanvasEdgeStyle,
   resolveNodeShape,
   resolveNodeSymbol,
+  resolveNodeTextAlign,
 } from '@kamiazya/whiteboard-facet-engine'
 import type {
   CanvasEdge,
@@ -471,8 +472,14 @@ function placeInNode(
   // box, so the offset is 0 and the top-aligned truncate+fade contract is
   // untouched; a plain rect never gets an offset, keeping every existing
   // canvas byte-identical.
+  //
+  // `visual.text/v0` OVERRIDES that default in either direction: a rect may
+  // ask to centre, a shaped node to start at the top. Absent, the default
+  // above is what happens — which is why the facet has no third value.
+  const align = resolveNodeTextAlign(node)
+  const centres = align === undefined ? options.nodeOutlines?.[node.id] !== undefined : align === 'center'
   let dy = 0
-  if (options.fitToBox && options.nodeOutlines?.[node.id] !== undefined) {
+  if (options.fitToBox && centres) {
     const innerH = bounds.h - 2 * padding
     const contentH = Math.max(
       0,

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -477,7 +477,8 @@ function placeInNode(
   // ask to centre, a shaped node to start at the top. Absent, the default
   // above is what happens — which is why the facet has no third value.
   const align = resolveNodeTextAlign(node)
-  const centres = align === undefined ? options.nodeOutlines?.[node.id] !== undefined : align === 'center'
+  const centres =
+    align === undefined ? options.nodeOutlines?.[node.id] !== undefined : align === 'center'
   let dy = 0
   if (options.fitToBox && centres) {
     const innerH = bounds.h - 2 * padding

--- a/packages/facet-engine/src/contributions.test.ts
+++ b/packages/facet-engine/src/contributions.test.ts
@@ -34,7 +34,11 @@ describe('resolveFacetContributions', () => {
     expect(groups.map((g) => g.namespace)).toEqual(['planning', 'visual'])
     expect(groups.map((g) => g.displayName)).toEqual(['Planning', 'Visual style'])
     expect(groups[0]?.facets.map((f) => f.key)).toEqual(['planning.assignee/v0', 'planning.due/v0'])
-    expect(groups[1]?.facets.map((f) => f.key)).toEqual(['visual.shape/v0', 'visual.symbol/v0'])
+    expect(groups[1]?.facets.map((f) => f.key)).toEqual([
+      'visual.shape/v0',
+      'visual.symbol/v0',
+      'visual.text/v0',
+    ])
   })
 
   it('a point only carries facets whose targets include its object', () => {

--- a/packages/facet-engine/src/visual.test.ts
+++ b/packages/facet-engine/src/visual.test.ts
@@ -7,9 +7,11 @@ import {
   resolveCanvasEdgeStyle,
   resolveNodeShape,
   resolveNodeSymbol,
+  resolveNodeTextAlign,
   VISUAL_EDGES_KEY,
   VISUAL_SHAPE_KEY,
   VISUAL_SYMBOL_KEY,
+  VISUAL_TEXT_KEY,
   visualPlugin,
   visualSymbolFacetSchema,
 } from './visual.js'
@@ -209,6 +211,49 @@ describe('visual.symbol/v0', () => {
     expect(resolveNodeSymbol(nodeWith(undefined), registry)).toBeUndefined()
     expect(
       resolveNodeSymbol(nodeWith({ facets: { [VISUAL_SYMBOL_KEY]: { bogus: true } } }), registry),
+    ).toBeUndefined()
+  })
+})
+
+describe('visual.text/v0', () => {
+  const nodeWith = (extension: SpatialCanvas['nodes'][number]['x-whiteboard']) =>
+    ({
+      id: 'n1',
+      type: 'text',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      text: '',
+      ...(extension === undefined ? {} : { 'x-whiteboard': extension }),
+    }) as SpatialCanvas['nodes'][number]
+
+  it('registers node-targeted, under the fixed key, declaring its own band', () => {
+    expect(VISUAL_TEXT_KEY).toBe('visual.text/v0')
+    expect(registry.targetsOf(VISUAL_TEXT_KEY)).toEqual(['node'])
+    const definition = registry.plugins
+      .flatMap((plugin) => plugin.facets)
+      .find((facet) => facet.name === 'text')
+    // Declared, not hand-written — the tier-2 path, like visual.shape.
+    expect(definition?.editor?.fields.align?.widget).toBe('segmented')
+    expect(definition?.editor?.fields.align?.quick).toBe(true)
+  })
+
+  it('resolveNodeTextAlign answers the stored choice, else undefined', () => {
+    expect(
+      resolveNodeTextAlign(
+        nodeWith({ facets: { [VISUAL_TEXT_KEY]: { align: 'center' } } }),
+        registry,
+      ),
+    ).toBe('center')
+    expect(
+      resolveNodeTextAlign(nodeWith({ facets: { [VISUAL_TEXT_KEY]: { align: 'start' } } }), registry),
+    ).toBe('start')
+    // Absent means "however this node would place text anyway" — the facet
+    // OVERRIDES a default, it does not restate one.
+    expect(resolveNodeTextAlign(nodeWith(undefined), registry)).toBeUndefined()
+    expect(
+      resolveNodeTextAlign(nodeWith({ facets: { [VISUAL_TEXT_KEY]: { align: 'middle' } } }), registry),
     ).toBeUndefined()
   })
 })

--- a/packages/facet-engine/src/visual.test.ts
+++ b/packages/facet-engine/src/visual.test.ts
@@ -247,13 +247,19 @@ describe('visual.text/v0', () => {
       ),
     ).toBe('center')
     expect(
-      resolveNodeTextAlign(nodeWith({ facets: { [VISUAL_TEXT_KEY]: { align: 'start' } } }), registry),
+      resolveNodeTextAlign(
+        nodeWith({ facets: { [VISUAL_TEXT_KEY]: { align: 'start' } } }),
+        registry,
+      ),
     ).toBe('start')
     // Absent means "however this node would place text anyway" — the facet
     // OVERRIDES a default, it does not restate one.
     expect(resolveNodeTextAlign(nodeWith(undefined), registry)).toBeUndefined()
     expect(
-      resolveNodeTextAlign(nodeWith({ facets: { [VISUAL_TEXT_KEY]: { align: 'middle' } } }), registry),
+      resolveNodeTextAlign(
+        nodeWith({ facets: { [VISUAL_TEXT_KEY]: { align: 'middle' } } }),
+        registry,
+      ),
     ).toBeUndefined()
   })
 })

--- a/packages/facet-engine/src/visual.ts
+++ b/packages/facet-engine/src/visual.ts
@@ -75,6 +75,24 @@ export type VisualSymbolFacet = z.infer<typeof visualSymbolFacetSchema>
 export const VISUAL_SYMBOL_KEY = 'visual.symbol/v0'
 
 /**
+ * Where a node's text sits inside the space it has. Separate from
+ * `visual.shape` on purpose: a plain rect may want centred text, and a
+ * shaped node may want its text at the top — tying placement to the
+ * silhouette would make one choice unreachable from the other.
+ *
+ * ABSENT means "however this node would place text anyway" (a shaped node
+ * centres what fits, a rect starts at the top). The facet overrides that
+ * default; it does not restate it, which is why there is no third value.
+ */
+export const visualTextFacetSchema = z.object({
+  align: z.enum(['start', 'center']),
+})
+
+export type VisualTextFacet = z.infer<typeof visualTextFacetSchema>
+
+export const VISUAL_TEXT_KEY = 'visual.text/v0'
+
+/**
  * The bundled plugin. Deliberately ordinary (ADR-0013 decision 3): it goes
  * through the same registry, validation and ordering as any deployment's
  * added plugins, and a deployment may disable it.
@@ -111,6 +129,26 @@ export const visualPlugin = definePlugin({
               { value: 'hexagon', label: 'Hexagon', glyph: 'hexagon' },
               { value: 'parallelogram', label: 'Parallelogram', glyph: 'parallelogram' },
               { value: 'cylinder', label: 'Cylinder', glyph: 'cylinder' },
+            ],
+          },
+        },
+      },
+    }),
+    defineFacet({
+      name: 'text',
+      version: 'v0',
+      targets: ['node'],
+      schema: visualTextFacetSchema,
+      editor: {
+        fields: {
+          align: {
+            widget: 'segmented',
+            label: 'Text',
+            quick: true,
+            options: [
+              { value: null, label: 'Default placement', glyph: 'none' },
+              { value: 'start', label: 'Top' },
+              { value: 'center', label: 'Middle' },
             ],
           },
         },
@@ -194,4 +232,20 @@ export function resolveNodeSymbol(
   const resolution = registry.resolveFacetPayload(VISUAL_SYMBOL_KEY, stored)
   if (resolution.kind !== 'resolved') return undefined
   return visualSymbolFacetSchema.parse(resolution.value)
+}
+
+/**
+ * The one read path for "where does this node's text sit": the
+ * `visual.text/v0` facet when it resolves, else undefined — which every
+ * consumer treats as the placement it would have chosen anyway.
+ */
+export function resolveNodeTextAlign(
+  node: SpatialCanvas['nodes'][number],
+  registry: FacetRegistry = bundledFacetRegistry,
+): VisualTextFacet['align'] | undefined {
+  const stored = node['x-whiteboard']?.facets?.[VISUAL_TEXT_KEY]
+  if (stored === undefined) return undefined
+  const resolution = registry.resolveFacetPayload(VISUAL_TEXT_KEY, stored)
+  if (resolution.kind !== 'resolved') return undefined
+  return visualTextFacetSchema.parse(resolution.value).align
 }


### PR DESCRIPTION
The inscribed-box increment fixed a placement policy: a **shaped** node centres
content that fits vertically, a plain **rect** tops it. That is a good default
and a bad law — a rect may want its text centred, and a shaped node may want it
at the top. `visual.text/v0` makes it a per-node facet.

```ts
z.object({ align: z.enum(['start', 'center']) })
```

**Absent means "however this node would place text anyway".** The facet
overrides a default rather than restating it, which is why there is no third
value and why every existing canvas renders byte-identically (900
`canvas-render` tests unchanged).

## The point of this increment

`apps/web` gains **no production code**. The entire editor UI — the row, the
segmented control, the Default/Top/Middle options, the write path, the clear —
comes from the tier-2 `editor` spec added in #1013:

```ts
editor: {
  fields: {
    align: {
      widget: 'segmented', label: 'Text', quick: true,
      options: [
        { value: null, label: 'Default placement', glyph: 'none' },
        { value: 'start', label: 'Top' },
        { value: 'center', label: 'Middle' },
      ],
    },
  },
}
```

That is the claim #1013 was built to make, now tested rather than argued: a new
node property ships as a facet definition in `facet-engine`, and the vessel
renders it sight-unseen.

## Visual repro

One canvas through the real `server-core` compose+SVG pipeline. Left pair is a
plain rect (default → `center`), right pair an ellipse (default → `start`).

![text-placement.png](https://github.com/user-attachments/assets/753dfc6f-5f33-4700-a30d-7d411e263c44)

## Tests

- `facet-engine`: registration, the editor spec, and `resolveNodeTextAlign` —
  including that an invalid `align` is dropped rather than thrown.
- `canvas-render`: both overrides, red-first (the rect case failed
  `expected 29.6 to be less than 6` before the change).
- `web-browser`: right-click → **Middle** stores the facet **and moves the
  drawn `<text>` y** — the second assertion is what makes it a wiring test
  rather than a state test.

Gates: `pnpm test` 9265 · apps/web CI-style 2723 + 77 · `test:browser` 775 ·
typecheck · lint · knip — all green.