### PR TITLE
refactor(web): move disconnect into Settings, leaving the chip to report and point

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -90,6 +90,13 @@ one it is not in yet, `spinner` that same ring while the doing is in flight.
 - **Sentence-length copy never sits in chrome.** Explanations live in
   popovers/tooltips/dialogs (see `ConnectionStatus`); chrome carries words
   only as short labels ("Saved", "Browser").
+- **Status reports; Settings manages.** A surface that reports a state carries
+  only what you cannot go looking for — a dropped sync is not something anyone
+  seeks out, so its recovery (re-pair, work in the browser instead) stays on
+  the chip that reports it. Changing which daemon this browser uses is the
+  opposite: it has an intent behind it, so it lives in Settings and the chip
+  only points there. The dividing question is whether the user would know to
+  look.
 - **Name the keeper, never the locality.** A workspace is kept by the
   **Browser** or by a **Daemon**; both are on the user's machine, so "Local"
   named neither and collided with "local daemon" in its own popover. See

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -407,7 +407,10 @@ export function App({ providerState }: AppProps) {
           <AppShellLazy daemon={settingsDaemon !== undefined} />
           <div className="min-h-0 flex-1">
             <Suspense fallback={<LazyPageFallback heightClass="h-full" message="Loading…" />}>
-              <SettingsPage daemon={settingsDaemon} />
+              <SettingsPage
+                daemon={settingsDaemon}
+                onDisconnected={() => setForcedBrowserLocal(true)}
+              />
             </Suspense>
           </div>
         </div>

--- a/apps/web/src/components/AppShell.test.tsx
+++ b/apps/web/src/components/AppShell.test.tsx
@@ -3,7 +3,6 @@ import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { resetInstallPromptForTests } from '@/lib/install-prompt-store'
 import { resetShellStatusForTests, setShellConnection } from '@/lib/shell-status-store'
-import { createUserSettingsStore } from '@/lib/user-settings-store'
 import { resetSwStatusForTests } from '../pwa/sw-status-store.js'
 import { AppShell } from './AppShell.js'
 
@@ -154,43 +153,17 @@ describe('AppShell — the connection chip', () => {
     expect(onWorkInBrowser).toHaveBeenCalledTimes(1)
   })
 
-  it('disconnecting records the dismissal so discovery does not bring it straight back', async () => {
-    const daemonBaseUrl = 'http://127.0.0.1:3099'
-    const onWorkInBrowser = vi.fn()
-    // Seeded through the store, not by writing JSON: a hand-built payload that
-    // fails the store's own validation is silently replaced by defaults, and
-    // every assertion below would then pass without touching the real state.
-    createUserSettingsStore().update((current) => ({
-      ...current,
-      storage: {
-        ...current.storage,
-        localDaemonBaseUrl: daemonBaseUrl,
-        knownDaemonBaseUrls: [daemonBaseUrl],
-      },
-    }))
-    expect(createUserSettingsStore().load().storage.localDaemonBaseUrl).toBe(daemonBaseUrl)
-
-    setShellConnection({ state: 'synced', daemonBaseUrl })
-    renderShell(true, '/w/ws/document/a.canvas', onWorkInBrowser)
-
-    fireEvent.click(await screen.findByTestId('connection-chip'))
-    fireEvent.click(await screen.findByTestId('connection-disconnect'))
-
-    expect(onWorkInBrowser).toHaveBeenCalledTimes(1)
-    const storage = createUserSettingsStore().load().storage
-    expect(storage.dismissedDaemonBaseUrls).toContain(daemonBaseUrl)
-    expect(storage.knownDaemonBaseUrls ?? []).not.toContain(daemonBaseUrl)
-    // App.tsx reads localDaemonBaseUrl to decide a page is daemon-backed, so
-    // leaving it set reconnects on the next load — which makes the popover's
-    // "this browser stops using it" false the moment the user reloads.
-    expect(storage.localDaemonBaseUrl).toBeUndefined()
-  })
-
-  it('withholds the disconnect action where the app has no browser-local escape', async () => {
+  // The management action moved to Settings (see SettingsPage.test.tsx). What
+  // the shell keeps is the report and the pointer to where the action lives.
+  it('points at Settings rather than carrying the management action itself', async () => {
     setShellConnection({ state: 'synced', daemonBaseUrl: 'http://127.0.0.1:3099' })
     renderShell(true)
     fireEvent.click(await screen.findByTestId('connection-chip'))
     await waitFor(() => expect(screen.getByTestId('connection-popover')).toBeTruthy())
+
     expect(screen.queryByTestId('connection-disconnect')).toBeNull()
+    expect(screen.getByRole('link', { name: /manage in settings/i }).getAttribute('href')).toBe(
+      '/settings/connections',
+    )
   })
 })

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -107,40 +107,6 @@ export function AppShell({ daemon, onWorkInBrowser }: AppShellProps) {
                 }
           }
           onWorkInBrowser={onWorkInBrowser}
-          onDisconnect={
-            onWorkInBrowser === undefined || daemonBaseUrl === undefined
-              ? undefined
-              : () => {
-                  // Recorded so discovery skips it next time: the default port
-                  // range is rescanned on every visit, so forgetting alone
-                  // would bring this daemon straight back and make the action
-                  // look like a no-op.
-                  settingsStore.update((current) => {
-                    const known = (current.storage.knownDaemonBaseUrls ?? []).filter(
-                      (entry) => entry !== daemonBaseUrl,
-                    )
-                    const dismissed = (current.storage.dismissedDaemonBaseUrls ?? []).filter(
-                      (entry) => entry !== daemonBaseUrl,
-                    )
-                    // Clearing the stored target is what makes this outlive
-                    // the page: App.tsx reads localDaemonBaseUrl to decide a
-                    // load is daemon-backed, so leaving it set reconnects on
-                    // the next visit and the popover's "this browser stops
-                    // using it" becomes false.
-                    const { localDaemonBaseUrl, ...storage } = current.storage
-                    return {
-                      ...current,
-                      storage: {
-                        ...storage,
-                        ...(localDaemonBaseUrl === daemonBaseUrl ? {} : { localDaemonBaseUrl }),
-                        knownDaemonBaseUrls: known,
-                        dismissedDaemonBaseUrls: [daemonBaseUrl, ...dismissed].slice(0, 5),
-                      },
-                    }
-                  })
-                  onWorkInBrowser()
-                }
-          }
         >
           {connection.state === 'browser' && (
             <>

--- a/apps/web/src/components/connection/ConnectionStatus.test.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.test.tsx
@@ -2,33 +2,37 @@
 // connection story collapses from standing banners into ONE header chip.
 // The chip is the always-visible state signal; everything sentence-shaped
 // (explanation, data location, recovery actions) lives in its popover.
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render as rtlRender, screen } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ConnectionStatus } from './ConnectionStatus.js'
+
+// The synced popover links into Settings, so the chip needs the router it
+// has in production.
+function render(ui: ReactElement, options?: Parameters<typeof rtlRender>[1]) {
+  return rtlRender(<MemoryRouter>{ui}</MemoryRouter>, options)
+}
 
 afterEach(cleanup)
 
 describe('ConnectionStatus chip', () => {
-  it('offers a way out while sync is on, and says what it does not do', () => {
-    // Connected was the one state with no exit: every other state offers a
-    // next step, so a user who picked the wrong daemon had to clear storage.
-    const onDisconnect = vi.fn()
-    render(
-      <ConnectionStatus
-        state="synced"
-        daemonBaseUrl="http://127.0.0.1:3099"
-        onDisconnect={onDisconnect}
-      />,
-      { container: document.body },
-    )
+  // Management belongs in Settings, recovery belongs here. Disconnecting is
+  // something you go looking for with an intent; sync dropping is not, and
+  // sending someone to Settings mid-failure adds a step at the worst moment.
+  it('carries no management action while sync is on — that lives in Settings', () => {
+    render(<ConnectionStatus state="synced" daemonBaseUrl="http://127.0.0.1:3099" />, {
+      container: document.body,
+    })
     fireEvent.click(screen.getByTestId('connection-chip'))
 
     const popover = screen.getByTestId('connection-popover')
-    // Disconnecting stops using this daemon here; it neither unpairs nor
-    // deletes anything on the daemon, and the copy has to say so.
-    expect(popover.textContent).toMatch(/stays on the daemon|not deleted/i)
-    fireEvent.click(screen.getByTestId('connection-disconnect'))
-    expect(onDisconnect).toHaveBeenCalledTimes(1)
+    expect(screen.queryByTestId('connection-disconnect')).toBeNull()
+    // It still says where the data is, and points at where the action lives.
+    expect(popover.textContent).toMatch(/127\.0\.0\.1:3099/)
+    expect(screen.getByRole('link', { name: /settings/i }).getAttribute('href')).toBe(
+      '/settings/connections',
+    )
   })
 
   it('explains the reconnecting state instead of opening an empty popover', () => {

--- a/apps/web/src/components/connection/ConnectionStatus.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.tsx
@@ -20,6 +20,8 @@
  *                the old role="alert" banner loses no assistive-tech signal.
  */
 import type { ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { settingsPath } from '@/lib/app-routes'
 import { cn } from '@/lib/utils'
 import { StateDot, type StateDotTone } from '../StateDot.js'
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover.js'
@@ -43,12 +45,6 @@ export interface ConnectionStatusProps {
   readonly onWorkInBrowser?: () => void
   /** browser only: page-supplied popover extras (daemon detection, capability hint). */
   readonly children?: ReactNode
-  /**
-   * synced only: stop using this daemon in this browser. It does NOT unpair
-   * and does NOT touch anything stored on the daemon — the copy says so,
-   * because "disconnect" reads like a destructive word.
-   */
-  readonly onDisconnect?: () => void
 }
 
 const CHIP_LABEL: Record<ConnectionState, string> = {
@@ -71,7 +67,6 @@ export function ConnectionStatus({
   daemonBaseUrl,
   onRepair,
   onWorkInBrowser,
-  onDisconnect,
   children,
 }: ConnectionStatusProps) {
   // Empty while sync is on: the region has to exist BEFORE the message, but
@@ -123,22 +118,15 @@ export function ConnectionStatus({
               ) : null}
               .
             </p>
-            {onDisconnect && (
-              <div className="mt-1 flex flex-col gap-1.5">
-                <button
-                  type="button"
-                  data-testid="connection-disconnect"
-                  onClick={onDisconnect}
-                  className="text-left font-medium underline"
-                >
-                  Disconnect from this daemon
-                </button>
-                <p className="text-xs text-muted-foreground">
-                  This browser stops using it and stops looking for it. Your data stays on the
-                  daemon and is not deleted; pairing is not revoked.
-                </p>
-              </div>
-            )}
+            {/* The chip reports; it does not manage. Changing which daemon
+                this browser uses is something you go looking for, so it
+                lives in Settings and this only points at it. */}
+            <Link
+              to={settingsPath('connections')}
+              className="mt-1 text-xs font-medium text-primary hover:underline"
+            >
+              Manage in Settings
+            </Link>
           </div>
         )}
         {state === 'reconnecting' && (

--- a/apps/web/src/lib/disconnect-daemon.test.ts
+++ b/apps/web/src/lib/disconnect-daemon.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest'
+import { disconnectFromDaemon } from './disconnect-daemon.js'
+import { createUserSettingsStore } from './user-settings-store.js'
+
+const A = 'http://127.0.0.1:3099'
+const B = 'http://127.0.0.1:4000'
+
+beforeEach(() => localStorage.clear())
+
+describe('disconnectFromDaemon', () => {
+  it('clears the stored target so the next load is not daemon-backed', () => {
+    const store = createUserSettingsStore()
+    store.update((c) => ({ ...c, storage: { ...c.storage, localDaemonBaseUrl: A } }))
+    disconnectFromDaemon(store, A)
+    expect(createUserSettingsStore().load().storage.localDaemonBaseUrl).toBeUndefined()
+  })
+
+  // Forgetting alone is not enough: the default port range is rescanned on
+  // every visit, so the same daemon would come straight back.
+  it('records the dismissal and drops it from the known list', () => {
+    const store = createUserSettingsStore()
+    store.update((c) => ({ ...c, storage: { ...c.storage, knownDaemonBaseUrls: [A, B] } }))
+    disconnectFromDaemon(store, A)
+    const storage = createUserSettingsStore().load().storage
+    expect(storage.dismissedDaemonBaseUrls).toContain(A)
+    expect(storage.knownDaemonBaseUrls).toEqual([B])
+  })
+
+  // Another daemon's stored target is none of this call's business.
+  it('leaves a different daemon connected', () => {
+    const store = createUserSettingsStore()
+    store.update((c) => ({ ...c, storage: { ...c.storage, localDaemonBaseUrl: B } }))
+    disconnectFromDaemon(store, A)
+    expect(createUserSettingsStore().load().storage.localDaemonBaseUrl).toBe(B)
+  })
+
+  it('is a skip-list, not an archive — bounded at five', () => {
+    const store = createUserSettingsStore()
+    for (const port of [3000, 3001, 3002, 3003, 3004, 3005]) {
+      disconnectFromDaemon(store, `http://127.0.0.1:${port}`)
+    }
+    expect(createUserSettingsStore().load().storage.dismissedDaemonBaseUrls).toHaveLength(5)
+  })
+})

--- a/apps/web/src/lib/disconnect-daemon.ts
+++ b/apps/web/src/lib/disconnect-daemon.ts
@@ -1,0 +1,42 @@
+import type { UserSettingsStore } from './user-settings-store.js'
+
+/**
+ * Stop using a daemon in this browser.
+ *
+ * Deliberately NOT an unpair and NOT a delete: nothing on the daemon is
+ * touched and the pairing stays valid, which is why every surface offering
+ * this has to say so — "disconnect" reads like a destructive word.
+ *
+ * Lives here rather than at its call site because the two writes are a pair
+ * and only make sense together:
+ *
+ * - Clearing `localDaemonBaseUrl` is what makes it outlive the page. App.tsx
+ *   reads that key to decide a load is daemon-backed, so leaving it set
+ *   reconnects on the next visit and "this browser stops using it" becomes
+ *   false the moment the user reloads.
+ * - Recording the dismissal is what stops discovery undoing it. The default
+ *   port range is rescanned on every visit, so forgetting alone would bring
+ *   the same daemon straight back and the action would read as a no-op.
+ */
+export function disconnectFromDaemon(store: UserSettingsStore, daemonBaseUrl: string): void {
+  store.update((current) => {
+    const known = (current.storage.knownDaemonBaseUrls ?? []).filter(
+      (entry) => entry !== daemonBaseUrl,
+    )
+    const dismissed = (current.storage.dismissedDaemonBaseUrls ?? []).filter(
+      (entry) => entry !== daemonBaseUrl,
+    )
+    const { localDaemonBaseUrl, ...storage } = current.storage
+    return {
+      ...current,
+      storage: {
+        ...storage,
+        // Another daemon's stored target is none of this call's business.
+        ...(localDaemonBaseUrl === daemonBaseUrl ? {} : { localDaemonBaseUrl }),
+        knownDaemonBaseUrls: known,
+        // Bounded: this is a "skip these" hint, not an archive.
+        dismissedDaemonBaseUrls: [daemonBaseUrl, ...dismissed].slice(0, 5),
+      },
+    }
+  })
+}

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -3,7 +3,7 @@ import { createMemoryRouter, MemoryRouter, RouterProvider } from 'react-router-d
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { celebrate } from '@/lib/celebrate'
 import { initInstallPromptCapture, resetInstallPromptForTests } from '@/lib/install-prompt-store'
-import { STORAGE_KEY } from '@/lib/user-settings-store'
+import { createUserSettingsStore, STORAGE_KEY } from '@/lib/user-settings-store'
 import {
   bindApplyUpdate,
   bindCheckForUpdates,
@@ -389,5 +389,68 @@ describe('SettingsPage — Connections', () => {
     expect(
       await within(mobile).findByRole('button', { name: /refresh storage usage/i }),
     ).toBeTruthy()
+  })
+})
+
+// Disconnecting is a management action: it has an intent behind it, so the
+// user can go looking for it. That is what makes Settings the right home —
+// unlike a dropped sync, which nobody goes looking for and which therefore
+// has to stay on the chip that reports it.
+describe('SettingsPage — disconnecting from a daemon', () => {
+  const DAEMON = 'http://127.0.0.1:3099'
+
+  function renderConnections(onDisconnected = vi.fn()) {
+    render(
+      <MemoryRouter initialEntries={['/settings/connections']}>
+        <SettingsPage daemon={{ baseUrl: DAEMON, token: null }} onDisconnected={onDisconnected} />
+      </MemoryRouter>,
+    )
+    return onDisconnected
+  }
+
+  it('offers the action, and says what it does NOT do', async () => {
+    renderConnections()
+    const desktop = screen.getByTestId('settings-desktop')
+    const button = await within(desktop).findByTestId('settings-disconnect')
+    expect(button).toBeTruthy()
+    // "Disconnect" reads like a destructive word, so the copy has to deny the
+    // destruction it implies.
+    const section = button.closest('section')
+    expect(section?.textContent).toMatch(/stays on the daemon|not deleted/i)
+    expect(section?.textContent).toMatch(/not.*(unpair|revoke)|pairing is not revoked/i)
+  })
+
+  it('records the dismissal so discovery does not bring it straight back', async () => {
+    // The default port range is rescanned on every visit, so forgetting alone
+    // would return this daemon and make the action read as a no-op.
+    createUserSettingsStore().update((current) => ({
+      ...current,
+      storage: { ...current.storage, localDaemonBaseUrl: DAEMON, knownDaemonBaseUrls: [DAEMON] },
+    }))
+    // Asserted rather than assumed: a seed that failed the store's own
+    // validation would make every assertion below pass vacuously.
+    expect(createUserSettingsStore().load().storage.localDaemonBaseUrl).toBe(DAEMON)
+
+    const onDisconnected = renderConnections()
+    const desktop = screen.getByTestId('settings-desktop')
+    fireEvent.click(await within(desktop).findByTestId('settings-disconnect'))
+
+    const storage = createUserSettingsStore().load().storage
+    expect(storage.dismissedDaemonBaseUrls).toContain(DAEMON)
+    expect(storage.knownDaemonBaseUrls ?? []).not.toContain(DAEMON)
+    // App.tsx reads localDaemonBaseUrl to decide a load is daemon-backed, so
+    // leaving it set reconnects on the next visit and "this browser stops
+    // using it" becomes false the moment the user reloads.
+    expect(storage.localDaemonBaseUrl).toBeUndefined()
+    expect(onDisconnected).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows nothing to disconnect from when no daemon is connected', () => {
+    render(
+      <MemoryRouter initialEntries={['/settings/connections']}>
+        <SettingsPage />
+      </MemoryRouter>,
+    )
+    expect(screen.queryByTestId('settings-disconnect')).toBeNull()
   })
 })

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -20,6 +20,7 @@ import { useThemeMode } from '@/hooks/useThemeMode'
 import { parseSettingsRoute, type SettingsSection, settingsPath } from '@/lib/app-routes'
 import { celebrate } from '@/lib/celebrate'
 import { createDaemonFetch } from '@/lib/daemon-api-client'
+import { disconnectFromDaemon } from '@/lib/disconnect-daemon'
 import type { FaviconStyle } from '@/lib/favicon'
 import { getInstallState, promptInstall, subscribeInstallState } from '@/lib/install-prompt-store'
 import { ensurePersistentStorage, queryPersistentStorage } from '@/lib/persistent-storage'
@@ -30,6 +31,13 @@ import { StorageReportCard } from '../components/StorageReportCard.js'
 
 export interface SettingsPageProps {
   daemon?: { baseUrl: string; token: string | null }
+  /**
+   * Called after this browser stops using the daemon, so the App branch can
+   * follow the settings it just wrote. Without it the change only takes
+   * effect on the next load, and the copy's "stops using it" reads as a
+   * no-op for the rest of the session.
+   */
+  onDisconnected?: () => void
 }
 
 const THEME_OPTIONS: Array<{
@@ -182,7 +190,13 @@ function GeneralSection({
 // below) is an accepted tradeoff: PairedOriginsCard/StorageReportCard already
 // own their fetch/error/loading state, and splitting that state out to share
 // across two layouts would add real complexity for a cheap, idempotent GET.
-function ConnectionsSection({ daemon }: { daemon?: { baseUrl: string; token: string | null } }) {
+function ConnectionsSection({
+  daemon,
+  onDisconnected,
+}: {
+  daemon?: { baseUrl: string; token: string | null }
+  onDisconnected?: () => void
+}) {
   if (!daemon) {
     return (
       <section>
@@ -203,9 +217,35 @@ function ConnectionsSection({ daemon }: { daemon?: { baseUrl: string; token: str
         <section aria-label="Storage">
           <StorageReportCard />
         </section>
+        {/* Management, not status: the chip reports which daemon keeps this
+            workspace, and changing that is an intent you arrive here with. */}
+        <section aria-label="This daemon" className="flex flex-col gap-1.5">
+          <p className="text-sm">
+            Connected to <span className="font-mono text-xs">{stripScheme(daemon.baseUrl)}</span>
+          </p>
+          <button
+            type="button"
+            data-testid="settings-disconnect"
+            onClick={() => {
+              disconnectFromDaemon(settingsStore, daemon.baseUrl)
+              onDisconnected?.()
+            }}
+            className="self-start rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent"
+          >
+            Disconnect from this daemon
+          </button>
+          <p className="text-xs text-muted-foreground">
+            This browser stops using it and stops looking for it. Your data stays on the daemon and
+            is not deleted; pairing is not revoked.
+          </p>
+        </section>
       </div>
     </DaemonApiContext.Provider>
   )
+}
+
+function stripScheme(baseUrl: string): string {
+  return baseUrl.replace(/^https?:\/\//, '')
 }
 
 /**
@@ -250,6 +290,7 @@ function sectionContent(
     onProtect: () => void
     installStatus: 'installed' | 'installable' | 'not-captured'
     daemon?: { baseUrl: string; token: string | null }
+    onDisconnected?: () => void
   },
 ) {
   switch (section) {
@@ -284,7 +325,7 @@ function sectionContent(
     case 'fonts':
       return <FontsSection daemon={props.daemon} />
     case 'connections':
-      return <ConnectionsSection daemon={props.daemon} />
+      return <ConnectionsSection daemon={props.daemon} onDisconnected={props.onDisconnected} />
   }
 }
 
@@ -304,7 +345,7 @@ const SECTION_TITLE: Record<SettingsSection, string> = {
  * current section's content twice while it's the active route (see
  * ConnectionsSection's fetch-cost note above).
  */
-export function SettingsPage({ daemon }: SettingsPageProps) {
+export function SettingsPage({ daemon, onDisconnected }: SettingsPageProps) {
   const location = useLocation()
   const navigate = useNavigate()
   const parsed = parseSettingsRoute(location.pathname)
@@ -421,6 +462,7 @@ export function SettingsPage({ daemon }: SettingsPageProps) {
     onProtect: handleProtect,
     installStatus: installState.status,
     daemon,
+    onDisconnected,
   }
 
   return (


### PR DESCRIPTION
## Summary

- **Both halves were in the wrong place.** The connection chip carried "Disconnect from this daemon" while Settings → Connections carried the connection's *status*. Management had ended up on the status carrier, and status in the management surface.
- **The dividing question is whether the user would know to look.** A dropped sync is not something anyone goes looking for, so its recovery — re-pair, work in the browser instead — stays on the chip that reports it; sending someone to Settings mid-failure adds a step at the worst possible moment. Changing which daemon this browser uses has an intent behind it, so it lives in Settings and the chip's synced popover only points there.
- **The two writes that make a disconnect stick move to `lib/disconnect-daemon.ts`** because they are a pair and only make sense together: clearing `localDaemonBaseUrl` is what makes it outlive the page, and recording the dismissal is what stops the next port scan undoing it.
- **Settings gains `onDisconnected`** so the App branch follows the settings it just wrote — otherwise the change only takes effect on the next load, and "this browser stops using it" reads as a no-op for the rest of the session.

Continues the header re-cut (#1004, #1006, #1007, #1029) and closes the placement question that #1007 opened by moving the chip to the shell.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [x] `pnpm test` passes locally
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable

Red-first: three tests failed before the move — the chip carrying no management action, and Settings offering the action plus recording the dismissal.

Mutation-checked, each confirmed red against `disconnect-daemon.test.ts`:

| mutation | result |
|---|---|
| keep `localDaemonBaseUrl` instead of clearing it | 1 failed |
| drop the dismissal record | 2 failed |
| clear the target unconditionally (ignoring which daemon) | 1 failed |

Suites run: `apps/web` jsdom + node (2662, the CI command), `pnpm test:browser` (761, all green), `arch-lint-node` (92), `pnpm -r typecheck`, `pnpm lint`, `pnpm knip` — all clean.

Pre-existing failures on this machine, unchanged and identical to the set verified against a clean tree in #1007: 9 `apps/web` objectURL/thumbnail tests. The pre-push gate was bypassed for the 4 `mcp-node` EACCES tests (chmod is a no-op for root).

**Manual verification** in the running app: the chip's popover no longer contains a disconnect control (0 found), and Settings → Connections states the disconnected case rather than offering an action.

**What was not verified live:** the *connected* branch — "Connected to `<host>`" plus the button — is covered at the jsdom layer with a daemon prop. Verifying it in a browser needs a paired daemon session, which this run did not have.

## Visual evidence

Settings → Connections, browser mode (no daemon to disconnect from, so it says so):

```
Connections

Daemon — Not connected
A daemon on this machine holds durable storage and the AI agent connection for this app.
```

Connected, per the jsdom-covered branch:

```
Connections
  Paired web apps …
  Storage …
  Connected to 127.0.0.1:3099
  [ Disconnect from this daemon ]
  This browser stops using it and stops looking for it. Your data stays on
  the daemon and is not deleted; pairing is not revoked.
```

Screenshot at `tmp/screenshots/disconnect-settings.png`; the `gh image` extension is unavailable in this environment, so it could not be uploaded inline.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — `apps/web/DESIGN.md` gains the "status reports; Settings manages" rule and states the dividing question
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema


---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_