### PR TITLE
fix(daemon): a fresh daemon holds a workspace, and the browser stops dead-ending when it does not

### DIFF
--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -1302,6 +1302,75 @@ describe('DaemonIndexPage', () => {
     expect(screen.queryByRole('status', { name: /loading documents/i })).toBeNull()
   })
 
+  it('a daemon holding no workspaces says so, instead of spinning on the skeleton forever', async () => {
+    // The list resolving EMPTY is not the same event as it failing, and it is
+    // not "still loading" either: there is simply nothing to select, so the
+    // documents fetch that would end the skeleton never runs. Measured before
+    // this test existed: `{ skeleton: true, createButtons: 0 }`, permanently.
+    const routes = {
+      workspaces: [] as Array<{ workspaceId: string }>,
+      documentsByWorkspace: {} as Record<string, never[]>,
+    }
+    installFetchMock(routes)
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenDocument={vi.fn()} />)
+
+    expect(await screen.findByText(/no workspaces/i)).toBeTruthy()
+    expect(screen.queryByRole('status', { name: /loading documents/i })).toBeNull()
+    // And no control that cannot work: every create path needs a workspace to
+    // create INTO, and there is none.
+    expect(screen.queryByRole('button', { name: /create a canvas/i })).toBeNull()
+  })
+
+  it('the no-workspaces state re-lists on demand, landing on a workspace that appeared since', async () => {
+    // The recovery here is someone else's write — an agent over MCP, the CLI —
+    // so the one action the page can honestly offer is to look again.
+    const routes = {
+      workspaces: [] as Array<{ workspaceId: string }>,
+      documentsByWorkspace: { 'ws-a': [{ path: 'alpha', updatedAt: new Date().toISOString() }] },
+    }
+    installFetchMock(routes)
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenDocument={vi.fn()} />)
+    await screen.findByText(/no workspaces/i)
+
+    routes.workspaces = [{ workspaceId: 'ws-a' }]
+    fireEvent.click(screen.getByRole('button', { name: /check again/i }))
+
+    expect(await screen.findByText('alpha')).toBeTruthy()
+  })
+
+  it('a failed workspace list offers a retry rather than a create button with nowhere to create', async () => {
+    // The create control this branch renders is a real recovery path when the
+    // DOCUMENTS list failed — the POST needs no rows. When the WORKSPACE list
+    // is what failed there is no selection behind it, so `handleCreate`
+    // returns at its first line and the button does nothing at all.
+    let listAttempts = 0
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.endsWith('/api/workspaces')) {
+        listAttempts += 1
+        if (listAttempts === 1) return Promise.resolve(jsonResponse({ message: 'boom' }, 500))
+        return Promise.resolve(jsonResponse({ workspaces: [{ workspaceId: 'ws-a' }] }))
+      }
+      if (url.endsWith('/api/workspaces/ws-a/documents')) {
+        return Promise.resolve(
+          jsonResponse({ documents: [{ path: 'alpha', updatedAt: new Date().toISOString() }] }),
+        )
+      }
+      return Promise.resolve(jsonResponse({}, 404))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenDocument={vi.fn()} />)
+
+    expect((await screen.findByRole('alert')).textContent).toBe('Failed to load workspaces.')
+    expect(screen.queryByRole('button', { name: /create a canvas/i })).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+    expect(await screen.findByText('alpha')).toBeTruthy()
+  })
+
   it('empty workspace shows one clear next action that creates and opens a canvas', async () => {
     const created: Array<[string, string]> = []
     installFetchMock({

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -1340,6 +1340,54 @@ describe('DaemonIndexPage', () => {
     expect(await screen.findByText('alpha')).toBeTruthy()
   })
 
+  it('a slower earlier retry cannot undo the newer one that found a workspace', async () => {
+    // Both retry controls call loadWorkspaces() with its default isStale,
+    // which is only ever false — nothing there orders two overlapping manual
+    // retries. Pressing "Check again" twice is enough: if the FIRST response
+    // lands last it writes its empty list over the second's, and the
+    // no-workspaces branch keys on `workspaces.length === 0` alone, so the
+    // page flips back to "no workspaces" while a workspace is selected and
+    // its documents are on screen.
+    const pending: Array<(workspaces: Array<{ workspaceId: string }>) => void> = []
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.endsWith('/api/workspaces') && (!init || init.method === undefined)) {
+        return new Promise<Response>((resolve) => {
+          pending.push((workspaces) => resolve(jsonResponse({ workspaces })))
+        })
+      }
+      if (url.endsWith('/api/workspaces/ws-a/documents')) {
+        return Promise.resolve(
+          jsonResponse({ documents: [{ path: 'alpha', updatedAt: new Date().toISOString() }] }),
+        )
+      }
+      return Promise.resolve(jsonResponse({}, 404))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenDocument={vi.fn()} />)
+
+    // The mount load settles empty, putting the page in the no-workspaces state.
+    await waitFor(() => expect(pending).toHaveLength(1))
+    await act(async () => pending[0]([]))
+    await screen.findByText(/no workspaces/i)
+
+    // Two overlapping retries, resolved in reverse order: the LATER one finds
+    // ws-a, then the EARLIER one answers with the list as it was.
+    fireEvent.click(screen.getByRole('button', { name: /check again/i }))
+    await waitFor(() => expect(pending).toHaveLength(2))
+    fireEvent.click(screen.getByRole('button', { name: /check again/i }))
+    await waitFor(() => expect(pending).toHaveLength(3))
+
+    await act(async () => pending[2]([{ workspaceId: 'ws-a' }]))
+    await screen.findByText('alpha')
+
+    await act(async () => pending[1]([]))
+
+    expect(screen.queryByText(/no workspaces/i)).toBeNull()
+    expect(screen.getByText('alpha')).toBeTruthy()
+  })
+
   it('a failed workspace list offers a retry rather than a create button with nowhere to create', async () => {
     // The create control this branch renders is a real recovery path when the
     // DOCUMENTS list failed — the POST needs no rows. When the WORKSPACE list

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -76,6 +76,11 @@ export function DaemonIndexPage({
   const daemonFetch = useMemo(() => createDaemonFetch(daemonBaseUrl, token), [daemonBaseUrl, token])
 
   const [workspaces, setWorkspaces] = useState<string[]>([])
+  // Whether the workspace LIST has settled, which `workspaces.length === 0`
+  // alone cannot say — it reads the same before the first fetch returns and
+  // after a daemon answers with nothing. Only the second of those is a state
+  // to render; the first is still loading.
+  const [workspacesLoaded, setWorkspacesLoaded] = useState(false)
   const [selectedWorkspace, setSelectedWorkspace] = useState<string | null>(null)
   // One source per (fetch, base, workspace): the panel re-reads whenever the
   // source identity changes, so this memo is also what scopes it to the
@@ -115,28 +120,41 @@ export function DaemonIndexPage({
   const selectedWorkspaceRef = useRef(selectedWorkspace)
   selectedWorkspaceRef.current = selectedWorkspace
 
-  useEffect(() => {
-    let cancelled = false
-    listWorkspaces(daemonFetch, daemonBaseUrl)
-      .then((res) => {
-        if (cancelled) return
+  // initialWorkspaceId is fixed for the page's lifetime (set once from the
+  // pairing payload App.tsx resolved at mount), so reading it through a ref
+  // keeps loadWorkspaces stable across renders — the mount effect below stays
+  // load-once, and the retry controls can share the same function.
+  const initialWorkspaceIdRef = useRef(initialWorkspaceId)
+  initialWorkspaceIdRef.current = initialWorkspaceId
+
+  const loadWorkspaces = useCallback(
+    async (isStale: () => boolean = () => false) => {
+      setLoadError(null)
+      try {
+        const res = await listWorkspaces(daemonFetch, daemonBaseUrl)
+        if (isStale()) return
         const ids = res.workspaces.map((w) => w.workspaceId)
         setWorkspaces(ids)
-        const targeted =
-          initialWorkspaceId && ids.includes(initialWorkspaceId) ? initialWorkspaceId : undefined
-        setSelectedWorkspace((current) => current ?? targeted ?? ids[0] ?? null)
-      })
-      .catch(() => {
-        if (!cancelled) setLoadError('Failed to load workspaces.')
-      })
+        setWorkspacesLoaded(true)
+        const targeted = initialWorkspaceIdRef.current
+        const wanted = targeted && ids.includes(targeted) ? targeted : undefined
+        setSelectedWorkspace((current) => current ?? wanted ?? ids[0] ?? null)
+      } catch {
+        if (isStale()) return
+        setWorkspacesLoaded(true)
+        setLoadError('Failed to load workspaces.')
+      }
+    },
+    [daemonFetch, daemonBaseUrl],
+  )
+
+  useEffect(() => {
+    let cancelled = false
+    void loadWorkspaces(() => cancelled)
     return () => {
       cancelled = true
     }
-    // initialWorkspaceId is fixed for the page's lifetime (set once from the
-    // pairing payload App.tsx resolved at mount) — it deliberately isn't a
-    // dependency so this effect stays load-once, matching daemonBaseUrl.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [daemonBaseUrl])
+  }, [loadWorkspaces])
 
   // Re-reads the workspace list and moves off the one that vanished.
   //
@@ -414,17 +432,60 @@ export function DaemonIndexPage({
           // deliberately has no create control — deriving a path from rows
           // that are still in flight invites a collision the loaded states
           // cannot produce.
+          //
+          // Which failed decides which recovery is real. Creating needs a
+          // workspace to create INTO, so when the WORKSPACE list is what
+          // failed there is nothing selected and `handleCreate` returns at its
+          // first line — the button would sit there doing nothing. Offer the
+          // request that failed instead.
           <div className="flex flex-col items-start gap-3">
             <div role="alert" className="text-sm text-destructive">
               {loadError}
             </div>
+            {selectedWorkspace ? (
+              <button
+                type="button"
+                disabled={creating}
+                onClick={() => void handleCreate('spatial')}
+                className="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent"
+              >
+                Create a canvas
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => void loadWorkspaces()}
+                className="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent"
+              >
+                Try again
+              </button>
+            )}
+          </div>
+        ) : workspacesLoaded && workspaces.length === 0 ? (
+          // A daemon that holds no workspaces at all. Nothing is selected, so
+          // the documents fetch that ends the loading state never runs and the
+          // skeleton below would spin for as long as the page stays open.
+          //
+          // There is no create control here on purpose: every create path
+          // addresses a (workspace, path) pair, and this page has no way to
+          // name a workspace the daemon would agree with — the daemon keeps
+          // its own current workspace id and does not publish it. So the one
+          // honest action is to look again, because the write that fixes this
+          // is someone else's.
+          <div className="flex flex-col items-start gap-3">
+            <div>
+              <p className="text-sm font-medium">This daemon has no workspaces yet.</p>
+              <p className="text-sm text-muted-foreground">
+                A workspace appears once something creates a document in it — an agent over MCP, or
+                the whiteboard CLI.
+              </p>
+            </div>
             <button
               type="button"
-              disabled={creating}
-              onClick={() => void handleCreate('spatial')}
+              onClick={() => void loadWorkspaces()}
               className="rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent"
             >
-              Create a canvas
+              Check again
             </button>
           </div>
         ) : !loaded ? (

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -127,33 +127,42 @@ export function DaemonIndexPage({
   const initialWorkspaceIdRef = useRef(initialWorkspaceId)
   initialWorkspaceIdRef.current = initialWorkspaceId
 
-  const loadWorkspaces = useCallback(
-    async (isStale: () => boolean = () => false) => {
-      setLoadError(null)
-      try {
-        const res = await listWorkspaces(daemonFetch, daemonBaseUrl)
-        if (isStale()) return
-        const ids = res.workspaces.map((w) => w.workspaceId)
-        setWorkspaces(ids)
-        setWorkspacesLoaded(true)
-        const targeted = initialWorkspaceIdRef.current
-        const wanted = targeted && ids.includes(targeted) ? targeted : undefined
-        setSelectedWorkspace((current) => current ?? wanted ?? ids[0] ?? null)
-      } catch {
-        if (isStale()) return
-        setWorkspacesLoaded(true)
-        setLoadError('Failed to load workspaces.')
-      }
-    },
-    [daemonFetch, daemonBaseUrl],
-  )
+  // Orders every list load, so only the newest one may write. The retry
+  // controls can overlap freely — nothing else sequences two presses — and an
+  // older answer landing last does not merely leave a stale message: the
+  // no-workspaces branch keys on `workspaces.length === 0` alone, so the page
+  // reverts to it with a workspace selected and its documents on screen.
+  //
+  // This replaces the `isStale` callback the sibling loaders take, rather than
+  // joining it. That callback asks whether the CALLER still cares, which only
+  // the mount effect can answer; a dep change already bumps the generation
+  // here (the cleanup runs, then the re-run), leaving it covering unmount
+  // alone — a setState no-op since React 18, and nothing a test can tell apart
+  // from its absence. Measured: with it removed, all 46 cases stay green.
+  const listGeneration = useRef(0)
+
+  const loadWorkspaces = useCallback(async () => {
+    const generation = ++listGeneration.current
+    const superseded = () => generation !== listGeneration.current
+    setLoadError(null)
+    try {
+      const res = await listWorkspaces(daemonFetch, daemonBaseUrl)
+      if (superseded()) return
+      const ids = res.workspaces.map((w) => w.workspaceId)
+      setWorkspaces(ids)
+      setWorkspacesLoaded(true)
+      const targeted = initialWorkspaceIdRef.current
+      const wanted = targeted && ids.includes(targeted) ? targeted : undefined
+      setSelectedWorkspace((current) => current ?? wanted ?? ids[0] ?? null)
+    } catch {
+      if (superseded()) return
+      setWorkspacesLoaded(true)
+      setLoadError('Failed to load workspaces.')
+    }
+  }, [daemonFetch, daemonBaseUrl])
 
   useEffect(() => {
-    let cancelled = false
-    void loadWorkspaces(() => cancelled)
-    return () => {
-      cancelled = true
-    }
+    void loadWorkspaces()
   }, [loadWorkspaces])
 
   // Re-reads the workspace list and moves off the one that vanished.
@@ -474,7 +483,7 @@ export function DaemonIndexPage({
           // is someone else's.
           <div className="flex flex-col items-start gap-3">
             <div>
-              <p className="text-sm font-medium">This daemon has no workspaces yet.</p>
+              <p className="text-sm font-medium">This daemon has no workspaces.</p>
               <p className="text-sm text-muted-foreground">
                 A workspace appears once something creates a document in it — an agent over MCP, or
                 the whiteboard CLI.

--- a/packages/mcp-server/src/server/http-server.first-run.test.ts
+++ b/packages/mcp-server/src/server/http-server.first-run.test.ts
@@ -1,0 +1,61 @@
+/**
+ * A daemon nobody has written to yet must still offer a workspace.
+ *
+ * `ensureWorkspaceId` gives the daemon a current workspace id, but nothing
+ * ran it at startup and it wrote only the `runtime` marker — so a browser
+ * connecting to a freshly installed daemon got `{"workspaces":[]}` (measured)
+ * and had nothing to select. `DaemonIndexPage` then sat on its loading
+ * skeleton indefinitely, because the documents fetch that ends that state is
+ * keyed on a selected workspace.
+ */
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let tempDir: string
+
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual<typeof import('./config.js')>('./config.js')
+  return {
+    ...actual,
+    get DATA_DIR() {
+      return tempDir
+    },
+    getDataDir: () => tempDir,
+  }
+})
+
+const { findAvailablePort } = await import('../cli/daemon-run.js')
+const { startHttpServer } = await import('./http-server.js')
+const { clearWorkspaceIdCache } = await import('./mcp/session-resolver.js')
+
+describe('startHttpServer on a data dir nothing has ever written to', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-http-first-run-'))
+    clearWorkspaceIdCache()
+  })
+
+  afterEach(async () => {
+    clearWorkspaceIdCache()
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it("lists the daemon's own workspace rather than nothing at all", async () => {
+    const port = await findAvailablePort(0)
+    const running = await startHttpServer({ port, host: '127.0.0.1' })
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/api/workspaces`)
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { workspaces: { workspaceId: string }[] }
+      expect(body.workspaces).toHaveLength(1)
+      // And the one it lists is the one its MCP tools would write into — a
+      // second, differently-named workspace would split the same daemon's
+      // browser view from its agent view.
+      const { ensureWorkspaceId } = await import('./mcp/session-resolver.js')
+      expect(body.workspaces[0].workspaceId).toBe(await ensureWorkspaceId(tempDir))
+    } finally {
+      await running.close()
+    }
+  })
+})

--- a/packages/mcp-server/src/server/http-server.ts
+++ b/packages/mcp-server/src/server/http-server.ts
@@ -14,6 +14,7 @@ import { createApp } from './app.js'
 import { DIST_WEB_APP_DIR, getDataDir } from './config.js'
 import { normalizeBindHost } from './daemon-auth-binding.js'
 import { getLogger } from './log.js'
+import { ensureWorkspaceId } from './mcp/session-resolver.js'
 import { getConnectionStats, handleWsUpgrade, setRuntimeTouchFn } from './routes/ws.js'
 import { authorizeWsUpgrade } from './routes/ws-auth.js'
 import { parseWsTargetFromRequestUrl } from './routes/ws-validation.js'
@@ -206,6 +207,13 @@ export async function startHttpServer(options: StartHttpServerOptions): Promise<
   // `no such table: workspaces` from the day it was mounted. Both are
   // memoized per data dir, so on an already-prepared dir this costs nothing.
   await prepareDataDir(dataDir)
+  // And give the daemon its current workspace before anything reads the list.
+  // `ensureWorkspaceId` had only ever run per `/mcp` request, so a daemon a
+  // browser reached first held no workspace at all: `GET /api/workspaces`
+  // answered `{"workspaces":[]}` (measured on a fresh data dir), which is not
+  // a state the document browser can select out of. Memoized per data dir, so
+  // the per-request MCP callers below share this one resolve.
+  await ensureWorkspaceId(dataDir)
   const serverDeps = resolveServerDeps(
     createContainer(createStoreLocalModule({ db: await getDb(dataDir), blobDir: dataDir })),
   )

--- a/packages/mcp-server/src/server/mcp/session-resolver.test.ts
+++ b/packages/mcp-server/src/server/mcp/session-resolver.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { getDb } from '../store/db/index.js'
 import { clearWorkspaceIdCache, ensureWorkspaceId } from './session-resolver.js'
 
 describe('ensureWorkspaceId', () => {
@@ -45,6 +46,19 @@ describe('ensureWorkspaceId', () => {
     } finally {
       await rm(otherDir, { recursive: true, force: true })
     }
+  })
+
+  it('materializes the current workspace as a row, not only as a runtime marker', async () => {
+    // The daemon commits to HAVING a current workspace the moment it resolves
+    // one, but the workspaces table only ever learned about it as a side
+    // effect of the first document write. Until then the daemon answered two
+    // of its own questions inconsistently: it had a workspace id, and
+    // `GET /api/workspaces` listed nothing — which is what left a browser
+    // connected to a fresh daemon with no workspace to select.
+    const id = await ensureWorkspaceId(dataDir)
+    const db = await getDb(dataDir)
+    const rows = await db.selectFrom('workspaces').select(['id']).execute()
+    expect(rows.map((r) => r.id)).toEqual([id])
   })
 
   it('drops a failed promise from the cache so a subsequent call can retry', async () => {

--- a/packages/mcp-server/src/server/mcp/session-resolver.ts
+++ b/packages/mcp-server/src/server/mcp/session-resolver.ts
@@ -1,11 +1,40 @@
 import { nanoid } from 'nanoid'
 import { getDb } from '../store/db/index.js'
 import { prepareDataDir } from '../store/db/prepare.js'
+import { upsertWorkspaceRow } from '../store/db/upsert-workspace.js'
 
 // The current workspace id is the live source of truth in the `runtime`
 // table. ensureWorkspaceId memoizes the lookup per dataDir; the first caller
 // pays for migrations and the row read, later callers share the promise.
 const ensureCache = new Map<string, Promise<string>>()
+
+async function resolveWorkspaceId(db: Awaited<ReturnType<typeof getDb>>): Promise<string> {
+  const row = await db
+    .selectFrom('runtime')
+    .select(['value'])
+    .where('key', '=', 'currentWorkspaceId')
+    .executeTakeFirst()
+  if (row?.value) return row.value
+
+  // Fresh install — no row yet. Pick a new id and upsert atomically so
+  // concurrent ensureWorkspaceId callers across worker threads cannot
+  // diverge on the chosen id.
+  const id = nanoid()
+  const now = Date.now()
+  await db
+    .insertInto('runtime')
+    .values({ key: 'currentWorkspaceId', value: id, updatedAt: now })
+    .onConflict((oc) => oc.column('key').doUpdateSet({ updatedAt: now }))
+    .execute()
+  // The conflict path leaves the existing value in place, so read it back
+  // to return whichever id won the race.
+  const settled = await db
+    .selectFrom('runtime')
+    .select(['value'])
+    .where('key', '=', 'currentWorkspaceId')
+    .executeTakeFirst()
+  return settled?.value ?? id
+}
 
 export function ensureWorkspaceId(dataDir: string): Promise<string> {
   const existing = ensureCache.get(dataDir)
@@ -14,33 +43,16 @@ export function ensureWorkspaceId(dataDir: string): Promise<string> {
     await prepareDataDir(dataDir)
     const db = await getDb(dataDir)
 
-    const row = await db
-      .selectFrom('runtime')
-      .select(['value'])
-      .where('key', '=', 'currentWorkspaceId')
-      .executeTakeFirst()
-    if (row?.value) {
-      return row.value
-    }
-
-    // Fresh install — no row yet. Pick a new id and upsert atomically so
-    // concurrent ensureWorkspaceId callers across worker threads cannot
-    // diverge on the chosen id.
-    const id = nanoid()
-    const now = Date.now()
-    await db
-      .insertInto('runtime')
-      .values({ key: 'currentWorkspaceId', value: id, updatedAt: now })
-      .onConflict((oc) => oc.column('key').doUpdateSet({ updatedAt: now }))
-      .execute()
-    // The conflict path leaves the existing value in place, so read it back
-    // to return whichever id won the race.
-    const settled = await db
-      .selectFrom('runtime')
-      .select(['value'])
-      .where('key', '=', 'currentWorkspaceId')
-      .executeTakeFirst()
-    return settled?.value ?? id
+    const resolved = await resolveWorkspaceId(db)
+    // Materialize the workspace as a ROW, not only as the runtime marker. The
+    // daemon commits to having a current workspace the moment it answers with
+    // one, but the workspaces table used to learn of it as a side effect of
+    // the first document write — so a daemon nobody had written to yet held an
+    // id that `GET /api/workspaces` did not list, and a browser connecting to
+    // it had no workspace to select. Idempotent, and memoized with the rest of
+    // this resolve, so it costs one no-op insert per process per data dir.
+    await upsertWorkspaceRow(db, resolved)
+    return resolved
   })()
   ensureCache.set(dataDir, pending)
   pending.catch(() => {


### PR DESCRIPTION
## Summary

- **A freshly installed daemon listed no workspaces at all.** `ensureWorkspaceId` gives the daemon a current workspace id and writes it to the `runtime` table, but the `workspaces` table only learned that id as a side effect of the first document write — and nothing ran the resolve at startup, it was per-`/mcp`-request. So a daemon a browser reached before any agent did answered its own two questions inconsistently: it had a workspace, and `GET /api/workspaces` listed none. Now the resolve materializes the row, and the daemon runs it at startup.
- **`DaemonIndexPage` sat on its loading skeleton forever when the list was empty.** Nothing is selected, so the documents fetch that ends the loading state never runs. Measured before the fix: `{ skeleton: true, createButtons: 0 }`, permanently. The page now says what is true and offers the one action it can honestly offer — look again — because the write that fixes this is someone else's (an agent over MCP, the CLI).
- **A failed workspace list offered a create button that did nothing.** Creating is a real recovery path when the *documents* list failed (the POST needs no rows), but a failed *workspace* list leaves nothing selected, so `handleCreate` returned at its first line. That branch now offers the request that actually failed.
- **Overlapping retries let an older list overwrite a newer one** (found in review, third commit). Details below.

The first bullet removes the common cause; the second is the guard for when the list really is empty (someone deleted the last workspace out from under the page). All are pre-existing — none was introduced by #1081.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — 4 `web-jsdom` cases in `DaemonIndexPage.test.tsx`, 1 in `session-resolver.test.ts`, and a new `http-server.first-run.test.ts` that boots a real daemon on a fresh temp data dir and fetches over real HTTP.
- [x] `pnpm test` passes locally — with the container's known baseline failures, unchanged by this branch and identical on a clean tree: 4 `mcp-node` EACCES cases (the sandbox runs as root, so `chmod 000` denies nothing) and 9 `web-jsdom` `createObjectURL` cases. Both sets are green in CI.
- [x] Manual verification completed — see below.
- [ ] E2E coverage added or extended where applicable — the first-run test already boots a real daemon over real HTTP, which is the layer the defect lived at.

Every guard was mutation-checked, with the restore verified afterwards:

| mutation | expected | observed |
|---|---|---|
| disable the no-workspaces render branch | the 2 zero-workspace cases fail | both failed |
| make the failed-list branch always render "Create a canvas" | the retry case fails | failed |
| drop `upsertWorkspaceRow` from the resolve | both server cases fail | both failed |
| drop `await ensureWorkspaceId(dataDir)` from `http-server.ts` only | the helper's own test stays green, the first-run test fails | exactly that |
| neutralize `superseded()` | the overlapping-retry case fails, and only it | exactly that |

The fourth is the point of testing the wiring separately from the helper: a helper nobody calls is the defect.

## Review finding, and what checking it turned up

CodeRabbit flagged that both retry controls call `loadWorkspaces()` with its default `isStale`, which is only ever false — nothing ordered two overlapping presses. Valid, and the consequence is worse than reported: the no-workspaces branch keys on `workspaces.length === 0` alone, so an older empty response landing last reverts the page to "This daemon has no workspaces." **with a workspace selected and its documents already on screen**. The red test pins that ordering (two presses, resolved in reverse) and failed on `expected <p class="text-sm font-medium"></p> to be null`.

Fixed with a generation counter, which **replaces** `isStale` here rather than joining it. `isStale` asks whether the caller still cares, which only the mount effect can answer, and a dep change already bumps the generation (cleanup runs, then the re-run) — leaving it covering unmount alone, a setState no-op since React 18. Measured: with it removed, all 46 cases stay green. Same reasoning this file already recorded when it removed `handleCreate`'s `creating` early-return.

Worth recording: the first mutation check of that new guard came back green and was **wrong** — `pnpm lint --write` had reduced the line's indentation when it collapsed the arrow function, so the patch matched nothing and the file was simply unchanged. Re-grepping the mutated line before believing the result is what caught it.

## Visual evidence

Visual evidence: none — ImageMagick is not installed in this container, so `compose-figure.mjs` cannot run (`pnpm test:scripts` reports its own test skipped for the same reason). What the figure would have shown is instead measured directly, A/B against **two real daemon processes on two fresh data dirs** — same command, same code path, only the two source files differing:

```
before (origin/main)   GET /api/workspaces → {"workspaces":[]}
after  (this branch)   GET /api/workspaces → {"workspaces":[{"workspaceId":"OTFHvn4Z-i5PNmT-Ymf7G"}]}
```

The empty answer is what the browser turned into a permanent skeleton. With the daemon answering the second, the page reaches its normal empty-workspace onboarding state, whose create button works — the state the existing `empty workspace shows one clear next action` test covers.

The browser half is pinned by the four `web-jsdom` cases rather than a screenshot; its two new states are a paragraph and a button, and the mutation table above is what says they are load-bearing.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [ ] Docs updated if this changes user-visible behavior or a published contract — no published contract moves: `GET /api/workspaces` keeps its shape, and what changed is that a fresh daemon has something to put in it. `docs/how-to/connect-to-local-daemon.md` says pairing "opens the daemon's workspaces in place", which this makes true rather than requiring an edit.
- [x] No `console.*` calls added to `src/server/**` — `pnpm lint:noconsole` clean.
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

## Note for a follow-up

`adapter-mechanic-check.ts` matches `store/<module>.js` and so cannot see `store/db/**` imports. Measured: that blind spot hides exactly 4 edges today, all in `mcp/index.ts` and `mcp/session-resolver.ts` — files that are arguably composition-root wiring rather than adapters, which is the classification the check would need before its regex could be widened. Worth deciding separately; not widened here.