### PR TITLE
feat(server-core): resolve the workspace handle once at the request boundary

### DIFF
--- a/packages/server-core/src/create-server.ts
+++ b/packages/server-core/src/create-server.ts
@@ -45,18 +45,34 @@ import { createVersionListTool } from './tools/version-list.js'
 import { createVersionRestoreTool } from './tools/version-restore.js'
 import { createVersionSaveTool } from './tools/version-save.js'
 import { createViewportSetTool } from './tools/viewport-set.js'
+import { resolveWorkspaceId, withResolvedWorkspaceHandles } from './workspace-handle.js'
 
 export function createServer(deps: ServerDeps) {
-  const app = new Hono()
+  const app = new Hono<{ Variables: { workspaceId: string } }>()
   // One stamp-validated content-facts cache per server: backlinks/mentions,
   // tags, and search all read through it, so a request after a quiet period
   // reloads only what changed — regardless of which write path changed it.
   const factsCache = new ContentFactsCache()
 
+  /**
+   * The workspace handle is resolved HERE, once per request, and every handler
+   * below reads the result rather than the raw path parameter.
+   *
+   * Middleware rather than a call in each handler: resolving twice in one
+   * request is the failure this ordering exists to prevent — everything
+   * downstream keys on the resolved id (write locks, document caches, sync
+   * docKeys), and two independent resolutions can disagree the moment a
+   * segment moves between workspaces mid-flight.
+   */
+  app.use('/api/v1/workspaces/:workspaceId/*', async (c, next) => {
+    c.set('workspaceId', await resolveWorkspaceId(deps.documentIndex, c.req.param('workspaceId')))
+    await next()
+  })
+
   app.post('/api/v1/workspaces/:workspaceId/documents', async (c) => {
     const body = await c.req.json().catch(() => ({}))
     const parsed = wbDocumentCreateInputSchema.safeParse({
-      workspaceId: c.req.param('workspaceId'),
+      workspaceId: c.get('workspaceId'),
       ...body,
     })
     if (!parsed.success) {
@@ -71,7 +87,7 @@ export function createServer(deps: ServerDeps) {
   })
 
   app.get('/api/v1/workspaces/:workspaceId/documents', async (c) => {
-    const parsed = wbDocumentListInputSchema.safeParse({ workspaceId: c.req.param('workspaceId') })
+    const parsed = wbDocumentListInputSchema.safeParse({ workspaceId: c.get('workspaceId') })
     if (!parsed.success) {
       return c.json({ error: 'invalid input', issues: parsed.error.issues }, 400)
     }
@@ -85,7 +101,7 @@ export function createServer(deps: ServerDeps) {
 
   app.get('/api/v1/workspaces/:workspaceId/documents/:documentId', async (c) => {
     const parsed = wbDocumentResolveInputSchema.safeParse({
-      workspaceId: c.req.param('workspaceId'),
+      workspaceId: c.get('workspaceId'),
       documentId: c.req.param('documentId'),
     })
     if (!parsed.success) {
@@ -101,7 +117,7 @@ export function createServer(deps: ServerDeps) {
 
   app.delete('/api/v1/workspaces/:workspaceId/documents/:documentId', async (c) => {
     const parsed = wbDocumentDeleteInputSchema.safeParse({
-      workspaceId: c.req.param('workspaceId'),
+      workspaceId: c.get('workspaceId'),
       documentId: c.req.param('documentId'),
     })
     if (!parsed.success) {
@@ -121,7 +137,7 @@ export function createServer(deps: ServerDeps) {
   // the tree wants markdown regardless of what wb_document_get would choose.
   app.get('/api/v1/workspaces/:workspaceId/search', async (c) => {
     const parsed = documentSearchInputSchema.safeParse({
-      workspaceId: c.req.param('workspaceId'),
+      workspaceId: c.get('workspaceId'),
       query: c.req.query('q'),
       ...(c.req.query('kind') === undefined ? {} : { kind: c.req.query('kind') }),
       ...(c.req.queries('tag') === undefined || c.req.queries('tag')?.length === 0
@@ -140,7 +156,7 @@ export function createServer(deps: ServerDeps) {
   })
 
   app.get('/api/v1/workspaces/:workspaceId/document-tags', async (c) => {
-    const parsed = documentTagsInputSchema.safeParse({ workspaceId: c.req.param('workspaceId') })
+    const parsed = documentTagsInputSchema.safeParse({ workspaceId: c.get('workspaceId') })
     if (!parsed.success) {
       return c.json({ error: 'invalid input', issues: parsed.error.issues }, 400)
     }
@@ -154,7 +170,7 @@ export function createServer(deps: ServerDeps) {
   app.post('/api/v1/workspaces/:workspaceId/documents/:documentId/linkify-mentions', async (c) => {
     const body = await c.req.json().catch(() => ({}))
     const parsed = linkifyMentionsInputSchema.safeParse({
-      workspaceId: c.req.param('workspaceId'),
+      workspaceId: c.get('workspaceId'),
       documentId: c.req.param('documentId'),
       ...body,
     })
@@ -173,7 +189,7 @@ export function createServer(deps: ServerDeps) {
 
   app.get('/api/v1/workspaces/:workspaceId/documents/:documentId/backlinks', async (c) => {
     const parsed = backlinksInputSchema.safeParse({
-      workspaceId: c.req.param('workspaceId'),
+      workspaceId: c.get('workspaceId'),
       documentId: c.req.param('documentId'),
     })
     if (!parsed.success) {
@@ -188,7 +204,7 @@ export function createServer(deps: ServerDeps) {
 
   app.get('/api/v1/workspaces/:workspaceId/documents/:documentId/okf', async (c) => {
     const parsed = exportOkfInputSchema.safeParse({
-      workspaceId: c.req.param('workspaceId'),
+      workspaceId: c.get('workspaceId'),
       documentId: c.req.param('documentId'),
     })
     if (!parsed.success) {
@@ -225,7 +241,7 @@ export function createServer(deps: ServerDeps) {
     versionList: createVersionListTool(deps),
     versionRestore: createVersionRestoreTool(deps),
   }
-  return { app, tools }
+  return { app, tools: withResolvedWorkspaceHandles(tools, deps.documentIndex) }
 }
 
 function mapDocumentError(c: Context, err: unknown) {

--- a/packages/server-core/src/workspace-handle.test.ts
+++ b/packages/server-core/src/workspace-handle.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Every address surface this package serves resolves its workspace handle the
+ * same way — through the port's `resolveWorkspace`, once, at the boundary.
+ *
+ * These are behavioural tests against `createServer`'s own outputs rather than
+ * against the wrapper in isolation: a helper that resolves correctly but is
+ * not APPLIED reads identically to one that is, and the applying is the part
+ * that has to hold across fourteen tools and every route.
+ */
+import { InMemoryDocumentIndex } from '@kamiazya/whiteboard-ports/test-utils'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createServer } from './create-server.js'
+import { ignoredDocumentWrites } from './test-utils/ignored-document-writes.js'
+import { createInMemoryDocumentStore } from './test-utils/in-memory-document-store.js'
+import { inMemoryDocumentTeardown } from './test-utils/unused-document-teardown.js'
+
+const CANONICAL = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+
+function makeServer(index: InMemoryDocumentIndex) {
+  return createServer({
+    documentStore: createInMemoryDocumentStore(),
+    blobStore: {} as never,
+    documentIndex: index,
+    documentTeardown: inMemoryDocumentTeardown(),
+    documentWritten: ignoredDocumentWrites(),
+  })
+}
+
+describe('workspace handles at the server boundary', () => {
+  let index: InMemoryDocumentIndex
+
+  beforeEach(async () => {
+    index = new InMemoryDocumentIndex()
+    await index.createWorkspace({ workspaceId: CANONICAL, segment: 'design' })
+    // Asserted, not assumed: every case below is about a segment resolving,
+    // and a registry that dropped it would make them all pass by falling
+    // through to the id branch.
+    expect((await index.listWorkspaces())[0]?.segment).toBe('design')
+    await index.createDocument({ workspaceId: CANONICAL, path: 'notes/spec', kind: 'markdown' })
+  })
+
+  it('lists by segment exactly as by canonical id, over HTTP', async () => {
+    const { app } = makeServer(index)
+    const bySegment = await app.request(`/api/v1/workspaces/design/documents`)
+    const byId = await app.request(`/api/v1/workspaces/${CANONICAL}/documents`)
+    expect(bySegment.status).toBe(200)
+    expect(await bySegment.json()).toEqual(await byId.json())
+  })
+
+  it('lists by segment through the MCP tool the daemon actually registers', async () => {
+    // Through `createServer(deps).tools`, not the tool factory directly: the
+    // wrapper is what is under test, and calling the factory would bypass it.
+    const { tools } = makeServer(index)
+    const bySegment = await tools.documentSearch.execute({ workspaceId: 'design', query: 'spec' })
+    const byId = await tools.documentSearch.execute({ workspaceId: CANONICAL, query: 'spec' })
+    expect(bySegment).toEqual(byId)
+  })
+
+  it('keeps an unresolvable handle failing exactly as before', async () => {
+    // Fallback-total: a handle that names nothing passes through unchanged, so
+    // the 404 comes from the same lookup and carries the same text it always
+    // did. No new error vocabulary is introduced by resolution.
+    const { app } = makeServer(index)
+    const res = await app.request('/api/v1/workspaces/no-such-workspace/documents')
+    expect(res.status).toBe(404)
+  })
+
+  it('is the identity over a segmentless registry — the Stage-1 no-op', async () => {
+    const plain = new InMemoryDocumentIndex()
+    await plain.createWorkspace({ workspaceId: 'default' })
+    await plain.createDocument({ workspaceId: 'default', path: 'a', kind: 'markdown' })
+    const { app } = makeServer(plain)
+    const res = await app.request('/api/v1/workspaces/default/documents')
+    expect(res.status).toBe(200)
+  })
+})

--- a/packages/server-core/src/workspace-handle.ts
+++ b/packages/server-core/src/workspace-handle.ts
@@ -1,0 +1,65 @@
+/**
+ * Where an incoming workspace ADDRESS becomes a workspace id.
+ *
+ * ADR-0019 splits one string into three layers, two of which — the canonical
+ * id and the per-keeper `segment` — can both arrive in the same position of a
+ * URL, a WS target, or an MCP tool argument. `resolveWorkspaceHandle` in ports
+ * fixes which wins; this file is where that decision is APPLIED, once, at the
+ * request boundary.
+ *
+ * Once is the load-bearing word. Everything downstream keys on the resolved
+ * id — workspace write locks, document caches, WS and SSE `docKey`s — and two
+ * of those resolving independently is how one request ends up holding a lock
+ * under one spelling while writing under another.
+ */
+import type { DocumentIndex } from '@kamiazya/whiteboard-ports'
+
+/**
+ * The canonical id for `handle`, or `handle` unchanged when nothing answers
+ * to it.
+ *
+ * Total by design: an unresolvable handle is NOT an error here. Passing it
+ * through means the lookup that follows fails exactly as it did before
+ * resolution existed — the same 404, the same `isError` text, from the same
+ * place. Answering with an error of its own would put a second vocabulary in
+ * front of every not-found, and every surface would have to learn it.
+ */
+export async function resolveWorkspaceId(index: DocumentIndex, handle: string): Promise<string> {
+  return (await index.resolveWorkspace(handle))?.workspaceId ?? handle
+}
+
+/** The shape every tool in `createServer`'s record shares. */
+interface WorkspaceScopedTool {
+  execute(input: never): Promise<unknown>
+}
+
+/**
+ * Wraps a record of tools so each one resolves `input.workspaceId` before its
+ * own `execute` sees it.
+ *
+ * A wrapper over the RECORD rather than an edit in each of the fourteen tools:
+ * a per-tool step is a step the fifteenth tool will not have, and its absence
+ * looks exactly like a tool nobody addresses by segment yet.
+ *
+ * The tool object is spread rather than rebuilt, so `inputSchema` and
+ * `outputSchema` keep their identities — `registerToolWithAnnotations` is
+ * generic over the output schema, and a copy would break that binding.
+ */
+export function withResolvedWorkspaceHandles<T extends Record<string, WorkspaceScopedTool>>(
+  tools: T,
+  index: DocumentIndex,
+): T {
+  const wrapped: Record<string, WorkspaceScopedTool> = {}
+  for (const [key, tool] of Object.entries(tools)) {
+    wrapped[key] = {
+      ...tool,
+      async execute(input: never) {
+        const scoped = input as { workspaceId?: unknown }
+        if (typeof scoped?.workspaceId !== 'string') return tool.execute(input)
+        const workspaceId = await resolveWorkspaceId(index, scoped.workspaceId)
+        return tool.execute({ ...scoped, workspaceId } as never)
+      },
+    }
+  }
+  return wrapped as T
+}


### PR DESCRIPTION
Stage 1b, first half. `/api/v1` and every MCP tool `createServer` returns now accept a workspace `segment` wherever they accepted an id, resolved through the port's single definition of the order (#1108).

The daemon's own surfaces — the path-route family, the enumerated workspace routes, `ws.ts`, and the bare tool registrations in `mcp-server` — are the second half and are still on a literal id match. Split here because the two halves have different seams and each is worth reading on its own; the intermediate state is coherent because no workspace has a segment yet.

## The two seams, and why they are shaped this way

**Resolution happens once per request.** That is the load-bearing property, not merely a nicety: everything downstream keys on the resolved id — workspace write locks, document caches, WS and SSE `docKey`s — and two independent resolutions can disagree the moment a segment moves between workspaces mid-flight. One request would then hold a lock under one spelling while writing under another.

So both seams are shaped to make "once" structural rather than remembered:

- **A Hono middleware** over `/api/v1/workspaces/:workspaceId/*` resolves the parameter, and all nine handlers below read `c.get('workspaceId')`. A handler cannot resolve a second time by writing the read differently, because reading the raw param is now the odd thing to do.
- **A wrapper over the tools RECORD**, not over each of the fourteen tools. A per-tool step is a step the fifteenth tool will not have — and its absence would look exactly like a tool nobody addresses by segment yet. The tool objects are spread rather than rebuilt, so `inputSchema`/`outputSchema` keep the identities `registerToolWithAnnotations` binds its output type to.

**`resolveWorkspaceId` is fallback-total.** A handle that names nothing passes through unchanged, so the lookup that follows fails exactly as it did before resolution existed — same status, same text, same place. An error of its own would put a second vocabulary in front of every not-found, and every surface would have to learn it.

## Behaviour today

Unchanged for every address that exists. No workspace has a segment yet, so over a segmentless registry resolution is the identity on every handle — pinned as its own case.

## Verification

The new tests go through `createServer`'s own outputs rather than the wrapper in isolation. A helper that resolves correctly but is not APPLIED reads identically to one that is, and the applying is what has to hold across fourteen tools and nine routes — so the MCP case calls `createServer(deps).tools`, never a tool factory directly, and the HTTP cases go through `app.request`.

Four cases: list by segment ≡ list by id over HTTP; the same through the MCP tool the daemon actually registers; an unresolvable handle still 404s; and the segmentless-registry identity. The first two were red before the seam and green after.

`server-core-node` 418/418, and 628/628 across `server-core-node` + `ports-node` + `workspace-index-node`; `pnpm -r typecheck` clean.

Both were run after the last edit this time. On #1108 I ran the tests and not the typecheck, and shipped a `TS2554` that took four CI jobs red — one of which was a test that shells out to `tsc`, which is why a green local `pnpm test` said nothing about it.

Visual evidence: none — a server-side addressing seam with no user-visible surface in the diff. `userReach` is real but narrow: a workspace that HAS a segment becomes addressable by it over `/api/v1` and MCP. Nothing mints segments yet, so no user reaches this today; that arrives with the create-time minting slice later in Wave 2.


---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace handles can now be used consistently across API routes and document search tools.
  * Recognized handles automatically resolve to their canonical workspace identifiers.
  * Unrecognized handles continue to return a not-found response.
  * Registries without workspace segments retain existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->