### PR TITLE
feat: promotion slice 3 — referenced image bytes travel with the record

### DIFF
--- a/apps/web/src/lib/promote-workspace.browser.test.tsx
+++ b/apps/web/src/lib/promote-workspace.browser.test.tsx
@@ -11,15 +11,19 @@ import {
   createWorkspaceDocumentAtPath,
   readWorkspaceDocuments,
   resolveWorkspaceDocumentById,
+  writeSpatialCanvas,
 } from '@kamiazya/whiteboard-loro-adapter'
+import { newImageRef } from '@kamiazya/whiteboard-model'
 import { LoroDoc } from 'loro-crdt'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
+import { DocumentFileStore } from './document-file-store.js'
 import { FoldingBrowserIndex } from './folding-browser-index.js'
 import { ensureLocalWorkspace } from './local-document-summary.js'
 import { promoteWorkspace } from './promote-workspace.js'
+import { seedWorkspaceDocumentContent } from './workspace-content.js'
 
 claimIsolatedWhiteboardDb('promote-workspace')
 
@@ -38,12 +42,16 @@ function targetDaemonRecord(): LoroDoc {
 }
 
 /**
- * A daemon standing in as two fetch routes: the update POST imports the
- * posted bytes into `target` (the verification, not a mock of it), and the
- * documents list answers from the merged target with the collision's loser
- * marked shadowed — the same projection the real route serves.
+ * A daemon standing in as three fetch routes: the update POST imports the
+ * posted bytes into `target` (the verification, not a mock of it), the file
+ * PUT records what arrived, and the documents list answers from the merged
+ * target with the collision's loser marked shadowed — the same projection
+ * the real route serves.
  */
