### PR TITLE
fix(server-core): the teardown seam brackets the delete, so the capture is under the lock

### DIFF
--- a/packages/mcp-server/src/server/store/document-delete-lock.test.ts
+++ b/packages/mcp-server/src/server/store/document-delete-lock.test.ts
@@ -1,0 +1,100 @@
+/**
+ * `wb_document_delete` must capture what it is going to clean up while
+ * holding the workspace write lock, the way the HTTP DELETE has always done.
+ *
+ * The HTTP path wraps its whole sequence in `withWorkspaceWriteLock`. The
+ * agent path does not: only the index's row delete takes the lock, from
+ * inside. That leaves the teardown's capture OUTSIDE it, so a version saved
+ * by a concurrent writer after the capture has its row cascaded away by the
+ * delete while its thumbnail was never in the captured set — the orphaned
+ * file the teardown seam exists to prevent, on the one path the seam was
+ * added for.
+ *
+ * Deterministic rather than racy: the writer holds the lock across the
+ * whole window, so the interleaving is imposed instead of hoped for.
+ */
+import { existsSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { LoroDoc } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let tempDir: string
+
+vi.mock('../config.js', () => ({
+  get DATA_DIR() {
+    return tempDir
+  },
+  getDataDir: () => tempDir,
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+  REPO_ROOT: '/tmp',
+}))
+
+const { withWorkspaceWriteLock } = await import('./workspace-lock.js')
+const { FileVersionStore, thumbnailPath } = await import('./version-store.js')
+const { getDb } = await import('./db/index.js')
+const { prepareDataDir } = await import('./db/prepare.js')
+const { createContainer, resolveServerDeps } = await import('../../di/container.js')
+const { createStoreLocalModule } = await import('../../di/store-local.module.js')
+const { wbDocumentCreate, wbDocumentDelete } = await import('@kamiazya/whiteboard-server-core')
+
+describe('wb_document_delete', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-delete-lock-'))
+  })
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('leaves no thumbnail behind for a version saved while the delete is in flight', async () => {
+    await prepareDataDir(tempDir)
+    const db = await getDb(tempDir)
+    const deps = resolveServerDeps(
+      createContainer(createStoreLocalModule({ db, blobDir: tempDir })),
+    )
+    const created = await wbDocumentCreate(deps, {
+      workspaceId: 'ws-1',
+      path: 'doomed',
+      kind: 'spatial',
+      createWorkspace: true,
+    })
+
+    // The writer holds the lock in its own async chain, so the delete
+    // started below cannot re-enter it — reentrancy is tracked per call
+    // chain, and starting the delete inside this callback would legitimately
+    // skip the queue rather than exposing what this test is about.
+    let releaseWriter!: () => void
+    const mayWrite = new Promise<void>((resolve) => {
+      releaseWriter = resolve
+    })
+    let writerAcquired!: () => void
+    const lockHeld = new Promise<void>((resolve) => {
+      writerAcquired = resolve
+    })
+    const versions = new FileVersionStore()
+    const writer = withWorkspaceWriteLock('ws-1', async () => {
+      writerAcquired()
+      await mayWrite
+      const entry = await versions.save('ws-1', 'doomed', new LoroDoc(), { auto: false })
+      await versions.saveThumbnail('ws-1', entry.id, new Uint8Array([1, 2, 3]))
+      return entry.id
+    })
+    await lockHeld
+
+    const deleted = wbDocumentDelete(deps, {
+      workspaceId: 'ws-1',
+      documentId: created.documentId,
+    })
+    // Let the delete run as far as it can before it needs the lock. What it
+    // manages to do here is exactly the part this test is about.
+    await new Promise((resolve) => setImmediate(resolve))
+
+    releaseWriter()
+    const versionId = await writer
+    await deleted
+
+    expect(existsSync(thumbnailPath('ws-1', versionId))).toBe(false)
+  })
+})

