### PR TITLE
feat(web): re-key the browser workspace off 'local' onto a canonical ULID

### DIFF
--- a/apps/web/src/boot.test.ts
+++ b/apps/web/src/boot.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The boot chain's degradation invariant: a `resolveBrowserWorkspaceId`
+ * rejection must never block `renderApp`, never escape as an unhandled
+ * rejection, and must leave `getBrowserWorkspaceId()` throwing a cause-
+ * carrying message a consumer's existing local error isolation can read.
+ */
+import 'fake-indexeddb/auto'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { startBootSequence } from './boot.js'
+import {
+  getBrowserWorkspaceId,
+  resetBrowserWorkspaceIdForTests,
+  resolveBrowserWorkspaceId,
+  setBrowserWorkspaceIdForTests,
+} from './lib/browser-workspace-id.js'
+
+const REAL_DB_NAME = 'whiteboard-boot-test'
+
+async function clearDb(): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase(REAL_DB_NAME)
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+  })
+}
+
+function rootEl(): HTMLElement {
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  return el
+}
+
+/**
+ * A connection at an old version with no `onversionchange` handler — the
+ * "stale tab" `openWhiteboardDb`'s `onblocked` branch (browser-idb.ts:531-533)
+ * exists for. Opening the real `whiteboard` schema at the current DB_VERSION
+ * against this database then rejects instead of hanging.
+ */
+async function openStubbornAtOldVersion(dbName: string): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(dbName, 1)
+    req.onupgradeneeded = () => {}
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+}
+
+describe('startBootSequence — resolver rejection does not block render', () => {
+  beforeEach(async () => {
+    resetBrowserWorkspaceIdForTests()
+    await clearDb()
+  })
+  afterEach(async () => {
+    resetBrowserWorkspaceIdForTests()
+    await clearDb()
+  })
+
+  it('settles, renders, and records the cause without an unhandled rejection, then recovers on retry', async () => {
+    let unhandled: unknown = null
+    const onUnhandled = (event: PromiseRejectionEvent) => {
+      unhandled = event.reason
+    }
+    window.addEventListener('unhandledrejection', onUnhandled)
+
+    // A real blocked open, through the REAL resolveBrowserWorkspaceId — not a
+    // double that bypasses it — so the cause it caches is the one this
+    // asserts on afterward, the same way production would reach it.
+    const stubborn = await openStubbornAtOldVersion(REAL_DB_NAME)
+    let rendered = false
+
+    try {
+      await startBootSequence({
+        rootEl: rootEl(),
+        resolveWorkspaceId: () => resolveBrowserWorkspaceId(REAL_DB_NAME),
+        loadFont: async () => undefined,
+        dismissSplash: async () => undefined,
+        render: () => {
+          rendered = true
+        },
+      })
+      // Give a real unhandled rejection a turn to surface, if one would.
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(rendered).toBe(true)
+      expect(unhandled).toBeNull()
+
+      // The FAILED state's message carries the cause, and reads differently
+      // from the unresolved-state message.
+      expect(() => getBrowserWorkspaceId()).toThrow(/browser workspace unavailable/)
+      expect(() => getBrowserWorkspaceId()).toThrow(/another tab/i)
+
+      // A consumer-shaped flow: an accessor read wrapped the way
+      // workspace-content.ts's `.open(...).catch(() => null)` wraps it lands
+      // in the null branch instead of crashing the caller.
+      const consumerResult = await Promise.resolve()
+        .then(() => getBrowserWorkspaceId())
+        .catch(() => null)
+      expect(consumerResult).toBeNull()
+    } finally {
+      window.removeEventListener('unhandledrejection', onUnhandled)
+      stubborn.close()
+    }
+
+    // Retryable: a later resolve against a database the stale tab no longer
+    // holds recovers, rather than replaying the cached rejection.
+    const recovered = await resolveBrowserWorkspaceId(REAL_DB_NAME)
+    expect(recovered).toMatch(/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/)
+    expect(getBrowserWorkspaceId()).toBe(recovered)
+  })
+
+  it('the unresolved-state message is distinct from the failed-state message', () => {
+    expect(() => getBrowserWorkspaceId()).toThrow(/resolveBrowserWorkspaceId/)
+    expect(() => getBrowserWorkspaceId()).not.toThrow(/browser workspace unavailable/)
+  })
+
+  it('a resolved id (the production success path) survives an unrelated boot with no resolver override', async () => {
+    setBrowserWorkspaceIdForTests('01ARZ3NDEKTSV4RRFFQ69G5FAV')
+    let rendered = false
+    await startBootSequence({
+      rootEl: rootEl(),
+      resolveWorkspaceId: async () => getBrowserWorkspaceId(),
+      loadFont: async () => undefined,
+      dismissSplash: async () => undefined,
+      render: () => {
+        rendered = true
+      },
+    })
+    expect(rendered).toBe(true)
+    expect(getBrowserWorkspaceId()).toBe('01ARZ3NDEKTSV4RRFFQ69G5FAV')
+  })
+})

--- a/apps/web/src/boot.test.ts
+++ b/apps/web/src/boot.test.ts
@@ -13,6 +13,7 @@ import {
   resolveBrowserWorkspaceId,
   setBrowserWorkspaceIdForTests,
 } from './lib/browser-workspace-id.js'
+import { loadWorkspaceDocumentProjection } from './lib/workspace-content.js'
 
 const REAL_DB_NAME = 'whiteboard-boot-test'
 
