### PR TITLE
fix(server-core): a blank name on create means no name, not a name the port forbids

### DIFF
--- a/packages/server-core/src/tools/document-crud.test.ts
+++ b/packages/server-core/src/tools/document-crud.test.ts
@@ -25,6 +25,31 @@ function makeDeps(): ServerDeps {
 }
 
 describe('wbDocumentCreate', () => {
+  // `DocumentEntry.name` is `z.string().min(1).optional()`, and its own
+  // comment says why: absent is the meaningful "no name" state, where a
+  // reader falls back to the path segment. An empty string is neither — a
+  // name that reads as nothing, which the port says cannot exist.
+  //
+  // Normalised rather than rejected, because ADR-0006 point 3 is the older
+  // rule and outranks tidiness here: naming must never gate creation. A
+  // caller that sends a blank name gets a document, not an error.
+  it('treats a blank name as no name rather than storing one the port forbids', async () => {
+    const deps = makeDeps()
+    const created = await wbDocumentCreate(deps, {
+      workspaceId: 'ws-1',
+      path: 'blank',
+      kind: 'spatial',
+      name: '   ',
+      createWorkspace: true,
+    })
+
+    const entry = await deps.documentIndex.resolveDocumentById({
+      workspaceId: 'ws-1',
+      documentId: created.documentId,
+    })
+    expect(entry?.name).toBeUndefined()
+  })
+
   it('creates a document and returns documentId + path', async () => {
     const deps = makeDeps()
     const result = await wbDocumentCreate(deps, {

--- a/packages/server-core/src/tools/document-crud.ts
+++ b/packages/server-core/src/tools/document-crud.ts
@@ -70,12 +70,20 @@ export async function wbDocumentCreate(
     }
   }
 
+  // Blank means no name, and that is a NORMALISATION rather than a rejection.
+  // `DocumentEntry.name` is `z.string().min(1).optional()` — absent is the
+  // meaningful "no name" state, where a reader falls back to the path
+  // segment, and an empty string is neither: a name that reads as nothing,
+  // which the port says cannot exist. But ADR-0006 point 3 is the older rule
+  // and outranks tidiness here — naming must never gate creation — so a
+  // caller sending a blank one gets a document, not an error.
+  const name = input.name?.trim()
   const entry = await rethrowWorkspaceNotFound(input.workspaceId, () =>
     deps.documentIndex.createDocument({
       workspaceId: input.workspaceId,
       path: input.path,
       kind: input.kind,
-      ...(input.name === undefined ? {} : { name: input.name }),
+      ...(name === undefined || name === '' ? {} : { name }),
     }),
   )
 


### PR DESCRIPTION
## Summary

`wb_document_create` passed `name` straight through, so `name: '   '` was stored verbatim.

`DocumentEntry.name` is `z.string().min(1).optional()`, and its own comment says why: **absent is the meaningful "no name" state**, where a reader falls back to the path segment. An empty string is neither — a name that reads as nothing, which the port declares cannot exist and then hands back to a caller that has been told it cannot.

Two schemas disagreed and neither was enforced at the call site:

| schema | `name` |
|---|---|
| `documentCreateCommonShape` (tool) | `z.string().optional()` — no `min` |
| `createDocumentInputSchema` (port) | `z.string().min(1).optional()` |

`createDocument` never parsed through the port's, so the stricter one was declarative only.

## Why normalised and not rejected — this is the whole decision

Making the tool schema `min(1)` would have made the two agree, and it is the wrong fix. It would break **ADR-0006 point 3**, which is the older rule and outranks tidiness here: *naming must never gate creation*. A caller sending a blank name should get a document, not an error — the name is the one field a person can correct afterwards, and a create that fails over it is worse than a document with no name.

So the operation trims and omits. The two schemas still differ in what they *say*, but the value the port forbids can no longer be produced.

## Provenance

Found while adapting the HTTP create onto this operation (#1071). That route trims and omits for exactly this reason, and its own `setDocumentDisplayName` predecessor did too — so the HTTP surface was already right, and only callers reaching the operation directly (an MCP client sending `name: ""`) landed the bad value. The route's trim becomes belt-to-this-braces once this lands and can be removed then; I have not touched it here, since it sits in an open PR.

## Test plan

- [x] New or updated tests added — one case in `document-crud.test.ts` (server-core-node), 26 total
- [x] `pnpm test` passes locally — `server-core-node` + `mcp-node`: **4194 passed**; the 4 failures are the pre-existing `EACCES` tests that cannot deny access to root in this container
- [x] Manual verification completed — see the mutation check
- [ ] E2E coverage — not applicable

The red test asserted through `resolveDocumentById` rather than on the return value, because the create's own output carries no name — the stored entry is the only place the defect is visible. Red before the change with `expected '   ' to be undefined` (note: not even trimmed).

**Mutation check:** dropping the empty-string check while keeping the trim turns it red with `expected '' to be undefined` — so the trim and the omit are pinned as one rule rather than the trim alone passing for it. Restore verified by re-grepping.

Local gates green: `lint`, `typecheck`, `knip`.

## Visual evidence

Visual evidence: none — a normalisation inside an MCP operation, with no user-visible surface. The observable effect is a stored field that is now absent instead of empty, which the test asserts directly.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — the rationale, including why ADR-0006 decides it, is recorded at the normalisation
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_019uxfgjcDPQRBtJn5XYQgLc)_