### PR TITLE
test(web): make the undo-probe flake diagnosable in one occurrence

### DIFF
--- a/apps/web/src/pages/BrowserDocumentPage.create-delete-node.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.create-delete-node.test.tsx
@@ -86,6 +86,27 @@ vi.setConfig({ testTimeout: 30_000 })
 // import — which under fake-indexeddb on a loaded runner does not fit 5s.
 configure({ asyncUtilTimeout: 15_000 })
 
+// What the mounted editor was last handed, with enough context to diagnose a
+// failure in one occurrence rather than one investigation. `.at(-1)` is the
+// right read — the stub records every RENDER, and only the newest says what
+// the page currently shows — but on its own it fails as
+// `expected [] to include 'undo-probe-node'`, which cannot distinguish an
+// edit that never propagated from a later render that replaced it. Both flake
+// write-ups in this repo's backlog say the same thing: the assertion text was
+// the missing evidence, and by the time anyone looked it was gone.
+function latestCanvasIds(): { ids: string[]; detail: string } {
+  const latest = latestMountedCanvases.at(-1)
+  const ids = latest === undefined ? [] : latest.nodes.map((n) => n.id)
+  const trail = latestMountedCanvases
+    .slice(-4)
+    .map((canvas, index) => `[${index}] ${JSON.stringify(canvas.nodes.map((n) => n.id))}`)
+    .join(' ')
+  return {
+    ids,
+    detail: `renders=${latestMountedCanvases.length} last4: ${trail || '(none)'}`,
+  }
+}
+
 describe('BrowserDocumentPage create/delete-node persistence (real IndexedDB)', () => {
   let documentId = ''
 
@@ -128,9 +149,9 @@ describe('BrowserDocumentPage create/delete-node persistence (real IndexedDB)', 
     })
 
     await waitFor(() => {
-      const latest = latestMountedCanvases.at(-1)
-      expect(latest).toBeDefined()
-      expect(latest!.nodes.map((n) => n.id)).not.toContain('undo-probe-node')
+      expect(latestMountedCanvases.at(-1)).toBeDefined()
+      const { ids, detail } = latestCanvasIds()
+      expect(ids, `undo did not remove the node — ${detail}`).not.toContain('undo-probe-node')
     })
     // And redo brings it back through the same cluster.
     const redoButton = screen.getByRole('button', { name: 'Redo' })
@@ -139,8 +160,8 @@ describe('BrowserDocumentPage create/delete-node persistence (real IndexedDB)', 
       redoButton.click()
     })
     await waitFor(() => {
-      const latest = latestMountedCanvases.at(-1)
-      expect(latest!.nodes.map((n) => n.id)).toContain('undo-probe-node')
+      const { ids, detail } = latestCanvasIds()
+      expect(ids, `redo did not restore the node — ${detail}`).toContain('undo-probe-node')
     })
   })
 


### PR DESCRIPTION
`BrowserDocumentPage.create-delete-node > tapping Undo in the history cluster reverts the last committed edit` fails under full-suite load with:

```
expected [] to include 'undo-probe-node'
```

That message cannot distinguish an edit that never propagated from a later render that replaced it — and both flake write-ups in this repo's backlog independently name the same gap: **the assertion text was the missing evidence, and it was gone by the time anyone looked.**

## What changed

The assertion itself is unchanged. Its failure now carries the render count and the last four canvases' node ids:

```
redo did not restore the node — renders=11 last4:
  [0] [] [1] [] [2] ["undo-probe-node"] [3] ["undo-probe-node"]
```

That trail is captured from a **passing** run, and it is already informative: empty canvases interleave with populated ones among the final renders. So "the last render is empty" is a reachable state rather than a theory. Whether it is what the flake actually hits is what the next occurrence will now say, instead of another investigation.

Mutation-checked: swapping the expected id for one that never exists prints the full message, so the diagnostic reaches the output rather than being computed and discarded.

## One suspected cause ruled out

The issue proposed `integrator-flow.md`'s "most recent handle" shape — another test's still-live worker making `.at(-1)` return someone else's canvas. **It cannot apply here.** `latestMountedCanvases` is a module-level binding in this file, reset in `beforeEach`, and vitest's default `isolate: true` gives every test file its own module registry. The sibling `multi-document` suite declares its own separate binding of the same name.

Recorded so the next person does not follow it.

## Not claimed

This does not fix the flake, and I did not reproduce it: three full `pnpm --filter @kamiazya/whiteboard-web test` runs on current main (2748 + 77 tests each, at load averages 0.14 / 10.51 / 15.56) were all green, including this test. Three passes do not refute an intermittent failure — which is why the diagnostic is the deliverable rather than a fix built on a guess.

## Verification

`web-jsdom` on this file: 2 passed. Mutation: 1 failed with the full message, restored to 2 passed.

Visual evidence: none — a test-only diagnostic; the evidence is the assertion output quoted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmbb1zNhiZitB7tn9LQ5f3