### PR TITLE
refactor(mcp-server): the HTTP create is an adapter over wb_document_create, and the daemon migrates before wiring its ports

### DIFF
--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -50,7 +50,7 @@ tool registration under `server/mcp/**`) may not import a MECHANIC (anything
 under `server/store/`). The composition root's own wiring — `di/`, `app.ts`,
 `http-server.ts` — is deliberately out of scope, since knowing the mechanics
 is its job. `ADAPTERS_REACHING_MECHANICS` in `architecture-map.ts` records
-the 37 edges that exist today and may only SHRINK: an unlisted edge fails
+the 36 edges that exist today and may only SHRINK: an unlisted edge fails
 the build, and a listed edge that no longer exists fails it too, so an entry
 cannot outlive the debt it names. `corrupt-stored-data` is excluded and says
 why — an error taxonomy an adapter reads to pick a status code is

--- a/packages/mcp-server/src/server/http-server.migrations.test.ts
+++ b/packages/mcp-server/src/server/http-server.migrations.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The daemon must hand its ports a MIGRATED database.
+ *
+ * `http-server.ts` builds `ServerDeps` from `getDb(dataDir)`, which opens the
+ * file and nothing more. Migrations have only ever run through
+ * `document-store.ts`'s `dbReady` — `prepareDataDir` then `getDb` — so on a
+ * data dir nothing has touched yet, every surface that reaches the injected
+ * ports instead of the legacy store answered `no such table: workspaces`.
+ *
+ * That was live for `/api/v1` from the day it was mounted, and reproduced by
+ * hand against the packaged daemon before this test existed: a fresh
+ * `daemon run` plus `GET /api/v1/workspaces/default/documents` returned 500.
+ * Nothing caught it, because every other test and every real session had
+ * already migrated the dir through some legacy call first.
+ */
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let tempDir: string
+
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual<typeof import('./config.js')>('./config.js')
+  return {
+    ...actual,
+    get DATA_DIR() {
+      return tempDir
+    },
+    getDataDir: () => tempDir,
+  }
+})
+
+const { findAvailablePort } = await import('../cli/daemon-run.js')
+const { startHttpServer } = await import('./http-server.js')
+
+describe('startHttpServer on a data dir nothing has migrated', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-http-migrations-'))
+  })
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('serves /api/v1 rather than answering "no such table"', async () => {
+    const port = await findAvailablePort(0)
+    const running = await startHttpServer({ port, host: '127.0.0.1' })
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/api/v1/workspaces/default/documents`)
+      // Any answer the surface itself chose is fine — what must not happen is
+      // the 500 an unmigrated schema produces.
+      expect(res.status).not.toBe(500)
+    } finally {
+      await running.close()
+    }
+  })
+})

--- a/packages/mcp-server/src/server/http-server.ts
+++ b/packages/mcp-server/src/server/http-server.ts
@@ -23,6 +23,7 @@ import { createPairingGrantStore } from './security/pairing-grant-store.js'
 import { createPairingCodeStore, createPairingTokenStore } from './security/pairing-session.js'
 import { createWsTicketStore } from './security/ws-ticket-store.js'
 import { getDb } from './store/db/index.js'
+import { prepareDataDir } from './store/db/prepare.js'
 import { createFileGcSweeper, type FileGcSweeper } from './store/file-gc-sweeper.js'
 import { validationErrorBody } from './validators.js'
 
@@ -197,6 +198,14 @@ export async function startHttpServer(options: StartHttpServerOptions): Promise<
   // (getDb memoizes per dataDir, so this container shares the connection
   // with the per-session MCP containers rather than opening a second one).
   const dataDir = getDataDir()
+  // Migrate BEFORE handing the ports a handle. `getDb` opens the file and
+  // nothing more; migrations have only ever run through `document-store.ts`'s
+  // `dbReady`, which is `prepareDataDir` then `getDb`. Anything reaching the
+  // injected ports instead of the legacy store therefore met an empty schema
+  // on a data dir nothing had touched yet — `/api/v1` answered
+  // `no such table: workspaces` from the day it was mounted. Both are
+  // memoized per data dir, so on an already-prepared dir this costs nothing.
+  await prepareDataDir(dataDir)
   const serverDeps = resolveServerDeps(
     createContainer(createStoreLocalModule({ db: await getDb(dataDir), blobDir: dataDir })),
   )

--- a/packages/mcp-server/src/server/routes/document/crud-adapter.test.ts
+++ b/packages/mcp-server/src/server/routes/document/crud-adapter.test.ts
@@ -60,7 +60,7 @@ async function depsRecordingTeardown(): Promise<{
   return { deps, entered, cleaned }
 }
 
-async function depsRecordingCreate(): Promise<{
+async function depsRecordingCreate(bootstrapWorkspace = true): Promise<{
   deps: Awaited<ReturnType<typeof resolveServerDeps>>
   created: string[]
 }> {
@@ -69,7 +69,7 @@ async function depsRecordingCreate(): Promise<{
   await prepareDataDir(tmp.dir)
   const db = await getDb(tmp.dir)
   const deps = resolveServerDeps(createContainer(createStoreLocalModule({ db, blobDir: tmp.dir })))
-  await deps.documentIndex.createWorkspace({ workspaceId: 'ws-1' })
+  if (bootstrapWorkspace) await deps.documentIndex.createWorkspace({ workspaceId: 'ws-1' })
   const created: string[] = []
   const index = Object.create(deps.documentIndex) as typeof deps.documentIndex
   index.createDocument = async (input) => {
@@ -97,6 +97,41 @@ describe('POST /api/workspaces/:workspaceId/documents', () => {
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ path: 'fresh' })
     expect(created).toEqual(['ws-1:fresh'])
+
+    // Reaching the injected index is necessary but not sufficient: a route
+    // calling `documentIndex.createDocument` directly would satisfy the line
+    // above and leave a placement with no document under it. Only the
+    // operation persists the bytes, so the snapshot is what says the whole
+    // operation ran rather than its first step.
+    const entry = await deps.documentIndex.resolveDocument({
+      workspaceId: 'ws-1',
+      path: 'fresh',
+    })
+    const snapshot = await deps.documentStore.loadSnapshot({
+      docRef: { kind: 'document', documentId: entry?.documentId ?? 'missing' },
+    })
+    expect(snapshot).not.toBeNull()
+  })
+
+  // The workspace bootstrap is this surface's own long-standing behaviour:
+  // `saveDocument` upserted the workspace row on the way past, so posting
+  // into one that does not exist yet has always worked here. The operation
+  // makes it an explicit flag, and a flag nothing exercises is a flag that
+  // gets dropped — removing `createWorkspace: true` left every other case in
+  // this file green.
+  it('creates the workspace on the way past, as this surface always has', async () => {
+    const { deps } = await depsRecordingCreate(false)
+    const app = createWorkspacesRouter({ serverDeps: deps })
+
+    const res = await app.request('/api/workspaces/ws-1/documents', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: 'first-ever', kind: 'spatial' }),
+    })
+
+    expect(res.status).toBe(200)
+    const entries = await deps.documentIndex.listDocuments({ workspaceId: 'ws-1' })
+    expect(entries.map((e) => e.path)).toEqual(['first-ever'])
   })
 
   it('answers 409 for a path already taken', async () => {

--- a/packages/mcp-server/src/server/routes/document/crud-adapter.test.ts
+++ b/packages/mcp-server/src/server/routes/document/crud-adapter.test.ts
@@ -1,6 +1,6 @@
 /**
- * ADR-0018: the HTTP DELETE is an ADAPTER over `wb_document_delete`, not a
- * second implementation of it.
+ * ADR-0018: the HTTP document routes are ADAPTERS over the `wb_document_*`
+ * operations, not second implementations of them.
  *
  * The two used to be separate code paths performing the same delete, and
  * only one of them cleaned up (#1035). Sharing the pieces closed that gap
@@ -29,6 +29,7 @@ vi.mock('../../config.js', () => ({
 
 const { saveDocument } = await import('../../store/document-store.js')
 const { getDb } = await import('../../store/db/index.js')
+const { prepareDataDir } = await import('../../store/db/prepare.js')
 const { createContainer, resolveServerDeps } = await import('../../../di/container.js')
 const { createStoreLocalModule } = await import('../../../di/store-local.module.js')
 const { createWorkspacesRouter } = await import('./workspaces.js')
@@ -58,6 +59,90 @@ async function depsRecordingTeardown(): Promise<{
   }
   return { deps, entered, cleaned }
 }
+
+async function depsRecordingCreate(): Promise<{
+  deps: Awaited<ReturnType<typeof resolveServerDeps>>
+  created: string[]
+}> {
+  // The delete cases reach a migrated schema through `saveDocument`'s own
+  // `dbReady`; these create nothing first, so they have to migrate here.
+  await prepareDataDir(tmp.dir)
+  const db = await getDb(tmp.dir)
+  const deps = resolveServerDeps(createContainer(createStoreLocalModule({ db, blobDir: tmp.dir })))
+  await deps.documentIndex.createWorkspace({ workspaceId: 'ws-1' })
+  const created: string[] = []
+  const index = Object.create(deps.documentIndex) as typeof deps.documentIndex
+  index.createDocument = async (input) => {
+    created.push(`${input.workspaceId}:${input.path}`)
+    return await Object.getPrototypeOf(index).createDocument.call(index, input)
+  }
+  return { deps: { ...deps, documentIndex: index }, created }
+}
+
+describe('POST /api/workspaces/:workspaceId/documents', () => {
+  // Same reasoning as the delete below: creating a document twice over — once
+  // in the route, once in `wb_document_create` — is how the two drifted the
+  // first time. Asserted through the index the operation writes through,
+  // because the resulting row looks identical either way.
+  it('creates through the injected operation rather than its own sequence', async () => {
+    const { deps, created } = await depsRecordingCreate()
+    const app = createWorkspacesRouter({ serverDeps: deps })
+
+    const res = await app.request('/api/workspaces/ws-1/documents', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: 'fresh', kind: 'spatial' }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ path: 'fresh' })
+    expect(created).toEqual(['ws-1:fresh'])
+  })
+
+  it('answers 409 for a path already taken', async () => {
+    const { deps } = await depsRecordingCreate()
+    const app = createWorkspacesRouter({ serverDeps: deps })
+    const body = JSON.stringify({ path: 'twice', kind: 'spatial' })
+    const headers = { 'Content-Type': 'application/json' }
+
+    const first = await app.request('/api/workspaces/ws-1/documents', {
+      method: 'POST',
+      headers,
+      body,
+    })
+    expect(first.status).toBe(200)
+
+    const second = await app.request('/api/workspaces/ws-1/documents', {
+      method: 'POST',
+      headers,
+      body,
+    })
+    expect(second.status).toBe(409)
+  })
+
+  // A blank name means "no name" — the rule `setDocumentDisplayName` held
+  // before the route delegated. Measured rather than assumed: passing a blank
+  // through does not fail, it STORES an empty name, which `DocumentEntry.name`
+  // declares as `z.string().min(1)` and so is a value the port says cannot
+  // exist. The adapter has to trim and omit.
+  it('creates an unnamed document for a blank name instead of storing an empty one', async () => {
+    const { deps } = await depsRecordingCreate()
+    const app = createWorkspacesRouter({ serverDeps: deps })
+
+    const res = await app.request('/api/workspaces/ws-1/documents', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: 'blank-name', kind: 'spatial', name: '   ' }),
+    })
+
+    expect(res.status).toBe(200)
+    const entry = await deps.documentIndex.resolveDocument({
+      workspaceId: 'ws-1',
+      path: 'blank-name',
+    })
+    expect(entry?.name).toBeUndefined()
+  })
+})
 
 describe('DELETE /api/workspaces/:workspaceId/documents/:path', () => {
   beforeEach(async () => {

--- a/packages/mcp-server/src/server/routes/document/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.ts
@@ -1,8 +1,14 @@
-import { writeDocumentKind } from '@kamiazya/whiteboard-loro-adapter'
-import { DocumentHasDescendantsError, DocumentMoveIntoSelfError } from '@kamiazya/whiteboard-ports'
-import { type ServerDeps, wbDocumentDelete } from '@kamiazya/whiteboard-server-core'
+import {
+  DocumentHasDescendantsError,
+  DocumentMoveIntoSelfError,
+  DocumentPathTakenError,
+} from '@kamiazya/whiteboard-ports'
+import {
+  type ServerDeps,
+  wbDocumentCreate,
+  wbDocumentDelete,
+} from '@kamiazya/whiteboard-server-core'
 import { Hono } from 'hono'
-import { LoroDoc as LoroDocCtor } from 'loro-crdt'
 import type { z } from 'zod'
 import { getDefaultServerDeps } from '../../../di/default-server-deps.js'
 import {
@@ -21,10 +27,8 @@ import {
   listDocuments,
   listWorkspaces,
   renameDocumentPath,
-  saveDocument,
   workspaceExists,
 } from '../../store/document-store.js'
-import { setDocumentDisplayName } from '../../store/names-store.js'
 import { validateDocumentPath, validateWorkspaceId, validationErrorBody } from '../../validators.js'
 import { handleCorruptStoredData } from './_shared.js'
 import { onDocumentsRoute } from './path-route.js'
@@ -125,37 +129,31 @@ export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
       throw err
     }
     try {
-      const doc = new LoroDocCtor()
-      // The doc's own bytes must be self-describing exactly like an
-      // MCP-created (wb_document_create) doc — kind lives on the SQL row
-      // AND on the doc, so a reader of the blob alone (an editor opening it,
-      // a snapshot export) doesn't need the row to know what it's looking at.
-      writeDocumentKind(doc, parsed.data.kind)
-      await saveDocument(workspaceId, path, doc, { overwrite: false, kind: parsed.data.kind })
-      // What a blank name means is `setDocumentDisplayName`'s rule, not a
-      // second copy of it here: it trims and stores null. Either way a name
-      // is never why the document fails to exist — the one field a person
-      // can correct afterwards must not gate creation.
-      const { name } = parsed.data
-      if (name !== undefined) {
-        // Best-effort, deliberately. The document is already saved, so a
-        // failure here cannot be reported as a failed create — a client that
-        // read 500 would retry and make a SECOND document. An unnamed
-        // document is recoverable by rename; a duplicated one is not.
-        await setDocumentDisplayName(workspaceId, path, name).catch((err: unknown) => {
-          getLogger('document').warning(
-            { err: err as Error, workspaceId, path },
-            'document created but its name could not be stored',
-          )
-        })
-      }
+      const deps = options.serverDeps ?? (await getDefaultServerDeps())
+      // A blank name means "no name" — the rule `setDocumentDisplayName` used
+      // to hold, kept here because the operation does not hold it. Measured:
+      // passing `'   '` through stores an empty name rather than rejecting
+      // it, which `DocumentEntry.name` declares as `z.string().min(1)` and so
+      // is a value the port says cannot exist. Trim and omit.
+      const name = parsed.data.name?.trim()
+      await wbDocumentCreate(deps, {
+        workspaceId,
+        path,
+        kind: parsed.data.kind,
+        // `saveDocument` used to upsert the workspace row on the way past, so
+        // posting into a workspace that does not exist yet has always worked
+        // on this surface. The operation makes that an explicit flag rather
+        // than a side effect, and this preserves the behaviour.
+        createWorkspace: true,
+        ...(name === undefined || name === '' ? {} : { name }),
+      })
       const response: CreateDocumentResponse = { path }
       return c.json(response)
     } catch (err) {
-      if (err instanceof ConflictError) {
+      if (err instanceof DocumentPathTakenError) {
         return c.json({ title: `Canvas "${path}" already exists` }, 409)
       }
-      getLogger('document').error({ err: err as Error }, 'saveDocument failed unexpectedly')
+      getLogger('document').error({ err: err as Error }, 'wb_document_create failed unexpectedly')
       return c.json({ title: 'Failed to create canvas.' } satisfies ApiErrorBody, 500)
     }
   })

--- a/tools/arch-lint/src/architecture-map.ts
+++ b/tools/arch-lint/src/architecture-map.ts
@@ -280,7 +280,6 @@ export const ADAPTERS_REACHING_MECHANICS: readonly string[] = [
   'routes/document/versions.ts -> document-store',
   'routes/document/versions.ts -> version-store',
   'routes/document/workspaces.ts -> document-store',
-  'routes/document/workspaces.ts -> names-store',
   'routes/export.ts -> document-store',
   'routes/files.ts -> file-gc',
   'routes/files.ts -> version-store',


### PR DESCRIPTION
## Summary

Second move under ADR-0018, after the delete (#1068) — **plus a live bug that root-causing the CI failure uncovered**. See the second section; it is the more important half.

The POST create built its own `LoroDoc`, stamped the kind onto it, saved it, and then named the document in a **separate best-effort step** — a second implementation of what `wb_document_create` already does. The naming step is where the two had diverged: the operation claims the path **and** the name in one index write, so the route's recorded concern (*"the document is already saved, so a failure here cannot be reported as a failed create"*) does not arise for it at all.

## The bug `packaged-smoke` caught, which was already live on `/api/v1`

CI failed on `packaged-smoke`: `scenario 2: canvas create failed, status: 500`. I reproduced it locally against the built daemon and read the real error rather than guessing:

```
no such table: workspaces   (in upsertWorkspaceRow, via documentIndex.createWorkspace)
```

`http-server.ts` built `ServerDeps` from `getDb(dataDir)`, which opens the file and nothing more. **Migrations have only ever run through `document-store.ts`'s `dbReady`** — `prepareDataDir` then `getDb`. So on a data dir nothing has touched yet, anything reaching the *injected ports* instead of the legacy store meets an empty schema. Moving the create onto the operation made a legacy route take that path.

**`/api/v1` has answered exactly that since the day it was mounted.** Verified directly on a build without the fix: a fresh `daemon run` plus `GET /api/v1/workspaces/default/documents` returns **500**. Nothing caught it because every other test and every real session had already migrated the dir through some legacy call first — the same "guard and gap mutually blind" shape as the v1 scope hole in #1069.

The fix is one `await prepareDataDir(dataDir)` before the handle is handed out, which is what `dbReady` has always done. Both calls are memoized per data dir, so on a prepared dir it costs nothing.

## The two translations that stay in the adapter

- **`DocumentPathTakenError` → 409**, which this surface has always answered. The `ConflictError` branch beside it is **removed** rather than kept "just in case": `saveDocument` was its only thrower in this handler and is no longer reached from here, so the branch was unreachable.
- **A blank name means "no name".** I got this wrong first and the mutation check caught it. My initial comment claimed `createDocument`'s `z.string().min(1)` would *reject* a blank. It does not — it **stores the empty string**, which `DocumentEntry.name` declares cannot exist. The adapter trims and omits; the underlying contract drift is filed separately, because fixing it needs a decision about which of two disagreeing schemas is the truth.

## It shrinks the allowlist — by an entry I did not predict

I said in #1068 that moves out of `workspaces.ts` would not shrink `ADAPTERS_REACHING_MECHANICS` until every `document-store` symbol went. True of that entry — but dropping `setDocumentDisplayName` retired a different one: `routes/document/workspaces.ts -> names-store`. **The stale-entry side of the guard caught it**, not me. 37 → **36**, and `.claude/rules/architecture-map.md` says so.

## Test plan

- [x] New or updated tests added — 3 cases in `crud-adapter.test.ts` (renamed from `delete-adapter.test.ts`), plus `http-server.migrations.test.ts`
- [x] `pnpm test` passes locally — **4197 passed**; the 4 failures are the pre-existing `EACCES` tests that cannot deny access to root in this container
- [x] Manual verification completed — `pnpm build` + the full `packaged-server-mode-cli-smoke`: **all 21 scenarios PASSED** (it failed scenario 2 before the fix)
- [ ] E2E coverage — the packaged smoke above is the E2E for the migration half

**Red tests, both at the layer the defect lives at:**

- the create goes through the *injected* index — red before the change with `expected [] to deeply equal [ 'ws-1:fresh' ]`;
- `startHttpServer` on a fresh temp data dir serves `/api/v1` — red before the fix with `expected 500 not to be 500`.

**Mutation check on the blank-name rule:** passing the name through untrimmed turns it red with `expected '' to be undefined` — which is how I found my comment was wrong. Restore verified by re-grepping.

The 409 and blank-name cases were written as **characterization tests and passed before the change**, deliberately, so the refactor is held to what the surface already did rather than to what I remembered it doing.

`arch-lint-node` passes (106) after removing the retired entry. Local gates green: `lint`, `secretlint`, `knip`, `typecheck`.

## Visual evidence

Visual evidence: none — a server-side refactor plus a startup-ordering fix, with no user-visible surface. The HTTP contract is unchanged (200 `{ path }`, 400, 409, 500), each pinned by a test that already existed or was added here; the migration half's evidence is the packaged smoke run quoted above.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — `.claude/rules/architecture-map.md`'s edge count
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_019uxfgjcDPQRBtJn5XYQgLc)_