### PR TITLE
feat(web): promote selector shows workspace display names, id only as the unnamed fallback

### DIFF
--- a/apps/web/src/components/settings/PromoteWorkspaceSection.browser.test.tsx
+++ b/apps/web/src/components/settings/PromoteWorkspaceSection.browser.test.tsx
@@ -38,6 +38,7 @@ interface StubOptions {
   updateDelayMs?: number
   putDelayMs?: number
   failUpdateStatus?: number
+  workspaces?: { workspaceId: string; displayName?: string }[]
 }
 
 /** The three daemon routes the flow touches, answering from `target`. */
@@ -45,7 +46,9 @@ function daemonStub(target: LoroDoc, opts: StubOptions = {}): typeof globalThis.
   return (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === 'string' ? input : input.toString()
     if (url.endsWith('/api/workspaces') && (init?.method ?? 'GET') === 'GET') {
-      return Response.json({ workspaces: [{ workspaceId: 'ws-a' }, { workspaceId: 'ws-b' }] })
+      return Response.json({
+        workspaces: opts.workspaces ?? [{ workspaceId: 'ws-a' }, { workspaceId: 'ws-b' }],
+      })
     }
     if (url.endsWith('/workspace-document/update') && init?.method === 'POST') {
       if (opts.updateDelayMs) await new Promise((r) => setTimeout(r, opts.updateDelayMs))
@@ -332,6 +335,56 @@ describe('PromoteWorkspaceSection', () => {
     )
     expect(screen.queryByTestId('promote-last-result')).toBeNull()
     expect(screen.queryByTestId('promote-reload')).toBeNull()
+  })
+
+  // DESIGN.md: "Raw identifiers are not chrome." A named daemon workspace
+  // shows its name in the target selector; only an unnamed one falls back to
+  // its identifier, the same fallback a document without a display name uses.
+  it('the target selector shows workspace names, and an id only as the unnamed fallback', async () => {
+    const { roadmapId } = await seedTwoDocuments()
+    const target = new LoroDoc()
+    render(
+      <PromoteWorkspaceSection
+        daemon={DAEMON}
+        settingsStore={createUserSettingsStore()}
+        baseFetch={daemonStub(target, {
+          workspaces: [{ workspaceId: 'ws-a', displayName: 'Team notes' }, { workspaceId: 'ws-b' }],
+        })}
+        reload={vi.fn()}
+      />,
+    )
+    await userEvent.click(screen.getByTestId('promote-workspace-open'))
+    const select = await screen.findByTestId('promote-target')
+    const labels = [...select.querySelectorAll('option')].map((o) => o.textContent)
+    expect(labels).toEqual(['Team notes', 'ws-b'])
+    // The value stays the identifier: names are chrome, ids are the address.
+    await userEvent.selectOptions(select, 'Team notes')
+    await userEvent.click(screen.getByTestId('promote-confirm'))
+    await screen.findByTestId('promote-last-result')
+    expect(resolveWorkspaceDocumentById(target, roadmapId)).not.toBeNull()
+  })
+
+  // The other half of the same DESIGN.md sentence: a single-choice selector
+  // renders nothing at all — one workspace is a fact, not a decision.
+  it('a single daemon workspace renders as its name, not a one-option selector', async () => {
+    await seedTwoDocuments()
+    render(
+      <PromoteWorkspaceSection
+        daemon={DAEMON}
+        settingsStore={createUserSettingsStore()}
+        baseFetch={daemonStub(new LoroDoc(), {
+          workspaces: [{ workspaceId: 'ws-a', displayName: 'Team notes' }],
+        })}
+        reload={vi.fn()}
+      />,
+    )
+    await userEvent.click(screen.getByTestId('promote-workspace-open'))
+    await screen.findByTestId('promote-dialog')
+    expect(screen.queryByTestId('promote-target')).toBeNull()
+    const single = screen.getByTestId('promote-target-single')
+    expect(single.textContent).toMatch(/team notes/i)
+    await userEvent.click(screen.getByTestId('promote-confirm'))
+    expect((await screen.findByTestId('promote-last-result')).textContent).toMatch(/moved 2/i)
   })
 
   // The section can be a session's FIRST surface (deep-link/reload straight

--- a/apps/web/src/components/settings/PromoteWorkspaceSection.tsx
+++ b/apps/web/src/components/settings/PromoteWorkspaceSection.tsx
@@ -50,7 +50,12 @@ export interface PromoteWorkspaceSectionProps {
 
 type PromoteFlow =
   | { step: 'idle' }
-  | { step: 'confirm'; documentCount: number; workspaceIds: string[]; targetId: string }
+  | {
+      step: 'confirm'
+      documentCount: number
+      targets: { workspaceId: string; displayName?: string }[]
+      targetId: string
+    }
   | { step: 'running'; phase: 'record' | 'blobs' }
   | { step: 'unavailable'; reason: string }
 
@@ -129,12 +134,15 @@ export function PromoteWorkspaceSection({
         log.warn('startup fold failed; continuing without it', err)
       }
       const documentCount = await countBrowserWorkspaceDocuments(new BrowserWorkspaceDocs())
-      const workspaceIds = workspaces.workspaces.map((ws) => ws.workspaceId)
+      const targets = workspaces.workspaces.map((ws) => ({
+        workspaceId: ws.workspaceId,
+        ...(ws.displayName === undefined ? {} : { displayName: ws.displayName }),
+      }))
       if (documentCount === 0) {
         setFlow({ step: 'unavailable', reason: 'This browser keeps no documents to move.' })
         return
       }
-      if (workspaceIds.length === 0) {
+      if (targets.length === 0) {
         setFlow({
           step: 'unavailable',
           reason: 'The daemon has no workspace to move into yet. Open one on the daemon first.',
@@ -144,8 +152,8 @@ export function PromoteWorkspaceSection({
       setFlow({
         step: 'confirm',
         documentCount,
-        workspaceIds,
-        targetId: workspaceIds[0] as string,
+        targets,
+        targetId: (targets[0] as { workspaceId: string }).workspaceId,
       })
     } catch {
       setFlow({ step: 'unavailable', reason: 'Could not reach the daemon to prepare the move.' })
@@ -304,22 +312,37 @@ export function PromoteWorkspaceSection({
                 </DialogDescription>
               </DialogHeader>
               <div className="flex flex-col gap-1.5">
-                <label htmlFor={targetSelectId} className="text-xs font-medium">
-                  Daemon workspace
-                </label>
-                <select
-                  id={targetSelectId}
-                  data-testid="promote-target"
-                  value={flow.targetId}
-                  onChange={(event) => setFlow({ ...flow, targetId: event.target.value })}
-                  className="rounded-md border bg-background px-2 py-1.5 text-sm"
-                >
-                  {flow.workspaceIds.map((id) => (
-                    <option key={id} value={id}>
-                      {id}
-                    </option>
-                  ))}
-                </select>
+                {/* Names are chrome, ids are the address (DESIGN.md): an
+                    option shows the display name and falls back to the
+                    identifier only when the workspace is unnamed — and a
+                    single choice renders as plain text, not a selector. */}
+                {flow.targets.length === 1 ? (
+                  <p className="text-xs">
+                    <span className="font-medium">Daemon workspace: </span>
+                    <span data-testid="promote-target-single">
+                      {flow.targets[0]?.displayName ?? flow.targets[0]?.workspaceId}
+                    </span>
+                  </p>
+                ) : (
+                  <>
+                    <label htmlFor={targetSelectId} className="text-xs font-medium">
+                      Daemon workspace
+                    </label>
+                    <select
+                      id={targetSelectId}
+                      data-testid="promote-target"
+                      value={flow.targetId}
+                      onChange={(event) => setFlow({ ...flow, targetId: event.target.value })}
+                      className="rounded-md border bg-background px-2 py-1.5 text-sm"
+                    >
+                      {flow.targets.map((target) => (
+                        <option key={target.workspaceId} value={target.workspaceId}>
+                          {target.displayName ?? target.workspaceId}
+                        </option>
+                      ))}
+                    </select>
+                  </>
+                )}
               </div>
               <DialogFooter>
                 <Button type="button" variant="ghost" onClick={() => setFlow({ step: 'idle' })}>


### PR DESCRIPTION
## What

Multi-workspace Wave 1, final slice ([ADR-0019](docs/contributing/adr/0019-workspace-identity.md)) — the first user-visible payoff of the identity split, and the fix for the `DESIGN.md` "Raw identifiers are not chrome" strain that motivated it: the promote dialog's target selector now renders each daemon workspace's **displayName** (from #1104's widened `listWorkspaces` contract), falling back to the identifier only for an unnamed workspace — the same fallback a document without a display name uses. The other half of the same DESIGN.md sentence lands with it: **a single daemon workspace renders as plain text, not a one-option selector**. Option values stay the `workspaceId` — names are chrome, ids are the address.

## Tests (red first)

Two new browser tests failed against the id-only selector before the change: option labels `['Team notes', 'ws-b']` with the move landing in the workspace selected **by its name**; and the single-workspace plain-text case (no `promote-target` select, `promote-target-single` text, move still lands). All 11 `PromoteWorkspaceSection` browser tests green after.

## Visual repro

Verified in the real running app against the live daemon: named `promote-fold-verify` to "Verify scratch" via `PUT /api/workspaces/.../name`, connected via `#wb=`, opened the promote dialog — the selector shows **Verify scratch** among unnamed neighbours' ids (before: the raw `promote-fold-verify`). Figure composed with the named workspace selected in the closed control, panel digests `364494eb` (before) / `1b6a777b` (after).

Two honesty notes: the first figure attempt was **refused as identical panels** — the closed select showed the same unnamed first option in both runs, which is `compose-figure.mjs` doing exactly its job — the recapture selects the named workspace so the closed control shows the difference; and the figure cannot be uploaded from this environment (`gh` CLI and the `gh image` extension are unavailable in this remote session), so the option-list transcripts recorded in both runs (`["dev-check",…,"promote-fold-verify"]` before vs `["dev-check",…,"Verify scratch"]` after) are the evidence on record, with the PNG at `tmp/screenshots/promote-names-figure.png` locally.

## Gates

`web-browser` PromoteWorkspaceSection 11/11; `pnpm --filter @kamiazya/whiteboard-web test` 2771 passed with exactly the 9 known undici env failures; typecheck, `pnpm check:local` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_