-function daemonStub(target: LoroDoc): typeof globalThis.fetch {
+function daemonStub(
+  target: LoroDoc,
+  putFiles?: Array<{ url: string; contentType: string; bytes: Uint8Array }>,
+): typeof globalThis.fetch {
   return (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === 'string' ? input : input.toString()
     if (url.endsWith('/workspace-document/update') && init?.method === 'POST') {
@@ -52,6 +60,15 @@ function daemonStub(target: LoroDoc): typeof globalThis.fetch {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       })
+    }
+    if (url.includes('/file/') && init?.method === 'PUT') {
+      const headers = init.headers as Record<string, string>
+      putFiles?.push({
+        url,
+        contentType: headers['Content-Type'] ?? '',
+        bytes: new Uint8Array(await new Response(init.body as BodyInit).arrayBuffer()),
+      })
+      return new Response(null, { status: 204 })
     }
     if (url.endsWith('/documents')) {
       const seen = new Set<string>()
@@ -78,7 +95,7 @@ function daemonStub(target: LoroDoc): typeof globalThis.fetch {
 describe('promoteWorkspace', () => {
   beforeEach(clearWhiteboardDb)
 
-  it('posts the record; ids resolve on the target and the collision reports shadowed', async () => {
+  it('posts the record; ids resolve on the target, the collision shadows, and referenced image bytes travel', async () => {
     const index = new FoldingBrowserIndex()
     await ensureLocalWorkspace(index)
     const roadmap = await index.createDocument({
@@ -91,10 +108,34 @@ describe('promoteWorkspace', () => {
       path: 'contested',
       kind: 'spatial',
     })
-    const target = targetDaemonRecord()
+    // The spatial document references a stored image — its bytes live in the
+    // browser's file store, OUTSIDE the record, so promotion must move them
+    // through the daemon's file route.
+    const imageBytes = new Uint8Array([137, 80, 78, 71, 1, 2, 3])
+    const FILE_ID = 'promoted-image-1'
+    await new DocumentFileStore().put(FILE_ID, {
+      mimeType: 'image/png',
+      blob: new Blob([imageBytes], { type: 'image/png' }),
+      created: Date.now(),
+    })
+    const content = new LoroDoc()
+    writeSpatialCanvas(content, {
+      nodes: [
+        { id: 'img', type: 'file', file: newImageRef(FILE_ID), x: 0, y: 0, width: 10, height: 10 },
+      ],
+      edges: [],
+    })
+    expect(
+      await seedWorkspaceDocumentContent(
+        contested.documentId,
+        new Uint8Array(content.export({ mode: 'snapshot' })),
+      ),
+    ).toBe(true)
 
+    const target = targetDaemonRecord()
+    const putFiles: Array<{ url: string; contentType: string; bytes: Uint8Array }> = []
     const result = await promoteWorkspace({
-      fetch: daemonStub(target),
+      fetch: daemonStub(target, putFiles),
       daemonBaseUrl: BASE,
       workspaceId: 'ws-a',
       workspaceDocs: new BrowserWorkspaceDocs(),
@@ -110,7 +151,54 @@ describe('promoteWorkspace', () => {
     expect(resolveWorkspaceDocumentById(target, contested.documentId)).not.toBeNull()
     expect(resolveWorkspaceDocumentById(target, DAEMON_OWN_ID)).not.toBeNull()
     expect(result.shadowedPaths).toEqual(['contested'])
-    expect(result.blobsPending).toBe(true)
+    // The image crossed: same bytes, right mime, addressed to the daemon's
+    // file route under the owning document's path.
+    expect(result.blobs).toEqual({ transferred: [FILE_ID], missing: [], failed: [] })
+    expect(putFiles).toHaveLength(1)
+    expect(putFiles[0]?.url).toContain(`/file/${FILE_ID}`)
+    expect(putFiles[0]?.contentType).toBe('image/png')
+    expect([...(putFiles[0]?.bytes ?? [])]).toEqual([...imageBytes])
+  })
+
+  it('a referenced image whose bytes are gone is reported missing, never a failed promotion', async () => {
+    const index = new FoldingBrowserIndex()
+    await ensureLocalWorkspace(index)
+    const sketch = await index.createDocument({
+      workspaceId: 'local',
+      path: 'sketch',
+      kind: 'spatial',
+    })
+    const content = new LoroDoc()
+    writeSpatialCanvas(content, {
+      nodes: [
+        {
+          id: 'img',
+          type: 'file',
+          file: newImageRef('gone-image'),
+          x: 0,
+          y: 0,
+          width: 5,
+          height: 5,
+        },
+      ],
+      edges: [],
+    })
+    expect(
+      await seedWorkspaceDocumentContent(
+        sketch.documentId,
+        new Uint8Array(content.export({ mode: 'snapshot' })),
+      ),
+    ).toBe(true)
+
+    const result = await promoteWorkspace({
+      fetch: daemonStub(new LoroDoc()),
+      daemonBaseUrl: BASE,
+      workspaceId: 'ws-a',
+      workspaceDocs: new BrowserWorkspaceDocs(),
+    })
+    expect(result.kind).toBe('ok')
+    if (result.kind !== 'ok') return
+    expect(result.blobs).toEqual({ transferred: [], missing: ['gone-image'], failed: [] })
   })
 
   it('a 404 target is a structured failure naming the missing daemon workspace', async () => {

--- a/apps/web/src/lib/promote-workspace.ts
+++ b/apps/web/src/lib/promote-workspace.ts
@@ -18,10 +18,16 @@
  * surface must run after the startup fold (any FoldingBrowserIndex read
  * performs it) — the same ordering every other record consumer relies on.
  */
-import { readWorkspaceDocuments } from '@kamiazya/whiteboard-loro-adapter'
-import { apiErrorReason } from '@kamiazya/whiteboard-mcp/api-contracts'
+import {
+  documentContainers,
+  readSpatialCanvas,
+  readWorkspaceDocuments,
+} from '@kamiazya/whiteboard-loro-adapter'
+import { apiErrorReason, documentFileApiUrl } from '@kamiazya/whiteboard-mcp/api-contracts'
+import { imageRefId, isImageRef } from '@kamiazya/whiteboard-model'
 import type { WorkspaceDocs } from '@kamiazya/whiteboard-workspace-index'
 import { listDocuments } from './daemon-api-client.js'
+import { DocumentFileStore } from './document-file-store.js'
 import { BROWSER_WORKSPACE_ID } from './local-document-summary.js'
 
 export interface PromoteWorkspaceOptions {
@@ -40,8 +46,17 @@ export type PromoteWorkspaceResult =
       promotedDocumentIds: string[]
       /** Paths the merge left contested; surfaced, never auto-resolved. */
       shadowedPaths: string[]
-      /** File/image bytes live outside the record; their transfer is its own increment. */
-      blobsPending: true
+      /**
+       * Image bytes live OUTSIDE the record (the content-addressed file
+       * store), so each referenced image travels separately through the
+       * daemon's file route. Per-file outcomes, because one unreadable image
+       * must not fail — or silently hollow out — the whole promotion:
+       * `missing` are references whose bytes are already gone in the browser
+       * (the promoted document was equally broken before), `failed` are
+       * uploads the daemon refused or the network dropped — safe to re-run,
+       * the whole promotion is an idempotent merge.
+       */
+      blobs: { transferred: string[]; missing: string[]; failed: string[] }
     }
   | { kind: 'failed'; reason: string }
 
@@ -69,10 +84,36 @@ export async function promoteWorkspace(
   }
 }
 
+/**
+ * The image references the record's spatial documents carry, each mapped to
+ * its owning document's path (the address the daemon's file route wants).
+ * The walk mirrors the daemon-side GC's live-state pass: a 'file' node whose
+ * value carries the asset prefix is a reference; markdown documents embed
+ * images only through those spatial nodes.
+ */
+function collectImageRefs(
+  record: Parameters<typeof readWorkspaceDocuments>[0],
+  entries: ReturnType<typeof readWorkspaceDocuments>,
+): Map<string, string> {
+  const refs = new Map<string, string>()
+  for (const entry of entries) {
+    if (entry.kind !== 'spatial') continue
+    for (const node of readSpatialCanvas(documentContainers(record, entry.documentId)).nodes) {
+      if (node.type !== 'file' || !isImageRef(node.file)) continue
+      const fileId = imageRefId(node.file)
+      if (!refs.has(fileId)) refs.set(fileId, entry.path)
+    }
+  }
+  return refs
+}
+
 async function promoteWorkspaceUnsafe(
   options: PromoteWorkspaceOptions,
 ): Promise<PromoteWorkspaceResult> {
   const { fetch, daemonBaseUrl, workspaceId, workspaceDocs } = options
+  // The keeper's own store, like BrowserWorkspaceDocs above: both address
+  // the same claimed database, so tests seed through the production path.
+  const fileStore = new DocumentFileStore()
 
   const record = await workspaceDocs.open(BROWSER_WORKSPACE_ID)
   if (record === null) {
@@ -81,7 +122,8 @@ async function promoteWorkspaceUnsafe(
   // Read from the record ITSELF, not echoed back from the daemon: identity
   // preservation means these exact ids resolve on the other side, and the
   // acceptance tests hold the route to that.
-  const promotedDocumentIds = readWorkspaceDocuments(record).map((entry) => entry.documentId)
+  const entries = readWorkspaceDocuments(record)
+  const promotedDocumentIds = entries.map((entry) => entry.documentId)
 
   const res = await fetch(
     `${daemonBaseUrl}/api/w/${encodeURIComponent(workspaceId)}/workspace-document/update`,
@@ -105,5 +147,25 @@ async function promoteWorkspaceUnsafe(
     )
     .catch(() => [])
 
-  return { kind: 'ok', promotedDocumentIds, shadowedPaths, blobsPending: true }
+  // The record is on the daemon now, so its documents already resolve there;
+  // the images travel last, and per-file — a single unreadable or refused
+  // upload lands in the report instead of failing the merge that already
+  // happened.
+  const blobs = { transferred: [] as string[], missing: [] as string[], failed: [] as string[] }
+  for (const [fileId, path] of collectImageRefs(record, entries)) {
+    const blob = await fileStore.get(fileId)
+    if (blob === null) {
+      blobs.missing.push(fileId)
+      continue
+    }
+    const res = await fetch(`${daemonBaseUrl}${documentFileApiUrl(workspaceId, path, fileId)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': blob.type || 'image/png' },
+      body: blob,
+    }).catch(() => null)
+    if (res?.ok) blobs.transferred.push(fileId)
+    else blobs.failed.push(fileId)
+  }
+
+  return { kind: 'ok', promotedDocumentIds, shadowedPaths, blobs }
 }


### PR DESCRIPTION
## Summary

- Completes the transfer half of the promotion decision "blob transfer ships in the same increment that first claims promotion": `promoteWorkspace` now walks the record's spatial documents for asset references — the same live-state walk the daemon-side file GC keeps (`file` nodes carrying the `asset:` prefix) — reads each image's bytes from the browser's content-addressed file store, and PUTs them to the daemon's **existing** per-document file route under the owning document's path. No new route.
- Per-file outcomes replace the `blobsPending` placeholder: `blobs: { transferred, missing, failed }`. `missing` are references whose bytes were already gone in the browser (the promoted document was equally broken before); `failed` are uploads the daemon refused (e.g. 415) or the network dropped. One bad image lands in the report instead of failing — or silently hollowing out — the merge that already happened, and the whole promotion stays safe to re-run: the record re-POST is an idempotent CRDT merge and the file PUT overwrites with the same content-addressed bytes.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added (`promote-workspace.browser.test.tsx` now 4 tests over real IndexedDB)
  - The happy path seeds a real image through `DocumentFileStore`, references it from a spatial document via `newImageRef`, and asserts the **exact bytes and mime** arrive at the file route addressed under the owning path; a dangling reference reports `missing` without failing the promotion.
- [x] `pnpm test` — web-browser file 4/4; biome/typecheck/knip clean; entry-graph loro-free guard green
- [x] Manual verification completed (the daemon file route is production code exercised daily by MCP `load_image`; this PR only adds a client of it — full dogfood against a running daemon arrives with the promote UI slice)
- [x] E2E coverage added or extended where applicable (route-level acceptance for the record half is on main; UI E2E arrives with the promote UI slice)

## Visual evidence

Visual evidence: none — library-level change with no UI surface; nothing renders differently.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract (no user-visible behavior yet — docs ship with the UI slice per the honesty rule)
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_