### PR TITLE
test(web): the stale-link guard test actually enters the window it guards

### DIFF
--- a/apps/web/src/pages/BrowserDocumentPage.stale-link.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.stale-link.test.tsx
@@ -178,9 +178,11 @@ describe('stale /local/:path deep link', () => {
     })
 
     // Held open so the navigation below lands inside the enumeration window.
-    // The FIRST call is the controller resolving `initialPath` — letting that
-    // through is what gets a document loaded at all; the page's own list
-    // effect is the second, and that is the one this test suspends.
+    // The page's own list effect is the FIRST call — holding it still lets the
+    // document load, because the controller resolves `initialPath` without
+    // going through here. An earlier version held the second call on the
+    // belief that the first was the controller's; nothing was suspended that
+    // mattered, and the test spent months exercising the fast path twice.
     let releaseList: (() => void) | undefined
     const held = new Promise<void>((resolve) => {
       releaseList = resolve
@@ -193,7 +195,7 @@ describe('stale /local/:path deep link', () => {
     let calls = 0
     store.index.listDocuments = async (input) => {
       calls += 1
-      if (calls === 2) await held
+      if (calls === 1) await held
       return listDocuments(input)
     }
 
@@ -225,6 +227,13 @@ describe('stale /local/:path deep link', () => {
       await router.navigate('/local/other-canvas')
     })
     expect(router.state.location.pathname).toBe('/local/other-canvas')
+    // The scaffold is IN the window, asserted rather than assumed. The page
+    // still shows the document it loaded, which is what "the list has not
+    // arrived" looks like from here — `switcherOptions` holds that document
+    // alone, so `other-canvas` resolves to nothing and the branch under test
+    // is the one that must not repair. Without this line the test passed for
+    // months while never entering the window at all.
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Real canvas')
 
     releaseList?.()
     await act(async () => {


### PR DESCRIPTION
## The test was outside the window it exists for

`does not repair a path it cannot judge yet, while the document list is still loading` guards a real invariant: while `documents` is still empty, "not in the list" means "not known yet", so repairing the URL there would overwrite a navigation to a perfectly valid document with nothing left to undo it.

It held the **second** `index.listDocuments` call, on a comment saying the first was the controller resolving `initialPath` and the second was the page's own list effect. That was true once. The page's list effect is the **first** call now.

So nothing that mattered was suspended. By the time the test navigated, the list had arrived, `switcherOptions` resolved `other-canvas` to a real id, and the run went down the `switchDocument` branch — which never reads `documentsEnumeratedRef` at all. **The guarded branch was never executed.**

## Measured, both ways

| held call | probe at the moment of the assertion | meaning |
|---|---|---|
| 2 (before) | `calls=2 heading=Other canvas` | page already switched — outside the window |
| 1 (after) | `calls=1 heading=Real canvas` | document held, URL moved — inside it |

Holding the first call still loads the document: the controller resolves `initialPath` without going through here, which is the assumption the old comment got backwards.

## The proof that it guarded nothing

Delete the `documentsEnumeratedRef.current` guard from `BrowserDocumentPage.tsx` and run the **old** test:

```
Tests  3 passed (3)
```

Run the **new** one against the same deletion:

```
× does not repair a path it cannot judge yet, while the document list is still loading
Tests  1 failed | 2 passed (3)
```

That is the whole change: a guard test that goes red when its guard is removed.

## The window assertion is part of the fix

```ts
expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Real canvas')
```

It stays on purpose. Its absence is why a test whose entire subject is a narrow window could sit outside that window for months and still read as coverage — the same shape as `fakeFilesSource` answering `[]` (#1043) and the seven `.cm-line` clicks (#1040) earlier today.

## Verification

apps/web jsdom 2756 + node 77, lint clean for the touched file. Diff is one test file, +13/-4.

Visual evidence: none — a test's scaffold; nothing here is rendered to anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoaNgqWUKbYJxk2azmRQKY