### PR TITLE
fix(web): stop the save indicator reporting "Saved" over unwritten markdown

### DIFF
--- a/apps/web/src/components/SaveStatusChip.test.tsx
+++ b/apps/web/src/components/SaveStatusChip.test.tsx
@@ -53,3 +53,41 @@ it('the popover explains the state as text on demand', () => {
   const popover = baseElement.querySelector('[data-testid="save-status-popover"]')
   expect(popover?.textContent).toContain('saved')
 })
+
+/**
+ * A document that has never been written and one whose write just landed are
+ * BOTH `Saved`, and the accessible name is identical for the two.
+ *
+ * That is correct for a person — "Saved" is what they want to read either way
+ * — but it makes the name useless as a test's proof that a write completed.
+ * Two browser tests waited on `getByRole('button', { name: 'Saved' })` for
+ * exactly that, one of them under a comment calling it "the page's own report
+ * that the write completed". It matched the state the page was already in, so
+ * they navigated away with the debounced write still pending and read the
+ * loss later as lost keystrokes.
+ *
+ * `data-last-saved-at` is the discriminator that was missing: absent until a
+ * write has actually landed for this document.
+ */
+it('distinguishes a landed write from having never written, which the name cannot', () => {
+  const neverWritten = render(<SaveStatusChip state={{ kind: 'saved', lastSavedAt: null }} />)
+  const landed = render(
+    <SaveStatusChip state={{ kind: 'saved', lastSavedAt: '2026-01-01T00:00:00.000Z' }} />,
+  )
+  const [first, second] = [neverWritten, landed].map((r) => chip(r.container))
+
+  // Identical to a reader, by design.
+  expect(first!.getAttribute('aria-label')).toBe(second!.getAttribute('aria-label'))
+
+  // Distinguishable to a test.
+  expect(first!.getAttribute('data-last-saved-at')).toBeNull()
+  expect(second!.getAttribute('data-last-saved-at')).toBe('2026-01-01T00:00:00.000Z')
+})
+
+it('publishes the state kind, so a wait can require a transition rather than a label', () => {
+  for (const kind of ['saved', 'saving', 'pending'] as const) {
+    cleanup()
+    const { container } = render(<SaveStatusChip state={{ kind, lastSavedAt: null }} />)
+    expect(chip(container).getAttribute('data-save-state')).toBe(kind)
+  }
+})

--- a/apps/web/src/components/SaveStatusChip.tsx
+++ b/apps/web/src/components/SaveStatusChip.tsx
@@ -49,6 +49,14 @@ export function SaveStatusChip({ state }: SaveStatusChipProps) {
             <button
               type="button"
               data-testid="save-status-chip"
+              // The accessible name is the same for "never written" and "the
+              // write landed" — correct for a reader, useless as a test's
+              // proof that a write completed. These two publish the state
+              // machine itself so a wait can require a TRANSITION: absent
+              // `data-last-saved-at` means nothing has been written for this
+              // document yet.
+              data-save-state={state.kind}
+              {...(state.lastSavedAt === null ? {} : { 'data-last-saved-at': state.lastSavedAt })}
               aria-label={label}
               className="flex shrink-0 items-center justify-center rounded-full p-1.5 transition-colors duration-(--motion-duration-normal) ease-(--motion-ease-out) hover:bg-accent"
             >

--- a/apps/web/src/pages/BrowserDocumentPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.markdown.browser.test.tsx
@@ -50,18 +50,28 @@ vi.mock('../components/spatial-editor/index.js', () => ({
 const { BrowserDocumentPage } = await import('./BrowserDocumentPage.js')
 
 /**
- * Waits until the page reports the debounced save as landed.
+ * Waits until a debounced save has actually LANDED for this document.
  *
- * The save is debounced 500ms and then has to reach IndexedDB, so a fixed
- * sleep is a bet on machine speed — the timing-based assertion this repo
- * treats as a recurring flake shape, and what tipped these tests over under
- * load. `Saved` is the page's own report that the write completed, which is
- * the condition these tests actually depend on before tearing the page down.
+ * Not `getByRole('button', { name: 'Saved' })`. A document that has never
+ * been written is already `Saved` — correct for a reader, and useless as
+ * proof that a write completed. That wait matched the state the page was
+ * already in, so these tests navigated away with the write still pending and
+ * read the loss later as lost keystrokes: `expected '# ' to contain
+ * '# From the list'` after reopening, with a 15s budget the write never
+ * needed because it was never going to happen.
+ *
+ * `data-last-saved-at` is absent until a write lands, so requiring it
+ * together with a settled `saved` state is a TRANSITION rather than a label.
  */
 async function waitForSaved(): Promise<void> {
-  await waitFor(() => expect(screen.getByRole('button', { name: 'Saved' })).toBeTruthy(), {
-    timeout: 15_000,
-  })
+  await waitFor(
+    () => {
+      const chip = document.querySelector('[data-testid="save-status-chip"]')
+      expect(chip?.getAttribute('data-save-state')).toBe('saved')
+      expect(chip?.getAttribute('data-last-saved-at')).toBeTruthy()
+    },
+    { timeout: 15_000 },
+  )
 }
 
 /**

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -54,6 +54,7 @@ import { cn } from '../lib/utils.js'
 import { useBrowserToolRegistry } from '../lib/webmcp/use-browser-tool-registry.js'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
 import { derivePageState, refineForContentReadFailure } from './browser-page-state.js'
+import { mergePersistence } from './merge-persistence.js'
 import {
   type LoroStoreLike,
   useBrowserDocumentController,
@@ -736,7 +737,15 @@ export function BrowserDocumentPage({
         <DocumentProperties
           inline
           key={documentId ?? 'no-canvas'}
-          status={<SaveStatusChip state={renderState.persistence} />}
+          // A markdown document has two writers — this page's controller and
+          // the body's own debounced save — and one dot. Showing the
+          // controller alone reported `Saved` over unwritten text, because a
+          // body edit never moves it.
+          status={
+            <SaveStatusChip
+              state={mergePersistence(renderState.persistence, markdownDoc.saveState)}
+            />
+          }
           actions={canvasRowActions}
           title={titleOf(documentName, documentPath)}
           onTitleChange={onTitleChange}

--- a/apps/web/src/pages/BrowserIndexPage.flow.browser.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.flow.browser.test.tsx
@@ -38,6 +38,31 @@ function renderApp() {
   return router
 }
 
+/**
+ * Waits until a debounced save has actually LANDED for this document.
+ *
+ * Not `getByRole('button', { name: 'Saved' })`. A document that has never
+ * been written is already `Saved` — correct for a reader, and useless as
+ * proof that a write completed. That wait matched the state the page was
+ * already in, so these tests navigated away with the write still pending and
+ * read the loss later as lost keystrokes: `expected '# ' to contain
+ * '# From the list'` after reopening, with a 15s budget the write never
+ * needed because it was never going to happen.
+ *
+ * `data-last-saved-at` is absent until a write lands, so requiring it
+ * together with a settled `saved` state is a TRANSITION rather than a label.
+ */
+async function waitForSaved(): Promise<void> {
+  await waitFor(
+    () => {
+      const chip = document.querySelector('[data-testid="save-status-chip"]')
+      expect(chip?.getAttribute('data-save-state')).toBe('saved')
+      expect(chip?.getAttribute('data-last-saved-at')).toBeTruthy()
+    },
+    { timeout: 15_000 },
+  )
+}
+
 describe('browser list landing (browser — real IndexedDB)', () => {
   beforeEach(async () => {
     await clearWhiteboardDb()
@@ -104,11 +129,7 @@ describe('browser list landing (browser — real IndexedDB)', () => {
     await waitFor(() => {
       expect(document.querySelector('.cm-content')?.textContent).toBe('# From the list')
     })
-    // The page's own report that the debounced write reached IndexedDB —
-    // waiting on it keeps this off the timing-flake shape.
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Saved' })).toBeTruthy(), {
-      timeout: 15_000,
-    })
+    await waitForSaved()
 
     // Back again: both documents listed, the note marked as markdown.
     await router.navigate(-1)

--- a/apps/web/src/pages/merge-persistence.test.ts
+++ b/apps/web/src/pages/merge-persistence.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { mergePersistence } from './merge-persistence.js'
+import type { BrowserPersistenceState } from './use-browser-document-controller.js'
+
+const saved = (at: string | null = null): BrowserPersistenceState => ({
+  kind: 'saved',
+  lastSavedAt: at,
+})
+const pending = (at: string | null = null): BrowserPersistenceState => ({
+  kind: 'pending',
+  lastSavedAt: at,
+})
+const saving = (at: string | null = null): BrowserPersistenceState => ({
+  kind: 'saving',
+  lastSavedAt: at,
+})
+const degraded = (at: string | null = null): BrowserPersistenceState => ({
+  kind: 'degraded',
+  reason: 'write-failed',
+  message: 'The last write to this browser failed.',
+  lastSavedAt: at,
+})
+
+/**
+ * A markdown document has TWO writers — the controller (rename, spatial) and
+ * the markdown body's own debounced save — and one indicator between them.
+ *
+ * The rule follows from what the indicator promises: it says "your work is
+ * safe here". It may only say that when BOTH writers agree, because the one
+ * that is behind is exactly the one holding unsaved work. Before this
+ * existed, the chip showed the controller alone, which never moves for a body
+ * edit — so it read `Saved` over text that had not been written.
+ */
+describe('mergePersistence', () => {
+  it('is saved only when both writers are', () => {
+    expect(mergePersistence(saved(), saved()).kind).toBe('saved')
+  })
+
+  it('reports the unsettled writer, whichever side it is on', () => {
+    expect(mergePersistence(saved(), pending()).kind).toBe('pending')
+    expect(mergePersistence(pending(), saved()).kind).toBe('pending')
+    expect(mergePersistence(saved(), saving()).kind).toBe('saving')
+    expect(mergePersistence(saving(), saved()).kind).toBe('saving')
+  })
+
+  /**
+   * A failure outranks work still in flight: the pending write may yet land,
+   * the failed one already did not, and that is the state a person needs to
+   * act on.
+   */
+  it('lets a failure outrank a pending write', () => {
+    expect(mergePersistence(degraded(), pending()).kind).toBe('degraded')
+    expect(mergePersistence(pending(), degraded()).kind).toBe('degraded')
+    expect(mergePersistence(degraded(), saving()).kind).toBe('degraded')
+  })
+
+  /**
+   * `lastSavedAt` answers "when was anything last written for this document",
+   * so the later of the two is the truthful answer regardless of which writer
+   * is currently unsettled.
+   */
+  it('carries the later lastSavedAt through', () => {
+    const earlier = '2026-01-01T00:00:00.000Z'
+    const later = '2026-06-01T00:00:00.000Z'
+    expect(mergePersistence(saved(earlier), pending(later)).lastSavedAt).toBe(later)
+    expect(mergePersistence(saved(later), pending(earlier)).lastSavedAt).toBe(later)
+    expect(mergePersistence(saved(later), pending(null)).lastSavedAt).toBe(later)
+    expect(mergePersistence(saved(null), saved(null)).lastSavedAt).toBeNull()
+  })
+
+  it('keeps the degraded message rather than flattening it to a kind', () => {
+    const merged = mergePersistence(saved(), degraded())
+    expect(merged.kind === 'degraded' && merged.message).toBe(
+      'The last write to this browser failed.',
+    )
+  })
+})

--- a/apps/web/src/pages/merge-persistence.ts
+++ b/apps/web/src/pages/merge-persistence.ts
@@ -1,0 +1,45 @@
+import type { BrowserPersistenceState } from './use-browser-document-controller.js'
+
+/**
+ * One indicator over the two writers a markdown document has.
+ *
+ * The controller persists renames and spatial content; the markdown body
+ * keeps its own debounced save. They write the same document and share one
+ * dot, so the dot has to answer for both.
+ *
+ * The rule follows from what the indicator promises — "your work is safe
+ * here". It may only say that when BOTH writers agree, because the one that
+ * is behind is precisely the one holding unsaved work. The page previously
+ * showed the controller's state alone, which never moves for a body edit, so
+ * the chip read `Saved` over text that had not been written: measured at
+ * `saved / null / "Saved"` three seconds (six debounce periods) after typing.
+ */
+
+// Worst-first: a failure outranks work in flight, because the pending write
+// may yet land while the failed one already did not, and that is the state a
+// person needs to act on.
+const SEVERITY: Record<BrowserPersistenceState['kind'], number> = {
+  degraded: 3,
+  saving: 2,
+  pending: 2,
+  saved: 1,
+}
+
+/** The later of two timestamps, treating absent as "never written". */
+function laterOf(a: string | null, b: string | null): string | null {
+  if (a === null) return b
+  if (b === null) return a
+  return a > b ? a : b
+}
+
+export function mergePersistence(
+  a: BrowserPersistenceState,
+  b: BrowserPersistenceState,
+): BrowserPersistenceState {
+  const lastSavedAt = laterOf(a.lastSavedAt, b.lastSavedAt)
+  // Ties go to `a` only after severity has decided, so `saving` vs `pending`
+  // (equal severity) keeps whichever side the caller passed first — both are
+  // "not settled yet", which is the only distinction the indicator draws.
+  const worst = SEVERITY[b.kind] > SEVERITY[a.kind] ? b : a
+  return { ...worst, lastSavedAt }
+}

--- a/apps/web/src/pages/use-markdown-document.ts
+++ b/apps/web/src/pages/use-markdown-document.ts
@@ -36,13 +36,14 @@ import {
 } from '@kamiazya/whiteboard-loro-adapter'
 import type { StoredCoreFacets } from '@kamiazya/whiteboard-model'
 import { Loro, type LoroText } from 'loro-crdt'
+import type { Dispatch, SetStateAction } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { getAppLogger } from '../lib/app-logger.js'
 import { BrowserWorkspaceDocs, openWorkspaceOrNull } from '../lib/browser-workspace-docs.js'
 import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import { foldWorkspaceDocuments } from '../lib/fold-workspace.js'
 import { touchContentTimestamp } from '../lib/loro-store.js'
-import type { LoroStoreLike } from './use-browser-document-controller.js'
+import type { BrowserPersistenceState, LoroStoreLike } from './use-browser-document-controller.js'
 
 const log = getAppLogger('markdown-document')
 
@@ -78,6 +79,33 @@ interface ContentHost {
  * Never rejects: a failed save is swallowed here exactly as a fire-and-forget
  * one was, so it cannot leave the queue permanently poisoned.
  */
+/**
+ * One write, with the indicator told what happened to it.
+ *
+ * `queueSave` swallows failures so the queue cannot be poisoned, which also
+ * means a failed write is invisible — the degraded branch here is the only
+ * thing that surfaces it. The error is re-thrown so `queueSave` still absorbs
+ * it exactly as before.
+ */
+async function reportingSave(
+  host: ContentHost,
+  report: Dispatch<SetStateAction<BrowserPersistenceState>>,
+): Promise<void> {
+  report((p) => ({ kind: 'saving', lastSavedAt: p.lastSavedAt }))
+  try {
+    await host.save()
+    report({ kind: 'saved', lastSavedAt: new Date().toISOString() })
+  } catch (err) {
+    report((p) => ({
+      kind: 'degraded',
+      reason: 'write-failed',
+      message: 'The last write to this browser failed. Your edits stay in memory for this session.',
+      lastSavedAt: p.lastSavedAt,
+    }))
+    throw err
+  }
+}
+
 function queueSave(documentId: string, save: () => Promise<void>): Promise<void> {
   const previous = pendingFlushes.get(documentId)
   const next = Promise.resolve(previous)
@@ -103,6 +131,15 @@ export interface MarkdownDocumentState {
   /** Null until the initial load resolves — render nothing editable before. */
   readonly body: string | null
   readonly setBody: (next: string) => void
+  /**
+   * Whether this hook's own debounced write has landed.
+   *
+   * Published because the page's save indicator reads the CONTROLLER's
+   * persistence, which a body edit never touches — so without this the dot
+   * reported `Saved` over text that had not been written. The page merges the
+   * two (`mergePersistence`); this side answers only for the body.
+   */
+  readonly saveState: BrowserPersistenceState
   /** Null until the initial load resolves, mirroring `body`. */
   readonly coreFacets: StoredCoreFacets | null
   readonly setCoreFacets: (next: StoredCoreFacets) => void
@@ -174,6 +211,14 @@ export function useMarkdownDocument(
   enabled: boolean,
 ): MarkdownDocumentState {
   const [body, setBodyState] = useState<string | null>(null)
+  const [saveState, setSaveState] = useState<BrowserPersistenceState>({
+    kind: 'saved',
+    lastSavedAt: null,
+  })
+  // Through a ref: the debounce closure and the unmount flush both report,
+  // and neither may re-arm the timer by depending on the setter's identity.
+  const setSaveStateRef = useRef(setSaveState)
+  setSaveStateRef.current = setSaveState
   const [coreFacets, setCoreMetaState] = useState<StoredCoreFacets | null>(null)
   const [doc, setDoc] = useState<Loro | null>(null)
   const hostRef = useRef<ContentHost | null>(null)
@@ -248,7 +293,11 @@ export function useMarkdownDocument(
         timerRef.current = null
         const host = hostRef.current
         if (host !== null && documentId !== null) {
-          void queueSave(documentId, () => host.save())
+          // Reports like any other write. The component is going away, so
+          // nothing renders the result — but this share the queue with the
+          // next load, and a silent branch here is how the two call sites
+          // drift apart later.
+          void queueSave(documentId, () => reportingSave(host, setSaveStateRef.current))
         }
       }
     }
@@ -262,6 +311,10 @@ export function useMarkdownDocument(
   const scheduleSave = useCallback(() => {
     if (documentId === null) return
     if (timerRef.current !== null) clearTimeout(timerRef.current)
+    // Unsaved from this instant, not from when the timer fires: the window
+    // between the keystroke and the debounce is exactly when the old
+    // indicator claimed everything was safe.
+    setSaveStateRef.current((p) => ({ kind: 'pending', lastSavedAt: p.lastSavedAt }))
     timerRef.current = setTimeout(() => {
       // Clearing the ref first means a cleanup arriving after this point
       // finds no timer to flush — so this save has to enqueue itself, or the
@@ -269,7 +322,7 @@ export function useMarkdownDocument(
       timerRef.current = null
       const host = hostRef.current
       if (host === null) return
-      void queueSave(documentId, () => host.save())
+      void queueSave(documentId, () => reportingSave(host, setSaveStateRef.current))
     }, SAVE_DEBOUNCE_MS)
   }, [documentId])
   scheduleSaveRef.current = scheduleSave
@@ -313,5 +366,5 @@ export function useMarkdownDocument(
     [documentId],
   )
 
-  return { body, setBody, coreFacets, setCoreFacets, doc, bodyTextOf }
+  return { body, setBody, saveState, coreFacets, setCoreFacets, doc, bodyTextOf }
 }


### PR DESCRIPTION
## Summary

The dot beside a markdown document's title claimed everything was safe while the body edit sat unwritten. This started as a CI flake on #1114 and turned out to be a product defect.

## Measured

In a real browser, after typing the full text:

```
PROBE immediately after typing: saved / null / "Saved"
PROBE 3s later:                 saved / null / "Saved"
PROBE editor content:           # From the list
```

Three seconds is six debounce periods. **The indicator never moved.**

## Why

A markdown document has **two writers**:

- `use-browser-document-controller` — renames and spatial content; publishes `persistence`.
- `useMarkdownDocument` — its own 500ms debounce and its own `pendingFlushes` queue; published **nothing**.

The page rendered the controller's state alone, and a body edit never touches it. So the chip showed its *initial* value, `{ kind: 'saved', lastSavedAt: null }`, for the whole session — over text that had not been written.

It is the same shape as the backup defect in #1114: reporting success while not having done the work. This one is in front of the user.

## The fix

`useMarkdownDocument` now reports `pending` **from the keystroke** rather than from the debounce — that window is precisely when the old dot lied — then `saving` around the write, `saved` with a timestamp when it lands, and `degraded` when it fails. That last state had no representation at all, because `queueSave` swallows failures to keep the queue from being poisoned.

`mergePersistence` combines the two writers, and its rule follows from what the indicator promises: it may say "saved" only when **both** agree, since the one that is behind is precisely the one holding unsaved work. A failure outranks a pending write — the pending one may yet land, the failed one already did not.

`SaveStatusChip` also publishes `data-save-state` and `data-last-saved-at`. The accessible name is identical for "never written" and "write landed" — right for a reader, useless as proof for a test — and `data-last-saved-at` is the discriminator that was missing.

## This is the root cause of the #1114 CI failure

`test-browser (2)` failed there with `expected '# ' to contain '# From the list'`, which reads as lost keystrokes. It was not.

The tests had **no signal** for a markdown save, so `getByRole('button', { name: 'Saved' })` matched the state the page was already in, and they navigated away at an arbitrary point relative to the debounce: sometimes it had fired, sometimes only `'# '` had been written. One of the two call sites carried a comment claiming that wait *"keeps this off the timing-flake shape"*. It did not — it could not fail.

Both waits now require a landed write.

## Test plan

- [x] `BrowserIndexPage.flow.browser.test.tsx` — the previously failing test passes, **in 9.9s rather than 24.8s**, because it waits on a landed write instead of racing one
- [x] `BrowserDocumentPage.markdown.browser.test.tsx` — 13/13
- [x] `pnpm --filter @kamiazya/whiteboard-web test` (the command CI runs) — **2805 passed**, against **2799** on clean main, with the same **9 pre-existing** thumbnail/objectURL failures in both. Baselined by stashing, not assumed
- [x] `mergePersistence` unit-tested for each rule; `SaveStatusChip` unit-tested that the name cannot discriminate and the data attributes can
- [x] `lint`, `knip`, `pnpm -r typecheck`, `arch-lint-node` all exit 0

Visual evidence: none — the change is to *when* an existing dot changes colour, not to how anything is drawn. The behavioural evidence is the probe output above: the dot previously stayed `saved/null` through six debounce periods and now transitions.

## Note

The nine failing thumbnail/objectURL tests are pre-existing on `main` in this container and unrelated to this change; they look environment-specific (blob URL handling) and are worth their own look.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_