### PR TITLE
feat(ports): DocumentIndex answers listWorkspaces, clearing the last store reach

### DIFF
--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -50,7 +50,7 @@ tool registration under `server/mcp/**`) may not import a MECHANIC (anything
 under `server/store/`). The composition root's own wiring — `di/`, `app.ts`,
 `http-server.ts` — is deliberately out of scope, since knowing the mechanics
 is its job. `ADAPTERS_REACHING_MECHANICS` in `architecture-map.ts` records
-the 36 edges that exist today and may only SHRINK: an unlisted edge fails
+the 35 edges that exist today and may only SHRINK: an unlisted edge fails
 the build, and a listed edge that no longer exists fails it too, so an entry
 cannot outlive the debt it names. `corrupt-stored-data` is excluded and says
 why — an error taxonomy an adapter reads to pick a status code is

--- a/apps/web/src/lib/idb-document-index.ts
+++ b/apps/web/src/lib/idb-document-index.ts
@@ -89,6 +89,15 @@ export class IdbDocumentIndex implements DocumentIndex {
     })
   }
 
+  async listWorkspaces(): Promise<{ workspaceId: string }[]> {
+    return this.tx([WORKSPACES_STORE], 'readonly', async (tx) => {
+      // The store is keyed by workspaceId, so the KEYS are the answer — no
+      // value read, and nothing to go stale between the two.
+      const keys = await request(tx.objectStore(WORKSPACES_STORE).getAllKeys())
+      return keys.map((key) => ({ workspaceId: String(key) }))
+    })
+  }
+
   async createDocument(input: CreateDocumentInput): Promise<DocumentEntry> {
     const row: IndexRow = {
       workspaceId: input.workspaceId,

--- a/packages/mcp-server/src/server/routes/document/crud-adapter.test.ts
+++ b/packages/mcp-server/src/server/routes/document/crud-adapter.test.ts
@@ -85,6 +85,29 @@ async function depsRecordingCreate(bootstrapWorkspace = true): Promise<{
   return { deps: { ...deps, documentIndex: index }, created, listed }
 }
 
+describe('GET /api/workspaces', () => {
+  it('lists through the injected index rather than the module store', async () => {
+    const { deps } = await depsRecordingCreate()
+    await deps.documentIndex.createWorkspace({ workspaceId: 'ws-2' })
+    const listed: string[] = []
+    const index = Object.create(deps.documentIndex) as typeof deps.documentIndex
+    index.listWorkspaces = async () => {
+      listed.push('called')
+      return await Object.getPrototypeOf(index).listWorkspaces.call(index)
+    }
+    const app = createWorkspacesRouter({ serverDeps: { ...deps, documentIndex: index } })
+
+    const res = await app.request('/api/workspaces')
+
+    expect(res.status).toBe(200)
+    // Both indexes read the same database, so the response alone cannot tell
+    // the injected one from the module-level store.
+    expect(listed).toEqual(['called'])
+    const body = (await res.json()) as { workspaces: { workspaceId: string }[] }
+    expect(body.workspaces.map((w) => w.workspaceId).sort()).toEqual(['ws-1', 'ws-2'])
+  })
+})
+
 describe('GET /api/workspaces/:workspaceId/documents', () => {
   it('lists through the injected operation, carrying kind and updatedAt', async () => {
     const { deps, listed } = await depsRecordingCreate()

--- a/packages/mcp-server/src/server/routes/document/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.ts
@@ -25,7 +25,6 @@ import {
 } from '../../../shared/api-contracts/document.js'
 import type { ApiErrorBody } from '../../../shared/api-contracts/errors.js'
 import { getLogger } from '../../log.js'
-import { listWorkspaces } from '../../store/document-store.js'
 import { validateDocumentPath, validateWorkspaceId, validationErrorBody } from '../../validators.js'
 import { handleCorruptStoredData } from './_shared.js'
 import { onDocumentsRoute } from './path-route.js'
@@ -57,7 +56,11 @@ export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
 
   app.get('/api/workspaces', async (c) => {
     try {
-      const workspaces = await listWorkspaces()
+      const deps = options.serverDeps ?? (await getDefaultServerDeps())
+      // Straight to the PORT, for the same reason the rename is (ADR-0018):
+      // listing workspaces is the port call and nothing else, so a use case
+      // here would forward no arguments and add a name.
+      const workspaces = await deps.documentIndex.listWorkspaces()
       const response: ListWorkspacesResponse = {
         workspaces: workspaces.map(({ workspaceId }) => ({ workspaceId })),
       }

--- a/packages/mcp-server/src/server/store/sqlite-document-index.ts
+++ b/packages/mcp-server/src/server/store/sqlite-document-index.ts
@@ -77,6 +77,11 @@ export class SqliteDocumentIndex implements DocumentIndex {
     })
   }
 
+  async listWorkspaces(): Promise<{ workspaceId: string }[]> {
+    const rows = await this.db.selectFrom('workspaces').select(['id']).execute()
+    return rows.map((row) => ({ workspaceId: row.id }))
+  }
+
   async createDocument({
     workspaceId,
     path,

--- a/packages/ports/src/document-index.ts
+++ b/packages/ports/src/document-index.ts
@@ -208,9 +208,11 @@ export interface DocumentIndex {
    * it, and hiding the empty ones would make a freshly created one look like
    * it failed.
    *
-   * An empty index answers with an empty list rather than throwing — unlike
+   * Answers rather than throwing when there are no documents yet — unlike
    * `listDocuments`, there is no id here that could have been a typo, so
-   * "none" is an answer rather than an ambiguity.
+   * "none" is an answer rather than an ambiguity. Note this does NOT promise
+   * the list is empty on a fresh index: apps/web's writes `local` when its
+   * store is created, because that is the one the browser UI opens.
    */
   listWorkspaces(): Promise<{ workspaceId: string }[]>
   /**

--- a/packages/ports/src/document-index.ts
+++ b/packages/ports/src/document-index.ts
@@ -203,6 +203,17 @@ export interface DocumentIndex {
    */
   createWorkspace(input: CreateWorkspaceInput): Promise<void>
   /**
+   * Every workspace this index holds, INCLUDING the ones with no documents in
+   * them: a workspace is a real, addressable place before anything is put in
+   * it, and hiding the empty ones would make a freshly created one look like
+   * it failed.
+   *
+   * An empty index answers with an empty list rather than throwing — unlike
+   * `listDocuments`, there is no id here that could have been a typo, so
+   * "none" is an answer rather than an ambiguity.
+   */
+  listWorkspaces(): Promise<{ workspaceId: string }[]>
+  /**
    * Fails `WorkspaceNotFoundError` if the workspace does not exist. Fails if
    * the path is taken. Creating never silently adopts an existing
    * document, because the caller that wanted a new one would otherwise

--- a/packages/ports/src/test-utils/document-index-conformance.ts
+++ b/packages/ports/src/test-utils/document-index-conformance.ts
@@ -405,10 +405,22 @@ export function describeDocumentIndexConformance(
       })
     })
 
-    it('answers with an empty list rather than throwing when there are none', async () => {
+    // Deliberately NOT `toEqual([])`. An implementation may legitimately hold
+    // a workspace of its own from the moment its store exists: apps/web's
+    // IndexedDB index writes `local` during its upgrade, because that is the
+    // one the browser UI opens. Pinning emptiness here forbade that, and the
+    // browser conformance run said so.
+    //
+    // What the contract does require is an ANSWER rather than a throw. Unlike
+    // `listDocuments`, there is no id here that could have been a typo, so
+    // "none" is a result and not an ambiguity — and a caller listing
+    // workspaces before any document exists must not meet an error.
+    it('answers rather than throwing on an index with no documents in it', async () => {
       const { index, dispose } = await makeIndex()
       try {
-        expect(await index.listWorkspaces()).toEqual([])
+        const workspaces = await index.listWorkspaces()
+        expect(Array.isArray(workspaces)).toBe(true)
+        expect(workspaces.every((w) => typeof w.workspaceId === 'string')).toBe(true)
       } finally {
         await dispose()
       }

--- a/packages/ports/src/test-utils/document-index-conformance.ts
+++ b/packages/ports/src/test-utils/document-index-conformance.ts
@@ -387,4 +387,31 @@ export function describeDocumentIndexConformance(
       })
     })
   })
+
+  describe('listWorkspaces', () => {
+    // The shared fixture creates two, so a listing that reported only the one
+    // a test had just touched would pass a weaker assertion.
+    it('reports every workspace the index holds, whether or not it has documents', async () => {
+      await withIndex(async (index) => {
+        await index.createDocument({ workspaceId: WS, path: 'p', kind: 'spatial' })
+
+        const ids = (await index.listWorkspaces()).map((w) => w.workspaceId).sort()
+
+        expect(ids).toContain(WS)
+        // `ws-other` holds nothing. A workspace is a real, addressable place
+        // before anything is put in it — a listing that hid the empty ones
+        // would make a freshly created workspace look like it failed.
+        expect(ids).toContain('ws-other')
+      })
+    })
+
+    it('answers with an empty list rather than throwing when there are none', async () => {
+      const { index, dispose } = await makeIndex()
+      try {
+        expect(await index.listWorkspaces()).toEqual([])
+      } finally {
+        await dispose()
+      }
+    })
+  })
 }

--- a/packages/ports/src/test-utils/in-memory-document-index.ts
+++ b/packages/ports/src/test-utils/in-memory-document-index.ts
@@ -64,6 +64,10 @@ export class InMemoryDocumentIndex implements DocumentIndex {
     this.#workspaces.add(workspaceId)
   }
 
+  async listWorkspaces(): Promise<{ workspaceId: string }[]> {
+    return [...this.#workspaces].map((workspaceId) => ({ workspaceId }))
+  }
+
   async createDocument({
     workspaceId,
     path,

--- a/packages/server-core/src/test-utils/unused-document-index.ts
+++ b/packages/server-core/src/test-utils/unused-document-index.ts
@@ -19,6 +19,7 @@ export function unusedDocumentIndex(): DocumentIndex {
   }
   return {
     createWorkspace: refuse('createWorkspace'),
+    listWorkspaces: refuse('listWorkspaces'),
     createDocument: refuse('createDocument'),
     resolveDocument: refuse('resolveDocument'),
     resolveDocumentById: refuse('resolveDocumentById'),

--- a/packages/server-core/src/tools/document-get.test.ts
+++ b/packages/server-core/src/tools/document-get.test.ts
@@ -22,6 +22,7 @@ function withResolveOverride(
 ): DocumentIndex {
   return {
     createWorkspace: index.createWorkspace.bind(index),
+    listWorkspaces: index.listWorkspaces.bind(index),
     createDocument: index.createDocument.bind(index),
     resolveDocument: index.resolveDocument.bind(index),
     resolveDocumentById,

--- a/tools/arch-lint/src/architecture-map.ts
+++ b/tools/arch-lint/src/architecture-map.ts
@@ -279,7 +279,6 @@ export const ADAPTERS_REACHING_MECHANICS: readonly string[] = [
   'routes/document/thumbnails.ts -> version-store',
   'routes/document/versions.ts -> document-store',
   'routes/document/versions.ts -> version-store',
-  'routes/document/workspaces.ts -> document-store',
   'routes/export.ts -> document-store',
   'routes/files.ts -> file-gc',
   'routes/files.ts -> version-store',


### PR DESCRIPTION
## Summary

`routes/document/workspaces.ts` **no longer imports `document-store` at all**, so `workspaces.ts -> document-store` leaves `ADAPTERS_REACHING_MECHANICS`. **36 → 35**, and `.claude/rules/architecture-map.md` says so.

That completes the ADR-0018 migration for this file, across five moves: delete (#1068), create (#1071), rename (#1076), the document list (#1079), and the workspace list here.

Straight to the **port** rather than through a `wb_document_*` operation, like the rename: listing workspaces *is* the port call and nothing else, so a use case would forward no arguments and add a name.

## The conformance suite caught a defect in my own conformance case

I added two cases, and the second was wrong. It asserted `toEqual([])` on a fresh index — which **forbade an implementation from holding a workspace of its own**. apps/web's IndexedDB index does exactly that on purpose: `backfillDocumentIndex` writes `{workspaceId:'local'}` during its upgrade, *"because that is the one the browser UI opens"*. The browser conformance run failed with `expected [ { workspaceId: 'local' } ] to deeply equal []`.

I had generalised the daemon's shape into a contract. What the contract actually requires is an **answer rather than a throw**: unlike `listDocuments` there is no id here that could have been a typo, so "none" is a result and not an ambiguity, and a caller listing workspaces before any document exists must not meet an error. Emptiness was never part of it.

The case now pins that, and the port's doc comment says outright that a fresh index is **not** promised to be empty.

## A correction to my first commit here

That commit claimed `IdbDocumentIndex` is not held to the conformance suite, and I filed a task for it. **Both were wrong.** It is held to it, by `apps/web/src/lib/idb-document-index.browser.test.tsx` — a file whose header states the factory was written for exactly that implementation, and which builds an isolated per-case IndexedDB database.

I concluded otherwise from `grep -rn … --include=*.ts`, which does not match `.tsx`. A search that finds nothing is evidence about the search as much as about the code. The task is withdrawn with that reasoning recorded rather than deleted.

All three implementations are covered, and the suite proved it by rejecting my assertion within one CI run.

## The contract, written where it is enforced

- **Empty workspaces are included.** A workspace is a real, addressable place before anything is put in it; hiding the empty ones would make a freshly created workspace look like it failed.
- **Answers rather than throwing** when no documents exist yet.

The `ws-other` assertion is deliberate: the shared fixture creates two workspaces and only one gets a document, so a listing that reported only the one the test had touched would pass a weaker assertion.

`listWorkspaces` is **required** on the interface, so TypeScript named every double that had not implemented it — two, both now filled.

## Test plan

- [x] New or updated tests added — 2 conformance cases (so all three implementations are held to them), 1 route-adapter case
- [x] `pnpm test` passes locally — `mcp-node` + `server-core-node` + `ports-node`: **4347 passed**; the 4 failures are the pre-existing `EACCES` tests that cannot deny access to root in this container
- [x] Manual verification completed — see below
- [ ] E2E coverage — not applicable

**The allowlist entry's removal was reported by the guard, not by me.** After the route change, `arch-lint` failed with `these edges are gone — delete them from ADAPTERS_REACHING_MECHANICS: [ "routes/document/workspaces.ts -> document-store" ]`.

**The route test records `listWorkspaces` on the injected index**, because both indexes read the same database and the response alone cannot tell them apart — the failure shape #1077 documents. Red before the change with `expected [] to deeply equal [ 'called' ]`.

**The browser conformance case cannot be run in this container** (`web-browser` launches no browser here), which is why the over-strict assertion reached CI. CI is the verification for that half.

Local gates green: `lint`, `typecheck`, `knip`, `secretlint`. `arch-lint-node` passes (106).

## Visual evidence

Visual evidence: none — a port addition and a route rewiring, with no user-visible change. The workspace list returns the same workspaces from the same table.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — `.claude/rules/architecture-map.md`'s edge count; the contract is recorded at the port method
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_019uxfgjcDPQRBtJn5XYQgLc)_