### PR TITLE
docs(model): the view facet stops describing a mechanism it does not have

### DIFF
--- a/packages/model/src/facets.ts
+++ b/packages/model/src/facets.ts
@@ -22,8 +22,19 @@ export const coreFacetsSchema = z.object({
    */
   resource: z.string().optional(),
   tags: z.array(z.string()).optional(),
-  // Explicit default-View override, used when multiple extension facets
-  // apply to the same canvas and the reader must pick one deterministically.
+  /**
+   * OKF's explicit default-View override: which extension facet a reader
+   * should render when a DOCUMENT carries several. (A canvas is the spatial
+   * surface and carries no facets at all — ADR-0009.)
+   *
+   * **Nothing reads it, and no tool writes it.** It round-trips through
+   * `writeCoreFacets`/`readCoreFacets` and stops there: core facets have no
+   * setter tool, and no renderer selects a template. Whether `view` becomes
+   * the selection key is an open question with a write path attached to it,
+   * so the field stays declared — dropping it would lose an author's value
+   * on the next save — while claiming a mechanism it does not have would be
+   * worse than saying nothing.
+   */
   view: z.string().optional(),
 })
 


### PR DESCRIPTION
## The comment was wrong twice in one line

```ts
// Explicit default-View override, used when multiple extension facets
// apply to the same canvas and the reader must pick one deterministically.
view: z.string().optional(),
```

**"the same canvas"** — a canvas is the spatial surface and carries no facets at all (ADR-0009 / `vocabulary.md`). Facets attach to a **document**.

**"the reader must pick one deterministically"** — there is no reader. Measured:

```
$ grep -rn "\.view\b" --include=*.ts --include=*.tsx packages apps | grep -v "\.test\." | <filter viewport/viewMode/viewer/…>
(no output)
```

`.view` has **zero production call sites**. It round-trips through `writeCoreFacets` / `readCoreFacets` — the loro-bridge tests pin that — and stops there. Core facets have no setter tool either, so nothing writes it but a test.

## What it says now

That it is OKF's own field, that it applies to a document, and that **nothing reads it and no tool writes it** — with why the field stays declared anyway: dropping it would lose an author's value on the next save.

`docs-sync`'s honesty rule is the standard here — document the shipped state, never the aspiration. A comment claiming a selection mechanism that does not exist is worse than saying nothing, because the next reader designs against it.

## Why it was still wrong

This is the vocabulary drive-by filed as slice S5 in the `resolveFileFacets` planning canvas, listed as a slice *"only so it does not get dropped"* and scheduled to ride inside the core-facet-card PR. That slice is gated on questions nobody has answered (a named domain owner, the precedence default, whether `view` becomes the selector), so the comment would have sat wrong indefinitely. It costs one comment to fix now and nothing to redo later.

## Verification

`pnpm -r typecheck` all Done, `arch-lint-node` 106 passed, `mcp-node` 3786 passed, biome clean on the touched file. Comment-only diff, +13/-2.

Visual evidence: none — a source comment; nothing here is rendered to anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoaNgqWUKbYJxk2azmRQKY