### PR TITLE
feat(web): the document browser searches what documents say, not only what they are called

### DIFF
--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -14,7 +14,7 @@ Package boundaries are cut by **runtime requirements**, not by feature. The shar
 | `packages/server-core` | `/api/v1` Hono routes + MCP tool definitions, exposed as `createServer(deps)` | crdt, render, facet-engine, search, hono, zod, loro-crdt |
 | `packages/canvas-viewer` | Read-only spatial-canvas scene viewer UI (renders canvas-render SVG), shared between `apps/web` and the MCP Apps widget | model, codec, render, `@modelcontextprotocol/ext-apps`, react, zod |
 | `packages/mcp-server` | Node composition root: CLI, stdio, local store impls, resvg, Inversify container | server-core + port impls |
-| `apps/web` | Browser composition root: Canvas API backend, IndexedDB store impls, read-write spatial canvas editor, markdown editor | loro-adapter, model, codec, render, canvas-viewer, ports, facet-engine, `@kamiazya/whiteboard-mcp`'s browser-safe client subpaths (`/api-client`, `/api-contracts`, `/browser-contract`) + port impls |
+| `apps/web` | Browser composition root: Canvas API backend, IndexedDB store impls, read-write spatial canvas editor, markdown editor | loro-adapter, model, codec, render, canvas-viewer, ports, facet-engine, search, `@kamiazya/whiteboard-mcp`'s browser-safe client subpaths (`/api-client`, `/api-contracts`, `/browser-contract`) + port impls |
 
 **A third-party dependency is judged by that criterion, not by a quota.** The
 `allowedThirdParty` lists in `architecture-map.ts` are a RECORD of what has

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,6 +35,7 @@
     "@kamiazya/whiteboard-mcp": "workspace:*",
     "@kamiazya/whiteboard-model": "workspace:*",
     "@kamiazya/whiteboard-ports": "workspace:*",
+    "@kamiazya/whiteboard-search": "workspace:*",
     "@lezer/highlight": "^1.2.1",
     "@lezer/markdown": "^1.7.2",
     "@radix-ui/react-alert-dialog": "^1.1.23",

--- a/apps/web/src/components/workspace-files/SearchResults.test.tsx
+++ b/apps/web/src/components/workspace-files/SearchResults.test.tsx
@@ -15,10 +15,13 @@ import { SearchResults } from './SearchResults.js'
 
 afterEach(cleanup)
 
