### PR TITLE
refactor: drop backward-compat remnants — viewport schema looseness and the excalidraw spelling

### DIFF
--- a/.claude/rules/vocabulary.md
+++ b/.claude/rules/vocabulary.md
@@ -92,10 +92,18 @@ a later sweep does not "fix" them.
 - **Judge by the RETURN TYPE, not the owner.** `documentSyncSession.getCanvas()`
   answers with a `SpatialCanvas`, so `Canvas` is correct even though a
   document-shaped object owns the method.
-- **Window-event VALUES** stay `'excalidraw:doc_changed'` /
-  `'excalidraw:wb_version_saved'`; four modules match the raw strings and
-  `document-sync-types.test.ts` pins both so a rename cannot take the wire
-  format with it.
+- **Window-event VALUES** are `'whiteboard:doc_changed'` /
+  `'whiteboard:wb_version_saved'` / `'whiteboard:merge_committed'`, and the WS
+  subprotocol is `'whiteboard-v1'`. The `excalidraw:*` / `excalidraw-v1`
+  spellings were retired in one coordinated rename (2026-08-28, 0.0.x
+  no-compat policy): window events never leave the bundle and are not
+  persisted, and both ends of the WS subprotocol ship from this repo — a
+  stale cached bundle fails the handshake until it updates, which is the
+  accepted cost. `document-sync-types.test.ts` still pins the event values so
+  a PARTIAL rename cannot split the four modules that match the raw strings.
+  What still legitimately spells `excalidraw`: assertions about foreign
+  formats (`.excalidrawlib` packs, the Excalidraw clipboard payload), the
+  sbom/import guards proving the old deps stay gone, and history in ADRs.
 - **User-visible copy** ("New canvas", "Canvas actions"). What the product
   calls a thing to its users is a product decision this rule does not reach.
 - **Assertions ABOUT the old word.** `resolve.test.ts` still writes

--- a/apps/web/src/components/HeaderBranchBanner.test.tsx
+++ b/apps/web/src/components/HeaderBranchBanner.test.tsx
@@ -97,11 +97,11 @@ describe('HeaderBranchBanner', () => {
     expect(screen.queryByTestId('header-branch-banner')).toBeNull()
   })
 
-  it('does NOT register an excalidraw:head_changed listener (callback model, not window bus)', () => {
+  it('does NOT register an whiteboard:head_changed listener (callback model, not window bus)', () => {
     const addSpy = vi.spyOn(window, 'addEventListener')
     render(<HeaderBranchBanner workspaceId="s1" path="c1" />)
     const registeredEvents = addSpy.mock.calls.map((call) => call[0])
-    expect(registeredEvents).not.toContain('excalidraw:head_changed')
+    expect(registeredEvents).not.toContain('whiteboard:head_changed')
     addSpy.mockRestore()
   })
 
@@ -150,7 +150,7 @@ describe('HeaderBranchBanner', () => {
 
     await act(async () => {
       window.dispatchEvent(
-        new CustomEvent('excalidraw:merge_committed', { detail: { not: 'valid' } }),
+        new CustomEvent('whiteboard:merge_committed', { detail: { not: 'valid' } }),
       )
       await Promise.resolve()
     })

--- a/apps/web/src/components/HeaderBranchBanner.tsx
+++ b/apps/web/src/components/HeaderBranchBanner.tsx
@@ -13,7 +13,7 @@ import { MergeDialog } from './MergeDialog'
 // - Refresh whenever HEAD or branches change; failures stay silent and simply hide the banner
 //
 // Unlike the packages/mcp-server original, this component does not subscribe to an
-// "excalidraw:head_changed" window event: apps/web's useBranches has no such
+// "whiteboard:head_changed" window event: apps/web's useBranches has no such
 // broadcast, so external HEAD changes reach this component passively through
 // its own hook state (a future caller wires useDocumentSync.onHeadChanged ->
 // branches.refetch()). merge_committed stays a window event, but is parsed

--- a/apps/web/src/components/MergeToast.tsx
+++ b/apps/web/src/components/MergeToast.tsx
@@ -19,7 +19,7 @@ const log = getAppLogger('merge-toast')
 // - Auto-dismiss: 5 seconds by default; pause while hovered
 // - Undo hides the toast immediately and restores preMergeVersionId
 //
-// MergeDialog dispatches excalidraw:merge_committed, and DocumentPage mounts this so it stays local to the canvas view.
+// MergeDialog dispatches whiteboard:merge_committed, and DocumentPage mounts this so it stays local to the canvas view.
 
 export interface MergeToastProps {
   workspaceId: string

--- a/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.browser.test.tsx
@@ -124,11 +124,11 @@ afterEach(async () => {
 })
 
 describe('WorkspaceTopBar browser mode', () => {
-  it('does not dispatch excalidraw:wb_version_saved when POST /versions returns invalid schema', async () => {
+  it('does not dispatch whiteboard:wb_version_saved when POST /versions returns invalid schema', async () => {
     // The default beforeEach mock returns { ok: true } for POST /versions,
     // which does not match saveVersionResponseSchema (missing version.id, branchName, etc.).
     const versionSavedFired = vi.fn()
-    window.addEventListener('excalidraw:wb_version_saved', versionSavedFired)
+    window.addEventListener('whiteboard:wb_version_saved', versionSavedFired)
 
     renderTopBar()
 
@@ -153,7 +153,7 @@ describe('WorkspaceTopBar browser mode', () => {
 
     expect(versionSavedFired).not.toHaveBeenCalled()
 
-    window.removeEventListener('excalidraw:wb_version_saved', versionSavedFired)
+    window.removeEventListener('whiteboard:wb_version_saved', versionSavedFired)
   })
 
   it('dispatches wb_version_saved on a conforming save, clearing HeaderVersionDot', async () => {
@@ -175,14 +175,14 @@ describe('WorkspaceTopBar browser mode', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const versionSavedFired = vi.fn()
-    window.addEventListener('excalidraw:wb_version_saved', versionSavedFired)
+    window.addEventListener('whiteboard:wb_version_saved', versionSavedFired)
 
     renderTopBar()
 
     // Mark the doc dirty first (as useWhiteboardSync would on a real edit) so
     // HeaderVersionDot's dot is visible before the save clears it.
     window.dispatchEvent(
-      new CustomEvent('excalidraw:doc_changed', {
+      new CustomEvent('whiteboard:doc_changed', {
         detail: { workspaceId: 'sess_1', path: 'design/login-flow' },
       }),
     )
@@ -209,7 +209,7 @@ describe('WorkspaceTopBar browser mode', () => {
       expect(screen.queryByRole('button', { name: /save/i })).toBeNull()
     })
 
-    window.removeEventListener('excalidraw:wb_version_saved', versionSavedFired)
+    window.removeEventListener('whiteboard:wb_version_saved', versionSavedFired)
   })
 
   it('issues PUT /versions/:id/thumbnail after a valid save when getThumbnailBlob returns a Blob', async () => {
@@ -276,7 +276,7 @@ describe('WorkspaceTopBar browser mode', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const versionSavedFired = vi.fn()
-    window.addEventListener('excalidraw:wb_version_saved', versionSavedFired)
+    window.addEventListener('whiteboard:wb_version_saved', versionSavedFired)
 
     renderTopBar({ getThumbnailBlob })
 
@@ -287,7 +287,7 @@ describe('WorkspaceTopBar browser mode', () => {
       expect(versionSavedFired).toHaveBeenCalledTimes(1)
     })
 
-    window.removeEventListener('excalidraw:wb_version_saved', versionSavedFired)
+    window.removeEventListener('whiteboard:wb_version_saved', versionSavedFired)
   })
 
   // RED-first: the ~400px collapse is a new UX decision, not part of the

--- a/apps/web/src/components/workspace-top-bar/useSaveVersion.ts
+++ b/apps/web/src/components/workspace-top-bar/useSaveVersion.ts
@@ -52,7 +52,7 @@ export function useSaveVersion({
         // Manual save can bypass the server's version_created websocket path; a later WS event becomes a no-op.
         if (typeof window !== 'undefined') {
           const detail: DirtyEventDetail = { workspaceId, path }
-          window.dispatchEvent(new CustomEvent('excalidraw:wb_version_saved', { detail }))
+          window.dispatchEvent(new CustomEvent('whiteboard:wb_version_saved', { detail }))
         }
         const id = parsed.data.version.id
         if (id && getThumbnailBlob) {

--- a/apps/web/src/hooks/useBranches.test.ts
+++ b/apps/web/src/hooks/useBranches.test.ts
@@ -323,7 +323,7 @@ describe('useBranches hook (callback model, no window event subscription)', () =
     consoleErrorSpy.mockRestore()
   })
 
-  it('does not register a window "excalidraw:head_changed" listener', async () => {
+  it('does not register a window "whiteboard:head_changed" listener', async () => {
     const addSpy = vi.spyOn(window, 'addEventListener')
 
     renderHook(() => useBranches('sess_1', 'canvas-a'))
@@ -332,7 +332,7 @@ describe('useBranches hook (callback model, no window event subscription)', () =
     })
 
     const headChangedCalls = addSpy.mock.calls.filter(
-      (args) => args[0] === 'excalidraw:head_changed',
+      (args) => args[0] === 'whiteboard:head_changed',
     )
     expect(headChangedCalls).toHaveLength(0)
 

--- a/apps/web/src/hooks/useDirtyState.test.ts
+++ b/apps/web/src/hooks/useDirtyState.test.ts
@@ -4,11 +4,11 @@ import { useDirtyState } from './useDirtyState.js'
 
 // Thin CustomEvent helpers; jsdom can dispatch these directly.
 function dispatchDocChanged(workspaceId: string, path: string): void {
-  window.dispatchEvent(new CustomEvent('excalidraw:doc_changed', { detail: { workspaceId, path } }))
+  window.dispatchEvent(new CustomEvent('whiteboard:doc_changed', { detail: { workspaceId, path } }))
 }
 function dispatchVersionSaved(workspaceId: string, path: string): void {
   window.dispatchEvent(
-    new CustomEvent('excalidraw:wb_version_saved', { detail: { workspaceId, path } }),
+    new CustomEvent('whiteboard:wb_version_saved', { detail: { workspaceId, path } }),
   )
 }
 
@@ -91,7 +91,7 @@ describe('useDirtyState', () => {
   it('ignores events where detail is missing', () => {
     const { result } = renderHook(() => useDirtyState('s1', 'c1'))
     act(() => {
-      window.dispatchEvent(new CustomEvent('excalidraw:doc_changed', { detail: null }))
+      window.dispatchEvent(new CustomEvent('whiteboard:doc_changed', { detail: null }))
     })
     expect(result.current.isDirty).toBe(false)
   })

--- a/apps/web/src/hooks/useDirtyState.ts
+++ b/apps/web/src/hooks/useDirtyState.ts
@@ -11,15 +11,15 @@ export type { DirtyEventDetail }
 // - dirty: show an amber dot in the header
 //
 // Implementation notes:
-//  useWhiteboardSync dispatches excalidraw:doc_changed whenever doc.subscribe observes a local or remote edit.
-//  When version_created arrives, it dispatches excalidraw:wb_version_saved.
+//  useWhiteboardSync dispatches whiteboard:doc_changed whenever doc.subscribe observes a local or remote edit.
+//  When version_created arrives, it dispatches whiteboard:wb_version_saved.
 //  This hook filters those events by workspaceId/path and tracks dirty vs clean counts.
 //  Passing the doc reference around would couple tests to Loro internals, so this stays event-based.
 
 export interface UseDirtyStateResult {
   isDirty: boolean
   // Call this when the UI needs to mark the document clean explicitly, such as right after Cmd+S succeeds.
-  // Most callers can rely on excalidraw:wb_version_saved instead.
+  // Most callers can rely on whiteboard:wb_version_saved instead.
   markSaved: () => void
 }
 
@@ -49,11 +49,11 @@ export function useDirtyState(workspaceId: string, path: string): UseDirtyStateR
       savedAtRef.current = changeCountRef.current
       setIsDirty(false)
     }
-    window.addEventListener('excalidraw:doc_changed', onChanged)
-    window.addEventListener('excalidraw:wb_version_saved', onSaved)
+    window.addEventListener('whiteboard:doc_changed', onChanged)
+    window.addEventListener('whiteboard:wb_version_saved', onSaved)
     return () => {
-      window.removeEventListener('excalidraw:doc_changed', onChanged)
-      window.removeEventListener('excalidraw:wb_version_saved', onSaved)
+      window.removeEventListener('whiteboard:doc_changed', onChanged)
+      window.removeEventListener('whiteboard:wb_version_saved', onSaved)
     }
   }, [workspaceId, path])
 

--- a/apps/web/src/hooks/useDocumentSync.test.ts
+++ b/apps/web/src/hooks/useDocumentSync.test.ts
@@ -572,7 +572,7 @@ describe('useDocumentSync', () => {
 
     it('does not dispatch doc_changed for the initial snapshot import', async () => {
       const backend = makeFakeBackend()
-      const docChanged = listenFor('excalidraw:doc_changed')
+      const docChanged = listenFor('whiteboard:doc_changed')
       renderHook(() => useDocumentSync(backend, { identity }))
 
       await hydrate(backend)
@@ -582,7 +582,7 @@ describe('useDocumentSync', () => {
 
     it('dispatches doc_changed on a local scene edit commit', async () => {
       const backend = makeFakeBackend()
-      const docChanged = listenFor('excalidraw:doc_changed')
+      const docChanged = listenFor('whiteboard:doc_changed')
       const { result } = renderHook(() => useDocumentSync(backend, { identity }))
 
       await hydrate(backend, TEXT_CANVAS)
@@ -594,7 +594,7 @@ describe('useDocumentSync', () => {
 
     it('dispatches wb_version_saved with identity detail when a version_created broadcast arrives', () => {
       const backend = makeFakeBackend()
-      const versionSaved = listenFor('excalidraw:wb_version_saved')
+      const versionSaved = listenFor('whiteboard:wb_version_saved')
       renderHook(() => useDocumentSync(backend, { identity }))
 
       act(() => {
@@ -607,8 +607,8 @@ describe('useDocumentSync', () => {
 
     it('does not dispatch any identity events when identity is absent', async () => {
       const backend = makeFakeBackend()
-      const docChanged = listenFor('excalidraw:doc_changed')
-      const versionSaved = listenFor('excalidraw:wb_version_saved')
+      const docChanged = listenFor('whiteboard:doc_changed')
+      const versionSaved = listenFor('whiteboard:wb_version_saved')
       renderHook(() => useDocumentSync(backend))
 
       await hydrate(backend)

--- a/apps/web/src/lib/document-sync-types.test.ts
+++ b/apps/web/src/lib/document-sync-types.test.ts
@@ -11,11 +11,11 @@ describe('document-sync event name constants', () => {
   // useBranches, merge-committed-event) still match on the raw string and are
   // out of this slice's scope, so a rename here must not change the wire value.
   it('keeps the doc_changed event name unchanged', () => {
-    expect(DOCUMENT_SYNC_CHANGED_EVENT).toBe('excalidraw:doc_changed')
+    expect(DOCUMENT_SYNC_CHANGED_EVENT).toBe('whiteboard:doc_changed')
   })
 
   it('keeps the wb_version_saved event name unchanged', () => {
-    expect(DOCUMENT_SYNC_VERSION_SAVED_EVENT).toBe('excalidraw:wb_version_saved')
+    expect(DOCUMENT_SYNC_VERSION_SAVED_EVENT).toBe('whiteboard:wb_version_saved')
   })
 
   it('dispatchIdentityEvent fires the constant event name it is called with', () => {

--- a/apps/web/src/lib/document-sync-types.ts
+++ b/apps/web/src/lib/document-sync-types.ts
@@ -32,8 +32,8 @@ export type SyncStatus = 'idle' | 'connected' | 'reconnecting' | 'error'
 // merge-committed-event) still match on the raw string and are out of this
 // slice's scope, so changing the constant's NAME here must never change its
 // VALUE.
-export const DOCUMENT_SYNC_CHANGED_EVENT = 'excalidraw:doc_changed'
-export const DOCUMENT_SYNC_VERSION_SAVED_EVENT = 'excalidraw:wb_version_saved'
+export const DOCUMENT_SYNC_CHANGED_EVENT = 'whiteboard:doc_changed'
+export const DOCUMENT_SYNC_VERSION_SAVED_EVENT = 'whiteboard:wb_version_saved'
 
 // Daemon-only callback seam. Every member is read via optionsRef in
 // useDocumentSync (see there) so passing a fresh inline object on every render
@@ -57,8 +57,8 @@ export interface UseDocumentSyncOptions {
   // can surface a dedicated banner instead of the generic error state.
   onAuthError?: () => void
   // When set, drives the window-event contract that useDirtyState/HeaderSaveDot
-  // listen for: 'excalidraw:doc_changed' on local/remote doc edits and
-  // 'excalidraw:wb_version_saved' on a version_created broadcast. Read via
+  // listen for: 'whiteboard:doc_changed' on local/remote doc edits and
+  // 'whiteboard:wb_version_saved' on a version_created broadcast. Read via
   // optionsRef (never in the connect effect's dep array) so passing a fresh
   // identity object every render never forces a reconnect. Only dispatched
   // when both fields are present — a browser caller that never sets

--- a/apps/web/src/lib/merge-committed-event.ts
+++ b/apps/web/src/lib/merge-committed-event.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod'
 import { getAppLogger } from './app-logger.js'
 
-// Single source of truth for the `excalidraw:merge_committed` window CustomEvent
+// Single source of truth for the `whiteboard:merge_committed` window CustomEvent
 // contract. MergeDialog dispatches; MergeToast subscribes. A schema here
 // instead of independently hand-written detail shapes on each side avoids the
 // drift pattern flagged in AGENTS.md's Zod Schema Discipline section.
-export const MERGE_COMMITTED_EVENT = 'excalidraw:merge_committed'
+export const MERGE_COMMITTED_EVENT = 'whiteboard:merge_committed'
 
 // Non-strict: unknown fields are stripped rather than rejected so the
 // dispatcher can grow the detail shape without a lockstep parser change.

--- a/apps/web/src/pages/DaemonDocumentPage.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.test.tsx
@@ -1457,7 +1457,7 @@ describe('DaemonDocumentPage', () => {
   describe('MergeToast integration', () => {
     const dispatchMergeCommitted = (overrides: Partial<Record<string, unknown>> = {}) => {
       window.dispatchEvent(
-        new CustomEvent('excalidraw:merge_committed', {
+        new CustomEvent('whiteboard:merge_committed', {
           detail: {
             workspaceId: 'w1',
             path: 'main',

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -540,7 +540,7 @@ export function DaemonDocumentPage({
       // and other peers' saves), so this button must dispatch the same
       // identity-scoped event useDocumentSync fires on a broadcast — otherwise
       // HeaderSaveDot never learns this save happened and stays dirty.
-      dispatchIdentityEvent('excalidraw:wb_version_saved', canvas ?? undefined)
+      dispatchIdentityEvent('whiteboard:wb_version_saved', canvas ?? undefined)
     } catch {
       setSaveVersionMessage({ kind: 'error', text: 'Save failed. Please try again.' })
     } finally {

--- a/packages/mcp-server/src/server/http-server.test.ts
+++ b/packages/mcp-server/src/server/http-server.test.ts
@@ -29,24 +29,24 @@ describe('authorizeWsUpgrade', () => {
       authorizeWsUpgrade(
         {
           host: '127.0.0.1:3099',
-          'sec-websocket-protocol': 'excalidraw-v1, daemon-token.nope',
+          'sec-websocket-protocol': 'whiteboard-v1, daemon-token.nope',
         },
         'secret',
       ),
     ).toEqual({ accept: false, statusCode: 401 })
   })
 
-  it('accepts websocket upgrade with the daemon subprotocol token and selects excalidraw-v1', () => {
+  it('accepts websocket upgrade with the daemon subprotocol token and selects whiteboard-v1', () => {
     expect(
       authorizeWsUpgrade(
         {
           host: '127.0.0.1:3099',
           origin: 'http://127.0.0.1:5173',
-          'sec-websocket-protocol': 'excalidraw-v1, daemon-token.secret',
+          'sec-websocket-protocol': 'whiteboard-v1, daemon-token.secret',
         },
         'secret',
       ),
-    ).toEqual({ accept: true, protocol: 'excalidraw-v1', scopes: ALL_AUTH_SCOPES })
+    ).toEqual({ accept: true, protocol: 'whiteboard-v1', scopes: ALL_AUTH_SCOPES })
   })
 
   it('keeps websocket auth disabled when daemon token is unset', () => {
@@ -66,18 +66,18 @@ describe('authorizeWsUpgrade', () => {
         {
           host: '127.0.0.1:3099',
           origin: 'http://localhost:5173',
-          'sec-websocket-protocol': 'excalidraw-v1, daemon-token.secret',
+          'sec-websocket-protocol': 'whiteboard-v1, daemon-token.secret',
         },
         'secret',
       ),
-    ).toEqual({ accept: true, protocol: 'excalidraw-v1', scopes: ALL_AUTH_SCOPES })
+    ).toEqual({ accept: true, protocol: 'whiteboard-v1', scopes: ALL_AUTH_SCOPES })
 
     expect(
       authorizeWsUpgrade(
         {
           host: '127.0.0.1:3099',
           origin: 'https://example.com',
-          'sec-websocket-protocol': 'excalidraw-v1, daemon-token.secret',
+          'sec-websocket-protocol': 'whiteboard-v1, daemon-token.secret',
         },
         'secret',
       ),

--- a/packages/mcp-server/src/server/routes/ws-auth.test.ts
+++ b/packages/mcp-server/src/server/routes/ws-auth.test.ts
@@ -189,7 +189,7 @@ describe('authorizeWsUpgrade', () => {
         {
           host: '127.0.0.1:3099',
           origin: 'http://localhost:5173',
-          'sec-websocket-protocol': 'excalidraw-v1, daemon-token.secret-token',
+          'sec-websocket-protocol': 'whiteboard-v1, daemon-token.secret-token',
         },
         'secret-token',
         [],

--- a/packages/mcp-server/src/shared/api-contracts/document-runtime.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/document-runtime.test.ts
@@ -1,20 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { z } from 'zod'
-
-const viewportResponseSchema = z.object({
-  ok: z.literal(true),
-})
-
-const viewportErrorBodySchema = z.object({
-  error: z.string().optional(),
-  message: z.string().optional(),
-  hint: z.string().optional(),
-})
-
-const clientCountResponseSchema = z.object({
-  count: z.number().int().nonnegative(),
-  readyCount: z.number().int().nonnegative(),
-})
+import {
+  clientCountResponseSchema,
+  viewportErrorBodySchema,
+  viewportResponseSchema,
+} from './document-runtime.js'
 
 describe('viewportResponseSchema', () => {
   it('accepts { ok: true }', () => {
@@ -31,17 +20,26 @@ describe('viewportResponseSchema', () => {
 })
 
 describe('viewportErrorBodySchema', () => {
-  it('accepts all fields present', () => {
+  // Every route branch is pinned here so the schema keeps matching what the
+  // sole producer (server/routes/viewport.ts) actually sends.
+  it('accepts the no_client body (hint present)', () => {
     const input = { error: 'no_client', message: 'No browser connected', hint: 'Open the canvas' }
     expect(viewportErrorBodySchema.parse(input)).toEqual(input)
   })
 
-  it('accepts empty object (all fields optional)', () => {
-    expect(viewportErrorBodySchema.parse({})).toEqual({})
+  it('accepts the timeout/internal bodies (no hint)', () => {
+    const input = { error: 'timeout', message: 'Viewport update timed out after 5s.' }
+    expect(viewportErrorBodySchema.parse(input)).toEqual(input)
+  })
+
+  it('rejects a body missing error or message — no producer emits one', () => {
+    expect(() => viewportErrorBodySchema.parse({})).toThrow()
+    expect(() => viewportErrorBodySchema.parse({ error: 'timeout' })).toThrow()
+    expect(() => viewportErrorBodySchema.parse({ message: 'lonely message' })).toThrow()
   })
 
   it('rejects non-string error', () => {
-    expect(() => viewportErrorBodySchema.parse({ error: 42 })).toThrow()
+    expect(() => viewportErrorBodySchema.parse({ error: 42, message: 'x' })).toThrow()
   })
 })
 

--- a/packages/mcp-server/src/shared/api-contracts/document-runtime.ts
+++ b/packages/mcp-server/src/shared/api-contracts/document-runtime.ts
@@ -9,20 +9,21 @@ import { z } from 'zod'
 // padding / animate / scrollX / scrollY / zoom) with no server-side schema —
 // the canonical shape lives in shared/ws-messages.ts as
 // viewportRequestMessageSchema.
-const viewportResponseSchema = z.object({
+export const viewportResponseSchema = z.object({
   ok: z.literal(true),
 })
 
 // Shared error body. The route emits this for no_client (503), timeout (504),
-// and internal (500). Optional fields cover legacy payloads.
-const viewportErrorBodySchema = z.object({
-  error: z.string().optional(),
-  message: z.string().optional(),
+// and internal (500). Every branch sets error and message; only no_client
+// carries a hint, so that is the one genuinely optional field.
+export const viewportErrorBodySchema = z.object({
+  error: z.string(),
+  message: z.string(),
   hint: z.string().optional(),
 })
 
 // ── GET /api/w/:workspaceId/document/<path>/client-count ────────────────────
-const clientCountResponseSchema = z.object({
+export const clientCountResponseSchema = z.object({
   count: z.number().int().nonnegative(),
   readyCount: z.number().int().nonnegative(),
 })

--- a/packages/mcp-server/src/shared/daemon-backend.ws-token.test.ts
+++ b/packages/mcp-server/src/shared/daemon-backend.ws-token.test.ts
@@ -72,7 +72,7 @@ describe('DaemonBackend WS credential selection', () => {
     })
     backend.connect(HANDLERS)
     expect(FakeWebSocket.instances[0]?.protocols).toEqual([
-      'excalidraw-v1',
+      'whiteboard-v1',
       'daemon-token.pairing-session-token',
     ])
   })
@@ -88,7 +88,7 @@ describe('DaemonBackend WS credential selection', () => {
     })
     backend.connect(HANDLERS)
     expect(FakeWebSocket.instances[0]?.protocols).toEqual([
-      'excalidraw-v1',
+      'whiteboard-v1',
       'daemon-token.bootstrap-token',
     ])
   })
@@ -104,7 +104,7 @@ describe('DaemonBackend WS credential selection', () => {
     backend.disconnect()
     backend.connect(HANDLERS)
     expect(FakeWebSocket.instances[1]?.protocols).toEqual([
-      'excalidraw-v1',
+      'whiteboard-v1',
       'daemon-token.rotated-token',
     ])
   })
@@ -114,6 +114,6 @@ describe('DaemonBackend WS credential selection', () => {
       fetch: globalThis.fetch,
     })
     backend.connect(HANDLERS)
-    expect(FakeWebSocket.instances[0]?.protocols).toEqual(['excalidraw-v1'])
+    expect(FakeWebSocket.instances[0]?.protocols).toEqual(['whiteboard-v1'])
   })
 })

--- a/packages/mcp-server/src/shared/ws-protocol.ts
+++ b/packages/mcp-server/src/shared/ws-protocol.ts
@@ -1,4 +1,4 @@
-export const WHITEBOARD_WS_PROTOCOL = 'excalidraw-v1'
+export const WHITEBOARD_WS_PROTOCOL = 'whiteboard-v1'
 export const DAEMON_TOKEN_WS_PROTOCOL_PREFIX = 'daemon-token.'
 // ADR-0005: a hosted-origin caller authorizes a WS upgrade with a short-lived,
 // single-use connection ticket (minted via POST /api/ws-ticket) rather than


### PR DESCRIPTION
## What

Two verified survivors of a whole-repo backward-compat audit (ad-hoc `backward-compat-debt` dimension, adversarially verified), removed under the 0.0.x no-compat policy the vocabulary rule already states.

**1. `viewportErrorBodySchema`: `error`/`message` required (mcp-server).** They were `.optional()` under a comment claiming "legacy payloads" — no such producer exists: every branch of the sole producer (`routes/viewport.ts`: no_client/503, timeout/504, internal/500) sets both; only `no_client` carries a `hint`, which stays optional. Bonus fix found on the way: the test file had **duplicated the schemas locally** instead of importing them — a guard that never reached its subject. The schemas are now exported and the test imports the real ones. Red-first: the import and the `{}`-rejection both failed against the old code.

**2. The `excalidraw` spelling retired from live wire values.** Window events become `whiteboard:doc_changed` / `whiteboard:wb_version_saved` / `whiteboard:merge_committed`; the WS subprotocol becomes `whiteboard-v1`. Safety argument, verified in code: the events never leave the bundle and are not persisted, and **both ends of the subprotocol import the same `WHITEBOARD_WS_PROTOCOL` constant** from `shared/ws-protocol.ts` (`daemon-backend.ts` client-side; `ws-auth.ts`/`http-server.ts` server-side), so a mismatch within one build is structurally impossible. The only mismatch is a stale cached bundle against a newer daemon — handshake fails until the bundle updates — which is the accepted 0.0.x cost, now recorded in `vocabulary.md`'s rewritten window-event bullet. Deliberately untouched: assertions about foreign formats (`.excalidrawlib` packs, the Excalidraw clipboard payload), the sbom/import guards proving the old `@excalidraw` deps stay gone, and ADR history.

## Audit context (what was checked and kept)

The same audit cleared, with reasons: `DocumentBackend.onError` optionality (refuted — mirrors the documented "backend with nothing to report" pattern), the daemon `documents` legacy inbox and browser fold machinery (live-data migration, self-draining), migration 0011's startup re-import (drain condition not yet provable), and OKF/x-whiteboard tolerances (spec compliance, not self-compat). Those retirements are tracked separately as whiteboard issues.

## Gates

`mcp-node` document-runtime 12/12 + WS-protocol suites 58/58; `pnpm --filter @kamiazya/whiteboard-web test` 2770 passed with exactly the 9 known undici env failures; `WorkspaceTopBar` browser tests 11/11; `pnpm check:local` exit 0.

Visual evidence: none — internal contract tightening and a value rename with no user-visible surface; the test output above is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Updated document-sync and merge notifications to use the `whiteboard:` event namespace.
  - Updated WebSocket connections to use the `whiteboard-v1` protocol.
  - Strengthened viewport error responses by requiring clear error and message details, while keeping hints optional.

- **Tests**
  - Updated coverage for renamed events and WebSocket protocol behavior.
  - Added validation for supported viewport error response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->