### PR TITLE
fix(web): declare the text editor's save key in the shortcut catalog

### DIFF
--- a/apps/web/src/components/spatial-editor/editor-state.property.test.ts
+++ b/apps/web/src/components/spatial-editor/editor-state.property.test.ts
@@ -352,6 +352,10 @@ const SHORTCUT_COVERAGE = {
   'reorder-front': 'covered',
   'reorder-back': 'covered',
   'delete-selection': 'covered',
+  // The overlay editors' commit. Cmd+Enter and a blur both reach the
+  // reducer through the same `commit-text-edit`, so the model drives the
+  // binding even though it never synthesises the keystroke.
+  'commit-text-edit': 'covered',
   'toggle-lock': 'covered',
   'nudge-selection': 'covered',
   cancel: 'covered',
@@ -1176,6 +1180,7 @@ class TypeText extends GestureCommand {
 
 class CommitTextEdit extends GestureCommand {
   event(real: Real): GestureEvent {
+    tallyShortcut(real, 'commit-text-edit')
     const text = real.gesture.kind === 'editing-text' ? real.gesture.pendingText : ''
     return { type: 'commit-text-edit', text }
   }

--- a/apps/web/src/components/spatial-editor/shortcuts.test.ts
+++ b/apps/web/src/components/spatial-editor/shortcuts.test.ts
@@ -120,3 +120,33 @@ describe('findShortcutIn modifier semantics', () => {
     }
   })
 })
+
+// The catalog calls itself "the ONE place every binding is declared", and
+// the overlay editors' exit verbs were missing from it — which is how
+// someone hunting for "how do I save while editing?" found nothing. They
+// are declared now, and this pins the part that matters: declaring them
+// changed no behaviour.
+//
+// There is deliberately no scan enforcing the catalog's own claim. The
+// overlay editors' keymaps carry the markdown grammar's style bindings
+// (Mod-b, Mod-i, list continuation) alongside the two exit verbs, and a
+// scan that cannot tell them apart would demand declaring every one — a
+// guard that cries wolf is worse than the prose it replaces.
+describe('the overlay editors bindings are declared but never dispatched', () => {
+  const declared = (id: string) => EDITOR_SHORTCUTS.find((spec) => spec.id === id)
+
+  it('the node editor commit and cancel are both in the catalog', () => {
+    expect(declared('commit-text-edit')?.display).toBe('Cmd+Enter')
+    expect(declared('cancel')?.display).toBe('Esc')
+  })
+
+  it('both are inline-handled, so the matcher never claims them', () => {
+    for (const id of ['commit-text-edit', 'cancel']) {
+      expect(declared(id)?.handledInline, `${id} must stay declared-only`).toBe(true)
+    }
+    // Cmd+Enter from anywhere: the matcher skips inline-handled specs.
+    expect(
+      findShortcutIn(EDITOR_SHORTCUTS, event({ key: 'Enter', metaKey: true }), 'select'),
+    ).toBeUndefined()
+  })
+})

--- a/apps/web/src/components/spatial-editor/shortcuts.ts
+++ b/apps/web/src/components/spatial-editor/shortcuts.ts
@@ -30,6 +30,7 @@ export type ShortcutId =
   | 'reorder-front'
   | 'reorder-back'
   | 'delete-selection'
+  | 'commit-text-edit'
   | 'cancel'
   | 'space-pan'
   | 'nudge-selection'
@@ -189,6 +190,24 @@ export const EDITOR_SHORTCUTS: readonly ShortcutSpec[] = [
     tools: ['select'],
   },
   // Pre-table bindings, declared for catalog completeness.
+  //
+  // The text-edit pair below live in the OVERLAY EDITORS
+  // (`MarkdownNodeEditor` for a node's body, `TextNodeEditor` for an edge
+  // or group label), not in `handleKeyDown`, and they were absent from
+  // this catalog until someone went looking for "how do I save?" and
+  // could not find it. `findShortcut` would refuse them anyway —
+  // `isTextEntryEvent` returns before any spec is matched, which is
+  // exactly right for a binding whose whole job is to work while typing —
+  // so they are declared, never dispatched, like the clipboard family
+  // above.
+  {
+    id: 'commit-text-edit',
+    keys: ['Enter'],
+    mod: true,
+    display: 'Cmd+Enter',
+    description: 'Save the text being edited and close the editor',
+    handledInline: true,
+  },
   {
     id: 'delete-selection',
     keys: ['Delete', 'Backspace'],
@@ -196,11 +215,19 @@ export const EDITOR_SHORTCUTS: readonly ShortcutSpec[] = [
     description: 'Delete the selected node(s) or edge',
     handledInline: true,
   },
+  // Escape does NOT clear a node selection, which this entry used to
+  // claim: `handleKeyDown`'s gesture arm requires a gesture in flight, and
+  // its earlier arms only retire an edge selection or a pending cut. What
+  // it cancels is the gesture — and in a text edit that means DISCARDING
+  // what was typed, with three outcomes worth knowing: an existing node
+  // keeps its committed text, a just-created note carrying typed text goes
+  // with the discard, and a just-created note with nothing typed survives
+  // as the empty box someone sketching a layout meant to leave.
   {
     id: 'cancel',
     keys: ['Escape'],
     display: 'Esc',
-    description: 'Cancel the gesture / clear the selection',
+    description: 'Cancel the gesture, discarding text being edited',
     handledInline: true,
   },
   {


### PR DESCRIPTION
## Summary

- Registers the overlay editors' **⌘/Ctrl+Enter** (save the text being edited) in `shortcuts.ts`, which calls itself "the ONE place every binding is declared" and did not have it.
- Corrects the `cancel` entry, whose description claimed Escape clears the selection. It does not.
- Behaviour is **unchanged** — both are `handledInline`, so the matcher never dispatches them. Two tests pin exactly that.

Found the ordinary way: someone went looking for how to save while editing a node's text and could not find it. Measured before writing anything — Shift+Enter inserts a newline and commits nothing (`set-text` count 0, editor still open); ⌘/Ctrl+Enter commits and closes; blur commits.

## Why it was missing, and why the fix is a declaration

The exit verbs live in the overlay editors (`MarkdownNodeEditor` for a node's body, `TextNodeEditor` for an edge or group label), not in `handleKeyDown` where the rest of the catalog's inline-handled entries live. `findShortcut` would refuse them anyway: `isTextEntryEvent` returns before any spec is matched, which is exactly right for a binding whose whole job is to work *while typing*. So they are declared and never dispatched, like the clipboard family already is.

That means a future help sheet reading the catalog now shows the save key. Nothing else changes.

## The `cancel` correction

The old description read `'Cancel the gesture / clear the selection'`. Escape does not clear a node selection — `handleKeyDown`'s gesture arm requires a gesture in flight, and its earlier arms only retire an edge selection or a pending cut.

What it cancels is the gesture, and in a text edit that means **discarding what was typed**, with three outcomes worth knowing (each already covered by `escape-cancels-new-note.browser.test.tsx`):

| situation | Escape |
|---|---|
| editing an existing node | typing discarded, node keeps its committed text |
| a just-created note with typed text | discarded, and the note goes with it |
| a just-created note with nothing typed | the empty box survives — it is what someone sketching a layout meant to leave |

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — two cases in `shortcuts.test.ts`
- [x] `pnpm test` passes locally — `web-jsdom` 433, `web-browser` 409 (spatial-editor), `pnpm -r typecheck`, `biome`, `knip` green against current `main`
- [x] Manual verification completed — the Shift+Enter / ⌘Enter behaviour above was measured in a real browser before the change, not read off the source
- [ ] E2E coverage added or extended where applicable — not applicable; no routing, websocket or persistence behaviour is involved

Both new assertions are mutation-checked: removing the catalog entry fails two of them, and dropping its `handledInline` fails one. A third assertion was **written and then deleted** — it checked that a text-entry surface refuses the spec, which passes either way once `handledInline` is set, and the existing suite already covers the text-entry rule. A guard that cannot fail reads as coverage.

## Visual evidence

**Visual evidence: none** — this changes a declaration table and two strings in it. No pixels move and no runtime behaviour differs; the tests above are the evidence that the second half is true.

## What is deliberately not here

No scan enforces the catalog's own claim to be the single place bindings are declared. The overlay editors' keymaps carry the markdown grammar's style bindings (Mod-b, Mod-i, list continuation) beside the two exit verbs, and a scan that cannot tell them apart would demand declaring every one of them. A guard that cries wolf is worse than the prose it replaces — the same call `editor-focus-discipline.test.ts` records for its own rule.

Also not here: making **Shift+Enter** a save alias. That is a product decision rather than a bug — CodeMirror and every textarea bind it to a newline, so claiming it would surprise the other half of users. Worth deciding on its own.

## Note for the reviewer

Follows #1119, and the ledger from that PR is why this touches a third file. Adding a `ShortcutId` member fails the build against `SHORTCUT_COVERAGE` until the new id is classified — the mechanism working on a real feature addition rather than a synthetic probe. The id is `covered`: ⌘Enter and a blur both reach the reducer through the same `commit-text-edit` the model already drives, and it now tallies there.

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_