### PR TITLE
refactor(mcp-server): the HTTP rename is an adapter over documentIndex.moveDocument

### DIFF
--- a/packages/mcp-server/src/server/routes/document/crud-adapter.test.ts
+++ b/packages/mcp-server/src/server/routes/document/crud-adapter.test.ts
@@ -179,6 +179,97 @@ describe('POST /api/workspaces/:workspaceId/documents', () => {
   })
 })
 
+describe('PUT /api/workspaces/:workspaceId/documents/:path/path', () => {
+  async function depsRecordingMove(): Promise<{
+    deps: Awaited<ReturnType<typeof resolveServerDeps>>
+    moved: string[]
+  }> {
+    await prepareDataDir(tmp.dir)
+    const db = await getDb(tmp.dir)
+    const deps = resolveServerDeps(
+      createContainer(createStoreLocalModule({ db, blobDir: tmp.dir })),
+    )
+    const moved: string[] = []
+    const index = Object.create(deps.documentIndex) as typeof deps.documentIndex
+    index.moveDocument = async (input) => {
+      moved.push(`${input.from}->${input.to}`)
+      await Object.getPrototypeOf(index).moveDocument.call(index, input)
+    }
+    return { deps: { ...deps, documentIndex: index }, moved }
+  }
+
+  it('renames through the injected operation rather than its own sequence', async () => {
+    const { deps, moved } = await depsRecordingMove()
+    await deps.documentIndex.createWorkspace({ workspaceId: 'ws-1' })
+    await deps.documentIndex.createDocument({ workspaceId: 'ws-1', path: 'plan', kind: 'spatial' })
+    const app = createWorkspacesRouter({ serverDeps: deps })
+
+    const res = await app.request('/api/workspaces/ws-1/documents/plan/path', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: 'archive' }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ path: 'archive' })
+    expect(moved).toEqual(['plan->archive'])
+  })
+
+  it('answers 404 for a path that names nothing', async () => {
+    const { deps, moved } = await depsRecordingMove()
+    await deps.documentIndex.createWorkspace({ workspaceId: 'ws-1' })
+    const app = createWorkspacesRouter({ serverDeps: deps })
+
+    const res = await app.request('/api/workspaces/ws-1/documents/absent/path', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: 'elsewhere' }),
+    })
+
+    expect(res.status).toBe(404)
+    expect(moved).toEqual(['absent->elsewhere'])
+  })
+
+  // The collision is on a PRODUCED path, not the one the caller named: moving
+  // `plan` to `archive` collides because `archive/child` is taken, while
+  // `archive` itself is free. Naming `archive` in the error would send the
+  // caller to retry the one thing that was never the problem, so the message
+  // the operation raised is forwarded rather than rebuilt.
+  it('forwards the produced colliding path in the 409, not the requested one', async () => {
+    const { deps } = await depsRecordingMove()
+    await deps.documentIndex.createWorkspace({ workspaceId: 'ws-1' })
+    for (const path of ['plan', 'plan/child', 'archive/child']) {
+      await deps.documentIndex.createDocument({ workspaceId: 'ws-1', path, kind: 'spatial' })
+    }
+    const app = createWorkspacesRouter({ serverDeps: deps })
+
+    const res = await app.request('/api/workspaces/ws-1/documents/plan/path', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: 'archive' }),
+    })
+
+    expect(res.status).toBe(409)
+    const body = (await res.json()) as { title?: string }
+    expect(body.title).toContain('archive/child')
+  })
+
+  it('answers 400 for a move into the document own subtree', async () => {
+    const { deps } = await depsRecordingMove()
+    await deps.documentIndex.createWorkspace({ workspaceId: 'ws-1' })
+    await deps.documentIndex.createDocument({ workspaceId: 'ws-1', path: 'plan', kind: 'spatial' })
+    const app = createWorkspacesRouter({ serverDeps: deps })
+
+    const res = await app.request('/api/workspaces/ws-1/documents/plan/path', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: 'plan/inside' }),
+    })
+
+    expect(res.status).toBe(400)
+  })
+})
+
 describe('DELETE /api/workspaces/:workspaceId/documents/:path', () => {
   beforeEach(async () => {
     await saveDocument('ws-1', 'doomed', new LoroDoc())

--- a/packages/mcp-server/src/server/routes/document/workspaces.test.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.test.ts
@@ -45,16 +45,16 @@ const { getDb } = await import('../../store/db/index.js')
 const { createContainer, resolveServerDeps } = await import('../../../di/container.js')
 const { createStoreLocalModule } = await import('../../../di/store-local.module.js')
 
-// The delete route is an adapter over `wb_document_delete` (ADR-0018), so
-// forcing the delete to fail means making the OPERATION fail, not stubbing a
-// store function the route no longer calls. `Object.create` rather than a
-// spread: the index is a class instance, and spreading one drops every method
-// it inherits from its prototype.
-async function depsWithFailingDelete(err: unknown) {
+// These routes are adapters over the document index (ADR-0018), so forcing
+// one to fail means making the OPERATION fail, not stubbing a store function
+// the route no longer calls. `Object.create` rather than a spread: the index
+// is a class instance, and spreading one drops every method it inherits from
+// its prototype.
+async function depsWithFailing(method: 'deleteDocument' | 'moveDocument', err: unknown) {
   const db = await getDb(tmp.dir)
   const deps = resolveServerDeps(createContainer(createStoreLocalModule({ db, blobDir: tmp.dir })))
   const index = Object.create(deps.documentIndex) as typeof deps.documentIndex
-  index.deleteDocument = () => Promise.reject(err)
+  index[method] = () => Promise.reject(err)
   return { ...deps, documentIndex: index }
 }
 
@@ -416,7 +416,8 @@ describe('DELETE /api/workspaces/:workspaceId/documents/:path', () => {
   it('maps a thrown CorruptStoredDataError to 500 { error: corrupt_stored_data }, and only that error type — a plain throw stays a generic 500', async () => {
     await saveDocument('session1', 'canvas-a', new LoroDoc())
     const corrupt = createDocumentRouter({
-      serverDeps: await depsWithFailingDelete(
+      serverDeps: await depsWithFailing(
+        'deleteDocument',
         corruptStoredData('/tmp/blobs/session1/document/abc.loro', 'broken canvas blob'),
       ),
     })
@@ -432,7 +433,7 @@ describe('DELETE /api/workspaces/:workspaceId/documents/:path', () => {
     // Mutation guard: a non-corruption throw must NOT hit the same branch —
     // proves the mapping checks the error type, not "any throw".
     const plain = createDocumentRouter({
-      serverDeps: await depsWithFailingDelete(new Error('disk exploded')),
+      serverDeps: await depsWithFailing('deleteDocument', new Error('disk exploded')),
     })
     const res2 = await plain.request('/api/workspaces/session1/documents/canvas-a', {
       method: 'DELETE',
@@ -761,38 +762,38 @@ describe('PUT /api/workspaces/:workspaceId/documents/:path/path', () => {
 
   it('maps a thrown CorruptStoredDataError to 500 { error: corrupt_stored_data }, and only that error type — a plain throw stays a generic 500', async () => {
     await saveDocument('session1', 'a', new LoroDoc())
-    const spy = vi
-      .spyOn(documentStore, 'renameDocumentPath')
-      .mockRejectedValueOnce(
+    const body = JSON.stringify({ path: 'b' })
+    const headers = { 'Content-Type': 'application/json' }
+    const corrupt = createDocumentRouter({
+      serverDeps: await depsWithFailing(
+        'moveDocument',
         corruptStoredData('/tmp/blobs/session1/document/abc.loro', 'broken canvas blob'),
-      )
-    const app = createDocumentRouter()
-    try {
-      const res = await app.request('/api/workspaces/session1/documents/a/path', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ path: 'b' }),
-      })
-      expect(res.status).toBe(500)
-      await expect(res.json()).resolves.toEqual({
-        error: 'corrupt_stored_data',
-        message: expect.stringContaining('broken canvas blob'),
-      })
+      ),
+    })
+    const res = await corrupt.request('/api/workspaces/session1/documents/a/path', {
+      method: 'PUT',
+      headers,
+      body,
+    })
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({
+      error: 'corrupt_stored_data',
+      message: expect.stringContaining('broken canvas blob'),
+    })
 
-      // Mutation guard: a non-corruption throw must NOT hit the same
-      // branch — proves the mapping checks the error type, not "any throw".
-      spy.mockRejectedValueOnce(new Error('disk exploded'))
-      const res2 = await app.request('/api/workspaces/session1/documents/a/path', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ path: 'b' }),
-      })
-      expect(res2.status).toBe(500)
-      const json2: unknown = await res2.json()
-      expect(json2).not.toMatchObject({ error: 'corrupt_stored_data' })
-    } finally {
-      spy.mockRestore()
-    }
+    // Mutation guard: a non-corruption throw must NOT hit the same branch —
+    // proves the mapping checks the error type, not "any throw".
+    const plain = createDocumentRouter({
+      serverDeps: await depsWithFailing('moveDocument', new Error('disk exploded')),
+    })
+    const res2 = await plain.request('/api/workspaces/session1/documents/a/path', {
+      method: 'PUT',
+      headers,
+      body,
+    })
+    expect(res2.status).toBe(500)
+    const json2: unknown = await res2.json()
+    expect(json2).not.toMatchObject({ error: 'corrupt_stored_data' })
   })
 })
 

--- a/packages/mcp-server/src/server/routes/document/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.ts
@@ -1,6 +1,7 @@
 import {
   DocumentHasDescendantsError,
   DocumentMoveIntoSelfError,
+  DocumentNotFoundError,
   DocumentPathTakenError,
 } from '@kamiazya/whiteboard-ports'
 import {
@@ -22,13 +23,7 @@ import {
 } from '../../../shared/api-contracts/document.js'
 import type { ApiErrorBody } from '../../../shared/api-contracts/errors.js'
 import { getLogger } from '../../log.js'
-import {
-  ConflictError,
-  listDocuments,
-  listWorkspaces,
-  renameDocumentPath,
-  workspaceExists,
-} from '../../store/document-store.js'
+import { listDocuments, listWorkspaces, workspaceExists } from '../../store/document-store.js'
 import { validateDocumentPath, validateWorkspaceId, validationErrorBody } from '../../validators.js'
 import { handleCorruptStoredData } from './_shared.js'
 import { onDocumentsRoute } from './path-route.js'
@@ -130,12 +125,6 @@ export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
     }
     try {
       const deps = options.serverDeps ?? (await getDefaultServerDeps())
-      // A blank name means "no name" — the rule `setDocumentDisplayName` used
-      // to hold, kept here because the operation does not hold it. Measured:
-      // passing `'   '` through stores an empty name rather than rejecting
-      // it, which `DocumentEntry.name` declares as `z.string().min(1)` and so
-      // is a value the port says cannot exist. Trim and omit.
-      const name = parsed.data.name?.trim()
       await wbDocumentCreate(deps, {
         workspaceId,
         path,
@@ -145,7 +134,10 @@ export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
         // on this surface. The operation makes that an explicit flag rather
         // than a side effect, and this preserves the behaviour.
         createWorkspace: true,
-        ...(name === undefined || name === '' ? {} : { name }),
+        // Passed through as given. A blank name meaning "no name" is the
+        // OPERATION's rule now, not a second copy of it here — two places
+        // normalising the same field is two places that can stop agreeing.
+        ...(parsed.data.name === undefined ? {} : { name: parsed.data.name }),
       })
       const response: CreateDocumentResponse = { path }
       return c.json(response)
@@ -201,9 +193,16 @@ export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
   // just a new path column. Old URLs carrying the old path 404 by design — no
   // redirect, no alias history (0.0.x).
   //
-  // Server-side foundation only: no MCP tool, CLI command, or apps/web
-  // affordance calls this route yet. The apps/web path-edit UI is a planned
-  // follow-up, not dead code.
+  // An ADAPTER over `documentIndex.moveDocument` (ADR-0018). Straight to the
+  // port rather than through a `wb_document_*` operation, because there is no
+  // operation to write: a move is the port call and nothing else, so a use
+  // case here would forward one argument set and add a name. The delete and
+  // create differ — each composes several steps that a second surface would
+  // otherwise repeat.
+  //
+  // The web app's move/rename UI reaches exactly this route
+  // (`WorkspaceFilesPanel` -> `daemon-files-source` -> `PUT …/documents/:path/path`),
+  // so a stale comment here claiming nothing called it has been removed.
   onDocumentsRoute(
     app,
     'put',
@@ -226,28 +225,31 @@ export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
         throw err
       }
       try {
-        const result = await renameDocumentPath(workspaceId, path, newPath)
-        if (!result) {
-          return c.json({ title: `Canvas "${path}" not found` }, 404)
-        }
+        const deps = options.serverDeps ?? (await getDefaultServerDeps())
+        await deps.documentIndex.moveDocument({ workspaceId, from: path, to: newPath })
         const response: RenameDocumentPathResponse = { path: newPath }
         return c.json(response)
       } catch (err) {
+        // Absent is a 404 here and a throw there — the same translation the
+        // delete makes, in the opposite direction.
+        if (err instanceof DocumentNotFoundError) {
+          return c.json({ title: `Canvas "${path}" not found` }, 404)
+        }
         // A move into the document's own subtree is an unusable target, not
         // a race with another document — 400, not 409.
         if (err instanceof DocumentMoveIntoSelfError) {
           return c.json({ title: err.message } satisfies ApiErrorBody, 400)
         }
-        // Forward the store's message rather than rebuilding one from
+        // Forward the raised message rather than rebuilding one from
         // newPath: a subtree move collides on a PRODUCED path, so the path
         // the caller asked for is often free and naming it sends them to
         // retry the one thing that was never the problem.
-        if (err instanceof ConflictError) {
+        if (err instanceof DocumentPathTakenError) {
           return c.json({ title: err.message } satisfies ApiErrorBody, 409)
         }
         const issue = handleCorruptStoredData(err)
         if (issue) return c.json(issue.body, issue.status)
-        getLogger('document').error({ err: err as Error }, 'renameDocumentPath failed unexpectedly')
+        getLogger('document').error({ err: err as Error }, 'moveDocument failed unexpectedly')
         return c.json({ title: 'Failed to rename canvas.' } satisfies ApiErrorBody, 500)
       }
     },


### PR DESCRIPTION
## Summary

Third and last of the **reachable** moves under ADR-0018, after the delete (#1068) and the create (#1071). `renameDocumentPath` and `documentIndex.moveDocument` were the same subtree move written twice — same `planSubtreeMove`, same `DocumentMoveIntoSelfError` — and this route no longer references the copy in `document-store.ts`.

**Straight to the port rather than through a `wb_document_*` operation, deliberately.** A move *is* the port call and nothing else, so a use case here would forward one argument set and add a name. The delete and create differ: each composes several steps a second surface would otherwise repeat. The arch-lint rule bans an adapter importing a **mechanic** (`store/`); reaching a port through injected deps is the shape it is asking for.

**What made this safe to do at all is #1072.** `renameDocumentPath` evicted the doc cache under every moved path and `moveDocument` evicted nothing, so without that fix landing first, this commit would have been a silent data-loss bug rather than a refactor — and a live one, since the web app's move/rename UI reaches this exact route.

## Three translations stay in the adapter, each pinned

- `DocumentNotFoundError` → the 404 this surface answers.
- `DocumentPathTakenError` → 409, **forwarding the raised message** rather than rebuilding one from `newPath`. A subtree move collides on a *produced* path, so the path the caller asked for is often free.
- `DocumentMoveIntoSelfError` → 400, unchanged — an unusable target, not a race.

## Two things fixed in passing, both in code this commit already touches

**The route's comment claimed nothing called it** — *"no MCP tool, CLI command, or apps/web affordance calls this route yet… a planned follow-up, not dead code."* That is false: `WorkspaceFilesPanel` → `daemon-files-source` → `renameDocumentPath` issues exactly this `PUT`. I checked because the comment contradicted a claim I had made in #1072's body; the comment was the wrong one. A comment asserting dead-code status about live code is worse than no comment, so it is gone.

**The create's blank-name trim is removed.** #1074 made that the *operation's* rule; keeping a second copy here is two places that can stop agreeing. I said in #1074 that it could go once that landed, and this is that.

## Test plan

- [x] New or updated tests added — 4 cases in `crud-adapter.test.ts` (11 total), plus the rename's corrupt-data test repointed at the operation
- [x] `pnpm test` passes locally — `mcp-node` + `server-core-node`: **4204 passed**; the 4 failures are the pre-existing `EACCES` tests that cannot deny access to root in this container
- [x] Manual verification completed — see the mutation checks
- [ ] E2E coverage — not applicable

**Mutation checks, both of which fired:**

| mutation | result |
|---|---|
| drop the `DocumentNotFoundError` translation | `expected 500 to be 404` |
| rebuild the 409 message from `newPath` instead of forwarding | `expected 'Canvas "archive" already exists' to contain 'archive/child'` |

The second one **reproduces the exact trap the original comment warned about** — the caller would be told to retry `archive`, which was never taken. That comment was prose for as long as the code existed; it is now a test.

The 409 and 400 cases were written as characterization and passed before the change. The blank-name test still passes with the route's trim removed, which is what says that removal is safe rather than an argument that it should be.

`arch-lint-node` passes (106). Local gates green: `lint`, `typecheck`, `knip`, `secretlint`.

## What this does not do

**The `workspaces.ts -> document-store` allowlist entry still does not clear.** `listDocuments`, `listWorkspaces` and `workspaceExists` remain, and the list route is blocked on a decision I am not making unilaterally: the HTTP `documentSummarySchema` requires `updatedAt`, the port's `DocumentEntry` has no such field, and adding it as required forces a **browser IndexedDB store migration** in `apps/web`, whose `IndexRow` does not carry one. `workspaceExists`/`listWorkspaces` have no port method at all. Both are recorded with their measurements rather than guessed at.

## Visual evidence

Visual evidence: none — a server-side refactor with no user-visible change. The HTTP contract is unchanged (200 `{ path }`, 400, 404, 409, 500), each pinned by a test that already existed or was added here.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — the stale route comment corrected; rationale recorded at the adapter
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_019uxfgjcDPQRBtJn5XYQgLc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document rename error handling, including clearer responses for missing paths, name conflicts, and moves into a document’s own folder.
  * Preserved document names as entered during creation, including whitespace, with blank-name validation handled consistently.
  * Improved handling of unexpected errors during document moves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->