### PR TITLE
fix(spatial-editor): a context-menu options row wraps instead of pushing options off the phone

### DIFF
--- a/apps/web/src/components/spatial-editor/ContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/ContextMenu.tsx
@@ -245,7 +245,17 @@ export function ContextMenu({
       style={
         sheet
           ? { position: 'absolute', zIndex: 20, left: 0, right: 0, bottom: 0 }
-          : { position: 'absolute', zIndex: 20, width: 'max-content', left: pos.x, top: pos.y }
+          : {
+              position: 'absolute',
+              zIndex: 20,
+              width: 'max-content',
+              // max-content alone lets a long options row set a box wider
+              // than the editor, and no clamp can place a box that does not
+              // fit. Measured at 390px: the menu came out 434.6px.
+              maxWidth: '100%',
+              left: pos.x,
+              top: pos.y,
+            }
       }
       onKeyDown={(e) => {
         if (e.key === 'Escape') {
@@ -317,10 +327,14 @@ export function ContextMenu({
       <Fragment key={item.label}>
         <fieldset
           aria-label={item.label}
-          className="m-0 flex items-center justify-between gap-2 border-0 p-0 px-3 py-1"
+          className="m-0 flex flex-wrap items-center justify-between gap-x-2 gap-y-1 border-0 p-0 px-3 py-1"
         >
           <span className="text-xs text-muted-foreground">{item.label}</span>
-          <span className="flex items-center gap-0.5">
+          {/* An options row is a PICKER, so an option pushed past the edge is
+              not merely ugly — it cannot be tapped. The set grows with every
+              contributing facet and the sheet is only as wide as the phone,
+              so the row wraps rather than trusting it to fit. */}
+          <span className="flex flex-wrap items-center justify-end gap-0.5">
             {item.options.map((option) => (
               <button
                 key={option.label}

--- a/apps/web/src/components/spatial-editor/context-menu-width.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu-width.browser.test.tsx
@@ -1,0 +1,81 @@
+// An options row is a picker, so an option pushed past the editor's own edge
+// is not merely ugly — it cannot be tapped. jsdom has no layout, so this is
+// only measurable in a real browser: every jsdom test stayed green while the
+// phone clipped Color, Shape and Symbol alike.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const initial: SpatialCanvas = {
+  nodes: [{ id: 'a', type: 'text', x: 60, y: 60, width: 140, height: 80, text: 'A' }],
+  edges: [],
+}
+
+/** Narrower than MINIMAP_MIN_ROOT_WIDTH_PX, so the ⋯ menu opens as a sheet. */
+function renderNarrow(width: number) {
+  function Host() {
+    const [canvas, setCanvas] = useState<SpatialCanvas>(initial)
+    return (
+      <div style={{ width, height: 700 }}>
+        <SpatialEditor
+          defaultTool="select"
+          canvas={canvas}
+          onChange={(next) => setCanvas(next)}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return render(<Host />)
+}
+
+/** Options that stick out of `bounds`, reported by name so a failure names them. */
+function escaping(menu: HTMLElement, bounds: DOMRect) {
+  return [...menu.querySelectorAll('fieldset button')]
+    .map((el) => ({ label: el.getAttribute('aria-label') ?? '?', box: el.getBoundingClientRect() }))
+    .filter(({ box }) => box.right > bounds.right + 0.5 || box.left < bounds.left - 0.5)
+    .map(({ label, box }) => `${label} @${Math.round(box.left)}..${Math.round(box.right)}`)
+}
+
+it('the right-click menu fits the editor width on a phone', () => {
+  const { container } = renderNarrow(390)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const r = root.getBoundingClientRect()
+  fireEvent.contextMenu(root, { clientX: r.left + 120, clientY: r.top + 100 })
+
+  const menu = container.querySelector('[data-testid="context-menu"]') as HTMLElement
+  // The MENU is what overflows here: `width: max-content` lets an options
+  // row set the box wider than the editor, and no clamp can place a box
+  // that does not fit.
+  expect(menu.getBoundingClientRect().width).toBeLessThanOrEqual(r.width)
+  expect(escaping(menu, r)).toEqual([])
+  // An empty menu would fit trivially.
+  expect(menu.querySelectorAll('fieldset button').length).toBeGreaterThan(10)
+})
+
+it('the ⋯ sheet keeps every option inside its own edges', () => {
+  const { container } = renderNarrow(390)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const r = root.getBoundingClientRect()
+  fireEvent.pointerDown(root, {
+    pointerId: 1,
+    isPrimary: true,
+    clientX: r.left + 130,
+    clientY: r.top + 100,
+  })
+  fireEvent.pointerUp(root, { pointerId: 1, clientX: r.left + 130, clientY: r.top + 100 })
+  // pointerup, not click: the ⋯ fires there (the root preventDefaults
+  // touchstart, so a tap never produces a click).
+  fireEvent.pointerUp(container.querySelector('[data-testid="more-actions-handle"]') as Element, {
+    pointerId: 2,
+  })
+
+  const menu = container.querySelector('[data-testid="context-menu"]') as HTMLElement
+  expect(menu.getAttribute('data-variant')).toBe('sheet')
+  // The sheet spans the editor, so here the options overflow the SHEET.
+  expect(escaping(menu, menu.getBoundingClientRect())).toEqual([])
+})


### PR DESCRIPTION
Reported from a phone: the property rows run off the right edge of the
screen. An options row is a **picker**, so an option past the edge is not
merely ugly — it cannot be tapped.

## Measured

| | before |
|---|---|
| right-click menu on a 390px editor | **434.6px wide** |
| last two emoji in the ⋯ sheet | `Emoji ⭐ @363..391`, `Emoji 📌 @393..421` against a 390px sheet |

Two independent halves, both needed:

- the options group never wrapped (`flex`, no `flex-wrap`, no cap), and
- `width: max-content` let the popover set a box wider than the editor —
  which no amount of edge-clamping can place.

**This is a core defect, not a facet one.** `Color` was clipped too, and
Color is not a facet. What made it visible is that the row set grows as
facets contribute bands.

## Why no existing test caught it

jsdom has no layout, so the whole jsdom suite stayed green while the phone
clipped three rows. The regression test is `web-browser`, and it asserts
against the box the options must fit inside — naming the escapees, so a
failure says *which* option is unreachable rather than just "too wide".

## After, at 390px

![menu-390.png](https://github.com/user-attachments/assets/e0d03478-2c98-410d-90f8-67432b53e59d)

Gates: `pnpm test` 945 files / 9267 · `test:browser` 777 · typecheck · lint.

Noted while capturing the shot, **not fixed here**: the `Text` band renders
three blank buttons — `declaredBands` always passes an `icon` element, so an
option whose glyph has no drawing gets an empty span instead of its label.
That is a defect in #1015's declared-band path and is fixed in the follow-up
that fences the facet region off from the core rows.