@@ -89,13 +90,14 @@ describe('startBootSequence — resolver rejection does not block render', () =>
       expect(() => getBrowserWorkspaceId()).toThrow(/browser workspace unavailable/)
       expect(() => getBrowserWorkspaceId()).toThrow(/another tab/i)
 
-      // A consumer-shaped flow: an accessor read wrapped the way
-      // workspace-content.ts's `.open(...).catch(() => null)` wraps it lands
-      // in the null branch instead of crashing the caller.
-      const consumerResult = await Promise.resolve()
-        .then(() => getBrowserWorkspaceId())
-        .catch(() => null)
-      expect(consumerResult).toBeNull()
+      // The REAL consumer, not a re-enactment of its shape: a hand-written
+      // `.then(accessor).catch(() => null)` absorbs the throw no matter how
+      // the production function is written, so it would stay green against a
+      // consumer that reads the id as a call ARGUMENT — where the throw
+      // precedes the promise and escapes the `.catch` entirely.
+      await expect(
+        loadWorkspaceDocumentProjection('01ARZ3NDEKTSV4RRFFQ69G5FAV'),
+      ).resolves.toBeNull()
     } finally {
       window.removeEventListener('unhandledrejection', onUnhandled)
       stubborn.close()

--- a/apps/web/src/boot.test.ts
+++ b/apps/web/src/boot.test.ts
@@ -7,6 +7,7 @@
 import 'fake-indexeddb/auto'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { startBootSequence } from './boot.js'
+import { DB_VERSION } from './lib/browser-idb.js'
 import {
   getBrowserWorkspaceId,
   resetBrowserWorkspaceIdForTests,
@@ -108,6 +109,58 @@ describe('startBootSequence — resolver rejection does not block render', () =>
     const recovered = await resolveBrowserWorkspaceId(REAL_DB_NAME)
     expect(recovered).toMatch(/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/)
     expect(getBrowserWorkspaceId()).toBe(recovered)
+  })
+
+  it('renders anyway when the resolver never settles, rather than holding the splash', async () => {
+    // A REJECTION is not the only way an IndexedDB open fails: it can also
+    // simply never settle. The `.catch` covers the first; only the bound
+    // covers this one, and without it the app would sit on the splash forever.
+    let rendered = false
+    let splashDismissed = false
+    const start = Date.now()
+    await startBootSequence({
+      rootEl: rootEl(),
+      resolveWorkspaceId: () => new Promise<string>(() => {}),
+      loadFont: async () => undefined,
+      dismissSplash: async () => {
+        splashDismissed = true
+      },
+      render: () => {
+        rendered = true
+      },
+    })
+    expect(rendered).toBe(true)
+    expect(splashDismissed).toBe(true)
+    // The bound is what released it, so this cannot have returned instantly —
+    // an assertion that would pass just as well against a `render()` that
+    // never waited for the resolver at all.
+    expect(Date.now() - start).toBeGreaterThanOrEqual(2500)
+    expect(() => getBrowserWorkspaceId()).toThrow(/resolveBrowserWorkspaceId/)
+  }, 15_000)
+
+  it('refuses a sole workspace key that is not a canonical id', async () => {
+    // What a rekey that silently did not run leaves behind. Caching it would
+    // put every later read and write under an id ADR-0019 says cannot exist.
+    await new Promise<void>((resolve, reject) => {
+      // At exactly DB_VERSION, so the app's own open finds nothing to upgrade
+      // and goes straight to the read — the state a rekey that silently did
+      // not run would leave, rather than a version the app cannot open at all.
+      const req = indexedDB.open(REAL_DB_NAME, DB_VERSION)
+      req.onupgradeneeded = () => {
+        const db = req.result
+        if (!db.objectStoreNames.contains('workspaces')) db.createObjectStore('workspaces')
+        req.transaction?.objectStore('workspaces').put({ workspaceId: 'local' }, 'local')
+      }
+      req.onsuccess = () => {
+        req.result.close()
+        resolve()
+      }
+      req.onerror = () => reject(req.error)
+    })
+    await expect(resolveBrowserWorkspaceId(REAL_DB_NAME)).rejects.toThrow(
+      /not keyed by a canonical/,
+    )
+    expect(() => getBrowserWorkspaceId()).toThrow(/browser workspace unavailable/)
   })
 
   it('the unresolved-state message is distinct from the failed-state message', () => {

--- a/apps/web/src/boot.ts
+++ b/apps/web/src/boot.ts
@@ -15,6 +15,10 @@
  * workspace consumer reads the accessor next — landing in that consumer's
  * existing local error isolation, not a new one invented for this path.
  */
+// Deliberately the narrow subpath, not the package barrel: the barrel
+// re-exports CanvasViewer and the scene codec, which drag canvas-render and
+// codec's remark pipeline onto the critical path for a module that only needs
+// the font loader. The bundle-size gate fails if this regresses.
 import { ensureViewerFontLoaded } from '@kamiazya/whiteboard-canvas-viewer/font-loading'
 import { createElement, StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
@@ -47,10 +51,24 @@ export async function startBootSequence({
   dismissSplash = () => dismissBootSplash(),
   render = renderApp,
 }: BootSequenceOptions): Promise<void> {
+  // Bounded await: every on-screen text measurement (SpatialEditor,
+  // MarkdownEditor's preview pane, useDocumentSync) must use the same vendored
+  // Roboto face the Node export pipeline measures, or wrapped-line counts and
+  // content sizing silently diverge between what a user sees and what they
+  // export. This is the one seam that covers all three, including
+  // useDocumentSync's non-React measurer construction. ensureViewerFontLoaded()
+  // bounds the wait itself (VIEWER_FONT_LOAD_TIMEOUT_MS), so a stalled font
+  // fetch delays first paint by at most that bound rather than hanging
+  // indefinitely — first paint then proceeds with fallback system-font metrics
+  // and self-corrects once the font finishes loading in the background (see
+  // CanvasViewer's useViewerFontReady for that path).
   await loadFont()
   await resolveWorkspaceId().catch((cause: unknown) => {
     log.warn('browser workspace id resolution failed; rendering degraded', cause)
   })
+  // Paces the index.html splash: the app is ready at this point, but the
+  // splash stays up until its draw animation lands plus a beat, and fades out
+  // before React's first commit replaces it.
   await dismissSplash()
   render(rootEl)
 }

--- a/apps/web/src/boot.ts
+++ b/apps/web/src/boot.ts
@@ -30,6 +30,13 @@ import { resolveBrowserWorkspaceId } from './lib/browser-workspace-id.js'
 
 const log = getAppLogger('boot')
 
+/**
+ * Matches the viewer font's own budget: both bound a first-paint wait on
+ * something that usually takes milliseconds, and neither is a delay — nothing
+ * that succeeds is slowed by it.
+ */
+const WORKSPACE_ID_RESOLVE_TIMEOUT_MS = 3000
+
 export interface BootSequenceOptions {
   rootEl: HTMLElement
   resolveWorkspaceId?: () => Promise<string>
@@ -63,9 +70,27 @@ export async function startBootSequence({
   // and self-corrects once the font finishes loading in the background (see
   // CanvasViewer's useViewerFontReady for that path).
   await loadFont()
-  await resolveWorkspaceId().catch((cause: unknown) => {
-    log.warn('browser workspace id resolution failed; rendering degraded', cause)
-  })
+  // Bounded, for the same reason the font load is: an IndexedDB open can fail
+  // by never settling as easily as by rejecting — a `deleteDatabase` in
+  // another tab, a browser that leaves the request pending under storage
+  // pressure — and an unbounded await there holds the splash forever, which
+  // is the one outcome worse than rendering without the id.
+  //
+  // Bounded rather than not awaited at all: on every normal load the resolve
+  // wins this race by orders of magnitude, and awaiting it is what guarantees
+  // no consumer reads the accessor unresolved. Dropping the await to fix the
+  // hang would trade a rare stall for a routine race.
+  await Promise.race([
+    resolveWorkspaceId().catch((cause: unknown) => {
+      log.warn('browser workspace id resolution failed; rendering degraded', cause)
+    }),
+    new Promise<void>((resolve) => {
+      setTimeout(() => {
+        log.warn('browser workspace id resolution did not settle; rendering degraded')
+        resolve()
+      }, WORKSPACE_ID_RESOLVE_TIMEOUT_MS)
+    }),
+  ])
   // Paces the index.html splash: the app is ready at this point, but the
   // splash stays up until its draw animation lands plus a beat, and fades out
   // before React's first commit replaces it.

--- a/apps/web/src/boot.ts
+++ b/apps/web/src/boot.ts
@@ -1,0 +1,56 @@
+/**
+ * The app's real boot chain, factored out of main.tsx so the resolver-
+ * rejection path is testable through the ACTUAL sequence rather than a
+ * re-implementation a test could drift from.
+ *
+ * The workspace-id resolver runs alongside render rather than gating it: no
+ * IndexedDB open has ever gated boot (every browser-workspace call site
+ * already isolates a failed open locally — see e.g. workspace-content.ts's
+ * `.open(...).catch(() => null)`), and a daemon-only route must not
+ * white-screen because THIS tab's browser storage is unavailable (a stale
+ * tab blocking the v14 upgrade, a quota failure, Safari private browsing).
+ * `resolveBrowserWorkspaceId()` caches the rejection's cause itself, so
+ * swallowing it here for boot purposes only still lets every later
+ * `getBrowserWorkspaceId()` read throw that cause into whichever browser-
+ * workspace consumer reads the accessor next — landing in that consumer's
+ * existing local error isolation, not a new one invented for this path.
+ */
+import { ensureViewerFontLoaded } from '@kamiazya/whiteboard-canvas-viewer/font-loading'
+import { createElement, StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import { App } from './App.js'
+import { dismissBootSplash } from './boot-splash.js'
+import { getAppLogger } from './lib/app-logger.js'
+import { resolveBrowserWorkspaceId } from './lib/browser-workspace-id.js'
+
+const log = getAppLogger('boot')
+
+export interface BootSequenceOptions {
+  rootEl: HTMLElement
+  resolveWorkspaceId?: () => Promise<string>
+  loadFont?: () => Promise<unknown>
+  dismissSplash?: () => Promise<void>
+  render?: (root: HTMLElement) => void
+}
+
+function renderApp(root: HTMLElement): void {
+  createRoot(root).render(
+    createElement(StrictMode, null, createElement(BrowserRouter, null, createElement(App))),
+  )
+}
+
+export async function startBootSequence({
+  rootEl,
+  resolveWorkspaceId = () => resolveBrowserWorkspaceId(),
+  loadFont = ensureViewerFontLoaded,
+  dismissSplash = () => dismissBootSplash(),
+  render = renderApp,
+}: BootSequenceOptions): Promise<void> {
+  await loadFont()
+  await resolveWorkspaceId().catch((cause: unknown) => {
+    log.warn('browser workspace id resolution failed; rendering degraded', cause)
+  })
+  await dismissSplash()
+  render(rootEl)
+}

--- a/apps/web/src/components/settings/PromoteWorkspaceSection.browser.test.tsx
+++ b/apps/web/src/components/settings/PromoteWorkspaceSection.browser.test.tsx
@@ -18,10 +18,11 @@ import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { LoroDoc } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { getBrowserWorkspaceId } from '../../lib/browser-workspace-id.js'
 import { DocumentFileStore } from '../../lib/document-file-store.js'
 import { FoldingBrowserIndex } from '../../lib/folding-browser-index.js'
 import { IdbDocumentIndex } from '../../lib/idb-document-index.js'
-import { BROWSER_WORKSPACE_ID, ensureLocalWorkspace } from '../../lib/local-document-summary.js'
+import { ensureLocalWorkspace } from '../../lib/local-document-summary.js'
 import { LoroStore } from '../../lib/loro-store.js'
 import { createUserSettingsStore, STORAGE_KEY } from '../../lib/user-settings-store.js'
 import { seedWorkspaceDocumentContent } from '../../lib/workspace-content.js'
@@ -82,12 +83,12 @@ async function seedTwoDocuments(): Promise<{ roadmapId: string; sketchId: string
   const index = new FoldingBrowserIndex()
   await ensureLocalWorkspace(index)
   const roadmap = await index.createDocument({
-    workspaceId: 'local',
+    workspaceId: getBrowserWorkspaceId(),
     path: 'notes/roadmap',
     kind: 'markdown',
   })
   const sketch = await index.createDocument({
-    workspaceId: 'local',
+    workspaceId: getBrowserWorkspaceId(),
     path: 'sketch',
     kind: 'spatial',
   })
@@ -123,9 +124,9 @@ async function seedImageOnSketch(sketchId: string): Promise<void> {
  */
 async function seedPreFoldDocument(path: string): Promise<string> {
   const index = new IdbDocumentIndex()
-  await index.createWorkspace({ workspaceId: BROWSER_WORKSPACE_ID })
+  await index.createWorkspace({ workspaceId: getBrowserWorkspaceId() })
   const entry = await index.createDocument({
-    workspaceId: BROWSER_WORKSPACE_ID,
+    workspaceId: getBrowserWorkspaceId(),
     path,
     kind: 'spatial',
   })
@@ -227,7 +228,9 @@ describe('PromoteWorkspaceSection', () => {
     // browser keeper still resolves them too (the copy here stays).
     expect(resolveWorkspaceDocumentById(target, roadmapId)).not.toBeNull()
     expect(resolveWorkspaceDocumentById(target, sketchId)).not.toBeNull()
-    const stillHere = await new FoldingBrowserIndex().listDocuments({ workspaceId: 'local' })
+    const stillHere = await new FoldingBrowserIndex().listDocuments({
+      workspaceId: getBrowserWorkspaceId(),
+    })
     expect([...stillHere.map((d) => d.documentId)].sort()).toEqual([roadmapId, sketchId].sort())
 
     // Not a toast: no alert/transient surface anywhere, and the report is

--- a/apps/web/src/components/settings/PromoteWorkspaceSection.fold-failure.browser.test.tsx
+++ b/apps/web/src/components/settings/PromoteWorkspaceSection.fold-failure.browser.test.tsx
@@ -14,10 +14,11 @@ import { cleanup, render, screen } from '@testing-library/react'
 import { LoroDoc } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { getBrowserWorkspaceId } from '../../lib/browser-workspace-id.js'
 import { foldWorkspaceDocuments } from '../../lib/fold-workspace.js'
 import { FoldingBrowserIndex } from '../../lib/folding-browser-index.js'
 import { IdbDocumentIndex } from '../../lib/idb-document-index.js'
-import { BROWSER_WORKSPACE_ID, ensureLocalWorkspace } from '../../lib/local-document-summary.js'
+import { ensureLocalWorkspace } from '../../lib/local-document-summary.js'
 import { LoroStore } from '../../lib/loro-store.js'
 import { createUserSettingsStore, STORAGE_KEY } from '../../lib/user-settings-store.js'
 import { clearWhiteboardDb } from '../../test-utils/browser-document.js'
@@ -52,10 +53,20 @@ describe('PromoteWorkspaceSection under a failing fold', () => {
     // and a pre-fold legacy record (only a successful fold would carry it).
     const tree = new FoldingBrowserIndex()
     await ensureLocalWorkspace(tree)
-    await tree.createDocument({ workspaceId: 'local', path: 'held', kind: 'markdown' })
+    await tree.createDocument({
+      workspaceId: getBrowserWorkspaceId(),
+      path: 'held',
+      kind: 'markdown',
+    })
     const legacy = new IdbDocumentIndex()
+    // `legacy` is the row-plane index, whose `WORKSPACES_STORE` row `tree`'s
+    // `ensureLocalWorkspace` above never wrote — that call went through the
+    // tree-backed `FoldingBrowserIndex`, which registers a workspace as a
+    // `workspace-tree:<id>` sync record instead. The row-plane index has its
+    // own registry and needs it seeded explicitly.
+    await ensureLocalWorkspace(legacy)
     const entry = await legacy.createDocument({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       path: 'legacy-only',
       kind: 'spatial',
     })

--- a/apps/web/src/lib/browser-backend.ts
+++ b/apps/web/src/lib/browser-backend.ts
@@ -13,9 +13,9 @@ import type { WorkspaceDocs } from '@kamiazya/whiteboard-workspace-index'
 import { Loro, type LoroDoc } from 'loro-crdt'
 import { getAppLogger } from './app-logger.js'
 import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import { DocumentFileStore, dataUrlToBlob } from './document-file-store.js'
 import { foldWorkspaceDocuments } from './fold-workspace.js'
-import { BROWSER_WORKSPACE_ID } from './local-document-summary.js'
 import { LoroStore, touchContentTimestamp } from './loro-store.js'
 
 /**
@@ -124,7 +124,7 @@ export class BrowserBackend implements DocumentBackend {
     if (workspaceDoc === null) return
     try {
       workspaceDoc.import(bytes)
-      await this.docs.save(BROWSER_WORKSPACE_ID, workspaceDoc)
+      await this.docs.save(getBrowserWorkspaceId(), workspaceDoc)
       // The listing's updatedAt: stamped per push, keyed by the document this
       // backend serves — the workspace document itself has no row to stamp.
       await touchContentTimestamp(this.target.documentId)
@@ -206,7 +206,7 @@ export class BrowserBackend implements DocumentBackend {
 
     let workspaceDoc: LoroDoc
     try {
-      workspaceDoc = await this.docs.create(BROWSER_WORKSPACE_ID)
+      workspaceDoc = await this.docs.create(getBrowserWorkspaceId())
     } catch {
       // The workspace record would not read back. Every document is in it,
       // so this is the browser twin of a corrupt per-document snapshot.
@@ -271,7 +271,7 @@ export class BrowserBackend implements DocumentBackend {
         ...(name === undefined ? {} : { name }),
       })
     }
-    await this.docs.save(BROWSER_WORKSPACE_ID, workspaceDoc)
+    await this.docs.save(getBrowserWorkspaceId(), workspaceDoc)
     return true
   }
 }

--- a/apps/web/src/lib/browser-idb-migration.browser.test.tsx
+++ b/apps/web/src/lib/browser-idb-migration.browser.test.tsx
@@ -15,9 +15,28 @@
 // fidelity contract (transaction/upgrade/abort semantics fake-indexeddb only
 // approximates). IndexedDB-only suites with no such stake run in jsdom via
 // fake-indexeddb instead — see e.g. local-document-summary.test.tsx.
+import {
+  adoptWorkspaceDocument,
+  resolveWorkspaceDocumentById,
+} from '@kamiazya/whiteboard-loro-adapter'
+import { chunkSnapshot, type SnapshotChunk } from '@kamiazya/whiteboard-ports'
 import { Loro } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { DB_VERSION, openWhiteboardDb, SYNC_DOCUMENTS_STORE } from './browser-idb.js'
+import {
+  DB_VERSION,
+  DOCUMENT_INDEX_STORE,
+  openWhiteboardDb,
+  rekeyBrowserWorkspace,
+  SYNC_DOCUMENTS_STORE,
+  SYNC_SNAPSHOT_CHUNKS_STORE,
+  WORKSPACES_STORE,
+} from './browser-idb.js'
+import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
+import {
+  getBrowserWorkspaceId,
+  resetBrowserWorkspaceIdForTests,
+  resolveBrowserWorkspaceId,
+} from './browser-workspace-id.js'
 import { IdbDocumentIndex } from './idb-document-index.js'
 import {
   IdbDefaultDocumentPointer,
@@ -41,19 +60,45 @@ import { purgeLegacyReconnectCredentials } from './purge-legacy-reconnect-creden
  */
 const MIGRATION_DB = 'whiteboard-migration-test'
 
+// Every test in this file re-seeds MIGRATION_DB from scratch (see `clearDb`
+// below), so the id `getBrowserWorkspaceId()` would answer is different on
+// every run — a v13 fixture's rekey step mints a fresh ULID each time the
+// database is torn down and rebuilt. Resetting the accessor's cache before
+// each test (rather than relying on the shared jsdom-only seam, which this
+// browser-mode file has none of) is what keeps `migratedLocal()` reading the
+// id THIS test's database actually holds instead of the previous test's.
+beforeEach(resetBrowserWorkspaceIdForTests)
+
 /**
  * The migrated database read back through the production wiring, rather than
  * through a test double: what this file asserts is what a real user's next
  * session would see after the upgrade ran.
+ *
+ * `listDocuments`/`load` resolve the workspace id fresh (idempotent once
+ * resolved for this test) before delegating, rather than assuming it is
+ * already resolved — production makes that same resolve part of the boot
+ * chain (`boot.ts`), which nothing in this file drives.
  */
 function migratedLocal() {
   const index = new IdbDocumentIndex(MIGRATION_DB)
   const clock = idbContentClock(MIGRATION_DB)
+  const ready = () => resolveBrowserWorkspaceId(MIGRATION_DB)
   return {
-    listDocuments: () => listLocalDocuments(index, clock),
-    load: (documentId: string) => loadLocalDocument(index, documentId, clock),
+    listDocuments: () => ready().then(() => listLocalDocuments(index, clock)),
+    load: (documentId: string) => ready().then(() => loadLocalDocument(index, documentId, clock)),
     getDefaultDocumentId: () => new IdbDefaultDocumentPointer(MIGRATION_DB).get(),
   }
+}
+
+/**
+ * `LoroStore` builds a `DocRef` that reads `getBrowserWorkspaceId()` (unused
+ * for `document:` keys, but still read — see `docRefKey`'s comment). A raw
+ * construction in these fixtures has to resolve it explicitly, the way
+ * production's boot chain always has by the time anything calls this.
+ */
+async function loroStore(): Promise<LoroStore> {
+  await resolveBrowserWorkspaceId(MIGRATION_DB)
+  return new LoroStore(MIGRATION_DB)
 }
 
 /**
@@ -305,6 +350,306 @@ async function metaKeys(): Promise<string[]> {
   })
 }
 
+/**
+ * Seeds a v13-shaped fixture via raw IDB: the current store layout (v9-v12
+ * additive changes already landed), keyed under the literal `'local'`
+ * workspace the v13->v14 rekey step exists to move off of. Every store this
+ * touches already existed by v13 — only the registry's KEY changes at v14 —
+ * so this creates them directly rather than replaying the intermediate
+ * upgrades the earlier fixtures above exercise.
+ */
+async function seedV13Fixture(input: {
+  documentId: string
+  path: string
+  kind?: string
+  name?: string
+  contentSnapshot: Uint8Array
+  workspaceTreeSnapshot?: Uint8Array
+  defaultDocumentId?: string
+}): Promise<void> {
+  function writeEnvelope(tx: IDBTransaction, key: string, snapshot: Uint8Array): void {
+    const { manifest, chunks } = chunkSnapshot(snapshot, 1_000_000)
+    tx.objectStore(SYNC_DOCUMENTS_STORE).put(
+      { v: 2, snapshot: { manifest }, frontier: new Uint8Array(), deltas: [] },
+      key,
+    )
+    const chunkStore = tx.objectStore(SYNC_SNAPSHOT_CHUNKS_STORE)
+    for (const chunk of chunks as SnapshotChunk[]) chunkStore.put(chunk, [key, chunk.index])
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(MIGRATION_DB, 13)
+    req.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result
+      if (!db.objectStoreNames.contains('meta')) db.createObjectStore('meta')
+      if (!db.objectStoreNames.contains(WORKSPACES_STORE)) db.createObjectStore(WORKSPACES_STORE)
+      if (!db.objectStoreNames.contains(DOCUMENT_INDEX_STORE)) {
+        const idx = db.createObjectStore(DOCUMENT_INDEX_STORE, { keyPath: ['workspaceId', 'path'] })
+        idx.createIndex('byId', ['workspaceId', 'documentId'], { unique: true })
+      }
+      if (!db.objectStoreNames.contains('documentFiles')) db.createObjectStore('documentFiles')
+      if (!db.objectStoreNames.contains('blobs')) db.createObjectStore('blobs')
+      if (!db.objectStoreNames.contains(SYNC_DOCUMENTS_STORE))
+        db.createObjectStore(SYNC_DOCUMENTS_STORE)
+      if (!db.objectStoreNames.contains(SYNC_SNAPSHOT_CHUNKS_STORE)) {
+        db.createObjectStore(SYNC_SNAPSHOT_CHUNKS_STORE)
+      }
+      if (!db.objectStoreNames.contains('contentTimestamps'))
+        db.createObjectStore('contentTimestamps')
+    }
+    req.onsuccess = () => {
+      const db = req.result
+      letFixtureStepAside(db)
+      const tx = db.transaction(
+        [
+          'meta',
+          WORKSPACES_STORE,
+          DOCUMENT_INDEX_STORE,
+          SYNC_DOCUMENTS_STORE,
+          SYNC_SNAPSHOT_CHUNKS_STORE,
+        ],
+        'readwrite',
+      )
+      tx.objectStore(WORKSPACES_STORE).put({ workspaceId: 'local' }, 'local')
+      tx.objectStore(DOCUMENT_INDEX_STORE).add({
+        workspaceId: 'local',
+        documentId: input.documentId,
+        path: input.path,
+        kind: input.kind ?? 'spatial',
+        ...(input.name === undefined ? {} : { name: input.name }),
+      })
+      if (input.defaultDocumentId !== undefined) {
+        tx.objectStore('meta').put(input.defaultDocumentId, 'defaultDocumentId')
+      }
+      writeEnvelope(tx, `document:${input.documentId}`, input.contentSnapshot)
+      if (input.workspaceTreeSnapshot !== undefined) {
+        writeEnvelope(tx, 'workspace-tree:local', input.workspaceTreeSnapshot)
+      }
+      tx.oncomplete = () => {
+        db.close()
+        resolve()
+      }
+      tx.onerror = () => {
+        db.close()
+        reject(tx.error)
+      }
+    }
+    req.onerror = () => reject(req.error)
+  })
+}
+
+/** Every key currently stored under the literal `'local'` workspace, across
+ *  all three stores the rekey touches — the "zero remnants" assertion. */
+/**
+ * Opens the database at whatever version it currently holds, rather than
+ * `openWhiteboardDb`'s pinned `DB_VERSION` — the one caller that needs this
+ * (`two-bump idempotence`, below) deliberately forces the database past
+ * `DB_VERSION`, and `openWhiteboardDb` would then reject with `VersionError`
+ * ("requested version is less than the existing version").
+ */
+async function openAtCurrentVersion(dbName: string): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(dbName)
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+}
+
+async function legacyLocalKeys(): Promise<{
+  workspaces: string[]
+  index: unknown[]
+  syncTree: string[]
+}> {
+  const db = await openAtCurrentVersion(MIGRATION_DB)
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(
+      [WORKSPACES_STORE, DOCUMENT_INDEX_STORE, SYNC_DOCUMENTS_STORE],
+      'readonly',
+    )
+    const workspacesReq = tx.objectStore(WORKSPACES_STORE).getAllKeys()
+    const range = IDBKeyRange.bound(['local'], ['local', []])
+    const indexReq = tx.objectStore(DOCUMENT_INDEX_STORE).getAll(range)
+    const syncReq = tx.objectStore(SYNC_DOCUMENTS_STORE).getAllKeys()
+    tx.onerror = () => reject(tx.error)
+    tx.oncomplete = () => {
+      db.close()
+      resolve({
+        workspaces: workspacesReq.result.map(String).filter((key) => key === 'local'),
+        index: indexReq.result,
+        syncTree: syncReq.result.map(String).filter((key) => key === 'workspace-tree:local'),
+      })
+    }
+  })
+}
+
+const V13_DOCUMENT_ID = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+
+describe("IndexedDB v13 -> v14 (re-keys the 'local' workspace)", () => {
+  beforeEach(clearDb)
+  afterEach(clearDb)
+
+  it('current DB_VERSION is 14 or higher', () => {
+    expect(DB_VERSION).toBeGreaterThanOrEqual(14)
+  })
+
+  it('moves registry, index and tree rows onto one ULID, zero local rows left', async () => {
+    const contentDoc = new Loro()
+    contentDoc.getMovableList('elements').push('one')
+    const contentSnapshot = contentDoc.export({ mode: 'snapshot' })
+
+    // A folded workspace document holding the SAME document as a tree node —
+    // real Loro bytes, not a placeholder, so "the workspace tree opens under
+    // the new key" is an actual read, not a shape assertion.
+    const workspaceDoc = new Loro()
+    adoptWorkspaceDocument(
+      workspaceDoc,
+      { path: 'design/login', documentId: V13_DOCUMENT_ID, kind: 'spatial', name: 'Login' },
+      contentDoc,
+    )
+    const workspaceTreeSnapshot = workspaceDoc.export({ mode: 'snapshot' })
+
+    await seedV13Fixture({
+      documentId: V13_DOCUMENT_ID,
+      path: 'design/login',
+      name: 'Login',
+      contentSnapshot,
+      workspaceTreeSnapshot,
+      defaultDocumentId: V13_DOCUMENT_ID,
+    })
+
+    const ulid = await resolveBrowserWorkspaceId(MIGRATION_DB)
+    expect(ulid).toMatch(/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/)
+
+    // Documents list/load byte-identical through production wiring.
+    const local = migratedLocal()
+    expect((await local.listDocuments()).map((d) => d.documentId)).toEqual([V13_DOCUMENT_ID])
+    const loaded = await new LoroStore(MIGRATION_DB).load(V13_DOCUMENT_ID)
+    expect(loaded.kind).toBe('ok')
+    if (loaded.kind === 'ok') expect([...loaded.snapshot]).toEqual([...contentSnapshot])
+    expect(await local.getDefaultDocumentId()).toBe(V13_DOCUMENT_ID)
+
+    // The workspace tree opens under the new key and holds the same node.
+    const tree = await new BrowserWorkspaceDocs(MIGRATION_DB).open(ulid)
+    expect(tree).not.toBeNull()
+    if (tree !== null) {
+      expect(resolveWorkspaceDocumentById(tree, V13_DOCUMENT_ID)).not.toBeNull()
+    }
+
+    // The registry holds exactly one ULID-keyed row.
+    const db = await openWhiteboardDb(MIGRATION_DB)
+    const workspaceKeys = await new Promise<string[]>((resolveKeys, rejectKeys) => {
+      const tx = db.transaction(WORKSPACES_STORE, 'readonly')
+      const req = tx.objectStore(WORKSPACES_STORE).getAllKeys()
+      req.onerror = () => rejectKeys(req.error)
+      tx.oncomplete = () => {
+        db.close()
+        resolveKeys(req.result.map(String))
+      }
+    })
+    expect(workspaceKeys).toEqual([ulid])
+
+    // Zero 'local'-keyed rows anywhere.
+    const remnants = await legacyLocalKeys()
+    expect(remnants).toEqual({ workspaces: [], index: [], syncTree: [] })
+  })
+
+  it("two-bump idempotence: same id both passes, re-put 'local' absorbed not stray", async () => {
+    const contentDoc = new Loro()
+    contentDoc.getMovableList('elements').push('stable')
+    await seedV13Fixture({
+      documentId: V13_DOCUMENT_ID,
+      path: 'stable-doc',
+      contentSnapshot: contentDoc.export({ mode: 'snapshot' }),
+    })
+
+    const firstUlid = await resolveBrowserWorkspaceId(MIGRATION_DB)
+
+    // Simulates what a REAL future migration bump would do — re-fire
+    // `onupgradeneeded` and let `backfillDocumentIndex` re-put
+    // `{workspaceId:'local'}` unconditionally — without replaying the whole
+    // upgrade chain (which reads stores like `documents`/`loroDocuments`
+    // that no longer exist by v14). Manually re-seeding the exact remnant
+    // `backfillDocumentIndex` would produce, then invoking the REAL exported
+    // `rekeyBrowserWorkspace` against it inside a genuine versionchange
+    // transaction, tests the actual convergence logic rather than a
+    // re-implementation of it.
+    resetBrowserWorkspaceIdForTests()
+    const secondPassKeys = await new Promise<string[]>((resolveOpen, rejectOpen) => {
+      const req = indexedDB.open(MIGRATION_DB, DB_VERSION + 1)
+      req.onupgradeneeded = () => {
+        const tx = req.transaction
+        if (!tx) return
+        tx.objectStore(WORKSPACES_STORE).put({ workspaceId: 'local' }, 'local')
+        rekeyBrowserWorkspace(tx, () => {})
+      }
+      req.onsuccess = async () => {
+        const db = req.result
+        const keys = await new Promise<string[]>((resolveKeys, rejectKeys) => {
+          const readTx = db.transaction(WORKSPACES_STORE, 'readonly')
+          const keysReq = readTx.objectStore(WORKSPACES_STORE).getAllKeys()
+          keysReq.onerror = () => rejectKeys(keysReq.error)
+          readTx.oncomplete = () => resolveKeys(keysReq.result.map(String))
+        })
+        db.close()
+        resolveOpen(keys)
+      }
+      req.onerror = () => rejectOpen(req.error)
+    })
+
+    // Asserted as a whole array, not `keys[0]`: a naive re-mint leaves the
+    // OLD target row behind (nothing deletes it) alongside a fresh one, and
+    // ULIDs sort roughly chronologically, so `keys[0]` after ascending
+    // `getAllKeys()` would silently read back the correct-looking old id even
+    // under that bug. Exactly one row, and it is the SAME one, is the real
+    // invariant.
+    expect(secondPassKeys).toEqual([firstUlid])
+    const secondUlid = secondPassKeys[0] as string
+
+    const remnants = await legacyLocalKeys()
+    expect(remnants).toEqual({ workspaces: [], index: [], syncTree: [] })
+
+    // The document is still reachable under the SAME id after both passes.
+    // Read raw (not through `migratedLocal()`/`openWhiteboardDb`, both
+    // pinned to `DB_VERSION`): this test forced the database past it with a
+    // bare `indexedDB.open`, exactly as a genuine future migration bump
+    // would in production — but unlike production, nothing here also moved
+    // `DB_VERSION` forward, so the pinned opener would VersionError on it.
+    const db = await openAtCurrentVersion(MIGRATION_DB)
+    const rowsUnderSecondUlid = await new Promise<unknown[]>((resolveRows, rejectRows) => {
+      const tx = db.transaction(DOCUMENT_INDEX_STORE, 'readonly')
+      const range = IDBKeyRange.bound([secondUlid], [secondUlid, []])
+      const req = tx.objectStore(DOCUMENT_INDEX_STORE).getAll(range)
+      req.onerror = () => rejectRows(req.error)
+      tx.oncomplete = () => {
+        db.close()
+        resolveRows(req.result)
+      }
+    })
+    expect(rowsUnderSecondUlid).toEqual([
+      expect.objectContaining({ documentId: V13_DOCUMENT_ID, workspaceId: secondUlid }),
+    ])
+  })
+
+  it('fresh install: v0 -> 14 yields one ULID workspace, zero local rows', async () => {
+    const ulid = await resolveBrowserWorkspaceId(MIGRATION_DB)
+    expect(ulid).toMatch(/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/)
+    expect(await migratedLocal().listDocuments()).toEqual([])
+
+    const db = await openWhiteboardDb(MIGRATION_DB)
+    const workspaceKeys = await new Promise<string[]>((resolveKeys, rejectKeys) => {
+      const tx = db.transaction(WORKSPACES_STORE, 'readonly')
+      const req = tx.objectStore(WORKSPACES_STORE).getAllKeys()
+      req.onerror = () => rejectKeys(req.error)
+      tx.oncomplete = () => {
+        db.close()
+        resolveKeys(req.result.map(String))
+      }
+    })
+    expect(workspaceKeys).toEqual([ulid])
+    expect(getBrowserWorkspaceId()).toBe(ulid)
+  })
+})
+
 describe('whiteboard IndexedDB v6 -> v7 upgrade (renames the container stores)', () => {
   beforeEach(clearDb)
   afterEach(clearDb)
@@ -362,7 +707,7 @@ describe('whiteboard IndexedDB v6 -> v7 upgrade (renames the container stores)',
     expect(await metaStore.load(documentId)).toBeNull()
     expect(await metaStore.listDocuments()).toEqual([])
     // The bytes go with it rather than lingering as storage nothing names.
-    expect((await new LoroStore(MIGRATION_DB).load(documentId)).kind).toBe('not-found')
+    expect((await (await loroStore()).load(documentId)).kind).toBe('not-found')
   })
 
   it('renames the meta pointer key, then clears it because v8 discarded its target', async () => {
@@ -434,7 +779,7 @@ describe('IndexedDB v5 -> v6 (removes reconnectKeypairs)', () => {
     expect(fileCount).toBe(1)
 
     // Discarded with its document — see the note below.
-    expect((await new LoroStore(MIGRATION_DB).load(documentId)).kind).toBe('not-found')
+    expect((await (await loroStore()).load(documentId)).kind).toBe('not-found')
 
     const metaStore = migratedLocal()
     // The row does not survive: v8 DISCARDS a document with no workspace and
@@ -504,7 +849,7 @@ describe('IndexedDB v4 -> v5', () => {
     expect(fileCount).toBe(1)
 
     // Discarded with its document — see the note below.
-    expect((await new LoroStore(MIGRATION_DB).load(documentId)).kind).toBe('not-found')
+    expect((await (await loroStore()).load(documentId)).kind).toBe('not-found')
 
     const metaStore = migratedLocal()
     // The row does not survive: v8 DISCARDS a document with no workspace and
@@ -538,7 +883,7 @@ describe('whiteboard IndexedDB v3 -> v4 upgrade', () => {
     db.close()
 
     // Discarded with its document — see the note below.
-    expect((await new LoroStore(MIGRATION_DB).load(documentId)).kind).toBe('not-found')
+    expect((await (await loroStore()).load(documentId)).kind).toBe('not-found')
 
     const metaStore = migratedLocal()
     // The row does not survive: v8 DISCARDS a document with no workspace and
@@ -582,7 +927,7 @@ describe('whiteboard IndexedDB v2 -> v3 upgrade', () => {
     expect(await migratedLocal().load(documentId)).toBeNull()
     expect(await metaStore.load(documentId)).toBeNull()
     expect(await metaStore.listDocuments()).toEqual([])
-    expect((await new LoroStore(MIGRATION_DB).load(documentId)).kind).toBe('not-found')
+    expect((await (await loroStore()).load(documentId)).kind).toBe('not-found')
     expect(await migratedLocal().getDefaultDocumentId()).toBeNull()
   })
 
@@ -759,8 +1104,16 @@ describe('whiteboard IndexedDB v7 -> v8 upgrade (discards pre-path documents)', 
       defaultDocumentId: POST_PATH_ID,
     })
 
+    // `workspaceId` is the one field that changes: the seeded row still
+    // spells the pre-rekey `'local'` (that is the v7 shape this fixture is
+    // pinning), but `listDocuments()` reads it back through the v14+ index,
+    // which reports the canonical id the rekey moved it onto.
     expect(await migratedLocal().listDocuments()).toEqual([
-      { ...row, updatedAt: expect.any(String) },
+      {
+        ...row,
+        workspaceId: await resolveBrowserWorkspaceId(MIGRATION_DB),
+        updatedAt: expect.any(String),
+      },
     ])
     expect(await storeKeys(SYNC_DOCUMENTS_STORE)).toEqual([`document:${POST_PATH_ID}`])
     expect(await migratedLocal().getDefaultDocumentId()).toBe(POST_PATH_ID)
@@ -947,7 +1300,9 @@ describe('IndexedDB v9 -> v10 (backfills the index)', () => {
     expect(await local.listDocuments()).toEqual([
       {
         documentId: POST_PATH_ID,
-        workspaceId: 'local',
+        // Reported through the v14+ index: the canonical id, not the seeded
+        // pre-rekey `'local'` literal (see the comment on the previous test).
+        workspaceId: await resolveBrowserWorkspaceId(MIGRATION_DB),
         path: 'design/login',
         name: 'Login',
         // The content record's stamp ('x', what the fixture wrote there), not
@@ -1008,7 +1363,7 @@ describe('IndexedDB v11 -> v12 (carries content to the port)', () => {
       ],
     })
 
-    const store = new LoroStore(MIGRATION_DB)
+    const store = await loroStore()
     const loaded = await store.load(POST_PATH_ID)
     expect(loaded.kind).toBe('ok')
     if (loaded.kind === 'ok') {
@@ -1032,7 +1387,7 @@ describe('IndexedDB v11 -> v12 (carries content to the port)', () => {
       loroRecord: [POST_PATH_ID, { v: 99, fromTheFuture: true }],
     })
 
-    const result = await new LoroStore(MIGRATION_DB).load(POST_PATH_ID)
+    const result = await (await loroStore()).load(POST_PATH_ID)
     expect(result.kind).toBe('unsupported-version')
   })
 

--- a/apps/web/src/lib/browser-idb.ts
+++ b/apps/web/src/lib/browser-idb.ts
@@ -7,6 +7,7 @@
  * Owning DB_VERSION and onupgradeneeded in one place makes that impossible by
  * construction instead of relying on a hand-synced comment.
  */
+import { generateDocumentId } from '@kamiazya/whiteboard-model'
 import { chunkSnapshot } from '@kamiazya/whiteboard-ports'
 import { loroRecordEnvelopeSchema } from './loro-record-envelope.js'
 
@@ -146,8 +147,16 @@ export function whiteboardDbName(): string {
  * happens anyway (a tab still running a pre-v8 bundle) rejects with a
  * message a caller can show instead of hanging on a request that never
  * settles.
+ *
+ * v13 -> v14: re-keys the browser's single workspace off the literal string
+ * `'local'` onto a canonical ULID (ADR-0019's browser-keeper half — the
+ * daemon keeper is a separate lane). `'local'` was never a valid
+ * `workspaceCanonicalIdSchema` value; it survived as a stand-in because
+ * nothing before this needed the two keepers' workspace ids to share a
+ * shape. See `rekeyBrowserWorkspace` for why this cannot be a plain
+ * rename-and-done.
  */
-export const DB_VERSION = 13
+export const DB_VERSION = 14
 
 /** The `DocumentIndex` port's two stores. Exported so the implementation and
  * the opener cannot disagree about a name. */
@@ -301,8 +310,9 @@ function discardPrePathDocuments(tx: IDBTransaction, done: () => void): void {
  * The workspace rows come from the documents themselves rather than from a
  * hardcoded `'local'`: this store never held more than one workspace, but
  * reading it from the data is the version that stays correct if it ever did.
- * `BROWSER_WORKSPACE_ID` is still written unconditionally, because that is the
- * one the browser UI opens.
+ * The literal `'local'` key below is still written unconditionally on every
+ * upgrade — `rekeyBrowserWorkspace` (v13->v14, further down) is what absorbs
+ * it onto the canonical id the browser UI actually opens.
  */
 /**
  * Moves every Loro content record into the `DocumentStore` port's store, and
@@ -391,13 +401,16 @@ function isEnvelopeV1(value: unknown): value is { v: 1; snapshot: unknown } {
  * store, splits nothing, and looks exactly like a successful upgrade — leaving
  * v1 records the new parser reports as unreadable documents.
  */
-function splitInlineSnapshotChunks(tx: IDBTransaction): void {
+function splitInlineSnapshotChunks(tx: IDBTransaction, done: () => void): void {
   const sync = tx.objectStore(SYNC_DOCUMENTS_STORE)
   const chunks = tx.objectStore(SYNC_SNAPSHOT_CHUNKS_STORE)
   const cursorReq = sync.openCursor()
   cursorReq.onsuccess = () => {
     const cursor = cursorReq.result
-    if (!cursor) return
+    if (!cursor) {
+      done()
+      return
+    }
     const record = cursor.value
     if (isEnvelopeV1(record)) {
       const snapshot = record.snapshot as { manifest?: unknown; chunks?: unknown } | null
@@ -410,6 +423,128 @@ function splitInlineSnapshotChunks(tx: IDBTransaction): void {
       }
     }
     cursor.continue()
+  }
+}
+
+/**
+ * The literal key the browser's single workspace lived under before v14.
+ * Spelled out rather than imported from anywhere else: this migration's job
+ * is to make the string stop meaning anything, and a migration's own text is
+ * history that names the shape it found, the way `defaultCanvasId` still
+ * does in the v6->v7 rename above.
+ */
+const LEGACY_BROWSER_WORKSPACE_ID = 'local'
+
+/**
+ * Re-keys the browser's one workspace off `'local'` onto a canonical ULID —
+ * the registry row, every `documentIndex` row it owns, and the
+ * `workspace-tree:local` sync record plus its chunk rows.
+ *
+ * Convergent, not run-once, because it CANNOT assume it runs exactly once:
+ * `backfillDocumentIndex` (v9->v10, above) unconditionally re-puts
+ * `{workspaceId:'local'}` under key `'local'` on every future upgrade — it
+ * has no way to know this step exists — so a later multi-version jump
+ * resurrects the very row this step just deleted, inside the SAME
+ * transaction, ordered right before it. The fix is not to skip when a ULID
+ * row already exists (that would leave the resurrected `'local'` row behind
+ * forever); it is to look for an existing target on every run and absorb
+ * whatever `'local'` remnant is present into it, minting a new id only when
+ * no target exists yet. Ordered last in the upgrade chain for the reason
+ * every carrier here is: it reads what `backfillDocumentIndex` just wrote.
+ *
+ * Exported (only `browser-idb-migration.browser.test.tsx` imports it): the
+ * convergence property this exists for can only be observed by running this
+ * step a second time, and `backfillDocumentIndex`'s re-put depends on stores
+ * (`documents`, `loroDocuments`) that no longer exist by v14 — replaying the
+ * WHOLE upgrade chain a second time throws on those, where a real future
+ * migration would still have them. Invoking this one step directly, against
+ * a manually re-seeded `'local'` remnant, tests the real convergence logic
+ * without needing a real v15 to reach it.
+ */
+export function rekeyBrowserWorkspace(tx: IDBTransaction, done: () => void): void {
+  const workspaces = tx.objectStore(WORKSPACES_STORE)
+  const index = tx.objectStore(DOCUMENT_INDEX_STORE)
+  const sync = tx.objectStore(SYNC_DOCUMENTS_STORE)
+  const chunks = tx.objectStore(SYNC_SNAPSHOT_CHUNKS_STORE)
+
+  const keysReq = workspaces.getAllKeys()
+  keysReq.onsuccess = () => {
+    const keys = keysReq.result.map(String)
+    const hasLegacyRemnant = keys.includes(LEGACY_BROWSER_WORKSPACE_ID)
+    const targetId = keys.find((key) => key !== LEGACY_BROWSER_WORKSPACE_ID) ?? generateDocumentId()
+
+    if (!hasLegacyRemnant) {
+      // Nothing to absorb this pass. A brand-new database (no row at all)
+      // still needs its registry row written; an already-converged one is
+      // left alone rather than re-put on every upgrade.
+      if (keys.length === 0) workspaces.put({ workspaceId: targetId }, targetId)
+      done()
+      return
+    }
+
+    workspaces.delete(LEGACY_BROWSER_WORKSPACE_ID)
+    workspaces.put({ workspaceId: targetId }, targetId)
+    rekeyLegacyIndexRows(index, targetId, () => rekeyLegacySyncTree(sync, chunks, targetId, done))
+  }
+}
+
+/** Moves every `documentIndex` row keyed under the legacy workspace onto `targetId`. */
+function rekeyLegacyIndexRows(index: IDBObjectStore, targetId: string, done: () => void): void {
+  const range = IDBKeyRange.bound([LEGACY_BROWSER_WORKSPACE_ID], [LEGACY_BROWSER_WORKSPACE_ID, []])
+  const cursorReq = index.openCursor(range)
+  cursorReq.onsuccess = () => {
+    const cursor = cursorReq.result
+    if (!cursor) {
+      done()
+      return
+    }
+    const row = cursor.value as Record<string, unknown>
+    cursor.delete()
+    // The new key's first element is `targetId`, entirely outside the
+    // `'local'` range this cursor walks, so the add cannot be observed by
+    // this same cursor and cannot loop.
+    index.add({ ...row, workspaceId: targetId })
+    cursor.continue()
+  }
+}
+
+/**
+ * Moves the `workspace-tree:local` sync record and its `syncSnapshotChunks`
+ * rows onto `workspace-tree:<targetId>`, as opaque values — no Loro decode,
+ * matching every other carrier in this file that only needs to relocate
+ * bytes it does not need to understand.
+ */
+function rekeyLegacySyncTree(
+  sync: IDBObjectStore,
+  chunks: IDBObjectStore,
+  targetId: string,
+  done: () => void,
+): void {
+  const legacyKey = `workspace-tree:${LEGACY_BROWSER_WORKSPACE_ID}`
+  const targetKey = `workspace-tree:${targetId}`
+  const getReq = sync.get(legacyKey)
+  getReq.onsuccess = () => {
+    const value = getReq.result
+    if (value === undefined) {
+      done()
+      return
+    }
+    sync.delete(legacyKey)
+    sync.put(value, targetKey)
+    const chunkRange = IDBKeyRange.bound([legacyKey], [legacyKey, []])
+    const cursorReq = chunks.openCursor(chunkRange)
+    cursorReq.onsuccess = () => {
+      const cursor = cursorReq.result
+      if (!cursor) {
+        done()
+        return
+      }
+      const [, chunkIndex] = cursor.primaryKey as [string, number]
+      const chunkValue = cursor.value
+      cursor.delete()
+      chunks.add(chunkValue, [targetKey, chunkIndex])
+      cursor.continue()
+    }
   }
 }
 
@@ -508,7 +643,9 @@ export function openWhiteboardDb(dbName: string = activeDbName): Promise<IDBData
           // nothing.
           discardPrePathDocuments(tx, () =>
             backfillDocumentIndex(tx, () =>
-              carryLoroDocuments(tx, () => splitInlineSnapshotChunks(tx)),
+              carryLoroDocuments(tx, () =>
+                splitInlineSnapshotChunks(tx, () => rekeyBrowserWorkspace(tx, () => {})),
+              ),
             ),
           )
         }

--- a/apps/web/src/lib/browser-workspace-docs.ts
+++ b/apps/web/src/lib/browser-workspace-docs.ts
@@ -10,11 +10,32 @@
  * only the port.
  */
 import { DocumentStoreWorkspaceDocs } from '@kamiazya/whiteboard-workspace-index'
+import type { LoroDoc } from 'loro-crdt'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import { IdbDocumentStore } from './idb-document-store.js'
 
 export class BrowserWorkspaceDocs extends DocumentStoreWorkspaceDocs {
   /** Only tests pass this; see `openWhiteboardDb`'s note on why it exists. */
   constructor(dbName?: string) {
     super(new IdbDocumentStore(dbName))
+  }
+}
+
+/**
+ * The workspace record, or null for BOTH an unreadable store and an
+ * unavailable workspace id.
+ *
+ * The id read has to sit INSIDE the isolation, which is why this is a
+ * function rather than the `docs.open(getBrowserWorkspaceId()).catch(…)` each
+ * caller would otherwise write: an argument is evaluated before `open`
+ * returns a promise, so an accessor throw is not a rejection that `.catch`
+ * can absorb — it escapes the caller entirely, past the very null branch the
+ * caller wrote to stay standing when storage is unavailable.
+ */
+export async function openWorkspaceOrNull(docs: BrowserWorkspaceDocs): Promise<LoroDoc | null> {
+  try {
+    return await docs.open(getBrowserWorkspaceId())
+  } catch {
+    return null
   }
 }

--- a/apps/web/src/lib/browser-workspace-id.test.ts
+++ b/apps/web/src/lib/browser-workspace-id.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The synchronous accessor + async resolver for the browser's own workspace
+ * id — the canonical ULID a v14+ database keys its `workspaces` row under.
+ */
+import 'fake-indexeddb/auto'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { setWhiteboardDbNameForTests } from './browser-idb.js'
+import {
+  getBrowserWorkspaceId,
+  resetBrowserWorkspaceIdForTests,
+  resolveBrowserWorkspaceId,
+  setBrowserWorkspaceIdForTests,
+} from './browser-workspace-id.js'
+
+const DB_NAME = 'whiteboard-workspace-id-test'
+
+async function clearDb(): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase(DB_NAME)
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+  })
+}
+
+describe('browser workspace id accessor', () => {
+  beforeEach(async () => {
+    resetBrowserWorkspaceIdForTests()
+    setWhiteboardDbNameForTests(DB_NAME)
+    await clearDb()
+  })
+  afterEach(async () => {
+    resetBrowserWorkspaceIdForTests()
+    await clearDb()
+  })
+
+  it('throws an actionable message before resolveBrowserWorkspaceId() has completed', () => {
+    expect(() => getBrowserWorkspaceId()).toThrow(/resolveBrowserWorkspaceId/)
+  })
+
+  it('returns the canonical ULID once resolved, matching documentIdSchema', async () => {
+    const id = await resolveBrowserWorkspaceId(DB_NAME)
+    expect(id).toMatch(/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/)
+    expect(getBrowserWorkspaceId()).toBe(id)
+  })
+
+  it('is idempotent: a second resolve reuses the cached id without reopening', async () => {
+    const first = await resolveBrowserWorkspaceId(DB_NAME)
+    const second = await resolveBrowserWorkspaceId(DB_NAME)
+    expect(second).toBe(first)
+  })
+
+  it('the test seam sets a resolved value directly, without opening a database', () => {
+    setBrowserWorkspaceIdForTests('01ARZ3NDEKTSV4RRFFQ69G5FAV')
+    expect(getBrowserWorkspaceId()).toBe('01ARZ3NDEKTSV4RRFFQ69G5FAV')
+  })
+})

--- a/apps/web/src/lib/browser-workspace-id.ts
+++ b/apps/web/src/lib/browser-workspace-id.ts
@@ -1,0 +1,118 @@
+/**
+ * The browser's own workspace id — a synchronous accessor over an id that
+ * can only be discovered asynchronously (an IndexedDB open + read).
+ *
+ * The split exists because most of this app's browser-workspace call sites
+ * are synchronous with respect to the id itself (they build a request object
+ * or a `DocRef` inline, inside an already-async function) and turning every
+ * one of them `async` would ripple through call signatures that have nothing
+ * to do with storage. `resolveBrowserWorkspaceId()` runs once, early (the
+ * boot chain — see `boot.ts`), and every later read is this cheap
+ * synchronous accessor.
+ *
+ * Three states, matching what a caller can actually be told:
+ * - unresolved: nobody has awaited `resolveBrowserWorkspaceId()` yet.
+ * - resolved: the canonical ULID a v14+ database's `workspaces` store holds.
+ * - failed: the resolve attempt rejected (a stale tab blocking the upgrade,
+ *   a quota failure, Safari private browsing). Retryable — the failure is
+ *   surfaced, not remembered forever, because closing the offending tab or
+ *   freeing quota is a normal recovery a reload should not be required for.
+ */
+import { openWhiteboardDb, WORKSPACES_STORE } from './browser-idb.js'
+
+type ResolutionState =
+  | { readonly kind: 'unresolved' }
+  | { readonly kind: 'resolved'; readonly workspaceId: string }
+  | { readonly kind: 'failed'; readonly cause: unknown }
+
+let state: ResolutionState = { kind: 'unresolved' }
+
+// Coalesces concurrent callers onto the SAME open+read rather than racing two
+// upgrade transactions against each other. Cleared on both settle paths so a
+// later call after a failure re-attempts instead of replaying the rejection.
+let inFlight: Promise<string> | null = null
+
+function causeMessage(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause)
+}
+
+/**
+ * The resolved id, or a throw naming which of the two non-resolved states
+ * this is — a caller's `catch` (or its own local error isolation) sees a
+ * message it can act on instead of a generic IndexedDB error.
+ */
+export function getBrowserWorkspaceId(): string {
+  switch (state.kind) {
+    case 'resolved':
+      return state.workspaceId
+    case 'unresolved':
+      throw new Error(
+        'browser workspace id read before resolveBrowserWorkspaceId() completed — ' +
+          'await it in the boot chain, or use the test seam',
+      )
+    case 'failed':
+      throw new Error(`browser workspace unavailable: ${causeMessage(state.cause)}`)
+  }
+}
+
+async function readSoleWorkspaceId(dbName: string | undefined): Promise<string> {
+  const db = await openWhiteboardDb(dbName)
+  try {
+    return await new Promise<string>((resolve, reject) => {
+      const tx = db.transaction(WORKSPACES_STORE, 'readonly')
+      const req = tx.objectStore(WORKSPACES_STORE).getAllKeys()
+      req.onsuccess = () => {
+        const keys = req.result
+        // The v14 migration converges on exactly one row (see browser-idb.ts's
+        // rekeyBrowserWorkspace); anything else means the migration did not
+        // run or did not converge, which is a bug this should surface loudly
+        // rather than silently guess a key.
+        if (keys.length !== 1) {
+          reject(new Error(`expected exactly one browser workspace, found ${keys.length}`))
+          return
+        }
+        resolve(String(keys[0]))
+      }
+      req.onerror = () => reject(req.error)
+      tx.onerror = () => reject(tx.error)
+    })
+  } finally {
+    db.close()
+  }
+}
+
+/**
+ * Opens the whiteboard database (running the v14+ migration if needed) and
+ * caches the one canonical workspace id it holds. Safe to call from more than
+ * one boot path or consumer — a resolved id is served from cache, and
+ * concurrent unresolved calls share one open.
+ */
+export async function resolveBrowserWorkspaceId(dbName?: string): Promise<string> {
+  if (state.kind === 'resolved') return state.workspaceId
+  if (inFlight !== null) return inFlight
+  const attempt = readSoleWorkspaceId(dbName)
+    .then((workspaceId) => {
+      state = { kind: 'resolved', workspaceId }
+      inFlight = null
+      return workspaceId
+    })
+    .catch((cause: unknown) => {
+      state = { kind: 'failed', cause }
+      inFlight = null
+      throw cause
+    })
+  inFlight = attempt
+  return attempt
+}
+
+/** Test seam: resolve synchronously to a fixed id, without opening a database. */
+export function setBrowserWorkspaceIdForTests(workspaceId: string): void {
+  state = { kind: 'resolved', workspaceId }
+  inFlight = null
+}
+
+/** Test seam: return to the unresolved state, as at module load. */
+export function resetBrowserWorkspaceIdForTests(): void {
+  state = { kind: 'unresolved' }
+  inFlight = null
+}

--- a/apps/web/src/lib/browser-workspace-id.ts
+++ b/apps/web/src/lib/browser-workspace-id.ts
@@ -18,6 +18,7 @@
  *   surfaced, not remembered forever, because closing the offending tab or
  *   freeing quota is a normal recovery a reload should not be required for.
  */
+import { workspaceCanonicalIdSchema } from '@kamiazya/whiteboard-model'
 import { openWhiteboardDb, WORKSPACES_STORE } from './browser-idb.js'
 
 type ResolutionState =
@@ -71,7 +72,18 @@ async function readSoleWorkspaceId(dbName: string | undefined): Promise<string> 
           reject(new Error(`expected exactly one browser workspace, found ${keys.length}`))
           return
         }
-        resolve(String(keys[0]))
+        // The SHAPE is checked too, not only the count. A single row keyed
+        // `'local'` is exactly what a rekey that silently did not run leaves
+        // behind, and caching it would put every later read and write under
+        // an id ADR-0019 says cannot exist — indistinguishable from working,
+        // until a keeper comparison or a promotion reads it.
+        const sole = String(keys[0])
+        const canonical = workspaceCanonicalIdSchema.safeParse(sole)
+        if (!canonical.success) {
+          reject(new Error(`browser workspace is not keyed by a canonical id: ${sole}`))
+          return
+        }
+        resolve(canonical.data)
       }
       req.onerror = () => reject(req.error)
       tx.onerror = () => reject(tx.error)
@@ -103,6 +115,23 @@ export async function resolveBrowserWorkspaceId(dbName?: string): Promise<string
     })
   inFlight = attempt
   return attempt
+}
+
+/**
+ * The id, or null when it is unavailable.
+ *
+ * For a caller whose own failure path is already a null — a deep link that
+ * falls through to the default document, say. Such a caller otherwise has to
+ * read the id in an ARGUMENT position, where a throw precedes the promise and
+ * escapes the `.catch` that was supposed to absorb it, turning a graceful
+ * fallback into a rejected load.
+ */
+export function browserWorkspaceIdOrNull(): string | null {
+  try {
+    return getBrowserWorkspaceId()
+  } catch {
+    return null
+  }
 }
 
 /** Test seam: resolve synchronously to a fixed id, without opening a database. */

--- a/apps/web/src/lib/document-embed-content.test.ts
+++ b/apps/web/src/lib/document-embed-content.test.ts
@@ -10,6 +10,7 @@ import { Loro } from 'loro-crdt'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import { loadMarkdownEmbedSource, resetEmbedIndexForTests } from './document-embed-content.js'
 import { FoldingBrowserIndex } from './folding-browser-index.js'
 import { IdbDocumentIndex } from './idb-document-index.js'
@@ -26,9 +27,9 @@ describe('loadMarkdownEmbedSource', () => {
 
   it('resolves the name of a document the workspace tree holds', async () => {
     const index = new FoldingBrowserIndex()
-    await index.createWorkspace({ workspaceId: 'local' }).catch(() => {})
+    await index.createWorkspace({ workspaceId: getBrowserWorkspaceId() }).catch(() => {})
     const entry = await index.createDocument({
-      workspaceId: 'local',
+      workspaceId: getBrowserWorkspaceId(),
       path: 'notes/spec',
       kind: 'markdown',
       name: 'The Spec',
@@ -42,7 +43,7 @@ describe('loadMarkdownEmbedSource', () => {
     const index = new IdbDocumentIndex()
     await ensureLocalWorkspace(index)
     const entry = await index.createDocument({
-      workspaceId: 'local',
+      workspaceId: getBrowserWorkspaceId(),
       path: 'notes/old',
       kind: 'markdown',
       name: 'Old Note',

--- a/apps/web/src/lib/document-embed-content.ts
+++ b/apps/web/src/lib/document-embed-content.ts
@@ -18,9 +18,9 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { isImageRef, newImageRef } from '@kamiazya/whiteboard-model'
 import type { DocumentFileAdapter, LoadedFileDocument } from '../hooks/use-document-file-seams.js'
 import { getAppLogger } from './app-logger.js'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import { DocumentFileStore } from './document-file-store.js'
 import { FoldingBrowserIndex } from './folding-browser-index.js'
-import { BROWSER_WORKSPACE_ID } from './local-document-summary.js'
 import { loadDocumentContent } from './workspace-content.js'
 
 const log = getAppLogger('document-embed-content')
@@ -51,7 +51,7 @@ async function loadDocumentName(documentId: string): Promise<string | undefined>
     // answer too — one read path, no second store of its own.
     embedIndex ??= new FoldingBrowserIndex()
     const entry = await embedIndex.resolveDocumentById({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       documentId,
     })
     // A document with no name of its own reports one as ABSENT rather than as

--- a/apps/web/src/lib/fold-workspace.browser.test.tsx
+++ b/apps/web/src/lib/fold-workspace.browser.test.tsx
@@ -16,9 +16,9 @@ import { Loro } from 'loro-crdt'
 import { beforeEach, expect, it } from 'vitest'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import { foldWorkspaceDocuments } from './fold-workspace.js'
 import { IdbDocumentIndex } from './idb-document-index.js'
-import { BROWSER_WORKSPACE_ID } from './local-document-summary.js'
 import { LoroStore } from './loro-store.js'
 
 const DB_NAME = claimIsolatedWhiteboardDb('fold-workspace')
@@ -35,9 +35,9 @@ beforeEach(deleteDb)
 
 async function seedDocument(path: string, text: string): Promise<string> {
   const index = new IdbDocumentIndex(DB_NAME)
-  await index.createWorkspace({ workspaceId: BROWSER_WORKSPACE_ID })
+  await index.createWorkspace({ workspaceId: getBrowserWorkspaceId() })
   const entry = await index.createDocument({
-    workspaceId: BROWSER_WORKSPACE_ID,
+    workspaceId: getBrowserWorkspaceId(),
     path,
     kind: 'spatial',
   })
@@ -57,7 +57,7 @@ it('folds every indexed document into the workspace document, content included',
 
   // Read back through a FRESH open — what was persisted, not what was in
   // memory when the fold ran.
-  const workspace = await new BrowserWorkspaceDocs(DB_NAME).open(BROWSER_WORKSPACE_ID)
+  const workspace = await new BrowserWorkspaceDocs(DB_NAME).open(getBrowserWorkspaceId())
   expect(workspace).not.toBeNull()
   if (workspace === null) return
   expect(
@@ -82,9 +82,9 @@ it('is idempotent, and picks up documents created between runs', async () => {
 
 it('skips an unreadable document rather than folding an empty one', async () => {
   const index = new IdbDocumentIndex(DB_NAME)
-  await index.createWorkspace({ workspaceId: BROWSER_WORKSPACE_ID })
+  await index.createWorkspace({ workspaceId: getBrowserWorkspaceId() })
   const entry = await index.createDocument({
-    workspaceId: BROWSER_WORKSPACE_ID,
+    workspaceId: getBrowserWorkspaceId(),
     path: 'damaged',
     kind: 'spatial',
   })
@@ -95,7 +95,7 @@ it('skips an unreadable document rather than folding an empty one', async () => 
 
   // Not in the tree: the old record stays the damaged document's home, where
   // the old read path reports it as present-but-unreadable.
-  const workspace = await new BrowserWorkspaceDocs(DB_NAME).open(BROWSER_WORKSPACE_ID)
+  const workspace = await new BrowserWorkspaceDocs(DB_NAME).open(getBrowserWorkspaceId())
   expect(
     workspace === null ? null : resolveWorkspaceDocumentById(workspace, entry.documentId),
   ).toBeNull()

--- a/apps/web/src/lib/fold-workspace.ts
+++ b/apps/web/src/lib/fold-workspace.ts
@@ -22,8 +22,8 @@ import { documentKindSchema } from '@kamiazya/whiteboard-model'
 import { WorkspaceNotFoundError } from '@kamiazya/whiteboard-ports'
 import { Loro } from 'loro-crdt'
 import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import { IdbDocumentIndex } from './idb-document-index.js'
-import { BROWSER_WORKSPACE_ID } from './local-document-summary.js'
 import { LoroStore } from './loro-store.js'
 
 export interface FoldReport {
@@ -37,7 +37,7 @@ export async function foldWorkspaceDocuments(dbName?: string): Promise<FoldRepor
   const index = new IdbDocumentIndex(dbName)
   let entries: Awaited<ReturnType<IdbDocumentIndex['listDocuments']>>
   try {
-    entries = await index.listDocuments({ workspaceId: BROWSER_WORKSPACE_ID })
+    entries = await index.listDocuments({ workspaceId: getBrowserWorkspaceId() })
   } catch (error) {
     // A browser that never created the workspace has nothing to fold. Every
     // other failure is real and stays loud.
@@ -46,7 +46,7 @@ export async function foldWorkspaceDocuments(dbName?: string): Promise<FoldRepor
   }
 
   const docs = new BrowserWorkspaceDocs(dbName)
-  const workspace = await docs.create(BROWSER_WORKSPACE_ID)
+  const workspace = await docs.create(getBrowserWorkspaceId())
   const loroStore = new LoroStore(dbName)
 
   let folded = 0
@@ -84,7 +84,7 @@ export async function foldWorkspaceDocuments(dbName?: string): Promise<FoldRepor
     )
     // Saved PER DOCUMENT, so a crash mid-fold loses at most the one in
     // flight — the next startup derives it as still-pending and retries.
-    await docs.save(BROWSER_WORKSPACE_ID, workspace)
+    await docs.save(getBrowserWorkspaceId(), workspace)
     folded += 1
   }
   return { folded, skipped }

--- a/apps/web/src/lib/folding-browser-index.browser.test.tsx
+++ b/apps/web/src/lib/folding-browser-index.browser.test.tsx
@@ -11,10 +11,10 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { seedSyncDocument } from '../test-utils/seed-sync-document.js'
 import { DOCUMENT_INDEX_STORE } from './browser-idb.js'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import { FoldingBrowserIndex } from './folding-browser-index.js'
 import { IdbDocumentIndex } from './idb-document-index.js'
 import { inTransaction, request } from './idb-tx.js'
-import { BROWSER_WORKSPACE_ID } from './local-document-summary.js'
 import { LoroStore } from './loro-store.js'
 import { loadDocumentContent, seedWorkspaceDocumentContent } from './workspace-content.js'
 
@@ -58,9 +58,9 @@ describe('FoldingBrowserIndex (tree-backed composition)', () => {
     // Seeded exactly as an older build left it: an index row and a
     // per-document Loro record, no workspace document anywhere.
     const legacyIndex = new IdbDocumentIndex()
-    await legacyIndex.createWorkspace({ workspaceId: BROWSER_WORKSPACE_ID })
+    await legacyIndex.createWorkspace({ workspaceId: getBrowserWorkspaceId() })
     const entry = await legacyIndex.createDocument({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       path: 'from-before',
       kind: 'spatial',
       name: 'From before',
@@ -70,7 +70,7 @@ describe('FoldingBrowserIndex (tree-backed composition)', () => {
     await new LoroStore().save(entry.documentId, doc.export({ mode: 'snapshot' }))
 
     const index = new FoldingBrowserIndex()
-    const rows = await index.listDocuments({ workspaceId: BROWSER_WORKSPACE_ID })
+    const rows = await index.listDocuments({ workspaceId: getBrowserWorkspaceId() })
     expect(rows.map((row) => row.path)).toEqual(['from-before'])
     expect(rows[0]?.name).toBe('From before')
 
@@ -87,9 +87,9 @@ describe('FoldingBrowserIndex (tree-backed composition)', () => {
     // fallback read is what keeps that sentence true — without it the
     // document vanishes from every listing while its bytes sit intact.
     const legacyIndex = new IdbDocumentIndex()
-    await legacyIndex.createWorkspace({ workspaceId: BROWSER_WORKSPACE_ID })
+    await legacyIndex.createWorkspace({ workspaceId: getBrowserWorkspaceId() })
     const readable = await legacyIndex.createDocument({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       path: 'readable',
       kind: 'spatial',
     })
@@ -97,7 +97,7 @@ describe('FoldingBrowserIndex (tree-backed composition)', () => {
     writeSpatialCanvas(readableDoc, canvasWith('fine'))
     await new LoroStore().save(readable.documentId, readableDoc.export({ mode: 'snapshot' }))
     const unreadable = await legacyIndex.createDocument({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       path: 'unreadable',
       kind: 'spatial',
       name: 'Damaged but present',
@@ -107,44 +107,44 @@ describe('FoldingBrowserIndex (tree-backed composition)', () => {
     await seedSyncDocument(unreadable.documentId, { raw: { v: 99 } })
 
     const index = new FoldingBrowserIndex()
-    const rows = await index.listDocuments({ workspaceId: BROWSER_WORKSPACE_ID })
+    const rows = await index.listDocuments({ workspaceId: getBrowserWorkspaceId() })
     expect(rows.map((row) => row.path)).toEqual(['readable', 'unreadable'])
 
     const resolved = await index.resolveDocumentById({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       documentId: unreadable.documentId,
     })
     expect(resolved?.path).toBe('unreadable')
     expect(resolved?.name).toBe('Damaged but present')
     expect(
-      await index.resolveDocument({ workspaceId: BROWSER_WORKSPACE_ID, path: 'unreadable' }),
+      await index.resolveDocument({ workspaceId: getBrowserWorkspaceId(), path: 'unreadable' }),
     ).not.toBeNull()
 
     // Deletable, so a user can clear a damaged document instead of keeping
     // an error screen forever.
-    await index.deleteDocument({ workspaceId: BROWSER_WORKSPACE_ID, path: 'unreadable' })
+    await index.deleteDocument({ workspaceId: getBrowserWorkspaceId(), path: 'unreadable' })
     expect(
-      (await index.listDocuments({ workspaceId: BROWSER_WORKSPACE_ID })).map((row) => row.path),
+      (await index.listDocuments({ workspaceId: getBrowserWorkspaceId() })).map((row) => row.path),
     ).toEqual(['readable'])
   })
 
   it('a kindless legacy row stays invisible — our own pre-kind data defect', async () => {
     const legacyIndex = new IdbDocumentIndex()
-    await legacyIndex.createWorkspace({ workspaceId: BROWSER_WORKSPACE_ID })
+    await legacyIndex.createWorkspace({ workspaceId: getBrowserWorkspaceId() })
     // createDocument requires a kind, so write the row the way the defect
     // actually exists: created, then stripped in place.
     const entry = await legacyIndex.createDocument({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       path: 'pre-kind',
       kind: 'spatial',
     })
     await stripKindInPlace(entry.documentId)
 
     const index = new FoldingBrowserIndex()
-    expect(await index.listDocuments({ workspaceId: BROWSER_WORKSPACE_ID })).toEqual([])
+    expect(await index.listDocuments({ workspaceId: getBrowserWorkspaceId() })).toEqual([])
     expect(
       await index.resolveDocumentById({
-        workspaceId: BROWSER_WORKSPACE_ID,
+        workspaceId: getBrowserWorkspaceId(),
         documentId: entry.documentId,
       }),
     ).toBeNull()
@@ -152,9 +152,9 @@ describe('FoldingBrowserIndex (tree-backed composition)', () => {
 
   it('delete evacuates into the trash; restore brings the document back under the same id', async () => {
     const index = new FoldingBrowserIndex()
-    await index.createWorkspace({ workspaceId: BROWSER_WORKSPACE_ID })
+    await index.createWorkspace({ workspaceId: getBrowserWorkspaceId() })
     const entry = await index.createDocument({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       path: 'doomed',
       kind: 'spatial',
       name: 'Doomed',
@@ -163,33 +163,33 @@ describe('FoldingBrowserIndex (tree-backed composition)', () => {
     writeSpatialCanvas(source, canvasWith('to bring back'))
     await seedWorkspaceDocumentContent(entry.documentId, source.export({ mode: 'snapshot' }))
 
-    await index.deleteDocument({ workspaceId: BROWSER_WORKSPACE_ID, path: 'doomed' })
-    const trash = await index.listTrash({ workspaceId: BROWSER_WORKSPACE_ID })
+    await index.deleteDocument({ workspaceId: getBrowserWorkspaceId(), path: 'doomed' })
+    const trash = await index.listTrash({ workspaceId: getBrowserWorkspaceId() })
     expect(trash.map((row) => row.documentId)).toEqual([entry.documentId])
     expect(trash[0]?.path).toBe('doomed')
 
     const restored = await index.restoreDocument({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       documentId: entry.documentId,
     })
     expect(restored?.documentId).toBe(entry.documentId)
     // Identity survives: the id resolves again, at the old path, with content.
     const back = await index.resolveDocumentById({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       documentId: entry.documentId,
     })
     expect(back?.path).toBe('doomed')
     const content = await loadDocumentContent(entry.documentId)
     const node = content === null ? null : readSpatialCanvas(content).nodes[0]
     expect(node?.type === 'text' ? node.text : null).toBe('to bring back')
-    expect(await index.listTrash({ workspaceId: BROWSER_WORKSPACE_ID })).toEqual([])
+    expect(await index.listTrash({ workspaceId: getBrowserWorkspaceId() })).toEqual([])
   })
 
   it('create, seed, rename and delete all round-trip through the tree', async () => {
     const index = new FoldingBrowserIndex()
-    await index.createWorkspace({ workspaceId: BROWSER_WORKSPACE_ID })
+    await index.createWorkspace({ workspaceId: getBrowserWorkspaceId() })
     const entry = await index.createDocument({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       path: 'fresh',
       kind: 'spatial',
     })
@@ -207,18 +207,18 @@ describe('FoldingBrowserIndex (tree-backed composition)', () => {
     expect((await new LoroStore().load(entry.documentId)).kind).toBe('not-found')
 
     await index.setDocumentName({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       documentId: entry.documentId,
       name: 'Renamed',
     })
     const renamed = await index.resolveDocumentById({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       documentId: entry.documentId,
     })
     expect(renamed?.name).toBe('Renamed')
 
-    await index.deleteDocument({ workspaceId: BROWSER_WORKSPACE_ID, path: 'fresh' })
-    expect(await index.listDocuments({ workspaceId: BROWSER_WORKSPACE_ID })).toEqual([])
+    await index.deleteDocument({ workspaceId: getBrowserWorkspaceId(), path: 'fresh' })
+    expect(await index.listDocuments({ workspaceId: getBrowserWorkspaceId() })).toEqual([])
     // Deleted from the tree means unreadable through the content path too.
     expect(await loadDocumentContent(entry.documentId)).toBeNull()
   })

--- a/apps/web/src/lib/local-document-summary.browser.test.tsx
+++ b/apps/web/src/lib/local-document-summary.browser.test.tsx
@@ -8,11 +8,12 @@
  * than bending the contract around them.
  */
 
+import { generateDocumentId } from '@kamiazya/whiteboard-model'
 import { Loro } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { getBrowserWorkspaceId, setBrowserWorkspaceIdForTests } from './browser-workspace-id.js'
 import { IdbDocumentIndex } from './idb-document-index.js'
 import {
-  BROWSER_WORKSPACE_ID,
   IdbDefaultDocumentPointer,
   idbContentClock,
   listLocalDocuments,
@@ -30,8 +31,13 @@ async function clearDb(): Promise<void> {
 }
 
 async function seedWorkspace(): Promise<IdbDocumentIndex> {
+  // This file's DB is claimed by literal name rather than through
+  // `claimIsolatedWhiteboardDb` (it predates that helper), so the
+  // `getBrowserWorkspaceId()` seam is not set for it automatically — set it
+  // fresh per test instead, matching what the seam-owning helper does.
+  setBrowserWorkspaceIdForTests(generateDocumentId())
   const index = new IdbDocumentIndex(DB_NAME)
-  await index.createWorkspace({ workspaceId: BROWSER_WORKSPACE_ID })
+  await index.createWorkspace({ workspaceId: getBrowserWorkspaceId() })
   return index
 }
 
@@ -48,7 +54,7 @@ describe('local document summary', () => {
   it('carries the index entry plus the time its content was last written', async () => {
     const index = await seedWorkspace()
     const entry = await index.createDocument({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       path: 'notes',
       kind: 'markdown',
       name: 'Notes',
@@ -70,7 +76,7 @@ describe('local document summary', () => {
     // a title. Choosing the fallback is this layer's job, not the port's.
     const index = await seedWorkspace()
     const entry = await index.createDocument({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       path: 'archive/untitled',
       kind: 'spatial',
     })
@@ -87,7 +93,7 @@ describe('local document summary', () => {
     // the sort puts it last rather than first.
     const index = await seedWorkspace()
     await index.createDocument({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       path: 'contentless',
       kind: 'spatial',
     })

--- a/apps/web/src/lib/local-document-summary.test.tsx
+++ b/apps/web/src/lib/local-document-summary.test.tsx
@@ -15,9 +15,9 @@
 import 'fake-indexeddb/auto'
 import { Loro } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import { IdbDocumentIndex } from './idb-document-index.js'
 import {
-  BROWSER_WORKSPACE_ID,
   IdbDefaultDocumentPointer,
   idbContentClock,
   listLocalDocuments,
@@ -36,7 +36,7 @@ async function clearDb(): Promise<void> {
 
 async function seedWorkspace(): Promise<IdbDocumentIndex> {
   const index = new IdbDocumentIndex(DB_NAME)
-  await index.createWorkspace({ workspaceId: BROWSER_WORKSPACE_ID })
+  await index.createWorkspace({ workspaceId: getBrowserWorkspaceId() })
   return index
 }
 
@@ -53,7 +53,7 @@ describe('local document summary', () => {
   it('carries the index entry plus the time its content was last written', async () => {
     const index = await seedWorkspace()
     const entry = await index.createDocument({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       path: 'notes',
       kind: 'markdown',
       name: 'Notes',
@@ -75,7 +75,7 @@ describe('local document summary', () => {
     // a title. Choosing the fallback is this layer's job, not the port's.
     const index = await seedWorkspace()
     const entry = await index.createDocument({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       path: 'archive/untitled',
       kind: 'spatial',
     })
@@ -92,7 +92,7 @@ describe('local document summary', () => {
     // the sort puts it last rather than first.
     const index = await seedWorkspace()
     await index.createDocument({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       path: 'contentless',
       kind: 'spatial',
     })

--- a/apps/web/src/lib/local-document-summary.ts
+++ b/apps/web/src/lib/local-document-summary.ts
@@ -1,16 +1,7 @@
 import type { DocumentEntry, DocumentIndex } from '@kamiazya/whiteboard-ports'
 import { CONTENT_TIMESTAMPS_STORE, openWhiteboardDb } from './browser-idb.js'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import type { DocumentSnapshot } from './whiteboard-client.js'
-
-/**
- * The one workspace a browser-kept setup has. Stored on every row rather than
- * implied, so a document kept here carries the same address a daemon one does.
- *
- * The VALUE keeps the retired keeper spelling because it is a stored shape:
- * every existing `DocumentIndex` row in IndexedDB is written against it, so
- * changing it here orphans them. It moves with a migration, not with a rename.
- */
-export const BROWSER_WORKSPACE_ID = 'local'
 
 /**
  * What `DocumentIndex` deliberately does not own, for browser mode.
@@ -76,7 +67,7 @@ async function contentUpdatedAt(db: IDBDatabase, ids: string[]): Promise<Map<str
 function toSnapshot(entry: DocumentEntry, updatedAt: string | undefined): DocumentSnapshot {
   return {
     documentId: entry.documentId,
-    workspaceId: BROWSER_WORKSPACE_ID,
+    workspaceId: getBrowserWorkspaceId(),
     path: entry.path,
     name: entry.name ?? entry.path,
     updatedAt: updatedAt ?? new Date(0).toISOString(),
@@ -116,14 +107,14 @@ export function idbContentClock(dbName?: string): ContentClock {
  * whether they are first.
  */
 export async function ensureLocalWorkspace(index: DocumentIndex): Promise<void> {
-  await index.createWorkspace({ workspaceId: BROWSER_WORKSPACE_ID })
+  await index.createWorkspace({ workspaceId: getBrowserWorkspaceId() })
 }
 
 export async function listLocalDocuments(
   index: DocumentIndex,
   clock: ContentClock = idbContentClock(),
 ): Promise<DocumentSnapshot[]> {
-  const entries = await index.listDocuments({ workspaceId: BROWSER_WORKSPACE_ID })
+  const entries = await index.listDocuments({ workspaceId: getBrowserWorkspaceId() })
   if (entries.length === 0) return []
   const stamps = await clock(entries.map((entry) => entry.documentId))
   return entries.map((entry) => toSnapshot(entry, stamps.get(entry.documentId)))
@@ -135,7 +126,10 @@ export async function loadLocalDocument(
   documentId: string,
   clock: ContentClock = idbContentClock(),
 ): Promise<DocumentSnapshot | null> {
-  const entry = await index.resolveDocumentById({ workspaceId: BROWSER_WORKSPACE_ID, documentId })
+  const entry = await index.resolveDocumentById({
+    workspaceId: getBrowserWorkspaceId(),
+    documentId,
+  })
   if (entry === null) return null
   const stamps = await clock([documentId])
   return toSnapshot(entry, stamps.get(documentId))

--- a/apps/web/src/lib/local-files-source.test.ts
+++ b/apps/web/src/lib/local-files-source.test.ts
@@ -8,6 +8,11 @@ import { Loro } from 'loro-crdt'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import {
+  getBrowserWorkspaceId,
+  resetBrowserWorkspaceIdForTests,
+  resolveBrowserWorkspaceId,
+} from './browser-workspace-id.js'
 import { FoldingBrowserIndex } from './folding-browser-index.js'
 import { IdbDocumentIndex } from './idb-document-index.js'
 import { ensureLocalWorkspace } from './local-document-summary.js'
@@ -22,11 +27,19 @@ describe('createLocalFilesSource', () => {
 
   it('lists a fresh database as empty, not as missing', async () => {
     // Written as the missing-workspace case first, and the test refuted its
-    // own premise: the v8+ IndexedDB upgrade seeds the `local` workspace row
+    // own premise: the v8+ IndexedDB upgrade seeds the browser workspace row
     // unconditionally, so a fresh database HAS the workspace before anything
     // else touches it. The `WorkspaceMissingError` mapping in the source
     // stays — it guards a state a hand-edited store can still reach — but the
     // reachable first-run behaviour is an empty list.
+    //
+    // Nothing seeds a workspace here on purpose — that is the point being
+    // tested — so `getBrowserWorkspaceId()` has to read the id the fresh
+    // database's own v14 upgrade actually minted, not the arbitrary id
+    // `claimIsolatedWhiteboardDb` claimed for tests that create their
+    // workspace explicitly under it.
+    resetBrowserWorkspaceIdForTests()
+    await resolveBrowserWorkspaceId()
     await expect(createLocalFilesSource().listDocuments()).resolves.toEqual([])
   })
 
@@ -37,7 +50,7 @@ describe('createLocalFilesSource', () => {
     const index = new IdbDocumentIndex()
     await ensureLocalWorkspace(index)
     const entry = await index.createDocument({
-      workspaceId: 'local',
+      workspaceId: getBrowserWorkspaceId(),
       path: 'a',
       kind: 'spatial',
       name: 'A',
@@ -57,9 +70,9 @@ describe('createLocalFilesSource', () => {
     // writes to — exactly the split the injectable parameter exists to
     // close, reopened by the default.
     const production = new FoldingBrowserIndex()
-    await production.createWorkspace({ workspaceId: 'local' }).catch(() => {})
+    await production.createWorkspace({ workspaceId: getBrowserWorkspaceId() }).catch(() => {})
     await production.createDocument({
-      workspaceId: 'local',
+      workspaceId: getBrowserWorkspaceId(),
       path: 'tree-only',
       kind: 'markdown',
       name: 'Tree Only',
@@ -119,7 +132,11 @@ describe('createLocalFilesSource', () => {
     const source = createLocalFilesSource()
     const index = new IdbDocumentIndex()
     await ensureLocalWorkspace(index)
-    const entry = await index.createDocument({ workspaceId: 'local', path: 'n', kind: 'markdown' })
+    const entry = await index.createDocument({
+      workspaceId: getBrowserWorkspaceId(),
+      path: 'n',
+      kind: 'markdown',
+    })
     const doc = new Loro()
     doc.getText('body').insert(0, '# Hello from local')
     await new LoroStore().save(entry.documentId, doc.export({ mode: 'snapshot' }))
@@ -132,7 +149,11 @@ describe('createLocalFilesSource', () => {
     const source = createLocalFilesSource()
     const index = new IdbDocumentIndex()
     await ensureLocalWorkspace(index)
-    const entry = await index.createDocument({ workspaceId: 'local', path: 's', kind: 'spatial' })
+    const entry = await index.createDocument({
+      workspaceId: getBrowserWorkspaceId(),
+      path: 's',
+      kind: 'spatial',
+    })
     const doc = new Loro()
     doc.getList('elements').push({ id: 'a' })
     doc.commit()
@@ -159,11 +180,15 @@ describe('createLocalFilesSource tags', () => {
     const index = new IdbDocumentIndex()
     await ensureLocalWorkspace(index)
     const tagged = await index.createDocument({
-      workspaceId: 'local',
+      workspaceId: getBrowserWorkspaceId(),
       path: 'tagged',
       kind: 'markdown',
     })
-    await index.createDocument({ workspaceId: 'local', path: 'plain', kind: 'markdown' })
+    await index.createDocument({
+      workspaceId: getBrowserWorkspaceId(),
+      path: 'plain',
+      kind: 'markdown',
+    })
 
     const doc = new Loro()
     writeCoreFacets(doc, { type: 'note', tags: ['release', 'q3'] })
@@ -182,13 +207,13 @@ describe('createLocalFilesSource trash', () => {
     const index = new FoldingBrowserIndex()
     await ensureLocalWorkspace(index)
     const entry = await index.createDocument({
-      workspaceId: 'local',
+      workspaceId: getBrowserWorkspaceId(),
       path: 'doomed',
       kind: 'spatial',
     })
     await seedWorkspaceDocumentContent(entry.documentId, new Loro().export({ mode: 'snapshot' }))
     const source = createLocalFilesSource({ index })
-    await index.deleteDocument({ workspaceId: 'local', path: 'doomed' })
+    await index.deleteDocument({ workspaceId: getBrowserWorkspaceId(), path: 'doomed' })
 
     const trash = await source.listTrash?.()
     expect(trash?.map((row) => row.documentId)).toEqual([entry.documentId])

--- a/apps/web/src/lib/local-files-source.ts
+++ b/apps/web/src/lib/local-files-source.ts
@@ -16,9 +16,9 @@ import {
   type WorkspaceFilesSource,
   WorkspaceMissingError,
 } from '../components/workspace-files/files-source.js'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import { FoldingBrowserIndex } from './folding-browser-index.js'
 import {
-  BROWSER_WORKSPACE_ID,
   type ContentClock,
   ensureLocalWorkspace,
   idbContentClock,
@@ -92,12 +92,12 @@ export function createLocalFilesSource(
     async listDocuments(): Promise<readonly WorkspaceDocumentEntry[]> {
       let entries: Awaited<ReturnType<DocumentIndex['listDocuments']>>
       try {
-        entries = await index.listDocuments({ workspaceId: BROWSER_WORKSPACE_ID })
+        entries = await index.listDocuments({ workspaceId: getBrowserWorkspaceId() })
       } catch (err) {
         // The panel's not-found state is mode-independent: this is the local
         // spelling of the daemon's 404.
         if (err instanceof WorkspaceNotFoundError) {
-          throw new WorkspaceMissingError(BROWSER_WORKSPACE_ID)
+          throw new WorkspaceMissingError(getBrowserWorkspaceId())
         }
         throw err
       }
@@ -140,7 +140,7 @@ export function createLocalFilesSource(
       await ensureLocalWorkspace(index)
       const trimmed = name?.trim()
       const entry = await index.createDocument({
-        workspaceId: BROWSER_WORKSPACE_ID,
+        workspaceId: getBrowserWorkspaceId(),
         path,
         kind,
         ...(trimmed ? { name: trimmed } : {}),
@@ -153,7 +153,7 @@ export function createLocalFilesSource(
         await loro.save(entry.documentId, loro.createEmptySnapshot())
       } catch (err) {
         try {
-          await index.deleteDocument({ workspaceId: BROWSER_WORKSPACE_ID, path: entry.path })
+          await index.deleteDocument({ workspaceId: getBrowserWorkspaceId(), path: entry.path })
         } catch {
           // Best-effort: a stray index row is harmless next to reporting a
           // create that did not happen.
@@ -163,7 +163,7 @@ export function createLocalFilesSource(
     },
 
     async renameDocumentPath(path: string, newPath: string): Promise<void> {
-      await index.moveDocument({ workspaceId: BROWSER_WORKSPACE_ID, from: path, to: newPath })
+      await index.moveDocument({ workspaceId: getBrowserWorkspaceId(), from: path, to: newPath })
     },
 
     async searchDocuments(query, limit = 20) {
@@ -217,7 +217,7 @@ export function createLocalFilesSource(
 
     async setDocumentName(entry, name): Promise<void> {
       await index.setDocumentName({
-        workspaceId: BROWSER_WORKSPACE_ID,
+        workspaceId: getBrowserWorkspaceId(),
         documentId: entry.documentId,
         // The port spells "clear" as absence, not empty string.
         ...(name === undefined ? {} : { name }),
@@ -242,7 +242,7 @@ export function createLocalFilesSource(
       ? {
           async listTrash() {
             const rows = await (index as FoldingBrowserIndex).listTrash({
-              workspaceId: BROWSER_WORKSPACE_ID,
+              workspaceId: getBrowserWorkspaceId(),
             })
             return rows.map((row) => ({
               documentId: row.documentId,
@@ -252,7 +252,7 @@ export function createLocalFilesSource(
           },
           async restoreFromTrash(documentId: string) {
             const restored = await (index as FoldingBrowserIndex).restoreDocument({
-              workspaceId: BROWSER_WORKSPACE_ID,
+              workspaceId: getBrowserWorkspaceId(),
               documentId,
             })
             // null means nothing came back — surfacing it is what lets the

--- a/apps/web/src/lib/local-search.browser.test.tsx
+++ b/apps/web/src/lib/local-search.browser.test.tsx
@@ -7,6 +7,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { Loro } from 'loro-crdt'
 import { describe, expect, it } from 'vitest'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import { IdbDocumentIndex } from './idb-document-index.js'
 import { ensureLocalWorkspace } from './local-document-summary.js'
 import { createLocalFilesSource } from './local-files-source.js'
@@ -20,7 +21,11 @@ import { seedWorkspaceDocumentContent } from './workspace-content.js'
 claimIsolatedWhiteboardDb('local-body-search')
 
 async function seedMarkdown(index: IdbDocumentIndex, path: string, body: string): Promise<string> {
-  const entry = await index.createDocument({ workspaceId: 'local', path, kind: 'markdown' })
+  const entry = await index.createDocument({
+    workspaceId: getBrowserWorkspaceId(),
+    path,
+    kind: 'markdown',
+  })
   const doc = new Loro()
   writeDocumentKind(doc, 'markdown')
   writeMarkdownBody(doc, body)
@@ -29,7 +34,11 @@ async function seedMarkdown(index: IdbDocumentIndex, path: string, body: string)
 }
 
 async function seedSpatial(index: IdbDocumentIndex, path: string, canvas: SpatialCanvas) {
-  const entry = await index.createDocument({ workspaceId: 'local', path, kind: 'spatial' })
+  const entry = await index.createDocument({
+    workspaceId: getBrowserWorkspaceId(),
+    path,
+    kind: 'spatial',
+  })
   const doc = new Loro()
   writeDocumentKind(doc, 'spatial')
   writeSpatialCanvas(doc, canvas)

--- a/apps/web/src/lib/loro-store-compaction.browser.test.tsx
+++ b/apps/web/src/lib/loro-store-compaction.browser.test.tsx
@@ -10,6 +10,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { COMPACT_DELTA_BYTES } from '@kamiazya/whiteboard-ports'
 import { LoroDoc } from 'loro-crdt'
 import { expect, it } from 'vitest'
+import { resolveBrowserWorkspaceId } from './browser-workspace-id.js'
 import { LoroStore } from './loro-store.js'
 
 function canvasWith(n: number, nudge = 0): SpatialCanvas {
@@ -32,6 +33,11 @@ function totalBytes(deltas: readonly Uint8Array[] | undefined): number {
 }
 
 it('folds the delta log once it passes the budget, keeping the content', async () => {
+  // Shared 'whiteboard' db, no isolation helper: `LoroStore` reads
+  // `getBrowserWorkspaceId()` to build a `DocRef` (unused for `document:`
+  // keys, but still read), so it has to be resolved once against whichever
+  // single workspace this shared database already holds.
+  await resolveBrowserWorkspaceId()
   const store = new LoroStore()
   const id = `doc-${Math.trunc(performance.now() * 1000)}`
 
@@ -75,6 +81,7 @@ it('folds the delta log once it passes the budget, keeping the content', async (
 // snapshot or the deltas already there, and the repo's own loro-store tests
 // seed a v:1 envelope carrying invalid Loro bytes.
 it('keeps a log it cannot replay rather than dropping the edits', async () => {
+  await resolveBrowserWorkspaceId()
   const store = new LoroStore()
   const id = `unfoldable-${Math.trunc(performance.now() * 1000)}`
 

--- a/apps/web/src/lib/loro-store.ts
+++ b/apps/web/src/lib/loro-store.ts
@@ -25,9 +25,9 @@ import {
 } from '@kamiazya/whiteboard-ports'
 import { Loro } from 'loro-crdt'
 import { CONTENT_TIMESTAMPS_STORE } from './browser-idb.js'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import { IdbDocumentStore } from './idb-document-store.js'
 import { inTransaction, request } from './idb-tx.js'
-import { BROWSER_WORKSPACE_ID } from './local-document-summary.js'
 
 /**
  * Narrow surface consumers need to seed, read back, and persist a document's
@@ -65,7 +65,7 @@ const EMPTY_FRONTIER = new Uint8Array()
 
 function refOf(documentId: string): DocRef {
   // Every document this store keeps lives in the browser's own workspace.
-  return { kind: 'document', workspaceId: BROWSER_WORKSPACE_ID, documentId }
+  return { kind: 'document', workspaceId: getBrowserWorkspaceId(), documentId }
 }
 
 /**

--- a/apps/web/src/lib/promote-workspace.browser.test.tsx
+++ b/apps/web/src/lib/promote-workspace.browser.test.tsx
@@ -19,6 +19,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import { DocumentFileStore } from './document-file-store.js'
 import { FoldingBrowserIndex } from './folding-browser-index.js'
 import { ensureLocalWorkspace } from './local-document-summary.js'
@@ -99,12 +100,12 @@ describe('promoteWorkspace', () => {
     const index = new FoldingBrowserIndex()
     await ensureLocalWorkspace(index)
     const roadmap = await index.createDocument({
-      workspaceId: 'local',
+      workspaceId: getBrowserWorkspaceId(),
       path: 'notes/roadmap',
       kind: 'markdown',
     })
     const contested = await index.createDocument({
-      workspaceId: 'local',
+      workspaceId: getBrowserWorkspaceId(),
       path: 'contested',
       kind: 'spatial',
     })
@@ -172,7 +173,7 @@ describe('promoteWorkspace', () => {
     const index = new FoldingBrowserIndex()
     await ensureLocalWorkspace(index)
     const sketch = await index.createDocument({
-      workspaceId: 'local',
+      workspaceId: getBrowserWorkspaceId(),
       path: 'sketch',
       kind: 'spatial',
     })
@@ -212,7 +213,11 @@ describe('promoteWorkspace', () => {
   it('a 404 target is a structured failure naming the missing daemon workspace', async () => {
     const index = new FoldingBrowserIndex()
     await ensureLocalWorkspace(index)
-    await index.createDocument({ workspaceId: 'local', path: 'doc', kind: 'markdown' })
+    await index.createDocument({
+      workspaceId: getBrowserWorkspaceId(),
+      path: 'doc',
+      kind: 'markdown',
+    })
     const fetch404 = (async () =>
       new Response(JSON.stringify({ title: 'Workspace "ws-gone" not found' }), {
         status: 404,
@@ -233,7 +238,11 @@ describe('promoteWorkspace', () => {
   it('a thrown fetch is a structured network failure, never a rejection', async () => {
     const index = new FoldingBrowserIndex()
     await ensureLocalWorkspace(index)
-    await index.createDocument({ workspaceId: 'local', path: 'doc', kind: 'markdown' })
+    await index.createDocument({
+      workspaceId: getBrowserWorkspaceId(),
+      path: 'doc',
+      kind: 'markdown',
+    })
     const fetchDown = (async () => {
       throw new TypeError('Failed to fetch')
     }) as typeof globalThis.fetch

--- a/apps/web/src/lib/promote-workspace.ts
+++ b/apps/web/src/lib/promote-workspace.ts
@@ -28,9 +28,9 @@ import {
 import { apiErrorReason, documentFileApiUrl } from '@kamiazya/whiteboard-mcp/api-contracts'
 import { imageRefId, isImageRef } from '@kamiazya/whiteboard-model'
 import type { WorkspaceDocs } from '@kamiazya/whiteboard-workspace-index'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import { listDocuments } from './daemon-api-client.js'
 import { DocumentFileStore } from './document-file-store.js'
-import { BROWSER_WORKSPACE_ID } from './local-document-summary.js'
 
 export interface PromoteWorkspaceOptions {
   fetch: typeof globalThis.fetch
@@ -55,7 +55,7 @@ export interface PromoteWorkspaceOptions {
 export async function countBrowserWorkspaceDocuments(
   workspaceDocs: WorkspaceDocs,
 ): Promise<number> {
-  const record = await workspaceDocs.open(BROWSER_WORKSPACE_ID)
+  const record = await workspaceDocs.open(getBrowserWorkspaceId())
   if (record === null) return 0
   return readWorkspaceDocuments(record).length
 }
@@ -136,7 +136,7 @@ async function promoteWorkspaceUnsafe(
   // the same claimed database, so tests seed through the production path.
   const fileStore = new DocumentFileStore()
 
-  const record = await workspaceDocs.open(BROWSER_WORKSPACE_ID)
+  const record = await workspaceDocs.open(getBrowserWorkspaceId())
   if (record === null) {
     return { kind: 'failed', reason: 'This browser keeps no workspace record to promote.' }
   }

--- a/apps/web/src/lib/workspace-content.ts
+++ b/apps/web/src/lib/workspace-content.ts
@@ -15,7 +15,7 @@ import {
 } from '@kamiazya/whiteboard-loro-adapter'
 import { Loro, type LoroDoc } from 'loro-crdt'
 import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
-import { BROWSER_WORKSPACE_ID } from './local-document-summary.js'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import { LoroStore, touchContentTimestamp } from './loro-store.js'
 
 /**
@@ -55,7 +55,7 @@ export async function loadWorkspaceDocumentProjection(
   dbName?: string,
 ): Promise<LoroDoc | null> {
   const workspace = await new BrowserWorkspaceDocs(dbName)
-    .open(BROWSER_WORKSPACE_ID)
+    .open(getBrowserWorkspaceId())
     .catch(() => null)
   if (workspace === null) return null
   return projectWorkspaceDocument(workspace, documentId)
@@ -71,7 +71,7 @@ export async function touchIfWorkspaceBacked(
   dbName?: string,
 ): Promise<boolean> {
   const workspace = await new BrowserWorkspaceDocs(dbName)
-    .open(BROWSER_WORKSPACE_ID)
+    .open(getBrowserWorkspaceId())
     .catch(() => null)
   if (workspace === null) return false
   if (resolveWorkspaceDocumentById(workspace, documentId) === null) return false
@@ -85,12 +85,12 @@ export async function seedWorkspaceDocumentContent(
   dbName?: string,
 ): Promise<boolean> {
   const docs = new BrowserWorkspaceDocs(dbName)
-  const workspace = await docs.open(BROWSER_WORKSPACE_ID).catch(() => null)
+  const workspace = await docs.open(getBrowserWorkspaceId()).catch(() => null)
   if (workspace === null) return false
   const source = new Loro()
   source.import(content)
   if (!writeWorkspaceDocumentContent(workspace, documentId, source)) return false
-  await docs.save(BROWSER_WORKSPACE_ID, workspace)
+  await docs.save(getBrowserWorkspaceId(), workspace)
   await touchContentTimestamp(documentId, dbName)
   return true
 }

--- a/apps/web/src/lib/workspace-content.ts
+++ b/apps/web/src/lib/workspace-content.ts
@@ -14,7 +14,7 @@ import {
   writeWorkspaceDocumentContent,
 } from '@kamiazya/whiteboard-loro-adapter'
 import { Loro, type LoroDoc } from 'loro-crdt'
-import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
+import { BrowserWorkspaceDocs, openWorkspaceOrNull } from './browser-workspace-docs.js'
 import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import { LoroStore, touchContentTimestamp } from './loro-store.js'
 
@@ -54,9 +54,7 @@ export async function loadWorkspaceDocumentProjection(
   documentId: string,
   dbName?: string,
 ): Promise<LoroDoc | null> {
-  const workspace = await new BrowserWorkspaceDocs(dbName)
-    .open(getBrowserWorkspaceId())
-    .catch(() => null)
+  const workspace = await openWorkspaceOrNull(new BrowserWorkspaceDocs(dbName))
   if (workspace === null) return null
   return projectWorkspaceDocument(workspace, documentId)
 }
@@ -70,9 +68,7 @@ export async function touchIfWorkspaceBacked(
   documentId: string,
   dbName?: string,
 ): Promise<boolean> {
-  const workspace = await new BrowserWorkspaceDocs(dbName)
-    .open(getBrowserWorkspaceId())
-    .catch(() => null)
+  const workspace = await openWorkspaceOrNull(new BrowserWorkspaceDocs(dbName))
   if (workspace === null) return false
   if (resolveWorkspaceDocumentById(workspace, documentId) === null) return false
   await touchContentTimestamp(documentId, dbName)
@@ -85,7 +81,7 @@ export async function seedWorkspaceDocumentContent(
   dbName?: string,
 ): Promise<boolean> {
   const docs = new BrowserWorkspaceDocs(dbName)
-  const workspace = await docs.open(getBrowserWorkspaceId()).catch(() => null)
+  const workspace = await openWorkspaceOrNull(docs)
   if (workspace === null) return false
   const source = new Loro()
   source.import(content)

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,13 +1,4 @@
-// Deliberately the narrow subpath, not the package barrel: the barrel
-// re-exports CanvasViewer and the scene codec, which drag canvas-render and
-// codec's remark pipeline onto the critical path for a module that
-// only needs the font loader. The bundle-size gate fails if this regresses.
-import { ensureViewerFontLoaded } from '@kamiazya/whiteboard-canvas-viewer/font-loading'
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
-import { App } from './App.js'
-import { dismissBootSplash } from './boot-splash.js'
+import { startBootSequence } from './boot.js'
 import { applyThemeClass, readPersistedTheme, resolveTheme } from './hooks/useThemeMode.js'
 import './index.css'
 import { initInstallPromptCapture } from './lib/install-prompt-store.js'
@@ -36,31 +27,8 @@ installMobileAppShellGuards()
 const rootEl = document.getElementById('root')
 if (!rootEl) throw new Error('Root element #root not found')
 
-function renderApp(root: HTMLElement): void {
-  createRoot(root).render(
-    <StrictMode>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </StrictMode>,
-  )
-}
-
-// Bounded await: every on-screen text measurement (SpatialEditor,
-// MarkdownEditor's preview pane, useDocumentSync) must use the same vendored
-// Roboto face the Node export pipeline measures, or wrapped-line counts and
-// content sizing silently diverge between what a user sees and what they
-// export. This is the one seam that covers all three, including
-// useDocumentSync's non-React measurer construction. ensureViewerFontLoaded()
-// bounds the wait itself (VIEWER_FONT_LOAD_TIMEOUT_MS), so a stalled font
-// fetch delays first paint by at most that bound rather than hanging
-// indefinitely — first paint then proceeds with fallback system-font
-// metrics and self-corrects once the font finishes loading in the
-// background (see CanvasViewer's useViewerFontReady for that path).
-//
-// dismissBootSplash then paces the index.html splash: the app is ready at
-// this point, but the splash stays up until its draw animation lands plus
-// a beat, and fades out before React's first commit replaces it.
-void ensureViewerFontLoaded()
-  .then(() => dismissBootSplash())
-  .then(() => renderApp(rootEl))
+// The full chain — font load, workspace-id resolve, splash dismissal, render
+// — lives in boot.ts, so the resolver-rejection path is testable through the
+// real sequence. See its module comment for why a rejection there must not
+// block this call.
+void startBootSequence({ rootEl })

--- a/apps/web/src/pages/BrowserDocumentPage.file-refs.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.file-refs.test.tsx
@@ -9,7 +9,7 @@ import { act, cleanup, render as rtlRender, screen, waitFor } from '@testing-lib
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { SpatialEditorProps } from '../components/spatial-editor/index.js'
-import { BROWSER_WORKSPACE_ID } from '../lib/local-document-summary.js'
+import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import type { LoroLoadResult } from '../lib/loro-store.js'
 import { LocalStoreDouble } from '../test-utils/local-index.js'
 import type { LoroStoreLike } from './use-browser-document-controller.js'
@@ -73,7 +73,7 @@ async function seededStore(): Promise<LocalStoreDouble> {
   await store.setDefaultDocumentId(HERE_ID)
   await store.save({
     documentId: HERE_ID,
-    workspaceId: BROWSER_WORKSPACE_ID,
+    workspaceId: getBrowserWorkspaceId(),
     path: 'here',
     name: 'Here',
     updatedAt: '2026-05-24T00:00:00.000Z',
@@ -81,7 +81,7 @@ async function seededStore(): Promise<LocalStoreDouble> {
   })
   await store.save({
     documentId: TARGET_ID,
-    workspaceId: BROWSER_WORKSPACE_ID,
+    workspaceId: getBrowserWorkspaceId(),
     // Deliberately unlike both the id and the display name: a fixture where
     // any of the three could stand in for another proves nothing about which
     // one the wiring actually used.

--- a/apps/web/src/pages/BrowserDocumentPage.fullscreen.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.fullscreen.browser.test.tsx
@@ -8,15 +8,25 @@
  * transitions. Focus-restore is the class behind three root-caused flakes,
  * so it is pinned here against the real thing.
  */
+import { generateDocumentId } from '@kamiazya/whiteboard-model'
 import { act, cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
 import type { ReactElement } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, expect, it } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import {
+  getBrowserWorkspaceId,
+  setBrowserWorkspaceIdForTests,
+} from '../lib/browser-workspace-id.js'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
 import { LocalStoreDouble } from '../test-utils/local-index.js'
 import { BrowserDocumentPage } from './BrowserDocumentPage.js'
 import '../index.css'
+
+// No real IndexedDB in this file (`LocalStoreDouble` is in-memory), so
+// nothing else in this page's module graph resolves the workspace-id
+// accessor the way `claimIsolatedWhiteboardDb` would for a real-DB file.
+setBrowserWorkspaceIdForTests(generateDocumentId())
 
 afterEach(async () => {
   if (document.fullscreenElement !== null) {
@@ -35,7 +45,7 @@ function render(ui: ReactElement) {
 
 const snap: DocumentSnapshot = {
   documentId: '0PV05AFMSY38DJQW16BGNTZ49E',
-  workspaceId: 'local',
+  workspaceId: getBrowserWorkspaceId(),
   path: 'canvas-a',
   name: 'Canvas A',
   kind: 'spatial',

--- a/apps/web/src/pages/BrowserDocumentPage.node-lock.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.node-lock.test.tsx
@@ -34,8 +34,9 @@ import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { EditorCommand } from '../components/spatial-editor/commands.js'
 import { BrowserWorkspaceDocs } from '../lib/browser-workspace-docs.js'
+import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import { IdbDocumentIndex } from '../lib/idb-document-index.js'
-import { BROWSER_WORKSPACE_ID, IdbDefaultDocumentPointer } from '../lib/local-document-summary.js'
+import { IdbDefaultDocumentPointer } from '../lib/local-document-summary.js'
 import {
   clearWhiteboardDb,
   createNodeCommand,
@@ -102,7 +103,7 @@ async function waitForStoredLocks(want: 'some' | 'none'): Promise<void> {
   await waitFor(
     async () => {
       const id = (await new IdbDefaultDocumentPointer().get()) ?? ''
-      const workspace = await new BrowserWorkspaceDocs().open(BROWSER_WORKSPACE_ID)
+      const workspace = await new BrowserWorkspaceDocs().open(getBrowserWorkspaceId())
       expect(workspace).not.toBeNull()
       if (workspace === null) return
       expect(resolveWorkspaceDocumentById(workspace, id)).not.toBeNull()

--- a/apps/web/src/pages/BrowserDocumentPage.stale-link.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.stale-link.test.tsx
@@ -9,7 +9,7 @@
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { BROWSER_WORKSPACE_ID } from '../lib/local-document-summary.js'
+import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import type { LoroLoadResult } from '../lib/loro-store.js'
 import { LocalStoreDouble } from '../test-utils/local-index.js'
 import type { LoroStoreLike } from './use-browser-document-controller.js'
@@ -59,7 +59,7 @@ describe('stale /local/:path deep link', () => {
     await store.setDefaultDocumentId('005AFMSY38DJQW16BGNTZ49EKR')
     await store.save({
       documentId: '005AFMSY38DJQW16BGNTZ49EKR',
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       // Deliberately not the id: the fallback below has to be reached by PATH,
       // and an id-shaped path could not tell the two apart.
       path: 'real-canvas',
@@ -110,7 +110,7 @@ describe('stale /local/:path deep link', () => {
     await store.setDefaultDocumentId('005AFMSY38DJQW16BGNTZ49EKR')
     await store.save({
       documentId: '005AFMSY38DJQW16BGNTZ49EKR',
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       path: 'real-canvas',
       name: 'Real canvas',
       updatedAt: '2026-05-24T00:00:00.000Z',
@@ -162,7 +162,7 @@ describe('stale /local/:path deep link', () => {
     await store.setDefaultDocumentId('005AFMSY38DJQW16BGNTZ49EKR')
     await store.save({
       documentId: '005AFMSY38DJQW16BGNTZ49EKR',
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       path: 'real-canvas',
       name: 'Real canvas',
       updatedAt: '2026-05-24T00:00:00.000Z',
@@ -170,7 +170,7 @@ describe('stale /local/:path deep link', () => {
     })
     await store.save({
       documentId: '01ARZ3NDEKTSV4RRFFQ69G5FB0',
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       path: 'other-canvas',
       name: 'Other canvas',
       updatedAt: '2026-05-25T00:00:00.000Z',

--- a/apps/web/src/pages/BrowserDocumentPage.unreadable-content.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.unreadable-content.test.tsx
@@ -13,6 +13,7 @@ import { cleanup, render as rtlRender, screen, waitFor } from '@testing-library/
 import type { ReactElement } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import { FoldingBrowserIndex } from '../lib/folding-browser-index.js'
 import { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { ensureLocalWorkspace, IdbDefaultDocumentPointer } from '../lib/local-document-summary.js'
@@ -45,7 +46,7 @@ async function seedDocumentWithContent(
   const index = new IdbDocumentIndex()
   await ensureLocalWorkspace(index)
   const entry = await index.createDocument({
-    workspaceId: 'local',
+    workspaceId: getBrowserWorkspaceId(),
     path: 'unreadable',
     name: 'Unreadable',
     kind: 'spatial',
@@ -92,14 +93,14 @@ describe('a document this build cannot read', () => {
     const index = new IdbDocumentIndex()
     await ensureLocalWorkspace(index)
     const broken = await index.createDocument({
-      workspaceId: 'local',
+      workspaceId: getBrowserWorkspaceId(),
       path: 'broken',
       name: 'Broken',
       kind: 'spatial',
     })
     await seedSyncDocument(broken.documentId, { raw: { v: 99 } }, DB)
     const sound = await index.createDocument({
-      workspaceId: 'local',
+      workspaceId: getBrowserWorkspaceId(),
       path: 'sound',
       name: 'Sound',
       kind: 'spatial',

--- a/apps/web/src/pages/BrowserIndexPage.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.test.tsx
@@ -2,7 +2,7 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { BROWSER_WORKSPACE_ID } from '../lib/local-document-summary.js'
+import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
 import { LocalStoreDouble } from '../test-utils/local-index.js'
 import { pickNewDocumentKind } from '../test-utils/new-document-menu.js'
@@ -383,7 +383,7 @@ describe('BrowserIndexPage', () => {
     const store = await seededStore([
       {
         documentId: '0CFJNRVY147ADGKPSWZ258BEHM',
-        workspaceId: BROWSER_WORKSPACE_ID,
+        workspaceId: getBrowserWorkspaceId(),
         path: 'diagrams/structure',
         name: '構成図',
         updatedAt: '2026-08-02T00:00:00Z',
@@ -391,7 +391,7 @@ describe('BrowserIndexPage', () => {
       },
       {
         documentId: '0KPSWZ258BEHMQTX0369CFJNRV',
-        workspaceId: BROWSER_WORKSPACE_ID,
+        workspaceId: getBrowserWorkspaceId(),
         path: 'notes/design',
         name: '設計メモ',
         updatedAt: '2026-08-01T00:00:00Z',

--- a/apps/web/src/pages/BrowserIndexPage.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.tsx
@@ -5,10 +5,10 @@ import { DeleteDocumentDialog } from '../components/document-list/DeleteDocument
 import { EmptyWorkspaceState } from '../components/workspace-files/EmptyWorkspaceState.js'
 import { WorkspaceFilesPanel } from '../components/workspace-files/WorkspaceFilesPanel.js'
 import { useRoutedFolder } from '../hooks/useRoutedFolder.js'
+import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import { sharedFoldingBrowserIndex } from '../lib/folding-browser-index.js'
 import { kindNoun } from '../lib/kind-noun.js'
 import {
-  BROWSER_WORKSPACE_ID,
   type ContentClock,
   type DefaultDocumentPointer,
   ensureLocalWorkspace,
@@ -128,10 +128,10 @@ export function BrowserIndexPage({
       // editor.
       const pointed = await pointer.get()
       const target = await index.resolveDocument({
-        workspaceId: BROWSER_WORKSPACE_ID,
+        workspaceId: getBrowserWorkspaceId(),
         path: pendingDelete.path,
       })
-      await index.deleteDocument({ workspaceId: BROWSER_WORKSPACE_ID, path: pendingDelete.path })
+      await index.deleteDocument({ workspaceId: getBrowserWorkspaceId(), path: pendingDelete.path })
       if (pointed !== null && target !== null && pointed === target.documentId) {
         await pointer.clear()
       }

--- a/apps/web/src/pages/local-body-search.browser.test.tsx
+++ b/apps/web/src/pages/local-body-search.browser.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { Loro } from 'loro-crdt'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { ensureLocalWorkspace } from '../lib/local-document-summary.js'
 import { LoroStore } from '../lib/loro-store.js'
@@ -21,7 +22,7 @@ describe('searching from the page', () => {
     const index = new IdbDocumentIndex()
     await ensureLocalWorkspace(index)
     const entry = await index.createDocument({
-      workspaceId: 'local',
+      workspaceId: getBrowserWorkspaceId(),
       path: 'untitled',
       kind: 'markdown',
     })

--- a/apps/web/src/pages/use-browser-document-controller.test.ts
+++ b/apps/web/src/pages/use-browser-document-controller.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook } from '@testing-library/react'
 import { Loro } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { BROWSER_WORKSPACE_ID } from '../lib/local-document-summary.js'
+import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import type { LoroLoadResult } from '../lib/loro-store.js'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
 import { LocalStoreDouble } from '../test-utils/local-index.js'
@@ -53,7 +53,7 @@ const C2 = '01ARZ3NDEKTSV4RRFFQ69G5FB0'
 
 const snap: DocumentSnapshot = {
   documentId: C1,
-  workspaceId: 'local',
+  workspaceId: getBrowserWorkspaceId(),
   path: 'untitled',
   name: 'untitled',
   updatedAt: '2026-05-24T00:00:00.000Z',
@@ -665,7 +665,7 @@ describe('useBrowserDocumentController', () => {
 
     expect(result.current.snapshot?.name).toBe('Restored name')
     const stored = await store.index.resolveDocumentById({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       documentId: C1,
     })
     expect(stored?.name).toBe('Restored name')
@@ -693,7 +693,7 @@ describe('useBrowserDocumentController', () => {
       await act(async () => {
         created = await result.current.createDocument('Second')
       })
-      expect(created?.workspaceId).toBe(BROWSER_WORKSPACE_ID)
+      expect(created?.workspaceId).toBe(getBrowserWorkspaceId())
     })
 
     // Two documents at one address is the failure the path exists to
@@ -727,7 +727,7 @@ describe('useBrowserDocumentController', () => {
   describe('initialPath (deep-linked document)', () => {
     const other: DocumentSnapshot = {
       documentId: C2,
-      workspaceId: 'local',
+      workspaceId: getBrowserWorkspaceId(),
       path: 'other-canvas',
       name: 'other canvas',
       updatedAt: '2026-05-24T00:00:00.000Z',
@@ -1337,7 +1337,7 @@ describe('useBrowserDocumentController', () => {
       await store.save(snap)
       await store.save({
         documentId: '01ARZ3NDEKTSV4RRFFQ69G5FD2',
-        workspaceId: 'local',
+        workspaceId: getBrowserWorkspaceId(),
         path: 'untitled-2',
         name: 'untitled (copy)',
         updatedAt: snap.updatedAt,

--- a/apps/web/src/pages/use-browser-document-controller.ts
+++ b/apps/web/src/pages/use-browser-document-controller.ts
@@ -2,7 +2,7 @@ import { projectWorkspaceDocument } from '@kamiazya/whiteboard-loro-adapter'
 import type { DocumentIndex } from '@kamiazya/whiteboard-ports'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { newDocumentPathIn } from '../components/workspace-files/new-document-path.js'
-import { BrowserWorkspaceDocs } from '../lib/browser-workspace-docs.js'
+import { BrowserWorkspaceDocs, openWorkspaceOrNull } from '../lib/browser-workspace-docs.js'
 import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import { deriveCopyName } from '../lib/derive-copy-name.js'
 import {
@@ -547,9 +547,7 @@ export function useBrowserDocumentController(
     // moment the editor commits. Projection first, old record as the fallback
     // for a document nothing has folded yet (and for jsdom tests, whose
     // injected store is the only storage there is).
-    const workspace = await new BrowserWorkspaceDocs()
-      .open(getBrowserWorkspaceId())
-      .catch(() => null)
+    const workspace = await openWorkspaceOrNull(new BrowserWorkspaceDocs())
     const projected =
       workspace === null ? null : projectWorkspaceDocument(workspace, source.documentId)
     let mergedSnapshot: Uint8Array

--- a/apps/web/src/pages/use-browser-document-controller.ts
+++ b/apps/web/src/pages/use-browser-document-controller.ts
@@ -3,7 +3,7 @@ import type { DocumentIndex } from '@kamiazya/whiteboard-ports'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { newDocumentPathIn } from '../components/workspace-files/new-document-path.js'
 import { BrowserWorkspaceDocs, openWorkspaceOrNull } from '../lib/browser-workspace-docs.js'
-import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
+import { browserWorkspaceIdOrNull, getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import { deriveCopyName } from '../lib/derive-copy-name.js'
 import {
   type ContentClock,
@@ -268,9 +268,17 @@ export function useBrowserDocumentController(
         // read throw instead would dead-end EVERY deep link on a degraded
         // store — and App mounts this page only with a path, so that is every
         // mount.
-        const requested = await indexRef.current
-          .resolveDocument({ workspaceId: getBrowserWorkspaceId(), path: initialPath })
-          .catch(() => null)
+        // The id is read through the null-answering accessor for the same
+        // reason: in an argument position its throw would precede the promise
+        // and escape the `.catch` below, dead-ending the deep link this
+        // fallback exists to keep open.
+        const workspaceId = browserWorkspaceIdOrNull()
+        const requested =
+          workspaceId === null
+            ? null
+            : await indexRef.current
+                .resolveDocument({ workspaceId, path: initialPath })
+                .catch(() => null)
         if (cancelled) return
         if (requested !== null) {
           const snap = await loadLocalDocument(

--- a/apps/web/src/pages/use-browser-document-controller.ts
+++ b/apps/web/src/pages/use-browser-document-controller.ts
@@ -3,9 +3,9 @@ import type { DocumentIndex } from '@kamiazya/whiteboard-ports'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { newDocumentPathIn } from '../components/workspace-files/new-document-path.js'
 import { BrowserWorkspaceDocs } from '../lib/browser-workspace-docs.js'
+import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import { deriveCopyName } from '../lib/derive-copy-name.js'
 import {
-  BROWSER_WORKSPACE_ID,
   type ContentClock,
   type DefaultDocumentPointer,
   ensureLocalWorkspace,
@@ -88,7 +88,7 @@ export async function createSeededDocument(
   const taken = (await listLocalDocuments(index, clock).catch(() => [])).map((row) => row.path)
   const trimmed = name?.trim()
   const entry = await index.createDocument({
-    workspaceId: BROWSER_WORKSPACE_ID,
+    workspaceId: getBrowserWorkspaceId(),
     path: newDocumentPathIn('', taken),
     kind,
     ...(trimmed ? { name: trimmed } : {}),
@@ -108,7 +108,7 @@ export async function createSeededDocument(
     }
   } catch (err) {
     try {
-      await index.deleteDocument({ workspaceId: BROWSER_WORKSPACE_ID, path: entry.path })
+      await index.deleteDocument({ workspaceId: getBrowserWorkspaceId(), path: entry.path })
     } catch {
       // Rollback is best-effort; a stray index row is harmless next to
       // reporting a create that did not happen.
@@ -229,7 +229,7 @@ export function useBrowserDocumentController(
           // A rename is the only mutation that reaches the save path, and the
           // index keys it by id so the document does not move.
           await indexRef.current.setDocumentName({
-            workspaceId: BROWSER_WORKSPACE_ID,
+            workspaceId: getBrowserWorkspaceId(),
             documentId: snap.documentId,
             // Omitted when it equals the path, which is how the index spells
             // "no name of its own" — see `toSnapshot`'s fallback.
@@ -269,7 +269,7 @@ export function useBrowserDocumentController(
         // store — and App mounts this page only with a path, so that is every
         // mount.
         const requested = await indexRef.current
-          .resolveDocument({ workspaceId: BROWSER_WORKSPACE_ID, path: initialPath })
+          .resolveDocument({ workspaceId: getBrowserWorkspaceId(), path: initialPath })
           .catch(() => null)
         if (cancelled) return
         if (requested !== null) {
@@ -390,12 +390,12 @@ export function useBrowserDocumentController(
     if (id === null) return
     try {
       const entry = await indexRef.current.resolveDocumentById({
-        workspaceId: BROWSER_WORKSPACE_ID,
+        workspaceId: getBrowserWorkspaceId(),
         documentId: id,
       })
       if (entry === null) return // the pointer names nothing: silent no-op
       await indexRef.current.deleteDocument({
-        workspaceId: BROWSER_WORKSPACE_ID,
+        workspaceId: getBrowserWorkspaceId(),
         path: entry.path,
       })
       await pointerRef.current.clear()
@@ -422,7 +422,7 @@ export function useBrowserDocumentController(
       if (existingId !== null && existingId !== fresh.documentId) {
         try {
           const stale = await indexRef.current.resolveDocumentById({
-            workspaceId: BROWSER_WORKSPACE_ID,
+            workspaceId: getBrowserWorkspaceId(),
             documentId: existingId,
           })
           if (stale !== null) {
@@ -434,7 +434,7 @@ export function useBrowserDocumentController(
             // deleting by path has no such coupling, so the clear is explicit.
             await pointerRef.current.clear()
             await indexRef.current.deleteDocument({
-              workspaceId: BROWSER_WORKSPACE_ID,
+              workspaceId: getBrowserWorkspaceId(),
               path: stale.path,
             })
           }
@@ -547,7 +547,9 @@ export function useBrowserDocumentController(
     // moment the editor commits. Projection first, old record as the fallback
     // for a document nothing has folded yet (and for jsdom tests, whose
     // injected store is the only storage there is).
-    const workspace = await new BrowserWorkspaceDocs().open(BROWSER_WORKSPACE_ID).catch(() => null)
+    const workspace = await new BrowserWorkspaceDocs()
+      .open(getBrowserWorkspaceId())
+      .catch(() => null)
     const projected =
       workspace === null ? null : projectWorkspaceDocument(workspace, source.documentId)
     let mergedSnapshot: Uint8Array

--- a/apps/web/src/pages/use-markdown-document.ts
+++ b/apps/web/src/pages/use-markdown-document.ts
@@ -39,8 +39,8 @@ import { Loro, type LoroText } from 'loro-crdt'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { getAppLogger } from '../lib/app-logger.js'
 import { BrowserWorkspaceDocs } from '../lib/browser-workspace-docs.js'
+import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import { foldWorkspaceDocuments } from '../lib/fold-workspace.js'
-import { BROWSER_WORKSPACE_ID } from '../lib/local-document-summary.js'
 import { touchContentTimestamp } from '../lib/loro-store.js'
 import type { LoroStoreLike } from './use-browser-document-controller.js'
 
@@ -135,7 +135,7 @@ async function openWorkspaceHost(documentId: string): Promise<ContentHost | null
     log.warn('startup fold failed; continuing without it', err)
   }
   const docs = new BrowserWorkspaceDocs()
-  const workspace = await docs.open(BROWSER_WORKSPACE_ID).catch(() => null)
+  const workspace = await docs.open(getBrowserWorkspaceId()).catch(() => null)
   if (workspace === null) return null
   if (resolveWorkspaceDocumentById(workspace, documentId) === null) return null
   return {
@@ -143,7 +143,7 @@ async function openWorkspaceHost(documentId: string): Promise<ContentHost | null
     doc: workspace,
     containers: documentContainers(workspace, documentId),
     save: async () => {
-      await docs.save(BROWSER_WORKSPACE_ID, workspace)
+      await docs.save(getBrowserWorkspaceId(), workspace)
       await touchContentTimestamp(documentId)
     },
   }

--- a/apps/web/src/pages/use-markdown-document.ts
+++ b/apps/web/src/pages/use-markdown-document.ts
@@ -38,7 +38,7 @@ import type { StoredCoreFacets } from '@kamiazya/whiteboard-model'
 import { Loro, type LoroText } from 'loro-crdt'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { getAppLogger } from '../lib/app-logger.js'
-import { BrowserWorkspaceDocs } from '../lib/browser-workspace-docs.js'
+import { BrowserWorkspaceDocs, openWorkspaceOrNull } from '../lib/browser-workspace-docs.js'
 import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import { foldWorkspaceDocuments } from '../lib/fold-workspace.js'
 import { touchContentTimestamp } from '../lib/loro-store.js'
@@ -135,7 +135,7 @@ async function openWorkspaceHost(documentId: string): Promise<ContentHost | null
     log.warn('startup fold failed; continuing without it', err)
   }
   const docs = new BrowserWorkspaceDocs()
-  const workspace = await docs.open(getBrowserWorkspaceId()).catch(() => null)
+  const workspace = await openWorkspaceOrNull(docs)
   if (workspace === null) return null
   if (resolveWorkspaceDocumentById(workspace, documentId) === null) return null
   return {

--- a/apps/web/src/test-utils/browser-document.ts
+++ b/apps/web/src/test-utils/browser-document.ts
@@ -14,7 +14,7 @@ import { Loro } from 'loro-crdt'
 import type { EditorCommand } from '../components/spatial-editor/commands.js'
 import { SYNC_DOCUMENTS_STORE, whiteboardDbName } from '../lib/browser-idb.js'
 import { BrowserWorkspaceDocs } from '../lib/browser-workspace-docs.js'
-import { BROWSER_WORKSPACE_ID } from '../lib/local-document-summary.js'
+import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import { LoroStore } from '../lib/loro-store.js'
 
 const DOCUMENT_STORE = SYNC_DOCUMENTS_STORE
@@ -73,7 +73,7 @@ export async function persistedNodeIds(documentId: string): Promise<string[]> {
   // below stays as the fallback for suites that seed the OLD stores and
   // assert before any backend has folded them.
   const workspace = await new BrowserWorkspaceDocs(whiteboardDbName())
-    .open(BROWSER_WORKSPACE_ID)
+    .open(getBrowserWorkspaceId())
     .catch(() => null)
   if (workspace !== null) {
     const projected = projectWorkspaceDocument(workspace, documentId)

--- a/apps/web/src/test-utils/browser-setup.ts
+++ b/apps/web/src/test-utils/browser-setup.ts
@@ -14,8 +14,24 @@
  * without it is testing a layout no user ever sees. Loading it here removes
  * the per-file decision entirely.
  */
+import { generateDocumentId } from '@kamiazya/whiteboard-model'
 import { configure } from '@testing-library/react'
 import '../index.css'
+import { setBrowserWorkspaceIdForTests } from '../lib/browser-workspace-id.js'
+
+/**
+ * A browser test renders production code that reads `getBrowserWorkspaceId()`
+ * at its ordinary call sites, but no test runs the boot chain that resolves
+ * it — so without a seed here the accessor's unresolved-state throw reaches
+ * any test whose fixture is purely in-memory (a `LocalStoreDouble`, say)
+ * rather than an IndexedDB one, where `claimIsolatedWhiteboardDb` seeds it.
+ * A fixed per-file id, minted once, is what those call sites see; the same
+ * default the jsdom setup installs, for the same reason.
+ *
+ * A test exercising the accessor's own unresolved/failed states resets it
+ * explicitly.
+ */
+setBrowserWorkspaceIdForTests(generateDocumentId())
 
 /**
  * Testing Library's `findBy*`/`waitFor` default is 1000ms, which is a

--- a/apps/web/src/test-utils/isolated-whiteboard-db.ts
+++ b/apps/web/src/test-utils/isolated-whiteboard-db.ts
@@ -1,4 +1,6 @@
+import { generateDocumentId } from '@kamiazya/whiteboard-model'
 import { setWhiteboardDbNameForTests } from '../lib/browser-idb.js'
+import { setBrowserWorkspaceIdForTests } from '../lib/browser-workspace-id.js'
 
 /**
  * Claim a private IndexedDB for this test FILE, and return its name.
@@ -14,9 +16,18 @@ import { setWhiteboardDbNameForTests } from '../lib/browser-idb.js'
  * stores pages construct internally included — resolves the claimed name from
  * then on, so page-level suites are covered without threading a parameter.
  * `clearWhiteboardDb()` clears the claimed database, not the shared one.
+ *
+ * Also seeds the `getBrowserWorkspaceId()` test seam with a freshly-minted
+ * ULID: a fixture that seeds the isolated DB's `workspaces` store directly
+ * (rather than through a real v14 open + resolve) never runs the migration
+ * that would otherwise supply one, and the production code paths under test
+ * read the accessor synchronously. Every caller in this file already spells
+ * `getBrowserWorkspaceId()` where it used to spell the retired
+ * `BROWSER_WORKSPACE_ID` constant, so the seeded id is what those calls see.
  */
 export function claimIsolatedWhiteboardDb(fileTag: string): string {
   const name = `whiteboard-${fileTag}`
   setWhiteboardDbNameForTests(name)
+  setBrowserWorkspaceIdForTests(generateDocumentId())
   return name
 }

--- a/apps/web/src/test-utils/local-index.ts
+++ b/apps/web/src/test-utils/local-index.ts
@@ -1,6 +1,6 @@
 import { InMemoryDocumentIndex } from '@kamiazya/whiteboard-ports/test-utils'
+import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import {
-  BROWSER_WORKSPACE_ID,
   type ContentClock,
   InMemoryDefaultDocumentPointer,
   listLocalDocuments,
@@ -73,11 +73,11 @@ export function seedLocal(
   // `LocalStoreDouble` read before its first `save` would answer
   // `WorkspaceNotFoundError` where production answers an empty list, which is
   // the one case a test of the empty state most wants to reach.
-  void index.createWorkspace({ workspaceId: BROWSER_WORKSPACE_ID })
+  void index.createWorkspace({ workspaceId: getBrowserWorkspaceId() })
   const stamps = new Map<string, string>()
   for (const snapshot of snapshots) {
     index.seed({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       documentId: snapshot.documentId,
       path: snapshot.path,
       kind: snapshot.kind,
@@ -122,12 +122,12 @@ export class LocalStoreDouble {
     // See `seedLocal` above: an unseeded double must still LIST, not throw.
     // The in-memory index registers the workspace synchronously, so the
     // promise is complete before any caller can observe it.
-    void this.index.createWorkspace({ workspaceId: BROWSER_WORKSPACE_ID })
+    void this.index.createWorkspace({ workspaceId: getBrowserWorkspaceId() })
   }
 
   async save(snapshot: DocumentSnapshot): Promise<void> {
     this.index.seed({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       documentId: snapshot.documentId,
       path: snapshot.path,
       kind: snapshot.kind,
@@ -159,10 +159,10 @@ export class LocalStoreDouble {
 
   async removeDocument(documentId: string): Promise<void> {
     const entry = await this.index.resolveDocumentById({
-      workspaceId: BROWSER_WORKSPACE_ID,
+      workspaceId: getBrowserWorkspaceId(),
       documentId,
     })
     if (entry === null) return
-    await this.index.deleteDocument({ workspaceId: BROWSER_WORKSPACE_ID, path: entry.path })
+    await this.index.deleteDocument({ workspaceId: getBrowserWorkspaceId(), path: entry.path })
   }
 }

--- a/apps/web/src/test-utils/seed-idb-document.ts
+++ b/apps/web/src/test-utils/seed-idb-document.ts
@@ -1,5 +1,6 @@
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import { Loro } from 'loro-crdt'
+import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import type { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { IdbDefaultDocumentPointer } from '../lib/local-document-summary.js'
 import { LoroStore } from '../lib/loro-store.js'
@@ -24,9 +25,9 @@ export async function seedIdbDocument(
     makeDefault = false,
   }: { path: string; name?: string; kind?: DocumentKind; makeDefault?: boolean },
 ): Promise<string> {
-  await index.createWorkspace({ workspaceId: 'local' })
+  await index.createWorkspace({ workspaceId: getBrowserWorkspaceId() })
   const entry = await index.createDocument({
-    workspaceId: 'local',
+    workspaceId: getBrowserWorkspaceId(),
     path,
     kind,
     ...(name === undefined ? {} : { name }),

--- a/apps/web/src/test-utils/seed-sync-document.ts
+++ b/apps/web/src/test-utils/seed-sync-document.ts
@@ -1,5 +1,6 @@
 import { chunkSnapshot } from '@kamiazya/whiteboard-ports'
 import { openWhiteboardDb, SYNC_DOCUMENTS_STORE } from '../lib/browser-idb.js'
+import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import { IdbDocumentStore } from '../lib/idb-document-store.js'
 
 /**
@@ -25,7 +26,12 @@ export async function seedSyncDocument(
   // writing it through `IdbDocumentStore` keeps this helper from carrying its
   // own copy of a storage layout that has already changed once underneath it.
   if (!('raw' in content)) {
-    const docRef = { kind: 'document', workspaceId: 'local', documentId } as const
+    // `docRefKey` never reads `workspaceId` for a `'document'` ref (a
+    // documentId is already globally unique — see its comment in ports), so
+    // this value is inert for the STORED key; it is still resolved through
+    // the real accessor rather than a stale literal so this fixture never
+    // reads as evidence for a workspace id that no longer exists.
+    const docRef = { kind: 'document', workspaceId: getBrowserWorkspaceId(), documentId } as const
     const store = new IdbDocumentStore(dbName)
     const { manifest, chunks } = chunkSnapshot(new Uint8Array(content.snapshot), 1_000_000)
     // Empty, matching what `LoroStore` writes: nothing in the browser reads a

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -26,11 +26,17 @@ export default defineConfig({
         __dirname,
         '../../packages/mcp-server/src/shared/test-utils/document-backend-contract.ts',
       ),
-      // Subpath alias must precede the root alias: rollup-alias prefix-matches,
+      // Subpath aliases must precede the root alias: rollup-alias prefix-matches,
       // so the root entry alone would rewrite '/scene' to 'index.ts/scene'.
       '@kamiazya/whiteboard-canvas-viewer/scene': resolve(
         __dirname,
         '../../packages/canvas-viewer/src/scene.ts',
+      ),
+      // boot.ts (main.tsx's boot chain) imports this narrow subpath so a
+      // jsdom test of the boot sequence does not need the whole viewer graph.
+      '@kamiazya/whiteboard-canvas-viewer/font-loading': resolve(
+        __dirname,
+        '../../packages/canvas-viewer/src/font-loading.ts',
       ),
       // Resolve canvas-viewer from source so tests run before `pnpm build`.
       '@kamiazya/whiteboard-canvas-viewer': resolve(

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,6 +1,17 @@
+import { generateDocumentId } from '@kamiazya/whiteboard-model'
 import { cleanup } from '@testing-library/react'
 import { afterEach, expect, vi } from 'vitest'
+import { setBrowserWorkspaceIdForTests } from './src/lib/browser-workspace-id.js'
 import { drainSchedulerMacrotasks } from './src/test-utils/scheduler-drain.js'
+
+// jsdom page/hook tests read `getBrowserWorkspaceId()` at their existing
+// production call sites (the id an IndexedDB-backed or in-memory double is
+// seeded under) without going through the real boot resolver. A fixed
+// per-file id — minted once here rather than per test — is what every such
+// call site sees; a test exercising the accessor's own unresolved/failed
+// states resets and restores it explicitly (see browser-workspace-id.test.ts
+// and boot.test.ts).
+setBrowserWorkspaceIdForTests(generateDocumentId())
 
 // jsdom ships no ResizeObserver; Radix popper-positioned surfaces
 // (DropdownMenu/Popover content) observe their anchor on mount and throw


### PR DESCRIPTION
ADR-0019 Wave-2, browser-keeper half. The browser's workspace stops being keyed by the compile-time literal `'local'` and becomes a per-installation canonical ULID, minted once and stable thereafter. The daemon keeper is a separate lane.

Invisible when correct: documents, the workspace tree, versions and the default-document pointer all survive the upgrade unchanged. The regression test *is* that assertion.

## What lands

**`DB_VERSION` 13 → 14.** A new `rekeyBrowserWorkspace` step moves the registry row, every `documentIndex` row, and the `workspace-tree:local` sync record plus its chunk rows onto the new key — as opaque values, inside the versionchange transaction. No Loro decode is needed anywhere: `docRefKey` deliberately omits `workspaceId` from `document:` keys, and the workspace-tree LoroDoc never stores its own id. So this is the same synchronous copy-then-delete shape as the store-rename migrations already in that file, not the async resumable machinery `fold-workspace` needs.

**Convergent, not run-once.** `backfillDocumentIndex` (v9→v10) re-puts `{workspaceId:'local'}` unconditionally on *every* future upgrade — it has no way to know this step exists — and the RENAMED_STORES loop re-creates the `documents` store it walks each time, so this is not hypothetical. Skipping when a ULID row already exists would therefore leave the resurrected `'local'` row behind forever. Instead the step looks for an existing target on every run and absorbs whatever remnant is present, minting only when there is no target yet. Ordered last in the chain, so it observes what the backfill just wrote.

**`BROWSER_WORKSPACE_ID` → a synchronous module-cached accessor.** The constant is gone; `getBrowserWorkspaceId()` is read at the same 11 production call sites, and `resolveBrowserWorkspaceId()` runs once in the boot chain. No call site becomes async. The accessor has three states with distinct messages — resolved, never-resolved, and resolution-failed (carrying the cause) — and a failed resolve stays retryable, so closing a blocking tab recovers without a reload.

**`boot.ts`.** The boot chain moved out of `main.tsx` so the resolver-rejection path is testable through the real sequence. A rejection does not block render: no IndexedDB open has ever gated boot, and a daemon-only route must not white-screen because *this* tab's browser storage is unavailable.

## Three defects found while verifying, fixed in the second commit

Each was found by running something the first pass did not, and each is the kind that reads as green.

1. **The accessor read sat in argument position.** `docs.open(getBrowserWorkspaceId()).catch(() => null)` evaluates the argument before `open` returns a promise, so the failed-state throw was never a rejection the `.catch` could absorb — it escaped the caller entirely, past the very null branch written to keep the page standing when storage is unavailable. Five call sites had the shape. `openWorkspaceOrNull` now performs the read inside the isolation.

2. **The test meant to pin that wrote the isolation itself.** `Promise.resolve().then(accessor).catch(() => null)` absorbs the throw regardless of how the production function is written — green against both the correct and the broken shape. It now calls the real `loadWorkspaceDocumentProjection`.

3. **Only the jsdom setup seeded the accessor.** The browser project's setup did not, so any browser test whose fixture is in-memory rather than IndexedDB-backed hit the never-resolved throw. The 25-file targeted batch missed it because every file in it calls `claimIsolatedWhiteboardDb`, which seeds; the full 150-file suite caught it in `WorkspaceTopBar.scopes`.

Also restores the bundle-critical narrow-subpath rationale and the font bounded-await / splash-pacing rationale, which moved out of `main.tsx` with the boot chain and were not carried into `boot.ts`.

## Verification

**Mutation checks, both directions.**

- *Convergence guard:* reverting `targetId = keys.find(…) ?? generateDocumentId()` to always mint turns the two-bump test red with a stray second ULID in the key array. The first version of that assertion read `keys[0]` and passed vacuously — ULIDs sort chronologically, so the stale id was still at index 0 despite the stray row. Comparing the whole array is what makes it reach its subject.
- *Isolation fix:* reverting `loadWorkspaceDocumentProjection` to the argument-position read turns the boot failure-path test red, and the failure names `workspace-content.ts:58` — i.e. it reached the real production line, not a re-enactment. Restored, 3/3 green again.

**Suites (local).**

- `pnpm test:browser` — **150 files / 828 tests, all green.** No `Re-optimizing` and no `ENOSPC` in the log.
- `pnpm --filter @kamiazya/whiteboard-web test` — 2780 passed, 9 failed across 5 files.

Those 9 are pre-existing and environmental, verified by measurement rather than assertion: the same 5 files were run on unmodified `origin/main` in a separate clean worktree (HEAD `300fd6e7`, clean tree) and produced **the identical `9 failed | 75 passed`**. They are undici `Response(blob)` shapes under this root-uid container, and CI passes them.

The remaining local gates (`pnpm test` across all projects, `check:local`, `build` + the bundle-size smoke) are deliberately left to CI. This container is a poor measuring instrument for them — it carries 9 undici failures and 3 root-uid `EACCES` failures that exist nowhere else, and one browser run accumulated 14 GB of vitest traces and exhausted the disk mid-suite, which surfaced as `tracing.stopChunk: ENOSPC` plus a lost test file and read exactly like two real failures. **The bundle-size smoke is the one worth watching here**: `boot.ts` puts `browser-idb` on the entry's critical path for the first time, against a 126 KB budget last measured at 114 KB.

Visual evidence: none — the change is invisible when correct, and its user-facing claim is that nothing moves. The evidence is the green 150-file browser suite above, whose v13→v14 case seeds a real pre-migration database (real Loro bytes, a folded workspace tree, a default-document pointer), opens it at 14, and asserts through production wiring that every document lists and loads byte-identical, the tree opens under the new key, the registry holds exactly one ULID-keyed row, and zero `'local'`-keyed rows remain in any of the three stores.

## Still owed

Driving the real app in a browser — create documents on `origin/main`, reload on this branch, confirm in DevTools that the `workspaces` store is keyed by a 26-char ULID with no `'local'` row, that a second reload keeps the same ULID, and that a stale tab holding the DB at v13 leaves the app painting with an inline error rather than a white screen. No browser-driving tool is available in this session.


---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser workspaces now receive unique, persistent identifiers instead of sharing a fixed default.
  * Existing browser data is migrated automatically while preserving documents, workspace content, and navigation.
  * Workspace access gracefully handles unavailable or unreadable data.
* **Bug Fixes**
  * Startup now continues to display the app even if workspace initialization fails, with clear error state handling and retry recovery.
* **Tests**
  * Expanded coverage for startup recovery, workspace identification, data migration, and cross-version compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->