### PR TITLE
fix(canvas-render): a contributed icon carries its own coordinate space and paint

### DIFF
--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -56,6 +56,14 @@ silhouette. `visual.symbol`'s badge is one of these and now lives in
 `plugin-visual`, taking its size, margin and corner with it; this package no
 longer knows what a badge is.
 
+**An icon contribution carries its coordinate space and paint**, not geometry
+alone (`IconContribution`, `svg/backend.ts`). Geometry means nothing without
+the box it is drawn in and the convention it is authored for; holding both as
+constants here made a contributed icon in any other space render wrong-sized
+and a fill-authored one render invisible. The bundled set declares its own, so
+the renderer's fallback (24x24, stroke-only) is only for a table that says
+neither.
+
 The default is the bundled plugin's set, NOT an opt-in, for the lowlight
 reason recorded in `architecture-map.md`: a resolution step four call sites
 have to remember is one a call site forgets, and the surface that forgets does

--- a/.claude/rules/package-plugin-visual.md
+++ b/.claude/rules/package-plugin-visual.md
@@ -78,7 +78,18 @@ split is the test-level form of the dependency rule above.
 
 ## Vendored icons
 
-`src/icons/` carries lucide geometry with its LICENSE and provenance README.
+`src/icons/` carries lucide geometry with its LICENSE and provenance README,
+and `VISUAL_ICONS` is that geometry plus the two things geometry is
+meaningless without: the **coordinate space** it is drawn in and the **paint**
+it is authored for. Both are declared HERE rather than defaulted in the
+renderer, because they are properties of this icon set and not of drawing
+icons in general — a contributed set in a different space, or one that fills
+rather than strokes, is equally valid and says so the same way.
+
+They were hard-coded in `canvas-render` until measured: a contributed 100x100
+icon rendered into lucide's 24x24 box, and a fill-authored one rendered as
+nothing at all.
+
 Geometry rather than the `lucide-react` package because the renderer has no
 React: lucide-react ships components, and only the badge picker can use them.
 Follow the README's recipe when adding one, and keep the table alphabetical.

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -1,8 +1,4 @@
-import {
-  LUCIDE_ICONS,
-  LUCIDE_VIEWBOX,
-  type LucideIconElement,
-} from '@kamiazya/whiteboard-plugin-visual'
+import { type LucideIconElement, VISUAL_ICONS } from '@kamiazya/whiteboard-plugin-visual'
 import { ARROW_MARKER, edgeArrowEnds } from '../edge-arrows.js'
 import { hopEndpoints, jumpsWithinSpan } from '../layout/edges/edge-flatten.js'
 import { EDGE_JUMP_RADIUS_PX } from '../layout/edges/edge-jumps.js'
@@ -523,20 +519,50 @@ const GLYPH_BASELINE_FACTOR = 0.35
  * (a full lucide dependency, a facet distribution's own glyphs) without
  * this package depending on one, and the table survives `postMessage`.
  */
-export type IconTable = Readonly<Record<string, ReadonlyArray<LucideIconElement>>>
+/**
+ * An icon set's paint, applied to the whole `<symbol>` definition so one def
+ * serves every referencing node. Only the stroke COLOR is left to inherit
+ * from each `<use>`.
+ */
+export type IconPaint = Readonly<Record<string, string | number>>
+
+/**
+ * One icon: its geometry plus the two things geometry is meaningless without.
+ *
+ * `viewBox` is the coordinate space the geometry is drawn in, and `paint` the
+ * convention it is authored for. Both were hard-coded to the bundled set's
+ * before this, so a contributed icon in any other space came out the wrong
+ * size and clipped, and one wanting a fill came out invisible.
+ */
+export interface IconContribution {
+  readonly geometry: ReadonlyArray<LucideIconElement>
+  readonly viewBox?: string
+  readonly paint?: IconPaint
+}
+
+export type IconTable = Readonly<Record<string, IconContribution>>
+
+/**
+ * What a set that declares neither gets. 24x24 stroke-only is what every icon
+ * in this repo is authored for, so a table saying nothing still draws.
+ */
+const FALLBACK_ICON_VIEWBOX = '0 0 24 24'
+const FALLBACK_ICON_PAINT: IconPaint = {
+  fill: 'none',
+  'stroke-width': 2,
+  'stroke-linecap': 'round',
+  'stroke-linejoin': 'round',
+}
 
 /**
  * `Array.isArray` and not a bare `!== undefined`: both tables are plain
  * objects, so a prototype-inherited name (`toString`) answers a function,
  * which must degrade like any unknown name rather than throw downstream.
  */
-function lookupIcon(
-  name: string,
-  icons: IconTable | undefined,
-): ReadonlyArray<LucideIconElement> | undefined {
+function lookupIcon(name: string, icons: IconTable | undefined): IconContribution | undefined {
   const fromCaller = icons === undefined ? undefined : icons[name]
-  const geometry = fromCaller ?? LUCIDE_ICONS[name]
-  return Array.isArray(geometry) ? geometry : undefined
+  const found = fromCaller ?? VISUAL_ICONS[name]
+  return Array.isArray(found?.geometry) ? found : undefined
 }
 
 function renderNode(node: SceneNode, tables?: ResolveTables): SvgChild {
@@ -688,25 +714,19 @@ function renderNode(node: SceneNode, tables?: ResolveTables): SvgChild {
       return renderShape(node, tables)
     case 'icon': {
       if (!isFiniteBox(node.bbox)) return []
-      const geometry = lookupIcon(node.icon, tables?.icons)
-      if (geometry === undefined) return []
+      const contribution = lookupIcon(node.icon, tables?.icons)
+      if (contribution === undefined) return []
       const id = `wb-icon-${idToken(node.icon)}`
       const def: SvgDef = {
         id,
-        node: el('symbol', { id, viewBox: LUCIDE_VIEWBOX }, [
-          // Lucide's stroke styling lives ON the definition (fill none,
-          // stroke-width 2, round caps/joins); only the stroke COLOR
+        node: el('symbol', { id, viewBox: contribution.viewBox ?? FALLBACK_ICON_VIEWBOX }, [
+          // The set's paint lives ON the definition; only the stroke COLOR
           // inherits from each referencing <use>, so one def serves every
           // color-assigned node.
           el(
             'g',
-            {
-              fill: 'none',
-              'stroke-width': 2,
-              'stroke-linecap': 'round',
-              'stroke-linejoin': 'round',
-            },
-            geometry.map(renderIconElement),
+            contribution.paint ?? FALLBACK_ICON_PAINT,
+            contribution.geometry.map(renderIconElement),
           ),
         ]),
       }

--- a/packages/canvas-render/src/svg/contributed-icon.test.ts
+++ b/packages/canvas-render/src/svg/contributed-icon.test.ts
@@ -1,0 +1,60 @@
+// An icon set has a COORDINATE SPACE and a PAINT CONVENTION, and geometry is
+// meaningless without both. `SvgDocumentOptions.icons` accepted geometry
+// alone and drew every entry into lucide's 24x24 box under lucide's
+// stroke-only styling — so a contributed icon drawn in any other space came
+// out the wrong size and clipped, and a contributed icon that wants a FILL
+// came out invisible.
+//
+// Measured before this, with a 100x100 square in a 48px box:
+//   <symbol viewBox="0 0 24 24"><g fill="none" stroke-width="2">
+//     <rect x="0" y="0" width="100" height="100"/>
+import { describe, expect, it } from 'vitest'
+import type { Scene } from '../scene-graph.js'
+import { renderSceneToSvg } from './backend.js'
+
+const sceneWith = (icon: string): Scene => ({
+  nodes: [{ kind: 'icon', bbox: { x: 0, y: 0, w: 48, h: 48 }, icon }],
+})
+
+const SQUARE = [{ tag: 'rect', x: 0, y: 0, width: 100, height: 100 }] as const
+
+describe('a contributed icon', () => {
+  it('is drawn in the coordinate space its own set declares', () => {
+    const svg = renderSceneToSvg(sceneWith('demo.box'), {
+      icons: { 'demo.box': { geometry: SQUARE, viewBox: '0 0 100 100' } },
+    })
+    expect(svg).toContain('viewBox="0 0 100 100"')
+    expect(svg).not.toContain('viewBox="0 0 24 24"')
+  })
+
+  it('is painted the way its own set declares, so a filled icon is visible', () => {
+    const svg = renderSceneToSvg(sceneWith('demo.box'), {
+      icons: {
+        'demo.box': { geometry: SQUARE, viewBox: '0 0 100 100', paint: { fill: 'currentColor' } },
+      },
+    })
+    // Not lucide's stroke-only convention, which renders a filled shape as
+    // nothing at all.
+    expect(svg).toContain('fill="currentColor"')
+    expect(svg).not.toContain('fill="none"')
+  })
+
+  it('falls back to the renderer’s own space when a set declares none', () => {
+    // A table that says nothing still has to draw something, and 24x24
+    // stroke-only is what every icon in this repo is authored for.
+    const svg = renderSceneToSvg(sceneWith('demo.box'), {
+      icons: { 'demo.box': { geometry: SQUARE } },
+    })
+    expect(svg).toContain('viewBox="0 0 24 24"')
+  })
+
+  it('leaves the bundled set drawing exactly as it did', () => {
+    // `visual`'s own icons declare their space and paint rather than relying
+    // on the fallback above — the renderer holding one plugin's conventions
+    // as its default is the coupling this seam exists to remove.
+    const svg = renderSceneToSvg(sceneWith('star'))
+    expect(svg).toContain('viewBox="0 0 24 24"')
+    expect(svg).toContain('fill="none"')
+    expect(svg).toContain('stroke-width="2"')
+  })
+})

--- a/packages/canvas-render/src/svg/icon.test.ts
+++ b/packages/canvas-render/src/svg/icon.test.ts
@@ -65,7 +65,7 @@ describe('caller-supplied icon table (SvgDocumentOptions.icons)', () => {
   it('a caller-supplied icon renders through the same symbol/use mechanism', () => {
     const svg = renderSceneToSvg(
       { nodes: [icon('rocket')] },
-      { icons: { rocket: [{ tag: 'circle', cx: 12, cy: 12, r: 8 }] } },
+      { icons: { rocket: { geometry: [{ tag: 'circle', cx: 12, cy: 12, r: 8 }] } } },
     )
     expect(svg).toContain('<symbol id="wb-icon-rocket" viewBox="0 0 24 24">')
     expect(svg).toContain('<circle cx="12" cy="12" r="8"/>')
@@ -75,7 +75,7 @@ describe('caller-supplied icon table (SvgDocumentOptions.icons)', () => {
   it('a caller entry overrides the vendored geometry under the same name', () => {
     const svg = renderSceneToSvg(
       { nodes: [icon('lock')] },
-      { icons: { lock: [{ tag: 'circle', cx: 12, cy: 12, r: 8 }] } },
+      { icons: { lock: { geometry: [{ tag: 'circle', cx: 12, cy: 12, r: 8 }] } } },
     )
     expect(svg).toContain('<circle cx="12" cy="12" r="8"/>')
     // The vendored lock body must be gone — the caller's table won.
@@ -85,7 +85,7 @@ describe('caller-supplied icon table (SvgDocumentOptions.icons)', () => {
   it('vendored names keep resolving when the caller table lacks them', () => {
     const svg = renderSceneToSvg(
       { nodes: [icon('lock')] },
-      { icons: { rocket: [{ tag: 'circle', cx: 12, cy: 12, r: 8 }] } },
+      { icons: { rocket: { geometry: [{ tag: 'circle', cx: 12, cy: 12, r: 8 }] } } },
     )
     expect(svg).toContain('<rect x="3" y="11" width="18" height="11" rx="2"/>')
   })

--- a/packages/plugin-visual/src/icons/icons.ts
+++ b/packages/plugin-visual/src/icons/icons.ts
@@ -67,3 +67,39 @@ export const LUCIDE_ICONS: Readonly<Record<string, ReadonlyArray<LucideIconEleme
  * never lists a name the backend would silently drop.
  */
 export const BUILT_IN_ICON_NAMES: readonly string[] = Object.keys(LUCIDE_ICONS).sort()
+
+/**
+ * This set as the renderer consumes it: the geometry above, plus the
+ * coordinate space it is drawn in and the paint it is authored for.
+ *
+ * Declared HERE rather than defaulted in the renderer, because they are
+ * properties of this icon set and not of drawing icons in general — a
+ * contributed set in a different space, or one that fills rather than
+ * strokes, is equally valid and says so the same way.
+ */
+export const VISUAL_ICONS: Readonly<
+  Record<
+    string,
+    {
+      readonly geometry: ReadonlyArray<LucideIconElement>
+      readonly viewBox: string
+      readonly paint: Readonly<Record<string, string | number>>
+    }
+  >
+> = Object.fromEntries(
+  Object.entries(LUCIDE_ICONS).map(([name, geometry]) => [
+    name,
+    {
+      geometry,
+      viewBox: LUCIDE_VIEWBOX,
+      // Lucide's own convention: outline only, so the stroke COLOR is the
+      // single thing a referencing `<use>` assigns.
+      paint: {
+        fill: 'none',
+        'stroke-width': 2,
+        'stroke-linecap': 'round',
+        'stroke-linejoin': 'round',
+      },
+    },
+  ]),
+)

--- a/packages/plugin-visual/src/index.ts
+++ b/packages/plugin-visual/src/index.ts
@@ -9,4 +9,4 @@
  */
 export * from './data.js'
 export type { LucideIconElement } from './icons/icons.js'
-export { BUILT_IN_ICON_NAMES, LUCIDE_ICONS, LUCIDE_VIEWBOX } from './icons/icons.js'
+export { BUILT_IN_ICON_NAMES, LUCIDE_ICONS, LUCIDE_VIEWBOX, VISUAL_ICONS } from './icons/icons.js'


### PR DESCRIPTION
Phase 3 started as "remove the four direct calls and drop the `canvas-render` → `plugin-visual` dependency". **Investigation retired that goal and found a real defect instead.**

## Why the original goal was wrong

`layoutSpatialCanvas` has **9** call sites and `renderSceneToSvg` **9**, across four packages. The lowlight incident `architecture-map.md` records was *four* sites, and one of them forgot — leaving export drawing every code fence plain. Asking eighteen sites to remember to pass a plugin's shapes and decorations does not fail loudly; it silently draws a plain node with no badge. The default has to come from inside the renderer, exactly as `highlightCode` depends on lowlight *and* takes an override.

What the remaining coupling actually is, once counted: `visualDecorations` is the intended default-supplier pattern; `resolveCanvasEdgeStyle` also reads a **legacy non-facet key** (`x-whiteboard.edgeRouting`), so it is not purely plugin knowledge; and the icon table was broken.

## The defect

`SvgDocumentOptions.icons` accepted geometry and nothing else, then drew every entry into lucide's 24×24 box under lucide's stroke-only styling. Measured, a 100×100 square in a 48px box:

```
<symbol viewBox="0 0 24 24"><g fill="none" stroke-width="2">
  <rect x="0" y="0" width="100" height="100"/>
```

So a contributed icon in any other coordinate space came out wrong-sized and clipped, and one authored to **fill** came out invisible. Geometry is meaningless without the space it is drawn in and the convention it is authored for, so `IconContribution` now carries all three.

This shipped before any of the plugin work — the extension point was there, and accepted input it could not honour.

The bundled set now **declares** its own viewBox and paint rather than relying on the renderer's fallback. They are properties of lucide's set, not of drawing icons in general, and holding them in `canvas-render` was one more piece of one plugin's knowledge living in the renderer. The fallback stays for a table that says neither, since 24×24 stroke-only is what every icon in this repo is authored for.

## Visual repro

![icon-figure.png](https://github.com/user-attachments/assets/731cd1d2-2937-4417-bf63-3c788bd5c8c9)

Same three icons, same pipeline. The contributed droplet is **absent entirely** in the before panel — stroke-only paint applied to a fill-authored path draws nothing. The two bundled icons are identical between panels, which is the other half of the evidence: the change is confined to the contributed one.

Panel digests: before `e2fe7cac`, after `4b2ea885`.

## Gates

- `pnpm test` — 9528 passed, 0 failed (978 files)
- `pnpm -r typecheck`, `pnpm lint`, `pnpm knip`, `@kamiazya/whiteboard-mcp typecheck`, `pnpm build` — clean

Mutation-checked: ignoring the set's viewBox (the bug as it shipped), ignoring its paint, and the plugin ceasing to declare its own each fail exactly the case that names them.

One process note worth recording: the first gate run reported **314 files / 3783 tests** and read as green. It was `packages/mcp-server`'s own suite — a leftover `cd` from rasterising a screenshot. The count being far below CI's is what caught it, which is the check `dev-flow.md` prescribes for exactly this.

## Next

The second half of the investigation — the plugin supplying its own facet READERS, so `canvas-render` hard-codes no facet key and the shape-reader asymmetry closes — is a separate increment. Edge style stays where it is, with its legacy fallback documented as the reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013avJozs9SoCuDzZJGuTcqH
