### PR TITLE
docs(dev-flow): a guard that never reaches its subject passes, and looks like one that checked

### DIFF
--- a/.claude/rules/dev-flow.md
+++ b/.claude/rules/dev-flow.md
@@ -80,6 +80,33 @@ TDD red-first; Zod single source of truth (`z.infer`, never a parallel hand-writ
 
 **Measure before you change what you cannot see in the diff.** A heuristic, a cost model, a search or an optimisation is correct-looking code whose worth is entirely in numbers nobody has taken — so the INSTRUMENT lands first, in its own commit, and the change is judged by it. Two exist: `edge-routing-quality.test.ts` (quality: a corpus plus aggregate counts pinned EXACTLY, so an improvement is as loud as a regression, with debt metrics separated from price metrics) and `pnpm bench` (performance: `vitest bench`, compared across INTERLEAVED paired runs because machine drift between separate runs exceeds the effect). For a behaviour-preserving optimisation the scoreboard NOT moving is the proof. This is not ceremony: the instruments rejected three changes that were obviously right on argument — per-blocker detours, a placement cache, and an excess-length penalty tier — and one cheap reachability probe (67 of 68 remaining defects had a clean path available) retired a planned task and redirected the work. They also **rescued** one: an aligned re-score was rejected in its first two shapes on cost (13x, then 4.5x layout time) and shipped in a third that reused machinery already in the file, at 2x — the measurement did not veto the idea, it priced each shape until one was worth paying for. Load the `measured-change` skill. When a change buys one metric with another, `PENALTY_RULES`' declared tier order decides it; when the currencies are genuinely different, that is a human decision worth interrupting for.
 
+**A guard that never reaches its subject passes, and reads exactly like a
+guard that checked.** Distinct from a vacuous PROPERTY (a generator too sparse
+to reach the interesting inputs) and from an empty `--project` filter: here the
+assertion is right, the subject is simply absent from the fixture, so nothing
+is wrong for it to find. Three instances in one session, each costing a real
+defect:
+
+- `route-scope-registry.test.ts` walked apps built WITHOUT `ServerDeps`, and
+  `/api/v1` mounts only when they are supplied — so nine routes were exempt
+  from the registry-wide guard by accident. Every `/api/v1/*` path resolved to
+  `null`, which server mode answers 500 to.
+- Nothing migrated the data dir before `http-server.ts` handed its ports a
+  handle. `/api/v1` had answered `no such table: workspaces` on a fresh dir
+  since the day it was mounted; no test saw it because every one of them
+  migrated through some legacy call first.
+- A route test's own helper pre-created the workspace, so `createWorkspace:
+  true` was pinned by nothing — removing it left every case green, on
+  behaviour the PR body claimed to preserve.
+
+The mutation check catches this ONLY if the mutation is on the production
+side; mutating a rule the fixture never exercises is green either way. So
+assert the subject is PRESENT, not merely that what is present passes —
+`expect(routes.some(r => r.path.startsWith('/api/v1/'))).toBe(true)` beside the
+walk, `expect(edges.length).toBeGreaterThan(20)` beside the allowlist. A count
+far below what the real surface holds is evidence the fixture missed, never
+good news.
+
 **The same scepticism applies one step earlier, to a DIAGNOSIS.** A failure message, a "not a
 regression", a mutation check, a hand-verified fix — each arrives looking like evidence while
 saying nothing about what was actually exercised. In one session that produced three published


### PR DESCRIPTION
## Summary

One paragraph in `.claude/rules/dev-flow.md`, recording a failure shape that cost **three real defects in one session**.

It is deliberately distinguished from the two already written down there, because the remedy differs:

| shape | why it passes | already recorded |
|---|---|---|
| vacuous property | generator too sparse to reach the interesting inputs | AGENTS.md (PBT) |
| empty `--project` filter | nothing ran, quietly | dev-flow.md |
| **guard never reaches its subject** | assertion is correct; the subject is absent from the fixture | **this** |

## The three instances

- **`route-scope-registry.test.ts` walked apps built without `ServerDeps`**, and `/api/v1` mounts only when they are supplied — so nine routes were exempt from the registry-wide guard by accident. Every `/api/v1/*` path resolved to `null`, which server mode answers 500 to. (#1069)
- **Nothing migrated the data dir before `http-server.ts` handed its ports a handle.** `/api/v1` had answered `no such table: workspaces` on a fresh dir since the day it was mounted; no test saw it because every one of them migrated through some legacy call first. (#1071)
- **A route test's own helper pre-created the workspace**, so `createWorkspace: true` was pinned by nothing — removing it left every case green, on behaviour the PR body claimed to preserve. Caught by CodeRabbit, not by me. (#1071)

## The part worth writing down

**The mutation check does not save you here.** That is the non-obvious half, and why this needs a rule rather than "be careful": mutating a rule the fixture never exercises is green either way, so the discipline this repo already relies on reports success. What works is asserting the subject is *present* beside asserting that what is present passes — `expect(routes.some(r => r.path.startsWith('/api/v1/'))).toBe(true)` beside the walk, `expect(edges.length).toBeGreaterThan(20)` beside the allowlist.

Both of those exist in the codebase already; the paragraph names the practice so it is applied deliberately rather than remembered by whoever happened to write the last guard.

## Test plan

- [x] New or updated tests added — n/a, a rules-file paragraph
- [x] `pnpm test` passes locally — unaffected
- [x] Manual verification completed — `pnpm lint` and `pnpm secretlint` pass (the vocabulary guard scans `.claude/`, so a rules edit is not free of gates)
- [ ] E2E coverage — not applicable

## Visual evidence

Visual evidence: none — a documentation change with no code or user-visible surface.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — this is the docs change
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_019uxfgjcDPQRBtJn5XYQgLc)_