### PR TITLE
fix(web): run the startup fold before the promote dialog counts documents

### DIFF
--- a/apps/web/src/components/settings/PromoteWorkspaceSection.browser.test.tsx
+++ b/apps/web/src/components/settings/PromoteWorkspaceSection.browser.test.tsx
@@ -20,7 +20,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
 import { DocumentFileStore } from '../../lib/document-file-store.js'
 import { FoldingBrowserIndex } from '../../lib/folding-browser-index.js'
-import { ensureLocalWorkspace } from '../../lib/local-document-summary.js'
+import { IdbDocumentIndex } from '../../lib/idb-document-index.js'
+import { BROWSER_WORKSPACE_ID, ensureLocalWorkspace } from '../../lib/local-document-summary.js'
+import { LoroStore } from '../../lib/loro-store.js'
 import { createUserSettingsStore, STORAGE_KEY } from '../../lib/user-settings-store.js'
 import { seedWorkspaceDocumentContent } from '../../lib/workspace-content.js'
 import { clearWhiteboardDb } from '../../test-utils/browser-document.js'
@@ -109,6 +111,28 @@ async function seedImageOnSketch(sketchId: string): Promise<void> {
       new Uint8Array(content.export({ mode: 'snapshot' })),
     ),
   ).toBe(true)
+}
+
+/**
+ * A document as an older build left it: an index row plus per-document Loro
+ * bytes, never absorbed into the workspace record. Exactly what a session
+ * that deep-links straight to Settings sees before any page ran the fold.
+ */
+async function seedPreFoldDocument(path: string): Promise<string> {
+  const index = new IdbDocumentIndex()
+  await index.createWorkspace({ workspaceId: BROWSER_WORKSPACE_ID })
+  const entry = await index.createDocument({
+    workspaceId: BROWSER_WORKSPACE_ID,
+    path,
+    kind: 'spatial',
+  })
+  const doc = new LoroDoc()
+  doc
+    .getMap('nodes')
+    .set('n1', { id: 'n1', type: 'text', x: 0, y: 0, width: 80, height: 40, text: 'pre-fold' })
+  doc.commit()
+  await new LoroStore().save(entry.documentId, doc.export({ mode: 'snapshot' }))
+  return entry.documentId
 }
 
 const NO_INTERNAL_VOCABULARY = /loro|crdt|oplog|snapshot/i
