### PR TITLE
fix(web): the fake files source stops contradicting its own listing

### DIFF
--- a/apps/web/src/components/workspace-files/card-context-menu.test.tsx
+++ b/apps/web/src/components/workspace-files/card-context-menu.test.tsx
@@ -119,9 +119,13 @@ describe('document card context menu', () => {
   })
 
   it('the grid layout of search results carries the menu too', async () => {
-    renderPanel({ onOpenDocument: () => {} })
+    const source = renderPanel({ onOpenDocument: () => {} })
     await waitFor(() => expect(screen.getAllByTestId('card-title').length).toBeGreaterThan(0))
     fireEvent.change(screen.getByLabelText('Search documents'), { target: { value: 'road' } })
+    // Wait for the SOURCE's answer, not just for something to render. Until
+    // it lands the panel is showing a client-side match over the loaded list,
+    // and a test that asserts inside that window is racing the debounce.
+    await waitFor(() => expect(source.searchDocuments).toHaveBeenCalledWith('road', 20))
     await screen.findByTestId('search-results-list')
     fireEvent.click(screen.getByRole('button', { name: 'Grid results' }))
     const row = await screen.findByTestId('result-title')

--- a/apps/web/src/test-utils/fake-files-source.test.ts
+++ b/apps/web/src/test-utils/fake-files-source.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { fakeFilesSource } from './fake-files-source.js'
+
+// The default `searchDocuments` used to answer `[]` for every query, which
+// reads as "quietest possible answer" and is really a source contradicting
+// its own listing: it says nothing matches while the documents it just
+// listed plainly do.
+//
+// That is not a harmless lie. WorkspaceFilesPanel shows a client-side match
+// over the loaded list only WHILE the source's answer is in flight, then
+// switches to what the source said — so a test that types a query saw its
+// results for ~150ms and then watched them vanish. Whether it passed came
+// down to whether its queries beat the debounce, which on a loaded machine
+// they do not. One test flaked on exactly this.
+describe('the fake source, asked to search', () => {
+  const entries = [
+    { documentId: 'd1', path: 'meeting-notes', name: 'Meeting notes', kind: 'markdown' as const },
+    { documentId: 'd2', path: 'plans/roadmap', name: 'Roadmap', kind: 'spatial' as const },
+  ]
+
+  it('answers from the documents it lists, so it cannot contradict itself', async () => {
+    const source = fakeFilesSource({ listDocuments: async () => entries })
+    const hits = await source.searchDocuments('road', 20)
+    expect(hits.map((hit) => hit.document.path)).toEqual(['plans/roadmap'])
+  })
+
+  it('answers nothing when nothing in the listing matches', async () => {
+    const source = fakeFilesSource({ listDocuments: async () => entries })
+    expect(await source.searchDocuments('zarquon', 20)).toEqual([])
+  })
+
+  it('still lets a test say exactly what the source found', async () => {
+    const hit = { document: entries[0] as (typeof entries)[number], contexts: ['a body match'] }
+    const source = fakeFilesSource({
+      listDocuments: async () => entries,
+      searchDocuments: async () => [hit],
+    })
+    expect(await source.searchDocuments('anything', 20)).toEqual([hit])
+  })
+
+  it('honours the limit', async () => {
+    const source = fakeFilesSource({ listDocuments: async () => entries })
+    expect((await source.searchDocuments('', 1)).length).toBeLessThanOrEqual(1)
+  })
+})

--- a/apps/web/src/test-utils/fake-files-source.ts
+++ b/apps/web/src/test-utils/fake-files-source.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest'
 import type { WorkspaceDocumentEntry } from '../components/workspace-files/document-entry.js'
 import type { WorkspaceFilesSource } from '../components/workspace-files/files-source.js'
+import { searchDocuments as matchLoadedDocuments } from '../components/workspace-files/search-documents.js'
 
 /** Every method a `vi.fn`, so call assertions need no casts. */
 export interface FakeFilesSource extends WorkspaceFilesSource {
@@ -23,13 +24,33 @@ export interface FakeFilesSource extends WorkspaceFilesSource {
  * `setPinned` is the exception: it is optional on the seam, and its ABSENCE
  * is what hides the pin affordance (browser-local has nowhere to keep a
  * pin). Defaulting it to a spy would make every test look like a daemon.
+ *
+ * `searchDocuments` is the other: its default answers from whatever
+ * `listDocuments` returns rather than from nothing. `[]` looks like the
+ * quietest possible answer and is really a source contradicting its own
+ * listing — and the panel believes the source, showing a client-side match
+ * only while the answer is in flight. A test that typed a query therefore
+ * saw its results for ~150ms and then watched them vanish, passing or
+ * failing on whether its queries beat the debounce.
  */
 export function fakeFilesSource(overrides: Partial<WorkspaceFilesSource> = {}): FakeFilesSource {
   return {
     listDocuments: vi.fn(overrides.listDocuments ?? (async () => [])),
     createDocument: vi.fn(overrides.createDocument ?? (async () => {})),
     renameDocumentPath: vi.fn(overrides.renameDocumentPath ?? (async () => {})),
-    searchDocuments: vi.fn(overrides.searchDocuments ?? (async () => [])),
+    searchDocuments: vi.fn(
+      overrides.searchDocuments ??
+        (async (query: string, limit = 20) => {
+          const listed = await (overrides.listDocuments?.() ?? Promise.resolve([]))
+          // 1-based `lexicalRank`, because a name/path match IS a keyword
+          // hit: without it the fake would be modelling the other kind — a
+          // row found by meaning alone, which the panel deliberately renders
+          // without a highlight.
+          return matchLoadedDocuments(listed, query)
+            .slice(0, limit)
+            .map((document, index) => ({ document, contexts: [], lexicalRank: index + 1 }))
+        }),
+    ),
     setDocumentName: vi.fn(overrides.setDocumentName ?? (async () => {})),
     loadMarkdown: vi.fn(overrides.loadMarkdown ?? (async () => '')),
     loadSpatialSnapshot: vi.fn(overrides.loadSpatialSnapshot ?? (async () => new Uint8Array())),


### PR DESCRIPTION
## The flake, and what it actually was

`card-context-menu.test.tsx > the grid layout of search results carries the menu too` fails intermittently on `main` under load.

Its message names the menu:

```
TestingLibraryElementError: Unable to find role="menu" and name "Document actions"
```

The DOM captured beside it says something else entirely:

```
Nothing matches “road” in the names, paths and contents of this workspace.
```

The menu was never the subject. There was no result row left to right-click.

## Cause

`fakeFilesSource`'s default `searchDocuments` answered `[]` for every query. That reads like the quietest possible default and is really **a source contradicting its own listing** — it says nothing matches while the documents it just listed plainly do.

#1023 is what made that lie load-bearing: the panel now believes the source. A client-side match over the loaded list is shown only **while the source's answer is in flight**, then replaced by whatever the source said. So a test that typed a query saw its results for ~150ms and then watched them vanish, and whether it passed came down to whether its queries beat the debounce.

That is my regression, from this session. I filed this as a pre-existing `main` flake earlier today on the strength of a control run — clean `main` failed it too. The control was right and the conclusion was wrong: `main` already contained #1023.

## Fix

The default now answers from whatever `listDocuments` returns, through the same matcher the panel falls back to, with a 1-based `lexicalRank` — because a name/path match IS a keyword hit. Without it the fake would model the other kind, a row found by meaning alone, which the panel deliberately renders without a highlight (#1025).

The test also waits for the source to have been **asked** before asserting, rather than for something to have rendered. Both halves matter: the fixture stops lying, and the test stops reading inside a window it did not know it was in.

## Verification

Mutation-checked — restoring the `[]` default turns **both** the fixture's own test and the panel test red:

```
× answers from the documents it lists, so it cannot contradict itself
× the grid layout of search results carries the menu too
Tests  2 failed | 22 passed (24)
```

That is the point of the fix: a probabilistic flake becomes a deterministic failure if the cause returns.

Under the load that reproduced it (12 of 16 cores saturated, full jsdom project), `card-context-menu` passes. A different, already-ticketed flake surfaced in that run (`flake-undo-probe-node-full-suite`) and is not this one.

Gates: apps/web jsdom 2748 + node 77, `web-browser` 764, lint / knip / typecheck clean.

## Scope checked, not assumed

Five test files type into the search box. Only this one used `fakeFilesSource` without overriding `searchDocuments`; the three page tests drive real adapters whose `/search` throws, which takes the panel's degraded path and keeps the fallback showing — safe. `body-search.test.tsx` and `panel-tooltips` already override it.

Visual evidence: none — a test fixture and one test's wait; nothing here is rendered to anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoaNgqWUKbYJxk2azmRQKY