### PR TITLE
test(mcp-server): assert the auto-compact count is zero going in, instead of capturing it

### DIFF
--- a/packages/mcp-server/src/server/store/document-written.test.ts
+++ b/packages/mcp-server/src/server/store/document-written.test.ts
@@ -46,7 +46,14 @@ describe('documentWritten', () => {
       .where('path', '=', 'agent-written')
       .executeTakeFirstOrThrow()
 
-    const before = _autoCompactTimerCountForTests()
+    // Asserted, not merely captured: `toBe(1)` below only proves the observer
+    // scheduled something if nothing was scheduled already. Creating the
+    // document IS a write, and a second schedule for the same document
+    // replaces the timer rather than adding one, so a count of 1 going in
+    // would make the assertion say nothing. Measured as 0 here — this line
+    // is what keeps it that way.
+    expect(_autoCompactTimerCountForTests()).toBe(0)
+
     await documentWritten({ documentId })
 
     expect(_autoCompactTimerCountForTests()).toBe(1)


### PR DESCRIPTION
## Summary

`document-written.test.ts` captured `const before = _autoCompactTimerCountForTests()` and never used it — a standing `noUnusedVariables` warning I left behind in #1046. The reason it was there is the interesting part.

`expect(count).toBe(1)` only proves `documentWritten` scheduled something **if nothing was scheduled already**. Creating the document is itself a write, and a second schedule for the same document *replaces* the timer rather than adding one — so a count of 1 going in would make the assertion vacuous while still passing.

I checked rather than assumed: probing both values prints `[ +0, 1 ]`, so the assertion is sound today. Asserting the 0 is what keeps it sound. A captured-and-discarded variable left that property true by accident and invisible to the next reader.

## Test plan

- [x] New or updated tests added — one assertion added to an existing test
- [x] `pnpm test` passes locally — `document-written.test.ts`, 3 passed
- [x] Manual verification completed — the probe above; `pnpm lint` drops from 1 error-free-but-noisy warning pair to the single remaining one
- [ ] E2E coverage — not applicable

The one warning still reported is `noUselessStringRaw` in `plugin-visual/src/canvas-render-type-only.test.ts`, deliberately left alone: the flagged `String.raw` is one of three in a concatenated regex, and dropping it breaks the symmetry that makes the construction readable. That is its author's call, not a drive-by.

## Visual evidence

Visual evidence: none — a test assertion, no user-visible surface.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — n/a
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_019uxfgjcDPQRBtJn5XYQgLc)_