### PR TITLE
feat(search): report each hit's lexical and semantic rank, and stop breaking fused ties by document id

### DIFF
--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -834,7 +834,19 @@ async function main() {
   if (!(searched.results[0].contexts[0] ?? '').includes('Imported body')) {
     throw new Error(`wb_document_search snippet mismatch: ${JSON.stringify(searched.results[0])}`)
   }
-  console.log('[e2e] wb_document_search → found the imported body with a snippet')
+  // The rank a caller uses to decide whether `contexts` is a match to
+  // highlight or just an opening excerpt. This daemon has no embedder, so
+  // every hit is lexical and none carries a semantic rank — the shape a
+  // client sees by default, and the one that must survive schema drift.
+  if (searched.results[0].lexicalRank !== 1) {
+    throw new Error(
+      `wb_document_search lexicalRank mismatch: ${JSON.stringify(searched.results[0])}`,
+    )
+  }
+  if (searched.results.some((r) => r.semanticRank !== undefined)) {
+    throw new Error(`wb_document_search reported a semantic rank with no embedder configured`)
+  }
+  console.log('[e2e] wb_document_search → found the imported body, snippet and lexical rank')
 
   const exported = await callTool('wb_document_get', {
     workspaceId: WORKSPACE_ID,

--- a/packages/server-core/src/search/semantic-search.test.ts
+++ b/packages/server-core/src/search/semantic-search.test.ts
@@ -137,6 +137,58 @@ describe('semantic fusion', () => {
     expect(out.results.map((r) => r.documentId)).toContain(bare.documentId)
   })
 
+  it('reports the lexical rank, 1-based, with no semantic rank when there is no embedder', async () => {
+    const deps = makeDeps()
+    const { storage } = await seed(deps)
+    const out = await createDocumentSearchTool(deps).execute({ workspaceId: WS, query: 'quota' })
+    expect(out.results[0]?.documentId).toBe(storage)
+    expect(out.results[0]?.lexicalRank).toBe(1)
+    // 0 would be falsy, so `if (hit.lexicalRank)` would read the top hit as
+    // no hit at all. There is no rank 0.
+    expect(out.results.every((r) => (r.lexicalRank ?? 1) >= 1)).toBe(true)
+    expect(out.results.every((r) => r.semanticRank === undefined)).toBe(true)
+  })
+
+  it('leaves the lexical rank undefined for a document only meaning could find', async () => {
+    const deps = makeDeps()
+    const { reconnect } = await seed(deps)
+    const out = await createDocumentSearchTool({ ...deps, embedder: fakeEmbedder() }).execute({
+      workspaceId: WS,
+      query: '復旧',
+    })
+    const hit = out.results.find((r) => r.documentId === reconnect)
+    // `復旧` shares no token with the English body, so BM25 never scored it:
+    // undefined is what tells a caller there is no match to highlight.
+    expect(hit?.lexicalRank).toBeUndefined()
+    expect(hit?.semanticRank).toBeGreaterThanOrEqual(1)
+  })
+
+  it('ranks against the WHOLE ranking, not the page the caller asked for', async () => {
+    const deps = makeDeps()
+    const { write } = await seed(deps)
+    // `zzz` is a term the fake embedder has never heard of, so it is a pure
+    // LEXICAL signal; `初回` is a pure SEMANTIC one. That separation is what
+    // lets the two rankings disagree on purpose.
+    await write('untitled-5', 'lexical only', 'zzz zzz zzz zzz zzz')
+    await write('untitled-6', 'both', 'zzz onboarding')
+    await write('untitled-7', 'partial a', 'onboarding 容量')
+    await write('untitled-8', 'partial b', 'onboarding socket')
+
+    const out = await createDocumentSearchTool({ ...deps, embedder: fakeEmbedder() }).execute({
+      workspaceId: WS,
+      query: 'zzz 初回',
+      limit: 1,
+    })
+
+    // One result asked for, and the winner is the document the two rankings
+    // AGREE on rather than the one keywords alone would put first — so its
+    // lexical rank is 2 while its position on this page is 1.
+    expect(out.results).toHaveLength(1)
+    expect(out.results[0]?.name).toBe('both')
+    expect(out.results[0]?.lexicalRank).toBe(2)
+    expect(out.results[0]?.semanticRank).toBe(1)
+  })
+
   it('an embedder that throws degrades to lexical-only', async () => {
     const deps = makeDeps()
     const { storage } = await seed(deps)

--- a/packages/server-core/src/search/semantic-search.test.ts
+++ b/packages/server-core/src/search/semantic-search.test.ts
@@ -189,6 +189,48 @@ describe('semantic fusion', () => {
     expect(out.results[0]?.semanticRank).toBe(1)
   })
 
+  it('breaks a fused tie on evidence, not on which document was created first', async () => {
+    // RRF collides BY CONSTRUCTION: 1/(K+1) + 1/(K+2) is exactly
+    // 1/(K+2) + 1/(K+1). Of the 400 rank pairs up to 20th place, only 210
+    // distinct fused scores exist and 190 of them are shared — ties are the
+    // norm here, not an edge case.
+    //
+    // What broke them was `documentId.localeCompare`, and a document id is
+    // `encodeTime(Date.now()) + encodeRandom()`: creation order, with chance
+    // deciding inside a millisecond. So the answer to "which of these two
+    // equally-ranked documents comes first" was when they happened to be
+    // written, which is not a fact about the query.
+    const deps = makeDeps()
+    const set = createDocumentSetTool(deps)
+    const write = async (path: string, name: string, body: string) => {
+      const created = await wbDocumentCreate(deps, {
+        workspaceId: WS,
+        path,
+        kind: 'markdown',
+        name,
+        createWorkspace: true,
+      })
+      await set.execute({
+        workspaceId: WS,
+        documentId: created.documentId,
+        markdown: `---\ntype: note\n---\n${body}`,
+      })
+    }
+    // `meaning` is written FIRST, so it holds the lower id and would win a
+    // tie decided by id. `keyword` matches the query's own word better, so
+    // it should win a tie decided by evidence.
+    await write('untitled-1', 'meaning', 'zzz onboarding') // lexical 2, semantic 1
+    await write('untitled-2', 'keyword', 'zzz zzz zzz') //    lexical 1, semantic 2
+
+    const out = await createDocumentSearchTool({ ...deps, embedder: fakeEmbedder() }).execute({
+      workspaceId: WS,
+      query: 'zzz 初回',
+      limit: 2,
+    })
+    expect(out.results.map((r) => r.name)).toEqual(['keyword', 'meaning'])
+    expect(out.results[0]?.score).toBeCloseTo(out.results[1]?.score ?? 0, 12)
+  })
+
   it('an embedder that throws degrades to lexical-only', async () => {
     const deps = makeDeps()
     const { storage } = await seed(deps)

--- a/packages/server-core/src/tools/document-search.ts
+++ b/packages/server-core/src/tools/document-search.ts
@@ -47,6 +47,34 @@ export const documentSearchOutputSchema = z
            * carries the opening of its text instead.
            */
           contexts: z.array(z.string()),
+          /**
+           * Where this document sat in the keyword ranking, 1-based, or
+           * absent when keywords never matched it.
+           *
+           * ABSENT IS THE USEFUL CASE: it says there is nothing in
+           * `contexts` to highlight, because the excerpt is the opening of
+           * the document rather than a match. A caller that highlights
+           * needs to know this and cannot infer it from the excerpt's
+           * shape. On this project's own docs it is not an edge case —
+           * 16 of 50 judged queries score no document lexically at all.
+           *
+           * 1-based deliberately: a rank of 0 is falsy, so `if (hit.lexicalRank)`
+           * would read the top hit as no hit.
+           */
+          lexicalRank: z.number().int().min(1).optional(),
+          /**
+           * Where this document sat in the semantic ranking, 1-based, or
+           * absent when no embedder was configured.
+           *
+           * Reported rather than folded into a "why did this match" label
+           * because every embedded document appears in the semantic
+           * ranking — so mere PRESENCE there carries no information, and a
+           * label built on it would tell the caller "meaning helped" about
+           * every result. Whether a semantic rank is good enough to have
+           * promoted a document is a judgement with a threshold in it, and
+           * the threshold belongs to whoever is displaying the results.
+           */
+          semanticRank: z.number().int().min(1).optional(),
         })
         .strict(),
     ),
@@ -100,7 +128,15 @@ export function createDocumentSearchTool(
       }
 
       const byId = new Map(searchable.map((doc) => [doc.documentId, doc]))
-      const describe = (documentId: string, score: number, contexts: readonly string[]) => {
+      /** documentId -> 1-based position, for whichever rankings exist. */
+      const ranksOf = (ranking: readonly string[]): Map<string, number> =>
+        new Map(ranking.map((documentId, index) => [documentId, index + 1]))
+      const describe = (
+        documentId: string,
+        score: number,
+        contexts: readonly string[],
+        ranks: { lexical?: number; semantic?: number },
+      ) => {
         const doc = byId.get(documentId)
         return {
           documentId,
@@ -109,6 +145,8 @@ export function createDocumentSearchTool(
           ...(doc?.kind === undefined ? {} : { kind: doc.kind }),
           score,
           contexts: [...contexts],
+          ...(ranks.lexical === undefined ? {} : { lexicalRank: ranks.lexical }),
+          ...(ranks.semantic === undefined ? {} : { semanticRank: ranks.semantic }),
         }
       }
 
@@ -118,8 +156,14 @@ export function createDocumentSearchTool(
       // inside it degrades to lexical-only rather than failing the search.
       const { embedder } = deps
       if (embedder === undefined) {
+        // The returned page IS the prefix of the full ranking here, so the
+        // index is the rank.
         const hits = fullTextSearch(searchable, parsed.query, { limit: parsed.limit })
-        return { results: hits.map((hit) => describe(hit.documentId, hit.score, hit.contexts)) }
+        return {
+          results: hits.map((hit, index) =>
+            describe(hit.documentId, hit.score, hit.contexts, { lexical: index + 1 }),
+          ),
+        }
       }
 
       // Fusion needs the WHOLE lexical ranking, not the page the caller asked
@@ -137,7 +181,9 @@ export function createDocumentSearchTool(
         return {
           results: lexical
             .slice(0, parsed.limit)
-            .map((hit) => describe(hit.documentId, hit.score, hit.contexts)),
+            .map((hit, index) =>
+              describe(hit.documentId, hit.score, hit.contexts, { lexical: index + 1 }),
+            ),
         }
       }
 
@@ -146,6 +192,11 @@ export function createDocumentSearchTool(
         .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
         .map(([documentId]) => documentId)
       const contexts = new Map(lexical.map((hit) => [hit.documentId, hit.contexts]))
+      // Ranks come from the COMPLETE rankings, not from the page returned:
+      // "3rd of 45" and "3rd of 5" are different facts, and only the former
+      // survives a change of `limit`.
+      const lexicalRanks = ranksOf(lexical.map((hit) => hit.documentId))
+      const semanticRanks = ranksOf(semantic)
       return {
         results: ordered
           .slice(0, parsed.limit)
@@ -154,6 +205,7 @@ export function createDocumentSearchTool(
               documentId,
               fused.get(documentId) ?? 0,
               contexts.get(documentId) ?? openingOf(byId.get(documentId)),
+              { lexical: lexicalRanks.get(documentId), semantic: semanticRanks.get(documentId) },
             ),
           ),
       }

--- a/packages/server-core/src/tools/document-search.ts
+++ b/packages/server-core/src/tools/document-search.ts
@@ -188,15 +188,37 @@ export function createDocumentSearchTool(
       }
 
       const fused = fuseByRank([lexical.map((hit) => hit.documentId), semantic])
-      const ordered = [...fused.entries()]
-        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
-        .map(([documentId]) => documentId)
       const contexts = new Map(lexical.map((hit) => [hit.documentId, hit.contexts]))
       // Ranks come from the COMPLETE rankings, not from the page returned:
       // "3rd of 45" and "3rd of 5" are different facts, and only the former
       // survives a change of `limit`.
       const lexicalRanks = ranksOf(lexical.map((hit) => hit.documentId))
       const semanticRanks = ranksOf(semantic)
+      /**
+       * Fused ties are the NORM, not an edge case: reciprocal-rank sums
+       * collide by construction, so a document at lexical 1 / semantic 2
+       * scores exactly what one at lexical 2 / semantic 1 does. Of the 400
+       * rank pairs inside the top 20, only 210 distinct scores exist and
+       * 190 are shared.
+       *
+       * Broken on evidence rather than on identity. The document whose
+       * keywords matched better wins, because those are the words the user
+       * actually typed; between two documents keywords never matched, the
+       * closer meaning wins. Ranks within a list are unique, so this is a
+       * total order with no appeal to a document id — which mattered, since
+       * an id is `encodeTime(Date.now()) + encodeRandom()` and ordering by
+       * it answered "which was written first", with chance deciding inside
+       * a millisecond.
+       */
+      const FAR = Number.MAX_SAFE_INTEGER
+      const ordered = [...fused.entries()]
+        .sort(
+          (a, b) =>
+            b[1] - a[1] ||
+            (lexicalRanks.get(a[0]) ?? FAR) - (lexicalRanks.get(b[0]) ?? FAR) ||
+            (semanticRanks.get(a[0]) ?? FAR) - (semanticRanks.get(b[0]) ?? FAR),
+        )
+        .map(([documentId]) => documentId)
       return {
         results: ordered
           .slice(0, parsed.limit)


### PR DESCRIPTION
Two changes to `wb_document_search`, the second found while building the first.

## 1. Every hit reports its lexical and semantic rank

A caller cannot currently tell whether `contexts` is a keyword match to highlight or the opening of a document, and the shape does not say — a lexical hit can also be one short excerpt. **`lexicalRank` absent IS that answer**: keywords never matched, so there is nothing to highlight.

Not the enum that was asked for. A three-value "why did this match" was requested by the UI session and turned out to be unbuildable as specified: `rankByVector` ranks **every** embedded document, so presence in the semantic ranking is true of everything. The enum would have labelled every result "meaning helped too" and its `lexical` case could never occur — three labels over a two-value distinction, asserting something vacuously true.

Measured on the docs corpus to check which half actually carries information:

```
BM25 scores per query:  mean 15.9 / median 8 / min 0 / max 45   (of 45 documents)
queries with no lexical hit at all:  16 of 50
```

The lexical side is informative; only the semantic side is degenerate. So: two ranks instead. They carry strictly more than the enum, need no threshold, and leave "did meaning promote this?" to whoever displays the results — which is where the threshold belongs. Agreed with the consuming session.

Both are **1-based** (0 is falsy, so `if (hit.lexicalRank)` would read the top hit as no hit) and both index the **complete pre-fusion ranking** ("3rd of 45" and "3rd of 5" are different facts; only the first survives a change of `limit`).

## 2. A fused tie was decided by which document was written first

Reciprocal-rank fusion collides **by construction**: `1/(K+1) + 1/(K+2)` is exactly `1/(K+2) + 1/(K+1)`. Enumerated over the 400 rank pairs inside the top 20, only **210 distinct fused scores exist and 190 are shared**. Ties are the norm, not an edge case.

They were broken by `documentId.localeCompare`, and a document id is `encodeTime(Date.now()) + encodeRandom()`. So "which of these two equally-ranked documents comes first" was answered by *when they happened to be written*, with chance deciding inside a millisecond — not a fact about the query, and a silent bias toward older documents.

Now broken on evidence: better keyword rank wins (those are the words the user typed); between two documents keywords never matched, closer meaning wins. Ranks are unique within a list, so this is a total order that never consults an id.

### Priced on the judged corpus

Same corpus digest `55fc4488db76`, so the difference is attributable to the tie-break alone:

| | before (id order) | after (evidence order) |
|---|---|---|
| nDCG@10 | 0.609 | 0.617 |
| MRR | 0.546 | 0.556 |
| recall@10 | 0.840 | 0.840 |
| stage 0 (control) | 0.328 | 0.328 |

**The +0.008 is not the argument.** It sits far below what this corpus can certify — detecting a 0.10 delta needs ~111 queries and there are 50. The change is justified because ordering by creation time is wrong regardless; the measurement's job here is to show it costs nothing. Stage 0 not moving is the control that confirms only the fused path was touched.

## Verification

- Mutation-checked on four claims — page-relative ranks, 0-based ranks, a fabricated rank for a semantic-only hit, and the restored id tie-break — each turns tests red, against a no-change control that stays green.
- The tie-break test constructs a genuine tie and writes the **loser first**, so id order and evidence order disagree. It also asserts the two scores are equal to twelve places: a test for tie-breaking that does not verify a tie is testing nothing.
- `pnpm smoke:e2e` now asserts the default shape a client sees — `lexicalRank` present, no `semanticRank` — because a daemon without an embedder must report no semantic ranking rather than an empty one.

## One correction worth recording

The measurement's numbers moved between runs and random ids were the obvious suspect. Two runs at the same corpus digest produced **identical** figures — ids ascend with creation time, so the random suffix only decides same-millisecond pairs. The drift came from the corpus itself changing, which the digest reported correctly. The tie-break defect is real and was found by direct test, not by that drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmbb1zNhiZitB7tn9LQ5f3
