### PR TITLE
fix(web): tell the truth about deleting, and name a note after its own title

### DIFF
--- a/apps/web/src/components/workspace-files/NewDocumentMenu.tsx
+++ b/apps/web/src/components/workspace-files/NewDocumentMenu.tsx
@@ -17,8 +17,10 @@ import { NewDocumentDialog } from './NewDocumentDialog.js'
  *
  * A kind is fixed for the document's life — nothing in the codebase writes
  * `kind` a second time, so the only way back from the wrong one is delete
- * (behind a "there is no undo" confirmation) and start again. An
- * irreversible choice must not be committed by a single press on an
+ * and start again, carrying whatever was written across by hand. (The delete
+ * itself is recoverable — it evacuates to the Trash — but the KIND is not:
+ * restoring returns the same document, of the same wrong kind.) A choice
+ * that cannot be taken back must not be committed by a single press on an
  * unlabeled glyph, which is what the two icon buttons this replaces did:
  * their names lived in tooltips, and a tooltip needs a pointer that a phone
  * does not have.
@@ -127,7 +129,13 @@ export function NewDocumentMenu({
               className="gap-2"
             >
               <SlidersHorizontal aria-hidden="true" className="size-4" />
-              Name and location…
+              {/* Says "folder" because that is the word someone looking for
+                  one searches the menu for, and this entry is the only place
+                  they can put a document in one. Folders here ARE the path
+                  (the dialog's Path help says so, and an emptied one is
+                  pruned), so there is no "New folder" to offer instead — a
+                  folder with nothing in it cannot exist to be created. */}
+              Name and folder…
             </DropdownMenuItem>
           </>
         )}

--- a/apps/web/src/components/workspace-files/new-document-path.test.ts
+++ b/apps/web/src/components/workspace-files/new-document-path.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { newDocumentPathIn } from './new-document-path.js'
+import { fc, fcTest, withDefaults } from '../../test-utils/fast-check.js'
+import { isGeneratedDocumentPath, newDocumentPathIn } from './new-document-path.js'
 
 describe('newDocumentPathIn', () => {
   it('creates in the folder the browser is standing in', () => {
@@ -37,4 +38,30 @@ describe('newDocumentPathIn', () => {
     expect(newDocumentPathIn('design', ['design-untitled'])).toBe('design/untitled')
     expect(newDocumentPathIn('design', ['design-system/untitled'])).toBe('design/untitled')
   })
+})
+
+describe('isGeneratedDocumentPath', () => {
+  it('recognises what newDocumentPathIn produces, at the root and in a folder', () => {
+    expect(isGeneratedDocumentPath('untitled')).toBe(true)
+    expect(isGeneratedDocumentPath('untitled-2')).toBe(true)
+    expect(isGeneratedDocumentPath('design/untitled-17')).toBe(true)
+  })
+
+  it('does not claim a path a person chose', () => {
+    expect(isGeneratedDocumentPath('weekly-review')).toBe(false)
+    expect(isGeneratedDocumentPath('untitled-notes')).toBe(false)
+    expect(isGeneratedDocumentPath('design/untitled/child')).toBe(false)
+    // `-1` and `-0` are never generated: the counter starts at 2.
+    expect(isGeneratedDocumentPath('untitled-1')).toBe(false)
+  })
+
+  // The pair has to agree, or the seeding gate opens on paths nobody generated.
+  fcTest.prop([fc.integer({ min: 0, max: 30 })], withDefaults())(
+    'every path the generator produces is recognised by the predicate',
+    (howMany) => {
+      const taken: string[] = []
+      for (let i = 0; i < howMany; i++) taken.push(newDocumentPathIn('design', taken))
+      for (const path of taken) expect(isGeneratedDocumentPath(path)).toBe(true)
+    },
+  )
 })

--- a/apps/web/src/components/workspace-files/new-document-path.ts
+++ b/apps/web/src/components/workspace-files/new-document-path.ts
@@ -29,6 +29,20 @@ export function newDocumentPathIn(folder: string, existingPaths: readonly string
 }
 
 /**
+ * Whether a path is one this function chose, rather than one a person did.
+ *
+ * The pair matters because "nobody has named this yet" is not something the
+ * tree records: clearing a name in the rename dialog leaves the same absent
+ * `name` a brand-new document has. A still-generated path is the closest
+ * honest proxy — someone who cleared the name of a document they had also
+ * placed somewhere has engaged with naming, and must not be overridden.
+ */
+export function isGeneratedDocumentPath(path: string): boolean {
+  const last = path.slice(path.lastIndexOf('/') + 1)
+  return /^untitled(?:-(?:[2-9]|[1-9]\d+))?$/.test(last)
+}
+
+/**
  * The paths a new document must number around, for the two callers where a
  * failed read must not dead-end the user: the list page's create button and
  * the editor's first-boot create.

--- a/apps/web/src/lib/title-from-body.test.ts
+++ b/apps/web/src/lib/title-from-body.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { titleFromMarkdownBody } from './title-from-body.js'
+
+describe('titleFromMarkdownBody', () => {
+  it('takes the first line when it is a level-1 heading', () => {
+    expect(titleFromMarkdownBody('# Weekly review\n\nnotes')).toBe('Weekly review')
+  })
+
+  it('skips blank lines before the heading', () => {
+    expect(titleFromMarkdownBody('\n\n  \n# Weekly review')).toBe('Weekly review')
+  })
+
+  it('drops a closed heading’s trailing markers', () => {
+    expect(titleFromMarkdownBody('# Weekly review ###')).toBe('Weekly review')
+  })
+
+  it('refuses a heading marker with no space — `#tag` is body text', () => {
+    expect(titleFromMarkdownBody('#tag\n')).toBeUndefined()
+  })
+
+  it('refuses a deeper heading: a section is not the document’s title', () => {
+    expect(titleFromMarkdownBody('## Section\n')).toBeUndefined()
+  })
+
+  it('refuses a heading that only appears after real content', () => {
+    expect(titleFromMarkdownBody('some prose\n\n# Later heading')).toBeUndefined()
+  })
+
+  it('refuses an empty heading and a body with nothing in it', () => {
+    expect(titleFromMarkdownBody('#   \n')).toBeUndefined()
+    expect(titleFromMarkdownBody('')).toBeUndefined()
+  })
+
+  it('refuses a heading long enough to be prose, rather than inventing a truncation', () => {
+    expect(titleFromMarkdownBody(`# ${'x'.repeat(121)}`)).toBeUndefined()
+  })
+
+  // A name is written into the workspace tree and rendered in a single-line
+  // card, a browser tab and a search result. These are what it may never be.
+  fcTest.prop([fc.string({ minLength: 1, maxLength: 100 })], withDefaults())(
+    'a title it accepts is single-line, trimmed, and non-empty',
+    (raw) => {
+      const title = titleFromMarkdownBody(`# ${raw}\nbody`)
+      if (title === undefined) return
+      expect(title).not.toBe('')
+      expect(title).toBe(title.trim())
+      expect(title.includes('\n')).toBe(false)
+      expect(title.length).toBeLessThanOrEqual(120)
+    },
+  )
+
+  fcTest.prop([fc.string({ minLength: 1, maxLength: 60 })], withDefaults())(
+    'round trip: a title it accepts is what re-reading its own heading gives back',
+    (raw) => {
+      const once = titleFromMarkdownBody(`# ${raw}\nbody`)
+      if (once === undefined) return
+      expect(titleFromMarkdownBody(`# ${once}\nbody`)).toBe(once)
+    },
+  )
+})

--- a/apps/web/src/lib/title-from-body.ts
+++ b/apps/web/src/lib/title-from-body.ts
@@ -1,0 +1,42 @@
+/**
+ * The title a markdown body announces about itself, if it announces one.
+ *
+ * Used to NAME a document that nobody named — see `use-markdown-document`.
+ * Deliberately line-anchored text matching rather than a markdown parse, the
+ * same call `set-heading-level.ts` and `toggle-task-checkbox.ts` make and for
+ * the same reason: a level-1 ATX heading is only ever `#` + whitespace + text
+ * at the start of a line, and a full parse buys nothing at that depth.
+ *
+ * The rule is narrow on purpose. Only the FIRST non-blank line counts: a
+ * heading further down is a section, not the document's title, and naming a
+ * document after its third section would be worse than leaving it unnamed.
+ */
+
+/**
+ * `# ` + text, with the space required — `#tag` is body text, matching
+ * `set-heading-level.ts`'s heading rule. A closed ATX heading (`# Title #`)
+ * drops its trailing run so the name does not keep a stray marker.
+ */
+const ATX_H1 = /^#[ \t]+(.+?)(?:[ \t]+#+)?[ \t]*$/
+
+/**
+ * Long enough for any title someone means as one, short enough that a name
+ * cannot become a paragraph. A heading past this is almost certainly prose
+ * that happens to start with `#`, and truncating it would invent a name
+ * nobody wrote — so it is refused outright rather than cut.
+ */
+const MAX_TITLE_LENGTH = 120
+
+export function titleFromMarkdownBody(body: string): string | undefined {
+  for (const line of body.split('\n')) {
+    if (line.trim() === '') continue
+    // The first thing actually written decides. If it is not a heading, the
+    // document has not told us what it is called.
+    const matched = ATX_H1.exec(line)
+    if (matched === null) return undefined
+    const title = (matched[1] ?? '').replace(/\s+/g, ' ').trim()
+    if (title === '' || title.length > MAX_TITLE_LENGTH) return undefined
+    return title
+  }
+  return undefined
+}

--- a/apps/web/src/pages/BrowserDocumentPage.delete-confirm.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.delete-confirm.browser.test.tsx
@@ -85,7 +85,12 @@ describe('BrowserDocumentPage delete confirmation (browser — real IndexedDB)',
 
     const dialog = await openDeleteDialog()
     expect(dialog).toHaveAccessibleName('Delete this note?')
-    expect(dialog).toHaveAccessibleDescription(/permanently removes the note/i)
+    // The delete EVACUATES to the trash (loro-workspace-document-index's
+    // "EVACUATE FIRST"), and the Trash section offers Restore — so a dialog
+    // claiming the opposite talks a reader out of a safe action.
+    expect(dialog).toHaveAccessibleDescription(/Trash/i)
+    expect(dialog).toHaveAccessibleDescription(/restore/i)
+    expect(dialog).not.toHaveAccessibleDescription(/no undo|cannot be undone/i)
   })
 
   it('opening the delete dialog does not delete the canvas yet', async () => {
@@ -146,7 +151,8 @@ describe('BrowserDocumentPage delete confirmation (browser — real IndexedDB)',
     const dialog = await openDeleteDialog()
 
     expect(dialog).toHaveAccessibleName('Delete this canvas?')
-    expect(dialog).toHaveAccessibleDescription(/permanently removes the canvas.*cannot be undone/i)
+    expect(dialog).toHaveAccessibleDescription(/Trash/i)
+    expect(dialog).not.toHaveAccessibleDescription(/no undo|cannot be undone/i)
   })
 
   it('focus moves into the dialog on open and returns to the kebab on close', async () => {

--- a/apps/web/src/pages/BrowserDocumentPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.markdown.browser.test.tsx
@@ -1,3 +1,4 @@
+import { FoldingBrowserIndex } from '../lib/folding-browser-index.js'
 import { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { listLocalDocuments } from '../lib/local-document-summary.js'
 import { seedIdbDocument } from '../test-utils/seed-idb-document.js'
@@ -697,5 +698,71 @@ describe('BrowserDocumentPage markdown 導線 (real IndexedDB)', () => {
         { timeout: 10_000 },
       )
     })
+  })
+
+  /**
+   * Someone who types `# Weekly review` has said what the note is called.
+   * Before this the workspace kept calling it `untitled` — in the card, the
+   * URL and every search result — and the only fix was typing the same words
+   * again into the rename dialog. The two cases below are the seed and its
+   * gate; the pure halves are covered by title-from-body and
+   * new-document-path, so what these pin is the WIRING through a real save.
+   */
+  it('names an unnamed note after the title its body announces', async () => {
+    const store = new IdbDocumentIndex()
+    await seedIdbDocument(store, { path: 'untitled', kind: 'markdown', makeDefault: true })
+    render(<BrowserDocumentPage store={store} />)
+
+    const resolveEditable = () => document.querySelector('[contenteditable="true"]')
+    await waitFor(() => expect(resolveEditable()).not.toBeNull())
+    await focusEditable(resolveEditable)
+    await userEvent.keyboard('# Weekly review')
+    await waitFor(() => {
+      expect(document.querySelector('.cm-content')?.textContent).toBe('# Weekly review')
+    })
+
+    await waitFor(
+      async () => {
+        const row = (await listLocalDocuments(new FoldingBrowserIndex())).find(
+          (r) => r.kind === 'markdown',
+        )
+        expect(row?.name).toBe('Weekly review')
+      },
+      { timeout: 10_000 },
+    )
+  })
+
+  it('leaves a note with no title unnamed rather than inventing one', async () => {
+    const store = new IdbDocumentIndex()
+    await seedIdbDocument(store, { path: 'untitled', kind: 'markdown', makeDefault: true })
+    render(<BrowserDocumentPage store={store} />)
+
+    const markdownRow = async () =>
+      (await listLocalDocuments(new FoldingBrowserIndex())).find((r) => r.kind === 'markdown')
+    const before = (await markdownRow())?.updatedAt
+
+    const resolveEditable = () => document.querySelector('[contenteditable="true"]')
+    await waitFor(() => expect(resolveEditable()).not.toBeNull())
+    await focusEditable(resolveEditable)
+    await userEvent.keyboard('just some prose')
+    await waitFor(() => {
+      expect(document.querySelector('.cm-content')?.textContent).toBe('just some prose')
+    })
+
+    // Wait for a save to LAND before asserting the absence, rather than
+    // waiting a fixed time and hoping: `touchContentTimestamp` moves
+    // updatedAt on every save, so a changed stamp is proof the seeding path
+    // ran and declined. Asserting the negative any earlier passes for the
+    // wrong reason — nothing had happened yet.
+    await waitFor(
+      async () => {
+        expect((await markdownRow())?.updatedAt).not.toBe(before)
+      },
+      { timeout: 10_000 },
+    )
+
+    // Still the path, projected by `entry.name ?? entry.path` — nobody named
+    // it, and prose is not a title.
+    expect((await markdownRow())?.name).toBe('untitled')
   })
 })

--- a/apps/web/src/pages/BrowserDocumentPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.markdown.browser.test.tsx
@@ -732,6 +732,68 @@ describe('BrowserDocumentPage markdown 導線 (real IndexedDB)', () => {
     )
   })
 
+  /**
+   * The counterexample CI found, pinned before the fix. Typing outlasts the
+   * 500ms debounce on a loaded machine, so a save lands while the heading is
+   * half written — and the first version of this seeding took that partial
+   * heading and stopped, because a name being present is what closed its
+   * gate. Measured in a real browser: `# From` … ` the list` produced a
+   * document called "From", forever. A wrong name is worse than `untitled`,
+   * because it looks deliberate.
+   */
+  it('keeps up with a heading that outlasts the save debounce', async () => {
+    const store = new IdbDocumentIndex()
+    await seedIdbDocument(store, { path: 'untitled', kind: 'markdown', makeDefault: true })
+    render(<BrowserDocumentPage store={store} />)
+
+    const markdownRow = async () =>
+      (await listLocalDocuments(new FoldingBrowserIndex())).find((r) => r.kind === 'markdown')
+
+    const resolveEditable = () => document.querySelector('[contenteditable="true"]')
+    await waitFor(() => expect(resolveEditable()).not.toBeNull())
+    await focusEditable(resolveEditable)
+
+    await userEvent.keyboard('# From')
+    // Long enough for a save to land on the partial heading — the whole
+    // point. Waiting for the name to BECOME "From" would pass vacuously if
+    // the seeding never ran at all, so this waits for the write instead.
+    await waitFor(async () => expect((await markdownRow())?.name).toBe('From'), {
+      timeout: 10_000,
+    })
+
+    await userEvent.keyboard(' the list')
+    await waitFor(async () => expect((await markdownRow())?.name).toBe('From the list'), {
+      timeout: 10_000,
+    })
+  })
+
+  it('never touches a name a person chose', async () => {
+    const store = new IdbDocumentIndex()
+    await seedIdbDocument(store, {
+      path: 'untitled',
+      name: 'Meeting',
+      kind: 'markdown',
+      makeDefault: true,
+    })
+    render(<BrowserDocumentPage store={store} />)
+
+    const markdownRow = async () =>
+      (await listLocalDocuments(new FoldingBrowserIndex())).find((r) => r.kind === 'markdown')
+    const before = (await markdownRow())?.updatedAt
+
+    const resolveEditable = () => document.querySelector('[contenteditable="true"]')
+    await waitFor(() => expect(resolveEditable()).not.toBeNull())
+    await focusEditable(resolveEditable)
+    await userEvent.keyboard('# From the list')
+
+    // Wait for a save to land, so the absence below is a decision rather
+    // than something that had not happened yet.
+    await waitFor(async () => expect((await markdownRow())?.updatedAt).not.toBe(before), {
+      timeout: 10_000,
+    })
+    expect((await markdownRow())?.name).toBe('Meeting')
+  })
+
   it('leaves a note with no title unnamed rather than inventing one', async () => {
     const store = new IdbDocumentIndex()
     await seedIdbDocument(store, { path: 'untitled', kind: 'markdown', makeDefault: true })

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -712,8 +712,7 @@ export function BrowserDocumentPage({
           <AlertDialogHeader>
             <AlertDialogTitle>Delete this {kindNoun(documentKind)}?</AlertDialogTitle>
             <AlertDialogDescription>
-              This permanently removes the {kindNoun(documentKind)} and its content from this
-              browser. This action cannot be undone.
+              The {kindNoun(documentKind)} moves to the Trash, where you can restore it.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/apps/web/src/pages/BrowserIndexPage.flow.browser.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.flow.browser.test.tsx
@@ -116,7 +116,11 @@ describe('browser list landing (browser — real IndexedDB)', () => {
     expect(noteIndex).toBeGreaterThanOrEqual(0)
 
     // Reopening the note restores the typed body from the same store.
-    await userEvent.click(screen.getAllByTestId('card-title')[noteIndex]!)
+    // The ROW, not its title span: a title span is located by its text, and
+    // the row's decorative SVG miniature renders the same words once the note
+    // carries a real name — two matches, and a strict-mode violation that
+    // reads like the card is missing.
+    await userEvent.click(screen.getAllByTestId('card-title')[noteIndex]!.closest('button')!)
     await userEvent.click(await screen.findByRole('button', { name: 'Open' }))
     await waitFor(
       () => {

--- a/apps/web/src/pages/BrowserIndexPage.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.test.tsx
@@ -295,14 +295,14 @@ describe('BrowserIndexPage', () => {
     await selectCard('Meeting notes')
     fireEvent.click(await screen.findByRole('button', { name: 'Delete' }))
     let dialog = await screen.findByRole('alertdialog')
-    expect(within(dialog).getByText(/removes the note from this browser/)).toBeTruthy()
+    expect(within(dialog).getByText(/^The note moves to the Trash/)).toBeTruthy()
     fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
     await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
 
     await selectCard('Trip plan')
     fireEvent.click(await screen.findByRole('button', { name: 'Delete' }))
     dialog = await screen.findByRole('alertdialog')
-    expect(within(dialog).getByText(/removes the canvas from this browser/)).toBeTruthy()
+    expect(within(dialog).getByText(/^The canvas moves to the Trash/)).toBeTruthy()
   })
 
   it('Delete opens a dialog naming the canvas; Cancel removes nothing', async () => {

--- a/apps/web/src/pages/BrowserIndexPage.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.tsx
@@ -257,7 +257,13 @@ export function BrowserIndexPage({
         pending={pendingDelete}
         busy={deleting}
         error={deleteError}
-        description={`This permanently removes the ${kindNoun(pendingDelete?.kind)} from this browser. There is no undo.`}
+        // The delete evacuates into the trash before removing anything
+        // (loro-workspace-document-index's "EVACUATE FIRST"), and the Trash
+        // section restores it. The old copy said "There is no undo", which
+        // talks a reader out of tidying up. A browser workspace keeps no
+        // versions — those are a daemon feature — so the trash is the whole
+        // story here.
+        description={`The ${kindNoun(pendingDelete?.kind)} moves to the Trash, where you can restore it.`}
         onCancel={() => {
           setPendingDelete(null)
           setDeleteError(null)

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -1252,14 +1252,18 @@ describe('DaemonIndexPage', () => {
     await selectCard('Meeting notes')
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
     let dialog = await screen.findByRole('alertdialog')
-    expect(within(dialog).getByText(/removes the note, including its versions/)).toBeTruthy()
+    // A daemon delete is recoverable — document-store.ts routes it through
+    // the index's evacuate-first path — so the dialog names the Trash. What
+    // it still warns about is the half that really is destroyed.
+    expect(within(dialog).getByText(/The note moves to the Trash/)).toBeTruthy()
+    expect(within(dialog).getByText(/versions and branches are deleted/)).toBeTruthy()
     fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
     await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
 
     await selectCard('Trip plan')
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
     dialog = await screen.findByRole('alertdialog')
-    expect(within(dialog).getByText(/removes the canvas, including its versions/)).toBeTruthy()
+    expect(within(dialog).getByText(/The canvas moves to the Trash/)).toBeTruthy()
   })
 
   it('Delete opens an AlertDialog naming the canvas; Cancel sends no DELETE', async () => {

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -633,7 +633,14 @@ export function DaemonIndexPage({
           pending={pendingDelete}
           busy={deleting}
           error={deleteError}
-          description={`This permanently removes the ${kindNoun(pendingDelete?.kind)}, including its versions and branches. There is no undo.`}
+          // Recoverable, like the browser's: document-store.ts routes the
+          // delete through the index, which evacuates into the trash and
+          // "keeps the same recoverability promise the agent-facing port
+          // makes". What genuinely does NOT come back is the versions and
+          // branches — documentTeardown deletes those rows, and the trash
+          // holds only the tree subtree — so that is the half worth warning
+          // about, instead of a blanket "no undo" that is simply false.
+          description={`The ${kindNoun(pendingDelete?.kind)} moves to the Trash, where you can restore it. Its versions and branches are deleted, and restoring does not bring them back.`}
           onCancel={closeDeleteDialog}
           onConfirm={() => void handleConfirmDelete()}
         />

--- a/apps/web/src/pages/use-markdown-document.ts
+++ b/apps/web/src/pages/use-markdown-document.ts
@@ -31,6 +31,7 @@ import {
   readCoreFacets,
   readMarkdownBody,
   resolveWorkspaceDocumentById,
+  setWorkspaceDocumentName,
   writeCoreFacets,
   writeMarkdownBody,
 } from '@kamiazya/whiteboard-loro-adapter'
@@ -38,11 +39,13 @@ import type { StoredCoreFacets } from '@kamiazya/whiteboard-model'
 import { Loro, type LoroText } from 'loro-crdt'
 import type { Dispatch, SetStateAction } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { isGeneratedDocumentPath } from '../components/workspace-files/new-document-path.js'
 import { getAppLogger } from '../lib/app-logger.js'
 import { BrowserWorkspaceDocs, openWorkspaceOrNull } from '../lib/browser-workspace-docs.js'
 import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import { foldWorkspaceDocuments } from '../lib/fold-workspace.js'
 import { touchContentTimestamp } from '../lib/loro-store.js'
+import { titleFromMarkdownBody } from '../lib/title-from-body.js'
 import type { BrowserPersistenceState, LoroStoreLike } from './use-browser-document-controller.js'
 
 const log = getAppLogger('markdown-document')
@@ -168,6 +171,43 @@ export interface MarkdownDocumentState {
   readonly bodyTextOf: (doc: Loro) => LoroText
 }
 
+/**
+ * Names a document after the title its body announces, while nobody has
+ * named it and nobody has placed it.
+ *
+ * Someone who opens a note and types `# Weekly review` has said what it is
+ * called. Without this the workspace keeps calling it `untitled`, in the
+ * card, the URL and every search result, and the only way to fix that is to
+ * type the same words a second time into the rename dialog.
+ *
+ * Two gates, and the second is the load-bearing one. `name` absent means
+ * "nobody named it" — but it is ALSO what the rename dialog leaves behind
+ * when someone deliberately clears a name to show the path instead, and
+ * re-seeding over that would be this codebase's recurring defect: state
+ * keyed on something that has since changed. A still-generated path is the
+ * proxy that separates them, since anyone who cleared a name on a document
+ * they had also placed has engaged with naming.
+ *
+ * The PATH is never touched. ADR-0008 measured deriving one from a display
+ * name and found every non-Latin title collapsing to `untitled-N`; ADR-0007's
+ * addendum retracted it. Seeding the name leaves the address alone, so a
+ * heading edit can never move a document out from under a link.
+ *
+ * Runs on every save rather than only the first: both gates shut the moment
+ * it succeeds, and a note whose heading arrives after its first paragraph
+ * still gets named.
+ */
+function seedNameFromTitle(workspace: Loro, documentId: string): void {
+  const entry = resolveWorkspaceDocumentById(workspace, documentId)
+  if (entry === null || entry.name !== undefined) return
+  if (!isGeneratedDocumentPath(entry.path)) return
+  const title = titleFromMarkdownBody(
+    documentContainers(workspace, documentId).getText(MARKDOWN_BODY_KEY).toString(),
+  )
+  if (title === undefined) return
+  setWorkspaceDocumentName(workspace, { documentId, name: title })
+}
+
 async function openWorkspaceHost(documentId: string): Promise<ContentHost | null> {
   // The fold first: the markdown page has no BrowserBackend, so this is the
   // one place a markdown-only visit carries an older build's per-document
@@ -186,6 +226,7 @@ async function openWorkspaceHost(documentId: string): Promise<ContentHost | null
     doc: workspace,
     containers: documentContainers(workspace, documentId),
     save: async () => {
+      seedNameFromTitle(workspace, documentId)
       await docs.save(getBrowserWorkspaceId(), workspace)
       await touchContentTimestamp(documentId)
     },

--- a/apps/web/src/pages/use-markdown-document.ts
+++ b/apps/web/src/pages/use-markdown-document.ts
@@ -193,18 +193,31 @@ export interface MarkdownDocumentState {
  * addendum retracted it. Seeding the name leaves the address alone, so a
  * heading edit can never move a document out from under a link.
  *
- * Runs on every save rather than only the first: both gates shut the moment
- * it succeeds, and a note whose heading arrives after its first paragraph
- * still gets named.
+ * Runs on every save, and KEEPS UP with a heading still being typed. Typing
+ * outlasts the 500ms debounce on a loaded machine, so a save lands while the
+ * title is half written — and a first version of this stopped there, because
+ * a name being present was what closed its gate. Measured in a real browser:
+ * `# From` … ` the list` produced a document called "From", forever. A wrong
+ * name is worse than `untitled`, because it looks deliberate.
+ *
+ * So a name this function produced may be replaced, and the test for "this
+ * one is ours" is that the title still STARTS WITH it — which is exactly the
+ * shape a half-typed heading leaves behind. Any other name is a person's, and
+ * is never touched: rename to "Meeting" over a body reading `# From the list`
+ * and the seeding is finished with this document.
  */
 function seedNameFromTitle(workspace: Loro, documentId: string): void {
   const entry = resolveWorkspaceDocumentById(workspace, documentId)
-  if (entry === null || entry.name !== undefined) return
+  if (entry === null) return
   if (!isGeneratedDocumentPath(entry.path)) return
   const title = titleFromMarkdownBody(
     documentContainers(workspace, documentId).getText(MARKDOWN_BODY_KEY).toString(),
   )
-  if (title === undefined) return
+  if (title === undefined || title === entry.name) return
+  // Absent: nobody has named it. A strict prefix of the title: we named it,
+  // from a heading that has since grown.
+  const ours = entry.name === undefined || title.startsWith(entry.name)
+  if (!ours) return
   setWorkspaceDocumentName(workspace, { documentId, name: title })
 }
 

--- a/packages/workspace-index/src/loro-workspace-document-index.ts
+++ b/packages/workspace-index/src/loro-workspace-document-index.ts
@@ -356,8 +356,9 @@ export class LoroWorkspaceDocumentIndex implements DocumentIndex {
       // The caller wants it gone and it is.
       if (target === undefined) return
       // Every document here can hold children, so a cascade is reachable from
-      // one call naming one path — and deletion is the operation with nothing
-      // to undo it. Refusing makes the caller name what it is destroying.
+      // one call naming one path, and only the NAMED path is evacuated below —
+      // a cascade would destroy the descendants with no trash row to bring
+      // them back. Refusing makes the caller name what it is destroying.
       const descendants = nodes.filter(
         (node) => node.path !== input.path && isSelfOrDescendant(node.path, input.path),
       )


### PR DESCRIPTION
## Summary

A dogfooding pass over document management, driven as a real user in a real browser rather than read off the source. Four frictions found, three fixed here; the fourth turned out to be a feature gap rather than a fix and is written up at the bottom instead of half-done.

## F1 — the delete dialog claimed an undo that exists

Measured, in this order:

```
DIALOG : Delete "untitled"? This permanently removes the note from this
         browser. There is no undo.
after  : Trash (1) appears
restore: "Weekly review / untitled / markdown · 6s ago" is back, content intact
```

The claim was false in **all three** places it appeared. `deleteDocument` evacuates a document into the trash *before* removing anything — its own comment says `EVACUATE FIRST` — and the daemon takes the same path, which `document-store.ts` describes as keeping "the same recoverability promise the agent-facing port makes".

The new copy says what each keeper actually does, and the two differ:

| | now says |
|---|---|
| Browser (index + document page) | The note moves to the Trash, where you can restore it. |
| Daemon (index) | …plus: its versions and branches are deleted, and restoring does not bring them back. |

That asymmetry is checked, not assumed: a browser workspace keeps no versions at all (`VersionTimeline` reads the daemon's HTTP API), while `documentTeardown` really does delete the daemon's version and branch rows, and the trash holds only the tree subtree.

**This is the worst direction for copy to be wrong in.** It tells someone a safe action is irreversible, so they keep documents they meant to tidy away. Two tests pinned the old wording — worth noting on its own: a test guarantees a claim stays *consistent*, never that it is *true*.

## F2 — a note's name never learned from its content

Typing `# Weekly review` left the workspace calling it `untitled` in the card, the URL and every search result, while the card rendered "Weekly review" right above that name from the body preview. The app already knew the title. Three notes in, the list read `untitled / untitled-2 / untitled-3`.

`seedNameFromTitle` now runs in the workspace host's save, so name and body land in one write. Two gates, and **the second is the load-bearing one**:

- `name` absent means nobody named it — but it is *also* what the rename dialog leaves behind when someone deliberately clears a name to show the path instead. Re-seeding over that would be this codebase's recurring defect: state keyed on something that has since changed.
- So the path must still be a **generated** one. Anyone who cleared a name on a document they had also placed has engaged with naming, and is left alone.

The **path is never touched**. ADR-0008 measured deriving one from a display name and found every non-Latin title collapsing to `untitled-N`; ADR-0007's addendum retracted it. Seeding only the name means a heading edit can never move a document out from under a link.

`isGeneratedDocumentPath` sits beside the generator it mirrors, and a property drives the generator and feeds every path it produces to the predicate. **That property failed immediately**: the first regex was `-[2-9]\d*`, which rejects `untitled-10` and every later one, because they begin with `1`. An example test would have had to guess that case.

## F3 — not fixed here, and not a wiring gap

`Duplicate` and `Pin` are offered in a daemon workspace and absent in a browser one, which is the default no-account experience the landing page advertises. My first read called this unwired. **That was wrong, and the correction is the point**: there is no `duplicateDocument`/`copyDocument` anywhere in `ports`, `workspace-index` or `apps/web/lib`, and no `pinOrder` in the browser index. The daemon composes duplicate at the page level from `getDocumentSnapshot` + create, against its HTTP API.

So bringing them to the browser means new operations in the shared packages, not a prop. That is a feature increment with its own product question — should a browser workspace have them at all? — and stapling it onto a copy-and-naming PR would have been the wrong shape.

## F4 — nothing on the fast path says "folder"

The New-document menu offered Canvas, Markdown note, and "Name and location…", and someone looking for a folder has no reason to open the third. There is deliberately **no "New folder" to add**: folders here *are* the path, and `pruneEmptyFolders` removes one the moment it holds nothing, so a folder created empty could not exist. The entry now says the word someone would search the menu for.

## Test plan

- [x] New or updated tests added — `title-from-body.test.ts` (8 examples + 2 properties), `new-document-path.test.ts` (+ a generator/predicate agreement property), two `web-browser` regressions for the naming seed and its gate, and the delete-dialog assertions inverted
- [x] `pnpm test` passes locally — see the pre-existing note below
- [x] Manual verification completed — every finding was *found* in a real browser and re-checked there after the fix, before any test was written
- [ ] E2E coverage added or extended where applicable — not applicable; no routing, websocket or daemon composition is involved

Verified after the fix, in the same real browser that found the problems:

```
card title after typing "# Weekly review" : ["Weekly review"]
same, for a note that opens with prose    : ["Weekly review","untitled-2"]
delete dialog                             : The note moves to the Trash, where you can restore it.
```

Gates: `web-jsdom` 209 (touched areas), `web-browser` 56 (pages), `arch-lint` 111, `pnpm knip`, `biome` over 1951 files, `pnpm -r typecheck` — all green. The naming seed is **mutation-checked**: removing the call fails the positive case alone, with the negative one still green.

**Pre-existing failures, not this PR:** `mcp-node` reports 3 failures in `migrator.test.ts` and `0011-import-fs-blobs.test.ts` — all three assert on `EACCES`/permission-denied, which cannot happen running as root in this container. Same three, unchanged, before and after this branch.

## Visual evidence

Before/after figures were composed for F1 and F2 and reviewed, but **could not be attached**: the `gh image` extension needs the `gh` CLI, which this environment does not have, and `.claude/scripts/compose-figure.mjs` needs ImageMagick, which is not installed here either — so the figures were composed with a headless-browser stand-in that keeps the part that matters (it refuses two identical panels and prints both digests; `790cc794…` vs `c3ea72a0…` for the delete pair, `72908581…` vs `83a81563…` for the naming pair).

For F1 the substance is text anyway, and it is quoted verbatim above: the old dialog said "There is no undo" and the trash restored the note. F4 is one word in a menu. F2's effect is the card title in the block above.

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Untitled documents now automatically use the first Markdown heading as their title.
  - Title detection supports headings with surrounding blank lines and normalized spacing.
  - Documents deleted from the browser can be restored from Trash.

- **Bug Fixes**
  - Explicitly named documents are no longer overwritten by Markdown headings.
  - Plain-text documents remain titled “untitled” instead of receiving an invented title.
  - Delete confirmations now accurately describe restoration and permanent version removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->