### PR TITLE
feat: surface the trash — list what deletes evacuated, restore in place

### DIFF
--- a/apps/web/src/components/workspace-files/TrashSection.tsx
+++ b/apps/web/src/components/workspace-files/TrashSection.tsx
@@ -1,0 +1,92 @@
+/**
+ * What deletes evacuated, restorable in place.
+ *
+ * Rendered only when there is something in it: an empty trash is silence,
+ * not an empty box — the section exists for the moment someone deleted a
+ * document and wants it back, and any other moment it would only push the
+ * list up. Collapsed by default for the same reason.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import type { TrashRow } from './files-source.js'
+import { formatRelative } from './format-relative.js'
+
+export interface TrashSectionProps {
+  listTrash: () => Promise<readonly TrashRow[]>
+  restoreFromTrash: (documentId: string) => Promise<void>
+  /** The document list above holds a restored document now — re-read it. */
+  onRestored: () => void
+  /** External writes (a delete just landed) — re-read the trash. */
+  revision?: unknown
+}
+
+export function TrashSection({
+  listTrash,
+  restoreFromTrash,
+  onRestored,
+  revision,
+}: TrashSectionProps) {
+  const [rows, setRows] = useState<readonly TrashRow[]>([])
+  const [busy, setBusy] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const reload = useCallback(() => {
+    // A failed trash read degrades to an absent section, never to an error
+    // banner: the list above is the primary surface and must not inherit a
+    // failure from an auxiliary one.
+    listTrash().then(setRows, () => setRows([]))
+  }, [listTrash])
+
+  useEffect(reload, [reload, revision])
+
+  const restore = useCallback(
+    async (documentId: string) => {
+      setBusy(documentId)
+      setError(null)
+      try {
+        await restoreFromTrash(documentId)
+        reload()
+        onRestored()
+      } catch {
+        setError('Could not restore this document.')
+      } finally {
+        setBusy(null)
+      }
+    },
+    [restoreFromTrash, reload, onRestored],
+  )
+
+  if (rows.length === 0) return null
+
+  return (
+    <details className="border-t px-2 py-1 text-sm" data-testid="trash-section">
+      <summary className="text-muted-foreground cursor-pointer text-xs font-medium">
+        Trash ({rows.length})
+      </summary>
+      {error !== null && (
+        <p role="alert" className="text-destructive text-xs">
+          {error}
+        </p>
+      )}
+      <ul className="flex flex-col gap-1 pt-1">
+        {rows.map((row) => (
+          <li key={row.documentId} className="flex items-center justify-between gap-2">
+            <span className="min-w-0 truncate" title={row.path}>
+              {row.path}
+              <span className="text-muted-foreground pl-2 text-xs">
+                deleted {formatRelative(new Date(row.deletedAt).toISOString())}
+              </span>
+            </span>
+            <button
+              type="button"
+              disabled={busy === row.documentId}
+              onClick={() => void restore(row.documentId)}
+              className="text-muted-foreground hover:text-foreground shrink-0 rounded border px-2 py-0.5 text-xs"
+            >
+              Restore
+            </button>
+          </li>
+        ))}
+      </ul>
+    </details>
+  )
+}

--- a/apps/web/src/components/workspace-files/TrashSection.tsx
+++ b/apps/web/src/components/workspace-files/TrashSection.tsx
@@ -6,7 +6,7 @@
  * document and wants it back, and any other moment it would only push the
  * list up. Collapsed by default for the same reason.
  */
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { TrashRow } from './files-source.js'
 import { formatRelative } from './format-relative.js'
 
@@ -29,11 +29,22 @@ export function TrashSection({
   const [busy, setBusy] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
+  // Only the NEWEST read may write: a slow pre-restore list resolving after
+  // the post-restore reload would put the restored row back in the section.
+  const readSeq = useRef(0)
   const reload = useCallback(() => {
+    const seq = ++readSeq.current
     // A failed trash read degrades to an absent section, never to an error
     // banner: the list above is the primary surface and must not inherit a
     // failure from an auxiliary one.
-    listTrash().then(setRows, () => setRows([]))
+    listTrash().then(
+      (next) => {
+        if (seq === readSeq.current) setRows(next)
+      },
+      () => {
+        if (seq === readSeq.current) setRows([])
+      },
+    )
   }, [listTrash])
 
   useEffect(reload, [reload, revision])

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -22,6 +22,7 @@ import { newDocumentPathIn } from './new-document-path.js'
 import { RenameDocumentDialog } from './RenameDocumentDialog.js'
 import { SearchResults } from './SearchResults.js'
 import { searchDocuments } from './search-documents.js'
+import { TrashSection } from './TrashSection.js'
 import { WorkspaceFileTree } from './WorkspaceFileTree.js'
 import { WorkspaceFolderTree } from './WorkspaceFolderTree.js'
 
@@ -914,6 +915,19 @@ export function WorkspaceFilesPanel({
           />
         </div>
       </div>
+      {source.listTrash !== undefined && source.restoreFromTrash !== undefined && (
+        <TrashSection
+          listTrash={source.listTrash.bind(source)}
+          restoreFromTrash={source.restoreFromTrash.bind(source)}
+          revision={revision}
+          onRestored={() => {
+            // A restore that landed but whose refresh failed leaves the list
+            // stale, not the restore undone — same rule as every other write
+            // here, so the trash section never invents its own error shape.
+            void readList().then(setDocuments, () => undefined)
+          }}
+        />
+      )}
       <RenameDocumentDialog
         document={renaming}
         busy={renameBusy}

--- a/apps/web/src/components/workspace-files/files-source.ts
+++ b/apps/web/src/components/workspace-files/files-source.ts
@@ -66,6 +66,21 @@ export interface WorkspaceFilesSource {
    * of a document the user is not looking at.
    */
   loadSpatialSnapshot(entry: WorkspaceDocumentEntry): Promise<Uint8Array>
+  /**
+   * What a delete evacuated, restorable. OPTIONAL like `setPinned`: the
+   * capability belongs to a keeper whose index keeps a trash, and the panel
+   * omits the section rather than offering a restore that cannot happen.
+   */
+  listTrash?(): Promise<readonly TrashRow[]>
+  /** Bring one evacuated document back under the SAME documentId. */
+  restoreFromTrash?(documentId: string): Promise<void>
+}
+
+/** One trash row, as the panel shows it: where it was, and when it went. */
+export interface TrashRow {
+  readonly documentId: string
+  readonly path: string
+  readonly deletedAt: number
 }
 
 /**

--- a/apps/web/src/components/workspace-files/trash-section.test.tsx
+++ b/apps/web/src/components/workspace-files/trash-section.test.tsx
@@ -9,6 +9,8 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
+import type { TrashRow } from './files-source.js'
+import { TrashSection } from './TrashSection.js'
 import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
 
 afterEach(cleanup)
@@ -45,6 +47,64 @@ describe('WorkspaceFilesPanel trash section', () => {
     await waitFor(() => {
       expect(screen.queryByText('old/plan')).toBeNull()
     })
+  })
+
+  it('announces a failed restore and keeps the row, instead of silently reloading', async () => {
+    const source = fakeFilesSource({
+      listDocuments: async () => [
+        { documentId: 'd-live', path: 'live', kind: 'markdown' as const },
+      ],
+    })
+    source.listTrash = vi.fn(async () => [ENTRY])
+    source.restoreFromTrash = vi.fn(async () => {
+      throw new Error('nothing restorable')
+    })
+    render(<WorkspaceFilesPanel source={source} />)
+
+    fireEvent.click(await screen.findByText(/^Trash/))
+    fireEvent.click(await screen.findByRole('button', { name: /restore/i }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('Could not restore')
+    expect(screen.getByText('old/plan')).toBeTruthy()
+  })
+
+  it('ignores a trash read superseded by a newer reload', async () => {
+    // The mount-time list is slow; a revision bump (a delete landing, say)
+    // starts a second read that answers first. When the FIRST finally
+    // resolves, its stale rows must not overwrite the newer answer — that is
+    // how a restored row climbs back into the section.
+    let resolveFirst: (rows: readonly TrashRow[]) => void = () => undefined
+    const first = new Promise<readonly TrashRow[]>((resolve) => {
+      resolveFirst = resolve
+    })
+    let calls = 0
+    const listTrash = vi.fn(() => {
+      calls += 1
+      return calls === 1 ? first : Promise.resolve<readonly TrashRow[]>([])
+    })
+    const { rerender } = render(
+      <TrashSection
+        listTrash={listTrash}
+        restoreFromTrash={async () => undefined}
+        onRestored={() => undefined}
+        revision={0}
+      />,
+    )
+    rerender(
+      <TrashSection
+        listTrash={listTrash}
+        restoreFromTrash={async () => undefined}
+        onRestored={() => undefined}
+        revision={1}
+      />,
+    )
+    await waitFor(() => expect(listTrash).toHaveBeenCalledTimes(2))
+
+    resolveFirst([ENTRY])
+    // Give the stale resolution a chance to (wrongly) apply itself.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(screen.queryByText('old/plan')).toBeNull()
   })
 
   it('renders no trash section when the trash is empty', async () => {

--- a/apps/web/src/components/workspace-files/trash-section.test.tsx
+++ b/apps/web/src/components/workspace-files/trash-section.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+/**
+ * The panel's Trash section: what a delete evacuated, restorable in place.
+ *
+ * The section renders only when the source CAN answer (the capability is
+ * optional, like `setPinned`) and only when there is something in it — an
+ * empty trash is silence, not an empty box.
+ */
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
+import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
+
+afterEach(cleanup)
+
+const ENTRY = { documentId: '01ARZ3NDEKTSV4RRFFQ69G5FAV', path: 'old/plan', deletedAt: 1_700_000 }
+
+describe('WorkspaceFilesPanel trash section', () => {
+  it('lists evacuated documents and restore calls the source, then both lists refresh', async () => {
+    let trash = [ENTRY]
+    const source = fakeFilesSource({
+      listDocuments: async () =>
+        trash.length > 0
+          ? [{ documentId: 'd-live', path: 'live', kind: 'markdown' as const }]
+          : [
+              { documentId: 'd-live', path: 'live', kind: 'markdown' as const },
+              { documentId: ENTRY.documentId, path: ENTRY.path, kind: 'spatial' as const },
+            ],
+    })
+    source.listTrash = vi.fn(async () => trash)
+    source.restoreFromTrash = vi.fn(async (documentId: string) => {
+      trash = trash.filter((entry) => entry.documentId !== documentId)
+    })
+    render(<WorkspaceFilesPanel source={source} />)
+
+    fireEvent.click(await screen.findByText(/^Trash/))
+    await screen.findByText('old/plan')
+
+    fireEvent.click(screen.getByRole('button', { name: /restore/i }))
+
+    await waitFor(() => {
+      expect(source.restoreFromTrash).toHaveBeenCalledWith(ENTRY.documentId)
+    })
+    // Restored: the entry leaves the trash, and the document list re-reads.
+    await waitFor(() => {
+      expect(screen.queryByText('old/plan')).toBeNull()
+    })
+  })
+
+  it('renders no trash section when the trash is empty', async () => {
+    const source = fakeFilesSource({
+      listDocuments: async () => [{ documentId: 'd1', path: 'doc', kind: 'markdown' as const }],
+    })
+    source.listTrash = vi.fn(async () => [])
+    render(<WorkspaceFilesPanel source={source} />)
+    await screen.findAllByTestId('card-title')
+
+    expect(screen.queryByText(/^Trash/)).toBeNull()
+  })
+
+  it('renders no trash section when the source has no trash capability', async () => {
+    const source = fakeFilesSource({
+      listDocuments: async () => [{ documentId: 'd1', path: 'doc', kind: 'markdown' as const }],
+    })
+    render(<WorkspaceFilesPanel source={source} />)
+    await screen.findAllByTestId('card-title')
+
+    expect(screen.queryByText(/^Trash/)).toBeNull()
+  })
+})

--- a/apps/web/src/lib/daemon-api-client.ts
+++ b/apps/web/src/lib/daemon-api-client.ts
@@ -18,14 +18,20 @@ import {
   type LinkifyMentionsResponse,
   type ListDocumentsResponse,
   type ListFontsResponse,
+  type ListTrashResponse,
   type ListWorkspacesResponse,
   linkifyMentionsResponseSchema,
   listDocumentsResponseSchema,
   listFontsResponseSchema,
+  listTrashResponseSchema,
   listWorkspacesResponseSchema,
   type RenameDocumentPathRequest,
   type RenameDocumentPathResponse,
+  type RestoreTrashResponse,
   renameDocumentPathResponseSchema,
+  restoreTrashResponseSchema,
+  trashApiUrl,
+  trashRestoreApiUrl,
   type UpdateDocumentResponse,
   updateDocumentResponseSchema,
   type WorkspaceDocumentTagsResponse,
@@ -211,6 +217,32 @@ export function getWorkspaceNames(
     fetchFn,
     `${daemonBaseUrl}/api/workspaces/${encodeURIComponent(workspaceId)}/names`,
     workspaceNamesSchema,
+  )
+}
+
+export function listTrash(
+  fetchFn: typeof globalThis.fetch,
+  daemonBaseUrl: string,
+  workspaceId: string,
+): Promise<ListTrashResponse> {
+  return fetchAndParse(
+    fetchFn,
+    `${daemonBaseUrl}${trashApiUrl(workspaceId)}`,
+    listTrashResponseSchema,
+  )
+}
+
+export function restoreFromTrash(
+  fetchFn: typeof globalThis.fetch,
+  daemonBaseUrl: string,
+  workspaceId: string,
+  documentId: string,
+): Promise<RestoreTrashResponse> {
+  return fetchAndParse(
+    fetchFn,
+    `${daemonBaseUrl}${trashRestoreApiUrl(workspaceId, documentId)}`,
+    restoreTrashResponseSchema,
+    { method: 'POST' },
   )
 }
 

--- a/apps/web/src/lib/daemon-files-source.test.ts
+++ b/apps/web/src/lib/daemon-files-source.test.ts
@@ -26,6 +26,38 @@ function fetchStub(handlers: {
   }) as unknown as typeof globalThis.fetch
 }
 
+describe('createDaemonFilesSource trash', () => {
+  it('lists the trash and restores through the daemon routes', async () => {
+    const calls: string[] = []
+    const fetchLike = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      calls.push(`${init?.method ?? 'GET'} ${url}`)
+      if (url.endsWith('/trash')) {
+        return Promise.resolve(
+          jsonResponse({
+            entries: [{ documentId: 'id-gone', path: 'old/plan', deletedAt: 1_700_000 }],
+          }),
+        )
+      }
+      if (url.endsWith('/restore') && init?.method === 'POST') {
+        return Promise.resolve(
+          jsonResponse({ restored: { documentId: 'id-gone', path: 'old/plan' } }),
+        )
+      }
+      return Promise.resolve(jsonResponse({ message: 'unexpected' }, 500))
+    }) as unknown as typeof globalThis.fetch
+    const source = createDaemonFilesSource(fetchLike, BASE, 'ws')
+
+    const entries = await source.listTrash?.()
+    expect(entries).toEqual([{ documentId: 'id-gone', path: 'old/plan', deletedAt: 1_700_000 }])
+
+    await source.restoreFromTrash?.('id-gone')
+    expect(
+      calls.some((line) => line === `POST ${BASE}/api/workspaces/ws/trash/id-gone/restore`),
+    ).toBe(true)
+  })
+})
+
 describe('createDaemonFilesSource setDocumentName', () => {
   function nameFetchStub(calls: Array<{ url: string; body: unknown }>): typeof globalThis.fetch {
     return vi.fn((input: RequestInfo | URL, init?: RequestInit) => {

--- a/apps/web/src/lib/daemon-files-source.ts
+++ b/apps/web/src/lib/daemon-files-source.ts
@@ -12,7 +12,9 @@ import {
   getWorkspaceDocumentTags,
   getWorkspaceNames,
   listDocuments,
+  listTrash,
   renameDocumentPath,
+  restoreFromTrash,
   searchWorkspaceDocuments,
   setDocumentDisplayName,
   setDocumentPinned,
@@ -113,6 +115,14 @@ export function createDaemonFilesSource(
 
     loadSpatialSnapshot(entry: WorkspaceDocumentEntry): Promise<Uint8Array> {
       return getDocumentSnapshot(daemonFetch, daemonBaseUrl, workspaceId, entry.path)
+    },
+
+    async listTrash() {
+      return (await listTrash(daemonFetch, daemonBaseUrl, workspaceId)).entries
+    },
+
+    async restoreFromTrash(documentId: string): Promise<void> {
+      await restoreFromTrash(daemonFetch, daemonBaseUrl, workspaceId, documentId)
     },
   }
 }

--- a/apps/web/src/lib/folding-browser-index.browser.test.tsx
+++ b/apps/web/src/lib/folding-browser-index.browser.test.tsx
@@ -150,6 +150,41 @@ describe('FoldingBrowserIndex (tree-backed composition)', () => {
     ).toBeNull()
   })
 
+  it('delete evacuates into the trash; restore brings the document back under the same id', async () => {
+    const index = new FoldingBrowserIndex()
+    await index.createWorkspace({ workspaceId: BROWSER_WORKSPACE_ID })
+    const entry = await index.createDocument({
+      workspaceId: BROWSER_WORKSPACE_ID,
+      path: 'doomed',
+      kind: 'spatial',
+      name: 'Doomed',
+    })
+    const source = new Loro()
+    writeSpatialCanvas(source, canvasWith('to bring back'))
+    await seedWorkspaceDocumentContent(entry.documentId, source.export({ mode: 'snapshot' }))
+
+    await index.deleteDocument({ workspaceId: BROWSER_WORKSPACE_ID, path: 'doomed' })
+    const trash = await index.listTrash({ workspaceId: BROWSER_WORKSPACE_ID })
+    expect(trash.map((row) => row.documentId)).toEqual([entry.documentId])
+    expect(trash[0]?.path).toBe('doomed')
+
+    const restored = await index.restoreDocument({
+      workspaceId: BROWSER_WORKSPACE_ID,
+      documentId: entry.documentId,
+    })
+    expect(restored?.documentId).toBe(entry.documentId)
+    // Identity survives: the id resolves again, at the old path, with content.
+    const back = await index.resolveDocumentById({
+      workspaceId: BROWSER_WORKSPACE_ID,
+      documentId: entry.documentId,
+    })
+    expect(back?.path).toBe('doomed')
+    const content = await loadDocumentContent(entry.documentId)
+    const node = content === null ? null : readSpatialCanvas(content).nodes[0]
+    expect(node?.type === 'text' ? node.text : null).toBe('to bring back')
+    expect(await index.listTrash({ workspaceId: BROWSER_WORKSPACE_ID })).toEqual([])
+  })
+
   it('create, seed, rename and delete all round-trip through the tree', async () => {
     const index = new FoldingBrowserIndex()
     await index.createWorkspace({ workspaceId: BROWSER_WORKSPACE_ID })

--- a/apps/web/src/lib/folding-browser-index.ts
+++ b/apps/web/src/lib/folding-browser-index.ts
@@ -161,6 +161,22 @@ export class FoldingBrowserIndex implements DocumentIndex {
     return this.inner.setDocumentName(input)
   }
 
+  /** What deletes evacuated; not on the port — callers hold this class. */
+  async listTrash(input: {
+    workspaceId: string
+  }): ReturnType<LoroWorkspaceDocumentIndex['listTrash']> {
+    await this.ensureFolded()
+    return this.inner.listTrash(input)
+  }
+
+  /** Bring one evacuated document back under the SAME documentId. */
+  async restoreDocument(
+    input: Parameters<LoroWorkspaceDocumentIndex['restoreDocument']>[0],
+  ): ReturnType<LoroWorkspaceDocumentIndex['restoreDocument']> {
+    await this.ensureFolded()
+    return this.inner.restoreDocument(input)
+  }
+
   async deleteDocument(input: DeleteDocumentInput): Promise<void> {
     await this.ensureFolded()
     if ((await this.inner.resolveDocument(input)) !== null) {

--- a/apps/web/src/lib/idb-blob-store.test.ts
+++ b/apps/web/src/lib/idb-blob-store.test.ts
@@ -1,0 +1,27 @@
+/**
+ * The stored-bytes predicate, pinned directly: the conformance suite can
+ * only reach it with values a real structured clone produces, and a clone
+ * DROPS symbol-keyed properties — so the spoof case below can never arrive
+ * through the store, and a test that went through it would pass with or
+ * without the guard.
+ */
+import { describe, expect, it } from 'vitest'
+import { isStoredUint8Array } from './idb-blob-store.js'
+
+describe('isStoredUint8Array', () => {
+  it('accepts a genuine Uint8Array', () => {
+    expect(isStoredUint8Array(new Uint8Array([1, 2]))).toBe(true)
+  })
+
+  it('rejects a plain object that merely wears the Uint8Array tag', () => {
+    // `Object.prototype.toString` honours Symbol.toStringTag on ordinary
+    // objects, so the tag check alone accepts this — and `new Uint8Array`
+    // over it silently yields empty bytes instead of a miss.
+    expect(isStoredUint8Array({ [Symbol.toStringTag]: 'Uint8Array' })).toBe(false)
+  })
+
+  it('rejects other ArrayBuffer views', () => {
+    expect(isStoredUint8Array(new DataView(new ArrayBuffer(2)))).toBe(false)
+    expect(isStoredUint8Array(new Int8Array(2))).toBe(false)
+  })
+})

--- a/apps/web/src/lib/idb-blob-store.ts
+++ b/apps/web/src/lib/idb-blob-store.ts
@@ -47,10 +47,20 @@ import { inTransaction, request } from './idb-tx.js'
  * properties on write, so the stored shape and the port's shape agree without
  * a conversion on either side.
  */
+// Realm-independent, unlike `z.instanceof(Uint8Array)`: structured clone can
+// hand back a Uint8Array minted in another realm (jsdom's fake-indexeddb
+// does), and instanceof then rejects a perfectly stored record — the same
+// class-identity family as ports' isWorkspaceNotFoundError. The toString tag
+// cannot be faked by a plain object and names exactly this type.
+const uint8ArraySchema = z.custom<Uint8Array>(
+  (value) =>
+    value instanceof Uint8Array || Object.prototype.toString.call(value) === '[object Uint8Array]',
+)
+
 const blobRecordSchema = z
   .object({
     v: z.literal(1),
-    bytes: z.instanceof(Uint8Array),
+    bytes: uint8ArraySchema,
     contentType: z.string().min(1).optional(),
   })
   .strict()

--- a/apps/web/src/lib/idb-blob-store.ts
+++ b/apps/web/src/lib/idb-blob-store.ts
@@ -38,6 +38,25 @@ import { BLOBS_STORE } from './browser-idb.js'
 import { inTransaction, request } from './idb-tx.js'
 
 /**
+ * Realm-independent, unlike `z.instanceof(Uint8Array)`: structured clone can
+ * hand back a Uint8Array minted in another realm (jsdom's fake-indexeddb
+ * does), and instanceof then rejects a perfectly stored record — the same
+ * class-identity family as ports' isWorkspaceNotFoundError. The toString tag
+ * names the type but IS spoofable by a plain object carrying
+ * `Symbol.toStringTag`, so `ArrayBuffer.isView` — which reads the internal
+ * typed-array slot and also holds across realms — is what proves the value
+ * is a genuine view rather than an object wearing the name.
+ */
+export function isStoredUint8Array(value: unknown): value is Uint8Array {
+  return (
+    value instanceof Uint8Array ||
+    (ArrayBuffer.isView(value) && Object.prototype.toString.call(value) === '[object Uint8Array]')
+  )
+}
+
+const uint8ArraySchema = z.custom<Uint8Array>(isStoredUint8Array)
+
+/**
  * A stored blob. `v` is the envelope version: a record written by a future
  * shape reads as a MISS rather than a crash, matching how every other store
  * in this app treats an envelope it does not recognise.
@@ -47,16 +66,6 @@ import { inTransaction, request } from './idb-tx.js'
  * properties on write, so the stored shape and the port's shape agree without
  * a conversion on either side.
  */
-// Realm-independent, unlike `z.instanceof(Uint8Array)`: structured clone can
-// hand back a Uint8Array minted in another realm (jsdom's fake-indexeddb
-// does), and instanceof then rejects a perfectly stored record — the same
-// class-identity family as ports' isWorkspaceNotFoundError. The toString tag
-// cannot be faked by a plain object and names exactly this type.
-const uint8ArraySchema = z.custom<Uint8Array>(
-  (value) =>
-    value instanceof Uint8Array || Object.prototype.toString.call(value) === '[object Uint8Array]',
-)
-
 const blobRecordSchema = z
   .object({
     v: z.literal(1),

--- a/apps/web/src/lib/local-files-source.test.ts
+++ b/apps/web/src/lib/local-files-source.test.ts
@@ -198,4 +198,24 @@ describe('createLocalFilesSource trash', () => {
     expect(listed.map((row) => row.documentId)).toContain(entry.documentId)
     expect(await source.listTrash?.()).toEqual([])
   })
+
+  it('rejects a restore that brought nothing back, so the UI can say so', async () => {
+    // The index answers null for an id that is not in the trash; swallowing
+    // that resolves the button's promise and the section reloads with the
+    // row still there — a silent no-op. The daemon path already rejects
+    // (its route 404s); the browser path must agree.
+    const index = new FoldingBrowserIndex()
+    await ensureLocalWorkspace(index)
+    const source = createLocalFilesSource({ index })
+
+    await expect(source.restoreFromTrash?.('01ARZ3NDEKTSV4RRFFQ69G5FAV')).rejects.toThrow()
+  })
+
+  it('stays capability-less over an index that keeps no trash', async () => {
+    // The legacy row-plane index has no listTrash/restoreDocument, so the
+    // source must not offer the affordance it could not honour.
+    const source = createLocalFilesSource({ index: new IdbDocumentIndex() })
+    expect(source.listTrash).toBeUndefined()
+    expect(source.restoreFromTrash).toBeUndefined()
+  })
 })

--- a/apps/web/src/lib/local-files-source.test.ts
+++ b/apps/web/src/lib/local-files-source.test.ts
@@ -13,6 +13,7 @@ import { IdbDocumentIndex } from './idb-document-index.js'
 import { ensureLocalWorkspace } from './local-document-summary.js'
 import { createLocalFilesSource } from './local-files-source.js'
 import { LoroStore } from './loro-store.js'
+import { seedWorkspaceDocumentContent } from './workspace-content.js'
 
 claimIsolatedWhiteboardDb('local-files-source')
 
@@ -171,5 +172,30 @@ describe('createLocalFilesSource tags', () => {
     const entries = await createLocalFilesSource().listDocuments()
     expect(entries.find((e) => e.path === 'tagged')?.tags).toEqual(['release', 'q3'])
     expect(entries.find((e) => e.path === 'plain')?.tags).toBeUndefined()
+  })
+})
+
+describe('createLocalFilesSource trash', () => {
+  beforeEach(clearWhiteboardDb)
+
+  it('exposes the shared index trash: delete lists it, restore brings it back', async () => {
+    const index = new FoldingBrowserIndex()
+    await ensureLocalWorkspace(index)
+    const entry = await index.createDocument({
+      workspaceId: 'local',
+      path: 'doomed',
+      kind: 'spatial',
+    })
+    await seedWorkspaceDocumentContent(entry.documentId, new Loro().export({ mode: 'snapshot' }))
+    const source = createLocalFilesSource({ index })
+    await index.deleteDocument({ workspaceId: 'local', path: 'doomed' })
+
+    const trash = await source.listTrash?.()
+    expect(trash?.map((row) => row.documentId)).toEqual([entry.documentId])
+
+    await source.restoreFromTrash?.(entry.documentId)
+    const listed = await source.listDocuments()
+    expect(listed.map((row) => row.documentId)).toContain(entry.documentId)
+    expect(await source.listTrash?.()).toEqual([])
   })
 })

--- a/apps/web/src/lib/local-files-source.ts
+++ b/apps/web/src/lib/local-files-source.ts
@@ -251,10 +251,17 @@ export function createLocalFilesSource(
             }))
           },
           async restoreFromTrash(documentId: string) {
-            await (index as FoldingBrowserIndex).restoreDocument({
+            const restored = await (index as FoldingBrowserIndex).restoreDocument({
               workspaceId: BROWSER_WORKSPACE_ID,
               documentId,
             })
+            // null means nothing came back — surfacing it is what lets the
+            // section show its restore error instead of silently reloading
+            // with the row still there. The daemon path already rejects here
+            // (its route answers 404); the two keepers must agree.
+            if (restored === null) {
+              throw new Error(`Nothing restorable for "${documentId}"`)
+            }
           },
         }
       : {}),

--- a/apps/web/src/lib/local-files-source.ts
+++ b/apps/web/src/lib/local-files-source.ts
@@ -234,5 +234,29 @@ export function createLocalFilesSource(
     async loadSpatialSnapshot(entry: WorkspaceDocumentEntry): Promise<Uint8Array> {
       return (await loadCurrentDoc(entry)).export({ mode: 'snapshot' })
     },
+
+    // Present exactly when the index keeps a trash (the tree index does; the
+    // port does not promise one). Structural rather than instanceof, for the
+    // same cross-realm reason ports' isWorkspaceNotFoundError exists.
+    ...('listTrash' in index && 'restoreDocument' in index
+      ? {
+          async listTrash() {
+            const rows = await (index as FoldingBrowserIndex).listTrash({
+              workspaceId: BROWSER_WORKSPACE_ID,
+            })
+            return rows.map((row) => ({
+              documentId: row.documentId,
+              path: row.path,
+              deletedAt: row.deletedAt,
+            }))
+          },
+          async restoreFromTrash(documentId: string) {
+            await (index as FoldingBrowserIndex).restoreDocument({
+              workspaceId: BROWSER_WORKSPACE_ID,
+              documentId,
+            })
+          },
+        }
+      : {}),
   }
 }

--- a/apps/web/src/pages/BrowserIndexPage.flow.browser.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.flow.browser.test.tsx
@@ -129,7 +129,9 @@ describe('browser list landing (browser — real IndexedDB)', () => {
     )
 
     // Back to the browser, then delete both documents through the preview
-    // pane's Delete and the real AlertDialog: the onboarding state returns.
+    // pane's Delete and the real AlertDialog. Deleting the LAST document must
+    // NOT swap to onboarding: the deletes just filled the trash, and the
+    // Trash section is the one affordance that undoes them.
     await router.navigate(-1)
     await screen.findAllByTestId('card-title', undefined, { timeout: 15_000 })
     for (let remaining = 2; remaining > 0; remaining--) {
@@ -147,6 +149,14 @@ describe('browser list landing (browser — real IndexedDB)', () => {
         },
       )
     }
-    await screen.findByText('What will you make first?', undefined, { timeout: 15_000 })
+    const trash = await screen.findByTestId('trash-section', undefined, { timeout: 15_000 })
+    expect(screen.queryByText('What will you make first?')).toBeNull()
+
+    // Restore one from the trash: the card returns to the list.
+    await userEvent.click(within(trash).getByText(/^Trash \(2\)/))
+    await userEvent.click((await within(trash).findAllByRole('button', { name: 'Restore' }))[0]!)
+    await waitFor(() => expect(screen.queryAllByTestId('card-title')).toHaveLength(1), {
+      timeout: 15_000,
+    })
   })
 })

--- a/apps/web/src/pages/BrowserIndexPage.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.test.tsx
@@ -47,6 +47,38 @@ async function selectCard(title: string) {
 }
 
 describe('BrowserIndexPage', () => {
+  it('an empty list with a non-empty trash keeps the panel — restore must stay reachable', async () => {
+    // Deleting the LAST document must not swap to onboarding: the Trash
+    // section lives in the panel, and onboarding would hide the one
+    // affordance that undoes the delete right when it is needed.
+    const store = await seededStore([])
+    const indexWithTrash = store.index as typeof store.index & {
+      listTrash?: () => Promise<{ documentId: string; path: string; deletedAt: number }[]>
+      restoreDocument?: (input: unknown) => Promise<null>
+    }
+    indexWithTrash.listTrash = async () => [
+      { documentId: '01ARZ3NDEKTSV4RRFFQ69G5FAV', path: 'gone', deletedAt: 1_700_000 },
+    ]
+    indexWithTrash.restoreDocument = async () => null
+    renderPage(store)
+
+    await screen.findByTestId('trash-section')
+    expect(screen.queryByText('What will you make first?')).toBeNull()
+  })
+
+  it('an empty list with an empty trash still onboards', async () => {
+    const store = await seededStore([])
+    const indexWithTrash = store.index as typeof store.index & {
+      listTrash?: () => Promise<{ documentId: string; path: string; deletedAt: number }[]>
+      restoreDocument?: (input: unknown) => Promise<null>
+    }
+    indexWithTrash.listTrash = async () => []
+    indexWithTrash.restoreDocument = async () => null
+    renderPage(store)
+
+    await screen.findByText('What will you make first?')
+  })
+
   it('lists documents in the folder pane with name and kind marker', async () => {
     const store = await seededStore([
       {

--- a/apps/web/src/pages/BrowserIndexPage.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.tsx
@@ -58,6 +58,11 @@ export function BrowserIndexPage({
   onOpenDocument,
 }: BrowserIndexPageProps) {
   const [snapshots, setSnapshots] = useState<DocumentSnapshot[] | null>(null)
+  // Consulted only for the onboarding decision below: a workspace whose list
+  // is empty but whose trash is not must keep the PANEL, because the Trash
+  // section is the one affordance that undoes the delete that just emptied
+  // the list. Failure degrades to 0 — onboarding — never to an error.
+  const [trashCount, setTrashCount] = useState(0)
   const [error, setError] = useState<string | null>(null)
   // The `disabled` attribute (via createDisabled) is the whole double-press
   // mechanism: React flushes this state before a second click can dispatch,
@@ -89,10 +94,16 @@ export function BrowserIndexPage({
       .catch(() => {
         if (!cancelled) setError('Failed to load documents from this browser.')
       })
+    filesSource
+      .listTrash?.()
+      .then((rows) => {
+        if (!cancelled) setTrashCount(rows.length)
+      })
+      .catch(() => undefined)
     return () => {
       cancelled = true
     }
-  }, [index, clock])
+  }, [index, clock, filesSource])
 
   // The index deletes by PATH, and the list already addresses rows that way,
   // so this carries the path rather than the id it used to need.
@@ -125,6 +136,10 @@ export function BrowserIndexPage({
         await pointer.clear()
       }
       setSnapshots(await listLocalDocuments(index, clock))
+      // The delete just moved a document INTO the trash — re-count so the
+      // onboarding decision below sees it before choosing what to render.
+      const trashRows = await filesSource.listTrash?.().catch(() => null)
+      if (trashRows != null) setTrashCount(trashRows.length)
       // The tree view holds its own copy of the list; this identity change is
       // its signal to re-read, same contract as the daemon page's `revision`.
       setFilesRevision((revision) => revision + 1)
@@ -134,7 +149,7 @@ export function BrowserIndexPage({
     } finally {
       setDeleting(false)
     }
-  }, [index, clock, pointer, pendingDelete])
+  }, [index, clock, pointer, pendingDelete, filesSource])
 
   const { folder: routedFolder, setFolder: setRoutedFolder } = useRoutedFolder()
 
@@ -186,7 +201,7 @@ export function BrowserIndexPage({
             </div>
           ))}
         </div>
-      ) : snapshots !== null && snapshots.length === 0 ? (
+      ) : snapshots !== null && snapshots.length === 0 && trashCount === 0 ? (
         // The onboarding state renders INSTEAD of the panel: a three-pane
         // browser of nothing teaches less than one sentence and one button,
         // and this button also OPENS what it creates.

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -71,6 +71,8 @@ interface MockRoutes {
    *  default. Consulted per call, so a test can answer 404 once and then
    *  behave normally — a workspace deleted out from under the page. */
   onListDocuments?: (workspaceId: string) => Response | undefined
+  /** Rows the trash GET answers with; defaults to an empty trash. */
+  trashByWorkspace?: Record<string, Array<{ documentId: string; path: string; deletedAt: number }>>
 }
 
 function installFetchMock(routes: MockRoutes) {
@@ -106,6 +108,13 @@ function installFetchMock(routes: MockRoutes) {
       const path = decodeURIComponent(canvasDeleteMatch[2])
       const override = routes.onDeleteCanvas?.(workspaceId, path)
       return Promise.resolve(override ?? jsonResponse({ ok: true }))
+    }
+    const trashMatch = url.match(/\/api\/workspaces\/([^/]+)\/trash$/)
+    if (trashMatch && (!init || init.method === undefined)) {
+      const workspaceId = decodeURIComponent(trashMatch[1])
+      return Promise.resolve(
+        jsonResponse({ entries: routes.trashByWorkspace?.[workspaceId] ?? [] }),
+      )
     }
     const namesMatch = url.match(/\/api\/workspaces\/([^/]+)\/names$/)
     if (namesMatch) {
@@ -1495,6 +1504,26 @@ describe('DaemonIndexPage', () => {
     // the result, same as the toolbar's "New canvas" control.
     await waitFor(() => expect(onOpenDocument).toHaveBeenCalledWith('ws-a', 'untitled'))
     expect(created).toEqual([['ws-a', 'untitled']])
+  })
+
+  it('keeps the panel when the workspace lists nothing but its trash is not empty', async () => {
+    // Deleting the last document just filled the trash; swapping to the
+    // onboarding state would hide the one affordance that undoes it — the
+    // same rule BrowserIndexPage keeps for the browser keeper.
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      documentsByWorkspace: { 'ws-a': [] },
+      trashByWorkspace: {
+        'ws-a': [
+          { documentId: '01ARZ3NDEKTSV4RRFFQ69G5FAV', path: 'doomed', deletedAt: 1_700_000 },
+        ],
+      },
+    })
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenDocument={vi.fn()} />)
+
+    expect(await screen.findByTestId('trash-section')).toBeTruthy()
+    expect(screen.queryByText('What will you make first?')).toBeNull()
   })
 
   it('the empty state also offers a markdown note, sending its kind and opening it', async () => {

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -13,6 +13,7 @@ import {
   getDocumentSnapshot,
   getWorkspaceNames,
   listDocuments,
+  listTrash,
   listWorkspaces,
   setDocumentDisplayName,
   updateDocument,
@@ -93,6 +94,12 @@ export function DaemonIndexPage({
     [daemonFetch, daemonBaseUrl, selectedWorkspace],
   )
   const [rows, setRows] = useState<DocumentRow[]>([])
+  // Consulted only for the onboarding decision: a workspace whose list is
+  // empty but whose trash is not must keep the PANEL, because the Trash
+  // section is the one affordance that undoes the delete that just emptied
+  // the list. Failure degrades to 0 — onboarding — never to an error. The
+  // same rule BrowserIndexPage keeps for the browser keeper.
+  const [trashCount, setTrashCount] = useState(0)
   // False from the moment a workspace switch clears rows until its documents
   // fetch settles — rows=[] alone cannot distinguish "still loading" from
   // "genuinely empty", and rendering an empty state during the gap reads as
@@ -205,11 +212,17 @@ export function DaemonIndexPage({
     async (workspaceId: string, isStale: () => boolean) => {
       setLoadError(null)
       try {
-        const [documentsRes, names] = await Promise.all([
+        const [documentsRes, names, trashEntries] = await Promise.all([
           listDocuments(daemonFetch, daemonBaseUrl, workspaceId),
           // Failure degrades to "nothing named, nothing pinned", never to a
           // failed list.
           getWorkspaceNames(daemonFetch, daemonBaseUrl, workspaceId).catch(() => null),
+          // Loaded HERE because this runs after every delete too (the dialog
+          // dismiss re-invokes it), which is exactly when the count decides
+          // whether onboarding may replace the panel.
+          listTrash(daemonFetch, daemonBaseUrl, workspaceId)
+            .then((res) => res.entries.length)
+            .catch(() => 0),
         ])
         if (isStale()) return
         const pinIndex = new Map((names?.pinned ?? []).map((path, i) => [path, i]))
@@ -225,6 +238,7 @@ export function DaemonIndexPage({
           }
         })
         setRows(sortRows(nextRows))
+        setTrashCount(trashEntries)
         setLoaded(true)
       } catch (err) {
         if (isStale()) return
@@ -266,6 +280,7 @@ export function DaemonIndexPage({
     // workspace's rows visible during the switch lets a click pair the new
     // workspace id with an old workspace's path — a mismatched identity.
     setRows([])
+    setTrashCount(0)
     setLoaded(false)
     setLoadError(null)
     void loadWorkspace(selectedWorkspace, () => cancelled)
@@ -510,7 +525,7 @@ export function DaemonIndexPage({
               </div>
             ))}
           </div>
-        ) : rows.length === 0 ? (
+        ) : rows.length === 0 && trashCount === 0 ? (
           // The onboarding state renders INSTEAD of the panel: a three-pane
           // browser of nothing teaches less than one sentence and one
           // button, and this button also OPENS what it creates (ADR-0006 —

--- a/docs/explanation/domain-model.md
+++ b/docs/explanation/domain-model.md
@@ -123,6 +123,12 @@ That split is **gone**, in four steps recorded in the migration log:
   by the listing contract. Rows recorded before kinds existed were this
   project's own pre-release data and are deleted at startup, so "kind never
   recorded" is no longer a state a surface has to render.
+- A delete **evacuates before it removes**: the document's subtree is
+  exported into content-addressed blob storage and recorded in the
+  workspace's trash, so the file browser can list what went and restore it
+  under the **same `documentId`** — anything that named the document (a
+  share link, an embed) resolves to it again after a restore. The trash
+  section appears only when it holds something.
 - Because placement is CRDT state, two replicas can merge into **one path
   holding two documents**. Nothing is auto-renamed: the earlier document
   keeps the path, later ones are listed as *shadowed* (the gallery badges

--- a/packages/mcp-server/src/di/container.ts
+++ b/packages/mcp-server/src/di/container.ts
@@ -5,6 +5,7 @@ import {
   TOKENS,
 } from '@kamiazya/whiteboard-ports'
 import type { ServerDeps } from '@kamiazya/whiteboard-server-core'
+import type { LoroWorkspaceDocumentIndex } from '@kamiazya/whiteboard-workspace-index'
 import { Container, type ContainerModule } from 'inversify'
 import { createCanvasClientNotifier } from '../server/canvas-client-notifier.js'
 import { createOpentypeMeasureText } from '../server/export/measure-text.js'
@@ -31,10 +32,33 @@ export function resolveServerDeps(container: Container): ServerDeps {
   const documentStore: DocumentStore = container.get(TOKENS.DocumentStore)
   const blobStore: BlobStore = container.get(TOKENS.BlobStore)
   const documentIndex: DocumentIndex = container.get(TOKENS.DocumentIndex)
+  const trashCapable =
+    'listTrash' in documentIndex && 'restoreDocument' in documentIndex
+      ? (documentIndex as DocumentIndex & LoroWorkspaceDocumentIndex)
+      : null
   return {
     documentStore,
     blobStore,
     documentIndex,
+    // The trash seam, present exactly when the bound index is the tree-backed
+    // one (listTrash/restoreDocument are its capability, not the port's).
+    // Structural rather than instanceof: the binding is this composition
+    // root's own choice, and vitest's module-graph split makes instanceof
+    // lie across realms (see ports' isWorkspaceNotFoundError).
+    ...(trashCapable === null
+      ? {}
+      : {
+          trash: {
+            list: async (input: { workspaceId: string }) =>
+              (await trashCapable.listTrash(input)).map((entry) => ({
+                documentId: entry.documentId,
+                path: entry.path,
+                deletedAt: entry.deletedAt,
+              })),
+            restore: (input: { workspaceId: string; documentId: string }) =>
+              trashCapable.restoreDocument(input),
+          },
+        }),
     // The real font metrics, so every tool that lays a scene out measures
     // text the same way an export does. Without this they fall back to a
     // constant-ratio estimate while the PNG exporter — same process, same

--- a/packages/mcp-server/src/server/routes/document.ts
+++ b/packages/mcp-server/src/server/routes/document.ts
@@ -9,6 +9,7 @@ import { createMaintenanceRouter } from './document/maintenance.js'
 import { createDocumentMetadataRouter } from './document/metadata.js'
 import { createRestoreRouter } from './document/restore.js'
 import { createThumbnailsRouter } from './document/thumbnails.js'
+import { createTrashRouter } from './document/trash.js'
 import { createVersionsRouter } from './document/versions.js'
 import { createWorkspaceDocumentRouter } from './document/workspace-document.js'
 import { createWorkspacesRouter } from './document/workspaces.js'
@@ -58,6 +59,7 @@ export function createDocumentRouter(options: DocumentRouterOptions = {}) {
   installAutoCompact(versionStore)
 
   app.route('/', createWorkspacesRouter({ serverDeps: options.serverDeps }))
+  app.route('/', createTrashRouter({ serverDeps: options.serverDeps }))
   app.route('/', createDocumentMetadataRouter())
   app.route('/', createLiveDocRouter({ triggerAutoVersion }))
   app.route('/', createWorkspaceDocumentRouter({ triggerAutoVersion }))

--- a/packages/mcp-server/src/server/routes/document/trash.test.ts
+++ b/packages/mcp-server/src/server/routes/document/trash.test.ts
@@ -1,0 +1,108 @@
+/**
+ * The trash surface: what a delete evacuated, listed and restorable.
+ *
+ * The machinery (evacuate-before-remove, restore-as-copy under the SAME
+ * documentId) lives in workspace-index and is conformance-tested there; what
+ * this file pins is the REACH — the HTTP adapter a human's Restore button
+ * calls, end to end through the real container deps and the real delete
+ * route.
+ */
+import { writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+import { LoroDoc } from 'loro-crdt'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  listTrashResponseSchema,
+  restoreTrashResponseSchema,
+} from '../../../shared/api-contracts/document.js'
+import { withTempDataDir } from '../_test-helpers.js'
+
+const tmp = withTempDataDir('whiteboard-trash-test-')
+
+vi.mock('../../config.js', () => ({
+  get DATA_DIR() {
+    return tmp.dir
+  },
+  getDataDir: () => tmp.dir,
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+  REPO_ROOT: '/tmp',
+}))
+
+const { saveDocument, resolveDocumentIdAtPath } = await import('../../store/document-store.js')
+const { clearCache } = await import('../../store/doc-cache.js')
+const { createDocumentRouter } = await import('../document.js')
+const { createContainer, resolveServerDeps } = await import('../../../di/container.js')
+const { createStoreLocalModule } = await import('../../../di/store-local.module.js')
+const { prepareDataDir } = await import('../../store/db/prepare.js')
+const { getDb } = await import('../../store/db/index.js')
+
+beforeEach(() => {
+  clearCache()
+})
+
+function canvasDoc(text: string): LoroDoc {
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, {
+    nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 80, height: 40, text }],
+    edges: [],
+  })
+  return doc
+}
+
+async function appWithRealDeps() {
+  await prepareDataDir(tmp.dir)
+  const db = await getDb(tmp.dir)
+  const deps = resolveServerDeps(createContainer(createStoreLocalModule({ db, blobDir: tmp.dir })))
+  return createDocumentRouter({ serverDeps: deps })
+}
+
+describe('trash routes', () => {
+  it('a deleted document is listed in the trash and restore brings it back under the SAME documentId', async () => {
+    const WS = 'ws-trash'
+    await saveDocument(WS, 'keep', canvasDoc('kept'), { kind: 'spatial' })
+    await saveDocument(WS, 'doomed', canvasDoc('to delete'), { kind: 'spatial' })
+    const documentId = await resolveDocumentIdAtPath(WS, 'doomed')
+    expect(documentId).not.toBeNull()
+    const app = await appWithRealDeps()
+
+    const del = await app.request(`/api/workspaces/${WS}/documents/doomed`, { method: 'DELETE' })
+    expect(del.status).toBe(200)
+
+    const listed = await app.request(`/api/workspaces/${WS}/trash`)
+    expect(listed.status).toBe(200)
+    const body = listTrashResponseSchema.parse(await listed.json())
+    expect(body.entries.map((entry) => entry.documentId)).toEqual([documentId])
+    expect(body.entries[0]?.path).toBe('doomed')
+    expect(body.entries[0]?.deletedAt).toBeGreaterThan(0)
+
+    const restored = await app.request(`/api/workspaces/${WS}/trash/${documentId}/restore`, {
+      method: 'POST',
+    })
+    expect(restored.status).toBe(200)
+    const restoredBody = restoreTrashResponseSchema.parse(await restored.json())
+    expect(restoredBody.restored.documentId).toBe(documentId)
+    expect(restoredBody.restored.path).toBe('doomed')
+
+    // The identity survives: the old address resolves to the old document.
+    expect(await resolveDocumentIdAtPath(WS, 'doomed')).toBe(documentId)
+    // And the trash no longer lists it.
+    const after = listTrashResponseSchema.parse(
+      await (await app.request(`/api/workspaces/${WS}/trash`)).json(),
+    )
+    expect(after.entries).toEqual([])
+  })
+
+  it('unknown workspace answers 404 on list; unknown documentId answers 404 on restore', async () => {
+    const WS = 'ws-trash-missing'
+    await saveDocument(WS, 'doc', canvasDoc('content'), { kind: 'spatial' })
+    const app = await appWithRealDeps()
+
+    expect((await app.request('/api/workspaces/ws-nowhere/trash')).status).toBe(404)
+    expect(
+      (
+        await app.request(`/api/workspaces/${WS}/trash/01ARZ3NDEKTSV4RRFFQ69G5FAV/restore`, {
+          method: 'POST',
+        })
+      ).status,
+    ).toBe(404)
+  })
+})

--- a/packages/mcp-server/src/server/routes/document/trash.test.ts
+++ b/packages/mcp-server/src/server/routes/document/trash.test.ts
@@ -52,6 +52,10 @@ async function appWithRealDeps() {
   await prepareDataDir(tmp.dir)
   const db = await getDb(tmp.dir)
   const deps = resolveServerDeps(createContainer(createStoreLocalModule({ db, blobDir: tmp.dir })))
+  // The store-local composition is the trash-capable one — pinned here so a
+  // regression in the DI's structural capability detection fails loudly,
+  // rather than as a cascade of 501s in the tests below.
+  expect(deps.trash).toBeDefined()
   return createDocumentRouter({ serverDeps: deps })
 }
 
@@ -89,6 +93,35 @@ describe('trash routes', () => {
       await (await app.request(`/api/workspaces/${WS}/trash`)).json(),
     )
     expect(after.entries).toEqual([])
+  })
+
+  it('an invalid workspaceId is a 400 request error, not a 500 server error', async () => {
+    const app = await appWithRealDeps()
+
+    const listed = await app.request('/api/workspaces/bad%20id/trash')
+    expect(listed.status).toBe(400)
+    const restored = await app.request(
+      '/api/workspaces/bad%20id/trash/01ARZ3NDEKTSV4RRFFQ69G5FAV/restore',
+      { method: 'POST' },
+    )
+    expect(restored.status).toBe(400)
+  })
+
+  it('a composition without the trash capability answers 501 on both routes', async () => {
+    // The default (in-memory) module binds an index with no listTrash /
+    // restoreDocument, so resolveServerDeps leaves deps.trash undefined.
+    const deps = resolveServerDeps(createContainer())
+    expect(deps.trash).toBeUndefined()
+    const app = createDocumentRouter({ serverDeps: deps })
+
+    expect((await app.request('/api/workspaces/ws/trash')).status).toBe(501)
+    expect(
+      (
+        await app.request('/api/workspaces/ws/trash/01ARZ3NDEKTSV4RRFFQ69G5FAV/restore', {
+          method: 'POST',
+        })
+      ).status,
+    ).toBe(501)
   })
 
   it('unknown workspace answers 404 on list; unknown documentId answers 404 on restore', async () => {

--- a/packages/mcp-server/src/server/routes/document/trash.ts
+++ b/packages/mcp-server/src/server/routes/document/trash.ts
@@ -17,7 +17,7 @@ import type {
 } from '../../../shared/api-contracts/document.js'
 import type { ApiErrorBody } from '../../../shared/api-contracts/errors.js'
 import { getLogger } from '../../log.js'
-import { validateWorkspaceId } from '../../validators.js'
+import { validateWorkspaceId, validationErrorBody } from '../../validators.js'
 
 export interface TrashRouterOptions {
   serverDeps?: ServerDeps
@@ -30,8 +30,16 @@ export function createTrashRouter(options: TrashRouterOptions = {}): Hono {
 
   app.get('/api/workspaces/:workspaceId/trash', async (c) => {
     const workspaceId = c.req.param('workspaceId')
+    // A malformed address is the caller's error, not this server's — kept
+    // outside the try below so it cannot fall through to the 500 arm.
     try {
       validateWorkspaceId(workspaceId)
+    } catch (err) {
+      const body = validationErrorBody(err)
+      if (body) return c.json(body, 400)
+      throw err
+    }
+    try {
       const deps = await depsOf()
       if (deps.trash === undefined) {
         return c.json({ title: 'This composition has no trash.' } satisfies ApiErrorBody, 501)
@@ -62,6 +70,12 @@ export function createTrashRouter(options: TrashRouterOptions = {}): Hono {
     const documentId = c.req.param('documentId')
     try {
       validateWorkspaceId(workspaceId)
+    } catch (err) {
+      const body = validationErrorBody(err)
+      if (body) return c.json(body, 400)
+      throw err
+    }
+    try {
       const deps = await depsOf()
       if (deps.trash === undefined) {
         return c.json({ title: 'This composition has no trash.' } satisfies ApiErrorBody, 501)

--- a/packages/mcp-server/src/server/routes/document/trash.ts
+++ b/packages/mcp-server/src/server/routes/document/trash.ts
@@ -1,0 +1,91 @@
+/**
+ * The trash surface: list what deletes evacuated, restore one entry.
+ *
+ * An ADAPTER over the deps' trash seam (ADR-0018): the evacuate/restore
+ * mechanics live in workspace-index behind `ServerDeps.trash`, and all this
+ * translates is the ADDRESS (workspaceId + documentId in the URL) and the
+ * absent cases — unknown workspace and unknown entry are both 404 here, a
+ * composition with no trash capability is 501.
+ */
+import { isWorkspaceNotFoundError } from '@kamiazya/whiteboard-ports'
+import type { ServerDeps } from '@kamiazya/whiteboard-server-core'
+import { Hono } from 'hono'
+import { getDefaultServerDeps } from '../../../di/default-server-deps.js'
+import type {
+  ListTrashResponse,
+  RestoreTrashResponse,
+} from '../../../shared/api-contracts/document.js'
+import type { ApiErrorBody } from '../../../shared/api-contracts/errors.js'
+import { getLogger } from '../../log.js'
+import { validateWorkspaceId } from '../../validators.js'
+
+export interface TrashRouterOptions {
+  serverDeps?: ServerDeps
+}
+
+export function createTrashRouter(options: TrashRouterOptions = {}): Hono {
+  const app = new Hono()
+
+  const depsOf = async () => options.serverDeps ?? (await getDefaultServerDeps())
+
+  app.get('/api/workspaces/:workspaceId/trash', async (c) => {
+    const workspaceId = c.req.param('workspaceId')
+    try {
+      validateWorkspaceId(workspaceId)
+      const deps = await depsOf()
+      if (deps.trash === undefined) {
+        return c.json({ title: 'This composition has no trash.' } satisfies ApiErrorBody, 501)
+      }
+      // The trash lives in the workspace record; an unknown workspace has no
+      // record to open, which the seam refuses — translated to 404 below.
+      // A known-but-empty trash is an empty list, never an error.
+      const entries = await deps.trash.list({ workspaceId })
+      const response: ListTrashResponse = {
+        entries: entries.map((entry) => ({
+          documentId: entry.documentId,
+          path: entry.path,
+          deletedAt: entry.deletedAt,
+        })),
+      }
+      return c.json(response)
+    } catch (err) {
+      if (isWorkspaceNotFoundError(err)) {
+        return c.json({ title: `Workspace "${workspaceId}" not found` }, 404)
+      }
+      getLogger('document').error({ err: err as Error }, 'trash list failed unexpectedly')
+      return c.json({ title: 'Failed to list the trash.' } satisfies ApiErrorBody, 500)
+    }
+  })
+
+  app.post('/api/workspaces/:workspaceId/trash/:documentId/restore', async (c) => {
+    const workspaceId = c.req.param('workspaceId')
+    const documentId = c.req.param('documentId')
+    try {
+      validateWorkspaceId(workspaceId)
+      const deps = await depsOf()
+      if (deps.trash === undefined) {
+        return c.json({ title: 'This composition has no trash.' } satisfies ApiErrorBody, 501)
+      }
+      const restored = await deps.trash.restore({ workspaceId, documentId })
+      // null covers both "never in the trash" and "entry present but the
+      // evacuated bytes are gone" — either way there is nothing to bring
+      // back, and inventing a distinction here would promise recovery the
+      // store cannot deliver.
+      if (restored === null) {
+        return c.json({ title: `Nothing restorable for "${documentId}"` }, 404)
+      }
+      const response: RestoreTrashResponse = {
+        restored: { documentId: restored.documentId, path: restored.path },
+      }
+      return c.json(response)
+    } catch (err) {
+      if (isWorkspaceNotFoundError(err)) {
+        return c.json({ title: `Workspace "${workspaceId}" not found` }, 404)
+      }
+      getLogger('document').error({ err: err as Error }, 'trash restore failed unexpectedly')
+      return c.json({ title: 'Failed to restore from the trash.' } satisfies ApiErrorBody, 500)
+    }
+  })
+
+  return app
+}

--- a/packages/mcp-server/src/shared/api-contracts/document-url.ts
+++ b/packages/mcp-server/src/shared/api-contracts/document-url.ts
@@ -39,6 +39,15 @@ export function documentsApiUrl(workspaceId: string, path: string, suffix = ''):
   return suffix === '' ? base : `${base}/${suffix}`
 }
 
+/** The workspace trash listing; restore appends /:documentId/restore. */
+export function trashApiUrl(workspaceId: string): string {
+  return `/api/workspaces/${encodeURIComponent(workspaceId)}/trash`
+}
+
+export function trashRestoreApiUrl(workspaceId: string, documentId: string): string {
+  return `${trashApiUrl(workspaceId)}/${encodeURIComponent(documentId)}/restore`
+}
+
 /**
  * Splits a request path in the shape above into its parts, or null when it
  * is not one. Written by hand rather than as a Hono `{.+}` param: Hono's

--- a/packages/mcp-server/src/shared/api-contracts/document.ts
+++ b/packages/mcp-server/src/shared/api-contracts/document.ts
@@ -116,6 +116,30 @@ export const updateDocumentResponseSchema = z.object({
 })
 
 // DELETE /api/workspaces/:workspaceId/documents/:path — success body.
+// The trash: what a delete evacuated, listed for a human and restorable by
+// documentId. Metadata only — blob digests are the store's business and
+// never cross this boundary.
+export const trashEntrySummarySchema = z
+  .object({
+    documentId: z.string().min(1),
+    path: z.string().min(1),
+    deletedAt: z.number().int().nonnegative(),
+  })
+  .strict()
+
+export const listTrashResponseSchema = z.object({
+  entries: z.array(trashEntrySummarySchema),
+})
+
+export const restoreTrashResponseSchema = z.object({
+  restored: z
+    .object({
+      documentId: z.string().min(1),
+      path: z.string().min(1),
+    })
+    .strict(),
+})
+
 export const deleteDocumentResponseSchema = z.object({
   ok: z.literal(true),
 })
@@ -205,6 +229,9 @@ export type ListDocumentsResponse = z.infer<typeof listDocumentsResponseSchema>
 export type CreateDocumentResponse = z.infer<typeof createDocumentResponseSchema>
 export type UpdateDocumentResponse = z.infer<typeof updateDocumentResponseSchema>
 export type DeleteDocumentResponse = z.infer<typeof deleteDocumentResponseSchema>
+export type TrashEntrySummary = z.infer<typeof trashEntrySummarySchema>
+export type ListTrashResponse = z.infer<typeof listTrashResponseSchema>
+export type RestoreTrashResponse = z.infer<typeof restoreTrashResponseSchema>
 export type RenameDocumentPathRequest = z.infer<typeof renameDocumentPathRequestSchema>
 export type RenameDocumentPathResponse = z.infer<typeof renameDocumentPathResponseSchema>
 export type DocumentExistsResponse = z.infer<typeof canvasExistsResponseSchema>

--- a/packages/server-core/src/server-deps.ts
+++ b/packages/server-core/src/server-deps.ts
@@ -69,6 +69,22 @@ export interface ServerDeps {
    */
   documentIndex: DocumentIndex
   /**
+   * The trash a delete evacuated into: listable, and restorable under the
+   * SAME documentId. OPTIONAL because it is a capability of the tree-backed
+   * index the daemon composition binds, not part of the `DocumentIndex`
+   * port — a deps literal without it simply has no trash surface, and the
+   * routes answer 501 rather than pretending.
+   */
+  trash?: {
+    list(input: {
+      workspaceId: string
+    }): Promise<{ documentId: string; path: string; deletedAt: number }[]>
+    restore(input: {
+      workspaceId: string
+      documentId: string
+    }): Promise<{ documentId: string; path: string } | null>
+  }
+  /**
    * How to measure text when laying a scene out. Optional because
    * server-core is a shared layer forbidden from loading a font itself
    * (architecture-map.md) — absent, the render/digest tools degrade to


### PR DESCRIPTION
## Summary

- Deletes already evacuate a document's tree node into the workspace record's trash (PR #1084); this PR makes that trash **visible and reversible**: a collapsed `Trash (N)` section at the bottom of the workspace files panel lists what deletes evacuated and restores a document **under its same `documentId`**, on both keepers.
- Server side: an optional `trash` seam on `ServerDeps`, `GET /api/workspaces/:ws/trash` + `POST /api/workspaces/:ws/trash/:documentId/restore` as ADR-0018 adapters (404 on unknown workspace, 501 when the deps don't carry the capability), Zod contracts in `api-contracts`, and DI wiring that detects the capability structurally on the index.
- Browser side: `listTrash`/`restoreFromTrash` as optional capabilities on `WorkspaceFilesSource` (daemon source via the new routes, browser source via `FoldingBrowserIndex`), a `TrashSection` that renders only when capable **and** non-empty, and a dogfood-found fix: deleting the last document no longer swaps to the onboarding empty state while the trash is non-empty — onboarding would hide the only affordance that undoes the delete.
- Also fixes a latent browser-store bug the trash tests exposed: `IdbBlobStore`'s record schema used `z.instanceof(Uint8Array)`, which rejects a structured-clone `Uint8Array` minted in another realm (fake-indexeddb does this), silently turning stored blobs into misses. Replaced with a realm-independent toString-tag check — the same class-identity family as ports' `isWorkspaceNotFoundError`.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
  - `mcp-node`: `routes/document/trash.test.ts` — full round-trip through the real container deps (delete → list → restore → same `documentId` resolvable), plus 404/501 cases.
  - `web-jsdom`: `trash-section.test.tsx`, `daemon-files-source.test.ts`, `local-files-source.test.ts` trash describes, and two `BrowserIndexPage.test.tsx` cases pinning the onboarding decision (empty list + non-empty trash keeps the panel).
  - `web-browser`: `folding-browser-index.browser.test.tsx` trash round-trip over real IndexedDB, and `BrowserIndexPage.flow.browser.test.tsx` now ends by deleting every document and asserting the panel + `Trash (2)` stay (not onboarding), then restoring one and seeing its card return.
- [x] `pnpm test` passes locally (known env-only failures in this container: 4 mcp-node root-EACCES cases, 9 web-jsdom undici `Response(blob)` cases; `web-browser` 142 files / 785 tests all green)
- [x] Manual verification completed (describe below)
- [x] E2E coverage added or extended where applicable (the flow browser test above locks the dogfooded scenario)

## Visual evidence

Manual verification was a scripted dogfood against the **built** app (`apps/web/dist` served statically, real Chromium via Playwright): create a markdown note through the real New-document menu → delete it through the card context menu + confirm dialog → `Trash (1)` section appears with the entry and a Restore button (screenshot captured at that point) → Restore brings the card back and the section disappears. Every step reported OK.

The capture cannot be embedded here: this environment has no `gh` CLI, so the `gh image` upload path from the repo's visual-evidence workflow is unavailable. The screenshot (`tmp/screenshots/trash-section.png`: empty folder, open `Trash (1)` row "untitled — deleted 0s ago", Restore button) was delivered to the session owner directly. A new affordance has no "before" to compose against, so per the workflow this would be a single-panel figure anyway.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract (`docs/explanation/domain-model.md` documents the trash surface)
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema (`z.infer` throughout the new contracts)

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Trash section to the workspace browser for viewing deleted documents and their deletion times.
  - Users can restore deleted documents while preserving their original location, identity, and references.
  - Added trash listing and restoration support across local and connected workspaces.
  - Empty workspaces with recoverable documents keep the restore option visible instead of showing onboarding.

- **Bug Fixes**
  - Improved validation of stored binary data across execution contexts.

- **Documentation**
  - Documented deletion, trash, and restoration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->