### PR TITLE
fix(spatial-editor): the node menu carries a doorway to facets, not their values

### DIFF
--- a/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
@@ -643,30 +643,13 @@ export function CanvasContextMenu({
             })
           }),
         )
-        // Facet quick bands ride the contribution seam: this surface asks the
-        // registry what the point carries and looks widgets up by key — it
-        // never names a plugin or facet itself (facet-wiring-guard.test.ts
-        // keeps it that way). Bands apply to the whole selection, the same
-        // semantics as Color.
-        let facetItems: readonly ContextMenuItem[] = []
-        {
-          const applyToSelection = (
-            commandsFor: (targetIds: readonly string[]) => readonly EditorCommand[],
-          ) => {
-            const members = new Set(selectedId !== null ? [selectedId, ...extraIds] : [])
-            const nodeTargets = members.has(node.id) ? [...members] : [node.id]
-            applyResult({ state: { kind: 'idle' }, commands: [...commandsFor(nodeTargets)] })
-          }
-          // Pushed AFTER the core rows below, so the menu reads
-          // core-then-extensions with a visible fence between them. The
-          // doorway to the full panel comes back with the bands — this
-          // surface owns where the region goes, never what is in it.
-          facetItems = nodePropertyItems(facetRegistry, {
-            node,
-            applyToSelection,
-            openPanel: () => setFacetPanelNodeId(node.id),
-          })
-        }
+        // Facets reach this surface as ONE doorway. This menu never names a
+        // plugin or facet key (facet-wiring-guard.test.ts keeps it that way),
+        // and now it does not carry their values either — an action menu runs
+        // an entry and closes; a facet is state you adjust repeatedly.
+        const facetItems = nodePropertyItems(facetRegistry, {
+          openPanel: () => setFacetPanelNodeId(node.id),
+        })
         // Z-order as one-tap options — the touch path to the [ / ]
         // keyboard shortcuts (see shortcuts.ts). Not a picker: no
         // option is ever "selected", each tap applies a move.

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -3329,12 +3329,22 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 node={target}
                 registry={bundledFacetRegistry}
                 onClose={() => setFacetPanelNodeId(null)}
-                onWrite={(key, payload) =>
+                onWrite={(key, payload) => {
+                  // Applies to the whole selection, the semantics the menu
+                  // bands had: reshaping five selected nodes must not become
+                  // five visits to this panel.
+                  const members = new Set(selectedId !== null ? [selectedId, ...extraIds] : [])
+                  const ids = members.has(target.id) ? [...members] : [target.id]
                   applyResult({
                     state: { kind: 'idle' },
-                    commands: [{ kind: 'set-node-facet', id: target.id, key, payload }],
+                    commands: ids.map((id) => ({
+                      kind: 'set-node-facet' as const,
+                      id,
+                      key,
+                      payload,
+                    })),
                   })
-                }
+                }}
               />
             )
           })()}

--- a/apps/web/src/components/spatial-editor/facet-panel.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/facet-panel.browser.test.tsx
@@ -55,10 +55,13 @@ it('the Facets entry opens the panel, and a pick there stores and draws', () => 
   // A CHOICE applies on pick, the way the same facet's quick band does —
   // there is no Save to press, and a facet made only of choices has none.
   fireEvent.click(hexagon)
-  // Scoped by accessible name: Symbol keeps a Save because it carries a
-  // free-entry field, so a panel-wide check would pass for the wrong reason.
-  expect(panel.querySelector('button[aria-label="Save Shape"]')).toBeNull()
-  expect(panel.querySelector('button[aria-label="Save Symbol"]')).not.toBeNull()
+  // Nothing in the bundled plugin needs a Save any more: shape and text are
+  // declared choices, and symbol renders its registered picker. A Save
+  // survives only for a facet with free entry — covered in the jsdom suite,
+  // where a fixture facet can have one.
+  expect(panel.querySelector('button[aria-label^="Save"]')).toBeNull()
+  // The picker that used to be a context-menu band is here instead.
+  expect(panel.querySelector('[aria-label="Emoji ⭐"]')).not.toBeNull()
 
   expect(latest.canvas.nodes[0]?.['x-whiteboard']?.facets?.['visual.shape/v0']).toEqual({
     kind: 'hexagon',

--- a/apps/web/src/components/spatial-editor/facet-widgets/FacetFormPanel.test.tsx
+++ b/apps/web/src/components/spatial-editor/facet-widgets/FacetFormPanel.test.tsx
@@ -30,6 +30,18 @@ const plain = definePlugin({
         weight: z.number().optional(),
       }),
     }),
+    // A discriminated union with no registered editor and no declared spec:
+    // the derived variants form is what this must fall back to.
+    defineFacet({
+      name: 'mark',
+      displayName: 'Mark',
+      version: 'v0',
+      targets: ['node'],
+      schema: z.union([
+        z.object({ kind: z.literal('icon'), name: z.string() }),
+        z.object({ kind: z.literal('emoji'), char: z.string() }),
+      ]),
+    }),
   ],
 })
 const registry = createFacetRegistry([...bundledPlugins, plain])
@@ -101,19 +113,19 @@ describe('control kinds the derived form emits', () => {
     const onWrite = vi.fn()
     render(
       <FacetFormPanel
-        node={node({ 'visual.symbol/v0': { kind: 'icon', name: 'star' } })}
+        node={node({ 'planning.mark/v0': { kind: 'icon', name: 'star' } })}
         registry={registry}
         onWrite={onWrite}
       />,
     )
     // Switching arms must not carry the previous arm's field into the
     // payload — `name` belongs to icon, `char` to emoji.
-    fireEvent.change(screen.getByLabelText('Symbol Kind'), {
+    fireEvent.change(screen.getByLabelText('Mark Kind'), {
       target: { value: 'emoji' },
     })
-    fireEvent.change(screen.getByLabelText('Symbol Char'), { target: { value: '⭐' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Save Symbol' }))
-    expect(onWrite).toHaveBeenCalledWith('visual.symbol/v0', { kind: 'emoji', char: '⭐' })
+    fireEvent.change(screen.getByLabelText('Mark Char'), { target: { value: '⭐' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save Mark' }))
+    expect(onWrite).toHaveBeenCalledWith('planning.mark/v0', { kind: 'emoji', char: '⭐' })
   })
 
   it('a toggle writes a boolean and a number control writes a number', () => {
@@ -184,18 +196,18 @@ describe('a draft never outlives what it was seeded from', () => {
     const onWrite = vi.fn()
     render(
       <FacetFormPanel
-        node={node({ 'visual.symbol/v0': { kind: 'icon', name: 'star' } })}
+        node={node({ 'planning.mark/v0': { kind: 'icon', name: 'star' } })}
         registry={registry}
         onWrite={onWrite}
       />,
     )
-    fireEvent.change(screen.getByLabelText('Symbol Kind'), {
+    fireEvent.change(screen.getByLabelText('Mark Kind'), {
       target: { value: 'emoji' },
     })
-    fireEvent.change(screen.getByLabelText('Symbol Char'), {
+    fireEvent.change(screen.getByLabelText('Mark Char'), {
       target: { value: '⭐' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Save Symbol' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save Mark' }))
     // `name` belonged to the icon arm and must not ride along: a schema
     // that passes unknown keys through would otherwise store it.
     const [, payload] = onWrite.mock.calls[0] as [string, Record<string, unknown>]
@@ -280,4 +292,33 @@ it('does not print a field label that repeats the facet name', () => {
   expect(screen.getAllByText('Shape')).toHaveLength(1)
   // The control still answers to that name.
   expect(screen.getByLabelText('Shape')).not.toBeNull()
+})
+
+describe('a registered editor replaces the derived form', () => {
+  it('renders the badge picker for visual.symbol, and writes through the registry', () => {
+    const onWrite = vi.fn()
+    render(<FacetFormPanel node={node()} registry={registry} onWrite={onWrite} />)
+    // The picker that used to live in the context menu now lives here, so
+    // the facet has one face instead of two.
+    fireEvent.click(screen.getByLabelText('Emoji ⭐'))
+    expect(onWrite).toHaveBeenCalledWith('visual.symbol/v0', { kind: 'emoji', char: '⭐' })
+    // And the derived variants form is NOT what got rendered.
+    expect(screen.queryByLabelText('Symbol Kind')).toBeNull()
+  })
+
+  it('cannot store what the facet would refuse', () => {
+    const onWrite = vi.fn()
+    const editors = {
+      'visual.symbol/v0': ({ write }: { write: (p: unknown) => void }) => (
+        <button type="button" onClick={() => write({ kind: 'emoji', char: 'too many' })}>
+          bad
+        </button>
+      ),
+    }
+    render(<FacetFormPanel node={node()} registry={registry} onWrite={onWrite} editors={editors} />)
+    fireEvent.click(screen.getByRole('button', { name: 'bad' }))
+    // `char` is a single grapheme. A hand-written editor gets no shorter
+    // path to storage than a declared one.
+    expect(onWrite).not.toHaveBeenCalled()
+  })
 })

--- a/apps/web/src/components/spatial-editor/facet-widgets/FacetFormPanel.tsx
+++ b/apps/web/src/components/spatial-editor/facet-widgets/FacetFormPanel.tsx
@@ -23,9 +23,22 @@ import type { SpatialNode } from '@kamiazya/whiteboard-model'
 import { useEffect, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
 import { glyphIcon } from './glyph.js'
+import { type FacetEditorWidget, NODE_FACET_EDITORS } from './index.js'
 
 export interface FacetFormPanelProps {
+  /**
+   * The node whose stored values the panel SHOWS. Writes go to the whole
+   * selection (see `onWrite`) — the same split the context-menu bands had,
+   * where the row reflected the node you opened on and applied to every
+   * selected node.
+   */
   readonly node: SpatialNode
+  /**
+   * Tier-3 editors by facet key. A facet with one registered renders it
+   * instead of the derived form — the picker the declared vocabulary
+   * cannot yet express (today: the icon-plus-emoji badge picker).
+   */
+  readonly editors?: Readonly<Record<string, FacetEditorWidget>>
   readonly registry: FacetRegistry
   /** `undefined` payload clears the facet, matching set-node-facet. */
   readonly onWrite: (key: string, payload: unknown) => void
@@ -335,7 +348,13 @@ function FacetEditor({
   )
 }
 
-export function FacetFormPanel({ node, registry, onWrite, onClose }: FacetFormPanelProps) {
+export function FacetFormPanel({
+  node,
+  registry,
+  onWrite,
+  onClose,
+  editors = NODE_FACET_EDITORS,
+}: FacetFormPanelProps) {
   const closeRef = useRef<HTMLButtonElement | null>(null)
   // Focus on open: a dialog that never takes focus leaves Escape and Tab
   // acting on the canvas behind it. The close button is the least
@@ -343,7 +362,7 @@ export function FacetFormPanel({ node, registry, onWrite, onClose }: FacetFormPa
   useEffect(() => {
     closeRef.current?.focus()
   }, [])
-  const groups = resolveFacetContributions(registry, 'contextMenu.node.properties')
+  const groups = resolveFacetContributions(registry, 'inspector.node')
   const stored = storedFacets(node)
   const body = (
     <div className="flex flex-col gap-3">
@@ -352,21 +371,38 @@ export function FacetFormPanel({ node, registry, onWrite, onClose }: FacetFormPa
           <span className="text-[0.65rem] font-medium tracking-wide text-muted-foreground">
             {group.displayName}
           </span>
-          {group.facets.map((facet) => (
-            <FacetEditor
-              // Keyed by NODE too: a draft belongs to the node it was typed
-              // against. Retargeting the panel without this reuses the
-              // instance, so an abandoned edit on one node would be shown —
-              // and saved — as another node's value.
-              key={`${node.id}:${facet.key}`}
-              facetKey={facet.key}
-              title={facet.definition.displayName}
-              form={deriveFacetForm(facet.definition.schema, facet.definition.editor)}
-              stored={stored[facet.key]}
-              registry={registry}
-              onWrite={onWrite}
-            />
-          ))}
+          {group.facets.map((facet) =>
+            editors[facet.key] !== undefined ? (
+              <div key={`${node.id}:${facet.key}`} className="flex flex-col gap-1.5">
+                <span className="text-xs font-medium">{facet.definition.displayName}</span>
+                {editors[facet.key]?.({
+                  value: stored[facet.key],
+                  // Straight through the registry, exactly like the derived
+                  // form's own writer — a hand-written editor gets no shorter
+                  // path to storage than a declared one.
+                  write: (payload) => {
+                    if (payload === undefined) return onWrite(facet.key, undefined)
+                    const result = registry.validateFacetWrite(facet.key, payload)
+                    if (result.ok) onWrite(facet.key, result.value)
+                  },
+                })}
+              </div>
+            ) : (
+              <FacetEditor
+                // Keyed by NODE too: a draft belongs to the node it was typed
+                // against. Retargeting the panel without this reuses the
+                // instance, so an abandoned edit on one node would be shown —
+                // and saved — as another node's value.
+                key={`${node.id}:${facet.key}`}
+                facetKey={facet.key}
+                title={facet.definition.displayName}
+                form={deriveFacetForm(facet.definition.schema, facet.definition.editor)}
+                stored={stored[facet.key]}
+                registry={registry}
+                onWrite={onWrite}
+              />
+            ),
+          )}
         </div>
       ))}
     </div>

--- a/apps/web/src/components/spatial-editor/facet-widgets/index.test.tsx
+++ b/apps/web/src/components/spatial-editor/facet-widgets/index.test.tsx
@@ -1,14 +1,9 @@
-// The namespace-container rule for the node context menu: EVERY contributing
-// namespace gets its displayName heading, the whole region is fenced off from
-// the core rows by a separator, and groups order by namespace ID regardless of
-// the display wording.
+// What the node context menu contributes, now that facets have an inspector:
+// a doorway, and only when there is something behind it.
 import { createFacetRegistry, defineFacet, definePlugin } from '@kamiazya/whiteboard-facet-engine'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
-import { type NodePropertiesWidget, nodePropertyItems } from './index.js'
-
-const node = { id: 'n1', type: 'text' as const, x: 0, y: 0, width: 10, height: 10, text: '' }
-const ctx = { node, applyToSelection: () => {}, openPanel: () => {} }
+import { nodePropertyItems } from './index.js'
 
 const nodeFacet = (name: string) =>
   defineFacet({
@@ -19,109 +14,44 @@ const nodeFacet = (name: string) =>
     schema: z.object({}),
   })
 
-const band =
-  (label: string): NodePropertiesWidget =>
-  () => [{ kind: 'options' as const, label, options: [] }]
-
-// zeta before apple by DISPLAY name — id order must win.
-const zeta = definePlugin({
-  id: 'aaa-zeta',
-  displayName: 'Zeta styling',
+const withNodeFacet = definePlugin({
+  id: 'demo',
+  displayName: 'Demo',
   facets: [nodeFacet('one')],
 })
-const apple = definePlugin({
-  id: 'zzz-apple',
-  displayName: 'Apple tools',
-  facets: [nodeFacet('two')],
+const canvasOnly = definePlugin({
+  id: 'other',
+  displayName: 'Other',
+  facets: [
+    defineFacet({
+      name: 'board',
+      displayName: 'Board',
+      version: 'v0',
+      targets: ['canvas' as const],
+      schema: z.object({}),
+    }),
+  ],
 })
 
 describe('nodePropertyItems', () => {
-  it('two namespaces get displayName headings, ordered by namespace id', () => {
-    const registry = createFacetRegistry([zeta, apple])
-    const widgets = { 'aaa-zeta.one/v0': band('One'), 'zzz-apple.two/v0': band('Two') }
-    const items = nodePropertyItems(registry, ctx, widgets)
-    expect(items.map((i) => (i.kind === 'heading' ? `#${i.label}` : (i.kind ?? 'action')))).toEqual(
-      ['separator', '#Zeta styling', 'options', '#Apple tools', 'options', 'action'],
-    )
-  })
-
-  it('a single contributing namespace is headed too — the region needs a boundary', () => {
-    const registry = createFacetRegistry([zeta, apple])
-    // apple has no widget registered, so only zeta actually contributes.
-    const widgets = { 'aaa-zeta.one/v0': band('One') }
-    const items = nodePropertyItems(registry, ctx, widgets)
-    expect(items.map((i) => (i.kind === 'heading' ? `#${i.label}` : (i.kind ?? 'action')))).toEqual(
-      ['separator', '#Zeta styling', 'options', 'action'],
-    )
-  })
-
-  it("the panel doorway is the vessel's, not the core surface's", () => {
-    const registry = createFacetRegistry([zeta])
+  it('offers one doorway, whatever a plugin contributes', () => {
     let opened = 0
-    const items = nodePropertyItems(
-      registry,
-      {
-        ...ctx,
-        openPanel: () => {
-          opened += 1
-        },
+    const items = nodePropertyItems(createFacetRegistry([withNodeFacet]), {
+      openPanel: () => {
+        opened += 1
       },
-      { 'aaa-zeta.one/v0': band('One') },
-    )
-    const doorway = items.find((i) => i.kind === undefined || i.kind === 'action')
-    expect(doorway).toBeDefined()
+    })
+    // A separator fences it off from the core rows above; the entry is the
+    // only thing this surface knows about facets.
+    expect(items.map((i) => i.kind ?? 'action')).toEqual(['separator', 'action'])
+    const doorway = items[1]
     if (doorway !== undefined && 'onSelect' in doorway) doorway.onSelect()
     expect(opened).toBe(1)
   })
 
-  it('contributes nothing at all when no namespace has a band', () => {
-    // No separator, no doorway: an empty region must not leave a stray rule
-    // across the menu.
-    expect(nodePropertyItems(createFacetRegistry([zeta]), ctx, {})).toEqual([])
-  })
-})
-
-describe('a declared band is legible', () => {
-  const shaped = definePlugin({
-    id: 'demo',
-    displayName: 'Demo',
-    facets: [
-      defineFacet({
-        name: 'place',
-        displayName: 'Placement',
-        version: 'v0',
-        targets: ['node' as const],
-        schema: z.object({ align: z.enum(['start', 'center']) }),
-        editor: {
-          fields: {
-            align: {
-              widget: 'segmented',
-              label: 'Text',
-              quick: true,
-              options: [
-                { value: null, label: 'Default', glyph: 'none' },
-                { value: 'start', label: 'Top' },
-                { value: 'center', label: 'Middle' },
-              ],
-            },
-          },
-        },
-      }),
-    ],
-  })
-
-  it('an option with no drawable glyph shows its declared label, not nothing', () => {
-    const items = nodePropertyItems(createFacetRegistry([shaped]), ctx, {})
-    const band = items.find((i) => i.kind === 'options')
-    // `icon` is a React ELEMENT even when the component renders nothing, so
-    // passing one unconditionally made the vessel choose the icon branch and
-    // draw an empty button. Three blank boxes, measured at 28px each.
-    expect(band?.kind === 'options' ? band.options.map((o) => o.label) : []).toEqual([
-      'Default',
-      'Top',
-      'Middle',
-    ])
-    const glyphless = band?.kind === 'options' ? band.options.slice(1) : []
-    expect(glyphless.map((o) => o.icon)).toEqual([undefined, undefined])
+  it('offers nothing when no facet targets a node — an empty inspector is a dead end', () => {
+    expect(nodePropertyItems(createFacetRegistry([canvasOnly]), { openPanel: () => {} })).toEqual(
+      [],
+    )
   })
 })

--- a/apps/web/src/components/spatial-editor/facet-widgets/index.tsx
+++ b/apps/web/src/components/spatial-editor/facet-widgets/index.tsx
@@ -83,22 +83,28 @@ const symbolEditor: FacetEditorWidget = ({ value, write }) => {
     on: boolean,
     payload: VisualSymbolFacet | undefined,
   ) => (
-    <button
+    // Real radios rather than buttons wearing the role: the roving-focus
+    // and arrow-key behaviour a segmented control needs comes free with the
+    // element, and the same choice was made for the declared controls.
+    <label
       key={key}
-      type="button"
-      role="radio"
-      aria-checked={on}
-      aria-label={label}
-      onClick={() => write(payload)}
       className={cn(
-        'flex h-7 min-w-7 items-center justify-center rounded px-1 text-xs',
+        'flex h-7 min-w-7 cursor-pointer items-center justify-center rounded px-1 text-xs',
         on ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-accent',
       )}
     >
+      <input
+        type="radio"
+        name="visual-symbol"
+        aria-label={label}
+        checked={on}
+        onChange={() => write(payload)}
+        className="sr-only"
+      />
       <span aria-hidden="true" className="[&>svg]:size-4">
         {content}
       </span>
-    </button>
+    </label>
   )
   return (
     <span role="radiogroup" aria-label="Symbol" className="flex flex-wrap items-center gap-0.5">

--- a/apps/web/src/components/spatial-editor/facet-widgets/index.tsx
+++ b/apps/web/src/components/spatial-editor/facet-widgets/index.tsx
@@ -14,39 +14,28 @@ import {
   LUCIDE_VIEWBOX,
 } from '@kamiazya/whiteboard-canvas-render'
 import {
-  deriveFacetForm,
-  type FacetDefinition,
   type FacetRegistry,
   resolveCanvasEdgeStyle,
   resolveFacetContributions,
-  resolveNodeSymbol,
-  VISUAL_SYMBOL_KEY,
   type VisualSymbolFacet,
+  visualSymbolFacetSchema,
 } from '@kamiazya/whiteboard-facet-engine'
-import type { EdgeRoutingStyle, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
+import type { EdgeRoutingStyle, SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { Ban, SlidersHorizontal } from 'lucide-react'
 import { createElement, type ReactNode } from 'react'
 import { cn } from '@/lib/utils'
 import type { ContextMenuItem } from '../ContextMenu.js'
 import type { EditorCommand } from '../commands.js'
-import { glyphIcon } from './glyph.js'
 
 /** `contextMenu.node.properties`: what a node quick-band widget receives. */
 export interface NodePropertiesContext {
-  readonly node: SpatialNode
-  /** Applies per-target commands with the menu's selection semantics. */
-  readonly applyToSelection: (
-    commandsFor: (targetIds: readonly string[]) => readonly EditorCommand[],
-  ) => void
   /**
-   * Opens the full facet panel for this node. The core surface owns the
-   * panel's mounting; the DOORWAY belongs here, so no point-owning surface
-   * has to name the facet concept to offer one.
+   * Opens the facet inspector for this node. The core surface owns the
+   * inspector's mounting; the DOORWAY belongs here, so no point-owning
+   * surface has to name the facet concept to offer one.
    */
   readonly openPanel: () => void
 }
-
-export type NodePropertiesWidget = (ctx: NodePropertiesContext) => readonly ContextMenuItem[]
 
 /** `canvasSettings`: what a canvas-settings panel widget receives. */
 export interface CanvasSettingsContext {
@@ -55,6 +44,22 @@ export interface CanvasSettingsContext {
 }
 
 export type CanvasSettingsWidget = (ctx: CanvasSettingsContext) => ReactNode
+
+/**
+ * `inspector.node`: a hand-written editor for one facet, rendered inside the
+ * inspector's row for it. Tier 3 of the editor ladder — for a picker the
+ * declared vocabulary cannot yet express.
+ *
+ * `write` is the panel's own writer, so it has already been through
+ * `validateFacetWrite`: a widget cannot store what `wb_facet_set` refuses.
+ * `undefined` clears the facet.
+ */
+export interface FacetEditorContext {
+  readonly value: unknown
+  readonly write: (payload: unknown) => void
+}
+
+export type FacetEditorWidget = (ctx: FacetEditorContext) => ReactNode
 
 // --- visual.shape/v0 -------------------------------------------------------
 
@@ -68,41 +73,53 @@ export type CanvasSettingsWidget = (ctx: CanvasSettingsContext) => ReactNode
  */
 const EMOJI_CHOICES = ['✅', '⚠️', '🔥', '⭐', '📌'] as const
 
-const visualSymbolBand: NodePropertiesWidget = ({ node, applyToSelection }) => {
-  const current = resolveNodeSymbol(node)
-  const applySymbol = (payload: VisualSymbolFacet | undefined) => {
-    applyToSelection((ids) =>
-      ids.map((id) => ({ kind: 'set-node-facet' as const, id, key: VISUAL_SYMBOL_KEY, payload })),
-    )
-  }
-  return [
-    {
-      kind: 'options' as const,
-      label: 'Symbol',
-      options: [
-        {
-          label: 'none',
-          ariaLabel: 'No symbol',
-          icon: <Ban />,
-          selected: current === undefined,
-          onSelect: () => applySymbol(undefined),
-        },
-        ...BUILT_IN_ICON_NAMES.map((name) => ({
-          label: name,
-          ariaLabel: `Icon ${name}`,
-          icon: <BuiltInIcon name={name} />,
-          selected: current?.kind === 'icon' && current.name === name,
-          onSelect: () => applySymbol({ kind: 'icon', name }),
-        })),
-        ...EMOJI_CHOICES.map((char) => ({
-          label: char,
-          ariaLabel: `Emoji ${char}`,
-          selected: current?.kind === 'emoji' && current.char === char,
-          onSelect: () => applySymbol({ kind: 'emoji', char }),
-        })),
-      ],
-    },
-  ]
+const symbolEditor: FacetEditorWidget = ({ value, write }) => {
+  const current = visualSymbolFacetSchema.safeParse(value)
+  const selected = current.success ? current.data : undefined
+  const option = (
+    key: string,
+    label: string,
+    content: ReactNode,
+    on: boolean,
+    payload: VisualSymbolFacet | undefined,
+  ) => (
+    <button
+      key={key}
+      type="button"
+      role="radio"
+      aria-checked={on}
+      aria-label={label}
+      onClick={() => write(payload)}
+      className={cn(
+        'flex h-7 min-w-7 items-center justify-center rounded px-1 text-xs',
+        on ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-accent',
+      )}
+    >
+      <span aria-hidden="true" className="[&>svg]:size-4">
+        {content}
+      </span>
+    </button>
+  )
+  return (
+    <span role="radiogroup" aria-label="Symbol" className="flex flex-wrap items-center gap-0.5">
+      {option('none', 'No symbol', <Ban />, selected === undefined, undefined)}
+      {BUILT_IN_ICON_NAMES.map((name) =>
+        option(
+          name,
+          `Icon ${name}`,
+          <BuiltInIcon name={name} />,
+          selected?.kind === 'icon' && selected.name === name,
+          { kind: 'icon', name },
+        ),
+      )}
+      {EMOJI_CHOICES.map((char) =>
+        option(char, `Emoji ${char}`, char, selected?.kind === 'emoji' && selected.char === char, {
+          kind: 'emoji',
+          char,
+        }),
+      )}
+    </span>
+  )
 }
 
 /**
@@ -215,92 +232,36 @@ const visualEdgesPanel: CanvasSettingsWidget = ({ canvas, run }) => {
  * phone once a third band landed.
  */
 /**
- * Tier 2: a facet that DECLARES its editor gets its quick band rendered
- * from the declaration — no per-facet React. The glyph vocabulary is the
- * core's (a plugin names one, it cannot ship one), which is what keeps a
- * declared editor a declaration rather than third-party UI code.
+ * The node context menu's entire facet surface: one doorway, and nothing
+ * that edits a facet.
+ *
+ * Quick bands used to live here. An action menu's entries run once and
+ * close it; a facet is state you look at and adjust several times in a row,
+ * so it belongs on the inspector — and the menu was growing a row per
+ * domain, with a stored value one tap from Delete.
+ *
+ * No doorway at all when nothing targets a node: an inspector with nothing
+ * in it is a dead end, not an empty state.
  */
-function declaredBands(
-  facetKey: string,
-  definition: FacetDefinition,
-  ctx: NodePropertiesContext,
-): readonly ContextMenuItem[] {
-  if (definition.editor === undefined) return []
-  const form = deriveFacetForm(definition.schema, definition.editor)
-  if (form.kind !== 'fields') return []
-  const stored = ctx.node['x-whiteboard']?.facets?.[facetKey] as Record<string, unknown> | undefined
-  return form.fields.flatMap((field) => {
-    if (!field.quick || field.control.kind !== 'segmented') return []
-    const current = stored?.[field.name]
-    return [
-      {
-        kind: 'options' as const,
-        label: field.label,
-        options: field.control.options.map((option) => ({
-          // The DECLARED label, both visible and accessible: a band whose
-          // options carry no drawable glyph is read, not looked at, and the
-          // stored value ("start") is not what a reader is choosing ("Top").
-          label: option.label,
-          ariaLabel: option.label,
-          // `icon` must be absent, not an element that renders nothing —
-          // the vessel branches on its presence, so an unconditional element
-          // drew three blank 28px buttons where the labels should be.
-          icon: glyphIcon(option.glyph),
-          // A null option means the facet's ABSENCE, which is why the
-          // comparison is against undefined rather than the value.
-          selected: option.value === null ? stored === undefined : current === option.value,
-          onSelect: () => {
-            ctx.applyToSelection((ids) =>
-              ids.map((id) => ({
-                kind: 'set-node-facet' as const,
-                id,
-                key: facetKey,
-                payload: option.value === null ? undefined : { [field.name]: option.value },
-              })),
-            )
-          },
-        })),
-      },
-    ]
-  })
-}
-
 export function nodePropertyItems(
   registry: FacetRegistry,
   ctx: NodePropertiesContext,
-  widgets: Readonly<Record<string, NodePropertiesWidget>> = NODE_PROPERTIES_WIDGETS,
 ): readonly ContextMenuItem[] {
-  const contributed = resolveFacetContributions(registry, 'contextMenu.node.properties')
-    .map((group) => ({
-      group,
-      // A hand-written widget still wins where one is registered (tier 2
-      // is a ladder, not a replacement): a picker the catalog cannot yet
-      // express keeps its code.
-      bands: group.facets.flatMap(
-        (facet) => widgets[facet.key]?.(ctx) ?? declaredBands(facet.key, facet.definition, ctx),
-      ),
-    }))
-    .filter((entry) => entry.bands.length > 0)
-  if (contributed.length === 0) return []
+  if (resolveFacetContributions(registry, 'inspector.node').length === 0) return []
   return [
     { kind: 'separator' as const },
-    ...contributed.flatMap(({ group, bands }) => [
-      { kind: 'heading' as const, label: group.displayName },
-      ...bands,
-    ]),
-    // The quick bands are one tier; everything a facet declares — including
-    // facets no band knows about — is reachable through here.
     { label: 'Facets…', icon: <SlidersHorizontal />, onSelect: ctx.openPanel },
   ]
 }
 
 // --- registrations ---------------------------------------------------------
 
-export const NODE_PROPERTIES_WIDGETS: Readonly<Record<string, NodePropertiesWidget>> = {
-  // visual.shape is NOT here: it declares its band (see visual.ts's editor
-  // spec) and is rendered from that declaration — the acceptance test for
-  // tier 2 being usable by the plugin that ships with the engine.
-  'visual.symbol/v0': visualSymbolBand,
+export const NODE_FACET_EDITORS: Readonly<Record<string, FacetEditorWidget>> = {
+  // visual.shape and visual.text are NOT here: they declare their editor
+  // (see visual.ts) and are rendered from that declaration. Only symbol
+  // needs code, because an icon-plus-emoji picker is outside the declared
+  // vocabulary — which is the gap the semantic layer is meant to close.
+  'visual.symbol/v0': symbolEditor,
 }
 
 export const CANVAS_SETTINGS_WIDGETS: Readonly<Record<string, CanvasSettingsWidget>> = {

--- a/apps/web/src/components/spatial-editor/facet-widgets/menu-carries-no-facet-operations.test.tsx
+++ b/apps/web/src/components/spatial-editor/facet-widgets/menu-carries-no-facet-operations.test.tsx
@@ -1,0 +1,25 @@
+// The node context menu is an ACTION surface: entries run once and close it.
+// A facet is state, not an action, so the menu carries a doorway to the
+// inspector and nothing else — no band, no picker, no per-domain row.
+//
+// This is the rule that answers the next domain too: whatever ticketing or
+// due-dates want, the menu's answer is the same doorway.
+import { bundledFacetRegistry } from '@kamiazya/whiteboard-facet-engine'
+import { describe, expect, it } from 'vitest'
+import { nodePropertyItems } from './index.js'
+
+describe('the node context menu', () => {
+  const items = nodePropertyItems(bundledFacetRegistry, { openPanel: () => {} })
+
+  it('offers a doorway and nothing that edits a facet', () => {
+    // `options` rows ARE the editing affordance — one would put a facet
+    // value one tap away from the action menu, which is the leak.
+    expect(items.filter((i) => i.kind === 'options')).toEqual([])
+    expect(items.filter((i) => i.kind === 'heading')).toEqual([])
+  })
+
+  it('is one entry, so a fifth domain does not make it a fifth line longer', () => {
+    const entries = items.filter((i) => i.kind === undefined || i.kind === 'action')
+    expect(entries).toHaveLength(1)
+  })
+})

--- a/apps/web/src/components/spatial-editor/node-shape-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/node-shape-menu.browser.test.tsx
@@ -1,4 +1,4 @@
-// The node context menu's Shape row: a pick must not just record the
+// The inspector's Shape row: a pick must not just record the
 // visual.shape/v0 facet on the node, it must change the silhouette the
 // scene DRAWS — and `rect` must remove the facet without a trace.
 import type { VisualShapeFacet } from '@kamiazya/whiteboard-facet-engine'
@@ -47,12 +47,25 @@ function openNodeMenu(container: HTMLElement): HTMLElement {
   return menu
 }
 
+/** Opens the node menu, then the inspector behind its one facet entry. */
+function openInspector(container: HTMLElement): HTMLElement {
+  const menu = openNodeMenu(container)
+  const entry = [...menu.querySelectorAll('button')].find((b) =>
+    (b.textContent ?? '').startsWith('Facets'),
+  )
+  expect(entry).toBeDefined()
+  fireEvent.click(entry as HTMLElement)
+  const panel = container.querySelector('[data-testid="facet-form-panel"]') as HTMLElement
+  expect(panel).not.toBeNull()
+  return panel
+}
+
 it('the Shape row stores the facet and the scene draws the silhouette', () => {
   const { Host, latest } = makeHost()
   const { container } = render(<Host />)
 
-  const menu = openNodeMenu(container)
-  fireEvent.click(menu.querySelector('[aria-label="Hexagon"]') as HTMLElement)
+  const panel = openInspector(container)
+  fireEvent.click(panel.querySelector('[aria-label="Hexagon"]') as HTMLElement)
 
   expect(shapeFacetOf(latest.canvas)).toEqual({ kind: 'hexagon' })
   // The node's chrome is no longer a plain rect: a hexagon draws as a
@@ -94,8 +107,14 @@ it('a shape pick from a multi-selection reshapes every selected node', async () 
   fireEvent.contextMenu(root, { clientX: r.left + 160, clientY: r.top + 125 })
   const menu = container.querySelector('[data-testid="context-menu"]') as HTMLElement
   expect(menu).not.toBeNull()
+  fireEvent.click(
+    [...menu.querySelectorAll('button')].find((b) =>
+      (b.textContent ?? '').startsWith('Facets'),
+    ) as HTMLElement,
+  )
+  const panel = container.querySelector('[data-testid="facet-form-panel"]') as HTMLElement
 
-  fireEvent.click(menu.querySelector('[aria-label="Diamond"]') as HTMLElement)
+  fireEvent.click(panel.querySelector('[aria-label="Diamond"]') as HTMLElement)
   await vi.waitFor(() => {
     for (const id of ['a', 'b']) {
       expect(
@@ -109,7 +128,7 @@ it('Rectangle removes the facet without a trace', () => {
   const { Host, latest } = makeHost()
   const { container } = render(<Host />)
 
-  const first = openNodeMenu(container)
+  const first = openInspector(container)
   fireEvent.click(first.querySelector('[aria-label="Cylinder"]') as HTMLElement)
   expect(shapeFacetOf(latest.canvas)).toEqual({ kind: 'cylinder' })
 

--- a/apps/web/src/components/spatial-editor/node-symbol-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/node-symbol-menu.browser.test.tsx
@@ -45,12 +45,25 @@ function openNodeMenu(container: HTMLElement): HTMLElement {
   return container.querySelector('[data-testid="context-menu"]') as HTMLElement
 }
 
+/** Opens the node menu, then the inspector behind its one facet entry. */
+function openInspector(container: HTMLElement): HTMLElement {
+  const menu = openNodeMenu(container)
+  const entry = [...menu.querySelectorAll('button')].find((b) =>
+    (b.textContent ?? '').startsWith('Facets'),
+  )
+  expect(entry).toBeDefined()
+  fireEvent.click(entry as HTMLElement)
+  const opened = container.querySelector('[data-testid="facet-form-panel"]') as HTMLElement
+  expect(opened).not.toBeNull()
+  return opened
+}
+
 it('an icon pick stores the facet and the scene draws the badge', () => {
   const { Host, latest } = makeHost()
   const { container } = render(<Host />)
 
-  const menu = openNodeMenu(container)
-  fireEvent.click(menu.querySelector('[aria-label="Icon star"]') as HTMLElement)
+  const panel = openInspector(container)
+  fireEvent.click(panel.querySelector('[aria-label="Icon star"]') as HTMLElement)
 
   expect(symbolOf(latest.canvas)).toEqual({ kind: 'icon', name: 'star' })
   // The badge is a <use> of the vendored icon symbol, drawn in the scene.
@@ -67,13 +80,13 @@ it('an emoji pick draws a glyph, and No symbol removes the facet', () => {
       .map((t) => t.textContent)
       .filter((value) => value === '⭐')
 
-  const menu = openNodeMenu(container)
-  fireEvent.click(menu.querySelector('[aria-label="Emoji ⭐"]') as HTMLElement)
+  const panel = openInspector(container)
+  fireEvent.click(panel.querySelector('[aria-label="Emoji ⭐"]') as HTMLElement)
   expect(symbolOf(latest.canvas)).toEqual({ kind: 'emoji', char: '⭐' })
   // The badge is DRAWN, not merely stored.
   expect(glyphText()).toHaveLength(1)
 
-  fireEvent.click(menu.querySelector('[aria-label="No symbol"]') as HTMLElement)
+  fireEvent.click(panel.querySelector('[aria-label="No symbol"]') as HTMLElement)
   expect(symbolOf(latest.canvas)).toBeUndefined()
   expect(latest.canvas.nodes[0]).not.toHaveProperty('x-whiteboard')
   expect(glyphText()).toHaveLength(0)

--- a/apps/web/src/components/spatial-editor/node-text-placement.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/node-text-placement.browser.test.tsx
@@ -1,5 +1,5 @@
-// visual.text/v0 reached the menu with NO apps/web change at all: it is a
-// facet definition carrying an editor spec, rendered by the tier-2 path.
+// visual.text/v0 reaches the inspector with NO apps/web change at all: it
+// is a facet definition carrying an editor spec, rendered by the tier-2 path.
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
@@ -42,7 +42,13 @@ it('the Text row stores the facet and moves the drawn text', () => {
   const r = root.getBoundingClientRect()
   fireEvent.contextMenu(root, { clientX: r.left + 180, clientY: r.top + 130 })
   const menu = container.querySelector('[data-testid="context-menu"]') as HTMLElement
-  fireEvent.click(menu.querySelector('[aria-label="Middle"]') as HTMLElement)
+  fireEvent.click(
+    [...menu.querySelectorAll('button')].find((b) =>
+      (b.textContent ?? '').startsWith('Facets'),
+    ) as HTMLElement,
+  )
+  const panel = container.querySelector('[data-testid="facet-form-panel"]') as HTMLElement
+  fireEvent.click(panel.querySelector('[aria-label="Middle"]') as HTMLElement)
 
   expect(latest.canvas.nodes[0]?.['x-whiteboard']?.facets?.['visual.text/v0']).toEqual({
     align: 'center',

--- a/packages/facet-engine/src/contributions.test.ts
+++ b/packages/facet-engine/src/contributions.test.ts
@@ -32,7 +32,7 @@ const registry = createFacetRegistry([visualPlugin, planning])
 
 describe('resolveFacetContributions', () => {
   it('groups a point by namespace in id order, facets in name order, headed by displayName', () => {
-    const groups = resolveFacetContributions(registry, 'contextMenu.node.properties')
+    const groups = resolveFacetContributions(registry, 'inspector.node')
     expect(groups.map((g) => g.namespace)).toEqual(['planning', 'visual'])
     expect(groups.map((g) => g.displayName)).toEqual(['Planning', 'Visual style'])
     expect(groups[0]?.facets.map((f) => f.key)).toEqual(['planning.assignee/v0', 'planning.due/v0'])
@@ -55,7 +55,7 @@ describe('resolveFacetContributions', () => {
   })
 
   it('each contribution carries its definition, so a vessel can read targets and schema', () => {
-    const groups = resolveFacetContributions(registry, 'contextMenu.node.properties')
+    const groups = resolveFacetContributions(registry, 'inspector.node')
     const shape = groups.find((g) => g.namespace === 'visual')?.facets[0]
     expect(shape?.definition.name).toBe('shape')
     expect(shape?.definition.targets).toContain('node')

--- a/packages/facet-engine/src/contributions.ts
+++ b/packages/facet-engine/src/contributions.ts
@@ -16,13 +16,20 @@ import type { FacetDefinition, FacetRegistry } from './registry.js'
  * increment, exactly like adding a widget kind — a plugin can neither mint
  * a point nor place itself outside its container. A point exists only once
  * its vessel does: `documentProperties` (the DocumentProperties disclosure)
- * joins together with the surface that consumes it, in the facet editor
- * increment.
+ * joins together with the surface that consumes it.
+ *
+ * Every point is a STATE surface, and that is the rule rather than a
+ * coincidence. An action menu's entries run once and close it; a facet is
+ * something you look at and adjust, often several times in a row. Facets
+ * were briefly carried by the node context menu and it went wrong in the
+ * predictable way: the menu grew a row per domain, and a value sat one tap
+ * from Delete. The menu keeps a doorway to the inspector, which is
+ * navigation, not a contribution.
  */
-export type ContributionPoint = 'contextMenu.node.properties' | 'canvasSettings'
+export type ContributionPoint = 'inspector.node' | 'canvasSettings'
 
 const POINT_TARGET = {
-  'contextMenu.node.properties': 'node',
+  'inspector.node': 'node',
   canvasSettings: 'canvas',
 } as const
 


### PR DESCRIPTION
Owner's report: facet operations should not be reachable from the top of the
context menu **at all**. The previous increment fenced them off with a
heading and a separator — which is a different thing, and not what was asked.

## The rule underneath

So the next domain does not reopen this:

| surface | holds | facets |
|---|---|---|
| **action menu** — an entry runs once and closes it | Copy / Cut / Delete / Order / Change target | no |
| **inspector** — you look at it and adjust, repeatedly | Shape / Symbol / Text placement / every future domain | **yes** |

A facet is always state, never a verb. The contribution point is renamed to
say so: `contextMenu.node.properties` → **`inspector.node`**. The menu keeps
the doorway, which is navigation rather than a contribution.

`Color` stays in the menu and that is not an exception — it is a JSON Canvas
node attribute, not a facet. "Is it a facet?" decides it, with no table of
special cases.

## The symbol picker moves with them

It lived in `apps/web` as a menu **band**, so the panel never knew about it
and drew its own derived form instead — one facet with two faces, a `Kind`
select and a `Char` text field beside an icon row. Deleting the band without
moving the picker would have deleted the picker, so it becomes a registered
**inspector editor**.

Its writes go through `validateFacetWrite` like every other path — a
hand-written editor gets no shorter route to storage than a declared one.
Mutation-checked: skipping the validation turns the guard red.

## A regression a test caught

Panel writes now apply to the whole **selection**, not to the one node the
menu was opened on. The bands did this, and
`a shape pick from a multi-selection reshapes every selected node` is what
caught that it was about to be dropped silently. Display still follows the
node you opened on — identical semantics to the band.

## Visual

| menu | inspector |
|---|---|
| ![menu.png](https://github.com/user-attachments/assets/764a8006-dbed-4e37-9be1-bd75ec0bf2bd) | ![inspector.png](https://github.com/user-attachments/assets/9d64a6c3-93a4-4041-b973-af24df9002b4) |

## Explicitly not in this increment

The panel is **still modal**: a shape change now costs two taps and a close,
and you cannot select another node while it is open. Making it follow the
selection is the next PR, and it is what makes this one's cost acceptable.

Gates: `pnpm test` 9346 · apps/web CI-style 2739 + 77 · `test:browser` 784 ·
typecheck · lint · knip.