### PR TITLE
feat(web): the signature mark carries the session, and the connection chip is gone

### DIFF
--- a/apps/web/BRAND.md
+++ b/apps/web/BRAND.md
@@ -33,6 +33,7 @@ and each appears only where it earns its keep:
 | PWA launcher icon | no | no | At launcher size, inside a mask, the frame only costs stroke weight and safe-zone space | `public/icon-192.png`, `public/icon-512.png` |
 | README hero | yes | yes | A document context: the image needs containment to read as an object | `docs/assets/readme-mark.svg` (repo root `docs/`) |
 | OG / social card | yes | yes | Same document logic, plus the card must carry the name on foreign surfaces | `public/og-image.png` |
+| App header | no | no | The one brand surface that is also a CONTROL: it names the workspace you are in and reports whether your work is safe, so it carries state (see below) and opens the connection popover. No frame — a 40px row is containment enough; no wordmark — the name is already in the tab title | `src/components/shell/ShellMark.tsx` |
 | Onboarding chooser (empty workspace) | no | yes | The first page arrivals meet; the viewport is the board (no frame), and the name is not in the surrounding chrome, so the lockup introduces the product. The full splash story plays here (draw, sketch, the spark tidies, the signature returns and breathes) — reused via `<img>` so the asset stays the story's single source | `public/boot-splash.svg` |
 
 The rule in one line: **the squiggle is the signature everywhere; the frame
@@ -57,6 +58,23 @@ Brand surfaces are mid-gray on any ground, plus exactly one accent:
   semantic family as the AI acting. The dashed frame is the load-bearing
   metaphor: the frame is the connection, and offline breaks it. Legible
   even at 16px.
+- **The app-header mark carries state too**, and takes its tones from the
+  app's `StateDot` set rather than from the favicon's — the header sits
+  inside the themed page, where `emerald-500` / `amber-500` already mean
+  "safe" / "attention" on three other carriers, while the favicon renders
+  outside the theme and needs its own fixed hues. Same idea, two palettes,
+  for a reason that is about where each one is painted.
+
+  That the signature can hold a state at all is not new: the favicon has
+  done it since the beginning, dot and dashed frame together. What the
+  header adds is MOTION as a second channel — `reconnecting` travels, using
+  the loader's own dash on the same path, and `sync-off` sits broken and
+  dimmed. It has to: those two share the amber tone, and on a mark with no
+  room for a word, colour alone cannot separate them.
+
+  This is the one departure from "the signature is static", and it is
+  deliberate rather than drift. The resting mark is still the plain
+  squiggle; nothing moves until the session does.
 
 In-app chrome state colors are DESIGN.md's domain and use a different
 palette (emerald/amber on the connection chip — picked against chrome
@@ -134,7 +152,8 @@ All commands run from `apps/web/`.
 
 | Asset | Source of truth | Regenerate |
 | --- | --- | --- |
-| in-app marks (error / not-found / home / welcome-static) | `src/brand/*.svg`, imported as React components via SVGR (`?react`) | edit the .svg directly |
+| in-app marks (error / not-found / welcome-static / loader) | `src/brand/*.svg`, imported as React components via SVGR (`?react`) | edit the .svg directly |
+| app-header mark | `src/components/shell/ShellMark.tsx` — the signature drawn in code, because it carries state | code |
 | ALPHA chip (AppShell) | `src/components/AppShell.tsx` — amber chip + honesty popover; the durable home of "data durability is not guaranteed" | code |
 | `public/boot-splash.svg` | hand-authored (this is the source) | edit directly; contract tests pin its grammar |
 | `docs/assets/readme-mark.svg` | hand-authored framed+captioned variant | edit directly |

--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -46,15 +46,38 @@ one it is not in yet, `spinner` that same ring while the doing is in flight.
   named set, and each member says what QUESTION it answers — two carriers
   that look alike but answer differently is the defect this naming exists to
   prevent:
-  - **connection chip** (`ConnectionStatus`) — who keeps this workspace, and
-    is the session reaching it? Filled dot. It lives in the AppShell, not in
-    a page. Those are two questions in one carrier and the split is still
-    open: `browser` names the KEEPER (and survives navigation), while
-    `synced`/`reconnecting`/`sync-off` report a live session (and do not).
+  - **the shell mark** (`ShellMark`, triggered through `ConnectionStatus`) —
+    who keeps this workspace, and is the session reaching it? A filled dot on
+    the signature's own end point. It lives in the AppShell, not in a page,
+    and it REPLACED a labelled chip at the far right of the row: a keeper and
+    a session are facts about the workspace, so they belong on the thing that
+    stands for it. Those are still two questions in one carrier and the split
+    is still open — `browser` names the KEEPER (and survives navigation),
+    while `synced`/`reconnecting`/`sync-off` report a live session (and do
+    not). Merging the carriers did not resolve that; it put the unresolved
+    pair in one place instead of implying two subjects.
+
+    This is the one carrier with a SECOND channel, and it is not decoration.
+    `reconnecting` and `sync-off` are both `attention`, and the chip's WORD
+    was what separated them for a sighted reader. A 26×16 signature has no
+    room for a word, so MOTION does it: reconnecting travels (`wb-loader` —
+    the loader mark's own dash, on the same path), sync-off sits broken and
+    dimmed. The word moves to the accessible name and the popover's header,
+    where assistive tech reads it either way.
+
+    Two gestures, both finite, one per direction. `sync-off` arriving keeps
+    the chip's attention echo verbatim. `reconnecting`/`sync-off` → `synced`
+    plays a recovery draw — the RARE moment, not the routine one. There is
+    deliberately no "a write landed" celebration: the daemon keeper has no
+    write-landed signal to hang one on (its `session` is derived from
+    transport liveness, not from an ack), so shipping it would light up for
+    browser-kept workspaces only and read as "the daemon is not saving" —
+    which is exactly what "never offer what the keeper cannot honour" below
+    forbids.
   - **save-state chip** (`SaveStatusChip`) — did the last write to this
     browser's storage land? Filled dot. Browser keeper only; on a daemon the
-    connection chip is what answers "is my work safe", and a second dot
-    saying so would be the same fact twice.
+    shell mark is what answers "is my work safe", and a second dot saying so
+    would be the same fact twice.
   - **version dot** (`HeaderVersionDot`) — are there edits no named version
     holds yet? RING, not filled, precisely because it shares the amber tone
     with the save-state chip while asking something else. It carried the
@@ -65,21 +88,36 @@ one it is not in yet, `spinner` that same ring while the doing is in flight.
   Anything else stateful in chrome needs this list amended first, and takes
   its paint from `StateDot` rather than a fresh literal.
 - **The AppShell owns brand, connection and settings.** Every page mounts
-  `AppShell` (brand mark = home, the ALPHA honesty chip, the connection chip,
-  the settings gear + attention dot) and never renders its own brand,
-  connection or settings chrome. Context and tools stay in the page's own
-  surface, always visible — collapsing them into menus is a narrow-viewport
+  `AppShell` (the signature mark, the ALPHA honesty chip, the settings gear +
+  attention dot) and never renders its own brand, connection or settings
+  chrome.
+
+  The row reads in two halves, and the spacer is the divider: **left of it is
+  what you are working IN** (the mark = this workspace), **right of it is the
+  app and its own state** (the alpha stage, settings). Position is what tells
+  a reader which layer a control belongs to, since chrome carries no
+  sentence-length copy to say so — and it is why the connection carrier moved
+  onto the mark rather than staying at the far right.
+
+  The mark's click changed with it: with a live session it opens the
+  connection popover, and Home is the last item there rather than the click
+  itself. With NO session published there is nothing to explain, so the mark
+  stays a plain link home — the popover appears exactly when it has something
+  to say.
+
+  Context and tools stay in the page's own surface, always visible —
+  collapsing them into menus is a narrow-viewport
   last resort, not a desktop pattern. Where BRAND.md (identity, motion) and
   this file (app chrome) disagree about chrome, this file wins and the
   exception gets documented here.
 - **What belongs in the shell is what does not change when you open a
-  different document.** Which daemon this browser talks to is one such fact,
-  so the connection chip is the shell's; the document's own title, actions
+  different document.** Which workspace you are in, and who keeps it, are
+  such facts, so the mark is the shell's; the document's own title, actions
   and history are the page's. The dividing question is not importance, it is
   whether the answer survives navigation.
 - **The shell states a connection only while a page holds one.** Pages report
   through `lib/shell-status-store`, and `null` — an index or settings page —
-  draws no chip at all. A daemon index page does talk to the daemon over
+  leaves the mark stateless (no dot at all). A daemon index page does talk to the daemon over
   HTTP but runs no document sync, so neither "Synced" nor "Reconnecting" is
   true there, and a chip that stayed behind from the last document would say
   one of them anyway. Clear on unmount; never latch.
@@ -100,10 +138,10 @@ one it is not in yet, `spinner` that same ring while the doing is in flight.
   it. Before adding a control, ask which keepers can actually deliver it.
 - **Status reports; Settings manages.** A surface that reports a state carries
   only what you cannot go looking for — a dropped sync is not something anyone
-  seeks out, so its recovery (re-pair, work in the browser instead) stays on
-  the chip that reports it. Changing which daemon this browser uses is the
-  opposite: it has an intent behind it, so it lives in Settings and the chip
-  only points there. The dividing question is whether the user would know to
+  seeks out, so its recovery (re-pair, work in the browser instead) stays in
+  the popover of the mark that reports it. Changing which daemon this browser uses is the
+  opposite: it has an intent behind it, so it lives in Settings and the
+  popover only points there. The dividing question is whether the user would know to
   look.
 - **Name the keeper, never the locality.** A workspace is kept by the
   **Browser** or by a **Daemon**; both are on the user's machine, so "Local"

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -733,7 +733,7 @@ describe('App daemon provider state', () => {
         daemonBaseUrl: 'http://127.0.0.1:3099',
       })
     })
-    fireEvent.click(await screen.findByTestId('connection-chip'))
+    fireEvent.click(await screen.findByTestId('shell-mark-trigger'))
     fireEvent.click(await screen.findByRole('button', { name: /work in this browser instead/i }))
     expect(await screen.findByTestId('browser-index-page')).toBeTruthy()
     expect(screen.queryByTestId('daemon-document-page')).toBeNull()
@@ -1024,9 +1024,13 @@ describe('App shell (single instance above the routed pages)', () => {
         })
       })
       expect(screen.getByTestId('settings-nudge')).toBeTruthy()
-      // The chip is the shell's now, so the state a page reports reaches the
-      // user here rather than inside the page's own top bar.
-      expect(screen.getByTestId('connection-chip').textContent).toMatch(/sync off/i)
+      // The mark is the shell's now, so the state a page reports reaches the
+      // user here rather than inside the page's own top bar. Read from the
+      // accessible name: the mark carries the state as colour and motion and
+      // has no room for the word.
+      expect(screen.getByTestId('shell-mark-trigger').getAttribute('aria-label')).toMatch(
+        /sync off/i,
+      )
     } finally {
       Object.defineProperty(navigator, 'storage', { value: undefined, configurable: true })
     }

--- a/apps/web/src/brand/home-mark.svg
+++ b/apps/web/src/brand/home-mark.svg
@@ -1,8 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="28" height="18" viewBox="0 0 88 56" fill="none" data-mark="home" aria-hidden="true">
-  <!--
-    Static signature mark (BRAND.md): the plain squiggle, no frame, no
-    animation - the brand as a wayfinding affordance (click = go home).
-    currentColor follows the theme.
-  -->
-  <path d="M20 44 C 27 22, 37 22, 44 33 S 58 50, 68 25" stroke="currentColor" stroke-width="8" stroke-linecap="round"/>
-</svg>

--- a/apps/web/src/components/AppShell.test.tsx
+++ b/apps/web/src/components/AppShell.test.tsx
@@ -36,10 +36,14 @@ function renderShell(daemonConnected: boolean, at = '/local/c1', onWorkInBrowser
 }
 
 describe('AppShell', () => {
-  it('brand mark links home', () => {
+  it('brand mark links home while no page holds a session', () => {
+    // With nothing to report the mark is not a menu: it is the way home,
+    // exactly as before. The popover appears only once there is a state for
+    // it to explain.
     renderShell(true)
     const home = screen.getByRole('link', { name: 'Home' })
     expect(home.getAttribute('href')).toBe('/')
+    expect(screen.getByTestId('shell-mark').getAttribute('data-keeper')).toBeNull()
   })
 
   it('alpha chip opens the honesty popover with a protect link', async () => {
@@ -99,15 +103,37 @@ describe('AppShell', () => {
 // this browser talks to does not change when you open a different document.
 // It lives beside the settings gear for the same reason the gear does — the
 // document's own surface is for the document.
-describe('AppShell — the connection chip', () => {
+describe('AppShell — the mark as the connection carrier', () => {
   // Matched loosely: the CTA is two sentences across JSX lines, so an exact
   // string match would be asserting the source's line breaks, not the copy.
   const CTA = /Connect a daemon \(MCP\) for version history/i
   const CTA_LIMIT = /move this workspace to it from Settings/i
 
-  it('shows no chip until a page publishes a live session', () => {
+  it('carries no state until a page publishes a live session', () => {
     renderShell(true)
-    expect(screen.queryByTestId('connection-chip')).toBeNull()
+    expect(screen.queryByTestId('shell-mark-trigger')).toBeNull()
+    expect(screen.getByTestId('shell-mark').getAttribute('data-keeper')).toBeNull()
+  })
+
+  it('leaves exactly one state carrier in the row, not two', async () => {
+    // The row had two carriers and no subject. One carrier now answers both
+    // "which workspace" and "is my work safe"; a chip left beside it would be
+    // the same fact twice, which DESIGN.md's closed-set rule exists to stop.
+    //
+    // Counted rather than named: asserting the OLD test id is absent would
+    // pass just as well if a replacement chip were added under a new one, and
+    // a guard that cannot see its subject is no guard.
+    setShellConnection({
+      state: { keeper: 'daemon', session: 'synced' },
+      daemonBaseUrl: 'http://127.0.0.1:3099',
+    })
+    renderShell(true)
+    const header = (await screen.findByTestId('shell-mark-trigger')).closest('header')
+    expect(header).not.toBeNull()
+    const carriers = header?.querySelectorAll(
+      '[data-testid="shell-mark-cap"], [data-testid="state-dot"]',
+    )
+    expect(carriers?.length).toBe(1)
   })
 
   it.each([
@@ -118,7 +144,11 @@ describe('AppShell — the connection chip', () => {
   ] as const)('renders the %s state the page published', async (_name, state, label) => {
     setShellConnection({ state, daemonBaseUrl: 'http://127.0.0.1:3099' })
     renderShell(state.keeper === 'daemon')
-    expect((await screen.findByTestId('connection-chip')).textContent).toMatch(label)
+    // The mark has no room for the word, so the accessible name carries it —
+    // and it must, because two of these four states share a tone.
+    expect((await screen.findByTestId('shell-mark-trigger')).getAttribute('aria-label')).toMatch(
+      label,
+    )
   })
 
   it('follows the page as its session changes, without a remount', async () => {
@@ -127,7 +157,9 @@ describe('AppShell — the connection chip', () => {
       daemonBaseUrl: 'http://127.0.0.1:3099',
     })
     renderShell(true)
-    expect((await screen.findByTestId('connection-chip')).textContent).toMatch(/synced/i)
+    expect((await screen.findByTestId('shell-mark-trigger')).getAttribute('aria-label')).toMatch(
+      /synced/i,
+    )
 
     act(() =>
       setShellConnection({
@@ -135,12 +167,16 @@ describe('AppShell — the connection chip', () => {
         daemonBaseUrl: 'http://127.0.0.1:3099',
       }),
     )
-    expect(screen.getByTestId('connection-chip').textContent).toMatch(/reconnecting/i)
+    expect(screen.getByTestId('shell-mark-trigger').getAttribute('aria-label')).toMatch(
+      /reconnecting/i,
+    )
+    expect(screen.getByTestId('shell-mark').getAttribute('data-session')).toBe('reconnecting')
 
     // Leaving the document takes the claim with it: nothing on an index page
-    // is synced, and a latched chip would say otherwise.
+    // is synced, and a latched mark would say otherwise.
     act(() => setShellConnection(null))
-    expect(screen.queryByTestId('connection-chip')).toBeNull()
+    expect(screen.queryByTestId('shell-mark-trigger')).toBeNull()
+    expect(screen.getByTestId('shell-mark').getAttribute('data-session')).toBeNull()
   })
 
   it('carries the capability CTA inside the Local popover, not in page chrome', async () => {
@@ -148,7 +184,7 @@ describe('AppShell — the connection chip', () => {
     renderShell(false)
     expect(screen.queryByText(CTA)).toBeNull()
 
-    fireEvent.click(await screen.findByTestId('connection-chip'))
+    fireEvent.click(await screen.findByTestId('shell-mark-trigger'))
     expect(await screen.findByText(CTA)).toBeTruthy()
     // The CTA points at where the move lives (Settings manages; the chip
     // only reports and nudges) — whole-workspace promotion is implemented,
@@ -178,7 +214,7 @@ describe('AppShell — the connection chip', () => {
     }))
     setShellConnection({ state: { keeper: 'browser' } })
     renderShell(false)
-    fireEvent.click(await screen.findByTestId('connection-chip'))
+    fireEvent.click(await screen.findByTestId('shell-mark-trigger'))
     const notice = await screen.findByTestId('promoted-elsewhere-notice')
     expect(notice.textContent).toMatch(/moved to the daemon/i)
     expect(notice.textContent).toMatch(/stay in this browser/i)
@@ -204,7 +240,7 @@ describe('AppShell — the connection chip', () => {
     }))
     setShellConnection({ state: { keeper: 'browser' } })
     renderShell(false)
-    fireEvent.click(await screen.findByTestId('connection-chip'))
+    fireEvent.click(await screen.findByTestId('shell-mark-trigger'))
     await screen.findByText(CTA)
     expect(screen.queryByTestId('promoted-elsewhere-notice')).toBeNull()
   })
@@ -217,7 +253,7 @@ describe('AppShell — the connection chip', () => {
     })
     renderShell(true, '/w/ws/document/a.canvas', onWorkInBrowser)
 
-    fireEvent.click(await screen.findByTestId('connection-chip'))
+    fireEvent.click(await screen.findByTestId('shell-mark-trigger'))
     fireEvent.click(await screen.findByRole('button', { name: /work in this browser instead/i }))
     expect(onWorkInBrowser).toHaveBeenCalledTimes(1)
   })
@@ -230,7 +266,7 @@ describe('AppShell — the connection chip', () => {
       daemonBaseUrl: 'http://127.0.0.1:3099',
     })
     renderShell(true)
-    fireEvent.click(await screen.findByTestId('connection-chip'))
+    fireEvent.click(await screen.findByTestId('shell-mark-trigger'))
     await waitFor(() => expect(screen.getByTestId('connection-popover')).toBeTruthy())
 
     expect(screen.queryByTestId('connection-disconnect')).toBeNull()

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -7,8 +7,8 @@ import { settingsPath } from '@/lib/app-routes'
 import { beginPairingGrant } from '@/lib/pairing-grant'
 import { getShellConnection, subscribeShellStatus } from '@/lib/shell-status-store'
 import { createUserSettingsStore } from '@/lib/user-settings-store'
-import HomeMark from '../brand/home-mark.svg?react'
 import { ConnectionStatus, isSyncOff } from './connection/ConnectionStatus.js'
+import { ShellMark } from './shell/ShellMark.js'
 
 // React.lazy for the same reason the browser page had it: the banner
 // pulls in daemon-probe.ts and its Zod parsing, and only the Local popover
@@ -66,12 +66,18 @@ export interface AppShellProps {
 }
 
 /**
- * The app-level chrome, deliberately minimal: brand (= go home) + the alpha
- * honesty chip on the left, the connection chip and the settings gear (+
- * attention dot) on the right. Nothing else ever moves in here — context and
- * tools stay in the page's own surface, always visible (see DESIGN.md's shell
- * rule). Pages mount this shared component instead of owning any brand,
- * connection or settings chrome themselves.
+ * The app-level chrome, deliberately minimal: the signature mark and the
+ * alpha honesty chip on the left, the settings gear (+ attention dot) on the
+ * right. Nothing else ever moves in here — context and tools stay in the
+ * page's own surface, always visible (see DESIGN.md's shell rule). Pages
+ * mount this shared component instead of owning any brand, connection or
+ * settings chrome themselves.
+ *
+ * The mark is the row's SUBJECT and its one state carrier. Left of the
+ * spacer is "what you are working in"; right of it is the app and its own
+ * state. There is no connection chip any more — a workspace's keeper and its
+ * session are things about the workspace, so they belong on the thing that
+ * names it rather than on a second widget at the other end of the row.
  */
 export function AppShell({ daemon, onWorkInBrowser }: AppShellProps) {
   const navigate = useNavigate()
@@ -90,40 +96,8 @@ export function AppShell({ daemon, onWorkInBrowser }: AppShellProps) {
 
   return (
     <header className="flex h-10 shrink-0 items-center gap-2 border-b bg-background px-3">
-      <Link
-        to="/"
-        aria-label="Home"
-        className="shrink-0 rounded-md p-1 text-foreground/70 hover:bg-accent hover:text-foreground"
-      >
-        <HomeMark className="h-[16px] w-[26px]" />
-      </Link>
-      <Popover>
-        <PopoverTrigger asChild>
-          <button
-            type="button"
-            aria-label="Alpha preview notes"
-            className="shrink-0 rounded-full border border-amber-600/55 px-1.5 font-mono text-[10px] leading-4 tracking-wide text-amber-600 hover:bg-amber-600/10 dark:border-amber-500/55 dark:text-amber-500"
-          >
-            ALPHA
-          </button>
-        </PopoverTrigger>
-        <PopoverContent align="start" className="w-72 text-sm">
-          <p className="font-medium">Alpha preview</p>
-          <p className="mt-1 text-xs text-muted-foreground">
-            Data durability is not guaranteed yet. Browser storage can be evicted by the device —
-            export what matters, or protect it with persistent storage and a daemon.
-          </p>
-          <Link
-            to={settingsPath('data')}
-            className="mt-2 inline-block text-xs font-semibold text-primary hover:underline"
-          >
-            Protect your data
-          </Link>
-        </PopoverContent>
-      </Popover>
-      <span className="min-w-0 flex-1" />
-      {connection && (
-        // The ONE connection affordance: the chip signals the state and its
+      {connection ? (
+        // The ONE connection affordance: the mark signals the state and its
         // popover carries the explanation and every recovery path. Re-pairing
         // navigates top-level to the daemon's own /pair consent page, the
         // same trust anchor first-time pairing uses.
@@ -161,7 +135,43 @@ export function AppShell({ daemon, onWorkInBrowser }: AppShellProps) {
             </>
           )}
         </ConnectionStatus>
+      ) : (
+        // No page holds a live session, so there is no state to carry and
+        // nothing for a popover to say. The mark is then what it has always
+        // been — the way home — rather than a menu with one item in it.
+        <Link
+          to="/"
+          aria-label="Home"
+          className="shrink-0 rounded-md p-1 text-foreground/70 hover:bg-accent hover:text-foreground"
+        >
+          <ShellMark />
+        </Link>
       )}
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label="Alpha preview notes"
+            className="shrink-0 rounded-full border border-amber-600/55 px-1.5 font-mono text-[10px] leading-4 tracking-wide text-amber-600 hover:bg-amber-600/10 dark:border-amber-500/55 dark:text-amber-500"
+          >
+            ALPHA
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-72 text-sm">
+          <p className="font-medium">Alpha preview</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Data durability is not guaranteed yet. Browser storage can be evicted by the device —
+            export what matters, or protect it with persistent storage and a daemon.
+          </p>
+          <Link
+            to={settingsPath('data')}
+            className="mt-2 inline-block text-xs font-semibold text-primary hover:underline"
+          >
+            Protect your data
+          </Link>
+        </PopoverContent>
+      </Popover>
+      <span className="min-w-0 flex-1" />
       <button
         type="button"
         // The dot is the only thing on the shell that can read as an alarm.

--- a/apps/web/src/components/connection/ConnectionStatus.test.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.test.tsx
@@ -30,7 +30,7 @@ describe('ConnectionStatus chip', () => {
         container: document.body,
       },
     )
-    fireEvent.click(screen.getByTestId('connection-chip'))
+    fireEvent.click(screen.getByTestId('shell-mark-trigger'))
 
     const popover = screen.getByTestId('connection-popover')
     expect(screen.queryByTestId('connection-disconnect')).toBeNull()
@@ -49,7 +49,7 @@ describe('ConnectionStatus chip', () => {
     render(<ConnectionStatus state={{ keeper: 'daemon', session: 'reconnecting' }} />, {
       container: document.body,
     })
-    fireEvent.click(screen.getByTestId('connection-chip'))
+    fireEvent.click(screen.getByTestId('shell-mark-trigger'))
 
     const popover = screen.getByTestId('connection-popover')
     expect(popover.textContent).toMatch(/not running/i)

--- a/apps/web/src/components/connection/ConnectionStatus.tsx
+++ b/apps/web/src/components/connection/ConnectionStatus.tsx
@@ -1,7 +1,14 @@
 /**
- * The ONE connection-state affordance. A small header
- * chip signals the state; every sentence-shaped explanation and recovery
- * action lives in its popover — no standing banners.
+ * The ONE connection-state affordance. The SIGNATURE MARK signals the state;
+ * every sentence-shaped explanation and recovery action lives in its popover
+ * — no standing banners.
+ *
+ * The mark, and not a chip beside it, because the row had no subject: the
+ * mark meant "home" and nothing else while a separate chip on the right
+ * answered "is my work safe" about a workspace nothing on screen named. One
+ * carrier now answers both, and the row reads left to right as "this
+ * workspace" rather than as two unrelated widgets. `ShellMark` owns the paint
+ * and the motion; this file owns what the popover says and offers.
  *
  * Keeper `browser` — the workspace is kept in this browser and nowhere else.
  * `children` hosts page-supplied extras (daemon detection, capability hint)
@@ -23,8 +30,7 @@
 import type { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { settingsPath } from '@/lib/app-routes'
-import { cn } from '@/lib/utils'
-import { StateDot, type StateDotTone } from '../StateDot.js'
+import { ShellMark } from '../shell/ShellMark.js'
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover.js'
 
 /** Health of the live document session a daemon-kept page runs. */
@@ -63,14 +69,21 @@ export interface ConnectionStatusProps {
   readonly children?: ReactNode
 }
 
-// Meaning, not paint — StateDot owns the palette (DESIGN.md's closed set).
-const SESSION_CHIP: Record<SessionHealth, { label: string; tone: StateDotTone }> = {
-  synced: { label: 'Synced', tone: 'safe' },
-  reconnecting: { label: 'Reconnecting', tone: 'attention' },
-  'sync-off': { label: 'Sync off', tone: 'attention' },
+/**
+ * The word the mark cannot say.
+ *
+ * A chip carried its label beside its dot; a 26x16 signature has room for
+ * neither. The label therefore moves into the accessible name and the
+ * popover's header — which is load-bearing rather than tidy, because
+ * `reconnecting` and `sync-off` share the `attention` tone and the chip's
+ * word was what told them apart for a sighted reader. The mark separates
+ * them by motion instead; assistive tech reads this.
+ */
+const SESSION_LABEL: Record<SessionHealth, string> = {
+  synced: 'Synced',
+  reconnecting: 'Reconnecting',
+  'sync-off': 'Sync off',
 }
-
-const BROWSER_CHIP = { label: 'Browser', tone: 'neutral' } as const
 
 export function ConnectionStatus({
   state,
@@ -79,7 +92,7 @@ export function ConnectionStatus({
   onWorkInBrowser,
   children,
 }: ConnectionStatusProps) {
-  const chip = state.keeper === 'browser' ? BROWSER_CHIP : SESSION_CHIP[state.session]
+  const label = state.keeper === 'browser' ? 'Browser' : SESSION_LABEL[state.session]
   const syncOff = isSyncOff(state)
   // Empty while sync is on: the region has to exist BEFORE the message, but
   // an empty one must not claim a name either.
@@ -96,25 +109,21 @@ export function ConnectionStatus({
       <PopoverTrigger asChild>
         <button
           type="button"
-          data-testid="connection-chip"
-          className={cn(
-            'flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors hover:bg-accent',
-            'duration-(--motion-duration-normal) ease-(--motion-ease-out)',
-            syncOff && 'border-amber-500/40 bg-amber-500/10 text-amber-700',
-          )}
+          data-testid="shell-mark-trigger"
+          // The state has no word on screen, so the accessible name carries
+          // it — the one place a colour-and-motion signal must not be the
+          // only signal.
+          aria-label={`Workspace — ${label}`}
+          title={label}
+          className="flex shrink-0 items-center justify-center rounded-md p-1 text-foreground/70 transition-colors duration-(--motion-duration-normal) ease-(--motion-ease-out) hover:bg-accent hover:text-foreground"
         >
-          <StateDot
-            tone={chip.tone}
-            // One-shot attention echo behind the dot: mounts exactly when the
-            // chip enters sync-off, pulses twice, then rests. Finite by
-            // design — a standing ping would be noise, not guidance.
-            pulse={syncOff}
-            pulseTestId="connection-chip-pulse"
-          />
-          {chip.label}
+          <ShellMark state={state} />
         </button>
       </PopoverTrigger>
-      <PopoverContent data-testid="connection-popover">
+      <PopoverContent align="start" data-testid="connection-popover">
+        {/* The state's word, stated once at the top for every branch below:
+            the mark cannot say it, and two of the four states share a tone. */}
+        <p className="mb-2 border-b pb-2 text-xs font-medium text-muted-foreground">{label}</p>
         {state.keeper === 'daemon' && state.session === 'synced' && (
           <div className="flex flex-col gap-1 text-sm">
             <p className="font-medium">Live sync is on</p>
@@ -188,6 +197,16 @@ export function ConnectionStatus({
             </div>
           </div>
         )}
+        {/* Going home was the mark's whole job before it became this
+            trigger. It keeps it, one level in, rather than leaving the shell
+            with no way back to the index. */}
+        <Link
+          to="/"
+          data-testid="shell-mark-home"
+          className="mt-3 block border-t pt-2 text-xs font-medium text-primary hover:underline"
+        >
+          Home
+        </Link>
       </PopoverContent>
     </Popover>
   )

--- a/apps/web/src/components/shell/ShellMark.test.tsx
+++ b/apps/web/src/components/shell/ShellMark.test.tsx
@@ -65,10 +65,55 @@ describe('ShellMark', () => {
     expect(screen.getByTestId('shell-mark').getAttribute('data-gesture')).toBe('recovered')
   })
 
+  it('ends the gesture the moment the session leaves synced', () => {
+    // Leaving synced cancelled the timer but left the flag set, so the mark
+    // went on claiming a gesture with no recovered session behind it.
+    const { rerender } = render(<ShellMark state={DAEMON('reconnecting')} />)
+    rerender(<ShellMark state={DAEMON('synced')} />)
+    expect(screen.getByTestId('shell-mark').getAttribute('data-gesture')).toBe('recovered')
+
+    // Well inside the gesture's own duration: this is the drop that arrives
+    // before it has finished playing.
+    rerender(<ShellMark />)
+    expect(screen.getByTestId('shell-mark').getAttribute('data-gesture')).toBeNull()
+  })
+
+  it('plays the SECOND recovery too, on a session that keeps dropping', () => {
+    // The sharper half of the same defect. A flag left set makes the next
+    // `setRecovered(true)` a no-op — React bails on identical state, the
+    // class never leaves the DOM, and the animation therefore never
+    // restarts. The user who most needs the reassurance, on a connection
+    // that drops repeatedly, is the one who would stop seeing it.
+    const { rerender } = render(<ShellMark state={DAEMON('reconnecting')} />)
+    rerender(<ShellMark state={DAEMON('synced')} />)
+    expect(screen.getByTestId('shell-mark').getAttribute('data-gesture')).toBe('recovered')
+
+    rerender(<ShellMark state={DAEMON('reconnecting')} />)
+    expect(screen.getByTestId('shell-mark').getAttribute('data-gesture')).toBeNull()
+
+    rerender(<ShellMark state={DAEMON('synced')} />)
+    expect(screen.getByTestId('shell-mark').getAttribute('data-gesture')).toBe('recovered')
+  })
+
   it('celebrates a recovery out of sync-off too', () => {
     const { rerender } = render(<ShellMark state={DAEMON('sync-off')} />)
     rerender(<ShellMark state={DAEMON('synced')} />)
     expect(screen.getByTestId('shell-mark').getAttribute('data-gesture')).toBe('recovered')
+  })
+
+  it('does not celebrate a later synced session that never dropped', () => {
+    // The path the two cases above do not reach: recover, then MOVE to the
+    // browser, then come back on a daemon. Nothing dropped on that last
+    // step — it is a keeper change — so a flag left over from the earlier
+    // recovery would make the mark congratulate a session that never fell
+    // over.
+    const { rerender } = render(<ShellMark state={DAEMON('reconnecting')} />)
+    rerender(<ShellMark state={DAEMON('synced')} />)
+    expect(screen.getByTestId('shell-mark').getAttribute('data-gesture')).toBe('recovered')
+
+    rerender(<ShellMark state={{ keeper: 'browser' }} />)
+    rerender(<ShellMark state={DAEMON('synced')} />)
+    expect(screen.getByTestId('shell-mark').getAttribute('data-gesture')).toBeNull()
   })
 
   it('does not celebrate a keeper change, which is not a recovery', () => {

--- a/apps/web/src/components/shell/ShellMark.test.tsx
+++ b/apps/web/src/components/shell/ShellMark.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { ConnectionState } from '../connection/ConnectionStatus.js'
+import { ShellMark } from './ShellMark.js'
+
+afterEach(cleanup)
+
+const DAEMON = (session: 'synced' | 'reconnecting' | 'sync-off'): ConnectionState => ({
+  keeper: 'daemon',
+  session,
+})
+
+describe('ShellMark', () => {
+  it('claims no state when no page has published a session', () => {
+    render(<ShellMark />)
+    const mark = screen.getByTestId('shell-mark')
+    // The shell's standing rule: an index or settings page holds no session,
+    // and a mark that kept the last one would go on claiming it.
+    expect(mark.getAttribute('data-keeper')).toBeNull()
+    expect(mark.getAttribute('data-session')).toBeNull()
+    expect(mark.querySelector('[data-testid="shell-mark-cap"]')).toBeNull()
+  })
+
+  it.each([
+    ['browser', { keeper: 'browser' } as ConnectionState, 'neutral'],
+    ['synced', DAEMON('synced'), 'safe'],
+    ['reconnecting', DAEMON('reconnecting'), 'attention'],
+    ['sync-off', DAEMON('sync-off'), 'attention'],
+  ])('paints the %s state with the %s tone', (_name, state, tone) => {
+    render(<ShellMark state={state} />)
+    expect(screen.getByTestId('shell-mark-cap').getAttribute('data-tone')).toBe(tone)
+  })
+
+  it('separates the two amber states by motion, since they share a tone', () => {
+    // `reconnecting` and `sync-off` are both attention-coloured in StateDot's
+    // closed set, so colour alone cannot tell them apart on a mark that has
+    // no label. The travelling stroke is what does — and it is the loader's
+    // own class, because "the pen is moving, work is happening" is already
+    // what this app means by it.
+    const { rerender } = render(<ShellMark state={DAEMON('reconnecting')} />)
+    expect(screen.getByTestId('shell-mark-stroke').getAttribute('class')).toMatch(/wb-loader/)
+
+    rerender(<ShellMark state={DAEMON('sync-off')} />)
+    expect(screen.getByTestId('shell-mark-stroke').getAttribute('class')).not.toMatch(/wb-loader/)
+    expect(screen.getByTestId('shell-mark').getAttribute('data-session')).toBe('sync-off')
+  })
+
+  it('does not celebrate a page that simply loaded already synced', () => {
+    // Otherwise every navigation twinkles, and the gesture stops meaning
+    // anything by the time something is actually wrong.
+    render(<ShellMark state={DAEMON('synced')} />)
+    expect(screen.getByTestId('shell-mark').getAttribute('data-gesture')).toBeNull()
+  })
+
+  it('celebrates only the recovery, not every render that stays synced', () => {
+    const { rerender } = render(<ShellMark state={DAEMON('reconnecting')} />)
+    expect(screen.getByTestId('shell-mark').getAttribute('data-gesture')).toBeNull()
+
+    rerender(<ShellMark state={DAEMON('synced')} />)
+    expect(screen.getByTestId('shell-mark').getAttribute('data-gesture')).toBe('recovered')
+
+    // A re-render that changes nothing must not replay it — the gesture is
+    // about the transition, and React re-renders for reasons of its own.
+    rerender(<ShellMark state={DAEMON('synced')} />)
+    expect(screen.getByTestId('shell-mark').getAttribute('data-gesture')).toBe('recovered')
+  })
+
+  it('celebrates a recovery out of sync-off too', () => {
+    const { rerender } = render(<ShellMark state={DAEMON('sync-off')} />)
+    rerender(<ShellMark state={DAEMON('synced')} />)
+    expect(screen.getByTestId('shell-mark').getAttribute('data-gesture')).toBe('recovered')
+  })
+
+  it('does not celebrate a keeper change, which is not a recovery', () => {
+    // Browser -> daemon is a MOVE, narrated by its own flow. Borrowing the
+    // recovery gesture for it would say "the session came back" about a
+    // session that never dropped.
+    const { rerender } = render(<ShellMark state={{ keeper: 'browser' }} />)
+    rerender(<ShellMark state={DAEMON('synced')} />)
+    expect(screen.getByTestId('shell-mark').getAttribute('data-gesture')).toBeNull()
+  })
+})

--- a/apps/web/src/components/shell/ShellMark.tsx
+++ b/apps/web/src/components/shell/ShellMark.tsx
@@ -1,0 +1,175 @@
+/**
+ * The signature mark, carrying the live session's state.
+ *
+ * The shell used to answer "is my work safe" with a labelled chip on the
+ * right while the mark sat on the left meaning nothing but "home". Two
+ * carriers, and the row had no subject. This is the merge: the mark is the
+ * one place the shell speaks about the workspace, and the chip is gone.
+ *
+ * The state vocabulary is deliberately borrowed rather than invented:
+ *
+ * - The TONE comes from `StateDot`'s closed set, so the mark cannot drift
+ *   from the save chip and the version dot the way three hand-copied colour
+ *   literals once did.
+ * - `reconnecting` reuses `wb-loader` — the loader mark's travelling dash,
+ *   on this exact same path (`loader-mark.svg` normalises it to 120 units
+ *   for the same dash math). BRAND.md already reads that gesture as "the pen
+ *   is moving, work is happening", which is what reconnecting means.
+ *
+ * That reuse is load-bearing, not tidiness: `reconnecting` and `sync-off`
+ * are BOTH attention-toned in StateDot's set. The chip separated them with
+ * its word; a mark has no word, so motion is what tells them apart — one
+ * travels, one sits broken and dimmed.
+ */
+import { useEffect, useRef, useState } from 'react'
+import { cn } from '@/lib/utils'
+import type { ConnectionState, SessionHealth } from '../connection/ConnectionStatus.js'
+import type { StateDotTone } from '../StateDot.js'
+
+/** The signature path, shared verbatim with `home-mark.svg` and `loader-mark.svg`. */
+const SIGNATURE = 'M20 44 C 27 22, 37 22, 44 33 S 58 50, 68 25'
+
+/**
+ * The signature's own end point, in the 88×56 view box. The state dot rides
+ * it rather than floating beside the mark: the squiggle already ends in a
+ * gesture, so the dot reads as its punctuation instead of as a second object
+ * competing with it in a 40px row.
+ */
+const TERMINUS = { x: 68, y: 25 } as const
+
+// Meaning, not paint — StateDot owns the palette (DESIGN.md's closed set).
+const SESSION_TONE: Record<SessionHealth, StateDotTone> = {
+  synced: 'safe',
+  reconnecting: 'attention',
+  'sync-off': 'attention',
+}
+
+const TONE_FILL: Record<StateDotTone, string> = {
+  safe: 'fill-emerald-500',
+  attention: 'fill-amber-500',
+  neutral: 'fill-muted-foreground/60',
+}
+
+/**
+ * How long the recovery gesture holds before the mark returns to rest.
+ * Matched to the animation in index.css; a stray value here would leave the
+ * gesture attribute set after the paint finished, which the next transition
+ * would then fail to re-trigger.
+ */
+const RECOVERED_MS = 900
+
+export interface ShellMarkProps {
+  /**
+   * Omitted when no page holds a live session. The mark then draws plain,
+   * with no dot at all — the shell's standing rule is that it states a
+   * connection only while a page holds one, and never latches the last.
+   */
+  readonly state?: ConnectionState
+  readonly className?: string
+}
+
+function toneOf(state: ConnectionState): StateDotTone {
+  return state.keeper === 'browser' ? 'neutral' : SESSION_TONE[state.session]
+}
+
+function sessionOf(state: ConnectionState | undefined): SessionHealth | undefined {
+  return state !== undefined && state.keeper === 'daemon' ? state.session : undefined
+}
+
+export function ShellMark({ state, className }: ShellMarkProps) {
+  const session = sessionOf(state)
+  const [recovered, setRecovered] = useState(false)
+  // The PREVIOUS session, so the gesture keys on a transition rather than on
+  // a value. Keyed on the value alone, every re-render that happened to be
+  // synced would replay it — and React re-renders for reasons of its own.
+  const previous = useRef<SessionHealth | undefined>(session)
+
+  useEffect(() => {
+    const before = previous.current
+    previous.current = session
+    // Only a session that had DROPPED and came back. A first mount that is
+    // already synced is not a recovery — celebrating it would make every
+    // navigation twinkle, and spend the gesture before anything went wrong.
+    // A keeper change is not one either: browser -> daemon is a move, with
+    // its own narration, and no session dropped for it to come back from.
+    if (session !== 'synced') return
+    if (before !== 'reconnecting' && before !== 'sync-off') return
+    setRecovered(true)
+    const timer = setTimeout(() => setRecovered(false), RECOVERED_MS)
+    return () => clearTimeout(timer)
+  }, [session])
+
+  const tone = state === undefined ? undefined : toneOf(state)
+
+  return (
+    <svg
+      data-testid="shell-mark"
+      {...(state === undefined ? {} : { 'data-keeper': state.keeper })}
+      {...(session === undefined ? {} : { 'data-session': session })}
+      {...(recovered ? { 'data-gesture': 'recovered' } : {})}
+      viewBox="0 0 88 56"
+      fill="none"
+      aria-hidden="true"
+      className={cn(
+        'h-[16px] w-[26px] overflow-visible',
+        recovered && 'wb-mark-recovered',
+        className,
+      )}
+    >
+      {/* The faint track the travelling dash runs on, exactly as the loader
+          mark draws it. Only while reconnecting: at rest there is one stroke,
+          and a permanent ghost behind it would thicken the mark. */}
+      {session === 'reconnecting' && (
+        <path
+          pathLength={120}
+          d={SIGNATURE}
+          stroke="currentColor"
+          strokeOpacity={0.25}
+          strokeWidth={8}
+          strokeLinecap="round"
+        />
+      )}
+      <path
+        data-testid="shell-mark-stroke"
+        pathLength={120}
+        d={SIGNATURE}
+        stroke="currentColor"
+        strokeWidth={8}
+        strokeLinecap="round"
+        className={cn(
+          session === 'reconnecting' && 'wb-loader',
+          // Broken and dimmed: the session was rejected and is not coming
+          // back on its own. Distinct from reconnecting's travel while
+          // sharing its tone, which is the whole reason motion carries this.
+          session === 'sync-off' && 'wb-mark-broken',
+          session === 'synced' && 'wb-mark-stroke',
+        )}
+      />
+      {/* One-shot attention echo behind the cap: mounts exactly when the mark
+          enters sync-off, pulses twice, then rests. Finite by design — a
+          standing ping would be noise, not guidance — and it is the failure
+          direction's counterpart to the recovery gesture above. Carried over
+          from the chip verbatim, including its keyframe: sync-off arriving is
+          the one thing in this shell that has to be noticed. */}
+      {session === 'sync-off' && (
+        <circle
+          data-testid="shell-mark-pulse"
+          cx={TERMINUS.x}
+          cy={TERMINUS.y}
+          r={8}
+          className="wb-mark-cap animate-[attention-pulse_900ms_var(--motion-ease-out)_2] fill-amber-500"
+        />
+      )}
+      {tone !== undefined && (
+        <circle
+          data-testid="shell-mark-cap"
+          data-tone={tone}
+          cx={TERMINUS.x}
+          cy={TERMINUS.y}
+          r={8}
+          className={cn('wb-mark-cap', TONE_FILL[tone])}
+        />
+      )}
+    </svg>
+  )
+}

--- a/apps/web/src/components/shell/ShellMark.tsx
+++ b/apps/web/src/components/shell/ShellMark.tsx
@@ -87,12 +87,21 @@ export function ShellMark({ state, className }: ShellMarkProps) {
   useEffect(() => {
     const before = previous.current
     previous.current = session
+    // Leaving synced ENDS the gesture, and clearing the flag is what makes
+    // the next recovery playable: `setRecovered(true)` on a flag that is
+    // already true is a no-op — React bails on identical state, the class
+    // never leaves the DOM, and the animation therefore never restarts. A
+    // connection that drops repeatedly would show the reassurance once and
+    // then never again, which is the opposite of who needs it.
+    if (session !== 'synced') {
+      setRecovered(false)
+      return
+    }
     // Only a session that had DROPPED and came back. A first mount that is
     // already synced is not a recovery — celebrating it would make every
     // navigation twinkle, and spend the gesture before anything went wrong.
     // A keeper change is not one either: browser -> daemon is a move, with
     // its own narration, and no session dropped for it to come back from.
-    if (session !== 'synced') return
     if (before !== 'reconnecting' && before !== 'sync-off') return
     setRecovered(true)
     const timer = setTimeout(() => setRecovered(false), RECOVERED_MS)
@@ -100,19 +109,28 @@ export function ShellMark({ state, className }: ShellMarkProps) {
   }, [session])
 
   const tone = state === undefined ? undefined : toneOf(state)
+  // Gated on the session as well as on the flag. `useEffect` is PASSIVE — it
+  // runs after paint — so between the render that carries the new session and
+  // the effect that clears the flag there is a real painted frame showing the
+  // recovery gesture under a session that has just dropped. The flag clear is
+  // what makes the NEXT recovery playable; this is what keeps the current one
+  // from outliving its session by a frame. Deliberately not test-pinned: a
+  // single pre-effect frame is not observable from jsdom, and asserting it
+  // would need a browser test that catches one paint.
+  const playingRecovery = recovered && session === 'synced'
 
   return (
     <svg
       data-testid="shell-mark"
       {...(state === undefined ? {} : { 'data-keeper': state.keeper })}
       {...(session === undefined ? {} : { 'data-session': session })}
-      {...(recovered ? { 'data-gesture': 'recovered' } : {})}
+      {...(playingRecovery ? { 'data-gesture': 'recovered' } : {})}
       viewBox="0 0 88 56"
       fill="none"
       aria-hidden="true"
       className={cn(
         'h-[16px] w-[26px] overflow-visible',
-        recovered && 'wb-mark-recovered',
+        playingRecovery && 'wb-mark-recovered',
         className,
       )}
     >

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -274,6 +274,68 @@
   }
 
   /*
+   * Shell mark (components/shell/ShellMark.tsx): the signature carrying the
+   * live session's state. `reconnecting` reuses `.wb-loader` above verbatim
+   * — same path, same 120-unit normalisation — so there is one definition of
+   * "the pen is moving" rather than two that can drift.
+   *
+   * What lives here is the rest of the vocabulary:
+   *
+   * `wb-mark-broken` is sync-off. It shares reconnecting's amber tone (both
+   * are `attention` in StateDot's closed set), so the STROKE is what tells
+   * them apart: one travels, this one sits in pieces and dimmed. Colour
+   * cannot carry that distinction on a mark that has no label.
+   *
+   * `wb-mark-recovered` is the one celebration in the shell, and it is
+   * deliberately the rare one: reconnecting/sync-off -> synced. The routine
+   * "a write landed" moment is NOT here, because the daemon keeper has no
+   * write-landed signal to hang it on — see DESIGN.md.
+   *
+   * The global reduced-motion floor below collapses all of it, which is
+   * sound only because the cap's tone states the resting state without any
+   * motion at all: the gesture is a flourish on a fact, never the fact.
+   */
+  .wb-mark-broken {
+    stroke-dasharray: 9 7;
+    opacity: 0.5;
+  }
+
+  .wb-mark-cap {
+    transform-box: view-box;
+    transform-origin: 68px 25px;
+  }
+
+  @keyframes wb-mark-draw {
+    from {
+      stroke-dashoffset: 120;
+    }
+    to {
+      stroke-dashoffset: 0;
+    }
+  }
+
+  @keyframes wb-mark-land {
+    0% {
+      transform: scale(0);
+    }
+    62% {
+      transform: scale(1.28);
+    }
+    100% {
+      transform: scale(1);
+    }
+  }
+
+  .wb-mark-recovered .wb-mark-stroke {
+    stroke-dasharray: 120;
+    animation: wb-mark-draw 520ms var(--motion-ease-out) 1 both;
+  }
+
+  .wb-mark-recovered .wb-mark-cap {
+    animation: wb-mark-land 360ms 360ms var(--motion-ease-out) 1 both;
+  }
+
+  /*
    * Skeletons appear only when the wait is real: invisible for a beat,
    * then a gentle fade-in. A skeleton that pops for a single frame
    * between a resolved chunk and first paint reads as a glitch, not as

--- a/apps/web/src/motion-feedback.browser.test.tsx
+++ b/apps/web/src/motion-feedback.browser.test.tsx
@@ -33,19 +33,19 @@ describe('feedback micro-motion', () => {
     expect(cs.animationDuration).toBe('0.22s')
   })
 
-  it('connection chip transitions colors on the token duration', () => {
+  it('the shell mark transitions colors on the token duration', () => {
     render(<ConnectionStatus state={{ keeper: 'daemon', session: 'synced' }} />)
-    const chip = document.querySelector('[data-testid="connection-chip"]') as HTMLElement
+    const chip = document.querySelector('[data-testid="shell-mark-trigger"]') as HTMLElement
     const cs = getComputedStyle(chip)
     expect(cs.transitionProperty).toContain('color')
     expect(cs.transitionDuration).toContain('0.22s')
   })
 
-  it('sync-off shows a finite attention pulse on the chip dot', () => {
+  it('sync-off shows a finite attention pulse on the mark', () => {
     render(
       <ConnectionStatus state={{ keeper: 'daemon', session: 'sync-off' }} onRepair={vi.fn()} />,
     )
-    const echo = document.querySelector('[data-testid="connection-chip-pulse"]') as HTMLElement
+    const echo = document.querySelector('[data-testid="shell-mark-pulse"]') as HTMLElement
     expect(echo).not.toBeNull()
     const cs = getComputedStyle(echo)
     expect(cs.animationName).toBe('attention-pulse')
@@ -54,8 +54,20 @@ describe('feedback micro-motion', () => {
     expect(cs.animationIterationCount).not.toBe('infinite')
   })
 
-  it('synced chip has no attention pulse', () => {
+  it('a synced mark has no attention pulse', () => {
     render(<ConnectionStatus state={{ keeper: 'daemon', session: 'synced' }} />)
-    expect(document.querySelector('[data-testid="connection-chip-pulse"]')).toBeNull()
+    expect(document.querySelector('[data-testid="shell-mark-pulse"]')).toBeNull()
+  })
+
+  it("reconnecting travels rather than pulsing, since it shares sync-off's tone", () => {
+    // The two amber states are told apart by motion, not colour. Pinned here
+    // because it is a COMPUTED-style claim: the class has to resolve to a
+    // real running animation, not merely be present in the markup.
+    render(<ConnectionStatus state={{ keeper: 'daemon', session: 'reconnecting' }} />)
+    expect(document.querySelector('[data-testid="shell-mark-pulse"]')).toBeNull()
+    const stroke = document.querySelector('[data-testid="shell-mark-stroke"]') as SVGPathElement
+    const cs = getComputedStyle(stroke)
+    expect(cs.animationName).toBe('wb-loader')
+    expect(cs.animationIterationCount).toBe('infinite')
   })
 })

--- a/apps/web/src/pages/BrowserDocumentPage.shell-connection.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.shell-connection.browser.test.tsx
@@ -37,7 +37,7 @@ function renderApp() {
   )
 }
 
-describe('shell connection chip over a real document kept in this browser', () => {
+describe('shell mark over a real document kept in this browser', () => {
   beforeEach(async () => {
     resetShellStatusForTests()
     await clearDb()
@@ -57,16 +57,20 @@ describe('shell connection chip over a real document kept in this browser', () =
       },
     )
 
-    const chip = await waitFor(() => screen.getByTestId('connection-chip'), { timeout: 5000 })
-    expect(chip.textContent).toMatch(/browser/i)
-    // The chip sits in the shell's own row, not inside the document's top bar
+    const mark = await waitFor(() => screen.getByTestId('shell-mark-trigger'), { timeout: 5000 })
+    // The mark carries the keeper as a tone, so the WORD lives in the
+    // accessible name rather than in chrome — which is what makes the state
+    // readable to assistive tech that cannot see a colour.
+    expect(mark.getAttribute('aria-label')).toMatch(/browser/i)
+    expect(screen.getByTestId('shell-mark-cap').getAttribute('data-tone')).toBe('neutral')
+    // The mark sits in the shell's own row, not inside the document's top bar
     // — that separation is the whole point of the move, and a DOM assertion is
     // the only thing that can tell the two rows apart.
-    expect(chip.closest('header')?.querySelector('[data-testid="shell-settings"]')).toBeTruthy()
+    expect(mark.closest('header')?.querySelector('[data-testid="shell-settings"]')).toBeTruthy()
 
     // Sentence-length copy stays out of chrome: it appears only once opened.
     expect(screen.queryByText(/other browsers cannot see them/i)).toBeNull()
-    fireEvent.click(chip)
+    fireEvent.click(mark)
     expect(await screen.findByText(/other browsers cannot see them/i)).toBeInTheDocument()
     expect(
       await screen.findByText(/Connect a daemon \(MCP\) for version history/i),
@@ -81,19 +85,20 @@ describe('shell connection chip over a real document kept in this browser', () =
         timeout: 5000,
       },
     )
-    await waitFor(() => expect(screen.getByTestId('connection-chip')).toBeInTheDocument(), {
+    await waitFor(() => expect(screen.getByTestId('shell-mark-trigger')).toBeInTheDocument(), {
       timeout: 5000,
     })
 
     // The shell outlives the page in production, so the page unmounting is
-    // exactly what must clear the chip — a latched one would keep telling an
-    // index page it is holding a session.
+    // exactly what must clear the state — a latched mark would keep telling
+    // an index page it is holding a session.
     cleanup()
     rtlRender(
       <MemoryRouter initialEntries={['/']}>
         <AppShell daemon={false} />
       </MemoryRouter>,
     )
-    expect(screen.queryByTestId('connection-chip')).toBeNull()
+    expect(screen.queryByTestId('shell-mark-trigger')).toBeNull()
+    expect(screen.getByTestId('shell-mark').getAttribute('data-keeper')).toBeNull()
   })
 })

--- a/apps/web/src/pages/BrowserDocumentPage.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.test.tsx
@@ -828,7 +828,7 @@ describe('BrowserDocumentPage', () => {
       // ...nor does the chip itself: the connection is app-level, so the
       // App-mounted shell draws it (and hosts the CTA in its popover) from
       // the state this page publishes.
-      expect(screen.queryByTestId('connection-chip')).toBeNull()
+      expect(screen.queryByTestId('shell-mark-trigger')).toBeNull()
       expect(getShellConnection()).toEqual({ state: { keeper: 'browser' } })
 
       cleanup()


### PR DESCRIPTION
A proposal, not a merge request — open for review rather than to land.

The shell's top row had no subject. The mark on the left meant "home" and nothing else, while a labelled chip at the far right answered "is my work safe" about a workspace nothing on screen named. A keeper and a session are facts **about the workspace**, so they now sit on the thing that stands for it, and the chip is **removed** rather than kept alongside — a second carrier would be the same fact twice, which `DESIGN.md`'s closed-set rule exists to stop.

## The vocabulary is borrowed, not invented

- The **tone** comes from `StateDot`'s closed set, so the mark cannot drift from the save chip and the version dot.
- **`reconnecting` reuses `wb-loader`** — the loader mark's travelling dash, on this *exact same path*. `loader-mark.svg` already normalises it to 120 units for the same dash math, and BRAND.md already reads that gesture as *"the pen is moving, work is happening"*.

That reuse is load-bearing rather than tidy. `reconnecting` and `sync-off` are **both** attention-toned, and the chip's *word* is what separated them for a sighted reader — a 26×16 signature has no room for one. Motion separates them instead: one travels, one sits broken and dimmed. The word moves to the accessible name and the popover header, where assistive tech reads it either way.

Two finite gestures, one per direction. `sync-off` arriving keeps the chip's attention echo verbatim. `reconnecting`/`sync-off` → `synced` plays a recovery draw.

## What is deliberately NOT here

The design conversation started from a debounced "sync completed" celebration. **It is not in this PR, and the reason is a finding rather than a scope cut.**

The daemon keeper has no write-landed signal to hang one on: `DaemonDocumentPage` derives `session` from `syncStatus === 'connected'`, which is **transport liveness, not an ack**. The browser keeper does have one (`BrowserPersistenceState`'s `saving → saved`), so wiring only what exists would light the gesture up for browser-kept workspaces and never for daemon-kept ones — reading as "the daemon is not saving". That is exactly what DESIGN.md's *"never offer what the keeper cannot honour"* forbids.

Adding that signal is a sync-contract change and its own increment. The recovery gesture needs no new plumbing, which is why it ships now.

## The one affordance change to weigh

Clicking the mark now opens the connection popover instead of navigating home, and **Home is the last item in that popover**. With no session published there is nothing to explain, so the mark stays a plain link home — the popover appears exactly when it has something to say.

This is the part most worth a second opinion: it costs one click on the most common navigation, on every document page.

## Records amended

| Where | What |
| --- | --- |
| `BRAND.md` | Surface matrix gains the app-header row; the Color section records that the signature carries state. Less of a departure than it sounds — the **favicon has carried session state since the beginning** (saved / unsaved / syncing / offline). What is new is *motion* as a second channel, and that is the part written down as deliberate. |
| `DESIGN.md` | The stateful-colour set names the mark instead of the chip, including why it is the one carrier with a second channel. The shell section adds the row's two halves — left of the spacer is what you are working *in*, right of it is the app — since position is the only layer cue chrome can carry without sentence-length copy. |
| `home-mark.svg` | **Deleted.** `ShellMark` supersedes it and nothing else imported it (verified by grep across `apps/web`, `docs`, `.github`). |

`DESIGN.md` also keeps recording the connection carrier's **still-open split** — `browser` names the keeper and survives navigation, `synced`/`reconnecting`/`sync-off` report a live session and do not. Merging the carriers did not resolve that; it put the unresolved pair in one place instead of implying two subjects.

## Verification

- `pnpm check:local` — clean.
- **`pnpm --filter @kamiazya/whiteboard-web test` — 2794 passed / 9 failed.** All nine are **pre-existing**, established by A/B rather than by inspection: the same nine fail on unmodified `origin/main` in this container (7 in `VersionThumbnail`/`DocumentThumb`/`daemon-file-adapter`, 2 in `MergeDialog`/`VersionTimeline`), all `objectURL`/thumbnail-related. `App.test.tsx` passes on clean main, so its one failure during development was mine and is fixed.
- `web-browser` for the touched files — 7/7, including a new case that reads **computed style** to confirm `wb-loader` actually resolves to a running animation rather than merely appearing in the markup.
- `ShellMark.test.tsx` — 10 cases, including the two that pin what must *not* happen: a page that simply loaded already-synced does not celebrate, and a keeper change is not a recovery.

One test of my own was caught by the suite mid-flight and is worth naming: a blanket test-id replace turned my new "replaces the chip" case into an assertion that the same element both exists and does not. It is now counted rather than named — the header must hold **exactly one** state carrier — because asserting the old id is absent would pass just as well if a replacement chip arrived under a new one.

Visual evidence: none — no `gh` CLI in this environment, so the `gh image` upload path the rule prescribes is unavailable. The behaviour is four resting states plus two gestures on a 26×16 mark; the interactive demo the design was settled from is the better artifact, and the computed-style browser assertions above are what actually pin the motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Replaced the connection chip with a compact shell mark in the app header.
  - The mark communicates connection states through color and motion, including reconnecting, offline, and recovery states.
  - Clicking the mark opens the connection popover during active sessions; otherwise, it links home.
  - Added accessible state labels and clearer session context in the popover.

- **Documentation**
  - Updated brand and design guidance for the shell mark and its interaction states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->