### PR TITLE
feat(mcp): wb_document_create takes the body, so a note is one call

### DIFF
--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -211,6 +211,40 @@ async function main() {
     kind: 'markdown',
     name: 'リリース計画 2026 / v2',
   })
+  // A markdown document arrives with its body in ONE call. The MCP SDK
+  // validates structuredContent against outputSchema at runtime, so this is
+  // also where a discriminated-union input schema proves it survives the
+  // wire: the shape a client sends is not the shape a test constructs.
+  const withBody = await callTool('wb_document_create', {
+    workspaceId: WORKSPACE_ID,
+    path: 'e2e-with-body',
+    kind: 'markdown',
+    name: 'created with its body',
+    markdown: '---\ntype: note\ntags:\n  - e2e\n---\nWritten at creation time.',
+  })
+  const readBack = await callTool('wb_document_get', {
+    workspaceId: WORKSPACE_ID,
+    documentId: withBody.documentId,
+  })
+  if (!readBack.content.includes('Written at creation time.')) {
+    throw new Error(`wb_document_create did not persist its body: ${readBack.content}`)
+  }
+  console.log('[e2e] wb_document_create → body written in one call')
+
+  // The union's other side: a spatial document takes no markdown, and the
+  // refusal must reach the client rather than the content being dropped.
+  await expectToolError(
+    'wb_document_create',
+    {
+      workspaceId: WORKSPACE_ID,
+      path: 'e2e-spatial-body',
+      kind: 'spatial',
+      markdown: '# nope',
+    },
+    'with markdown on a spatial document',
+    'markdown',
+  )
+
   const namedList = await callTool('wb_document_list', { workspaceId: WORKSPACE_ID })
   const namedRow = namedList.documents.find((c) => c.documentId === named.documentId)
   if (namedRow?.name !== 'リリース計画 2026 / v2') {

--- a/packages/mcp-server/src/server/mcp/document-tools.ts
+++ b/packages/mcp-server/src/server/mcp/document-tools.ts
@@ -306,7 +306,7 @@ export function registerDocumentTools(server: McpServer, deps: ServerDeps): void
     'wb_document_create',
     {
       description: WB_DOCUMENT_CREATE_DESCRIPTION,
-      inputSchema: wbDocumentCreateInputSchema.shape,
+      inputSchema: wbDocumentCreateInputSchema,
       outputSchema: wbDocumentCreateOutputSchema,
     },
     async (args) => {

--- a/packages/server-core/src/tools/document-create-body.test.ts
+++ b/packages/server-core/src/tools/document-create-body.test.ts
@@ -1,0 +1,65 @@
+import { InMemoryDocumentIndex } from '@kamiazya/whiteboard-ports/test-utils'
+import { describe, expect, it } from 'vitest'
+import { createInMemoryDocumentStore } from '../test-utils/in-memory-document-store.js'
+import { wbDocumentCreate } from './document-crud.js'
+import { createDocumentGetTool } from './document-get.js'
+
+const WS = 'create-body'
+
+function makeDeps() {
+  return {
+    documentStore: createInMemoryDocumentStore(),
+    blobStore: {} as never,
+    documentIndex: new InMemoryDocumentIndex(),
+  }
+}
+
+const MARKDOWN = '---\ntype: note\ntags:\n  - alpha\n---\nThe body, written at creation time.'
+
+describe('creating a markdown document with its body', () => {
+  it('needs one call, not two', async () => {
+    const deps = makeDeps()
+    const created = await wbDocumentCreate(deps, {
+      workspaceId: WS,
+      path: 'untitled-1',
+      kind: 'markdown',
+      name: 'note',
+      createWorkspace: true,
+      markdown: MARKDOWN,
+    })
+    const read = await createDocumentGetTool(deps).execute({
+      workspaceId: WS,
+      documentId: created.documentId,
+    })
+    expect(read.content).toContain('The body, written at creation time.')
+    expect(read.content).toContain('alpha')
+  })
+
+  it('still creates an empty document when no body is given', async () => {
+    const deps = makeDeps()
+    const created = await wbDocumentCreate(deps, {
+      workspaceId: WS,
+      path: 'untitled-2',
+      kind: 'markdown',
+      createWorkspace: true,
+    })
+    expect(created.documentId).toBeTruthy()
+    expect(created.path).toBe('untitled-2')
+  })
+
+  it('refuses a body on a spatial document rather than dropping it', async () => {
+    // A spatial document's content is JSON Canvas, edited through
+    // `wb_canvas_edit`. Accepting markdown here and ignoring it would lose
+    // a caller's content silently; the type says no, and so does the parse.
+    const deps = makeDeps()
+    await expect(
+      wbDocumentCreate(deps, {
+        workspaceId: WS,
+        path: 'untitled-3',
+        kind: 'spatial',
+        createWorkspace: true,
+        markdown: MARKDOWN,
+      } as never),
+    ).rejects.toThrow()
+  })
+})

--- a/packages/server-core/src/tools/document-crud.schemas.ts
+++ b/packages/server-core/src/tools/document-crud.schemas.ts
@@ -1,36 +1,71 @@
-import {
-  documentIdSchema,
-  documentKindSchema,
-  documentPathSchema,
-  workspaceIdSchema,
-} from '@kamiazya/whiteboard-model'
+import { documentIdSchema, documentPathSchema, workspaceIdSchema } from '@kamiazya/whiteboard-model'
 import { z } from 'zod'
 
+/**
+ * Fields every new document has, whatever its kind.
+ */
+const documentCreateCommonShape = {
+  workspaceId: workspaceIdSchema,
+  path: documentPathSchema.describe(
+    'Where the document goes, as a slash-separated path from the workspace root. Hierarchy is the path: `plan/sub` sits under `plan`, and no separate parent id is involved.',
+  ),
+  name: z
+    .string()
+    .optional()
+    .describe(
+      'What a human reads. Free text, unlike `path`, which is a path and decides placement. Omit it and the document has no name of its own — a reader falls back to the segment rather than being handed the path as a title.',
+    ),
+  // Workspaces are never materialized implicitly: a typo'd or hallucinated
+  // workspaceId must fail loudly instead of silently writing data into a
+  // workspace nobody asked for. Creating a genuinely new workspace is an
+  // explicit opt-in via this flag.
+  createWorkspace: z
+    .boolean()
+    .optional()
+    .describe('Set true to create the workspace if it does not exist yet.'),
+}
+
+/**
+ * A discriminated union on `kind` rather than one flat object, because the
+ * two kinds do not accept the same content and a flat shape could only
+ * check that at runtime — after a caller had already been told the call was
+ * well-formed.
+ *
+ * Only `markdown` takes a body here. A spatial document's content is JSON
+ * Canvas, built through `wb_canvas_edit`, whose batch shape exists precisely
+ * so a diagram is not assembled one call at a time; funnelling a canvas
+ * through a string on this tool would be a second, worse way to do it.
+ */
 export const wbDocumentCreateInputSchema = z
-  .object({
-    workspaceId: workspaceIdSchema,
-    path: documentPathSchema.describe(
-      'Where the document goes, as a slash-separated path from the workspace root. Hierarchy is the path: `plan/sub` sits under `plan`, and no separate parent id is involved.',
-    ),
-    kind: documentKindSchema.describe(
-      'What the document is. `markdown` serialises as OKF, `spatial` as JSON Canvas. Required: the format follows from the document rather than from a read parameter, so a document created without one cannot be read back.',
-    ),
-    name: z
-      .string()
-      .optional()
-      .describe(
-        'What a human reads. Free text, unlike `path`, which is a path and decides placement. Omit it and the document has no name of its own — a reader falls back to the segment rather than being handed the path as a title.',
-      ),
-    // Workspaces are never materialized implicitly: a typo'd or hallucinated
-    // workspaceId must fail loudly instead of silently writing data into a
-    // workspace nobody asked for. Creating a genuinely new workspace is an
-    // explicit opt-in via this flag.
-    createWorkspace: z
-      .boolean()
-      .optional()
-      .describe('Set true to create the workspace if it does not exist yet.'),
-  })
-  .strict()
+  .discriminatedUnion('kind', [
+    z
+      .object({
+        ...documentCreateCommonShape,
+        kind: z
+          .literal('markdown')
+          .describe('An OKF markdown document. Serialises as OKF Markdown.'),
+        markdown: z
+          .string()
+          .optional()
+          .describe(
+            'The document, as OKF Markdown — frontmatter and body. Optional; without it the document is created empty, which is what a caller wants when the content comes from somewhere else. Supplying it here saves the separate `wb_document_set` that every "create a note" flow otherwise needs.',
+          ),
+      })
+      .strict(),
+    z
+      .object({
+        ...documentCreateCommonShape,
+        kind: z
+          .literal('spatial')
+          .describe(
+            'A JSON Canvas document. Its content is built with `wb_canvas_edit`, so this tool takes no body for it.',
+          ),
+      })
+      .strict(),
+  ])
+  .describe(
+    'Creates one document. The format follows from the document rather than from a read parameter, so `kind` is required: a document created without one cannot be read back.',
+  )
 
 export const wbDocumentCreateOutputSchema = z
   .object({

--- a/packages/server-core/src/tools/document-crud.ts
+++ b/packages/server-core/src/tools/document-crud.ts
@@ -5,7 +5,6 @@ import type { z } from 'zod'
 import type { ServerDeps } from '../server-deps.js'
 import { WorkspaceDocumentNotFoundError, WorkspaceNotFoundError } from './document-crud.errors.js'
 import type {
-  wbDocumentCreateInputSchema,
   wbDocumentCreateOutputSchema,
   wbDocumentDeleteInputSchema,
   wbDocumentDeleteOutputSchema,
@@ -14,7 +13,9 @@ import type {
   wbDocumentResolveInputSchema,
   wbDocumentResolveOutputSchema,
 } from './document-crud.schemas.js'
+import { wbDocumentCreateInputSchema } from './document-crud.schemas.js'
 import { saveDocumentSnapshot } from './document-io.js'
+import { createDocumentSetTool } from './document-set.js'
 
 /**
  * The index refuses an unknown workspace in its own words; the tool surface
@@ -38,8 +39,14 @@ async function rethrowWorkspaceNotFound<T>(
 
 export async function wbDocumentCreate(
   deps: ServerDeps,
-  input: z.infer<typeof wbDocumentCreateInputSchema>,
+  rawInput: z.infer<typeof wbDocumentCreateInputSchema>,
 ): Promise<z.infer<typeof wbDocumentCreateOutputSchema>> {
+  // Parsed here as well as at the MCP boundary. The union is what stops a
+  // body being handed to a spatial document, and a caller reaching this
+  // function directly — every test in this repo, and `createServer`'s own
+  // routes — would otherwise skip that and have the content silently
+  // dropped. A schema only guarantees what something actually runs.
+  const input = wbDocumentCreateInputSchema.parse(rawInput)
   // Workspaces never materialize implicitly: a typo'd or hallucinated
   // workspaceId must fail loudly rather than silently writing data into a
   // workspace nobody asked for. `createWorkspace: true` is the explicit
@@ -64,6 +71,20 @@ export async function wbDocumentCreate(
   const doc = new LoroDoc()
   writeDocumentKind(doc, input.kind)
   await saveDocumentSnapshot(deps, entry.documentId, doc)
+
+  // A body is written by DELEGATING to `wb_document_set` rather than by
+  // repeating what it does. Its write is not a one-liner — it parses OKF,
+  // decides what the document's kind may become, and projects frontmatter
+  // into the model — and a second copy of that reasoning here would be a
+  // second answer to the same question, drifting from the first the moment
+  // either changes.
+  if (input.kind === 'markdown' && input.markdown !== undefined) {
+    await createDocumentSetTool(deps).execute({
+      workspaceId: input.workspaceId,
+      documentId: entry.documentId,
+      markdown: input.markdown,
+    })
+  }
 
   return { documentId: entry.documentId, path: entry.path }
 }


### PR DESCRIPTION
Creating a markdown document with content cost **two calls** — `create` to mint the id, then `set` to write anything into it — and three if it carried tags. Every "file this finding", "write this note", "record this decision" flow paid that, and the repo's own ticketing convention is written around it.

```
wb_document_create  path kind:"markdown"  markdown:"---\ntype: note\n---\nbody"
  → one call
```

## Why a discriminated union, not an optional field

The two kinds do not accept the same content, and a flat object could only say so **at runtime — after a caller had been told the call was well-formed.**

Only `markdown` takes a body. A spatial document's content is JSON Canvas, built through `wb_canvas_edit`, whose batch shape exists precisely so a diagram is not assembled one call at a time; funnelling a canvas through a string here would be a second, worse way to do the same thing.

`registerToolWithAnnotations` already accepts `z.ZodRawShape | z.ZodTypeAny`, so the union registers directly — only the `.shape` at the call site had to go.

## The body is delegated, not reimplemented

`wb_document_set`'s write is not a one-liner: it parses OKF, decides what the document's kind may become, and projects frontmatter into the model. A second copy of that reasoning here would be a second answer to the same question, drifting from the first the moment either changed. So `create` calls it.

## And it found a real hole

**`wbDocumentCreate` never parsed its input.** The MCP boundary parses, but every caller reaching the function directly — every test in this repo, and `createServer`'s own routes — skipped it.

That matters because the new union is what refuses a body on a spatial document. Without parsing inside the function, that content would have been accepted and **silently dropped**. It parses there now: a schema only guarantees what something actually runs.

## Verified over MCP, not only in unit tests

`pnpm smoke:e2e` writes a body at creation and asserts the spatial refusal reaches the client *with a reason* rather than the content vanishing:

```
[e2e] wb_document_create → body written in one call
[e2e] wb_document_create with markdown on a spatial document → isError (expected)
```

The smoke's own `expectToolError` requires matching the error text, not just `isError` — "isError alone says a call failed, not that it failed for the reason under test".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmbb1zNhiZitB7tn9LQ5f3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown documents can now be created with their content included in the initial request.
  * Empty markdown documents continue to be supported.
* **Bug Fixes**
  * Invalid content fields for spatial documents are now rejected with a clear validation error.
  * Document creation input validation is consistently enforced across supported integrations.
* **Tests**
  * Added coverage for markdown persistence, empty documents, invalid spatial content, and end-to-end behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->