### PR TITLE
refactor(web): name the workspace's keeper (Browser / Daemon) instead of calling one of them "local"

### DIFF
--- a/.claude/rules/vocabulary.md
+++ b/.claude/rules/vocabulary.md
@@ -17,6 +17,7 @@ this rule is how it converges without anyone scheduling a big-bang rename.
 | **OpenCanvas** | nothing. Retired — it was a working name for this project's document world, never a spec | the format (that is **JSON Canvas 1.0**) or the entity (that is a **Document**) |
 | **Scene** | the laid-out projection of a spatial document (what `composeCanvasScene` produces) | stored content |
 | **Version** | a saved point in a document's history | a branch |
+| **Browser** / **Daemon** | who KEEPS a workspace — the browser's own storage, or the whiteboard daemon | a claim about network locality; both run on the same machine |
 
 Two consequences that catch people out:
 
@@ -105,6 +106,48 @@ a later sweep does not "fix" them.
   stood at its point in the log. ADR-0007/0008/0009 keep `slug` and
   `OpenCanvas` behind a dated note: a decision record is history, and
   rewriting the reasoning would misreport what was decided.
+
+## The keeper axis, and why `local` was never on it
+
+A workspace is KEPT by something: today the browser's own storage or the
+whiteboard daemon, later a self-hosted or SaaS backend. **`Browser` and
+`Daemon` name the keeper.** They are not modes and not an exclusive pair —
+the intended model is that connecting a daemon PROMOTES a workspace's source
+of truth to it, with everything below becoming a replica.
+
+That model is **not implemented**. What ships is a per-document, one-way
+import (`components/migration/import-browser-local.ts`) whose request carries
+`{ path, kind }` and no document id, so the daemon mints a new one and the
+document's identity does not survive. Copy may use the keeper vocabulary —
+"Kept in this browser" is true today — but must not promise the promotion:
+the capability CTA says outright that documents already in the browser stay
+there and are imported one at a time.
+
+`local` was the wrong word for this axis and could never have been the right
+one, because **a daemon is local too**. Two names spelled it that way and
+meant opposite things — `browser-local` (kept in the browser) and
+`local-daemon` (kept by the daemon) — which is as confusable as a pair gets,
+and it was visible: the chip read `Local` while its own popover said "Connect
+a local daemon".
+
+`local` is therefore NOT retired, and cannot be. It still means "on this
+machine rather than remote", which is its correct sense in `localhost`, in
+`Local Network Access` (a W3C spec name), in `local-network-gate.ts`, and in
+`packages/mcp-server`'s `authMode: 'local-daemon'` — whose opposite is
+`'server-mode'`, making it exactly the network sense. Only `local` used for
+WHERE A WORKSPACE IS KEPT is retired.
+
+`vocabulary-check.test.ts` pins the retired spellings as DISCRIMINANT VALUES
+(a quoted `'browser-local'` / `'local-daemon'`) and as `BROWSER_LOCAL_` /
+`LOCAL_DAEMON_` constants, scoped to `apps/web/src`. Two things it
+deliberately does not yet claim, each its own increment:
+
+- **File names and test ids** (`browser-local-backend.ts`,
+  `data-testid="browser-local-index-page"`) — mechanical, ~100 files.
+- **`localDaemonBaseUrl`**, the persisted settings key
+  (`lib/user-settings-store.ts`). A stored shape: renaming it drops an
+  existing reader's daemon connection at schema validation, so it needs a
+  settings migration rather than a sweep.
 
 `slug` is the one word retired outright, and `vocabulary-check.test.ts` in
 `tools/arch-lint` keeps it retired — the only part of this rule that is not

--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -46,8 +46,11 @@ one it is not in yet, `spinner` that same ring while the doing is in flight.
   named set, and each member says what QUESTION it answers — two carriers
   that look alike but answer differently is the defect this naming exists to
   prevent:
-  - **connection chip** (`ConnectionStatus`) — is this browser reaching its
-    backend? Filled dot. It lives in the AppShell, not in a page.
+  - **connection chip** (`ConnectionStatus`) — who keeps this workspace, and
+    is the session reaching it? Filled dot. It lives in the AppShell, not in
+    a page. Those are two questions in one carrier and the split is still
+    open: `browser` names the KEEPER (and survives navigation), while
+    `synced`/`reconnecting`/`sync-off` report a live session (and do not).
   - **save-state chip** (`SaveStatusChip`) — did the last write to this
     browser's storage land? Filled dot. Browser-local only; on a daemon the
     connection chip is what answers "is my work safe", and a second dot
@@ -86,7 +89,13 @@ one it is not in yet, `spinner` that same ring while the doing is in flight.
   an `aria-label`.
 - **Sentence-length copy never sits in chrome.** Explanations live in
   popovers/tooltips/dialogs (see `ConnectionStatus`); chrome carries words
-  only as short labels ("Saved", "Local").
+  only as short labels ("Saved", "Browser").
+- **Name the keeper, never the locality.** A workspace is kept by the
+  **Browser** or by a **Daemon**; both are on the user's machine, so "Local"
+  named neither and collided with "local daemon" in its own popover. See
+  `.claude/rules/vocabulary.md`'s keeper section — including the rule that
+  copy may use the keeper framing but must not promise the source-of-truth
+  promotion, which is not implemented.
 - **Dialogs**: `max-h` + `overflow-y-auto` when content can grow; page-width
   cards must wrap (`min-w-0`, `break-all` for unbreakable strings) before
   entering a dialog.

--- a/apps/web/src/App.notfound-chunk.test.tsx
+++ b/apps/web/src/App.notfound-chunk.test.tsx
@@ -14,13 +14,13 @@ vi.mock('./components/status/NotFoundPage.js', () => {
 
 import { App } from './App.js'
 import { errorBoundaryLog } from './components/ErrorBoundary.js'
-import { BROWSER_LOCAL_CAPABILITIES, type ProviderState } from './lib/provider.js'
+import { BROWSER_CAPABILITIES, type ProviderState } from './lib/provider.js'
 
 afterEach(cleanup)
 
-const BROWSER_LOCAL_STATE: ProviderState = {
-  kind: 'browser-local',
-  capabilities: BROWSER_LOCAL_CAPABILITIES,
+const BROWSER_STATE: ProviderState = {
+  kind: 'browser',
+  capabilities: BROWSER_CAPABILITIES,
 }
 
 describe('App not-found chunk failure', () => {
@@ -28,7 +28,7 @@ describe('App not-found chunk failure', () => {
     const reportSpy = vi.spyOn(errorBoundaryLog, 'report').mockImplementation(() => {})
     render(
       <MemoryRouter initialEntries={['/definitely/not/a/route']}>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
     expect(await screen.findByRole('alert')).toBeTruthy()

--- a/apps/web/src/App.notfound-recovery.browser.test.tsx
+++ b/apps/web/src/App.notfound-recovery.browser.test.tsx
@@ -2,22 +2,22 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it } from 'vitest'
 import { App } from './App.js'
-import { BROWSER_LOCAL_CAPABILITIES, type ProviderState } from './lib/provider.js'
+import { BROWSER_CAPABILITIES, type ProviderState } from './lib/provider.js'
 
 // Real browser: the not-found page arrives as a REAL lazy chunk (no ESM
 // cache priming, no mocks), and clicking "Back to documents" navigates away
 // from it. The destination page's own full mount is covered elsewhere —
 // this pins the recovery affordance end-to-end in a real browser.
-const BROWSER_LOCAL_STATE: ProviderState = {
-  kind: 'browser-local',
-  capabilities: BROWSER_LOCAL_CAPABILITIES,
+const BROWSER_STATE: ProviderState = {
+  kind: 'browser',
+  capabilities: BROWSER_CAPABILITIES,
 }
 
 describe('unknown-route recovery (real browser)', () => {
   it('loads the lazy not-found page and leaves it via Back to documents', async () => {
     render(
       <MemoryRouter initialEntries={['/definitely/not/a/route']}>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
     const back = await screen.findByRole('button', { name: /back to documents/i })

--- a/apps/web/src/App.route-sync-stale-replay.test.tsx
+++ b/apps/web/src/App.route-sync-stale-replay.test.tsx
@@ -90,8 +90,8 @@ vi.mock('./hooks/useDaemonConnection.js', () => ({
 
 const { App } = await import('./App.js')
 
-const BROWSER_LOCAL_STATE: ProviderState = {
-  kind: 'browser-local',
+const BROWSER_STATE: ProviderState = {
+  kind: 'browser',
   capabilities: {
     workspaces: false,
     versions: false,
@@ -117,7 +117,7 @@ describe('App route sync against an asynchronously-propagating router', () => {
   it('a StrictMode replay must not overwrite the #wb= canvas view with the stale pathname', async () => {
     render(
       <StrictMode>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </StrictMode>,
     )
     // Drain the navigation timers until the system settles (or the storm

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -23,7 +23,7 @@ import { resetShellStatusForTests, setShellConnection } from './lib/shell-status
 import './components/status/NotFoundPage.js'
 import './pages/PairConsentPage.js'
 import {
-  BROWSER_LOCAL_CAPABILITIES,
+  BROWSER_CAPABILITIES,
   type ProviderState,
   resolveHostedProviderStateFromRaw,
   type WhiteboardCapabilities,
@@ -128,8 +128,8 @@ vi.mock('./pages/DaemonIndexPage.js', () => ({
   },
 }))
 
-const BROWSER_LOCAL_STATE: ProviderState = {
-  kind: 'browser-local',
+const BROWSER_STATE: ProviderState = {
+  kind: 'browser',
   capabilities: {
     workspaces: false,
     versions: false,
@@ -138,8 +138,8 @@ const BROWSER_LOCAL_STATE: ProviderState = {
   },
 }
 
-const LOCAL_DAEMON_STATE: ProviderState = {
-  kind: 'local-daemon',
+const DAEMON_STATE: ProviderState = {
+  kind: 'daemon',
   daemonBaseUrl: 'http://127.0.0.1:3000',
   capabilities: {
     workspaces: true,
@@ -176,7 +176,7 @@ describe('silent renewal on a hosted origin', () => {
     await act(async () => {
       render(
         <MemoryRouter initialEntries={['/']}>
-          <App providerState={BROWSER_LOCAL_STATE} />
+          <App providerState={BROWSER_STATE} />
         </MemoryRouter>,
       )
     })
@@ -205,7 +205,7 @@ describe('silent renewal on a hosted origin', () => {
     await act(async () => {
       render(
         <MemoryRouter initialEntries={['/']}>
-          <App providerState={BROWSER_LOCAL_STATE} />
+          <App providerState={BROWSER_STATE} />
         </MemoryRouter>,
       )
     })
@@ -228,7 +228,7 @@ describe('silent renewal on a hosted origin', () => {
     await act(async () => {
       render(
         <MemoryRouter initialEntries={['/']}>
-          <App providerState={BROWSER_LOCAL_STATE} />
+          <App providerState={BROWSER_STATE} />
         </MemoryRouter>,
       )
     })
@@ -243,7 +243,7 @@ describe('silent renewal on a hosted origin', () => {
     await act(async () => {
       render(
         <MemoryRouter initialEntries={['/']}>
-          <App providerState={BROWSER_LOCAL_STATE} />
+          <App providerState={BROWSER_STATE} />
         </MemoryRouter>,
       )
     })
@@ -265,7 +265,7 @@ describe('grant exchange failure surfacing', () => {
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/']}>
-            <App providerState={BROWSER_LOCAL_STATE} />
+            <App providerState={BROWSER_STATE} />
           </MemoryRouter>,
         )
       })
@@ -292,7 +292,7 @@ describe('/pair consent route', () => {
       [
         {
           path: '*',
-          element: <App providerState={LOCAL_DAEMON_STATE} />,
+          element: <App providerState={DAEMON_STATE} />,
         },
       ],
       {
@@ -320,7 +320,7 @@ describe('App backend configuration chip', () => {
   it('renders no fixed backend-config overlay (D1: the header connection chip owns this)', () => {
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
     expect(screen.queryByTestId('backend-config-chip')).toBeNull()
@@ -330,7 +330,7 @@ describe('App backend configuration chip', () => {
   it('renders no daemon-URL overlay when configured for a local daemon', () => {
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={LOCAL_DAEMON_STATE} />
+        <App providerState={DAEMON_STATE} />
       </MemoryRouter>,
     )
     expect(screen.queryByTestId('backend-config-chip')).toBeNull()
@@ -363,7 +363,7 @@ describe('App backend configuration chip', () => {
 
   it('lets the browser-local escape override invalid-config after a failed pairing', async () => {
     // A pairing error can coexist with an invalid runtime config; clicking
-    // "Continue in browser-local" must land on the browser-local page, not
+    // "Work in this browser instead" must land on the browser-local page, not
     // bounce the user onto the invalid-config error page.
     mockDaemonConnectionResult = { status: 'error', detail: 'malformed fragment' }
     try {
@@ -372,7 +372,7 @@ describe('App backend configuration chip', () => {
           <App providerState={INVALID_CONFIG_STATE} />
         </MemoryRouter>,
       )
-      fireEvent.click(screen.getByRole('button', { name: /continue in browser-local/i }))
+      fireEvent.click(screen.getByRole('button', { name: /work in this browser instead/i }))
       expect(await screen.findByTestId('browser-local-index-page')).toBeTruthy()
       expect(screen.queryByText('Runtime configuration is invalid.')).toBeNull()
     } finally {
@@ -389,18 +389,18 @@ describe('App capability wiring', () => {
   it('passes the browser-local capabilities down to BrowserLocalDocumentPage', async () => {
     render(
       <MemoryRouter initialEntries={['/local/c1']}>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
     await screen.findByTestId('browser-local-document-page')
-    expect(receivedCapabilities).toEqual(BROWSER_LOCAL_STATE.capabilities)
+    expect(receivedCapabilities).toEqual(BROWSER_STATE.capabilities)
   })
 
   it('derives initialPath from a /local/:path cold-load URL, folders and all', async () => {
     receivedInitialPath = undefined
     render(
       <MemoryRouter initialEntries={['/local/design/login%20flow']}>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
     await screen.findByTestId('browser-local-document-page')
@@ -412,7 +412,7 @@ describe('App capability wiring', () => {
   it('lands a plain "/" cold load on the canvas list, not the editor', async () => {
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
     expect(await screen.findByTestId('browser-local-index-page')).toBeTruthy()
@@ -423,7 +423,7 @@ describe('App capability wiring', () => {
     receivedInitialPath = undefined
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
     await screen.findByTestId('browser-local-index-page')
@@ -453,7 +453,7 @@ describe('App daemon-pairing routing', () => {
     }
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
     // DaemonDocumentPage is React.lazy — resolves after a microtask even with
@@ -470,11 +470,11 @@ describe('App daemon-pairing routing', () => {
     mockDaemonConnectionResult = { status: 'error', detail: 'malformed fragment' }
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
     expect(screen.getByRole('alert')).toBeTruthy()
-    const button = screen.getByRole('button', { name: /continue in browser-local/i })
+    const button = screen.getByRole('button', { name: /work in this browser instead/i })
     expect(button).toBeTruthy()
     fireEvent.click(button)
     expect(await screen.findByTestId('browser-local-index-page')).toBeTruthy()
@@ -484,7 +484,7 @@ describe('App daemon-pairing routing', () => {
     mockDaemonConnectionResult = { status: 'none' }
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
     expect(await screen.findByTestId('browser-local-index-page')).toBeTruthy()
@@ -514,7 +514,7 @@ describe('App reconnect-target persistence', () => {
     }
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
     await screen.findByTestId('daemon-document-page')
@@ -538,7 +538,7 @@ describe('App reconnect-target persistence', () => {
     }
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
     await screen.findByTestId('daemon-document-page')
@@ -550,7 +550,7 @@ describe('App reconnect-target persistence', () => {
     mockDaemonConnectionResult = { status: 'none' }
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
     expect(createUserSettingsStore().load().storage.localDaemonBaseUrl).toBeUndefined()
@@ -572,21 +572,21 @@ describe('App local-daemon provider state', () => {
   it('mounts DaemonIndexPage (the gallery) instead of auto-opening a canvas', async () => {
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={LOCAL_DAEMON_STATE} />
+        <App providerState={DAEMON_STATE} />
       </MemoryRouter>,
     )
     expect(await screen.findByTestId('daemon-index-page')).toBeTruthy()
     expect(screen.queryByTestId('daemon-document-page')).toBeNull()
     expect(screen.queryByTestId('browser-local-document-page')).toBeNull()
     expect(screen.queryByText('Whiteboard')).toBeNull()
-    expect(receivedDaemonIndexPageProps?.daemonBaseUrl).toBe(LOCAL_DAEMON_STATE.daemonBaseUrl)
+    expect(receivedDaemonIndexPageProps?.daemonBaseUrl).toBe(DAEMON_STATE.daemonBaseUrl)
     expect(receivedDaemonIndexPageProps?.onOpenDocument).toBeInstanceOf(Function)
   })
 
   it('mounts DaemonDocumentPage with the opened canvas identity after a gallery selection', async () => {
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={LOCAL_DAEMON_STATE} />
+        <App providerState={DAEMON_STATE} />
       </MemoryRouter>,
     )
     await screen.findByTestId('daemon-index-page')
@@ -601,7 +601,7 @@ describe('App local-daemon provider state', () => {
     expect(screen.queryByTestId('daemon-index-page')).toBeNull()
     expect(receivedDaemonPageProps?.workspaceId).toBe('w1')
     expect(receivedDaemonPageProps?.path).toBe('main')
-    expect(receivedDaemonPageProps?.capabilities).toEqual(LOCAL_DAEMON_STATE.capabilities)
+    expect(receivedDaemonPageProps?.capabilities).toEqual(DAEMON_STATE.capabilities)
     expect(receivedDaemonPageProps?.browserLocalStore).toBeDefined()
     expect(receivedDaemonPageProps?.onNavigateBack).toBeInstanceOf(Function)
   })
@@ -610,7 +610,7 @@ describe('App local-daemon provider state', () => {
     ;(window as { __WHITEBOARD_DAEMON_TOKEN__?: unknown }).__WHITEBOARD_DAEMON_TOKEN__ = 'tok-x'
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={LOCAL_DAEMON_STATE} />
+        <App providerState={DAEMON_STATE} />
       </MemoryRouter>,
     )
     expect(await screen.findByTestId('daemon-index-page')).toBeTruthy()
@@ -620,7 +620,7 @@ describe('App local-daemon provider state', () => {
   it('mounts gracefully with token undefined when the daemon has not injected one', async () => {
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={LOCAL_DAEMON_STATE} />
+        <App providerState={DAEMON_STATE} />
       </MemoryRouter>,
     )
     expect(await screen.findByTestId('daemon-index-page')).toBeTruthy()
@@ -630,7 +630,7 @@ describe('App local-daemon provider state', () => {
   it('returns to the index when DaemonDocumentPage invokes onNavigateBack', async () => {
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={LOCAL_DAEMON_STATE} />
+        <App providerState={DAEMON_STATE} />
       </MemoryRouter>,
     )
     await screen.findByTestId('daemon-index-page')
@@ -653,7 +653,7 @@ describe('App local-daemon provider state', () => {
   it('preserves the opened canvas workspaceId as initialWorkspaceId when navigating back to the index', async () => {
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={LOCAL_DAEMON_STATE} />
+        <App providerState={DAEMON_STATE} />
       </MemoryRouter>,
     )
     await screen.findByTestId('daemon-index-page')
@@ -676,7 +676,7 @@ describe('App local-daemon provider state', () => {
   it('remounts DaemonDocumentPage cleanly when opening a different canvas after returning to the index', async () => {
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={LOCAL_DAEMON_STATE} />
+        <App providerState={DAEMON_STATE} />
       </MemoryRouter>,
     )
     await screen.findByTestId('daemon-index-page')
@@ -707,10 +707,10 @@ describe('App local-daemon provider state', () => {
     expect(receivedDaemonPageProps?.path).toBe('canvas-b')
   })
 
-  it('escapes to browser-local with BROWSER_LOCAL_CAPABILITIES', async () => {
+  it('escapes to browser-local with BROWSER_CAPABILITIES', async () => {
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={LOCAL_DAEMON_STATE} />
+        <App providerState={DAEMON_STATE} />
       </MemoryRouter>,
     )
     await screen.findByTestId('daemon-index-page')
@@ -729,13 +729,13 @@ describe('App local-daemon provider state', () => {
       setShellConnection({ state: 'sync-off', daemonBaseUrl: 'http://127.0.0.1:3099' })
     })
     fireEvent.click(await screen.findByTestId('connection-chip'))
-    fireEvent.click(await screen.findByRole('button', { name: /continue in browser-local/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /work in this browser instead/i }))
     expect(await screen.findByTestId('browser-local-index-page')).toBeTruthy()
     expect(screen.queryByTestId('daemon-document-page')).toBeNull()
     // Capabilities flow to the editor: open a canvas from the escaped list.
     act(() => receivedIndexPageOnOpenCanvas?.('c1'))
     await screen.findByTestId('browser-local-document-page')
-    expect(receivedCapabilities).toEqual(BROWSER_LOCAL_CAPABILITIES)
+    expect(receivedCapabilities).toEqual(BROWSER_CAPABILITIES)
     expect(screen.queryByText(/Configured for local daemon/)).toBeNull()
   })
 
@@ -743,7 +743,7 @@ describe('App local-daemon provider state', () => {
     throwInDaemonDocumentPage = true
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={LOCAL_DAEMON_STATE} />
+        <App providerState={DAEMON_STATE} />
       </MemoryRouter>,
     )
     await screen.findByTestId('daemon-index-page')
@@ -788,7 +788,7 @@ describe('App daemon-pairing routing (index vs canvas)', () => {
     }
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
     expect(await screen.findByTestId('daemon-index-page')).toBeTruthy()
@@ -808,7 +808,7 @@ describe('App daemon-pairing routing (index vs canvas)', () => {
     }
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
     expect(await screen.findByTestId('daemon-index-page')).toBeTruthy()
@@ -857,7 +857,7 @@ describe('App URL routing', () => {
   })
 
   it('cold-loads a /w/:workspaceId/document/:path deep link straight into DaemonDocumentPage', async () => {
-    renderAppWithRouter(LOCAL_DAEMON_STATE, '/w/w1/document/main')
+    renderAppWithRouter(DAEMON_STATE, '/w/w1/document/main')
     expect(await screen.findByTestId('daemon-document-page')).toBeTruthy()
     expect(receivedDaemonPageProps?.workspaceId).toBe('w1')
     expect(receivedDaemonPageProps?.path).toBe('main')
@@ -866,20 +866,20 @@ describe('App URL routing', () => {
   it('cold-loads a NESTED document path deep link, path intact', async () => {
     // The tail is the document's path since the data layer converged on
     // paths; the page must receive it verbatim, separators and all.
-    renderAppWithRouter(LOCAL_DAEMON_STATE, '/w/w1/document/notes/2026/plan')
+    renderAppWithRouter(DAEMON_STATE, '/w/w1/document/notes/2026/plan')
     expect(await screen.findByTestId('daemon-document-page')).toBeTruthy()
     expect(receivedDaemonPageProps?.workspaceId).toBe('w1')
     expect(receivedDaemonPageProps?.path).toBe('notes/2026/plan')
   })
 
   it('cold-loads a /w/:workspaceId deep link into the gallery pre-scoped to that workspace', async () => {
-    renderAppWithRouter(LOCAL_DAEMON_STATE, '/w/workspace-b')
+    renderAppWithRouter(DAEMON_STATE, '/w/workspace-b')
     expect(await screen.findByTestId('daemon-index-page')).toBeTruthy()
     expect(receivedDaemonIndexPageProps?.initialWorkspaceId).toBe('workspace-b')
   })
 
   it('updates the URL when in-app navigation opens a canvas from the gallery', async () => {
-    const router = renderAppWithRouter(LOCAL_DAEMON_STATE, '/')
+    const router = renderAppWithRouter(DAEMON_STATE, '/')
     await screen.findByTestId('daemon-index-page')
     act(() => {
       const onOpenDocument = receivedDaemonIndexPageProps?.onOpenDocument as (
@@ -893,7 +893,7 @@ describe('App URL routing', () => {
   })
 
   it('updates the URL back to the gallery when onNavigateBack fires', async () => {
-    const router = renderAppWithRouter(LOCAL_DAEMON_STATE, '/w/w1/document/main')
+    const router = renderAppWithRouter(DAEMON_STATE, '/w/w1/document/main')
     await screen.findByTestId('daemon-document-page')
     const onNavigateBack = receivedDaemonPageProps?.onNavigateBack as () => void
     act(() => {
@@ -904,7 +904,7 @@ describe('App URL routing', () => {
   })
 
   it('responds to browser back/forward by updating the rendered view', async () => {
-    const router = renderAppWithRouter(LOCAL_DAEMON_STATE, '/')
+    const router = renderAppWithRouter(DAEMON_STATE, '/')
     await screen.findByTestId('daemon-index-page')
     act(() => {
       const onOpenDocument = receivedDaemonIndexPageProps?.onOpenDocument as (
@@ -938,7 +938,7 @@ describe('App URL routing', () => {
         bootstrapToken: 'tok',
       },
     }
-    const router = renderAppWithRouter(BROWSER_LOCAL_STATE, '/')
+    const router = renderAppWithRouter(BROWSER_STATE, '/')
     await screen.findByTestId('daemon-document-page')
     expect(router.state.location.pathname).toBe('/w/w1/document/main')
     // The replace must not have added a new history entry: going back from
@@ -948,7 +948,7 @@ describe('App URL routing', () => {
   })
 
   it('shows the not-found page for an unrecognized path (no blank page, no silent redirect)', async () => {
-    renderAppWithRouter(LOCAL_DAEMON_STATE, '/something/unrelated/entirely')
+    renderAppWithRouter(DAEMON_STATE, '/something/unrelated/entirely')
     expect(await screen.findByRole('button', { name: /back to documents/i })).toBeTruthy()
     expect(screen.queryByTestId('daemon-index-page')).toBeNull()
   })
@@ -957,7 +957,7 @@ describe('App URL routing', () => {
 describe('App shell (single instance above the routed pages)', () => {
   it('browser-local branch renders exactly one shell whose gear navigates with the entry point', async () => {
     const router = createMemoryRouter(
-      [{ path: '*', element: <App providerState={BROWSER_LOCAL_STATE} /> }],
+      [{ path: '*', element: <App providerState={BROWSER_STATE} /> }],
       {
         initialEntries: ['/'],
       },
@@ -988,7 +988,7 @@ describe('App shell (single instance above the routed pages)', () => {
     }
     render(
       <MemoryRouter initialEntries={['/']}>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
     await screen.findByTestId('daemon-document-page')
@@ -1005,7 +1005,7 @@ describe('App shell (single instance above the routed pages)', () => {
     try {
       render(
         <MemoryRouter initialEntries={['/']}>
-          <App providerState={LOCAL_DAEMON_STATE} />
+          <App providerState={DAEMON_STATE} />
         </MemoryRouter>,
       )
       await screen.findByTestId('daemon-index-page')
@@ -1041,29 +1041,29 @@ describe('App /settings routing', () => {
       '/settings/data',
       '/settings/connections',
     ]) {
-      renderAppWithRouter(BROWSER_LOCAL_STATE, path)
+      renderAppWithRouter(BROWSER_STATE, path)
       expect(await screen.findByTestId('settings-page')).toBeTruthy()
       cleanup()
     }
   })
 
   it('does not rewrite /settings to the daemon route (the URL-sync guard)', async () => {
-    const router = renderAppWithRouter(LOCAL_DAEMON_STATE, '/settings')
+    const router = renderAppWithRouter(DAEMON_STATE, '/settings')
     await screen.findByTestId('settings-page')
     expect(router.state.location.pathname).toBe('/settings')
   })
 
   it('passes no daemon prop in browser-local mode with no active connection', async () => {
-    renderAppWithRouter(BROWSER_LOCAL_STATE, '/settings')
+    renderAppWithRouter(BROWSER_STATE, '/settings')
     await screen.findByTestId('settings-page')
     expect(receivedSettingsPageProps?.daemon).toBeUndefined()
   })
 
   it('passes the local-daemon baseUrl/token when the provider state is local-daemon', async () => {
-    renderAppWithRouter(LOCAL_DAEMON_STATE, '/settings')
+    renderAppWithRouter(DAEMON_STATE, '/settings')
     await screen.findByTestId('settings-page')
     expect(receivedSettingsPageProps?.daemon).toEqual({
-      baseUrl: LOCAL_DAEMON_STATE.kind === 'local-daemon' ? LOCAL_DAEMON_STATE.daemonBaseUrl : '',
+      baseUrl: DAEMON_STATE.kind === 'daemon' ? DAEMON_STATE.daemonBaseUrl : '',
       token: null,
     })
   })
@@ -1079,7 +1079,7 @@ describe('App /settings routing', () => {
         bootstrapToken: 'tok',
       },
     }
-    renderAppWithRouter(BROWSER_LOCAL_STATE, '/settings')
+    renderAppWithRouter(BROWSER_STATE, '/settings')
     await screen.findByTestId('settings-page')
     expect(receivedSettingsPageProps?.daemon).toEqual({
       baseUrl: 'http://127.0.0.1:3099',
@@ -1097,7 +1097,7 @@ describe('App /settings routing', () => {
         authMode: 'none',
       },
     }
-    renderAppWithRouter(BROWSER_LOCAL_STATE, '/settings')
+    renderAppWithRouter(BROWSER_STATE, '/settings')
     await screen.findByTestId('settings-page')
     expect(receivedSettingsPageProps?.daemon).toEqual({
       baseUrl: 'http://127.0.0.1:3099',
@@ -1124,7 +1124,7 @@ describe('App /settings routing', () => {
     await act(async () => {
       render(
         <MemoryRouter initialEntries={['/settings']}>
-          <App providerState={BROWSER_LOCAL_STATE} />
+          <App providerState={BROWSER_STATE} />
         </MemoryRouter>,
       )
     })
@@ -1152,7 +1152,7 @@ describe('App error boundary', () => {
     const reportSpy = vi.spyOn(errorBoundaryLog, 'report').mockImplementation(() => {})
     render(
       <MemoryRouter initialEntries={['/local/c1']}>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
     expect(await screen.findByRole('alert')).toBeTruthy()
@@ -1177,7 +1177,7 @@ describe('App error boundary', () => {
     try {
       render(
         <MemoryRouter initialEntries={['/']}>
-          <App providerState={BROWSER_LOCAL_STATE} />
+          <App providerState={BROWSER_STATE} />
         </MemoryRouter>,
       )
       // The lazy module resolves after a microtask; the throw then propagates
@@ -1209,7 +1209,7 @@ describe('App not-found route', () => {
   it('shows the not-found page for a path outside the closed route set', async () => {
     render(
       <MemoryRouter initialEntries={['/definitely/not/a/route']}>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
     // The page chunk is lazy — wait for it to resolve.
@@ -1220,7 +1220,7 @@ describe('App not-found route', () => {
   it('keeps known routes on their normal pages', () => {
     render(
       <MemoryRouter initialEntries={['/local/c9']}>
-        <App providerState={BROWSER_LOCAL_STATE} />
+        <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
     expect(document.querySelector('[data-mark="not-found"]')).toBeNull()

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -44,7 +44,7 @@ import {
 } from './lib/app-routes.js'
 import { IdbDocumentIndex } from './lib/idb-document-index.js'
 import {
-  BROWSER_LOCAL_CAPABILITIES,
+  BROWSER_CAPABILITIES,
   type ProviderState,
   resolveHostedProviderStateFromRaw,
 } from './lib/provider.js'
@@ -188,7 +188,7 @@ export function App({ providerState }: AppProps) {
     if (isPairRoute) return
     if (daemonConnection.status !== 'none') return
     if (grantConnection !== null) return
-    if ((providerState ?? defaultProviderState).kind !== 'browser-local') return
+    if ((providerState ?? defaultProviderState).kind !== 'browser') return
     const storedBaseUrl = userSettingsStore.load().storage.localDaemonBaseUrl
     if (storedBaseUrl === undefined) return
     void renewPairingToken({
@@ -369,7 +369,7 @@ export function App({ providerState }: AppProps) {
         }
       : grantPairedForSettings !== null
         ? { baseUrl: grantPairedForSettings.daemonBaseUrl, token: grantPairedForSettings.token }
-        : providerStateForSettings.kind === 'local-daemon'
+        : providerStateForSettings.kind === 'daemon'
           ? { baseUrl: providerStateForSettings.daemonBaseUrl, token: daemonToken ?? null }
           : undefined
 
@@ -415,7 +415,7 @@ export function App({ providerState }: AppProps) {
     )
   }
 
-  // The 'Continue in browser-local' escape hatch opts out of the pairing
+  // The 'Work in this browser instead' escape hatch opts out of the pairing
   // fragment entirely, so once it's set both daemon branches are skipped.
   if (!forcedBrowserLocal) {
     // Both pairing paths converge here: the legacy #wb= fragment carries
@@ -443,10 +443,7 @@ export function App({ providerState }: AppProps) {
         // boundary, which must be here to catch it.
         <ErrorBoundary>
           <div className="flex h-dvh flex-col">
-            <AppShellLazy
-              daemon={true}
-              onContinueBrowserLocal={() => setForcedBrowserLocal(true)}
-            />
+            <AppShellLazy daemon={true} onWorkInBrowser={() => setForcedBrowserLocal(true)} />
             <div className="min-h-0 flex-1">
               <Suspense
                 fallback={<LazyPageFallback heightClass="h-full" message="Connecting to daemon…" />}
@@ -497,7 +494,7 @@ export function App({ providerState }: AppProps) {
               onClick={() => setForcedBrowserLocal(true)}
               className="rounded-md border bg-background px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-accent"
             >
-              Continue in browser-local
+              Work in this browser instead
             </button>
           </div>
         </ErrorBoundary>
@@ -507,15 +504,15 @@ export function App({ providerState }: AppProps) {
 
   const state = providerState ?? defaultProviderState
 
-  // The 'Continue in browser-local' escape hatch collapses a local-daemon OR
+  // The 'Work in this browser instead' escape hatch collapses a daemon OR
   // invalid-config state to browser-local capabilities, so every downstream
   // consumer (chip, banner, canvas page) reads this effective state rather
   // than the raw one — otherwise the escape could leave daemon capabilities
   // or copy leaking into a mode the user explicitly opted out of, or bounce
   // a failed-pairing escape onto the invalid-config error page.
   const effectiveState =
-    forcedBrowserLocal && (state.kind === 'local-daemon' || state.kind === 'invalid-config')
-      ? { kind: 'browser-local' as const, capabilities: BROWSER_LOCAL_CAPABILITIES }
+    forcedBrowserLocal && (state.kind === 'daemon' || state.kind === 'invalid-config')
+      ? { kind: 'browser' as const, capabilities: BROWSER_CAPABILITIES }
       : state
 
   if (effectiveState.kind === 'invalid-config') {
@@ -528,11 +525,11 @@ export function App({ providerState }: AppProps) {
     )
   }
 
-  if (effectiveState.kind === 'local-daemon') {
+  if (effectiveState.kind === 'daemon') {
     return (
       <ErrorBoundary>
         <div className="flex h-dvh flex-col">
-          <AppShellLazy daemon={true} onContinueBrowserLocal={() => setForcedBrowserLocal(true)} />
+          <AppShellLazy daemon={true} onWorkInBrowser={() => setForcedBrowserLocal(true)} />
           <div className="min-h-0 flex-1 overflow-hidden">
             <Suspense
               fallback={<LazyPageFallback heightClass="h-full" message="Connecting to daemon…" />}

--- a/apps/web/src/components/AppShell.test.tsx
+++ b/apps/web/src/components/AppShell.test.tsx
@@ -19,18 +19,12 @@ afterEach(() => {
   Object.defineProperty(navigator, 'storage', { value: undefined, configurable: true })
 })
 
-function renderShell(
-  daemonConnected: boolean,
-  at = '/local/c1',
-  onContinueBrowserLocal?: () => void,
-) {
+function renderShell(daemonConnected: boolean, at = '/local/c1', onWorkInBrowser?: () => void) {
   const router = createMemoryRouter(
     [
       {
         path: '*',
-        element: (
-          <AppShell daemon={daemonConnected} onContinueBrowserLocal={onContinueBrowserLocal} />
-        ),
+        element: <AppShell daemon={daemonConnected} onWorkInBrowser={onWorkInBrowser} />,
       },
     ],
     {
@@ -103,8 +97,10 @@ describe('AppShell', () => {
 // It lives beside the settings gear for the same reason the gear does — the
 // document's own surface is for the document.
 describe('AppShell — the connection chip', () => {
-  const CTA_TEXT =
-    'Connect a local daemon (MCP) to unlock version history, workspaces, variations, and combining changes'
+  // Matched loosely: the CTA is two sentences across JSX lines, so an exact
+  // string match would be asserting the source's line breaks, not the copy.
+  const CTA = /Connect a daemon \(MCP\) for version history/i
+  const CTA_LIMIT = /Documents already in this browser stay here/i
 
   it('shows no chip until a page publishes a live session', () => {
     renderShell(true)
@@ -112,13 +108,13 @@ describe('AppShell — the connection chip', () => {
   })
 
   it.each([
-    ['local', /local/i],
+    ['browser', /browser/i],
     ['synced', /synced/i],
     ['reconnecting', /reconnecting/i],
     ['sync-off', /sync off/i],
   ] as const)('renders the %s state the page published', async (state, label) => {
     setShellConnection({ state, daemonBaseUrl: 'http://127.0.0.1:3099' })
-    renderShell(state !== 'local')
+    renderShell(state !== 'browser')
     expect((await screen.findByTestId('connection-chip')).textContent).toMatch(label)
   })
 
@@ -137,27 +133,30 @@ describe('AppShell — the connection chip', () => {
   })
 
   it('carries the capability CTA inside the Local popover, not in page chrome', async () => {
-    setShellConnection({ state: 'local' })
+    setShellConnection({ state: 'browser' })
     renderShell(false)
-    expect(screen.queryByText(CTA_TEXT)).toBeNull()
+    expect(screen.queryByText(CTA)).toBeNull()
 
     fireEvent.click(await screen.findByTestId('connection-chip'))
-    expect(await screen.findByText(CTA_TEXT)).toBeTruthy()
+    expect(await screen.findByText(CTA)).toBeTruthy()
+    // The CTA names what connecting does NOT do today: documents already in
+    // this browser are not carried over, they are imported one at a time.
+    expect(screen.getByText(CTA_LIMIT)).toBeTruthy()
   })
 
   it('offers the browser-local escape from the sync-off popover', async () => {
-    const onContinueBrowserLocal = vi.fn()
+    const onWorkInBrowser = vi.fn()
     setShellConnection({ state: 'sync-off', daemonBaseUrl: 'http://127.0.0.1:3099' })
-    renderShell(true, '/w/ws/document/a.canvas', onContinueBrowserLocal)
+    renderShell(true, '/w/ws/document/a.canvas', onWorkInBrowser)
 
     fireEvent.click(await screen.findByTestId('connection-chip'))
-    fireEvent.click(await screen.findByRole('button', { name: /continue in browser-local/i }))
-    expect(onContinueBrowserLocal).toHaveBeenCalledTimes(1)
+    fireEvent.click(await screen.findByRole('button', { name: /work in this browser instead/i }))
+    expect(onWorkInBrowser).toHaveBeenCalledTimes(1)
   })
 
   it('disconnecting records the dismissal so discovery does not bring it straight back', async () => {
     const daemonBaseUrl = 'http://127.0.0.1:3099'
-    const onContinueBrowserLocal = vi.fn()
+    const onWorkInBrowser = vi.fn()
     // Seeded through the store, not by writing JSON: a hand-built payload that
     // fails the store's own validation is silently replaced by defaults, and
     // every assertion below would then pass without touching the real state.
@@ -172,12 +171,12 @@ describe('AppShell — the connection chip', () => {
     expect(createUserSettingsStore().load().storage.localDaemonBaseUrl).toBe(daemonBaseUrl)
 
     setShellConnection({ state: 'synced', daemonBaseUrl })
-    renderShell(true, '/w/ws/document/a.canvas', onContinueBrowserLocal)
+    renderShell(true, '/w/ws/document/a.canvas', onWorkInBrowser)
 
     fireEvent.click(await screen.findByTestId('connection-chip'))
     fireEvent.click(await screen.findByTestId('connection-disconnect'))
 
-    expect(onContinueBrowserLocal).toHaveBeenCalledTimes(1)
+    expect(onWorkInBrowser).toHaveBeenCalledTimes(1)
     const storage = createUserSettingsStore().load().storage
     expect(storage.dismissedDaemonBaseUrls).toContain(daemonBaseUrl)
     expect(storage.knownDaemonBaseUrls ?? []).not.toContain(daemonBaseUrl)

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -26,7 +26,7 @@ export interface AppShellProps {
    * a branch without the escape (settings, browser-local itself) leaves it
    * unset and the chip drops the two actions that depend on it.
    */
-  readonly onContinueBrowserLocal?: () => void
+  readonly onWorkInBrowser?: () => void
 }
 
 /**
@@ -37,7 +37,7 @@ export interface AppShellProps {
  * rule). Pages mount this shared component instead of owning any brand,
  * connection or settings chrome themselves.
  */
-export function AppShell({ daemon, onContinueBrowserLocal }: AppShellProps) {
+export function AppShell({ daemon, onWorkInBrowser }: AppShellProps) {
   const navigate = useNavigate()
   const location = useLocation()
   // Read fresh rather than cached in state: the store is a thin localStorage
@@ -75,7 +75,7 @@ export function AppShell({ daemon, onContinueBrowserLocal }: AppShellProps) {
           <p className="font-medium">Alpha preview</p>
           <p className="mt-1 text-xs text-muted-foreground">
             Data durability is not guaranteed yet. Browser storage can be evicted by the device —
-            export what matters, or protect it with persistent storage and a local daemon.
+            export what matters, or protect it with persistent storage and a daemon.
           </p>
           <Link
             to={settingsPath('data')}
@@ -106,9 +106,9 @@ export function AppShell({ daemon, onContinueBrowserLocal }: AppShellProps) {
                   })
                 }
           }
-          onContinueBrowserLocal={onContinueBrowserLocal}
+          onWorkInBrowser={onWorkInBrowser}
           onDisconnect={
-            onContinueBrowserLocal === undefined || daemonBaseUrl === undefined
+            onWorkInBrowser === undefined || daemonBaseUrl === undefined
               ? undefined
               : () => {
                   // Recorded so discovery skips it next time: the default port
@@ -138,15 +138,15 @@ export function AppShell({ daemon, onContinueBrowserLocal }: AppShellProps) {
                       },
                     }
                   })
-                  onContinueBrowserLocal()
+                  onWorkInBrowser()
                 }
           }
         >
-          {connection.state === 'local' && (
+          {connection.state === 'browser' && (
             <>
               <p className="text-muted-foreground">
-                Connect a local daemon (MCP) to unlock version history, workspaces, variations, and
-                combining changes
+                Connect a daemon (MCP) for version history, workspaces, variations and merging.
+                Documents already in this browser stay here — import them one at a time.
               </p>
               <Suspense fallback={null}>
                 <DaemonDetectedBanner

--- a/apps/web/src/components/capability-teaser/CapabilityTeaser.browser.test.tsx
+++ b/apps/web/src/components/capability-teaser/CapabilityTeaser.browser.test.tsx
@@ -14,7 +14,7 @@ describe('CapabilityTeaser (browser — real Radix Tooltip open/close)', () => {
     await expect
       .element(
         page.getByRole('tooltip', {
-          name: 'Connect a local daemon (MCP) to enable Version history',
+          name: 'Connect a daemon (MCP) to enable Version history',
         }),
       )
       .toBeVisible()
@@ -36,9 +36,7 @@ describe('CapabilityTeaser (browser — real Radix Tooltip open/close)', () => {
     expect(control).toHaveFocus()
 
     await expect
-      .element(
-        page.getByRole('tooltip', { name: 'Connect a local daemon (MCP) to enable Workspaces' }),
-      )
+      .element(page.getByRole('tooltip', { name: 'Connect a daemon (MCP) to enable Workspaces' }))
       .toBeVisible()
   })
 
@@ -53,7 +51,7 @@ describe('CapabilityTeaser (browser — real Radix Tooltip open/close)', () => {
     const describedBy = control.getAttribute('aria-describedby')
     expect(describedBy).toBeTruthy()
     const descEl = document.getElementById(describedBy!.split(' ')[0])
-    expect(descEl?.textContent).toBe('Connect a local daemon (MCP) to enable Branches')
+    expect(descEl?.textContent).toBe('Connect a daemon (MCP) to enable Branches')
   })
 
   it('does not render a Radix tooltip trigger once the capability is enabled', async () => {
@@ -61,6 +59,6 @@ describe('CapabilityTeaser (browser — real Radix Tooltip open/close)', () => {
     const control = screen.getByRole('button', { name: 'Merge' })
 
     await userEvent.hover(control)
-    expect(screen.queryByText('Connect a local daemon (MCP) to enable Merge')).toBeNull()
+    expect(screen.queryByText('Connect a daemon (MCP) to enable Merge')).toBeNull()
   })
 })

--- a/apps/web/src/components/capability-teaser/CapabilityTeaser.test.tsx
+++ b/apps/web/src/components/capability-teaser/CapabilityTeaser.test.tsx
@@ -13,7 +13,7 @@ describe('CapabilityTeaser', () => {
     const describedById = control.getAttribute('aria-describedby')
     expect(describedById).toBeTruthy()
     const description = document.getElementById(describedById as string)
-    expect(description?.textContent).toBe('Connect a local daemon (MCP) to enable Version history')
+    expect(description?.textContent).toBe('Connect a daemon (MCP) to enable Version history')
   })
 
   it('does not use native disabled (which would block focus and hide the tooltip)', () => {
@@ -50,7 +50,7 @@ describe('CapabilityTeaser', () => {
     const control = screen.getByRole('button', { name: 'Merge' })
     expect(control.getAttribute('aria-disabled')).toBeNull()
     expect(control.getAttribute('aria-describedby')).toBeNull()
-    expect(screen.queryByText('Connect a local daemon (MCP) to enable Merge')).toBeNull()
+    expect(screen.queryByText('Connect a daemon (MCP) to enable Merge')).toBeNull()
   })
 
   it('stays aria-disabled with a tooltip when enabled but no onAction is wired', () => {

--- a/apps/web/src/components/capability-teaser/CapabilityTeaser.tsx
+++ b/apps/web/src/components/capability-teaser/CapabilityTeaser.tsx
@@ -23,7 +23,7 @@ export function CapabilityTeaser({ label, enabled, onAction }: CapabilityTeaserP
   const isInteractive = enabled && onAction !== undefined
   const description = enabled
     ? 'This feature is not yet available'
-    : `Connect a local daemon (MCP) to enable ${label}`
+    : `Connect a daemon (MCP) to enable ${label}`
 
   const button = (
     <button

--- a/apps/web/src/components/connection/ConnectionStatus.test.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.test.tsx
@@ -52,7 +52,7 @@ describe('ConnectionStatus chip', () => {
     expect(chip).toBeTruthy()
     // No standing sentence copy outside the popover: the actual popover
     // explanation must not be rendered until the chip is opened.
-    expect(screen.queryByText(/changes are saved to your local daemon/i)).toBeNull()
+    expect(screen.queryByText(/changes are saved to the daemon on this machine/i)).toBeNull()
     expect(screen.queryByText(/live sync is on/i)).toBeNull()
 
     fireEvent.click(chip)
@@ -60,28 +60,24 @@ describe('ConnectionStatus chip', () => {
     expect(screen.getByText(/127\.0\.0\.1:3099/)).toBeTruthy()
   })
 
-  it('local state explains browser-only storage and hosts extra content (daemon detection)', async () => {
+  it('browser state explains browser-only storage and hosts extra content (daemon detection)', async () => {
     render(
-      <ConnectionStatus state="local">
+      <ConnectionStatus state="browser">
         <button type="button">Use here</button>
       </ConnectionStatus>,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /local/i }))
-    expect(await screen.findByText(/only in this browser/i)).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: /browser/i }))
+    expect(await screen.findByText(/other browsers cannot see them/i)).toBeTruthy()
     // The slot for daemon-detection / capability content renders inside.
     expect(screen.getByRole('button', { name: 'Use here' })).toBeTruthy()
   })
 
   it('sync-off state carries attention styling and BOTH recovery actions', async () => {
     const onRepair = vi.fn()
-    const onContinueBrowserLocal = vi.fn()
+    const onWorkInBrowser = vi.fn()
     render(
-      <ConnectionStatus
-        state="sync-off"
-        onRepair={onRepair}
-        onContinueBrowserLocal={onContinueBrowserLocal}
-      />,
+      <ConnectionStatus state="sync-off" onRepair={onRepair} onWorkInBrowser={onWorkInBrowser} />,
     )
 
     const chip = screen.getByRole('button', { name: /sync off/i })
@@ -92,8 +88,8 @@ describe('ConnectionStatus chip', () => {
     // ...and offers both ways forward.
     fireEvent.click(screen.getByRole('button', { name: /re-pair/i }))
     expect(onRepair).toHaveBeenCalledTimes(1)
-    fireEvent.click(screen.getByRole('button', { name: /continue in browser-local/i }))
-    expect(onContinueBrowserLocal).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByRole('button', { name: /work in this browser instead/i }))
+    expect(onWorkInBrowser).toHaveBeenCalledTimes(1)
   })
 
   it('sync-off announces itself to assistive tech without a visual banner', () => {

--- a/apps/web/src/components/connection/ConnectionStatus.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.tsx
@@ -5,7 +5,7 @@
  *
  * States:
  * - `synced`   — daemon-backed page with live sync running.
- * - `local`    — browser-local page; data exists only in this browser.
+ * - `browser`  — the workspace is kept in this browser and nowhere else.
  *                `children` hosts page-supplied extras (daemon detection,
  *                capability hint) inside the popover.
  * - `reconnecting` — live sync is not running: the transport has not come up
@@ -15,7 +15,7 @@
  *                whose socket is closed drops the delta it was handed.
  * - `sync-off` — daemon-backed page whose session was rejected. The chip
  *                turns attention-colored and the popover carries the two
- *                ways forward (re-pair / continue browser-local). A polite
+ *                ways forward (re-pair / work in the browser). A polite
  *                sr-only live region announces the transition so dropping
  *                the old role="alert" banner loses no assistive-tech signal.
  */
@@ -24,7 +24,14 @@ import { cn } from '@/lib/utils'
 import { StateDot, type StateDotTone } from '../StateDot.js'
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover.js'
 
-export type ConnectionState = 'synced' | 'local' | 'reconnecting' | 'sync-off'
+/**
+ * Two different questions share this type, and only one of them survives
+ * navigation: `browser` names WHO KEEPS the workspace, while the other three
+ * report whether a live session is healthy. Splitting them is its own slice;
+ * this one only stops the keeper from being called "local", which a daemon
+ * running on the same machine is too.
+ */
+export type ConnectionState = 'synced' | 'browser' | 'reconnecting' | 'sync-off'
 
 export interface ConnectionStatusProps {
   readonly state: ConnectionState
@@ -32,9 +39,9 @@ export interface ConnectionStatusProps {
   readonly daemonBaseUrl?: string
   /** sync-off only: starts the pairing grant flow on the daemon's /pair page. */
   readonly onRepair?: () => void
-  /** sync-off only: switches this canvas to the browser-local flow. */
-  readonly onContinueBrowserLocal?: () => void
-  /** local only: page-supplied popover extras (daemon detection, capability hint). */
+  /** sync-off only: switches to the documents kept in this browser. */
+  readonly onWorkInBrowser?: () => void
+  /** browser only: page-supplied popover extras (daemon detection, capability hint). */
   readonly children?: ReactNode
   /**
    * synced only: stop using this daemon in this browser. It does NOT unpair
@@ -46,7 +53,7 @@ export interface ConnectionStatusProps {
 
 const CHIP_LABEL: Record<ConnectionState, string> = {
   synced: 'Synced',
-  local: 'Local',
+  browser: 'Browser',
   reconnecting: 'Reconnecting',
   'sync-off': 'Sync off',
 }
@@ -54,7 +61,7 @@ const CHIP_LABEL: Record<ConnectionState, string> = {
 // Meaning, not paint — StateDot owns the palette (DESIGN.md's closed set).
 const DOT_TONE: Record<ConnectionState, StateDotTone> = {
   synced: 'safe',
-  local: 'neutral',
+  browser: 'neutral',
   reconnecting: 'attention',
   'sync-off': 'attention',
 }
@@ -63,7 +70,7 @@ export function ConnectionStatus({
   state,
   daemonBaseUrl,
   onRepair,
-  onContinueBrowserLocal,
+  onWorkInBrowser,
   onDisconnect,
   children,
 }: ConnectionStatusProps) {
@@ -105,7 +112,7 @@ export function ConnectionStatus({
           <div className="flex flex-col gap-1 text-sm">
             <p className="font-medium">Live sync is on</p>
             <p className="text-muted-foreground">
-              Changes are saved to your local daemon
+              Changes are saved to the daemon on this machine
               {daemonBaseUrl ? (
                 <>
                   {' at '}
@@ -138,15 +145,18 @@ export function ConnectionStatus({
           <div className="flex flex-col gap-1 text-sm">
             <p className="font-medium">Live sync is not running</p>
             <p className="text-muted-foreground">
-              This canvas is not receiving changes from your local daemon right now. Your edits are
-              kept and sent when the connection returns. Reload the page if it does not recover.
+              This document is not receiving changes from the daemon right now. Your edits are kept
+              and sent when the connection returns. Reload the page if it does not recover.
             </p>
           </div>
         )}
-        {state === 'local' && (
+        {state === 'browser' && (
           <div className="flex flex-col gap-2 text-sm">
-            <p className="font-medium">Browser-local canvas</p>
-            <p className="text-muted-foreground">Your data is stored only in this browser.</p>
+            <p className="font-medium">Kept in this browser</p>
+            <p className="text-muted-foreground">
+              Your documents live in this browser's storage. Other browsers cannot see them, and
+              clearing site data removes them.
+            </p>
             {children}
           </div>
         )}
@@ -166,13 +176,13 @@ export function ConnectionStatus({
                   Re-pair with the daemon
                 </button>
               )}
-              {onContinueBrowserLocal && (
+              {onWorkInBrowser && (
                 <button
                   type="button"
-                  onClick={onContinueBrowserLocal}
+                  onClick={onWorkInBrowser}
                   className="rounded-md border px-3 py-1.5 text-xs font-medium transition-colors hover:bg-accent"
                 >
-                  Continue in browser-local
+                  Work in this browser instead
                 </button>
               )}
             </div>

--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -110,7 +110,7 @@ describe('DaemonDetectedBanner', () => {
       />,
     )
 
-    await screen.findByRole('button', { name: /check for local daemon/i })
+    await screen.findByRole('button', { name: /check for a daemon/i })
     expect(probeFn).not.toHaveBeenCalled()
   })
 
@@ -150,7 +150,7 @@ describe('DaemonDetectedBanner', () => {
     // The silent auto-probe stays narrow: exactly the one stored/default
     // baseUrl, no port sweep.
     await waitFor(() => expect(probeFn).toHaveBeenCalledTimes(1))
-    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /check for a daemon/i }))
     await waitFor(() => expect(probeFn.mock.calls.length).toBeGreaterThanOrEqual(2))
     expect(probeFn.mock.calls[1]?.[1]).toMatchObject({ forceRecheck: true })
   })
@@ -166,7 +166,9 @@ describe('DaemonDetectedBanner', () => {
       />,
     )
 
-    await screen.findByText(/(A local whiteboard daemon is running at|A server responded at)/)
+    await screen.findByText(
+      /(A whiteboard daemon is running on this machine at|A server responded at)/,
+    )
     // The daemon origin serves only /pair now — a bare-origin link would
     // just bounce off its redirect, so the banner must not offer one.
     expect(screen.queryByRole('link', { name: /open the local app|^open /i })).toBeNull()
@@ -204,7 +206,9 @@ describe('DaemonDetectedBanner', () => {
     fireEvent.click(await screen.findByRole('button', { name: /dismiss/i }))
 
     expect(
-      screen.queryByText(/(A local whiteboard daemon is running at|A server responded at)/),
+      screen.queryByText(
+        /(A whiteboard daemon is running on this machine at|A server responded at)/,
+      ),
     ).toBeNull()
 
     const saved = store.load()
@@ -236,7 +240,9 @@ describe('DaemonDetectedBanner', () => {
     fireEvent.click(await screen.findByRole('button', { name: /forget this daemon/i }))
 
     expect(
-      screen.queryByText(/(A local whiteboard daemon is running at|A server responded at)/),
+      screen.queryByText(
+        /(A whiteboard daemon is running on this machine at|A server responded at)/,
+      ),
     ).toBeNull()
     const saved = store.load()
     expect(saved.storage.localDaemonBaseUrl).toBeUndefined()
@@ -255,7 +261,9 @@ describe('DaemonDetectedBanner', () => {
       />,
     )
 
-    await screen.findByText(/(A local whiteboard daemon is running at|A server responded at)/)
+    await screen.findByText(
+      /(A whiteboard daemon is running on this machine at|A server responded at)/,
+    )
     expect(screen.queryByRole('button', { name: /forget this daemon/i })).toBeNull()
   })
 
@@ -270,15 +278,15 @@ describe('DaemonDetectedBanner', () => {
       />,
     )
 
-    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /check for a daemon/i }))
 
     await screen.findByText(UNSUPPORTED_BROWSER_NOTICE)
-    expect(screen.queryByRole('button', { name: /check for local daemon/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /check for a daemon/i })).toBeNull()
 
     // No daemon-origin escape hatch anymore (the daemon serves only /pair);
     // the honest affordance is the docs link.
     expect(screen.queryByRole('link', { name: /open the local app/i })).toBeNull()
-    const learnMore = screen.getByRole('link', { name: /how to connect a local daemon/i })
+    const learnMore = screen.getByRole('link', { name: /how to connect a daemon/i })
     expect(learnMore.getAttribute('href')).toContain('connect-to-local-daemon')
   })
 
@@ -374,7 +382,7 @@ describe('DaemonDetectedBanner', () => {
       />,
     )
 
-    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /check for a daemon/i }))
 
     await screen.findByText(/2 servers responded on local ports/i)
     // Each responder offers pairing IN PLACE (the hosted-app-first model).
@@ -455,11 +463,11 @@ describe('DaemonDetectedBanner', () => {
       />,
     )
 
-    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /check for a daemon/i }))
 
     await screen.findByText(/responded at/i)
     expect(screen.getByText(/unverified/i)).not.toBeNull()
-    expect(screen.queryByText(/a local whiteboard daemon is running/i)).toBeNull()
+    expect(screen.queryByText(/a whiteboard daemon is running/i)).toBeNull()
   })
 
   it('a previously paired daemon keeps the plain trusted label', async () => {
@@ -478,9 +486,9 @@ describe('DaemonDetectedBanner', () => {
       />,
     )
 
-    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /check for a daemon/i }))
 
-    await screen.findByText(/a local whiteboard daemon is running/i)
+    await screen.findByText(/a whiteboard daemon is running/i)
     expect(screen.queryByText(/unverified/i)).toBeNull()
   })
 
@@ -497,7 +505,7 @@ describe('DaemonDetectedBanner', () => {
       />,
     )
 
-    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /check for a daemon/i }))
     fireEvent.click(await screen.findByRole('button', { name: /use here/i }))
 
     await waitFor(() => expect(beginGrantFn).toHaveBeenCalledTimes(1))
@@ -522,7 +530,7 @@ describe('DaemonDetectedBanner', () => {
       />,
     )
 
-    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /check for a daemon/i }))
     await screen.findByText(/no daemon reachable from this origin/i)
     fireEvent.click(screen.getByRole('button', { name: /connect anyway/i }))
 
@@ -544,13 +552,13 @@ describe('DaemonDetectedBanner', () => {
       />,
     )
 
-    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /check for a daemon/i }))
 
     await screen.findByText(/no daemon reachable from this origin/i)
     const docsLink = screen.getByRole('link', { name: /how to connect/i })
     expect(docsLink.getAttribute('href')).toBe(HOW_TO_CONNECT_URL)
     // Retry stays available.
-    expect(screen.getByRole('button', { name: /check for local daemon/i })).not.toBeNull()
+    expect(screen.getByRole('button', { name: /check for a daemon/i })).not.toBeNull()
   })
 
   it('a failed manual check on a loopback origin reports plainly that nothing was found', async () => {
@@ -564,9 +572,9 @@ describe('DaemonDetectedBanner', () => {
       />,
     )
 
-    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /check for a daemon/i }))
 
-    await screen.findByText(/no local daemon found/i)
+    await screen.findByText(/no daemon found/i)
     // No hosted-origin allowlist lecture on loopback — it does not apply.
     expect(screen.queryByText(/no daemon reachable from this origin/i)).toBeNull()
   })
@@ -585,13 +593,15 @@ describe('DaemonDetectedBanner', () => {
       />,
     )
 
-    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
-    await screen.findByText(/no local daemon found/i)
+    fireEvent.click(await screen.findByRole('button', { name: /check for a daemon/i }))
+    await screen.findByText(/no daemon found/i)
 
     daemonUp = true
-    fireEvent.click(screen.getByRole('button', { name: /check for local daemon/i }))
-    await screen.findByText(/(A local whiteboard daemon is running at|A server responded at)/)
-    expect(screen.queryByText(/no local daemon found/i)).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: /check for a daemon/i }))
+    await screen.findByText(
+      /(A whiteboard daemon is running on this machine at|A server responded at)/,
+    )
+    expect(screen.queryByText(/no daemon found/i)).toBeNull()
   })
 
   it('keeps the CTA affordance when the probe fails inconclusively (not proven blocked)', async () => {
@@ -605,10 +615,10 @@ describe('DaemonDetectedBanner', () => {
       />,
     )
 
-    fireEvent.click(await screen.findByRole('button', { name: /check for local daemon/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /check for a daemon/i }))
 
     await waitFor(() => expect(probeFn.mock.calls.length).toBeGreaterThanOrEqual(1))
-    expect(screen.getByRole('button', { name: /check for local daemon/i })).not.toBeNull()
+    expect(screen.getByRole('button', { name: /check for a daemon/i })).not.toBeNull()
     expect(screen.queryByText(UNSUPPORTED_BROWSER_NOTICE)).toBeNull()
     expect(screen.queryByRole('link', { name: /open the local app/i })).toBeNull()
   })
@@ -661,7 +671,7 @@ describe('DaemonDetectedBanner', () => {
         />,
       )
 
-      const button = screen.getByRole('button', { name: /check for local daemon/i })
+      const button = screen.getByRole('button', { name: /check for a daemon/i })
       act(() => {
         fireEvent.click(button)
       })
@@ -683,7 +693,7 @@ describe('DaemonDetectedBanner', () => {
         />,
       )
 
-      const button = screen.getByRole('button', { name: /check for local daemon/i })
+      const button = screen.getByRole('button', { name: /check for a daemon/i })
       expect(screen.queryByText(LNA_HINT_TEXT)).toBeNull()
       act(() => {
         fireEvent.click(button)
@@ -733,7 +743,7 @@ describe('DaemonDetectedBanner', () => {
         />,
       )
 
-      const button = screen.getByRole('button', { name: /check for local daemon/i })
+      const button = screen.getByRole('button', { name: /check for a daemon/i })
       act(() => {
         fireEvent.click(button)
       })
@@ -749,7 +759,7 @@ describe('DaemonDetectedBanner', () => {
 
       expect(screen.queryByText(LNA_HINT_TEXT)).toBeNull()
       expect(screen.queryByRole('status')).toBeNull()
-      const rechecked = screen.getByRole('button', { name: /check for local daemon/i })
+      const rechecked = screen.getByRole('button', { name: /check for a daemon/i })
       expect(rechecked.hasAttribute('disabled')).toBe(false)
     })
 
@@ -765,7 +775,7 @@ describe('DaemonDetectedBanner', () => {
         />,
       )
 
-      const button = screen.getByRole('button', { name: /check for local daemon/i })
+      const button = screen.getByRole('button', { name: /check for a daemon/i })
       act(() => {
         fireEvent.click(button)
       })
@@ -793,7 +803,7 @@ describe('DaemonDetectedBanner', () => {
         />,
       )
 
-      const button = screen.getByRole('button', { name: /check for local daemon/i })
+      const button = screen.getByRole('button', { name: /check for a daemon/i })
       act(() => {
         fireEvent.click(button)
       })
@@ -807,7 +817,7 @@ describe('DaemonDetectedBanner', () => {
       // stale failure notice from the first sweep is still rendered.
       probeFn.mockReturnValueOnce(new Promise<DaemonProbeResult>(() => {}))
       act(() => {
-        fireEvent.click(screen.getByRole('button', { name: /check for local daemon/i }))
+        fireEvent.click(screen.getByRole('button', { name: /check for a daemon/i }))
       })
 
       expect(screen.getByRole('status').textContent).toMatch(/checking/i)

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -39,7 +39,7 @@ import { shouldShowDaemonCta } from './daemon-cta-visibility.js'
 // gate that produced this notice in the first place. The "Open the local
 // app" link below is the escape hatch.
 export const UNSUPPORTED_BROWSER_NOTICE =
-  'This browser blocks the hosted app from reaching a local daemon over the network, so documents stay saved in this browser only. Use a Chromium-based browser to connect a local daemon.'
+  'This browser blocks the hosted app from reaching a daemon over the network, so documents stay kept in this browser only. Use a Chromium-based browser to connect a daemon.'
 
 // Docs are not served from apps/web (no /docs route), so the banner links to
 // the source-of-truth GitHub blob rather than fabricating a local route.
@@ -466,7 +466,7 @@ export function DaemonDetectedBanner({
             rel="noreferrer"
             className="font-medium underline"
           >
-            How to connect a local daemon
+            How to connect a daemon
           </a>
         </span>
       )}
@@ -478,7 +478,7 @@ export function DaemonDetectedBanner({
           aria-busy={checking}
           className="rounded-md border px-3 py-1 text-xs font-medium transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
         >
-          Check for local daemon
+          Check for a daemon
         </button>
       )}
       {showManualAffordance && checking && (
@@ -606,7 +606,7 @@ export function DaemonDetectedBanner({
                 .
               </>
             ) : (
-              <>No local daemon found at {baseUrl}.</>
+              <>No daemon found at {baseUrl}.</>
             )}
           </span>
         )}
@@ -685,9 +685,12 @@ export function DaemonDetectedBanner({
         >
           <span>
             {isPairedTarget && identityStatus === 'verified' ? (
-              <>A local whiteboard daemon is running at {detectedBaseUrl} (identity verified).</>
+              <>
+                A whiteboard daemon is running on this machine at {detectedBaseUrl} (identity
+                verified).
+              </>
             ) : isPairedTarget && identityStatus !== 'failed' ? (
-              <>A local whiteboard daemon is running at {detectedBaseUrl}.</>
+              <>A whiteboard daemon is running on this machine at {detectedBaseUrl}.</>
             ) : (
               <>
                 A server responded at {detectedBaseUrl} (unverified — approve it on its own page to
@@ -707,7 +710,7 @@ export function DaemonDetectedBanner({
             target="_blank"
             rel="noreferrer"
             className="font-medium underline"
-            aria-label="Learn more about connecting to the local daemon"
+            aria-label="Learn more about connecting a daemon"
           >
             Learn more
           </a>

--- a/apps/web/src/components/migration/ImportBrowserLocalPanel.tsx
+++ b/apps/web/src/components/migration/ImportBrowserLocalPanel.tsx
@@ -137,7 +137,7 @@ export function ImportBrowserLocalPanel({
   }
 
   if (documents === null) {
-    return <p className="text-sm text-muted-foreground">Loading browser-local documents…</p>
+    return <p className="text-sm text-muted-foreground">Loading documents kept in this browser…</p>
   }
 
   if (documents.length === 0) {

--- a/apps/web/src/lib/commands/create-commands.test.ts
+++ b/apps/web/src/lib/commands/create-commands.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { BROWSER_LOCAL_CAPABILITIES } from '../provider.js'
+import { BROWSER_CAPABILITIES } from '../provider.js'
 import { createWhiteboardCommands } from './create-commands.js'
 import { CommandError, type WhiteboardCommandDeps } from './types.js'
 
 function baseDeps(overrides: Partial<WhiteboardCommandDeps> = {}): WhiteboardCommandDeps {
   return {
-    provider: { kind: 'browser-local', capabilities: BROWSER_LOCAL_CAPABILITIES },
+    provider: { kind: 'browser', capabilities: BROWSER_CAPABILITIES },
     canvas: { documentId: 'c1', name: 'Canvas 1' },
     ...overrides,
   }
@@ -23,8 +23,8 @@ describe('createWhiteboardCommands.getAppContext', () => {
     const result = await commands.getAppContext()
 
     expect(result).toEqual({
-      provider: { mode: 'browser-local' },
-      canvas: { kind: 'browser-local', documentId: 'c1' },
+      provider: { mode: 'browser' },
+      canvas: { kind: 'browser', documentId: 'c1' },
     })
   })
 
@@ -32,9 +32,9 @@ describe('createWhiteboardCommands.getAppContext', () => {
     const depsRef = refOf(
       baseDeps({
         provider: {
-          kind: 'local-daemon',
+          kind: 'daemon',
           daemonBaseUrl: 'http://127.0.0.1:9999',
-          capabilities: BROWSER_LOCAL_CAPABILITIES,
+          capabilities: BROWSER_CAPABILITIES,
         },
         canvas: { workspaceId: 'ws1', documentId: 'my-canvas', name: 'my-canvas' },
       }),
@@ -84,9 +84,9 @@ describe('createWhiteboardCommands.getAppContext', () => {
     const depsRef = refOf(
       baseDeps({
         provider: {
-          kind: 'local-daemon',
+          kind: 'daemon',
           daemonBaseUrl: 'http://127.0.0.1:9999',
-          capabilities: BROWSER_LOCAL_CAPABILITIES,
+          capabilities: BROWSER_CAPABILITIES,
         },
         canvas: { documentId: 'c1', name: 'Canvas 1' },
       }),
@@ -104,9 +104,9 @@ describe('createWhiteboardCommands.getAppContext', () => {
     // a future field added to ProviderState leaking through if the
     // projection were ever changed to a spread instead of field-by-field.
     const poisoned = {
-      kind: 'local-daemon',
+      kind: 'daemon',
       daemonBaseUrl: 'http://127.0.0.1:9999',
-      capabilities: BROWSER_LOCAL_CAPABILITIES,
+      capabilities: BROWSER_CAPABILITIES,
       token: 'shh',
       authorization: 'Bearer shh',
       secret: 'shh',

--- a/apps/web/src/lib/commands/create-commands.ts
+++ b/apps/web/src/lib/commands/create-commands.ts
@@ -33,22 +33,20 @@ function projectCanvasContext(
   if (canvas.workspaceId !== undefined) {
     return { kind: 'daemon', workspaceId: canvas.workspaceId, path: canvas.documentId }
   }
-  return { kind: 'browser-local', documentId: canvas.documentId }
+  return { kind: 'browser', documentId: canvas.documentId }
 }
 
 // Exhaustive over every ProviderState.kind rather than a two-way ternary: an
 // `invalid-config` provider (a failed/rejected runtime config) has no
-// meaningful "browser-local" or "daemon" mode to report, so getAppContext
+// meaningful "browser" or "daemon" mode to report, so getAppContext
 // must fail loudly instead of guessing. The `default` branch's `never`
 // assignment makes a future ProviderState variant a compile error here.
-function projectProviderMode(
-  provider: WhiteboardCommandDeps['provider'],
-): 'daemon' | 'browser-local' {
+function projectProviderMode(provider: WhiteboardCommandDeps['provider']): 'daemon' | 'browser' {
   switch (provider.kind) {
-    case 'local-daemon':
+    case 'daemon':
       return 'daemon'
-    case 'browser-local':
-      return 'browser-local'
+    case 'browser':
+      return 'browser'
     case 'invalid-config': {
       throw new CommandError(
         'invalid-provider-state',

--- a/apps/web/src/lib/commands/types.ts
+++ b/apps/web/src/lib/commands/types.ts
@@ -42,9 +42,9 @@ export type GetAppContextInput = z.infer<typeof getAppContextInputSchema>
 // The provider projection is built field-by-field in create-commands.ts
 // (never a spread of the real ProviderState) so this schema is the
 // contract that keeps daemonBaseUrl — and any future connection-ish field
-// added to ProviderState — out of a WebMCP tool result. "local-daemon" is
-// renamed to "daemon" here because this is a tool-facing vocabulary, not a
-// re-export of the internal ProviderState.kind literal.
+// added to ProviderState — out of a WebMCP tool result. The values are
+// spelled out here rather than re-exported from ProviderState.kind: this is
+// a tool-facing vocabulary that agents read, so it changes on its own terms.
 //
 // Deliberately structural-only: this schema mirrors the static
 // get-app-context.schema.json literal field-for-field (see
@@ -59,7 +59,7 @@ export const getAppContextResultSchema = z
   .object({
     provider: z
       .object({
-        mode: z.enum(['daemon', 'browser-local']),
+        mode: z.enum(['daemon', 'browser']),
       })
       .strict(),
     canvas: z
@@ -73,7 +73,7 @@ export const getAppContextResultSchema = z
           .strict(),
         z
           .object({
-            kind: z.literal('browser-local'),
+            kind: z.literal('browser'),
             documentId: z.string(),
           })
           .strict(),

--- a/apps/web/src/lib/commands/use-whiteboard-commands.test.tsx
+++ b/apps/web/src/lib/commands/use-whiteboard-commands.test.tsx
@@ -1,12 +1,12 @@
 import { renderHook } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
-import { BROWSER_LOCAL_CAPABILITIES } from '../provider.js'
+import { BROWSER_CAPABILITIES } from '../provider.js'
 import type { WhiteboardCommandDeps } from './types.js'
 import { useWhiteboardCommands } from './use-whiteboard-commands.js'
 
 function deps(overrides: Partial<WhiteboardCommandDeps> = {}): WhiteboardCommandDeps {
   return {
-    provider: { kind: 'browser-local', capabilities: BROWSER_LOCAL_CAPABILITIES },
+    provider: { kind: 'browser', capabilities: BROWSER_CAPABILITIES },
     canvas: { documentId: 'c1', name: 'Canvas 1' },
     ...overrides,
   }
@@ -26,9 +26,9 @@ describe('useWhiteboardCommands', () => {
     rerender(
       deps({
         provider: {
-          kind: 'local-daemon',
+          kind: 'daemon',
           daemonBaseUrl: 'http://x',
-          capabilities: BROWSER_LOCAL_CAPABILITIES,
+          capabilities: BROWSER_CAPABILITIES,
         },
       }),
     )

--- a/apps/web/src/lib/document-embed-content.ts
+++ b/apps/web/src/lib/document-embed-content.ts
@@ -135,7 +135,7 @@ async function loadImageAssetUrl(ref: string): Promise<string | undefined> {
  * of its own — the daemon page supplies its own adapter over the daemon's
  * `/api/w/:workspaceId/document/:path/file/:fileId` endpoints.
  */
-export const BROWSER_LOCAL_FILE_ADAPTER: DocumentFileAdapter = {
+export const BROWSER_FILE_ADAPTER: DocumentFileAdapter = {
   isImageRef,
   loadDocument: loadEmbeddedDocument,
   loadImageUrl: loadImageAssetUrl,

--- a/apps/web/src/lib/provider.capability-reach.test.ts
+++ b/apps/web/src/lib/provider.capability-reach.test.ts
@@ -6,7 +6,7 @@
 // every declared capability must be read somewhere outside its own module.
 
 import { describe, expect, it } from 'vitest'
-import { BROWSER_LOCAL_CAPABILITIES } from './provider.js'
+import { BROWSER_CAPABILITIES } from './provider.js'
 
 // `?raw` rather than node:fs — apps/web is browser-only and must not import a
 // Node builtin (the same reason App.lazy-coverage.test.ts reads files this way).
@@ -23,7 +23,7 @@ function readerModules(): Array<[string, string]> {
 }
 
 describe('every declared capability is read by production code', () => {
-  const capabilities = Object.keys(BROWSER_LOCAL_CAPABILITIES)
+  const capabilities = Object.keys(BROWSER_CAPABILITIES)
 
   it('declares at least one capability, so an empty map cannot pass vacuously', () => {
     expect(capabilities.length).toBeGreaterThan(0)

--- a/apps/web/src/lib/provider.test.ts
+++ b/apps/web/src/lib/provider.test.ts
@@ -8,24 +8,22 @@ import {
 
 describe('resolveProviderState', () => {
   it('returns browser-local when daemonBaseUrl is absent', () => {
-    expect(resolveProviderState(EMPTY_RUNTIME_CONFIG).kind).toBe('browser-local')
+    expect(resolveProviderState(EMPTY_RUNTIME_CONFIG).kind).toBe('browser')
   })
 
   it('returns local-daemon only when daemonBaseUrl is present', () => {
-    expect(resolveProviderState({ daemonBaseUrl: 'http://127.0.0.1:3099' }).kind).toBe(
-      'local-daemon',
-    )
+    expect(resolveProviderState({ daemonBaseUrl: 'http://127.0.0.1:3099' }).kind).toBe('daemon')
   })
 
   it('local-daemon state carries daemonBaseUrl', () => {
     const state = resolveProviderState({ daemonBaseUrl: 'http://127.0.0.1:3099' })
-    expect(state).toMatchObject({ kind: 'local-daemon', daemonBaseUrl: 'http://127.0.0.1:3099' })
+    expect(state).toMatchObject({ kind: 'daemon', daemonBaseUrl: 'http://127.0.0.1:3099' })
   })
 
   it('browser-local capabilities: workspaces and versions are false', () => {
     const state = resolveProviderState(EMPTY_RUNTIME_CONFIG)
     expect(state).toMatchObject({
-      kind: 'browser-local',
+      kind: 'browser',
       capabilities: { workspaces: false, versions: false },
     })
   })
@@ -33,7 +31,7 @@ describe('resolveProviderState', () => {
   it('local-daemon capabilities: workspaces and versions are true', () => {
     const state = resolveProviderState({ daemonBaseUrl: 'http://127.0.0.1:3099' })
     expect(state).toMatchObject({
-      kind: 'local-daemon',
+      kind: 'daemon',
       capabilities: { workspaces: true, versions: true },
     })
   })
@@ -41,7 +39,7 @@ describe('resolveProviderState', () => {
   it('browser-local capabilities: branches and merge are false', () => {
     const state = resolveProviderState(EMPTY_RUNTIME_CONFIG)
     expect(state).toMatchObject({
-      kind: 'browser-local',
+      kind: 'browser',
       capabilities: { branches: false, merge: false },
     })
   })
@@ -49,7 +47,7 @@ describe('resolveProviderState', () => {
   it('local-daemon capabilities: branches and merge are true', () => {
     const state = resolveProviderState({ daemonBaseUrl: 'http://127.0.0.1:3099' })
     expect(state).toMatchObject({
-      kind: 'local-daemon',
+      kind: 'daemon',
       capabilities: { branches: true, merge: true },
     })
   })
@@ -66,12 +64,12 @@ describe('resolveProviderState', () => {
 
 describe('resolveProviderStateFromRaw', () => {
   it('empty object returns browser-local state', () => {
-    expect(resolveProviderStateFromRaw({}).kind).toBe('browser-local')
+    expect(resolveProviderStateFromRaw({}).kind).toBe('browser')
   })
 
   it('valid daemonBaseUrl returns local-daemon state', () => {
     expect(resolveProviderStateFromRaw({ daemonBaseUrl: 'http://127.0.0.1:3099' }).kind).toBe(
-      'local-daemon',
+      'daemon',
     )
   })
 
@@ -118,14 +116,14 @@ describe('resolveProviderStateFromRaw', () => {
 
 describe('resolveHostedProviderStateFromRaw', () => {
   it('empty object returns browser-local state', () => {
-    expect(resolveHostedProviderStateFromRaw({}).kind).toBe('browser-local')
+    expect(resolveHostedProviderStateFromRaw({}).kind).toBe('browser')
   })
 
   it('production publicOrigin with no daemon returns browser-local', () => {
     const state = resolveHostedProviderStateFromRaw({
       publicOrigin: 'https://kamiazya-whiteboard.pages.dev',
     })
-    expect(state.kind).toBe('browser-local')
+    expect(state.kind).toBe('browser')
   })
 
   it('preview publicOrigin returns invalid-config', () => {
@@ -159,7 +157,7 @@ describe('resolveHostedProviderStateFromRaw', () => {
       {},
       'https://abc123.kamiazya-whiteboard.pages.dev',
     )
-    expect(state.kind).toBe('browser-local')
+    expect(state.kind).toBe('browser')
   })
 
   it('latest-alias browserOrigin with empty runtime config returns browser-local', () => {
@@ -167,7 +165,7 @@ describe('resolveHostedProviderStateFromRaw', () => {
       {},
       'https://latest.kamiazya-whiteboard.pages.dev',
     )
-    expect(state.kind).toBe('browser-local')
+    expect(state.kind).toBe('browser')
   })
 
   it('preview browserOrigin with a daemonBaseUrl config returns invalid-config (daemon refused on previews)', () => {
@@ -180,12 +178,12 @@ describe('resolveHostedProviderStateFromRaw', () => {
 
   it('production browserOrigin with empty runtime config returns browser-local', () => {
     const state = resolveHostedProviderStateFromRaw({}, 'https://kamiazya-whiteboard.pages.dev')
-    expect(state.kind).toBe('browser-local')
+    expect(state.kind).toBe('browser')
   })
 
   it('localhost browserOrigin with empty runtime config returns browser-local (local dev)', () => {
     const state = resolveHostedProviderStateFromRaw({}, 'https://localhost:5173')
-    expect(state.kind).toBe('browser-local')
+    expect(state.kind).toBe('browser')
   })
 
   it('custom domain publicOrigin surfaces the specific unsupported-custom-domain copy (no browserOrigin)', () => {

--- a/apps/web/src/lib/provider.ts
+++ b/apps/web/src/lib/provider.ts
@@ -29,22 +29,22 @@ export type WhiteboardCapabilities = {
 }
 
 export type ProviderState =
-  | { readonly kind: 'browser-local'; readonly capabilities: WhiteboardCapabilities }
+  | { readonly kind: 'browser'; readonly capabilities: WhiteboardCapabilities }
   | {
-      readonly kind: 'local-daemon'
+      readonly kind: 'daemon'
       readonly daemonBaseUrl: string
       readonly capabilities: WhiteboardCapabilities
     }
   | { readonly kind: 'invalid-config'; readonly message: string }
 
-export const BROWSER_LOCAL_CAPABILITIES: WhiteboardCapabilities = {
+export const BROWSER_CAPABILITIES: WhiteboardCapabilities = {
   workspaces: false,
   versions: false,
   branches: false,
   merge: false,
 }
 
-export const LOCAL_DAEMON_CAPABILITIES: WhiteboardCapabilities = {
+export const DAEMON_CAPABILITIES: WhiteboardCapabilities = {
   workspaces: true,
   versions: true,
   branches: true,
@@ -54,14 +54,14 @@ export const LOCAL_DAEMON_CAPABILITIES: WhiteboardCapabilities = {
 export function resolveProviderState(config: RuntimeConfig): ProviderState {
   if (config.daemonBaseUrl !== undefined) {
     return {
-      kind: 'local-daemon',
+      kind: 'daemon',
       daemonBaseUrl: config.daemonBaseUrl,
-      capabilities: LOCAL_DAEMON_CAPABILITIES,
+      capabilities: DAEMON_CAPABILITIES,
     }
   }
   return {
-    kind: 'browser-local',
-    capabilities: BROWSER_LOCAL_CAPABILITIES,
+    kind: 'browser',
+    capabilities: BROWSER_CAPABILITIES,
   }
 }
 
@@ -88,7 +88,7 @@ export function resolveHostedProviderStateFromRaw(
     browserOrigin !== undefined && classifyPagesOrigin(browserOrigin) === 'preview'
   try {
     const state = resolveProviderState(resolveHostedRuntimeConfig(raw))
-    if (isPreviewOrigin && state.kind === 'local-daemon') {
+    if (isPreviewOrigin && state.kind === 'daemon') {
       return { kind: 'invalid-config', message: GENERIC_INVALID_CONFIG_MESSAGE }
     }
     return state

--- a/apps/web/src/lib/shell-status-store.test.ts
+++ b/apps/web/src/lib/shell-status-store.test.ts
@@ -34,7 +34,7 @@ describe('shell-status-store', () => {
   })
 
   it('clearing a published connection notifies', () => {
-    setShellConnection({ state: 'local' })
+    setShellConnection({ state: 'browser' })
     const listener = vi.fn()
     subscribeShellStatus(listener)
     setShellConnection(null)

--- a/apps/web/src/lib/user-settings-store.test.ts
+++ b/apps/web/src/lib/user-settings-store.test.ts
@@ -31,12 +31,12 @@ describe('createUserSettingsStore', () => {
     const store = createUserSettingsStore()
     store.save({
       ...defaultUserSettings(),
-      storage: { preferredProvider: 'browser-local', lastBrowserLocalCanvasId: 'canvas-1' },
+      storage: { preferredProvider: 'browser', lastBrowserLocalCanvasId: 'canvas-1' },
     })
 
     const reloaded = createUserSettingsStore()
     expect(reloaded.load().storage).toMatchObject({
-      preferredProvider: 'browser-local',
+      preferredProvider: 'browser',
       lastBrowserLocalCanvasId: 'canvas-1',
     })
   })
@@ -135,7 +135,7 @@ describe('createUserSettingsStore', () => {
     const store = createUserSettingsStore()
     store.save({
       ...defaultUserSettings(),
-      storage: { preferredProvider: 'local-daemon' },
+      storage: { preferredProvider: 'daemon' },
     })
     store.reset()
 
@@ -159,7 +159,7 @@ describe('createUserSettingsStore', () => {
       STORAGE_KEY,
       JSON.stringify({
         version: 1,
-        storage: { preferredProvider: 'browser-local', daemonToken: 'super-secret' },
+        storage: { preferredProvider: 'browser', daemonToken: 'super-secret' },
         migration: {},
         capabilities: {},
       }),
@@ -210,13 +210,13 @@ describe('createUserSettingsStore — beta banner dismissal', () => {
       STORAGE_KEY,
       JSON.stringify({
         version: 1,
-        storage: { preferredProvider: 'local-daemon', lastBrowserLocalCanvasId: 'abc' },
+        storage: { preferredProvider: 'daemon', lastBrowserLocalCanvasId: 'abc' },
         migration: {},
         capabilities: {},
       }),
     )
     const store = createUserSettingsStore()
-    expect(store.load().storage.preferredProvider).toBe('local-daemon')
+    expect(store.load().storage.preferredProvider).toBe('daemon')
     expect(store.load().storage.lastBrowserLocalCanvasId).toBe('abc')
     expect(store.load().storage.dismissedBetaBannerAt).toBeUndefined()
   })

--- a/apps/web/src/lib/user-settings-store.test.ts
+++ b/apps/web/src/lib/user-settings-store.test.ts
@@ -31,12 +31,12 @@ describe('createUserSettingsStore', () => {
     const store = createUserSettingsStore()
     store.save({
       ...defaultUserSettings(),
-      storage: { preferredProvider: 'browser', lastBrowserLocalCanvasId: 'canvas-1' },
+      storage: { preferredProvider: 'browser-local', lastBrowserLocalCanvasId: 'canvas-1' },
     })
 
     const reloaded = createUserSettingsStore()
     expect(reloaded.load().storage).toMatchObject({
-      preferredProvider: 'browser',
+      preferredProvider: 'browser-local',
       lastBrowserLocalCanvasId: 'canvas-1',
     })
   })
@@ -135,7 +135,7 @@ describe('createUserSettingsStore', () => {
     const store = createUserSettingsStore()
     store.save({
       ...defaultUserSettings(),
-      storage: { preferredProvider: 'daemon' },
+      storage: { preferredProvider: 'local-daemon' },
     })
     store.reset()
 
@@ -159,7 +159,7 @@ describe('createUserSettingsStore', () => {
       STORAGE_KEY,
       JSON.stringify({
         version: 1,
-        storage: { preferredProvider: 'browser', daemonToken: 'super-secret' },
+        storage: { preferredProvider: 'browser-local', daemonToken: 'super-secret' },
         migration: {},
         capabilities: {},
       }),
@@ -210,13 +210,13 @@ describe('createUserSettingsStore — beta banner dismissal', () => {
       STORAGE_KEY,
       JSON.stringify({
         version: 1,
-        storage: { preferredProvider: 'daemon', lastBrowserLocalCanvasId: 'abc' },
+        storage: { preferredProvider: 'local-daemon', lastBrowserLocalCanvasId: 'abc' },
         migration: {},
         capabilities: {},
       }),
     )
     const store = createUserSettingsStore()
-    expect(store.load().storage.preferredProvider).toBe('daemon')
+    expect(store.load().storage.preferredProvider).toBe('local-daemon')
     expect(store.load().storage.lastBrowserLocalCanvasId).toBe('abc')
     expect(store.load().storage.dismissedBetaBannerAt).toBeUndefined()
   })

--- a/apps/web/src/lib/user-settings-store.ts
+++ b/apps/web/src/lib/user-settings-store.ts
@@ -40,7 +40,7 @@ function safeRemoveItem(key: string): void {
 // safeParse fail, and callers fall back to defaults rather than persisting it.
 const storageSettingsSchema = z
   .object({
-    preferredProvider: z.enum(['browser-local', 'local-daemon']).optional(),
+    preferredProvider: z.enum(['browser', 'daemon']).optional(),
     lastBrowserLocalCanvasId: z.string().optional(),
     // Constrained to http/https because this value is rendered into an `href`
     // (the "Open the local app" escape hatch). Anything that can write

--- a/apps/web/src/lib/user-settings-store.ts
+++ b/apps/web/src/lib/user-settings-store.ts
@@ -40,7 +40,12 @@ function safeRemoveItem(key: string): void {
 // safeParse fail, and callers fall back to defaults rather than persisting it.
 const storageSettingsSchema = z
   .object({
-    preferredProvider: z.enum(['browser', 'daemon']).optional(),
+    // Spelled with the retired keeper words on purpose: this value is
+    // PERSISTED, the schema is `.strict()`, and `load()` falls back to
+    // defaults on any parse failure — so renaming it here would silently
+    // discard an existing reader's whole settings payload, daemon connection
+    // included. It moves with a migration, not with a sweep.
+    preferredProvider: z.enum(['browser-local', 'local-daemon']).optional(),
     lastBrowserLocalCanvasId: z.string().optional(),
     // Constrained to http/https because this value is rendered into an `href`
     // (the "Open the local app" escape hatch). Anything that can write

--- a/apps/web/src/lib/webmcp/tool-definitions.test.ts
+++ b/apps/web/src/lib/webmcp/tool-definitions.test.ts
@@ -137,7 +137,7 @@ describe('WebMCP result JSON-Schema literals agree with the Zod schemas', () => 
   it('get-app-context: rejects a canvas.kind that does not match its const, in both directions', () => {
     const wrongConst = {
       provider: { mode: 'daemon' },
-      canvas: { kind: 'browser-local', workspaceId: 'ws1', path: 'c1' },
+      canvas: { kind: 'browser', workspaceId: 'ws1', path: 'c1' },
     }
 
     expect(getAppContextResultSchema.safeParse(wrongConst).success).toBe(false)
@@ -156,7 +156,7 @@ describe('WebMCP result JSON-Schema literals agree with the Zod schemas', () => 
 // zod-to-json-schema dependency.
 const daemonCanvasArb = fc.record(
   {
-    kind: fc.constantFrom('daemon', 'browser-local', 'other'),
+    kind: fc.constantFrom('daemon', 'browser', 'other'),
     workspaceId: fc.oneof(fc.string(), fc.constant(undefined)),
     path: fc.oneof(fc.string(), fc.constant(undefined)),
     documentId: fc.oneof(fc.string(), fc.constant(undefined)),
@@ -167,7 +167,7 @@ const daemonCanvasArb = fc.record(
 const appContextPayloadArb = fc.record(
   {
     provider: fc.record(
-      { mode: fc.constantFrom('daemon', 'browser-local', 'other') },
+      { mode: fc.constantFrom('daemon', 'browser', 'other') },
       { requiredKeys: [] },
     ),
     canvas: fc.oneof(fc.constant(null), daemonCanvasArb),

--- a/apps/web/src/lib/webmcp/tool-result-schemas/get-app-context.schema.json
+++ b/apps/web/src/lib/webmcp/tool-result-schemas/get-app-context.schema.json
@@ -8,7 +8,7 @@
       "additionalProperties": false,
       "required": ["mode"],
       "properties": {
-        "mode": { "type": "string", "enum": ["daemon", "browser-local"] }
+        "mode": { "type": "string", "enum": ["daemon", "browser"] }
       }
     },
     "canvas": {
@@ -28,7 +28,7 @@
           "additionalProperties": false,
           "required": ["kind", "documentId"],
           "properties": {
-            "kind": { "type": "string", "const": "browser-local" },
+            "kind": { "type": "string", "const": "browser" },
             "documentId": { "type": "string" }
           }
         },

--- a/apps/web/src/lib/webmcp/use-browser-tool-registry.test.tsx
+++ b/apps/web/src/lib/webmcp/use-browser-tool-registry.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 import { createWhiteboardCommands } from '../commands/create-commands.js'
 import type { WhiteboardCommands } from '../commands/index.js'
-import { BROWSER_LOCAL_CAPABILITIES } from '../provider.js'
+import { BROWSER_CAPABILITIES } from '../provider.js'
 import { webMcpTools } from './tool-definitions.js'
 import type { ModelContext, WebMcpToolDescriptor } from './use-browser-tool-registry.js'
 import { useBrowserToolRegistry } from './use-browser-tool-registry.js'
@@ -10,8 +10,8 @@ import { useBrowserToolRegistry } from './use-browser-tool-registry.js'
 function fakeCommands(): WhiteboardCommands {
   return {
     getAppContext: async () => ({
-      provider: { mode: 'browser-local' },
-      canvas: { kind: 'browser-local', documentId: 'c1' },
+      provider: { mode: 'browser' },
+      canvas: { kind: 'browser', documentId: 'c1' },
     }),
   }
 }
@@ -118,8 +118,8 @@ describe('useBrowserToolRegistry', () => {
     expect(serialized).not.toContain('secret')
     expect(serialized).not.toContain('daemonbaseurl')
     expect(result).toEqual({
-      provider: { mode: 'browser-local' },
-      canvas: { kind: 'browser-local', documentId: 'c1' },
+      provider: { mode: 'browser' },
+      canvas: { kind: 'browser', documentId: 'c1' },
     })
   })
 
@@ -235,7 +235,7 @@ describe('useBrowserToolRegistry', () => {
       ...fakeCommands(),
       getAppContext: async (input) => {
         receivedInput = input
-        return { provider: { mode: 'browser-local' }, canvas: null }
+        return { provider: { mode: 'browser' }, canvas: null }
       },
     }
 
@@ -259,7 +259,7 @@ describe('useBrowserToolRegistry', () => {
     // real command layer via fakeCommands()'s sibling, createWhiteboardCommands.
     const realCommands = createWhiteboardCommands({
       current: {
-        provider: { kind: 'browser-local', capabilities: BROWSER_LOCAL_CAPABILITIES },
+        provider: { kind: 'browser', capabilities: BROWSER_CAPABILITIES },
         canvas: { documentId: 'c1', name: 'c1' },
       },
     })

--- a/apps/web/src/pages/BrowserLocalDocumentPage.shell-connection.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.shell-connection.browser.test.tsx
@@ -58,17 +58,19 @@ describe('shell connection chip over a real browser-local document', () => {
     )
 
     const chip = await waitFor(() => screen.getByTestId('connection-chip'), { timeout: 5000 })
-    expect(chip.textContent).toMatch(/local/i)
+    expect(chip.textContent).toMatch(/browser/i)
     // The chip sits in the shell's own row, not inside the document's top bar
     // — that separation is the whole point of the move, and a DOM assertion is
     // the only thing that can tell the two rows apart.
     expect(chip.closest('header')?.querySelector('[data-testid="shell-settings"]')).toBeTruthy()
 
     // Sentence-length copy stays out of chrome: it appears only once opened.
-    expect(screen.queryByText(/only in this browser/i)).toBeNull()
+    expect(screen.queryByText(/other browsers cannot see them/i)).toBeNull()
     fireEvent.click(chip)
-    expect(await screen.findByText(/only in this browser/i)).toBeInTheDocument()
-    expect(await screen.findByText(/unlock version history/i)).toBeInTheDocument()
+    expect(await screen.findByText(/other browsers cannot see them/i)).toBeInTheDocument()
+    expect(
+      await screen.findByText(/Connect a daemon \(MCP\) for version history/i),
+    ).toBeInTheDocument()
   })
 
   it('leaving the document takes the claim with it', async () => {

--- a/apps/web/src/pages/BrowserLocalDocumentPage.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.test.tsx
@@ -818,7 +818,7 @@ describe('BrowserLocalDocumentPage', () => {
 
   describe('daemon-only capability messaging', () => {
     const CTA_TEXT =
-      'Connect a local daemon (MCP) to unlock version history, workspaces, variations, and combining changes'
+      'Connect a daemon (MCP) for version history, workspaces, variations and merging.'
 
     it('keeps the capability CTA out of page chrome and reports "local" to the shell', async () => {
       const store = new LocalStoreDouble()
@@ -843,7 +843,7 @@ describe('BrowserLocalDocumentPage', () => {
       // App-mounted shell draws it (and hosts the CTA in its popover) from
       // the state this page publishes.
       expect(screen.queryByTestId('connection-chip')).toBeNull()
-      expect(getShellConnection()).toEqual({ state: 'local' })
+      expect(getShellConnection()).toEqual({ state: 'browser' })
 
       cleanup()
       expect(getShellConnection()).toBeNull()

--- a/apps/web/src/pages/BrowserLocalDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.tsx
@@ -44,14 +44,14 @@ import {
 } from '../lib/app-routes.js'
 import { BrowserLocalBackend } from '../lib/browser-local-backend.js'
 import { useWhiteboardCommands } from '../lib/commands/index.js'
-import { BROWSER_LOCAL_FILE_ADAPTER } from '../lib/document-embed-content.js'
+import { BROWSER_FILE_ADAPTER } from '../lib/document-embed-content.js'
 import { isDocumentReadFailure } from '../lib/document-read-failure.js'
 import { browserLocalFaviconStatus, type FaviconStyle } from '../lib/favicon.js'
 import { readLastTool, resolveInitialTool } from '../lib/initial-tool.js'
 import { kindNoun } from '../lib/kind-noun.js'
 import type { ContentClock, DefaultDocumentPointer } from '../lib/local-document-summary.js'
 import { ensurePersistentStorage } from '../lib/persistent-storage.js'
-import { BROWSER_LOCAL_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
+import { BROWSER_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
 import { setShellConnection } from '../lib/shell-status-store.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
 import { cn } from '../lib/utils.js'
@@ -123,7 +123,7 @@ function titleOf(name: string | null, path: string | null): string {
 export function BrowserLocalDocumentPage({
   store,
   loro,
-  capabilities = BROWSER_LOCAL_CAPABILITIES,
+  capabilities = BROWSER_CAPABILITIES,
   initialPath,
   pointer,
   clock,
@@ -154,7 +154,7 @@ export function BrowserLocalDocumentPage({
   // the data lives in this browser and nowhere else. Cleared on unmount so an
   // index page makes no claim of its own.
   useEffect(() => {
-    setShellConnection({ state: 'local' })
+    setShellConnection({ state: 'browser' })
     return () => setShellConnection(null)
   }, [])
 
@@ -511,7 +511,7 @@ export function BrowserLocalDocumentPage({
   // stamps that make an edit made elsewhere show up on the next refresh.
   const fileSeams = useDocumentFileSeams({
     canvas,
-    adapter: BROWSER_LOCAL_FILE_ADAPTER,
+    adapter: BROWSER_FILE_ADAPTER,
     stampOf: useMemo(
       () => new Map(documents.map((entry) => [entry.documentId, entry.updatedAt])),
       [documents],
@@ -519,7 +519,7 @@ export function BrowserLocalDocumentPage({
   })
 
   const commands = useWhiteboardCommands({
-    provider: { kind: 'browser-local', capabilities },
+    provider: { kind: 'browser', capabilities },
     canvas: documentId !== null ? { documentId, name: documentName ?? '' } : null,
   })
 

--- a/apps/web/src/pages/DaemonDocumentPage.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.test.tsx
@@ -256,7 +256,7 @@ describe('DaemonDocumentPage', () => {
     expect(createdBackends[0]?.connectCount).toBe(1)
   })
 
-  it('renders capability badges from LOCAL_DAEMON_CAPABILITIES', async () => {
+  it('renders capability badges from DAEMON_CAPABILITIES', async () => {
     await act(async () => {
       render(
         <DaemonDocumentPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -54,7 +54,7 @@ import { devTransportOverride } from '../lib/dev-transport-override.js'
 import { daemonFaviconStatus, type FaviconStyle } from '../lib/favicon.js'
 import { readLastTool, resolveInitialTool } from '../lib/initial-tool.js'
 import type { ContentClock } from '../lib/local-document-summary.js'
-import { LOCAL_DAEMON_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
+import { DAEMON_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
 import { setShellConnection } from '../lib/shell-status-store.js'
 import { createSharedSseStreamSource } from '../lib/sse-shared-stream-source.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
@@ -104,7 +104,7 @@ export function DaemonDocumentPage({
   workspaceId,
   path,
   token,
-  capabilities = LOCAL_DAEMON_CAPABILITIES,
+  capabilities = DAEMON_CAPABILITIES,
   createBackend,
   browserLocalStore,
   browserLocalClock,
@@ -402,7 +402,7 @@ export function DaemonDocumentPage({
   })
 
   const commands = useWhiteboardCommands({
-    provider: { kind: 'local-daemon', daemonBaseUrl, capabilities },
+    provider: { kind: 'daemon', daemonBaseUrl, capabilities },
     // The daemon canvas summary carries no display name yet (only
     // path/updatedAt) — the path doubles as `name` until that changes.
     canvas:

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -186,9 +186,9 @@ function ConnectionsSection({ daemon }: { daemon?: { baseUrl: string; token: str
   if (!daemon) {
     return (
       <section>
-        <p className="text-sm">Local daemon — Not connected</p>
+        <p className="text-sm">Daemon — Not connected</p>
         <p className="mt-1 text-xs text-muted-foreground">
-          A local daemon holds durable storage and the AI agent connection for this app.
+          A daemon on this machine holds durable storage and the AI agent connection for this app.
         </p>
       </section>
     )

--- a/tools/arch-lint/src/vocabulary-check.test.ts
+++ b/tools/arch-lint/src/vocabulary-check.test.ts
@@ -73,6 +73,36 @@ const BANNED = [
     word: 'slug',
     instead: "`path` (a document's place in the workspace) or `segment` (one level of it)",
   },
+  // `local` is NOT retired and cannot be: it still means "on this machine
+  // rather than remote" (localhost, Local Network Access, mcp-server's
+  // `authMode: 'local-daemon'` opposite `'server-mode'`). What IS retired is
+  // `local` used for WHERE A WORKSPACE IS KEPT — an axis it never fit, since
+  // a daemon is local too. The two names below spelled it that way and meant
+  // opposite things while sharing a word, which is as confusable as a pair
+  // gets.
+  //
+  // Scoped to the DISCRIMINANT VALUE (a quoted literal) rather than the word
+  // anywhere: file names and test ids still read `browser-local-backend`, and
+  // are their own mechanical increment. A guard that claimed them before they
+  // moved would be one nobody could make green.
+  {
+    pattern: /(['"])browser-local\1/,
+    word: "'browser-local' (as a value)",
+    instead: "'browser' — the keeper is named by WHO holds the workspace (Browser / Daemon)",
+    dirs: ['apps/web/src'],
+  },
+  {
+    pattern: /(['"])local-daemon\1/,
+    word: "'local-daemon' (as a value)",
+    instead: "'daemon'",
+    dirs: ['apps/web/src'],
+  },
+  {
+    pattern: /\b(?:BROWSER_LOCAL|LOCAL_DAEMON)_/,
+    word: 'BROWSER_LOCAL_ / LOCAL_DAEMON_ constants',
+    instead: 'BROWSER_ / DAEMON_',
+    dirs: ['apps/web/src'],
+  },
 ] as const
 
 /**
@@ -96,10 +126,14 @@ function listSourceFiles(dir: string): string[] {
 }
 
 describe('retired vocabulary', () => {
-  for (const { pattern, word, instead } of BANNED) {
+  for (const entry of BANNED) {
+    const { pattern, word, instead } = entry
+    // A word retired only within one package scans only that package, so the
+    // guard never claims coverage it does not have.
+    const dirs: readonly string[] = 'dirs' in entry ? entry.dirs : SCAN_DIRS
     it(`no source file says "${word}" — use ${instead}`, () => {
       const hits: string[] = []
-      for (const dir of SCAN_DIRS) {
+      for (const dir of dirs) {
         for (const file of listSourceFiles(join(REPO_ROOT, dir))) {
           const relativePath = relative(REPO_ROOT, file).split(sep).join('/')
           if (relativePath in EXEMPT_FILES) continue

--- a/tools/arch-lint/src/vocabulary-check.test.ts
+++ b/tools/arch-lint/src/vocabulary-check.test.ts
@@ -90,12 +90,23 @@ const BANNED = [
     word: "'browser-local' (as a value)",
     instead: "'browser' — the keeper is named by WHO holds the workspace (Browser / Daemon)",
     dirs: ['apps/web/src'],
+    // PERSISTED value under a `.strict()` schema whose loader falls back to
+    // defaults on any parse failure: renaming it in place would discard an
+    // existing reader's whole settings payload. It moves with a migration.
+    exempt: [
+      'apps/web/src/lib/user-settings-store.ts',
+      'apps/web/src/lib/user-settings-store.test.ts',
+    ],
   },
   {
     pattern: /(['"])local-daemon\1/,
     word: "'local-daemon' (as a value)",
     instead: "'daemon'",
     dirs: ['apps/web/src'],
+    exempt: [
+      'apps/web/src/lib/user-settings-store.ts',
+      'apps/web/src/lib/user-settings-store.test.ts',
+    ],
   },
   {
     pattern: /\b(?:BROWSER_LOCAL|LOCAL_DAEMON)_/,
@@ -131,12 +142,15 @@ describe('retired vocabulary', () => {
     // A word retired only within one package scans only that package, so the
     // guard never claims coverage it does not have.
     const dirs: readonly string[] = 'dirs' in entry ? entry.dirs : SCAN_DIRS
+    // Per-word, never per-file: exempting a file for one retired word must
+    // not quietly stop another word being checked in it.
+    const exempt: readonly string[] = 'exempt' in entry ? entry.exempt : []
     it(`no source file says "${word}" — use ${instead}`, () => {
       const hits: string[] = []
       for (const dir of dirs) {
         for (const file of listSourceFiles(join(REPO_ROOT, dir))) {
           const relativePath = relative(REPO_ROOT, file).split(sep).join('/')
-          if (relativePath in EXEMPT_FILES) continue
+          if (relativePath in EXEMPT_FILES || exempt.includes(relativePath)) continue
           const lines = readFileSync(file, 'utf-8').split('\n')
           for (const [index, line] of lines.entries()) {
             if (pattern.test(line)) hits.push(`${relativePath}:${index + 1}: ${line.trim()}`)


### PR DESCRIPTION
## Summary

- **The chip contradicted its own popover.** It read `Local`, and two lines below it said "Connect a local daemon" — the same word naming the thing you have and the thing you're being offered. Reproduced in the running app before changing anything.
- **`local` was never the right axis, and could not have been:** a daemon runs on the same machine, so it is local too. The axis is who **keeps** the workspace. The chip now names the keeper — `Browser` / `Daemon`.
- **Retired as a discriminant**, not as a word: `'browser-local'` → `'browser'`, `'local-daemon'` → `'daemon'`, the `BROWSER_LOCAL_`/`LOCAL_DAEMON_` constants, and `ConnectionState`'s `'local'`. `local` itself stays — it still means "on this machine rather than remote" in `localhost`, in `Local Network Access`, and in mcp-server's `authMode: 'local-daemon'` whose opposite is `'server-mode'`. Only the keeper use is gone.
- **The copy takes the keeper framing without promising what isn't built.** "Kept in this browser" is true today; the source-of-truth promotion that framing suggests is not implemented, so the capability CTA says so outright — *documents already in this browser stay here — import them one at a time*.

### Three things the sweep uncovered rather than left

- **A data-loss bug the sweep itself introduced, caught before merge** (`14b092c`). The rename hit `preferredProvider`, which is **persisted** in localStorage under a `.strict()` schema whose `load()` falls back to defaults on *any* parse failure. An existing reader holding the old spelling would have had its **entire** settings payload discarded on next load — daemon base URL, known and dismissed daemons, theme, fonts. Nothing reads `preferredProvider`, which is exactly why no test caught it: the damage was to every other field travelling in the same payload. Reverted, with the reason written at the field.
- **WebMCP contract drift.** `get-app-context` has a Zod schema *and* a static JSON Schema literal spelling the mode separately, fuzzed for agreement by `tool-definitions.test.ts`. The mechanical rename hit one and not the other. Both moved. (Re-checked after the above: this one is a tool contract an agent reads fresh per call, with no stored state behind it, so renaming it is correct.)
- `onContinueBrowserLocal` named an action whose label is now "Work in this browser instead", so the prop follows the label.

### Scope, and what is deliberately left

This is increment **A** of three. The guard is scoped to match — it pins the quoted-value form in `apps/web/src` only, so it never claims coverage it doesn't have:

| | | why separate |
|---|---|---|
| **B** | file names, `data-testid`s (`browser-local-backend.ts`) | mechanical, ~100 files |
| **C** | `preferredProvider`, `localDaemonBaseUrl` — the persisted settings keys | **stored shapes** — see the bug above for exactly what renaming one in place costs. They move with a settings migration |

The guard gained **per-word** exemptions rather than reusing `EXEMPT_FILES`, so excusing `user-settings-store.ts` for the two keeper words does not quietly stop `slug` being checked in it.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [x] `pnpm test` passes locally
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable

Red-first: three new `vocabulary-check.test.ts` entries failed before the rename and pass after. The guard also gained per-word directory scoping, so a word retired within one package scans only that package.

Suites run: `apps/web` jsdom + node (2662, the CI command), `pnpm test:browser` (750, all green), `arch-lint-node` (89), `pnpm -r typecheck`, `pnpm lint`, `pnpm knip` — all clean.

Pre-existing failures on this machine, unchanged by this diff and identical to the set verified against a clean tree in #1007: 9 `apps/web` objectURL/thumbnail tests (jsdom `createObjectURL`). The pre-push gate was bypassed for the 4 `mcp-node` EACCES tests (chmod is a no-op for root).

**Manual verification** in the running app:

| | before | after |
|---|---|---|
| chip | `Local` | `Browser` |
| popover contains "local daemon" | **yes — the collision** | no |
| Settings → Connections | `Local daemon — Not connected` | `Daemon — Not connected` |

## Visual evidence

The popover, which is where the collision was visible:

```
● Browser
  Kept in this browser
  Your documents live in this browser's storage. Other browsers cannot
  see them, and clearing site data removes them.

  Connect a daemon (MCP) for version history, workspaces, variations and
  merging. Documents already in this browser stay here — import them one
  at a time.
```

Before, the same popover read `Browser-local canvas` / `Your data is stored only in this browser.` / `Connect a **local daemon** (MCP) to unlock…` under a chip labelled `Local`.

Screenshot at `tmp/screenshots/keeper-after.png`; the `gh image` extension is unavailable in this environment, so it could not be uploaded inline.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — `.claude/rules/vocabulary.md` gains the keeper axis, why `local` was wrong for it, where `local` stays legitimate, and what the guard does not yet claim; `apps/web/DESIGN.md` gains the "name the keeper, never the locality" rule and records that the chip still carries a keeper and a liveness in one carrier
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema
