### PR TITLE
test(web): every browser test puts the caret in an editor through one helper

### DIFF
--- a/apps/web/src/components/document-editor/NodeTextEditorOverlay.browser.test.tsx
+++ b/apps/web/src/components/document-editor/NodeTextEditorOverlay.browser.test.tsx
@@ -5,6 +5,7 @@
 import { cleanup, render, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { focusEditable } from '../../test-utils/focus-editable.js'
 import { NodeTextEditorOverlay } from './NodeTextEditorOverlay.js'
 
 afterEach(cleanup)
@@ -35,9 +36,9 @@ function renderOverlay(
 }
 
 async function typeInto(container: HTMLElement, text: string): Promise<void> {
-  const editable = container.querySelector('[contenteditable="true"]')
-  if (!editable) throw new Error('expected a contenteditable CodeMirror host')
-  await userEvent.click(editable.querySelector('.cm-line') as HTMLElement)
+  // The click this replaces contributed nothing but its own wait: Ctrl+End
+  // discards whatever caret it produced.
+  await focusEditable(() => container.querySelector('[contenteditable="true"]'))
   await userEvent.keyboard('{Control>}{End}{/Control}')
   await userEvent.keyboard(text)
 }

--- a/apps/web/src/components/markdown-editor/editor-catalog.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/editor-catalog.browser.test.tsx
@@ -6,6 +6,7 @@
 import { cleanup, render, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { focusEditable } from '../../test-utils/focus-editable.js'
 import { MarkdownEditor } from './MarkdownEditor.js'
 
 afterEach(() => {
@@ -14,11 +15,17 @@ afterEach(() => {
 })
 
 async function caretInto(container: HTMLElement, right: number): Promise<void> {
-  const editable = container
-    .querySelector('[data-testid="markdown-source-pane"]')
-    ?.querySelector('[contenteditable="true"]')
-  if (!editable) throw new Error('expected a contenteditable CodeMirror host')
-  await userEvent.click(editable.querySelector('.cm-line') as HTMLElement)
+  // Focus, then place the caret absolutely. The click this replaces was never
+  // placing it — Ctrl+Home discards whatever position it produced — so all it
+  // contributed was `userEvent.click`'s wait for the target to be "stable",
+  // which the preview pane's Canvas 2D re-measurement never satisfies under a
+  // saturated run.
+  await focusEditable(
+    () =>
+      container
+        .querySelector('[data-testid="markdown-source-pane"]')
+        ?.querySelector('[contenteditable="true"]') ?? null,
+  )
   await userEvent.keyboard('{Control>}{Home}{/Control}')
   for (let i = 0; i < right; i++) await userEvent.keyboard('{ArrowRight}')
 }

--- a/apps/web/src/components/markdown-editor/link-picker.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/link-picker.browser.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { focusEditable } from '../../test-utils/focus-editable.js'
 import type { LinkTarget } from './link-target.js'
 import { MarkdownEditor } from './MarkdownEditor.js'
 
@@ -21,11 +22,17 @@ const targets: readonly LinkTarget[] = [
 ]
 
 async function caretInto(container: HTMLElement, right: number): Promise<void> {
-  const editable = container
-    .querySelector('[data-testid="markdown-source-pane"]')
-    ?.querySelector('[contenteditable="true"]')
-  if (!editable) throw new Error('expected a contenteditable CodeMirror host')
-  await userEvent.click(editable.querySelector('.cm-line') as HTMLElement)
+  // Focus, then place the caret absolutely. The click this replaces was never
+  // placing it — Ctrl+Home discards whatever position it produced — so all it
+  // contributed was `userEvent.click`'s wait for the target to be "stable",
+  // which the preview pane's Canvas 2D re-measurement never satisfies under a
+  // saturated run.
+  await focusEditable(
+    () =>
+      container
+        .querySelector('[data-testid="markdown-source-pane"]')
+        ?.querySelector('[contenteditable="true"]') ?? null,
+  )
   await userEvent.keyboard('{Control>}{Home}{/Control}')
   for (let i = 0; i < right; i++) await userEvent.keyboard('{ArrowRight}')
 }
@@ -153,8 +160,7 @@ describe('the link picker (real browser)', () => {
 
     // Back into the document, caret to the end, then pick from the still-open
     // dialog.
-    const editable = container.querySelector('[contenteditable="true"]') as HTMLElement
-    await userEvent.click(editable.querySelector('.cm-line') as HTMLElement)
+    await focusEditable(() => container.querySelector('[contenteditable="true"]'))
     await userEvent.keyboard('{Control>}{End}{/Control}')
     await userEvent.click(container.querySelectorAll('[role="option"]')[0] as HTMLElement)
 
@@ -174,8 +180,7 @@ describe('the link picker (real browser)', () => {
     expect((picker.querySelector('#link-picker-search') as HTMLInputElement).value).toBe('weekly')
 
     // Type at the very start of the document while the picker is open.
-    const editable = container.querySelector('[contenteditable="true"]') as HTMLElement
-    await userEvent.click(editable.querySelector('.cm-line') as HTMLElement)
+    await focusEditable(() => container.querySelector('[contenteditable="true"]'))
     await userEvent.keyboard('{Control>}{Home}{/Control}')
     await userEvent.keyboard('SEE ')
     await userEvent.click(container.querySelectorAll('[role="option"]')[0] as HTMLElement)

--- a/apps/web/src/components/markdown-editor/markdown-editor.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/markdown-editor.browser.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { focusEditable } from '../../test-utils/focus-editable.js'
 import { MarkdownEditor } from './MarkdownEditor.js'
 
 // CodeMirror's own DOM/input handling, and real Canvas 2D text measurement,
@@ -19,27 +20,13 @@ describe('MarkdownEditor (real browser)', () => {
       <MarkdownEditor initialViewMode="split" value="" onChange={onChange} />,
     )
 
-    const editable = getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]')
-    expect(editable).not.toBeNull()
-    if (!editable)
-      throw new Error('expected a contenteditable CodeMirror host')
-
-      // focus(), not click(). A click waits for the element to be "visible,
-      // enabled and stable", and the preview pane beside this one re-renders
-      // through real Canvas 2D text measurement — under a saturated run the
-      // layout keeps settling and that actionability check never passes. It is
-      // not slowness: this test costs 369ms idle and spends the entire 60s
-      // budget in CI, which is a wait for a condition, not a slow pass.
-      //
-      // What the test is about is that typing produces onChange, so focus is a
-      // precondition to establish rather than an interaction to perform. Exact
-      // contentDOM identity is what real keyboard delivery depends on —
-      // `BrowserLocalIndexPage.flow.browser.test.tsx` asserts the same thing for
-      // the same reason.
-    ;(editable as HTMLElement).focus()
-    await vi.waitFor(() => {
-      expect(document.activeElement).toBe(editable)
-    })
+    // Focus is a precondition to establish here, not an interaction to
+    // perform — what the test is about is that typing produces onChange. The
+    // helper carries the rest of the reasoning, including why the focus call
+    // has to be re-done on every attempt rather than once before the wait.
+    await focusEditable(() =>
+      getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]'),
+    )
     await userEvent.keyboard('# Hello world')
 
     expect(onChange).toHaveBeenCalled()
@@ -53,12 +40,15 @@ describe('MarkdownEditor (real browser)', () => {
       <MarkdownEditor initialViewMode="split" value="make this bold" onChange={onChange} />,
     )
 
-    const editable = getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]')
-    if (!editable) throw new Error('expected a contenteditable CodeMirror host')
-
-    // Select the word "this" (offsets 5..9) from the document start.
-    await userEvent.click(editable.querySelector('.cm-line') as HTMLElement)
-    await userEvent.keyboard('{Home}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}')
+    // Select the word "this" (offsets 5..9) from the document start. Ctrl+Home
+    // rather than Home: the click this replaces only ever reached the first
+    // line by hit-testing, and an absolute move says what the test means.
+    await focusEditable(() =>
+      getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]'),
+    )
+    await userEvent.keyboard(
+      '{Control>}{Home}{/Control}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}',
+    )
     await userEvent.keyboard('{Shift>}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}{/Shift}')
 
     await userEvent.click(getByRole('button', { name: 'Editing actions' }))

--- a/apps/web/src/components/markdown-editor/placeholder-caret.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/placeholder-caret.browser.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { focusEditable } from '../../test-utils/focus-editable.js'
 import { MarkdownEditor } from './MarkdownEditor.js'
 
 afterEach(() => {
@@ -17,12 +18,12 @@ describe('empty-document caret', () => {
     const { getByTestId } = render(
       <MarkdownEditor initialViewMode="write" value="" onChange={() => {}} />,
     )
-    const editable = getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]')
-    if (!editable) throw new Error('expected a contenteditable CodeMirror host')
-    ;(editable as HTMLElement).focus()
-    await vi.waitFor(() => {
-      expect(document.activeElement).toBe(editable)
-    })
+    const resolveEditable = () =>
+      getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]')
+    await focusEditable(resolveEditable)
+    // Read AFTER the helper settled, not from a node captured before it: the
+    // contentDOM it focused is the one this test means.
+    const editable = resolveEditable() as HTMLElement
 
     const placeholder = editable.querySelector('.cm-placeholder')
     expect(placeholder).not.toBeNull()

--- a/apps/web/src/components/markdown-editor/source-pane-reconcile.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/source-pane-reconcile.browser.test.tsx
@@ -76,10 +76,12 @@ describe('SourcePane external value reconciliation (real browser)', () => {
       <MarkdownEditor initialViewMode="write" value={'keep me\ntail'} onChange={onChange} />,
     )
 
-    // Click the FIRST LINE, not the content element: the content column has
-    // vertical padding, so its center point can map to a different line.
-    await userEvent.click(editableOf().querySelector('.cm-line') as HTMLElement)
-    await userEvent.keyboard('{Home}')
+    // Ctrl+Home rather than a click on the first line: the click had to reach
+    // that line by hit-testing (the content column's vertical padding could
+    // map its center to another line), and an absolute move states the intent
+    // without depending on layout at all.
+    await focusEditable(editableOf)
+    await userEvent.keyboard('{Control>}{Home}{/Control}')
     // Select "keep" on the first line.
     await userEvent.keyboard('{Shift>}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}{/Shift}')
 

--- a/apps/web/src/components/markdown-editor/wiki-link-completion.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/wiki-link-completion.browser.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { focusEditable } from '../../test-utils/focus-editable.js'
 import { MarkdownEditor } from './MarkdownEditor.js'
 
 // Real-keyboard regression for the [[ completion: CodeMirror's completion
@@ -27,12 +28,9 @@ describe('wiki link completion (real browser)', () => {
     const { getByTestId } = render(
       <MarkdownEditor initialViewMode="write" value="" onChange={onChange} linkTargets={TARGETS} />,
     )
-    const editable = getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]')
-    if (!editable) throw new Error('expected a contenteditable CodeMirror host')
-    ;(editable as HTMLElement).focus()
-    await vi.waitFor(() => {
-      expect(document.activeElement).toBe(editable)
-    })
+    await focusEditable(() =>
+      getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]'),
+    )
 
     // user-event treats [[ as an escaped literal [ — four brackets type two.
     await userEvent.keyboard('see [[[[Re')
@@ -72,12 +70,9 @@ describe('wiki link completion (real browser)', () => {
         linkTargets={TARGETS}
       />,
     )
-    const editable = getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]')
-    if (!editable) throw new Error('expected a contenteditable CodeMirror host')
-    ;(editable as HTMLElement).focus()
-    await vi.waitFor(() => {
-      expect(document.activeElement).toBe(editable)
-    })
+    await focusEditable(() =>
+      getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]'),
+    )
     await userEvent.keyboard('see [[[[Ret')
     const option = await vi.waitFor(() => {
       const el = [...document.querySelectorAll('.cm-tooltip-autocomplete li')].find((li) =>
@@ -110,12 +105,9 @@ describe('wiki link completion (real browser)', () => {
       )
     }
     const { getByTestId } = render(<Harness />)
-    const editable = getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]')
-    if (!editable) throw new Error('expected a contenteditable CodeMirror host')
-    ;(editable as HTMLElement).focus()
-    await vi.waitFor(() => {
-      expect(document.activeElement).toBe(editable)
-    })
+    await focusEditable(() =>
+      getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]'),
+    )
     await userEvent.keyboard('see [[[[Re')
     await vi.waitFor(() => {
       expect(
@@ -147,12 +139,9 @@ describe('wiki link completion (real browser)', () => {
         linkTargets={TARGETS}
       />,
     )
-    const editable = getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]')
-    if (!editable) throw new Error('expected a contenteditable CodeMirror host')
-    ;(editable as HTMLElement).focus()
-    await vi.waitFor(() => {
-      expect(document.activeElement).toBe(editable)
-    })
+    await focusEditable(() =>
+      getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]'),
+    )
     await userEvent.keyboard('see [[[[Ret')
     const option = await vi.waitFor(() => {
       const el = [...document.querySelectorAll('.cm-tooltip-autocomplete li')].find((li) =>
@@ -215,12 +204,9 @@ describe('wiki link completion (real browser)', () => {
     const { getByTestId } = render(
       <MarkdownEditor initialViewMode="write" value="" onChange={() => {}} linkTargets={TARGETS} />,
     )
-    const editable = getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]')
-    if (!editable) throw new Error('expected a contenteditable CodeMirror host')
-    ;(editable as HTMLElement).focus()
-    await vi.waitFor(() => {
-      expect(document.activeElement).toBe(editable)
-    })
+    await focusEditable(() =>
+      getByTestId('markdown-source-pane').querySelector('[contenteditable="true"]'),
+    )
     await userEvent.keyboard('Release plan is due')
     // Give any (wrong) async popup a beat to appear before asserting absence.
     await new Promise((resolve) => setTimeout(resolve, 300))

--- a/apps/web/src/editor-focus-discipline.test.ts
+++ b/apps/web/src/editor-focus-discipline.test.ts
@@ -1,0 +1,72 @@
+// `userEvent.click` waits for its target to be "visible, enabled and stable".
+// A CodeMirror editor in this app sits beside a preview pane that re-renders
+// through real Canvas 2D text measurement, so under a saturated run the layout
+// keeps settling and that check never passes: the test spends its whole budget
+// on a precondition and never reaches what it asserts. Measured on one such
+// test: 369ms idle, 60s in CI.
+//
+// Clicking a `.cm-line` is how that wait gets in. `focusEditable` does the same
+// job without it — see `test-utils/focus-editable.ts`.
+//
+// The rule is precise rather than a judgement call: a click followed by an
+// ABSOLUTE caret move (`Ctrl+Home` / `Ctrl+End`) is a focus click, because that
+// move discards whatever position the click produced. All seven `.cm-line`
+// clicks that existed when this guard was written turned out to be exactly
+// that, so none of them was buying what it looked like it was buying.
+//
+// A test that genuinely needs the click's OWN position is a different case and
+// this guard does not know how to tell them apart — say so with the escape
+// comment on the line above and it will pass.
+//
+// Source is captured at build time via `?raw` rather than read at runtime, so
+// this stays free of `node:fs` — apps/web is browser-only (see
+// web-app-boundary.test.ts).
+
+import { describe, expect, it } from 'vitest'
+
+const sources = import.meta.glob('./**/*.browser.test.tsx', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+/** Opt out on the line above the click, naming why the position is the point. */
+const ESCAPE = 'cm-line-click-is-deliberate:'
+
+// `.*` rather than `[^)]*`: the resolver is often a CALL
+// (`editableOf().querySelector('.cm-line')`), and stopping at the first `)`
+// silently skipped one of the seven this guard was written for.
+const CLICK_ON_A_LINE = /userEvent\.click\(.*\.cm-line/
+
+/**
+ * The other way the caret gets into an editor without the helper: `focus()`
+ * called on a node the test resolved earlier. Two shapes, one defect —
+ * `focus()` on a detached or not-yet-mounted contentDOM is a no-op, and
+ * whatever waits afterwards cannot recover because nothing re-attempts it.
+ * `focusEditable` re-resolves AND re-focuses on every attempt.
+ */
+const RAW_FOCUS_ON_AN_EDITABLE = /\beditable[A-Za-z]*\s*(?:as HTMLElement\)?)?\s*\.focus\(\)/
+
+describe('putting the caret in a CodeMirror editor from a browser test', () => {
+  it('goes through focusEditable, not a .cm-line click or a bare focus()', () => {
+    const offenders: string[] = []
+    for (const [path, source] of Object.entries(sources)) {
+      const lines = source.split('\n')
+      lines.forEach((line, i) => {
+        if (!CLICK_ON_A_LINE.test(line) && !RAW_FOCUS_ON_AN_EDITABLE.test(line)) return
+        const preceding = lines.slice(Math.max(0, i - 3), i).join('\n')
+        if (preceding.includes(ESCAPE)) return
+        offenders.push(`${path}:${i + 1}`)
+      })
+    }
+    expect(
+      offenders,
+      `These put the caret in a CodeMirror editor without focusEditable — by clicking a ` +
+        `.cm-line (which waits for the neighbouring preview to be "stable", and under load it ` +
+        `never is) or by calling focus() on a node resolved earlier (a no-op if it is detached ` +
+        `or not yet mounted, and nothing re-attempts it). Use focusEditable(resolver), and ` +
+        `place the caret with an absolute move. If the click's own position IS the test, put a ` +
+        `"${ESCAPE} <why>" comment above it.\n  ${offenders.join('\n  ')}`,
+    ).toEqual([])
+  })
+})

--- a/apps/web/src/pages/BrowserLocalDocumentPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserLocalDocumentPage.markdown.browser.test.tsx
@@ -413,15 +413,14 @@ describe('BrowserLocalDocumentPage markdown 導線 (real IndexedDB)', () => {
     })
     render(<BrowserLocalDocumentPage store={store} />)
 
-    const editable = await waitFor(
-      () => {
-        const el = document.querySelector('[contenteditable="true"]')
-        expect(el).not.toBeNull()
-        return el as HTMLElement
-      },
-      { timeout: 10_000 },
-    )
-    editable.focus()
+    // focusEditable rather than focus() on the node resolved a moment ago:
+    // under load the contentDOM can arrive late or be swapped, and focus()
+    // on a detached element is a spec'd no-op that no wait here would
+    // recover from — the keystrokes simply go nowhere. It also answers the
+    // reason a click is wrong on this page: there are TWO role=textbox
+    // elements (the title input and CodeMirror's content), so a click
+    // locator on the contenteditable is ambiguous under strict mode.
+    await focusEditable(() => document.querySelector('[contenteditable="true"]'))
 
     await userEvent.click(await screen.findByRole('button', { name: 'Editing actions' }))
     await userEvent.click(await screen.findByRole('menuitem', { name: 'Link' }))
@@ -456,18 +455,14 @@ describe('BrowserLocalDocumentPage markdown 導線 (real IndexedDB)', () => {
       </>,
     )
 
-    const editable = await waitFor(
-      () => {
-        const el = document.querySelector('[contenteditable="true"]')
-        expect(el).not.toBeNull()
-        return el as HTMLElement
-      },
-      { timeout: 10_000 },
-    )
-    // focus() instead of click(): the page has TWO role=textbox elements
-    // (the title input and CodeMirror's content), so a click locator on the
-    // contenteditable is ambiguous under playwright's strict mode.
-    editable.focus()
+    // focusEditable rather than focus() on the node resolved a moment ago:
+    // under load the contentDOM can arrive late or be swapped, and focus()
+    // on a detached element is a spec'd no-op that no wait here would
+    // recover from — the keystrokes simply go nowhere. It also answers the
+    // reason a click is wrong on this page: there are TWO role=textbox
+    // elements (the title input and CodeMirror's content), so a click
+    // locator on the contenteditable is ambiguous under strict mode.
+    await focusEditable(() => document.querySelector('[contenteditable="true"]'))
     // `[[` doubled: userEvent.keyboard's escape for a literal `[`.
     await userEvent.keyboard('See [[[[Target note]] here.')
 
@@ -513,15 +508,14 @@ describe('BrowserLocalDocumentPage markdown 導線 (real IndexedDB)', () => {
     await new LoroStore().save(TARGET_ID, targetDoc.export({ mode: 'snapshot' }))
     render(<BrowserLocalDocumentPage store={store} />)
 
-    const editable = await waitFor(
-      () => {
-        const el = document.querySelector('[contenteditable="true"]')
-        expect(el).not.toBeNull()
-        return el as HTMLElement
-      },
-      { timeout: 10_000 },
-    )
-    editable.focus()
+    // focusEditable rather than focus() on the node resolved a moment ago:
+    // under load the contentDOM can arrive late or be swapped, and focus()
+    // on a detached element is a spec'd no-op that no wait here would
+    // recover from — the keystrokes simply go nowhere. It also answers the
+    // reason a click is wrong on this page: there are TWO role=textbox
+    // elements (the title input and CodeMirror's content), so a click
+    // locator on the contenteditable is ambiguous under strict mode.
+    await focusEditable(() => document.querySelector('[contenteditable="true"]'))
     // Trailing keystrokes AFTER the reference completes are the regression
     // surface: each one re-runs the embed-content effect while the load is
     // in flight, and a per-effect cancellation dropped the result with
@@ -596,15 +590,14 @@ describe('BrowserLocalDocumentPage markdown 導線 (real IndexedDB)', () => {
       await seedLegacyNote(store, 'Legacy note')
       const first = render(<BrowserLocalDocumentPage store={store} />)
 
-      const editable = await waitFor(
-        () => {
-          const el = document.querySelector('.cm-content')
-          expect(el).not.toBeNull()
-          return el as HTMLElement
-        },
-        { timeout: 10_000 },
-      )
-      editable.focus()
+      // focusEditable rather than focus() on the node resolved a moment ago:
+      // under load the contentDOM can arrive late or be swapped, and focus()
+      // on a detached element is a spec'd no-op that no wait here would
+      // recover from — the keystrokes simply go nowhere. It also answers the
+      // reason a click is wrong on this page: there are TWO role=textbox
+      // elements (the title input and CodeMirror's content), so a click
+      // locator on the contenteditable is ambiguous under strict mode.
+      await focusEditable(() => document.querySelector('[contenteditable="true"]'))
       await userEvent.keyboard('{Control>}{End}{/Control}{Enter}and an appended line')
       await waitFor(() => {
         expect(document.querySelector('.cm-content')?.textContent).toContain('and an appended line')
@@ -635,15 +628,14 @@ describe('BrowserLocalDocumentPage markdown 導線 (real IndexedDB)', () => {
       })
       render(<BrowserLocalDocumentPage store={store} />)
 
-      const editable = await waitFor(
-        () => {
-          const el = document.querySelector('[contenteditable="true"]')
-          expect(el).not.toBeNull()
-          return el as HTMLElement
-        },
-        { timeout: 10_000 },
-      )
-      editable.focus()
+      // focusEditable rather than focus() on the node resolved a moment ago:
+      // under load the contentDOM can arrive late or be swapped, and focus()
+      // on a detached element is a spec'd no-op that no wait here would
+      // recover from — the keystrokes simply go nowhere. It also answers the
+      // reason a click is wrong on this page: there are TWO role=textbox
+      // elements (the title input and CodeMirror's content), so a click
+      // locator on the contenteditable is ambiguous under strict mode.
+      await focusEditable(() => document.querySelector('[contenteditable="true"]'))
       await userEvent.keyboard(`![[[[${LEGACY_ID}]]{Enter}{Enter}trailing`)
 
       await waitFor(

--- a/apps/web/src/test-utils/focus-editable.ts
+++ b/apps/web/src/test-utils/focus-editable.ts
@@ -16,10 +16,20 @@ import { expect, vi } from 'vitest'
  * so this waits for `document.activeElement` to BE the element rather than to
  * contain it: focus sitting on an ancestor drops the keystrokes silently.
  *
- * Use this only where the click exists to establish focus. A click on a
- * specific `.cm-line` also places the caret at that position, and replacing it
- * with `focus()` would move the caret to wherever CodeMirror last had it — a
- * different test.
+ * Use this where the caret's position is not what the click was for. The rule
+ * is precise rather than a judgement call: **a click followed by an absolute
+ * caret move is a focus click**, because `Ctrl+Home` / `Ctrl+End` discards
+ * whatever position either the click or `focus()` produced. Only a test that
+ * reads the click's OWN position — one that does not immediately move the
+ * caret somewhere absolute — is a different test after the swap.
+ *
+ * That distinction was worth measuring rather than assuming. Every one of the
+ * seven `.cm-line` clicks left in this repo turned out to discard its own
+ * caret on the very next keystroke, so all seven converted without changing
+ * what they assert. Two of them wrote `{Home}` (start of the CURRENT line)
+ * and relied on the click having landed on the first line by hit-testing;
+ * those became `{Control>}{Home}{/Control}`, which states the same intent and
+ * cannot be moved by layout.
  *
  * Everything below is re-done on EVERY attempt, because each step can be
  * invalidated between attempts by state this test does not own:


### PR DESCRIPTION
## The mechanism

The load-dependent `web-browser` flake family has one mechanism, and it is not slowness: a test never actually gets focus into CodeMirror, then spends its whole 60s budget waiting on something the missing keystrokes were supposed to cause. `focusEditable` was written for exactly this (#919, #929). **19 sites still went around it.**

Three shapes, one defect:

| shape | sites | why it fails under load |
|---|---:|---|
| click on a `.cm-line` | 7 | `userEvent.click` waits for "visible, enabled and stable"; the preview pane beside the editor re-renders through real Canvas 2D measurement, so under saturation that check never passes |
| hand-rolled focus-then-wait | 7 | `focus()` called once OUTSIDE the retry, then a wait for `document.activeElement` — the shape #919 fixed in the helper, because a focus landing before CodeMirror finishes mounting is void and nothing re-attempts it |
| bare `editable.focus()` on a node resolved earlier | 5 | no wait at all, and `focus()` on a detached element is a spec'd no-op |

The third shape is the one that was actually failing when this started: `renders as an ![[embed]] target`, 68s, in a file the ticket's list did not mention.

## The blocker the ticket recorded turned out not to hold

The ticket scoped this to the 7 `.cm-line` clicks and called them stuck: those clicks also place the caret, so swapping in `focus()` would make them different tests. `focusEditable`'s own doc comment carried the same caveat.

Reading all seven says otherwise — **every one discards the click's caret on its very next keystroke** (`Ctrl+Home`, `Ctrl+End`, or `{Home}`), so the click was only ever buying its own wait:

| site | next keystroke | uses the click's caret? |
|---|---|---|
| editor-catalog:21 | `Ctrl+Home` then N× → | no |
| link-picker:28 | `Ctrl+Home` then N× → | no |
| link-picker:157 | `Ctrl+End` | no |
| link-picker:178 | `Ctrl+Home` | no |
| markdown-editor:60 | `{Home}` then 5× → | no |
| NodeTextEditorOverlay:40 | `Ctrl+End` | no |
| source-pane-reconcile:81 | `{Home}` | no |

Two wrote bare `{Home}` (start of the CURRENT line) and relied on the click having reached the first line by hit-testing; those became `{Control>}{Home}{/Control}`, which states the same intent and cannot be moved by layout. The helper's caveat now carries the measured rule: **a click followed by an absolute caret move is a focus click.**

## The guard

`editor-focus-discipline.test.ts` keeps both shapes out, with an escape comment for a test whose click position genuinely IS the assertion.

Its first regex used `[^)]*` and so stopped at the first `)` — missing `editableOf().querySelector('.cm-line')`, one of the seven, silently. Comparing what it found (6) against the known count (7) is what caught it.

## Verification

`web-browser` 765/765, apps/web jsdom 2750 + node 77, lint / knip / typecheck clean.

Both halves of the guard mutation-checked, each printing the planted line count before the run so a no-op edit cannot read as a pass:

- bare click, no escape → `Tests 1 failed`, `planted: clicks=1 escape=0`
- same click with the escape comment → `Tests 1 passed`, `planted: clicks=1 escape=1`
- raw `focus()` planted → guard names the file and line

## What this does NOT claim

**No local before/after timing number.** The two full-project runs under the ticket's load harness were not comparable: one had orphaned load generators from a killed run still burning 12 cores (my own cleanup missed them — the process name is `wbload<pid>`, so `pgrep -c wbload` answered 0), and another session was building throughout. Pass/fail under saturation is itself probabilistic — the unconverted tree failed 3 tests in one run and 0 in the very next.

The honest scoreboard is the one the ticket already uses: **`test-browser` failures on main, currently ~3 in 12 runs.** That is where this should be judged over the coming runs, and it is now cheaper to read since #952 split the job into two shards.

Visual evidence: none — test-harness changes only; nothing here is rendered to anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoaNgqWUKbYJxk2azmRQKY