### PR TITLE
feat: promotion slice 4 — the promote-workspace library function

### DIFF
--- a/apps/web/src/lib/promote-workspace.browser.test.tsx
+++ b/apps/web/src/lib/promote-workspace.browser.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * The promotion library function over REAL IndexedDB: the browser keeper's
+ * workspace record leaves through the same bytes the daemon route merges.
+ * The daemon side of those bytes is pinned in mcp-server's
+ * promote-workspace.test.ts; what this file adds is the browser half — the
+ * record actually read from IndexedDB, and the posted snapshot verified by
+ * importing it into a target record rather than by trusting the POST
+ * happened.
+ */
+import {
+  createWorkspaceDocumentAtPath,
+  readWorkspaceDocuments,
+  resolveWorkspaceDocumentById,
+} from '@kamiazya/whiteboard-loro-adapter'
+import { LoroDoc } from 'loro-crdt'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
+import { FoldingBrowserIndex } from './folding-browser-index.js'
+import { ensureLocalWorkspace } from './local-document-summary.js'
+import { promoteWorkspace } from './promote-workspace.js'
+
+claimIsolatedWhiteboardDb('promote-workspace')
+
+const BASE = 'http://127.0.0.1:3099'
+const DAEMON_OWN_ID = '01DMNAAAAAAAAAAAAAAAAAAAA0'
+
+function targetDaemonRecord(): LoroDoc {
+  const doc = new LoroDoc()
+  createWorkspaceDocumentAtPath(doc, {
+    path: 'contested',
+    documentId: DAEMON_OWN_ID,
+    kind: 'markdown',
+  })
+  doc.commit()
+  return doc
+}
+
+/**
+ * A daemon standing in as two fetch routes: the update POST imports the
+ * posted bytes into `target` (the verification, not a mock of it), and the
+ * documents list answers from the merged target with the collision's loser
+ * marked shadowed — the same projection the real route serves.
+ */
+function daemonStub(target: LoroDoc): typeof globalThis.fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    if (url.endsWith('/workspace-document/update') && init?.method === 'POST') {
+      target.import(new Uint8Array(init.body as Uint8Array))
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    if (url.endsWith('/documents')) {
+      const seen = new Set<string>()
+      const documents = readWorkspaceDocuments(target).map((entry) => {
+        const shadowed = seen.has(entry.path)
+        seen.add(entry.path)
+        return {
+          path: entry.path,
+          id: entry.documentId,
+          kind: entry.kind,
+          updatedAt: new Date().toISOString(),
+          ...(shadowed ? { shadowed: true as const } : {}),
+        }
+      })
+      return new Response(JSON.stringify({ documents }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    throw new Error(`unexpected fetch: ${url}`)
+  }) as typeof globalThis.fetch
+}
+
+describe('promoteWorkspace', () => {
+  beforeEach(clearWhiteboardDb)
+
+  it('posts the record; ids resolve on the target and the collision reports shadowed', async () => {
+    const index = new FoldingBrowserIndex()
+    await ensureLocalWorkspace(index)
+    const roadmap = await index.createDocument({
+      workspaceId: 'local',
+      path: 'notes/roadmap',
+      kind: 'markdown',
+    })
+    const contested = await index.createDocument({
+      workspaceId: 'local',
+      path: 'contested',
+      kind: 'spatial',
+    })
+    const target = targetDaemonRecord()
+
+    const result = await promoteWorkspace({
+      fetch: daemonStub(target),
+      daemonBaseUrl: BASE,
+      workspaceId: 'ws-a',
+      workspaceDocs: new BrowserWorkspaceDocs(),
+    })
+
+    expect(result.kind).toBe('ok')
+    if (result.kind !== 'ok') return
+    expect([...result.promotedDocumentIds].sort()).toEqual(
+      [roadmap.documentId, contested.documentId].sort(),
+    )
+    // Identity through the REAL posted bytes, not through the report.
+    expect(resolveWorkspaceDocumentById(target, roadmap.documentId)).not.toBeNull()
+    expect(resolveWorkspaceDocumentById(target, contested.documentId)).not.toBeNull()
+    expect(resolveWorkspaceDocumentById(target, DAEMON_OWN_ID)).not.toBeNull()
+    expect(result.shadowedPaths).toEqual(['contested'])
+    expect(result.blobsPending).toBe(true)
+  })
+
+  it('a 404 target is a structured failure naming the missing daemon workspace', async () => {
+    const index = new FoldingBrowserIndex()
+    await ensureLocalWorkspace(index)
+    await index.createDocument({ workspaceId: 'local', path: 'doc', kind: 'markdown' })
+    const fetch404 = (async () =>
+      new Response(JSON.stringify({ title: 'Workspace "ws-gone" not found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      })) as typeof globalThis.fetch
+
+    const result = await promoteWorkspace({
+      fetch: fetch404,
+      daemonBaseUrl: BASE,
+      workspaceId: 'ws-gone',
+      workspaceDocs: new BrowserWorkspaceDocs(),
+    })
+    expect(result.kind).toBe('failed')
+    if (result.kind !== 'failed') return
+    expect(result.reason).toContain('not found')
+  })
+
+  it('a thrown fetch is a structured network failure, never a rejection', async () => {
+    const index = new FoldingBrowserIndex()
+    await ensureLocalWorkspace(index)
+    await index.createDocument({ workspaceId: 'local', path: 'doc', kind: 'markdown' })
+    const fetchDown = (async () => {
+      throw new TypeError('Failed to fetch')
+    }) as typeof globalThis.fetch
+
+    const result = await promoteWorkspace({
+      fetch: fetchDown,
+      daemonBaseUrl: BASE,
+      workspaceId: 'ws-a',
+      workspaceDocs: new BrowserWorkspaceDocs(),
+    })
+    expect(result.kind).toBe('failed')
+  })
+})

--- a/apps/web/src/lib/promote-workspace.ts
+++ b/apps/web/src/lib/promote-workspace.ts
@@ -1,0 +1,109 @@
+/**
+ * Promotion: the browser keeper's whole workspace record transferred into a
+ * daemon workspace, identity and history intact.
+ *
+ * A plain function, not a component — the UI that offers it arrives in its
+ * own increment, and keeping loro-crdt behind the lazy chunks is that
+ * increment's job too (entry-graph-loro-free.test.ts guards the entry
+ * closure; nothing on the entry path may import this file statically).
+ *
+ * The core move needs no dedicated route: POSTing the record's snapshot to
+ * the existing workspace-document/update endpoint IS the CRDT merge — the
+ * daemon side of exactly these bytes is pinned by mcp-server's
+ * promote-workspace.test.ts (identity, shadowed collisions, idempotent
+ * retry, the unregistered-target 404, and the fan-out to live sessions).
+ *
+ * The caller owns the fold: a legacy row-plane document that has not been
+ * absorbed into the tree yet is not in the record this reads, so the promote
+ * surface must run after the startup fold (any FoldingBrowserIndex read
+ * performs it) — the same ordering every other record consumer relies on.
+ */
+import { readWorkspaceDocuments } from '@kamiazya/whiteboard-loro-adapter'
+import { apiErrorReason } from '@kamiazya/whiteboard-mcp/api-contracts'
+import type { WorkspaceDocs } from '@kamiazya/whiteboard-workspace-index'
+import { listDocuments } from './daemon-api-client.js'
+import { BROWSER_WORKSPACE_ID } from './local-document-summary.js'
+
+export interface PromoteWorkspaceOptions {
+  fetch: typeof globalThis.fetch
+  daemonBaseUrl: string
+  /** The TARGET daemon workspace — promotion merges into an existing one. */
+  workspaceId: string
+  /** The browser keeper's records (production: `new BrowserWorkspaceDocs()`). */
+  workspaceDocs: WorkspaceDocs
+}
+
+export type PromoteWorkspaceResult =
+  | {
+      kind: 'ok'
+      /** Every documentId the record carried across — the same ids, by design. */
+      promotedDocumentIds: string[]
+      /** Paths the merge left contested; surfaced, never auto-resolved. */
+      shadowedPaths: string[]
+      /** File/image bytes live outside the record; their transfer is its own increment. */
+      blobsPending: true
+    }
+  | { kind: 'failed'; reason: string }
+
+async function failureReason(res: Response): Promise<string> {
+  try {
+    const reason = apiErrorReason(await res.json())
+    if (reason !== undefined) return reason
+  } catch {
+    // fall through to the generic message below
+  }
+  return `Request failed (${res.status}).`
+}
+
+export async function promoteWorkspace(
+  options: PromoteWorkspaceOptions,
+): Promise<PromoteWorkspaceResult> {
+  try {
+    return await promoteWorkspaceUnsafe(options)
+  } catch {
+    // A thrown fetch (daemon offline, connection dropped mid-transfer) must
+    // surface as a structured failure the confirmation UI can show, never a
+    // rejected promise. The transfer itself is safe to re-run: the same
+    // snapshot re-POSTed is an idempotent merge.
+    return { kind: 'failed', reason: 'Could not reach the daemon (network error).' }
+  }
+}
+
+async function promoteWorkspaceUnsafe(
+  options: PromoteWorkspaceOptions,
+): Promise<PromoteWorkspaceResult> {
+  const { fetch, daemonBaseUrl, workspaceId, workspaceDocs } = options
+
+  const record = await workspaceDocs.open(BROWSER_WORKSPACE_ID)
+  if (record === null) {
+    return { kind: 'failed', reason: 'This browser keeps no workspace record to promote.' }
+  }
+  // Read from the record ITSELF, not echoed back from the daemon: identity
+  // preservation means these exact ids resolve on the other side, and the
+  // acceptance tests hold the route to that.
+  const promotedDocumentIds = readWorkspaceDocuments(record).map((entry) => entry.documentId)
+
+  const res = await fetch(
+    `${daemonBaseUrl}/api/w/${encodeURIComponent(workspaceId)}/workspace-document/update`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: record.export({ mode: 'snapshot' }) as BodyInit,
+    },
+  )
+  if (!res.ok) {
+    return { kind: 'failed', reason: await failureReason(res) }
+  }
+
+  // The daemon's own post-merge list is what reports collisions — shadowed
+  // is its projection, not something this side can compute without knowing
+  // what the target already held. A failed read-back degrades to "no
+  // collisions reported", never to a failed promotion: the merge landed.
+  const shadowedPaths = await listDocuments(fetch, daemonBaseUrl, workspaceId)
+    .then((response) =>
+      response.documents.filter((entry) => entry.shadowed === true).map((entry) => entry.path),
+    )
+    .catch(() => [])
+
+  return { kind: 'ok', promotedDocumentIds, shadowedPaths, blobsPending: true }
+}


### PR DESCRIPTION
## Summary

- First production code of the daemon-promotion initiative: `apps/web/src/lib/promote-workspace.ts`, a **plain function, no component** — opens the browser keeper's workspace record from IndexedDB (`WorkspaceDocs.open`), POSTs its snapshot to the existing `workspace-document/update` route (the CRDT merge whose daemon side is pinned by mcp-server's `promote-workspace.test.ts`: identity, shadowed collisions, idempotent retry, unregistered-target 404, live-session fan-out), and reports a structured result: `promotedDocumentIds` read from the record itself, `shadowedPaths` from the daemon's own post-merge list (a failed read-back degrades to no-collisions-reported, never a failed promotion), and `blobsPending: true` until the blob-transfer increment lands.
- Failures are structured, never rejections (404 surfaces the daemon's title; a network drop a fixed message), and a re-run is safe either way — the same snapshot re-POSTed is an idempotent merge.
- **Foundation, wired by a named follow-up**: the promote UI (Settings > Connections confirmation flow, plan slice 6) is what reaches a user. Nothing on the entry path imports this module, so `entry-graph-loro-free.test.ts` holds unchanged.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added (`promote-workspace.browser.test.tsx`, 3 tests over **real IndexedDB**)
  - The happy path verifies the POSTed bytes by **importing them into a target record** — identity through the real bytes, not through the report — plus the shadowed-collision projection, the 404 shape, and the thrown-fetch shape.
- [x] `pnpm test` — web-browser file 3/3; `pnpm knip` clean; entry-graph guard green
- [x] Manual verification completed (the daemon side of these exact bytes is exercised end-to-end by the mcp-node acceptance tests merged in #1087/#1088; a full dogfood against a running daemon arrives with the UI slice that makes the flow reachable)
- [x] E2E coverage added or extended where applicable (route-level acceptance already on main; UI E2E arrives with the promote UI slice)

## Visual evidence

Visual evidence: none — a library function with no UI surface; nothing renders differently.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract (no user-visible behavior yet — docs ship with the UI slice per the honesty rule)
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema (HTTP payloads go through the existing Zod contracts; the function result is an internal type, not a process-boundary contract)

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added workspace promotion from the browser to a daemon workspace.
  - Reports successfully promoted documents, shadowed paths, and pending blobs.
  - Provides clear structured failure results for missing destinations and network errors.
  - Supports safe, repeatable workspace promotion without duplicate effects.

- **Tests**
  - Added browser coverage using real local storage and simulated server responses.
  - Validates successful promotion, document collisions, missing workspaces, and network failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->