### PR TITLE
fix(security): declare /api/v1 scopes, and let the guard see the routes at all

### DIFF
--- a/packages/mcp-server/src/server/security/route-scope-registry.test.ts
+++ b/packages/mcp-server/src/server/security/route-scope-registry.test.ts
@@ -9,6 +9,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createContainer, resolveServerDeps } from '../../di/container.js'
 // Imported STATICALLY, though nothing here mocks it. As `await import()`
 // inside the test body, the cost of transforming and loading app.ts's whole
 // module graph was charged to the 10s per-test budget — fine on an idle
@@ -61,6 +62,11 @@ describe('resolveApiRouteScope — registry-wide coverage of mounted /api/* rout
         clients: { connected: 0, ready: 0 },
       }),
       shutdown: () => Promise.resolve(),
+      // Without this /api/v1 is not mounted, so the walk below never sees a
+      // single v1 route and the whole surface is exempt from the guard by
+      // accident. The in-memory container is enough: this test inspects
+      // `app.routes` and never issues a request.
+      serverDeps: resolveServerDeps(createContainer()),
     })
 
     // `app.routes` conflates middleware mounts (`app.use('/api/*', ...)`,
@@ -74,6 +80,12 @@ describe('resolveApiRouteScope — registry-wide coverage of mounted /api/* rout
       (route) => route.path.startsWith('/api/') && !route.path.endsWith('*'),
     )
     expect(apiRoutes.length).toBeGreaterThan(0)
+    // The walk is only as wide as what got mounted. /api/v1 mounts only when
+    // ServerDeps are supplied, and for a long time this test supplied none —
+    // so nine v1 routes were exempt from the guard by accident rather than by
+    // decision. Assert the surface is present, not merely that what is
+    // present is declared.
+    expect(apiRoutes.some((route) => route.path.startsWith('/api/v1/'))).toBe(true)
 
     const undeclared = apiRoutes
       .map((route) => ({ ...route, decision: resolveApiRouteScope(route.method, route.path) }))
@@ -112,6 +124,11 @@ describe('resolveApiRouteScope — registry-wide coverage of mounted /api/* rout
         clients: { connected: 0, ready: 0 },
       }),
       shutdown: () => Promise.resolve(),
