### PR TITLE
fix(deps): pin body-parser to 2.3.0 (GHSA-v422-hmwv-36x6)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,7 @@ overrides:
   ip-address@<=10.3.0: '>=10.3.1'
   js-yaml@>=4.0.0 <4.3.1: ^4.3.1
   ip-address@<=10.1.0: ^10.1.1
+  body-parser@<2.3.0: ^2.3.0
   mermaid@<11.15.0: ^11.16.0
   dompurify@<3.4.12: ^3.4.12
   immutable@<4.3.9: ^4.3.9
@@ -4689,8 +4690,8 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
   boolean@3.2.0:
@@ -4877,6 +4878,10 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -7743,6 +7748,10 @@ packages:
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -12046,17 +12055,17 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  body-parser@2.2.2:
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
-      content-type: 1.0.5
+      content-type: 2.1.0
       debug: 4.4.3
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
       qs: 6.15.2
       raw-body: 3.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12229,6 +12238,8 @@ snapshots:
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
+
+  content-type@2.1.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -12865,7 +12876,7 @@ snapshots:
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.3.0
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -15683,6 +15694,12 @@ snapshots:
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.1.0
       media-typer: 1.1.0
       mime-types: 3.0.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -78,6 +78,7 @@ overrides:
   ip-address@<=10.3.0: '>=10.3.1'
   js-yaml@>=4.0.0 <4.3.1: ^4.3.1
   ip-address@<=10.1.0: ^10.1.1
+  body-parser@<2.3.0: ^2.3.0
   mermaid@<11.15.0: ^11.16.0
   dompurify@<3.4.12: ^3.4.12
   immutable@<4.3.9: ^4.3.9


### PR DESCRIPTION
## What this closes

`body-parser@2.2.2` reaches the **published package** as a runtime transitive:

```
@kamiazya/whiteboard-mcp → @modelcontextprotocol/ext-apps → MCP SDK → express → body-parser
```

GHSA-v422-hmwv-36x6 (low): denial of service when an invalid `limit` value is silently discarded. Fixed in 2.3.0 — the release notes list **no breaking changes**; the only other thing this lockfile moves is the `content-type` bump 2.3.0 brings with it.

`pnpm audit --prod` goes from **1 low** to **`No known vulnerabilities found`**.

## Two things that silently do nothing here

Both were measured, not assumed, and either one would have shipped a no-op "fix":

- **`pnpm up -r body-parser` does nothing.** `pnpm up` only touches packages a `package.json` lists, and this is transitive. Run on its own it churned **332 lockfile lines**, left `body-parser` at 2.2.2, and added a *third* `esbuild` copy while leaving the vulnerable one in place. Reverted.
- **Overrides do not live in `package.json`.** pnpm v11 stopped reading the `pnpm` field there — `pnpm-workspace.yaml` is the real location, and the repo already keeps a dozen entries in it. An override written to `package.json` installs cleanly and changes nothing; verified by checking the resolved version, which stayed 2.2.2.

The diff is therefore one line of `pnpm-workspace.yaml` plus what it re-resolves.

## The other alert is held, deliberately

`esbuild@0.27.7` (GHSA-g7r4-m6w7-qqqr, low) is **not** pinned.

`tsup@8.5.1` declares `esbuild: ^0.27.0`, so 0.28.x is outside the range its author tested — and tsup is what builds the published package. The advisory needs esbuild's **own dev server**, on **Windows**, which tsup never starts. The cost is real and the exposure is not, so it waits for tsup to move. Recorded in the `deps-esbuild-alert-held` note with the release condition, so it is a decision on the record rather than an alert nobody looked at.

## Verification

- `pnpm audit --prod` → `No known vulnerabilities found`
- `pnpm install --frozen-lockfile` → clean
- `pnpm -r typecheck` → all packages Done
- `pnpm test --project mcp-node` → 3778 passed
- `pnpm smoke:e2e` → ALL OK (exercises the MCP HTTP path this dependency sits under — the skill's load-bearing table puts the MCP SDK there, and body-parser is beneath it)

Visual evidence: none — a dependency pin; nothing here is rendered to anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoaNgqWUKbYJxk2azmRQKY