### PR TITLE
refactor(web): migrate the persisted settings key off the retired keeper word

### DIFF
--- a/.claude/rules/vocabulary.md
+++ b/.claude/rules/vocabulary.md
@@ -141,9 +141,15 @@ WHERE A WORKSPACE IS KEPT is retired.
 (`/browser[-_]?local/i` — so `browser-local`, `browserLocal`, `BrowserLocal`,
 `BROWSER_LOCAL` and `browserlocal` alike), across `apps/web/src`,
 `apps/web/scripts`, `docs`, `.github`, `.claude`, and the root `README.md`
-and `apps/web/DESIGN.md`. The daemon half is deliberately narrower — only the
-discriminant value (a quoted `'local-daemon'`) and `LOCAL_DAEMON_` constants
-— because `localDaemonBaseUrl` is still legal until its migration lands.
+and `apps/web/DESIGN.md`. The daemon half is pinned over the same surface,
+but only in its IDENTIFIER casings (`/local_?daemon/i` — `localDaemonBaseUrl`,
+`LOCAL_DAEMON_*`), because the hyphenated `local-daemon` is still CORRECT in
+its network sense and always will be: `packages/mcp-server`'s
+`authMode: 'local-daemon'` opposite `'server-mode'`, the
+`connect-to-local-daemon` how-to, the `config-file-local-daemon` anchor. A
+daemon on this machine really is local. The quoted VALUE `'local-daemon'`
+stays banned in `apps/web/src` alone, since in mcp-server that same string is
+the auth mode.
 
 The scan is that wide because a hand grep kept missing places, three times in
 one increment: `claimIsolatedWhiteboardDb('browserlocaldocumentpage-…')` had
@@ -155,16 +161,27 @@ word decays, so prose is what the guard reads.
 `migrations` and `adr` are excluded as history, and THIS FILE is exempt — it
 is the one place that has to spell the retired words in order to retire them.
 
-One thing it deliberately does not yet claim, its own increment:
+Nothing is left unclaimed. The last increment was the persisted settings key
+`localDaemonBaseUrl`, which became `daemonBaseUrl` under a real migration
+rather than a sweep — the store reads `whiteboard:user-settings:v2` and falls
+back to migrating the `:v1` key exactly once when v2 is absent.
 
-- **`localDaemonBaseUrl`**, the persisted settings key
-  (`lib/user-settings-store.ts`), and `preferredProvider`'s enum beside it.
-  A stored shape under a `.strict()` schema whose loader falls back to
-  defaults on ANY parse failure — so renaming it in place discards an
-  existing reader's WHOLE settings payload (daemon URL, known and dismissed
-  daemons, theme, fonts), not merely the daemon connection. Measured, not
-  assumed: a sweep did exactly that and the loss was invisible because
-  nothing reads `preferredProvider`. It needs a settings migration.
+Why it could not be a sweep, measured rather than argued: the schema is
+`.strict()` and the loader falls back to defaults on ANY parse failure, so
+renaming the key in place discards an existing reader's WHOLE payload —
+daemon URL, known and dismissed daemons, theme, fonts — not merely the daemon
+connection. A sweep did exactly that earlier in this work, and the loss was
+invisible because nothing reads `preferredProvider`.
+
+Two fields went in that migration rather than through it. `preferredProvider`
+and `lastBrowserCanvasId` were read and written by nothing, so they are
+dropped: a field nobody reads does not need a better name. `lastBrowserCanvasId`
+was also the last `canvas`-as-container-noun in a stored shape, retired by
+deletion instead of a rename.
+
+`user-settings-store.ts` and its test are therefore exempt from the daemon
+guard, for the reason a migration always is: spelling the old key is how they
+read a payload written under it.
 
 `slug` is the one word retired outright, and `vocabulary-check.test.ts` in
 `tools/arch-lint` keeps it retired — the only part of this rule that is not

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -166,8 +166,8 @@ describe('silent renewal on a hosted origin', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 1,
-        storage: { localDaemonBaseUrl: 'http://127.0.0.1:3099' },
+        version: 2,
+        storage: { daemonBaseUrl: 'http://127.0.0.1:3099' },
         migration: {},
         capabilities: {},
       }),
@@ -195,8 +195,8 @@ describe('silent renewal on a hosted origin', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 1,
-        storage: { localDaemonBaseUrl: 'http://127.0.0.1:3099' },
+        version: 2,
+        storage: { daemonBaseUrl: 'http://127.0.0.1:3099' },
         migration: {},
         capabilities: {},
       }),
@@ -218,8 +218,8 @@ describe('silent renewal on a hosted origin', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 1,
-        storage: { localDaemonBaseUrl: 'http://127.0.0.1:3099' },
+        version: 2,
+        storage: { daemonBaseUrl: 'http://127.0.0.1:3099' },
         migration: {},
         capabilities: {},
       }),
@@ -520,7 +520,7 @@ describe('App reconnect-target persistence', () => {
     await screen.findByTestId('daemon-document-page')
 
     const saved = createUserSettingsStore().load()
-    expect(saved.storage.localDaemonBaseUrl).toBe('http://127.0.0.1:3099')
+    expect(saved.storage.daemonBaseUrl).toBe('http://127.0.0.1:3099')
     expect(saved.storage.lastConnectedWorkspaceId).toBe('w1')
     expect(saved.storage.lastConnectedPath).toBe('main')
   })
@@ -553,7 +553,7 @@ describe('App reconnect-target persistence', () => {
         <App providerState={BROWSER_STATE} />
       </MemoryRouter>,
     )
-    expect(createUserSettingsStore().load().storage.localDaemonBaseUrl).toBeUndefined()
+    expect(createUserSettingsStore().load().storage.daemonBaseUrl).toBeUndefined()
   })
 })
 
@@ -1107,15 +1107,15 @@ describe('App /settings routing', () => {
 
   it('passes the daemon from a session grant established via the silent-renewal seam', async () => {
     // Same mechanism as the "silent renewal" suite above: a stored
-    // localDaemonBaseUrl plus a 'paired' renewPairingToken result lands in
+    // daemonBaseUrl plus a 'paired' renewPairingToken result lands in
     // grantConnection, which /settings must resolve exactly like a #wb-grant
     // fragment consumed directly on this route would.
     localStorage.clear()
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 1,
-        storage: { localDaemonBaseUrl: 'http://127.0.0.1:3099' },
+        version: 2,
+        storage: { daemonBaseUrl: 'http://127.0.0.1:3099' },
         migration: {},
         capabilities: {},
       }),

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -189,7 +189,7 @@ export function App({ providerState }: AppProps) {
     if (daemonConnection.status !== 'none') return
     if (grantConnection !== null) return
     if ((providerState ?? defaultProviderState).kind !== 'browser') return
-    const storedBaseUrl = userSettingsStore.load().storage.localDaemonBaseUrl
+    const storedBaseUrl = userSettingsStore.load().storage.daemonBaseUrl
     if (storedBaseUrl === undefined) return
     void renewPairingToken({
       daemonBaseUrl: storedBaseUrl,
@@ -321,7 +321,7 @@ export function App({ providerState }: AppProps) {
     // when the stored target already matches what we would write.
     const stored = userSettingsStore.load().storage
     if (
-      stored.localDaemonBaseUrl === baseUrl &&
+      stored.daemonBaseUrl === baseUrl &&
       stored.lastConnectedWorkspaceId === workspaceId &&
       stored.lastConnectedPath === path
     ) {
@@ -331,7 +331,7 @@ export function App({ providerState }: AppProps) {
       ...current,
       storage: {
         ...current.storage,
-        localDaemonBaseUrl: baseUrl,
+        daemonBaseUrl: baseUrl,
         lastConnectedWorkspaceId: workspaceId,
         lastConnectedPath: path,
       },
@@ -346,7 +346,7 @@ export function App({ providerState }: AppProps) {
     if (grantConnection?.status !== 'paired') return
     userSettingsStore.update((current) => ({
       ...current,
-      storage: { ...current.storage, localDaemonBaseUrl: grantConnection.daemonBaseUrl },
+      storage: { ...current.storage, daemonBaseUrl: grantConnection.daemonBaseUrl },
     }))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [grantConnection?.status])

--- a/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.test.tsx
@@ -223,7 +223,7 @@ describe('DaemonDetectedBanner', () => {
       ...current,
       storage: {
         ...current.storage,
-        localDaemonBaseUrl: 'http://127.0.0.1:3099',
+        daemonBaseUrl: 'http://127.0.0.1:3099',
         lastConnectedWorkspaceId: 'w1',
         lastConnectedPath: 'main',
       },
@@ -245,7 +245,7 @@ describe('DaemonDetectedBanner', () => {
       ),
     ).toBeNull()
     const saved = store.load()
-    expect(saved.storage.localDaemonBaseUrl).toBeUndefined()
+    expect(saved.storage.daemonBaseUrl).toBeUndefined()
     expect(saved.storage.lastConnectedWorkspaceId).toBeUndefined()
     expect(saved.storage.lastConnectedPath).toBeUndefined()
   })
@@ -408,7 +408,7 @@ describe('DaemonDetectedBanner', () => {
     const store = makeStore()
     store.update((current) => ({
       ...current,
-      storage: { ...current.storage, localDaemonBaseUrl: 'http://127.0.0.1:3099' },
+      storage: { ...current.storage, daemonBaseUrl: 'http://127.0.0.1:3099' },
     }))
     const challengeFn = vi.fn(async () => 'verified' as const)
     render(
@@ -430,7 +430,7 @@ describe('DaemonDetectedBanner', () => {
     const store = makeStore()
     store.update((current) => ({
       ...current,
-      storage: { ...current.storage, localDaemonBaseUrl: 'http://127.0.0.1:3099' },
+      storage: { ...current.storage, daemonBaseUrl: 'http://127.0.0.1:3099' },
     }))
     const challengeFn = vi.fn(async () => 'failed' as const)
     render(
@@ -474,7 +474,7 @@ describe('DaemonDetectedBanner', () => {
     const store = makeStore()
     store.update((current) => ({
       ...current,
-      storage: { ...current.storage, localDaemonBaseUrl: 'http://127.0.0.1:3099' },
+      storage: { ...current.storage, daemonBaseUrl: 'http://127.0.0.1:3099' },
     }))
     const probeFn = vi.fn().mockResolvedValue(DETECTED)
     render(

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -147,19 +147,19 @@ export function DaemonDetectedBanner({
   // to be recomputed explicitly when we write to it — a useMemo keyed on the
   // store would keep serving pre-Forget values until a reload.
   const [storedTarget, setStoredTarget] = useState(() => {
-    const { localDaemonBaseUrl, lastConnectedWorkspaceId, lastConnectedPath } =
+    const { daemonBaseUrl, lastConnectedWorkspaceId, lastConnectedPath } =
       settingsStore.load().storage
-    return { localDaemonBaseUrl, lastConnectedWorkspaceId, lastConnectedPath }
+    return { daemonBaseUrl, lastConnectedWorkspaceId, lastConnectedPath }
   })
 
   // Trailing slashes would otherwise produce `http://host:3099//document/...`.
-  const baseUrl = (storedTarget.localDaemonBaseUrl ?? DEFAULT_DAEMON_BASE_URL).replace(/\/+$/, '')
+  const baseUrl = (storedTarget.daemonBaseUrl ?? DEFAULT_DAEMON_BASE_URL).replace(/\/+$/, '')
 
   // Whether a reconnect target was ever actually persisted (as opposed to
   // baseUrl above, which always resolves to DEFAULT_DAEMON_BASE_URL even with
   // nothing stored) — this gates whether "Forget this daemon" has anything
   // to forget.
-  const hasStoredTarget = storedTarget.localDaemonBaseUrl !== undefined
+  const hasStoredTarget = storedTarget.daemonBaseUrl !== undefined
 
   // Since R3 the daemon serves the canonical apps/web build at its own
   // origin with no pairing needed at all, so the primary CTA is a plain
@@ -177,7 +177,7 @@ export function DaemonDetectedBanner({
   // that daemon's own consent page — earns the app's trust label. Everything
   // else is labelled unverified. This is presentation-level honesty, not a
   // security boundary: the durable fix is daemon->browser mutual auth.
-  const isPairedTarget = detectedBaseUrl === storedTarget.localDaemonBaseUrl
+  const isPairedTarget = detectedBaseUrl === storedTarget.daemonBaseUrl
 
   const detectedCount = found?.length ?? 0
   useEffect(() => {
@@ -355,13 +355,13 @@ export function DaemonDetectedBanner({
       ...current,
       storage: {
         ...current.storage,
-        localDaemonBaseUrl: undefined,
+        daemonBaseUrl: undefined,
         lastConnectedWorkspaceId: undefined,
         lastConnectedPath: undefined,
       },
     }))
     setStoredTarget({
-      localDaemonBaseUrl: undefined,
+      daemonBaseUrl: undefined,
       lastConnectedWorkspaceId: undefined,
       lastConnectedPath: undefined,
     })

--- a/apps/web/src/lib/daemon-probe.ts
+++ b/apps/web/src/lib/daemon-probe.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 
 // Default loopback origin for the local daemon (matches
 // packages/mcp-server's default runtime port). Callers that know a
-// non-default port (settings.storage.localDaemonBaseUrl) pass it explicitly.
+// non-default port (settings.storage.daemonBaseUrl) pass it explicitly.
 export const DEFAULT_DAEMON_BASE_URL = 'http://127.0.0.1:3099'
 
 const DEFAULT_TIMEOUT_MS = 2000

--- a/apps/web/src/lib/disconnect-daemon.test.ts
+++ b/apps/web/src/lib/disconnect-daemon.test.ts
@@ -11,9 +11,9 @@ beforeEach(() => localStorage.clear())
 describe('disconnectFromDaemon', () => {
   it('clears the stored target so the next load is not daemon-backed', () => {
     const store = createUserSettingsStore()
-    store.update((c) => ({ ...c, storage: { ...c.storage, localDaemonBaseUrl: A } }))
+    store.update((c) => ({ ...c, storage: { ...c.storage, daemonBaseUrl: A } }))
     disconnectFromDaemon(store, A)
-    expect(createUserSettingsStore().load().storage.localDaemonBaseUrl).toBeUndefined()
+    expect(createUserSettingsStore().load().storage.daemonBaseUrl).toBeUndefined()
   })
 
   // Forgetting alone is not enough: the default port range is rescanned on
@@ -30,9 +30,9 @@ describe('disconnectFromDaemon', () => {
   // Another daemon's stored target is none of this call's business.
   it('leaves a different daemon connected', () => {
     const store = createUserSettingsStore()
-    store.update((c) => ({ ...c, storage: { ...c.storage, localDaemonBaseUrl: B } }))
+    store.update((c) => ({ ...c, storage: { ...c.storage, daemonBaseUrl: B } }))
     disconnectFromDaemon(store, A)
-    expect(createUserSettingsStore().load().storage.localDaemonBaseUrl).toBe(B)
+    expect(createUserSettingsStore().load().storage.daemonBaseUrl).toBe(B)
   })
 
   it('is a skip-list, not an archive — bounded at five', () => {

--- a/apps/web/src/lib/disconnect-daemon.ts
+++ b/apps/web/src/lib/disconnect-daemon.ts
@@ -10,7 +10,7 @@ import type { UserSettingsStore } from './user-settings-store.js'
  * Lives here rather than at its call site because the two writes are a pair
  * and only make sense together:
  *
- * - Clearing `localDaemonBaseUrl` is what makes it outlive the page. App.tsx
+ * - Clearing `daemonBaseUrl` is what makes it outlive the page. App.tsx
  *   reads that key to decide a load is daemon-backed, so leaving it set
  *   reconnects on the next visit and "this browser stops using it" becomes
  *   false the moment the user reloads.
@@ -18,24 +18,22 @@ import type { UserSettingsStore } from './user-settings-store.js'
  *   port range is rescanned on every visit, so forgetting alone would bring
  *   the same daemon straight back and the action would read as a no-op.
  */
-export function disconnectFromDaemon(store: UserSettingsStore, daemonBaseUrl: string): void {
+export function disconnectFromDaemon(store: UserSettingsStore, target: string): void {
   store.update((current) => {
-    const known = (current.storage.knownDaemonBaseUrls ?? []).filter(
-      (entry) => entry !== daemonBaseUrl,
-    )
+    const known = (current.storage.knownDaemonBaseUrls ?? []).filter((entry) => entry !== target)
     const dismissed = (current.storage.dismissedDaemonBaseUrls ?? []).filter(
-      (entry) => entry !== daemonBaseUrl,
+      (entry) => entry !== target,
     )
-    const { localDaemonBaseUrl, ...storage } = current.storage
+    const { daemonBaseUrl, ...storage } = current.storage
     return {
       ...current,
       storage: {
         ...storage,
         // Another daemon's stored target is none of this call's business.
-        ...(localDaemonBaseUrl === daemonBaseUrl ? {} : { localDaemonBaseUrl }),
+        ...(daemonBaseUrl === target ? {} : { daemonBaseUrl }),
         knownDaemonBaseUrls: known,
         // Bounded: this is a "skip these" hint, not an archive.
-        dismissedDaemonBaseUrls: [daemonBaseUrl, ...dismissed].slice(0, 5),
+        dismissedDaemonBaseUrls: [target, ...dismissed].slice(0, 5),
       },
     }
   })

--- a/apps/web/src/lib/user-settings-store.test.ts
+++ b/apps/web/src/lib/user-settings-store.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createUserSettingsStore, defaultUserSettings, STORAGE_KEY } from './user-settings-store.js'
+import {
+  createUserSettingsStore,
+  defaultUserSettings,
+  LEGACY_V1_STORAGE_KEY,
+  STORAGE_KEY,
+} from './user-settings-store.js'
 
 describe('knownDaemonBaseUrls bound', () => {
   it('an oversized stored array fails validation and load falls back to defaults', () => {
@@ -7,11 +12,11 @@ describe('knownDaemonBaseUrls bound', () => {
     const oversized = Array.from({ length: 6 }, (_, i) => `http://127.0.0.1:${3099 + i}`)
     localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify({ version: 1, storage: { knownDaemonBaseUrls: oversized } }),
+      JSON.stringify({ version: 2, storage: { knownDaemonBaseUrls: oversized } }),
     )
     const store = createUserSettingsStore()
     // Consistent with the store's existing invalid-value semantics (e.g. a
-    // non-http localDaemonBaseUrl): safeParse fails and defaults win, so
+    // non-http daemonBaseUrl): safeParse fails and defaults win, so
     // discovery can never fan out over an unbounded tampered list.
     expect(store.load().storage.knownDaemonBaseUrls).toBeUndefined()
   })
@@ -31,13 +36,13 @@ describe('createUserSettingsStore', () => {
     const store = createUserSettingsStore()
     store.save({
       ...defaultUserSettings(),
-      storage: { preferredProvider: 'browser-local', lastBrowserCanvasId: 'canvas-1' },
+      storage: { daemonBaseUrl: 'http://127.0.0.1:3099', lastConnectedWorkspaceId: 'ws-1' },
     })
 
     const reloaded = createUserSettingsStore()
     expect(reloaded.load().storage).toMatchObject({
-      preferredProvider: 'browser-local',
-      lastBrowserCanvasId: 'canvas-1',
+      daemonBaseUrl: 'http://127.0.0.1:3099',
+      lastConnectedWorkspaceId: 'ws-1',
     })
   })
 
@@ -69,20 +74,20 @@ describe('createUserSettingsStore', () => {
     expect(reloaded.storage.dismissedDaemonCtaInstanceId).toBe('instance-1')
   })
 
-  it('persists localDaemonBaseUrl, lastConnectedWorkspaceId and lastConnectedPath (reconnect target)', () => {
+  it('persists daemonBaseUrl, lastConnectedWorkspaceId and lastConnectedPath (reconnect target)', () => {
     const store = createUserSettingsStore()
     store.update((current) => ({
       ...current,
       storage: {
         ...current.storage,
-        localDaemonBaseUrl: 'http://127.0.0.1:3099',
+        daemonBaseUrl: 'http://127.0.0.1:3099',
         lastConnectedWorkspaceId: 'w1',
         lastConnectedPath: 'main',
       },
     }))
 
     const reloaded = createUserSettingsStore().load()
-    expect(reloaded.storage.localDaemonBaseUrl).toBe('http://127.0.0.1:3099')
+    expect(reloaded.storage.daemonBaseUrl).toBe('http://127.0.0.1:3099')
     expect(reloaded.storage.lastConnectedWorkspaceId).toBe('w1')
     expect(reloaded.storage.lastConnectedPath).toBe('main')
   })
@@ -95,22 +100,22 @@ describe('createUserSettingsStore', () => {
     'javascript:alert(1)',
     'data:text/html,<script>alert(1)</script>',
     'not a url',
-  ])('rejects a stored localDaemonBaseUrl that is not http(s): %s', (hostile) => {
+  ])('rejects a stored daemonBaseUrl that is not http(s): %s', (hostile) => {
     // Everything else in this payload is valid, so only the URL constraint
     // can be what rejects it — otherwise the test would pass whether or not
     // the constraint exists.
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 1,
-        storage: { localDaemonBaseUrl: hostile, lastConnectedWorkspaceId: 'w1' },
+        version: 2,
+        storage: { daemonBaseUrl: hostile, lastConnectedWorkspaceId: 'w1' },
         migration: {},
         capabilities: {},
       }),
     )
 
     const loaded = createUserSettingsStore().load()
-    expect(loaded.storage.localDaemonBaseUrl).toBeUndefined()
+    expect(loaded.storage.daemonBaseUrl).toBeUndefined()
     // The whole payload is discarded, not just the offending field.
     expect(loaded.storage.lastConnectedWorkspaceId).toBeUndefined()
   })
@@ -119,23 +124,21 @@ describe('createUserSettingsStore', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 1,
-        storage: { localDaemonBaseUrl: 'http://127.0.0.1:3099', lastConnectedWorkspaceId: 'w1' },
+        version: 2,
+        storage: { daemonBaseUrl: 'http://127.0.0.1:3099', lastConnectedWorkspaceId: 'w1' },
         migration: {},
         capabilities: {},
       }),
     )
 
-    expect(createUserSettingsStore().load().storage.localDaemonBaseUrl).toBe(
-      'http://127.0.0.1:3099',
-    )
+    expect(createUserSettingsStore().load().storage.daemonBaseUrl).toBe('http://127.0.0.1:3099')
   })
 
   it('reset() clears stored settings back to defaults', () => {
     const store = createUserSettingsStore()
     store.save({
       ...defaultUserSettings(),
-      storage: { preferredProvider: 'local-daemon' },
+      storage: { daemonBaseUrl: 'http://127.0.0.1:3099' },
     })
     store.reset()
 
@@ -158,8 +161,8 @@ describe('createUserSettingsStore', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 1,
-        storage: { preferredProvider: 'browser-local', daemonToken: 'super-secret' },
+        version: 2,
+        storage: { daemonBaseUrl: 'http://127.0.0.1:3099', daemonToken: 'super-secret' },
         migration: {},
         capabilities: {},
       }),
@@ -209,15 +212,15 @@ describe('createUserSettingsStore — beta banner dismissal', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 1,
-        storage: { preferredProvider: 'local-daemon', lastBrowserCanvasId: 'abc' },
+        version: 2,
+        storage: { daemonBaseUrl: 'http://127.0.0.1:3099', lastConnectedPath: 'abc' },
         migration: {},
         capabilities: {},
       }),
     )
     const store = createUserSettingsStore()
-    expect(store.load().storage.preferredProvider).toBe('local-daemon')
-    expect(store.load().storage.lastBrowserCanvasId).toBe('abc')
+    expect(store.load().storage.daemonBaseUrl).toBe('http://127.0.0.1:3099')
+    expect(store.load().storage.lastConnectedPath).toBe('abc')
     expect(store.load().storage.dismissedBetaBannerAt).toBeUndefined()
   })
 })
@@ -264,10 +267,10 @@ describe('appearance settings', () => {
   it('parses a stored payload from before the appearance section existed', () => {
     localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify({ version: 1, storage: {}, migration: {}, capabilities: {} }),
+      JSON.stringify({ version: 2, storage: {}, migration: {}, capabilities: {} }),
     )
     const settings = createUserSettingsStore().load()
-    expect(settings.version).toBe(1)
+    expect(settings.version).toBe(2)
     expect(settings.appearance?.faviconStyle).toBeUndefined()
   })
 
@@ -275,7 +278,7 @@ describe('appearance settings', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 1,
+        version: 2,
         storage: {},
         migration: {},
         capabilities: {},
@@ -283,5 +286,130 @@ describe('appearance settings', () => {
       }),
     )
     expect(createUserSettingsStore().load().appearance).toEqual({})
+  })
+})
+
+describe('v1 -> v2 migration', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  // A full v1 payload: every field a real reader could be holding.
+  function writeV1(storage: Record<string, unknown> = {}): void {
+    localStorage.setItem(
+      LEGACY_V1_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        storage: {
+          localDaemonBaseUrl: 'http://127.0.0.1:3099',
+          knownDaemonBaseUrls: ['http://127.0.0.1:3099'],
+          dismissedDaemonBaseUrls: ['http://127.0.0.1:4000'],
+          lastConnectedWorkspaceId: 'ws-1',
+          lastConnectedPath: 'notes/plan',
+          dismissedPersistenceWarningAt: '2026-07-05T00:00:00.000Z',
+          dismissedBetaBannerAt: '2026-07-06T00:00:00.000Z',
+          dismissedDaemonCtaAt: '2026-07-07T00:00:00.000Z',
+          dismissedDaemonCtaInstanceId: 'inst-1',
+          ...storage,
+        },
+        migration: { browserToDaemon: { lastImportedDocumentId: 'doc-1' } },
+        capabilities: { webMcpEnabled: true, webMcpMaxTier: 2 },
+        appearance: { faviconStyle: 'dot' },
+      }),
+    )
+  }
+
+  it('carries the daemon connection across under its new name', () => {
+    writeV1()
+    expect(createUserSettingsStore().load().storage.daemonBaseUrl).toBe('http://127.0.0.1:3099')
+  })
+
+  // The whole point of the increment: renaming in place would have discarded
+  // ALL of this, not just the daemon URL, because the schema is `.strict()`
+  // and load() falls back to defaults on any parse failure.
+  it('carries every other stored field across unchanged', () => {
+    writeV1()
+    const loaded = createUserSettingsStore().load()
+    expect(loaded.storage).toMatchObject({
+      knownDaemonBaseUrls: ['http://127.0.0.1:3099'],
+      dismissedDaemonBaseUrls: ['http://127.0.0.1:4000'],
+      lastConnectedWorkspaceId: 'ws-1',
+      lastConnectedPath: 'notes/plan',
+      dismissedPersistenceWarningAt: '2026-07-05T00:00:00.000Z',
+      dismissedBetaBannerAt: '2026-07-06T00:00:00.000Z',
+      dismissedDaemonCtaAt: '2026-07-07T00:00:00.000Z',
+      dismissedDaemonCtaInstanceId: 'inst-1',
+    })
+    expect(loaded.migration).toEqual({ browserToDaemon: { lastImportedDocumentId: 'doc-1' } })
+    expect(loaded.capabilities).toEqual({ webMcpEnabled: true, webMcpMaxTier: 2 })
+    expect(loaded.appearance).toEqual({ faviconStyle: 'dot' })
+  })
+
+  // Both are fields nothing read or wrote. A dead field does not need a better
+  // name, so the migration drops them rather than carrying them under one.
+  it('drops the two dead fields rather than renaming them', () => {
+    writeV1({ preferredProvider: 'local-daemon', lastBrowserCanvasId: 'canvas-1' })
+    const loaded = createUserSettingsStore().load()
+    expect(loaded.storage).not.toHaveProperty('preferredProvider')
+    expect(loaded.storage).not.toHaveProperty('lastBrowserCanvasId')
+    // and their presence must not fail the parse and cost the rest
+    expect(loaded.storage.daemonBaseUrl).toBe('http://127.0.0.1:3099')
+  })
+
+  it('persists the migrated payload under the v2 key and removes the v1 one', () => {
+    writeV1()
+    createUserSettingsStore().load()
+    expect(localStorage.getItem(LEGACY_V1_STORAGE_KEY)).toBeNull()
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null')
+    expect(stored.version).toBe(2)
+    expect(stored.storage.daemonBaseUrl).toBe('http://127.0.0.1:3099')
+  })
+
+  it('a v2 payload wins and no migration runs, so a stale v1 key cannot resurrect', () => {
+    writeV1()
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 2,
+        storage: { daemonBaseUrl: 'http://127.0.0.1:4321' },
+        migration: {},
+        capabilities: {},
+      }),
+    )
+    expect(createUserSettingsStore().load().storage.daemonBaseUrl).toBe('http://127.0.0.1:4321')
+    // untouched, because the v2 key answered
+    expect(localStorage.getItem(LEGACY_V1_STORAGE_KEY)).not.toBeNull()
+  })
+
+  // The v1 schema was `.strict()` for exactly this reason; the migration must
+  // not become the hole that lets a token-shaped key through.
+  it('refuses a v1 payload carrying an unknown token-shaped key', () => {
+    localStorage.setItem(
+      LEGACY_V1_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        storage: { localDaemonBaseUrl: 'http://127.0.0.1:3099', daemonToken: 'super-secret' },
+        migration: {},
+        capabilities: {},
+      }),
+    )
+    expect(createUserSettingsStore().load()).toEqual(defaultUserSettings())
+  })
+
+  it('reset() clears the un-migrated v1 key too, so nothing resurrects', () => {
+    writeV1()
+    const store = createUserSettingsStore()
+    store.reset()
+    expect(store.load()).toEqual(defaultUserSettings())
+  })
+
+  it('a v1 payload with no daemon connection migrates without inventing one', () => {
+    localStorage.setItem(
+      LEGACY_V1_STORAGE_KEY,
+      JSON.stringify({ version: 1, storage: {}, migration: {}, capabilities: {} }),
+    )
+    const loaded = createUserSettingsStore().load()
+    expect(loaded.storage).not.toHaveProperty('daemonBaseUrl')
+    expect(loaded.version).toBe(2)
   })
 })

--- a/apps/web/src/lib/user-settings-store.ts
+++ b/apps/web/src/lib/user-settings-store.ts
@@ -5,8 +5,21 @@ import { z } from 'zod'
 // safeParse-fail on it only transiently), so it does NOT bump the key/version —
 // bumping would discard every existing user's stored settings. Bump BOTH this
 // suffix and the `version` literal only for a BREAKING change (removing a
-// field, changing a type, or making a field required).
-export const STORAGE_KEY = 'whiteboard:user-settings:v1'
+// field, changing a type, or making a field required), AND ship a migration
+// in the same increment: bumping alone is the discard this comment warns
+// about, just spelled differently.
+export const STORAGE_KEY = 'whiteboard:user-settings:v2'
+
+/**
+ * The key v2 migrates FROM, read once and then removed.
+ *
+ * Two keys rather than a version discriminator inside one, because that is
+ * what makes a concurrently-open OLD tab harmless: it keeps reading and
+ * writing v1, which this build no longer looks at once v2 exists, instead of
+ * safeParse-failing on the bumped `version` and overwriting v2 with its
+ * defaults.
+ */
+export const LEGACY_V1_STORAGE_KEY = 'whiteboard:user-settings:v1'
 
 // localStorage access itself can throw (SecurityError when the browser blocks
 // storage via privacy settings or embedded contexts). The store's contract is
@@ -35,37 +48,33 @@ function safeRemoveItem(key: string): void {
   }
 }
 
+/**
+ * Constrained to http/https because these values are rendered into an `href`
+ * and fetched. Anything that can write localStorage — a same-origin script, a
+ * browser extension — could otherwise store `javascript:…` and turn a link
+ * click into script execution. Rejecting it at the schema protects every
+ * consumer, not just the one that renders it today.
+ */
+const httpUrl = z.string().refine((value) => {
+  try {
+    const { protocol } = new URL(value)
+    return protocol === 'http:' || protocol === 'https:'
+  } catch {
+    return false
+  }
+}, 'must be an http(s) URL')
+
 // `.strict()` at every level is the enforcement point for "no daemon/cloud
 // token in UserSettings": an unknown key (e.g. a token-shaped field) makes
 // safeParse fail, and callers fall back to defaults rather than persisting it.
 const storageSettingsSchema = z
   .object({
-    // Spelled with the retired keeper words on purpose: this value is
-    // PERSISTED, the schema is `.strict()`, and `load()` falls back to
-    // defaults on any parse failure — so renaming it here would silently
-    // discard an existing reader's whole settings payload, daemon connection
-    // included. It moves with a migration, not with a sweep.
-    preferredProvider: z.enum(['browser-local', 'local-daemon']).optional(),
-    lastBrowserCanvasId: z.string().optional(),
-    // Constrained to http/https because this value is rendered into an `href`
-    // (the "Open the local app" escape hatch). Anything that can write
-    // localStorage — a same-origin script, a browser extension — could
-    // otherwise store `javascript:…` here and turn a link click into script
-    // execution. Rejecting it at the schema protects every consumer, not just
-    // the one that renders it today.
-    localDaemonBaseUrl: z
-      .string()
-      .refine((value) => {
-        try {
-          const { protocol } = new URL(value)
-          return protocol === 'http:' || protocol === 'https:'
-        } catch {
-          return false
-        }
-      }, 'must be an http(s) URL')
-      .optional(),
+    // Which daemon this browser uses. `local` is gone from the name because
+    // it never named this axis: a daemon runs on this machine too, so the
+    // word said nothing that distinguished it from the browser keeper.
+    daemonBaseUrl: httpUrl.optional(),
     // The (workspaceId, path) last reached via a #wb= pairing, alongside
-    // localDaemonBaseUrl above — together they let a later hosted-app load
+    // daemonBaseUrl above — together they let a later hosted-app load
     // offer a one-click reconnect to the same daemon and canvas instead of
     // just the daemon's root. path is meaningless without workspaceId, but
     // this is UI-hint state (not an access boundary), so it is not enforced
@@ -73,20 +82,9 @@ const storageSettingsSchema = z
     lastConnectedWorkspaceId: z.string().optional(),
     lastConnectedPath: z.string().optional(),
     // Every daemon baseUrl a probe has actually confirmed, most recent
-    // first (see daemon-discovery.ts's MRU helper). Same http(s)-only
-    // constraint as localDaemonBaseUrl above and for the same reason:
-    // these values are rendered into hrefs and fetched.
+    // first (see daemon-discovery.ts's MRU helper).
     knownDaemonBaseUrls: z
-      .array(
-        z.string().refine((value) => {
-          try {
-            const { protocol } = new URL(value)
-            return protocol === 'http:' || protocol === 'https:'
-          } catch {
-            return false
-          }
-        }, 'must be an http(s) URL'),
-      )
+      .array(httpUrl)
       // The writer keeps this MRU-capped (daemon-discovery's helper), and
       // every stored entry is re-probed on the next check — an oversized
       // tampered array must not turn discovery into an unbounded fan-out.
@@ -95,19 +93,10 @@ const storageSettingsSchema = z
     // Daemons the user explicitly disconnected from. Discovery skips these
     // even inside its scanned port range, which is what makes a disconnect
     // outlive the page — without it the default-port daemon reappears on the
-    // next load and the action reads as a no-op. Same http(s) constraint and
-    // same cap as the known list, for the same reasons.
+    // next load and the action reads as a no-op. Same cap as the known list,
+    // for the same reason.
     dismissedDaemonBaseUrls: z
-      .array(
-        z.string().refine((value) => {
-          try {
-            const { protocol } = new URL(value)
-            return protocol === 'http:' || protocol === 'https:'
-          } catch {
-            return false
-          }
-        }, 'must be an http(s) URL'),
-      )
+      .array(httpUrl)
       .max(5, 'must contain at most 5 daemon URLs')
       .optional(),
     dismissedPersistenceWarningAt: z.string().optional(),
@@ -149,7 +138,7 @@ const appearanceSettingsSchema = z
 
 const userSettingsSchema = z
   .object({
-    version: z.literal(1),
+    version: z.literal(2),
     storage: storageSettingsSchema,
     migration: migrationSettingsSchema,
     capabilities: capabilitySettingsSchema,
@@ -159,11 +148,69 @@ const userSettingsSchema = z
   })
   .strict()
 
+/**
+ * The shape v2 migrates FROM, kept parse-only.
+ *
+ * It spells the retired keeper words on purpose, for the same reason a
+ * database migration names the columns as they stood at its point in the log:
+ * this schema's whole job is to read a payload that was written under those
+ * names. Correcting them here would make it parse nothing.
+ *
+ * Not derived from `storageSettingsSchema` by `.extend()`/`.omit()`, because
+ * the two shapes are only coincidentally similar — v2 is free to move without
+ * silently changing what a v1 payload is allowed to contain.
+ */
+const legacyV1SettingsSchema = z
+  .object({
+    version: z.literal(1),
+    storage: z
+      .object({
+        // Dead on arrival: nothing in the app ever read or wrote either of
+        // these. They are dropped rather than renamed — a field nobody reads
+        // does not need a better name.
+        preferredProvider: z.enum(['browser-local', 'local-daemon']).optional(),
+        lastBrowserCanvasId: z.string().optional(),
+        localDaemonBaseUrl: httpUrl.optional(),
+        lastConnectedWorkspaceId: z.string().optional(),
+        lastConnectedPath: z.string().optional(),
+        knownDaemonBaseUrls: z.array(httpUrl).max(5).optional(),
+        dismissedDaemonBaseUrls: z.array(httpUrl).max(5).optional(),
+        dismissedPersistenceWarningAt: z.string().optional(),
+        dismissedBetaBannerAt: z.string().optional(),
+        dismissedDaemonCtaAt: z.string().optional(),
+        dismissedDaemonCtaInstanceId: z.string().optional(),
+      })
+      // `.strict()` here for the same reason v2 has it: the migration must not
+      // become the hole a token-shaped key travels through.
+      .strict(),
+    migration: migrationSettingsSchema,
+    capabilities: capabilitySettingsSchema,
+    appearance: appearanceSettingsSchema.optional(),
+  })
+  .strict()
+
 export type UserSettings = z.infer<typeof userSettingsSchema>
+
+function migrateV1(legacy: z.infer<typeof legacyV1SettingsSchema>): UserSettings {
+  const { preferredProvider, lastBrowserCanvasId, localDaemonBaseUrl, ...carried } = legacy.storage
+  return {
+    version: 2,
+    storage: {
+      ...carried,
+      // Spread conditionally rather than assigning `undefined`: the value is
+      // JSON.stringify-ed straight back out, and an explicit `undefined` and
+      // an absent key are the same there but not to `toHaveProperty`.
+      ...(localDaemonBaseUrl === undefined ? {} : { daemonBaseUrl: localDaemonBaseUrl }),
+    },
+    migration: legacy.migration,
+    capabilities: legacy.capabilities,
+    ...(legacy.appearance === undefined ? {} : { appearance: legacy.appearance }),
+  }
+}
 
 export function defaultUserSettings(): UserSettings {
   return {
-    version: 1,
+    version: 2,
     storage: {},
     migration: {},
     capabilities: {},
@@ -179,18 +226,34 @@ export interface UserSettingsStore {
 }
 
 export function createUserSettingsStore(): UserSettingsStore {
-  function load(): UserSettings {
-    const raw = safeGetItem(STORAGE_KEY)
-    if (raw === null) return defaultUserSettings()
-
-    let parsedJson: unknown
+  function readJson(key: string): unknown {
+    const raw = safeGetItem(key)
+    if (raw === null) return undefined
     try {
-      parsedJson = JSON.parse(raw)
+      return JSON.parse(raw)
     } catch {
-      return defaultUserSettings()
+      return undefined
     }
+  }
 
-    const result = userSettingsSchema.safeParse(parsedJson)
+  /**
+   * Migrates only when the v2 key is ABSENT, never when it is merely invalid.
+   * A corrupt or tampered v2 payload keeps the store's existing
+   * invalid-means-defaults contract instead of quietly resurrecting settings
+   * the user may have since changed.
+   */
+  function migrateFromV1(): UserSettings | null {
+    const result = legacyV1SettingsSchema.safeParse(readJson(LEGACY_V1_STORAGE_KEY))
+    if (!result.success) return null
+    const migrated = migrateV1(result.data)
+    save(migrated)
+    safeRemoveItem(LEGACY_V1_STORAGE_KEY)
+    return migrated
+  }
+
+  function load(): UserSettings {
+    if (safeGetItem(STORAGE_KEY) === null) return migrateFromV1() ?? defaultUserSettings()
+    const result = userSettingsSchema.safeParse(readJson(STORAGE_KEY))
     return result.success ? result.data : defaultUserSettings()
   }
 
@@ -206,6 +269,10 @@ export function createUserSettingsStore(): UserSettingsStore {
 
   function reset(): void {
     safeRemoveItem(STORAGE_KEY)
+    // Both keys, or a reset on a browser that has not migrated yet clears
+    // nothing that lasts: load() would find v2 absent, migrate v1 again, and
+    // hand back the settings the user just reset.
+    safeRemoveItem(LEGACY_V1_STORAGE_KEY)
   }
 
   return { load, save, update, reset }

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -142,7 +142,7 @@ describe('SettingsPage — General', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 1,
+        version: 2,
         storage: {},
         migration: {},
         capabilities: {},
@@ -425,11 +425,11 @@ describe('SettingsPage — disconnecting from a daemon', () => {
     // would return this daemon and make the action read as a no-op.
     createUserSettingsStore().update((current) => ({
       ...current,
-      storage: { ...current.storage, localDaemonBaseUrl: DAEMON, knownDaemonBaseUrls: [DAEMON] },
+      storage: { ...current.storage, daemonBaseUrl: DAEMON, knownDaemonBaseUrls: [DAEMON] },
     }))
     // Asserted rather than assumed: a seed that failed the store's own
     // validation would make every assertion below pass vacuously.
-    expect(createUserSettingsStore().load().storage.localDaemonBaseUrl).toBe(DAEMON)
+    expect(createUserSettingsStore().load().storage.daemonBaseUrl).toBe(DAEMON)
 
     const onDisconnected = renderConnections()
     const desktop = screen.getByTestId('settings-desktop')
@@ -438,10 +438,10 @@ describe('SettingsPage — disconnecting from a daemon', () => {
     const storage = createUserSettingsStore().load().storage
     expect(storage.dismissedDaemonBaseUrls).toContain(DAEMON)
     expect(storage.knownDaemonBaseUrls ?? []).not.toContain(DAEMON)
-    // App.tsx reads localDaemonBaseUrl to decide a load is daemon-backed, so
+    // App.tsx reads daemonBaseUrl to decide a load is daemon-backed, so
     // leaving it set reconnects on the next visit and "this browser stops
     // using it" becomes false the moment the user reloads.
-    expect(storage.localDaemonBaseUrl).toBeUndefined()
+    expect(storage.daemonBaseUrl).toBeUndefined()
     expect(onDisconnected).toHaveBeenCalledTimes(1)
   })
 

--- a/docs/how-to/connect-to-local-daemon.md
+++ b/docs/how-to/connect-to-local-daemon.md
@@ -36,7 +36,7 @@ hosted app as a PWA while online to keep an offline-capable editor.
 ## How detection works
 
 The web app probes `GET /api/runtime/ping` on the daemon's default loopback
-origin (`http://127.0.0.1:3099`, or a custom `localDaemonBaseUrl` from your
+origin (`http://127.0.0.1:3099`, or a custom `daemonBaseUrl` from your
 settings). That endpoint is unauthenticated and only confirms a daemon is
 listening — it does not grant access to any workspace or canvas data.
 

--- a/tools/arch-lint/src/vocabulary-check.test.ts
+++ b/tools/arch-lint/src/vocabulary-check.test.ts
@@ -128,11 +128,39 @@ const BANNED = [
       '.claude/rules/vocabulary.md',
     ],
   },
-  // Deliberately NARROWER than its sibling above, and not an oversight: only
-  // the discriminant VALUE is claimed. `localDaemonBaseUrl` is a persisted
-  // settings key whose rename needs a settings migration, so the identifier
-  // casings stay legal until that increment lands. Widening this pattern
-  // before then produces a guard nobody can make green.
+  // The HYPHENATED spelling is deliberately absent from this pattern, and
+  // that is the whole point of splitting the daemon half from the browser
+  // one. `local-daemon` is still CORRECT in its network sense — mcp-server's
+  // `authMode: 'local-daemon'` opposite `'server-mode'`, the
+  // `connect-to-local-daemon` how-to, the `config-file-local-daemon` anchor
+  // — because a daemon on this machine really is local. Only the identifier
+  // casings (`localDaemonBaseUrl`, `LOCAL_DAEMON_*`) ever named the KEEPER,
+  // and those are what this claims.
+  {
+    pattern: /local_?daemon/i,
+    word: 'localDaemon / LOCAL_DAEMON (as an identifier)',
+    instead: "'daemonBaseUrl' / 'DAEMON_' — the keeper is named by WHO holds the workspace",
+    dirs: [
+      'apps/web/src',
+      'apps/web/scripts',
+      'docs',
+      '.github',
+      '.claude',
+      'README.md',
+      'apps/web/DESIGN.md',
+    ],
+    exempt: [
+      // The v1->v2 settings migration and its tests. They spell the old key
+      // because reading a payload written under it is their entire job —
+      // the same reason a database migration names the columns as they stood
+      // at its point in the log.
+      'apps/web/src/lib/user-settings-store.ts',
+      'apps/web/src/lib/user-settings-store.test.ts',
+      '.claude/rules/vocabulary.md',
+    ],
+  },
+  // The discriminant VALUE, still apps/web-only: in `packages/mcp-server` the
+  // same quoted string is the network-sense auth mode and is correct there.
   {
     pattern: /(['"])local-daemon\1/,
     word: "'local-daemon' (as a value)",
@@ -142,12 +170,6 @@ const BANNED = [
       'apps/web/src/lib/user-settings-store.ts',
       'apps/web/src/lib/user-settings-store.test.ts',
     ],
-  },
-  {
-    pattern: /\bLOCAL_DAEMON_/,
-    word: 'LOCAL_DAEMON_ constants',
-    instead: 'DAEMON_',
-    dirs: ['apps/web/src'],
   },
 ] as const
 


### PR DESCRIPTION
Increment C, and the last of the keeper-vocabulary work (#1029 values and copy, #1042 file names and prose). The persisted `localDaemonBaseUrl` becomes `daemonBaseUrl` — under a real migration, because this is the one place a sweep could not go.

## Why not a sweep

Measured, not argued: `storageSettingsSchema` is `.strict()` and `load()` falls back to defaults on **any** parse failure, so renaming the key in place discards an existing reader's **whole** payload — daemon URL, known and dismissed daemons, theme, fonts — not merely the daemon connection.

A sweep did exactly that earlier in this series, and the loss was invisible precisely because nothing reads the field it renamed. That incident is what scoped this increment out in the first place.

## The migration

`STORAGE_KEY` moves to `whiteboard:user-settings:v2`. The store reads the `:v1` key once and migrates when v2 is **absent** — never when v2 is merely invalid, which keeps the existing invalid-means-defaults contract exactly as it was.

Two keys rather than a version discriminator inside one, because that is what makes a concurrently-open **old** tab harmless: it keeps reading and writing v1, which this build stops looking at once v2 exists, instead of `safeParse`-failing on the bumped literal and overwriting v2 with its defaults.

Seven tests pin the migration: the renamed field, every other field surviving, the dead fields dropped, the v1 key removed after the write, a v2 payload winning so a stale v1 cannot resurrect, a token-shaped key still refused (the migration must not become the hole `.strict()` exists to close), and a payload with no daemon connection not inventing one.

## Two fields go IN the migration, not through it

`preferredProvider` and `lastBrowserCanvasId` were read and written by **nothing** — verified at every `.storage` access, all of which name their field explicitly, so no spread could be reading them. They are dropped rather than renamed: a field nobody reads does not need a better name.

`lastBrowserCanvasId` was also the last `canvas`-as-container-noun in a stored shape, retired by deletion instead of a rename.

## Two defects found on the way, neither of them the rename

**The mechanical pass introduced a real bug.** `disconnect-daemon.ts` already had a *parameter* named `daemonBaseUrl`, so the renamed destructured field shadowed it and the guard became `daemonBaseUrl === daemonBaseUrl` — always true, which would have cleared **any** daemon's stored URL rather than only the one being disconnected. The parameter is now `target`. Mutation-checked: the always-true form turns `leaves a different daemon connected` red, so the existing test does cover it.

**`reset()` did not reset.** It removed only the v2 key, so a browser that had not migrated yet would have had its settings resurrected by the very next `load()`. It clears both keys now, pinned by its own test and mutation-checked.

## Five tests had been passing for the wrong reason

`App.test.tsx` (×4) and `SettingsPage.test.tsx` (×1) hand-seed a payload at `STORAGE_KEY` and still stamped `version: 1`, so after the bump they silently exercised the *defaults* path instead of the stored one. Bumped to v2. One of them (`falls back to the browser when renewal reports none`) asserts the fallback, so it had been green regardless of whether its seed parsed at all.

## The guard

The daemon half is now pinned in its **identifier** casings (`/local_?daemon/i`) over the same prose surface as the browser half.

The hyphenated `local-daemon` is deliberately **not** claimed, and never will be — it is correct in its network sense, because a daemon on this machine really is local: `packages/mcp-server`'s `authMode: 'local-daemon'` opposite `'server-mode'`, the `connect-to-local-daemon` how-to, the `config-file-local-daemon` anchor. Only the identifier casings ever named the *keeper*.

Mutation-checked in both directions, and the negative direction is the one that matters:

```
localDaemonBaseUrl planted in browser-backend.ts   -> 1 failed
                   in README.md                    -> 1 failed
                   in connect-to-local-daemon.md   -> 1 failed
                   in preview-pr-deploy.yml        -> 1 failed
hyphenated local-daemon planted in README.md       -> 1 passed   <- must stay legal
store exemption removed                            -> 1 failed   <- load-bearing
```

`user-settings-store.ts` and its test are exempt for the reason a migration always is: spelling the old key is how they read a payload written under it.

## Also

Extracts the http(s) refine the schema had three copies of (the legacy shape would have made six), and fixes the one doc line that named the settings key.

## Verification

| gate | result |
|---|---|
| `pnpm -r typecheck` | clean |
| `pnpm test --project arch-lint-node` | 92 passed |
| `pnpm test --project web-browser` | **767 passed (140 files)** |
| `pnpm --filter @kamiazya/whiteboard-web test` (CI's `test-jsdom`) | 2746 passed, 9 failed |
| `pnpm knip` | clean |
| `pnpm lint:noconsole` / `biome check` | clean |

The 9 failures are the known objectURL/thumbnail family that this container reproduces on an unmodified tree — no `createObjectURL` in jsdom here. They are **not** assumed: the same 9 were verified against a clean `origin/main` tree during #1042, and CI's `test-jsdom` job was green on that PR, which is the direct evidence they do not occur in CI. The first full run of this branch showed 13, and the 4 extra were real regressions of mine — the five hand-seeded payloads above — now fixed and back to 9.

This diff touches no `packages/` file.

Visual evidence: none — nothing here reaches a rendered surface. The change is a persisted-schema migration, an identifier rename behind it, one doc line, and a lint guard. `web-browser` at 767/767 plus the seven migration tests are the behavioural evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_