+      // Without this /api/v1 is not mounted, so the walk below never sees a
+      // single v1 route and the whole surface is exempt from the guard by
+      // accident. The in-memory container is enough: this test inspects
+      // `app.routes` and never issues a request.
+      serverDeps: resolveServerDeps(createContainer()),
     })
 
     const apiRoutes = app.routes.filter(
@@ -141,6 +158,28 @@ describe('resolveApiRouteScope — registry-wide coverage of mounted /api/* rout
   // The reconnect surface that used to occupy these paths is gone. Removing
   // its registry entries must move the paths from a decision to null
   // (fail closed), never silently to a default-allow.
+  // Pinned separately from the walk above: the walk proves every mounted
+  // route HAS a decision, not that the decision is the right one.
+  it('v1 document routes carry the same workspace scopes as their path-addressed twins', () => {
+    const read = { kind: 'scoped', scopes: ['workspace:read'] }
+    const write = { kind: 'scoped', scopes: ['workspace:write'] }
+    const doc = '/api/v1/workspaces/default/documents/01ARZ3NDEKTSV4RRFFQ69G5FAV'
+
+    expect(resolveApiRouteScope('GET', '/api/v1/workspaces/default/documents')).toEqual(read)
+    expect(resolveApiRouteScope('POST', '/api/v1/workspaces/default/documents')).toEqual(write)
+    expect(resolveApiRouteScope('GET', doc)).toEqual(read)
+    expect(resolveApiRouteScope('DELETE', doc)).toEqual(write)
+    expect(resolveApiRouteScope('GET', `${doc}/backlinks`)).toEqual(read)
+    expect(resolveApiRouteScope('GET', `${doc}/okf`)).toEqual(read)
+    expect(resolveApiRouteScope('POST', `${doc}/linkify-mentions`)).toEqual(write)
+    expect(resolveApiRouteScope('GET', '/api/v1/workspaces/default/search')).toEqual(read)
+    expect(resolveApiRouteScope('GET', '/api/v1/workspaces/default/document-tags')).toEqual(read)
+
+    // The same document reached by path gets the same answer — the point of
+    // giving v1 the workspace scopes rather than scopes of its own.
+    expect(resolveApiRouteScope('GET', '/api/workspaces/default/documents')).toEqual(read)
+  })
+
   it('the removed reconnect routes now resolve to null, not a stale decision', () => {
     expect(resolveApiRouteScope('POST', '/api/reconnect-credential')).toBeNull()
     expect(resolveApiRouteScope('POST', '/api/reconnect-challenge')).toBeNull()

--- a/packages/mcp-server/src/server/security/route-scope-registry.ts
+++ b/packages/mcp-server/src/server/security/route-scope-registry.ts
@@ -134,6 +134,25 @@ export function resolveApiRouteScope(method: string, path: string): RouteScopeDe
     return { kind: 'scoped', scopes: [isWrite ? 'workspace:write' : 'workspace:read'] }
   }
 
+  // The /api/v1 document surface (server-core's createServer, mounted when
+  // the daemon is given ServerDeps). Same resources as /api/workspaces above
+  // and deliberately the SAME decision, because what differs between the two
+  // is how a document is ADDRESSED — by path there, by the id the index
+  // assigned here — not what a caller may do to it. Splitting them would mean
+  // one grant that reaches a document by id and a different one that reaches
+  // the same document by path.
+  //
+  // This rule is why the prefix is spelled out rather than folded into the
+  // one above: `startsWith('/api/workspaces')` does not match
+  // `/api/v1/workspaces`, so before this every v1 path resolved to null. That
+  // is fail-closed (server-mode answers 500 auth.route-undeclared), so nothing
+  // was ever under-protected — but it made the surface unusable in server mode
+  // for a reason no one had decided, and the registry-wide guard could not see
+  // it because the apps it walked were built without ServerDeps.
+  if (path.startsWith('/api/v1/workspaces')) {
+    return { kind: 'scoped', scopes: [isWrite ? 'workspace:write' : 'workspace:read'] }
+  }
+
   // touch/shutdown/logs-prune all mutate daemon-managed process state
   // (liveness timer, process lifecycle, on-disk log files) and require the
   // admin tier even though the HTTP verb for prune is POST like any other


### PR DESCRIPTION
## Summary

`resolveApiRouteScope` returned **null for every `/api/v1/*` path**. The registry's rule is `path.startsWith('/api/workspaces')`, which does not match `/api/v1/workspaces`.

In server mode that is **fail-closed** — `createServerModeApiAuthMiddleware` answers `500 auth.route-undeclared` on a null decision — so nothing was ever under-protected. What it did mean is that the v1 surface could not be exposed in server mode for a reason nobody had decided.

**The registry-wide guard could not catch it.** It walks `app.routes` of an app built *without* `ServerDeps`, and `/api/v1` mounts only when they are supplied (`app.ts:392`), so **nine routes were exempt by accident rather than by decision** — the guard and the gap were mutually blind. Both apps in that test now get an in-memory container, which is enough: the test inspects `app.routes` and never issues a request.

Found while answering "is server mode meant to have no `/api/v1` at all?" — verified by *running* `resolveApiRouteScope('GET', '/api/v1/workspaces/default/documents')` and getting `null`, not by reading the regex.

## The scope decision

v1 gets the **same** decision as `/api/workspaces`: `workspace:write` for POST/PUT/PATCH/DELETE, `workspace:read` otherwise.

What differs between the two surfaces is how a document is **addressed** — by path there, by the id the index assigned here — not what a caller may do to it. Separate scopes would mean one grant that reaches a document by id and a different grant that reaches *the same document* by path, which is a distinction no operator would want to reason about.

The nine routes are document create/list/get/delete, search, document-tags, linkify-mentions, backlinks and okf — all the same resource family the `/api/workspaces` fallback already covers.

## Test plan

- [x] New or updated tests added — `route-scope-registry.test.ts`, 13 tests (was 12)
- [x] `pnpm test` passes locally
- [x] Manual verification completed — see the red output below
- [ ] E2E coverage — not applicable

**The red test names the exact gap.** Giving the walked apps `ServerDeps` turns both registry-wide tests red with all nine routes listed:

```
routes mounted with no scope declaration:
POST /api/v1/workspaces/:workspaceId/documents,
GET /api/v1/workspaces/:workspaceId/documents,
GET /api/v1/workspaces/:workspaceId/documents/:documentId,
DELETE /api/v1/workspaces/:workspaceId/documents/:documentId,
GET /api/v1/workspaces/:workspaceId/search,
GET /api/v1/workspaces/:workspaceId/document-tags,
POST /api/v1/workspaces/:workspaceId/documents/:documentId/linkify-mentions,
GET /api/v1/workspaces/:workspaceId/documents/:documentId/backlinks,
GET /api/v1/workspaces/:workspaceId/documents/:documentId/okf
```

**Three assertions, because the walk alone is not enough.** It proves every mounted route *has* a decision — not that the decision is right, and not that the surface was mounted to begin with. So:

1. the walk itself (now with v1 mounted);
2. `expect(apiRoutes.some(r => r.path.startsWith('/api/v1/'))).toBe(true)` — without this, dropping `serverDeps` from the test silently reopens exactly this gap and the guard goes green;
3. the nine decisions pinned explicitly, including that the same document reached by path gets the same answer.

## What this does not do

It does **not** expose `/api/v1` in server mode. `server-mode-http.ts` still constructs no `ServerDeps`, so the surface stays unmounted there. This removes the *second*, accidental reason it could not work, leaving the mount a decision someone can now make on purpose.

## Visual evidence

Visual evidence: none — an auth-scope declaration and a test-harness fix, with no user-visible surface.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — the rationale is recorded at the rule itself, including why the prefix is spelled out separately
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_019uxfgjcDPQRBtJn5XYQgLc)_