@@ -308,6 +332,30 @@ describe('PromoteWorkspaceSection', () => {
     )
     expect(screen.queryByTestId('promote-last-result')).toBeNull()
     expect(screen.queryByTestId('promote-reload')).toBeNull()
+  })
+
+  // The section can be a session's FIRST surface (deep-link/reload straight
+  // to Settings): no browser page has run the startup fold, so the workspace
+  // record does not hold pre-fold legacy documents yet. The count and the
+  // transfer must still include them — silently omitting a document from a
+  // data-migration UI is the data-loss shape this pins.
+  it('counts and moves a document held only by pre-fold records, with no page mounted first', async () => {
+    const legacyId = await seedPreFoldDocument('legacy/roadmap')
+    const target = new LoroDoc()
+    render(
+      <PromoteWorkspaceSection
+        daemon={DAEMON}
+        settingsStore={createUserSettingsStore()}
+        baseFetch={daemonStub(target)}
+        reload={vi.fn()}
+      />,
+    )
+    await userEvent.click(screen.getByTestId('promote-workspace-open'))
+    const dialog = await screen.findByTestId('promote-dialog')
+    expect(dialog.textContent).toMatch(/all 1 document\b/i)
+    await userEvent.click(screen.getByTestId('promote-confirm'))
+    await screen.findByTestId('promote-last-result')
+    expect(resolveWorkspaceDocumentById(target, legacyId)).not.toBeNull()
   })
 
   it('stays discoverable but disabled with no daemon connected', async () => {

--- a/apps/web/src/components/settings/PromoteWorkspaceSection.fold-failure.browser.test.tsx
+++ b/apps/web/src/components/settings/PromoteWorkspaceSection.fold-failure.browser.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * The promote dialog's fold-failure degradation, in its own file: vi.mock is
+ * hoisted file-wide, and the positive-path tests next door must exercise the
+ * REAL fold — a shared file would put the spy under them too.
+ *
+ * The decided degradation: a failed fold falls back to exactly the pre-fold
+ * view — tree-held documents only, undercounted but OPEN — and never reads
+ * as a daemon failure, because it is a storage-side problem. Note the
+ * observability asymmetry: an un-called fold and a failed fold are identical
+ * at the dialog, so the load-bearing assertion is that the fold was ATTEMPTED
+ * (the spy fired); the count and copy assertions pin the degradation shape.
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import { LoroDoc } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { foldWorkspaceDocuments } from '../../lib/fold-workspace.js'
+import { FoldingBrowserIndex } from '../../lib/folding-browser-index.js'
+import { IdbDocumentIndex } from '../../lib/idb-document-index.js'
+import { BROWSER_WORKSPACE_ID, ensureLocalWorkspace } from '../../lib/local-document-summary.js'
+import { LoroStore } from '../../lib/loro-store.js'
+import { createUserSettingsStore, STORAGE_KEY } from '../../lib/user-settings-store.js'
+import { clearWhiteboardDb } from '../../test-utils/browser-document.js'
+import { claimIsolatedWhiteboardDb } from '../../test-utils/isolated-whiteboard-db.js'
+import { PromoteWorkspaceSection } from './PromoteWorkspaceSection.js'
+
+vi.mock('../../lib/fold-workspace.js', { spy: true })
+
+claimIsolatedWhiteboardDb('promote-fold-failure')
+
+const DAEMON = { baseUrl: 'http://127.0.0.1:3099', token: 'tok-1' }
+
+/** Only the workspace listing — the scenario never reaches the transfer. */
+const listOnlyStub = (async (input: RequestInfo | URL) => {
+  const url = typeof input === 'string' ? input : input.toString()
+  if (url.endsWith('/api/workspaces')) {
+    return Response.json({ workspaces: [{ workspaceId: 'ws-a' }] })
+  }
+  throw new Error(`unexpected fetch: ${url}`)
+}) as typeof globalThis.fetch
+
+beforeEach(async () => {
+  localStorage.removeItem(STORAGE_KEY)
+  await clearWhiteboardDb()
+  vi.mocked(foldWorkspaceDocuments).mockClear()
+})
+afterEach(cleanup)
+
+describe('PromoteWorkspaceSection under a failing fold', () => {
+  it('attempts the fold, degrades to the tree-held count, never claims a daemon failure', async () => {
+    // One document each side of the fold: tree-held (survives a failed fold)
+    // and a pre-fold legacy record (only a successful fold would carry it).
+    const tree = new FoldingBrowserIndex()
+    await ensureLocalWorkspace(tree)
+    await tree.createDocument({ workspaceId: 'local', path: 'held', kind: 'markdown' })
+    const legacy = new IdbDocumentIndex()
+    const entry = await legacy.createDocument({
+      workspaceId: BROWSER_WORKSPACE_ID,
+      path: 'legacy-only',
+      kind: 'spatial',
+    })
+    const doc = new LoroDoc()
+    doc.getMap('nodes').set('n1', { id: 'n1', type: 'text', x: 0, y: 0, width: 8, height: 4 })
+    doc.commit()
+    await new LoroStore().save(entry.documentId, doc.export({ mode: 'snapshot' }))
+
+    // The seeding above runs the real (spied) fold via FoldingBrowserIndex;
+    // only the component's own call is under test.
+    vi.mocked(foldWorkspaceDocuments).mockClear()
+    vi.mocked(foldWorkspaceDocuments).mockRejectedValueOnce(new Error('injected fold failure'))
+
+    render(
+      <PromoteWorkspaceSection
+        daemon={DAEMON}
+        settingsStore={createUserSettingsStore()}
+        baseFetch={listOnlyStub}
+        reload={vi.fn()}
+      />,
+    )
+    await userEvent.click(screen.getByTestId('promote-workspace-open'))
+
+    // The flow reaches the confirmation, not a stuck or error state...
+    const dialog = await screen.findByTestId('promote-dialog')
+    // ...the fold was attempted exactly once (an un-called fold shows the
+    // same dialog, which is why this assertion carries the test)...
+    expect(vi.mocked(foldWorkspaceDocuments)).toHaveBeenCalledTimes(1)
+    // ...the count is the pre-fold degradation value: the tree-held document
+    // alone, the legacy record left behind by the failed fold...
+    expect(dialog.textContent).toMatch(/all 1 document\b/i)
+    // ...and nothing blames the daemon for a storage-side failure.
+    expect(screen.queryByTestId('promote-unavailable')).toBeNull()
+    expect(document.body.textContent).not.toMatch(/could not reach the daemon/i)
+  })
+})

--- a/apps/web/src/components/settings/PromoteWorkspaceSection.tsx
+++ b/apps/web/src/components/settings/PromoteWorkspaceSection.tsx
@@ -27,8 +27,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { getAppLogger } from '@/lib/app-logger'
 import { createDaemonFetch, listWorkspaces } from '@/lib/daemon-api-client'
 import type { PromotionResultRecord, UserSettings } from '@/lib/user-settings-store'
+
+const log = getAppLogger('promote-workspace-section')
 
 export interface PromoteWorkspaceSectionProps {
   daemon?: { baseUrl: string; token: string | null }
@@ -102,12 +105,29 @@ export function PromoteWorkspaceSection({
       baseFetch ?? globalThis.fetch.bind(globalThis),
     )
     try {
-      const [{ countBrowserWorkspaceDocuments }, { BrowserWorkspaceDocs }, workspaces] =
-        await Promise.all([
-          import('../../lib/promote-workspace.js'),
-          import('../../lib/browser-workspace-docs.js'),
-          listWorkspaces(fetchImpl, daemon.baseUrl),
-        ])
+      const [
+        { countBrowserWorkspaceDocuments },
+        { BrowserWorkspaceDocs },
+        { foldWorkspaceDocuments },
+        workspaces,
+      ] = await Promise.all([
+        import('../../lib/promote-workspace.js'),
+        import('../../lib/browser-workspace-docs.js'),
+        import('../../lib/fold-workspace.js'),
+        listWorkspaces(fetchImpl, daemon.baseUrl),
+      ])
+      // Settings can be a session's first surface (deep-link/reload), so the
+      // startup fold may not have run yet — and this count reads the
+      // workspace record, which without the fold silently omits an older
+      // build's per-document records. Non-fatal, and its OWN catch: a fold
+      // failure degrades to the pre-fold view (undercounted but open) and is
+      // a storage-side problem, so it must not read as the outer catch's
+      // "could not reach the daemon".
+      try {
+        await foldWorkspaceDocuments()
+      } catch (err) {
+        log.warn('startup fold failed; continuing without it', err)
+      }
       const documentCount = await countBrowserWorkspaceDocuments(new BrowserWorkspaceDocs())
       const workspaceIds = workspaces.workspaces.map((ws) => ws.workspaceId)
       if (documentCount === 0) {

--- a/apps/web/src/lib/promote-workspace.ts
+++ b/apps/web/src/lib/promote-workspace.ts
@@ -16,7 +16,9 @@
  * The caller owns the fold: a legacy row-plane document that has not been
  * absorbed into the tree yet is not in the record this reads, so the promote
  * surface must run after the startup fold (any FoldingBrowserIndex read
- * performs it) — the same ordering every other record consumer relies on.
+ * performs it; the Settings section folds explicitly before counting, since
+ * it can be a session's first surface) — the same ordering every other
+ * record consumer relies on.
  */
 import {
   documentContainers,


### PR DESCRIPTION
## What

Settings can be a session's first surface — a deep-link or reload straight to `/settings/connections` mounts no browser page, so the startup fold never runs. The promote dialog's count (and the transfer) read the workspace record alone, silently omitting an older build's per-document records; worst case the user is told **"This browser keeps no documents to move"** — a false negative in a data-migration UI. (audit-triage verified finding.)

`openConfirmation` now awaits `foldWorkspaceDocuments()` (added to the existing dynamic-import `Promise.all`, keeping loro off the settings chunk) before counting, in its **own** non-fatal catch: a storage-side fold failure degrades to the pre-fold count (undercounted but open) and never reads as the outer catch's "Could not reach the daemon".

## Tests (red first)

- **Positive path** (`PromoteWorkspaceSection.browser.test.tsx`): seeds a document only through the legacy pre-fold primitives (`IdbDocumentIndex` + `LoroStore`, never `FoldingBrowserIndex`), mounts the section, and asserts the dialog counts it and the move lands it on the daemon stub under the same `documentId`. Failed against the unfixed component (dialog never opens — flow hits the "no documents" branch).
- **Negative path** (`PromoteWorkspaceSection.fold-failure.browser.test.tsx`, separate file because `vi.mock` is hoisted file-wide and the positive tests need the real fold): injected fold rejection → fold attempted exactly once, dialog still opens, count degrades to the tree-held document alone, no daemon-failure copy.
- **Mutation check**: removing the fold call fails both (`findByTestId('promote-dialog')` timeout at line 354; `expected "vi.fn()" to be called 1 times, but got 0 times`); restore is 9/9.

## Gates

- `web-browser` full project: 570 tests — one load-dependent failure in the first (concurrent) run, full re-run green with no failing test.
- `pnpm --filter @kamiazya/whiteboard-web test`: 2770 passed, 9 failed — exactly the 9 known undici `Response(blob)` environment failures (VersionThumbnail×4, DocumentThumb×2, MergeDialog×1, VersionTimeline×1, daemon-file-adapter×1), unchanged from main.
- `pnpm check:local` exit 0; typecheck green.

## Visual repro

Manually verified in the real running app (vite dev + the real daemon on :3099): seeded a legacy record through the app's own modules in the page, connected the daemon via a `#wb=` fragment, deep-linked to Settings with no other page visited.

- **before** (panel digest `c34cccc7`): "This browser keeps no documents to move."
- **after** (panel digest `3daefdc9`): dialog says "All 1 document", the move reports "Moved 1 document to daemon workspace \"promote-fold-verify\"", and the daemon listing shows the document under the **same `documentId`** (`01M14JEFADB4RJHE5F16W634KN`) and path — identity preserved end to end.

The composed before/after figure (`compose-figure.mjs`, refuses identical panels) exists locally at `tmp/screenshots/promote-fold-figure.png` but cannot be uploaded from this environment: the `gh` CLI (and thus the `gh image` extension) is unavailable in this remote session, so the figure upload step is impossible here — the transcript above and the two panel digests are the evidence on record. Staged aspects: the legacy state was console-seeded through the same production primitives an old build used (no old build was on hand), and the "before" run used the pre-fix component checked out file-wise under the same dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_