### PR TITLE
feat(ports): DocumentEntry carries updatedAt, and the HTTP list becomes an adapter

### DIFF
--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -44,7 +44,7 @@ export interface DaemonIndexPageProps {
 interface DocumentRow {
   path: string
   displayName: string
-  updatedAt: string
+  updatedAt: string | undefined
   // Absent when the daemon records no kind for the row (pre-kind documents):
   // the list says nothing rather than claiming spatial.
   kind?: DocumentKind
@@ -56,7 +56,13 @@ function sortRows(rows: DocumentRow[]): DocumentRow[] {
   return [...rows].sort((a, b) => {
     if (a.pinned !== b.pinned) return a.pinned ? -1 : 1
     if (a.pinned && b.pinned) return a.pinOrder - b.pinOrder
-    if (a.updatedAt !== b.updatedAt) return a.updatedAt < b.updatedAt ? 1 : -1
+    // Newest first, and a document with no recorded timestamp sorts last
+    // rather than winning by accident: `undefined` fails every `<`
+    // comparison, so a bare `a.updatedAt < b.updatedAt` would have quietly
+    // ordered it as if it were the newest.
+    const left = a.updatedAt ?? ''
+    const right = b.updatedAt ?? ''
+    if (left !== right) return left < right ? 1 : -1
     return 0
   })
 }

--- a/packages/mcp-server/src/server/routes/document/crud-adapter.test.ts
+++ b/packages/mcp-server/src/server/routes/document/crud-adapter.test.ts
@@ -63,6 +63,7 @@ async function depsRecordingTeardown(): Promise<{
 async function depsRecordingCreate(bootstrapWorkspace = true): Promise<{
   deps: Awaited<ReturnType<typeof resolveServerDeps>>
   created: string[]
+  listed: string[]
 }> {
   // The delete cases reach a migrated schema through `saveDocument`'s own
   // `dbReady`; these create nothing first, so they have to migrate here.
@@ -71,13 +72,53 @@ async function depsRecordingCreate(bootstrapWorkspace = true): Promise<{
   const deps = resolveServerDeps(createContainer(createStoreLocalModule({ db, blobDir: tmp.dir })))
   if (bootstrapWorkspace) await deps.documentIndex.createWorkspace({ workspaceId: 'ws-1' })
   const created: string[] = []
+  const listed: string[] = []
   const index = Object.create(deps.documentIndex) as typeof deps.documentIndex
   index.createDocument = async (input) => {
     created.push(`${input.workspaceId}:${input.path}`)
     return await Object.getPrototypeOf(index).createDocument.call(index, input)
   }
-  return { deps: { ...deps, documentIndex: index }, created }
+  index.listDocuments = async (input) => {
+    listed.push(input.workspaceId)
+    return await Object.getPrototypeOf(index).listDocuments.call(index, input)
+  }
+  return { deps: { ...deps, documentIndex: index }, created, listed }
 }
+
+describe('GET /api/workspaces/:workspaceId/documents', () => {
+  it('lists through the injected operation, carrying kind and updatedAt', async () => {
+    const { deps, listed } = await depsRecordingCreate()
+    await deps.documentIndex.createDocument({ workspaceId: 'ws-1', path: 'a', kind: 'markdown' })
+    const app = createWorkspacesRouter({ serverDeps: deps })
+
+    const res = await app.request('/api/workspaces/ws-1/documents')
+
+    expect(res.status).toBe(200)
+    // Reaching the same database is not the same as reaching the injected
+    // index: the module-level store reads these very rows, so without this the
+    // case passes either way.
+    expect(listed).toEqual(['ws-1'])
+    const body = (await res.json()) as { documents: Record<string, unknown>[] }
+    expect(body.documents).toHaveLength(1)
+    expect(body.documents[0]).toMatchObject({ path: 'a', kind: 'markdown' })
+    // The daemon's index owns a timestamp, so this surface must still report
+    // one — the field is optional on the port for the browser's sake, not
+    // because the daemon may omit it.
+    expect(typeof body.documents[0]?.updatedAt).toBe('string')
+  })
+
+  // "Empty" and "never registered" are different answers, and conflating them
+  // is what let a stale pairing render as an empty workspace with a Create
+  // button. The operation raises it; this surface translates it.
+  it('answers 404 for a workspace that was never registered', async () => {
+    const { deps } = await depsRecordingCreate()
+    const app = createWorkspacesRouter({ serverDeps: deps })
+
+    const res = await app.request('/api/workspaces/never-made/documents')
+
+    expect(res.status).toBe(404)
+  })
+})
 
 describe('POST /api/workspaces/:workspaceId/documents', () => {
   // Same reasoning as the delete below: creating a document twice over — once

--- a/packages/mcp-server/src/server/routes/document/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.ts
@@ -6,8 +6,10 @@ import {
 } from '@kamiazya/whiteboard-ports'
 import {
   type ServerDeps,
+  WorkspaceNotFoundError,
   wbDocumentCreate,
   wbDocumentDelete,
+  wbDocumentList,
 } from '@kamiazya/whiteboard-server-core'
 import { Hono } from 'hono'
 import type { z } from 'zod'
@@ -23,7 +25,7 @@ import {
 } from '../../../shared/api-contracts/document.js'
 import type { ApiErrorBody } from '../../../shared/api-contracts/errors.js'
 import { getLogger } from '../../log.js'
-import { listDocuments, listWorkspaces, workspaceExists } from '../../store/document-store.js'
+import { listWorkspaces } from '../../store/document-store.js'
 import { validateDocumentPath, validateWorkspaceId, validationErrorBody } from '../../validators.js'
 import { handleCorruptStoredData } from './_shared.js'
 import { onDocumentsRoute } from './path-route.js'
@@ -77,16 +79,31 @@ export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
       throw err
     }
     try {
-      // "Empty" and "never registered" are different answers, and conflating
-      // them is what let a stale pairing render as an empty workspace with a
-      // Create button. Same problem-details shape as live-doc's snapshot 404.
-      if (!(await workspaceExists(workspaceId))) {
-        return c.json({ title: `Workspace "${workspaceId}" not found` }, 404)
+      const deps = options.serverDeps ?? (await getDefaultServerDeps())
+      const { documents } = await wbDocumentList(deps, { workspaceId })
+      // The port names a document by the id the index assigned and calls what
+      // a human reads its `name`; this surface has always said `id` and
+      // `displayName`. Renaming either would be a published break for a
+      // translation an adapter is there to do.
+      const response: ListDocumentsResponse = {
+        documents: documents.map((entry) => ({
+          path: entry.path,
+          id: entry.documentId,
+          ...(entry.name === undefined ? {} : { displayName: entry.name }),
+          ...(entry.kind === undefined ? {} : { kind: entry.kind }),
+          ...(entry.updatedAt === undefined ? {} : { updatedAt: entry.updatedAt }),
+        })),
       }
-      const documents = await listDocuments(workspaceId)
-      const response: ListDocumentsResponse = { documents }
       return c.json(response)
     } catch (err) {
+      // "Empty" and "never registered" are different answers, and conflating
+      // them is what let a stale pairing render as an empty workspace with a
+      // Create button. The operation refuses an unknown workspace rather than
+      // answering with an empty list, which is what makes this translation
+      // possible without a second existence query.
+      if (err instanceof WorkspaceNotFoundError) {
+        return c.json({ title: `Workspace "${workspaceId}" not found` }, 404)
+      }
       const issue = handleCorruptStoredData(err)
       if (issue) return c.json(issue.body, issue.status)
       throw err

--- a/packages/mcp-server/src/server/store/sqlite-document-index.ts
+++ b/packages/mcp-server/src/server/store/sqlite-document-index.ts
@@ -37,12 +37,17 @@ function toEntry(row: {
   path: string
   kind: string | null
   displayName: string | null
+  updatedAt: number
 }): DocumentEntry {
   return {
     documentId: row.id,
     path: row.path,
     ...(row.kind === null ? {} : { kind: row.kind as DocumentEntry['kind'] }),
     ...(row.displayName === null ? {} : { name: row.displayName }),
+    // The column is epoch millis; the port publishes ISO 8601, which is what
+    // every reader of it compares and formats. Converted here rather than at
+    // each caller, so the storage representation stops at this boundary.
+    updatedAt: new Date(row.updatedAt).toISOString(),
   }
 }
 
@@ -111,7 +116,16 @@ export class SqliteDocumentIndex implements DocumentIndex {
       if ((inserted.numInsertedOrUpdatedRows ?? 0n) === 0n) {
         throw new DocumentPathTakenError(workspaceId, path)
       }
-      return { documentId, path, kind, ...(name === undefined ? {} : { name }) }
+      // `now` rather than a re-read: it is the value just written, and a
+      // create whose returned entry disagrees with a later `resolveDocument`
+      // is what the conformance suite exists to catch.
+      return {
+        documentId,
+        path,
+        kind,
+        ...(name === undefined ? {} : { name }),
+        updatedAt: new Date(now).toISOString(),
+      }
     })
   }
 
@@ -121,7 +135,7 @@ export class SqliteDocumentIndex implements DocumentIndex {
   }: ResolveDocumentInput): Promise<DocumentEntry | null> {
     const row = await this.db
       .selectFrom('documents')
-      .select(['id', 'path', 'kind', 'displayName'])
+      .select(['id', 'path', 'kind', 'displayName', 'updatedAt'])
       .where('workspaceId', '=', workspaceId)
       .where('path', '=', path)
       .executeTakeFirst()
@@ -135,7 +149,7 @@ export class SqliteDocumentIndex implements DocumentIndex {
   }: ResolveDocumentByIdInput): Promise<DocumentEntry | null> {
     const row = await this.db
       .selectFrom('documents')
-      .select(['id', 'path', 'kind', 'displayName'])
+      .select(['id', 'path', 'kind', 'displayName', 'updatedAt'])
       .where('workspaceId', '=', workspaceId)
       .where('id', '=', documentId)
       .executeTakeFirst()
@@ -166,7 +180,7 @@ export class SqliteDocumentIndex implements DocumentIndex {
     }
     const rows = await this.db
       .selectFrom('documents')
-      .select(['id', 'path', 'kind', 'displayName'])
+      .select(['id', 'path', 'kind', 'displayName', 'updatedAt'])
       .where('workspaceId', '=', workspaceId)
       .execute()
     // Sorted here rather than in SQL: segment-wise order is not what any

--- a/packages/mcp-server/src/shared/api-contracts/document.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/document.test.ts
@@ -370,8 +370,17 @@ describe('documentSummarySchema', () => {
     expect(result).toEqual(valid)
   })
 
-  it('rejects missing updatedAt', () => {
-    expect(documentSummarySchema.safeParse({ path: 'canvas-1' }).success).toBe(false)
+  // Was `rejects missing updatedAt`. Required stopped being true when the
+  // list route became an adapter over `wbDocumentList`: `DocumentEntry`
+  // leaves the field optional because an index may genuinely not own a
+  // timestamp — apps/web's IndexedDB index reads them from a separate store —
+  // and a response type cannot promise more than the port it reads from.
+  //
+  // Absent is still not the same as arbitrary: a value that IS present must
+  // be a string, which is the half worth keeping.
+  it('leaves updatedAt ABSENT rather than requiring one the port cannot promise', () => {
+    expect(documentSummarySchema.safeParse({ path: 'canvas-1' }).success).toBe(true)
+    expect(documentSummarySchema.safeParse({ path: 'canvas-1', updatedAt: 7 }).success).toBe(false)
   })
 
   it('accepts an explicit kind: markdown', () => {

--- a/packages/mcp-server/src/shared/api-contracts/document.ts
+++ b/packages/mcp-server/src/shared/api-contracts/document.ts
@@ -159,7 +159,13 @@ export const documentSummarySchema = z.object({
   // `[[Name]]` reference reads the name from the same response it renders
   // the list from — the split is what let the two disagree.
   displayName: z.string().min(1).optional(),
-  updatedAt: z.string(),
+  // Optional, matching `DocumentEntry`, which is optional because an index
+  // may genuinely not own a timestamp — apps/web's IndexedDB index reads them
+  // from a separate store. The daemon's SQL index always has one, so this
+  // surface still reports it in practice; what changed is that the TYPE no
+  // longer claims a guarantee the port cannot make. Every UI site that
+  // renders it already treated absence as "no age to show".
+  updatedAt: z.string().optional(),
   // ABSENT when the row records no kind. Defaulting it to 'spatial' used to
   // hide that state: a caller could not tell a stored spatial document from
   // one whose kind was never recorded, and the guess escaped into new rows

--- a/packages/ports/src/document-index.ts
+++ b/packages/ports/src/document-index.ts
@@ -23,6 +23,18 @@ export const documentEntrySchema = z
      * though somebody typed the path in as a title.
      */
     name: z.string().min(1).optional(),
+    /**
+     * When the placement last changed, ISO 8601.
+     *
+     * OPTIONAL because an index may genuinely not own it: the daemon's SQL
+     * twin has the column, while apps/web's IndexedDB index does not — that
+     * app reads timestamps from a separate store keyed by documentId. A
+     * required field would have forced one of them to invent a value, and an
+     * invented timestamp is worse than an absent one because it reads as
+     * fact. Every UI site that renders it already treats absence as "no age
+     * to show".
+     */
+    updatedAt: z.string().optional(),
   })
   .strict()
 export type DocumentEntry = z.infer<typeof documentEntrySchema>

--- a/packages/server-core/src/tools/document-crud.schemas.ts
+++ b/packages/server-core/src/tools/document-crud.schemas.ts
@@ -1,5 +1,6 @@
 import {
   documentIdSchema,
+  documentKindSchema,
   documentPathSchema,
   okfActorSchema,
   workspaceIdSchema,
@@ -99,6 +100,12 @@ const documentDetailSchema = z
     // wants that fallback can choose it, and a listing that invents one reads
     // as if somebody typed the path as the title.
     name: z.string().optional(),
+    // Both carried straight from `DocumentEntry`, and both absent rather than
+    // guessed. Dropping them here is what kept the HTTP list route reaching
+    // the store directly — an adapter cannot report what the operation
+    // refuses to carry.
+    kind: documentKindSchema.optional(),
+    updatedAt: z.string().optional(),
   })
   .strict()
 

--- a/packages/server-core/src/tools/document-crud.test.ts
+++ b/packages/server-core/src/tools/document-crud.test.ts
@@ -187,6 +187,35 @@ describe('wbDocumentResolve', () => {
 })
 
 describe('wbDocumentList', () => {
+  // The HTTP list surface reports both, and it used to reach the store
+  // directly because this operation dropped them — an adapter cannot report
+  // what the operation refuses to carry. `updatedAt` is OPTIONAL on
+  // `DocumentEntry` because the browser's index genuinely does not own it
+  // (apps/web reads timestamps from a separate store), so this asserts the
+  // pass-through, not that every index supplies one.
+  it('carries kind and updatedAt through rather than dropping them', async () => {
+    const deps = makeDeps()
+    await deps.documentIndex.createWorkspace({ workspaceId: 'ws-1' })
+    ;(deps.documentIndex as InMemoryDocumentIndex).seed({
+      workspaceId: 'ws-1',
+      documentId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      path: 'a',
+      kind: 'markdown',
+      updatedAt: '2026-08-01T00:00:00.000Z',
+    })
+
+    const out = await wbDocumentList(deps, { workspaceId: 'ws-1' })
+
+    expect(out.documents).toEqual([
+      {
+        documentId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        path: 'a',
+        kind: 'markdown',
+        updatedAt: '2026-08-01T00:00:00.000Z',
+      },
+    ])
+  })
+
   it('throws WorkspaceNotFoundError for a workspace that was never created', async () => {
     const deps = makeDeps()
     await expect(wbDocumentList(deps, { workspaceId: 'ghost' })).rejects.toThrow(

--- a/packages/server-core/src/tools/document-crud.test.ts
+++ b/packages/server-core/src/tools/document-crud.test.ts
@@ -136,6 +136,33 @@ describe('wbDocumentCreate', () => {
 })
 
 describe('wbDocumentResolve', () => {
+  // `documentDetailSchema` is shared with the list, so resolve must EMIT what
+  // that schema declares. Omitting these left the schema saying more than the
+  // runtime did.
+  it('carries kind and updatedAt through, like the list does', async () => {
+    const deps = makeDeps()
+    await deps.documentIndex.createWorkspace({ workspaceId: 'ws-1' })
+    ;(deps.documentIndex as InMemoryDocumentIndex).seed({
+      workspaceId: 'ws-1',
+      documentId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      path: 'a',
+      kind: 'markdown',
+      updatedAt: '2026-08-01T00:00:00.000Z',
+    })
+
+    const out = await wbDocumentResolve(deps, {
+      workspaceId: 'ws-1',
+      documentId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+    })
+
+    expect(out).toEqual({
+      documentId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      path: 'a',
+      kind: 'markdown',
+      updatedAt: '2026-08-01T00:00:00.000Z',
+    })
+  })
+
   it('returns the document with its path', async () => {
     const deps = makeDeps()
     const created = await wbDocumentCreate(deps, {
@@ -148,7 +175,14 @@ describe('wbDocumentResolve', () => {
       workspaceId: 'ws-1',
       documentId: created.documentId,
     })
-    expect(got).toEqual({ documentId: created.documentId, path: 'parent/child' })
+    // `kind` is reported now that resolve emits what its schema declares. The
+    // in-memory index records no timestamp, which is why `updatedAt` is absent
+    // here and present in the case below that seeds one.
+    expect(got).toEqual({
+      documentId: created.documentId,
+      path: 'parent/child',
+      kind: 'spatial',
+    })
   })
 
   it('throws WorkspaceDocumentNotFoundError for a documentId that does not exist', async () => {

--- a/packages/server-core/src/tools/document-crud.ts
+++ b/packages/server-core/src/tools/document-crud.ts
@@ -128,6 +128,12 @@ export async function wbDocumentResolve(
     documentId: entry.documentId,
     path: entry.path,
     ...(entry.name === undefined ? {} : { name: entry.name }),
+    // Same pass-through as the list below. These share `documentDetailSchema`,
+    // so omitting them here would leave resolve DECLARING two fields it never
+    // emits — a schema saying more than the runtime does, which is the drift
+    // this repo keeps a single source of truth to prevent.
+    ...(entry.kind === undefined ? {} : { kind: entry.kind }),
+    ...(entry.updatedAt === undefined ? {} : { updatedAt: entry.updatedAt }),
   }
 }
 

--- a/packages/server-core/src/tools/document-crud.ts
+++ b/packages/server-core/src/tools/document-crud.ts
@@ -146,6 +146,8 @@ export async function wbDocumentList(
       documentId: entry.documentId,
       path: entry.path,
       ...(entry.name === undefined ? {} : { name: entry.name }),
+      ...(entry.kind === undefined ? {} : { kind: entry.kind }),
+      ...(entry.updatedAt === undefined ? {} : { updatedAt: entry.updatedAt }),
     })),
   }
 }


### PR DESCRIPTION
## Summary

The GET list route reached the store directly because **the operation could not report what the surface publishes**: `wbDocumentList` dropped `kind`, the port had no `updatedAt` at all, and `documentSummarySchema` required one. An adapter cannot report what the operation refuses to carry.

Fourth ADR-0018 move, after delete (#1068), create (#1071) and rename (#1076).

## `updatedAt` is optional on the port, and that is the load-bearing choice

I previously recorded that this was blocked on a browser IndexedDB migration. **That was wrong**, and the error is worth stating: I assumed "add it to `DocumentEntry`" meant *required*, costed that, and never checked whether optional worked.

What is actually true, measured:

- **apps/web's index does not own timestamps.** `local-files-source` reads them from a separate `stamps` store keyed by documentId, conditionally, with no relation to `IndexRow`. No migration is involved.
- **A required field would have forced some index to invent a value**, and an invented timestamp is worse than an absent one, because it reads as fact.
- **4 of the 5 UI sites already treated absence as "no age to show"** — `FolderContentsList`, `DocumentPreview`, and both sources.

The daemon's SQL index *does* own the column, so this surface still reports a timestamp in practice. What changed is that the **type** stopped promising a guarantee the port cannot make.

The fifth UI site was a sort comparator, and it is why `?? ''` appears there rather than a bare `<`: `undefined` fails every comparison, so a document with no timestamp would have quietly sorted **as if it were the newest**.

## `workspaceExists` goes with it

The operation refuses an unknown workspace rather than answering with an empty list, so the 404 is a translation of what it raises rather than a second existence query. "Empty" and "never registered" stay different answers — that distinction is what once let a stale pairing render as an empty workspace with a Create button.

## Test plan

- [x] New or updated tests added — `document-crud.test.ts` (pass-through), `crud-adapter.test.ts` (list via the injected index, 404 translation), `document.test.ts` (schema)
- [x] `pnpm test` passes locally — `mcp-node` + `server-core-node` + `ports-node`: **4340 passed**
- [x] Manual verification completed — see below
- [ ] E2E coverage — not applicable

**My first list test passed before the change, and that is the interesting part.** It asserted the response shape, which the module-level store produces identically — both read the same database. It could not tell the two apart. That is exactly the failure shape #1077 documented an hour ago, hit immediately after writing it down. The fix is the one that rule prescribes: record `listDocuments` on the *injected* index, which makes it fail with `expected [] to deeply equal [ 'ws-1' ]`.

**The conformance suite caught a real inconsistency**: adding `updatedAt` to `toEntry` alone made `createDocument`'s return disagree with a later `resolveDocument` on the same row. `createDocument` now returns the `now` it just wrote.

**One deliberate guard was rewritten, not deleted.** `rejects missing updatedAt` pinned the old requirement. It now pins what survives — absent is allowed, a *non-string* is still rejected, because absent is not the same as arbitrary.

Pre-existing failures unrelated to this change, confirmed identical on a clean `origin/main` checkout: 4 `EACCES` tests (root cannot be denied access in this container) and 9 apps/web objectURL/fetch tests (`9 failed | 2751 passed` on both sides).

`arch-lint-node` passes (106). Gates green: `lint`, `knip`, `secretlint`, `typecheck`.

## What this does not do

**The `workspaces.ts -> document-store` allowlist entry still does not clear.** `listWorkspaces` remains, and it has no `DocumentIndex` method at all — a port addition rather than a route refactor. It is now the *only* thing left in that file reaching the store.

## Visual evidence

Visual evidence: none — the rendered list is unchanged. The daemon still supplies `updatedAt` for every document, so `FolderContentsList` and `DaemonIndexPage` show exactly what they showed before; only the type admits it may be absent.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — rationale recorded at `DocumentEntry.updatedAt` and at the relaxed response field
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_019uxfgjcDPQRBtJn5XYQgLc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document listings now include document type and last-updated information when available.
  * Document summaries support entries without timestamps.
  * Timestamps are provided in ISO 8601 format.

* **Bug Fixes**
  * Documents without update timestamps now sort after timestamped documents while maintaining newest-first ordering.
  * Requests for unknown workspaces now return a not-found response, while empty workspaces remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->