### PR TITLE
fix(mcp-server): moveDocument must evict the doc cache for every path it touches

### DIFF
--- a/packages/mcp-server/src/server/store/sqlite-document-index.test.ts
+++ b/packages/mcp-server/src/server/store/sqlite-document-index.test.ts
@@ -3,9 +3,11 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { documentEntrySchema } from '@kamiazya/whiteboard-ports'
 import { describeDocumentIndexConformance } from '@kamiazya/whiteboard-ports/test-utils'
+import { LoroDoc } from 'loro-crdt'
 import { describe, expect, it } from 'vitest'
 import { captureLogsForTests } from '../log.js'
 import { createIsolatedDb } from './db/test-helpers.js'
+import { clearCache, getOrLoad, peekDoc } from './doc-cache.js'
 import { SqliteDocumentIndex } from './sqlite-document-index.js'
 
 describe('SqliteDocumentIndex', () => {
@@ -18,6 +20,52 @@ describe('SqliteDocumentIndex', () => {
         await handle.dispose()
         await rm(tempDir, { recursive: true, force: true })
       },
+    }
+  })
+
+  // The doc cache is keyed by (workspaceId, path), so a move invalidates
+  // entries under BOTH the path a document left and the one it arrived at.
+  //
+  // The destination half is the surprising one and the reason this is not
+  // just tidiness: `getDoc` lazily creates an empty doc for any path with no
+  // row yet, so a read through the destination BEFORE the move leaves a
+  // phantom cached there — and after the move that phantom shadows the real
+  // content, with the next write persisting it over the top.
+  //
+  // `document-store.renameDocumentPath` has always done this. This index's
+  // `moveDocument` did not, and nothing called it yet, so the gap was latent
+  // rather than live — which is exactly the state the delete's thumbnail gap
+  // was in before a second surface reached it.
+  it('evicts the doc cache for every path a move touches, source and destination', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-document-index-move-'))
+    const handle = await createIsolatedDb({ dataDir: tempDir })
+    clearCache()
+    try {
+      const index = new SqliteDocumentIndex(handle.db)
+      await index.createWorkspace({ workspaceId: 'ws1' })
+      await index.createDocument({ workspaceId: 'ws1', path: 'plan', kind: 'spatial' })
+      await index.createDocument({ workspaceId: 'ws1', path: 'plan/child', kind: 'spatial' })
+
+      // Warm every key the move will touch: the two sources, and the two
+      // destinations a reader could have reached first.
+      for (const path of ['plan', 'plan/child', 'archive', 'archive/child']) {
+        await getOrLoad('ws1', path, async () => new LoroDoc())
+      }
+
+      await index.moveDocument({ workspaceId: 'ws1', from: 'plan', to: 'archive' })
+
+      const stillCached = ['plan', 'plan/child', 'archive', 'archive/child'].filter(
+        (path) => peekDoc('ws1', path) !== undefined,
+      )
+      expect(
+        stillCached,
+        'a cached doc survived the move — under a source path it resurrects the moved ' +
+          "document, under a destination path it shadows the moved document's content.",
+      ).toEqual([])
+    } finally {
+      clearCache()
+      await handle.dispose()
+      await rm(tempDir, { recursive: true, force: true })
     }
   })
 

--- a/packages/mcp-server/src/server/store/sqlite-document-index.ts
+++ b/packages/mcp-server/src/server/store/sqlite-document-index.ts
@@ -24,6 +24,7 @@ import { getLogger } from '../log.js'
 import { deleteDocumentRow } from './db/delete-document-row.js'
 import type { Database } from './db/index.js'
 import { upsertWorkspaceRow } from './db/upsert-workspace.js'
