### PR TITLE
feat(mcp-server): restore the pairing-link MCP tool as wb_pairing_link_create

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,12 @@ In your agent session, ask it to call `wb_document_create({ workspaceId: "defaul
 ## Pair with your local daemon
 
 Already have the browser canvas open (see [Get started](docs/tutorials/getting-started.md))
-and a local daemon running? Ask your AI agent to call the `create_pairing_link`
-MCP tool. It mints a `#wb=` link that carries a short-lived bootstrap token —
-open it in your browser to connect that tab to the daemon's workspaces,
-version history, branches, and merge, with live sync over WebSocket.
+and a local daemon running? Ask your AI agent to call the `wb_pairing_link_create`
+MCP tool. It mints a `#wb=` link that carries the daemon's bootstrap token —
+the same full-authority credential that authenticates every `/api/*` request,
+valid until it is rotated, not a short-lived or single-use token — open it in
+your browser to connect that tab to the daemon's workspaces, version history,
+branches, and merge, with live sync over WebSocket.
 
 - Loopback web origins (`http://127.0.0.1:...`) need no extra configuration.
 - The official hosted web app (`https://kamiazya-whiteboard.pages.dev`) can

--- a/apps/web/src/lib/daemon-connection-payload.test.ts
+++ b/apps/web/src/lib/daemon-connection-payload.test.ts
@@ -1,4 +1,5 @@
 import { fc, test as fcTest } from '@fast-check/vitest'
