### PR TITLE
fix(release): stop biome and release-please reformatting the same files, and unbreak main's typecheck

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -69,6 +69,16 @@
   "overrides": [
     {
       "includes": [
+        ".claude-plugin/marketplace.json",
+        ".claude-plugin/plugin.json",
+        ".codex-plugin/plugin.json",
+        "gemini-extension.json",
+        "server.json"
+      ],
+      "formatter": { "enabled": false }
+    },
+    {
+      "includes": [
         "packages/mcp-server/src/server/**/*.ts",
         "!packages/mcp-server/src/server/log.ts",
         "!packages/mcp-server/src/server/**/*.test.ts",

--- a/packages/mcp-server/src/server/release/release-please-json-format.test.ts
+++ b/packages/mcp-server/src/server/release/release-please-json-format.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../../..')
+
+/**
+ * release-please's `type: json` updater does not edit a line — it parses the
+ * whole file and re-serialises it, and its serialiser puts every array
+ * element on its own line. Biome's formatter does the opposite: a short array
+ * that fits the line width is collapsed onto one. So the two disagree about
+ * any release-please target that contains a short array, and the release PR
+ * arrives with `check` red on files nobody wrote.
+ *
+ * It hid for a long time because it depends on CONTENT, not configuration:
+ * `server.json` is a target too and survives untouched, having no short
+ * array to expand. The failure appeared when `keywords` and `args` arrays
+ * were added to the plugin manifests, long after the config was written.
+ *
+ * The fix is to let release-please's shape stand — these files are edited by
+ * a bot far more often than by a person — so biome's formatter is off for
+ * exactly the targets and nothing else. Linting still applies.
+ *
+ * This test is what stops the exemption drifting from the target list: add a
+ * file to `extra-files` without exempting it and the next release PR is red
+ * again, for the same reason, months later.
+ */
+describe('release-please JSON targets are exempt from biome formatting', () => {
+  const config = JSON.parse(readFileSync(join(REPO_ROOT, 'release-please-config.json'), 'utf-8'))
+  const biome = JSON.parse(readFileSync(join(REPO_ROOT, 'biome.json'), 'utf-8'))
+
+  const targets: string[] = [
+    ...new Set(
+      Object.values(config.packages as Record<string, { 'extra-files'?: unknown[] }>)
+        .flatMap((pkg) => pkg['extra-files'] ?? [])
+        .filter((entry): entry is { type: string; path: string } => {
+          const candidate = entry as { type?: unknown; path?: unknown }
+          return candidate.type === 'json' && typeof candidate.path === 'string'
+        })
+        .map((entry) => entry.path),
+    ),
+  ]
+
+  const exempted: string[] = (biome.overrides as { includes?: string[]; formatter?: unknown }[])
+    .filter((override) => (override.formatter as { enabled?: boolean })?.enabled === false)
+    .flatMap((override) => override.includes ?? [])
+
+  it('finds the targets, so an empty comparison cannot pass vacuously', () => {
+    expect(targets.length).toBeGreaterThan(3)
+    expect(targets).toContain('server.json')
+  })
+
+  for (const target of targets) {
+    it(`${target} is exempt`, () => {
+      expect(exempted).toContain(target)
+    })
+  }
+})

--- a/packages/server-core/src/tools/document-create-orphan.test.ts
+++ b/packages/server-core/src/tools/document-create-orphan.test.ts
@@ -1,5 +1,6 @@
 import { InMemoryDocumentIndex } from '@kamiazya/whiteboard-ports/test-utils'
 import { describe, expect, it } from 'vitest'
+import { ignoredDocumentWrites } from '../test-utils/ignored-document-writes.js'
 import { createInMemoryDocumentStore } from '../test-utils/in-memory-document-store.js'
 import { unusedDocumentTeardown } from '../test-utils/unused-document-teardown.js'
 import { wbDocumentCreate } from './document-crud.js'
@@ -17,6 +18,7 @@ describe('a create that cannot finish leaves nothing behind', () => {
       documentStore: createInMemoryDocumentStore(),
       blobStore: {} as never,
       documentTeardown: unusedDocumentTeardown(),
+      documentWritten: ignoredDocumentWrites(),
       documentIndex: new InMemoryDocumentIndex(),
     }
     await expect(

--- a/packages/server-core/src/tools/workspace-edit.test.ts
+++ b/packages/server-core/src/tools/workspace-edit.test.ts
@@ -1,5 +1,6 @@
 import { InMemoryDocumentIndex } from '@kamiazya/whiteboard-ports/test-utils'
 import { describe, expect, it } from 'vitest'
+import { ignoredDocumentWrites } from '../test-utils/ignored-document-writes.js'
 import { createInMemoryDocumentStore } from '../test-utils/in-memory-document-store.js'
 import { inMemoryDocumentTeardown } from '../test-utils/unused-document-teardown.js'
 import { createDocumentGetTool } from './document-get.js'
@@ -12,6 +13,7 @@ function makeDeps() {
     documentStore: createInMemoryDocumentStore(),
     blobStore: {} as never,
     documentTeardown: inMemoryDocumentTeardown(),
+    documentWritten: ignoredDocumentWrites(),
     documentIndex: new InMemoryDocumentIndex(),
   }
 }


### PR DESCRIPTION
Two fixes. The first is urgent.

## 1. `main` does not typecheck

`#1046` made `documentWritten` a required `ServerDeps` member. `#1044` was reviewed, green, and merged *after* `#1046`'s CI ran but *before* it carried that member — so each PR was correct on its own branch and their merge is not.

```
packages/server-core typecheck: src/tools/document-create-orphan.test.ts(23,24): error TS2345
packages/server-core typecheck: src/tools/document-create-orphan.test.ts(39,44): error TS2345
packages/server-core typecheck: src/tools/workspace-edit.test.ts(23,47): error TS2345
```

Neither PR's checks could see it. Both tests now take `ignoredDocumentWrites()`, the no-op double the package already uses for tests with no composition root behind them. `pnpm -r typecheck` clean; `server-core-node` 400 passed.

## 2. Every release PR arrives with `check` red on files nobody wrote

`#258`'s failing job is Lint: **`Found 4 errors`**, all `Formatter would have printed the following content`, on `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.codex-plugin/plugin.json`, `gemini-extension.json`.

**Two formatters are fighting over the same files.** release-please's `type: json` updater does not edit a line — it parses the whole file and re-serialises it, and its serialiser puts every array element on its own line:

```diff
-      "args": ["-y", "@kamiazya/whiteboard-mcp@latest"]
+      "args": [
+        "-y",
+        "@kamiazya/whiteboard-mcp@latest"
+      ]
```

Biome does the opposite: a short array that fits the line width is collapsed onto one.

**Why it looked new.** It depends on CONTENT, not configuration. `server.json` is a release-please target too and comes through untouched — it has no short array to expand. Releases through `0.0.19` were clean (`f85ed959` changes only the version line); the `keywords` and `args` arrays arrived in the plugin manifests long after the config was written.

**Resolution: release-please's shape wins.** These files are edited by a bot far more often than by a person, and nobody reads a manifest for its line breaks. Biome's *formatter* is off for exactly the five release-please JSON targets — linting still applies, and nothing else changes.

Verified against the real thing rather than by argument: with `#258`'s actual file contents in the tree, `pnpm lint` reports **zero errors**; with `main`'s own contents, it also reports zero. Both shapes now pass.

### The guard

`release-please-json-format.test.ts` derives the target list from `release-please-config.json` itself and fails on any target not exempted, so adding an `extra-files` entry cannot quietly reopen this months later. It also asserts the derived list is non-empty and contains a known member, so it cannot pass by comparing two empty lists — it was red on all five before the override.

## Verification

`pnpm -r typecheck` clean · `mcp-node` 3778 passed | 6 skipped · `server-core-node` 400 passed · `pnpm lint` zero errors against both file shapes.

Visual evidence: none — build tooling and lint config; the evidence is the `pnpm lint` result against #258's own file contents, quoted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmbb1zNhiZitB7tn9LQ5f3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of document creation and workspace edits when document-write notifications are intentionally ignored.

* **Tests**
  * Added regression coverage to ensure release configuration files remain excluded from formatting.
  * Updated document and workspace-edit tests to reflect the supported notification behavior.

* **Chores**
  * Refined formatting rules for selected plugin and extension manifest files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->