+import { evictDoc } from './doc-cache.js'
 import { withWorkspaceWriteLock } from './workspace-lock.js'
 
 /**
@@ -197,6 +198,7 @@ export class SqliteDocumentIndex implements DocumentIndex {
       throw new DocumentMoveIntoSelfError(from, to)
     }
     await withWorkspaceWriteLock(workspaceId, async () => {
+      let moved: readonly { readonly from: string; readonly path: string }[] = []
       await this.db.transaction().execute(async (trx) => {
         const rows = await trx
           .selectFrom('documents')
@@ -219,7 +221,26 @@ export class SqliteDocumentIndex implements DocumentIndex {
             .where('id', '=', move.id)
             .execute()
         }
+        moved = plan.moves
       })
+
+      // After the commit, and still under the workspace lock: the cache is
+      // keyed by (workspaceId, path), so every path this move touched now
+      // holds a doc filed under a name that no longer means what it did.
+      //
+      // Both halves matter, and the destination half is the one that
+      // corrupts rather than merely staling. A source path: a reader still
+      // going through it must lazily create a fresh document rather than
+      // resurrect the moved one. A destination path: `getDoc` creates an
+      // empty doc for any path with no row yet, so a read that arrived
+      // before this move left a phantom cached there — leaving it would
+      // shadow the moved document's real content, and the next write through
+      // it would persist the phantom over the top. Both apply to every
+      // descendant, not only the two paths the caller named.
+      for (const move of moved) {
+        evictDoc(workspaceId, move.from)
+        evictDoc(workspaceId, move.path)
+      }
     })
   }
 


### PR DESCRIPTION
## Summary

`document-store.renameDocumentPath` evicts the doc cache under **every path a move touches** — both the path a document left and the one it arrived at, for every descendant. `SqliteDocumentIndex.moveDocument` performs the same subtree move (same `planSubtreeMove`, same `DocumentMoveIntoSelfError`, same workspace lock) and evicted **nothing**.

**The destination half is the one that corrupts rather than merely stales.** `getDoc` lazily creates an empty document for any path with no row yet, so a read that arrived *before* the move leaves a phantom cached at the destination. After the move that phantom shadows the moved document's real content, and the next write through it persists the phantom over the top.

## Latent today, live after the next step — which is why it lands now

Nothing calls `moveDocument` in production. I checked rather than assumed: the only references are `unused-document-index`'s refusing double and a comment. The rename route uses `renameDocumentPath`, and that is what the web app's move/rename UI reaches (`WorkspaceFilesPanel` → `source.renameDocumentPath` → `PUT /api/workspaces/…`), so the *correct* implementation is the one users hit.

It stops being latent the moment that route becomes an adapter over the port — the next step in the ADR-0018 migration, and one with a real UI consumer. Landing the fix first keeps that step a pure move rather than a move quietly carrying a data-loss bug.

This is deliberately **not** a third `ServerDeps` seam. `documentTeardown` exists because a delete's cleanup spans more than the index — blob files, and thumbnails whose version ids must be captured before the cascade. A move touches only the doc cache, which is squarely inside the index's own rows, so the eviction belongs in `SqliteDocumentIndex` itself: it is this package's own adapter, already imports `withWorkspaceWriteLock`, and importing `evictDoc` costs no new contract. Seam count stays at two.

## Test plan

- [x] New or updated tests added — one case in `sqlite-document-index.test.ts`
- [x] `pnpm test` passes locally — `src/server/store`: **459 passed**; the 4 failures are the pre-existing `EACCES` tests that cannot deny access to root in this container
- [x] Manual verification completed — see the mutation check
- [ ] E2E coverage — not applicable; there is no caller to drive end to end yet, which is the point above

The test warms all four keys a `plan → archive` move touches (two sources, two destinations) and asserts none survive. Red before the fix with all four listed.

**Mutation check on the half that matters:** dropping the destination eviction and keeping the source one leaves `['archive', 'archive/child']` cached and turns the test red — so the two halves are pinned independently rather than one assertion covering for the other. Restore verified by re-grepping.

Eviction happens **after the transaction commits** and still **under the workspace write lock**, matching what `renameDocumentPath` has always done.

`arch-lint-node` passes (106), including the cycle check over the new `doc-cache` import. Local gates green: `lint`, `typecheck`, `knip`.

## Visual evidence

Visual evidence: none — a cache-invalidation fix in a store adapter, with no user-visible surface today (no caller). The observable effect is a cache entry that no longer survives a move, which the test asserts directly.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — the rationale is recorded at the eviction itself
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_019uxfgjcDPQRBtJn5XYQgLc)_