### PR TITLE
feat(server-core): the server mints a workspace id and the caller's string becomes its segment

### DIFF
--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -214,18 +214,29 @@ async function main() {
   if (typeof created.documentId !== 'string' || created.path !== 'e2e-src') {
     throw new Error(`wb_document_create returned unexpected shape: ${JSON.stringify(created)}`)
   }
-  // A create says which workspace it filed the document under (ADR-0019).
-  // Asserted here rather than only in a unit test because the MCP SDK
-  // validates structuredContent against outputSchema at runtime through the
-  // PUBLISHED artifact — this is the last place a schema and the value it
-  // describes can be caught travelling separately.
-  if (created.workspaceId !== WORKSPACE_ID) {
+  // ADR-0019's mint boundary, end to end through the PUBLISHED artifact.
+  // The create decides the workspace's canonical id — so what it REPORTS is
+  // a ULID, not the `e2e` handle that was sent. Asserted here as well as in
+  // a unit test because the MCP SDK validates structuredContent against
+  // outputSchema at runtime, and this is the last place a schema and the
+  // value it describes can be caught travelling separately.
+  if (!/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/.test(created.workspaceId ?? '')) {
     throw new Error(
-      `wb_document_create did not report the workspace it wrote to: ${JSON.stringify(created)}`,
+      `wb_document_create did not mint a canonical workspace id: ${JSON.stringify(created)}`,
     )
   }
+  if (created.workspaceId === WORKSPACE_ID) {
+    throw new Error(`wb_document_create echoed the handle instead of minting: ${WORKSPACE_ID}`)
+  }
   const documentId = created.documentId
-  console.log(`[e2e] wb_document_create → ${documentId} in ${created.workspaceId}`)
+  console.log(
+    `[e2e] wb_document_create → ${documentId} in ${created.workspaceId} (segment ${WORKSPACE_ID})`,
+  )
+
+  // ...and every call after this one still addresses the workspace as
+  // `WORKSPACE_ID`. That the rest of this smoke passes unchanged IS the
+  // proof that segment-first resolution works through the published
+  // artifact: the id underneath changed, and the address did not.
 
   // A document's name is the workspace's, not its content's (ADR-0009), so
   // it round-trips through create -> list without any document read.

--- a/packages/mcp-server/scripts/smoke/mcp-http-convergence-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-http-convergence-smoke.mjs
@@ -273,7 +273,12 @@ async function main() {
     throw new Error(`wb_document_create returned unexpected shape: ${JSON.stringify(created)}`)
   }
   const documentId = created.documentId
-  log(`[e2e] wb_document_create → ${documentId}`)
+  // ADR-0019's mint: the server chose this workspace's canonical id, and
+  // `WORKSPACE_ID` is now its SEGMENT. Everything below keeps addressing it
+  // by that segment — only a lookup that compares against a served row needs
+  // the canonical id, which is why it is captured here.
+  const workspaceId = created.workspaceId
+  log(`[e2e] wb_document_create → ${documentId} in ${workspaceId} (segment ${WORKSPACE_ID})`)
 
   // ── Step 2b: ADR-0019 — GET /api/workspaces serves the displayName a
   //    plain HTTP PUT set, through the published listWorkspacesResponseSchema.
@@ -295,11 +300,20 @@ async function main() {
     throw new Error(`GET /api/workspaces failed: HTTP ${listWorkspacesRes.status}`)
   }
   const listWorkspacesBody = listWorkspacesResponseSchema.parse(await listWorkspacesRes.json())
-  const ourWorkspace = listWorkspacesBody.workspaces.find((w) => w.workspaceId === WORKSPACE_ID)
+  const ourWorkspace = listWorkspacesBody.workspaces.find((w) => w.workspaceId === workspaceId)
   if (ourWorkspace?.displayName !== WORKSPACE_DISPLAY_NAME) {
     throw new Error(`GET /api/workspaces did not echo displayName: ${JSON.stringify(ourWorkspace)}`)
   }
-  log('[e2e] GET /api/workspaces → displayName echoed through the published schema')
+  // The PUT above addressed the workspace as `conv-e2e` and the row it wrote
+  // is keyed by a ULID, so this row arriving at all is segment-first
+  // resolution working across two separate HTTP requests — and the segment
+  // is served back beside the name.
+  if (ourWorkspace.segment !== WORKSPACE_ID) {
+    throw new Error(
+      `GET /api/workspaces did not serve the segment: ${JSON.stringify(ourWorkspace)}`,
+    )
+  }
+  log('[e2e] GET /api/workspaces → displayName and segment echoed through the published schema')
 
   const NODE_A = {
     id: 'node-a',

--- a/packages/mcp-server/src/server/mcp/document-tools.ts
+++ b/packages/mcp-server/src/server/mcp/document-tools.ts
@@ -1,26 +1,7 @@
 import {
   createServer,
-  createWorkspaceEditTool,
   type ServerDeps,
   setLogSink as setServerCoreLogSink,
-  WB_DOCUMENT_CREATE_DESCRIPTION,
-  WB_DOCUMENT_DELETE_DESCRIPTION,
-  WB_DOCUMENT_LIST_DESCRIPTION,
-  WB_DOCUMENT_RESOLVE_DESCRIPTION,
-  wbDocumentCreate,
-  wbDocumentCreateInputSchema,
-  wbDocumentCreateOutputSchema,
-  wbDocumentDelete,
-  wbDocumentDeleteInputSchema,
-  wbDocumentDeleteOutputSchema,
-  wbDocumentList,
-  wbDocumentListInputSchema,
-  wbDocumentListOutputSchema,
-  wbDocumentResolve,
-  wbDocumentResolveInputSchema,
-  wbDocumentResolveOutputSchema,
-  workspaceEditInputSchema,
-  workspaceEditOutputSchema,
 } from '@kamiazya/whiteboard-server-core'
 import type { McpServer } from '@modelcontextprotocol/server'
 import { getLogger } from '../log.js'
@@ -308,77 +289,79 @@ export function registerDocumentTools(server: McpServer, deps: ServerDeps): void
   // have to be wrapped in an ops array to happen.
   registerToolWithAnnotations(
     server,
-    'wb_workspace_edit',
+    tools.workspaceEdit.name,
     {
-      description: createWorkspaceEditTool(deps).description,
-      inputSchema: workspaceEditInputSchema,
-      outputSchema: workspaceEditOutputSchema,
+      description: tools.workspaceEdit.description,
+      inputSchema: tools.workspaceEdit.inputSchema,
+      outputSchema: tools.workspaceEdit.outputSchema,
     },
     async (args) => {
-      const result = await createWorkspaceEditTool(deps).execute(
-        workspaceEditInputSchema.parse(args),
+      const result = await tools.workspaceEdit.execute(tools.workspaceEdit.inputSchema.parse(args))
+      return structuredJsonResult(result)
+    },
+  )
+
+  // Document CRUD. These have no Hono route counterpart registered here, but
+  // they still come from `createServer`'s tool record rather than from the
+  // bare operations, so the handle resolution that record carries applies.
+  registerToolWithAnnotations(
+    server,
+    tools.documentCreate.name,
+    {
+      description: tools.documentCreate.description,
+      inputSchema: tools.documentCreate.inputSchema,
+      outputSchema: tools.documentCreate.outputSchema,
+    },
+    async (args) => {
+      const result = await tools.documentCreate.execute(
+        tools.documentCreate.inputSchema.parse(args),
       )
       return structuredJsonResult(result)
     },
   )
 
-  // Canvas CRUD (wired as standalone MCP tools, not through createServer's Hono routes)
   registerToolWithAnnotations(
     server,
-    'wb_document_create',
+    tools.documentList.name,
     {
-      description: WB_DOCUMENT_CREATE_DESCRIPTION,
-      inputSchema: wbDocumentCreateInputSchema,
-      outputSchema: wbDocumentCreateOutputSchema,
+      description: tools.documentList.description,
+      inputSchema: tools.documentList.inputSchema.shape,
+      outputSchema: tools.documentList.outputSchema,
     },
     async (args) => {
-      const parsed = wbDocumentCreateInputSchema.parse(args)
-      const result = await wbDocumentCreate(deps, parsed)
+      const result = await tools.documentList.execute(tools.documentList.inputSchema.parse(args))
       return structuredJsonResult(result)
     },
   )
 
   registerToolWithAnnotations(
     server,
-    'wb_document_list',
+    tools.documentResolve.name,
     {
-      description: WB_DOCUMENT_LIST_DESCRIPTION,
-      inputSchema: wbDocumentListInputSchema.shape,
-      outputSchema: wbDocumentListOutputSchema,
+      description: tools.documentResolve.description,
+      inputSchema: tools.documentResolve.inputSchema.shape,
+      outputSchema: tools.documentResolve.outputSchema,
     },
     async (args) => {
-      const parsed = wbDocumentListInputSchema.parse(args)
-      const result = await wbDocumentList(deps, parsed)
+      const result = await tools.documentResolve.execute(
+        tools.documentResolve.inputSchema.parse(args),
+      )
       return structuredJsonResult(result)
     },
   )
 
   registerToolWithAnnotations(
     server,
-    'wb_document_resolve',
+    tools.documentDelete.name,
     {
-      description: WB_DOCUMENT_RESOLVE_DESCRIPTION,
-      inputSchema: wbDocumentResolveInputSchema.shape,
-      outputSchema: wbDocumentResolveOutputSchema,
+      description: tools.documentDelete.description,
+      inputSchema: tools.documentDelete.inputSchema.shape,
+      outputSchema: tools.documentDelete.outputSchema,
     },
     async (args) => {
-      const parsed = wbDocumentResolveInputSchema.parse(args)
-      const result = await wbDocumentResolve(deps, parsed)
-      return structuredJsonResult(result)
-    },
-  )
-
-  registerToolWithAnnotations(
-    server,
-    'wb_document_delete',
-    {
-      description: WB_DOCUMENT_DELETE_DESCRIPTION,
-      inputSchema: wbDocumentDeleteInputSchema.shape,
-      outputSchema: wbDocumentDeleteOutputSchema,
-    },
-    async (args) => {
-      const parsed = wbDocumentDeleteInputSchema.parse(args)
-      const result = await wbDocumentDelete(deps, parsed)
+      const result = await tools.documentDelete.execute(
+        tools.documentDelete.inputSchema.parse(args),
+      )
       return structuredJsonResult(result)
     },
   )

--- a/packages/mcp-server/src/server/mcp/segment-addressable-tools.test.ts
+++ b/packages/mcp-server/src/server/mcp/segment-addressable-tools.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Every workspace-scoped MCP tool must be addressable by a workspace's
+ * SEGMENT, not only by its canonical id.
+ *
+ * `withResolvedWorkspaceHandles` wraps `createServer`'s tool RECORD, for the
+ * reason its own doc comment gives — a per-tool resolution step is a step the
+ * next tool will not have. What that wrapper cannot see is a registration
+ * built from something OTHER than the record: five here called a bare
+ * operation or a tool factory instead, so they never resolved. The gap was
+ * invisible while a workspace's id and its handle were the same string, and
+ * ADR-0019's mint turned it into "workspace not found" on every call after a
+ * create.
+ *
+ * Two guards, because neither is sufficient alone. The first is structural
+ * and cheap, and covers tools this file has no valid arguments for. The
+ * second drives the one the published smoke actually caught, end to end.
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import type { McpServer } from '@modelcontextprotocol/server'
+import { describe, expect, it, vi } from 'vitest'
+import { withTempDataDir } from '../routes/_test-helpers.js'
+
+const tmp = withTempDataDir('whiteboard-segment-tools-')
+
+vi.mock('../config.js', () => ({
+  get DATA_DIR() {
+    return tmp.dir
+  },
+  getDataDir: () => tmp.dir,
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+  REPO_ROOT: '/tmp',
+}))
+
+const { getDb } = await import('../store/db/index.js')
+const { prepareDataDir } = await import('../store/db/prepare.js')
+const { createContainer, resolveServerDeps } = await import('../../di/container.js')
+const { createStoreLocalModule } = await import('../../di/store-local.module.js')
+const { registerDocumentTools } = await import('./document-tools.js')
+
+const SEGMENT = 'by-segment'
+const WORKSPACE_ID = '01M162AQMVCNXR7J9X636HBA5J'
+
+describe('every registration takes its tool from the resolving record', () => {
+  it('calls tools.<name>.execute and never a bare operation', () => {
+    const source = readFileSync(
+      fileURLToPath(new URL('./document-tools.ts', import.meta.url)),
+      'utf8',
+    )
+    // Registrations are the unit here, not tools: a registration is what can
+    // reach past the record, and reading them from the source is what lets
+    // this cover the tools whose arguments this file could not construct.
+    const blocks = source.split('registerToolWithAnnotations(').slice(1)
+    // A scan that finds nothing passes. The real surface is well into double
+    // digits; a count far below that means the split stopped matching.
+    expect(blocks.length).toBeGreaterThan(14)
+
+    const bypassing = blocks
+      .filter((block) => !/tools\.\w+\.execute\(/.test(block))
+      .map((block) => block.slice(0, 80).replace(/\s+/g, ' ').trim())
+    expect(bypassing, 'these registrations bypass the resolving record').toEqual([])
+  })
+})
+
+describe('a batch addressed by segment reaches the workspace behind it', () => {
+  it('applies wb_workspace_edit ops when the handle is a segment, not an id', async () => {
+    await prepareDataDir(tmp.dir)
+    const db = await getDb(tmp.dir)
+    const deps = resolveServerDeps(
+      createContainer(createStoreLocalModule({ db, blobDir: tmp.dir })),
+    )
+    await deps.documentIndex.createWorkspace({ workspaceId: WORKSPACE_ID, segment: SEGMENT })
+    // The fixture is only useful if the two spellings differ — otherwise
+    // "resolved by segment" is satisfied by resolving nothing at all.
+    expect(WORKSPACE_ID).not.toBe(SEGMENT)
+
+    const registerTool = vi.fn()
+    registerDocumentTools({ registerTool } as unknown as McpServer, deps)
+    const call = registerTool.mock.calls.find((c) => c[0] === 'wb_workspace_edit')
+    if (call === undefined) throw new Error('wb_workspace_edit is not registered')
+
+    const result = (await (call[2] as (a: unknown, e: unknown) => Promise<unknown>)(
+      {
+        workspaceId: SEGMENT,
+        ops: [{ op: 'document.create', path: 'filed', kind: 'markdown', name: 'Filed' }],
+      },
+      {},
+    )) as { isError?: boolean; structuredContent?: { workspaceId?: string; applied?: number } }
+
+    expect(result.isError, JSON.stringify(result)).toBeUndefined()
+    expect(result.structuredContent?.applied).toBe(1)
+    // Reported as the canonical id, and the document really landed in that
+    // workspace rather than in one the segment accidentally minted.
+    expect(result.structuredContent?.workspaceId).toBe(WORKSPACE_ID)
+    const listed = await deps.documentIndex.listDocuments({ workspaceId: WORKSPACE_ID })
+    expect(listed.map((d) => d.path)).toEqual(['filed'])
+  })
+})

--- a/packages/mcp-server/src/server/routes/_test-helpers.ts
+++ b/packages/mcp-server/src/server/routes/_test-helpers.ts
@@ -24,3 +24,29 @@ export function withTempDataDir(prefix = 'whiteboard-test-'): { get dir(): strin
     },
   }
 }
+
+/**
+ * Registers a workspace under EXACTLY the id given, so a fixture that
+ * addresses it by that literal afterwards still finds it.
+ *
+ * Needed because these suites bootstrap by POSTing a document, and that
+ * route passes `createWorkspace: true` — which is ADR-0019's mint boundary.
+ * A mint keys the workspace by a fresh ULID and files the posted handle as
+ * its `segment`, so the literal the fixture goes on to read the store by
+ * would name nothing. Creating it up front makes the route's flag the no-op
+ * it is for every workspace that already exists.
+ *
+ * Deliberately the port call rather than a `saveDocument`: seeding a
+ * throwaway document would show up in the listings several of these cases
+ * assert on.
+ */
+export async function seedWorkspaceRow(dataDir: string, workspaceId: string): Promise<void> {
+  const { getDb } = await import('../store/db/index.js')
+  const { prepareDataDir } = await import('../store/db/prepare.js')
+  const { createContainer, resolveServerDeps } = await import('../../di/container.js')
+  const { createStoreLocalModule } = await import('../../di/store-local.module.js')
+  await prepareDataDir(dataDir)
+  const db = await getDb(dataDir)
+  const deps = resolveServerDeps(createContainer(createStoreLocalModule({ db, blobDir: dataDir })))
+  await deps.documentIndex.createWorkspace({ workspaceId })
+}

--- a/packages/mcp-server/src/server/routes/document/crud-adapter.test.ts
+++ b/packages/mcp-server/src/server/routes/document/crud-adapter.test.ts
@@ -228,7 +228,7 @@ describe('POST /api/workspaces/:workspaceId/documents', () => {
   // makes it an explicit flag, and a flag nothing exercises is a flag that
   // gets dropped — removing `createWorkspace: true` left every other case in
   // this file green.
-  it('creates the workspace on the way past, as this surface always has', async () => {
+  it('creates the workspace on the way past, keyed canonically with the posted handle as its segment', async () => {
     const { deps } = await depsRecordingCreate(false)
     const app = createWorkspacesRouter({ serverDeps: deps })
 
@@ -239,7 +239,18 @@ describe('POST /api/workspaces/:workspaceId/documents', () => {
     })
 
     expect(res.status).toBe(200)
-    const entries = await deps.documentIndex.listDocuments({ workspaceId: 'ws-1' })
+    // This surface has always created the workspace on the way past. What
+    // ADR-0019 changes is WHICH id it gets: the server mints a canonical one
+    // and files `ws-1` as the segment, so the caller's address keeps working
+    // through segment-first resolution while the id underneath is canonical.
+    const workspaces = await deps.documentIndex.listWorkspaces()
+    expect(workspaces).toHaveLength(1)
+    expect(workspaces[0]?.workspaceId).toMatch(/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/)
+    expect(workspaces[0]?.segment).toBe('ws-1')
+
+    const entries = await deps.documentIndex.listDocuments({
+      workspaceId: workspaces[0]?.workspaceId ?? '',
+    })
     expect(entries.map((e) => e.path)).toEqual(['first-ever'])
   })
 

--- a/packages/mcp-server/src/server/routes/document/mint-daemon.test.ts
+++ b/packages/mcp-server/src/server/routes/document/mint-daemon.test.ts
@@ -55,3 +55,49 @@ describe('the daemon mints and then resolves its own segment', () => {
     expect(resolved?.workspaceId).toBe(created.workspaceId)
   })
 })
+
+describe('two concurrent creates into the same new handle converge', () => {
+  it('agrees on one workspace instead of one of them losing the segment race', async () => {
+    await prepareDataDir(tmp.dir)
+    const db = await getDb(tmp.dir)
+    const deps = resolveServerDeps(
+      createContainer(createStoreLocalModule({ db, blobDir: tmp.dir })),
+    )
+
+    // The mint reads `resolveWorkspace` and then writes, and the write lock
+    // is keyed by the id it just GENERATED — so two callers bootstrapping
+    // the same new handle take different locks and never serialise. Both see
+    // no workspace, both mint, and the second reaches the `segment` unique
+    // index (migration 0018) and raises `WorkspaceSegmentTakenError`. That
+    // turns an idempotent bootstrap — a flag callers are told they may set on
+    // every request — into a failure that depends on timing.
+    const before = (await deps.documentIndex.listWorkspaces()).length
+    const [a, b] = await Promise.all([
+      wbDocumentCreate(deps, {
+        workspaceId: 'contested',
+        path: 'a',
+        kind: 'markdown',
+        createWorkspace: true,
+      }),
+      wbDocumentCreate(deps, {
+        workspaceId: 'contested',
+        path: 'b',
+        kind: 'markdown',
+        createWorkspace: true,
+      }),
+    ])
+
+    expect(a.workspaceId).toBe(b.workspaceId)
+    const listed = await deps.documentIndex.listWorkspaces()
+    expect(listed.filter((w) => w.segment === 'contested')).toHaveLength(1)
+    // Both documents landed in the agreed workspace — a loser that silently
+    // wrote into its own minted id would satisfy the count above.
+    const docs = await deps.documentIndex.listDocuments({ workspaceId: a.workspaceId })
+    expect(docs.map((d) => d.path).sort()).toEqual(['a', 'b'])
+    // Exactly one workspace appeared. The loser generated an id before it
+    // wrote, so a keeper that claimed the tree record ahead of the segment
+    // would strand a segment-less workspace under that id — which the
+    // segment filter above cannot see.
+    expect(listed.length - before).toBe(1)
+  })
+})

--- a/packages/mcp-server/src/server/routes/document/mint-daemon.test.ts
+++ b/packages/mcp-server/src/server/routes/document/mint-daemon.test.ts
@@ -1,0 +1,57 @@
+/**
+ * ADR-0019's mint against the DAEMON's real index, not the in-memory double.
+ *
+ * The operation is shared, but the registry is not: `CacheCoherentDocumentIndex`
+ * writes segments to a SQLite column and reads them back through a separate
+ * collaborator, so "the segment resolves" has to be asserted here too.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { withTempDataDir } from '../_test-helpers.js'
+
+const tmp = withTempDataDir('whiteboard-mint-daemon-')
+
+vi.mock('../../config.js', () => ({
+  get DATA_DIR() {
+    return tmp.dir
+  },
+  getDataDir: () => tmp.dir,
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+  REPO_ROOT: '/tmp',
+}))
+
+const { getDb } = await import('../../store/db/index.js')
+const { prepareDataDir } = await import('../../store/db/prepare.js')
+const { createContainer, resolveServerDeps } = await import('../../../di/container.js')
+const { createStoreLocalModule } = await import('../../../di/store-local.module.js')
+const { wbDocumentCreate } = await import('@kamiazya/whiteboard-server-core')
+
+describe('the daemon mints and then resolves its own segment', () => {
+  it('files the posted handle as a segment the registry can resolve back', async () => {
+    await prepareDataDir(tmp.dir)
+    const db = await getDb(tmp.dir)
+    const deps = resolveServerDeps(
+      createContainer(createStoreLocalModule({ db, blobDir: tmp.dir })),
+    )
+
+    const created = await wbDocumentCreate(deps, {
+      workspaceId: 'e2e',
+      path: 'spec',
+      kind: 'markdown',
+      createWorkspace: true,
+    })
+
+    expect(created.workspaceId).toMatch(/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/)
+
+    // The registry row carries the segment...
+    const listed = await deps.documentIndex.listWorkspaces()
+    expect(listed).toHaveLength(1)
+    expect(listed[0]).toMatchObject({ workspaceId: created.workspaceId, segment: 'e2e' })
+
+    // ...and resolution reads it back. This is the step the published smoke
+    // caught failing: everything after a create addresses the workspace by
+    // the handle, and if the daemon's own index cannot resolve it, every one
+    // of those calls answers "workspace not found".
+    const resolved = await deps.documentIndex.resolveWorkspace('e2e')
+    expect(resolved?.workspaceId).toBe(created.workspaceId)
+  })
+})

--- a/packages/mcp-server/src/server/routes/document/promote-workspace.test.ts
+++ b/packages/mcp-server/src/server/routes/document/promote-workspace.test.ts
@@ -25,6 +25,7 @@ import {
 } from '@kamiazya/whiteboard-loro-adapter'
 import { LoroDoc } from 'loro-crdt'
 import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { seedWorkspaceRow } from '../_test-helpers.js'
 
 let tempDir: string
 vi.mock('../../config.js', () => ({
@@ -49,6 +50,12 @@ beforeEach(async () => {
   handle = await createIsolatedDb({ dataDir: tempDir })
   clearCache()
   _clearWorkspaceDocCacheForTests()
+  // The workspace exists because this fixture says so, not because the first
+  // POST created it: that route passes `createWorkspace: true`, which is
+  // ADR-0019's MINT boundary — a mint keys the workspace by a fresh ULID and
+  // files `session1` as its segment, leaving the direct store reads in these
+  // cases naming nothing.
+  await seedWorkspaceRow(tempDir, 'session1')
 })
 afterEach(async () => {
   await handle.dispose()

--- a/packages/mcp-server/src/server/routes/document/restore-workspace.test.ts
+++ b/packages/mcp-server/src/server/routes/document/restore-workspace.test.ts
@@ -15,6 +15,7 @@ import { join } from 'node:path'
 import { readSpatialCanvas, writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
 import { LoroDoc } from 'loro-crdt'
 import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { seedWorkspaceRow } from '../_test-helpers.js'
 
 let tempDir: string
 vi.mock('../../config.js', () => ({
@@ -39,6 +40,12 @@ beforeEach(async () => {
   handle = await createIsolatedDb({ dataDir: tempDir })
   clearCache()
   _clearWorkspaceDocCacheForTests()
+  // The workspace exists because this fixture says so, not because the first
+  // POST created it: that route passes `createWorkspace: true`, which is
+  // ADR-0019's MINT boundary — a mint keys the workspace by a fresh ULID and
+  // files `session1` as its segment, leaving the direct store reads in these
+  // cases naming nothing.
+  await seedWorkspaceRow(tempDir, 'session1')
 })
 afterEach(async () => {
   await handle.dispose()

--- a/packages/mcp-server/src/server/routes/document/workspace-document.test.ts
+++ b/packages/mcp-server/src/server/routes/document/workspace-document.test.ts
@@ -20,6 +20,7 @@ import {
 } from '@kamiazya/whiteboard-loro-adapter'
 import { LoroDoc } from 'loro-crdt'
 import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { seedWorkspaceRow } from '../_test-helpers.js'
 
 let tempDir: string
 vi.mock('../../config.js', () => ({
@@ -44,6 +45,12 @@ beforeEach(async () => {
   handle = await createIsolatedDb({ dataDir: tempDir })
   clearCache()
   _clearWorkspaceDocCacheForTests()
+  // The workspace exists because this fixture says so, not because the first
+  // POST created it: that route passes `createWorkspace: true`, which is
+  // ADR-0019's MINT boundary — a mint keys the workspace by a fresh ULID and
+  // files `session1` as its segment, leaving the direct store reads in these
+  // cases naming nothing.
+  await seedWorkspaceRow(tempDir, 'session1')
 })
 afterEach(async () => {
   await handle.dispose()

--- a/packages/mcp-server/src/server/routes/document/workspaces.test.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.test.ts
@@ -9,7 +9,7 @@ import {
   listWorkspacesResponseSchema,
   renameDocumentPathResponseSchema,
 } from '../../../shared/api-contracts/document.js'
-import { withTempDataDir } from '../_test-helpers.js'
+import { seedWorkspaceRow, withTempDataDir } from '../_test-helpers.js'
 
 const tmp = withTempDataDir('whiteboard-workspaces-test-')
 
@@ -303,6 +303,11 @@ describe('POST /api/workspaces/:workspaceId/documents', () => {
   })
 
   it('writes kind onto the stored Loro doc itself, not only the SQL row', async () => {
+    // Registered up front so the POST below is not the thing that creates it:
+    // that route passes `createWorkspace: true`, which is ADR-0019's mint
+    // boundary, and a mint would key the workspace by a ULID and file `ws1`
+    // as its segment — leaving the store reads further down naming nothing.
+    await seedWorkspaceRow(tmp.dir, 'ws1')
     const app = createDocumentRouter()
 
     const markdownRes = await app.request('/api/workspaces/ws1/documents', {
@@ -325,6 +330,11 @@ describe('POST /api/workspaces/:workspaceId/documents', () => {
   })
 
   it('stamps the schema-defaulted kind onto the doc bytes when kind is omitted', async () => {
+    // Registered up front so the POST below is not the thing that creates it:
+    // that route passes `createWorkspace: true`, which is ADR-0019's mint
+    // boundary, and a mint would key the workspace by a ULID and file `ws1`
+    // as its segment — leaving the store reads further down naming nothing.
+    await seedWorkspaceRow(tmp.dir, 'ws1')
     const app = createDocumentRouter()
     const res = await app.request('/api/workspaces/ws1/documents', {
       method: 'POST',
@@ -489,6 +499,11 @@ describe('DELETE /api/workspaces/:workspaceId/documents/:path', () => {
   })
 
   it('evicts the doc-cache on delete, so re-creating the same path after a warm cache read yields a fresh empty doc', async () => {
+    // Registered up front so the POST below is not the thing that creates it:
+    // that route passes `createWorkspace: true`, which is ADR-0019's mint
+    // boundary, and a mint would key the workspace by a ULID and file `ws1`
+    // as its segment — leaving the store reads further down naming nothing.
+    await seedWorkspaceRow(tmp.dir, 'session1')
     const app = createDocumentRouter()
     await app.request('/api/workspaces/session1/documents', {
       method: 'POST',
@@ -742,6 +757,11 @@ describe('PUT /api/workspaces/:workspaceId/documents/:path/path', () => {
   })
 
   it('evicts the doc-cache on rename: updating via the OLD path afterward lazily creates a FRESH canvas rather than resurrecting the warmed doc, while the new path keeps the real content', async () => {
+    // Registered up front so the POST below is not the thing that creates it:
+    // that route passes `createWorkspace: true`, which is ADR-0019's mint
+    // boundary, and a mint would key the workspace by a ULID and file `ws1`
+    // as its segment — leaving the store reads further down naming nothing.
+    await seedWorkspaceRow(tmp.dir, 'session1')
     const app = createDocumentRouter()
     await app.request('/api/workspaces/session1/documents', {
       method: 'POST',

--- a/packages/mcp-server/src/server/routes/document/workspaces.test.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.test.ts
@@ -501,8 +501,9 @@ describe('DELETE /api/workspaces/:workspaceId/documents/:path', () => {
   it('evicts the doc-cache on delete, so re-creating the same path after a warm cache read yields a fresh empty doc', async () => {
     // Registered up front so the POST below is not the thing that creates it:
     // that route passes `createWorkspace: true`, which is ADR-0019's mint
-    // boundary, and a mint would key the workspace by a ULID and file `ws1`
-    // as its segment — leaving the store reads further down naming nothing.
+    // boundary, and a mint would key the workspace by a ULID and file
+    // `session1` as its segment — leaving the store reads further down
+    // naming nothing.
     await seedWorkspaceRow(tmp.dir, 'session1')
     const app = createDocumentRouter()
     await app.request('/api/workspaces/session1/documents', {
@@ -759,8 +760,9 @@ describe('PUT /api/workspaces/:workspaceId/documents/:path/path', () => {
   it('evicts the doc-cache on rename: updating via the OLD path afterward lazily creates a FRESH canvas rather than resurrecting the warmed doc, while the new path keeps the real content', async () => {
     // Registered up front so the POST below is not the thing that creates it:
     // that route passes `createWorkspace: true`, which is ADR-0019's mint
-    // boundary, and a mint would key the workspace by a ULID and file `ws1`
-    // as its segment — leaving the store reads further down naming nothing.
+    // boundary, and a mint would key the workspace by a ULID and file
+    // `session1` as its segment — leaving the store reads further down
+    // naming nothing.
     await seedWorkspaceRow(tmp.dir, 'session1')
     const app = createDocumentRouter()
     await app.request('/api/workspaces/session1/documents', {

--- a/packages/mcp-server/src/server/routes/document/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.ts
@@ -161,10 +161,22 @@ export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
         workspaceId,
         path,
         kind: parsed.data.kind,
-        // `saveDocument` used to upsert the workspace row on the way past, so
-        // posting into a workspace that does not exist yet has always worked
-        // on this surface. The operation makes that an explicit flag rather
-        // than a side effect, and this preserves the behaviour.
+        // Kept, and now safe. `saveDocument` used to upsert the workspace
+        // row on the way past, so posting into a workspace that does not
+        // exist has always worked here — the one surface that opted out of
+        // "workspaces never materialize implicitly".
+        //
+        // Under ADR-0019's mint boundary the flag no longer risks a phantom:
+        // it resolves first, so an existing workspace is a no-op, and a
+        // handle that names nothing is either minted with that handle as its
+        // segment or refused (400) when it cannot be one — which is what a
+        // browser posting a canonical id for a workspace the daemon no
+        // longer has now gets, instead of a silent new workspace.
+        //
+        // Removing it outright is a real improvement and a SEPARATE
+        // increment: measured, six other suites bootstrap their fixtures by
+        // POSTing here, so it is a 20-test fixture change rather than the
+        // no-op `workspaces.test.ts` alone suggests.
         createWorkspace: true,
         // Passed through as given. A blank name meaning "no name" is the
         // OPERATION's rule now, not a second copy of it here — two places

--- a/packages/mcp-server/src/server/store/document-delete-lock.test.ts
+++ b/packages/mcp-server/src/server/store/document-delete-lock.test.ts
@@ -54,11 +54,14 @@ describe('wb_document_delete', () => {
     const deps = resolveServerDeps(
       createContainer(createStoreLocalModule({ db, blobDir: tempDir })),
     )
+    // Registered explicitly: `createWorkspace: true` is ADR-0019's MINT
+    // boundary, and a mint would key the workspace by a fresh ULID with
+    // `ws-1` as its segment — leaving the store reads below naming nothing.
+    await deps.documentIndex.createWorkspace({ workspaceId: 'ws-1' })
     const created = await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
       path: 'doomed',
       kind: 'spatial',
-      createWorkspace: true,
     })
 
     // The writer holds the lock in its own async chain, so the delete

--- a/packages/mcp-server/src/server/store/document-written.test.ts
+++ b/packages/mcp-server/src/server/store/document-written.test.ts
@@ -74,11 +74,14 @@ describe('documentWritten', () => {
     const deps = resolveServerDeps(
       createContainer(createStoreLocalModule({ db, blobDir: tempDir })),
     )
+    // Registered explicitly: `createWorkspace: true` is ADR-0019's MINT
+    // boundary, and a mint would key the workspace by a fresh ULID with
+    // `ws-1` as its segment — leaving the store reads below naming nothing.
+    await deps.documentIndex.createWorkspace({ workspaceId: 'ws-1' })
     const created = await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
       path: 'agent-edited',
       kind: 'spatial',
-      createWorkspace: true,
     })
 
     // Creating is a write too, so it has already scheduled one — and a

--- a/packages/server-core/src/create-server.ts
+++ b/packages/server-core/src/create-server.ts
@@ -4,6 +4,7 @@ import {
 } from '@kamiazya/whiteboard-ports'
 import type { Context } from 'hono'
 import { Hono } from 'hono'
+import type { z } from 'zod'
 import { ContentFactsCache } from './references/content-facts-cache.js'
 import type { ServerDeps } from './server-deps.js'
 import { backlinksInputSchema, computeBacklinks } from './tools/backlinks.js'
@@ -15,6 +16,7 @@ import { createCanvasViewTool } from './tools/canvas-view.js'
 import {
   WorkspaceDocumentNotFoundError,
   WorkspaceNotFoundError,
+  WorkspaceSegmentUnusableError,
 } from './tools/document-crud.errors.js'
 import {
   wbDocumentCreate,
@@ -23,10 +25,18 @@ import {
   wbDocumentResolve,
 } from './tools/document-crud.js'
 import {
+  WB_DOCUMENT_CREATE_DESCRIPTION,
+  WB_DOCUMENT_DELETE_DESCRIPTION,
+  WB_DOCUMENT_LIST_DESCRIPTION,
+  WB_DOCUMENT_RESOLVE_DESCRIPTION,
   wbDocumentCreateInputSchema,
+  wbDocumentCreateOutputSchema,
   wbDocumentDeleteInputSchema,
+  wbDocumentDeleteOutputSchema,
   wbDocumentListInputSchema,
+  wbDocumentListOutputSchema,
   wbDocumentResolveInputSchema,
+  wbDocumentResolveOutputSchema,
 } from './tools/document-crud.schemas.js'
 import { createDocumentGetTool } from './tools/document-get.js'
 import { SnapshotNotFoundError } from './tools/document-io.js'
@@ -45,6 +55,7 @@ import { createVersionListTool } from './tools/version-list.js'
 import { createVersionRestoreTool } from './tools/version-restore.js'
 import { createVersionSaveTool } from './tools/version-save.js'
 import { createViewportSetTool } from './tools/viewport-set.js'
+import { createWorkspaceEditTool } from './tools/workspace-edit.js'
 import { resolveWorkspaceId, withResolvedWorkspaceHandles } from './workspace-handle.js'
 
 export function createServer(deps: ServerDeps) {
@@ -226,6 +237,46 @@ export function createServer(deps: ServerDeps) {
   })
 
   const tools = {
+    // The document CRUD operations are exposed HERE as tool objects, not only
+    // as the bare functions the routes above call. An MCP registration that
+    // reaches for the operation instead sits OUTSIDE the record
+    // `withResolvedWorkspaceHandles` wraps — so it never resolves a segment,
+    // which is invisible for as long as a workspace's id and its handle are
+    // the same string, and becomes "workspace not found" the moment ADR-0019's
+    // mint makes them differ. The routes are unaffected: they resolve once in
+    // the middleware above and pass the canonical id straight to the operation.
+    documentCreate: {
+      name: 'wb_document_create' as const,
+      description: WB_DOCUMENT_CREATE_DESCRIPTION,
+      inputSchema: wbDocumentCreateInputSchema,
+      outputSchema: wbDocumentCreateOutputSchema,
+      execute: (input: z.infer<typeof wbDocumentCreateInputSchema>) =>
+        wbDocumentCreate(deps, input),
+    },
+    documentList: {
+      name: 'wb_document_list' as const,
+      description: WB_DOCUMENT_LIST_DESCRIPTION,
+      inputSchema: wbDocumentListInputSchema,
+      outputSchema: wbDocumentListOutputSchema,
+      execute: (input: z.infer<typeof wbDocumentListInputSchema>) => wbDocumentList(deps, input),
+    },
+    documentResolve: {
+      name: 'wb_document_resolve' as const,
+      description: WB_DOCUMENT_RESOLVE_DESCRIPTION,
+      inputSchema: wbDocumentResolveInputSchema,
+      outputSchema: wbDocumentResolveOutputSchema,
+      execute: (input: z.infer<typeof wbDocumentResolveInputSchema>) =>
+        wbDocumentResolve(deps, input),
+    },
+    documentDelete: {
+      name: 'wb_document_delete' as const,
+      description: WB_DOCUMENT_DELETE_DESCRIPTION,
+      inputSchema: wbDocumentDeleteInputSchema,
+      outputSchema: wbDocumentDeleteOutputSchema,
+      execute: (input: z.infer<typeof wbDocumentDeleteInputSchema>) =>
+        wbDocumentDelete(deps, input),
+    },
+    workspaceEdit: createWorkspaceEditTool(deps),
     facetList: createFacetListTool(deps),
     facetSet: createFacetSetTool(deps),
     bodyPatch: createBodyPatchTool(deps),
@@ -259,6 +310,13 @@ function mapDocumentError(c: Context, err: unknown) {
   }
   if (err instanceof DocumentPathTakenError) {
     return c.json({ error: err.message }, 409)
+  }
+  // The caller asked to create a workspace under a handle that cannot be a
+  // segment (ADR-0019). 400, not 500: the request is well-formed and the
+  // server is fine — the NAME is the problem, and only the caller can pick
+  // another one.
+  if (err instanceof WorkspaceSegmentUnusableError) {
+    return c.json({ error: err.message }, 400)
   }
   throw err
 }

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -49,6 +49,7 @@ export {
 export {
   WorkspaceDocumentNotFoundError,
   WorkspaceNotFoundError,
+  WorkspaceSegmentUnusableError,
 } from './tools/document-crud.errors.js'
 export {
   wbDocumentCreate,

--- a/packages/server-core/src/tools/document-create-orphan.test.ts
+++ b/packages/server-core/src/tools/document-create-orphan.test.ts
@@ -21,12 +21,18 @@ describe('a create that cannot finish leaves nothing behind', () => {
       documentWritten: ignoredDocumentWrites(),
       documentIndex: new InMemoryDocumentIndex(),
     }
+    // The workspace exists up front, so this case is only about the DOCUMENT.
+    // It used to arrive via `createWorkspace: true` and the comment claimed
+    // the refusal left no workspace either — which was not true then (the
+    // bootstrap ran before the preflight) and was asserted by nothing. It IS
+    // true now, and `document-crud.mint.test.ts` is where it is checked.
+    await deps.documentIndex.createWorkspace({ workspaceId: WS })
+
     await expect(
       wbDocumentCreate(deps, {
         workspaceId: WS,
         path: 'taken-by-nothing',
         kind: 'markdown',
-        createWorkspace: true,
         markdown: '---\nthis: [is: not: yaml\n---\nbody',
       }),
     ).rejects.toThrow(/okf|frontmatter|yaml|parse/i)
@@ -36,13 +42,10 @@ describe('a create that cannot finish leaves nothing behind', () => {
     ).toEqual([])
 
     // And the path is still free, which is the thing a caller retries into.
-    // `createWorkspace` is needed again: refusing before any write means the
-    // workspace was not created either, which is the point.
     const retried = await wbDocumentCreate(deps, {
       workspaceId: WS,
       path: 'taken-by-nothing',
       kind: 'markdown',
-      createWorkspace: true,
       markdown: '---\ntype: note\n---\nvalid this time',
     })
     expect(retried.path).toBe('taken-by-nothing')

--- a/packages/server-core/src/tools/document-crud.errors.ts
+++ b/packages/server-core/src/tools/document-crud.errors.ts
@@ -26,3 +26,29 @@ export class WorkspaceNotFoundError extends Error {
     this.name = 'WorkspaceNotFoundError'
   }
 }
+
+/**
+ * ADR-0019: creating a workspace mints its canonical id here and files the
+ * caller's string as the `segment` — so a handle that could never BE a
+ * segment is refused rather than minted with none.
+ *
+ * The alternative reads as success and is not: the workspace would exist,
+ * keyed by an id the caller has to fish out of the response, while the
+ * address they chose named nothing from their very next request onward.
+ *
+ * A BACKFILL of already-stored workspaces settles for a NULL segment on the
+ * same input (migration 0019), and the difference is principled rather than
+ * inconsistent: a backfill has data it must not discard, and a create has
+ * nothing yet.
+ */
+export class WorkspaceSegmentUnusableError extends Error {
+  constructor(readonly handle: string) {
+    super(
+      `Cannot create workspace "${handle}": a new workspace is addressed by its segment, ` +
+        'which must be ASCII letters, digits and interior hyphens, and must not itself be ' +
+        'shaped like a canonical id. Choose a name that fits, or address an existing ' +
+        'workspace by its id.',
+    )
+    this.name = 'WorkspaceSegmentUnusableError'
+  }
+}

--- a/packages/server-core/src/tools/document-crud.mint.test.ts
+++ b/packages/server-core/src/tools/document-crud.mint.test.ts
@@ -1,0 +1,220 @@
+/**
+ * ADR-0019's mint boundary: the SERVER decides a workspace's canonical id,
+ * and the string a caller sent becomes its `segment`.
+ *
+ * This is the one place a workspace comes into existence on this side —
+ * `wbDocumentCreate`'s `createWorkspace: true` branch, which `wb_workspace_edit`
+ * and the HTTP create route both delegate to — so it is the one place the
+ * rule can be stated.
+ */
+import { InMemoryDocumentIndex } from '@kamiazya/whiteboard-ports/test-utils'
+import { describe, expect, it } from 'vitest'
+import type { ServerDeps } from '../server-deps.js'
+import { ignoredDocumentWrites } from '../test-utils/ignored-document-writes.js'
+import { createInMemoryDocumentStore } from '../test-utils/in-memory-document-store.js'
+import { inMemoryDocumentTeardown } from '../test-utils/unused-document-teardown.js'
+import { wbDocumentCreate } from './document-crud.js'
+
+const CANONICAL = /^[0-7][0-9A-HJKMNP-TV-Z]{25}$/
+
+function makeDeps(): ServerDeps {
+  return {
+    documentStore: createInMemoryDocumentStore(),
+    blobStore: {} as never,
+    documentIndex: new InMemoryDocumentIndex(),
+    documentTeardown: inMemoryDocumentTeardown(),
+    documentWritten: ignoredDocumentWrites(),
+  }
+}
+
+describe('wbDocumentCreate mints the workspace id', () => {
+  it('keys the new workspace by a canonical ULID, not by what the caller sent', async () => {
+    const deps = makeDeps()
+
+    await wbDocumentCreate(deps, {
+      workspaceId: 'design',
+      path: 'spec',
+      kind: 'markdown',
+      createWorkspace: true,
+    })
+
+    const entries = await deps.documentIndex.listWorkspaces()
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.workspaceId).toMatch(CANONICAL)
+    // Asserted explicitly rather than left to the regex: `design` failing the
+    // ULID shape is the whole point, and a future id format that happened to
+    // accept it would make the check above pass while the rule was gone.
+    expect(entries[0]?.workspaceId).not.toBe('design')
+  })
+
+  it('carries the string the caller sent into the segment layer', async () => {
+    const deps = makeDeps()
+
+    await wbDocumentCreate(deps, {
+      workspaceId: 'design',
+      path: 'spec',
+      kind: 'markdown',
+      createWorkspace: true,
+    })
+
+    const entries = await deps.documentIndex.listWorkspaces()
+    expect(entries[0]?.segment).toBe('design')
+    // ...and it is a real address, not decoration: this is the resolution the
+    // caller's next request goes through.
+    expect((await deps.documentIndex.resolveWorkspace('design'))?.workspaceId).toBe(
+      entries[0]?.workspaceId,
+    )
+  })
+
+  it('reports the workspace it minted, so the caller can name what it just made', async () => {
+    // Without this the contract is unusable: the server picks an id, files
+    // the document under it, and never says what it was. `path` and
+    // `documentId` alone do not identify a workspace.
+    const deps = makeDeps()
+
+    const created = await wbDocumentCreate(deps, {
+      workspaceId: 'design',
+      path: 'spec',
+      kind: 'markdown',
+      createWorkspace: true,
+    })
+
+    const entries = await deps.documentIndex.listWorkspaces()
+    expect(created.workspaceId).toBe(entries[0]?.workspaceId)
+    // Both halves are needed. The line above alone passes without the mint
+    // too — the field echoes the input, and without a mint the input IS the
+    // stored id, so the two agree for the wrong reason. What says the mint
+    // happened is that the REPORTED id is canonical and is not the handle.
+    expect(created.workspaceId).toMatch(CANONICAL)
+    expect(created.workspaceId).not.toBe('design')
+    // The document really is filed under the reported id — a field that
+    // merely echoed something plausible would read the same here.
+    const entry = await deps.documentIndex.resolveDocumentById({
+      workspaceId: created.workspaceId,
+      documentId: created.documentId,
+    })
+    expect(entry?.path).toBe('spec')
+  })
+
+  it('refuses to create under a handle that could never be a segment', async () => {
+    // A mint with no segment would leave the caller's own string naming
+    // nothing — their very next request 404s on the address they chose.
+    // Stage 2's BACKFILL settles for NULL because it has existing data it
+    // must not discard; a create has nothing yet, so it can refuse and keep
+    // "the string you sent is the address" true without exception.
+    const deps = makeDeps()
+
+    await expect(
+      wbDocumentCreate(deps, {
+        workspaceId: 'V1StGXR8_Z5jdHi6B-myT',
+        path: 'spec',
+        kind: 'markdown',
+        createWorkspace: true,
+      }),
+    ).rejects.toThrow(/segment/i)
+    expect(await deps.documentIndex.listWorkspaces()).toEqual([])
+  })
+
+  it('refuses a handle already shaped like a canonical id', async () => {
+    // The other half of the same rule: a ULID-shaped segment collides with
+    // the canonical-id fallback in the one address position.
+    const deps = makeDeps()
+
+    await expect(
+      wbDocumentCreate(deps, {
+        workspaceId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        path: 'spec',
+        kind: 'markdown',
+        createWorkspace: true,
+      }),
+    ).rejects.toThrow(/segment/i)
+    expect(await deps.documentIndex.listWorkspaces()).toEqual([])
+  })
+
+  it('mints nothing and echoes the id when the workspace already exists', async () => {
+    // The non-creating path is the common one and must be untouched: by the
+    // time an existing workspace is addressed, its handle has already been
+    // resolved at the boundary, so what arrives here IS the canonical id.
+    const deps = makeDeps()
+    await deps.documentIndex.createWorkspace({
+      workspaceId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      segment: 'design',
+    })
+
+    const created = await wbDocumentCreate(deps, {
+      workspaceId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      path: 'spec',
+      kind: 'markdown',
+    })
+
+    expect(created.workspaceId).toBe('01ARZ3NDEKTSV4RRFFQ69G5FAV')
+    expect(await deps.documentIndex.listWorkspaces()).toHaveLength(1)
+  })
+
+  it('mints nothing when the create is refused for a malformed body', async () => {
+    // The preflight runs BEFORE the mint, so a refusal leaves no workspace —
+    // which is what `document-create-orphan` asserted in prose while the code
+    // bootstrapped first. Without this order the caller's retry mints a
+    // SECOND workspace and the first is unreachable rubble.
+    const deps = makeDeps()
+
+    await expect(
+      wbDocumentCreate(deps, {
+        workspaceId: 'design',
+        path: 'spec',
+        kind: 'markdown',
+        createWorkspace: true,
+        markdown: '---\nthis: [is: not: yaml\n---\nbody',
+      }),
+    ).rejects.toThrow(/okf|frontmatter|yaml|parse/i)
+
+    expect(await deps.documentIndex.listWorkspaces()).toEqual([])
+
+    // ...and the retry makes exactly one, rather than a second alongside
+    // rubble from the first attempt.
+    const retried = await wbDocumentCreate(deps, {
+      workspaceId: 'design',
+      path: 'spec',
+      kind: 'markdown',
+      createWorkspace: true,
+      markdown: '---\ntype: note\n---\nvalid this time',
+    })
+    const entries = await deps.documentIndex.listWorkspaces()
+    expect(entries).toHaveLength(1)
+    expect(retried.workspaceId).toBe(entries[0]?.workspaceId)
+  })
+
+  it('is idempotent: the flag on an existing workspace mints no rival', async () => {
+    // The flag has always been safe to set on every request. Minting
+    // unconditionally would have broken that in two ways at once — a second
+    // create into the same workspace making a rival, and a handle the
+    // boundary already resolved to a canonical id being refused for being
+    // ULID-shaped, which is how `/api/v1`'s own duplicate-path case failed.
+    const deps = makeDeps()
+
+    const first = await wbDocumentCreate(deps, {
+      workspaceId: 'design',
+      path: 'a',
+      kind: 'spatial',
+      createWorkspace: true,
+    })
+    const second = await wbDocumentCreate(deps, {
+      workspaceId: 'design',
+      path: 'b',
+      kind: 'spatial',
+      createWorkspace: true,
+    })
+    // ...and by the CANONICAL id too, which is what a resolved handle looks
+    // like by the time it reaches here.
+    const third = await wbDocumentCreate(deps, {
+      workspaceId: first.workspaceId,
+      path: 'c',
+      kind: 'spatial',
+      createWorkspace: true,
+    })
+
+    expect(second.workspaceId).toBe(first.workspaceId)
+    expect(third.workspaceId).toBe(first.workspaceId)
+    expect(await deps.documentIndex.listWorkspaces()).toHaveLength(1)
+  })
+})

--- a/packages/server-core/src/tools/document-crud.test.ts
+++ b/packages/server-core/src/tools/document-crud.test.ts
@@ -14,14 +14,27 @@ import {
   wbDocumentResolve,
 } from './document-crud.js'
 
-function makeDeps(): ServerDeps {
-  return {
+const WS = 'ws-1'
+
+/**
+ * The workspace exists because this fixture says so. It used to appear as a
+ * side effect of the first `createWorkspace: true` — which is ADR-0019's MINT
+ * boundary, and now keys the workspace by a fresh ULID, leaving the `ws-1`
+ * every case below addresses naming nothing.
+ *
+ * The three cases that are ABOUT creating a workspace keep saying so
+ * explicitly; everything else just needs one to exist.
+ */
+async function makeDeps(): Promise<ServerDeps> {
+  const deps: ServerDeps = {
     documentStore: createInMemoryDocumentStore(),
     blobStore: {} as never,
     documentIndex: new InMemoryDocumentIndex(),
     documentTeardown: inMemoryDocumentTeardown(),
     documentWritten: ignoredDocumentWrites(),
   }
+  await deps.documentIndex.createWorkspace({ workspaceId: WS })
+  return deps
 }
 
 describe('wbDocumentCreate', () => {
@@ -34,13 +47,12 @@ describe('wbDocumentCreate', () => {
   // rule and outranks tidiness here: naming must never gate creation. A
   // caller that sends a blank name gets a document, not an error.
   it('treats a blank name as no name rather than storing one the port forbids', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     const created = await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
       path: 'blank',
       kind: 'spatial',
       name: '   ',
-      createWorkspace: true,
     })
 
     const entry = await deps.documentIndex.resolveDocumentById({
@@ -51,24 +63,22 @@ describe('wbDocumentCreate', () => {
   })
 
   it('creates a document and returns documentId + path', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     const result = await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
       path: 'doc-a',
       kind: 'spatial',
-      createWorkspace: true,
     })
     expect(result.path).toBe('doc-a')
     expect(() => documentIdSchema.parse(result.documentId)).not.toThrow()
   })
 
   it('nests by path, with no parent id involved', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
       path: 'parent',
       kind: 'spatial',
-      createWorkspace: true,
     })
     const child = await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
@@ -84,12 +94,11 @@ describe('wbDocumentCreate', () => {
   })
 
   it('refuses a path that is already taken', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
       path: 'doc-a',
       kind: 'spatial',
-      createWorkspace: true,
     })
     await expect(
       wbDocumentCreate(deps, { workspaceId: 'ws-1', path: 'doc-a', kind: 'markdown' }),
@@ -97,7 +106,7 @@ describe('wbDocumentCreate', () => {
   })
 
   it('throws WorkspaceNotFoundError for an unknown workspaceId, and list agrees', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     await expect(
       wbDocumentCreate(deps, { workspaceId: 'nope', path: 'doc-a', kind: 'spatial' }),
     ).rejects.toThrow(WorkspaceNotFoundError)
@@ -107,24 +116,28 @@ describe('wbDocumentCreate', () => {
   })
 
   it('materializes the workspace when createWorkspace: true is passed', async () => {
-    const deps = makeDeps()
-    await wbDocumentCreate(deps, {
+    const deps = await makeDeps()
+    const created = await wbDocumentCreate(deps, {
       workspaceId: 'ws-new',
       path: 'doc-a',
       kind: 'spatial',
       createWorkspace: true,
     })
-    const { documents } = await wbDocumentList(deps, { workspaceId: 'ws-new' })
+    // Listed by the id the create REPORTS, not by the handle that was sent:
+    // creating is ADR-0019's mint boundary, so `ws-new` is now the new
+    // workspace's segment rather than its id. That the handle still resolves
+    // is the mint suite's subject; this one is only about the workspace
+    // coming into existence with the document in it.
+    const { documents } = await wbDocumentList(deps, { workspaceId: created.workspaceId })
     expect(documents).toHaveLength(1)
   })
 
   it('succeeds without the flag once the workspace exists', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     await wbDocumentCreate(deps, {
-      workspaceId: 'ws-1',
+      workspaceId: WS,
       path: 'first',
       kind: 'spatial',
-      createWorkspace: true,
     })
     const second = await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
@@ -137,7 +150,7 @@ describe('wbDocumentCreate', () => {
 
 describe('wbDocumentList shadowed threading', () => {
   it('carries a shadowed marker through — the collision signal must survive the tool boundary', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     await deps.documentIndex.createWorkspace({ workspaceId: 'ws-1' })
     ;(deps.documentIndex as InMemoryDocumentIndex).seed({
       workspaceId: 'ws-1',
@@ -165,7 +178,7 @@ describe('wbDocumentResolve', () => {
   // that schema declares. Omitting these left the schema saying more than the
   // runtime did.
   it('carries kind and updatedAt through, like the list does', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     await deps.documentIndex.createWorkspace({ workspaceId: 'ws-1' })
     ;(deps.documentIndex as InMemoryDocumentIndex).seed({
       workspaceId: 'ws-1',
@@ -189,12 +202,11 @@ describe('wbDocumentResolve', () => {
   })
 
   it('returns the document with its path', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     const created = await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
       path: 'parent/child',
       kind: 'spatial',
-      createWorkspace: true,
     })
     const got = await wbDocumentResolve(deps, {
       workspaceId: 'ws-1',
@@ -211,12 +223,11 @@ describe('wbDocumentResolve', () => {
   })
 
   it('throws WorkspaceDocumentNotFoundError for a documentId that does not exist', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
       path: 'doc-a',
       kind: 'spatial',
-      createWorkspace: true,
     })
     await expect(
       wbDocumentResolve(deps, { workspaceId: 'ws-1', documentId: '01ARZ3NDEKTSV4RRFFQ69G5FAV' }),
@@ -224,18 +235,18 @@ describe('wbDocumentResolve', () => {
   })
 
   it('does not resolve a document from another workspace', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
+    // A SECOND workspace, which makeDeps does not provide.
+    await deps.documentIndex.createWorkspace({ workspaceId: 'ws-2' })
     const mine = await wbDocumentCreate(deps, {
-      workspaceId: 'ws-1',
+      workspaceId: WS,
       path: 'doc-a',
       kind: 'spatial',
-      createWorkspace: true,
     })
     await wbDocumentCreate(deps, {
       workspaceId: 'ws-2',
       path: 'doc-a',
       kind: 'spatial',
-      createWorkspace: true,
     })
     // An id is a handle within a workspace, not a capability that reaches
     // across them.
@@ -253,7 +264,7 @@ describe('wbDocumentList', () => {
   // (apps/web reads timestamps from a separate store), so this asserts the
   // pass-through, not that every index supplies one.
   it('carries kind and updatedAt through rather than dropping them', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     await deps.documentIndex.createWorkspace({ workspaceId: 'ws-1' })
     ;(deps.documentIndex as InMemoryDocumentIndex).seed({
       workspaceId: 'ws-1',
@@ -276,19 +287,18 @@ describe('wbDocumentList', () => {
   })
 
   it('throws WorkspaceNotFoundError for a workspace that was never created', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     await expect(wbDocumentList(deps, { workspaceId: 'ghost' })).rejects.toThrow(
       WorkspaceNotFoundError,
     )
   })
 
   it('returns an empty list for a workspace that exists and holds nothing', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
       path: 'only',
       kind: 'spatial',
-      createWorkspace: true,
     })
     await wbDocumentDelete(deps, {
       workspaceId: 'ws-1',
@@ -298,13 +308,12 @@ describe('wbDocumentList', () => {
   })
 
   it('returns every document, ordered so each subtree stays together', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     for (const path of ['b-side', 'a', 'a/deep', 'a-sibling']) {
       await wbDocumentCreate(deps, {
         workspaceId: 'ws-1',
         path,
         kind: 'spatial',
-        createWorkspace: true,
       })
     }
     const { documents } = await wbDocumentList(deps, { workspaceId: 'ws-1' })
@@ -314,12 +323,11 @@ describe('wbDocumentList', () => {
   })
 
   it('excludes a deleted document', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     const keep = await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
       path: 'keep',
       kind: 'spatial',
-      createWorkspace: true,
     })
     const drop = await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
@@ -335,12 +343,11 @@ describe('wbDocumentList', () => {
 
 describe('wbDocumentDelete', () => {
   it('deletes a document so a later get throws WorkspaceDocumentNotFoundError', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     const created = await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
       path: 'doc-a',
       kind: 'spatial',
-      createWorkspace: true,
     })
     expect(
       await wbDocumentDelete(deps, { workspaceId: 'ws-1', documentId: created.documentId }),
@@ -353,12 +360,11 @@ describe('wbDocumentDelete', () => {
   })
 
   it('deletes the stored document, not only its placement', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     const created = await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
       path: 'doc-a',
       kind: 'spatial',
-      createWorkspace: true,
     })
     const docRef = {
       kind: 'document',
@@ -373,12 +379,11 @@ describe('wbDocumentDelete', () => {
   })
 
   it('throws WorkspaceDocumentNotFoundError when deleting a documentId that does not exist', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
       path: 'doc-a',
       kind: 'spatial',
-      createWorkspace: true,
     })
     await expect(
       wbDocumentDelete(deps, { workspaceId: 'ws-1', documentId: '01ARZ3NDEKTSV4RRFFQ69G5FAV' }),
@@ -386,12 +391,11 @@ describe('wbDocumentDelete', () => {
   })
 
   it('refuses to delete a document that still has documents below it', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     const parent = await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
       path: 'parent',
       kind: 'spatial',
-      createWorkspace: true,
     })
     const child = await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
@@ -420,20 +424,19 @@ describe('document name', () => {
       workspaceId: 'ws-1',
       path: 'doc-a',
       kind: 'spatial',
-      createWorkspace: true,
       ...(name === undefined ? {} : { name }),
     })
   }
 
   it('creation accepts a name and the listing returns it', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     await createNamed(deps, 'Quarterly plan')
     const { documents } = await wbDocumentList(deps, { workspaceId: 'ws-1' })
     expect(documents[0]?.name).toBe('Quarterly plan')
   })
 
   it('omits the name entirely when none was given, rather than echoing the path', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     await createNamed(deps)
     const { documents } = await wbDocumentList(deps, { workspaceId: 'ws-1' })
     expect(documents[0]).toBeDefined()
@@ -441,7 +444,7 @@ describe('document name', () => {
   })
 
   it('a name is free text, not a second path', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     const created = await createNamed(deps, 'Q3 / plan — draft')
     const got = await wbDocumentResolve(deps, {
       workspaceId: 'ws-1',
@@ -453,7 +456,7 @@ describe('document name', () => {
   })
 
   it('wbDocumentResolve returns the name too', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     const created = await createNamed(deps, 'Named')
     const got = await wbDocumentResolve(deps, {
       workspaceId: 'ws-1',
@@ -487,14 +490,13 @@ describe('wbDocumentDelete document teardown seam', () => {
   }
 
   it('enters teardown while the document still exists and cleans up after it is gone', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     const { events, teardown } = makeRecordingTeardown()
     deps.documentTeardown = teardown
     const created = await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
       path: 'doc-a',
       kind: 'spatial',
-      createWorkspace: true,
     })
     const docRef = {
       kind: 'document',
@@ -538,14 +540,13 @@ describe('wbDocumentDelete document teardown seam', () => {
   })
 
   it('passes the workspace, path and documentId the cleanup needs to find its files', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     const { events, teardown } = makeRecordingTeardown()
     deps.documentTeardown = teardown
     const created = await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
       path: 'nested/doc-a',
       kind: 'spatial',
-      createWorkspace: true,
     })
 
     await wbDocumentDelete(deps, { workspaceId: 'ws-1', documentId: created.documentId })
@@ -557,14 +558,13 @@ describe('wbDocumentDelete document teardown seam', () => {
   // documents sit below this one, and that refusal happens INSIDE the
   // bracket — it throws past the cleanup rather than being caught by it.
   it('does not clean up when the index refuses the delete', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     const { events, teardown } = makeRecordingTeardown()
     deps.documentTeardown = teardown
     const parent = await wbDocumentCreate(deps, {
       workspaceId: 'ws-1',
       path: 'parent',
       kind: 'spatial',
-      createWorkspace: true,
     })
     await wbDocumentCreate(deps, { workspaceId: 'ws-1', path: 'parent/child', kind: 'spatial' })
 
@@ -576,7 +576,7 @@ describe('wbDocumentDelete document teardown seam', () => {
   })
 
   it('never enters teardown for a documentId that does not exist', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     const { events, teardown } = makeRecordingTeardown()
     deps.documentTeardown = teardown
 

--- a/packages/server-core/src/tools/document-crud.ts
+++ b/packages/server-core/src/tools/document-crud.ts
@@ -1,7 +1,10 @@
 import { parseOkf } from '@kamiazya/whiteboard-codec'
 import { writeDocumentKind } from '@kamiazya/whiteboard-loro-adapter'
 import { generateDocumentId, workspaceSegmentSchema } from '@kamiazya/whiteboard-model'
-import { WorkspaceNotFoundError as PortWorkspaceNotFoundError } from '@kamiazya/whiteboard-ports'
+import {
+  isWorkspaceSegmentTakenError,
+  WorkspaceNotFoundError as PortWorkspaceNotFoundError,
+} from '@kamiazya/whiteboard-ports'
 import { LoroDoc } from 'loro-crdt'
 import type { z } from 'zod'
 import type { ServerDeps } from '../server-deps.js'
@@ -66,7 +69,28 @@ async function mintWorkspace(deps: ServerDeps, handle: string): Promise<string> 
     throw new WorkspaceSegmentUnusableError(handle)
   }
   const workspaceId = generateDocumentId()
-  await deps.documentIndex.createWorkspace({ workspaceId, segment: handle })
+  try {
+    await deps.documentIndex.createWorkspace({ workspaceId, segment: handle })
+  } catch (err) {
+    if (!isWorkspaceSegmentTakenError(err)) throw err
+    // Another create bootstrapped this handle between the resolve above and
+    // this write. The two cannot serialise on their own: each generates its
+    // id BEFORE writing, and the keeper's write lock is keyed by that id, so
+    // two mints of one handle take two different locks and only the unique
+    // `segment` index notices. Converging on the winner is what keeps the
+    // flag the idempotent bootstrap callers are told they may always set —
+    // rethrowing would make it fail on timing alone.
+    //
+    // The loser leaves nothing behind: a keeper claims the registry identity
+    // BEFORE the tree record precisely so a refused segment cannot strand a
+    // half-created workspace.
+    const winner = await deps.documentIndex.resolveWorkspace(handle)
+    // Nothing answers to a segment the write just reported as taken: the row
+    // is gone again, or this keeper does not resolve what it stores. Either
+    // way it is not a race this can settle, so the original error stands.
+    if (winner === null) throw err
+    return winner.workspaceId
+  }
   return workspaceId
 }
 

--- a/packages/server-core/src/tools/document-crud.ts
+++ b/packages/server-core/src/tools/document-crud.ts
@@ -1,10 +1,15 @@
 import { parseOkf } from '@kamiazya/whiteboard-codec'
 import { writeDocumentKind } from '@kamiazya/whiteboard-loro-adapter'
+import { generateDocumentId, workspaceSegmentSchema } from '@kamiazya/whiteboard-model'
 import { WorkspaceNotFoundError as PortWorkspaceNotFoundError } from '@kamiazya/whiteboard-ports'
 import { LoroDoc } from 'loro-crdt'
 import type { z } from 'zod'
 import type { ServerDeps } from '../server-deps.js'
-import { WorkspaceDocumentNotFoundError, WorkspaceNotFoundError } from './document-crud.errors.js'
+import {
+  WorkspaceDocumentNotFoundError,
+  WorkspaceNotFoundError,
+  WorkspaceSegmentUnusableError,
+} from './document-crud.errors.js'
 import type {
   wbDocumentCreateOutputSchema,
   wbDocumentDeleteInputSchema,
@@ -38,6 +43,33 @@ async function rethrowWorkspaceNotFound<T>(
   }
 }
 
+/**
+ * ADR-0019's mint: a new workspace is keyed by a canonical ULID the server
+ * chooses, and the handle the caller sent is filed as its `segment`.
+ *
+ * A handle that cannot BE a segment is refused rather than minted with none
+ * — see `WorkspaceSegmentUnusableError` for why that is not the same choice
+ * migration 0019 makes when backfilling workspaces that already exist.
+ */
+async function mintWorkspace(deps: ServerDeps, handle: string): Promise<string> {
+  // The flag has always been an IDEMPOTENT bootstrap — a no-op when the
+  // workspace is already there, which is why a caller can set it on every
+  // request without keeping track. Minting unconditionally would break that:
+  // a second create into the same workspace would mint a rival, and a handle
+  // already resolved to a canonical id would be refused for being
+  // ULID-shaped. So an existing workspace short-circuits, and only a handle
+  // that names nothing reaches the mint.
+  const existing = await deps.documentIndex.resolveWorkspace(handle)
+  if (existing !== null) return existing.workspaceId
+
+  if (!workspaceSegmentSchema.safeParse(handle).success) {
+    throw new WorkspaceSegmentUnusableError(handle)
+  }
+  const workspaceId = generateDocumentId()
+  await deps.documentIndex.createWorkspace({ workspaceId, segment: handle })
+  return workspaceId
+}
+
 export async function wbDocumentCreate(
   deps: ServerDeps,
   rawInput: z.infer<typeof wbDocumentCreateInputSchema>,
@@ -49,33 +81,47 @@ export async function wbDocumentCreate(
   // dropped. A schema only guarantees what something actually runs.
   const input = wbDocumentCreateInputSchema.parse(rawInput)
 
-  // Workspaces never materialize implicitly: a typo'd or hallucinated
-  // workspaceId must fail loudly rather than silently writing data into a
-  // workspace nobody asked for. `createWorkspace: true` is the explicit
-  // opt-in that bootstraps a genuinely new workspace.
+  // Parsed BEFORE anything exists, so a refusal leaves nothing behind. The
+  // body is applied by delegating to `wb_document_set` once the document
+  // exists, so a malformed one used to fail there — leaving an empty
+  // document squatting the requested path while the caller held an error
+  // saying the create had not happened, and the retry then collided with
+  // the ghost.
   //
-  // Everything below reads `workspaceId` rather than `input.workspaceId`.
-  // Today they are the same string; ADR-0019's mint boundary lands here
-  // next, at which point a create decides the canonical id and these two
-  // stop being interchangeable. Threading it now keeps that change to the
-  // one branch that causes it.
-  const workspaceId = input.workspaceId
-  if (input.createWorkspace === true) {
-    await deps.documentIndex.createWorkspace({ workspaceId })
-  }
-
-  // Parsed before anything is written, and AFTER the workspace bootstrap so
-  // a missing workspace still reports itself first. The body is applied by
-  // delegating to `wb_document_set` once the document exists, so a
-  // malformed one used to fail there — leaving an empty document squatting
-  // the requested path while the caller held an error saying the create had
-  // not happened, and the retry then collided with the ghost.
+  // It used to run AFTER the workspace bootstrap, "so a missing workspace
+  // still reports itself first". That order cannot survive the mint below:
+  // bootstrapping first would leave a freshly minted workspace behind every
+  // refused body, and the caller's retry would mint a SECOND one. What the
+  // old order bought was the error a caller gets when their request is
+  // wrong in BOTH ways at once, which no test pins and which is the less
+  // useful of the two — a malformed body has to be fixed either way.
   if (input.kind === 'markdown' && input.markdown !== undefined) {
     const preflight = parseOkf(input.markdown)
     if (!preflight.ok) {
       throw new OkfParseError(preflight.error.stage, preflight.error.message)
     }
   }
+
+  // Workspaces never materialize implicitly: a typo'd or hallucinated
+  // workspaceId must fail loudly rather than silently writing data into a
+  // workspace nobody asked for. `createWorkspace: true` is the explicit
+  // opt-in that bootstraps a genuinely new workspace.
+  //
+  // It is also ADR-0019's MINT BOUNDARY, and the only one on this side: the
+  // SERVER decides the canonical id, and the string the caller sent becomes
+  // the workspace's `segment`. Every later request may keep using that
+  // string — segment-first resolution at the boundary turns it back into
+  // this id — which is why the caller is not asked to change anything, and
+  // why the minted id is REPORTED rather than merely stored.
+  //
+  // Everything below therefore works from `workspaceId`, never from
+  // `input.workspaceId`: after a mint those name two different workspaces,
+  // and reading the input again would file the document under one that does
+  // not exist.
+  const workspaceId =
+    input.createWorkspace === true
+      ? await mintWorkspace(deps, input.workspaceId)
+      : input.workspaceId
 
   // Blank means no name, and that is a NORMALISATION rather than a rejection.
   // `DocumentEntry.name` is `z.string().min(1).optional()` — absent is the

--- a/packages/server-core/src/tools/workspace-edit.test.ts
+++ b/packages/server-core/src/tools/workspace-edit.test.ts
@@ -1,5 +1,6 @@
 import { InMemoryDocumentIndex } from '@kamiazya/whiteboard-ports/test-utils'
 import { describe, expect, it } from 'vitest'
+import type { ServerDeps } from '../server-deps.js'
 import { ignoredDocumentWrites } from '../test-utils/ignored-document-writes.js'
 import { createInMemoryDocumentStore } from '../test-utils/in-memory-document-store.js'
 import { inMemoryDocumentTeardown } from '../test-utils/unused-document-teardown.js'
@@ -8,23 +9,31 @@ import { createWorkspaceEditTool } from './workspace-edit.js'
 
 const WS = 'batch'
 
-function makeDeps() {
-  return {
+/**
+ * The workspace exists because this fixture says so. It used to appear as a
+ * side effect of `createWorkspace: true` on op 0 — which is ADR-0019's MINT
+ * boundary, and now keys it by a fresh ULID, leaving the `WS` these cases
+ * read back by naming nothing. The one case that is ABOUT bootstrapping
+ * keeps the flag and reads the id the batch reports.
+ */
+async function makeDeps() {
+  const deps = {
     documentStore: createInMemoryDocumentStore(),
     blobStore: {} as never,
     documentTeardown: inMemoryDocumentTeardown(),
     documentWritten: ignoredDocumentWrites(),
     documentIndex: new InMemoryDocumentIndex(),
   }
+  await deps.documentIndex.createWorkspace({ workspaceId: WS })
+  return deps
 }
 const body = (text: string) => `---\ntype: note\n---\n${text}`
 
 describe('wb_workspace_edit', () => {
   it('creates several documents in one call and reports the ids it minted', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     const out = await createWorkspaceEditTool(deps).execute({
       workspaceId: WS,
-      createWorkspace: true,
       ops: [
         { op: 'document.create', path: 'a', kind: 'markdown', name: 'A', markdown: body('one') },
         { op: 'document.create', path: 'b', kind: 'markdown', name: 'B', markdown: body('two') },
@@ -46,11 +55,10 @@ describe('wb_workspace_edit', () => {
   })
 
   it('stops at the failing op and says how far it got', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     const tool = createWorkspaceEditTool(deps)
     await tool.execute({
       workspaceId: WS,
-      createWorkspace: true,
       ops: [{ op: 'document.create', path: 'taken', kind: 'markdown' }],
     })
 
@@ -77,11 +85,10 @@ describe('wb_workspace_edit', () => {
   })
 
   it('names how many ops succeeded in the message, since only .message survives MCP', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     const tool = createWorkspaceEditTool(deps)
     await tool.execute({
       workspaceId: WS,
-      createWorkspace: true,
       ops: [{ op: 'document.create', path: 'dup', kind: 'markdown' }],
     })
     await expect(
@@ -96,11 +103,10 @@ describe('wb_workspace_edit', () => {
   })
 
   it('deletes and sets alongside creates', async () => {
-    const deps = makeDeps()
+    const deps = await makeDeps()
     const tool = createWorkspaceEditTool(deps)
     const made = await tool.execute({
       workspaceId: WS,
-      createWorkspace: true,
       ops: [{ op: 'document.create', path: 'edit-me', kind: 'markdown', markdown: body('before') }],
     })
     const documentId = made.results[0]?.documentId ?? ''
@@ -122,5 +128,42 @@ describe('wb_workspace_edit', () => {
     })
     const after = await deps.documentIndex.listDocuments({ workspaceId: WS })
     expect(after.map((d) => d.path)).not.toContain('doomed')
+  })
+
+  it('bootstraps the workspace on op 0 and applies the REST of the batch inside it', async () => {
+    // The threading guard. Creating is ADR-0019's mint boundary, so op 0
+    // decides an id the caller never sent — and ops 1..n reach the port
+    // directly, with no resolution between. Before the batch carried that id
+    // forward, op 1 addressed the caller's handle, which by then named
+    // nothing: `ops[1] ... Workspace not found: "batch"`.
+    const deps: ServerDeps = {
+      documentStore: createInMemoryDocumentStore(),
+      blobStore: {} as never,
+      documentTeardown: inMemoryDocumentTeardown(),
+      documentWritten: ignoredDocumentWrites(),
+      documentIndex: new InMemoryDocumentIndex(),
+    }
+
+    const out = await createWorkspaceEditTool(deps).execute({
+      workspaceId: WS,
+      createWorkspace: true,
+      ops: [
+        { op: 'document.create', path: 'first', kind: 'markdown', markdown: body('one') },
+        { op: 'document.create', path: 'second', kind: 'markdown', markdown: body('two') },
+      ],
+    })
+
+    expect(out.applied).toBe(2)
+    expect(out.workspaceId).toMatch(/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/)
+    expect(out.workspaceId).not.toBe(WS)
+
+    // BOTH documents in ONE workspace — the id op 0 minted, which is also
+    // the one reported. Two workspaces, or a second op that failed, is the
+    // shape this guards.
+    const workspaces = await deps.documentIndex.listWorkspaces()
+    expect(workspaces).toHaveLength(1)
+    expect(workspaces[0]?.segment).toBe(WS)
+    const listed = await deps.documentIndex.listDocuments({ workspaceId: out.workspaceId })
+    expect(listed.map((d) => d.path).sort()).toEqual(['first', 'second'])
   })
 })

--- a/packages/server-core/src/tools/workspace-edit.ts
+++ b/packages/server-core/src/tools/workspace-edit.ts
@@ -91,6 +91,16 @@ export type WorkspaceEditInput = z.infer<typeof workspaceEditInputSchema>
 
 export const workspaceEditOutputSchema = z
   .object({
+    /**
+     * The workspace the batch applied to, as its CANONICAL id (ADR-0019).
+     * Always present, not only when `createWorkspace: true` minted one: a
+     * caller that addressed an existing workspace by its segment learns the
+     * id behind it, and a caller that created one learns what the server
+     * minted. Without it a bootstrapping batch is unusable in the same way
+     * a bootstrapping `wb_document_create` was — the server picks an id,
+     * files the whole batch under it, and never says which.
+     */
+    workspaceId: workspaceIdSchema,
     applied: z
       .number()
       .int()
@@ -136,12 +146,20 @@ export function createWorkspaceEditTool(deps: ServerDeps) {
       const input = workspaceEditInputSchema.parse(rawInput)
       const set = createDocumentSetTool(deps)
       const results: WorkspaceEditOutput['results'] = []
+      // The batch addresses ONE workspace, and a bootstrapping first op is
+      // what decides which. Creating is ADR-0019's mint boundary, so after
+      // op 0 the caller's handle is that workspace's SEGMENT rather than its
+      // id — and every later op in this loop reaches the port directly, with
+      // no resolution step between. Carrying the id the create reported is
+      // what keeps ops 1..n inside the workspace op 0 made, instead of
+      // failing against a handle that now names nothing.
+      let workspaceId = input.workspaceId
 
       for (const [index, op] of input.ops.entries()) {
         try {
           if (op.op === 'document.create') {
             const created = await wbDocumentCreate(deps, {
-              workspaceId: input.workspaceId,
+              workspaceId,
               path: op.path,
               ...(op.kind === 'markdown'
                 ? {
@@ -154,17 +172,18 @@ export function createWorkspaceEditTool(deps: ServerDeps) {
               // per op would make a typo'd id create one silently.
               ...(index === 0 && input.createWorkspace === true ? { createWorkspace: true } : {}),
             })
+            workspaceId = created.workspaceId
             results.push({ op: op.op, documentId: created.documentId, path: created.path })
           } else if (op.op === 'document.set') {
             await set.execute({
-              workspaceId: input.workspaceId,
+              workspaceId,
               documentId: op.documentId,
               markdown: op.markdown,
             })
             results.push({ op: op.op, documentId: op.documentId })
           } else {
             await wbDocumentDelete(deps, {
-              workspaceId: input.workspaceId,
+              workspaceId,
               documentId: op.documentId,
             })
             results.push({ op: op.op, documentId: op.documentId })
@@ -179,7 +198,7 @@ export function createWorkspaceEditTool(deps: ServerDeps) {
         }
       }
 
-      return { applied: results.length, results }
+      return { workspaceId, applied: results.length, results }
     },
   }
 }

--- a/tests/e2e/distribution/packaged-daemon-backup-restore-smoke.mjs
+++ b/tests/e2e/distribution/packaged-daemon-backup-restore-smoke.mjs
@@ -238,14 +238,23 @@ try {
 
   // /api/workspaces only returns workspace rows the daemon has
   // observed. After the canvas POST above the workspace row is
-  // present, so the listing must include our seeded id.
+  // present, so the listing must include the workspace we seeded.
+  //
+  // Found by its SEGMENT, not by `WORKSPACE_ID` as an id: under ADR-0019's
+  // mint boundary the POST above filed that string as the new workspace's
+  // segment and keyed the row by a canonical ULID the daemon chose. The
+  // canonical id is captured here because the backup/restore assertions
+  // below are about the ROW surviving, which is an id-level claim — while
+  // every request in this smoke keeps addressing the workspace by the same
+  // segment, which is the half that must not change.
   const wsListA = await (await authedFetch(daemonA, '/api/workspaces')).json()
-  const workspaceIdsA = (wsListA?.workspaces ?? []).map((w) => w.workspaceId)
-  if (!workspaceIdsA.includes(WORKSPACE_ID)) {
+  const seededA = (wsListA?.workspaces ?? []).find((w) => w.segment === WORKSPACE_ID)
+  if (seededA === undefined) {
     throw new Error(
-      `seeded workspaceId not present in daemon A list: ${JSON.stringify(workspaceIdsA)}`,
+      `no workspace with segment ${WORKSPACE_ID} in daemon A list: ${JSON.stringify(wsListA?.workspaces ?? [])}`,
     )
   }
+  const seededWorkspaceId = seededA.workspaceId
 
   const seededList = await (
     await authedFetch(daemonA, `/api/workspaces/${encodeURIComponent(WORKSPACE_ID)}/documents`)
@@ -254,7 +263,9 @@ try {
   if (!seededPaths.includes(SEED_CANVAS_PATH)) {
     throw new Error(`seeded canvas not present after POST: ${JSON.stringify(seededPaths)}`)
   }
-  console.log(`[packaged-daemon-backup-restore-smoke] seeded workspaceId → ${WORKSPACE_ID}`)
+  console.log(
+    `[packaged-daemon-backup-restore-smoke] seeded workspaceId → ${seededWorkspaceId} (segment ${WORKSPACE_ID})`,
+  )
 
   // Capture the canvas Loro snapshot through daemon A's HTTP route
   // BEFORE stopping it. The route reads from
@@ -372,12 +383,16 @@ try {
     throw new Error(`daemon B status pid ${statusB.pid} !== spawned ${daemonB.child.pid}`)
   }
 
-  // The restored DB must surface the same workspace + canvas.
+  // The restored DB must surface the same workspace + canvas. Asserted on
+  // the CANONICAL id daemon A minted, not merely on the segment: a restore
+  // that re-created the workspace under a fresh id would satisfy a
+  // segment-only check while having lost the row this smoke exists to
+  // round-trip.
   const wsListB = await (await authedFetch(daemonB, '/api/workspaces')).json()
   const workspaceIdsB = (wsListB?.workspaces ?? []).map((w) => w.workspaceId)
-  if (!workspaceIdsB.includes(WORKSPACE_ID)) {
+  if (!workspaceIdsB.includes(seededWorkspaceId)) {
     throw new Error(
-      `restored daemon does not surface seeded workspaceId ${WORKSPACE_ID}: ${JSON.stringify(workspaceIdsB)}`,
+      `restored daemon does not surface seeded workspaceId ${seededWorkspaceId}: ${JSON.stringify(workspaceIdsB)}`,
     )
   }
   const restoredCanvases = await (
@@ -388,7 +403,7 @@ try {
     throw new Error(`restored daemon missing seeded canvas: ${JSON.stringify(restoredPaths)}`)
   }
   console.log(
-    `[packaged-daemon-backup-restore-smoke] restored data round-tripped (workspace=${WORKSPACE_ID}, canvas=${SEED_CANVAS_PATH})`,
+    `[packaged-daemon-backup-restore-smoke] restored data round-tripped (workspace=${seededWorkspaceId}, canvas=${SEED_CANVAS_PATH})`,
   )
 
   // Loro snapshot CONTENT equality. Without this assertion a regression


### PR DESCRIPTION
ADR-0019's **mint boundary** on the creation surface, and the Stage-1b gap it exposed.

`createWorkspace: true` now files the handle the caller sent as the workspace's `segment`, and keys the workspace by a canonical ULID the **server** chooses — which the create reports back. Callers change nothing: every later request may keep sending the same string, because segment-first resolution at the request boundary turns it back into that id.

## The mint

- `wbDocumentCreate` mints, and **refuses** a handle that cannot be a segment (`WorkspaceSegmentUnusableError` → 400). That is deliberately a different choice from migration 0019's backfill, which settles for NULL: a backfill has data it must not discard, and a create has nothing yet.
- The mint **short-circuits on an existing workspace**, so the flag keeps the idempotent-bootstrap meaning it has always had. Without that, a second create into the same workspace minted a rival, and a boundary-resolved canonical id was refused for being ULID-shaped — which is how `/api/v1`'s own duplicate-path 409 case failed.
- **Two concurrent creates of the same new handle converge** (found by CodeRabbit, verified by reproduction). The mint reads `resolveWorkspace` then writes, and the keeper's write lock is keyed by the id it just *generated* — so two mints of one handle take two different locks and never serialise. Both saw nothing, both minted, and the second hit migration 0018's unique `segment` index with `WorkspaceSegmentTakenError`, which nothing handled. The loser now re-resolves and adopts the winner's id; a non-race failure still surfaces as itself.

## An ordering change, stated

The OKF preflight moved **before** the workspace bootstrap. It used to run after, with the comment "so a missing workspace still reports itself first". That order cannot survive the mint: bootstrapping first would leave a freshly minted workspace behind every refused body, and the caller's retry would mint a second one.

What the old order bought was the error a caller gets when their request is wrong in *both* ways at once — no test pinned it, and it is the less useful of the two, since a malformed body has to be fixed either way. `document-create-orphan.test.ts` also had prose claiming a refused create left no workspace; that was **not true** before this change (the bootstrap ran first) and was asserted by nothing. It is true now, and the assertion lives in the new mint suite.

## A real bug in `wb_workspace_edit`

Ops 1..n reach the port directly, with no resolution between, so after op 0 minted they still addressed `input.workspaceId` — a handle that by then named nothing:

```
ops[1] (document.create) could not be applied: Workspace not found: "batch"
```

The batch now threads the id op 0 minted, and `workspaceEditOutputSchema` reports it. Mutation-checked.

## The Stage-1b gap — a correction to #1110

I concluded in #1110 that "MCP tools needed nothing here". That was true only for the tools registered via `tools.*`. **Five registrations were built from a bare operation or a tool factory instead**, so they sat outside the record `withResolvedWorkspaceHandles` wraps and never resolved a handle. Invisible while a workspace's id and its handle were the same string; `Workspace not found` on every call after a create once they differ. The published smoke is what caught it.

`withResolvedWorkspaceHandles`' own doc comment already named this failure — *"a per-tool step is a step the fifteenth tool will not have"* — so the fix is structural rather than five more resolution steps: the four document CRUD operations and `wb_workspace_edit` are now tool objects **on the record**, and every registration in `document-tools.ts` takes its `execute` from there. The routes are unaffected; they resolve once in middleware and pass the canonical id straight to the operation. `resolveWorkspaceId` is no longer exported from server-core, which is knip's confirmation that nothing outside needs its own step any more.

## Guards

`segment-addressable-tools.test.ts` carries two, because neither is sufficient alone:

1. **Structural** — every `registerToolWithAnnotations` block must call `` tools.<name>.execute( ``, with a floor on the block count so a scan that stops matching fails rather than passes.
2. **Behavioural** — a segment-addressed `wb_workspace_edit` batch against the real `CacheCoherentDocumentIndex`, asserting the document lands under the canonical id.

My first attempt at the behavioural guard was a sweep calling every workspace-scoped tool with `{workspaceId}` alone and asserting none answered "not found". **It passed against the broken code.** Zod parse runs before the lookup, so thin arguments never reach the workspace at all — the assertion was right and the subject absent. Both guards above were mutation-checked against the exact defect (restoring the bare `createWorkspaceEditTool(deps)` registration turns both red, and the restore was re-run green).

The concurrency guard has the same shape of constraint, in the opposite direction: it can only live at the daemon, because the port explicitly permits an implementation to ignore `segment`, so `InMemoryDocumentIndex` has no unique index to violate and cannot express the race at all.

## Verification

- `pnpm check:local` — clean (typecheck, lint, noconsole, audit, knip, intent:validate, secretlint, test:scripts).
- `mcp-node` + `server-core-node` + `arch-lint-node` + `ports-node` + `workspace-index-node` — **4649 passed / 3 failed**. The three are `0011-import-fs-blobs` (×2) and `migrator.test.ts`, all root-uid EACCES: that container runs as root, so `chmod 000` stays readable. Measured identically on unmodified `origin/main`, and **CI's non-root `test-unit` shards run them green**, which settles it.
- Re-run after rebasing onto `28078e7d` — same three, nothing new.
- **`pnpm smoke:e2e` — both smokes `ALL OK` through the published artifact.** This is the load-bearing check: the create is asserted to report a ULID and *not* the handle, and the rest of each smoke addressing the workspace by that handle **unchanged** is what proves segment-first resolution works end to end (54 uses of the handle in the e2e smoke; a `PUT /api/workspaces/conv-e2e/name` followed by a `GET /api/workspaces` lookup by canonical id in the convergence smoke).
- All seven packaged distribution smokes the `packaged-smoke` job runs, after that job caught the third instance of the same class (below).

## Three smokes compared a handle against a served workspace id

That is the whole class, and all three are fixed here — the convergence smoke, and the daemon backup/restore distribution smoke that CI caught. Nothing else in the repo makes that comparison; everything else only *addresses* the workspace by its handle, which is the half that must keep working.

Both failures were misreported by their own messages, which is worth recording:

- `did not echo displayName: undefined` — but `JSON.stringify(ourWorkspace)` printing a bare `undefined` says the whole row was missing, not the field.
- `seeded workspaceId not present in daemon A list: ["9delJufhAfllw3EfoALRK","01M163RY9P86898WAK9974KR86"]` — the ULID in that list *is* the diagnosis.

The backup/restore smoke now finds the workspace by `segment` (what the assertion always meant) and captures the minted id, and the restore side still asserts on that **id** rather than the segment: a restore that re-created the workspace under a fresh id would satisfy a segment-only check while having lost the row the smoke exists to round-trip.

## Follow-up, not in this PR

The daemon's `POST /api/v1/workspaces` route passes `createWorkspace: true`, which is now the mint boundary. Removing it is a real improvement and a **separate increment**: measured at ~20 test changes across six suites, because they bootstrap by POSTing through that route. I earlier claimed "no test pins it — verified"; what I had actually verified was only `workspaces.test.ts`, and removing the flag produced 21 failures. The flag is restored with the measurement recorded in a comment.

Visual evidence: none — server-side identity/contract change with no rendered surface. The observable behaviour is the MCP/HTTP payload, and it is covered by the published-smoke assertions quoted above rather than by a picture. (The `gh image` upload path is also unavailable in this environment — no `gh` CLI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2