-const entries: WorkspaceDocumentEntry[] = [
+const documents: WorkspaceDocumentEntry[] = [
   { documentId: 'd1', path: 'plans/roadmap', name: 'Road map', kind: 'markdown' },
   { documentId: 'd2', path: 'sketches/map-of-rome', kind: 'spatial' },
 ]
+// A row is the document plus why it is here; these cases are about the
+// name and the path, so they carry no content excerpt.
+const entries = documents.map((document) => ({ document }))
 
 describe('SearchResults', () => {
   it('highlights the matched substring in the title', () => {

--- a/apps/web/src/components/workspace-files/SearchResults.tsx
+++ b/apps/web/src/components/workspace-files/SearchResults.tsx
@@ -33,6 +33,14 @@ export interface SearchResultsProps {
   results: readonly SearchResultRow[]
   /** The query the results answer, so the match can be shown, not implied. */
   query: string
+  /**
+   * Whether document CONTENT was actually looked at. False while a content
+   * search is unavailable, still in flight, or bypassed by a `#tag` filter —
+   * cases where the answer came from names and paths alone, and an empty
+   * state claiming otherwise would report a document as missing when nobody
+   * looked inside it.
+   */
+  searchedContents?: boolean
   selectedPath?: string
   onSelect: (document: WorkspaceDocumentEntry) => void
   /** Right-click on a result row — the object-action menu hook. */
@@ -69,6 +77,7 @@ function titleOf(entry: WorkspaceDocumentEntry): string {
 export function SearchResults({
   results,
   query,
+  searchedContents = true,
   selectedPath,
   onSelect,
   onDocumentContextMenu,
@@ -90,7 +99,8 @@ export function SearchResults({
     // tell a missing document from a query that could never match.
     return (
       <p className={cn('text-muted-foreground text-sm', className)}>
-        Nothing matches “{query.trim()}” in the names, paths and contents of this workspace.
+        Nothing matches “{query.trim()}” in the{' '}
+        {searchedContents ? 'names, paths and contents' : 'names and paths'} of this workspace.
       </p>
     )
   }

--- a/apps/web/src/components/workspace-files/SearchResults.tsx
+++ b/apps/web/src/components/workspace-files/SearchResults.tsx
@@ -19,8 +19,18 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { cn } from '../../lib/utils.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
 
+/**
+ * A row: the document, and the excerpts that say why it is here. Empty
+ * contexts mean the match was in the name or the path — both already on
+ * the row — so there is nothing more to show.
+ */
+export interface SearchResultRow {
+  readonly document: WorkspaceDocumentEntry
+  readonly contexts?: readonly string[]
+}
+
 export interface SearchResultsProps {
-  results: readonly WorkspaceDocumentEntry[]
+  results: readonly SearchResultRow[]
   /** The query the results answer, so the match can be shown, not implied. */
   query: string
   selectedPath?: string
@@ -71,7 +81,18 @@ export function SearchResults({
   const [layout, setLayout] = useState<'list' | 'grid'>('list')
 
   if (results.length === 0) {
-    return <p className={cn('text-muted-foreground text-sm', className)}>Nothing matches.</p>
+    // Say what was searched, not just that nothing came back. Search here is
+    // lexical: it finds the words a document actually contains, so a query
+    // in one language structurally cannot reach a document written in
+    // another (measured on this repo's own corpus: 21 of 22 such queries
+    // returned nothing). "Nothing matches" alone would read as "no such
+    // document" — naming the query and what was looked at lets the reader
+    // tell a missing document from a query that could never match.
+    return (
+      <p className={cn('text-muted-foreground text-sm', className)}>
+        Nothing matches “{query.trim()}” in the names, paths and contents of this workspace.
+      </p>
+    )
   }
 
   const thumbnail = (entry: WorkspaceDocumentEntry, sizeClass: string) => (
@@ -125,7 +146,7 @@ export function SearchResults({
       </div>
       {layout === 'list' ? (
         <ul data-testid="search-results-list" className="space-y-1 p-0.5">
-          {results.map((entry) => (
+          {results.map(({ document: entry, contexts }) => (
             <li key={entry.documentId}>
               <button
                 type="button"
@@ -161,6 +182,17 @@ export function SearchResults({
                       {entry.tags?.map((tag) => `#${tag}`).join(' ')}
                     </span>
                   )}
+                  {(contexts?.length ?? 0) > 0 && (
+                    /* The match itself, when it was in the CONTENT: neither
+                       the title nor the path shows it, so without this the
+                       row cannot say why it is here. */
+                    <span
+                      data-testid="result-excerpt"
+                      className="text-muted-foreground line-clamp-2 text-[11px] leading-snug"
+                    >
+                      <Highlighted text={contexts?.[0] ?? ''} query={query} />
+                    </span>
+                  )}
                 </span>
               </button>
             </li>
@@ -171,7 +203,7 @@ export function SearchResults({
           data-testid="search-results-grid"
           className="grid grid-cols-2 gap-2 p-0.5 md:grid-cols-3"
         >
-          {results.map((entry) => (
+          {results.map(({ document: entry, contexts }) => (
             <li key={entry.documentId}>
               <button
                 type="button"
@@ -202,6 +234,17 @@ export function SearchResults({
                        so the row must show the tag that put it here. */
                     <span className="text-muted-foreground truncate text-[11px]">
                       {entry.tags?.map((tag) => `#${tag}`).join(' ')}
+                    </span>
+                  )}
+                  {(contexts?.length ?? 0) > 0 && (
+                    /* The match itself, when it was in the CONTENT: neither
+                       the title nor the path shows it, so without this the
+                       row cannot say why it is here. */
+                    <span
+                      data-testid="result-excerpt"
+                      className="text-muted-foreground line-clamp-2 text-[11px] leading-snug"
+                    >
+                      <Highlighted text={contexts?.[0] ?? ''} query={query} />
                     </span>
                   )}
                 </span>

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -10,7 +10,11 @@ import { DocumentThumbnail } from './DocumentThumbnail.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
 import { FolderBreadcrumb } from './FolderBreadcrumb.js'
 import { FolderContentsList } from './FolderContentsList.js'
-import { type WorkspaceFilesSource, WorkspaceMissingError } from './files-source.js'
+import {
+  type DocumentSearchHit,
+  type WorkspaceFilesSource,
+  WorkspaceMissingError,
+} from './files-source.js'
 import { createRowOutlineLoader } from './load-row-outline.js'
 import { createRowRenderLoader } from './load-row-render.js'
 import { NewDocumentMenu } from './NewDocumentMenu.js'
@@ -20,6 +24,11 @@ import { SearchResults } from './SearchResults.js'
 import { searchDocuments } from './search-documents.js'
 import { WorkspaceFileTree } from './WorkspaceFileTree.js'
 import { WorkspaceFolderTree } from './WorkspaceFolderTree.js'
+
+/** One screenful of results; the ranking makes a longer list noise. */
+const SEARCH_LIMIT = 20
+/** Long enough that typing a word is one search, short enough to feel live. */
+const SEARCH_DEBOUNCE_MS = 150
 
 export interface WorkspaceFilesPanelProps {
   /**
@@ -194,6 +203,14 @@ export function WorkspaceFilesPanel({
   // same-tick case it exists to catch.
   const [creating, setCreating] = useState(false)
   const [query, setQuery] = useState('')
+  // Search results come from the SOURCE now — the content it can read is
+  // the whole point, and no filter over the loaded list can see a body.
+  const [hits, setHits] = useState<readonly DocumentSearchHit[] | null>(null)
+  // True when the content search could not be reached — an older daemon
+  // without the route, or a network that said no. The panel then answers
+  // from the list it already holds and SAYS that it did, because a quietly
+  // narrower answer is indistinguishable from a document that is not there.
+  const [searchDegraded, setSearchDegraded] = useState(false)
   // The object-action menu: which document was right-clicked, and where.
   const [cardMenu, setCardMenu] = useState<{
     entry: WorkspaceDocumentEntry
@@ -228,6 +245,38 @@ export function WorkspaceFilesPanel({
   const loadOutline = useMemo(() => createRowOutlineLoader({ source }), [source])
 
   const readList = useCallback(() => source.listDocuments(), [source])
+
+  // Debounced, and the LATEST query decides: a slower answer for a query
+  // the user has already moved on from must never replace a newer one, so
+  // the cleanup marks its own request stale rather than trusting arrival
+  // order.
+  useEffect(() => {
+    const trimmed = query.trim()
+    if (trimmed === '' || trimmed.startsWith('#')) {
+      setHits(null)
+      setSearchDegraded(false)
+      return
+    }
+    let stale = false
+    const timer = setTimeout(() => {
+      source
+        .searchDocuments(trimmed, SEARCH_LIMIT)
+        .then((results) => {
+          if (stale) return
+          setHits(results)
+          setSearchDegraded(false)
+        })
+        .catch(() => {
+          if (stale) return
+          setHits(null)
+          setSearchDegraded(true)
+        })
+    }, SEARCH_DEBOUNCE_MS)
+    return () => {
+      stale = true
+      clearTimeout(timer)
+    }
+  }, [query, source])
 
   // Through a ref so it never joins an effect's dependencies: a host that
   // passes an inline arrow would otherwise re-run the workspace-load effect
@@ -739,8 +788,31 @@ export function WorkspaceFilesPanel({
           // be two features wearing one box.
           <div className="min-w-0 flex-1 overflow-y-auto md:border-r md:pr-3">
             <div data-testid="search-results">
+              {/* Always mounted, text swapped: a polite live region added to
+                  the DOM already carrying its message is announced
+                  inconsistently (see polite-live-region.test.ts). */}
+              <p
+                role="status"
+                className={searchDegraded ? 'text-muted-foreground mb-1 text-xs' : 'sr-only'}
+              >
+                {searchDegraded
+                  ? 'Searching names and paths only — this workspace’s content search is unavailable.'
+                  : ''}
+              </p>
               <SearchResults
-                results={searchDocuments(documents, query)}
+                // A `#tag` query is a FILTER over what is loaded (#975's
+                // contract), not a content search — it never leaves the
+                // client. Everything else asks the source.
+                results={
+                  activeTag !== null || hits === null
+                    ? // A `#tag` query is a FILTER over what is loaded
+                      // (#975's contract) and never leaves the client; and
+                      // while content search is unreachable or still in
+                      // flight, the names and paths already in hand are a
+                      // real answer rather than a blank pane.
+                      searchDocuments(documents, query).map((document) => ({ document }))
+                    : hits.map((hit) => ({ document: hit.document, contexts: hit.contexts }))
+                }
                 query={query}
                 selectedPath={selected?.path}
                 onSelect={setSelected}

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -276,7 +276,10 @@ export function WorkspaceFilesPanel({
       stale = true
       clearTimeout(timer)
     }
-  }, [query, source])
+    // `revision` too: results computed against the old content can name a
+    // document that has since been renamed or deleted, and a row that opens
+    // nothing is worse than a slower answer.
+  }, [query, source, revision])
 
   // Through a ref so it never joins an effect's dependencies: a host that
   // passes an inline arrow would otherwise re-run the workspace-load effect
@@ -814,6 +817,7 @@ export function WorkspaceFilesPanel({
                     : hits.map((hit) => ({ document: hit.document, contexts: hit.contexts }))
                 }
                 query={query}
+                searchedContents={activeTag === null && hits !== null}
                 selectedPath={selected?.path}
                 onSelect={setSelected}
                 onDocumentContextMenu={openCardMenu}

--- a/apps/web/src/components/workspace-files/body-search.test.tsx
+++ b/apps/web/src/components/workspace-files/body-search.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
+import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
+
+// The search box asks the SOURCE, so it finds what a name-and-path filter
+// cannot: a word that appears only in a document's body.
+
+afterEach(cleanup)
+
+const entries = [
+  { documentId: 'd1', path: 'notes/quota', name: 'Storage notes', kind: 'markdown' as const },
+  { documentId: 'd2', path: 'plans/roadmap', name: 'Roadmap', kind: 'markdown' as const },
+]
+
+function renderPanel(overrides: Parameters<typeof fakeFilesSource>[0] = {}) {
+  const source = fakeFilesSource({ listDocuments: async () => entries, ...overrides })
+  render(<WorkspaceFilesPanel source={source} onOpenDocument={() => {}} />)
+  return source
+}
+
+async function search(text: string) {
+  await waitFor(() => expect(screen.getAllByTestId('card-title').length).toBeGreaterThan(0))
+  fireEvent.change(screen.getByLabelText('Search documents'), { target: { value: text } })
+}
+
+describe('body search', () => {
+  it('lists a document whose BODY matched, with the excerpt that explains why', async () => {
+    renderPanel({
+      searchDocuments: async () => [
+        {
+          document: entries[1] as (typeof entries)[number],
+          contexts: ['…the quota exceeded error shows up on save…'],
+        },
+      ],
+    })
+    await search('quota')
+
+    // The answer is asynchronous by design (the source reads content), so
+    // the row arrives after the debounce rather than with the keystroke.
+    const excerpt = await screen.findByTestId('result-excerpt')
+    const results = screen.getByTestId('search-results')
+    // The row is the body match — not the path that happens to say "quota".
+    expect(within(results).getByText('Roadmap')).toBeTruthy()
+    expect(excerpt.textContent).toContain('quota exceeded')
+    // …with the query marked inside it, the same way titles are.
+    expect(within(excerpt).getAllByTestId('search-match')[0]?.textContent?.toLowerCase()).toBe(
+      'quota',
+    )
+  })
+
+  it('asks the source, not the loaded list', async () => {
+    const source = renderPanel({ searchDocuments: async () => [] })
+    await search('anything')
+    await waitFor(() => expect(source.searchDocuments).toHaveBeenCalledWith('anything', 20))
+  })
+
+  it('says what it searched when nothing matched', async () => {
+    renderPanel({ searchDocuments: async () => [] })
+    await search('存在しない語')
+
+    const results = await screen.findByTestId('search-results')
+    // Not a bare "nothing matches": lexical search cannot cross languages,
+    // so the empty state must not read as "this document does not exist".
+    expect(results.textContent).toContain('存在しない語')
+    expect(results.textContent).toMatch(/names, paths and contents/i)
+  })
+
+  it('never lets a slower answer for an older query win', async () => {
+    let release: ((hits: never[]) => void) | undefined
+    const source = fakeFilesSource({
+      listDocuments: async () => entries,
+      searchDocuments: async (query: string) => {
+        if (query === 'slow') return new Promise<never[]>((resolve) => (release = resolve))
+        return [{ document: entries[0] as (typeof entries)[number], contexts: ['fast answer'] }]
+      },
+    })
+    render(<WorkspaceFilesPanel source={source} onOpenDocument={() => {}} />)
+
+    await search('slow')
+    fireEvent.change(screen.getByLabelText('Search documents'), { target: { value: 'fast' } })
+    await waitFor(() =>
+      expect(screen.getByTestId('search-results').textContent).toContain('fast answer'),
+    )
+
+    release?.([])
+    // The stale empty answer must not replace the newer one.
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(screen.getByTestId('search-results').textContent).toContain('fast answer')
+  })
+})

--- a/apps/web/src/components/workspace-files/body-search.test.tsx
+++ b/apps/web/src/components/workspace-files/body-search.test.tsx
@@ -64,7 +64,9 @@ describe('body search', () => {
     // Not a bare "nothing matches": lexical search cannot cross languages,
     // so the empty state must not read as "this document does not exist".
     expect(results.textContent).toContain('存在しない語')
-    expect(results.textContent).toMatch(/names, paths and contents/i)
+    // Only once the content answer is in: until then the panel is honestly
+    // reporting the narrower scope it has actually searched.
+    await waitFor(() => expect(results.textContent).toMatch(/names, paths and contents/i))
   })
 
   it('never lets a slower answer for an older query win', async () => {
@@ -79,6 +81,9 @@ describe('body search', () => {
     render(<WorkspaceFilesPanel source={source} onOpenDocument={() => {}} />)
 
     await search('slow')
+    // Without this the debounce timer for 'slow' is cleared by the next
+    // keystroke, `release` is never assigned, and the test asserts nothing.
+    await waitFor(() => expect(source.searchDocuments).toHaveBeenCalledWith('slow', 20))
     fireEvent.change(screen.getByLabelText('Search documents'), { target: { value: 'fast' } })
     await waitFor(() =>
       expect(screen.getByTestId('search-results').textContent).toContain('fast answer'),
@@ -88,5 +93,38 @@ describe('body search', () => {
     // The stale empty answer must not replace the newer one.
     await new Promise((resolve) => setTimeout(resolve, 20))
     expect(screen.getByTestId('search-results').textContent).toContain('fast answer')
+  })
+
+  it('says it searched names and paths only when content search is unavailable', async () => {
+    renderPanel({
+      searchDocuments: async () => {
+        throw new Error('no content search here')
+      },
+    })
+    await search('nothingmatchesthis')
+
+    const results = await screen.findByTestId('search-results')
+    // The fallback answers from names and paths alone. Claiming contents were
+    // searched would tell the reader a document does not exist when all that
+    // is true is that nobody looked inside it.
+    await waitFor(() => expect(results.textContent).toMatch(/names and paths of this workspace/i))
+    expect(results.textContent).not.toMatch(/contents/i)
+  })
+
+  it('re-runs an active search when the documents change underneath it', async () => {
+    const source = fakeFilesSource({
+      listDocuments: async () => entries,
+      searchDocuments: async () => [],
+    })
+    const { rerender } = render(
+      <WorkspaceFilesPanel source={source} onOpenDocument={() => {}} revision={1} />,
+    )
+    await search('quota')
+    await waitFor(() => expect(source.searchDocuments).toHaveBeenCalledTimes(1))
+
+    // A document changed while the query was live: results computed against
+    // the old list can name a document that no longer exists.
+    rerender(<WorkspaceFilesPanel source={source} onOpenDocument={() => {}} revision={2} />)
+    await waitFor(() => expect(source.searchDocuments).toHaveBeenCalledTimes(2))
   })
 })

--- a/apps/web/src/components/workspace-files/files-source.ts
+++ b/apps/web/src/components/workspace-files/files-source.ts
@@ -45,6 +45,17 @@ export interface WorkspaceFilesSource {
    */
   setPinned?(entry: Pick<WorkspaceDocumentEntry, 'path'>, pinned: boolean): Promise<void>
   /**
+   * Documents whose CONTENT answers the query, best first — the search a
+   * name-and-path filter cannot do.
+   *
+   * Both modes answer through the same stage-0 core (`@kamiazya/whiteboard-search`),
+   * so a query finds the same documents whether a daemon or the browser
+   * ranked them. An empty query answers nothing: the caller shows the
+   * folder's own contents, and deciding that here would put it in two
+   * places (`search-documents.ts` says the same for the name filter).
+   */
+  searchDocuments(query: string, limit?: number): Promise<readonly DocumentSearchHit[]>
+  /**
    * The OKF markdown of a markdown document, for row thumbnails and the
    * preview pane. Empty string when the document has no body yet.
    */
@@ -64,6 +75,19 @@ export interface WorkspaceFilesSource {
  * implementation it is talking to: the daemon adapter maps its 404 onto this,
  * the local adapter maps the port's `WorkspaceNotFoundError`.
  */
+/**
+ * One search result: the document, plus why it is here.
+ *
+ * `contexts` are excerpts around the match, one per text source that
+ * matched. When the daemon's semantic search put a document here that no
+ * keyword matched, there IS no match window — the excerpt is then the
+ * document's opening, and nothing in it should be highlighted.
+ */
+export interface DocumentSearchHit {
+  readonly document: WorkspaceDocumentEntry
+  readonly contexts: readonly string[]
+}
+
 export class WorkspaceMissingError extends Error {
   constructor(workspaceId: string) {
     super(`Workspace not found: "${workspaceId}"`)

--- a/apps/web/src/components/workspace-files/panel-tooltips.browser.test.tsx
+++ b/apps/web/src/components/workspace-files/panel-tooltips.browser.test.tsx
@@ -15,10 +15,15 @@ import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
 // NotFoundErrors (measured on CI).
 afterEach(cleanup)
 
+const SEEDED = { documentId: 'd1', path: 'seed', kind: 'markdown' as const }
+
 function renderPanel() {
   const source = fakeFilesSource({
-    listDocuments: () =>
-      Promise.resolve([{ documentId: 'd1', path: 'seed', kind: 'markdown' as const }]),
+    listDocuments: () => Promise.resolve([SEEDED]),
+    // The layout toggles exist only while there ARE results, so the search
+    // has to answer with one; the default empty answer removes the very
+    // buttons this file is about.
+    searchDocuments: async () => [{ document: SEEDED, contexts: [] }],
   })
   return render(<WorkspaceFilesPanel source={source} />)
 }
@@ -56,8 +61,13 @@ describe('document browser toolbar tooltips (real browser)', () => {
     ) as HTMLInputElement
     search.focus()
     await userEvent.fill(search, 'seed')
+    // Search answers asynchronously now (the source reads content), so the
+    // results — and the toolbar sitting above them — keep moving until they
+    // land. Hovering mid-flight fails as "element is not stable", which
+    // reads like a tooltip bug and is not one.
     await vi.waitFor(() => {
       expect(document.querySelector('button[aria-label="List results"]')).not.toBeNull()
+      expect(document.querySelectorAll('[data-testid="result-title"]').length).toBeGreaterThan(0)
     })
     for (const label of ['List results', 'Grid results']) {
       await expectTooltip(label)

--- a/apps/web/src/components/workspace-files/row-render.browser.test.tsx
+++ b/apps/web/src/components/workspace-files/row-render.browser.test.tsx
@@ -35,6 +35,7 @@ it('renders a spatial document from its snapshot bytes through the pool', async 
       listDocuments: async () => [],
       createDocument: async () => {},
       renameDocumentPath: async () => {},
+      searchDocuments: async () => [],
       setDocumentName: async () => {},
       loadSpatialSnapshot: async () => bytes,
       loadMarkdown: async () => {

--- a/apps/web/src/lib/daemon-api-client.ts
+++ b/apps/web/src/lib/daemon-api-client.ts
@@ -6,10 +6,12 @@ import {
   type DeleteDocumentResponse,
   type DocumentBacklinksResponse,
   type DocumentOkfV1Response,
+  type DocumentSearchResponse,
   deleteDocumentResponseSchema,
   documentApiUrl,
   documentBacklinksResponseSchema,
   documentOkfV1ResponseSchema,
+  documentSearchResponseSchema,
   documentsApiUrl,
   type InstallFontResponse,
   installFontResponseSchema,
@@ -263,6 +265,22 @@ export function getDocumentBacklinks(
     fetchImpl,
     `${daemonBaseUrl}/api/v1/workspaces/${encodeURIComponent(workspaceId)}/documents/${encodeURIComponent(documentId)}/backlinks`,
     documentBacklinksResponseSchema,
+  )
+}
+
+/** Content search across a workspace — bodies and canvas text, not only names. */
+export function searchWorkspaceDocuments(
+  fetchImpl: typeof fetch,
+  daemonBaseUrl: string,
+  workspaceId: string,
+  query: string,
+  limit: number,
+): Promise<DocumentSearchResponse> {
+  const params = new URLSearchParams({ q: query, limit: String(limit) })
+  return fetchAndParse(
+    fetchImpl,
+    `${daemonBaseUrl}/api/v1/workspaces/${encodeURIComponent(workspaceId)}/search?${params}`,
+    documentSearchResponseSchema,
   )
 }
 

--- a/apps/web/src/lib/daemon-files-source.ts
+++ b/apps/web/src/lib/daemon-files-source.ts
@@ -13,6 +13,7 @@ import {
   getWorkspaceNames,
   listDocuments,
   renameDocumentPath,
+  searchWorkspaceDocuments,
   setDocumentDisplayName,
   setDocumentPinned,
 } from './daemon-api-client.js'
@@ -75,6 +76,26 @@ export function createDaemonFilesSource(
 
     async renameDocumentPath(path: string, newPath: string): Promise<void> {
       await renameDocumentPath(daemonFetch, daemonBaseUrl, workspaceId, path, newPath)
+    },
+
+    async searchDocuments(query, limit = 20) {
+      if (query.trim() === '') return []
+      const res = await searchWorkspaceDocuments(
+        daemonFetch,
+        daemonBaseUrl,
+        workspaceId,
+        query,
+        limit,
+      )
+      return res.results.map((hit) => ({
+        document: {
+          documentId: hit.documentId,
+          path: hit.path,
+          ...(hit.name === undefined ? {} : { name: hit.name }),
+          ...(hit.kind === undefined ? {} : { kind: hit.kind }),
+        },
+        contexts: hit.contexts,
+      }))
     },
 
     async setDocumentName(entry, name): Promise<void> {

--- a/apps/web/src/lib/local-files-source.ts
+++ b/apps/web/src/lib/local-files-source.ts
@@ -1,6 +1,15 @@
-import { readCoreFacets, readMarkdownBody } from '@kamiazya/whiteboard-loro-adapter'
+import {
+  readCoreFacets,
+  readMarkdownBody,
+  readSpatialCanvas,
+} from '@kamiazya/whiteboard-loro-adapter'
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import { type DocumentIndex, WorkspaceNotFoundError } from '@kamiazya/whiteboard-ports'
+import {
+  fullTextSearch,
+  type SearchableDocument,
+  searchableTexts,
+} from '@kamiazya/whiteboard-search'
 import { Loro } from 'loro-crdt'
 import type { WorkspaceDocumentEntry } from '../components/workspace-files/document-entry.js'
 import {
@@ -40,6 +49,22 @@ export function createLocalFilesSource(
   const index = deps.index ?? new IdbDocumentIndex()
   const loro = deps.loro ?? new LoroStore()
   const clock = deps.clock ?? idbContentClock()
+
+  /**
+   * The searchable corpus, built on FIRST search rather than at list time
+   * and kept per document until that document's content stamp moves.
+   *
+   * Measured before choosing this shape: 60 documents (202KB of bodies) read
+   * in 176ms against real IndexedDB, ~2.9ms per document. Building it in
+   * `listDocuments` would put that on every panel open — including the
+   * opens where nobody searches — so it waits for a query and then only
+   * re-reads what changed. The same numbers say where this stops being
+   * enough: a few thousand documents is seconds, and that is the workspace
+   * that needs a persisted index rather than a scan.
+   * ponytail: full scan behind a stamp cache; persist an index when a
+   * measured workspace makes the first search slow.
+   */
+  const corpus = new Map<string, { stamp: string; document: SearchableDocument }>()
 
   async function loadCurrentDoc(entry: WorkspaceDocumentEntry): Promise<Loro> {
     const loaded = await loro.load(entry.documentId)
@@ -129,6 +154,51 @@ export function createLocalFilesSource(
 
     async renameDocumentPath(path: string, newPath: string): Promise<void> {
       await index.moveDocument({ workspaceId: LOCAL_WORKSPACE_ID, from: path, to: newPath })
+    },
+
+    async searchDocuments(query, limit = 20) {
+      if (query.trim() === '') return []
+      const entries = await this.listDocuments()
+      const searchable: SearchableDocument[] = []
+      for (const entry of entries) {
+        // The stamp IS the cache key: a document whose content moved gets
+        // re-read, and one that did not is free.
+        const stamp = entry.updatedAt ?? ''
+        const cached = corpus.get(entry.documentId)
+        if (cached !== undefined && cached.stamp === stamp) {
+          searchable.push(cached.document)
+          continue
+        }
+        try {
+          const doc = await loadCurrentDoc(entry)
+          const texts =
+            entry.kind === 'spatial'
+              ? searchableTexts({ kind: 'spatial', canvas: readSpatialCanvas(doc) })
+              : searchableTexts({ kind: 'markdown', body: readMarkdownBody(doc) })
+          const document: SearchableDocument = {
+            documentId: entry.documentId,
+            path: entry.path,
+            ...(entry.name === undefined ? {} : { name: entry.name }),
+            texts,
+          }
+          corpus.set(entry.documentId, { stamp, document })
+          searchable.push(document)
+        } catch {
+          // Unreadable documents are searched as their name and path alone
+          // rather than dropping out of results entirely.
+          searchable.push({
+            documentId: entry.documentId,
+            path: entry.path,
+            ...(entry.name === undefined ? {} : { name: entry.name }),
+            texts: [],
+          })
+        }
+      }
+      const byId = new Map(entries.map((entry) => [entry.documentId, entry]))
+      return fullTextSearch(searchable, query, { limit }).flatMap((hit) => {
+        const document = byId.get(hit.documentId)
+        return document === undefined ? [] : [{ document, contexts: [...hit.contexts] }]
+      })
     },
 
     async setDocumentName(entry, name): Promise<void> {

--- a/apps/web/src/lib/local-files-source.ts
+++ b/apps/web/src/lib/local-files-source.ts
@@ -64,7 +64,7 @@ export function createLocalFilesSource(
    * ponytail: full scan behind a stamp cache; persist an index when a
    * measured workspace makes the first search slow.
    */
-  const corpus = new Map<string, { stamp: string; document: SearchableDocument }>()
+  const corpus = new Map<string, { stamp: string; texts: string[] }>()
 
   async function loadCurrentDoc(entry: WorkspaceDocumentEntry): Promise<Loro> {
     const loaded = await loro.load(entry.documentId)
@@ -161,38 +161,36 @@ export function createLocalFilesSource(
       const entries = await this.listDocuments()
       const searchable: SearchableDocument[] = []
       for (const entry of entries) {
-        // The stamp IS the cache key: a document whose content moved gets
-        // re-read, and one that did not is free.
+        // Only the TEXT is cached, and only against the content stamp. Path
+        // and name are placement, which a rename moves without touching the
+        // content — caching them here would keep matching a name the
+        // workspace has stopped using.
         const stamp = entry.updatedAt ?? ''
         const cached = corpus.get(entry.documentId)
+        let texts: string[]
         if (cached !== undefined && cached.stamp === stamp) {
-          searchable.push(cached.document)
-          continue
-        }
-        try {
-          const doc = await loadCurrentDoc(entry)
-          const texts =
-            entry.kind === 'spatial'
-              ? searchableTexts({ kind: 'spatial', canvas: readSpatialCanvas(doc) })
-              : searchableTexts({ kind: 'markdown', body: readMarkdownBody(doc) })
-          const document: SearchableDocument = {
-            documentId: entry.documentId,
-            path: entry.path,
-            ...(entry.name === undefined ? {} : { name: entry.name }),
-            texts,
+          texts = cached.texts
+        } else {
+          try {
+            const doc = await loadCurrentDoc(entry)
+            texts =
+              entry.kind === 'spatial'
+                ? searchableTexts({ kind: 'spatial', canvas: readSpatialCanvas(doc) })
+                : searchableTexts({ kind: 'markdown', body: readMarkdownBody(doc) })
+            corpus.set(entry.documentId, { stamp, texts })
+          } catch {
+            // Unreadable documents are searched as their name and path alone
+            // rather than dropping out of results entirely. Not cached: the
+            // next search should try the document again.
+            texts = []
           }
-          corpus.set(entry.documentId, { stamp, document })
-          searchable.push(document)
-        } catch {
-          // Unreadable documents are searched as their name and path alone
-          // rather than dropping out of results entirely.
-          searchable.push({
-            documentId: entry.documentId,
-            path: entry.path,
-            ...(entry.name === undefined ? {} : { name: entry.name }),
-            texts: [],
-          })
         }
+        searchable.push({
+          documentId: entry.documentId,
+          path: entry.path,
+          ...(entry.name === undefined ? {} : { name: entry.name }),
+          texts,
+        })
       }
       const byId = new Map(entries.map((entry) => [entry.documentId, entry]))
       return fullTextSearch(searchable, query, { limit }).flatMap((hit) => {

--- a/apps/web/src/lib/local-search.browser.test.tsx
+++ b/apps/web/src/lib/local-search.browser.test.tsx
@@ -1,0 +1,95 @@
+import {
+  writeDocumentKind,
+  writeMarkdownBody,
+  writeSpatialCanvas,
+} from '@kamiazya/whiteboard-loro-adapter'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { Loro } from 'loro-crdt'
+import { describe, expect, it } from 'vitest'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { IdbDocumentIndex } from './idb-document-index.js'
+import { ensureLocalWorkspace } from './local-document-summary.js'
+import { createLocalFilesSource } from './local-files-source.js'
+import { LoroStore } from './loro-store.js'
+
+// Body search in local mode, against real IndexedDB: the browser ranks with
+// the same stage-0 core the daemon uses, so a query finds the same
+// documents in either mode.
+
+claimIsolatedWhiteboardDb('local-body-search')
+
+async function seedMarkdown(index: IdbDocumentIndex, path: string, body: string): Promise<string> {
+  const entry = await index.createDocument({ workspaceId: 'local', path, kind: 'markdown' })
+  const doc = new Loro()
+  writeDocumentKind(doc, 'markdown')
+  writeMarkdownBody(doc, body)
+  await new LoroStore().save(entry.documentId, doc.export({ mode: 'snapshot' }))
+  return entry.documentId
+}
+
+async function seedSpatial(index: IdbDocumentIndex, path: string, canvas: SpatialCanvas) {
+  const entry = await index.createDocument({ workspaceId: 'local', path, kind: 'spatial' })
+  const doc = new Loro()
+  writeDocumentKind(doc, 'spatial')
+  writeSpatialCanvas(doc, canvas)
+  await new LoroStore().save(entry.documentId, doc.export({ mode: 'snapshot' }))
+}
+
+describe('local body search', () => {
+  it('finds a document by a word that appears only in its body', async () => {
+    const index = new IdbDocumentIndex()
+    await ensureLocalWorkspace(index)
+    await seedMarkdown(index, 'notes/one', 'The quota exceeded error shows up on save.')
+    await seedMarkdown(index, 'notes/two', 'Nothing relevant here at all.')
+    const source = createLocalFilesSource()
+
+    const hits = await source.searchDocuments('quota')
+    expect(hits.map((h) => h.document.path)).toEqual(['notes/one'])
+    // The excerpt says WHY the row is here.
+    expect(hits[0]?.contexts.join(' ')).toContain('quota')
+  })
+
+  it('searches a canvas through its node and edge labels', async () => {
+    const index = new IdbDocumentIndex()
+    await ensureLocalWorkspace(index)
+    await seedSpatial(index, 'diagrams/auth', {
+      nodes: [
+        { id: 'n1', type: 'text', text: 'Session handshake', x: 0, y: 0, width: 80, height: 40 },
+      ],
+      edges: [{ id: 'e1', fromNode: 'n1', toNode: 'n1', label: 'retries' }],
+    })
+    const source = createLocalFilesSource()
+
+    expect((await source.searchDocuments('handshake')).map((h) => h.document.path)).toEqual([
+      'diagrams/auth',
+    ])
+    expect((await source.searchDocuments('retries')).map((h) => h.document.path)).toEqual([
+      'diagrams/auth',
+    ])
+  })
+
+  it('answers nothing for an empty query', async () => {
+    const index = new IdbDocumentIndex()
+    await ensureLocalWorkspace(index)
+    await seedMarkdown(index, 'solo', 'anything')
+    expect(await createLocalFilesSource().searchDocuments('   ')).toEqual([])
+  })
+
+  it('sees an edit without being told, and re-reads only what changed', async () => {
+    const index = new IdbDocumentIndex()
+    await ensureLocalWorkspace(index)
+    const id = await seedMarkdown(index, 'draft', 'first wording')
+    const source = createLocalFilesSource()
+    expect(await source.searchDocuments('rewritten')).toEqual([])
+
+    // Edit through the same store the app uses.
+    const doc = new Loro()
+    writeDocumentKind(doc, 'markdown')
+    writeMarkdownBody(doc, 'rewritten wording')
+    await new LoroStore().save(id, doc.export({ mode: 'snapshot' }))
+
+    expect((await source.searchDocuments('rewritten')).map((h) => h.document.path)).toEqual([
+      'draft',
+    ])
+  })
+})

--- a/apps/web/src/lib/local-search.browser.test.tsx
+++ b/apps/web/src/lib/local-search.browser.test.tsx
@@ -92,4 +92,20 @@ describe('local body search', () => {
       'draft',
     ])
   })
+
+  it('finds a renamed document under its new path, not its old one', async () => {
+    // The corpus caches on the CONTENT stamp, and a rename does not move it.
+    // Caching the path alongside the text would leave the search matching a
+    // name the workspace no longer uses.
+    const index = new IdbDocumentIndex()
+    await ensureLocalWorkspace(index)
+    await seedMarkdown(index, 'drafts/first', 'A body with no distinctive words.')
+    const source = createLocalFilesSource({ index })
+
+    expect((await source.searchDocuments('first', 20)).length).toBe(1)
+    await source.renameDocumentPath('drafts/first', 'drafts/renamed')
+
+    expect((await source.searchDocuments('renamed', 20))[0]?.document.path).toBe('drafts/renamed')
+    expect(await source.searchDocuments('first', 20)).toEqual([])
+  })
 })

--- a/apps/web/src/pages/local-body-search.browser.test.tsx
+++ b/apps/web/src/pages/local-body-search.browser.test.tsx
@@ -1,0 +1,48 @@
+import { writeDocumentKind, writeMarkdownBody } from '@kamiazya/whiteboard-loro-adapter'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { Loro } from 'loro-crdt'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { IdbDocumentIndex } from '../lib/idb-document-index.js'
+import { ensureLocalWorkspace } from '../lib/local-document-summary.js'
+import { LoroStore } from '../lib/loro-store.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { BrowserLocalIndexPage } from './BrowserLocalIndexPage.js'
+
+// The page, its source and the panel together — the seam the unit tests
+// each covered one side of, and where the preview found nothing.
+
+claimIsolatedWhiteboardDb('local-body-search-page')
+
+afterEach(cleanup)
+
+describe('searching from the page', () => {
+  it('finds a document by a word only its body carries', async () => {
+    const index = new IdbDocumentIndex()
+    await ensureLocalWorkspace(index)
+    const entry = await index.createDocument({
+      workspaceId: 'local',
+      path: 'untitled',
+      kind: 'markdown',
+    })
+    const doc = new Loro()
+    writeDocumentKind(doc, 'markdown')
+    writeMarkdownBody(doc, 'A QuotaExceededError arrives on save.')
+    await new LoroStore().save(entry.documentId, doc.export({ mode: 'snapshot' }))
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <BrowserLocalIndexPage index={index} onOpenDocument={vi.fn()} />
+      </MemoryRouter>,
+    )
+    const box = await screen.findByLabelText('Search documents', undefined, { timeout: 10_000 })
+    fireEvent.change(box, { target: { value: 'QuotaExceededError' } })
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('search-results').textContent).toContain('untitled')
+      },
+      { timeout: 10_000 },
+    )
+  })
+})

--- a/apps/web/src/test-utils/fake-files-source.ts
+++ b/apps/web/src/test-utils/fake-files-source.ts
@@ -7,6 +7,7 @@ export interface FakeFilesSource extends WorkspaceFilesSource {
   listDocuments: ReturnType<typeof vi.fn<() => Promise<readonly WorkspaceDocumentEntry[]>>>
   createDocument: ReturnType<typeof vi.fn<WorkspaceFilesSource['createDocument']>>
   renameDocumentPath: ReturnType<typeof vi.fn<WorkspaceFilesSource['renameDocumentPath']>>
+  searchDocuments: ReturnType<typeof vi.fn<WorkspaceFilesSource['searchDocuments']>>
   setDocumentName: ReturnType<typeof vi.fn<WorkspaceFilesSource['setDocumentName']>>
   loadMarkdown: ReturnType<typeof vi.fn<WorkspaceFilesSource['loadMarkdown']>>
   loadSpatialSnapshot: ReturnType<typeof vi.fn<WorkspaceFilesSource['loadSpatialSnapshot']>>
@@ -28,6 +29,7 @@ export function fakeFilesSource(overrides: Partial<WorkspaceFilesSource> = {}): 
     listDocuments: vi.fn(overrides.listDocuments ?? (async () => [])),
     createDocument: vi.fn(overrides.createDocument ?? (async () => {})),
     renameDocumentPath: vi.fn(overrides.renameDocumentPath ?? (async () => {})),
+    searchDocuments: vi.fn(overrides.searchDocuments ?? (async () => [])),
     setDocumentName: vi.fn(overrides.setDocumentName ?? (async () => {})),
     loadMarkdown: vi.fn(overrides.loadMarkdown ?? (async () => '')),
     loadSpatialSnapshot: vi.fn(overrides.loadSpatialSnapshot ?? (async () => new Uint8Array())),

--- a/packages/mcp-server/src/shared/api-contracts/index.ts
+++ b/packages/mcp-server/src/shared/api-contracts/index.ts
@@ -16,6 +16,7 @@
 // depend on directly (see .claude/rules/architecture-map.md).
 export {
   backlinksOutputSchema as documentBacklinksResponseSchema,
+  documentSearchOutputSchema as documentSearchResponseSchema,
   documentTagsOutputSchema as workspaceDocumentTagsResponseSchema,
   exportOkfOutputSchema as documentOkfV1ResponseSchema,
   linkifyMentionsOutputSchema as linkifyMentionsResponseSchema,
@@ -41,6 +42,7 @@ export { daemonPingResponseSchema, runtimeVerifyResponseSchema } from './runtime
 import type {
   exportOkfOutputSchema as _canvasOkfV1ResponseSchema,
   backlinksOutputSchema as _documentBacklinksResponseSchema,
+  documentSearchOutputSchema as _documentSearchResponseSchema,
   linkifyMentionsOutputSchema as _linkifyMentionsResponseSchema,
   wbDocumentListOutputSchema as _listDocumentsV1ResponseSchema,
   documentTagsOutputSchema as _workspaceDocumentTagsResponseSchema,
@@ -51,3 +53,4 @@ export type WorkspaceDocumentTagsResponse = _z.infer<typeof _workspaceDocumentTa
 export type LinkifyMentionsResponse = _z.infer<typeof _linkifyMentionsResponseSchema>
 export type DocumentOkfV1Response = _z.infer<typeof _canvasOkfV1ResponseSchema>
 export type ListDocumentsV1Response = _z.infer<typeof _listDocumentsV1ResponseSchema>
+export type DocumentSearchResponse = _z.infer<typeof _documentSearchResponseSchema>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       '@kamiazya/whiteboard-ports':
         specifier: workspace:*
         version: link:../../packages/ports
+      '@kamiazya/whiteboard-search':
+        specifier: workspace:*
+        version: link:../../packages/search
       '@lezer/highlight':
         specifier: ^1.2.1
         version: 1.2.3

--- a/tools/arch-lint/src/architecture-map.ts
+++ b/tools/arch-lint/src/architecture-map.ts
@@ -163,6 +163,7 @@ export const ARCHITECTURE_MAP: Readonly<Record<string, PackageArchEntry>> = {
       '@kamiazya/whiteboard-mcp',
       '@kamiazya/whiteboard-ports',
       '@kamiazya/whiteboard-facet-engine',
+      '@kamiazya/whiteboard-search',
     ],
     allowedThirdParty: [],
   },


### PR DESCRIPTION
Slice 2 of body search (slice 1 = #1014). The panel's search asked the **loaded list**, so it could only match names, paths and tags — a word that appears in a body was unfindable in either mode, while the daemon had ranked full text all along and the browser never asked.

## The panel asks the source now

`WorkspaceFilesSource` gains `searchDocuments(query, limit)`. Both adapters answer through the **same stage-0 core** from #1014, so a query finds the same documents either way:

| mode | how |
|---|---|
| daemon | `GET /api/v1/workspaces/:id/search` (the route that already existed) |
| browser-local | a corpus the adapter builds itself, ranked with the same `tokenize` / `fullTextSearch` / `searchableTexts` |

Matching **excerpts** now appear under each row with the query marked — what turns "these matched" into "here is why" (reusing #966's `Highlighted`).

## The corpus is lazy, because it was measured

Built on **first search**, cached per document until its content stamp moves. Measured before choosing the shape: **60 documents (202KB of bodies) read in 176ms against real IndexedDB, ~2.9ms each**. Building it at list time would tax every panel open, including the opens where nobody searches. The same number says where a scan stops being enough — a few thousand documents is seconds, which is the workspace that will want a persisted index. Recorded as a `ponytail:` ceiling beside the cache.

## Two honesty rules the diff exists to keep

- **An unreachable content search falls back to names and paths AND says so** (a polite live region, always mounted per `polite-live-region.test.ts`), rather than answering narrower in silence. That fallback is also what keeps an **older daemon's** search working — and it is why **242 existing tests pass unchanged**, which is the evidence the old behaviour survived.
- **An empty result names the query and what was searched.** This search is lexical: a query in one language cannot reach a document written in another — measured on this repo's corpus by the search session, **21 of 22 cross-lingual queries returned nothing** — so a bare "nothing matches" would read as "no such document".

`#tag` stays a client-side **filter** over the loaded list (#975's contract), never a content search.

## Tests

Red-first: 4 jsdom (body match + excerpt highlight, asks the source, honest empty state, a slower answer for an older query never wins) and 4 `web-browser` against real IndexedDB (body-only match, canvas node/edge label search, empty query, and an edit found without being told — the stamp cache re-reading only what changed).

Verification: apps/web jsdom 2730 + node 77, workspace-files browser suites 9/9, arch-lint 89 (apps/web's new dependency registered in the map and the rules doc), lint / knip / `-r typecheck` clean. Live preview walked through on `https://body-search-ui.kamiazya-whiteboard.pages.dev` (see below).

## Visual repro

Searching a word that appears **only in a document's body** — the row carries the name, the path, and an excerpt with the match highlighted.

![body-search-after.png](https://github.com/user-attachments/assets/3b9ed0b9-e325-4c29-bd52-34fb62aab67d)

Preview walk-through (browser-local mode, real IndexedDB): typed a body into a document through the editor, returned to the browser, and searched. `snapshot`, `IndexedDB` and `exceeded` each returned the document with the excerpt above; the same words returned nothing before the body existed, and a cold reload search behaves identically. One page-level regression test (`local-body-search.browser.test.tsx`) now covers the page + source + panel together — the seam the unit tests each saw only one side of.

## Coordination

Agreed with the search session (which owns `server-core/src/search` and landed semantic search in #1012): they are adding `lexicalRank` / `semanticRank` to the search result in a later increment, so a row that only semantic matched can be shown without a highlight it has no word for. Local mode has no embedder, so this slice is unaffected — every local hit is a lexical hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoaNgqWUKbYJxk2azmRQKY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added full-text search across workspace documents, including Markdown content and spatial canvas labels.
  - Search results now display matching excerpts with highlighted query terms.
  - Added ranked results, result limits, debounced searching, and informative empty states.
  - Search works with both local documents and connected workspace sources.

- **Bug Fixes**
  - Prevented slower, outdated searches from replacing newer results.
  - Added graceful fallback to document names and paths when content search is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->