### PR TITLE
feat(mcp-server): resolve the workspace handle on the daemon's own surfaces

### DIFF
--- a/packages/mcp-server/src/server/routes/document/export-svg.test.ts
+++ b/packages/mcp-server/src/server/routes/document/export-svg.test.ts
@@ -23,6 +23,12 @@ const mockDocumentExists = vi.fn<(workspaceId: string, path: string) => Promise<
 )
 vi.mock('../../store/document-store.js', () => ({
   documentExists: (workspaceId: string, path: string) => mockDocumentExists(workspaceId, path),
+  // The route family resolves an ADDRESS before it reaches the store
+  // (ADR-0019), and that read goes through this same module — so a double
+  // that omits it makes every export 500 on a TypeError rather than on
+  // anything the case is about. Empty registry: these tests address
+  // workspaces by id, which resolution leaves alone.
+  workspaceRegistry: () => ({ listWorkspaces: async () => [] }),
 }))
 
 const mockExportCanvasHeadlessSvg =

--- a/packages/mcp-server/src/server/routes/document/maintenance.ts
+++ b/packages/mcp-server/src/server/routes/document/maintenance.ts
@@ -3,6 +3,7 @@ import { evictDoc } from '../../store/doc-cache.js'
 import { compactDocument, listDocuments } from '../../store/document-store.js'
 import type { VersionStore } from '../../store/version-store.js'
 import { validateWorkspaceId, validationErrorBody } from '../../validators.js'
+import { workspaceIdFromHandle } from '../../workspace-handle.js'
 import { handleCorruptStoredData } from './_shared.js'
 import { onDocumentsRoute } from './path-route.js'
 
@@ -37,14 +38,15 @@ export function createMaintenanceRouter(options: MaintenanceRouterOptions) {
   // autos add no rollback value once both bracket points exist. Loops over
   // every canvas in the workspace and aggregates totals.
   app.post('/api/workspaces/:workspaceId/versions/prune-sandwiched', async (c) => {
-    const { workspaceId } = c.req.param()
+    const handle = c.req.param('workspaceId')
     try {
-      validateWorkspaceId(workspaceId)
+      validateWorkspaceId(handle)
     } catch (err) {
       const body = validationErrorBody(err)
       if (body) return c.json(body, 400)
       throw err
     }
+    const workspaceId = await workspaceIdFromHandle(c, handle)
     try {
       const documents = await listDocuments(workspaceId)
       const results: Array<{ path: string; deletedCount: number }> = []
@@ -68,14 +70,15 @@ export function createMaintenanceRouter(options: MaintenanceRouterOptions) {
   // adds race risk. Returns a per-canvas array plus aggregated totals so
   // the UI can show a meaningful summary in one round-trip.
   app.post('/api/workspaces/:workspaceId/documents/optimize-all', async (c) => {
-    const { workspaceId } = c.req.param()
+    const handle = c.req.param('workspaceId')
     try {
-      validateWorkspaceId(workspaceId)
+      validateWorkspaceId(handle)
     } catch (err) {
       const body = validationErrorBody(err)
       if (body) return c.json(body, 400)
       throw err
     }
+    const workspaceId = await workspaceIdFromHandle(c, handle)
     try {
       const documents = await listDocuments(workspaceId)
       const results: Array<{

--- a/packages/mcp-server/src/server/routes/document/metadata.ts
+++ b/packages/mcp-server/src/server/routes/document/metadata.ts
@@ -10,6 +10,7 @@ import {
   setWorkspaceName,
 } from '../../store/names-store.js'
 import { validateWorkspaceId, validationErrorBody } from '../../validators.js'
+import { workspaceIdFromHandle } from '../../workspace-handle.js'
 import { handleCorruptStoredData, handleDocumentNotFound } from './_shared.js'
 import { onDocumentsRoute } from './path-route.js'
 
@@ -24,14 +25,15 @@ export function createDocumentMetadataRouter() {
   const app = new Hono()
 
   app.get('/api/workspaces/:workspaceId/names', async (c) => {
-    const { workspaceId } = c.req.param()
+    const handle = c.req.param('workspaceId')
     try {
-      validateWorkspaceId(workspaceId)
+      validateWorkspaceId(handle)
     } catch (err) {
       const body = validationErrorBody(err)
       if (body) return c.json(body, 400)
       throw err
     }
+    const workspaceId = await workspaceIdFromHandle(c, handle)
     try {
       const names = await loadWorkspaceNames(workspaceId)
       return c.json(names)
@@ -45,14 +47,15 @@ export function createDocumentMetadataRouter() {
   })
 
   app.put('/api/workspaces/:workspaceId/name', async (c) => {
-    const { workspaceId } = c.req.param()
+    const handle = c.req.param('workspaceId')
     try {
-      validateWorkspaceId(workspaceId)
+      validateWorkspaceId(handle)
     } catch (err) {
       const body = validationErrorBody(err)
       if (body) return c.json(body, 400)
       throw err
     }
+    const workspaceId = await workspaceIdFromHandle(c, handle)
     const parsed = setNameRequestSchema.safeParse(await c.req.json().catch(() => null))
     if (!parsed.success) {
       return c.json({ error: 'invalid_body' }, 400)

--- a/packages/mcp-server/src/server/routes/document/path-route.ts
+++ b/packages/mcp-server/src/server/routes/document/path-route.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../shared/api-contracts/document-url.js'
 import type { ApiErrorBody } from '../../../shared/api-contracts/errors.js'
 import { validateDocumentPath, validateWorkspaceId, validationErrorBody } from '../../validators.js'
+import { workspaceIdFromHandle } from '../../workspace-handle.js'
 
 export const DOCUMENT_WILDCARD = '/api/w/:workspaceId/document/*'
 
@@ -64,7 +65,11 @@ export function onDocumentAction(
     const parsed = parseDocumentApiPath(c.req.path)
     const path = parsed === null ? null : documentPathForAction(parsed.tail, action)
     if (parsed === null || path === null) return next()
-    return validated(c, parsed.workspaceId, path) ?? handler(c, parsed.workspaceId, path)
+    // Validated on the handle AS WRITTEN, so a malformed one keeps its 400;
+    // resolved afterwards, so the handler only ever sees a canonical id.
+    const invalid = validated(c, parsed.workspaceId, path)
+    if (invalid) return invalid
+    return handler(c, await workspaceIdFromHandle(c, parsed.workspaceId), path)
   }
   app[method](DOCUMENT_WILDCARD, ...(middleware as []), dispatch)
 }
@@ -80,10 +85,9 @@ export function onDocumentFile(
     const parsed = parseDocumentApiPath(c.req.path)
     const file = parsed === null ? null : documentPathForFile(parsed.tail)
     if (parsed === null || file === null) return next()
-    return (
-      validated(c, parsed.workspaceId, file.path) ??
-      handler(c, parsed.workspaceId, file.path, file.fileId)
-    )
+    const invalid = validated(c, parsed.workspaceId, file.path)
+    if (invalid) return invalid
+    return handler(c, await workspaceIdFromHandle(c, parsed.workspaceId), file.path, file.fileId)
   }
   app[method](DOCUMENT_WILDCARD, ...(middleware as []), dispatch)
 }
@@ -134,9 +138,9 @@ export function onDocumentsRoute(
       else if (actual !== expected) return next()
     }
     const path = (tail.slice(0, suffixStart) as string[]).join('/')
-    return (
-      validated(c, workspaceId, path, options.badRequest) ?? handler(c, workspaceId, path, params)
-    )
+    const invalid = validated(c, workspaceId, path, options.badRequest)
+    if (invalid) return invalid
+    return handler(c, await workspaceIdFromHandle(c, workspaceId), path, params)
   }
   app[method](DOCUMENTS_WILDCARD, ...(middleware as []), dispatch)
 }

--- a/packages/mcp-server/src/server/routes/document/trash.ts
+++ b/packages/mcp-server/src/server/routes/document/trash.ts
@@ -18,6 +18,7 @@ import type {
 import type { ApiErrorBody } from '../../../shared/api-contracts/errors.js'
 import { getLogger } from '../../log.js'
 import { validateWorkspaceId, validationErrorBody } from '../../validators.js'
+import { workspaceIdFromHandle } from '../../workspace-handle.js'
 
 export interface TrashRouterOptions {
   serverDeps?: ServerDeps
@@ -29,16 +30,17 @@ export function createTrashRouter(options: TrashRouterOptions = {}): Hono {
   const depsOf = async () => options.serverDeps ?? (await getDefaultServerDeps())
 
   app.get('/api/workspaces/:workspaceId/trash', async (c) => {
-    const workspaceId = c.req.param('workspaceId')
+    const handle = c.req.param('workspaceId')
     // A malformed address is the caller's error, not this server's — kept
     // outside the try below so it cannot fall through to the 500 arm.
     try {
-      validateWorkspaceId(workspaceId)
+      validateWorkspaceId(handle)
     } catch (err) {
       const body = validationErrorBody(err)
       if (body) return c.json(body, 400)
       throw err
     }
+    const workspaceId = await workspaceIdFromHandle(c, handle)
     try {
       const deps = await depsOf()
       if (deps.trash === undefined) {
@@ -66,15 +68,16 @@ export function createTrashRouter(options: TrashRouterOptions = {}): Hono {
   })
 
   app.post('/api/workspaces/:workspaceId/trash/:documentId/restore', async (c) => {
-    const workspaceId = c.req.param('workspaceId')
+    const handle = c.req.param('workspaceId')
     const documentId = c.req.param('documentId')
     try {
-      validateWorkspaceId(workspaceId)
+      validateWorkspaceId(handle)
     } catch (err) {
       const body = validationErrorBody(err)
       if (body) return c.json(body, 400)
       throw err
     }
+    const workspaceId = await workspaceIdFromHandle(c, handle)
     try {
       const deps = await depsOf()
       if (deps.trash === undefined) {

--- a/packages/mcp-server/src/server/routes/document/workspace-document.ts
+++ b/packages/mcp-server/src/server/routes/document/workspace-document.ts
@@ -14,6 +14,7 @@ import {
 import type { VersionEntry } from '../../store/version-store.js'
 import { withWorkspaceWriteLock } from '../../store/workspace-lock.js'
 import { validateWorkspaceId, validationErrorBody } from '../../validators.js'
+import { workspaceIdFromHandle } from '../../workspace-handle.js'
 
 // Same ceiling as the per-document update path: a workspace-granularity
 // update carries the same kind of Loro delta, just scoped wider.
@@ -38,14 +39,15 @@ export function createWorkspaceDocumentRouter(options: WorkspaceDocumentRouterOp
   const app = new Hono()
 
   app.get('/api/w/:workspaceId/workspace-document/snapshot', async (c) => {
-    const workspaceId = c.req.param('workspaceId')
+    const handle = c.req.param('workspaceId')
     try {
-      validateWorkspaceId(workspaceId)
+      validateWorkspaceId(handle)
     } catch (err) {
       const body = validationErrorBody(err)
       if (body) return c.json({ title: body.message }, 400)
       throw err
     }
+    const workspaceId = await workspaceIdFromHandle(c, handle)
     // Same honesty rule as the per-document snapshot: an unregistered
     // workspace is a refusal, not a phantom. Inside a registered workspace,
     // a missing workspace document is minted empty — the workspace is real,
@@ -72,14 +74,15 @@ export function createWorkspaceDocumentRouter(options: WorkspaceDocumentRouterOp
         ),
     }),
     async (c) => {
-      const workspaceId = c.req.param('workspaceId')
+      const handle = c.req.param('workspaceId')
       try {
-        validateWorkspaceId(workspaceId)
+        validateWorkspaceId(handle)
       } catch (err) {
         const body = validationErrorBody(err)
         if (body) return c.json({ title: body.message }, 400)
         throw err
       }
+      const workspaceId = await workspaceIdFromHandle(c, handle)
       if (!(await workspaceExists(workspaceId))) {
         return c.json({ title: `Workspace "${workspaceId}" not found` }, 404)
       }

--- a/packages/mcp-server/src/server/routes/document/workspace-handle.test.ts
+++ b/packages/mcp-server/src/server/routes/document/workspace-handle.test.ts
@@ -1,0 +1,129 @@
+/**
+ * The daemon's OWN routes resolve a workspace handle the way `/api/v1` and
+ * the MCP tools do — segment first, canonical id second (ADR-0019).
+ *
+ * Separate from server-core's suite because this is a different surface with
+ * a different seam: these handlers fetch their dependencies per-request from
+ * module state rather than from one injected `deps`, so no single middleware
+ * covers them and the resolve is a line per address read. A case per READ
+ * MECHANISM is what says the line is actually there — `c.req.param()`, the
+ * `/api/workspaces/.../documents/*` hand parse, and the `/api/w/...` one are
+ * three separate places to forget.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { withTempDataDir } from '../_test-helpers.js'
+
+const tmp = withTempDataDir('whiteboard-workspace-handle-')
+
+vi.mock('../../config.js', () => ({
+  get DATA_DIR() {
+    return tmp.dir
+  },
+  getDataDir: () => tmp.dir,
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+  REPO_ROOT: '/tmp',
+}))
+
+const { getDb } = await import('../../store/db/index.js')
+const { prepareDataDir } = await import('../../store/db/prepare.js')
+const { createContainer, resolveServerDeps } = await import('../../../di/container.js')
+const { createStoreLocalModule } = await import('../../../di/store-local.module.js')
+const { createWorkspacesRouter } = await import('./workspaces.js')
+const { createDocumentMetadataRouter } = await import('./metadata.js')
+const { createWorkspaceDocumentRouter } = await import('./workspace-document.js')
+
+const CANONICAL = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+const SEGMENT = 'design'
+
+async function seeded(): Promise<Awaited<ReturnType<typeof resolveServerDeps>>> {
+  await prepareDataDir(tmp.dir)
+  const db = await getDb(tmp.dir)
+  const deps = resolveServerDeps(createContainer(createStoreLocalModule({ db, blobDir: tmp.dir })))
+  await deps.documentIndex.createWorkspace({ workspaceId: CANONICAL, segment: SEGMENT })
+  // Asserted, not assumed: every case below is about a SEGMENT resolving, and
+  // a registry that quietly dropped it would make them pass by falling through
+  // to the id branch against a handle that happens to match nothing.
+  const entry = (await deps.documentIndex.listWorkspaces()).find((w) => w.workspaceId === CANONICAL)
+  expect(entry?.segment).toBe(SEGMENT)
+  await deps.documentIndex.createDocument({
+    workspaceId: CANONICAL,
+    path: 'spec',
+    kind: 'markdown',
+  })
+  return deps
+}
+
+describe('daemon routes address a workspace by its segment', () => {
+  it('answers GET /api/workspaces/<segment>/documents as it does the canonical id', async () => {
+    const deps = await seeded()
+    const app = createWorkspacesRouter({ serverDeps: deps })
+
+    const bySegment = await app.request(`/api/workspaces/${SEGMENT}/documents`)
+    const byId = await app.request(`/api/workspaces/${CANONICAL}/documents`)
+
+    expect(byId.status).toBe(200)
+    expect(bySegment.status).toBe(200)
+    expect(await bySegment.json()).toEqual(await byId.json())
+  })
+
+  it('answers GET /api/workspaces/<segment>/names as it does the canonical id', async () => {
+    await seeded()
+    const app = createDocumentMetadataRouter()
+    // Named through the CANONICAL id first, so the two responses differ from
+    // each other unless the segment reached the same workspace. Comparing the
+    // bare payloads would pass on two empty ones — which is what an
+    // unresolved handle answers here, since names has no absent-workspace
+    // refusal to fail on.
+    const named = await app.request(`/api/workspaces/${CANONICAL}/documents/spec/name`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'The spec' }),
+    })
+    expect(named.status).toBe(200)
+
+    const bySegment = await app.request(`/api/workspaces/${SEGMENT}/names`)
+    const byId = await app.request(`/api/workspaces/${CANONICAL}/names`)
+
+    expect(byId.status).toBe(200)
+    const canonical = await byId.json()
+    expect(JSON.stringify(canonical)).toContain('The spec')
+    expect(bySegment.status).toBe(200)
+    expect(await bySegment.json()).toEqual(canonical)
+  })
+
+  it('resolves the handle inside the /api/workspaces/.../documents/* hand parse', async () => {
+    await seeded()
+    const app = createDocumentMetadataRouter()
+
+    const res = await app.request(`/api/workspaces/${SEGMENT}/documents/spec/name`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'The spec' }),
+    })
+
+    // 404 here means the segment reached the store unresolved: the canonical
+    // workspace holds `spec`, a workspace literally named `design` does not.
+    expect(res.status).toBe(200)
+  })
+
+  it('resolves the handle inside the /api/w/... workspace-document surface', async () => {
+    await seeded()
+    const app = createWorkspaceDocumentRouter({ triggerAutoVersion: async () => null })
+
+    const res = await app.request(`/api/w/${SEGMENT}/workspace-document/snapshot`)
+
+    expect(res.status).toBe(200)
+  })
+
+  it('leaves a handle that resolves to nothing failing exactly as before', async () => {
+    const deps = await seeded()
+    const app = createWorkspacesRouter({ serverDeps: deps })
+
+    const res = await app.request('/api/workspaces/no-such-workspace/documents')
+
+    expect(res.status).toBe(404)
+    // The unresolved handle passes through unchanged, so the existing message
+    // still names what the caller actually typed.
+    expect(await res.json()).toEqual({ title: 'Workspace "no-such-workspace" not found' })
+  })
+})

--- a/packages/mcp-server/src/server/routes/document/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.ts
@@ -26,6 +26,7 @@ import {
 import type { ApiErrorBody } from '../../../shared/api-contracts/errors.js'
 import { getLogger } from '../../log.js'
 import { validateDocumentPath, validateWorkspaceId, validationErrorBody } from '../../validators.js'
+import { workspaceIdFromHandle } from '../../workspace-handle.js'
 import { handleCorruptStoredData } from './_shared.js'
 import { onDocumentsRoute } from './path-route.js'
 
@@ -77,14 +78,15 @@ export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
   })
 
   app.get('/api/workspaces/:workspaceId/documents', async (c) => {
-    const { workspaceId } = c.req.param()
+    const handle = c.req.param('workspaceId')
     try {
-      validateWorkspaceId(workspaceId)
+      validateWorkspaceId(handle)
     } catch (err) {
       const body = validationErrorBody(err)
       if (body) return c.json(body, 400)
       throw err
     }
+    const workspaceId = await workspaceIdFromHandle(c, handle)
     try {
       const deps = options.serverDeps ?? (await getDefaultServerDeps())
       const { documents } = await wbDocumentList(deps, { workspaceId })
@@ -125,14 +127,15 @@ export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
   // Save a new empty LoroDoc under path. Return 409 for conflicts and 400 for invalid paths.
   // On success, return { path } for client-side navigation.
   app.post('/api/workspaces/:workspaceId/documents', async (c) => {
-    const { workspaceId } = c.req.param()
+    const handle = c.req.param('workspaceId')
     try {
-      validateWorkspaceId(workspaceId)
+      validateWorkspaceId(handle)
     } catch (err) {
       const body = validationErrorBody(err)
       if (body) return c.json({ title: body.message } satisfies ApiErrorBody, 400)
       throw err
     }
+    const workspaceId = await workspaceIdFromHandle(c, handle)
     const raw = await c.req.json().catch(() => null)
     if (raw === null) {
       return c.json({ title: 'JSON body required' } satisfies ApiErrorBody, 400)

--- a/packages/mcp-server/src/server/routes/export.test.ts
+++ b/packages/mcp-server/src/server/routes/export.test.ts
@@ -64,6 +64,12 @@ const mockDocumentExists = vi.fn<(workspaceId: string, path: string) => Promise<
 )
 vi.mock('../store/document-store.js', () => ({
   documentExists: (workspaceId: string, path: string) => mockDocumentExists(workspaceId, path),
+  // The route family resolves an ADDRESS before it reaches the store
+  // (ADR-0019), and that read goes through this same module — so a double
+  // that omits it makes every export 500 on a TypeError rather than on
+  // anything the case is about. Empty registry: these tests address
+  // workspaces by id, which resolution leaves alone.
+  workspaceRegistry: () => ({ listWorkspaces: async () => [] }),
 }))
 
 // Spies on the real implementation so most tests exercise genuine random

--- a/packages/mcp-server/src/server/routes/files.ts
+++ b/packages/mcp-server/src/server/routes/files.ts
@@ -12,6 +12,7 @@ import { incompleteFileGcScanErrorBody, purgeDanglingFiles } from '../store/file
 import type { VersionStore } from '../store/version-store.js'
 import { withWorkspaceWriteLock } from '../store/workspace-lock.js'
 import { validateFileId, validateWorkspaceId, validationErrorBody } from '../validators.js'
+import { workspaceIdFromHandle } from '../workspace-handle.js'
 import { onDocumentFile } from './document/path-route.js'
 
 // Per-file size limit. Loro thumbnails are around 2 MiB and assets pasted into
@@ -158,14 +159,15 @@ export function createFilesRouter(options: FilesRouterOptions = {}) {
   // only ever removed once nothing across that full reference set points
   // at it, so branch/version restore never regresses to a broken image.
   app.post('/api/workspaces/:workspaceId/files/purge-dangling', async (c) => {
-    const { workspaceId } = c.req.param()
+    const handle = c.req.param('workspaceId')
     try {
-      validateWorkspaceId(workspaceId)
+      validateWorkspaceId(handle)
     } catch (err) {
       const body = validationErrorBody(err)
       if (body) return c.json(body, 400)
       throw err
     }
+    const workspaceId = await workspaceIdFromHandle(c, handle)
     try {
       const result = await purgeDanglingFiles(workspaceId, {
         versionStore: options.versionStore,

--- a/packages/mcp-server/src/server/routes/ws.test.ts
+++ b/packages/mcp-server/src/server/routes/ws.test.ts
@@ -25,8 +25,16 @@ const { clearCache } = await import('../store/doc-cache.js')
 const { loadDocument, saveDocument } = await import('../store/document-store.js')
 const { corruptStoredData } = await import('../store/corrupt-stored-data.js')
 const { createAutoVersionTrigger } = await import('./document.js')
-const { handleWsUpgrade, setAutoVersionTrigger, sendViewportRequest, setOnPersistedForTests } =
-  await import('./ws.js')
+const {
+  handleWsUpgrade,
+  setAutoVersionTrigger,
+  sendViewportRequest,
+  setOnPersistedForTests,
+  getClientCount,
+} = await import('./ws.js')
+const { upsertWorkspaceRow } = await import('../store/db/upsert-workspace.js')
+const { getDb } = await import('../store/db/index.js')
+const { prepareDataDir } = await import('../store/db/prepare.js')
 const { captureLogsForTests } = await import('../log.js')
 
 // Build a binary frame in the WORKSPACE lineage — the only binary contract:
@@ -98,6 +106,8 @@ class FakeWebSocket {
   }
 }
 
+const CANONICAL = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+
 describe('handleWsUpgrade workspace existence', () => {
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-ws-test-'))
@@ -147,6 +157,30 @@ describe('handleWsUpgrade workspace existence', () => {
     expect(ws.closes).toEqual([])
     // The initial snapshot for the lazily-created empty doc.
     expect(ws.sent.length).toBe(1)
+  })
+
+  it('registers a socket opened by segment under the canonical id, not the segment', async () => {
+    // The socket's registry key is what every later fan-out looks it up by
+    // (sendVersionCreated, the binary broadcast, SSE). Registered under the
+    // segment while the senders resolve to the canonical id, it stays open,
+    // reports "Synced", and receives NOTHING for the rest of its life — so
+    // asserting only that the connect succeeded would miss the whole defect.
+    // Segment claimed on the INITIAL insert: upsertWorkspaceRow is
+    // onConflict-doNothing, so the row saveDocument would create first
+    // cannot be given one afterwards.
+    await prepareDataDir(tempDir)
+    await upsertWorkspaceRow(await getDb(tempDir), CANONICAL, { segment: 'design' })
+    await saveDocument(CANONICAL, 'spec', new LoroDoc())
+
+    const ws = new FakeWebSocket()
+    await handleWsUpgrade(
+      { url: '/ws/design/spec', headers: { host: 'localhost:3099' } } as never,
+      ws as never,
+    )
+
+    expect(ws.closes).toEqual([])
+    expect(getClientCount(CANONICAL, 'spec')).toBe(1)
+    expect(getClientCount('design', 'spec')).toBe(0)
   })
 })
 

--- a/packages/mcp-server/src/server/routes/ws.ts
+++ b/packages/mcp-server/src/server/routes/ws.ts
@@ -22,6 +22,7 @@ import {
 } from '../store/document-store.js'
 import type { VersionEntry } from '../store/version-store.js'
 import { withWorkspaceWriteLock } from '../store/workspace-lock.js'
+import { resolveWorkspaceHandleToId } from '../workspace-handle.js'
 import {
   setSyncSseHooks,
   sseBroadcastText,
@@ -253,6 +254,13 @@ export async function handleWsUpgrade(
     ws.close()
     return
   }
+
+  // Resolved before ANY use, and OUTSIDE the parse guard above so a registry
+  // failure is not absorbed as a malformed address: `key` and both connection
+  // registries below are keyed by this, and a socket registered under the
+  // segment while its fan-out looks up the canonical id would go permanently
+  // silent.
+  workspaceId = await resolveWorkspaceHandleToId(workspaceId)
 
   const key = `${workspaceId}/${path}`
 

--- a/packages/mcp-server/src/server/workspace-handle.ts
+++ b/packages/mcp-server/src/server/workspace-handle.ts
@@ -1,0 +1,44 @@
+import { resolveWorkspaceHandle } from '@kamiazya/whiteboard-ports'
+import type { Context } from 'hono'
+import { workspaceRegistry } from './store/document-store.js'
+
+/**
+ * ADR-0019: an address carries a HANDLE, which is either a workspace's
+ * per-keeper `segment` or its canonical id. This is the daemon's one place
+ * that turns one into the other, so no route, tool or socket can answer
+ * differently — `resolveWorkspaceHandle` in ports fixes the precedence, and
+ * this fixes which registry it reads.
+ *
+ * TOTAL by design: a handle matching nothing passes through unchanged, so
+ * every existing refusal keeps the status, body and wording it already had,
+ * and names what the caller actually typed rather than something derived.
+ */
+export async function resolveWorkspaceHandleToId(handle: string): Promise<string> {
+  const entries = await workspaceRegistry().listWorkspaces()
+  return resolveWorkspaceHandle(entries, handle)?.workspaceId ?? handle
+}
+
+/**
+ * Per-REQUEST memo, keyed on the underlying `Request`, so a handle is
+ * resolved once no matter how many composed routers and helpers read it.
+ * The daemon has no single middleware to hang this on: its handlers reach
+ * module-level store state rather than one injected `deps`, and two of the
+ * three address families are hand-parsed out of a wildcard path rather than
+ * bound as a route param. Resolving twice would be worse than untidy — the
+ * second answer keys write locks, doc caches and connection registries, and
+ * two independent resolutions of the same handle are two chances to disagree.
+ */
+const memo = new WeakMap<Request, Map<string, string>>()
+
+export async function workspaceIdFromHandle(c: Context, handle: string): Promise<string> {
+  let perRequest = memo.get(c.req.raw)
+  if (perRequest === undefined) {
+    perRequest = new Map()
+    memo.set(c.req.raw, perRequest)
+  }
+  const hit = perRequest.get(handle)
+  if (hit !== undefined) return hit
+  const workspaceId = await resolveWorkspaceHandleToId(handle)
+  perRequest.set(handle, workspaceId)
+  return workspaceId
+}


### PR DESCRIPTION
Stage 1b, second half. The daemon's own HTTP routes and its WebSocket upgrade now accept a workspace `segment` wherever they accepted an id — same order the port fixes (#1108), same order `/api/v1` and the MCP tools already use (#1109).

## Why this is a separate increment from #1109

The seam is genuinely different, not merely elsewhere.

server-core has one injected `deps` and one path prefix, so a single Hono middleware covers all nine of its routes. The daemon has neither: its handlers reach **module-level store state** per request rather than one injected object, and two of its three address families are **hand-parsed out of a wildcard path** rather than bound as a route param. There is no one place to hang a middleware on.

So resolution is a line per address READ, and `server/workspace-handle.ts` carries a **per-request memo keyed on the `Request`** so "once" survives that shape.

**Resolving once is load-bearing, not tidiness.** The resolved id keys workspace write locks, the doc cache, and both WS connection registries. A socket registered under the segment while every fan-out looks up the canonical id stays open, reports "Synced", and receives nothing for the rest of its life. That is the failure the memo and the `ws.ts` ordering exist to prevent, and it is what the new WS case asserts on — `getClientCount(canonical) === 1 && getClientCount(segment) === 0`, not merely that the connect succeeded.

## What is preserved exactly

- **Validation runs on the handle AS WRITTEN**, before resolution, so a malformed one keeps its 400 — including both shapes this surface has (`{error, message}` and Problem Details `{title}`).
- **Resolution is fallback-total.** An unresolvable handle reaches the store unchanged, so every refusal keeps its status, body and wording, and still names what the caller typed. Pinned as its own case.
- In `ws.ts` the resolve sits **outside** the URL-parse `try`, so a registry failure is not absorbed as "malformed address".

## Behaviour today

Unchanged for every address that exists. No workspace has a segment yet, so over this registry resolution is the identity on every handle.

MCP tools needed nothing here: `createServer` already returns them wrapped (#1109), and `registerDocumentTools` registers exactly what it returns.

## Verification

The new test file has a case per READ MECHANISM rather than per route — `c.req.param()`, the `/api/workspaces/.../documents/*` hand parse, and the `/api/w/...` one are three separate places to forget, while a fourth route sharing a mechanism is not. Plus the WS registry-key case and the unresolvable-handle passthrough.

Two of the cases needed strengthening after they passed on the first run for the wrong reason: `/names` has no absent-workspace refusal to fail on, so comparing bare payloads by segment and by id compared two empty objects. It now names a document through the canonical id first, so the two responses differ unless the segment reached the same workspace.

Mutation-checked both halves. Replacing `resolveWorkspaceHandle` with an id-only match: 4 of 5 red. Deleting the single `ws.ts` line: the WS case red.

`mcp-node` + `arch-lint-node`: **4005 passed, 3 failed** — the three that fail identically on unmodified `origin/main` in this container (`0011-import-fs-blobs` ×2 and `migrator` ×1, all root-uid EACCES: the process is root, so a `chmod 000` directory stays readable and the "permission denied" they provoke never happens). `pnpm -r typecheck`, `pnpm knip` and `pnpm lint:noconsole` clean.

### One measured regression, found and fixed before pushing

`export.test.ts` and `export-svg.test.ts` `vi.mock` `document-store.js` with a **partial** factory exposing only `documentExists`. The route family they cover now also imports `workspaceRegistry` from that module, so it was `undefined` and every export 500'd on a TypeError. Measured: **37 failures** before the doubles were extended, **0** after. The doubles gained the dependency their subject gained; production stays strict, because a real daemon migrates at boot and a registry that is genuinely broken should not be papered over at this layer — the store read right after it fails on the same database.

Visual evidence: none — a server-side addressing seam with no user-visible surface in the diff. `userReach` is real but narrow, and the same as #1109's: a workspace that HAS a segment becomes addressable by it, now over the daemon's own routes and sockets too. Nothing mints segments yet, so no user reaches this today; that arrives with the create-time minting slice later in Wave 2.

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_