### PR TITLE
feat(server-core): a document create reports the workspace it wrote to

### DIFF
--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -214,8 +214,18 @@ async function main() {
   if (typeof created.documentId !== 'string' || created.path !== 'e2e-src') {
     throw new Error(`wb_document_create returned unexpected shape: ${JSON.stringify(created)}`)
   }
+  // A create says which workspace it filed the document under (ADR-0019).
+  // Asserted here rather than only in a unit test because the MCP SDK
+  // validates structuredContent against outputSchema at runtime through the
+  // PUBLISHED artifact — this is the last place a schema and the value it
+  // describes can be caught travelling separately.
+  if (created.workspaceId !== WORKSPACE_ID) {
+    throw new Error(
+      `wb_document_create did not report the workspace it wrote to: ${JSON.stringify(created)}`,
+    )
+  }
   const documentId = created.documentId
-  console.log(`[e2e] wb_document_create → ${documentId}`)
+  console.log(`[e2e] wb_document_create → ${documentId} in ${created.workspaceId}`)
 
   // A document's name is the workspace's, not its content's (ADR-0009), so
   // it round-trips through create -> list without any document read.

--- a/packages/mcp-server/src/server/routes/viewport.test.ts
+++ b/packages/mcp-server/src/server/routes/viewport.test.ts
@@ -51,16 +51,18 @@ describe('POST /api/w/:workspaceId/document/:path/viewport - error handling', ()
     await rm(tempDir, { recursive: true, force: true })
   })
 
-  it('returns 503 immediately when there are no WS clients', async () => {
+  it('returns 503 without waiting for the response timeout when there are no WS clients', async () => {
+    // Pinned by the TIMEOUT the route was given, not by the wall clock. The
+    // zero-client branch answers before the timer is ever armed, so a
+    // regression into the waiting path would blow the per-test budget and
+    // say so — where `elapsed < 500ms` instead measured how loaded the
+    // machine was, and failed on CI at 721ms with nothing wrong.
     mockGetClientCount.mockReturnValue(0)
-    const app = makeApp()
+    const app = makeApp({ timeoutMs: 30_000 })
 
-    const start = Date.now()
     const res = await app.request('/api/w/s1/document/canvas-a/viewport', { method: 'POST' })
-    const elapsed = Date.now() - start
 
     expect(res.status).toBe(503)
-    expect(elapsed).toBeLessThan(500)
     expect(mockSendViewportRequest).not.toHaveBeenCalled()
   })
 

--- a/packages/server-core/src/references/content-facts-cache.test.ts
+++ b/packages/server-core/src/references/content-facts-cache.test.ts
@@ -20,12 +20,15 @@ function makeDeps() {
 }
 
 async function seedTwo(deps: ReturnType<typeof makeDeps>) {
+  // The workspace exists because this fixture says so, not as a side effect
+  // of the first create: creating one is ADR-0019's MINT boundary, which
+  // keys it by a fresh ULID and would leave the literal below naming nothing.
+  await deps.documentIndex.createWorkspace({ workspaceId: WS })
   const create = (path: string, name?: string) =>
     wbDocumentCreate(deps, {
       workspaceId: WS,
       path,
       kind: 'markdown',
-      createWorkspace: true,
       ...(name === undefined ? {} : { name }),
     })
   const a = await create('a', 'Alpha')
@@ -43,11 +46,11 @@ describe('ContentFactsCache', () => {
     const deps = makeDeps()
     await seedTwo(deps) // ws-1
     const OTHER = 'ws-2'
+    await deps.documentIndex.createWorkspace({ workspaceId: OTHER })
     const c = await wbDocumentCreate(deps, {
       workspaceId: OTHER,
       path: 'c',
       kind: 'markdown',
-      createWorkspace: true,
       name: 'Gamma',
     })
     await createDocumentSetTool(deps).execute({
@@ -148,11 +151,11 @@ describe('ContentFactsCache', () => {
 
   it('carries content tags for the tags projection', async () => {
     const deps = makeDeps()
+    await deps.documentIndex.createWorkspace({ workspaceId: WS })
     const doc = await wbDocumentCreate(deps, {
       workspaceId: WS,
       path: 'tagged',
       kind: 'markdown',
-      createWorkspace: true,
     })
     await createDocumentSetTool(deps).execute({
       workspaceId: WS,

--- a/packages/server-core/src/references/reference-semantics.property.test.ts
+++ b/packages/server-core/src/references/reference-semantics.property.test.ts
@@ -216,6 +216,11 @@ describe('reference semantics under command sequences', () => {
         documentTeardown: unusedDocumentTeardown(),
         documentWritten: ignoredDocumentWrites(),
       }
+      // The workspace exists because this run says so, not as a side effect of
+      // whichever command happens to create first: creating one is ADR-0019's
+      // MINT boundary, which keys it by a fresh ULID — and here that would
+      // also make the identity depend on the generated command sequence.
+      await deps.documentIndex.createWorkspace({ workspaceId: WS })
       const setTool = createDocumentSetTool(deps)
       const editTool = createCanvasEditTool(deps)
       const model = new Model()
@@ -237,7 +242,6 @@ describe('reference semantics under command sequences', () => {
                   workspaceId: WS,
                   path: cmd.path,
                   kind: cmd.kind,
-                  createWorkspace: true,
                   ...(cmd.name === undefined ? {} : { name: cmd.name }),
                 }),
               ).rejects.toThrow()
@@ -247,7 +251,6 @@ describe('reference semantics under command sequences', () => {
               workspaceId: WS,
               path: cmd.path,
               kind: cmd.kind,
-              createWorkspace: true,
               ...(cmd.name === undefined ? {} : { name: cmd.name }),
             })
             slots[cmd.slot] = created.documentId

--- a/packages/server-core/src/search/embedder-identity.test.ts
+++ b/packages/server-core/src/search/embedder-identity.test.ts
@@ -36,12 +36,15 @@ function embedderNamed(id: string, fill: number): Embedder & { calls: number } {
 }
 
 async function seed(deps: ReturnType<typeof makeDeps>) {
+  // The workspace exists because this fixture says so, not as a side effect
+  // of the first create: creating one is ADR-0019's MINT boundary, which
+  // keys it by a fresh ULID and would leave the literal below naming nothing.
+  await deps.documentIndex.createWorkspace({ workspaceId: WS })
   const created = await wbDocumentCreate(deps, {
     workspaceId: WS,
     path: 'untitled-1',
     kind: 'markdown',
     name: 'note',
-    createWorkspace: true,
   })
   await createDocumentSetTool(deps).execute({
     workspaceId: WS,

--- a/packages/server-core/src/search/search-quality.test.ts
+++ b/packages/server-core/src/search/search-quality.test.ts
@@ -68,13 +68,16 @@ beforeAll(async () => {
   }
   const set = createDocumentSetTool(deps)
   const edit = createCanvasEditTool(deps)
+  // The workspace exists because this fixture says so, not as a side effect
+  // of the first create: creating one is ADR-0019's MINT boundary, which
+  // keys it by a fresh ULID and would leave the literal below naming nothing.
+  await deps.documentIndex.createWorkspace({ workspaceId: WS })
   for (const doc of CORPUS_DOCUMENTS) {
     const created = await wbDocumentCreate(deps, {
       workspaceId: WS,
       path: doc.path,
       kind: doc.kind,
       name: doc.name,
-      createWorkspace: true,
     })
     if (doc.kind === 'markdown') {
       const frontmatter =

--- a/packages/server-core/src/search/semantic-search.test.ts
+++ b/packages/server-core/src/search/semantic-search.test.ts
@@ -62,6 +62,10 @@ function fakeEmbedder(): Embedder & { calls: number } {
 }
 
 async function seed(deps: ReturnType<typeof makeDeps>) {
+  // The workspace exists because this fixture says so, not as a side effect
+  // of the first create: creating one is ADR-0019's MINT boundary, which
+  // keys it by a fresh ULID and would leave the literal below naming nothing.
+  await deps.documentIndex.createWorkspace({ workspaceId: WS })
   const set = createDocumentSetTool(deps)
   const write = async (path: string, name: string, body: string) => {
     const created = await wbDocumentCreate(deps, {
@@ -69,7 +73,6 @@ async function seed(deps: ReturnType<typeof makeDeps>) {
       path,
       kind: 'markdown',
       name,
-      createWorkspace: true,
     })
     await set.execute({
       workspaceId: WS,
@@ -206,6 +209,10 @@ describe('semantic fusion', () => {
     // equally-ranked documents comes first" was when they happened to be
     // written, which is not a fact about the query.
     const deps = makeDeps()
+    // The workspace exists because this fixture says so, not as a side effect
+    // of the first create: creating one is ADR-0019's MINT boundary, which
+    // keys it by a fresh ULID and would leave the literal below naming nothing.
+    await deps.documentIndex.createWorkspace({ workspaceId: WS })
     const set = createDocumentSetTool(deps)
     const write = async (path: string, name: string, body: string) => {
       const created = await wbDocumentCreate(deps, {
@@ -213,7 +220,6 @@ describe('semantic fusion', () => {
         path,
         kind: 'markdown',
         name,
-        createWorkspace: true,
       })
       await set.execute({
         workspaceId: WS,

--- a/packages/server-core/src/tools/backlinks.test.ts
+++ b/packages/server-core/src/tools/backlinks.test.ts
@@ -22,12 +22,15 @@ function makeDeps() {
 }
 
 async function seed(deps: ReturnType<typeof makeDeps>) {
+  // The workspace exists because this fixture says so, not as a side effect
+  // of the first create: creating one is ADR-0019's MINT boundary, which
+  // keys it by a fresh ULID and would leave the literal below naming nothing.
+  await deps.documentIndex.createWorkspace({ workspaceId: WS })
   const create = (path: string, kind: 'markdown' | 'spatial', name?: string) =>
     wbDocumentCreate(deps, {
       workspaceId: WS,
       path,
       kind,
-      createWorkspace: true,
       ...(name === undefined ? {} : { name }),
     })
   const target = await create('target', 'markdown', 'Release plan')

--- a/packages/server-core/src/tools/document-crud.schemas.test.ts
+++ b/packages/server-core/src/tools/document-crud.schemas.test.ts
@@ -128,14 +128,26 @@ describe('wbDocumentCreateInputSchema', () => {
 describe('wbDocumentCreateOutputSchema', () => {
   it('accepts valid output', () => {
     const result = wbDocumentCreateOutputSchema.safeParse({
+      workspaceId: 'ws-1',
       documentId: VALID_DOCUMENT_ID,
       path: 'my-doc',
     })
     expect(result.success).toBe(true)
   })
 
+  it('requires the workspace the document was filed under', () => {
+    // A create that does not say which workspace it wrote to is unusable
+    // once the server, rather than the caller, decides that id (ADR-0019).
+    const result = wbDocumentCreateOutputSchema.safeParse({
+      documentId: VALID_DOCUMENT_ID,
+      path: 'my-doc',
+    })
+    expect(result.success).toBe(false)
+  })
+
   it('rejects invalid documentId', () => {
     const result = wbDocumentCreateOutputSchema.safeParse({
+      workspaceId: 'ws-1',
       documentId: 'not-a-ulid',
       path: 'my-doc',
     })
@@ -144,6 +156,7 @@ describe('wbDocumentCreateOutputSchema', () => {
 
   it('rejects extra keys (strict)', () => {
     const result = wbDocumentCreateOutputSchema.safeParse({
+      workspaceId: 'ws-1',
       documentId: VALID_DOCUMENT_ID,
       path: 'my-doc',
       extra: 1,

--- a/packages/server-core/src/tools/document-crud.schemas.ts
+++ b/packages/server-core/src/tools/document-crud.schemas.ts
@@ -80,6 +80,15 @@ export const wbDocumentCreateInputSchema = z
 
 export const wbDocumentCreateOutputSchema = z
   .object({
+    /**
+     * The workspace the document was filed under, as its CANONICAL id
+     * (ADR-0019). Always present, not only when this call created one: a
+     * caller that addressed an existing workspace by its segment learns the
+     * id behind it, and a caller that created one learns what the server
+     * minted. Without it a create is unusable — the server picks an id,
+     * files the document under it, and never says which.
+     */
+    workspaceId: workspaceIdSchema,
     documentId: documentIdSchema,
     path: documentPathSchema,
   })

--- a/packages/server-core/src/tools/document-crud.ts
+++ b/packages/server-core/src/tools/document-crud.ts
@@ -53,8 +53,15 @@ export async function wbDocumentCreate(
   // workspaceId must fail loudly rather than silently writing data into a
   // workspace nobody asked for. `createWorkspace: true` is the explicit
   // opt-in that bootstraps a genuinely new workspace.
+  //
+  // Everything below reads `workspaceId` rather than `input.workspaceId`.
+  // Today they are the same string; ADR-0019's mint boundary lands here
+  // next, at which point a create decides the canonical id and these two
+  // stop being interchangeable. Threading it now keeps that change to the
+  // one branch that causes it.
+  const workspaceId = input.workspaceId
   if (input.createWorkspace === true) {
-    await deps.documentIndex.createWorkspace({ workspaceId: input.workspaceId })
+    await deps.documentIndex.createWorkspace({ workspaceId })
   }
 
   // Parsed before anything is written, and AFTER the workspace bootstrap so
@@ -78,9 +85,9 @@ export async function wbDocumentCreate(
   // and outranks tidiness here — naming must never gate creation — so a
   // caller sending a blank one gets a document, not an error.
   const name = input.name?.trim()
-  const entry = await rethrowWorkspaceNotFound(input.workspaceId, () =>
+  const entry = await rethrowWorkspaceNotFound(workspaceId, () =>
     deps.documentIndex.createDocument({
-      workspaceId: input.workspaceId,
+      workspaceId,
       path: input.path,
       kind: input.kind,
       ...(name === undefined || name === '' ? {} : { name }),
@@ -93,7 +100,7 @@ export async function wbDocumentCreate(
   // document yet to ask. The kind is written once, at birth.
   const doc = new LoroDoc()
   writeDocumentKind(doc, input.kind)
-  await saveDocumentSnapshot(deps, input.workspaceId, entry.documentId, doc)
+  await saveDocumentSnapshot(deps, workspaceId, entry.documentId, doc)
 
   // A body is written by DELEGATING to `wb_document_set` rather than by
   // repeating what it does. Its write is not a one-liner — it parses OKF,
@@ -103,14 +110,14 @@ export async function wbDocumentCreate(
   // either changes.
   if (input.kind === 'markdown' && input.markdown !== undefined) {
     await createDocumentSetTool(deps).execute({
-      workspaceId: input.workspaceId,
+      workspaceId,
       documentId: entry.documentId,
       markdown: input.markdown,
       ...(input.actor === undefined ? {} : { actor: input.actor }),
     })
   }
 
-  return { documentId: entry.documentId, path: entry.path }
+  return { workspaceId, documentId: entry.documentId, path: entry.path }
 }
 
 export async function wbDocumentResolve(

--- a/packages/server-core/src/tools/document-get.test.ts
+++ b/packages/server-core/src/tools/document-get.test.ts
@@ -45,11 +45,15 @@ function makeDeps(): ServerDeps {
 }
 
 async function createDoc(deps: ServerDeps, kind: 'spatial' | 'markdown') {
+  // The workspace exists because this fixture says so, not as a side effect
+  // of the first create: creating one is ADR-0019's MINT boundary, which
+  // keys it by a fresh ULID and would leave the literal below naming nothing.
+  // Idempotent on the in-memory double, so calling it per document is fine.
+  await deps.documentIndex.createWorkspace({ workspaceId: 'ws' })
   const { documentId } = await wbDocumentCreate(deps, {
     workspaceId: 'ws',
     path: `doc-${kind}`,
     kind,
-    createWorkspace: true,
   })
   return documentId
 }

--- a/packages/server-core/src/tools/document-search.test.ts
+++ b/packages/server-core/src/tools/document-search.test.ts
@@ -22,12 +22,15 @@ function makeDeps() {
 }
 
 async function seed(deps: ReturnType<typeof makeDeps>) {
+  // The workspace exists because this fixture says so, not as a side effect
+  // of the first create: creating one is ADR-0019's MINT boundary, which
+  // keys it by a fresh ULID and would leave the literal below naming nothing.
+  await deps.documentIndex.createWorkspace({ workspaceId: WS })
   const create = (path: string, kind: 'markdown' | 'spatial', name?: string) =>
     wbDocumentCreate(deps, {
       workspaceId: WS,
       path,
       kind,
-      createWorkspace: true,
       ...(name === undefined ? {} : { name }),
     })
   const set = createDocumentSetTool(deps)

--- a/packages/server-core/src/tools/document-tags.test.ts
+++ b/packages/server-core/src/tools/document-tags.test.ts
@@ -23,8 +23,12 @@ function makeDeps() {
 describe('GET /document-tags', () => {
   it('lists tagged markdown documents and omits tagless, spatial, and snapshotless ones', async () => {
     const deps = makeDeps()
+    // The workspace exists because this fixture says so, not as a side effect
+    // of the first create: creating one is ADR-0019's MINT boundary, which
+    // keys it by a fresh ULID and would leave the literal below naming nothing.
+    await deps.documentIndex.createWorkspace({ workspaceId: WS })
     const create = (path: string, kind: 'markdown' | 'spatial') =>
-      wbDocumentCreate(deps, { workspaceId: WS, path, kind, createWorkspace: true })
+      wbDocumentCreate(deps, { workspaceId: WS, path, kind })
     const tagged = await create('tagged', 'markdown')
     const plain = await create('plain', 'markdown')
     await create('board', 'spatial')

--- a/packages/server-core/src/tools/linkify-mentions.test.ts
+++ b/packages/server-core/src/tools/linkify-mentions.test.ts
@@ -23,14 +23,17 @@ function makeDeps() {
   }
 }
 
-function harness(deps: ReturnType<typeof makeDeps>) {
+async function harness(deps: ReturnType<typeof makeDeps>) {
+  // The workspace exists because this fixture says so, not as a side effect
+  // of the first create: creating one is ADR-0019's MINT boundary, which
+  // keys it by a fresh ULID and would leave the literal below naming nothing.
+  await deps.documentIndex.createWorkspace({ workspaceId: WS })
   const app = createServer(deps).app
   const create = (path: string, kind: 'markdown' | 'spatial', name?: string) =>
     wbDocumentCreate(deps, {
       workspaceId: WS,
       path,
       kind,
-      createWorkspace: true,
       ...(name === undefined ? {} : { name }),
     })
   const set = createDocumentSetTool(deps)
@@ -65,7 +68,7 @@ function harness(deps: ReturnType<typeof makeDeps>) {
 describe('POST /linkify-mentions', () => {
   it('wraps every prose occurrence, skips existing references, and the mention disappears', async () => {
     const deps = makeDeps()
-    const h = harness(deps)
+    const h = await harness(deps)
     const target = await h.create('target', 'markdown', '設計メモ')
     const src = await h.create('src', 'markdown', '日報')
     await h.writeBody(
@@ -91,7 +94,7 @@ describe('POST /linkify-mentions', () => {
 
   it('an ambiguous name links by id with the name as alias', async () => {
     const deps = makeDeps()
-    const h = harness(deps)
+    const h = await harness(deps)
     const target = await h.create('target', 'markdown', 'Dup')
     await h.create('rival', 'markdown', 'Dup')
     const src = await h.create('src', 'markdown')
@@ -102,7 +105,7 @@ describe('POST /linkify-mentions', () => {
 
   it('rewrites canvas text nodes but never labels', async () => {
     const deps = makeDeps()
-    const h = harness(deps)
+    const h = await harness(deps)
     const target = await h.create('target', 'markdown', 'Redis')
     const board = await h.create('board', 'spatial')
     const edit = createCanvasEditTool(deps)
@@ -131,7 +134,7 @@ describe('POST /linkify-mentions', () => {
 
   it('refuses a nameless target and unknown documents', async () => {
     const deps = makeDeps()
-    const h = harness(deps)
+    const h = await harness(deps)
     const nameless = await h.create('nameless', 'markdown')
     const src = await h.create('src', 'markdown')
     expect((await h.linkify(src.documentId, nameless.documentId)).status).toBe(400)


### PR DESCRIPTION
Two behaviour-neutral commits, both preparation for Wave-2's mint boundary, split out because the mint's own diff was otherwise a contract change buried under a 40-site fixture sweep.

## 1. `wb_document_create` reports its workspace

It answered `{documentId, path}` — which does not identify a workspace. That is fine only while the **caller** decides the workspace id. ADR-0019's mint boundary moves that decision to the server, and a create that picks an id and never reports it is unusable: the caller would have made a workspace it cannot name.

Landing the field now, while it is still an echo of the input, means **consumers and fixtures can start reading the reported value before the value starts differing from what they sent.** The mint then changes behaviour without also changing shape — two things a reviewer can judge separately.

`wbDocumentCreate` also now works from a local `workspaceId` rather than reading `input.workspaceId` at each of its four later uses (index create, snapshot save, delegated body write, return). Today they are the same string. After the mint they are two different workspaces, and a use that still read the input would file the document under one that does not exist — so the threading happens now, confining that change to the one branch that causes it.

## 2. Fixtures state the workspace they need

Nine test files got their workspace as a **side effect** of the first `createWorkspace: true` and then addressed it by the literal they had passed in. Measured: with the mint in place that is **65 failures across 15 files**, all one shape. They now call `documentIndex.createWorkspace` where a workspace merely needs to exist, which says what they mean and is a no-op change today.

The remaining four files (`document-crud`, `document-routes`, `workspace-edit`, `document-create-body`) are exactly the ones whose subject *is* creation, so they move with the mint rather than ahead of it.

## What the sweep surfaced, for the next increment

`document-create-orphan` asserts **in prose** that a create refused for a malformed body leaves no workspace behind. The code does the OKF preflight *after* the bootstrap, so today it does leave one — the test passes anyway because it only checks that no DOCUMENT survives. Under the mint that stops being harmless (the retry mints a second workspace), and the fix is to preflight before bootstrapping, which finally makes the invariant the comment claims true.

Separately: the HTTP route `POST /api/workspaces/:workspaceId/documents` passes `createWorkspace: true` unconditionally, and I confirmed no test pins it — every case in `workspaces.test.ts` pre-creates its workspace, exactly as `dev-flow.md` already records for this flag. Under the mint it should stop passing it, restoring "workspaces never materialize implicitly" on the one surface that opted out.

## Verification

- `server-core-node` 419/419. The output-schema test gains a case pinning that the field is **required**, not merely accepted — a `.strict()` object accepts an added optional field silently, and the point is that a create cannot decline to say where it wrote.
- **The smoke asserts the field rather than merely surviving it.** The MCP SDK validates `structuredContent` against `outputSchema` at runtime through the *published* artifact, so `pnpm smoke:e2e` is the last place a schema and the value it describes can be caught travelling separately. `pnpm build` + both smokes (`mcp-e2e-smoke`, `mcp-http-convergence-smoke`) green.
- `mcp-node` + `arch-lint-node`: 4012 passed, 3 failed — the three that fail identically on unmodified `origin/main` in this container (root-uid EACCES: the process is root, so a `chmod 000` directory stays readable and the "permission denied" those cases provoke never happens). `pnpm -r typecheck` clean.

Visual evidence: none — one field added to an MCP tool's output schema plus test-only changes, with no user-visible surface in the diff and, deliberately, no behaviour change at all.