### PR TITLE
feat(web): a hit no keyword produced is shown without a highlight

### DIFF
--- a/apps/web/src/components/workspace-files/SearchResults.tsx
+++ b/apps/web/src/components/workspace-files/SearchResults.tsx
@@ -27,6 +27,12 @@ import type { WorkspaceDocumentEntry } from './document-entry.js'
 export interface SearchResultRow {
   readonly document: WorkspaceDocumentEntry
   readonly contexts?: readonly string[]
+  /**
+   * The keyword rank behind this row, absent when keywords did not produce
+   * it. Absent means the excerpt is the document's opening rather than a
+   * match window, so there is no word in it the query is responsible for.
+   */
+  readonly lexicalRank?: number
 }
 
 export interface SearchResultsProps {
@@ -156,7 +162,7 @@ export function SearchResults({
       </div>
       {layout === 'list' ? (
         <ul data-testid="search-results-list" className="space-y-1 p-0.5">
-          {results.map(({ document: entry, contexts }) => (
+          {results.map(({ document: entry, contexts, lexicalRank }) => (
             <li key={entry.documentId}>
               <button
                 type="button"
@@ -200,7 +206,11 @@ export function SearchResults({
                       data-testid="result-excerpt"
                       className="text-muted-foreground line-clamp-2 text-[11px] leading-snug"
                     >
-                      <Highlighted text={contexts?.[0] ?? ''} query={query} />
+                      {lexicalRank === undefined ? (
+                        (contexts?.[0] ?? '')
+                      ) : (
+                        <Highlighted text={contexts?.[0] ?? ''} query={query} />
+                      )}
                     </span>
                   )}
                 </span>
@@ -213,7 +223,7 @@ export function SearchResults({
           data-testid="search-results-grid"
           className="grid grid-cols-2 gap-2 p-0.5 md:grid-cols-3"
         >
-          {results.map(({ document: entry, contexts }) => (
+          {results.map(({ document: entry, contexts, lexicalRank }) => (
             <li key={entry.documentId}>
               <button
                 type="button"
@@ -254,7 +264,11 @@ export function SearchResults({
                       data-testid="result-excerpt"
                       className="text-muted-foreground line-clamp-2 text-[11px] leading-snug"
                     >
-                      <Highlighted text={contexts?.[0] ?? ''} query={query} />
+                      {lexicalRank === undefined ? (
+                        (contexts?.[0] ?? '')
+                      ) : (
+                        <Highlighted text={contexts?.[0] ?? ''} query={query} />
+                      )}
                     </span>
                   )}
                 </span>

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -814,7 +814,11 @@ export function WorkspaceFilesPanel({
                       // flight, the names and paths already in hand are a
                       // real answer rather than a blank pane.
                       searchDocuments(documents, query).map((document) => ({ document }))
-                    : hits.map((hit) => ({ document: hit.document, contexts: hit.contexts }))
+                    : hits.map((hit) => ({
+                        document: hit.document,
+                        contexts: hit.contexts,
+                        ...(hit.lexicalRank === undefined ? {} : { lexicalRank: hit.lexicalRank }),
+                      }))
                 }
                 query={query}
                 searchedContents={activeTag === null && hits !== null}

--- a/apps/web/src/components/workspace-files/body-search.test.tsx
+++ b/apps/web/src/components/workspace-files/body-search.test.tsx
@@ -32,6 +32,7 @@ describe('body search', () => {
         {
           document: entries[1] as (typeof entries)[number],
           contexts: ['…the quota exceeded error shows up on save…'],
+          lexicalRank: 1,
         },
       ],
     })
@@ -126,5 +127,33 @@ describe('body search', () => {
     // the old list can name a document that no longer exists.
     rerender(<WorkspaceFilesPanel source={source} onOpenDocument={() => {}} revision={2} />)
     await waitFor(() => expect(source.searchDocuments).toHaveBeenCalledTimes(2))
+  })
+
+  it('marks nothing in an excerpt that no keyword produced', async () => {
+    renderPanel({
+      searchDocuments: async () => [
+        {
+          document: entries[1] as (typeof entries)[number],
+          // A hit the daemon's semantic search put here: the excerpt is the
+          // document's opening, not a match window. Marking the query inside
+          // it would point at a word that had nothing to do with the hit.
+          contexts: ['An opening line that happens to contain quota.'],
+        },
+        {
+          document: entries[0] as (typeof entries)[number],
+          contexts: ['…the quota exceeded error…'],
+          lexicalRank: 1,
+        },
+      ],
+    })
+    await search('quota')
+
+    const excerpts = await screen.findAllByTestId('result-excerpt')
+    expect(within(excerpts[0] as HTMLElement).queryAllByTestId('search-match')).toEqual([])
+    expect(excerpts[0]?.textContent).toContain('opening line')
+    // The lexical hit still gets its match marked.
+    expect(
+      within(excerpts[1] as HTMLElement).getAllByTestId('search-match').length,
+    ).toBeGreaterThan(0)
   })
 })

--- a/apps/web/src/components/workspace-files/files-source.ts
+++ b/apps/web/src/components/workspace-files/files-source.ts
@@ -86,6 +86,26 @@ export interface WorkspaceFilesSource {
 export interface DocumentSearchHit {
   readonly document: WorkspaceDocumentEntry
   readonly contexts: readonly string[]
+  /**
+   * Where this document sat in the KEYWORD ranking, 1-based, or absent when
+   * keywords never matched it.
+   *
+   * Absent is the case worth having: it says there is nothing in `contexts`
+   * to highlight, which no reader can infer from the excerpt's shape. Local
+   * mode has no embedder, so every hit it produces carries one.
+   *
+   * 1-based deliberately — a rank of 0 is falsy, and `if (hit.lexicalRank)`
+   * would read the top hit as no hit.
+   */
+  readonly lexicalRank?: number
+  /**
+   * Where this document sat in the semantic ranking, 1-based, or absent when
+   * no embedder was configured. Reported rather than folded into a "matched
+   * by meaning" label: every embedded document appears in that ranking, so
+   * presence alone says nothing, and the threshold that would make it mean
+   * something belongs to whoever displays the results.
+   */
+  readonly semanticRank?: number
 }
 
 export class WorkspaceMissingError extends Error {

--- a/apps/web/src/lib/daemon-files-source.test.ts
+++ b/apps/web/src/lib/daemon-files-source.test.ts
@@ -151,3 +151,43 @@ describe('createDaemonFilesSource tags', () => {
     expect(degraded[0]?.tags).toBeUndefined()
   })
 })
+
+describe('createDaemonFilesSource searchDocuments', () => {
+  function searchFetchStub(results: unknown[]): typeof globalThis.fetch {
+    return vi.fn((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.includes('/search')) return Promise.resolve(jsonResponse({ results }))
+      return Promise.resolve(jsonResponse({ message: 'unexpected' }, 500))
+    }) as unknown as typeof globalThis.fetch
+  }
+
+  it('carries the ranks through, so a semantic-only hit can be told apart', async () => {
+    const source = createDaemonFilesSource(
+      searchFetchStub([
+        {
+          documentId: '01M0P7D8CDZ5TP3C8ZYM8G275W',
+          path: 'plans/roadmap',
+          score: 2.5,
+          contexts: ['…the quota exceeded error…'],
+          lexicalRank: 1,
+          semanticRank: 3,
+        },
+        // Found by meaning alone: its excerpt is the document's opening, and
+        // there is no keyword in it to mark.
+        {
+          documentId: '01M0P7D8CDZ5TP3C8ZYM8G276X',
+          path: 'notes/storage',
+          score: 1.1,
+          contexts: ['An opening line.'],
+          semanticRank: 1,
+        },
+      ]),
+      BASE,
+      'ws',
+    )
+
+    const hits = await source.searchDocuments('quota', 20)
+    expect(hits.map((hit) => hit.lexicalRank)).toEqual([1, undefined])
+    expect(hits.map((hit) => hit.semanticRank)).toEqual([3, 1])
+  })
+})

--- a/apps/web/src/lib/daemon-files-source.ts
+++ b/apps/web/src/lib/daemon-files-source.ts
@@ -95,6 +95,8 @@ export function createDaemonFilesSource(
           ...(hit.kind === undefined ? {} : { kind: hit.kind }),
         },
         contexts: hit.contexts,
+        ...(hit.lexicalRank === undefined ? {} : { lexicalRank: hit.lexicalRank }),
+        ...(hit.semanticRank === undefined ? {} : { semanticRank: hit.semanticRank }),
       }))
     },
 

--- a/apps/web/src/lib/local-files-source.ts
+++ b/apps/web/src/lib/local-files-source.ts
@@ -193,9 +193,15 @@ export function createLocalFilesSource(
         })
       }
       const byId = new Map(entries.map((entry) => [entry.documentId, entry]))
+      // Every hit here is a keyword hit — there is no embedder in the
+      // browser — so each carries its rank, and the panel highlights.
+      let rank = 0
       return fullTextSearch(searchable, query, { limit }).flatMap((hit) => {
         const document = byId.get(hit.documentId)
-        return document === undefined ? [] : [{ document, contexts: [...hit.contexts] }]
+        rank += 1
+        return document === undefined
+          ? []
+          : [{ document, contexts: [...hit.contexts], lexicalRank: rank }]
       })
     },
 

--- a/apps/web/src/lib/local-search.browser.test.tsx
+++ b/apps/web/src/lib/local-search.browser.test.tsx
@@ -108,4 +108,19 @@ describe('local body search', () => {
     expect((await source.searchDocuments('renamed', 20))[0]?.document.path).toBe('drafts/renamed')
     expect(await source.searchDocuments('first', 20)).toEqual([])
   })
+
+  it('ranks its own hits 1-based, so a caller can tell a keyword hit from none', async () => {
+    // Local mode has no embedder, so every hit here IS a lexical hit — the
+    // rank is what says so, and its absence is what a semantic-only hit
+    // from the daemon would carry.
+    const index = new IdbDocumentIndex()
+    await ensureLocalWorkspace(index)
+    await seedMarkdown(index, 'ranked/heavy', 'zarquon zarquon zarquon exceeded on save')
+    await seedMarkdown(index, 'ranked/light', 'a passing mention of zarquon')
+    const source = createLocalFilesSource({ index })
+
+    const hits = await source.searchDocuments('zarquon', 20)
+    expect(hits.map((hit) => hit.document.path)).toEqual(['ranked/heavy', 'ranked/light'])
+    expect(hits.map((hit) => hit.lexicalRank)).toEqual([1, 2])
+  })
 })


### PR DESCRIPTION
## What this closes

#1023 shipped body search in the document browser and highlighted the query inside every excerpt. That is right for a keyword hit and wrong for the other kind: when the daemon's semantic search puts a document in the results that no keyword matched, the excerpt is the document's **opening**, not a match window — and marking the query inside it points at a coincidence and calls it the reason the row is there.

The daemon's search now reports `lexicalRank` and `semanticRank` (1-based, ranks within the full pre-fusion ranking, landed by the search session in `server-core/src/tools/document-search.ts`). The web seam carried neither. This PR propagates both and gates the highlight on the lexical rank being present.

## Why a rank and not a "matched by" label

Rejected during the design discussion, and the reason is worth keeping: `rankByVector` ranks **every** document that has a vector, so mere presence in the semantic ranking carries no information — a `matchedBy: 'semantic'` label would claim meaning helped for every result. Whether a semantic rank is good enough to have *promoted* a document is a judgement with a threshold in it, and the threshold belongs to whoever displays the results.

**Absence is the useful case.** A missing `lexicalRank` is the one thing a caller cannot infer from the excerpt's shape, and it is not an edge case: on this repo's own docs, 16 of 50 judged queries score no document lexically at all.

1-based, because a rank of 0 is falsy and `if (hit.lexicalRank)` would read the top hit as no hit.

## Scope

- `DocumentSearchHit` gains `lexicalRank?` / `semanticRank?`
- daemon adapter maps both from the response
- local adapter assigns 1-based ranks in `fullTextSearch` order — browser-local has no embedder, so every hit there is a keyword hit and nothing about local search changes
- `SearchResults` renders an unranked excerpt as plain text

## Tests

Red-first, one per layer: jsdom (an unranked hit's excerpt carries no `search-match`, while a ranked one still does), a daemon-adapter test (both ranks survive the response, `undefined` for a semantic-only hit), and a `web-browser` test against real IndexedDB (local hits are ranked 1, 2 in score order).

Mutation-checked: making the highlight unconditional again turns the jsdom test red (`1 failed | 6 passed`), restored verified.

Gates: apps/web jsdom 2740 + node 77, `web-browser` 762, lint / knip / `-r typecheck` clean.

## Visual repro

Both panels are the SAME two results rendered through the real `WorkspaceFilesPanel` in the `web-browser` project — one keyword hit (`lexicalRank: 1`) and one semantic-only hit (`semanticRank: 1`, no lexical rank). The ring is on the semantic-only row's excerpt.

![lexical-rank-figure.png](https://github.com/user-attachments/assets/6f2a72c0-6bac-4435-b699-63939feaf357)

Before, the word `quota` inside that excerpt is marked — but the row is not there because of that word, and the excerpt is the document's opening rather than a match window. After, it is left alone. The keyword hit above it keeps every mark in both panels: the change is a gate, not a removal.

Produced by rendering the component twice, the second time with the gate mutated back to unconditional highlighting, and the two PNGs were byte-compared before composing (`d70dd086…` vs `0127adff…`) — the trap the `visual-evidence` skill names is a "before" that silently came out identical to the "after".

**What this figure cannot show**: browser-local mode has no embedder, so it can never produce an unranked hit — the case above is reachable only against a daemon with `WHITEBOARD_SEMANTIC_SEARCH=1`. The panel state in the figure is real and rendered by the real component; the hit that produces it was supplied through the source seam rather than by a live embedder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoaNgqWUKbYJxk2azmRQKY
