### PR TITLE
feat: name and size the workspace, and give the daemon its write surface

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -198,6 +198,15 @@ one it is not in yet, `spinner` that same ring while the doing is in flight.
   else's, and that was true while every create path addressed a
   (workspace, path) pair the page could not name; `POST /api/workspaces`
   retired the premise by minting the id itself.
+- **An address the page cannot resolve yet leaves NOTHING selected.** The
+  daemon page re-reads its list once when the address names a workspace the
+  list does not hold, because the switcher may have just created it. That
+  re-read can fail — and keeping the previous workspace selected through the
+  failure puts the page on one workspace under an address naming another,
+  which is the mismatch the stale-address fallback already refuses to leave
+  behind. The error state offers `Create a canvas` only while something is
+  selected, so the stale selection is not cosmetic: a create there posts the
+  document to the workspace the URL does not name.
 - **A rename changes identity and nothing else.** The switcher's rename
   answers with the three identity layers, and the row it lands on also carries
   what the keeper counted — so the answer is MERGED into the row, never

--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -186,6 +186,44 @@ one it is not in yet, `spinner` that same ring while the doing is in flight.
   Each layer is written on its own, never as a form submitting both: an
   unchanged URL sent back would put every name edit behind the one write that
   can be refused for a collision.
+- **The document browser heads itself with the workspace name.** The other
+  half of the answer above, and the only place a sighted reader sees the name
+  at all — the shell states it in the mark's accessible name and draws it only
+  inside the popover. Both index pages carry it as a visible `h1`, and the
+  generic word did not disappear when it left that heading: it moved to the
+  panel's own region label (`role="region" aria-label="Documents"`), which is
+  where it was always true.
+
+  What it reads is `workspaceLabel` — display name, else segment, else id —
+  never a per-site re-derivation, because a site that re-derives ends up
+  knowing about fewer layers than there are. Before the row lands the heading
+  falls back to the handle the address carries, and past that to the generic
+  word: a document browser with no `h1` at all is a worse outcome than a
+  generic one.
+
+  **`createWorkspace` on a workspace that exists leaves it alone.** Not merely
+  "is not an error" — not an overwrite either. A blind `put` of the input let
+  the bare `{ workspaceId }` call an "ensure it exists" caller makes clear the
+  identity layers a rename had written. `IdbDocumentIndex` and the in-memory
+  double both did this; the daemon never did, because its identity lives in a
+  registry its `createWorkspace` does not touch.
+
+  **This was latent, not live, and the distinction is on the record because it
+  was first reported the other way round.** Reading the code found a real
+  contract violation, and a conformance mutation check confirmed the contract
+  was broken — neither says anything about REACHABILITY, and the consequence
+  narrated from them ("visiting the document list undoes a rename") turned out
+  to be false. An A/B of the built bundle before and after refuted it: the
+  segment survived on both. `FoldingBrowserIndex` routes `createWorkspace` to
+  the tree index and keeps the IndexedDB one only for `listWorkspaces`,
+  `renameWorkspace`, `listDocuments` and `deleteDocument`, so no caller reaches
+  the overwrite at all. It is still worth fixing — the row it would clobber is
+  the one `renameWorkspace` writes on that same store — but as debt, not as a
+  defect anyone hit.
+
+  Pinned for every implementation by the port's conformance suite, whose
+  earlier idempotency case re-created with the SAME layers and so could not
+  tell an overwriting implementation from a leaving-alone one.
 - **The shell states a connection only while a page holds one.** Pages report
   through `lib/shell-status-store`, and `null` — an index or settings page —
   leaves the mark stateless (no dot at all). A daemon index page does talk to the daemon over

--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -186,6 +186,33 @@ one it is not in yet, `spinner` that same ring while the doing is in flight.
   Each layer is written on its own, never as a form submitting both: an
   unchanged URL sent back would put every name edit behind the one write that
   can be refused for a collision.
+- **Each switcher row says how much is in that workspace.** A list of names
+  gives no reason to pick one; the count is what makes it readable. It reads
+  as part of the row rather than as a column, so a keeper that does not count
+  leaves no hole where a number would be.
+
+  **Absent is not zero, and the difference is the whole rule.** Zero says the
+  workspace is empty — the row a person most needs to recognise — while absent
+  says this keeper did not count. So the render is guarded on `undefined`,
+  never on falsiness, which would hide exactly the empty ones. Today the
+  daemon counts and the browser does not: documents live in the workspace
+  tree, and reading it from the shell would put loro-crdt behind a control
+  that renders on every page, which `browser-workspaces.ts` deliberately
+  avoids. That asymmetry is a keeper difference with a recorded cost, not an
+  oversight — and it is the reason the field is optional rather than
+  defaulted.
+
+  The count includes SHADOWED documents. A concurrent create can leave two
+  documents on one path and the listing shows both, one marked, precisely so
+  the convergent state is visible; a count that quietly omitted the marked one
+  would put back the disagreement the mark exists to prevent.
+
+  Measured before it was added, because the cost is invisible in the diff: the
+  tree index answers a document listing by OPENING each workspace's record, so
+  this turns one registry read into N. On the daemon store at 10 workspaces
+  holding 200 documents between them, 0.2ms became 5.8ms. The ratio says don't
+  and the figure says it does not matter, on a control a person opens by
+  clicking — which is why it was measured rather than argued.
 - **The document browser heads itself with the workspace name.** The other
   half of the answer above, and the only place a sighted reader sees the name
   at all — the shell states it in the mark's accessible name and draws it only

--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -186,6 +186,23 @@ one it is not in yet, `spinner` that same ring while the doing is in flight.
   Each layer is written on its own, never as a form submitting both: an
   unchanged URL sent back would put every name edit behind the one write that
   can be refused for a collision.
+- **The switcher is offered even when the address names no workspace.** A
+  daemon holding nothing serves `/`, and the switcher is the only place
+  creation lives — so requiring a handle before rendering it left a fresh
+  daemon with no way to make its first workspace. With no handle the menu has
+  no current row, which is already how it behaves for an address it cannot
+  resolve: the rename section sits behind a resolved row, so what is left is a
+  list and a create button, which is exactly what that state needs.
+
+  The empty-daemon copy moved with it. It used to say the write was someone
+  else's, and that was true while every create path addressed a
+  (workspace, path) pair the page could not name; `POST /api/workspaces`
+  retired the premise by minting the id itself.
+- **A rename changes identity and nothing else.** The switcher's rename
+  answers with the three identity layers, and the row it lands on also carries
+  what the keeper counted — so the answer is MERGED into the row, never
+  substituted for it. Replacing dropped the count until something else
+  happened to reload the list.
 - **Each switcher row says how much is in that workspace.** A list of names
   gives no reason to pick one; the count is what makes it readable. It reads
   as part of the row rather than as a column, so a keeper that does not count

--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -209,10 +209,17 @@ one it is not in yet, `spinner` that same ring while the doing is in flight.
 
   Measured before it was added, because the cost is invisible in the diff: the
   tree index answers a document listing by OPENING each workspace's record, so
-  this turns one registry read into N. On the daemon store at 10 workspaces
-  holding 200 documents between them, 0.2ms became 5.8ms. The ratio says don't
-  and the figure says it does not matter, on a control a person opens by
-  clicking — which is why it was measured rather than argued.
+  this turns one registry read into N. Against a live daemon holding 11
+  workspaces and 38 documents, the whole call is 4.2ms end-to-end over HTTP —
+  on a control a person opens by clicking.
+
+  The daemon counts the rows ONE AT A TIME, and that is not an oversight. The
+  obvious `Promise.all` opens N workspace records at once against the one
+  SQLite file, and on that same daemon it failed the entire listing with
+  `SQLITE_BUSY` — every row lost to contention the count itself introduced.
+  A/B against the running daemon: concurrent 500, sequential 200. No unit test
+  reaches it, because each gets a fresh database with nothing else touching it;
+  this is the class of defect only a real keeper with real data shows.
 - **The document browser heads itself with the workspace name.** The other
   half of the answer above, and the only place a sighted reader sees the name
   at all — the shell states it in the mark's accessible name and draws it only

--- a/apps/web/src/App.switcher-source-parity.test.ts
+++ b/apps/web/src/App.switcher-source-parity.test.ts
@@ -1,0 +1,66 @@
+// One switcher, two keepers — and the switcher decides what to OFFER by
+// asking whether its source carries the method. That is the mechanism behind
+// DESIGN.md's "never offer what the keeper cannot honour", and it is invisible
+// at the call site: a source missing `create` produces a menu with no create
+// entry and no error anywhere.
+//
+// Which is right while the keeper genuinely cannot honour it, and became WRONG
+// the moment the daemon published its write surface — with nothing to say so.
+// The daemon's source went months without `create` behind a comment explaining
+// why, and that comment stayed true only until the routes landed.
+//
+// So the two sources are pinned to offer the SAME set. A keeper that really
+// cannot honour something needs this test changed, which is the point: the
+// asymmetry becomes a decision on the record instead of a method somebody
+// forgot to add.
+//
+// Read at build time via `?raw` rather than at runtime, so this stays free of
+// `node:fs` — apps/web is browser-only (see web-app-boundary.test.ts).
+
+import { describe, expect, it } from 'vitest'
+import appSource from './App.tsx?raw'
+
+/**
+ * The `source: { ... }` literal that follows a declaration, as text.
+ *
+ * Deliberately textual, and deliberately dumb: the alternative is rendering
+ * App twice with a live daemon and a live registry, which tests a great deal
+ * besides the question asked here. An earlier version of this walked the
+ * literal and enumerated every key it found, which picked up tokens inside
+ * nested arrow bodies and needed a fix per false positive — a guard that has
+ * to be repaired whenever unrelated code moves is one somebody eventually
+ * deletes. Asking whether three NAMED methods are declared cannot drift that
+ * way.
+ */
+function sourceBlock(source: string, after: string): string {
+  const start = source.indexOf(after)
+  if (start < 0) return ''
+  const open = source.indexOf('source: {', start)
+  if (open < 0) return ''
+  let depth = 0
+  for (let i = open + 'source: '.length; i < source.length; i++) {
+    if (source[i] === '{') depth++
+    else if (source[i] === '}') {
+      depth--
+      if (depth === 0) return source.slice(open, i + 1)
+    }
+  }
+  return ''
+}
+
+const OFFERED = ['list', 'create', 'rename'] as const
+
+describe('both keepers offer the same switcher affordances', () => {
+  it.each([
+    ['daemon', 'const daemonWorkspaces'],
+    ['browser', 'const browserWorkspaces'],
+  ])('%s declares list, create and rename', (_keeper, declaration) => {
+    const block = sourceBlock(appSource, declaration)
+    // A scan that found nothing would make every assertion below vacuous, and
+    // would read as agreement rather than as a scan that missed.
+    expect(block.length).toBeGreaterThan(100)
+    for (const method of OFFERED) {
+      expect(block).toContain(`${method}:`)
+    }
+  })
+})

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -409,11 +409,10 @@ export function App({ providerState }: AppProps) {
   // branch is talking to. Dynamic import for the same reason the browser's
   // is: the shell is lazy, App is not.
   //
-  // No `create`: the daemon publishes `GET /api/workspaces` and nothing that
-  // writes one, so the switcher offers no creation there. DESIGN.md's
-  // standing rule — never offer what the keeper cannot honour — and absent
-  // rather than disabled, because a disabled control says "not right now"
-  // about something that is not there at all.
+  // Creation and renaming are offered here now that the daemon publishes a
+  // write surface for workspaces. DESIGN.md's standing rule is what decided
+  // that both ways round: they were ABSENT — not disabled — while the keeper
+  // could not honour them, and they appear the moment it can.
   //
   // Switching is an in-app navigation, unlike the browser's: this keeper has
   // no synchronous singleton to re-point, so setting the view is enough. The
@@ -432,6 +431,27 @@ export function App({ providerState }: AppProps) {
                       daemonShellTarget.baseUrl,
                     )
                     .then((res) => res.workspaces),
+                ),
+              // Both halves are present now that the daemon publishes a write
+              // surface. They take the same arguments as the browser's, which
+              // is the point: the switcher asks its source, and the source is
+              // the only thing that knows which keeper answered.
+              create: (displayName: string) =>
+                import('./lib/daemon-api-client.js').then((m) =>
+                  m.createWorkspace(
+                    m.createDaemonFetch(daemonShellTarget.baseUrl, daemonShellTarget.token),
+                    daemonShellTarget.baseUrl,
+                    displayName,
+                  ),
+                ),
+              rename: (workspaceId: string, input: Omit<RenameWorkspaceInput, 'workspaceId'>) =>
+                import('./lib/daemon-api-client.js').then((m) =>
+                  m.renameWorkspace(
+                    m.createDaemonFetch(daemonShellTarget.baseUrl, daemonShellTarget.token),
+                    daemonShellTarget.baseUrl,
+                    workspaceId,
+                    input,
+                  ),
                 ),
             },
             onSwitch: (workspace: string) => setDaemonView({ kind: 'index', workspace }),

--- a/apps/web/src/components/AppShell.test.tsx
+++ b/apps/web/src/components/AppShell.test.tsx
@@ -115,6 +115,65 @@ describe('AppShell', () => {
     expect(screen.getByRole('menuitem', { name: /notes/i })).toBeTruthy()
   })
 
