### PR TITLE
fix(web): re-list workspaces when the selected one has been deleted

### DIFF
--- a/apps/web/src/pages/DaemonIndexPage.files-tab.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.files-tab.test.tsx
@@ -712,16 +712,28 @@ describe('DaemonIndexPage tree view', () => {
     expect((await screen.findByTestId('search-results')).textContent).toContain('Nothing matches')
   })
 
-  it('treats a 404 list as an empty workspace (onboarding, no alert)', async () => {
-    // A workspace with no document tree yet is a calm empty workspace the
-    // onboarding state can create into — not a broken page.
+  // Was `treats a 404 list as an empty workspace (onboarding, no alert)`, on
+  // the premise that "a workspace with no document tree yet is a calm empty
+  // workspace the onboarding state can create into". Measured against the real
+  // route, that premise is false: an existing workspace holding nothing
+  // answers 200 with an empty array, and only an ABSENT one answers 404. So a
+  // 404 means gone, and the onboarding state was offering to create into
+  // something that is not there — a create the route honours by silently
+  // making a DIFFERENT workspace, since it passes `createWorkspace: true`.
+  //
+  // This fixture is the disagreeing case specifically: the workspace list
+  // still reports `default` while its documents 404. There is nothing to move
+  // to, and re-selecting `default` would come straight back here forever, so
+  // the page reports the failure rather than spinning or pretending.
+  it('reports the failure when the list still names a workspace whose documents 404', async () => {
     installFetchMock({ status: 404, body: { error: 'Workspace not found: "default".' } })
     render(
       <DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} token="secret" onOpenDocument={() => {}} />,
     )
 
-    await screen.findByText('What will you make first?')
-    expect(screen.queryByRole('alert')).toBeNull()
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('Failed to load documents for this workspace.')
+    expect(screen.queryByText('What will you make first?')).toBeNull()
   })
 
   it('still shows the failure alert when the list fails for a non-404 reason', async () => {

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -1,4 +1,5 @@
 import {
+  act,
   cleanup,
   fireEvent,
   type RenderOptions,
@@ -48,6 +49,9 @@ interface MockRoutes {
   onSetCanvasName?: (workspaceId: string, path: string, name: string) => void
   /** When set, the documents fetch resolves only after this promise settles. */
   delayCanvases?: Promise<void>
+  /** Same, for the workspaces list. Consulted per call, so a test can leave
+   *  it unset for the initial load and set it before the re-list. */
+  delayWorkspaces?: Promise<void>
   /** Override the documents GET. Return undefined to fall through to the
    *  default. Consulted per call, so a test can answer 404 once and then
    *  behave normally — a workspace deleted out from under the page. */
@@ -58,7 +62,11 @@ function installFetchMock(routes: MockRoutes) {
   const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === 'string' ? input : input.toString()
     if (url.endsWith('/api/workspaces') && (!init || init.method === undefined)) {
-      return Promise.resolve(jsonResponse({ workspaces: routes.workspaces }))
+      const respond = () => jsonResponse({ workspaces: routes.workspaces })
+      // Held open so a test can inspect what renders WHILE the re-list is in
+      // flight — the window in which a deleted workspace is still selected.
+      if (routes.delayWorkspaces) return routes.delayWorkspaces.then(respond)
+      return Promise.resolve(respond())
     }
     const documentsMatch = url.match(/\/api\/workspaces\/([^/]+)\/documents$/)
     if (documentsMatch && (!init || init.method === undefined)) {
@@ -299,6 +307,53 @@ describe('DaemonIndexPage', () => {
     // would still reach ws-b eventually in some orderings, and the defect
     // this pins is the repetition, not the destination.
     expect(staleFetches).toBe(1)
+  })
+
+  // The window between "this workspace is gone" and "here is another one".
+  // Marking the load COMPLETE during it renders the onboarding empty state for
+  // a workspace that does not exist, Create button live — and that button
+  // passes `createWorkspace: true`, so a fast click would silently make a
+  // different workspace. The page must stay in its loading state until the
+  // re-list has actually chosen something.
+  it('does not offer the empty-workspace create state while re-listing', async () => {
+    let staleFetches = 0
+    let releaseRelist!: () => void
+    const relistGate = new Promise<void>((resolve) => {
+      releaseRelist = resolve
+    })
+    const routes: Parameters<typeof installFetchMock>[0] = {
+      workspaces: [{ workspaceId: 'ws-a' }, { workspaceId: 'ws-b' }],
+      documentsByWorkspace: {
+        'ws-b': [{ path: 'beta', updatedAt: new Date().toISOString() }],
+      },
+      onListDocuments: (workspaceId) => {
+        if (workspaceId !== 'ws-a') return undefined
+        staleFetches += 1
+        // Only the re-list is held open; the first workspaces GET already ran.
+        routes.delayWorkspaces = relistGate
+        routes.workspaces = [{ workspaceId: 'ws-b' }]
+        return jsonResponse({ title: 'Workspace "ws-a" not found' }, 404)
+      },
+    }
+    installFetchMock(routes)
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenDocument={vi.fn()} />)
+
+    // Land INSIDE the window deliberately: wait until the 404 has actually
+    // been served, then flush the render it causes. Sampling earlier would
+    // catch the initial load's skeleton and pass whatever the 404 path does —
+    // the assertion has to be about the state AFTER the failure.
+    await waitFor(() => {
+      expect(staleFetches).toBe(1)
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(screen.getByRole('status', { name: 'Loading documents' })).toBeTruthy()
+
+    releaseRelist()
+    expect(await screen.findByText('beta')).toBeTruthy()
   })
 
   it('honors initialWorkspaceId over the daemon-listed first workspace', async () => {

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -48,6 +48,10 @@ interface MockRoutes {
   onSetCanvasName?: (workspaceId: string, path: string, name: string) => void
   /** When set, the documents fetch resolves only after this promise settles. */
   delayCanvases?: Promise<void>
+  /** Override the documents GET. Return undefined to fall through to the
+   *  default. Consulted per call, so a test can answer 404 once and then
+   *  behave normally — a workspace deleted out from under the page. */
+  onListDocuments?: (workspaceId: string) => Response | undefined
 }
 
 function installFetchMock(routes: MockRoutes) {
@@ -59,6 +63,8 @@ function installFetchMock(routes: MockRoutes) {
     const documentsMatch = url.match(/\/api\/workspaces\/([^/]+)\/documents$/)
     if (documentsMatch && (!init || init.method === undefined)) {
       const workspaceId = decodeURIComponent(documentsMatch[1])
+      const override = routes.onListDocuments?.(workspaceId)
+      if (override) return Promise.resolve(override)
       const documents = routes.documentsByWorkspace[workspaceId]
       if (!documents) return Promise.resolve(jsonResponse({ message: 'not found' }, 500))
       const respond = () => jsonResponse({ documents })
@@ -222,6 +228,77 @@ describe('DaemonIndexPage', () => {
     const wrapper = panel.closest('.animate-in') as HTMLElement | null
     expect(wrapper).not.toBeNull()
     expect(wrapper?.className).toMatch(/\bfade-in-0\b/)
+  })
+
+  // A 404 from the documents list means the workspace is GONE, not empty: an
+  // existing workspace with no documents answers 200 with an empty array
+  // (measured against the real route). And `selectedWorkspace` is only ever
+  // set from `GET /api/workspaces`, so the only way to reach this is that the
+  // workspace was deleted after that list was taken — by an agent, another
+  // tab, or the CLI.
+  //
+  // Re-listing is the repair: the selection is what went stale, so replacing
+  // it is what fixes the page. Showing an empty create-into-it state instead
+  // would hide a real anomaly, and creating into a workspace that no longer
+  // exists would silently make a DIFFERENT one.
+  it('re-lists and selects another workspace when the selected one has been deleted', async () => {
+    const routes: Parameters<typeof installFetchMock>[0] = {
+      workspaces: [{ workspaceId: 'ws-a' }, { workspaceId: 'ws-b' }],
+      documentsByWorkspace: {
+        'ws-a': [{ path: 'alpha', updatedAt: new Date().toISOString() }],
+        'ws-b': [{ path: 'beta', updatedAt: new Date().toISOString() }],
+      },
+      onListDocuments: (workspaceId) => {
+        if (workspaceId !== 'ws-a') return undefined
+        // ws-a is gone; the workspace list the page already holds is stale.
+        routes.workspaces = [{ workspaceId: 'ws-b' }]
+        return jsonResponse({ title: 'Workspace "ws-a" not found' }, 404)
+      },
+    }
+    installFetchMock(routes)
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenDocument={vi.fn()} />)
+
+    // Lands on ws-b's documents rather than an empty state for a workspace
+    // that is not there.
+    expect(await screen.findByText('beta')).toBeTruthy()
+    await waitFor(() => {
+      expect(
+        (screen.queryByRole('combobox', { name: 'Workspace' }) as HTMLSelectElement | null)
+          ?.value ?? 'ws-b',
+      ).toBe('ws-b')
+    })
+  })
+
+  // The loop guard, which the case above does NOT exercise: there the server
+  // stops listing the deleted workspace, so `ids[0]` happens to be the right
+  // answer and picking "any other" is indistinguishable from picking "first".
+  // Here the list and the documents disagree — the workspace is still listed
+  // but 404s — and selecting it again would send the page back through the
+  // same path forever.
+  it('does not re-select the stale workspace when the list still reports it', async () => {
+    let staleFetches = 0
+    const routes: Parameters<typeof installFetchMock>[0] = {
+      // ws-a is never removed from the listing, on purpose.
+      workspaces: [{ workspaceId: 'ws-a' }, { workspaceId: 'ws-b' }],
+      documentsByWorkspace: {
+        'ws-b': [{ path: 'beta', updatedAt: new Date().toISOString() }],
+      },
+      onListDocuments: (workspaceId) => {
+        if (workspaceId !== 'ws-a') return undefined
+        staleFetches += 1
+        return jsonResponse({ title: 'Workspace "ws-a" not found' }, 404)
+      },
+    }
+    installFetchMock(routes)
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenDocument={vi.fn()} />)
+
+    expect(await screen.findByText('beta')).toBeTruthy()
+    // Counted rather than merely landing on ws-b: re-selecting the stale one
+    // would still reach ws-b eventually in some orderings, and the defect
+    // this pins is the repetition, not the destination.
+    expect(staleFetches).toBe(1)
   })
 
   it('honors initialWorkspaceId over the daemon-listed first workspace', async () => {

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -138,6 +138,29 @@ export function DaemonIndexPage({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [daemonBaseUrl])
 
+  // Re-reads the workspace list and moves off the one that vanished.
+  //
+  // Deliberately picks a workspace OTHER than the stale id even if the server
+  // still lists it: were the two to disagree, selecting it again would send
+  // the page straight back into this path and loop. Choosing a different one
+  // — or nothing — always terminates, and the dropdown still lets a person
+  // pick it by hand.
+  const reselectAfterStale = useCallback(
+    async (staleWorkspaceId: string, isStale: () => boolean) => {
+      try {
+        const res = await listWorkspaces(daemonFetch, daemonBaseUrl)
+        if (isStale()) return
+        const ids = res.workspaces.map((w) => w.workspaceId)
+        setWorkspaces(ids)
+        setSelectedWorkspace(ids.find((id) => id !== staleWorkspaceId) ?? null)
+      } catch {
+        if (isStale()) return
+        setLoadError('Failed to load workspaces.')
+      }
+    },
+    [daemonFetch, daemonBaseUrl],
+  )
+
   const loadWorkspace = useCallback(
     async (workspaceId: string, isStale: () => boolean) => {
       setLoadError(null)
@@ -167,15 +190,26 @@ export function DaemonIndexPage({
         if (isStale()) return
         setRows([])
         setLoaded(true)
-        // A 404 is a workspace with no document tree yet — a calm empty
-        // workspace (the onboarding state can create into it), not a broken
-        // page. Anything else is a genuine failure and keeps the alert.
-        if (!(err instanceof DaemonApiError && err.status === 404)) {
-          setLoadError('Failed to load documents for this workspace.')
+        // A 404 means the workspace is GONE, not empty. An existing workspace
+        // with no documents answers 200 with an empty array; only an absent
+        // one 404s. And `selectedWorkspace` is only ever set from
+        // `GET /api/workspaces`, so the sole way to arrive here is that the
+        // workspace was deleted AFTER that list was taken — by an agent,
+        // another tab, or the CLI.
+        //
+        // So the selection is what went stale, and re-listing is the repair.
+        // Rendering the empty create-into-it state instead would hide a real
+        // anomaly, and a create issued against a workspace that no longer
+        // exists would silently make a DIFFERENT one (the route passes
+        // `createWorkspace: true`).
+        if (err instanceof DaemonApiError && err.status === 404) {
+          void reselectAfterStale(workspaceId, isStale)
+          return
         }
+        setLoadError('Failed to load documents for this workspace.')
       }
     },
-    [daemonFetch, daemonBaseUrl],
+    [daemonFetch, daemonBaseUrl, reselectAfterStale],
   )
 
   useEffect(() => {

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -152,6 +152,13 @@ export function DaemonIndexPage({
         if (isStale()) return
         const ids = res.workspaces.map((w) => w.workspaceId)
         setWorkspaces(ids)
+        // A replacement re-enters the selection effect, which owns `loaded`
+        // from there. Nothing replacing it leaves the page exactly where a
+        // daemon that lists no workspaces at all already leaves it — measured:
+        // the loading state, no create control. That end state is a
+        // pre-existing dead end and deliberately not redesigned here; what
+        // matters is that a vanished workspace does not get a state of its
+        // own that the same emptiness reached any other way would not.
         setSelectedWorkspace(ids.find((id) => id !== staleWorkspaceId) ?? null)
       } catch {
         if (isStale()) return
@@ -189,7 +196,6 @@ export function DaemonIndexPage({
       } catch (err) {
         if (isStale()) return
         setRows([])
-        setLoaded(true)
         // A 404 means the workspace is GONE, not empty. An existing workspace
         // with no documents answers 200 with an empty array; only an absent
         // one 404s. And `selectedWorkspace` is only ever set from
@@ -203,9 +209,17 @@ export function DaemonIndexPage({
         // exists would silently make a DIFFERENT one (the route passes
         // `createWorkspace: true`).
         if (err instanceof DaemonApiError && err.status === 404) {
+          // Deliberately NOT `setLoaded(true)` here. The load is not over —
+          // the page is still deciding what it is showing. Marking it
+          // complete renders the onboarding empty state for the workspace
+          // that just vanished, with a live Create button that passes
+          // `createWorkspace: true`, so a click inside this window would
+          // silently make a DIFFERENT workspace. `reselectAfterStale` sets it
+          // only once there is nothing left to choose.
           void reselectAfterStale(workspaceId, isStale)
           return
         }
+        setLoaded(true)
         setLoadError('Failed to load documents for this workspace.')
       }
     },

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -152,14 +152,20 @@ export function DaemonIndexPage({
         if (isStale()) return
         const ids = res.workspaces.map((w) => w.workspaceId)
         setWorkspaces(ids)
-        // A replacement re-enters the selection effect, which owns `loaded`
-        // from there. Nothing replacing it leaves the page exactly where a
-        // daemon that lists no workspaces at all already leaves it — measured:
-        // the loading state, no create control. That end state is a
-        // pre-existing dead end and deliberately not redesigned here; what
-        // matters is that a vanished workspace does not get a state of its
-        // own that the same emptiness reached any other way would not.
-        setSelectedWorkspace(ids.find((id) => id !== staleWorkspaceId) ?? null)
+        const next = ids.find((id) => id !== staleWorkspaceId)
+        if (next === undefined) {
+          // Nothing to move to — this was the only workspace, or the list and
+          // the documents disagree about it. Re-selecting the same one would
+          // come straight back here forever, and leaving the page in its
+          // loading state would spin without end. Say so instead: the request
+          // that failed is the one the person is waiting on.
+          setLoaded(true)
+          setLoadError('Failed to load documents for this workspace.')
+          return
+        }
+        // A real replacement re-enters the selection effect, which clears
+        // `loaded` itself and owns it from there.
+        setSelectedWorkspace(next)
       } catch {
         if (isStale()) return
         setLoadError('Failed to load workspaces.')

--- a/packages/mcp-server/src/server/routes/document/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.ts
@@ -104,6 +104,10 @@ export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
       // Create button. The operation refuses an unknown workspace rather than
       // answering with an empty list, which is what makes this translation
       // possible without a second existence query.
+      //
+      // So the two cases a client must tell apart are: a workspace that
+      // exists and holds nothing answers 200 with an empty array, and only an
+      // ABSENT one answers 404. A 404 here therefore means gone, never empty.
       if (err instanceof WorkspaceNotFoundError) {
         return c.json({ title: `Workspace "${workspaceId}" not found` }, 404)
       }


### PR DESCRIPTION
## Summary

`DaemonIndexPage` treated a 404 from the document list as *"a workspace with no document tree yet — a calm empty workspace (the onboarding state can create into it)"*.

**That premise is false**, measured against the real route:

| case | response |
|---|---|
| workspace exists, holds nothing | **200** `{"documents":[]}` |
| workspace absent | **404** |

And `selectedWorkspace` is only ever set from `GET /api/workspaces` — including `initialWorkspaceId`, which is filtered through `ids.includes(...)`, and the `<select>`, which is populated from the same list. `createDaemonFilesSource` has exactly one call site. `getWorkspaceNames` has its own `.catch`, so `listDocuments` is the only thing that can put a 404 into that handler.

So the **only** way to reach it is a workspace deleted *after* the list was taken — by an agent, another tab, or the CLI. The stale thing is the selection, and re-listing is the repair.

What the old behaviour did instead was hide a real anomaly behind an empty state, and offer a Create button pointed at a workspace that no longer exists — a create the route would have honoured by silently making a **different** one, since it passes `createWorkspace: true`.

The route's own comment has warned about exactly this symptom for a long time (*"conflating them is what let a stale pairing render as an empty workspace with a Create button"*). The two comments contradicted each other; the route's was correct.

## The loop guard, and why it needed its own test

The repair deliberately selects a workspace **other than** the stale id, even if the server still lists it. Were the list and the documents to disagree, re-selecting it would send the page straight back through this path forever; choosing a different one — or nothing — always terminates, and the dropdown still lets a person pick it by hand.

My first test did **not** exercise that: it had the server drop the deleted workspace from the listing, so `ids[0]` was already the right answer and "any other" was indistinguishable from "first". The mutation `ids.find(id => id !== stale)` → `ids[0]` **passed**. That is the fixture-never-reaches-the-subject shape from `.claude/rules/dev-flow.md`, so a second case now makes the list and the documents disagree, and counts the stale fetches rather than only checking the destination — the defect being pinned is the repetition, not where it lands.

## Test plan

- [x] New or updated tests added — 2 cases in `DaemonIndexPage.test.tsx` (web-jsdom), 41 total in that file
- [x] `pnpm test` passes locally — `web-jsdom`: **2753 passed**; the 9 failures are pre-existing in this container (identical count on a clean tree) and green in CI
- [x] Manual verification completed — the route probe quoted above, run against the real router
- [ ] E2E coverage — not applicable

**Both mutations fire:**

| mutation | result |
|---|---|
| drop the re-list, keep the old empty state | first case fails — `beta` never appears |
| `ids.find(id => id !== stale)` → `ids[0]` | second case fails on the stale-fetch count |

The nearest layer is jsdom per the repo's test-layer rule: this is React state and fetch wiring, with no browser layout or pointer behaviour at stake.

## Also

The route's comment now states the contract a client has to tell apart — that an existing-but-empty workspace answers 200 and only an absent one 404s. It took a measurement to establish, so it belongs where it is produced.

Local gates green: `lint`, `typecheck`, `knip`.

## Visual evidence

Visual evidence: none — the change is which workspace the page ends up showing after a deletion it did not make. There is no before/after picture that is not just two screenshots of a document list; the two tests describe the difference precisely, and the failing-mutation output above is the evidence that they do.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — the contract is recorded at the route; the client comment that asserted the false premise is gone
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_019uxfgjcDPQRBtJn5XYQgLc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when a selected workspace is deleted.
  * Automatically refreshes the workspace list and selects another available workspace, or clears the selection when none remain.
  * Prevents deleted workspaces from being reselected.
  * Preserves the distinction between an empty workspace and a workspace that no longer exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->