### PR TITLE
refactor(mcp-server): the HTTP delete is an adapter over wb_document_delete

### DIFF
--- a/packages/mcp-server/src/di/default-server-deps.ts
+++ b/packages/mcp-server/src/di/default-server-deps.ts
@@ -1,0 +1,42 @@
+import type { ServerDeps } from '@kamiazya/whiteboard-server-core'
+import { getDataDir } from '../server/config.js'
+import { getDb } from '../server/store/db/index.js'
+import { prepareDataDir } from '../server/store/db/prepare.js'
+import { createContainer, resolveServerDeps } from './container.js'
+import { createStoreLocalModule } from './store-local.module.js'
+
+/**
+ * The `ServerDeps` the daemon's own HTTP routes fall back to.
+ *
+ * `http-server.ts` builds these explicitly and hands them to `createApp`,
+ * which is the path production takes. This exists for routers built WITHOUT
+ * that wiring — the many route tests that construct one directly against a
+ * mocked data dir, and any ad-hoc caller — so that a route needing an
+ * operation does not have to be threaded through eighty construction sites
+ * before it can stop reimplementing one.
+ *
+ * Deliberately NOT the `documentTeardown` situation, where optional meant
+ * "silently absent". The fallback here is the real production wiring over
+ * the same memoized database connection the legacy routes already read
+ * through, so a caller that supplies nothing gets correct behaviour rather
+ * than a no-op.
+ *
+ * `prepareDataDir` first, exactly as `document-store.ts`'s own `dbReady`
+ * does, because this is the same entry condition: a caller that reaches a
+ * route before anything has migrated the data dir must not meet a missing
+ * table. The daemon migrates at boot and both are memoized, so on the
+ * production path this is already satisfied.
+ *
+ * Not memoized. `getDb` already is, which is the part that costs anything;
+ * what is left is a few container binds on a request that deletes a
+ * document. Caching it would key on the data dir and outlive
+ * `createIsolatedDb`'s `dispose()`, handing a later caller a `ServerDeps`
+ * holding a destroyed connection — a real trap in exchange for a saving
+ * nobody has measured.
+ */
+export async function getDefaultServerDeps(): Promise<ServerDeps> {
+  const dataDir = getDataDir()
+  await prepareDataDir(dataDir)
+  const db = await getDb(dataDir)
+  return resolveServerDeps(createContainer(createStoreLocalModule({ db, blobDir: dataDir })))
+}

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -396,6 +396,7 @@ export function createApp(options: AppOptions) {
   app.route(
     '/',
     createDocumentRouter({
+      ...(options.serverDeps === undefined ? {} : { serverDeps: options.serverDeps }),
       // Attach the current HEAD branch name to saved versions when available.
       getHeadBranch: async (sid, path) => {
         try {

--- a/packages/mcp-server/src/server/routes/document.ts
+++ b/packages/mcp-server/src/server/routes/document.ts
@@ -1,3 +1,4 @@
+import type { ServerDeps } from '@kamiazya/whiteboard-server-core'
 import { Hono } from 'hono'
 import { installAutoCompact } from '../store/auto-compact.js'
 import { FileVersionStore, type VersionStore } from '../store/version-store.js'
@@ -22,6 +23,10 @@ export interface DocumentRouterOptions {
   // Resolve the HEAD branch name for manual and auto version saves.
   // If omitted, ignore branch metadata. Production wires this from app.ts.
   getHeadBranch?: (workspaceId: string, path: string) => Promise<string | null>
+  // The operations the routes below adapt onto (ADR-0018). Production wires
+  // this from app.ts; see `getDefaultServerDeps` for what a caller that
+  // omits it gets, which is the same wiring rather than a stand-in.
+  serverDeps?: ServerDeps
 }
 
 // Entry point that composes the canvas API's sub-routers: workspace/canvas
@@ -52,7 +57,7 @@ export function createDocumentRouter(options: DocumentRouterOptions = {}) {
   // compact path calls `uninstallAutoCompact()`.
   installAutoCompact(versionStore)
 
-  app.route('/', createWorkspacesRouter())
+  app.route('/', createWorkspacesRouter({ serverDeps: options.serverDeps }))
   app.route('/', createDocumentMetadataRouter())
   app.route('/', createLiveDocRouter({ triggerAutoVersion }))
   app.route('/', createVersionsRouter({ versionStore, getHeadBranch: options.getHeadBranch }))

--- a/packages/mcp-server/src/server/routes/document/delete-adapter.test.ts
+++ b/packages/mcp-server/src/server/routes/document/delete-adapter.test.ts
@@ -36,18 +36,27 @@ const { createWorkspacesRouter } = await import('./workspaces.js')
 async function depsRecordingTeardown(): Promise<{
   deps: Awaited<ReturnType<typeof resolveServerDeps>>
   entered: string[]
+  cleaned: string[]
 }> {
   const db = await getDb(tmp.dir)
   const deps = resolveServerDeps(createContainer(createStoreLocalModule({ db, blobDir: tmp.dir })))
   const entered: string[] = []
+  const cleaned: string[] = []
   const real = deps.documentTeardown
   deps.documentTeardown = {
     around(input, deleteDocument) {
       entered.push(`${input.workspaceId}:${input.path}`)
-      return real.around(input, deleteDocument)
+      return real.around(input, async () => {
+        const result = await deleteDocument()
+        // Recorded INSIDE the bracket, after the delete returns: a refusal
+        // throws past this line, which is what "the cleanup did not run"
+        // means and the only way to observe it from out here.
+        cleaned.push(`${input.workspaceId}:${input.path}`)
+        return result
+      })
     },
   }
-  return { deps, entered }
+  return { deps, entered, cleaned }
 }
 
 describe('DELETE /api/workspaces/:workspaceId/documents/:path', () => {
@@ -60,13 +69,33 @@ describe('DELETE /api/workspaces/:workspaceId/documents/:path', () => {
   })
 
   it('deletes through the injected operation rather than its own sequence', async () => {
-    const { deps, entered } = await depsRecordingTeardown()
+    const { deps, entered, cleaned } = await depsRecordingTeardown()
     const app = createWorkspacesRouter({ serverDeps: deps })
 
     const res = await app.request('/api/workspaces/ws-1/documents/doomed', { method: 'DELETE' })
 
     expect(res.status).toBe(200)
     expect(entered).toEqual(['ws-1:doomed'])
+    expect(cleaned).toEqual(['ws-1:doomed'])
+  })
+
+  // The refusal has to travel OUT of the operation and past the bracket's
+  // cleanup — a refused delete destroys nothing (#1066). Covered here rather
+  // than only through the default wiring, because the seam is the only place
+  // "the cleanup did not run" is observable at all.
+  it('surfaces the descendant refusal as 409 without entering cleanup', async () => {
+    await saveDocument('ws-1', 'doomed/child', new LoroDoc())
+    const { deps, entered, cleaned } = await depsRecordingTeardown()
+    const app = createWorkspacesRouter({ serverDeps: deps })
+
+    const res = await app.request('/api/workspaces/ws-1/documents/doomed', { method: 'DELETE' })
+
+    expect(res.status).toBe(409)
+    expect((await res.json()) as { title?: string }).toMatchObject({
+      title: expect.stringContaining('doomed/child'),
+    })
+    expect(entered).toEqual(['ws-1:doomed'])
+    expect(cleaned).toEqual([])
   })
 
   it('still answers 404 for a path that names nothing', async () => {

--- a/packages/mcp-server/src/server/routes/document/delete-adapter.test.ts
+++ b/packages/mcp-server/src/server/routes/document/delete-adapter.test.ts
@@ -1,0 +1,85 @@
+/**
+ * ADR-0018: the HTTP DELETE is an ADAPTER over `wb_document_delete`, not a
+ * second implementation of it.
+ *
+ * The two used to be separate code paths performing the same delete, and
+ * only one of them cleaned up (#1035). Sharing the pieces closed that gap
+ * one piece at a time; sharing the OPERATION is what stops the next piece
+ * from drifting, because there is no longer a second sequence to forget to
+ * update.
+ *
+ * Asserted through the seam the operation goes through rather than on the
+ * rows afterwards: identical end state is exactly what the two divergent
+ * implementations produced right up until one of them grew a step.
+ */
+import { LoroDoc } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { withTempDataDir } from '../_test-helpers.js'
+
+const tmp = withTempDataDir('whiteboard-delete-adapter-')
+
+vi.mock('../../config.js', () => ({
+  get DATA_DIR() {
+    return tmp.dir
+  },
+  getDataDir: () => tmp.dir,
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+  REPO_ROOT: '/tmp',
+}))
+
+const { saveDocument } = await import('../../store/document-store.js')
+const { getDb } = await import('../../store/db/index.js')
+const { createContainer, resolveServerDeps } = await import('../../../di/container.js')
+const { createStoreLocalModule } = await import('../../../di/store-local.module.js')
+const { createWorkspacesRouter } = await import('./workspaces.js')
+
+async function depsRecordingTeardown(): Promise<{
+  deps: Awaited<ReturnType<typeof resolveServerDeps>>
+  entered: string[]
+}> {
+  const db = await getDb(tmp.dir)
+  const deps = resolveServerDeps(createContainer(createStoreLocalModule({ db, blobDir: tmp.dir })))
+  const entered: string[] = []
+  const real = deps.documentTeardown
+  deps.documentTeardown = {
+    around(input, deleteDocument) {
+      entered.push(`${input.workspaceId}:${input.path}`)
+      return real.around(input, deleteDocument)
+    },
+  }
+  return { deps, entered }
+}
+
+describe('DELETE /api/workspaces/:workspaceId/documents/:path', () => {
+  beforeEach(async () => {
+    await saveDocument('ws-1', 'doomed', new LoroDoc())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('deletes through the injected operation rather than its own sequence', async () => {
+    const { deps, entered } = await depsRecordingTeardown()
+    const app = createWorkspacesRouter({ serverDeps: deps })
+
+    const res = await app.request('/api/workspaces/ws-1/documents/doomed', { method: 'DELETE' })
+
+    expect(res.status).toBe(200)
+    expect(entered).toEqual(['ws-1:doomed'])
+  })
+
+  it('still answers 404 for a path that names nothing', async () => {
+    const { deps, entered } = await depsRecordingTeardown()
+    const app = createWorkspacesRouter({ serverDeps: deps })
+
+    const res = await app.request('/api/workspaces/ws-1/documents/never-existed', {
+      method: 'DELETE',
+    })
+
+    expect(res.status).toBe(404)
+    // A delete that found nothing must not enter teardown: the cleanup would
+    // be reaching for files belonging to a document it never identified.
+    expect(entered).toEqual([])
+  })
+})

--- a/packages/mcp-server/src/server/routes/document/workspaces.test.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.test.ts
@@ -41,6 +41,22 @@ const { saveDocument } = documentStore
 const { corruptStoredData } = await import('../../store/corrupt-stored-data.js')
 const { createWorkspacesRouter } = await import('./workspaces.js')
 const { createDocumentRouter } = await import('../document.js')
+const { getDb } = await import('../../store/db/index.js')
+const { createContainer, resolveServerDeps } = await import('../../../di/container.js')
+const { createStoreLocalModule } = await import('../../../di/store-local.module.js')
+
+// The delete route is an adapter over `wb_document_delete` (ADR-0018), so
+// forcing the delete to fail means making the OPERATION fail, not stubbing a
+// store function the route no longer calls. `Object.create` rather than a
+// spread: the index is a class instance, and spreading one drops every method
+// it inherits from its prototype.
+async function depsWithFailingDelete(err: unknown) {
+  const db = await getDb(tmp.dir)
+  const deps = resolveServerDeps(createContainer(createStoreLocalModule({ db, blobDir: tmp.dir })))
+  const index = Object.create(deps.documentIndex) as typeof deps.documentIndex
+  index.deleteDocument = () => Promise.reject(err)
+  return { ...deps, documentIndex: index }
+}
 
 beforeEach(() => {
   clearCache()
@@ -399,34 +415,31 @@ describe('DELETE /api/workspaces/:workspaceId/documents/:path', () => {
 
   it('maps a thrown CorruptStoredDataError to 500 { error: corrupt_stored_data }, and only that error type — a plain throw stays a generic 500', async () => {
     await saveDocument('session1', 'canvas-a', new LoroDoc())
-    const spy = vi
-      .spyOn(documentStore, 'deleteDocument')
-      .mockRejectedValueOnce(
+    const corrupt = createDocumentRouter({
+      serverDeps: await depsWithFailingDelete(
         corruptStoredData('/tmp/blobs/session1/document/abc.loro', 'broken canvas blob'),
-      )
-    const app = createDocumentRouter()
-    try {
-      const res = await app.request('/api/workspaces/session1/documents/canvas-a', {
-        method: 'DELETE',
-      })
-      expect(res.status).toBe(500)
-      await expect(res.json()).resolves.toEqual({
-        error: 'corrupt_stored_data',
-        message: expect.stringContaining('broken canvas blob'),
-      })
+      ),
+    })
+    const res = await corrupt.request('/api/workspaces/session1/documents/canvas-a', {
+      method: 'DELETE',
+    })
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({
+      error: 'corrupt_stored_data',
+      message: expect.stringContaining('broken canvas blob'),
+    })
 
-      // Mutation guard: a non-corruption throw must NOT hit the same
-      // branch — proves the mapping checks the error type, not "any throw".
-      spy.mockRejectedValueOnce(new Error('disk exploded'))
-      const res2 = await app.request('/api/workspaces/session1/documents/canvas-a', {
-        method: 'DELETE',
-      })
-      expect(res2.status).toBe(500)
-      const json2: unknown = await res2.json()
-      expect(json2).not.toMatchObject({ error: 'corrupt_stored_data' })
-    } finally {
-      spy.mockRestore()
-    }
+    // Mutation guard: a non-corruption throw must NOT hit the same branch —
+    // proves the mapping checks the error type, not "any throw".
+    const plain = createDocumentRouter({
+      serverDeps: await depsWithFailingDelete(new Error('disk exploded')),
+    })
+    const res2 = await plain.request('/api/workspaces/session1/documents/canvas-a', {
+      method: 'DELETE',
+    })
+    expect(res2.status).toBe(500)
+    const json2: unknown = await res2.json()
+    expect(json2).not.toMatchObject({ error: 'corrupt_stored_data' })
   })
 
   it('evicts the doc-cache on delete, so re-creating the same path after a warm cache read yields a fresh empty doc', async () => {

--- a/packages/mcp-server/src/server/routes/document/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.ts
@@ -1,8 +1,10 @@
 import { writeDocumentKind } from '@kamiazya/whiteboard-loro-adapter'
 import { DocumentHasDescendantsError, DocumentMoveIntoSelfError } from '@kamiazya/whiteboard-ports'
+import { type ServerDeps, wbDocumentDelete } from '@kamiazya/whiteboard-server-core'
 import { Hono } from 'hono'
 import { LoroDoc as LoroDocCtor } from 'loro-crdt'
 import type { z } from 'zod'
+import { getDefaultServerDeps } from '../../../di/default-server-deps.js'
 import {
   type CreateDocumentResponse,
   createDocumentRequestSchema,
@@ -16,7 +18,6 @@ import type { ApiErrorBody } from '../../../shared/api-contracts/errors.js'
 import { getLogger } from '../../log.js'
 import {
   ConflictError,
-  deleteDocument,
   listDocuments,
   listWorkspaces,
   renameDocumentPath,
@@ -40,10 +41,17 @@ function createDocumentRequestErrorTitle(error: z.ZodError): string {
   return issue?.message ?? 'invalid request body'
 }
 
+export interface WorkspacesRouterOptions {
+  /** The operations this router adapts onto. Omitted by callers that have
+   *  not been given a container — see `getDefaultServerDeps`, which is the
+   *  same wiring production passes in, not a stand-in for it. */
+  serverDeps?: ServerDeps
+}
+
 // GET /api/workspaces
 // GET /api/workspaces/:workspaceId/documents
 // POST /api/workspaces/:workspaceId/documents  body: { path: string }
-export function createWorkspacesRouter() {
+export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
   const app = new Hono()
 
   app.get('/api/workspaces', async (c) => {
@@ -155,16 +163,26 @@ export function createWorkspacesRouter() {
   // Delete a canvas: row (branches/versions cascade via FK), .loro blob,
   // version thumbnails, and doc-cache entry. Idempotent-shaped 404 for a
   // missing canvas rather than a throw.
+  //
+  // An ADAPTER over `wb_document_delete` (ADR-0018), not a second
+  // implementation of it. The two were separate sequences performing the
+  // same delete, and only one of them cleaned up; sharing the pieces closed
+  // that gap once, and sharing the operation is what stops the next piece
+  // from drifting. All this translates is the ADDRESS — this surface names a
+  // document by path, the operation by the id the index assigned — and the
+  // absent case, which is a 404 here and a throw there.
   onDocumentsRoute(
     app,
     'delete',
     [],
     async (c, workspaceId, path) => {
       try {
-        const deleted = await deleteDocument(workspaceId, path)
-        if (!deleted) {
+        const deps = options.serverDeps ?? (await getDefaultServerDeps())
+        const entry = await deps.documentIndex.resolveDocument({ workspaceId, path })
+        if (entry === null) {
           return c.json({ title: `Canvas "${path}" not found` }, 404)
         }
+        await wbDocumentDelete(deps, { workspaceId, documentId: entry.documentId })
         const response: DeleteDocumentResponse = { ok: true }
         return c.json(response)
       } catch (err) {
@@ -174,7 +192,7 @@ export function createWorkspacesRouter() {
         }
         const issue = handleCorruptStoredData(err)
         if (issue) return c.json(issue.body, issue.status)
-        getLogger('document').error({ err: err as Error }, 'deleteDocument failed unexpectedly')
+        getLogger('document').error({ err: err as Error }, 'wb_document_delete failed unexpectedly')
         return c.json({ title: 'Failed to delete canvas.' } satisfies ApiErrorBody, 500)
       }
     },

--- a/packages/mcp-server/src/server/store/db/delete-document-row.ts
+++ b/packages/mcp-server/src/server/store/db/delete-document-row.ts
@@ -3,12 +3,15 @@ import { DocumentHasDescendantsError, findDescendantPath } from '@kamiazya/white
 import type { Database } from './index.js'
 
 /**
- * The one implementation of "remove a document's row", shared by the two
- * callers that used to each hold a copy: `SqliteDocumentIndex.deleteDocument`
- * (the agent-facing path, reached as `deps.documentIndex`) and
- * `document-store.ts`'s `deleteDocument` (the HTTP path). Two copies of a
- * refusal rule is two chances for them to stop agreeing about what a delete
- * refuses.
+ * The one implementation of "remove a document's row", reached through
+ * `SqliteDocumentIndex.deleteDocument` (`deps.documentIndex`).
+ *
+ * It was extracted when the HTTP delete and `wb_document_delete` were two
+ * sequences that each held a copy of this refusal rule — two chances for
+ * them to stop agreeing about what a delete refuses. The HTTP route is now
+ * an adapter over the operation, so there is one caller again; the rule
+ * stays here rather than back inside the index because that is where the
+ * index's own contract says it belongs.
  *
  * Refusing on descendants rather than cascading is the DocumentIndex
  * contract: a cascade is reachable from one call naming one path, and

--- a/packages/mcp-server/src/server/store/document-store.test.ts
+++ b/packages/mcp-server/src/server/store/document-store.test.ts
@@ -24,7 +24,6 @@ const {
   listDocuments,
   listWorkspaces,
   compactDocument,
-  deleteDocument,
   renameDocumentPath,
   ConflictError,
   getDocumentKind,
@@ -38,6 +37,8 @@ const {
   _isDisposingAutoCompactForTests,
 } = await import('./auto-compact.js')
 const { captureLogsForTests } = await import('../log.js')
+const { getDefaultServerDeps } = await import('../../di/default-server-deps.js')
+const { wbDocumentDelete } = await import('@kamiazya/whiteboard-server-core')
 const { FileVersionStore } = await import('./version-store.js')
 const { createIsolatedDb } = await import('./db/test-helpers.js')
 
@@ -1267,7 +1268,27 @@ describe('compactDocument', () => {
   })
 })
 
-describe('deleteDocument', () => {
+// `document-store.deleteDocument` is gone: it was a second implementation of
+// `wb_document_delete`, and the HTTP route that called it is now an adapter
+// over the operation (ADR-0018). These cases are storage-level — blobs,
+// thumbnails, rows, the descendant refusal — so they stay at this layer and
+// drive the surviving implementation instead.
+//
+// The local helper is the ROUTE's translation, written once here rather than
+// at each call below: this surface addresses a document by path and answers
+// `false` for one that does not exist, where the operation addresses it by
+// the id the index assigned and throws. Everything else the cases assert is
+// unchanged, which is the point — the implementation moved, the behaviour
+// did not.
+async function deleteDocument(workspaceId: string, path: string): Promise<boolean> {
+  const deps = await getDefaultServerDeps()
+  const entry = await deps.documentIndex.resolveDocument({ workspaceId, path })
+  if (entry === null) return false
+  await wbDocumentDelete(deps, { workspaceId, documentId: entry.documentId })
+  return true
+}
+
+describe('deleting a document', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-delete-test-'))
     await setupIsolatedDb()

--- a/packages/mcp-server/src/server/store/document-store.ts
+++ b/packages/mcp-server/src/server/store/document-store.ts
@@ -9,11 +9,11 @@
  * survives only as an identity label for corrupt-data error messages and as
  * the legacy-migration backup path. Any blob file still on disk is swept
  * away by `sweep-imported-fs-blobs.ts` once its bytes are proven to live in
- * Libsql, so `deleteDocument`'s unlink below is a straggler cleanup, not the
+ * Libsql, so `documentTeardown`'s unlink below is a straggler cleanup, not the
  * primary deletion path.
  *
- * `listDocuments`/`deleteDocument` here are NOT `DocumentIndex`'s methods of
- * the same names — that is the agent-facing side of the same split, reached
+ * `listDocuments` here is NOT `DocumentIndex`'s method of the same name —
+ * that is the agent-facing side of the same split, reached
  * as `deps.documentIndex.*` and addressing documents by ULID rather than by
  * `(workspaceId, path)`. The names match because the concept does; the two
  * stores are what do not see each other. Both now write the same
@@ -43,7 +43,6 @@ import {
   isCorruptStoredDataError,
   isMissingFileError,
 } from './corrupt-stored-data.js'
-import { deleteDocumentRow } from './db/delete-document-row.js'
 import { getDb } from './db/index.js'
 import { prepareDataDir } from './db/prepare.js'
 import { getDocumentIdByPath, upsertWorkspaceRow } from './db/upsert-workspace.js'
@@ -547,33 +546,6 @@ export const documentTeardown: DocumentTeardown = {
   },
 }
 
-export async function deleteDocument(workspaceId: string, path: string): Promise<boolean> {
-  validateWorkspaceId(workspaceId)
-  validateDocumentPath(path)
-  return withWorkspaceWriteLock(workspaceId, async () => {
-    const db = await dbReady()
-    const documentId = await getDocumentIdByPath(db, workspaceId, path)
-    if (!documentId) return false
-
-    // Same steps, in the same order, as wb_document_delete (server-core's
-    // document-crud.ts) — deliberately, because the two used to be separate
-    // implementations and only one of them cleaned up. Each step is now one
-    // shared piece rather than a copy: `deleteDocumentRow` holds the
-    // descendant refusal, `documentTeardown` holds the lock and the files.
-    await documentTeardown.around({ workspaceId, documentId, path }, async () => {
-      await deleteDocumentRow(db, workspaceId, path)
-
-      // The identity row goes first, then the Libsql snapshot/delta/frontier
-      // rows, so a crash between the two leaves an orphaned-but-unreachable
-      // snapshot rather than a listed canvas with no content.
-      const documentStore = await documentStoreReady()
-      await documentStore.deleteDoc({ docRef: { kind: 'document', documentId } })
-    })
-
-    return true
-  })
-}
-
 // Null for both "no such canvas" and "the canvas records no kind" — its
 // callers want the same thing from either, which is to stamp nothing.
 //
@@ -722,8 +694,8 @@ export async function listWorkspaces(): Promise<{ workspaceId: string }[]> {
 // ── rename a canvas's path ──
 // Updates only documents.path. branches/versions FK on documentId and the blob
 // path also uses documentId, so none of that moves. Returns null (never
-// throws) for a missing source canvas, matching deleteDocument's boolean-
-// shaped "already gone" handling; a rename onto an already-taken path
+// throws) for a missing source canvas — the same "already gone" shape the
+// delete route translates into a 404; a rename onto an already-taken path
 // throws ConflictError instead of a raw unique-constraint error.
 export async function renameDocumentPath(
   workspaceId: string,


### PR DESCRIPTION
## Summary

The HTTP `DELETE` and `wb_document_delete` were **two sequences performing the same delete**, and only one of them cleaned up (#1035). Sharing the *pieces* closed that gap once — `deleteDocumentRow` for the descendant refusal, `documentTeardown` for the files and (since #1066) the lock. Sharing the **operation** is what stops the next piece from drifting, because there is no longer a second sequence to forget to update.

`document-store.deleteDocument` is **gone**. The route resolves the path to the id the index assigned and calls `wbDocumentDelete`. All it translates now is:

- the **address** — this surface names a document by path, the operation by id;
- the **absent case** — a 404 here, a throw there.

The 409 for a document with descendants and the corrupt-data 500 are unchanged translations of what the operation throws.

This is the first **move** under ADR-0018, following the guard that landed in #1065.

## Getting the operation to the route

The route needed `ServerDeps`. Threading them as a *required* option would have touched **86 router construction sites** for a change with no behaviour in it, so `getDefaultServerDeps()` is the fallback for routers built without a container: the same production wiring, over the same memoized connection the legacy routes already read through — not a stand-in for it. A caller that supplies nothing gets **correct behaviour**, not a no-op, which is what makes this unlike the `documentTeardown` case where optional meant "silently absent" (#1042).

It is deliberately **not memoized**. `getDb` already is, which is the part that costs anything; caching a `ServerDeps` per data dir would outlive `createIsolatedDb`'s `dispose()` and hand a later caller a destroyed connection — a real trap in exchange for a saving nobody has measured.

One thing the first attempt got wrong and is worth recording: `getDefaultServerDeps` initially called `getDb` alone, where the old `deleteDocument` went through `dbReady()`, which **migrates first**. The 404 case turned into a 500 for any caller that reached the route before anything had migrated the data dir. It now calls `prepareDataDir` for exactly the reason `dbReady` does.

## What this does NOT do

It does **not** shrink `ADAPTERS_REACHING_MECHANICS`. `workspaces.ts` still imports `listDocuments`, `saveDocument`, `renameDocumentPath` and `workspaceExists` from `document-store`, and the allowlist is per module, not per symbol. Those are the next moves. Saying so explicitly because the #1065 body predicted this PR would delete entries, and it does not.

## Test plan

- [x] New or updated tests added — `delete-adapter.test.ts` (mcp-node), 2 tests
- [x] `pnpm test` passes locally — `mcp-node` + `server-core-node`: **4188 passed**; the 4 failures are the pre-existing `EACCES` tests that cannot deny access to root in this container, identical on a clean `origin/main`
- [x] Manual verification completed — see the mutation check
- [ ] E2E coverage — not applicable

**The red test asserts through the seam, not on the rows afterwards.** Identical end state is exactly what the two divergent implementations produced right up until one of them grew a step, so the test injects a recording `documentTeardown` and asserts the HTTP DELETE entered it.

**Mutation check:** making the route ignore its injected deps turns it red — `expected [] to deeply equal [ 'ws-1:doomed' ]`. Restore verified by re-grepping the file.

**A first attempt at the red test was red for the wrong reason** and is worth recording: it used `/api/w/:workspaceId/document/:path`, which is not this route's URL, so both cases 404'd and the "red" said nothing about the behaviour under test. The failure message (`expected 404 to be 200`) is indistinguishable from a genuine one.

**Existing coverage is preserved, not deleted.** `document-store.test.ts` keeps all **twelve** delete cases — blobs, `.pre-migrate-bak`, thumbnails, rows, idempotence, the row-only case, swept-then-deleted, the descendant refusal — and drives the surviving implementation through a local helper that states the route's translation once. `workspaces.test.ts`'s corrupt-data case now forces the **operation** to fail rather than stubbing a store function the route no longer calls (`Object.create` rather than a spread, because the index is a class instance and spreading one drops its prototype methods).

`arch-lint-node` passes (106 tests), including the stale-entry side of the adapter/mechanic allowlist.

Local gates green: `lint`, `secretlint`, `knip`, `intent:validate`, `audit --prod --audit-level=high`, `typecheck`. `test:scripts` was not run — this container has no ImageMagick, which `pnpm check:local` (#1067) surfaced.

## Visual evidence

Visual evidence: none — a server-side refactor with no user-visible change. The HTTP contract is byte-identical: 200 `{ ok: true }`, 404 Problem Details, 409 naming the descendant, 500 `corrupt_stored_data`, each pinned by an existing test that was kept rather than rewritten.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — the rationale lives at `getDefaultServerDeps` and on the route; ADR-0018 already states the rule this follows
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_019uxfgjcDPQRBtJn5XYQgLc)_