+import { daemonConnectionPayloadSchema as sharedDaemonConnectionPayloadSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
   consumeDaemonConnectionFragment,
@@ -8,6 +9,10 @@ import {
 } from './daemon-connection-payload.js'
 
 describe('daemonConnectionPayloadSchema', () => {
+  it('is the exact schema object re-exported from @kamiazya/whiteboard-mcp/api-contracts, not a mirror', () => {
+    expect(daemonConnectionPayloadSchema).toBe(sharedDaemonConnectionPayloadSchema)
+  })
+
   it('accepts a minimal valid payload', () => {
     const result = daemonConnectionPayloadSchema.safeParse({
       baseUrl: 'http://127.0.0.1:3099',

--- a/apps/web/src/lib/daemon-connection-payload.ts
+++ b/apps/web/src/lib/daemon-connection-payload.ts
@@ -1,73 +1,25 @@
-import { z } from 'zod'
-import { bareOriginSchema } from '../runtime-config.js'
+import {
+  type DaemonConnectionPayload,
+  daemonConnectionPayloadSchema,
+  decodeBase64UrlText,
+  encodeBase64UrlText,
+  DAEMON_CONNECTION_FRAGMENT_KEY as FRAGMENT_KEY,
+} from '@kamiazya/whiteboard-mcp/api-contracts'
+import type { z } from 'zod'
 
-// URL hash key carrying the daemon-pairing payload: `#wb=<base64url-json>`.
-const FRAGMENT_KEY = 'wb'
-
-// Minimum bootstrapToken length is a defense-in-depth floor, not the real security
-// boundary — the daemon itself decides whether a bootstrapToken is valid and
-// exchanges it for a short-lived sessionToken (see ADR-0002).
-const MIN_BOOTSTRAP_TOKEN_LENGTH = 8
-
-// bareOriginSchema alone permits any URL scheme (ws:, file:, etc.); daemon pairing is
-// restricted to http(s) since that is the only transport ADR-0002 defines.
-const daemonBaseUrlSchema = bareOriginSchema.refine(
-  (v) => v.startsWith('http://') || v.startsWith('https://'),
-  { message: 'baseUrl must use http or https' },
-)
-
-// authMode is a literal union rather than a bare string so new modes require an
-// explicit schema change instead of silently round-tripping unknown values.
-export const daemonConnectionPayloadSchema = z
-  .object({
-    baseUrl: daemonBaseUrlSchema,
-    workspaceId: z.string().min(1).optional(),
-    path: z.string().min(1).optional(),
-    bootstrapToken: z.string().min(MIN_BOOTSTRAP_TOKEN_LENGTH).optional(),
-    authMode: z.enum(['bootstrap', 'none']),
-    fullscreen: z.boolean().optional(),
-  })
-  .strict()
-  // ADR-0002's bootstrap pairing exchange has no meaning without a token to
-  // exchange, so the schema — not just the docs — enforces the pairing.
-  .refine((payload) => payload.authMode !== 'bootstrap' || payload.bootstrapToken !== undefined, {
-    message: 'bootstrapToken is required when authMode is "bootstrap"',
-    path: ['bootstrapToken'],
-  })
-  // A canvas is addressed by the (workspaceId, path) pair, so a path is
-  // meaningless without a workspaceId. workspaceId alone is a valid
-  // workspace-level target, so the constraint is one-directional.
-  .refine((payload) => payload.path === undefined || payload.workspaceId !== undefined, {
-    message: 'workspaceId is required when path is set',
-    path: ['workspaceId'],
-  })
-
-export type DaemonConnectionPayload = z.infer<typeof daemonConnectionPayloadSchema>
+export type { DaemonConnectionPayload }
+// The payload schema and its base64url fragment codec are declared ONCE in
+// mcp-server's shared api-contracts, not here: the tool that mints a pairing
+// link (wb_pairing_link_create) and this parser used to keep two
+// independently hand-written copies, which is exactly the shape that drifts
+// silently. Re-exported so existing importers of this module keep working.
+export { daemonConnectionPayloadSchema }
 
 export type ParseDaemonConnectionFragmentResult =
   | { status: 'ok'; payload: DaemonConnectionPayload }
   | { status: 'not-present' }
   | { status: 'malformed'; stage: 'base64' | 'json'; message: string }
   | { status: 'invalid'; issues: z.ZodIssue[] }
-
-// Decodes a base64url string to its original UTF-8 text.
-// Throws on invalid base64url input (surfaced by the caller as a 'malformed' result).
-function decodeBase64Url(value: string): string {
-  const base64 = value.replace(/-/g, '+').replace(/_/g, '/')
-  const paddingLength = (4 - (base64.length % 4)) % 4
-  const padded = base64 + '='.repeat(paddingLength)
-  const binary = atob(padded)
-  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0))
-  return new TextDecoder().decode(bytes)
-}
-
-// Encodes UTF-8 text to a base64url string (no padding), matching the `#wb=` fragment format.
-function encodeBase64Url(value: string): string {
-  const bytes = new TextEncoder().encode(value)
-  let binary = ''
-  for (const byte of bytes) binary += String.fromCharCode(byte)
-  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
-}
 
 // Extracts the raw `wb` fragment value from a location.hash-shaped string, tolerant of
 // a missing leading '#' and of other unrelated fragment params sharing the hash.
@@ -101,7 +53,7 @@ export function parseDaemonConnectionFragment(hash: string): ParseDaemonConnecti
 
   let decoded: string
   try {
-    decoded = decodeBase64Url(raw)
+    decoded = decodeBase64UrlText(raw)
   } catch (err) {
     return {
       status: 'malformed',
@@ -133,7 +85,7 @@ export function parseDaemonConnectionFragment(hash: string): ParseDaemonConnecti
 // leading '#'. Primarily a test/dev helper for round-tripping parseDaemonConnectionFragment.
 export function encodeDaemonConnectionFragment(payload: DaemonConnectionPayload): string {
   const json = JSON.stringify(daemonConnectionPayloadSchema.parse(payload))
-  return `#${FRAGMENT_KEY}=${encodeBase64Url(json)}`
+  return `#${FRAGMENT_KEY}=${encodeBase64UrlText(json)}`
 }
 
 // Removes only the `wb=...` segment from a location.hash-shaped string, leaving any

--- a/docs/explanation/security-model.md
+++ b/docs/explanation/security-model.md
@@ -81,7 +81,7 @@ What the UI does about it:
   not lend its own trust to an unproven claim.
 - Approving a grant is always an explicit click on the responding daemon's
   own consent page, which shows the requesting origin.
-- The trusted-direction bootstraps — the `create_pairing_link` MCP tool, or
+- The trusted-direction bootstraps — the `wb_pairing_link_create` MCP tool, or
   opening the hosted app from the daemon itself — carry the base URL and
   credential from the real daemon, so they avoid this exposure entirely.
   Prefer them when available.

--- a/docs/how-to/connect-to-local-daemon.md
+++ b/docs/how-to/connect-to-local-daemon.md
@@ -111,12 +111,14 @@ the daemon's own page — there is no silent grant path.
 ## Connect with an agent-minted link
 
 1. Ask your AI agent (Claude, Codex, or any MCP client connected to the
-   whiteboard daemon) to call the `create_pairing_link` MCP tool. Optionally
+   whiteboard daemon) to call the `wb_pairing_link_create` MCP tool. Optionally
    pass `workspaceId` / `path` to target a specific canvas, or `webOrigin` to
    point at a non-default web app deployment.
-2. The tool returns a URL carrying a `#wb=` fragment with a short-lived
+2. The tool returns a URL carrying a `#wb=` fragment with the daemon's
    bootstrap token (see [ADR-0002](../contributing/adr/0002-browser-to-daemon-transport.md)
-   for the transport design). Open that URL in your browser.
+   for the transport design) — the same full-authority credential that
+   authenticates every `/api/*` request, valid until it is rotated, not a
+   short-lived or single-use token. Open that URL in your browser.
 3. On a hosted `https:` origin, the browser's Local Network Access permission
    prompt appears — grant it to let the page reach your loopback daemon.
 4. The web app consumes the fragment and connects to the paired workspace.
@@ -140,7 +142,7 @@ must also be configured to accept that origin via
 as an exact match or via a `https://*.example.com` wildcard subdomain pattern
 that covers it (see
 [Configuration → Wildcard subdomain patterns](../reference/configuration.md#wildcard-subdomain-patterns)).
-`create_pairing_link` cannot confirm that allowlist coverage on its own, so
+`wb_pairing_link_create` cannot confirm that allowlist coverage on its own, so
 verify it yourself before sharing a hosted pairing link. Loopback origins
 need no allowlist entry.
 

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -152,6 +152,7 @@ const EXPECTED_TOOLS = [
   'wb_document_delete',
   'wb_document_resolve',
   'wb_document_list',
+  'wb_pairing_link_create',
 ]
 
 async function main() {
@@ -181,6 +182,18 @@ async function main() {
     throw new Error(lines.join('\n'))
   }
   console.log(`[e2e] tools/list → ${names.length} tools match expected set`)
+
+  // wb_pairing_link_create is registered on this stdio entrypoint too (one
+  // authoritative tools/list across transports), but stdio has no HTTP
+  // daemon of its own to embed in a pairing link — the success path is
+  // covered elsewhere (pairing-link.test.ts's in-process MCP client, and the
+  // HTTP-daemon verification recorded outside this offline smoke).
+  await expectToolError(
+    'wb_pairing_link_create',
+    {},
+    'over stdio with no HTTP daemon to pair with',
+    'standalone over stdio',
+  )
 
   // Unknown-workspace guard: without createWorkspace the create must fail
   // (workspaces never materialize implicitly from a typo'd workspaceId).

--- a/packages/mcp-server/src/server/app-types.ts
+++ b/packages/mcp-server/src/server/app-types.ts
@@ -56,6 +56,12 @@ interface LocalDaemonAppOptions {
   /** Daemon signing identity (security/daemon-identity.ts). Injectable for
    *  tests; when omitted, createApp loads-or-creates it from the data dir. */
   identity?: DaemonIdentity
+  /** This daemon's own bare origin (e.g. `http://127.0.0.1:3099`), threaded
+   *  into wb_pairing_link_create so the tool embeds the daemon's real
+   *  address instead of reading it from process.env. Absent in ad-hoc/test
+   *  callers with no real listener — the tool still registers and answers
+   *  isError, the same standalone behavior the stdio entrypoint gets. */
+  daemonBaseUrl?: string
 }
 
 export interface ServerModeAppOptions {

--- a/packages/mcp-server/src/server/app.server-mode.test.ts
+++ b/packages/mcp-server/src/server/app.server-mode.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import type { RuntimeStatusResponse } from '../shared/api-contracts/runtime.js'
 import type { AppOptions, ServerModeAppOptions } from './app.js'
@@ -405,6 +406,40 @@ describe('app — server-mode composition', () => {
         body: JSON.stringify({ jsonrpc: '2.0', method: 'ping', id: 1 }),
       })
       expect(res.status).toBe(403)
+    })
+  })
+
+  // Regression: app.ts's pairingLinkContext is undefined for server-mode
+  // exactly as it is for the stdio entrypoint, so without a threaded
+  // unavailableReason the tool's refusal message wrongly told an
+  // already-connected server-mode HTTP caller to "connect through its HTTP
+  // /mcp endpoint instead" — which it is already doing.
+  describe('server-mode wb_pairing_link_create over the real /mcp endpoint', () => {
+    it('answers isError naming server-mode, never the stdio-standalone message', async () => {
+      const app = createApp(makeServerModeOptions(['mcp:call']))
+      const client = new Client({ name: 'server-mode-pairing-test', version: '1.0.0' })
+      const transport = new StreamableHTTPClientTransport(new URL('http://127.0.0.1/mcp'), {
+        fetch: (input, init) => {
+          const headers = new Headers(init?.headers)
+          headers.set('Authorization', BEARER)
+          headers.set('Origin', PUBLIC_URL)
+          return app.request(input instanceof URL ? input.toString() : String(input), {
+            ...init,
+            headers,
+          })
+        },
+      })
+      await client.connect(transport)
+      try {
+        const res = await client.callTool({ name: 'wb_pairing_link_create', arguments: {} })
+        expect(res.isError).toBe(true)
+        const text = (res.content as Array<{ text: string }>)[0]?.text ?? ''
+        expect(text).toMatch(/server-mode/i)
+        expect(text).not.toMatch(/standalone over stdio/i)
+        expect(text).not.toMatch(/connect through its HTTP/i)
+      } finally {
+        await transport.close()
+      }
     })
   })
 

--- a/packages/mcp-server/src/server/app.test.ts
+++ b/packages/mcp-server/src/server/app.test.ts
@@ -1530,6 +1530,118 @@ describe('createApp daemon mutation auth', () => {
     })
   })
 
+  describe('wb_pairing_link_create daemonBaseUrl wiring (createApp -> pairingLinkContext)', () => {
+    // Exercises the real composition path — createApp's daemonBaseUrl option
+    // through to the tool's actual /mcp response — rather than
+    // registerPairingLinkTool called directly with a hand-built context
+    // (pairing-link.test.ts), which cannot see a wiring regression in app.ts
+    // or http-server.ts (wrong host/port composition, or the
+    // authMode/daemonBaseUrl condition silently never true).
+    it('embeds the daemonBaseUrl passed into createApp in the minted pairing link', async () => {
+      const { decodeBase64UrlText } = await import('../shared/api-contracts/pairing-link.js')
+      // Longer than MIN_BOOTSTRAP_TOKEN_LENGTH — 'secret' alone is 6 chars,
+      // which the tool refuses to embed as too short.
+      const token = 'secret-daemon-token'
+      const app = createApp({
+        ...createRuntimeOptions(token),
+        daemonBaseUrl: 'http://127.0.0.1:3099',
+      })
+      const client = new Client({ name: 'app-test-client', version: '1.0.0' })
+      const transport = new StreamableHTTPClientTransport(new URL('http://127.0.0.1/mcp'), {
+        fetch: (input, init) => {
+          const headers = new Headers(init?.headers)
+          headers.set('Authorization', `Bearer ${token}`)
+          headers.set('Origin', 'http://127.0.0.1:6274')
+          return app.request(input instanceof URL ? input.toString() : String(input), {
+            ...init,
+            headers,
+          })
+        },
+      })
+      await client.connect(transport)
+
+      const res = await client.callTool({ name: 'wb_pairing_link_create', arguments: {} })
+      expect(res.isError, JSON.stringify(res)).not.toBe(true)
+      const result = res.structuredContent as { url: string; authMode: string }
+      expect(result.authMode).toBe('bootstrap')
+
+      const fragment = result.url.split('#wb=')[1]
+      const decoded = JSON.parse(decodeBase64UrlText(fragment)) as { baseUrl: string }
+      expect(decoded.baseUrl).toBe('http://127.0.0.1:3099')
+
+      await transport.close()
+    })
+
+    it('answers isError over the real /mcp endpoint when createApp received no daemonBaseUrl', async () => {
+      const app = createApp(createRuntimeOptions('secret'))
+      const client = new Client({ name: 'app-test-client', version: '1.0.0' })
+      const transport = new StreamableHTTPClientTransport(new URL('http://127.0.0.1/mcp'), {
+        fetch: (input, init) => {
+          const headers = new Headers(init?.headers)
+          headers.set('Authorization', 'Bearer secret')
+          headers.set('Origin', 'http://127.0.0.1:6274')
+          return app.request(input instanceof URL ? input.toString() : String(input), {
+            ...init,
+            headers,
+          })
+        },
+      })
+      await client.connect(transport)
+
+      const res = await client.callTool({ name: 'wb_pairing_link_create', arguments: {} })
+      expect(res.isError).toBe(true)
+
+      await transport.close()
+    })
+
+    it('re-reads a live allowedWebOrigins() provider on every call rather than snapshotting it once at createApp time', async () => {
+      // options.allowedWebOrigins in local-daemon mode is a FUNCTION backed
+      // by pairing grants approved at runtime (see http-server.ts), so /api
+      // CORS, /mcp origin, and WS upgrade all read it live. This exercises
+      // the real createApp -> pairingLinkContext wiring to confirm the
+      // pairing-link tool's own advisory text tracks the same live set
+      // instead of freezing whatever the provider returned at construction.
+      const token = 'secret-daemon-token'
+      let origins: readonly string[] = []
+      const app = createApp({
+        ...createRuntimeOptions(token),
+        daemonBaseUrl: 'http://127.0.0.1:3099',
+        allowedWebOrigins: () => origins,
+      })
+      const client = new Client({ name: 'app-test-client', version: '1.0.0' })
+      const transport = new StreamableHTTPClientTransport(new URL('http://127.0.0.1/mcp'), {
+        fetch: (input, init) => {
+          const headers = new Headers(init?.headers)
+          headers.set('Authorization', `Bearer ${token}`)
+          headers.set('Origin', 'http://127.0.0.1:6274')
+          return app.request(input instanceof URL ? input.toString() : String(input), {
+            ...init,
+            headers,
+          })
+        },
+      })
+      await client.connect(transport)
+
+      const before = await client.callTool({
+        name: 'wb_pairing_link_create',
+        arguments: { webOrigin: 'https://granted-later.example.com' },
+      })
+      const beforeText = (before.content as Array<{ text: string }>)[0]?.text ?? ''
+      expect(beforeText).toContain('would be rejected by CORS/origin checks')
+
+      origins = ['https://granted-later.example.com']
+
+      const after = await client.callTool({
+        name: 'wb_pairing_link_create',
+        arguments: { webOrigin: 'https://granted-later.example.com' },
+      })
+      const afterText = (after.content as Array<{ text: string }>)[0]?.text ?? ''
+      expect(afterText).not.toContain('would be rejected by CORS/origin checks')
+
+      await transport.close()
+    })
+  })
+
   describe('/api/runtime/ping Zod schema', () => {
     it('ping response parses via daemonPingResponseSchema', async () => {
       const { daemonPingResponseSchema } = await import('../shared/api-contracts/runtime.js')

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -29,6 +29,7 @@ import type { AppOptions } from './app-types.js'
 import { DIST_WEB_APP_DIR, getDataDir } from './config.js'
 import { getLogger, getLogLevel, setLogLevel } from './log.js'
 import { createMcpServer } from './mcp/index.js'
+import type { PairingUnavailableReason } from './mcp/pairing-link.js'
 import { tracingMiddleware } from './observability/http-tracing.js'
 import { createCspNonce, pairPageCsp } from './pair-page-csp.js'
 import { createDaemonAuthMiddleware } from './routes/auth.js'
@@ -109,6 +110,33 @@ export function createApp(options: AppOptions) {
   const app = new Hono()
 
   const instanceId = options.instanceId ?? randomUUID()
+  // wb_pairing_link_create's daemon context — undefined in server-mode (no
+  // single daemon origin to embed the way local-daemon has) and in any
+  // local-daemon caller that supplies no daemonBaseUrl (ad-hoc/test
+  // callers); the tool itself treats "no context" as the standalone case.
+  const pairingLinkContext =
+    options.authMode === 'local-daemon' && options.daemonBaseUrl !== undefined
+      ? {
+          daemonBaseUrl: options.daemonBaseUrl,
+          bootstrapToken: options.token,
+          // The raw provider (not a resolved snapshot) so the tool's
+          // allowlist check re-reads the SAME live set CORS/mcp-origin/WS
+          // consult on every call — options.allowedWebOrigins is itself a
+          // function backed by pairing grants approved at runtime, and
+          // resolving it once here would freeze the tool's advisory text
+          // stale for the rest of the process the moment a grant is
+          // approved after startup.
+          allowedWebOrigins: options.allowedWebOrigins,
+        }
+      : undefined
+  // Only consulted by wb_pairing_link_create when pairingLinkContext above is
+  // undefined, so it only has to distinguish the two ways THAT happens here
+  // (server-mode has no pairing concept at all; local-daemon with no
+  // daemonBaseUrl is an ad-hoc/test caller with no real HTTP listener) — the
+  // stdio-entrypoint reason lives in mcp/index.ts's own default, since this
+  // module is never on that path.
+  const pairingUnavailableReason: PairingUnavailableReason =
+    options.authMode === 'server-mode' ? 'server-mode' : 'no-daemon-base-url'
   // The signing identity behind /api/runtime/ping's `identity`,
   // /api/runtime/verify, and pairing-token response signatures.
   const identity = options.identity ?? createDaemonIdentity({ dataDir: getDataDir() })
@@ -270,12 +298,15 @@ export function createApp(options: AppOptions) {
   // `enableJsonResponse: true`, which the entry's built-in legacy fallback
   // does not set, and changing legacy clients' response framing (JSON body →
   // SSE) would break the stdio proxy and the web app's daemon client.
-  const modernMcpHandler = createMcpHandler(() => createMcpServer(), {
-    legacy: 'reject',
-    onerror: (error) => {
-      httpLog.warning({ err: error }, 'mcp-http:modern-error')
+  const modernMcpHandler = createMcpHandler(
+    () => createMcpServer({ pairing: pairingLinkContext, pairingUnavailableReason }),
+    {
+      legacy: 'reject',
+      onerror: (error) => {
+        httpLog.warning({ err: error }, 'mcp-http:modern-error')
+      },
     },
-  })
+  )
 
   app.all('/mcp', async (c) => {
     const startedAt = Date.now()
@@ -333,7 +364,10 @@ export function createApp(options: AppOptions) {
     let response: Response | undefined
     try {
       const constructStartedAt = debug ? Date.now() : 0
-      const server = await createMcpServer()
+      const server = await createMcpServer({
+        pairing: pairingLinkContext,
+        pairingUnavailableReason,
+      })
       if (debug) {
         httpLog.info({ durationMs: Date.now() - constructStartedAt }, 'mcp-http:construct')
       }

--- a/packages/mcp-server/src/server/daemon-auth-binding.test.ts
+++ b/packages/mcp-server/src/server/daemon-auth-binding.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { assertLoopbackBindHost, isLoopbackHost, normalizeBindHost } from './daemon-auth-binding.js'
+import {
+  assertLoopbackBindHost,
+  buildDaemonBaseUrl,
+  formatHostForUrl,
+  isLoopbackHost,
+  normalizeBindHost,
+} from './daemon-auth-binding.js'
 
 describe('normalizeBindHost', () => {
   it('strips URI brackets from IPv6 so the host is valid for server.listen', () => {
@@ -10,6 +16,40 @@ describe('normalizeBindHost', () => {
 
   it.each(['127.0.0.1', 'localhost', '::1', '0.0.0.0'])('passes %s through unchanged', (host) => {
     expect(normalizeBindHost(host)).toBe(host)
+  })
+})
+
+describe('formatHostForUrl', () => {
+  it('brackets a bare IPv6 literal so new URL() can parse the authority', () => {
+    // The inverse of normalizeBindHost: server.listen() wants '::1', but a
+    // URL authority requires the RFC 3986 §3.2.2 bracketed form — without
+    // this, `new URL('http://::1:3099')` throws Invalid URL.
+    expect(formatHostForUrl('::1')).toBe('[::1]')
+    expect(() => new URL(`http://${formatHostForUrl('::1')}:3099`)).not.toThrow()
+  })
+
+  it.each(['127.0.0.1', 'localhost', '0.0.0.0'])('passes %s through unchanged', (host) => {
+    expect(formatHostForUrl(host)).toBe(host)
+  })
+})
+
+describe('buildDaemonBaseUrl', () => {
+  // This is the exact composition wb_pairing_link_create's daemonBaseUrl
+  // wiring relies on (http-server.ts) — pinning it here catches a wrong
+  // interpolation or a dropped formatHostForUrl call even where a real
+  // IPv6 bind is unavailable (e.g. an IPv6-disabled sandbox/container).
+  it('composes a well-formed, parseable origin for an IPv4 host', () => {
+    const url = buildDaemonBaseUrl('127.0.0.1', 3099)
+    expect(url).toBe('http://127.0.0.1:3099')
+    expect(new URL(url).origin).toBe('http://127.0.0.1:3099')
+  })
+
+  it('brackets an IPv6 loopback host so the composed origin is parseable', () => {
+    const url = buildDaemonBaseUrl('::1', 3099)
+    expect(url).toBe('http://[::1]:3099')
+    // WHATWG URL keeps the brackets in .hostname for an IPv6 authority.
+    expect(new URL(url).hostname).toBe('[::1]')
+    expect(new URL(url).port).toBe('3099')
   })
 })
 

--- a/packages/mcp-server/src/server/daemon-auth-binding.ts
+++ b/packages/mcp-server/src/server/daemon-auth-binding.ts
@@ -15,6 +15,26 @@ export function normalizeBindHost(host: string): string {
   return host
 }
 
+// The inverse of normalizeBindHost: a bare IPv6 literal (what server.listen()
+// wants, and what normalizeBindHost produces) is not valid inside a URL
+// authority — `new URL('http://::1:3099')` throws Invalid URL because the
+// colons are indistinguishable from a port separator. RFC 3986 §3.2.2
+// requires the bracketed form there. A colon-free host (IPv4 or a hostname)
+// never needs bracketing.
+export function formatHostForUrl(host: string): string {
+  return host.includes(':') ? `[${host}]` : host
+}
+
+// The one place http-server.ts composes wb_pairing_link_create's
+// daemonBaseUrl, pulled out of that call site so the exact expression
+// (including the formatHostForUrl bracketing) is reachable from a unit test
+// without needing a real socket bind — startHttpServer's own IPv6 bind is
+// unavailable on hosts/containers with IPv6 disabled, which this function
+// does not depend on.
+export function buildDaemonBaseUrl(host: string, port: number): string {
+  return `http://${formatHostForUrl(host)}:${port}`
+}
+
 export type LoopbackBindGuardResult = { ok: true } | { ok: false; code: 'bind_host_not_loopback' }
 
 // Pre-startup guard: called before the HTTP server binds, so a local-daemon

--- a/packages/mcp-server/src/server/http-server.test.ts
+++ b/packages/mcp-server/src/server/http-server.test.ts
@@ -1,8 +1,10 @@
 import { createHash } from 'node:crypto'
 import { request } from 'node:http'
 import { createServer } from 'node:net'
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client'
 import { afterEach, describe, expect, it } from 'vitest'
 import { findAvailablePort } from '../cli/daemon-run.js'
+import { decodeBase64UrlText } from '../shared/api-contracts/pairing-link.js'
 import {
   buildWhiteboardWsProtocolsWithTicket,
   WHITEBOARD_WS_PROTOCOL,
@@ -197,6 +199,42 @@ describe('startHttpServer oauth client registry', () => {
 
     const res = await fetch(`http://127.0.0.1:${port}/token`, { method: 'POST' })
     expect(res.status).toBe(404)
+  })
+})
+
+// The wiring this covers: http-server.ts composes daemonBaseUrl from the
+// bound host/port and threads it into createApp -> pairingLinkContext ->
+// wb_pairing_link_create. app.test.ts only feeds createApp a hand-built
+// daemonBaseUrl string, so a wrong interpolation in http-server.ts's own
+// composition (wrong variable, dropped port, mismatched host) would pass
+// every existing test green. This starts the real server via
+// startHttpServer and calls the tool over the real socket to confirm the
+// minted link's baseUrl actually matches the address the server bound.
+describe('startHttpServer daemonBaseUrl -> wb_pairing_link_create wiring', () => {
+  let running: RunningServer | undefined
+
+  afterEach(async () => {
+    await running?.close()
+    running = undefined
+  })
+
+  it('embeds the real bound host:port in the minted pairing link', async () => {
+    const port = await findAvailablePort(4650)
+    running = await startHttpServer({ port, host: '127.0.0.1' })
+
+    const client = new Client({ name: 'http-server-pairing-test', version: '1.0.0' })
+    const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`))
+    await client.connect(transport)
+    try {
+      const res = await client.callTool({ name: 'wb_pairing_link_create', arguments: {} })
+      expect(res.isError, JSON.stringify(res)).not.toBe(true)
+      const result = res.structuredContent as { url: string }
+      const fragment = result.url.split('#wb=')[1]
+      const decoded = JSON.parse(decodeBase64UrlText(fragment ?? '')) as { baseUrl: string }
+      expect(decoded.baseUrl).toBe(`http://127.0.0.1:${port}`)
+    } finally {
+      await transport.close()
+    }
   })
 })
 

--- a/packages/mcp-server/src/server/http-server.ts
+++ b/packages/mcp-server/src/server/http-server.ts
@@ -13,7 +13,7 @@ import { WHITEBOARD_WS_PROTOCOL } from '../shared/ws-protocol.js'
 import { createApp } from './app.js'
 import { DIST_WEB_APP_DIR, getDataDir } from './config.js'
 import { ensureWorkspaceId } from './current-workspace.js'
-import { normalizeBindHost } from './daemon-auth-binding.js'
+import { buildDaemonBaseUrl, normalizeBindHost } from './daemon-auth-binding.js'
 import { getLogger } from './log.js'
 import { getConnectionStats, handleWsUpgrade, setRuntimeTouchFn } from './routes/ws.js'
 import { authorizeWsUpgrade } from './routes/ws-auth.js'
@@ -231,6 +231,10 @@ export async function startHttpServer(options: StartHttpServerOptions): Promise<
     wsTicketStore,
     pairing,
     serverDeps,
+    // host is the bare form normalizeBindHost produced for server.listen();
+    // pairing-link.ts parses this string with `new URL(...)`, which needs
+    // an IPv6 literal bracketed.
+    daemonBaseUrl: buildDaemonBaseUrl(host, options.port),
   })
 
   setRuntimeTouchFn(touch)

--- a/packages/mcp-server/src/server/mcp/index.ts
+++ b/packages/mcp-server/src/server/mcp/index.ts
@@ -13,6 +13,11 @@ import { registerDocumentTools } from './document-tools.js'
 import { wireMcpLogging } from './logging.js'
 import { registerMcpAppsExtension } from './mcp-apps.js'
 import {
+  type PairingLinkContext,
+  type PairingUnavailableReason,
+  registerPairingLinkTool,
+} from './pairing-link.js'
+import {
   buildDrawDiagramPrompt,
   getStandaloneHelpText,
   WHITEBOARD_DRAW_PROMPT,
@@ -20,7 +25,20 @@ import {
 } from './standalone-help.js'
 import { installStdioLifecycle } from './stdio-lifecycle.js'
 
-export async function createMcpServer() {
+export interface CreateMcpServerOptions {
+  /** Daemon origin + bootstrap token for wb_pairing_link_create. Absent on
+   *  the stdio entrypoint, which has no HTTP listener of its own to embed in
+   *  a pairing link — the tool stays registered there too (so tools/list is
+   *  one authoritative list across transports) but answers isError. */
+  pairing?: PairingLinkContext
+  /** Why `pairing` is absent, so the tool's refusal message names the real
+   *  cause instead of assuming stdio. Defaults to 'stdio' since that is this
+   *  module's own standalone entrypoint's reason — http-server.ts overrides
+   *  it per authMode when pairing is absent for an HTTP-connected caller. */
+  pairingUnavailableReason?: PairingUnavailableReason
+}
+
+export async function createMcpServer(options: CreateMcpServerOptions = {}) {
   // ensureWorkspaceId memoizes the resolve+save sequence per getDataDir() so the
   // HTTP /mcp handler does not race concurrent requests on the marker file.
   // Called for its prepareDataDir migration side effect ahead of the DB use
@@ -103,6 +121,7 @@ export async function createMcpServer() {
   )
 
   registerMcpAppsExtension(server)
+  registerPairingLinkTool(server, options.pairing, options.pairingUnavailableReason)
 
   const dataDir = getDataDir()
   const db = await getDb(dataDir)

--- a/packages/mcp-server/src/server/mcp/mcp-smoke-coverage.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-smoke-coverage.ts
@@ -62,6 +62,7 @@ export const ALL_REGISTERED_TOOLS = [
   'wb_document_resolve',
   'wb_document_list',
   'canvas_view',
+  'wb_pairing_link_create',
 ] as const satisfies readonly string[]
 
 export const COVERED_TOOLS = [
@@ -84,9 +85,13 @@ export const COVERED_TOOLS = [
   'wb_document_list',
 ] as const
 
-// Empty since the seeding batch gives every later step something to act on: every tool
-// either reaches its success path in the smoke or is listed below.
-export const ERROR_PATH_ONLY_TOOLS = [] as const
+// wb_pairing_link_create's smoke coverage is deliberately its error path
+// only: the offline stdio smoke has no HTTP daemon to pair with, so it can
+// only exercise the standalone-stdio refusal. The success path (a real
+// daemon origin threaded in) is covered at the unit layer
+// (pairing-link.test.ts, a real MCP client over an in-memory transport) and
+// by the HTTP-daemon verification recorded outside this repeatable smoke.
+export const ERROR_PATH_ONLY_TOOLS = ['wb_pairing_link_create'] as const
 
 // MCP Apps (SEP-1865) UI-linked tools: their registered definition carries
 // `_meta.ui.resourceUri` pointing at CANVAS_VIEW_RESOURCE_URI (mcp-apps.ts).

--- a/packages/mcp-server/src/server/mcp/pairing-link.test.ts
+++ b/packages/mcp-server/src/server/mcp/pairing-link.test.ts
@@ -1,0 +1,378 @@
+// These tests drive a real McpServer + Client over an in-memory transport
+// (the same pattern body-patch-registration.test.ts uses), so the SDK's own
+// argument/output validation is what judges the tool rather than a
+// restatement of it.
+import { Client } from '@modelcontextprotocol/client'
+import { InMemoryTransport, McpServer } from '@modelcontextprotocol/server'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  daemonConnectionPayloadSchema,
+  decodeBase64UrlText,
+} from '../../shared/api-contracts/pairing-link.js'
+import { DEFAULT_ALLOWED_WEB_ORIGINS } from '../security/web-origin-allowlist.js'
+import {
+  PAIRING_LINK_CREDENTIAL_NOTE,
+  type PairingLinkContext,
+  registerPairingLinkTool,
+} from './pairing-link.js'
+
+function decodeFragment(url: string): unknown {
+  const marker = '#wb='
+  const idx = url.indexOf(marker)
+  if (idx === -1) throw new Error(`url missing #wb= fragment: ${url}`)
+  const fragment = url.slice(idx + marker.length)
+  return JSON.parse(decodeBase64UrlText(fragment))
+}
+
+async function connectedClient(
+  pairing: PairingLinkContext | undefined,
+  unavailableReason?: Parameters<typeof registerPairingLinkTool>[2],
+) {
+  const server = new McpServer({ name: 'whiteboard-test', version: '0.0.0' })
+  registerPairingLinkTool(server, pairing, unavailableReason)
+
+  const [clientSide, serverSide] = InMemoryTransport.createLinkedPair()
+  await server.connect(serverSide)
+  const client = new Client({ name: 'pairing-link-test', version: '0.0.0' })
+  await client.connect(clientSide)
+  return { client, server }
+}
+
+describe('wb_pairing_link_create — with a daemon pairing context', () => {
+  let harness: Awaited<ReturnType<typeof connectedClient>>
+
+  beforeEach(async () => {
+    harness = await connectedClient({
+      daemonBaseUrl: 'http://127.0.0.1:54231',
+      bootstrapToken: 'x'.repeat(24),
+    })
+  })
+
+  afterEach(async () => {
+    await harness.client.close().catch(() => {})
+    await harness.server.close().catch(() => {})
+  })
+
+  const call = (args: Record<string, unknown>) =>
+    harness.client.callTool({ name: 'wb_pairing_link_create', arguments: args })
+
+  it('emits a url whose fragment decodes to a shared-schema-valid bootstrap payload', async () => {
+    const res = await call({ workspaceId: 'ws1', path: 'canvas-a', fullscreen: true })
+    expect(res.isError, JSON.stringify(res)).not.toBe(true)
+    const result = res.structuredContent as {
+      url: string
+      webOrigin: string
+      authMode: string
+    }
+    expect(result.authMode).toBe('bootstrap')
+    expect(result.url.startsWith(`${result.webOrigin}/#wb=`)).toBe(true)
+    expect(result.url.split('#').length - 1).toBe(1)
+
+    const decoded = daemonConnectionPayloadSchema.parse(decodeFragment(result.url))
+    expect(decoded).toEqual({
+      baseUrl: 'http://127.0.0.1:54231',
+      workspaceId: 'ws1',
+      path: 'canvas-a',
+      fullscreen: true,
+      authMode: 'bootstrap',
+      bootstrapToken: 'x'.repeat(24),
+    })
+
+    // The credential warning has to reach the tool's REAL content, not just
+    // be buildable from the structuredContent in a test — a client only
+    // ever sees res.content, never a value it computes for itself.
+    const text = (res.content as Array<{ text: string }>)[0]?.text ?? ''
+    expect(text).toContain(result.url)
+    expect(text).toContain(PAIRING_LINK_CREDENTIAL_NOTE)
+  })
+
+  it('rejects path without workspaceId before any daemon interaction', async () => {
+    const res = await call({ path: 'canvas-a' })
+    expect(res.isError).toBe(true)
+    expect((res.content as Array<{ text: string }>)[0]?.text).toMatch(/workspaceId/i)
+  })
+
+  it('resolves webOrigin: explicit input > default production origin', async () => {
+    const defaultResult = await call({})
+    expect((defaultResult.structuredContent as { webOrigin: string }).webOrigin).toBe(
+      'https://kamiazya-whiteboard.pages.dev',
+    )
+
+    const explicit = await call({ webOrigin: 'https://explicit.example.com' })
+    expect((explicit.structuredContent as { webOrigin: string }).webOrigin).toBe(
+      'https://explicit.example.com',
+    )
+  })
+
+  it('rejects a non-bare-origin webOrigin at the input schema layer', async () => {
+    const res = await call({ webOrigin: 'https://example.com/some/path' })
+    expect(res.isError).toBe(true)
+  })
+
+  it('warns about the allowlist for a non-loopback webOrigin, not for loopback', async () => {
+    // Asserts on the tool's REAL content array (what a client actually
+    // receives), not on buildPairingLinkText called directly against
+    // structuredContent — that would pass even if the handler never
+    // called buildPairingLinkText at all.
+    // PAIRING_LINK_CREDENTIAL_NOTE itself always mentions
+    // WHITEBOARD_ALLOWED_WEB_ORIGINS in its general-rule sentence, so the
+    // per-call not-admitted warning is identified by its own distinct
+    // substring instead.
+    const NOT_ADMITTED_MARKER = 'would be rejected by CORS/origin checks'
+
+    const hosted = await call({ webOrigin: 'https://example.pages.dev' })
+    const hostedText = (hosted.content as Array<{ text: string }>)[0]?.text ?? ''
+    expect(hostedText).toContain(PAIRING_LINK_CREDENTIAL_NOTE)
+    expect(hostedText).toContain(NOT_ADMITTED_MARKER)
+
+    const loopback = await call({ webOrigin: 'http://localhost:5173' })
+    const loopbackText = (loopback.content as Array<{ text: string }>)[0]?.text ?? ''
+    expect(loopbackText).toContain(PAIRING_LINK_CREDENTIAL_NOTE)
+    expect(loopbackText).not.toContain(NOT_ADMITTED_MARKER)
+  })
+})
+
+describe('wb_pairing_link_create — daemon reports its own resolved allowlist', () => {
+  it('confirms coverage instead of warning when webOrigin is actually admitted', async () => {
+    const { client, server } = await connectedClient({
+      daemonBaseUrl: 'http://127.0.0.1:54231',
+      bootstrapToken: 'x'.repeat(24),
+      allowedWebOrigins: ['https://admitted.example.com'],
+    })
+    try {
+      const res = await client.callTool({
+        name: 'wb_pairing_link_create',
+        arguments: { webOrigin: 'https://admitted.example.com' },
+      })
+      const text = (res.content as Array<{ text: string }>)[0]?.text ?? ''
+      expect(text).toContain(PAIRING_LINK_CREDENTIAL_NOTE)
+      expect(text).not.toContain('would be rejected by CORS/origin checks')
+    } finally {
+      await client.close().catch(() => {})
+      await server.close().catch(() => {})
+    }
+  })
+
+  it('still warns when webOrigin is non-loopback and absent from the resolved allowlist', async () => {
+    const { client, server } = await connectedClient({
+      daemonBaseUrl: 'http://127.0.0.1:54231',
+      bootstrapToken: 'x'.repeat(24),
+      allowedWebOrigins: ['https://admitted.example.com'],
+    })
+    try {
+      const res = await client.callTool({
+        name: 'wb_pairing_link_create',
+        arguments: { webOrigin: 'https://unlisted.example.com' },
+      })
+      const text = (res.content as Array<{ text: string }>)[0]?.text ?? ''
+      expect(text).toContain('would be rejected by CORS/origin checks')
+    } finally {
+      await client.close().catch(() => {})
+      await server.close().catch(() => {})
+    }
+  })
+
+  it('re-reads a live allowedWebOrigins provider on every call instead of a startup snapshot', async () => {
+    // http-server.ts passes allowedWebOrigins as a FUNCTION so a pairing
+    // grant approved after daemon startup is admitted immediately by CORS,
+    // /mcp origin, and WS — this pins that wb_pairing_link_create's own
+    // advisory text tracks the same live set instead of freezing whatever
+    // the provider returned at construction time.
+    let origins: readonly string[] = []
+    const { client, server } = await connectedClient({
+      daemonBaseUrl: 'http://127.0.0.1:54231',
+      bootstrapToken: 'x'.repeat(24),
+      allowedWebOrigins: () => origins,
+    })
+    try {
+      const before = await client.callTool({
+        name: 'wb_pairing_link_create',
+        arguments: { webOrigin: 'https://granted-later.example.com' },
+      })
+      const beforeText = (before.content as Array<{ text: string }>)[0]?.text ?? ''
+      expect(beforeText).toContain('would be rejected by CORS/origin checks')
+
+      // Simulate a pairing grant approved mid-process: the provider now
+      // returns the newly admitted origin.
+      origins = ['https://granted-later.example.com']
+
+      const after = await client.callTool({
+        name: 'wb_pairing_link_create',
+        arguments: { webOrigin: 'https://granted-later.example.com' },
+      })
+      const afterText = (after.content as Array<{ text: string }>)[0]?.text ?? ''
+      expect(afterText).not.toContain('would be rejected by CORS/origin checks')
+    } finally {
+      await client.close().catch(() => {})
+      await server.close().catch(() => {})
+    }
+  })
+})
+
+describe('wb_pairing_link_create — daemon has no bootstrap token', () => {
+  it('uses authMode "none" and omits bootstrapToken from the fragment', async () => {
+    const { client, server } = await connectedClient({ daemonBaseUrl: 'http://127.0.0.1:54231' })
+    try {
+      const res = await client.callTool({ name: 'wb_pairing_link_create', arguments: {} })
+      const result = res.structuredContent as { url: string; authMode: string }
+      expect(result.authMode).toBe('none')
+      const decoded = decodeFragment(result.url) as Record<string, unknown>
+      expect('bootstrapToken' in decoded).toBe(false)
+    } finally {
+      await client.close().catch(() => {})
+      await server.close().catch(() => {})
+    }
+  })
+})
+
+describe('wb_pairing_link_create — daemon has a too-short bootstrap token', () => {
+  it('refuses loudly instead of emitting a dead link', async () => {
+    const { client, server } = await connectedClient({
+      daemonBaseUrl: 'http://127.0.0.1:54231',
+      bootstrapToken: 'short',
+    })
+    try {
+      const res = await client.callTool({ name: 'wb_pairing_link_create', arguments: {} })
+      expect(res.isError).toBe(true)
+      expect((res.content as Array<{ text: string }>)[0]?.text).toMatch(/token/i)
+    } finally {
+      await client.close().catch(() => {})
+      await server.close().catch(() => {})
+    }
+  })
+})
+
+describe('wb_pairing_link_create — standalone stdio (no pairing context)', () => {
+  it('is still listed in tools/list and answers isError explaining the HTTP-daemon requirement', async () => {
+    const { client, server } = await connectedClient(undefined)
+    try {
+      const tools = await client.listTools()
+      expect(tools.tools.map((t) => t.name)).toContain('wb_pairing_link_create')
+
+      const res = await client.callTool({ name: 'wb_pairing_link_create', arguments: {} })
+      expect(res.isError).toBe(true)
+      const text = (res.content as Array<{ text: string }>)[0]?.text ?? ''
+      expect(text).toMatch(/http/i)
+      expect(text).toMatch(/daemon/i)
+    } finally {
+      await client.close().catch(() => {})
+      await server.close().catch(() => {})
+    }
+  })
+})
+
+describe('wb_pairing_link_create — server-mode (no pairing context, reason: server-mode)', () => {
+  it('names server-mode, not stdio, and does not tell an already-HTTP-connected caller to connect over HTTP', async () => {
+    // Regression: app.ts's pairingLinkContext is undefined for
+    // authMode: 'server-mode' exactly as it is for stdio, but a server-mode
+    // caller is reached over a real, working HTTP /mcp connection — the
+    // stdio-shaped message ("running standalone over stdio ... connect
+    // through its HTTP /mcp endpoint instead") is false for this caller.
+    const { client, server } = await connectedClient(undefined, 'server-mode')
+    try {
+      const res = await client.callTool({ name: 'wb_pairing_link_create', arguments: {} })
+      expect(res.isError).toBe(true)
+      const text = (res.content as Array<{ text: string }>)[0]?.text ?? ''
+      expect(text).toMatch(/server-mode/i)
+      expect(text).not.toMatch(/standalone over stdio/i)
+      expect(text).not.toMatch(/connect through its HTTP/i)
+    } finally {
+      await client.close().catch(() => {})
+      await server.close().catch(() => {})
+    }
+  })
+})
+
+describe('wb_pairing_link_create — WHITEBOARD_WEB_ORIGIN env fallback', () => {
+  const ENV_KEY = 'WHITEBOARD_WEB_ORIGIN'
+  let originalValue: string | undefined
+
+  beforeEach(() => {
+    originalValue = process.env[ENV_KEY]
+  })
+
+  afterEach(() => {
+    if (originalValue === undefined) delete process.env[ENV_KEY]
+    else process.env[ENV_KEY] = originalValue
+  })
+
+  it('uses WHITEBOARD_WEB_ORIGIN when no explicit webOrigin arg is passed', async () => {
+    process.env[ENV_KEY] = 'https://env-configured.example.com'
+    const { client, server } = await connectedClient({
+      daemonBaseUrl: 'http://127.0.0.1:54231',
+      bootstrapToken: 'x'.repeat(24),
+    })
+    try {
+      const res = await client.callTool({ name: 'wb_pairing_link_create', arguments: {} })
+      expect((res.structuredContent as { webOrigin: string }).webOrigin).toBe(
+        'https://env-configured.example.com',
+      )
+    } finally {
+      await client.close().catch(() => {})
+      await server.close().catch(() => {})
+    }
+  })
+
+  it('an explicit webOrigin arg still wins over the env fallback', async () => {
+    process.env[ENV_KEY] = 'https://env-configured.example.com'
+    const { client, server } = await connectedClient({
+      daemonBaseUrl: 'http://127.0.0.1:54231',
+      bootstrapToken: 'x'.repeat(24),
+    })
+    try {
+      const res = await client.callTool({
+        name: 'wb_pairing_link_create',
+        arguments: { webOrigin: 'https://explicit.example.com' },
+      })
+      expect((res.structuredContent as { webOrigin: string }).webOrigin).toBe(
+        'https://explicit.example.com',
+      )
+    } finally {
+      await client.close().catch(() => {})
+      await server.close().catch(() => {})
+    }
+  })
+
+  it('treats an empty-string WHITEBOARD_WEB_ORIGIN as unset, falling back to the default origin', async () => {
+    // resolveEnvWebOrigin() has an explicit `if (!raw) return undefined`
+    // branch distinguishing "" (a cleared env var in shell scripts) from a
+    // real misconfiguration — pin it separately from the misconfigured case
+    // below so a regression treating "" as an error (or as a literal origin)
+    // is caught.
+    process.env[ENV_KEY] = ''
+    const { client, server } = await connectedClient({
+      daemonBaseUrl: 'http://127.0.0.1:54231',
+      bootstrapToken: 'x'.repeat(24),
+    })
+    try {
+      const res = await client.callTool({ name: 'wb_pairing_link_create', arguments: {} })
+      expect(res.isError, JSON.stringify(res)).not.toBe(true)
+      expect((res.structuredContent as { webOrigin: string }).webOrigin).toBe(
+        DEFAULT_ALLOWED_WEB_ORIGINS[0],
+      )
+    } finally {
+      await client.close().catch(() => {})
+      await server.close().catch(() => {})
+    }
+  })
+
+  it('surfaces isError instead of minting a broken link when the env var is misconfigured', async () => {
+    // A path makes this fail bareHttpOriginSchema — the same check an
+    // explicit webOrigin arg goes through at the input-schema layer, but the
+    // env fallback bypasses that layer unless resolveEnvWebOrigin re-checks.
+    process.env[ENV_KEY] = 'https://example.com/some/path'
+    const { client, server } = await connectedClient({
+      daemonBaseUrl: 'http://127.0.0.1:54231',
+      bootstrapToken: 'x'.repeat(24),
+    })
+    try {
+      const res = await client.callTool({ name: 'wb_pairing_link_create', arguments: {} })
+      expect(res.isError).toBe(true)
+      const text = (res.content as Array<{ text: string }>)[0]?.text ?? ''
+      expect(text).toMatch(/WHITEBOARD_WEB_ORIGIN/)
+    } finally {
+      await client.close().catch(() => {})
+      await server.close().catch(() => {})
+    }
+  })
+})

--- a/packages/mcp-server/src/server/mcp/pairing-link.ts
+++ b/packages/mcp-server/src/server/mcp/pairing-link.ts
@@ -1,0 +1,267 @@
+import type { McpServer } from '@modelcontextprotocol/server'
+import { z } from 'zod'
+import {
+  daemonConnectionPayloadSchema,
+  encodeBase64UrlText,
+  isBareHttpOrigin,
+  MIN_BOOTSTRAP_TOKEN_LENGTH,
+} from '../../shared/api-contracts/pairing-link.js'
+import {
+  type AllowedWebOrigins,
+  DEFAULT_ALLOWED_WEB_ORIGINS,
+  isAllowedWebOrigin,
+  resolveAllowedWebOrigins,
+} from '../security/web-origin-allowlist.js'
+import { registerToolWithAnnotations } from './tool-support.js'
+
+// The daemon's own default onboarding destination — kept in sync with the
+// hosted-origin CORS allowlist so a link minted with no explicit webOrigin
+// always points somewhere the daemon itself admits by default.
+const DEFAULT_PRODUCTION_WEB_ORIGIN = DEFAULT_ALLOWED_WEB_ORIGINS[0]
+
+// Bare http(s) origin: scheme + host + optional port, nothing else — the
+// shared contract's predicate, so this cannot drift from what the payload
+// schema itself enforces on baseUrl. A pairing link targets one concrete
+// origin, so a wildcard host is rejected here even though
+// WHITEBOARD_ALLOWED_WEB_ORIGINS itself may admit one.
+const bareHttpOriginSchema = z.string().url().refine(isBareHttpOrigin, {
+  message:
+    'webOrigin must be a bare http(s) origin (scheme + host + optional port, no path, query, hash, credentials, or wildcards)',
+})
+
+// Single source of truth for wb_pairing_link_create's input: a raw shape so
+// it can be passed directly to registerToolWithAnnotations (which requires
+// z.ZodRawShape and cannot accept a refined z.object()). The cross-field
+// "path requires workspaceId" rule cannot live here for that reason — it is
+// enforced in execute() below instead.
+export const pairingLinkInputShape = {
+  workspaceId: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('Target workspace ID. Required when path is set.'),
+  path: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('Target document path within workspaceId. Requires workspaceId to also be set.'),
+  webOrigin: bareHttpOriginSchema
+    .optional()
+    .describe(
+      'Web app origin to embed in the link (e.g. "https://app.example.com"). Defaults to the WHITEBOARD_WEB_ORIGIN env var, or the official hosted whiteboard web app origin.',
+    ),
+  fullscreen: z
+    .boolean()
+    .optional()
+    .describe('Open the paired document in fullscreen mode once connected.'),
+} satisfies z.ZodRawShape
+
+export const pairingLinkInputSchema = z.object(pairingLinkInputShape)
+
+export const pairingLinkOutputSchema = z.object({
+  url: z.string().url().describe('The `<webOrigin>/#wb=<payload>` pairing URL.'),
+  webOrigin: z.string().describe('The web app origin embedded in url.'),
+  authMode: z.enum(['bootstrap', 'none']).describe('Auth mode encoded in the pairing payload.'),
+  // Omitted entirely (never emitted as `undefined`) whenever no real expiry
+  // source exists — which is always today: bootstrapToken here is the
+  // daemon's own static bearer token, embedded as-is, with no TTL of its
+  // own (valid until rotated). Flip this to always-emitted only if a
+  // genuinely time-boxed credential replaces it.
+  expiresHint: z.string().optional().describe('Human-readable expiry hint, when known.'),
+})
+
+// The explicit webOrigin input is constrained by bareHttpOriginSchema at the
+// schema layer; the env var fallback bypasses that layer entirely unless it
+// is re-validated here, so a misconfigured WHITEBOARD_WEB_ORIGIN would
+// otherwise silently mint a link with a path/query/wrong-scheme origin the
+// web app parser rejects outright.
+function resolveEnvWebOrigin(): string | undefined {
+  const raw = process.env.WHITEBOARD_WEB_ORIGIN
+  // Empty string means "unset" (a cleared env var in shell scripts), not a
+  // misconfiguration — fall back to the default rather than failing loudly.
+  if (!raw) return undefined
+
+  const parsed = bareHttpOriginSchema.safeParse(raw)
+  if (!parsed.success) {
+    throw new Error(
+      `wb_pairing_link_create: WHITEBOARD_WEB_ORIGIN is not a bare http(s) origin: ${raw}`,
+    )
+  }
+  return parsed.data
+}
+
+function isLoopbackOrigin(origin: string): boolean {
+  try {
+    const { hostname } = new URL(origin)
+    return (
+      hostname === 'localhost' ||
+      // The whole 127.0.0.0/8 block is loopback, not just 127.0.0.1.
+      /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname) ||
+      // Node's WHATWG URL keeps the brackets ('[::1]'); the bare form is
+      // retained for runtimes that strip them.
+      hostname === '::1' ||
+      hostname === '[::1]'
+    )
+  } catch {
+    return false
+  }
+}
+
+export const PAIRING_LINK_CREDENTIAL_NOTE =
+  'SECURITY: this URL embeds the daemon bootstrap token — treat it like a credential and share it only with the intended recipient. Hosted (non-loopback) webOrigin values must be added to WHITEBOARD_ALLOWED_WEB_ORIGINS on the daemon (an exact origin or a https://*.example.com wildcard subdomain pattern); loopback origins need no allowlist entry.'
+
+// A non-loopback webOrigin absent from the daemon's own admitted set: the
+// link would open, but the paired web app's request to the daemon is exactly
+// what /api CORS, /mcp origin, and WS upgrade would reject — so the mint
+// itself is not wrong, but the resulting link is dead until the operator
+// adds the entry.
+const HOSTED_ORIGIN_NOT_ALLOWLISTED_WARNING =
+  'This webOrigin is not in WHITEBOARD_ALLOWED_WEB_ORIGINS on this daemon — the paired web app would be rejected by CORS/origin checks until you add it there.'
+
+export function buildPairingLinkText(
+  result: z.infer<typeof pairingLinkOutputSchema>,
+  webOrigin: string,
+  allowedWebOrigins: readonly string[] = [],
+): string {
+  const lines = [result.url, '', PAIRING_LINK_CREDENTIAL_NOTE]
+  if (!isLoopbackOrigin(webOrigin) && !isAllowedWebOrigin(webOrigin, allowedWebOrigins)) {
+    lines.push(HOSTED_ORIGIN_NOT_ALLOWLISTED_WARNING)
+  }
+  return lines.join('\n')
+}
+
+// The daemon's own origin + bootstrap token, threaded in by the composition
+// root (http-server.ts, via createApp/createMcpServer) rather than read from
+// process.env inside this module — the stdio entrypoint has no HTTP daemon
+// of its own to describe, which is the standalone case below.
+export interface PairingLinkContext {
+  daemonBaseUrl: string
+  bootstrapToken?: string
+  // The daemon's own WHITEBOARD_ALLOWED_WEB_ORIGINS (the same set /api CORS,
+  // /mcp origin, and WS upgrade enforce), so a non-loopback webOrigin can be
+  // checked against real coverage instead of only reminding the caller to
+  // check it themselves. Kept as the raw array-or-provider value (never
+  // resolved here) and re-resolved on every call via resolveAllowedWebOrigins
+  // — in local-daemon mode this is a live function backed by pairing grants
+  // approved at runtime, and freezing its result once at app construction
+  // would make this tool's advisory text stale for the rest of the process.
+  // Absent (rather than defaulted here) when the caller has no allowlist to
+  // report — e.g. server-mode has no meaning for this field at all.
+  allowedWebOrigins?: AllowedWebOrigins
+}
+
+const PAIRING_LINK_TOOL_NAME = 'wb_pairing_link_create'
+
+// Why `pairing` is absent — the caller (createMcpServer's composition root)
+// knows which of these it is; this module cannot infer it from `undefined`
+// alone. 'stdio' is the default because that is this module's own standalone
+// entrypoint's reason, with no HTTP daemon of any kind.
+export type PairingUnavailableReason =
+  // The stdio entrypoint: no HTTP listener exists at all to embed a link to.
+  | 'stdio'
+  // A real HTTP /mcp connection, but server-mode has no single daemon
+  // origin/bootstrap-token to embed — clients authenticate via their own
+  // configured strategy (API key/OAuth) instead.
+  | 'server-mode'
+  // local-daemon mode, but the composition root gave no daemonBaseUrl (an
+  // ad-hoc or test caller with no real HTTP listener behind it).
+  | 'no-daemon-base-url'
+
+const PAIRING_UNAVAILABLE_MESSAGES: Record<PairingUnavailableReason, string> = {
+  stdio:
+    'wb_pairing_link_create: this MCP server is running standalone over stdio, which has no HTTP daemon to pair with. Start the `whiteboard` daemon (pnpm mcp:http:dev in development, or the installed daemon in production) and connect through its HTTP /mcp endpoint instead.',
+  'server-mode':
+    'wb_pairing_link_create: this MCP server is running in server-mode, which has no single daemon origin or bootstrap token to embed in a pairing link — server-mode clients authenticate through their own configured strategy (API key or OAuth) instead of a daemon pairing link.',
+  'no-daemon-base-url':
+    'wb_pairing_link_create: this MCP server has no daemonBaseUrl configured, so there is no HTTP origin to embed in a pairing link.',
+}
+
+export function registerPairingLinkTool(
+  server: McpServer,
+  pairing: PairingLinkContext | undefined,
+  unavailableReason: PairingUnavailableReason = 'stdio',
+): void {
+  registerToolWithAnnotations(
+    server,
+    PAIRING_LINK_TOOL_NAME,
+    {
+      description:
+        'Mint a `#wb=` daemon-pairing URL that lets the whiteboard web app connect to this local daemon, optionally targeting a specific workspace/document. ' +
+        PAIRING_LINK_CREDENTIAL_NOTE,
+      inputSchema: pairingLinkInputShape,
+      outputSchema: pairingLinkOutputSchema,
+    },
+    async (rawArgs) => {
+      if (pairing === undefined) {
+        // Registered on every transport/mode too (so tools/list stays one
+        // authoritative list), but not every caller has a daemon origin to
+        // embed in the link — refuse with the reason-specific remedy rather
+        // than one message that only fits one of the three cases.
+        throw new Error(PAIRING_UNAVAILABLE_MESSAGES[unavailableReason])
+      }
+
+      const args = pairingLinkInputSchema.parse(rawArgs)
+
+      // Cross-field guard: raw-shape registration cannot express this as a
+      // schema refinement (registerToolWithAnnotations requires
+      // z.ZodRawShape), so it is enforced here, before any daemon
+      // interaction.
+      if (args.path !== undefined && args.workspaceId === undefined) {
+        throw new Error('wb_pairing_link_create: workspaceId is required when path is set')
+      }
+
+      const webOrigin = args.webOrigin ?? resolveEnvWebOrigin() ?? DEFAULT_PRODUCTION_WEB_ORIGIN
+
+      const token = pairing.bootstrapToken ?? ''
+      const hasToken = token.length > 0
+      if (hasToken && token.length < MIN_BOOTSTRAP_TOKEN_LENGTH) {
+        // Fail loudly rather than emit a URL the web-side schema would
+        // reject as invalid once opened — a dead link is worse than an
+        // explicit tool error.
+        throw new Error(
+          `wb_pairing_link_create: daemon bootstrap token is only ${token.length} chars (minimum ${MIN_BOOTSTRAP_TOKEN_LENGTH}); refusing to mint a pairing link the web app would reject`,
+        )
+      }
+
+      const payload = daemonConnectionPayloadSchema.parse({
+        // Normalize to a bare origin: a trailing slash (or any
+        // non-normalized form) in the daemon's baseUrl would fail the
+        // strict shared schema and turn a valid daemon into a tool error.
+        baseUrl: new URL(pairing.daemonBaseUrl).origin,
+        workspaceId: args.workspaceId,
+        path: args.path,
+        fullscreen: args.fullscreen,
+        authMode: hasToken ? 'bootstrap' : 'none',
+        bootstrapToken: hasToken ? token : undefined,
+      })
+
+      const fragment = encodeBase64UrlText(JSON.stringify(payload))
+      const url = `${webOrigin}/#wb=${fragment}`
+
+      const result: z.infer<typeof pairingLinkOutputSchema> = {
+        url,
+        webOrigin,
+        authMode: payload.authMode,
+      }
+      // Deliberately NOT structuredJsonResult(result): that helper emits
+      // only the bare structuredContent JSON as content[0].text, which is
+      // the one place a caller (or a transcript relaying this call's
+      // output) actually sees the minted link. The credential warning has
+      // to travel with the URL on every call, not just once in the static
+      // tool description.
+      return {
+        structuredContent: result,
+        content: [
+          {
+            type: 'text' as const,
+            text: buildPairingLinkText(
+              result,
+              webOrigin,
+              resolveAllowedWebOrigins(pairing.allowedWebOrigins),
+            ),
+          },
+        ],
+      }
+    },
+  )
+}

--- a/packages/mcp-server/src/server/mcp/tool-naming.test.ts
+++ b/packages/mcp-server/src/server/mcp/tool-naming.test.ts
@@ -38,6 +38,10 @@ const ENTITIES = [
   // document in it, so `document` would be the wrong noun rather than a
   // shorter one.
   'workspace',
+  // wb_pairing_link_create: an agent asking the DAEMON to mint its own
+  // pairing handoff — a daemon concern, not stored document content, so it
+  // belongs beside 'viewport' rather than the document-model nouns above.
+  'pairing',
 ] as const
 
 /**

--- a/packages/mcp-server/src/server/mcp/tool-profiles.ts
+++ b/packages/mcp-server/src/server/mcp/tool-profiles.ts
@@ -65,4 +65,11 @@ export const TOOL_PROFILES: Record<string, { profile: AnnotationProfile; title: 
   // plane on purpose: it is a UI contract with the host, not a tool a model
   // reads data through.
   canvas_view: { profile: READ_ONLY, title: 'Show a canvas inline in the chat' },
+  // Deliberately MUTATING rather than READ_ONLY despite touching no stored
+  // state: the result embeds a live daemon credential (a bootstrap token),
+  // so it must never be a candidate for an auto-run/read-only approval path.
+  wb_pairing_link_create: {
+    profile: MUTATING,
+    title: 'Mint a daemon-pairing link for the whiteboard web app',
+  },
 }

--- a/packages/mcp-server/src/server/release/api-contracts-barrel.test.ts
+++ b/packages/mcp-server/src/server/release/api-contracts-barrel.test.ts
@@ -47,6 +47,10 @@ describe('api-contracts barrel scope', () => {
       // what keeps a URL out of the request (ADR-0012).
       './fonts.js',
       './pairing.js',
+      // pairing-link: the daemon-pairing-link `#wb=` fragment contract,
+      // exported so apps/web parses the same schema wb_pairing_link_create
+      // writes instead of a hand-written mirror that can silently drift.
+      './pairing-link.js',
       './runtime.js',
     ])
   })

--- a/packages/mcp-server/src/shared/api-contracts/index.ts
+++ b/packages/mcp-server/src/shared/api-contracts/index.ts
@@ -36,6 +36,17 @@ export {
   pairingTokenRequestSchema,
   pairingTokenResponseSchema,
 } from './pairing.js'
+// The daemon-pairing-link fragment contract: shared by the wb_pairing_link_create
+// MCP tool (mints the link) and apps/web's fragment parser (reads it back), so
+// the two cannot silently disagree on the payload shape.
+export type { DaemonConnectionPayload } from './pairing-link.js'
+export {
+  DAEMON_CONNECTION_FRAGMENT_KEY,
+  daemonConnectionPayloadSchema,
+  decodeBase64UrlText,
+  encodeBase64UrlText,
+  MIN_BOOTSTRAP_TOKEN_LENGTH,
+} from './pairing-link.js'
 export type { DaemonPingResponse, RuntimeVerifyResponse } from './runtime.js'
 export { daemonPingResponseSchema, runtimeVerifyResponseSchema } from './runtime.js'
 

--- a/packages/mcp-server/src/shared/api-contracts/pairing-link.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/pairing-link.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Roundtrip + validation tests for the daemon-pairing-link api-contract
+ * schema and its base64url fragment codec.
+ *
+ * The property below is the single guarantee that lets the MCP tool (Node)
+ * and the browser parser (apps/web) share one fragment format instead of
+ * each hand-rolling their own encoder: decode(encode(x)) === x for every
+ * schema-valid payload, non-ASCII strings included.
+ */
+import { describe, expect, it } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import {
+  DAEMON_CONNECTION_FRAGMENT_KEY,
+  daemonConnectionPayloadSchema,
+  decodeBase64UrlText,
+  encodeBase64UrlText,
+  isBareHttpOrigin,
+  MIN_BOOTSTRAP_TOKEN_LENGTH,
+} from './pairing-link.js'
+
+describe('isBareHttpOrigin', () => {
+  it('accepts a plain http(s) origin, with or without a port', () => {
+    expect(isBareHttpOrigin('http://127.0.0.1:54231')).toBe(true)
+    expect(isBareHttpOrigin('https://example.com')).toBe(true)
+  })
+
+  it('rejects an origin carrying credentials', () => {
+    // new URL('https://user:pass@host').origin drops the credentials, so
+    // the round-trip equality check (url.origin === value) is what actually
+    // rejects this — pinned directly so a future rewrite of the predicate
+    // (e.g. checking url.username/url.password instead) cannot silently
+    // start accepting it.
+    expect(isBareHttpOrigin('https://user:pass@example.com')).toBe(false)
+  })
+
+  it('rejects a wildcard host', () => {
+    // WHITEBOARD_ALLOWED_WEB_ORIGINS may admit a `https://*.example.com`
+    // pattern, but a pairing link targets one concrete origin — the
+    // hostname.includes('*') check is what rejects it here.
+    expect(isBareHttpOrigin('https://*.example.com')).toBe(false)
+  })
+})
+
+describe('daemonConnectionPayloadSchema', () => {
+  const valid = {
+    baseUrl: 'http://127.0.0.1:54231',
+    workspaceId: 'ws1',
+    path: 'canvas-a',
+    fullscreen: true,
+    authMode: 'bootstrap' as const,
+    bootstrapToken: 'x'.repeat(24),
+  }
+
+  it('accepts a well-formed bootstrap payload', () => {
+    expect(daemonConnectionPayloadSchema.safeParse(valid).success).toBe(true)
+  })
+
+  it('accepts authMode "none" with no bootstrapToken', () => {
+    expect(
+      daemonConnectionPayloadSchema.safeParse({ baseUrl: valid.baseUrl, authMode: 'none' }).success,
+    ).toBe(true)
+  })
+
+  it('rejects authMode "bootstrap" without a bootstrapToken', () => {
+    const { bootstrapToken: _omit, ...missing } = valid
+    expect(daemonConnectionPayloadSchema.safeParse(missing).success).toBe(false)
+  })
+
+  it('rejects a path without workspaceId', () => {
+    const { workspaceId: _omit, ...withoutWorkspace } = valid
+    expect(daemonConnectionPayloadSchema.safeParse(withoutWorkspace).success).toBe(false)
+  })
+
+  it('rejects a bootstrapToken shorter than MIN_BOOTSTRAP_TOKEN_LENGTH', () => {
+    expect(
+      daemonConnectionPayloadSchema.safeParse({
+        ...valid,
+        bootstrapToken: 'x'.repeat(MIN_BOOTSTRAP_TOKEN_LENGTH - 1),
+      }).success,
+    ).toBe(false)
+  })
+
+  it('rejects a non-bare-origin baseUrl', () => {
+    expect(
+      daemonConnectionPayloadSchema.safeParse({
+        ...valid,
+        baseUrl: 'http://127.0.0.1:54231/some/path',
+      }).success,
+    ).toBe(false)
+  })
+
+  it('rejects an unknown top-level key (strict)', () => {
+    expect(daemonConnectionPayloadSchema.safeParse({ ...valid, extra: 'nope' }).success).toBe(false)
+  })
+
+  it('the fragment key is "wb"', () => {
+    expect(DAEMON_CONNECTION_FRAGMENT_KEY).toBe('wb')
+  })
+})
+
+describe('base64url text codec', () => {
+  it('round-trips a plain ASCII string', () => {
+    expect(decodeBase64UrlText(encodeBase64UrlText('hello world'))).toBe('hello world')
+  })
+
+  it('round-trips a non-ASCII string', () => {
+    const text = '日本語のワークスペース 🎨'
+    expect(decodeBase64UrlText(encodeBase64UrlText(text))).toBe(text)
+  })
+
+  it('produces unpadded output using the URL-safe alphabet', () => {
+    const encoded = encodeBase64UrlText('a')
+    expect(encoded).not.toMatch(/[+/=]/)
+  })
+
+  fcTest.prop(
+    [
+      fc
+        .record({
+          baseUrl: fc.constantFrom('http://127.0.0.1:54231', 'https://example.pages.dev'),
+          workspaceId: fc.option(fc.string({ minLength: 1, maxLength: 20 }), { nil: undefined }),
+          bootstrapToken: fc.option(
+            fc.string({ minLength: MIN_BOOTSTRAP_TOKEN_LENGTH, maxLength: 40 }),
+            { nil: undefined },
+          ),
+          fullscreen: fc.option(fc.boolean(), { nil: undefined }),
+          // Non-ASCII generator: exercises the encoder's UTF-8 path, which the
+          // hand-rolled charCode loop in a naive implementation gets wrong.
+          note: fc.string({ minLength: 0, maxLength: 12, unit: 'grapheme-composite' }),
+        })
+        .map(({ baseUrl, workspaceId, bootstrapToken, fullscreen, note }) => {
+          const authMode = bootstrapToken !== undefined ? ('bootstrap' as const) : ('none' as const)
+          const path = workspaceId !== undefined && note.length > 0 ? note : undefined
+          return { baseUrl, workspaceId, path, bootstrapToken, fullscreen, authMode }
+        }),
+    ],
+    withDefaults(),
+  )('sharedDecode(sharedEncode(x)) deep-equals x for every schema-valid payload', (candidate) => {
+    const parsed = daemonConnectionPayloadSchema.safeParse(candidate)
+    if (!parsed.success) return // arbitrary occasionally produces a refine-rejected shape; skip it
+    const json = JSON.stringify(parsed.data)
+    const roundTripped = JSON.parse(decodeBase64UrlText(encodeBase64UrlText(json)))
+    expect(roundTripped).toEqual(parsed.data)
+  })
+})

--- a/packages/mcp-server/src/shared/api-contracts/pairing-link.ts
+++ b/packages/mcp-server/src/shared/api-contracts/pairing-link.ts
@@ -1,0 +1,95 @@
+import { z } from 'zod'
+
+// The daemon-pairing URL fragment contract (`#wb=<base64url-json>`), shared
+// between the MCP tool that mints the link (server/mcp/pairing-link.ts) and
+// the browser that parses it (apps/web/src/lib/daemon-connection-payload.ts)
+// so the wire shape cannot drift between two independently-written schemas —
+// the failure mode a mirrored copy had before this file existed. Deliberately
+// free of any node:* import: apps/web consumes this module directly.
+
+// URL hash key carrying the daemon-pairing payload: `#wb=<base64url-json>`.
+export const DAEMON_CONNECTION_FRAGMENT_KEY = 'wb'
+
+// Minimum bootstrapToken length is a defense-in-depth floor, not the real
+// security boundary — the daemon itself decides whether a bootstrapToken is
+// valid. The token is the daemon's full-authority bearer credential, live
+// until rotated (ADR-0002): it is NOT exchanged for a short-lived session
+// token, which is why every surface that emits it carries a credential
+// warning.
+export const MIN_BOOTSTRAP_TOKEN_LENGTH = 8
+
+// Bare http(s) origin: scheme + host + optional port, nothing else. Daemon
+// pairing (ADR-0002) never uses another scheme, and never carries a path,
+// query, hash, credentials, or a wildcard host. Exported so the MCP tool's
+// webOrigin input validates against the same predicate as this schema.
+export function isBareHttpOrigin(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return (
+      url.origin === value &&
+      !url.hostname.includes('*') &&
+      (url.protocol === 'http:' || url.protocol === 'https:')
+    )
+  } catch {
+    return false
+  }
+}
+
+const bareHttpOriginSchema = z.string().url().refine(isBareHttpOrigin, {
+  message:
+    'must be a bare http(s) origin (scheme + host + optional port, no path, query, hash, credentials, or wildcards)',
+})
+
+// authMode is a literal union rather than a bare string so new modes require
+// an explicit schema change instead of silently round-tripping unknown values.
+export const daemonConnectionPayloadSchema = z
+  .object({
+    baseUrl: bareHttpOriginSchema,
+    workspaceId: z.string().min(1).optional(),
+    path: z.string().min(1).optional(),
+    bootstrapToken: z.string().min(MIN_BOOTSTRAP_TOKEN_LENGTH).optional(),
+    authMode: z.enum(['bootstrap', 'none']),
+    fullscreen: z.boolean().optional(),
+  })
+  .strict()
+  // ADR-0002's bootstrap pairing exchange has no meaning without a token to
+  // exchange, so the schema — not just the docs — enforces the pairing.
+  .refine((payload) => payload.authMode !== 'bootstrap' || payload.bootstrapToken !== undefined, {
+    message: 'bootstrapToken is required when authMode is "bootstrap"',
+    path: ['bootstrapToken'],
+  })
+  // A document is addressed by the (workspaceId, path) pair, so a path is
+  // meaningless without a workspaceId. workspaceId alone is a valid
+  // workspace-level target, so the constraint is one-directional.
+  .refine((payload) => payload.path === undefined || payload.workspaceId !== undefined, {
+    message: 'workspaceId is required when path is set',
+    path: ['workspaceId'],
+  })
+
+export type DaemonConnectionPayload = z.infer<typeof daemonConnectionPayloadSchema>
+
+// Runtime-agnostic base64url text codec (TextEncoder/TextDecoder + btoa/atob):
+// no Buffer, so this holds in Node, the browser, and a worker alike. Node's
+// 'base64url' Buffer encoding and this pair produce byte-identical output for
+// the same UTF-8 text, which is what lets the tool (Node) and the browser
+// parser share one fragment format without a second implementation to drift.
+
+// Encodes UTF-8 text to a base64url string (no padding), matching the `#wb=`
+// fragment format.
+export function encodeBase64UrlText(value: string): string {
+  const bytes = new TextEncoder().encode(value)
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+// Decodes a base64url string to its original UTF-8 text. Throws on invalid
+// base64url input.
+export function decodeBase64UrlText(value: string): string {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/')
+  const paddingLength = (4 - (base64.length % 4)) % 4
+  const padded = base64 + '='.repeat(paddingLength)
+  const binary = atob(padded)
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0))
+  return new TextDecoder().decode(bytes)
+}


### PR DESCRIPTION
## What

Restores the agent-minted daemon-pairing link (Task from audit-triage, CRITICAL: README and two docs pages documented `create_pairing_link` while no tool answered). History verified: the tool was deleted in `3f528147` (#341) as unintended collateral of the Excalidraw-tool directory removal — never superseded, no deliberate decision against it; the receiving `#wb=` side stayed fully wired.

Modernized rather than reverted:

- **Named `wb_pairing_link_create`** — `tool-naming.test.ts`'s ADR-0009 shape check forbids the old `create_pairing_link`; `pairing` joins the tool-naming entities with a rationale. All three doc surfaces (README, `connect-to-local-daemon.md`, `security-model.md`) renamed in the same increment; ADR-0005 stays as history.
- **Payload schema declared once.** `shared/api-contracts/pairing-link.ts` holds the daemon-connection payload schema (`path` vocabulary, replacing the retired spelling) plus a runtime-agnostic base64url codec (no `Buffer`/`node:*` — the api-contracts browser-safety scan enforces it). `apps/web/src/lib/daemon-connection-payload.ts` now imports it instead of maintaining the mirrored copy + drift test the old implementation needed; an identity test pins that both sides hold the same object.
- **Daemon origin + bootstrap token threaded, not env-read**: `http-server.ts` → `createApp` → `createMcpServer({pairing})`. The stdio entrypoint still registers the tool (tools/list parity guards run over stdio) and answers a clear `isError` pointing at the HTTP daemon.
- **Guards**: smoke-coverage lists, tool profiles (MUTATING — the result embeds a live credential, never auto-run), `smoke:e2e` calls the tool, structured-content property partition.

## Review

Independent review workflow: 3 raw → 2 confirmed MEDIUM, both resolved on the branch:
1. Contradicted comment about bootstrapToken lifetime → corrected to match the runtime (full-authority bearer, live until rotated — the docs added in this diff say exactly this).
2. "Live credential reaches the calling agent's transcript" → **accepted by design**: minting a credential-bearing link IS the tool's documented purpose (ADR-0002); mitigations are the credential warning in every response, the MUTATING (never auto-run) profile, and the security-model docs. Not fixable without deleting the feature.

Plus fixes made during the loop: live `allowedWebOrigins` re-read (not a startup snapshot), IPv6 `daemonBaseUrl`, warning text wired into the response, reason-accurate stdio refusal.

## Verification

Real daemon over HTTP MCP (worktree dev daemon): `tools/list` includes the tool; `tools/call` minted `https://kamiazya-whiteboard.pages.dev/#wb=<fragment>` whose fragment base64url-decodes to a payload the shared schema parses, `baseUrl` equal to the daemon's own origin. `pnpm smoke:e2e` ALL OK (includes the new tool call).

Gates on the folded branch: mcp-node 3899 passed (4 known root-environment EACCES-simulation failures, reproduce on unmodified main in this container); web 2771 passed (exactly the 9 known undici env failures); `pnpm -r typecheck`, `pnpm build`, `pnpm check:local` all green.

Visual evidence: none — agent-facing MCP tool with no human-visible UI surface; the smoke:e2e output and the recorded HTTP MCP transcripts above are the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_