### PR TITLE
feat: promotion slice 8 — disclose a moved workspace in the browser popover

### DIFF
--- a/apps/web/src/components/AppShell.test.tsx
+++ b/apps/web/src/components/AppShell.test.tsx
@@ -3,6 +3,7 @@ import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { resetInstallPromptForTests } from '@/lib/install-prompt-store'
 import { resetShellStatusForTests, setShellConnection } from '@/lib/shell-status-store'
+import { createUserSettingsStore } from '@/lib/user-settings-store'
 import { resetSwStatusForTests } from '../pwa/sw-status-store.js'
 import { AppShell } from './AppShell.js'
 
@@ -153,6 +154,59 @@ describe('AppShell — the connection chip', () => {
     // only reports and nudges) — whole-workspace promotion is implemented,
     // so the old "import them one at a time" disclaimer would now be false.
     expect(screen.getByText(CTA_LIMIT)).toBeTruthy()
+  })
+
+  // Slice 8's honest-detach floor: a cold load whose silent renewal fails
+  // falls back to the browser flow with the stored daemon still configured.
+  // For a workspace that was MOVED to that daemon, resuming keeper duties
+  // silently would hide that edits made here diverge from the daemon copy —
+  // so the browser popover discloses the move instead of claiming nothing.
+  it('the browser popover discloses a recorded move to the still-configured daemon', async () => {
+    createUserSettingsStore().update((current) => ({
+      ...current,
+      storage: { ...current.storage, daemonBaseUrl: 'http://127.0.0.1:3099' },
+      migration: {
+        ...current.migration,
+        promotion: {
+          at: '2026-08-28T12:00:00.000Z',
+          daemonBaseUrl: 'http://127.0.0.1:3099',
+          workspaceId: 'ws-a',
+          ok: true,
+          promotedCount: 2,
+        },
+      },
+    }))
+    setShellConnection({ state: { keeper: 'browser' } })
+    renderShell(false)
+    fireEvent.click(await screen.findByTestId('connection-chip'))
+    const notice = await screen.findByTestId('promoted-elsewhere-notice')
+    expect(notice.textContent).toMatch(/moved to the daemon/i)
+    expect(notice.textContent).toMatch(/stay in this browser/i)
+    // Reachability is unknown from here, so the copy must not claim it.
+    expect(notice.textContent).not.toMatch(/unreachable|offline|cannot be reached/i)
+  })
+
+  it('no move disclosure without a matching promotion record', async () => {
+    // A promotion recorded against a daemon the browser no longer uses (or
+    // none at all) is not this connection's story to tell.
+    createUserSettingsStore().update((current) => ({
+      ...current,
+      storage: { ...current.storage, daemonBaseUrl: 'http://127.0.0.1:3099' },
+      migration: {
+        ...current.migration,
+        promotion: {
+          at: '2026-08-28T12:00:00.000Z',
+          daemonBaseUrl: 'http://127.0.0.1:4200',
+          workspaceId: 'ws-a',
+          ok: true,
+        },
+      },
+    }))
+    setShellConnection({ state: { keeper: 'browser' } })
+    renderShell(false)
+    fireEvent.click(await screen.findByTestId('connection-chip'))
+    await screen.findByText(CTA)
+    expect(screen.queryByTestId('promoted-elsewhere-notice')).toBeNull()
   })
 
   it('offers the escape to the browser from the sync-off popover', async () => {

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -19,6 +19,42 @@ const DaemonDetectedBanner = lazy(() =>
   })),
 )
 
+/**
+ * The honest-detach floor for a moved workspace: a cold load whose silent
+ * daemon renewal fails lands in the browser flow with the stored daemon
+ * still configured. For a workspace that was MOVED to that daemon, resuming
+ * browser keeper duties silently would hide that edits made here diverge
+ * from the daemon copy — so the browser popover discloses the move. Only
+ * when the recorded move targets the SAME daemon the browser still points
+ * at: a move to a daemon this browser no longer uses is not this
+ * connection's story. Reachability is unknown from here and deliberately
+ * not claimed.
+ */
+function PromotedElsewhereNotice({
+  settingsStore,
+}: {
+  settingsStore: ReturnType<typeof createUserSettingsStore>
+}) {
+  const settings = settingsStore.load()
+  const promotion = settings.migration.promotion
+  const storedDaemon = settings.storage.daemonBaseUrl
+  if (
+    promotion === undefined ||
+    !promotion.ok ||
+    storedDaemon === undefined ||
+    promotion.daemonBaseUrl !== storedDaemon
+  ) {
+    return null
+  }
+  return (
+    <p data-testid="promoted-elsewhere-notice" className="text-muted-foreground">
+      This workspace has been moved to the daemon at{' '}
+      <span className="font-mono text-xs">{storedDaemon.replace(/^https?:\/\//, '')}</span>. Changes
+      made here stay in this browser until you move it again from Settings.
+    </p>
+  )
+}
+
 export interface AppShellProps {
   readonly daemon: boolean
   /**
@@ -115,6 +151,7 @@ export function AppShell({ daemon, onWorkInBrowser }: AppShellProps) {
                 connected, you can move this workspace to it from Settings — documents, their
                 history and images together.
               </p>
+              <PromotedElsewhereNotice settingsStore={settingsStore} />
               <Suspense fallback={null}>
                 <DaemonDetectedBanner
                   settingsStore={settingsStore}

--- a/docs/how-to/connect-to-local-daemon.md
+++ b/docs/how-to/connect-to-local-daemon.md
@@ -207,4 +207,9 @@ workspace, both versions are kept and the pre-existing one is marked
 *shadowed* — nothing is renamed or overwritten. Your documents also stay in
 this browser; moving again later is safe and simply re-merges.
 
+If the app later opens in browser mode while that daemon is unavailable,
+the connection chip's popover notes that the workspace has been moved and
+that changes made in the browser stay there until you move it again — the
+two copies do not sync on their own.
+
 ← Back to [How-to guides](README.md)


### PR DESCRIPTION
## Summary

- Slice 8's minimal v1 (honest detach floor): a cold load whose silent daemon renewal fails falls back to the browser flow with the stored daemon still configured — and for a workspace that was **moved** to that daemon, silently resuming browser keeper duties would hide that edits made here diverge from the daemon copy. The connection chip's browser popover now renders a `promoted-elsewhere-notice`: "This workspace has been moved to the daemon at &lt;host&gt;. Changes made here stay in this browser until you move it again from Settings."
- Shown only when the recorded move (`migration.promotion`, `ok`, bound to a daemon since #1092) targets the **same** daemon the browser still points at (`storage.daemonBaseUrl`). Explicitly disconnecting clears the stored daemon and with it the notice; a move recorded against some other daemon is not this connection's story. Reachability is deliberately not claimed — this surface cannot know it, and the test pins that the copy never says "unreachable/offline".
- A dedicated demote/rollback action stays out of scope for v1 per the initiative plan (the browser record surviving promotion by construction is the safety net; this notice is what keeps that honest). The how-to gains a matching paragraph: the two copies do not sync on their own.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — `AppShell.test.tsx`, red-first: the disclosure renders with a matching promotion record (and never claims reachability), and stays absent when the record targets a different daemon or does not exist.
- [x] `pnpm test` passes locally — full `@kamiazya/whiteboard-web` suite green except the 9 known environment-only undici `Response(blob)` failures, unchanged from main. `pnpm -r typecheck`, `pnpm knip`, `pnpm lint:noconsole` green.
- [ ] Manual verification completed (describe below) — not separately re-run: the state is reached by seeding the same persisted settings the #1092 dogfood produced (a recorded move + a stored daemon), and the notice is pure conditional popover copy over those two fields; the jsdom tests exercise the real store and the real popover.
- [ ] E2E coverage added or extended where applicable — n/a; no flow changes, one conditional paragraph in an existing popover.

## Visual evidence

Visual evidence: none — a single conditional paragraph of muted text inside the existing browser-connection popover, reachable only with a recorded move; the popover layout, chip, and every other state are untouched, and the exact copy is pinned by the new AppShell tests.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — how-to paragraph in this diff
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a connection notice explaining when a workspace has been moved to the currently configured daemon.
  * Clarified that browser changes remain separate when the daemon is unavailable and the workspace has been moved.

* **Documentation**
  * Updated local daemon connection guidance with details about moved workspaces and browser-only changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->