### PR TITLE
docs: fix the Docker self-host Quick start build command

### DIFF
--- a/docs/how-to/self-host-with-docker.md
+++ b/docs/how-to/self-host-with-docker.md
@@ -19,8 +19,9 @@ tokens with server JWT authentication.
 # 1. Copy the env template and fill in your values.
 cp .env.server.example .env
 
-# 2. Build and start the container.
-docker compose -f docker-compose.server.yml up -d
+# 2. Build and start the container. NODE_VERSION is a required build
+#    argument — the image pins the same Node release the repo develops on.
+NODE_VERSION="$(cat .node-version)" docker compose -f docker-compose.server.yml up -d --build
 
 # 3. Check the server is healthy.
 docker compose -f docker-compose.server.yml ps


### PR DESCRIPTION
## What

The self-host how-to's Quick start step 2 said `docker compose -f docker-compose.server.yml up -d`, which fails verbatim with `required variable NODE_VERSION is missing a value` — `docker-compose.server.yml` requires `NODE_VERSION` via `:?` interpolation, and the doc also omitted `--build`. This is literally a new self-hoster's first command after copying the env template (audit-triage verified finding).

Step 2 now matches the compose file's own usage header and `.env.server.example`:

```sh
NODE_VERSION="$(cat .node-version)" docker compose -f docker-compose.server.yml up -d --build
```

## Verification

Both directions checked against the real compose file: with `.env` copied and `NODE_VERSION` set, `docker compose config` parses clean; without `NODE_VERSION`, it reproduces the exact documented failure. `pnpm check:local` exit 0.

Visual evidence: none — docs-only change to a shell command; the `docker compose config` reproduction above is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_