### PR TITLE
feat(mcp-server): re-key every daemon workspace onto a canonical ULID

### DIFF
--- a/packages/mcp-server/src/server/store/db/migrations/0012-ulid-remaining-document-ids.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0012-ulid-remaining-document-ids.test.ts
@@ -168,11 +168,17 @@ describe('0012-ulid-remaining-document-ids', () => {
       .executeTakeFirstOrThrow()) as { documentId: string }
     expect(branch.documentId).toBe(row.id)
 
-    await handle.migrateToHead()
+    // Pinned at 0013, the last migration these assertions are ABOUT, rather
+    // than at head: 0019 re-keys the workspace and renames `blobs/ws-1`
+    // out from under the blob assertion below. Spelling "run my migration"
+    // as `migrateToHead()` is what drifts — this file has already been
+    // caught by it once, when 0013 landed.
+    //
+    // 0013 rewrites the prefix 0012 wrote. The SEED above stays `canvas:` —
+    // it reproduces a pre-0013 database, and rewriting it would leave 0013
+    // untested.
+    await handle.migrateTo('0013-document-dockey-prefix')
 
-    // migrateToHead now runs 0013 too, which rewrites the prefix this
-    // migration wrote. The SEED above stays `canvas:` — it reproduces a
-    // pre-0013 database, and rewriting it would leave 0013 untested.
     const newDocKey = `document:${row.id}`
     for (const table of [
       'documentSnapshots',

--- a/packages/mcp-server/src/server/store/db/migrations/0015-versions-branches-workspace-id.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0015-versions-branches-workspace-id.test.ts
@@ -144,7 +144,9 @@ describe('0015-versions-branches-workspace-id', () => {
     await seedBranchRow(handle.db, DOC_A, 'main')
     await seedBranchRow(handle.db, DOC_B, 'feature')
 
-    await handle.migrateToHead()
+    // At 0015, not at head: the backfill this asserts writes `ws-1`/`ws-2`,
+    // and 0019 later re-keys those workspaces onto canonical ULIDs.
+    await handle.migrateTo0015()
 
     const versions = await handle.db
       .selectFrom('versions')

--- a/packages/mcp-server/src/server/store/db/migrations/0018-workspace-segment.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0018-workspace-segment.test.ts
@@ -79,7 +79,10 @@ describe('0018-workspace-segment', () => {
     await handle.migrateTo(PRE_0018)
     await seedWorkspace(handle.db, 'ws-legacy')
 
-    await handle.migrateToHead()
+    // At 0018, not at head: 0019 re-keys `ws-legacy` onto a canonical ULID
+    // and carries the old handle into the very column this is asserting is
+    // NULL, so head would be checking 0019's behaviour under 0018's name.
+    await handle.migrateTo('0018-workspace-segment')
 
     expect(await columnNames(handle.db, 'workspaces')).toContain('segment')
     const row = await handle.db

--- a/packages/mcp-server/src/server/store/db/migrations/0019-workspace-canonical-id.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0019-workspace-canonical-id.test.ts
@@ -1,0 +1,375 @@
+/**
+ * ADR-0019's canonical layer: a workspace is keyed by a bare ULID, and the
+ * string a human typed becomes its `segment`. This migration re-keys every
+ * workspace a daemon already holds.
+ *
+ * The re-key has to move everything that names a workspace at once —
+ * dependent rows, four `docKey` tables, a runtime marker, and two directory
+ * trees on disk. What makes that safe to write as plain statements rather
+ * than as 0008's ordering dance is measured, not assumed: on a fully
+ * migrated database the ONLY foreign key left in the schema is
+ * `documentSnapshotChunks.docKey -> documentSnapshots.docKey`, so the
+ * snapshot pair needs 0013's copy-then-delete and nothing else does.
+ */
+import { mkdir, mkdtemp, readdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createWorkspaceDocument } from '@kamiazya/whiteboard-loro-adapter'
+import { generateDocumentId } from '@kamiazya/whiteboard-model'
+import { Kysely, type MigrationProvider, Migrator, SqliteDialect, sql } from 'kysely'
+import LibsqlNativeDatabase from 'libsql'
+import { LoroDoc } from 'loro-crdt'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { migrations } from './index.js'
+
+let dataDir = ''
+vi.mock('../../../config.js', () => ({
+  get DATA_DIR() {
+    return dataDir
+  },
+  getDataDir: () => dataDir,
+}))
+
+const PRE_0019 = '0018-workspace-segment'
+const CANONICAL = /^[0-7][0-9A-HJKMNP-TV-Z]{25}$/
+
+interface Handle {
+  db: Kysely<Record<string, Record<string, unknown>>>
+  migrateTo(name: string): Promise<void>
+  migrateToHead(): Promise<void>
+}
+
+async function openDb(): Promise<Handle> {
+  const db = new Kysely<Record<string, Record<string, unknown>>>({
+    dialect: new SqliteDialect({
+      database: new LibsqlNativeDatabase(
+        join(dataDir, 'whiteboard.db'),
+      ) as unknown as ConstructorParameters<typeof SqliteDialect>[0]['database'],
+    }),
+  })
+  await sql`PRAGMA foreign_keys = ON`.execute(db)
+  const provider: MigrationProvider = { getMigrations: async () => migrations }
+  const migrator = new Migrator({ db: db as never, provider })
+  return {
+    db,
+    async migrateTo(name: string) {
+      const { error } = await migrator.migrateTo(name)
+      expect(error).toBeUndefined()
+    },
+    async migrateToHead() {
+      const { error } = await migrator.migrateToLatest()
+      expect(error).toBeUndefined()
+    },
+  }
+}
+
+/** A workspace as a pre-0019 writer left it: the handle IS the id. */
+async function seedWorkspace(handle: Handle, workspaceId: string): Promise<void> {
+  const now = Date.now()
+  const { db } = handle
+  await db
+    .insertInto('workspaces')
+    .values({ id: workspaceId, displayName: null, segment: null, createdAt: now, updatedAt: now })
+    .execute()
+  await db
+    .insertInto('branches')
+    .values({
+      documentId: `doc-${workspaceId}`,
+      workspaceId,
+      name: 'main',
+      tipFrontiers: '[]',
+      color: null,
+      sourceBranchName: null,
+      sourceVersionId: null,
+      createdAt: now,
+    })
+    .execute()
+  await db
+    .insertInto('versions')
+    .values({
+      id: `v-${workspaceId}`,
+      documentId: `doc-${workspaceId}`,
+      workspaceId,
+      branchName: 'main',
+      auto: 0,
+      label: null,
+      operatorKind: 'human',
+      operatorPeerId: 'peer-1',
+      operatorDisplayName: null,
+      operatorAgentId: null,
+      // Attribution: which workspace the operator was acting in. Points at
+      // this daemon's own workspace here, which is the case the re-key has
+      // to move; a foreign value it does not recognise must be left alone.
+      operatorWorkspaceId: workspaceId,
+      elementCount: 0,
+      frontiers: '[]',
+      hasThumbnail: 0,
+      createdAt: now,
+    })
+    .execute()
+
+  const docKey = `workspace-tree:${workspaceId}`
+  await db
+    .insertInto('documentSnapshots')
+    .values({
+      docKey,
+      chunkCount: 1,
+      totalBytes: 3,
+      maxChunkBytes: 3,
+      frontier: Uint8Array.from([1, 2, 3]),
+    })
+    .execute()
+  await db
+    .insertInto('documentSnapshotChunks')
+    .values({ docKey, chunkIndex: 0, bytes: Uint8Array.from([9, 9, 9]) })
+    .execute()
+  await db
+    .insertInto('documentDeltas')
+    .values({ docKey, seq: 1, bytes: Uint8Array.from([4]), frontier: Uint8Array.from([5]) })
+    .execute()
+  await db
+    .insertInto('documentFrontiers')
+    .values({ docKey, frontier: Uint8Array.from([6]) })
+    .execute()
+
+  // The two workspace-keyed directory trees on disk.
+  await mkdir(join(dataDir, workspaceId, 'files'), { recursive: true })
+  await writeFile(join(dataDir, workspaceId, 'files', 'a.png'), 'png')
+  await mkdir(join(dataDir, 'blobs', workspaceId, 'versions'), { recursive: true })
+  await writeFile(join(dataDir, 'blobs', workspaceId, 'versions', 'v1.png'), 'thumb')
+}
+
+async function setCurrentWorkspace(handle: Handle, workspaceId: string): Promise<void> {
+  await handle.db
+    .insertInto('runtime')
+    .values({ key: 'currentWorkspaceId', value: workspaceId, updatedAt: Date.now() })
+    .execute()
+}
+
+async function idOf(handle: Handle, segment: string | null): Promise<string> {
+  const row = await handle.db
+    .selectFrom('workspaces')
+    .select(['id'])
+    .where('segment', segment === null ? 'is' : '=', segment)
+    .executeTakeFirstOrThrow()
+  return row.id as string
+}
+
+describe('0019-workspace-canonical-id', () => {
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'migration-0019-'))
+  })
+
+  it('re-keys a legacy workspace onto a ULID and keeps the old handle as its segment', async () => {
+    const handle = await openDb()
+    await handle.migrateTo(PRE_0019)
+    await seedWorkspace(handle, 'default')
+
+    await handle.migrateToHead()
+
+    const rows = await handle.db.selectFrom('workspaces').select(['id', 'segment']).execute()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.id).toMatch(CANONICAL)
+    // `default` is segment-valid, so the address a user already types keeps
+    // working through segment-first resolution rather than being retired.
+    expect(rows[0]?.segment).toBe('default')
+  })
+
+  it('leaves the segment NULL when the old handle cannot be one', async () => {
+    const handle = await openDb()
+    await handle.migrateTo(PRE_0019)
+    // A nanoid-minted id: `_` is outside the segment charset, so there is no
+    // honest segment to carry over. NULL rather than a mangled approximation
+    // — a segment nobody chose is worse than none.
+    await seedWorkspace(handle, 'V1StGXR8_Z5jdHi6B-myT')
+
+    await handle.migrateToHead()
+
+    const rows = await handle.db.selectFrom('workspaces').select(['id', 'segment']).execute()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.id).toMatch(CANONICAL)
+    expect(rows[0]?.segment).toBeNull()
+  })
+
+  it('moves every row and docKey that named the workspace', async () => {
+    const handle = await openDb()
+    await handle.migrateTo(PRE_0019)
+    await seedWorkspace(handle, 'default')
+    await setCurrentWorkspace(handle, 'default')
+
+    await handle.migrateToHead()
+    const newId = await idOf(handle, 'default')
+
+    const branch = await handle.db
+      .selectFrom('branches')
+      .select(['workspaceId'])
+      .executeTakeFirstOrThrow()
+    expect(branch.workspaceId).toBe(newId)
+
+    const version = await handle.db
+      .selectFrom('versions')
+      .select(['workspaceId', 'operatorWorkspaceId'])
+      .executeTakeFirstOrThrow()
+    expect(version.workspaceId).toBe(newId)
+    expect(version.operatorWorkspaceId).toBe(newId)
+
+    const marker = await handle.db
+      .selectFrom('runtime')
+      .select(['value'])
+      .where('key', '=', 'currentWorkspaceId')
+      .executeTakeFirstOrThrow()
+    expect(marker.value).toBe(newId)
+
+    const newKey = `workspace-tree:${newId}`
+    for (const table of [
+      'documentSnapshots',
+      'documentSnapshotChunks',
+      'documentDeltas',
+      'documentFrontiers',
+    ]) {
+      const keys = await handle.db.selectFrom(table).select(['docKey']).execute()
+      expect(keys.map((r) => r.docKey)).toEqual([newKey])
+    }
+    // The one FK in the schema: the chunk must survive the parent's move
+    // with its BYTES, which a delete-then-reinsert of the parent alone would
+    // have cascaded away.
+    // Read as an ArrayBuffer, which is what this raw handle hands back for a
+    // blob — `Array.from` on one answers `[]` whether or not the bytes
+    // survived, so the length is asserted in SQL as well rather than trusting
+    // a JS view to have reached the column at all.
+    const chunk = await handle.db
+      .selectFrom('documentSnapshotChunks')
+      .select(['bytes'])
+      .executeTakeFirstOrThrow()
+    expect(Array.from(new Uint8Array(chunk.bytes as ArrayBuffer))).toEqual([9, 9, 9])
+    const size = await sql<{ n: number }>`
+      select length("bytes") as n from "documentSnapshotChunks"
+    `.execute(handle.db)
+    expect(size.rows.map((r) => r.n)).toEqual([3])
+  })
+
+  it('renames both workspace-keyed directory trees on disk', async () => {
+    const handle = await openDb()
+    await handle.migrateTo(PRE_0019)
+    await seedWorkspace(handle, 'default')
+
+    await handle.migrateToHead()
+    const newId = await idOf(handle, 'default')
+
+    expect(await readdir(join(dataDir, newId, 'files'))).toEqual(['a.png'])
+    expect(await readdir(join(dataDir, 'blobs', newId, 'versions'))).toEqual(['v1.png'])
+    expect(await readdir(dataDir)).not.toContain('default')
+    expect(await readdir(join(dataDir, 'blobs'))).not.toContain('default')
+  })
+
+  it('leaves a workspace that is already canonically keyed exactly as it is', async () => {
+    const handle = await openDb()
+    await handle.migrateTo(PRE_0019)
+    await seedWorkspace(handle, '01ARZ3NDEKTSV4RRFFQ69G5FAV')
+
+    await handle.migrateToHead()
+
+    const rows = await handle.db.selectFrom('workspaces').select(['id', 'segment']).execute()
+    // Untouched, and NOT given itself as a segment — a ULID-shaped segment is
+    // exactly what workspaceSegmentSchema forbids, because it would collide
+    // with the canonical-id fallback in the one address position.
+    expect(rows).toEqual([{ id: '01ARZ3NDEKTSV4RRFFQ69G5FAV', segment: null }])
+    const keys = await handle.db.selectFrom('documentFrontiers').select(['docKey']).execute()
+    expect(keys.map((r) => r.docKey)).toEqual(['workspace-tree:01ARZ3NDEKTSV4RRFFQ69G5FAV'])
+  })
+
+  it('re-keys several workspaces independently in one run', async () => {
+    const handle = await openDb()
+    await handle.migrateTo(PRE_0019)
+    await seedWorkspace(handle, 'default')
+    await seedWorkspace(handle, 'notes')
+
+    await handle.migrateToHead()
+
+    const rows = await handle.db
+      .selectFrom('workspaces')
+      .select(['id', 'segment'])
+      .orderBy('segment')
+      .execute()
+    expect(rows.map((r) => r.segment)).toEqual(['default', 'notes'])
+    const ids = rows.map((r) => r.id as string)
+    expect(ids.every((id) => CANONICAL.test(id))).toBe(true)
+    expect(new Set(ids).size).toBe(2)
+    // Each workspace's own tree moved with it, rather than both landing on
+    // whichever id was minted last.
+    const keys = await handle.db
+      .selectFrom('documentFrontiers')
+      .select(['docKey'])
+      .orderBy('docKey')
+      .execute()
+    expect(keys.map((r) => r.docKey).sort()).toEqual(ids.map((id) => `workspace-tree:${id}`).sort())
+  })
+
+  it('leaves the workspace reachable by the handle a user already types', async () => {
+    // The point of the whole two-stage ordering, asserted end to end rather
+    // than argued: the id under every row changes, and the address does not.
+    // A DB-level check cannot say this — it is the ROUTE, resolving
+    // segment-first (Stage 1b), that has to answer.
+    //
+    // Seeded as a REAL workspace tree at the pre-0019 point, because the
+    // route reads one: fake snapshot bytes would fail to import and the case
+    // would pass or fail for a reason that has nothing to do with addressing.
+    const handle = await openDb()
+    await handle.migrateTo(PRE_0019)
+    await handle.db
+      .insertInto('workspaces')
+      .values({
+        id: 'default',
+        displayName: null,
+        segment: null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      })
+      .execute()
+
+    const tree = new LoroDoc()
+    createWorkspaceDocument(tree, {
+      documentId: generateDocumentId(),
+      segment: 'spec',
+      kind: 'markdown',
+    })
+    const snapshot = tree.export({ mode: 'snapshot' })
+    await handle.db
+      .insertInto('documentSnapshots')
+      .values({
+        docKey: 'workspace-tree:default',
+        chunkCount: 1,
+        totalBytes: snapshot.length,
+        maxChunkBytes: snapshot.length,
+        frontier: Uint8Array.from([]),
+      })
+      .execute()
+    await handle.db
+      .insertInto('documentSnapshotChunks')
+      .values({ docKey: 'workspace-tree:default', chunkIndex: 0, bytes: snapshot })
+      .execute()
+
+    await handle.migrateToHead()
+    await handle.db.destroy()
+
+    const newId = await (async () => {
+      const h = await openDb()
+      const row = await h.db.selectFrom('workspaces').select(['id']).executeTakeFirstOrThrow()
+      await h.db.destroy()
+      return row.id as string
+    })()
+    expect(newId).toMatch(CANONICAL)
+    expect(newId).not.toBe('default')
+
+    const { createWorkspacesRouter } = await import('../../../routes/document/workspaces.js')
+    const app = createWorkspacesRouter()
+    const bySegment = await app.request('/api/workspaces/default/documents')
+    const byId = await app.request(`/api/workspaces/${newId}/documents`)
+
+    expect(byId.status).toBe(200)
+    const canonical = (await byId.json()) as { documents: { path: string }[] }
+    expect(canonical.documents.map((d) => d.path)).toEqual(['spec'])
+    expect(bySegment.status).toBe(200)
+    expect(await bySegment.json()).toEqual(canonical)
+  })
+})

--- a/packages/mcp-server/src/server/store/db/migrations/0019-workspace-canonical-id.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0019-workspace-canonical-id.ts
@@ -1,0 +1,186 @@
+import { rename } from 'node:fs/promises'
+import { join } from 'node:path'
+import { generateDocumentId } from '@kamiazya/whiteboard-model'
+import { type Kysely, type Migration, sql } from 'kysely'
+import { getDataDir } from '../../../config.js'
+import { getLogger } from '../../../log.js'
+
+// ADR-0019 splits one overloaded string into three layers. This re-keys every
+// workspace this daemon already holds onto the canonical layer — a bare ULID —
+// and carries the string a user actually typed into the `segment` layer, where
+// segment-first resolution keeps every existing address working.
+//
+// Every table and column name below is a FROZEN literal, current as of 0018,
+// and so are both PATTERNS: a recorded migration must not read the live schema
+// or a live Zod schema, either of which is free to change out from under it.
+// What "canonical" and "segment-shaped" meant at this point in the log is part
+// of what this migration decided.
+const CANONICAL_ULID = /^[0-7][0-9A-HJKMNP-TV-Z]{25}$/
+const SEGMENT_SHAPE = /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$/
+
+const TREE_KEY_PREFIX = 'workspace-tree:'
+
+/** `docKey` tables carrying no foreign key in either direction. */
+const UNCONSTRAINED_DOC_KEY_TABLES = ['documentDeltas', 'documentFrontiers'] as const
+
+interface WorkspaceRow {
+  id: string
+}
+
+/**
+ * The old handle becomes the segment only when it can BE one. A nanoid-minted
+ * id (`V1StGXR8_Z5jdHi6B-myT`) is outside the charset, and an id that is
+ * already a ULID must not become a segment at all — a ULID-shaped segment is
+ * precisely the ambiguity `workspaceSegmentSchema` exists to forbid, since
+ * segment and canonical id share one position in an address.
+ *
+ * NULL rather than a mangled approximation: a segment nobody chose reads as
+ * one somebody did.
+ */
+function segmentFor(oldId: string): string | null {
+  if (CANONICAL_ULID.test(oldId.toUpperCase())) return null
+  return SEGMENT_SHAPE.test(oldId) ? oldId : null
+}
+
+/**
+ * `documentSnapshotChunks.docKey` references `documentSnapshots.docKey` with
+ * `on delete cascade` and no `on update` action — measured on a fully migrated
+ * database, it is the ONLY foreign key left in the schema. Neither side can be
+ * updated in place: parent-first orphans the chunks, child-first points them at
+ * a key that does not exist yet, and `pragma defer_foreign_keys` does not
+ * rescue it (see 0013, which measured that the pragma reads back as `1` while
+ * the UPDATE still fails, because it only has effect inside an explicit
+ * transaction and kysely's Migrator does not open one).
+ *
+ * So the rewrite is a copy, then a delete that cascades the old chunks away.
+ * Every statement is independently valid, which is what makes this correct
+ * however the caller manages transactions.
+ */
+async function moveSnapshotTree(db: Kysely<unknown>, from: string, to: string): Promise<void> {
+  const oldKey = `${TREE_KEY_PREFIX}${from}`
+  const newKey = `${TREE_KEY_PREFIX}${to}`
+
+  await sql`
+    insert into "documentSnapshots" ("docKey", "chunkCount", "totalBytes", "maxChunkBytes", "frontier")
+    select ${sql.lit(newKey)}, "chunkCount", "totalBytes", "maxChunkBytes", "frontier"
+    from "documentSnapshots" where "docKey" = ${sql.lit(oldKey)}
+  `.execute(db)
+
+  await sql`
+    insert into "documentSnapshotChunks" ("docKey", "chunkIndex", "bytes")
+    select ${sql.lit(newKey)}, "chunkIndex", "bytes"
+    from "documentSnapshotChunks" where "docKey" = ${sql.lit(oldKey)}
+  `.execute(db)
+
+  // Cascades the old chunk rows away with their parent.
+  await sql`delete from "documentSnapshots" where "docKey" = ${sql.lit(oldKey)}`.execute(db)
+
+  for (const table of UNCONSTRAINED_DOC_KEY_TABLES) {
+    await sql`
+      update ${sql.ref(table)} set "docKey" = ${sql.lit(newKey)}
+      where "docKey" = ${sql.lit(oldKey)}
+    `.execute(db)
+  }
+}
+
+/**
+ * The two directory trees named by a workspace: uploaded files, and version
+ * thumbnails. Absent is normal — a workspace that never took an upload has no
+ * `files/` — so a missing source is a no-op rather than a failure.
+ */
+function workspaceDirs(workspaceId: string): string[] {
+  const dataDir = getDataDir()
+  return [join(dataDir, workspaceId), join(dataDir, 'blobs', workspaceId)]
+}
+
+export const migration: Migration = {
+  async up(db: Kysely<unknown>): Promise<void> {
+    const tdb = db as Kysely<{ workspaces: WorkspaceRow }>
+    const log = getLogger('migration-0019')
+
+    const rows = await tdb.selectFrom('workspaces').select(['id']).execute()
+    const legacy = rows.filter((row) => !CANONICAL_ULID.test(row.id))
+    if (legacy.length === 0) return
+
+    // A directory rename is the one step here a transaction cannot roll back.
+    // If a LATER workspace fails, the migrator rolls the database back to the
+    // old ids — and a tree already renamed onto a fresh ULID would be orphaned
+    // FOREVER, because the ULID is regenerated on the next attempt and nothing
+    // could find it again. So every completed rename is recorded and unwound
+    // (best effort, loudly) before the error propagates: the disk then matches
+    // the rolled-back database and the migration is safe to retry.
+    const completed: { from: string; to: string }[] = []
+    try {
+      for (const { id: oldId } of legacy) {
+        const newId = generateDocumentId()
+        const segment = segmentFor(oldId)
+
+        // Rows first: a renamed tree with an un-renamed row is an outage,
+        // while a row that moved ahead of its files is recoverable.
+        //
+        // Nothing references `workspaces.id` any more (0016 dropped the last
+        // foreign key onto it, 0017 dropped the table that carried it), so
+        // these are plain statements in any order rather than 0008's
+        // insert-new / repoint-children / delete-old dance.
+        await sql`
+          update "workspaces" set "id" = ${sql.lit(newId)}, "segment" = ${
+            segment === null ? sql.lit(null) : sql.lit(segment)
+          } where "id" = ${sql.lit(oldId)}
+        `.execute(db)
+        await sql`update "branches" set "workspaceId" = ${sql.lit(newId)} where "workspaceId" = ${sql.lit(oldId)}`.execute(
+          db,
+        )
+        await sql`update "versions" set "workspaceId" = ${sql.lit(newId)} where "workspaceId" = ${sql.lit(oldId)}`.execute(
+          db,
+        )
+        // Attribution — which workspace the operator was acting in. Matched by
+        // exact equality against an id THIS daemon is re-keying, so a value
+        // naming somebody else's workspace is left exactly as recorded.
+        await sql`update "versions" set "operatorWorkspaceId" = ${sql.lit(newId)} where "operatorWorkspaceId" = ${sql.lit(oldId)}`.execute(
+          db,
+        )
+        await sql`
+          update "runtime" set "value" = ${sql.lit(newId)}
+          where "key" = 'currentWorkspaceId' and "value" = ${sql.lit(oldId)}
+        `.execute(db)
+
+        await moveSnapshotTree(db, oldId, newId)
+
+        for (const [i, from] of workspaceDirs(oldId).entries()) {
+          const to = workspaceDirs(newId)[i] as string
+          try {
+            await rename(from, to)
+            completed.push({ from, to })
+          } catch (err) {
+            if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+          }
+        }
+
+        log.info({ oldId, newId, segment }, 're-keyed workspace onto a canonical id')
+      }
+    } catch (err) {
+      for (const done of completed.reverse()) {
+        try {
+          await rename(done.to, done.from)
+        } catch (undoErr) {
+          log.error(
+            { from: done.to, to: done.from, err: undoErr },
+            'could not undo a directory rename while unwinding — reconcile by hand',
+          )
+        }
+      }
+      throw err
+    }
+  },
+
+  async down(): Promise<void> {
+    // Not reversible: the old handles are recoverable only for the workspaces
+    // whose id could BE a segment, and the ones that got NULL are gone. A
+    // `down` that restored some ids and invented others would be worse than
+    // none — it would report success while leaving half the daemon addressed
+    // by strings nobody ever used.
+    throw new Error(
+      '0019-workspace-canonical-id cannot be reversed: legacy handles are not all recoverable',
+    )
+  },
+}

--- a/packages/mcp-server/src/server/store/db/migrations/index.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/index.ts
@@ -17,6 +17,7 @@ import { migration as versionsBranchesWorkspaceId } from './0015-versions-branch
 import { migration as dropDocumentsFk } from './0016-drop-documents-fk.js'
 import { migration as dropDocumentsTable } from './0017-drop-documents-table.js'
 import { migration as workspaceSegment } from './0018-workspace-segment.js'
+import { migration as workspaceCanonicalId } from './0019-workspace-canonical-id.js'
 
 // Ordered map; kysely sorts by key so the numeric prefix decides execution order.
 // 0003 still says `canvas-doc-store` after the port it creates was renamed to
@@ -45,4 +46,5 @@ export const migrations: Record<string, Migration> = {
   '0016-drop-documents-fk': dropDocumentsFk,
   '0017-drop-documents-table': dropDocumentsTable,
   '0018-workspace-segment': workspaceSegment,
+  '0019-workspace-canonical-id': workspaceCanonicalId,
 }

--- a/packages/mcp-server/src/server/store/db/published-migration-names.ts
+++ b/packages/mcp-server/src/server/store/db/published-migration-names.ts
@@ -29,4 +29,5 @@ export const PUBLISHED_MIGRATION_NAMES = [
   '0016-drop-documents-fk',
   '0017-drop-documents-table',
   '0018-workspace-segment',
+  '0019-workspace-canonical-id',
 ] as const satisfies readonly string[]


### PR DESCRIPTION
Wave-2 Stage 2. ADR-0019's canonical layer, for the keeper that never had one: every workspace this daemon holds moves from the string a user typed to a bare ULID, and that string becomes its `segment`.

This is why the two Stage-1 increments went first. Segment-first resolution (#1108, #1109, #1110) is already in place on every address surface, so `default` keeps working as an address after it stops being an id. Landing this before them would have broken every existing address at once.

## The shape is measured, not assumed

The migration is plain UPDATEs rather than 0008's insert-new / repoint-children / delete-old dance, because on a **fully migrated database the only foreign key left in the entire schema** is `documentSnapshotChunks.docKey -> documentSnapshots.docKey`. Measured directly with `pragma_foreign_key_list` over every table, not read off migration history: 0016 dropped the last FK onto `workspaces.id` and 0017 dropped the table that carried it.

So only the snapshot pair needs 0013's copy-then-delete — and the reason it cannot be an in-place UPDATE is the one 0013 already measured: `pragma defer_foreign_keys` reads back as `1` and the UPDATE still fails, because it only has effect inside an explicit transaction and kysely's Migrator does not open one.

## What moves

`workspaces.id` · `branches.workspaceId` · `versions.workspaceId` · `versions.operatorWorkspaceId` · the `currentWorkspaceId` runtime marker · the `workspace-tree:` docKey across all four byte tables · and the two directory trees on disk (`<dataDir>/<id>/`, `<dataDir>/blobs/<id>/`).

`operatorWorkspaceId` is attribution — which workspace the operator was acting in — matched by exact equality against an id **this** daemon is re-keying, so a value naming somebody else's workspace is left as recorded.

Directory renames carry 0008's unwind discipline. A rename is the one step a rollback cannot undo, and a tree already moved onto a fresh ULID would be orphaned forever, because the next attempt mints a different one and nothing could find it again.

`prepareDataDir` runs migrations and nothing else (the `importFsBlobs` re-invoke was removed earlier), so no boot-time writer can undo this — the trap that bit a previous rename.

## Segment backfill: valid-only, else NULL

An id already shaped like a ULID gets **no** segment — a ULID-shaped segment is precisely the ambiguity `workspaceSegmentSchema` forbids, since segment and canonical id share one position in an address. A nanoid id (`V1StGXR8_Z5jdHi6B-myT`) is outside the charset, so it gets NULL too: a segment nobody chose reads as one somebody did.

Both patterns are **frozen literals** in the migration rather than imports of the live Zod schemas. What "canonical" and "segment-shaped" meant at this point in the log is part of what this migration decided.

`down` throws. Old handles are recoverable only for the workspaces whose id could BE a segment; a `down` that restored some and invented the rest would report success while leaving half the daemon addressed by strings nobody ever used.

## Verification

Seven cases. The one that matters most is end to end rather than argued: seed a **real** workspace tree at the pre-0019 point (fake snapshot bytes would fail to import and the case would pass or fail for a reason unrelated to addressing), migrate, then hit the real route by the old handle and by the new id and compare. The id under every row changes; the address does not. Mutation-checked by reverting the resolve in `workspaces.ts` — red.

Three more mutations, each red: chunks not copied (the FK cascade eats them), segment taken without the shape check, directory renames dropped.

One assertion had to be fixed after passing for the wrong reason: the raw kysely handle returns an `ArrayBuffer` for a blob, and `Array.from(ArrayBuffer)` is `[]` — for the *original* row too, with SQL `length()` reporting 3. It would have read `[]` whether or not the bytes survived. Now read through a `Uint8Array` view **and** length-checked in SQL.

### Three existing tests drifted, and it is a class worth naming

`0012`, `0015` and `0018` spelled "run my migration" as `migrateToHead()`, so they broke the moment 0019 touched their fixtures. `0012` had already been caught by this once when 0013 landed — its own comment records it. Each is now pinned at the migration its assertions are actually about, which is the convention `0012` and `0015` already state in prose ("asserted at 0014, the last point the row still exists"; "pins the state AT 0015, not at head").

`mcp-node` + `arch-lint-node`: **4012 passed, 3 failed** — the three that fail identically on unmodified `origin/main` in this container (root-uid EACCES: the process is root, so a `chmod 000` directory stays readable and the "permission denied" those cases provoke never happens). `pnpm -r typecheck`, `pnpm knip`, `pnpm lint:noconsole` clean.

Visual evidence: none — a storage migration with no user-visible surface in the diff. The user-visible consequence is deliberately *nothing changing*: the end-to-end case above exists to assert exactly that, since a re-key a user could notice would be the defect.

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_