+  it('still offers creation when the address names no workspace, which is the empty daemon', async () => {
+    // A daemon holding nothing serves `/`, so the address carries no handle.
+    // The switcher is the ONLY place creation is offered, so hiding it there
+    // left a fresh daemon with no way to make its first workspace — while
+    // this increment's whole point is that the keeper can now honour one.
+    const create = vi.fn(() =>
+      Promise.resolve({ workspaceId: '01BX5ZZKBKACTAV9WEVGEMMVRZ', segment: 'first' }),
+    )
+    renderShell(true, '/', undefined, {
+      source: { list: () => Promise.resolve([]), create },
+      onSwitch: () => {},
+    })
+
+    fireEvent.click(await screen.findByTestId('shell-mark-trigger'))
+    expect(await screen.findByRole('menuitem', { name: /new workspace/i })).toBeTruthy()
+  })
+
+  it('keeps a row document count through a rename, which only changes identity', async () => {
+    // `onRenamed` is handed a WorkspaceEntry — the three identity layers and
+    // nothing else — while the row it replaces is a WorkspaceRow carrying the
+    // count this increment added. Replacing rather than merging dropped the
+    // count until the shell happened to reload the list.
+    const rename = vi.fn(() =>
+      Promise.resolve({
+        workspaceId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        segment: 'default',
+        displayName: 'Renamed team',
+      }),
+    )
+    renderShell(true, '/w/default', undefined, {
+      source: {
+        list: () =>
+          Promise.resolve([
+            {
+              workspaceId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+              segment: 'default',
+              displayName: 'Design team',
+              documentCount: 7,
+            },
+          ]),
+        rename,
+      },
+      onSwitch: () => {},
+    })
+
+    fireEvent.click(await screen.findByTestId('shell-mark-trigger'))
+    const row = await screen.findByRole('menuitem', { name: /design team/i })
+    expect(row.textContent).toContain('7')
+
+    const nameField = await screen.findByLabelText(/^workspace name$/i)
+    fireEvent.change(nameField, { target: { value: 'Renamed team' } })
+    fireEvent.blur(nameField)
+
+    await waitFor(() => expect(rename).toHaveBeenCalled())
+    await waitFor(() =>
+      expect(screen.getByRole('menuitem', { name: /renamed team/i }).textContent).toContain('7'),
+    )
+  })
+
   it('switches from the mark popover by handle, and closes it', async () => {
     const onSwitch = vi.fn()
     renderShell(true, '/w/default', undefined, { ...WORKSPACES, onSwitch })

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -1,4 +1,3 @@
-import type { WorkspaceEntry } from '@kamiazya/whiteboard-ports'
 import { Settings } from 'lucide-react'
 import { lazy, Suspense, useEffect, useState, useSyncExternalStore } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
@@ -10,7 +9,11 @@ import { getShellConnection, subscribeShellStatus } from '@/lib/shell-status-sto
 import { createUserSettingsStore } from '@/lib/user-settings-store'
 import { workspaceHandle, workspaceLabel } from '@/lib/workspace-handle'
 import { ConnectionStatus, connectionLabel, isSyncOff } from './connection/ConnectionStatus.js'
-import { WorkspaceMenu, type WorkspaceSwitcherSource } from './shell/WorkspaceMenu.js'
+import {
+  WorkspaceMenu,
+  type WorkspaceRow,
+  type WorkspaceSwitcherSource,
+} from './shell/WorkspaceMenu.js'
 
 // React.lazy for the same reason the browser page had it: the banner
 // pulls in daemon-probe.ts and its Zod parsing, and only the Local popover
@@ -116,7 +119,7 @@ export function AppShell({ daemon, onWorkInBrowser, workspaces }: AppShellProps)
   // The rows live HERE rather than in the menu, because the popover's head
   // names the current workspace and the head is the shell's. One fetch, two
   // readers.
-  const [rows, setRows] = useState<readonly WorkspaceEntry[]>([])
+  const [rows, setRows] = useState<readonly WorkspaceRow[]>([])
   const source = workspaces?.source
   useEffect(() => {
     if (source === undefined) return

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -164,16 +164,31 @@ export function AppShell({ daemon, onWorkInBrowser, workspaces }: AppShellProps)
         daemonBaseUrl={daemonBaseUrl}
         {...(activeName === undefined ? {} : { workspaceName: activeName })}
         workspaceMenu={
-          workspaces && workspaceHandleInAddress !== null ? (
+          // Rendered whenever a keeper published a switcher, INCLUDING when
+          // the address names no workspace. A daemon holding nothing serves
+          // `/`, and this menu is the only place creation is offered — so
+          // requiring a handle here left a fresh daemon with no way to make
+          // its first workspace, which is the one thing this increment set out
+          // to make possible. With no handle the menu simply has no current
+          // row: the rename section is already behind `active !== undefined`,
+          // so it degrades to a list and a create button on its own.
+          workspaces ? (
             <WorkspaceMenu
               current={workspaceHandleInAddress}
               workspaces={rows}
               source={workspaces.source}
               onSwitch={workspaces.onSwitch}
               sessionLabel={connectionLabel(connection?.state ?? null)}
+              // MERGED, not replaced. A rename answers with a WorkspaceEntry —
+              // the three identity layers and nothing else — while the row it
+              // lands on is a WorkspaceRow that also carries what the keeper
+              // counted. Replacing dropped that count until something else
+              // reloaded the list.
               onRenamed={(entry) =>
                 setRows((current) =>
-                  current.map((row) => (row.workspaceId === entry.workspaceId ? entry : row)),
+                  current.map((row) =>
+                    row.workspaceId === entry.workspaceId ? { ...row, ...entry } : row,
+                  ),
                 )
               }
             />

--- a/apps/web/src/components/shell/WorkspaceMenu.test.tsx
+++ b/apps/web/src/components/shell/WorkspaceMenu.test.tsx
@@ -9,7 +9,7 @@
 import type { WorkspaceEntry } from '@kamiazya/whiteboard-ports'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { WorkspaceMenu, type WorkspaceSwitcherSource } from './WorkspaceMenu.js'
+import { WorkspaceMenu, type WorkspaceRow, type WorkspaceSwitcherSource } from './WorkspaceMenu.js'
 
 const DESIGN = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
 const NOTES = '01BX5ZZKBKACTAV9WEVGEMMVRZ'
@@ -17,7 +17,7 @@ const NOTES = '01BX5ZZKBKACTAV9WEVGEMMVRZ'
 const listOnly: WorkspaceSwitcherSource = { list: () => Promise.resolve([]) }
 
 function renderMenu(
-  workspaces: WorkspaceEntry[],
+  workspaces: WorkspaceRow[],
   source: Partial<WorkspaceSwitcherSource> = {},
   {
     onSwitch = vi.fn(),
@@ -331,5 +331,37 @@ describe('WorkspaceMenu — naming, in place', () => {
   it('states nothing to edit until the rows say which workspace the address names', () => {
     renderMenu([], { rename: () => Promise.reject(new Error('not expected')) })
     expect(screen.queryByLabelText(/workspace name/i)).toBeNull()
+  })
+})
+
+describe('WorkspaceMenu — how much is in each workspace', () => {
+  it('puts the count on the row, so a list of names becomes a reason to pick one', () => {
+    renderMenu([
+      { workspaceId: DESIGN, segment: 'design', displayName: 'Design team', documentCount: 12 },
+      { workspaceId: NOTES, segment: 'notes', displayName: 'Notes', documentCount: 3 },
+    ])
+
+    expect(screen.getByRole('menuitem', { name: /design team/i }).textContent).toContain('12')
+    expect(screen.getByRole('menuitem', { name: /notes/i }).textContent).toContain('3')
+  })
+
+  it('shows a count of zero, which is the row a person most needs to recognise', () => {
+    // Guarded on `undefined`, not on falsiness: a truthiness check would hide
+    // every empty workspace, which is exactly the one whose emptiness is the
+    // useful fact.
+    renderMenu([
+      { workspaceId: DESIGN, segment: 'design', displayName: 'Design team', documentCount: 0 },
+    ])
+    expect(screen.getByRole('menuitem', { name: /design team/i }).textContent).toContain('0')
+  })
+
+  it('leaves the row alone when the keeper did not count', () => {
+    // Absent is not zero. The browser keeper counts nothing today — documents
+    // live in the workspace tree, and reading it would put loro-crdt behind a
+    // control the shell renders — so its rows must read as a plain name, not
+    // as an empty workspace.
+    renderMenu([{ workspaceId: DESIGN, segment: 'design', displayName: 'Design team' }])
+    const row = screen.getByRole('menuitem', { name: /design team/i })
+    expect(row.textContent).not.toMatch(/\d/)
   })
 })

--- a/apps/web/src/components/shell/WorkspaceMenu.tsx
+++ b/apps/web/src/components/shell/WorkspaceMenu.tsx
@@ -23,8 +23,20 @@ import { workspaceHandle, workspaceLabel } from '@/lib/workspace-handle'
  * read in an effect keyed on this object, so a fresh one per render is a
  * fetch per render.
  */
+/**
+ * A workspace as the switcher needs it: its identity, plus how much is in it.
+ *
+ * `documentCount` is optional and absent is NOT zero — zero says the
+ * workspace is empty, which is exactly the row a person needs to recognise,
+ * while absent says this keeper did not count. The browser keeper is the
+ * absent case today: documents live in the workspace tree, so counting them
+ * means loading loro-crdt behind a control that renders in the app shell,
+ * which `browser-workspaces.ts` deliberately avoids.
+ */
+export type WorkspaceRow = WorkspaceEntry & { readonly documentCount?: number }
+
 export interface WorkspaceSwitcherSource {
-  list(): Promise<readonly WorkspaceEntry[]>
+  list(): Promise<readonly WorkspaceRow[]>
   /**
    * Answers the workspace that was created — including the handle it was
    * actually given.
@@ -56,7 +68,7 @@ export interface WorkspaceMenuProps {
   /** The handle the address currently carries. */
   readonly current: string
   /** The rows, loaded by the shell so its head can name the current one. */
-  readonly workspaces: readonly WorkspaceEntry[]
+  readonly workspaces: readonly WorkspaceRow[]
   readonly source: WorkspaceSwitcherSource
   readonly onSwitch: (handle: string) => void
   /** Replaces a row in the shell's copy after a rename answers. */
@@ -318,6 +330,17 @@ export function WorkspaceMenu({
                 {isCurrent ? '\u2713' : ''}
               </span>
               <span className="truncate">{workspaceLabel(w)}</span>
+              {/* Reads as part of the row's own sentence rather than as a
+                  separate column, so a keeper that does not count leaves no
+                  hole where a number would be. `0` is rendered like any other
+                  count — the check is against undefined, not against
+                  falsiness, which would silently hide every empty
+                  workspace. */}
+              {w.documentCount !== undefined && (
+                <span className="ml-auto shrink-0 pl-2 text-xs font-normal text-muted-foreground tabular-nums">
+                  {w.documentCount}
+                </span>
+              )}
             </button>
           )
         })}

--- a/apps/web/src/components/shell/WorkspaceMenu.tsx
+++ b/apps/web/src/components/shell/WorkspaceMenu.tsx
@@ -65,8 +65,13 @@ export interface WorkspaceSwitcherSource {
 }
 
 export interface WorkspaceMenuProps {
-  /** The handle the address currently carries. */
-  readonly current: string
+  /**
+   * The handle the address currently carries, or `null` when it carries none
+   * — a daemon holding no workspaces yet serves `/`. With no current handle
+   * no row is marked and the rename section does not render, which is right:
+   * there is nothing to rename, and creation is what the reader needs.
+   */
+  readonly current: string | null
   /** The rows, loaded by the shell so its head can name the current one. */
   readonly workspaces: readonly WorkspaceRow[]
   readonly source: WorkspaceSwitcherSource

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -677,8 +677,14 @@ export function WorkspaceFilesPanel({
         ]
 
   return (
+    // The panel names ITSELF, because the page heading above it now names the
+    // workspace ("Mark as Switcher"). The generic word did not disappear when
+    // it left the h1 — it moved to the region that actually holds the list,
+    // which is where it was always true.
     <div
       ref={rootRef}
+      role="region"
+      aria-label="Documents"
       className="relative flex min-h-0 flex-1 flex-col gap-2"
       data-testid="workspace-files-panel"
     >

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -681,9 +681,8 @@ export function WorkspaceFilesPanel({
     // workspace ("Mark as Switcher"). The generic word did not disappear when
     // it left the h1 — it moved to the region that actually holds the list,
     // which is where it was always true.
-    <div
+    <section
       ref={rootRef}
-      role="region"
       aria-label="Documents"
       className="relative flex min-h-0 flex-1 flex-col gap-2"
       data-testid="workspace-files-panel"
@@ -956,6 +955,6 @@ export function WorkspaceFilesPanel({
           onClose={() => setCardMenu(null)}
         />
       )}
-    </div>
+    </section>
   )
 }

--- a/apps/web/src/lib/create-browser-workspace.ts
+++ b/apps/web/src/lib/create-browser-workspace.ts
@@ -13,32 +13,15 @@
  * address it derives has to be unique — within this browser, since the
  * registry is IndexedDB and cannot collide with anyone else's.
  */
-import { generateDocumentId, workspaceSegmentSchema } from '@kamiazya/whiteboard-model'
+import {
+  deriveWorkspaceSegment,
+  generateDocumentId,
+  workspaceSegmentSchema,
+} from '@kamiazya/whiteboard-model'
 import type { DocumentIndex, WorkspaceEntry } from '@kamiazya/whiteboard-ports'
 
 export interface CreateBrowserWorkspaceInput {
   readonly displayName: string
-}
-
-/**
- * The segment a display name yields, or `undefined` when it yields none.
- *
- * Absent is a real answer, not a failure to try. A name written in a script
- * the segment charset cannot spell produces nothing, and ADR-0019 already
- * settled what to do about that: 0019's migration left a legacy segment NULL
- * rather than writing a mangled approximation, and a workspace with no
- * segment is addressed by its canonical id — which is the whole point of
- * keeping that layer resolvable. An invented `workspace-2` would be a name
- * nobody chose, sitting in the URL for as long as the workspace lives.
- *
- * Rename is where such a workspace gets an address it likes.
- */
-function deriveSegment(displayName: string): string | undefined {
-  const candidate = displayName
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-  return workspaceSegmentSchema.safeParse(candidate).success ? candidate : undefined
 }
 
 /**
@@ -62,7 +45,7 @@ export async function createBrowserWorkspace(
   if (name === '') throw new Error('a workspace needs a name')
 
   const workspaceId = generateDocumentId()
-  const base = deriveSegment(name)
+  const base = deriveWorkspaceSegment(name)
   const segment = base === undefined ? undefined : await firstFreeSegment(index, base)
 
   const entry: WorkspaceEntry = {

--- a/apps/web/src/lib/daemon-api-client.test.ts
+++ b/apps/web/src/lib/daemon-api-client.test.ts
@@ -2,11 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createDaemonFetch,
   createDocument,
+  createWorkspace,
   deleteDocument,
   getDocumentSnapshot,
   listDocuments,
   listWorkspaces,
   renameDocumentPath,
+  renameWorkspace,
   setDocumentDisplayName,
   updateDocument,
 } from './daemon-api-client.js'
@@ -325,5 +327,72 @@ describe('renameDocumentPath', () => {
     await expect(
       renameDocumentPath(fetchFn, DAEMON_BASE_URL, 'w1', 'design/notes', 'archive/notes'),
     ).rejects.toMatchObject({ status: 409, message: 'Path "archive/notes/a" already exists' })
+  })
+})
+
+describe('createWorkspace', () => {
+  it('POSTs the display name and nothing else, and parses what came back', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({ workspaceId: 'w1', segment: 'marketing', displayName: 'Marketing' }, 201),
+      )
+    const result = await createWorkspace(fetchFn, DAEMON_BASE_URL, 'Marketing')
+
+    expect(result).toEqual({ workspaceId: 'w1', segment: 'marketing', displayName: 'Marketing' })
+    const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${DAEMON_BASE_URL}/api/workspaces`)
+    expect(init.method).toBe('POST')
+    // The other two of ADR-0019's layers are the server's to decide. Sending
+    // either would be this client claiming an identity it does not own.
+    expect(JSON.parse(String(init.body))).toEqual({ displayName: 'Marketing' })
+  })
+
+  it('rejects a malformed response body without returning raw JSON', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ nope: true }, 201))
+    await expect(createWorkspace(fetchFn, DAEMON_BASE_URL, 'X')).rejects.toThrow(/validation/i)
+  })
+
+  it('surfaces the daemon reason for a refused segment', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ title: 'Segment "taken" is already in use' }, 409))
+    await expect(createWorkspace(fetchFn, DAEMON_BASE_URL, 'Taken')).rejects.toThrow(
+      /already in use/i,
+    )
+  })
+})
+
+describe('renameWorkspace', () => {
+  it('PATCHes only the layers it was given, so an omitted one stays untouched', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ workspaceId: 'w1', segment: 'kept', displayName: 'New' }))
+    const result = await renameWorkspace(fetchFn, DAEMON_BASE_URL, 'w1', { displayName: 'New' })
+
+    expect(result.segment).toBe('kept')
+    const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`${DAEMON_BASE_URL}/api/workspaces/w1`)
+    expect(init.method).toBe('PATCH')
+    // Absent, not null: the port reads an absent field as "leave this layer
+    // alone", and a null would be a different request entirely.
+    expect(JSON.parse(String(init.body))).toEqual({ displayName: 'New' })
+  })
+
+  it('addresses the workspace by whatever handle it was given', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ workspaceId: 'w1', segment: 'by-segment' }))
+    await renameWorkspace(fetchFn, DAEMON_BASE_URL, 'by segment', { segment: 'moved' })
+    expect(fetchFn.mock.calls[0]?.[0]).toBe(`${DAEMON_BASE_URL}/api/workspaces/by%20segment`)
+  })
+
+  it('surfaces the daemon reason for a refused rename', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ title: 'Segment "taken" is already in use' }, 409))
+    await expect(
+      renameWorkspace(fetchFn, DAEMON_BASE_URL, 'w1', { segment: 'taken' }),
+    ).rejects.toThrow(/already in use/i)
   })
 })

--- a/apps/web/src/lib/daemon-api-client.ts
+++ b/apps/web/src/lib/daemon-api-client.ts
@@ -27,6 +27,7 @@ import {
   listWorkspacesResponseSchema,
   type RenameDocumentPathRequest,
   type RenameDocumentPathResponse,
+  type RenameWorkspaceRequest,
   type RestoreTrashResponse,
   renameDocumentPathResponseSchema,
   restoreTrashResponseSchema,
@@ -36,8 +37,10 @@ import {
   updateDocumentResponseSchema,
   type WorkspaceDocumentTagsResponse,
   type WorkspaceNames,
+  type WorkspaceSummary,
   workspaceDocumentTagsResponseSchema,
   workspaceNamesSchema,
+  workspaceSummarySchema,
 } from '@kamiazya/whiteboard-mcp/api-contracts'
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import type { z } from 'zod'
@@ -93,6 +96,52 @@ export function listWorkspaces(
   daemonBaseUrl: string,
 ): Promise<ListWorkspacesResponse> {
   return fetchAndParse(fetchFn, `${daemonBaseUrl}/api/workspaces`, listWorkspacesResponseSchema)
+}
+
+/**
+ * Create a workspace the daemon keeps.
+ *
+ * Takes a DISPLAY NAME and nothing else, because the other two of ADR-0019's
+ * layers are the server's: it mints the canonical id and derives the segment.
+ * That is what lets one switcher control call `create(displayName)` without
+ * knowing which keeper is answering.
+ */
+export function createWorkspace(
+  fetchFn: typeof globalThis.fetch,
+  daemonBaseUrl: string,
+  displayName: string,
+): Promise<WorkspaceSummary> {
+  return fetchAndParse(fetchFn, `${daemonBaseUrl}/api/workspaces`, workspaceSummarySchema, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ displayName }),
+  })
+}
+
+/**
+ * Rename the two layers a workspace's owner chooses.
+ *
+ * PATCH, and a field left out is left ALONE — never cleared. The caller passes
+ * only what it is changing, which is why the switcher can write the name and
+ * the address independently instead of submitting one form that would put
+ * every name edit behind the write that can be refused for a collision.
+ */
+export function renameWorkspace(
+  fetchFn: typeof globalThis.fetch,
+  daemonBaseUrl: string,
+  handle: string,
+  input: RenameWorkspaceRequest,
+): Promise<WorkspaceSummary> {
+  return fetchAndParse(
+    fetchFn,
+    `${daemonBaseUrl}/api/workspaces/${encodeURIComponent(handle)}`,
+    workspaceSummarySchema,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    },
+  )
 }
 
 export function listDocuments(

--- a/apps/web/src/lib/idb-document-index.ts
+++ b/apps/web/src/lib/idb-document-index.ts
@@ -93,9 +93,24 @@ export class IdbDocumentIndex implements DocumentIndex {
     displayName,
   }: CreateWorkspaceInput): Promise<void> {
     await this.tx([WORKSPACES_STORE], 'readwrite', async (tx) => {
-      // put, not add: creating one that exists is explicitly not an error.
+      const store = tx.objectStore(WORKSPACES_STORE)
+      // Creating one that exists is not an error — and not an overwrite. A
+      // blind `put` of the input let the bare `{ workspaceId }` call clear
+      // whatever identity layers the row already carried.
+      //
+      // No caller reaches that today: `FoldingBrowserIndex` routes
+      // `createWorkspace` to the tree index and keeps this one for
+      // `listWorkspaces`/`renameWorkspace`/`listDocuments`/`deleteDocument`
+      // only. It is fixed because the row it would clobber is the one
+      // `renameWorkspace` — right below, on this same store — writes, so the
+      // two halves of one registry sat one call apart from disagreeing.
+      //
+      // Read and return inside the SAME transaction, so the check and the
+      // write cannot be split by a concurrent create.
+      const existing = await request(store.get(workspaceId))
+      if (existing !== undefined) return
       await request(
-        tx.objectStore(WORKSPACES_STORE).put(
+        store.put(
           {
             workspaceId,
             ...(segment === undefined ? {} : { segment }),

--- a/apps/web/src/pages/BrowserIndexPage.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.test.tsx
@@ -474,6 +474,75 @@ describe('the workspace names the page', () => {
     expect(screen.getByRole('region', { name: 'Documents' })).toBeTruthy()
   })
 
+  it('drops the previous name on a switch, even when the new lookup does not answer', async () => {
+    // The heading is a projection of a workspace, so it has to move WITH the
+    // workspace. The name lookup is deliberately its own chain — a name that
+    // will not load must not surface as "Failed to load documents" — and its
+    // `.catch` swallowed the failure without clearing what was on screen. The
+    // result is the worst reading available: the new workspace, under the old
+    // workspace's name, indefinitely and with nothing saying so.
+    const store = await seededStore([
+      {
+        documentId: '0CFJNRVY147ADGKPSWZ258BEHM',
+        workspaceId: getBrowserWorkspaceId(),
+        path: 'alpha',
+        name: 'Alpha',
+        updatedAt: '2026-08-01T00:00:00Z',
+        kind: 'spatial',
+      },
+    ])
+    await store.index.renameWorkspace({
+      workspaceId: getBrowserWorkspaceId(),
+      segment: 'studio',
+      displayName: 'Studio',
+    })
+
+    // Answers the first read and fails every one after it: the name has to be
+    // ON screen before a stale one can be the defect.
+    let reads = 0
+    const flakyIndex = new Proxy(store.index, {
+      get(target, prop, receiver) {
+        if (prop === 'resolveWorkspace') {
+          return (input: Parameters<typeof store.index.resolveWorkspace>[0]) => {
+            reads += 1
+            return reads === 1
+              ? store.index.resolveWorkspace(input)
+              : Promise.reject(new Error('index read failed'))
+          }
+        }
+        const value = Reflect.get(target, prop, receiver)
+        return typeof value === 'function' ? value.bind(target) : value
+      },
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <BrowserIndexPage
+          index={flakyIndex}
+          loro={store.loro}
+          pointer={store.pointer}
+          clock={store.clock}
+          onOpenDocument={vi.fn()}
+        />
+      </MemoryRouter>,
+      { container: document.body },
+    )
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Studio'),
+    )
+
+    await act(async () => {
+      setBrowserWorkspaceIdForTests('0DGKPSWZ258BEHM1CFJNRVY147', 'other-space')
+    })
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { level: 1 }).textContent).not.toBe('Studio'),
+    )
+    // Not merely "not Studio": the handle is what the address carries, and it
+    // is true about the workspace now on screen.
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('other-space')
+  })
+
   it('falls back through the identity layers rather than showing a raw id', async () => {
     const store = await seededStore([
       {

--- a/apps/web/src/pages/BrowserIndexPage.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.test.tsx
@@ -444,3 +444,55 @@ describe('BrowserIndexPage', () => {
     expect((await screen.findByTestId('okf-preview')).textContent).toContain('diagrams/structure')
   })
 })
+
+// The other keeper, same rule. "Mark as Switcher": the shell does not name the
+// workspace — the document browser does, as its own heading.
+describe('the workspace names the page', () => {
+  it('heads the page with the workspace name, and keeps Documents as the list label', async () => {
+    const store = await seededStore([
+      {
+        documentId: '0CFJNRVY147ADGKPSWZ258BEHM',
+        workspaceId: getBrowserWorkspaceId(),
+        path: 'alpha',
+        name: 'Alpha',
+        updatedAt: '2026-08-01T00:00:00Z',
+        kind: 'spatial',
+      },
+    ])
+    await store.index.renameWorkspace({
+      workspaceId: getBrowserWorkspaceId(),
+      segment: 'studio',
+      displayName: 'Studio',
+    })
+
+    renderPage(store)
+    await screen.findByText('Alpha')
+
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(heading.textContent).toBe('Studio')
+    expect(heading.className).not.toContain('sr-only')
+    expect(screen.getByRole('region', { name: 'Documents' })).toBeTruthy()
+  })
+
+  it('falls back through the identity layers rather than showing a raw id', async () => {
+    const store = await seededStore([
+      {
+        documentId: '0CFJNRVY147ADGKPSWZ258BEHM',
+        workspaceId: getBrowserWorkspaceId(),
+        path: 'alpha',
+        name: 'Alpha',
+        updatedAt: '2026-08-01T00:00:00Z',
+        kind: 'spatial',
+      },
+    ])
+    await store.index.renameWorkspace({
+      workspaceId: getBrowserWorkspaceId(),
+      segment: 'studio',
+    })
+
+    renderPage(store)
+    await screen.findByText('Alpha')
+
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('studio')
+  })
+})

--- a/apps/web/src/pages/BrowserIndexPage.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.tsx
@@ -21,9 +21,9 @@ import {
   listLocalDocuments,
 } from '../lib/local-document-summary.js'
 import { createLocalFilesSource } from '../lib/local-files-source.js'
-import { workspaceLabel } from '../lib/workspace-handle.js'
 import { LoroStore } from '../lib/loro-store.js'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
+import { workspaceLabel } from '../lib/workspace-handle.js'
 import { createSeededDocument, type LoroStoreLike } from './use-browser-document-controller.js'
 
 export interface BrowserIndexPageProps {

--- a/apps/web/src/pages/BrowserIndexPage.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.tsx
@@ -102,6 +102,14 @@ export function BrowserIndexPage({
 
   useEffect(() => {
     let cancelled = false
+    // Cleared BEFORE the lookup, not merely overwritten after it. On a switch
+    // this state still holds the workspace the person just left, and the
+    // `.catch` below deliberately swallows a failed read — so without this the
+    // new workspace renders under the old one's name, indefinitely and with
+    // nothing saying so. Dropping to the handle fallback for the round trip is
+    // the right trade: the handle is what the address already carries, and it
+    // is true about the workspace on screen.
+    setWorkspaceName(null)
     // Its own chain, deliberately not folded into the documents load below: a
     // name that will not load leaves the heading on the handle, which is still
     // true, and must not surface as "Failed to load documents from this

--- a/apps/web/src/pages/BrowserIndexPage.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.tsx
@@ -21,6 +21,7 @@ import {
   listLocalDocuments,
 } from '../lib/local-document-summary.js'
 import { createLocalFilesSource } from '../lib/local-files-source.js'
+import { workspaceLabel } from '../lib/workspace-handle.js'
 import { LoroStore } from '../lib/loro-store.js'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
 import { createSeededDocument, type LoroStoreLike } from './use-browser-document-controller.js'
@@ -94,8 +95,23 @@ export function BrowserIndexPage({
     browserWorkspaceIdentitySnapshot,
   )
 
+  // What this page calls itself. The identity the accessor publishes carries
+  // no display name (it is the ADDRESSING half), so the row has to be read —
+  // in the same effect, which already re-runs on a switch.
+  const [workspaceName, setWorkspaceName] = useState<string | null>(null)
+
   useEffect(() => {
     let cancelled = false
+    // Its own chain, deliberately not folded into the documents load below: a
+    // name that will not load leaves the heading on the handle, which is still
+    // true, and must not surface as "Failed to load documents from this
+    // browser."
+    Promise.resolve()
+      .then(() => index.resolveWorkspace(getBrowserWorkspaceId()))
+      .then((row) => {
+        if (!cancelled) setWorkspaceName(row === null ? null : workspaceLabel(row))
+      })
+      .catch(() => undefined)
     // On a device that has never created a document there is no workspace to
     // list, and the port answers that with an error rather than an empty
     // list. Ensuring it here is what makes a first visit render the empty
@@ -201,7 +217,12 @@ export function BrowserIndexPage({
 
   return (
     <div className="flex h-full flex-col overflow-y-auto p-4">
-      <h1 className="sr-only">Documents</h1>
+      {/* The generic word moved to the panel's own region label. Before the
+          row lands the segment is what the address carries, and the last
+          fallback keeps the page from ever having no h1 at all. */}
+      <h1 className="mb-3 truncate text-lg font-semibold">
+        {workspaceName ?? activeWorkspace?.segment ?? 'Documents'}
+      </h1>
       {error && (
         <div role="alert" className="mb-2 text-sm text-destructive">
           {error}

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -97,6 +97,10 @@ interface MockRoutes {
    *  default. Consulted per call, so a test can answer 404 once and then
    *  behave normally — a workspace deleted out from under the page. */
   onListDocuments?: (workspaceId: string) => Response | undefined
+  /** Override the workspaces GET. Return undefined to fall through to the
+   *  default. Consulted per call, so a test can answer 500 only on the
+   *  re-list a switch triggers. */
+  onListWorkspaces?: () => Response | undefined
   /** Rows the trash GET answers with; defaults to an empty trash. */
   trashByWorkspace?: Record<string, Array<{ documentId: string; path: string; deletedAt: number }>>
 }
@@ -105,6 +109,8 @@ function installFetchMock(routes: MockRoutes) {
   const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === 'string' ? input : input.toString()
     if (url.endsWith('/api/workspaces') && (!init || init.method === undefined)) {
+      const override = routes.onListWorkspaces?.()
+      if (override) return Promise.resolve(override)
       const respond = () => jsonResponse({ workspaces: routes.workspaces })
       // Held open so a test can inspect what renders WHILE the re-list is in
       // flight — the window in which a deleted workspace is still selected.
@@ -534,6 +540,55 @@ describe('DaemonIndexPage', () => {
     expect(await screen.findByText('freshly-made')).toBeTruthy()
     expect(screen.queryByText('alpha')).toBeNull()
     expect(onWorkspaceResolved).not.toHaveBeenCalledWith('ws-a')
+  })
+
+  it('does not leave the old workspace usable when the re-list for a new one fails', async () => {
+    // The refetch above is a second chance, not a guarantee. When it fails the
+    // page still holds the PREVIOUS workspace selected while the address names
+    // the new one — and a create from that state posts the document to the
+    // workspace the URL does not name. The same mismatch the stale-address
+    // branch below already refuses to leave behind.
+    let workspaceCalls = 0
+    const routes = {
+      workspaces: [{ workspaceId: 'ws-a' }] as Array<{ workspaceId: string; segment?: string }>,
+      documentsByWorkspace: {
+        'ws-a': [{ path: 'alpha', updatedAt: new Date().toISOString() }],
+      },
+      onListWorkspaces: () => {
+        workspaceCalls += 1
+        // The first load settles the page; the re-list a switch triggers fails.
+        return workspaceCalls === 1 ? undefined : jsonResponse({ message: 'nope' }, 500)
+      },
+    }
+    installFetchMock(routes)
+    const onOpenDocument = vi.fn()
+    const { rerender } = render(
+      <DaemonIndexPage
+        daemonBaseUrl={DAEMON_BASE_URL}
+        workspace="ws-a"
+        onOpenDocument={onOpenDocument}
+      />,
+    )
+    expect(await screen.findByText('alpha')).toBeTruthy()
+
+    rerender(
+      <MemoryRouter initialEntries={['/']}>
+        <DaemonIndexPage
+          daemonBaseUrl={DAEMON_BASE_URL}
+          workspace="ws-new"
+          onOpenDocument={onOpenDocument}
+        />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy())
+    // The error state offers `Create a canvas` only while a workspace is still
+    // SELECTED, and that selection would be the one the address just left. So
+    // the affordance itself is the evidence: a create here posts the document
+    // to `ws-a` under an address naming `ws-new`.
+    expect(screen.queryByRole('button', { name: /create a canvas/i })).toBeNull()
+    expect(screen.getByRole('button', { name: /try again/i })).toBeTruthy()
+    expect(screen.queryByText('alpha')).toBeNull()
   })
 
   it('follows a segment the workspace was renamed to a moment ago', async () => {

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -490,6 +490,102 @@ describe('DaemonIndexPage', () => {
     expect(screen.getByText('alpha')).toBeTruthy()
   })
 
+  it('finds a workspace created since its list was read, instead of falling back off it', async () => {
+    // The switcher is the SHELL's, and it writes through its own source. This
+    // page's `workspaces` is a snapshot taken before that write, so a freshly
+    // created workspace is ABSENT from it — and a handle the list does not
+    // hold used to mean one thing only: a stale bookmark, fall back to
+    // first-listed. So creating a workspace from the switcher landed on a
+    // different workspace and rewrote the address to name it.
+    const routes = {
+      workspaces: [{ workspaceId: 'ws-a' }] as Array<{ workspaceId: string; segment?: string }>,
+      documentsByWorkspace: {
+        'ws-a': [{ path: 'alpha', updatedAt: new Date().toISOString() }],
+        'ws-new': [{ path: 'freshly-made', updatedAt: new Date().toISOString() }],
+      },
+    }
+    installFetchMock(routes)
+    const onWorkspaceResolved = vi.fn()
+    const { rerender } = render(
+      <DaemonIndexPage
+        daemonBaseUrl={DAEMON_BASE_URL}
+        workspace="ws-a"
+        onWorkspaceResolved={onWorkspaceResolved}
+        onOpenDocument={vi.fn()}
+      />,
+    )
+    expect(await screen.findByText('alpha')).toBeTruthy()
+    onWorkspaceResolved.mockClear()
+
+    // What the switcher's create did: the daemon now holds it, and the
+    // address moved onto it.
+    routes.workspaces.push({ workspaceId: 'ws-new' })
+    rerender(
+      <MemoryRouter initialEntries={['/']}>
+        <DaemonIndexPage
+          daemonBaseUrl={DAEMON_BASE_URL}
+          workspace="ws-new"
+          onWorkspaceResolved={onWorkspaceResolved}
+          onOpenDocument={vi.fn()}
+        />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('freshly-made')).toBeTruthy()
+    expect(screen.queryByText('alpha')).toBeNull()
+    expect(onWorkspaceResolved).not.toHaveBeenCalledWith('ws-a')
+  })
+
+  it('follows a segment the workspace was renamed to a moment ago', async () => {
+    // The rename half of the same shape. `onSwitch` carries the NEW segment,
+    // which the page's pre-rename snapshot spells the old way — so the
+    // resolve missed and the page fell off the workspace the person had just
+    // renamed, onto first-listed.
+    const routes = {
+      workspaces: [
+        { workspaceId: WS_ULID, segment: 'studio' },
+        { workspaceId: 'ws-other' },
+      ] as Array<{ workspaceId: string; segment?: string }>,
+      // Keyed by HANDLE, which for a workspace holding a segment is that
+      // segment — the page addresses the daemon by what it settled on, not by
+      // the canonical id. Both spellings are present because the rename below
+      // moves which one it asks for.
+      documentsByWorkspace: {
+        studio: [{ path: 'alpha', updatedAt: new Date().toISOString() }],
+        marketing: [{ path: 'alpha', updatedAt: new Date().toISOString() }],
+        'ws-other': [{ path: 'beta', updatedAt: new Date().toISOString() }],
+      },
+    }
+    installFetchMock(routes)
+    const onWorkspaceResolved = vi.fn()
+    const { rerender } = render(
+      <DaemonIndexPage
+        daemonBaseUrl={DAEMON_BASE_URL}
+        workspace="studio"
+        onWorkspaceResolved={onWorkspaceResolved}
+        onOpenDocument={vi.fn()}
+      />,
+    )
+    expect(await screen.findByText('alpha')).toBeTruthy()
+    onWorkspaceResolved.mockClear()
+
+    routes.workspaces[0] = { workspaceId: WS_ULID, segment: 'marketing' }
+    rerender(
+      <MemoryRouter initialEntries={['/']}>
+        <DaemonIndexPage
+          daemonBaseUrl={DAEMON_BASE_URL}
+          workspace="marketing"
+          onWorkspaceResolved={onWorkspaceResolved}
+          onOpenDocument={vi.fn()}
+        />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(onWorkspaceResolved).toHaveBeenCalledWith('marketing'))
+    expect(screen.getByText('alpha')).toBeTruthy()
+    expect(screen.queryByText('beta')).toBeNull()
+  })
+
   it('follows the workspace the address names when it changes under the page', async () => {
     // The switcher is the SHELL's now, and it changes the address; the page
     // renders whatever workspace the address names. Until this, `workspace`

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -1692,3 +1692,50 @@ describe('DaemonIndexPage', () => {
     expect(screen.queryByRole('button', { name: 'Tree view' })).toBeNull()
   })
 })
+
+// "Mark as Switcher" answers "where does the workspace name appear at all?"
+// with: not in the shell row — the document browser names it, as its own
+// heading. The shell half shipped first, which left the name nowhere a
+// sighted reader could see it; this is the other half.
+describe('the workspace names the page', () => {
+  it('heads the page with the workspace name, and keeps Documents as the list label', async () => {
+    installFetchMock({
+      workspaces: [{ workspaceId: WS_ULID, segment: 'marketing-team', displayName: 'Marketing' }],
+      // Keyed by the SEGMENT, because that is what the page addresses with:
+      // `selectedWorkspace` holds `workspaceHandle(...)`, not the id.
+      documentsByWorkspace: {
+        'marketing-team': [{ path: 'alpha', updatedAt: new Date().toISOString() }],
+      },
+    })
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenDocument={vi.fn()} />)
+    await screen.findByText('alpha')
+
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(heading.textContent).toBe('Marketing')
+    // Not merely absent from the h1 — the generic word moves to the region
+    // that actually holds the list, so nothing announces the page as
+    // "Documents" while the heading names the workspace.
+    expect(heading.className).not.toContain('sr-only')
+    expect(screen.getByRole('region', { name: 'Documents' })).toBeTruthy()
+  })
+
+  it('falls back through the identity layers rather than showing a raw id', async () => {
+    // A workspace with a segment and no display name: the middle layer is
+    // what a person chose, so it is what they read. workspaceLabel owns this
+    // precedence — the page must not re-derive it and skip a layer.
+    installFetchMock({
+      workspaces: [{ workspaceId: WS_ULID, segment: 'marketing-team' }],
+      // Keyed by the SEGMENT, because that is what the page addresses with:
+      // `selectedWorkspace` holds `workspaceHandle(...)`, not the id.
+      documentsByWorkspace: {
+        'marketing-team': [{ path: 'alpha', updatedAt: new Date().toISOString() }],
+      },
+    })
+
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenDocument={vi.fn()} />)
+    await screen.findByText('alpha')
+
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('marketing-team')
+  })
+})

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -598,18 +598,22 @@ export function DaemonIndexPage({
           // the documents fetch that ends the loading state never runs and the
           // skeleton below would spin for as long as the page stays open.
           //
-          // There is no create control here on purpose: every create path
-          // addresses a (workspace, path) pair, and this page has no way to
-          // name a workspace the daemon would agree with — the daemon keeps
-          // its own current workspace id and does not publish it. So the one
-          // honest action is to look again, because the write that fixes this
-          // is someone else's.
+          // Creation is offered by the SWITCHER, not here — one carrier, the
+          // same one every other page uses. This state points at it rather
+          // than growing a second create control beside it.
+          //
+          // It used to say the write was someone else's, and that was true
+          // while every create path addressed a (workspace, path) pair this
+          // page could not name. `POST /api/workspaces` retired that: the
+          // daemon mints the id and derives the address from a display name,
+          // so the client no longer has to guess an identifier the daemon
+          // would agree with.
           <div className="flex flex-col items-start gap-3">
             <div>
               <p className="text-sm font-medium">This daemon has no workspaces.</p>
               <p className="text-sm text-muted-foreground">
-                A workspace appears once something creates a document in it — an agent over MCP, or
-                the whiteboard CLI.
+                Create one from the workspace menu in the header — or one appears on its own once an
+                agent over MCP, or the whiteboard CLI, writes a document.
               </p>
             </div>
             <button

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -26,7 +26,7 @@ import { deriveCopyPath } from '../lib/derive-copy-path.js'
 import { deriveNewDocumentPath } from '../lib/derive-new-document-path.js'
 import { kindNoun } from '../lib/kind-noun.js'
 import type { WhiteboardCapabilities } from '../lib/provider.js'
-import { workspaceHandle } from '../lib/workspace-handle.js'
+import { workspaceHandle, workspaceLabel } from '../lib/workspace-handle.js'
 
 // The document browser for a connected daemon, scoped to ONE workspace at a
 // time — the one the ADDRESS names. Choosing which is the shell switcher's,
@@ -505,10 +505,30 @@ export function DaemonIndexPage({
     }
   }, [daemonFetch, daemonBaseUrl, selectedWorkspace, pendingDelete, closeDeleteDialog])
 
+  // What the page calls itself. `selectedWorkspace` holds a HANDLE, not an id,
+  // so the row is found through `resolveWorkspaceHandle` — the same reason the
+  // loader above gives, one layer up. `workspaceLabel` owns the precedence
+  // across ADR-0019's three layers; re-deriving it here is how a site ends up
+  // knowing about fewer layers than there are.
+  //
+  // The fallbacks are each a true statement about where you are, in order of
+  // how much they say: the name, then the handle the address carries, then
+  // the generic word for the moments before any workspace is known (this page
+  // also mounts at `/`, where there is no handle to fall back to). The
+  // heading is never absent — a document browser with no h1 is a worse
+  // outcome than a generic one.
+  const activeWorkspace =
+    selectedWorkspace === null ? null : resolveWorkspaceHandle(workspaces, selectedWorkspace)
+  const pageHeading =
+    (activeWorkspace ? workspaceLabel(activeWorkspace) : null) ??
+    selectedWorkspace ??
+    workspace ??
+    'Documents'
+
   return (
     <DaemonApiContext.Provider value={daemonFetch}>
       <div className="flex h-full flex-col overflow-y-auto p-4">
-        <h1 className="sr-only">Documents</h1>
+        <h1 className="mb-3 truncate text-lg font-semibold">{pageHeading}</h1>
         {createError && (
           <div role="alert" className="mb-2 text-sm text-destructive">
             {createError}

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -246,6 +246,16 @@ export function DaemonIndexPage({
     // first-listed fallback below, unchanged.
     if (wanted === null && refetchedForRef.current !== workspace) {
       refetchedForRef.current = workspace
+      // Unselected for the duration, and that is the load-bearing half. The
+      // re-read can FAIL, and leaving the previous workspace selected under an
+      // address naming another is the mismatch the stale-address branch below
+      // exists to refuse: the error state offers `Create a canvas` while
+      // something is selected, so a create there would post the document to
+      // the workspace the URL does not name. With nothing selected the same
+      // state offers `Try again`, which is the only honest action while the
+      // address is unresolved. On success `loadWorkspaces` selects the
+      // addressed workspace itself, since there is no current value to keep.
+      setSelectedWorkspace(null)
       void loadWorkspaces()
       return
     }

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -229,9 +229,26 @@ export function DaemonIndexPage({
   // -address branch above has to clear this deliberately.
   const reportedWorkspaceRef = useRef<string | null>(null)
 
+  // The handles this page has already re-read the list for. A miss has two
+  // causes that look identical from here, and only one of them is stale.
+  const refetchedForRef = useRef<string | null>(null)
+
   useEffect(() => {
     if (workspace === undefined || !workspacesLoaded) return
     const wanted = resolveWorkspaceHandle(workspaces, workspace)
+    // A handle this list does not hold is EITHER a stale bookmark or a
+    // workspace the switcher created or renamed a moment ago. The switcher is
+    // the SHELL's and writes through its own source, so this page's list is a
+    // snapshot taken before that write — and treating every miss as stale
+    // meant creating a workspace landed on a DIFFERENT one and rewrote the
+    // address to name it. So a miss re-reads the list once per handle; a
+    // handle still missing after that is genuinely stale and gets the
+    // first-listed fallback below, unchanged.
+    if (wanted === null && refetchedForRef.current !== workspace) {
+      refetchedForRef.current = workspace
+      void loadWorkspaces()
+      return
+    }
     const fallback = workspaces[0]
     const target = wanted ?? fallback
     if (target === undefined) return
@@ -252,7 +269,7 @@ export function DaemonIndexPage({
     // when the fallback IS a different workspace and that effect does fire.
     reportedWorkspaceRef.current = handle
     onWorkspaceResolved?.(handle)
-  }, [workspace, workspaces, workspacesLoaded, onWorkspaceResolved])
+  }, [workspace, workspaces, workspacesLoaded, onWorkspaceResolved, loadWorkspaces])
 
   useEffect(() => {
     if (selectedWorkspace === null) return

--- a/packages/mcp-server/src/server/routes/document/workspaces.test.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.test.ts
@@ -1169,3 +1169,47 @@ describe('GET /api/workspaces document counts', () => {
     ).toBe(0)
   })
 })
+
+// Found by hitting a REAL daemon, not by any test here: a workspace can sit in
+// the registry with no workspace TREE yet. `listWorkspaces` returns the row and
+// `listDocuments` throws for it, so counting every row turned one such
+// workspace into a 500 for the WHOLE list — a listing that worked before the
+// count was added.
+//
+// Every case above creates its workspaces THROUGH the route, which makes the
+// tree as a side effect, so none of them could reach this state. The registry
+// row is written directly here for exactly that reason.
+describe('GET /api/workspaces with a registry row that has no tree', () => {
+  async function registryRowOnly(workspaceId: string) {
+    const { getDb } = await import('../../store/db/index.js')
+    const { upsertWorkspaceRow } = await import('../../store/db/upsert-workspace.js')
+    await upsertWorkspaceRow(await getDb(tmp.dir), workspaceId, {})
+  }
+
+  it('counts it as empty instead of failing the whole listing', async () => {
+    const app = createWorkspacesRouter()
+    const withTree = workspaceSummarySchema.parse(
+      await (
+        await app.request('/api/workspaces', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ displayName: 'Has a tree' }),
+        })
+      ).json(),
+    )
+    await registryRowOnly('01ARZ3NDEKTSV4RRFFQ69G5FAV')
+
+    const res = await app.request('/api/workspaces')
+    expect(res.status).toBe(200)
+    const { workspaces } = listWorkspacesResponseSchema.parse(await res.json())
+
+    // The row is LISTED — dropping it would hide a workspace that exists.
+    const treeless = workspaces.find((w) => w.workspaceId === '01ARZ3NDEKTSV4RRFFQ69G5FAV')
+    expect(treeless).toBeDefined()
+    // And counted as what it is: a workspace holding nothing.
+    expect(treeless?.documentCount).toBe(0)
+    // Its neighbour is unaffected — one row's missing tree must not cost the
+    // others their counts.
+    expect(workspaces.find((w) => w.workspaceId === withTree.workspaceId)?.documentCount).toBe(0)
+  })
+})

--- a/packages/mcp-server/src/server/routes/document/workspaces.test.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.test.ts
@@ -93,9 +93,12 @@ describe('GET /api/workspaces', () => {
 
     expect(res.status).toBe(200)
     const json = (await res.json()) as {
-      workspaces: Array<{ workspaceId: string }>
+      workspaces: Array<{ workspaceId: string; documentCount?: number }>
     }
-    expect(json.workspaces).toEqual([{ workspaceId: 'workspace-a' }])
+    // `documentCount` joined the row when the switcher started showing it.
+    // This case pins WHICH workspaces are listed, so it carries the field
+    // rather than asserting a shape the route no longer has.
+    expect(json.workspaces).toEqual([{ workspaceId: 'workspace-a', documentCount: 1 }])
   })
 
   // ADR-0019: segment/displayName flow from the registry row through this
@@ -124,9 +127,14 @@ describe('GET /api/workspaces', () => {
       workspaceId: 'workspace-named',
       segment: 'team-notes',
       displayName: 'Team notes',
+      documentCount: 0,
     })
     const bare = parsed.workspaces.find((w) => w.workspaceId === 'workspace-bare')
-    expect(bare).toEqual({ workspaceId: 'workspace-bare' })
+    // Zero, and PRESENT: an empty workspace is counted, not left uncounted.
+    // Which is the distinction the two assertions below are about — those
+    // layers are absent because nobody chose them, and this test's subject is
+    // that absence, not the row's total width.
+    expect(bare).toEqual({ workspaceId: 'workspace-bare', documentCount: 0 })
     expect('segment' in (bare ?? {})).toBe(false)
     expect('displayName' in (bare ?? {})).toBe(false)
   })
@@ -1084,5 +1092,80 @@ describe('PATCH /api/workspaces/:workspaceId', () => {
     })
     expect(res.status).toBe(200)
     expect(workspaceSummarySchema.parse(await res.json()).displayName).toBe('Named at last')
+  })
+})
+
+// A switcher row that says only a name gives no reason to pick one workspace
+// over another. The count is what makes the list readable — and it must agree
+// with the list the document browser then shows, which is why a SHADOWED
+// document counts: it is a document in the workspace, it appears in the
+// listing with its mark, and a number that quietly omitted it would recreate
+// the disagreement the mark exists to prevent.
+describe('GET /api/workspaces document counts', () => {
+  async function created(app: ReturnType<typeof createWorkspacesRouter>, displayName: string) {
+    const res = await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ displayName }),
+    })
+    return workspaceSummarySchema.parse(await res.json())
+  }
+
+  async function listed(app: ReturnType<typeof createWorkspacesRouter>) {
+    return listWorkspacesResponseSchema.parse(await (await app.request('/api/workspaces')).json())
+  }
+
+  it('counts each workspace its own documents', async () => {
+    const app = createWorkspacesRouter()
+    const two = await created(app, 'Two docs')
+    const none = await created(app, 'No docs')
+
+    for (const path of ['alpha', 'beta']) {
+      await app.request(`/api/workspaces/${two.workspaceId}/documents`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path }),
+      })
+    }
+
+    const { workspaces } = await listed(app)
+    expect(workspaces.find((w) => w.workspaceId === two.workspaceId)?.documentCount).toBe(2)
+    // Zero is a real answer and must be REPORTED, not left absent: an empty
+    // workspace is exactly the one a person needs to recognise in the list.
+    expect(workspaces.find((w) => w.workspaceId === none.workspaceId)?.documentCount).toBe(0)
+  })
+
+  it('counts documents in folders, not just at the root', async () => {
+    const app = createWorkspacesRouter()
+    const ws = await created(app, 'Nested')
+    for (const path of ['top', 'folder/one', 'folder/deeper/two']) {
+      await app.request(`/api/workspaces/${ws.workspaceId}/documents`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path }),
+      })
+    }
+
+    const { workspaces } = await listed(app)
+    expect(workspaces.find((w) => w.workspaceId === ws.workspaceId)?.documentCount).toBe(3)
+  })
+
+  it('stops counting a document once it is deleted', async () => {
+    const app = createWorkspacesRouter()
+    const ws = await created(app, 'Deletes')
+    await app.request(`/api/workspaces/${ws.workspaceId}/documents`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: 'gone' }),
+    })
+    expect(
+      (await listed(app)).workspaces.find((w) => w.workspaceId === ws.workspaceId)?.documentCount,
+    ).toBe(1)
+
+    await app.request(`/api/workspaces/${ws.workspaceId}/documents/gone`, { method: 'DELETE' })
+
+    expect(
+      (await listed(app)).workspaces.find((w) => w.workspaceId === ws.workspaceId)?.documentCount,
+    ).toBe(0)
   })
 })

--- a/packages/mcp-server/src/server/routes/document/workspaces.test.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.test.ts
@@ -8,6 +8,7 @@ import {
   deleteDocumentResponseSchema,
   listWorkspacesResponseSchema,
   renameDocumentPathResponseSchema,
+  workspaceMutationResponseSchema,
 } from '../../../shared/api-contracts/document.js'
 import { seedWorkspaceRow, withTempDataDir } from '../_test-helpers.js'
 
@@ -920,5 +921,172 @@ describe('GET /api/workspaces/:workspaceId/documents', () => {
     expect(res.status).toBe(200)
     const json = (await res.json()) as { documents: { path: string }[] }
     expect(json.documents).toEqual([expect.objectContaining({ path: 'canvas-a' })])
+  })
+})
+
+// The write half of the workspace resource. Until this, the daemon published
+// `GET /api/workspaces` and nothing that changes one, so the shell's switcher
+// offered neither creation nor renaming there — the keeper could not honour
+// them, so it did not promise them.
+describe('POST /api/workspaces', () => {
+  async function create(app: ReturnType<typeof createWorkspacesRouter>, body: unknown) {
+    return app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  }
+
+  it('mints the canonical id and derives the address from the name it was given', async () => {
+    const app = createWorkspacesRouter()
+    const res = await create(app, { displayName: 'Marketing Team' })
+
+    expect(res.status).toBe(201)
+    const created = workspaceMutationResponseSchema.parse(await res.json())
+    expect(created.displayName).toBe('Marketing Team')
+    expect(created.segment).toBe('marketing-team')
+    // ADR-0019's canonical layer is minted HERE. A caller naming one would be
+    // choosing the single identity that is not theirs to choose.
+    expect(created.workspaceId).toMatch(/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/)
+
+    const listed = listWorkspacesResponseSchema.parse(
+      await (await app.request('/api/workspaces')).json(),
+    )
+    expect(listed.workspaces.map((w) => w.workspaceId)).toContain(created.workspaceId)
+  })
+
+  it('gives the second workspace of the same name an address of its own', async () => {
+    const app = createWorkspacesRouter()
+    const first = workspaceMutationResponseSchema.parse(
+      await (await create(app, { displayName: 'Notes' })).json(),
+    )
+    const second = workspaceMutationResponseSchema.parse(
+      await (await create(app, { displayName: 'Notes' })).json(),
+    )
+
+    // A display name may repeat as often as its owner likes; the address it
+    // derives may not.
+    expect(first.displayName).toBe('Notes')
+    expect(second.displayName).toBe('Notes')
+    expect(first.segment).toBe('notes')
+    expect(second.segment).not.toBe('notes')
+    expect(second.segment).toBeDefined()
+  })
+
+  it('creates a workspace with NO segment when the name yields none', async () => {
+    const app = createWorkspacesRouter()
+    // A name the segment charset cannot spell. ADR-0019 leaves the layer
+    // absent rather than writing a mangled approximation — the workspace is
+    // addressed by its canonical id until a rename gives it one.
+    const created = workspaceMutationResponseSchema.parse(
+      await (await create(app, { displayName: '設計ノート' })).json(),
+    )
+    expect(created.displayName).toBe('設計ノート')
+    expect(created.segment).toBeUndefined()
+  })
+
+  it('refuses a name that is empty once trimmed', async () => {
+    const app = createWorkspacesRouter()
+    expect((await create(app, { displayName: '   ' })).status).toBe(400)
+    expect((await create(app, {})).status).toBe(400)
+  })
+})
+
+describe('PATCH /api/workspaces/:workspaceId', () => {
+  async function created(app: ReturnType<typeof createWorkspacesRouter>, displayName: string) {
+    const res = await app.request('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ displayName }),
+    })
+    return workspaceMutationResponseSchema.parse(await res.json())
+  }
+
+  async function patch(
+    app: ReturnType<typeof createWorkspacesRouter>,
+    handle: string,
+    body: unknown,
+  ) {
+    return app.request(`/api/workspaces/${handle}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  }
+
+  it('renames both layers and answers with the workspace as it now stands', async () => {
+    const app = createWorkspacesRouter()
+    const before = await created(app, 'Before')
+
+    const res = await patch(app, before.workspaceId, { segment: 'after', displayName: 'After' })
+    expect(res.status).toBe(200)
+    expect(workspaceMutationResponseSchema.parse(await res.json())).toEqual({
+      workspaceId: before.workspaceId,
+      segment: 'after',
+      displayName: 'After',
+    })
+  })
+
+  it('leaves a layer the body omits alone, rather than clearing it', async () => {
+    const app = createWorkspacesRouter()
+    const before = await created(app, 'Keeps its url')
+    expect(before.segment).toBe('keeps-its-url')
+
+    const res = await patch(app, before.workspaceId, { displayName: 'Renamed' })
+    const renamed = workspaceMutationResponseSchema.parse(await res.json())
+    expect(renamed.displayName).toBe('Renamed')
+    expect(renamed.segment).toBe('keeps-its-url')
+  })
+
+  it('accepts the SEGMENT in the address, like every other addressed surface', async () => {
+    const app = createWorkspacesRouter()
+    const before = await created(app, 'Addressed by segment')
+
+    const res = await patch(app, 'addressed-by-segment', { displayName: 'Renamed through it' })
+    expect(res.status).toBe(200)
+    expect(workspaceMutationResponseSchema.parse(await res.json()).workspaceId).toBe(
+      before.workspaceId,
+    )
+  })
+
+  it('answers 404 for a workspace that does not exist', async () => {
+    const app = createWorkspacesRouter()
+    const res = await patch(app, '01ARZ3NDEKTSV4RRFFQ69G5FAV', { displayName: 'Nobody' })
+    expect(res.status).toBe(404)
+  })
+
+  it('refuses a segment another workspace holds, and changes nothing', async () => {
+    const app = createWorkspacesRouter()
+    const other = await created(app, 'Held by someone else')
+    const mine = await created(app, 'Mine')
+
+    const res = await patch(app, mine.workspaceId, {
+      segment: other.segment,
+      displayName: 'Renamed anyway',
+    })
+    expect(res.status).toBe(409)
+
+    // One refused OPERATION, not a partial one: the display name in the same
+    // body must not have landed either.
+    const listed = listWorkspacesResponseSchema.parse(
+      await (await app.request('/api/workspaces')).json(),
+    )
+    const after = listed.workspaces.find((w) => w.workspaceId === mine.workspaceId)
+    expect(after?.segment).toBe('mine')
+    expect(after?.displayName).toBe('Mine')
+  })
+
+  it('accepts the workspace its OWN segment names, which is not a collision', async () => {
+    const app = createWorkspacesRouter()
+    const before = await created(app, 'Unchanged')
+
+    const res = await patch(app, before.workspaceId, {
+      segment: before.segment,
+      displayName: 'Named at last',
+    })
+    expect(res.status).toBe(200)
+    expect(workspaceMutationResponseSchema.parse(await res.json()).displayName).toBe(
+      'Named at last',
+    )
   })
 })

--- a/packages/mcp-server/src/server/routes/document/workspaces.test.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.test.ts
@@ -8,7 +8,7 @@ import {
   deleteDocumentResponseSchema,
   listWorkspacesResponseSchema,
   renameDocumentPathResponseSchema,
-  workspaceMutationResponseSchema,
+  workspaceSummarySchema,
 } from '../../../shared/api-contracts/document.js'
 import { seedWorkspaceRow, withTempDataDir } from '../_test-helpers.js'
 
@@ -942,7 +942,7 @@ describe('POST /api/workspaces', () => {
     const res = await create(app, { displayName: 'Marketing Team' })
 
     expect(res.status).toBe(201)
-    const created = workspaceMutationResponseSchema.parse(await res.json())
+    const created = workspaceSummarySchema.parse(await res.json())
     expect(created.displayName).toBe('Marketing Team')
     expect(created.segment).toBe('marketing-team')
     // ADR-0019's canonical layer is minted HERE. A caller naming one would be
@@ -957,10 +957,10 @@ describe('POST /api/workspaces', () => {
 
   it('gives the second workspace of the same name an address of its own', async () => {
     const app = createWorkspacesRouter()
-    const first = workspaceMutationResponseSchema.parse(
+    const first = workspaceSummarySchema.parse(
       await (await create(app, { displayName: 'Notes' })).json(),
     )
-    const second = workspaceMutationResponseSchema.parse(
+    const second = workspaceSummarySchema.parse(
       await (await create(app, { displayName: 'Notes' })).json(),
     )
 
@@ -978,7 +978,7 @@ describe('POST /api/workspaces', () => {
     // A name the segment charset cannot spell. ADR-0019 leaves the layer
     // absent rather than writing a mangled approximation — the workspace is
     // addressed by its canonical id until a rename gives it one.
-    const created = workspaceMutationResponseSchema.parse(
+    const created = workspaceSummarySchema.parse(
       await (await create(app, { displayName: '設計ノート' })).json(),
     )
     expect(created.displayName).toBe('設計ノート')
@@ -999,7 +999,7 @@ describe('PATCH /api/workspaces/:workspaceId', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ displayName }),
     })
-    return workspaceMutationResponseSchema.parse(await res.json())
+    return workspaceSummarySchema.parse(await res.json())
   }
 
   async function patch(
@@ -1020,7 +1020,7 @@ describe('PATCH /api/workspaces/:workspaceId', () => {
 
     const res = await patch(app, before.workspaceId, { segment: 'after', displayName: 'After' })
     expect(res.status).toBe(200)
-    expect(workspaceMutationResponseSchema.parse(await res.json())).toEqual({
+    expect(workspaceSummarySchema.parse(await res.json())).toEqual({
       workspaceId: before.workspaceId,
       segment: 'after',
       displayName: 'After',
@@ -1033,7 +1033,7 @@ describe('PATCH /api/workspaces/:workspaceId', () => {
     expect(before.segment).toBe('keeps-its-url')
 
     const res = await patch(app, before.workspaceId, { displayName: 'Renamed' })
-    const renamed = workspaceMutationResponseSchema.parse(await res.json())
+    const renamed = workspaceSummarySchema.parse(await res.json())
     expect(renamed.displayName).toBe('Renamed')
     expect(renamed.segment).toBe('keeps-its-url')
   })
@@ -1044,9 +1044,7 @@ describe('PATCH /api/workspaces/:workspaceId', () => {
 
     const res = await patch(app, 'addressed-by-segment', { displayName: 'Renamed through it' })
     expect(res.status).toBe(200)
-    expect(workspaceMutationResponseSchema.parse(await res.json()).workspaceId).toBe(
-      before.workspaceId,
-    )
+    expect(workspaceSummarySchema.parse(await res.json()).workspaceId).toBe(before.workspaceId)
   })
 
   it('answers 404 for a workspace that does not exist', async () => {
@@ -1085,8 +1083,6 @@ describe('PATCH /api/workspaces/:workspaceId', () => {
       displayName: 'Named at last',
     })
     expect(res.status).toBe(200)
-    expect(workspaceMutationResponseSchema.parse(await res.json()).displayName).toBe(
-      'Named at last',
-    )
+    expect(workspaceSummarySchema.parse(await res.json()).displayName).toBe('Named at last')
   })
 })

--- a/packages/mcp-server/src/server/routes/document/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.ts
@@ -1,9 +1,16 @@
 import {
+  deriveWorkspaceSegment,
+  generateDocumentId,
+  workspaceSegmentSchema,
+} from '@kamiazya/whiteboard-model'
+import {
+  type DocumentIndex,
   DocumentHasDescendantsError,
   DocumentMoveIntoSelfError,
   DocumentNotFoundError,
   DocumentPathTakenError,
   isWorkspaceNotFoundError,
+  WorkspaceSegmentTakenError,
 } from '@kamiazya/whiteboard-ports'
 import {
   type ServerDeps,
@@ -17,11 +24,14 @@ import { getDefaultServerDeps } from '../../../di/default-server-deps.js'
 import {
   type CreateDocumentResponse,
   createDocumentRequestSchema,
+  createWorkspaceRequestSchema,
   type DeleteDocumentResponse,
   type ListDocumentsResponse,
   type ListWorkspacesResponse,
   type RenameDocumentPathResponse,
   renameDocumentPathRequestSchema,
+  renameWorkspaceRequestSchema,
+  type WorkspaceMutationResponse,
 } from '../../../shared/api-contracts/document.js'
 import type { ApiErrorBody } from '../../../shared/api-contracts/errors.js'
 import { getLogger } from '../../log.js'
@@ -40,6 +50,36 @@ function createDocumentRequestErrorTitle(error: z.ZodError): string {
   if (field === 'kind') return 'kind must be "spatial" or "markdown"'
   if (field === 'path') return 'path is required'
   return issue?.message ?? 'invalid request body'
+}
+
+/**
+ * The first segment nobody holds, starting from the candidate a display name
+ * derived. Reads the registry rather than counting from a stored number:
+ * what makes a segment unavailable is another row holding it, and asking is
+ * the only thing that stays true after a delete or a rename.
+ *
+ * Advisory, not authoritative — two creates can both find the same candidate
+ * free. The registry's unique index is what actually decides, and the caller
+ * translates its refusal.
+ */
+async function firstFreeSegment(index: DocumentIndex, base: string): Promise<string | undefined> {
+  const taken = new Set((await index.listWorkspaces()).map((w) => w.segment))
+  if (!taken.has(base)) return base
+  // Starts at 2 because the unsuffixed segment IS the first one. A `-1` would
+  // read as the first of a series whose first member is spelled differently.
+  //
+  // Bounded, and each candidate re-validated — both mirrored from the
+  // browser's `createBrowserWorkspace`, which is the same decision one keeper
+  // over: a suffix can push a long base out of the segment charset, and a
+  // segment nothing validated is one the address layer refuses later,
+  // somewhere less obvious. Past the bound the workspace is addressed by its
+  // canonical id, which is what that layer is for.
+  for (let n = 2; n < 1000; n++) {
+    const candidate = `${base}-${n}`
+    if (!workspaceSegmentSchema.safeParse(candidate).success) return undefined
+    if (!taken.has(candidate)) return candidate
+  }
+  return undefined
 }
 
 export interface WorkspacesRouterOptions {
@@ -71,6 +111,93 @@ export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
       }
       return c.json(response)
     } catch (err) {
+      const issue = handleCorruptStoredData(err)
+      if (issue) return c.json(issue.body, issue.status)
+      throw err
+    }
+  })
+
+  // POST /api/workspaces  body: { displayName }
+  //
+  // Straight to the PORT, like the list above and for the same ADR-0018
+  // reason: creating a workspace IS the port call, and a use case here would
+  // forward its arguments and add a name.
+  app.post('/api/workspaces', async (c) => {
+    const parsed = createWorkspaceRequestSchema.safeParse(await c.req.json().catch(() => null))
+    if (!parsed.success) {
+      return c.json({ title: 'displayName is required' } satisfies ApiErrorBody, 400)
+    }
+    const { displayName } = parsed.data
+
+    try {
+      const deps = options.serverDeps ?? (await getDefaultServerDeps())
+      const workspaceId = generateDocumentId()
+      const base = deriveWorkspaceSegment(displayName)
+      const segment =
+        base === undefined ? undefined : await firstFreeSegment(deps.documentIndex, base)
+
+      await deps.documentIndex.createWorkspace({
+        workspaceId,
+        ...(segment === undefined ? {} : { segment }),
+        displayName,
+      })
+      const response: WorkspaceMutationResponse = {
+        workspaceId,
+        ...(segment === undefined ? {} : { segment }),
+        displayName,
+      }
+      return c.json(response, 201)
+    } catch (err) {
+      // A segment the suffix loop believed free can still be taken by the
+      // time the insert lands. The registry's own unique index is what
+      // actually decides, and it reports the same named error a rename does.
+      if (err instanceof WorkspaceSegmentTakenError) {
+        return c.json({ title: err.message } satisfies ApiErrorBody, 409)
+      }
+      const issue = handleCorruptStoredData(err)
+      if (issue) return c.json(issue.body, issue.status)
+      throw err
+    }
+  })
+
+  // PATCH /api/workspaces/:workspaceId  body: { segment?, displayName? }
+  //
+  // PATCH, not PUT: a field ABSENT means "leave this layer alone", which is
+  // the port's contract and something PUT cannot express — under PUT a body
+  // carrying only a name would be asking to drop the address.
+  app.patch('/api/workspaces/:workspaceId', async (c) => {
+    const handle = c.req.param('workspaceId')
+    try {
+      validateWorkspaceId(handle)
+    } catch (err) {
+      const body = validationErrorBody(err)
+      if (body) return c.json(body, 400)
+      throw err
+    }
+    const parsed = renameWorkspaceRequestSchema.safeParse(await c.req.json().catch(() => null))
+    if (!parsed.success) {
+      return c.json({ title: 'segment or displayName must be valid' } satisfies ApiErrorBody, 400)
+    }
+
+    try {
+      const deps = options.serverDeps ?? (await getDefaultServerDeps())
+      // Resolved through the handle, so this route accepts either layer in
+      // the address exactly as every other addressed surface does.
+      const workspaceId = await workspaceIdFromHandle(c, handle)
+      const renamed = await deps.documentIndex.renameWorkspace({ workspaceId, ...parsed.data })
+      const response: WorkspaceMutationResponse = {
+        workspaceId: renamed.workspaceId,
+        ...(renamed.segment === undefined ? {} : { segment: renamed.segment }),
+        ...(renamed.displayName === undefined ? {} : { displayName: renamed.displayName }),
+      }
+      return c.json(response)
+    } catch (err) {
+      if (err instanceof WorkspaceSegmentTakenError) {
+        return c.json({ title: err.message } satisfies ApiErrorBody, 409)
+      }
+      if (isWorkspaceNotFoundError(err)) {
+        return c.json({ title: `Workspace "${handle}" not found` } satisfies ApiErrorBody, 404)
+      }
       const issue = handleCorruptStoredData(err)
       if (issue) return c.json(issue.body, issue.status)
       throw err

--- a/packages/mcp-server/src/server/routes/document/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.ts
@@ -4,8 +4,8 @@ import {
   workspaceSegmentSchema,
 } from '@kamiazya/whiteboard-model'
 import {
-  type DocumentIndex,
   DocumentHasDescendantsError,
+  type DocumentIndex,
   DocumentMoveIntoSelfError,
   DocumentNotFoundError,
   DocumentPathTakenError,
@@ -31,7 +31,7 @@ import {
   type RenameDocumentPathResponse,
   renameDocumentPathRequestSchema,
   renameWorkspaceRequestSchema,
-  type WorkspaceMutationResponse,
+  type WorkspaceSummary,
 } from '../../../shared/api-contracts/document.js'
 import type { ApiErrorBody } from '../../../shared/api-contracts/errors.js'
 import { getLogger } from '../../log.js'
@@ -141,7 +141,7 @@ export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
         ...(segment === undefined ? {} : { segment }),
         displayName,
       })
-      const response: WorkspaceMutationResponse = {
+      const response: WorkspaceSummary = {
         workspaceId,
         ...(segment === undefined ? {} : { segment }),
         displayName,
@@ -185,7 +185,7 @@ export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
       // the address exactly as every other addressed surface does.
       const workspaceId = await workspaceIdFromHandle(c, handle)
       const renamed = await deps.documentIndex.renameWorkspace({ workspaceId, ...parsed.data })
-      const response: WorkspaceMutationResponse = {
+      const response: WorkspaceSummary = {
         workspaceId: renamed.workspaceId,
         ...(renamed.segment === undefined ? {} : { segment: renamed.segment }),
         ...(renamed.displayName === undefined ? {} : { displayName: renamed.displayName }),

--- a/packages/mcp-server/src/server/routes/document/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.ts
@@ -102,13 +102,25 @@ export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
       // listing workspaces is the port call and nothing else, so a use case
       // here would forward no arguments and add a name.
       const workspaces = await deps.documentIndex.listWorkspaces()
-      const response: ListWorkspacesResponse = {
-        workspaces: workspaces.map(({ workspaceId, segment, displayName }) => ({
+      // The count costs a document listing per row, which the tree index
+      // answers by OPENING each workspace's record — so this turns a registry
+      // read into N of them. Measured on this store at 10 workspaces holding
+      // 200 documents between them: 0.2ms for the bare list, 5.8ms with the
+      // counts. The RATIO says don't (35x) and the figure says it does not
+      // matter (5.7ms, once, on a control a person opens by clicking), which
+      // is the whole reason it was measured rather than argued. Warm cache;
+      // the first open after a restart pays more.
+      //
+      // Revisit if this list ever feeds something that polls.
+      const counted = await Promise.all(
+        workspaces.map(async ({ workspaceId, segment, displayName }) => ({
           workspaceId,
           ...(segment === undefined ? {} : { segment }),
           ...(displayName === undefined ? {} : { displayName }),
+          documentCount: (await deps.documentIndex.listDocuments({ workspaceId })).length,
         })),
-      }
+      )
+      const response: ListWorkspacesResponse = { workspaces: counted }
       return c.json(response)
     } catch (err) {
       const issue = handleCorruptStoredData(err)

--- a/packages/mcp-server/src/server/routes/document/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.ts
@@ -82,6 +82,31 @@ async function firstFreeSegment(index: DocumentIndex, base: string): Promise<str
   return undefined
 }
 
+/**
+ * How many documents one workspace holds, for the listing.
+ *
+ * A registry row can exist with no workspace TREE behind it — `listWorkspaces`
+ * returns it and `listDocuments` throws `WorkspaceNotFoundError` for it. That
+ * is a real state on a live daemon, and counting every row without allowing
+ * for it turned ONE such workspace into a 500 for the whole list: a listing
+ * that worked before the count was added stopped working at all.
+ *
+ * Zero, not absent: the row is a workspace, and it holds nothing. Absent means
+ * "this keeper does not count", which is a different statement and belongs to
+ * the browser, not to a daemon workspace that simply has no tree yet.
+ *
+ * Caught per ROW rather than around the whole listing, so one workspace's
+ * missing tree costs the others nothing.
+ */
+async function countDocuments(index: DocumentIndex, workspaceId: string): Promise<number> {
+  try {
+    return (await index.listDocuments({ workspaceId })).length
+  } catch (err) {
+    if (isWorkspaceNotFoundError(err)) return 0
+    throw err
+  }
+}
+
 export interface WorkspacesRouterOptions {
   /** The operations this router adapts onto. Omitted by callers that have
    *  not been given a container — see `getDefaultServerDeps`, which is the
@@ -104,22 +129,29 @@ export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
       const workspaces = await deps.documentIndex.listWorkspaces()
       // The count costs a document listing per row, which the tree index
       // answers by OPENING each workspace's record — so this turns a registry
-      // read into N of them. Measured on this store at 10 workspaces holding
-      // 200 documents between them: 0.2ms for the bare list, 5.8ms with the
-      // counts. The RATIO says don't (35x) and the figure says it does not
-      // matter (5.7ms, once, on a control a person opens by clicking), which
-      // is the whole reason it was measured rather than argued. Warm cache;
-      // the first open after a restart pays more.
+      // read into N of them.
       //
-      // Revisit if this list ever feeds something that polls.
-      const counted = await Promise.all(
-        workspaces.map(async ({ workspaceId, segment, displayName }) => ({
+      // SEQUENTIAL, and that is the load-bearing part. `Promise.all` over the
+      // rows opens N workspace records at once against the one SQLite file,
+      // and on a real daemon holding real workspaces that made the whole
+      // listing fail with `SQLITE_BUSY: database is locked` — a 500 for every
+      // row because of contention this route introduced. A/B against a live
+      // daemon: concurrent 500, sequential 200. No test here reaches it; each
+      // one gets a fresh temp database with nothing else touching it.
+      //
+      // The cost that buys: measured end-to-end over HTTP against that same
+      // daemon — 11 workspaces, 38 documents — best of 7 is 4.2ms, on a
+      // control a person opens by clicking. Revisit if this list ever feeds
+      // something that polls.
+      const counted = []
+      for (const { workspaceId, segment, displayName } of workspaces) {
+        counted.push({
           workspaceId,
           ...(segment === undefined ? {} : { segment }),
           ...(displayName === undefined ? {} : { displayName }),
-          documentCount: (await deps.documentIndex.listDocuments({ workspaceId })).length,
-        })),
-      )
+          documentCount: await countDocuments(deps.documentIndex, workspaceId),
+        })
+      }
       const response: ListWorkspacesResponse = { workspaces: counted }
       return c.json(response)
     } catch (err) {

--- a/packages/mcp-server/src/shared/api-contracts/document.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/document.test.ts
@@ -47,6 +47,9 @@ import {
   type VersionEntry,
   versionEntrySchema,
   type WorkspaceSummary,
+  type CreateWorkspaceRequest,
+  createWorkspaceRequestSchema,
+  renameWorkspaceRequestSchema,
   workspaceSummarySchema,
 } from './document.js'
 import { roundtrip } from './roundtrip.test-helper.js'
@@ -552,5 +555,67 @@ describe('purgeResultSchema', () => {
   it('rejects negative or fractional counts and byte totals', () => {
     expect(purgeResultSchema.safeParse({ purgedCount: -1, purgedBytes: 0 }).success).toBe(false)
     expect(purgeResultSchema.safeParse({ purgedCount: 0, purgedBytes: 0.5 }).success).toBe(false)
+  })
+})
+
+describe('createWorkspaceRequestSchema', () => {
+  it('parses a well-formed value', () => {
+    const result: CreateWorkspaceRequest = createWorkspaceRequestSchema.parse({
+      displayName: 'Marketing',
+    })
+    expect(result.displayName).toBe('Marketing')
+  })
+
+  it('roundtrip preserves fields', () => {
+    const valid: CreateWorkspaceRequest = { displayName: 'Marketing' }
+    expect(roundtrip(createWorkspaceRequestSchema, valid)).toEqual(valid)
+  })
+
+  it('requires a display name — a workspace with no name has nothing to show', () => {
+    expect(createWorkspaceRequestSchema.safeParse({}).success).toBe(false)
+    expect(createWorkspaceRequestSchema.safeParse({ displayName: '' }).success).toBe(false)
+    expect(createWorkspaceRequestSchema.safeParse({ displayName: '  padded  ' }).success).toBe(
+      false,
+    )
+  })
+
+  it('does not accept a caller-chosen segment or id', () => {
+    // Both are the server's to decide (ADR-0019): the id is minted, and the
+    // segment is derived so the two keepers' create surfaces agree. A body
+    // naming either parses, but the field is dropped rather than honoured —
+    // pinned so a later widening is a deliberate act.
+    const parsed = createWorkspaceRequestSchema.parse({
+      displayName: 'Marketing',
+      segment: 'chosen-by-me',
+      workspaceId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+    })
+    expect('segment' in parsed).toBe(false)
+    expect('workspaceId' in parsed).toBe(false)
+  })
+})
+
+describe('renameWorkspaceRequestSchema', () => {
+  it('parses each layer alone, and both together', () => {
+    expect(renameWorkspaceRequestSchema.parse({ segment: 'moved' }).segment).toBe('moved')
+    expect(renameWorkspaceRequestSchema.parse({ displayName: 'Named' }).displayName).toBe('Named')
+    expect(renameWorkspaceRequestSchema.parse({ segment: 'a', displayName: 'B' })).toEqual({
+      segment: 'a',
+      displayName: 'B',
+    })
+  })
+
+  it('accepts an empty body — every layer absent means change nothing', () => {
+    expect(renameWorkspaceRequestSchema.safeParse({}).success).toBe(true)
+  })
+
+  it('rejects a segment shaped like a canonical id, which the address cannot disambiguate', () => {
+    expect(
+      renameWorkspaceRequestSchema.safeParse({ segment: '01ARZ3NDEKTSV4RRFFQ69G5FAV' }).success,
+    ).toBe(false)
+  })
+
+  it('rejects a segment outside the path-segment charset', () => {
+    expect(renameWorkspaceRequestSchema.safeParse({ segment: 'has spaces' }).success).toBe(false)
+    expect(renameWorkspaceRequestSchema.safeParse({ segment: 'nested/path' }).success).toBe(false)
   })
 })

--- a/packages/mcp-server/src/shared/api-contracts/document.test.ts
+++ b/packages/mcp-server/src/shared/api-contracts/document.test.ts
@@ -14,8 +14,10 @@ import { describe, expect, it } from 'vitest'
 import {
   type CreateDocumentRequest,
   type CreateDocumentResponse,
+  type CreateWorkspaceRequest,
   createDocumentRequestSchema,
   createDocumentResponseSchema,
+  createWorkspaceRequestSchema,
   type DocumentSummary,
   documentSummarySchema,
   type ExportDocumentJsonRequest,
@@ -35,6 +37,7 @@ import {
   pruneSandwichedVersionsResponseSchema,
   purgeResultSchema,
   type RestoreVersionRequest,
+  renameWorkspaceRequestSchema,
   restoreVersionRequestSchema,
   type SaveVersionRequest,
   type SaveVersionResponse,
@@ -47,9 +50,6 @@ import {
   type VersionEntry,
   versionEntrySchema,
   type WorkspaceSummary,
-  type CreateWorkspaceRequest,
-  createWorkspaceRequestSchema,
-  renameWorkspaceRequestSchema,
   workspaceSummarySchema,
 } from './document.js'
 import { roundtrip } from './roundtrip.test-helper.js'

--- a/packages/mcp-server/src/shared/api-contracts/document.ts
+++ b/packages/mcp-server/src/shared/api-contracts/document.ts
@@ -175,6 +175,11 @@ export const canvasExistsResponseSchema = z.object({
 // is none. Both fields are additive to keep an old daemon's response and a
 // new client — and a new daemon's response and an old client — mutually
 // parseable.
+// Both WRITES answer with this same shape, deliberately: a create and a rename
+// each hand back the workspace as it now stands, so a caller that has just
+// moved an address does not have to re-list to learn the handle it should use
+// next. One workspace is one workspace whichever call produced it, and a
+// second name for the identical schema would be a synonym to keep in step.
 export const workspaceSummarySchema = z.object({
   workspaceId: z.string(),
   segment: workspaceSegmentSchema.optional(),
@@ -216,14 +221,6 @@ export const renameWorkspaceRequestSchema = z.object({
   segment: workspaceSegmentSchema.optional(),
   displayName: workspaceDisplayNameSchema.optional(),
 })
-
-/**
- * Both writes answer with the workspace AS IT NOW STANDS, so a caller that has
- * just moved an address does not have to re-list to learn the handle it should
- * use next. Same shape as a list row, deliberately — one workspace is one
- * workspace whichever call produced it.
- */
-export const workspaceMutationResponseSchema = workspaceSummarySchema
 
 export const documentSummarySchema = z.object({
   path: z.string(),
@@ -280,7 +277,6 @@ export type WorkspaceSummary = z.infer<typeof workspaceSummarySchema>
 export type ListWorkspacesResponse = z.infer<typeof listWorkspacesResponseSchema>
 export type CreateWorkspaceRequest = z.infer<typeof createWorkspaceRequestSchema>
 export type RenameWorkspaceRequest = z.infer<typeof renameWorkspaceRequestSchema>
-export type WorkspaceMutationResponse = z.infer<typeof workspaceMutationResponseSchema>
 export type DocumentSummary = z.infer<typeof documentSummarySchema>
 export type ListDocumentsResponse = z.infer<typeof listDocumentsResponseSchema>
 export type CreateDocumentResponse = z.infer<typeof createDocumentResponseSchema>

--- a/packages/mcp-server/src/shared/api-contracts/document.ts
+++ b/packages/mcp-server/src/shared/api-contracts/document.ts
@@ -184,6 +184,22 @@ export const workspaceSummarySchema = z.object({
   workspaceId: z.string(),
   segment: workspaceSegmentSchema.optional(),
   displayName: workspaceDisplayNameSchema.optional(),
+  /**
+   * How many documents the workspace holds — what makes a switcher row worth
+   * reading, since a list of names alone gives no reason to pick one.
+   *
+   * SHADOWED documents count. A concurrent create can leave two documents on
+   * one path, and the listing shows both (one marked) precisely so the
+   * convergent state is visible rather than hidden; a count that quietly
+   * omitted the marked one would put back the disagreement the mark exists to
+   * prevent.
+   *
+   * Optional for the same additive reason as the two layers above, and
+   * absent is not zero: zero means "this workspace is empty", which is
+   * exactly the row a person needs to recognise, while absent means the
+   * responder did not count. Only a keeper that cannot count leaves it out.
+   */
+  documentCount: z.number().int().nonnegative().optional(),
 })
 
 export const listWorkspacesResponseSchema = z.object({

--- a/packages/mcp-server/src/shared/api-contracts/document.ts
+++ b/packages/mcp-server/src/shared/api-contracts/document.ts
@@ -185,6 +185,46 @@ export const listWorkspacesResponseSchema = z.object({
   workspaces: z.array(workspaceSummarySchema),
 })
 
+/**
+ * POST /api/workspaces — create one.
+ *
+ * What a person supplies is a DISPLAY NAME, and only that. The other two
+ * layers are not the caller's to choose: ADR-0019 makes `workspaceId` a
+ * machine-minted ULID, and the segment is DERIVED from the name here so the
+ * one switcher control behaves the same on either keeper — the browser's
+ * `createBrowserWorkspace` has taken a display name and derived from it since
+ * it shipped, and two creation surfaces that disagree about what a caller
+ * supplies is the asymmetry this contract exists to avoid.
+ *
+ * Choosing the address is what RENAME is for, one call later, where a
+ * collision can be reported against a workspace that already exists.
+ */
+export const createWorkspaceRequestSchema = z.object({
+  displayName: workspaceDisplayNameSchema,
+})
+
+/**
+ * PATCH /api/workspaces/:workspaceId — rename the two chosen layers.
+ *
+ * PATCH rather than PUT because the port's contract is partial in a way PUT
+ * cannot express: a field ABSENT means "leave this layer alone", never "clear
+ * it". Under PUT, a client sending only a display name would be asking to drop
+ * the segment — which is the one reading a caller would never intend, and the
+ * reason `RenameWorkspaceInput` has no way to clear a layer at all.
+ */
+export const renameWorkspaceRequestSchema = z.object({
+  segment: workspaceSegmentSchema.optional(),
+  displayName: workspaceDisplayNameSchema.optional(),
+})
+
+/**
+ * Both writes answer with the workspace AS IT NOW STANDS, so a caller that has
+ * just moved an address does not have to re-list to learn the handle it should
+ * use next. Same shape as a list row, deliberately — one workspace is one
+ * workspace whichever call produced it.
+ */
+export const workspaceMutationResponseSchema = workspaceSummarySchema
+
 export const documentSummarySchema = z.object({
   path: z.string(),
   // The immutable id behind the path (the documents row's nanoid PK).
@@ -238,6 +278,9 @@ export type ListVersionsResponse = z.infer<typeof listVersionsResponseSchema>
 export type SaveVersionResponse = z.infer<typeof saveVersionResponseSchema>
 export type WorkspaceSummary = z.infer<typeof workspaceSummarySchema>
 export type ListWorkspacesResponse = z.infer<typeof listWorkspacesResponseSchema>
+export type CreateWorkspaceRequest = z.infer<typeof createWorkspaceRequestSchema>
+export type RenameWorkspaceRequest = z.infer<typeof renameWorkspaceRequestSchema>
+export type WorkspaceMutationResponse = z.infer<typeof workspaceMutationResponseSchema>
 export type DocumentSummary = z.infer<typeof documentSummarySchema>
 export type ListDocumentsResponse = z.infer<typeof listDocumentsResponseSchema>
 export type CreateDocumentResponse = z.infer<typeof createDocumentResponseSchema>

--- a/packages/model/src/derive-workspace-segment.test.ts
+++ b/packages/model/src/derive-workspace-segment.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { deriveWorkspaceSegment } from './derive-workspace-segment.js'
+import { workspaceSegmentSchema } from './ids.js'
+import { fc, fcTest, withDefaults } from './test-utils/fast-check.js'
+
+/**
+ * Dense on the arrangements this function is ABOUT: dashes, spaces and other
+ * punctuation at the edges and in runs. `fc.string()` reaches them only by
+ * accident, which is how a property ends up passing without ever meeting its
+ * subject.
+ */
+const nameArb = fc.string({
+  unit: fc.constantFrom(...'ab1 -_/.。 '.split('')),
+  maxLength: 24,
+})
+
+describe('deriveWorkspaceSegment', () => {
+  it('lowercases and joins words with a single dash', () => {
+    expect(deriveWorkspaceSegment('Marketing Team')).toBe('marketing-team')
+  })
+
+  it('collapses a RUN of non-alphanumerics to one dash, never several', () => {
+    expect(deriveWorkspaceSegment('Marketing   ///   Team')).toBe('marketing-team')
+  })
+
+  it('trims the dash a leading or trailing run would otherwise leave', () => {
+    expect(deriveWorkspaceSegment('  Studio  ')).toBe('studio')
+    expect(deriveWorkspaceSegment('---Studio---')).toBe('studio')
+  })
+
+  it('answers undefined for a name the segment charset cannot spell', () => {
+    // Absent is a real answer, not a failure to try: ADR-0019 addresses such a
+    // workspace by its canonical id rather than by a mangled approximation.
+    expect(deriveWorkspaceSegment('設計チーム')).toBeUndefined()
+    expect(deriveWorkspaceSegment('---')).toBeUndefined()
+    expect(deriveWorkspaceSegment('')).toBeUndefined()
+  })
+
+  fcTest.prop([nameArb], withDefaults())(
+    'never yields a leading, trailing or doubled dash',
+    (displayName) => {
+      const segment = deriveWorkspaceSegment(displayName)
+      if (segment === undefined) return
+      expect(segment.startsWith('-')).toBe(false)
+      expect(segment.endsWith('-')).toBe(false)
+      expect(segment.includes('--')).toBe(false)
+    },
+  )
+
+  // The trims are written `^-` and `-$` rather than `^-+` and `-+$`, because
+  // the collapse above already guarantees at most ONE dash can be leading or
+  // trailing. These two pin that the narrower form is not a behaviour change:
+  // it is the same function, stated without the claim that a RUN might be
+  // there.
+  //
+  // The wider form made that claim, and a reader of it was right to worry —
+  // `-+$` over a string that may hold a long run is the shape CodeQL reports
+  // as polynomial backtracking, on a name that arrives in a request body.
+  fcTest.prop([nameArb], withDefaults({ numRuns: 500 }))(
+    'the narrow trim and the wider one it replaced produce the same candidate',
+    (displayName) => {
+      const collapsed = displayName.toLowerCase().replace(/[^a-z0-9]+/g, '-')
+      expect(collapsed.replace(/^-/, '').replace(/-$/, '')).toBe(collapsed.replace(/^-+|-+$/g, ''))
+    },
+  )
+
+  fcTest.prop([nameArb], withDefaults({ numRuns: 500 }))(
+    'and the whole derivation answers what the wider pipeline answered',
+    (displayName) => {
+      const wider = displayName
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+      expect(deriveWorkspaceSegment(displayName)).toBe(
+        workspaceSegmentSchema.safeParse(wider).success ? wider : undefined,
+      )
+    },
+  )
+})

--- a/packages/model/src/derive-workspace-segment.ts
+++ b/packages/model/src/derive-workspace-segment.ts
@@ -23,9 +23,16 @@ import { workspaceSegmentSchema } from './ids.js'
  * knows. Callers take this candidate and ask their own registry.
  */
 export function deriveWorkspaceSegment(displayName: string): string | undefined {
+  // The trims take no `+`, and that is a statement rather than a shortcut: the
+  // collapse above replaces each maximal RUN of non-alphanumerics with one
+  // dash, so the candidate can never hold two adjacent dashes and at most one
+  // can be leading or trailing. Writing `^-+|-+$` claimed a run might be there
+  // — a claim CodeQL reads, correctly, as polynomial backtracking on a name
+  // that arrives in a request body.
   const candidate = displayName
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
+    .replace(/^-/, '')
+    .replace(/-$/, '')
   return workspaceSegmentSchema.safeParse(candidate).success ? candidate : undefined
 }

--- a/packages/model/src/derive-workspace-segment.ts
+++ b/packages/model/src/derive-workspace-segment.ts
@@ -1,0 +1,31 @@
+import { workspaceSegmentSchema } from './ids.js'
+
+/**
+ * The address a workspace's display name yields, or `undefined` when it
+ * yields none.
+ *
+ * ONE rule, because both keepers mint a workspace and a derivation that
+ * differed between them would put the same name at two addresses. It lives in
+ * model rather than beside either caller for the reason `workspaceHandle` and
+ * `workspaceLabel` were pulled together: a per-site copy does not disagree
+ * loudly, it disagrees quietly.
+ *
+ * Absent is a real answer, not a failure to try. A name written in a script
+ * the segment charset cannot spell produces nothing, and ADR-0019 already
+ * settled what to do about that — its migration left a legacy segment NULL
+ * rather than writing a mangled approximation, and a workspace with no segment
+ * is addressed by its canonical id, which is exactly why that layer stays
+ * resolvable. An invented `workspace-2` would be a name nobody chose, sitting
+ * in the URL for as long as the workspace lives.
+ *
+ * Uniqueness is NOT decided here and cannot be: what makes a segment
+ * unavailable is another row holding it, which only the keeper's registry
+ * knows. Callers take this candidate and ask their own registry.
+ */
+export function deriveWorkspaceSegment(displayName: string): string | undefined {
+  const candidate = displayName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return workspaceSegmentSchema.safeParse(candidate).success ? candidate : undefined
+}

--- a/packages/model/src/index.ts
+++ b/packages/model/src/index.ts
@@ -5,6 +5,7 @@ export * from './facets.js'
 // The mdast subset is intentionally NOT re-exported here — it is
 // versioned, reached via the package's `./mdast` subpath export instead of
 // the stable public surface.
+export { deriveWorkspaceSegment } from './derive-workspace-segment.js'
 export { generateDocumentId } from './generate-document-id.js'
 export * from './ids.js'
 export * from './json-schema.js'

--- a/packages/model/src/index.ts
+++ b/packages/model/src/index.ts
@@ -1,11 +1,11 @@
 export * from './asset-ref.js'
 export * from './clipboard.js'
-export * from './document-kind.js'
-export * from './facets.js'
 // The mdast subset is intentionally NOT re-exported here — it is
 // versioned, reached via the package's `./mdast` subpath export instead of
 // the stable public surface.
 export { deriveWorkspaceSegment } from './derive-workspace-segment.js'
+export * from './document-kind.js'
+export * from './facets.js'
 export { generateDocumentId } from './generate-document-id.js'
 export * from './ids.js'
 export * from './json-schema.js'

--- a/packages/ports/src/test-utils/document-index-conformance.ts
+++ b/packages/ports/src/test-utils/document-index-conformance.ts
@@ -485,6 +485,40 @@ export function describeDocumentIndexConformance(
       })
     })
 
+    // The case the idempotency test above cannot reach: it re-creates with the
+    // SAME layers, so an implementation that overwrites is indistinguishable
+    // from one that leaves the row alone. A BARE re-create is what separates
+    // them, and it is the shape an "ensure it exists" caller has — apps/web's
+    // `ensureLocalWorkspace` passes `{ workspaceId }` alone.
+    //
+    // Seeded through `renameWorkspace` rather than `createWorkspace` because
+    // that one is REQUIRED to echo its layers back, so the precondition below
+    // is real in every implementation instead of vacuous in the ones that
+    // accept and ignore them on create.
+    it('leaves an existing workspace identity alone when re-created bare', async () => {
+      await withIndex(async (index) => {
+        await index.createWorkspace({ workspaceId: 'ws-keep-layers' })
+        await index.renameWorkspace({
+          workspaceId: 'ws-keep-layers',
+          segment: 'keep-me',
+          displayName: 'Keep me',
+        })
+        const before = await index.resolveWorkspace('ws-keep-layers')
+        // The subject has to be PRESENT for the assertion below to mean
+        // anything: a row with no layers survives an overwrite unchanged.
+        expect(before?.segment).toBe('keep-me')
+        expect(before?.displayName).toBe('Keep me')
+
+        await index.createWorkspace({ workspaceId: 'ws-keep-layers' })
+
+        const after = await index.resolveWorkspace('ws-keep-layers')
+        expect(after?.segment).toBe('keep-me')
+        expect(after?.displayName).toBe('Keep me')
+        // And the address still resolves through the layer it was given.
+        expect((await index.resolveWorkspace('keep-me'))?.workspaceId).toBe('ws-keep-layers')
+      })
+    })
+
     it('every listWorkspaces row parses against workspaceEntrySchema', async () => {
       await withIndex(async (index) => {
         const rows = await index.listWorkspaces()

--- a/packages/ports/src/test-utils/in-memory-document-index.ts
+++ b/packages/ports/src/test-utils/in-memory-document-index.ts
@@ -75,6 +75,11 @@ export class InMemoryDocumentIndex implements DocumentIndex {
     segment,
     displayName,
   }: CreateWorkspaceInput): Promise<void> {
+    // Creating one that exists leaves it ALONE — it is not an error, and it is
+    // not an overwrite either. The bare `{ workspaceId }` call is what an
+    // "ensure it exists" caller makes, and treating it as a full row would
+    // clear the identity layers a rename put there.
+    if (this.#workspaces.has(workspaceId)) return
     this.#workspaces.set(workspaceId, {
       workspaceId,
       ...(segment === undefined ? {} : { segment }),


### PR DESCRIPTION
## Summary

- **The document browser heads itself with the workspace name.** The other half of *Mark as Switcher*'s answer to "where does the workspace name appear at all?" — the shell states it only in the mark's accessible name, so until now a sighted reader saw it nowhere. Both index pages carry it as a visible `h1`; the generic word did not disappear, it moved to the panel's own region label.
- **The daemon publishes a workspace write surface.** `POST /api/workspaces` and `PATCH /api/workspaces/:workspaceId`. The switcher offered neither creation nor renaming there because the keeper could not honour them; now it does, through the same control the browser uses.
- **Each switcher row says how many documents the workspace holds.** A list of names gives no reason to pick one.

## Test plan

- [x] New or updated `mcp-node` / `web-jsdom` tests added
- [ ] `pnpm test` passes locally
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable

`pnpm check:local` → **exit 0**, with the exit code captured directly rather than through a pipe (a `| tail` had masked it once in this work, so the earlier green was not evidence). All seven steps reached typecheck.

Focused suites green: workspaces routes **51**, api-contracts **77**, ports + model + arch-lint **488**, shell + AppShell **56**, both index pages **71**.

`pnpm test` is NOT claimed. The 9 `apps/web` failures this branch sees are pre-existing and were A/B-established on `origin/main` without these commits — same 9, same root cause, a jsdom `Blob` with no `.stream()` that Node's `Response` requires, thrown from the tests' own mock construction. One earlier run of the identical commit showed 10, so at least one is also load-dependent.

### Manual verification — against a real daemon

The routes were driven with `curl` against a live `mcp:http:dev` daemon holding real workspaces. **It found two defects no test here could reach**, both fixed in `a199872d`:

- **A registry row can exist with no workspace tree.** `listWorkspaces` returns it, `listDocuments` throws for it — so counting every row turned ONE such workspace into a 500 for the whole listing. A call that worked before the count was added stopped working at all. Every route test creates its workspaces *through* the route, which makes the tree as a side effect, so none could reach the state; the regression test writes the registry row directly.
- **`Promise.all` over the rows fails under real data.** N workspace records opened at once against one SQLite file answered `SQLITE_BUSY: database is locked`. A/B against the running daemon: concurrent 500, sequential 200. No unit test reaches this either — each gets a fresh temp database with nothing else touching it — so the reason is recorded at the loop rather than guarded by a test that could not fail.

Final state on that daemon:

```
dev-check              docs=3
default                docs=21
(no segment)           docs=0   <- the treeless row that used to 500 the list
marketing-team         docs=0   <- minted by POST, segment derived from "Marketing Team"
… 11 rows total, 38 documents
```

### Manual verification — apps/web

Against the production `pnpm build` bundle served over loopback in a real Chromium with a fresh profile (this environment's network policy denies the Cloudflare preview host with a 403 on CONNECT). 11/11 checks, including the ones unit tests cannot reach — a rename moving the address, and the name surviving two reloads onto the index page, which goes through boot's own resolve against IndexedDB.

## Visual evidence

**No figure attached — no image upload path in this session.** GitHub access here is through the MCP server, not `gh`, so the `gh image` step AGENTS.md specifies cannot run. Screenshots were captured during verification (`tmp/screenshots/heading-*.png`) and the before/after is described here:

- **before** (`origin/main` bundle): the index page's `h1` reads `Documents`, and there is no `Documents` region.
- **after**: the `h1` reads the workspace name (`Studio`, then `Marketing` after a rename), and the generic word is the panel's region label.

The daemon's create / rename / count were verified by `curl`, not through the UI, so no figure exists for them.

## Measured, not argued

The count turns one registry read into N document listings, which is invisible in the diff. Against the live daemon — 11 workspaces, 38 documents — the whole call is **4.2ms** end to end over HTTP.

An earlier number in this branch (5.8ms) was taken with the broken concurrent shape and has been replaced. An in-process probe at 10 workspaces also showed the ratio (35×) saying *don't* while the figure said *it does not matter*; judging by the ratio alone would have been the wrong call.

## Two things deliberately not done

- **The browser keeper does not count.** Documents live in the workspace tree, and reading it from the shell would put loro-crdt behind a control that renders on every page — which `browser-workspaces.ts` avoids on purpose. `documentCount` is optional and **absent is not zero**: zero says the workspace is empty, absent says this keeper did not count. Recorded in `DESIGN.md` with the cost, and tracked as follow-up work that starts with measuring the bundle impact.
- **`createWorkspace` no longer overwrites an existing workspace**, but this was **latent, not live**, and an earlier version of that commit message said otherwise. Reading the code found a real contract violation and a conformance mutation check confirmed the contract was broken — neither speaks to reachability, and the consequence narrated from them ("visiting the document list undoes a rename") was refuted by an A/B of the built bundle. `FoldingBrowserIndex` routes `createWorkspace` to the tree index, so nothing reaches the overwrite. Fixed as debt, with the correction on the record.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — `apps/web/DESIGN.md`
- [x] No `console.*` added to `src/server/**`
- [x] No hand-written TypeScript interface duplicates a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Create and rename workspaces from the workspace switcher, including before a workspace is selected.
  - Workspace lists show document counts, including zero for empty workspaces.
  - Document pages display the workspace name as a clear heading, with sensible fallbacks.
  - Added validation for workspace names and address segments.

- **Bug Fixes**
  - Existing workspace details and document counts are preserved during renames and repeated creation.
  - Improved handling of newly created, renamed, missing, or conflicting workspaces.

- **Accessibility**
  - Document lists now use clearer semantic labeling for assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->