--- a/packages/mcp-server/src/server/store/document-store.ts
+++ b/packages/mcp-server/src/server/store/document-store.ts
@@ -514,15 +514,22 @@ async function unlinkIfExists(path: string): Promise<void> {
  * have to be captured while the document is still whole.
  */
 export const documentTeardown: DocumentTeardown = {
-  async begin({ workspaceId, documentId, path }) {
-    const db = await dbReady()
-    const versionRows = await db
-      .selectFrom('versions')
-      .select(['id'])
-      .where('documentId', '=', documentId)
-      .execute()
+  around({ workspaceId, documentId, path }, deleteDocument) {
+    // The whole delete runs under this workspace's write barrier, capture
+    // included. A version saved between the capture and the row delete
+    // would otherwise have its row cascaded away while its thumbnail was
+    // never in the captured set — an orphaned file, from the one seam that
+    // exists to prevent them.
+    return withWorkspaceWriteLock(workspaceId, async () => {
+      const db = await dbReady()
+      const versionRows = await db
+        .selectFrom('versions')
+        .select(['id'])
+        .where('documentId', '=', documentId)
+        .execute()
 
-    return async () => {
+      const result = await deleteDocument()
+
       const blobPath = documentBlobPath(workspaceId, documentId)
       await unlinkIfExists(blobPath)
       await unlinkIfExists(`${blobPath}.pre-migrate-bak`)
@@ -534,7 +541,9 @@ export const documentTeardown: DocumentTeardown = {
       // reload from — a fresh create should not inherit a doc instance that
       // still holds the deleted canvas's history).
       evictDoc(workspaceId, path)
-    }
+
+      return result
+    })
   },
 }
 
@@ -546,22 +555,20 @@ export async function deleteDocument(workspaceId: string, path: string): Promise
     const documentId = await getDocumentIdByPath(db, workspaceId, path)
     if (!documentId) return false
 
-    // Same three steps, in the same order, as wb_document_delete
-    // (server-core's document-crud.ts) — deliberately, because the two used
-    // to be separate implementations and only one of them cleaned up. Each
-    // step is now one shared piece rather than a copy: `deleteDocumentRow`
-    // holds the descendant refusal, `documentTeardown` holds the files.
-    const finalizeTeardown = await documentTeardown.begin({ workspaceId, documentId, path })
+    // Same steps, in the same order, as wb_document_delete (server-core's
+    // document-crud.ts) — deliberately, because the two used to be separate
+    // implementations and only one of them cleaned up. Each step is now one
+    // shared piece rather than a copy: `deleteDocumentRow` holds the
+    // descendant refusal, `documentTeardown` holds the lock and the files.
+    await documentTeardown.around({ workspaceId, documentId, path }, async () => {
+      await deleteDocumentRow(db, workspaceId, path)
 
-    await deleteDocumentRow(db, workspaceId, path)
-
-    // The identity row goes first, then the Libsql snapshot/delta/frontier
-    // rows, so a crash between the two leaves an orphaned-but-unreachable
-    // snapshot rather than a listed canvas with no content.
-    const documentStore = await documentStoreReady()
-    await documentStore.deleteDoc({ docRef: { kind: 'document', documentId } })
-
-    await finalizeTeardown()
+      // The identity row goes first, then the Libsql snapshot/delta/frontier
+      // rows, so a crash between the two leaves an orphaned-but-unreachable
+      // snapshot rather than a listed canvas with no content.
+      const documentStore = await documentStoreReady()
+      await documentStore.deleteDoc({ docRef: { kind: 'document', documentId } })
+    })
 
     return true
   })

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -20,7 +20,6 @@ export type {
   CanvasClientNotifier,
   DocumentTeardown,
   DocumentWritten,
-  FinalizeDocumentTeardown,
   ServerDeps,
   ViewportRequest,
 } from './server-deps.js'

--- a/packages/server-core/src/server-deps.ts
+++ b/packages/server-core/src/server-deps.ts
@@ -119,7 +119,7 @@ export interface ServerDeps {
    * ever covers the dependencies somebody remembered to write one for.
    *
    * A test whose subject is elsewhere passes `unusedDocumentTeardown()`,
-   * whose `begin` throws — the same idiom as `unusedDocumentIndex`, and for
+   * whose `around` throws — the same idiom as `unusedDocumentIndex`, and for
    * the same reason: a no-op double would let a delete test pass while
    * asserting nothing about the cleanup, which is the state this repo was
    * in before the seam existed.
@@ -151,21 +151,32 @@ export interface ServerDeps {
 export type DocumentWritten = (input: { documentId: DocumentId }) => Promise<void>
 
 /**
- * Split in two because the information the cleanup needs stops existing
- * partway through the delete: a version's thumbnail is filed under the
- * version id, and version rows cascade away with the document. `begin` runs
- * while the document is still whole and returns what to run once it is gone.
+ * A BRACKET around the delete, not a pair of hooks, because two separate
+ * things have to be true at once.
  *
- * The finalizer runs only if the delete actually happened — the index
- * refuses while documents sit below this one, and a refused delete must
- * destroy nothing.
+ * The information the cleanup needs stops existing partway through: a
+ * version's thumbnail is filed under the version id, and version rows
+ * cascade away with the document, so what to unlink can only be read while
+ * the document is still whole. And a composition root may need to hold
+ * something across the WHOLE delete — the daemon holds its per-workspace
+ * write lock — which a `begin` that has already returned cannot do.
+ *
+ * A begin/finalize pair gave the first without the second, and the gap was
+ * real: a version saved between the capture and the row delete had its row
+ * cascaded away while its thumbnail was never in the captured set, leaving
+ * the orphaned file this seam exists to prevent.
+ *
+ * `deleteDocument` runs the delete itself. What it throws propagates, and
+ * the cleanup is then skipped — the index refuses while documents sit below
+ * this one, and a refused delete must destroy nothing.
  */
 export interface DocumentTeardown {
-  begin(input: {
-    workspaceId: string
-    documentId: string
-    path: string
-  }): Promise<FinalizeDocumentTeardown>
+  around<T>(
+    input: {
+      workspaceId: string
+      documentId: string
+      path: string
+    },
+    deleteDocument: () => Promise<T>,
+  ): Promise<T>
 }
-
-export type FinalizeDocumentTeardown = () => Promise<void>

--- a/packages/server-core/src/test-utils/unused-document-teardown.ts
+++ b/packages/server-core/src/test-utils/unused-document-teardown.ts
@@ -1,7 +1,7 @@
 import type { DocumentTeardown } from '../server-deps.js'
 
 /**
- * A `DocumentTeardown` for tests whose subject is elsewhere. `begin` throws,
+ * A `DocumentTeardown` for tests whose subject is elsewhere. `around` throws,
  * so a test that starts deleting documents fails loudly here instead of
  * passing against a double that quietly does nothing — which is exactly the
  * shape of the defect the seam exists to close.
@@ -13,9 +13,9 @@ import type { DocumentTeardown } from '../server-deps.js'
  */
 export function unusedDocumentTeardown(): DocumentTeardown {
   return {
-    begin() {
+    around() {
       throw new Error(
-        'documentTeardown.begin: this test composed a DocumentTeardown it does not exercise. ' +
+        'documentTeardown.around: this test composed a DocumentTeardown it does not exercise. ' +
           'Compose a real one if the behaviour under test now depends on document cleanup.',
       )
     },
@@ -36,8 +36,8 @@ export function unusedDocumentTeardown(): DocumentTeardown {
  */
 export function inMemoryDocumentTeardown(): DocumentTeardown {
   return {
-    async begin() {
-      return async () => undefined
+    around(_input, deleteDocument) {
+      return deleteDocument()
     },
   }
 }

--- a/packages/server-core/src/tools/document-crud.test.ts
+++ b/packages/server-core/src/tools/document-crud.test.ts
@@ -356,17 +356,20 @@ describe('wbDocumentDelete document teardown seam', () => {
     return {
       events,
       teardown: {
-        async begin(input: { workspaceId: string; documentId: string; path: string }) {
-          events.push(`begin:${input.workspaceId}:${input.path}:${input.documentId}`)
-          return async () => {
-            events.push('finalize')
-          }
+        async around<T>(
+          input: { workspaceId: string; documentId: string; path: string },
+          deleteDocument: () => Promise<T>,
+        ) {
+          events.push(`enter:${input.workspaceId}:${input.path}:${input.documentId}`)
+          const result = await deleteDocument()
+          events.push('cleanup')
+          return result
         },
       },
     }
   }
 
-  it('begins teardown while the document still exists and finalizes after it is gone', async () => {
+  it('enters teardown while the document still exists and cleans up after it is gone', async () => {
     const deps = makeDeps()
     const { events, teardown } = makeRecordingTeardown()
     deps.documentTeardown = teardown
@@ -379,37 +382,37 @@ describe('wbDocumentDelete document teardown seam', () => {
     const docRef = { kind: 'document', documentId: created.documentId } as const
 
     // Recorded from inside the seam, not asserted afterwards: whether the
-    // row was still there AT begin is the whole point — a version's
+    // row was still there ON ENTRY is the whole point — a version's
     // thumbnail is filed under a version id that cascades away with it.
     const index = deps.documentIndex
     const store = deps.documentStore
     deps.documentTeardown = {
-      async begin(input) {
+      async around(input, deleteDocument) {
         const stillIndexed = await index.resolveDocumentById({
           workspaceId: input.workspaceId,
           documentId: input.documentId,
         })
-        events.push(`begin:indexed=${stillIndexed !== null}`)
-        return async () => {
-          events.push(
-            `finalize:indexed=${
-              (await index.resolveDocumentById({
-                workspaceId: input.workspaceId,
-                documentId: input.documentId,
-              })) !== null
-            }`,
-          )
-          events.push(`finalize:snapshot=${(await store.loadSnapshot({ docRef })) !== null}`)
-        }
+        events.push(`enter:indexed=${stillIndexed !== null}`)
+        const result = await deleteDocument()
+        events.push(
+          `cleanup:indexed=${
+            (await index.resolveDocumentById({
+              workspaceId: input.workspaceId,
+              documentId: input.documentId,
+            })) !== null
+          }`,
+        )
+        events.push(`cleanup:snapshot=${(await store.loadSnapshot({ docRef })) !== null}`)
+        return result
       },
     }
 
     await wbDocumentDelete(deps, { workspaceId: 'ws-1', documentId: created.documentId })
 
     expect(events).toEqual([
-      'begin:indexed=true',
-      'finalize:indexed=false',
-      'finalize:snapshot=false',
+      'enter:indexed=true',
+      'cleanup:indexed=false',
+      'cleanup:snapshot=false',
     ])
   })
 
@@ -426,12 +429,13 @@ describe('wbDocumentDelete document teardown seam', () => {
 
     await wbDocumentDelete(deps, { workspaceId: 'ws-1', documentId: created.documentId })
 
-    expect(events).toEqual([`begin:ws-1:nested/doc-a:${created.documentId}`, 'finalize'])
+    expect(events).toEqual([`enter:ws-1:nested/doc-a:${created.documentId}`, 'cleanup'])
   })
 
   // A refused delete must not destroy anything. The index refuses while
-  // documents sit below this one, and that refusal happens AFTER begin.
-  it('does not finalize when the index refuses the delete', async () => {
+  // documents sit below this one, and that refusal happens INSIDE the
+  // bracket — it throws past the cleanup rather than being caught by it.
+  it('does not clean up when the index refuses the delete', async () => {
     const deps = makeDeps()
     const { events, teardown } = makeRecordingTeardown()
     deps.documentTeardown = teardown
@@ -447,10 +451,10 @@ describe('wbDocumentDelete document teardown seam', () => {
       wbDocumentDelete(deps, { workspaceId: 'ws-1', documentId: parent.documentId }),
     ).rejects.toThrow(DocumentHasDescendantsError)
 
-    expect(events).not.toContain('finalize')
+    expect(events).not.toContain('cleanup')
   })
 
-  it('never begins teardown for a documentId that does not exist', async () => {
+  it('never enters teardown for a documentId that does not exist', async () => {
     const deps = makeDeps()
     const { events, teardown } = makeRecordingTeardown()
     deps.documentTeardown = teardown

--- a/packages/server-core/src/tools/document-crud.ts
+++ b/packages/server-core/src/tools/document-crud.ts
@@ -153,22 +153,29 @@ export async function wbDocumentDelete(
   if (entry === null) {
     throw new WorkspaceDocumentNotFoundError(input.workspaceId, input.documentId)
   }
-  // Before either delete: what the composition root has to clean up is only
-  // discoverable while the document is still whole (see DocumentTeardown).
-  const finalizeTeardown = await deps.documentTeardown.begin({
-    workspaceId: input.workspaceId,
-    documentId: entry.documentId,
-    path: entry.path,
-  })
-  // Placement first: the index refuses while documents sit below this one, so
-  // the bytes are only discarded once nothing can still be orphaned by it.
-  // That refusal throws past the finalizer, which is what keeps a refused
-  // delete from destroying anything.
-  await deps.documentIndex.deleteDocument({
-    workspaceId: input.workspaceId,
-    path: entry.path,
-  })
-  await deps.documentStore.deleteDoc({ docRef: { kind: 'document', documentId: entry.documentId } })
-  await finalizeTeardown()
-  return { deleted: true }
+  // Both deletes run inside the composition root's bracket: what it has to
+  // clean up is only discoverable while the document is still whole, and
+  // whatever it holds around the delete (the daemon holds its per-workspace
+  // write lock) has to cover both steps. See DocumentTeardown.
+  return await deps.documentTeardown.around(
+    {
+      workspaceId: input.workspaceId,
+      documentId: entry.documentId,
+      path: entry.path,
+    },
+    async () => {
+      // Placement first: the index refuses while documents sit below this
+      // one, so the bytes are only discarded once nothing can still be
+      // orphaned by it. That refusal throws past the bracket's cleanup,
+      // which is what keeps a refused delete from destroying anything.
+      await deps.documentIndex.deleteDocument({
+        workspaceId: input.workspaceId,
+        path: entry.path,
+      })
+      await deps.documentStore.deleteDoc({
+        docRef: { kind: 'document', documentId: entry.documentId },
+      })
+      return { deleted: true }
+    },
+  )
 }


### PR DESCRIPTION
## Summary

`wb_document_delete` could leave an **orphaned thumbnail** behind — the exact failure the teardown seam (#1035) was added to prevent, on the one path it was added for.

The seam was a `begin()` returning a finalizer. `begin` captured the version ids while the document was still whole, because version rows cascade away with it and a thumbnail is filed under a version id. But `begin` had **already returned** by the time the delete ran, so nothing could be held across the whole sequence: the daemon's per-workspace write lock was taken only by the index's row delete, from inside. A version saved by a concurrent writer after the capture therefore had its row cascaded away by the delete while its thumbnail was never in the captured set.

`DocumentTeardown.around(input, deleteDocument)` gives both at once: the composition root captures, runs the delete, and cleans up, all inside whatever it needs to hold. The daemon now holds `withWorkspaceWriteLock` across all three — which is what the HTTP DELETE has always done, and is a step toward the two paths being one implementation (#17).

The lock is re-entrant along a call chain, so the index's own acquisition inside `deleteDocument()` still nests exactly as before. A refused delete still destroys nothing: the descendant refusal throws out of `deleteDocument()` and past the cleanup, which is a plain `await` rather than a `finally` — `document-crud.test.ts` pins that.

## Why not keep begin/finalize and take the lock somewhere else

There is nowhere else it fits. `withWorkspaceWriteLock(id, fn)` scopes the lock to a callback and tracks reentrancy through `AsyncLocalStorage` along the acquiring call chain, so a lock acquired inside `begin` would be released when `begin` returned, and one acquired by the adapter above would put the mechanic in the adapter. The bracket is the shape that lets the composition root hold something without server-core knowing what.

## Test plan

- [x] New or updated tests added — `document-delete-lock.test.ts` (mcp-node)
- [x] `pnpm test` passes locally — `mcp-node` + `server-core-node`: **4186 passed**, 4 pre-existing failures unrelated to this change (see below)
- [x] Manual verification completed — see the mutation check
- [ ] E2E coverage — not applicable

**The red test is deterministic, not racy.** A writer holds the workspace lock across the whole window and saves a real version + thumbnail inside it, so the interleaving is *imposed* rather than hoped for. A racy test that usually passes is how this class of defect survives.

**Mutation check:** dropping `withWorkspaceWriteLock` from the bracket (leaving everything else identical) turns it red on the leaked thumbnail — `expected true to be false` on `existsSync(thumbnailPath(...))`. Restore verified by re-grepping the file, not assumed.

**A first attempt at this test passed against the unfixed code** and is worth recording: it asserted that `wbDocumentDelete` does not *complete* while the lock is held. It does not — the index's own internal acquisition already blocks the whole promise — so the assertion was vacuous for the claim it was making. The invariant that actually needed pinning is narrower: the **capture** must be inside the lock, which only a leaked-file assertion can see.

The 4 pre-existing failures (`migrator.test.ts`, `prepare.test.ts`, `0011-import-fs-blobs.test.ts`) are `EACCES` tests that cannot deny access to root in this container. Confirmed identical on a clean `origin/main` checkout, and green on main in CI.

All five local gates pass: `pnpm -r typecheck`, `pnpm lint`, `pnpm lint:noconsole`, `pnpm audit --prod --audit-level=high`, `pnpm knip`.

## Visual evidence

Visual evidence: none — a server-side seam and a concurrency invariant, with no user-visible surface. The observable effect is a file that is no longer left on disk, which the new test asserts directly.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — n/a, the seam is internal and documented at its declaration
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_019uxfgjcDPQRBtJn5XYQgLc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document deletion reliability when a document is being saved concurrently.
  * Ensured associated thumbnails and other stored files are cleaned up after deletion.
  * Prevented cleanup from running when deletion fails or the document does not exist.
  * Added safeguards to keep document records and files consistent during deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->