### PR TITLE
feat: promotion slices 5b+6 — move the browser workspace to a daemon from Settings, with a narrated reload

### DIFF
--- a/.claude/rules/vocabulary.md
+++ b/.claude/rules/vocabulary.md
@@ -115,13 +115,20 @@ whiteboard daemon, later a self-hosted or SaaS backend. **`Browser` and
 the intended model is that connecting a daemon PROMOTES a workspace's source
 of truth to it, with everything below becoming a replica.
 
-That model is **not implemented**. What ships is a per-document, one-way
-import (`components/migration/import-from-browser.ts`) whose request carries
-`{ path, kind }` and no document id, so the daemon mints a new one and the
-document's identity does not survive. Copy may use the keeper vocabulary —
-"Kept in this browser" is true today — but must not promise the promotion:
-the capability CTA says outright that documents already in the browser stay
-there and are imported one at a time.
+The MOVE half of that model is implemented: Settings > Connections'
+"This workspace" section (`components/settings/PromoteWorkspaceSection.tsx`
+over `lib/promote-workspace.ts`) transfers the browser's whole workspace
+record into a daemon workspace as a CRDT merge — identity, history and
+referenced images survive, and path collisions surface as shadowed. What is
+still NOT implemented is the automatic demotion below it: after the move the
+browser record remains its own store rather than a subscribed replica, and
+continuing from the daemon is a narrated reload the user takes, never a
+silent source-of-truth swap. Copy may therefore promise the MOVE ("move this
+workspace to the daemon") but must not claim the browser has become a
+replica. The older per-document import
+(`components/migration/import-from-browser.ts`), which preserves no document
+identity, still exists and is scheduled for deletion — user decision,
+2026-08-28 — now that the whole-workspace move supersedes it.
 
 `local` was the wrong word for this axis and could never have been the right
 one, because **a daemon is local too**. Two names spelled it that way and

--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -108,9 +108,12 @@ one it is not in yet, `spinner` that same ring while the doing is in flight.
 - **Name the keeper, never the locality.** A workspace is kept by the
   **Browser** or by a **Daemon**; both are on the user's machine, so "Local"
   named neither and collided with "local daemon" in its own popover. See
-  `.claude/rules/vocabulary.md`'s keeper section — including the rule that
-  copy may use the keeper framing but must not promise the source-of-truth
-  promotion, which is not implemented.
+  `.claude/rules/vocabulary.md`'s keeper section — including the line copy
+  may now cross and the one it may not: the whole-workspace MOVE to a daemon
+  is implemented (Settings > Connections, "This workspace"), but the browser
+  does not become a replica afterwards, so copy promises the move and never a
+  silent source-of-truth swap. Continuing from the daemon is a narrated
+  reload the user takes.
 - **Dialogs**: `max-h` + `overflow-y-auto` when content can grow; page-width
   cards must wrap (`min-w-0`, `break-all` for unbreakable strings) before
   entering a dialog.

--- a/apps/web/src/components/AppShell.test.tsx
+++ b/apps/web/src/components/AppShell.test.tsx
@@ -102,7 +102,7 @@ describe('AppShell — the connection chip', () => {
   // Matched loosely: the CTA is two sentences across JSX lines, so an exact
   // string match would be asserting the source's line breaks, not the copy.
   const CTA = /Connect a daemon \(MCP\) for version history/i
-  const CTA_LIMIT = /Documents already in this browser stay here/i
+  const CTA_LIMIT = /move this workspace to it from Settings/i
 
   it('shows no chip until a page publishes a live session', () => {
     renderShell(true)
@@ -149,8 +149,9 @@ describe('AppShell — the connection chip', () => {
 
     fireEvent.click(await screen.findByTestId('connection-chip'))
     expect(await screen.findByText(CTA)).toBeTruthy()
-    // The CTA names what connecting does NOT do today: documents already in
-    // this browser are not carried over, they are imported one at a time.
+    // The CTA points at where the move lives (Settings manages; the chip
+    // only reports and nudges) — whole-workspace promotion is implemented,
+    // so the old "import them one at a time" disclaimer would now be false.
     expect(screen.getByText(CTA_LIMIT)).toBeTruthy()
   })
 

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -111,8 +111,9 @@ export function AppShell({ daemon, onWorkInBrowser }: AppShellProps) {
           {connection.state.keeper === 'browser' && (
             <>
               <p className="text-muted-foreground">
-                Connect a daemon (MCP) for version history, workspaces, variations and merging.
-                Documents already in this browser stay here — import them one at a time.
+                Connect a daemon (MCP) for version history, workspaces, variations and merging. Once
+                connected, you can move this workspace to it from Settings — documents, their
+                history and images together.
               </p>
               <Suspense fallback={null}>
                 <DaemonDetectedBanner

--- a/apps/web/src/components/settings/PromoteWorkspaceSection.browser.test.tsx
+++ b/apps/web/src/components/settings/PromoteWorkspaceSection.browser.test.tsx
@@ -281,6 +281,35 @@ describe('PromoteWorkspaceSection', () => {
     expect(reload).toHaveBeenCalledTimes(1)
   })
 
+  it("a result recorded under one daemon is not shown as another daemon's", async () => {
+    await seedTwoDocuments()
+    const view = render(
+      <PromoteWorkspaceSection
+        daemon={DAEMON}
+        settingsStore={createUserSettingsStore()}
+        baseFetch={daemonStub(new LoroDoc())}
+        reload={vi.fn()}
+      />,
+    )
+    await userEvent.click(screen.getByTestId('promote-workspace-open'))
+    await userEvent.click(await screen.findByTestId('promote-confirm'))
+    await screen.findByTestId('promote-last-result')
+    view.unmount()
+
+    // Same browser, different daemon: the stored result (and its reload
+    // offer) belongs to the first daemon and must not read as this one's.
+    render(
+      <PromoteWorkspaceSection
+        daemon={{ baseUrl: 'http://127.0.0.1:4200', token: 'tok-2' }}
+        settingsStore={createUserSettingsStore()}
+        baseFetch={daemonStub(new LoroDoc())}
+        reload={vi.fn()}
+      />,
+    )
+    expect(screen.queryByTestId('promote-last-result')).toBeNull()
+    expect(screen.queryByTestId('promote-reload')).toBeNull()
+  })
+
   it('stays discoverable but disabled with no daemon connected', async () => {
     render(<PromoteWorkspaceSection settingsStore={createUserSettingsStore()} />)
     const trigger = screen.getByTestId('promote-workspace-open')

--- a/apps/web/src/components/settings/PromoteWorkspaceSection.browser.test.tsx
+++ b/apps/web/src/components/settings/PromoteWorkspaceSection.browser.test.tsx
@@ -1,0 +1,290 @@
+/**
+ * Slice 6 acceptance for the promote UI, one test per criterion from the
+ * initiative plan: focus trap, live-announced progress, persistent (never
+ * toast-only) result, no internal vocabulary — plus the cross-feature
+ * invariant that promotion preserves document identity end to end.
+ *
+ * web-browser layer on purpose: focus trapping and dialog behavior are real
+ * pointer/focus risk, and the seeded workspace lives in real IndexedDB so the
+ * section's count and the posted bytes come from the production read path.
+ */
+import {
+  readWorkspaceDocuments,
+  resolveWorkspaceDocumentById,
+  writeSpatialCanvas,
+} from '@kamiazya/whiteboard-loro-adapter'
+import { newImageRef } from '@kamiazya/whiteboard-model'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { LoroDoc } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { DocumentFileStore } from '../../lib/document-file-store.js'
+import { FoldingBrowserIndex } from '../../lib/folding-browser-index.js'
+import { ensureLocalWorkspace } from '../../lib/local-document-summary.js'
+import { createUserSettingsStore, STORAGE_KEY } from '../../lib/user-settings-store.js'
+import { seedWorkspaceDocumentContent } from '../../lib/workspace-content.js'
+import { clearWhiteboardDb } from '../../test-utils/browser-document.js'
+import { claimIsolatedWhiteboardDb } from '../../test-utils/isolated-whiteboard-db.js'
+import { PromoteWorkspaceSection } from './PromoteWorkspaceSection.js'
+
+claimIsolatedWhiteboardDb('promote-section')
+
+const BASE = 'http://127.0.0.1:3099'
+const DAEMON = { baseUrl: BASE, token: 'tok-1' }
+
+interface StubOptions {
+  updateDelayMs?: number
+  putDelayMs?: number
+  failUpdateStatus?: number
+}
+
+/** The three daemon routes the flow touches, answering from `target`. */
+function daemonStub(target: LoroDoc, opts: StubOptions = {}): typeof globalThis.fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    if (url.endsWith('/api/workspaces') && (init?.method ?? 'GET') === 'GET') {
+      return Response.json({ workspaces: [{ workspaceId: 'ws-a' }, { workspaceId: 'ws-b' }] })
+    }
+    if (url.endsWith('/workspace-document/update') && init?.method === 'POST') {
+      if (opts.updateDelayMs) await new Promise((r) => setTimeout(r, opts.updateDelayMs))
+      if (opts.failUpdateStatus) {
+        return Response.json(
+          { title: `Workspace "ws-a" not found` },
+          { status: opts.failUpdateStatus },
+        )
+      }
+      target.import(new Uint8Array(init.body as Uint8Array))
+      return Response.json({ ok: true })
+    }
+    if (url.includes('/file/') && init?.method === 'PUT') {
+      if (opts.putDelayMs) await new Promise((r) => setTimeout(r, opts.putDelayMs))
+      return new Response(null, { status: 204 })
+    }
+    if (url.endsWith('/documents')) {
+      const documents = readWorkspaceDocuments(target).map((entry) => ({
+        path: entry.path,
+        id: entry.documentId,
+        kind: entry.kind,
+        updatedAt: new Date().toISOString(),
+      }))
+      return Response.json({ documents })
+    }
+    throw new Error(`unexpected fetch: ${url}`)
+  }) as typeof globalThis.fetch
+}
+
+async function seedTwoDocuments(): Promise<{ roadmapId: string; sketchId: string }> {
+  const index = new FoldingBrowserIndex()
+  await ensureLocalWorkspace(index)
+  const roadmap = await index.createDocument({
+    workspaceId: 'local',
+    path: 'notes/roadmap',
+    kind: 'markdown',
+  })
+  const sketch = await index.createDocument({
+    workspaceId: 'local',
+    path: 'sketch',
+    kind: 'spatial',
+  })
+  return { roadmapId: roadmap.documentId, sketchId: sketch.documentId }
+}
+
+/** Gives the sketch a stored image, so promotion has a real blob phase. */
+async function seedImageOnSketch(sketchId: string): Promise<void> {
+  await new DocumentFileStore().put('img-1', {
+    mimeType: 'image/png',
+    blob: new Blob([new Uint8Array([137, 80, 78, 71])], { type: 'image/png' }),
+    created: Date.now(),
+  })
+  const content = new LoroDoc()
+  writeSpatialCanvas(content, {
+    nodes: [
+      { id: 'img', type: 'file', file: newImageRef('img-1'), x: 0, y: 0, width: 5, height: 5 },
+    ],
+    edges: [],
+  })
+  expect(
+    await seedWorkspaceDocumentContent(
+      sketchId,
+      new Uint8Array(content.export({ mode: 'snapshot' })),
+    ),
+  ).toBe(true)
+}
+
+const NO_INTERNAL_VOCABULARY = /loro|crdt|oplog|snapshot/i
+
+beforeEach(async () => {
+  // Only the key this component reads — a blanket clear() would wipe theme
+  // and view-mode state out from under concurrently running files
+  // (view-mode-isolation.test.ts guards exactly this).
+  localStorage.removeItem(STORAGE_KEY)
+  await clearWhiteboardDb()
+})
+afterEach(cleanup)
+
+describe('PromoteWorkspaceSection', () => {
+  it('confirmation dialog traps focus and Escape returns it to the trigger', async () => {
+    await seedTwoDocuments()
+    render(
+      <PromoteWorkspaceSection
+        daemon={DAEMON}
+        settingsStore={createUserSettingsStore()}
+        baseFetch={daemonStub(new LoroDoc())}
+        reload={vi.fn()}
+      />,
+    )
+    const trigger = screen.getByTestId('promote-workspace-open')
+    await userEvent.click(trigger)
+    const dialog = await screen.findByTestId('promote-dialog')
+
+    // Tab past the end and Shift+Tab past the start: focus never leaves.
+    for (let i = 0; i < 8; i++) {
+      await userEvent.keyboard('{Tab}')
+      expect(dialog.contains(document.activeElement)).toBe(true)
+    }
+    for (let i = 0; i < 8; i++) {
+      await userEvent.keyboard('{Shift>}{Tab}{/Shift}')
+      expect(dialog.contains(document.activeElement)).toBe(true)
+    }
+
+    await userEvent.keyboard('{Escape}')
+    await waitFor(() => expect(screen.queryByTestId('promote-dialog')).toBeNull())
+    // Focus restoration runs after the close animation settles.
+    await waitFor(() => expect(document.activeElement).toBe(trigger))
+  })
+
+  it('progress is a polite live region whose text updates before completion', async () => {
+    const { sketchId } = await seedTwoDocuments()
+    // A real blob phase (a stored image behind a slowed upload) is what makes
+    // the second phase text observable rather than a one-frame flicker.
+    await seedImageOnSketch(sketchId)
+    render(
+      <PromoteWorkspaceSection
+        daemon={DAEMON}
+        settingsStore={createUserSettingsStore()}
+        baseFetch={daemonStub(new LoroDoc(), { updateDelayMs: 150, putDelayMs: 400 })}
+        reload={vi.fn()}
+      />,
+    )
+    await userEvent.click(screen.getByTestId('promote-workspace-open'))
+    await userEvent.click(await screen.findByTestId('promote-confirm'))
+
+    const progress = await screen.findByTestId('promote-progress')
+    expect(progress.getAttribute('role')).toBe('status')
+    expect(progress.getAttribute('aria-live')).toBe('polite')
+    expect(progress.textContent).toMatch(/moving documents and their history/i)
+    // The text advances with the transfer's real phases, before the flow ends.
+    await waitFor(() => {
+      expect(screen.getByTestId('promote-progress').textContent).toMatch(/referenced images/i)
+    })
+    await screen.findByTestId('promote-last-result')
+  })
+
+  it('the result persists across a remount and ids resolve unchanged — never a toast', async () => {
+    const { roadmapId, sketchId } = await seedTwoDocuments()
+    const target = new LoroDoc()
+    const view = render(
+      <PromoteWorkspaceSection
+        daemon={DAEMON}
+        settingsStore={createUserSettingsStore()}
+        baseFetch={daemonStub(target)}
+        reload={vi.fn()}
+      />,
+    )
+    await userEvent.click(screen.getByTestId('promote-workspace-open'))
+    await userEvent.click(await screen.findByTestId('promote-confirm'))
+    const result = await screen.findByTestId('promote-last-result')
+    expect(result.textContent).toMatch(/moved 2 documents to daemon workspace "ws-a"/i)
+
+    // Identity invariant: the same ids resolve on the daemon target, and the
+    // browser keeper still resolves them too (the copy here stays).
+    expect(resolveWorkspaceDocumentById(target, roadmapId)).not.toBeNull()
+    expect(resolveWorkspaceDocumentById(target, sketchId)).not.toBeNull()
+    const stillHere = await new FoldingBrowserIndex().listDocuments({ workspaceId: 'local' })
+    expect([...stillHere.map((d) => d.documentId)].sort()).toEqual([roadmapId, sketchId].sort())
+
+    // Not a toast: no alert/transient surface anywhere, and the report is
+    // still standing after a full unmount/remount (a later Settings visit).
+    expect(document.querySelector('[role="alert"]')).toBeNull()
+    view.unmount()
+    render(
+      <PromoteWorkspaceSection
+        daemon={DAEMON}
+        settingsStore={createUserSettingsStore()}
+        baseFetch={daemonStub(target)}
+        reload={vi.fn()}
+      />,
+    )
+    expect((await screen.findByTestId('promote-last-result')).textContent).toMatch(
+      /moved 2 documents/i,
+    )
+    expect(screen.getByTestId('promote-reload')).toBeTruthy()
+  })
+
+  it('every user-facing string avoids internal vocabulary, in success and failure alike', async () => {
+    await seedTwoDocuments()
+    const failing = render(
+      <PromoteWorkspaceSection
+        daemon={DAEMON}
+        settingsStore={createUserSettingsStore()}
+        baseFetch={daemonStub(new LoroDoc(), { failUpdateStatus: 404 })}
+        reload={vi.fn()}
+      />,
+    )
+    expect(document.body.textContent).not.toMatch(NO_INTERNAL_VOCABULARY)
+    await userEvent.click(screen.getByTestId('promote-workspace-open'))
+    await screen.findByTestId('promote-dialog')
+    expect(document.body.textContent).not.toMatch(NO_INTERNAL_VOCABULARY)
+    await userEvent.click(screen.getByTestId('promote-confirm'))
+    const failure = await screen.findByTestId('promote-last-result')
+    expect(failure.textContent).toMatch(/failed/i)
+    expect(document.body.textContent).not.toMatch(NO_INTERNAL_VOCABULARY)
+    failing.unmount()
+
+    localStorage.removeItem(STORAGE_KEY)
+    render(
+      <PromoteWorkspaceSection
+        daemon={DAEMON}
+        settingsStore={createUserSettingsStore()}
+        baseFetch={daemonStub(new LoroDoc(), { updateDelayMs: 120 })}
+        reload={vi.fn()}
+      />,
+    )
+    await userEvent.click(screen.getByTestId('promote-workspace-open'))
+    await userEvent.click(await screen.findByTestId('promote-confirm'))
+    await screen.findByTestId('promote-progress')
+    expect(document.body.textContent).not.toMatch(NO_INTERNAL_VOCABULARY)
+    await screen.findByTestId('promote-last-result')
+    expect(document.body.textContent).not.toMatch(NO_INTERNAL_VOCABULARY)
+  })
+
+  it('the success surface narrates the reload instead of navigating by itself', async () => {
+    await seedTwoDocuments()
+    const reload = vi.fn()
+    render(
+      <PromoteWorkspaceSection
+        daemon={DAEMON}
+        settingsStore={createUserSettingsStore()}
+        baseFetch={daemonStub(new LoroDoc())}
+        reload={reload}
+      />,
+    )
+    await userEvent.click(screen.getByTestId('promote-workspace-open'))
+    await userEvent.click(await screen.findByTestId('promote-confirm'))
+    await screen.findByTestId('promote-last-result')
+    // Success alone navigates nowhere — the reload is an offer, taken by the
+    // user, and its label says where it leads.
+    expect(reload).not.toHaveBeenCalled()
+    const button = screen.getByTestId('promote-reload')
+    expect(button.textContent).toMatch(/reload and continue from the daemon/i)
+    await userEvent.click(button)
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('stays discoverable but disabled with no daemon connected', async () => {
+    render(<PromoteWorkspaceSection settingsStore={createUserSettingsStore()} />)
+    const trigger = screen.getByTestId('promote-workspace-open')
+    expect(trigger.hasAttribute('disabled')).toBe(true)
+    expect(document.body.textContent).toMatch(/connect a daemon/i)
+  })
+})

--- a/apps/web/src/components/settings/PromoteWorkspaceSection.tsx
+++ b/apps/web/src/components/settings/PromoteWorkspaceSection.tsx
@@ -1,0 +1,324 @@
+/**
+ * Settings > Connections' "This workspace" section: move the workspace this
+ * browser keeps to a daemon, whole — documents, their edit history, and the
+ * images they reference — with identity preserved (links keep resolving).
+ *
+ * Discoverable-but-disabled until a daemon is connected, per DESIGN.md's
+ * "Status reports; Settings manages": the chip popover only nudges here.
+ *
+ * The result is a standing report, never a toast: the outcome persists in
+ * user settings (migration.promotion) and renders in this section, so it
+ * survives navigating away and a full reload. After a success the section
+ * offers a narrated reload — mid-session backend swap is out (ADR-0004:
+ * backend mode is decided once at page load), so continuing from the daemon
+ * is a reload the user takes knowingly, never a navigation done to them.
+ *
+ * promote-workspace.js (and the loro machinery behind it) loads on demand:
+ * this section renders on a settings page that must not pay for the CRDT
+ * bundle until the user actually reaches for promotion.
+ */
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { createDaemonFetch, listWorkspaces } from '@/lib/daemon-api-client'
+import type { PromotionResultRecord, UserSettings } from '@/lib/user-settings-store'
+
+export interface PromoteWorkspaceSectionProps {
+  daemon?: { baseUrl: string; token: string | null }
+  settingsStore: {
+    load: () => UserSettings
+    update: (fn: (current: UserSettings) => UserSettings) => void
+  }
+  /**
+   * The reload the success surface narrates. Injectable because jsdom and
+   * browser-mode tests cannot survive a real navigation mid-test.
+   */
+  reload?: () => void
+  /** Test seam for the daemon HTTP surface; production uses window.fetch. */
+  baseFetch?: typeof globalThis.fetch
+}
+
+type PromoteFlow =
+  | { step: 'idle' }
+  | { step: 'confirm'; documentCount: number; workspaceIds: string[]; targetId: string }
+  | { step: 'running'; phase: 'record' | 'blobs' }
+  | { step: 'unavailable'; reason: string }
+
+function describeResult(result: PromotionResultRecord): string {
+  if (!result.ok) {
+    return `Move to daemon workspace "${result.workspaceId}" failed: ${result.reason ?? 'unknown error'}`
+  }
+  const parts = [
+    `Moved ${result.promotedCount ?? 0} document${(result.promotedCount ?? 0) === 1 ? '' : 's'} to daemon workspace "${result.workspaceId}"`,
+  ]
+  if ((result.shadowedPaths?.length ?? 0) > 0) {
+    parts.push(
+      `${result.shadowedPaths?.length} path${result.shadowedPaths?.length === 1 ? '' : 's'} already existed there — both versions are kept, the earlier one marked shadowed: ${result.shadowedPaths?.join(', ')}`,
+    )
+  }
+  if ((result.blobsMissing?.length ?? 0) > 0) {
+    parts.push(
+      `${result.blobsMissing?.length} referenced image${result.blobsMissing?.length === 1 ? ' was' : 's were'} already missing from this browser and could not be moved`,
+    )
+  }
+  if ((result.blobsFailed?.length ?? 0) > 0) {
+    parts.push(
+      `${result.blobsFailed?.length} image upload${result.blobsFailed?.length === 1 ? '' : 's'} failed — moving again retries them safely`,
+    )
+  }
+  return `${parts.join('. ')}.`
+}
+
+export function PromoteWorkspaceSection({
+  daemon,
+  settingsStore,
+  reload,
+  baseFetch,
+}: PromoteWorkspaceSectionProps) {
+  const targetSelectId = useId()
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const [flow, setFlow] = useState<PromoteFlow>({ step: 'idle' })
+  const [lastResult, setLastResult] = useState<PromotionResultRecord | undefined>(
+    () => settingsStore.load().migration.promotion,
+  )
+
+  // Re-read on daemon change so a reconnect shows the result recorded under it.
+  useEffect(() => {
+    setLastResult(settingsStore.load().migration.promotion)
+  }, [settingsStore])
+
+  const openConfirmation = useCallback(async () => {
+    if (!daemon) return
+    const fetchImpl = createDaemonFetch(
+      daemon.baseUrl,
+      daemon.token ?? undefined,
+      baseFetch ?? globalThis.fetch.bind(globalThis),
+    )
+    try {
+      const [{ countBrowserWorkspaceDocuments }, { BrowserWorkspaceDocs }, workspaces] =
+        await Promise.all([
+          import('../../lib/promote-workspace.js'),
+          import('../../lib/browser-workspace-docs.js'),
+          listWorkspaces(fetchImpl, daemon.baseUrl),
+        ])
+      const documentCount = await countBrowserWorkspaceDocuments(new BrowserWorkspaceDocs())
+      const workspaceIds = workspaces.workspaces.map((ws) => ws.workspaceId)
+      if (documentCount === 0) {
+        setFlow({ step: 'unavailable', reason: 'This browser keeps no documents to move.' })
+        return
+      }
+      if (workspaceIds.length === 0) {
+        setFlow({
+          step: 'unavailable',
+          reason: 'The daemon has no workspace to move into yet. Open one on the daemon first.',
+        })
+        return
+      }
+      setFlow({
+        step: 'confirm',
+        documentCount,
+        workspaceIds,
+        targetId: workspaceIds[0] as string,
+      })
+    } catch {
+      setFlow({ step: 'unavailable', reason: 'Could not reach the daemon to prepare the move.' })
+    }
+  }, [daemon, baseFetch])
+
+  const runPromotion = useCallback(
+    async (targetId: string) => {
+      if (!daemon) return
+      setFlow({ step: 'running', phase: 'record' })
+      const fetchImpl = createDaemonFetch(
+        daemon.baseUrl,
+        daemon.token ?? undefined,
+        baseFetch ?? globalThis.fetch.bind(globalThis),
+      )
+      const [{ promoteWorkspace }, { BrowserWorkspaceDocs }] = await Promise.all([
+        import('../../lib/promote-workspace.js'),
+        import('../../lib/browser-workspace-docs.js'),
+      ])
+      const outcome = await promoteWorkspace({
+        fetch: fetchImpl,
+        daemonBaseUrl: daemon.baseUrl,
+        workspaceId: targetId,
+        workspaceDocs: new BrowserWorkspaceDocs(),
+        onProgress: (phase) => setFlow({ step: 'running', phase }),
+      })
+      const record: PromotionResultRecord =
+        outcome.kind === 'ok'
+          ? {
+              at: new Date().toISOString(),
+              workspaceId: targetId,
+              ok: true,
+              promotedCount: outcome.promotedDocumentIds.length,
+              shadowedPaths: outcome.shadowedPaths,
+              blobsMissing: outcome.blobs.missing,
+              blobsFailed: outcome.blobs.failed,
+            }
+          : {
+              at: new Date().toISOString(),
+              workspaceId: targetId,
+              ok: false,
+              reason: outcome.reason,
+            }
+      settingsStore.update((current) => ({
+        ...current,
+        migration: { ...current.migration, promotion: record },
+      }))
+      setLastResult(record)
+      setFlow({ step: 'idle' })
+    },
+    [daemon, baseFetch, settingsStore],
+  )
+
+  return (
+    <section aria-label="This workspace" className="flex flex-col gap-1.5">
+      <p className="text-sm font-medium">This workspace</p>
+      {daemon ? (
+        <p className="text-xs text-muted-foreground">
+          Move everything this browser keeps — documents, their edit history, and referenced images
+          — to the daemon. Documents keep their identity, so links between them keep working. Your
+          documents also stay in this browser.
+        </p>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          Connect a daemon to move the documents this browser keeps onto it, with their edit history
+          and images.
+        </p>
+      )}
+      <Button
+        type="button"
+        ref={triggerRef}
+        variant="outline"
+        size="sm"
+        className="self-start"
+        data-testid="promote-workspace-open"
+        disabled={!daemon || flow.step === 'running'}
+        onClick={() => void openConfirmation()}
+      >
+        Move to daemon…
+      </Button>
+
+      {/* Mounted whenever there is anything to report, so the outcome reads
+          here on every later visit — the persistent surface, not a toast. */}
+      {flow.step === 'unavailable' && (
+        <p data-testid="promote-unavailable" className="text-xs text-muted-foreground">
+          {flow.reason}
+        </p>
+      )}
+      {lastResult !== undefined && flow.step !== 'running' && (
+        <div data-testid="promote-last-result" className="rounded-md border px-3 py-2 text-xs">
+          <p>{describeResult(lastResult)}</p>
+          {lastResult.ok && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mt-2"
+              data-testid="promote-reload"
+              onClick={() => (reload ?? (() => window.location.assign('/')))()}
+            >
+              Reload and continue from the daemon
+            </Button>
+          )}
+        </div>
+      )}
+
+      <Dialog
+        open={flow.step === 'confirm' || flow.step === 'running'}
+        onOpenChange={(open) => {
+          // No mid-transfer cancel: the merge is atomic on the daemon side and
+          // aborting the dialog would only hide, not stop, the request.
+          if (!open && flow.step === 'confirm') setFlow({ step: 'idle' })
+        }}
+      >
+        <DialogContent
+          data-testid="promote-dialog"
+          showCloseButton={flow.step === 'confirm'}
+          // The dialog opens from a plain controlled button (no Radix
+          // trigger), so closing must hand focus back to it explicitly.
+          onCloseAutoFocus={(event) => {
+            event.preventDefault()
+            triggerRef.current?.focus()
+          }}
+        >
+          {flow.step === 'confirm' && (
+            <>
+              <DialogHeader>
+                <DialogTitle>Move this workspace to the daemon</DialogTitle>
+                <DialogDescription>
+                  All {flow.documentCount} document{flow.documentCount === 1 ? '' : 's'} move to the
+                  daemon workspace you choose, with their full edit history and referenced images.
+                  If a path already exists there, both versions are kept and the existing one is
+                  marked shadowed — nothing is renamed or overwritten. Your documents also stay in
+                  this browser.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor={targetSelectId} className="text-xs font-medium">
+                  Daemon workspace
+                </label>
+                <select
+                  id={targetSelectId}
+                  data-testid="promote-target"
+                  value={flow.targetId}
+                  onChange={(event) => setFlow({ ...flow, targetId: event.target.value })}
+                  className="rounded-md border bg-background px-2 py-1.5 text-sm"
+                >
+                  {flow.workspaceIds.map((id) => (
+                    <option key={id} value={id}>
+                      {id}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <DialogFooter>
+                <Button type="button" variant="ghost" onClick={() => setFlow({ step: 'idle' })}>
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  data-testid="promote-confirm"
+                  onClick={() => void runPromotion(flow.targetId)}
+                >
+                  Move workspace
+                </Button>
+              </DialogFooter>
+            </>
+          )}
+          {flow.step === 'running' && (
+            <>
+              <DialogHeader>
+                <DialogTitle>Moving this workspace</DialogTitle>
+                <DialogDescription>
+                  This can take a moment. Keep this page open until it finishes.
+                </DialogDescription>
+              </DialogHeader>
+              {/* Indeterminate and narrated from the transfer's real phases —
+                  no fake progress bar. Polite live region so the change is
+                  announced without stealing focus. */}
+              <p
+                role="status"
+                aria-live="polite"
+                data-testid="promote-progress"
+                className="text-sm"
+              >
+                {flow.phase === 'record'
+                  ? 'Moving documents and their history…'
+                  : 'Moving referenced images…'}
+              </p>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </section>
+  )
+}

--- a/apps/web/src/components/settings/PromoteWorkspaceSection.tsx
+++ b/apps/web/src/components/settings/PromoteWorkspaceSection.tsx
@@ -136,39 +136,55 @@ export function PromoteWorkspaceSection({
     async (targetId: string) => {
       if (!daemon) return
       setFlow({ step: 'running', phase: 'record' })
-      const fetchImpl = createDaemonFetch(
-        daemon.baseUrl,
-        daemon.token ?? undefined,
-        baseFetch ?? globalThis.fetch.bind(globalThis),
-      )
-      const [{ promoteWorkspace }, { BrowserWorkspaceDocs }] = await Promise.all([
-        import('../../lib/promote-workspace.js'),
-        import('../../lib/browser-workspace-docs.js'),
-      ])
-      const outcome = await promoteWorkspace({
-        fetch: fetchImpl,
-        daemonBaseUrl: daemon.baseUrl,
-        workspaceId: targetId,
-        workspaceDocs: new BrowserWorkspaceDocs(),
-        onProgress: (phase) => setFlow({ step: 'running', phase }),
-      })
-      const record: PromotionResultRecord =
-        outcome.kind === 'ok'
-          ? {
-              at: new Date().toISOString(),
-              workspaceId: targetId,
-              ok: true,
-              promotedCount: outcome.promotedDocumentIds.length,
-              shadowedPaths: outcome.shadowedPaths,
-              blobsMissing: outcome.blobs.missing,
-              blobsFailed: outcome.blobs.failed,
-            }
-          : {
-              at: new Date().toISOString(),
-              workspaceId: targetId,
-              ok: false,
-              reason: outcome.reason,
-            }
+      let record: PromotionResultRecord
+      try {
+        const fetchImpl = createDaemonFetch(
+          daemon.baseUrl,
+          daemon.token ?? undefined,
+          baseFetch ?? globalThis.fetch.bind(globalThis),
+        )
+        const [{ promoteWorkspace }, { BrowserWorkspaceDocs }] = await Promise.all([
+          import('../../lib/promote-workspace.js'),
+          import('../../lib/browser-workspace-docs.js'),
+        ])
+        const outcome = await promoteWorkspace({
+          fetch: fetchImpl,
+          daemonBaseUrl: daemon.baseUrl,
+          workspaceId: targetId,
+          workspaceDocs: new BrowserWorkspaceDocs(),
+          onProgress: (phase) => setFlow({ step: 'running', phase }),
+        })
+        record =
+          outcome.kind === 'ok'
+            ? {
+                at: new Date().toISOString(),
+                daemonBaseUrl: daemon.baseUrl,
+                workspaceId: targetId,
+                ok: true,
+                promotedCount: outcome.promotedDocumentIds.length,
+                shadowedPaths: outcome.shadowedPaths,
+                blobsMissing: outcome.blobs.missing,
+                blobsFailed: outcome.blobs.failed,
+              }
+            : {
+                at: new Date().toISOString(),
+                daemonBaseUrl: daemon.baseUrl,
+                workspaceId: targetId,
+                ok: false,
+                reason: outcome.reason,
+              }
+      } catch {
+        // promoteWorkspace itself never throws — this net is for the dynamic
+        // imports (an offline chunk load). Without it the flow would stay
+        // 'running' forever, dialog open, trigger disabled, with no way out.
+        record = {
+          at: new Date().toISOString(),
+          daemonBaseUrl: daemon.baseUrl,
+          workspaceId: targetId,
+          ok: false,
+          reason: 'Part of the app failed to load. Reload the page and try again.',
+        }
+      }
       settingsStore.update((current) => ({
         ...current,
         migration: { ...current.migration, promotion: record },
@@ -208,29 +224,34 @@ export function PromoteWorkspaceSection({
       </Button>
 
       {/* Mounted whenever there is anything to report, so the outcome reads
-          here on every later visit — the persistent surface, not a toast. */}
+          here on every later visit — the persistent surface, not a toast.
+          Bound to the daemon it happened against: a result recorded under
+          daemon A (and its reload offer) must not read as actionable while
+          connected to daemon B. */}
       {flow.step === 'unavailable' && (
         <p data-testid="promote-unavailable" className="text-xs text-muted-foreground">
           {flow.reason}
         </p>
       )}
-      {lastResult !== undefined && flow.step !== 'running' && (
-        <div data-testid="promote-last-result" className="rounded-md border px-3 py-2 text-xs">
-          <p>{describeResult(lastResult)}</p>
-          {lastResult.ok && (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="mt-2"
-              data-testid="promote-reload"
-              onClick={() => (reload ?? (() => window.location.assign('/')))()}
-            >
-              Reload and continue from the daemon
-            </Button>
-          )}
-        </div>
-      )}
+      {lastResult !== undefined &&
+        lastResult.daemonBaseUrl === daemon?.baseUrl &&
+        flow.step !== 'running' && (
+          <div data-testid="promote-last-result" className="rounded-md border px-3 py-2 text-xs">
+            <p>{describeResult(lastResult)}</p>
+            {lastResult.ok && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-2"
+                data-testid="promote-reload"
+                onClick={() => (reload ?? (() => window.location.assign('/')))()}
+              >
+                Reload and continue from the daemon
+              </Button>
+            )}
+          </div>
+        )}
 
       <Dialog
         open={flow.step === 'confirm' || flow.step === 'running'}

--- a/apps/web/src/lib/promote-workspace.browser.test.tsx
+++ b/apps/web/src/lib/promote-workspace.browser.test.tsx
@@ -22,7 +22,7 @@ import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
 import { DocumentFileStore } from './document-file-store.js'
 import { FoldingBrowserIndex } from './folding-browser-index.js'
 import { ensureLocalWorkspace } from './local-document-summary.js'
-import { promoteWorkspace } from './promote-workspace.js'
+import { countBrowserWorkspaceDocuments, promoteWorkspace } from './promote-workspace.js'
 import { seedWorkspaceDocumentContent } from './workspace-content.js'
 
 claimIsolatedWhiteboardDb('promote-workspace')
@@ -132,14 +132,22 @@ describe('promoteWorkspace', () => {
       ),
     ).toBe(true)
 
+    // The confirmation UI states the document count BEFORE promoting, from
+    // the same record the transfer will read.
+    expect(await countBrowserWorkspaceDocuments(new BrowserWorkspaceDocs())).toBe(2)
+
     const target = targetDaemonRecord()
     const putFiles: Array<{ url: string; contentType: string; bytes: Uint8Array }> = []
+    const phases: string[] = []
     const result = await promoteWorkspace({
       fetch: daemonStub(target, putFiles),
       daemonBaseUrl: BASE,
       workspaceId: 'ws-a',
       workspaceDocs: new BrowserWorkspaceDocs(),
+      onProgress: (phase) => phases.push(phase),
     })
+    // Real progress, not staged: the record phase precedes the blob phase.
+    expect(phases).toEqual(['record', 'blobs'])
 
     expect(result.kind).toBe('ok')
     if (result.kind !== 'ok') return

--- a/apps/web/src/lib/promote-workspace.ts
+++ b/apps/web/src/lib/promote-workspace.ts
@@ -37,6 +37,25 @@ export interface PromoteWorkspaceOptions {
   workspaceId: string
   /** The browser keeper's records (production: `new BrowserWorkspaceDocs()`). */
   workspaceDocs: WorkspaceDocs
+  /**
+   * Called as each real phase starts — 'record' before the CRDT merge POST,
+   * 'blobs' before the image uploads. The progress UI narrates from these
+   * instead of inventing a timeline.
+   */
+  onProgress?: (phase: 'record' | 'blobs') => void
+}
+
+/**
+ * How many documents a promotion would move, read from the same record the
+ * transfer reads — the confirmation dialog's number, computed before any
+ * request leaves the browser. 0 both for an empty record and for no record.
+ */
+export async function countBrowserWorkspaceDocuments(
+  workspaceDocs: WorkspaceDocs,
+): Promise<number> {
+  const record = await workspaceDocs.open(BROWSER_WORKSPACE_ID)
+  if (record === null) return 0
+  return readWorkspaceDocuments(record).length
 }
 
 export type PromoteWorkspaceResult =
@@ -110,7 +129,7 @@ function collectImageRefs(
 async function promoteWorkspaceUnsafe(
   options: PromoteWorkspaceOptions,
 ): Promise<PromoteWorkspaceResult> {
-  const { fetch, daemonBaseUrl, workspaceId, workspaceDocs } = options
+  const { fetch, daemonBaseUrl, workspaceId, workspaceDocs, onProgress } = options
   // The keeper's own store, like BrowserWorkspaceDocs above: both address
   // the same claimed database, so tests seed through the production path.
   const fileStore = new DocumentFileStore()
@@ -125,6 +144,7 @@ async function promoteWorkspaceUnsafe(
   const entries = readWorkspaceDocuments(record)
   const promotedDocumentIds = entries.map((entry) => entry.documentId)
 
+  onProgress?.('record')
   const res = await fetch(
     `${daemonBaseUrl}/api/w/${encodeURIComponent(workspaceId)}/workspace-document/update`,
     {
@@ -151,6 +171,7 @@ async function promoteWorkspaceUnsafe(
   // the images travel last, and per-file — a single unreadable or refused
   // upload lands in the report instead of failing the merge that already
   // happened.
+  onProgress?.('blobs')
   const blobs = { transferred: [] as string[], missing: [] as string[], failed: [] as string[] }
   for (const [fileId, path] of collectImageRefs(record, entries)) {
     const blob = await fileStore.get(fileId)

--- a/apps/web/src/lib/user-settings-store.test.ts
+++ b/apps/web/src/lib/user-settings-store.test.ts
@@ -188,6 +188,53 @@ describe('createUserSettingsStore', () => {
   })
 })
 
+describe('promotion result persistence', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  // The promote UI's result surface is persistent (never toast-only): the
+  // outcome must survive navigating away from Settings and back, and a full
+  // reload — so it lives here, beside the other browser-to-daemon migration
+  // state.
+  it('round-trips a success result under migration.promotion', () => {
+    const result = {
+      at: '2026-08-28T12:00:00.000Z',
+      workspaceId: 'ws-a',
+      ok: true,
+      promotedCount: 3,
+      shadowedPaths: ['contested'],
+      blobsMissing: [],
+      blobsFailed: [],
+    }
+    createUserSettingsStore().update((current) => ({
+      ...current,
+      migration: { ...current.migration, promotion: result },
+    }))
+    expect(createUserSettingsStore().load().migration.promotion).toEqual(result)
+  })
+
+  it('round-trips a failure result carrying the reason', () => {
+    const result = {
+      at: '2026-08-28T12:00:00.000Z',
+      workspaceId: 'ws-a',
+      ok: false,
+      reason: 'Could not reach the daemon (network error).',
+    }
+    createUserSettingsStore().update((current) => ({
+      ...current,
+      migration: { ...current.migration, promotion: result },
+    }))
+    expect(createUserSettingsStore().load().migration.promotion).toEqual(result)
+  })
+
+  it('parses a stored payload from before the promotion field existed', () => {
+    const store = createUserSettingsStore()
+    store.save(defaultUserSettings())
+    expect(createUserSettingsStore().load().migration.promotion).toBeUndefined()
+  })
+})
+
 describe('createUserSettingsStore — beta banner dismissal', () => {
   beforeEach(() => {
     localStorage.clear()

--- a/apps/web/src/lib/user-settings-store.test.ts
+++ b/apps/web/src/lib/user-settings-store.test.ts
@@ -200,6 +200,9 @@ describe('promotion result persistence', () => {
   it('round-trips a success result under migration.promotion', () => {
     const result = {
       at: '2026-08-28T12:00:00.000Z',
+      // The origin binding: the result surface shows a stored result as
+      // actionable only while connected to this same daemon.
+      daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws-a',
       ok: true,
       promotedCount: 3,
@@ -217,6 +220,7 @@ describe('promotion result persistence', () => {
   it('round-trips a failure result carrying the reason', () => {
     const result = {
       at: '2026-08-28T12:00:00.000Z',
+      daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws-a',
       ok: false,
       reason: 'Could not reach the daemon (network error).',

--- a/apps/web/src/lib/user-settings-store.ts
+++ b/apps/web/src/lib/user-settings-store.ts
@@ -116,6 +116,15 @@ const storageSettingsSchema = z
 const promotionResultSchema = z
   .object({
     at: z.string(),
+    /**
+     * The daemon the move targeted. The result surface renders a stored
+     * result as actionable only while connected to this same daemon —
+     * without the binding, a result from daemon A (and its reload offer)
+     * would keep showing after connecting to daemon B. Optional because
+     * records persisted before the field existed lack it; those simply
+     * never match and age out on the next move.
+     */
+    daemonBaseUrl: httpUrl.optional(),
     /** The TARGET daemon workspace the record merged into. */
     workspaceId: z.string(),
     ok: z.boolean(),

--- a/apps/web/src/lib/user-settings-store.ts
+++ b/apps/web/src/lib/user-settings-store.ts
@@ -106,6 +106,29 @@ const storageSettingsSchema = z
   })
   .strict()
 
+/**
+ * The last whole-workspace promotion's outcome. Persisted (not component
+ * state) because the promote UI's result surface is a standing report, never
+ * a toast: it must survive navigating away from Settings and a full reload.
+ * One slot, overwritten by the next run — promotion is an idempotent merge,
+ * so only the latest outcome is actionable.
+ */
+const promotionResultSchema = z
+  .object({
+    at: z.string(),
+    /** The TARGET daemon workspace the record merged into. */
+    workspaceId: z.string(),
+    ok: z.boolean(),
+    promotedCount: z.number().optional(),
+    shadowedPaths: z.array(z.string()).optional(),
+    blobsMissing: z.array(z.string()).optional(),
+    blobsFailed: z.array(z.string()).optional(),
+    reason: z.string().optional(),
+  })
+  .strict()
+
+export type PromotionResultRecord = z.infer<typeof promotionResultSchema>
+
 const migrationSettingsSchema = z
   .object({
     browserToDaemon: z
@@ -116,6 +139,7 @@ const migrationSettingsSchema = z
       })
       .strict()
       .optional(),
+    promotion: promotionResultSchema.optional(),
   })
   .strict()
 

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -371,6 +371,35 @@ describe('SettingsPage — Connections', () => {
     expect(await within(mobile).findByRole('button', { name: 'Install Noto Sans JP' })).toBeTruthy()
   })
 
+  // Discoverable before its precondition is met: the move to a daemon is
+  // something the user should be able to find and read about while still
+  // unpaired, not a control that materialises only once it is usable.
+  it('offers the workspace move disabled until a daemon is connected', () => {
+    renderAt('/settings/connections')
+    const mobile = screen.getByTestId('settings-mobile')
+    const button = within(mobile).getByTestId('promote-workspace-open')
+    expect(button.hasAttribute('disabled')).toBe(true)
+    expect(within(mobile).getByText(/connect a daemon to move/i)).toBeTruthy()
+  })
+
+  it('enables the workspace move when a daemon is connected', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString()
+        if (url.includes('/api/pairing/grants')) return jsonResponse({ grants: [] })
+        if (url.includes('/api/runtime/storage')) {
+          return jsonResponse({ totalBytes: 0, fileCount: 0, byCategory: {} })
+        }
+        return jsonResponse({}, 404)
+      }),
+    )
+    renderAt('/settings/connections', { baseUrl: 'http://127.0.0.1:9999', token: 'tok' })
+    const mobile = screen.getByTestId('settings-mobile')
+    const button = await within(mobile).findByTestId('promote-workspace-open')
+    expect(button.hasAttribute('disabled')).toBe(false)
+  })
+
   it('renders the paired-origins and storage cards when a daemon is provided', async () => {
     vi.stubGlobal(
       'fetch',

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -13,6 +13,7 @@ import {
 import { useCallback, useEffect, useId, useRef, useState, useSyncExternalStore } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { AppVersionRow } from '@/components/settings/AppVersionRow'
+import { PromoteWorkspaceSection } from '@/components/settings/PromoteWorkspaceSection'
 import type { PersistStepState } from '@/components/settings/SetupJourney'
 import { findVisibleJourneyBadge, SetupJourney } from '@/components/settings/SetupJourney'
 import { DaemonApiContext } from '@/contexts/DaemonApiContext'
@@ -199,12 +200,17 @@ function ConnectionsSection({
 }) {
   if (!daemon) {
     return (
-      <section>
-        <p className="text-sm">Daemon — Not connected</p>
-        <p className="mt-1 text-xs text-muted-foreground">
-          A daemon on this machine holds durable storage and the AI agent connection for this app.
-        </p>
-      </section>
+      <div className="space-y-6">
+        <section>
+          <p className="text-sm">Daemon — Not connected</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            A daemon on this machine holds durable storage and the AI agent connection for this app.
+          </p>
+        </section>
+        {/* Discoverable while disabled: the move exists before its
+            precondition is met, so its condition can be read here. */}
+        <PromoteWorkspaceSection settingsStore={settingsStore} />
+      </div>
     )
   }
   const daemonFetch = createDaemonFetch(daemon.baseUrl, daemon.token ?? undefined)
@@ -217,6 +223,7 @@ function ConnectionsSection({
         <section aria-label="Storage">
           <StorageReportCard />
         </section>
+        <PromoteWorkspaceSection daemon={daemon} settingsStore={settingsStore} />
         {/* Management, not status: the chip reports which daemon keeps this
             workspace, and changing that is an intent you arrive here with. */}
         <section aria-label="This daemon" className="flex flex-col gap-1.5">

--- a/docs/how-to/connect-to-local-daemon.md
+++ b/docs/how-to/connect-to-local-daemon.md
@@ -188,6 +188,25 @@ no operator action is needed, and no CLI command exists to inspect or revoke
 individual entries any more. If you are auditing the data directory after an
 upgrade and the file is gone, this is why.
 
+## Move this workspace to the daemon
+
+Once a daemon is connected, you can move everything this browser keeps in
+one step from **Settings → Connections → This workspace**:
+
+1. Open **Settings → Connections** and find the **This workspace** section.
+2. Click **Move to daemon…**, choose the daemon workspace to move into, and
+   confirm.
+3. When the move finishes, the result stays visible in that section. Use
+   **Reload and continue from the daemon** to switch to working from the
+   daemon, or keep working in the browser.
+
+The move carries your documents, their full edit history, and the images
+they reference. Documents keep their identity, so links between them keep
+working on the daemon. If a path already exists in the chosen daemon
+workspace, both versions are kept and the pre-existing one is marked
+*shadowed* — nothing is renamed or overwritten. Your documents also stay in
+this browser; moving again later is safe and simply re-merges.
+
 ## Copy-first import
 
 If you have canvases stored only in this browser (from before a daemon was


### PR DESCRIPTION
## Summary

- **Settings → Connections gains a "This workspace" section** (`PromoteWorkspaceSection`): move everything the browser keeps — documents, their full edit history, and referenced images — into a daemon workspace as one merge, identity preserved. Discoverable-but-disabled until a daemon is connected; the connection chip's popover only nudges here (DESIGN.md's "Status reports; Settings manages").
- **The flow**: a focus-trapped confirmation dialog (existing Radix `Dialog` primitive — no new theming surface; target workspace choice; plain statement of what moves and that path collisions surface as *shadowed*, nothing renamed or overwritten) → an indeterminate progress line narrated from the transfer's two real phases via `role="status" aria-live="polite"` (no fake progress bar, no mid-transfer cancel) → a **persistent result**: the outcome is stored in user settings (`migration.promotion`, new optional strict field) and rendered by the section, so it survives navigating away and a full reload — never a toast.
- **Slice 5b's v1 default, the narrated reload**: success offers "Reload and continue from the daemon". Per ADR-0004 the backend mode is decided once at page load, so continuing from the daemon is a reload the user takes knowingly — success alone navigates nowhere, and the browser copy of the workspace remains (no silent source-of-truth swap; the degraded-session states post-reload are the existing DaemonDocumentPage behavior over #1091's keeper/session axes).
- **`promote-workspace.ts`** gains `onProgress` (called at the two real phases) and `countBrowserWorkspaceDocuments` (the dialog's number, read from the same record the transfer reads). The section loads it and the workspace-record machinery via dynamic `import()`, keeping the settings chunk free of the CRDT bundle until promotion is actually used (the App entry closure guard is unaffected either way).
- **Copy/docs honesty**: the chip popover's browser CTA drops the now-false "import them one at a time" limit and points at Settings; `vocabulary.md`'s keeper section and `apps/web/DESIGN.md` now state what copy may promise (the move) and may not (a silent replica swap); the connect-to-local-daemon how-to gains the move section. The old per-document import panel still exists and is deleted in the next slice per the standing decision.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — `PromoteWorkspaceSection.browser.test.tsx` (one test per plan criterion: focus trap + Escape-returns-focus; polite live-region progress that updates before completion; result persistence across remount with document ids resolving unchanged on **both** keepers, and no `role="alert"`/toast; no internal vocabulary (`/loro|crdt|oplog|snapshot/i`) across confirm/running/success/failure states; the reload is offered, labeled, and never automatic; disabled-until-paired). Plus `promote-workspace.browser.test.tsx` (onProgress phases, count), `user-settings-store.test.ts` (promotion field round-trip, red-first), `SettingsPage.test.tsx` (section disabled/enabled per daemon), `AppShell.test.tsx` (new CTA copy).
- [x] `pnpm test` passes locally — full `@kamiazya/whiteboard-web` suite (jsdom + node configs) green except the 9 known environment-only undici `Response(blob)` failures, unchanged from main. `pnpm -r typecheck`, `pnpm knip`, `pnpm lint:noconsole` green.
- [x] Manual verification completed (describe below) — real-daemon dogfood: built web app (vite preview) + dev daemon on 3099, driven by a real Chromium. Created three browser-kept documents (a canvas and two notes, one containing a `[[Roadmap]]` reference), connected the daemon, ran the move from Settings into a freshly created daemon workspace: result reported "Moved 3 documents", the daemon's documents API showed all three arrived beside the daemon's own pre-existing document (intact), and the narrated reload landed in the daemon flow.
- [ ] E2E coverage added or extended where applicable — the web-browser acceptance file covers the flow against a stubbed daemon whose update POST actually imports the posted bytes; the daemon side of the same bytes is already pinned by mcp-server's `promote-workspace.test.ts` (merged in #1087/#1090).

## Visual evidence

New affordance — nothing exists to compare against, so the evidence is captures of the new surface, taken during the real-daemon dogfood above: (1) the "This workspace" section in Settings → Connections, (2) the confirmation dialog with the target workspace select over the dimmed page, (3) the persistent result panel reading `Moved 3 documents to daemon workspace "dogfood-…"` with the "Reload and continue from the daemon" button. This remote session has no `gh` CLI, so the PNGs cannot be uploaded as GitHub user-attachments from here; they were delivered to the session owner directly (tmp/screenshots/promote-{1,2,3}*.png) and can be attached to this PR from there. What the captures cannot show: the daemon in the dogfood is the dev daemon reached via the `#wb=` bootstrap fragment rather than the /pair consent flow — the pairing UI itself is unchanged by this PR.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — how-to + DESIGN.md + vocabulary.md in this diff
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema — the new persisted shape is `promotionResultSchema` + `z.infer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Settings → Connections action to move the complete browser workspace to a connected daemon.
  * Transfers documents, edit history, and referenced images while preserving document links and keeping local copies.
  * Shows transfer progress and a persistent result summary, including collision and failure details.
  * Added guidance for moving workspaces to a local daemon.

* **Bug Fixes**
  * Updated connection messaging to accurately describe workspace moves and available daemon features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->