### PR TITLE
feat(ports): widen listWorkspaces/createWorkspace with optional segment + displayName

### DIFF
--- a/packages/ports/src/document-index.test.ts
+++ b/packages/ports/src/document-index.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { compareDocumentPaths, documentEntrySchema } from './document-index.js'
+import {
+  compareDocumentPaths,
+  createWorkspaceInputSchema,
+  documentEntrySchema,
+  workspaceEntrySchema,
+} from './document-index.js'
 import { fc, fcTest } from './test-utils/fast-check.js'
 
 describe('compareDocumentPaths', () => {
@@ -73,5 +78,91 @@ describe('documentEntrySchema', () => {
       kind: 'spatial',
     })
     expect(parsed.success).toBe(false)
+  })
+})
+
+// ADR-0019's identity layers, their first consumer in this package. See
+// document-index.ts's doc comment for why canonicalId is not a separate
+// field: workspaceId already IS the canonical layer.
+describe('createWorkspaceInputSchema (ADR-0019 segment/displayName widening)', () => {
+  it('accepts a bare legacy workspaceId with neither field, as before', () => {
+    expect(createWorkspaceInputSchema.safeParse({ workspaceId: 'ws-conformance' }).success).toBe(
+      true,
+    )
+  })
+
+  it('accepts a workspaceId carrying a valid segment and displayName', () => {
+    const parsed = createWorkspaceInputSchema.safeParse({
+      workspaceId: 'ws-conformance',
+      segment: 'team-notes',
+      displayName: 'Team notes',
+    })
+    expect(parsed.success).toBe(true)
+  })
+
+  it('rejects a ULID-shaped segment, case-insensitively', () => {
+    expect(
+      createWorkspaceInputSchema.safeParse({
+        workspaceId: 'ws',
+        segment: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      }).success,
+    ).toBe(false)
+    expect(
+      createWorkspaceInputSchema.safeParse({
+        workspaceId: 'ws',
+        segment: '01arz3ndektsv4rrffq69g5fav',
+      }).success,
+    ).toBe(false)
+  })
+
+  it('rejects a segment containing a path separator', () => {
+    expect(
+      createWorkspaceInputSchema.safeParse({ workspaceId: 'ws', segment: 'a/b' }).success,
+    ).toBe(false)
+  })
+
+  it('rejects an untrimmed or empty displayName', () => {
+    expect(
+      createWorkspaceInputSchema.safeParse({ workspaceId: 'ws', displayName: ' x ' }).success,
+    ).toBe(false)
+    expect(
+      createWorkspaceInputSchema.safeParse({ workspaceId: 'ws', displayName: '' }).success,
+    ).toBe(false)
+  })
+
+  it('rejects an unknown key', () => {
+    expect(
+      createWorkspaceInputSchema.safeParse({ workspaceId: 'ws', displayname: 'typo' }).success,
+    ).toBe(false)
+  })
+})
+
+describe('workspaceEntrySchema', () => {
+  it('accepts a bare legacy row (Wave-2-unminted rows carry neither field)', () => {
+    expect(workspaceEntrySchema.safeParse({ workspaceId: 'ws-conformance' }).success).toBe(true)
+  })
+
+  it('accepts a row carrying a valid segment and displayName', () => {
+    const parsed = workspaceEntrySchema.safeParse({
+      workspaceId: 'ws-conformance',
+      segment: 'team-notes',
+      displayName: 'Team notes',
+    })
+    expect(parsed.success).toBe(true)
+  })
+
+  it('rejects a ULID-shaped segment', () => {
+    expect(
+      workspaceEntrySchema.safeParse({
+        workspaceId: 'ws',
+        segment: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      }).success,
+    ).toBe(false)
+  })
+
+  it('rejects an unknown key', () => {
+    expect(workspaceEntrySchema.safeParse({ workspaceId: 'ws', displayname: 'typo' }).success).toBe(
+      false,
+    )
   })
 })

--- a/packages/ports/src/document-index.ts
+++ b/packages/ports/src/document-index.ts
@@ -2,7 +2,9 @@ import {
   documentIdSchema,
   documentKindSchema,
   documentPathSchema,
+  workspaceDisplayNameSchema,
   workspaceIdSchema,
+  workspaceSegmentSchema,
 } from '@kamiazya/whiteboard-model'
 import { z } from 'zod'
 
@@ -55,8 +57,45 @@ export const createDocumentInputSchema = z
   .strict()
 export type CreateDocumentInput = z.infer<typeof createDocumentInputSchema>
 
-export const createWorkspaceInputSchema = z.object({ workspaceId: workspaceIdSchema }).strict()
+/**
+ * ADR-0019's user-facing (`segment`) and naming (`displayName`) layers, both
+ * optional: shape-validated here via the model schemas, but their PERSISTENCE
+ * and — for `segment` — their per-keeper UNIQUENESS are the registry
+ * implementation's job, not this contract's. An implementation is free to
+ * accept and currently ignore both fields; today every implementation does
+ * (serving them is the follow-up slice: mcp-server's `workspaceSummarySchema`
+ * + `workspaces` table columns + `smoke:e2e`).
+ *
+ * No `canonicalId` field: ADR-0019's canonical layer already IS
+ * `workspaceId`. Its schema tightens from `workspaceIdSchema` to the
+ * stricter `workspaceCanonicalIdSchema` only after both keepers' minting
+ * migrations land (tightening first would reject live data such as
+ * `'default'`/`'local'`) — a separate `canonicalId` field would just be a
+ * second spelling of the same layer racing that migration.
+ */
+export const createWorkspaceInputSchema = z
+  .object({
+    workspaceId: workspaceIdSchema,
+    segment: workspaceSegmentSchema.optional(),
+    displayName: workspaceDisplayNameSchema.optional(),
+  })
+  .strict()
 export type CreateWorkspaceInput = z.infer<typeof createWorkspaceInputSchema>
+
+/**
+ * A `listWorkspaces` row. `segment`/`displayName` are OPTIONAL for the same
+ * reason `DocumentEntry`'s `name` is: a workspace created before ADR-0019's
+ * minting migration lands has neither, and an invented value would read as
+ * fact where there is none.
+ */
+export const workspaceEntrySchema = z
+  .object({
+    workspaceId: workspaceIdSchema,
+    segment: workspaceSegmentSchema.optional(),
+    displayName: workspaceDisplayNameSchema.optional(),
+  })
+  .strict()
+export type WorkspaceEntry = z.infer<typeof workspaceEntrySchema>
 
 export const resolveDocumentByIdInputSchema = z
   .object({ workspaceId: workspaceIdSchema, documentId: documentIdSchema })
@@ -257,7 +296,7 @@ export interface DocumentIndex {
    * the list is empty on a fresh index: apps/web's writes `local` when its
    * store is created, because that is the one the browser UI opens.
    */
-  listWorkspaces(): Promise<{ workspaceId: string }[]>
+  listWorkspaces(): Promise<WorkspaceEntry[]>
   /**
    * Fails `WorkspaceNotFoundError` if the workspace does not exist. Fails if
    * the path is taken. Creating never silently adopts an existing

--- a/packages/ports/src/test-utils/document-index-conformance.ts
+++ b/packages/ports/src/test-utils/document-index-conformance.ts
@@ -6,6 +6,7 @@ import {
   DocumentNotFoundError,
   DocumentPathTakenError,
   WorkspaceNotFoundError,
+  workspaceEntrySchema,
 } from '../index.js'
 
 /**
@@ -430,6 +431,43 @@ export function describeDocumentIndexConformance(
       } finally {
         await dispose()
       }
+    })
+
+    // ADR-0019's identity layers ride along on createWorkspace/listWorkspaces
+    // without being SERVED yet: every implementation accepts segment and
+    // displayName and currently ignores them, so this deliberately does NOT
+    // assert echo-back. Serving stored values is the follow-up slice
+    // (mcp-server: widen workspaceSummarySchema + workspaces table columns +
+    // smoke:e2e).
+    it('accepts a createWorkspace carrying segment and displayName, currently ignored', async () => {
+      await withIndex(async (index) => {
+        await index.createWorkspace({
+          workspaceId: 'ws-identity',
+          segment: 'team-notes',
+          displayName: 'Team notes',
+        })
+        // Idempotent, same as the bare-id case: re-creating is not an error.
+        await index.createWorkspace({
+          workspaceId: 'ws-identity',
+          segment: 'team-notes',
+          displayName: 'Team notes',
+        })
+
+        const ids = (await index.listWorkspaces()).map((w) => w.workspaceId)
+        expect(ids).toContain('ws-identity')
+      })
+    })
+
+    it('every listWorkspaces row parses against workspaceEntrySchema', async () => {
+      await withIndex(async (index) => {
+        const rows = await index.listWorkspaces()
+        // A guard that never reaches its subject passes vacuously — the
+        // shared fixture creates two workspaces, so this cannot be empty.
+        expect(rows.length).toBeGreaterThan(0)
+        for (const row of rows) {
+          expect(workspaceEntrySchema.safeParse(row).success).toBe(true)
+        }
+      })
     })
   })
 }

--- a/packages/ports/src/test-utils/in-memory-document-index.ts
+++ b/packages/ports/src/test-utils/in-memory-document-index.ts
@@ -11,6 +11,7 @@ import type {
   ResolveDocumentByIdInput,
   ResolveDocumentInput,
   SetDocumentNameInput,
+  WorkspaceEntry,
 } from '../index.js'
 import {
   compareDocumentPaths,
@@ -64,7 +65,7 @@ export class InMemoryDocumentIndex implements DocumentIndex {
     this.#workspaces.add(workspaceId)
   }
 
-  async listWorkspaces(): Promise<{ workspaceId: string }[]> {
+  async listWorkspaces(): Promise<WorkspaceEntry[]> {
     return [...this.#workspaces].map((workspaceId) => ({ workspaceId }))
   }
 

--- a/packages/ports/src/types.test.ts
+++ b/packages/ports/src/types.test.ts
@@ -9,6 +9,7 @@ import type {
   BlobPutResult,
   BlobStore,
 } from './blob-store.js'
+import type { CreateWorkspaceInput, DocumentIndex, WorkspaceEntry } from './document-index.js'
 import type {
   AppendDeltasInput,
   AppendDeltasResult,
@@ -63,6 +64,17 @@ it('BlobStore: every method param/return is exactly its named DTO', () => {
 
   expectTypeOf<Parameters<BlobStore['delete']>[0]>().toEqualTypeOf<BlobDeleteInput>()
   expectTypeOf<Awaited<ReturnType<BlobStore['delete']>>>().toEqualTypeOf<void>()
+})
+
+it('DocumentIndex: createWorkspace/listWorkspaces param/return are exactly their named DTOs', () => {
+  expectTypeOf<
+    Parameters<DocumentIndex['createWorkspace']>[0]
+  >().toEqualTypeOf<CreateWorkspaceInput>()
+  expectTypeOf<Awaited<ReturnType<DocumentIndex['createWorkspace']>>>().toEqualTypeOf<void>()
+
+  expectTypeOf<Awaited<ReturnType<DocumentIndex['listWorkspaces']>>>().toEqualTypeOf<
+    WorkspaceEntry[]
+  >()
 })
 
 it('PresenceChannel: publish param and subscribe callback param are PresenceState; subscribe return is control-plane (not a DTO)', () => {


### PR DESCRIPTION
## What

Multi-workspace Wave 1, slice 4 — the port-contract widening on top of #1099's model schemas ([ADR-0019](docs/contributing/adr/0019-workspace-identity.md)). Contract only; no implementation behavior changes.

- **New `workspaceEntrySchema` / `WorkspaceEntry`** (`.strict()`) in `packages/ports`: `workspaceId` + optional `segment` + optional `displayName`, composing the model schemas via import (never restated). `DocumentIndex.listWorkspaces()` is retyped to `Promise<WorkspaceEntry[]>`, retiring an inline hand-written return literal that violated the package's own named-DTO convention.
- **`createWorkspaceInputSchema`** gains the same two optional fields, stays `.strict()`. Doc comments pin the ADR's split: segment **uniqueness** is the keeper registry's job (shape only here), and implementations currently **accept-and-ignore** the fields — serving stored values is the named follow-up slice (mcp-server `workspaceSummarySchema` + `workspaces` table widening).
- **Decided and documented: no `canonicalId` field.** ADR-0019's canonical layer IS `workspaceId` — its schema tightens to the canonical-ULID shape only after the Wave-2 minting migrations. A separate field would be a second spelling of the same layer. `DocRef` untouched (diff over `doc-ref.ts` is empty).

## Tests

- Red-first schema examples: input carrying `segment`/`displayName` fails against the pre-widening `.strict()` schema, passes after; ULID-shaped segment rejected case-insensitively (the segment-first URL-resolution invariant, inherited transitively from model); `.strict()` unknown-key rejection pinned.
- Conformance suite (`describeDocumentIndexConformance`) gains create-with-identity + every-row-parses cases, with a subject-presence assertion so the row guard cannot pass vacuously; all implementations (in-memory double, `workspace-index`'s tree index, apps/web IndexedDB impls) pass unchanged.
- `types.test.ts` gains `expectTypeOf` coverage for both touched `DocumentIndex` methods.
- Mutation checks recorded: dropping the `.optional()` fields reddens the accept tests; swapping the segment schema for `z.string()` reddens the ULID-shaped reject.

## Gates

Independent review workflow over the diff: 0 findings, QA pass. `ports-node` + `workspace-index-node` 194 passed; `pnpm -r typecheck`, `pnpm check:local` exit 0. `mcp-node` full run shows 4 failures in permission-denied/EACCES simulation tests (`0011-import-fs-blobs` ×2, `prepare` ×1, `migrator` ×1) that reproduce identically on unmodified `origin/main` in this environment — the session container runs as root (uid 0), so `chmod`-based denial fixtures are no-ops; they pass in CI's non-root runner and are unrelated to this diff.

Visual evidence: none — port-contract foundation slice with no user-visible surface; the conformance/test output above is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_