### PR TITLE
docs: promotion as-built — ADR-0007 addendum and domain-model keeper crossing

### DIFF
--- a/docs/contributing/adr/0007-canvas-identity-and-store-split.md
+++ b/docs/contributing/adr/0007-canvas-identity-and-store-split.md
@@ -222,3 +222,42 @@ As built:
 Decisions 1–3 and 5 still stand; decision 2's rename is now the tree
 index's `moveDocument`, one operation with the collision rules in one
 place.
+
+## Addendum (2026-08-28): browser-to-daemon promotion — identity crosses the keeper boundary
+
+The Context's original observation — "documents kept in the browser cross
+into daemon mode only by an explicit, user-initiated copy, which re-creates
+the document under a new path" — no longer holds, and the change is the
+workspace-document design paying off once more rather than a new mechanism.
+
+As built (whole-workspace move, Settings → Connections → "This workspace"):
+
+- **The move is a CRDT merge of the whole workspace record.** The browser
+  exports its `workspace-tree` record as one snapshot and POSTs it to the
+  daemon's existing `workspace-document/update` route; nothing new was
+  added server-side. Every ULID `documentId`, every display name, and the
+  full edit history arrive intact, so references between documents keep
+  resolving on the daemon.
+- **Referenced images travel beside the record**, per file through the
+  existing document-file route, with per-file outcomes (`missing` /
+  `failed`) that never fail the merge that already landed. Re-running the
+  move is an idempotent merge.
+- **Collisions are surfaced, never auto-resolved** — the same shadowed
+  rule as the dual-plane collapse above: a path both sides hold lists both
+  documents, the pre-existing one marked shadowed.
+- **Chunking was measured out, not built.** A 300-document record measured
+  ≈0.88 MiB against the route's 16 MiB body cap, so whole-record import
+  ships and a chunked transfer stays unbuilt until a real corpus needs it.
+- **The browser does not become a replica.** After the move its record
+  remains an independent store; continuing from the daemon is a narrated
+  reload the user takes (backend mode is decided at page load, ADR-0004),
+  and when the app later runs in browser mode with that daemon still
+  configured, the connection popover discloses the move and that browser
+  edits stay local. A dedicated demote action is deliberately absent: the
+  browser record surviving by construction is the rollback.
+- **The per-document copy import is deleted.** It preserved no identity —
+  the daemon minted a new id per copy — and keeping it beside the move
+  would have left users a worse path to the same outcome.
+
+Decisions 1–3 and 5 still stand; this addendum updates only the Context's
+account of how browser-kept documents reach a daemon.

--- a/docs/explanation/domain-model.md
+++ b/docs/explanation/domain-model.md
@@ -143,9 +143,15 @@ That split is **gone**, in four steps recorded in the migration log:
   Deleting old versions (or the automatic version pruning) is therefore
   what lets compaction reclaim space; a branch left on an old state keeps
   the history its checkout needs for as long as the branch exists.
-- Documents kept in the browser still cross into daemon mode only by an explicit,
-  user-initiated copy, which re-creates the document under a new path — no
-  identifier carries over. That half of ADR-0007 is unchanged.
+- Documents kept in the browser cross to a daemon by an explicit,
+  user-initiated **move of the whole workspace** (Settings → Connections →
+  "This workspace"): the browser's workspace record merges into the chosen
+  daemon workspace, so every `documentId`, the full edit history, and
+  referenced images carry over, and a path both sides hold is surfaced as
+  shadowed rather than renamed. The browser's own copy remains — the two
+  copies do not sync on their own, and continuing from the daemon is a
+  reload the user takes. The old per-document copy (which re-created
+  documents under new identities) is deleted.
 
 The identity decision itself — `(workspaceId, path)` as the canonical
 user-facing identity — is still


### PR DESCRIPTION
## Summary

- The promotion initiative's closing docs-sync slice, written strictly to the shipped state (never the aspiration, per vocabulary.md's own honesty rule):
  - **`docs/explanation/domain-model.md`**: the closing bullet still described the retired per-document copy ("no identifier carries over"). It now describes what ships — an explicit whole-workspace move whose CRDT merge carries every `documentId`, the full edit history, and referenced images; surfaces path collisions as *shadowed*; and leaves the browser's own copy in place with no automatic sync between the two.
  - **ADR-0007** gains a dated addendum (2026-08-28) recording the promotion as built on the workspace-document design: the move is a POST of the browser's record to the **existing** `workspace-document/update` route (nothing new server-side); images travel per file with per-file outcomes that never fail the landed merge; chunking was **measured out** rather than built (~0.88 MiB at 300 documents against the 16 MiB body cap); the browser does not become a replica (narrated reload per ADR-0004, the browser-mode disclosure notice, and deliberately no demote action — the surviving record is the rollback); and the identity-less per-document copy is deleted.
- `vocabulary.md`'s keeper section and `apps/web/DESIGN.md` were already brought to the shipped state inside the implementing slices (#1092/#1093), so this PR does not touch them — landing docs beside the capability, never ahead of it.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — n/a for a docs-only change; the vocabulary guard (`arch-lint-node`, 111 tests) passes over the new prose.
- [x] `pnpm test` passes locally — `pnpm check:local` (the full CI-`check`-derived gate + knip) green.
- [ ] Manual verification completed (describe below) — n/a: prose only; every behavioral claim in the addendum is the one pinned by the merged slices' tests and the #1092 real-daemon dogfood.
- [ ] E2E coverage added or extended where applicable — n/a.

## Visual evidence

Visual evidence: none — documentation-only change (an ADR addendum and one explanation bullet); no surface a human looks at in the app is touched.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — this PR is that update
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_