### PR TITLE
feat(mcp-server): store and serve workspace segment + displayName through the published contract

### DIFF
--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { createMemoryRouter, MemoryRouter, RouterProvider } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { celebrate } from '@/lib/celebrate'
@@ -224,7 +224,11 @@ describe('SettingsPage — Data & app setup journey', () => {
     const mobile = screen.getByTestId('settings-mobile')
     fireEvent.click(await within(mobile).findByRole('button', { name: 'Protect' }))
     expect(await within(mobile).findByText('granted')).toBeTruthy()
-    expect(celebrate).toHaveBeenCalledTimes(1)
+    // celebrate fires from a passive effect on the same commit that renders
+    // "granted", and the handler's promise chain runs outside act — so a
+    // synchronous assertion here races the effect flush under load. Wait for
+    // the call; the exactly-once claim is unchanged.
+    await waitFor(() => expect(celebrate).toHaveBeenCalledTimes(1))
   })
 
   it('never celebrates a step that was already complete when the page opened', async () => {

--- a/packages/mcp-server/scripts/smoke/mcp-http-convergence-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-http-convergence-smoke.mjs
@@ -32,6 +32,7 @@ import {
 } from '@kamiazya/whiteboard-loro-adapter'
 import { LoroDoc } from 'loro-crdt'
 import { WebSocket } from 'ws'
+import { listWorkspacesResponseSchema } from '../../src/shared/api-contracts/document.js'
 import { documentApiUrl } from '../../src/shared/api-contracts/document-url.js'
 import { buildWhiteboardWsProtocols, buildWhiteboardWsUrl } from '../../src/shared/ws-protocol.js'
 import { waitForEventWithTimeout } from './lib/wait-for-event.mjs'
@@ -273,6 +274,32 @@ async function main() {
   }
   const documentId = created.documentId
   log(`[e2e] wb_document_create → ${documentId}`)
+
+  // ── Step 2b: ADR-0019 — GET /api/workspaces serves the displayName a
+  //    plain HTTP PUT set, through the published listWorkspacesResponseSchema.
+  //    (segment has no accepting MCP/HTTP input surface yet — that half is
+  //    verified at the store/route-test level, not here.) ──
+  const WORKSPACE_DISPLAY_NAME = 'Convergence E2E'
+  const putNameRes = await fetch(`http://127.0.0.1:${port}/api/workspaces/${WORKSPACE_ID}/name`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${TOKEN}` },
+    body: JSON.stringify({ name: WORKSPACE_DISPLAY_NAME }),
+  })
+  if (!putNameRes.ok) {
+    throw new Error(`PUT workspace name failed: HTTP ${putNameRes.status}`)
+  }
+  const listWorkspacesRes = await fetch(`http://127.0.0.1:${port}/api/workspaces`, {
+    headers: { Authorization: `Bearer ${TOKEN}` },
+  })
+  if (!listWorkspacesRes.ok) {
+    throw new Error(`GET /api/workspaces failed: HTTP ${listWorkspacesRes.status}`)
+  }
+  const listWorkspacesBody = listWorkspacesResponseSchema.parse(await listWorkspacesRes.json())
+  const ourWorkspace = listWorkspacesBody.workspaces.find((w) => w.workspaceId === WORKSPACE_ID)
+  if (ourWorkspace?.displayName !== WORKSPACE_DISPLAY_NAME) {
+    throw new Error(`GET /api/workspaces did not echo displayName: ${JSON.stringify(ourWorkspace)}`)
+  }
+  log('[e2e] GET /api/workspaces → displayName echoed through the published schema')
 
   const NODE_A = {
     id: 'node-a',

--- a/packages/mcp-server/src/server/routes/document/workspaces.test.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.test.ts
@@ -6,6 +6,7 @@ import { LoroDoc, LoroMap } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   deleteDocumentResponseSchema,
+  listWorkspacesResponseSchema,
   renameDocumentPathResponseSchema,
 } from '../../../shared/api-contracts/document.js'
 import { withTempDataDir } from '../_test-helpers.js'
@@ -94,6 +95,39 @@ describe('GET /api/workspaces', () => {
       workspaces: Array<{ workspaceId: string }>
     }
     expect(json.workspaces).toEqual([{ workspaceId: 'workspace-a' }])
+  })
+
+  // ADR-0019: segment/displayName flow from the registry row through this
+  // route, and a workspace with neither omits the keys rather than serving
+  // null/undefined — the same "absent, not invented" contract the port uses.
+  it('serves segment/displayName for a workspace that has them, and omits the keys for one that does not', async () => {
+    const db = await getDb(tmp.dir)
+    const deps = resolveServerDeps(
+      createContainer(createStoreLocalModule({ db, blobDir: tmp.dir })),
+    )
+    await deps.documentIndex.createWorkspace({
+      workspaceId: 'workspace-named',
+      segment: 'team-notes',
+      displayName: 'Team notes',
+    })
+    await deps.documentIndex.createWorkspace({ workspaceId: 'workspace-bare' })
+
+    const app = createDocumentRouter()
+    const res = await app.request('/api/workspaces')
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    const parsed = listWorkspacesResponseSchema.parse(json)
+
+    const named = parsed.workspaces.find((w) => w.workspaceId === 'workspace-named')
+    expect(named).toEqual({
+      workspaceId: 'workspace-named',
+      segment: 'team-notes',
+      displayName: 'Team notes',
+    })
+    const bare = parsed.workspaces.find((w) => w.workspaceId === 'workspace-bare')
+    expect(bare).toEqual({ workspaceId: 'workspace-bare' })
+    expect('segment' in (bare ?? {})).toBe(false)
+    expect('displayName' in (bare ?? {})).toBe(false)
   })
 })
 

--- a/packages/mcp-server/src/server/routes/document/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.ts
@@ -62,7 +62,11 @@ export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
       // here would forward no arguments and add a name.
       const workspaces = await deps.documentIndex.listWorkspaces()
       const response: ListWorkspacesResponse = {
-        workspaces: workspaces.map(({ workspaceId }) => ({ workspaceId })),
+        workspaces: workspaces.map(({ workspaceId, segment, displayName }) => ({
+          workspaceId,
+          ...(segment === undefined ? {} : { segment }),
+          ...(displayName === undefined ? {} : { displayName }),
+        })),
       }
       return c.json(response)
     } catch (err) {

--- a/packages/mcp-server/src/server/store/db/migrations/0018-workspace-segment.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0018-workspace-segment.test.ts
@@ -1,0 +1,119 @@
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Kysely, type MigrationProvider, Migrator, SqliteDialect, sql } from 'kysely'
+import LibsqlNativeDatabase from 'libsql'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { migrations } from './index.js'
+
+let dataDir = ''
+vi.mock('../../../config.js', () => ({
+  get DATA_DIR() {
+    return dataDir
+  },
+  getDataDir: () => dataDir,
+}))
+
+const PRE_0018 = '0017-drop-documents-table'
+
+interface Handle {
+  db: Kysely<Record<string, Record<string, unknown>>>
+  migrateTo(name: string): Promise<void>
+  migrateToHead(): Promise<void>
+}
+
+async function openDb(): Promise<Handle> {
+  const dbPath = join(dataDir, 'whiteboard.db')
+  const db = new Kysely<Record<string, Record<string, unknown>>>({
+    dialect: new SqliteDialect({
+      database: new LibsqlNativeDatabase(dbPath) as unknown as ConstructorParameters<
+        typeof SqliteDialect
+      >[0]['database'],
+    }),
+  })
+  await sql`PRAGMA foreign_keys = ON`.execute(db)
+  const provider: MigrationProvider = { getMigrations: async () => migrations }
+  const migrator = new Migrator({ db: db as never, provider })
+  return {
+    db,
+    async migrateTo(name: string) {
+      const { error } = await migrator.migrateTo(name)
+      expect(error).toBeUndefined()
+    },
+    async migrateToHead() {
+      const { error } = await migrator.migrateToLatest()
+      expect(error).toBeUndefined()
+    },
+  }
+}
+
+async function columnNames(db: Handle['db'], table: string): Promise<string[]> {
+  const rows = await sql<{ name: string }>`PRAGMA table_info(${sql.raw(table)})`.execute(db)
+  return rows.rows.map((r) => r.name)
+}
+
+async function seedWorkspace(
+  db: Handle['db'],
+  id: string,
+  segment: string | null = null,
+): Promise<void> {
+  const now = Date.now()
+  // Pre-0018 rows have no `segment` column at all — insert without it, as a
+  // pre-migration writer would have.
+  await db
+    .insertInto('workspaces')
+    .values({ id, displayName: null, createdAt: now, updatedAt: now })
+    .execute()
+  if (segment !== null) {
+    await db.updateTable('workspaces').set({ segment }).where('id', '=', id).execute()
+  }
+}
+
+describe('0018-workspace-segment', () => {
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'migration-0018-'))
+  })
+
+  it('adds a nullable segment column, preserving pre-existing rows with segment NULL', async () => {
+    const handle = await openDb()
+    await handle.migrateTo(PRE_0018)
+    await seedWorkspace(handle.db, 'ws-legacy')
+
+    await handle.migrateToHead()
+
+    expect(await columnNames(handle.db, 'workspaces')).toContain('segment')
+    const row = await handle.db
+      .selectFrom('workspaces')
+      .select(['id', 'segment'])
+      .where('id', '=', 'ws-legacy')
+      .executeTakeFirst()
+    expect(row).toEqual({ id: 'ws-legacy', segment: null })
+  })
+
+  it('rejects a duplicate non-NULL segment via the unique index', async () => {
+    const handle = await openDb()
+    await handle.migrateToHead()
+    await seedWorkspace(handle.db, 'ws-a', 'team-notes')
+
+    await expect(seedWorkspace(handle.db, 'ws-b', 'team-notes')).rejects.toThrow(
+      /UNIQUE constraint failed/,
+    )
+  })
+
+  it('allows multiple rows with a NULL segment to coexist', async () => {
+    const handle = await openDb()
+    await handle.migrateToHead()
+    await seedWorkspace(handle.db, 'ws-a')
+    await seedWorkspace(handle.db, 'ws-b')
+
+    const rows = await handle.db
+      .selectFrom('workspaces')
+      .select(['id', 'segment'])
+      .orderBy('id')
+      .execute()
+    expect(rows).toEqual([
+      { id: 'ws-a', segment: null },
+      { id: 'ws-b', segment: null },
+    ])
+  })
+})

--- a/packages/mcp-server/src/server/store/db/migrations/0018-workspace-segment.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0018-workspace-segment.ts
@@ -1,0 +1,24 @@
+import type { Kysely, Migration } from 'kysely'
+
+// ADR-0019: a workspace's user-facing handle. Nullable — legacy workspaces
+// minted before this migration have none until Wave-2 backfill/minting, and
+// there is no value to invent for them. The UNIQUE index is the registry's
+// enforcement of "unique per keeper" (ADR-0019's user-facing layer);
+// SQLite's unique-index semantics treat every NULL as distinct from every
+// other NULL, so any number of legacy rows can coexist under no segment at
+// all — only two NON-NULL rows sharing one segment collide.
+export const migration: Migration = {
+  async up(db: Kysely<unknown>): Promise<void> {
+    await db.schema.alterTable('workspaces').addColumn('segment', 'text').execute()
+    await db.schema
+      .createIndex('workspaces_segment_unique')
+      .on('workspaces')
+      .column('segment')
+      .unique()
+      .execute()
+  },
+  async down(db: Kysely<unknown>): Promise<void> {
+    await db.schema.dropIndex('workspaces_segment_unique').execute()
+    await db.schema.alterTable('workspaces').dropColumn('segment').execute()
+  },
+}

--- a/packages/mcp-server/src/server/store/db/migrations/index.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/index.ts
@@ -16,6 +16,7 @@ import { migration as versionsWorkspaceScoped } from './0014-versions-workspace-
 import { migration as versionsBranchesWorkspaceId } from './0015-versions-branches-workspace-id.js'
 import { migration as dropDocumentsFk } from './0016-drop-documents-fk.js'
 import { migration as dropDocumentsTable } from './0017-drop-documents-table.js'
+import { migration as workspaceSegment } from './0018-workspace-segment.js'
 
 // Ordered map; kysely sorts by key so the numeric prefix decides execution order.
 // 0003 still says `canvas-doc-store` after the port it creates was renamed to
@@ -43,4 +44,5 @@ export const migrations: Record<string, Migration> = {
   '0015-versions-branches-workspace-id': versionsBranchesWorkspaceId,
   '0016-drop-documents-fk': dropDocumentsFk,
   '0017-drop-documents-table': dropDocumentsTable,
+  '0018-workspace-segment': workspaceSegment,
 }

--- a/packages/mcp-server/src/server/store/db/published-migration-names.ts
+++ b/packages/mcp-server/src/server/store/db/published-migration-names.ts
@@ -28,4 +28,5 @@ export const PUBLISHED_MIGRATION_NAMES = [
   '0015-versions-branches-workspace-id',
   '0016-drop-documents-fk',
   '0017-drop-documents-table',
+  '0018-workspace-segment',
 ] as const satisfies readonly string[]

--- a/packages/mcp-server/src/server/store/db/schema.ts
+++ b/packages/mcp-server/src/server/store/db/schema.ts
@@ -8,6 +8,11 @@ type Bool = ColumnType<number, number, number>
 interface WorkspacesTable {
   id: string
   displayName: string | null
+  // ADR-0019's user-facing handle: unique per keeper (enforced by the
+  // `workspaces_segment_unique` index added in migration 0018), nullable
+  // because a workspace minted before that migration has none until Wave-2
+  // backfill/minting.
+  segment: string | null
   createdAt: Timestamp
   updatedAt: Timestamp
 }

--- a/packages/mcp-server/src/server/store/db/upsert-workspace.ts
+++ b/packages/mcp-server/src/server/store/db/upsert-workspace.ts
@@ -1,19 +1,54 @@
+import { WorkspaceSegmentTakenError } from '@kamiazya/whiteboard-ports'
 import type { Database } from './index.js'
 
-// A no-op when the workspace row already exists; displayName is left
-// untouched so a name set elsewhere does not get clobbered by a follow-up
-// child write.
+/**
+ * `segment`/`displayName` are ADR-0019's identity layers, claimed only on
+ * the INITIAL insert — the `onConflict('id').doNothing()` below means a
+ * bare call on an already-existing workspace (every `wb_document_create
+ * createWorkspace: true` call, for one) never touches them, so a name or
+ * segment set elsewhere is never clobbered by a follow-up child write.
+ */
+export interface WorkspaceIdentity {
+  segment?: string
+  displayName?: string
+}
 
-export async function upsertWorkspaceRow(db: Database, workspaceId: string): Promise<void> {
+// A no-op when the workspace row already exists; displayName/segment are
+// left untouched so a name set elsewhere does not get clobbered by a
+// follow-up child write.
+export async function upsertWorkspaceRow(
+  db: Database,
+  workspaceId: string,
+  identity: WorkspaceIdentity = {},
+): Promise<void> {
   const now = Date.now()
-  await db
-    .insertInto('workspaces')
-    .values({
-      id: workspaceId,
-      displayName: null,
-      createdAt: now,
-      updatedAt: now,
-    })
-    .onConflict((oc) => oc.column('id').doNothing())
-    .execute()
+  try {
+    await db
+      .insertInto('workspaces')
+      .values({
+        id: workspaceId,
+        displayName: identity.displayName ?? null,
+        segment: identity.segment ?? null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflict((oc) => oc.column('id').doNothing())
+      .execute()
+  } catch (err) {
+    // `onConflict` above names only the `id` unique constraint; a violation
+    // of the SEPARATE `workspaces_segment_unique` index (migration 0018)
+    // still raises normally and is translated here into the named port
+    // error, so a caller sees a segment collision distinctly from any other
+    // write failure.
+    if (
+      identity.segment !== undefined &&
+      err instanceof Error &&
+      'code' in err &&
+      (err as { code?: unknown }).code === 'SQLITE_CONSTRAINT_UNIQUE' &&
+      err.message.includes('workspaces.segment')
+    ) {
+      throw new WorkspaceSegmentTakenError(identity.segment)
+    }
+    throw err
+  }
 }

--- a/packages/mcp-server/src/server/store/document-store.test.ts
+++ b/packages/mcp-server/src/server/store/document-store.test.ts
@@ -5,6 +5,7 @@ import {
   DocumentHasDescendantsError,
   DocumentMoveIntoSelfError,
   isWorkspaceNotFoundError,
+  isWorkspaceSegmentTakenError,
 } from '@kamiazya/whiteboard-ports'
 import { LoroDoc, LoroMap } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -906,6 +907,118 @@ describe('listWorkspaces', () => {
 
   // listWorkspaces is now backed by the workspaces table, so the previous
   // "non-directory DATA_DIR" corruption check no longer applies.
+})
+
+// ADR-0019: the daemon's own DocumentIndex (CacheCoherentDocumentIndex) is
+// the first implementation that PERSISTS and SERVES segment/displayName —
+// the shared ports conformance suite deliberately stays accept-and-ignore,
+// so this echo/validation/conflict/non-clobber coverage lives here.
+describe('createWorkspace — ADR-0019 identity (segment/displayName)', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-ws-identity-test-'))
+    await setupIsolatedDb()
+  })
+
+  afterEach(async () => {
+    await teardownIsolatedDb()
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('echoes stored segment and displayName back through listWorkspaces', async () => {
+    const deps = await getDefaultServerDeps()
+    await deps.documentIndex.createWorkspace({
+      workspaceId: 'ws-echo',
+      segment: 'team-notes',
+      displayName: 'Team notes',
+    })
+
+    const rows = await deps.documentIndex.listWorkspaces()
+    const row = rows.find((r) => r.workspaceId === 'ws-echo')
+    expect(row).toEqual({
+      workspaceId: 'ws-echo',
+      segment: 'team-notes',
+      displayName: 'Team notes',
+    })
+  })
+
+  it('a legacy workspace with no identity lists with the keys absent, not null', async () => {
+    const deps = await getDefaultServerDeps()
+    await deps.documentIndex.createWorkspace({ workspaceId: 'ws-legacy' })
+
+    const rows = await deps.documentIndex.listWorkspaces()
+    const row = rows.find((r) => r.workspaceId === 'ws-legacy')
+    expect(row).toEqual({ workspaceId: 'ws-legacy' })
+  })
+
+  it('a bare re-create (the wb_document_create createWorkspace:true path) does not clobber stored identity', async () => {
+    const deps = await getDefaultServerDeps()
+    await deps.documentIndex.createWorkspace({
+      workspaceId: 'ws-preserved',
+      segment: 'kept',
+      displayName: 'Kept',
+    })
+
+    // Every wbDocumentCreate({ createWorkspace: true }) call reaches this
+    // bare shape — the identity claimed above must survive it.
+    await deps.documentIndex.createWorkspace({ workspaceId: 'ws-preserved' })
+
+    const rows = await deps.documentIndex.listWorkspaces()
+    const row = rows.find((r) => r.workspaceId === 'ws-preserved')
+    expect(row).toEqual({ workspaceId: 'ws-preserved', segment: 'kept', displayName: 'Kept' })
+  })
+
+  it('re-creating with identical fields is idempotent', async () => {
+    const deps = await getDefaultServerDeps()
+    const input = { workspaceId: 'ws-idem', segment: 'idem', displayName: 'Idem' }
+    await deps.documentIndex.createWorkspace(input)
+    await expect(deps.documentIndex.createWorkspace(input)).resolves.toBeUndefined()
+
+    const rows = await deps.documentIndex.listWorkspaces()
+    expect(rows.find((r) => r.workspaceId === 'ws-idem')).toEqual(input)
+  })
+
+  it('a second workspace claiming an already-taken segment is refused, and neither row is left partial', async () => {
+    const deps = await getDefaultServerDeps()
+    await deps.documentIndex.createWorkspace({ workspaceId: 'ws-first', segment: 'contested' })
+
+    const err = await deps.documentIndex
+      .createWorkspace({ workspaceId: 'ws-second', segment: 'contested' })
+      .catch((e: unknown) => e)
+    expect(isWorkspaceSegmentTakenError(err)).toBe(true)
+
+    const rows = await deps.documentIndex.listWorkspaces()
+    expect(rows.find((r) => r.workspaceId === 'ws-second')).toBeUndefined()
+    expect(rows.find((r) => r.workspaceId === 'ws-first')).toEqual({
+      workspaceId: 'ws-first',
+      segment: 'contested',
+    })
+  })
+
+  // The inbound half of zod-schema-discipline: what listWorkspaces serves
+  // was validated on write, so the strict outbound workspaceSummarySchema
+  // never meets a poisoned row.
+  it('rejects a ULID-shaped segment at the boundary, before any row is written', async () => {
+    const deps = await getDefaultServerDeps()
+    await expect(
+      deps.documentIndex.createWorkspace({
+        workspaceId: 'ws-rejected',
+        segment: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      }),
+    ).rejects.toThrow()
+
+    const rows = await deps.documentIndex.listWorkspaces()
+    expect(rows.find((r) => r.workspaceId === 'ws-rejected')).toBeUndefined()
+  })
+
+  it('rejects an empty displayName at the boundary, before any row is written', async () => {
+    const deps = await getDefaultServerDeps()
+    await expect(
+      deps.documentIndex.createWorkspace({ workspaceId: 'ws-rejected-2', displayName: '' }),
+    ).rejects.toThrow()
+
+    const rows = await deps.documentIndex.listWorkspaces()
+    expect(rows.find((r) => r.workspaceId === 'ws-rejected-2')).toBeUndefined()
+  })
 })
 
 describe('compactDocument', () => {

--- a/packages/mcp-server/src/server/store/document-store.ts
+++ b/packages/mcp-server/src/server/store/document-store.ts
@@ -31,7 +31,13 @@ import {
 } from '@kamiazya/whiteboard-loro-adapter'
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import { generateDocumentId } from '@kamiazya/whiteboard-model'
-import { chunkSnapshot, DocumentPathTakenError } from '@kamiazya/whiteboard-ports'
+import {
+  type CreateWorkspaceInput,
+  chunkSnapshot,
+  createWorkspaceInputSchema,
+  DocumentPathTakenError,
+  type WorkspaceEntry,
+} from '@kamiazya/whiteboard-ports'
 import type { DocumentTeardown } from '@kamiazya/whiteboard-server-core'
 import {
   DocumentStoreWorkspaceDocs,
@@ -314,13 +320,24 @@ export function cacheBackedWorkspaceDocs(): {
  * one row-shaped truth the collapse kept (who this daemon keeps, not what
  * they contain). `saveWorkspaceDoc` upserts it, so a workspace exists here
  * exactly when a stored record does.
+ *
+ * Serves ADR-0019's `segment`/`displayName` identity layers when the row
+ * carries them — absent, never `null`/`''`, for a legacy workspace that
+ * predates migration 0018 or was never given either.
  */
-export function workspaceRegistry(): { listWorkspaces(): Promise<{ workspaceId: string }[]> } {
+export function workspaceRegistry(): { listWorkspaces(): Promise<WorkspaceEntry[]> } {
   return {
     async listWorkspaces() {
       const db = await dbReady()
-      const rows = await db.selectFrom('workspaces').select(['id']).execute()
-      return rows.map((row) => ({ workspaceId: row.id }))
+      const rows = await db
+        .selectFrom('workspaces')
+        .select(['id', 'segment', 'displayName'])
+        .execute()
+      return rows.map((row) => ({
+        workspaceId: row.id,
+        ...(row.segment === null ? {} : { segment: row.segment }),
+        ...(row.displayName === null ? {} : { displayName: row.displayName }),
+      }))
     },
   }
 }
@@ -343,8 +360,26 @@ export class CacheCoherentDocumentIndex extends LoroWorkspaceDocumentIndex {
   // disjoint mutexes over the same workspace record allow the lost-update
   // interleaving workspace-lock.ts's doc comment describes. Re-entrant, so
   // a caller already inside the lock (routes, teardown) is unaffected.
-  override async createWorkspace(input: { workspaceId: string }): Promise<void> {
-    return withWorkspaceWriteLock(input.workspaceId, () => super.createWorkspace(input))
+  /**
+   * Validated at this boundary (createWorkspaceInputSchema.parse) BEFORE any
+   * write, so a rejected segment/displayName leaves no half-created
+   * workspace. The registry identity (segment/displayName) is claimed
+   * FIRST, inside the write lock, ahead of the tree record `super` creates —
+   * a refused segment must not leave a workspace with a tree record and no
+   * registry row. `upsertWorkspaceRow` translates a segment collision into
+   * `WorkspaceSegmentTakenError`; `super.createWorkspace`'s own bare
+   * `upsertWorkspaceRow` call then no-ops on the `id` conflict, so it cannot
+   * clobber what was just claimed.
+   */
+  override async createWorkspace(input: CreateWorkspaceInput): Promise<void> {
+    const parsed = createWorkspaceInputSchema.parse(input)
+    return withWorkspaceWriteLock(parsed.workspaceId, async () => {
+      await upsertWorkspaceRow(await dbReady(), parsed.workspaceId, {
+        ...(parsed.segment === undefined ? {} : { segment: parsed.segment }),
+        ...(parsed.displayName === undefined ? {} : { displayName: parsed.displayName }),
+      })
+      await super.createWorkspace(parsed)
+    })
   }
 
   override async createDocument(

--- a/packages/mcp-server/src/server/store/names-store.test.ts
+++ b/packages/mcp-server/src/server/store/names-store.test.ts
@@ -93,6 +93,19 @@ describe('names-store', () => {
     expect(names.documents).toEqual({})
   })
 
+  // Pins that PUT /api/workspaces/:id/name (setWorkspaceName) writes the
+  // SAME `workspaces.displayName` column GET /api/workspaces
+  // (workspaceRegistry().listWorkspaces()) serves — one column, two routes.
+  it('setWorkspaceName writes the column workspaceRegistry().listWorkspaces() serves', async () => {
+    const { workspaceRegistry } = await import('./document-store.js')
+    await setWorkspaceName('sess-1', 'My Workspace')
+    const rows = await workspaceRegistry().listWorkspaces()
+    expect(rows.find((r) => r.workspaceId === 'sess-1')).toEqual({
+      workspaceId: 'sess-1',
+      displayName: 'My Workspace',
+    })
+  })
+
   it('setDocumentDisplayName stores names per path', async () => {
     await setDocumentDisplayName('sess-1', 'arch/overview', 'Architecture Overview')
     await setDocumentDisplayName('sess-1', 'notes/meeting', 'Team meeting notes')

--- a/packages/mcp-server/src/shared/api-contracts/document.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/document.test.ts
@@ -333,6 +333,35 @@ describe('workspaceSummarySchema', () => {
   it('rejects missing workspaceId', () => {
     expect(workspaceSummarySchema.safeParse({}).success).toBe(false)
   })
+
+  // ADR-0019: old daemons and pre-minting workspaces answer {workspaceId}
+  // alone — the widened schema must keep accepting that shape so an old
+  // daemon's response and a new client stay compatible.
+  it('accepts a bare workspaceId with no segment/displayName', () => {
+    expect(workspaceSummarySchema.safeParse({ workspaceId: 'ws-abc' }).success).toBe(true)
+  })
+
+  it('accepts segment and displayName when the daemon serves them', () => {
+    const full: WorkspaceSummary = {
+      workspaceId: 'ws-abc',
+      segment: 'team-notes',
+      displayName: 'Team notes',
+    }
+    const result: WorkspaceSummary = workspaceSummarySchema.parse(full)
+    expect(result).toEqual(full)
+  })
+
+  // The refinement is model's, not a restated copy — this only proves the
+  // widened field actually delegates to workspaceSegmentSchema rather than a
+  // bare z.string().
+  it('rejects a ULID-shaped segment', () => {
+    expect(
+      workspaceSummarySchema.safeParse({
+        workspaceId: 'ws-abc',
+        segment: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      }).success,
+    ).toBe(false)
+  })
 })
 
 describe('listWorkspacesResponseSchema', () => {

--- a/packages/mcp-server/src/shared/api-contracts/document.ts
+++ b/packages/mcp-server/src/shared/api-contracts/document.ts
@@ -1,4 +1,8 @@
-import { documentKindSchema } from '@kamiazya/whiteboard-model'
+import {
+  documentKindSchema,
+  workspaceDisplayNameSchema,
+  workspaceSegmentSchema,
+} from '@kamiazya/whiteboard-model'
 import { z } from 'zod'
 
 // Request/response schemas for the canvas / workspace mutation endpoints.
@@ -163,8 +167,18 @@ export const canvasExistsResponseSchema = z.object({
 
 // Workspace + canvas listings consumed by IndexPage to render the
 // "open workspaces" grid.
+//
+// ADR-0019's user-facing (`segment`) and naming (`displayName`) layers, both
+// optional: a workspace minted before that migration, or served by an
+// implementation that has not adopted it yet (apps/web's browser registry,
+// today), has neither, and an invented value would read as fact where there
+// is none. Both fields are additive to keep an old daemon's response and a
+// new client — and a new daemon's response and an old client — mutually
+// parseable.
 export const workspaceSummarySchema = z.object({
   workspaceId: z.string(),
+  segment: workspaceSegmentSchema.optional(),
+  displayName: workspaceDisplayNameSchema.optional(),
 })
 
 export const listWorkspacesResponseSchema = z.object({

--- a/packages/ports/src/document-index.ts
+++ b/packages/ports/src/document-index.ts
@@ -62,9 +62,15 @@ export type CreateDocumentInput = z.infer<typeof createDocumentInputSchema>
  * optional: shape-validated here via the model schemas, but their PERSISTENCE
  * and — for `segment` — their per-keeper UNIQUENESS are the registry
  * implementation's job, not this contract's. An implementation is free to
- * accept and currently ignore both fields; today every implementation does
- * (serving them is the follow-up slice: mcp-server's `workspaceSummarySchema`
- * + `workspaces` table columns + `smoke:e2e`).
+ * accept and currently ignore both fields — the conformance suite's base
+ * case stays satisfiable that way, which is what apps/web's browser registry
+ * and the in-memory double still rely on. mcp-server's daemon
+ * (`CacheCoherentDocumentIndex`) is the first implementation that actually
+ * PERSISTS and SERVES them: the `workspaces` table carries a `segment`
+ * column with a unique index (a collision throws
+ * `WorkspaceSegmentTakenError`, below), and `workspaceSummarySchema` serves
+ * both fields through the published `@kamiazya/whiteboard-mcp/api-contracts`
+ * subpath.
  *
  * No `canonicalId` field: ADR-0019's canonical layer already IS
  * `workspaceId`. Its schema tightens from `workspaceIdSchema` to the
@@ -197,6 +203,33 @@ export class DocumentPathTakenError extends Error {
   ) {
     super(`Document path "${path}" already exists in workspace "${workspaceId}"`)
     this.name = 'DocumentPathTakenError'
+  }
+}
+
+/**
+ * Cross-realm-safe guard for `WorkspaceSegmentTakenError`, on the same
+ * reasoning as `isWorkspaceNotFoundError` above.
+ */
+export function isWorkspaceSegmentTakenError(error: unknown): error is WorkspaceSegmentTakenError {
+  return (
+    error instanceof WorkspaceSegmentTakenError ||
+    (error instanceof Error && error.name === 'WorkspaceSegmentTakenError')
+  )
+}
+
+/**
+ * Thrown when a `createWorkspace` segment (ADR-0019's user-facing layer) is
+ * already held by another workspace in the same keeper's registry.
+ *
+ * A registry-level refusal, not a `DocumentPathTakenError`-shaped collision:
+ * a segment names a WORKSPACE, not a document inside one, and uniqueness is
+ * enforced by whichever registry persists it (mcp-server's `workspaces`
+ * table, today) rather than by this contract.
+ */
+export class WorkspaceSegmentTakenError extends Error {
+  constructor(readonly segment: string) {
+    super(`Workspace segment "${segment}" is already taken`)
+    this.name = 'WorkspaceSegmentTakenError'
   }
 }
 

--- a/packages/ports/src/test-utils/document-index-conformance.ts
+++ b/packages/ports/src/test-utils/document-index-conformance.ts
@@ -434,11 +434,14 @@ export function describeDocumentIndexConformance(
     })
 
     // ADR-0019's identity layers ride along on createWorkspace/listWorkspaces
-    // without being SERVED yet: every implementation accepts segment and
-    // displayName and currently ignores them, so this deliberately does NOT
-    // assert echo-back. Serving stored values is the follow-up slice
-    // (mcp-server: widen workspaceSummarySchema + workspaces table columns +
-    // smoke:e2e).
+    // without every implementation SERVING them: this base case only proves
+    // segment/displayName do not break an implementation that accepts and
+    // ignores them (apps/web's browser registry, the in-memory double), so
+    // it deliberately does NOT assert echo-back. mcp-server's daemon DOES
+    // persist and serve these fields now — that echo is pinned by its own
+    // tests (document-store.test.ts), not by this shared suite, because
+    // adding the assertion here would fail the implementations that still
+    // legitimately ignore them.
     it('accepts a createWorkspace carrying segment and displayName, currently ignored', async () => {
       await withIndex(async (index) => {
         await index.createWorkspace({

--- a/packages/workspace-index/src/loro-workspace-document-index.ts
+++ b/packages/workspace-index/src/loro-workspace-document-index.ts
@@ -46,6 +46,7 @@ import type {
   ResolveDocumentByIdInput,
   ResolveDocumentInput,
   SetDocumentNameInput,
+  WorkspaceEntry,
 } from '@kamiazya/whiteboard-ports'
 import {
   compareDocumentPaths,
@@ -65,7 +66,7 @@ import type { WorkspaceDocs } from './workspace-docs.js'
  * `WorkspaceDocs` because a record store opens by id and cannot enumerate.
  */
 export interface WorkspaceRegistry {
-  listWorkspaces(): Promise<{ workspaceId: string }[]>
+  listWorkspaces(): Promise<WorkspaceEntry[]>
 }
 
 /** `a/b/c` -> `a/b/x` when the subtree at `a/b` moves to `a/b/x`. */
@@ -96,7 +97,7 @@ export class LoroWorkspaceDocumentIndex implements DocumentIndex {
    * id only. Required, not optional — an unwired registry would make every
    * workspace invisible to the one call that lists them.
    */
-  async listWorkspaces(): Promise<{ workspaceId: string }[]> {
+  async listWorkspaces(): Promise<WorkspaceEntry[]> {
     return this.registry.listWorkspaces()
   }
 


### PR DESCRIPTION
## What

Multi-workspace Wave 1, slice 5 ([ADR-0019](docs/contributing/adr/0019-workspace-identity.md)) — the daemon now STORES and SERVES the identity layers the model (#1099) and ports (#1100) slices declared.

- **Migration `0018-workspace-segment`**: nullable `segment` column on the `workspaces` registry with a UNIQUE index — multiple NULLs allowed (SQLite unique-index NULL semantics pinned explicitly); no backfill, legacy rows stay NULL until Wave-2 minting. Registered in `migrations/index.ts` + published-migration-names in the same commit.
- **Registry write path**: `createWorkspace` validates through `createWorkspaceInputSchema.parse` at the boundary (red-first inbound test: a ULID-shaped segment is rejected with **no partial row written**), persists segment/displayName, keeps a bare re-create from clobbering stored identity, and translates a duplicate segment into a new `WorkspaceSegmentTakenError` in the ports error taxonomy — ADR-0019's registry-owns-uniqueness rule, **mutation-checked** (guard removed → test red → restore verified).
- **Serve path**: daemon `listWorkspaces` rows carry both fields; the published `workspaceSummarySchema`/`listWorkspacesResponseSchema` (`@kamiazya/whiteboard-mcp/api-contracts`, consumed by `daemon-api-client.ts`) widen additively; `GET /api/workspaces` flows them through with conditional spread (keys omitted, never null). The names-store seam test pins that `PUT .../name` writes the same column `GET /api/workspaces` serves.
- **Conformance discipline held**: the shared ports conformance base case stays satisfiable by accept-and-ignore implementations (the browser registry serves these in a later slice); only the daemon's own tests pin echo-back. The slice-4 "accepted and currently ignored" comments are flipped to the shipped state.
- No MCP tool schema touched — no workspace-listing tool exists (verified, none invented); `segment` has no accepting MCP/HTTP surface yet, so it is verified at store/route level and stated as such.

## Verification

Real daemon on a scratch dataDir: create with `createWorkspace:true`, `PUT /api/workspaces/<ws>/name`, then `GET /api/workspaces` returns the displayName through the published schema; the HTTP convergence smoke now asserts this permanently. Independent review workflow over the diff: 0 findings.

## Gates

mcp-node 3889 passed (exactly the 3 known root-environment failures); full `pnpm test` 9882 tests with only the 12 combined known env failures; `pnpm -r typecheck`, `pnpm build`, `pnpm smoke:e2e`, `pnpm knip`, `pnpm check:local` all green.

Visual evidence: none — foundation slice by design (userReach: foundation, wired by the next slice that renders display names in the promote selector); the route/smoke output is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspaces can now persist and display a user-facing segment and display name.
  * Workspace listings now return available segment and display-name metadata.
  * Workspace segments are unique, preventing duplicate assignments.

* **Bug Fixes**
  * Workspace identity updates now preserve existing values and report conflicts clearly.
  * Legacy workspaces remain supported without requiring missing metadata.

* **API Improvements**
  * Workspace responses validate and return optional identity fields consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->