### PR TITLE
feat: promotion slice 5a — split the connection chip state into keeper and session-health axes

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -728,7 +728,10 @@ describe('App daemon provider state', () => {
     // and the chip's popover carries the way out. Driving it from here is
     // what proves App still wires the branch switch behind it.
     act(() => {
-      setShellConnection({ state: 'sync-off', daemonBaseUrl: 'http://127.0.0.1:3099' })
+      setShellConnection({
+        state: { keeper: 'daemon', session: 'sync-off' },
+        daemonBaseUrl: 'http://127.0.0.1:3099',
+      })
     })
     fireEvent.click(await screen.findByTestId('connection-chip'))
     fireEvent.click(await screen.findByRole('button', { name: /work in this browser instead/i }))
@@ -1015,7 +1018,10 @@ describe('App shell (single instance above the routed pages)', () => {
       await waitFor(() => expect(screen.queryByTestId('settings-nudge')).toBeNull())
 
       act(() => {
-        setShellConnection({ state: 'sync-off', daemonBaseUrl: 'http://127.0.0.1:3099' })
+        setShellConnection({
+          state: { keeper: 'daemon', session: 'sync-off' },
+          daemonBaseUrl: 'http://127.0.0.1:3099',
+        })
       })
       expect(screen.getByTestId('settings-nudge')).toBeTruthy()
       // The chip is the shell's now, so the state a page reports reaches the

--- a/apps/web/src/components/AppShell.test.tsx
+++ b/apps/web/src/components/AppShell.test.tsx
@@ -74,7 +74,10 @@ describe('AppShell', () => {
     })
     // Sync off IS the auth error: re-pairing is the only way out of it, so it
     // counts as disconnected for the attention dot. Transient reconnects do not.
-    setShellConnection({ state: 'sync-off', daemonBaseUrl: 'http://127.0.0.1:3099' })
+    setShellConnection({
+      state: { keeper: 'daemon', session: 'sync-off' },
+      daemonBaseUrl: 'http://127.0.0.1:3099',
+    })
     renderShell(true)
     expect(await screen.findByTestId('settings-nudge')).toBeTruthy()
   })
@@ -107,22 +110,30 @@ describe('AppShell — the connection chip', () => {
   })
 
   it.each([
-    ['browser', /browser/i],
-    ['synced', /synced/i],
-    ['reconnecting', /reconnecting/i],
-    ['sync-off', /sync off/i],
-  ] as const)('renders the %s state the page published', async (state, label) => {
+    ['browser-kept', { keeper: 'browser' }, /browser/i],
+    ['synced', { keeper: 'daemon', session: 'synced' }, /synced/i],
+    ['reconnecting', { keeper: 'daemon', session: 'reconnecting' }, /reconnecting/i],
+    ['sync-off', { keeper: 'daemon', session: 'sync-off' }, /sync off/i],
+  ] as const)('renders the %s state the page published', async (_name, state, label) => {
     setShellConnection({ state, daemonBaseUrl: 'http://127.0.0.1:3099' })
-    renderShell(state !== 'browser')
+    renderShell(state.keeper === 'daemon')
     expect((await screen.findByTestId('connection-chip')).textContent).toMatch(label)
   })
 
   it('follows the page as its session changes, without a remount', async () => {
-    setShellConnection({ state: 'synced', daemonBaseUrl: 'http://127.0.0.1:3099' })
+    setShellConnection({
+      state: { keeper: 'daemon', session: 'synced' },
+      daemonBaseUrl: 'http://127.0.0.1:3099',
+    })
     renderShell(true)
     expect((await screen.findByTestId('connection-chip')).textContent).toMatch(/synced/i)
 
-    act(() => setShellConnection({ state: 'reconnecting', daemonBaseUrl: 'http://127.0.0.1:3099' }))
+    act(() =>
+      setShellConnection({
+        state: { keeper: 'daemon', session: 'reconnecting' },
+        daemonBaseUrl: 'http://127.0.0.1:3099',
+      }),
+    )
     expect(screen.getByTestId('connection-chip').textContent).toMatch(/reconnecting/i)
 
     // Leaving the document takes the claim with it: nothing on an index page
@@ -132,7 +143,7 @@ describe('AppShell — the connection chip', () => {
   })
 
   it('carries the capability CTA inside the Local popover, not in page chrome', async () => {
-    setShellConnection({ state: 'browser' })
+    setShellConnection({ state: { keeper: 'browser' } })
     renderShell(false)
     expect(screen.queryByText(CTA)).toBeNull()
 
@@ -145,7 +156,10 @@ describe('AppShell — the connection chip', () => {
 
   it('offers the escape to the browser from the sync-off popover', async () => {
     const onWorkInBrowser = vi.fn()
-    setShellConnection({ state: 'sync-off', daemonBaseUrl: 'http://127.0.0.1:3099' })
+    setShellConnection({
+      state: { keeper: 'daemon', session: 'sync-off' },
+      daemonBaseUrl: 'http://127.0.0.1:3099',
+    })
     renderShell(true, '/w/ws/document/a.canvas', onWorkInBrowser)
 
     fireEvent.click(await screen.findByTestId('connection-chip'))
@@ -156,7 +170,10 @@ describe('AppShell — the connection chip', () => {
   // The management action moved to Settings (see SettingsPage.test.tsx). What
   // the shell keeps is the report and the pointer to where the action lives.
   it('points at Settings rather than carrying the management action itself', async () => {
-    setShellConnection({ state: 'synced', daemonBaseUrl: 'http://127.0.0.1:3099' })
+    setShellConnection({
+      state: { keeper: 'daemon', session: 'synced' },
+      daemonBaseUrl: 'http://127.0.0.1:3099',
+    })
     renderShell(true)
     fireEvent.click(await screen.findByTestId('connection-chip'))
     await waitFor(() => expect(screen.getByTestId('connection-popover')).toBeTruthy())

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -8,7 +8,7 @@ import { beginPairingGrant } from '@/lib/pairing-grant'
 import { getShellConnection, subscribeShellStatus } from '@/lib/shell-status-store'
 import { createUserSettingsStore } from '@/lib/user-settings-store'
 import HomeMark from '../brand/home-mark.svg?react'
-import { ConnectionStatus } from './connection/ConnectionStatus.js'
+import { ConnectionStatus, isSyncOff } from './connection/ConnectionStatus.js'
 
 // React.lazy for the same reason the browser page had it: the banner
 // pulls in daemon-probe.ts and its Zod parsing, and only the Local popover
@@ -49,7 +49,7 @@ export function AppShell({ daemon, onWorkInBrowser }: AppShellProps) {
   // Sync off means the daemon rejected the session and re-pairing is the only
   // way out, so it counts as disconnected for the attention dot. A transient
   // reconnect does not — it recovers on its own.
-  const nudge = useSettingsNudge(daemon && connection?.state !== 'sync-off')
+  const nudge = useSettingsNudge(daemon && !(connection !== null && isSyncOff(connection.state)))
   const daemonBaseUrl = connection?.daemonBaseUrl
 
   return (
@@ -108,7 +108,7 @@ export function AppShell({ daemon, onWorkInBrowser }: AppShellProps) {
           }
           onWorkInBrowser={onWorkInBrowser}
         >
-          {connection.state === 'browser' && (
+          {connection.state.keeper === 'browser' && (
             <>
               <p className="text-muted-foreground">
                 Connect a daemon (MCP) for version history, workspaces, variations and merging.

--- a/apps/web/src/components/connection/ConnectionStatus.test.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.test.tsx
@@ -21,9 +21,15 @@ describe('ConnectionStatus chip', () => {
   // something you go looking for with an intent; sync dropping is not, and
   // sending someone to Settings mid-failure adds a step at the worst moment.
   it('carries no management action while sync is on — that lives in Settings', () => {
-    render(<ConnectionStatus state="synced" daemonBaseUrl="http://127.0.0.1:3099" />, {
-      container: document.body,
-    })
+    render(
+      <ConnectionStatus
+        state={{ keeper: 'daemon', session: 'synced' }}
+        daemonBaseUrl="http://127.0.0.1:3099"
+      />,
+      {
+        container: document.body,
+      },
+    )
     fireEvent.click(screen.getByTestId('connection-chip'))
 
     const popover = screen.getByTestId('connection-popover')
@@ -37,8 +43,12 @@ describe('ConnectionStatus chip', () => {
 
   it('explains the reconnecting state instead of opening an empty popover', () => {
     // The chip can reach this state, so the popover must have something to
-    // say; a state with no branch renders an empty box on click.
-    render(<ConnectionStatus state="reconnecting" />, { container: document.body })
+    // say; a state with no branch renders an empty box on click. Reconnecting
+    // is SESSION health on a daemon-kept document — the keeper axis cannot
+    // say it, which is the point of the two-axis state.
+    render(<ConnectionStatus state={{ keeper: 'daemon', session: 'reconnecting' }} />, {
+      container: document.body,
+    })
     fireEvent.click(screen.getByTestId('connection-chip'))
 
     const popover = screen.getByTestId('connection-popover')
@@ -50,7 +60,12 @@ describe('ConnectionStatus chip', () => {
   })
 
   it('synced state shows a quiet chip and explains where data lives in the popover', async () => {
-    render(<ConnectionStatus state="synced" daemonBaseUrl="http://127.0.0.1:3099" />)
+    render(
+      <ConnectionStatus
+        state={{ keeper: 'daemon', session: 'synced' }}
+        daemonBaseUrl="http://127.0.0.1:3099"
+      />,
+    )
 
     const chip = screen.getByRole('button', { name: /synced/i })
     expect(chip).toBeTruthy()
@@ -66,7 +81,7 @@ describe('ConnectionStatus chip', () => {
 
   it('browser state explains browser-only storage and hosts extra content (daemon detection)', async () => {
     render(
-      <ConnectionStatus state="browser">
+      <ConnectionStatus state={{ keeper: 'browser' }}>
         <button type="button">Use here</button>
       </ConnectionStatus>,
     )
@@ -81,7 +96,11 @@ describe('ConnectionStatus chip', () => {
     const onRepair = vi.fn()
     const onWorkInBrowser = vi.fn()
     render(
-      <ConnectionStatus state="sync-off" onRepair={onRepair} onWorkInBrowser={onWorkInBrowser} />,
+      <ConnectionStatus
+        state={{ keeper: 'daemon', session: 'sync-off' }}
+        onRepair={onRepair}
+        onWorkInBrowser={onWorkInBrowser}
+      />,
     )
 
     const chip = screen.getByRole('button', { name: /sync off/i })
@@ -97,7 +116,9 @@ describe('ConnectionStatus chip', () => {
   })
 
   it('sync-off announces itself to assistive tech without a visual banner', () => {
-    render(<ConnectionStatus state="sync-off" onRepair={vi.fn()} />)
+    render(
+      <ConnectionStatus state={{ keeper: 'daemon', session: 'sync-off' }} onRepair={vi.fn()} />,
+    )
     // A polite live region replaces the old role="alert" banner.
     expect(screen.getByRole('status', { name: /live sync off/i })).toBeTruthy()
   })

--- a/apps/web/src/components/connection/ConnectionStatus.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.tsx
@@ -3,21 +3,22 @@
  * chip signals the state; every sentence-shaped explanation and recovery
  * action lives in its popover — no standing banners.
  *
- * States:
- * - `synced`   — daemon-backed page with live sync running.
- * - `browser`  — the workspace is kept in this browser and nowhere else.
- *                `children` hosts page-supplied extras (daemon detection,
- *                capability hint) inside the popover.
+ * Keeper `browser` — the workspace is kept in this browser and nowhere else.
+ * `children` hosts page-supplied extras (daemon detection, capability hint)
+ * inside the popover.
+ *
+ * Keeper `daemon` reports the live session's health on top:
+ * - `synced`   — live sync running.
  * - `reconnecting` — live sync is not running: the transport has not come up
  *                yet, dropped, or failed. Edits made meanwhile are not lost:
  *                the session re-sends the whole document when the transport
  *                returns, which is what makes that claim true — a backend
  *                whose socket is closed drops the delta it was handed.
- * - `sync-off` — daemon-backed page whose session was rejected. The chip
- *                turns attention-colored and the popover carries the two
- *                ways forward (re-pair / work in the browser). A polite
- *                sr-only live region announces the transition so dropping
- *                the old role="alert" banner loses no assistive-tech signal.
+ * - `sync-off` — the session was rejected. The chip turns attention-colored
+ *                and the popover carries the two ways forward (re-pair / work
+ *                in the browser). A polite sr-only live region announces the
+ *                transition so dropping the old role="alert" banner loses no
+ *                assistive-tech signal.
  */
 import type { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
@@ -26,14 +27,29 @@ import { cn } from '@/lib/utils'
 import { StateDot, type StateDotTone } from '../StateDot.js'
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover.js'
 
+/** Health of the live document session a daemon-kept page runs. */
+export type SessionHealth = 'synced' | 'reconnecting' | 'sync-off'
+
 /**
- * Two different questions share this type, and only one of them survives
- * navigation: `browser` names WHO KEEPS the workspace, while the other three
- * report whether a live session is healthy. Splitting them is its own slice;
- * this one only stops the keeper from being called "local", which a daemon
- * running on the same machine is too.
+ * Two axes, not one enum: WHO KEEPS the workspace, and — daemon-kept only —
+ * whether the live session is healthy. They used to share one four-value
+ * union, which made `browser` and `reconnecting` alternatives of each other
+ * and so could not say "daemon-kept, but the daemon is unreachable while the
+ * browser holds the live replica" — the resting state promotion (a browser
+ * workspace merged into a daemon) leaves behind. A browser-kept workspace has
+ * no daemon session, so the browser arm carries no health field at all.
  */
-export type ConnectionState = 'synced' | 'browser' | 'reconnecting' | 'sync-off'
+export type ConnectionState =
+  | { readonly keeper: 'browser' }
+  | { readonly keeper: 'daemon'; readonly session: SessionHealth }
+
+/**
+ * The one state whose only exit is re-pairing — what the shell's attention
+ * dot keys on. A transient reconnect is not it: that recovers on its own.
+ */
+export function isSyncOff(state: ConnectionState): boolean {
+  return state.keeper === 'daemon' && state.session === 'sync-off'
+}
 
 export interface ConnectionStatusProps {
   readonly state: ConnectionState
@@ -47,20 +63,14 @@ export interface ConnectionStatusProps {
   readonly children?: ReactNode
 }
 
-const CHIP_LABEL: Record<ConnectionState, string> = {
-  synced: 'Synced',
-  browser: 'Browser',
-  reconnecting: 'Reconnecting',
-  'sync-off': 'Sync off',
+// Meaning, not paint — StateDot owns the palette (DESIGN.md's closed set).
+const SESSION_CHIP: Record<SessionHealth, { label: string; tone: StateDotTone }> = {
+  synced: { label: 'Synced', tone: 'safe' },
+  reconnecting: { label: 'Reconnecting', tone: 'attention' },
+  'sync-off': { label: 'Sync off', tone: 'attention' },
 }
 
-// Meaning, not paint — StateDot owns the palette (DESIGN.md's closed set).
-const DOT_TONE: Record<ConnectionState, StateDotTone> = {
-  synced: 'safe',
-  browser: 'neutral',
-  reconnecting: 'attention',
-  'sync-off': 'attention',
-}
+const BROWSER_CHIP = { label: 'Browser', tone: 'neutral' } as const
 
 export function ConnectionStatus({
   state,
@@ -69,9 +79,11 @@ export function ConnectionStatus({
   onWorkInBrowser,
   children,
 }: ConnectionStatusProps) {
+  const chip = state.keeper === 'browser' ? BROWSER_CHIP : SESSION_CHIP[state.session]
+  const syncOff = isSyncOff(state)
   // Empty while sync is on: the region has to exist BEFORE the message, but
   // an empty one must not claim a name either.
-  const syncOffAnnouncement = state === 'sync-off' ? 'Live sync off' : ''
+  const syncOffAnnouncement = syncOff ? 'Live sync off' : ''
 
   return (
     <Popover>
@@ -88,22 +100,22 @@ export function ConnectionStatus({
           className={cn(
             'flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors hover:bg-accent',
             'duration-(--motion-duration-normal) ease-(--motion-ease-out)',
-            state === 'sync-off' && 'border-amber-500/40 bg-amber-500/10 text-amber-700',
+            syncOff && 'border-amber-500/40 bg-amber-500/10 text-amber-700',
           )}
         >
           <StateDot
-            tone={DOT_TONE[state]}
+            tone={chip.tone}
             // One-shot attention echo behind the dot: mounts exactly when the
             // chip enters sync-off, pulses twice, then rests. Finite by
             // design — a standing ping would be noise, not guidance.
-            pulse={state === 'sync-off'}
+            pulse={syncOff}
             pulseTestId="connection-chip-pulse"
           />
-          {CHIP_LABEL[state]}
+          {chip.label}
         </button>
       </PopoverTrigger>
       <PopoverContent data-testid="connection-popover">
-        {state === 'synced' && (
+        {state.keeper === 'daemon' && state.session === 'synced' && (
           <div className="flex flex-col gap-1 text-sm">
             <p className="font-medium">Live sync is on</p>
             <p className="text-muted-foreground">
@@ -129,7 +141,7 @@ export function ConnectionStatus({
             </Link>
           </div>
         )}
-        {state === 'reconnecting' && (
+        {state.keeper === 'daemon' && state.session === 'reconnecting' && (
           <div className="flex flex-col gap-1 text-sm">
             <p className="font-medium">Live sync is not running</p>
             <p className="text-muted-foreground">
@@ -138,7 +150,7 @@ export function ConnectionStatus({
             </p>
           </div>
         )}
-        {state === 'browser' && (
+        {state.keeper === 'browser' && (
           <div className="flex flex-col gap-2 text-sm">
             <p className="font-medium">Kept in this browser</p>
             <p className="text-muted-foreground">
@@ -148,7 +160,7 @@ export function ConnectionStatus({
             {children}
           </div>
         )}
-        {state === 'sync-off' && (
+        {syncOff && (
           <div className="flex flex-col gap-2 text-sm">
             <p className="font-medium">Live sync is off</p>
             <p className="text-muted-foreground">

--- a/apps/web/src/lib/shell-status-store.test.ts
+++ b/apps/web/src/lib/shell-status-store.test.ts
@@ -18,23 +18,49 @@ describe('shell-status-store', () => {
   it('publishing a connection notifies subscribers', () => {
     const listener = vi.fn()
     subscribeShellStatus(listener)
-    setShellConnection({ state: 'synced', daemonBaseUrl: 'http://127.0.0.1:3099' })
-    expect(getShellConnection()?.state).toBe('synced')
+    setShellConnection({
+      state: { keeper: 'daemon', session: 'synced' },
+      daemonBaseUrl: 'http://127.0.0.1:3099',
+    })
+    expect(getShellConnection()?.state).toEqual({ keeper: 'daemon', session: 'synced' })
     expect(listener).toHaveBeenCalledTimes(1)
   })
 
   // useSyncExternalStore reads a fresh object as a change, so an identity
-  // comparison here would re-render the shell on every page render.
+  // comparison here would re-render the shell on every page render. The state
+  // is an object now, so the comparison has to reach INTO it — a fresh but
+  // equal literal is exactly what a render-scoped effect republishes.
   it('re-publishing the same fields does not notify', () => {
-    setShellConnection({ state: 'synced', daemonBaseUrl: 'http://127.0.0.1:3099' })
+    setShellConnection({
+      state: { keeper: 'daemon', session: 'synced' },
+      daemonBaseUrl: 'http://127.0.0.1:3099',
+    })
     const listener = vi.fn()
     subscribeShellStatus(listener)
-    setShellConnection({ state: 'synced', daemonBaseUrl: 'http://127.0.0.1:3099' })
+    setShellConnection({
+      state: { keeper: 'daemon', session: 'synced' },
+      daemonBaseUrl: 'http://127.0.0.1:3099',
+    })
     expect(listener).not.toHaveBeenCalled()
   })
 
+  it('a session-health change under the same keeper notifies', () => {
+    setShellConnection({
+      state: { keeper: 'daemon', session: 'synced' },
+      daemonBaseUrl: 'http://127.0.0.1:3099',
+    })
+    const listener = vi.fn()
+    subscribeShellStatus(listener)
+    setShellConnection({
+      state: { keeper: 'daemon', session: 'reconnecting' },
+      daemonBaseUrl: 'http://127.0.0.1:3099',
+    })
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(getShellConnection()?.state).toEqual({ keeper: 'daemon', session: 'reconnecting' })
+  })
+
   it('clearing a published connection notifies', () => {
-    setShellConnection({ state: 'browser' })
+    setShellConnection({ state: { keeper: 'browser' } })
     const listener = vi.fn()
     subscribeShellStatus(listener)
     setShellConnection(null)

--- a/apps/web/src/lib/shell-status-store.ts
+++ b/apps/web/src/lib/shell-status-store.ts
@@ -31,11 +31,23 @@ export function getShellConnection(): ShellConnection | null {
   return connection
 }
 
+// Compared field by field, never by identity: useSyncExternalStore reads a
+// fresh object as a change, so publishing from a render-scoped effect would
+// otherwise re-render the shell on every page render — and the state is an
+// object now, so the comparison has to reach into both of its axes.
+function sameConnection(a: ShellConnection | null, b: ShellConnection | null): boolean {
+  if (a === null || b === null) return a === b
+  if (a.daemonBaseUrl !== b.daemonBaseUrl) return false
+  if (a.state.keeper !== b.state.keeper) return false
+  return (
+    a.state.keeper === 'browser' ||
+    b.state.keeper === 'browser' ||
+    a.state.session === b.state.session
+  )
+}
+
 export function setShellConnection(next: ShellConnection | null): void {
-  // Compared field by field, never by identity: useSyncExternalStore reads a
-  // fresh object as a change, so publishing from a render-scoped effect would
-  // otherwise re-render the shell on every page render.
-  if (next?.state === connection?.state && next?.daemonBaseUrl === connection?.daemonBaseUrl) return
+  if (sameConnection(next, connection)) return
   connection = next
   for (const listener of listeners) listener()
 }

--- a/apps/web/src/motion-feedback.browser.test.tsx
+++ b/apps/web/src/motion-feedback.browser.test.tsx
@@ -34,7 +34,7 @@ describe('feedback micro-motion', () => {
   })
 
   it('connection chip transitions colors on the token duration', () => {
-    render(<ConnectionStatus state="synced" />)
+    render(<ConnectionStatus state={{ keeper: 'daemon', session: 'synced' }} />)
     const chip = document.querySelector('[data-testid="connection-chip"]') as HTMLElement
     const cs = getComputedStyle(chip)
     expect(cs.transitionProperty).toContain('color')
@@ -42,7 +42,9 @@ describe('feedback micro-motion', () => {
   })
 
   it('sync-off shows a finite attention pulse on the chip dot', () => {
-    render(<ConnectionStatus state="sync-off" onRepair={vi.fn()} />)
+    render(
+      <ConnectionStatus state={{ keeper: 'daemon', session: 'sync-off' }} onRepair={vi.fn()} />,
+    )
     const echo = document.querySelector('[data-testid="connection-chip-pulse"]') as HTMLElement
     expect(echo).not.toBeNull()
     const cs = getComputedStyle(echo)
@@ -53,7 +55,7 @@ describe('feedback micro-motion', () => {
   })
 
   it('synced chip has no attention pulse', () => {
-    render(<ConnectionStatus state="synced" />)
+    render(<ConnectionStatus state={{ keeper: 'daemon', session: 'synced' }} />)
     expect(document.querySelector('[data-testid="connection-chip-pulse"]')).toBeNull()
   })
 })

--- a/apps/web/src/pages/BrowserDocumentPage.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.test.tsx
@@ -829,7 +829,7 @@ describe('BrowserDocumentPage', () => {
       // App-mounted shell draws it (and hosts the CTA in its popover) from
       // the state this page publishes.
       expect(screen.queryByTestId('connection-chip')).toBeNull()
-      expect(getShellConnection()).toEqual({ state: 'browser' })
+      expect(getShellConnection()).toEqual({ state: { keeper: 'browser' } })
 
       cleanup()
       expect(getShellConnection()).toBeNull()

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -154,7 +154,7 @@ export function BrowserDocumentPage({
   // the data lives in this browser and nowhere else. Cleared on unmount so an
   // index page makes no claim of its own.
   useEffect(() => {
-    setShellConnection({ state: 'browser' })
+    setShellConnection({ state: { keeper: 'browser' } })
     return () => setShellConnection(null)
   }, [])
 

--- a/apps/web/src/pages/DaemonDocumentPage.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.test.tsx
@@ -397,19 +397,22 @@ describe('DaemonDocumentPage', () => {
       )
     })
     await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
-    expect(getShellConnection()).toEqual({ state: 'synced', daemonBaseUrl: DAEMON_BASE_URL })
+    expect(getShellConnection()).toEqual({
+      state: { keeper: 'daemon', session: 'synced' },
+      daemonBaseUrl: DAEMON_BASE_URL,
+    })
 
     const backend = createdBackends[0]!
     await act(async () => {
       backend.handlers?.onDisconnected?.()
     })
-    expect(getShellConnection()?.state).toBe('reconnecting')
+    expect(getShellConnection()?.state).toEqual({ keeper: 'daemon', session: 'reconnecting' })
 
     // …and back, so a recovered stream clears it rather than latching.
     await act(async () => {
       backend.handlers?.onConnected()
     })
-    expect(getShellConnection()?.state).toBe('synced')
+    expect(getShellConnection()?.state).toEqual({ keeper: 'daemon', session: 'synced' })
   })
 
   it('reports "sync-off" on WS auth failure (close 1008 -> onAuthError) without replacing the page', async () => {
@@ -424,14 +427,14 @@ describe('DaemonDocumentPage', () => {
     // docks in Select mode, so tests exercising it switch first.
     fireEvent.click(await screen.findByTestId('select-tool-button'))
     // Healthy session.
-    expect(getShellConnection()?.state).toBe('synced')
+    expect(getShellConnection()?.state).toEqual({ keeper: 'daemon', session: 'synced' })
 
     const backend = createdBackends[0]!
     await act(async () => {
       backend.handlers?.onAuthError?.()
     })
 
-    expect(getShellConnection()?.state).toBe('sync-off')
+    expect(getShellConnection()?.state).toEqual({ keeper: 'daemon', session: 'sync-off' })
     // D1: no standing role=alert banner anywhere on the page — the shell's
     // chip carries the state and its own live region announces it.
     expect(screen.queryByRole('alert')).toBeNull()
@@ -447,14 +450,14 @@ describe('DaemonDocumentPage', () => {
       )
     })
     await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
-    expect(getShellConnection()?.state).toBe('synced')
+    expect(getShellConnection()?.state).toEqual({ keeper: 'daemon', session: 'synced' })
 
     await act(async () => {
       createdBackends[0]?.handlers?.onAuthError?.()
     })
     // The App-mounted shell reads this to draw the chip and to light the
     // gear's attention dot.
-    expect(getShellConnection()?.state).toBe('sync-off')
+    expect(getShellConnection()?.state).toEqual({ keeper: 'daemon', session: 'sync-off' })
 
     // Cleared on unmount: an index page holds no session, and a latched chip
     // would keep claiming one.
@@ -477,14 +480,14 @@ describe('DaemonDocumentPage', () => {
     await act(async () => {
       createdBackends[0]?.handlers?.onAuthError?.()
     })
-    expect(getShellConnection()?.state).toBe('sync-off')
+    expect(getShellConnection()?.state).toEqual({ keeper: 'daemon', session: 'sync-off' })
 
     await act(async () => {
       await switchDocumentViaConnections('Second board')
     })
 
     // The stale sync-off state must not outlive the backend that produced it.
-    expect(getShellConnection()?.state).toBe('synced')
+    expect(getShellConnection()?.state).toEqual({ keeper: 'daemon', session: 'synced' })
   })
 
   it('shows a structural skeleton while workspace/canvas resolution is pending', async () => {

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -503,7 +503,10 @@ export function DaemonDocumentPage({
   // and a latched chip would keep claiming one.
   useEffect(() => {
     setShellConnection({
-      state: authError ? 'sync-off' : syncStatus === 'connected' ? 'synced' : 'reconnecting',
+      state: {
+        keeper: 'daemon',
+        session: authError ? 'sync-off' : syncStatus === 'connected' ? 'synced' : 'reconnecting',
+      },
       daemonBaseUrl,
     })
     return () => setShellConnection(null)


### PR DESCRIPTION
## Summary

- Splits `ConnectionState` from one four-value union (`'synced' | 'browser' | 'reconnecting' | 'sync-off'`) into a discriminated union over the keeper axis: `{ keeper: 'browser' }` (no session field at all — a browser-kept workspace runs no daemon session) vs `{ keeper: 'daemon'; session: 'synced' | 'reconnecting' | 'sync-off' }`. The old shape made WHO KEEPS the workspace and whether the live session is healthy alternatives of each other, so "daemon-kept but currently unreachable while the browser holds the live replica" — the resting state workspace promotion leaves behind — was literally inexpressible. The file's own comment had called this split out as its own slice since the keeper-vocabulary increment.
- Rendering is unchanged: the same four chips (labels, dot tones, popovers, sync-off pulse and sr-only live region), now derived from the axis pair. New `isSyncOff()` names the one state whose only exit is re-pairing, which the shell's attention dot keys on.
- `shell-status-store`'s change comparison now reaches into both axes, so a fresh-but-equal state object republished from a render-scoped effect still does not notify (the state used to be a string, where identity comparison was enough). Pinned by the existing no-notify test plus a new session-health-change-notifies case.
- Callers updated: `AppShell`, `DaemonDocumentPage` / `BrowserDocumentPage` (the two publishers), and the five test files that spell states.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — `ConnectionStatus.test.tsx`, `shell-status-store.test.ts` (red-first: 7 failing before the implementation), `AppShell.test.tsx`, `App.test.tsx`, `DaemonDocumentPage.test.tsx`, `BrowserDocumentPage.test.tsx`, `motion-feedback.browser.test.tsx`
- [x] `pnpm test` passes locally — full `@kamiazya/whiteboard-web` suite green except the 9 known environment-only undici `Response(blob)` failures (VersionThumbnail/DocumentThumb/MergeDialog/VersionTimeline/daemon-file-adapter), unchanged from main
- [ ] Manual verification completed (describe below) — not run: behavior-preserving type refactor; every state the UI can reach renders through the same assertions as before
- [ ] E2E coverage added or extended where applicable — n/a, no flow changed

## Visual evidence

Visual evidence: none — behavior-preserving type refactor; the chip renders the identical four states (labels, tones, popover copy, pulse and live region unchanged), held to that by the pre-existing assertions in `ConnectionStatus.test.tsx`, `AppShell.test.tsx` and `motion-feedback.browser.test.tsx`, which only changed in how they spell the state.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — no user-visible or published-contract change
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connection-status handling across browser and daemon sessions.
  - Settings prompts, recovery messaging, and connection indicators now remain accurate as sessions reconnect or go offline.
  - Updates to session health are detected reliably, ensuring the interface refreshes when connection conditions change.

- **Tests**
  - Expanded coverage for browser, synced, reconnecting, and sync-off connection states.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->