### PR TITLE
fix(web): stop the save indicator reporting "saved" over an unwritten edit

### DIFF
--- a/apps/web/src/pages/save-scheduler.property.test.ts
+++ b/apps/web/src/pages/save-scheduler.property.test.ts
@@ -1,0 +1,189 @@
+/**
+ * The save scheduler, under every interleaving of typing, timers, leaving,
+ * and writes landing.
+ *
+ * This exists because the same 500ms debounce produced two defects in two
+ * consecutive PRs, and neither reproduced on an idle machine: both needed a
+ * timer to fire PART-WAY through typing. An example test has to guess that
+ * arrangement; a model generates it.
+ *
+ * Time is a command here rather than a clock. `tick` fires whatever timer is
+ * armed, `settle` lands whatever write is in flight, and the generator is
+ * free to put an edit between them — which is precisely the window both
+ * defects lived in.
+ */
+import { afterAll, describe, expect, it } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { createSaveScheduler, type SaveTimer } from './save-scheduler.js'
+import type { BrowserPersistenceState } from './use-browser-document-controller.js'
+
+/** A fake host: one armed timer, one in-flight write, and what has landed. */
+class Harness {
+  state: BrowserPersistenceState = { kind: 'saved', lastSavedAt: null }
+  /** The edit number the document currently holds. */
+  current = 0
+  /** The edit number the last landed write persisted. */
+  persisted = 0
+  /** How many writes have landed, for the vacuity guard. */
+  landed = 0
+
+  #armed: (() => void) | null = null
+  #inFlight: { resolve: () => void; reject: () => void } | null = null
+  #queue: Promise<unknown> = Promise.resolve()
+  #capturedBySave = 0
+
+  readonly scheduler = createSaveScheduler({
+    debounceMs: 500,
+    now: () => new Date(1e12 + this.landed).toISOString(),
+    report: (update) => {
+      this.state = typeof update === 'function' ? update(this.state) : update
+    },
+    beginSave: () => () => {
+      // A write persists what the document holds AT THE MOMENT IT STARTS —
+      // an edit arriving later is not in it. That is the whole subject.
+      this.#capturedBySave = this.current
+      return new Promise<void>((resolve, reject) => {
+        this.#inFlight = {
+          resolve: () => {
+            this.persisted = this.#capturedBySave
+            this.landed += 1
+            resolve()
+          },
+          reject: () => reject(new Error('write failed')),
+        }
+      })
+    },
+    enqueue: (save) => {
+      this.#queue = this.#queue.then(() => save()).catch(() => {})
+    },
+    setTimer: (fire) => {
+      this.#armed = fire
+      return fire as SaveTimer
+    },
+    clearTimer: () => {
+      this.#armed = null
+    },
+  })
+
+  get timerArmed(): boolean {
+    return this.#armed !== null
+  }
+  get writeInFlight(): boolean {
+    return this.#inFlight !== null
+  }
+
+  type(): void {
+    this.current += 1
+    this.scheduler.edit()
+  }
+  tick(): void {
+    const fire = this.#armed
+    this.#armed = null
+    fire?.()
+  }
+  leave(): void {
+    this.scheduler.flush()
+  }
+  async settle(outcome: 'ok' | 'fail'): Promise<void> {
+    const flight = this.#inFlight
+    if (flight === null) return
+    this.#inFlight = null
+    if (outcome === 'ok') flight.resolve()
+    else flight.reject()
+  }
+
+  /**
+   * Lets whatever the queue has chained actually start. Without this a step
+   * boundary is not a moment in time — `enqueue` defers through a promise, so
+   * a fired timer has not begun its write yet, and "an edit arrives while a
+   * write is in flight" becomes unreachable. The vacuity guard below is what
+   * caught that: the counter read 0.
+   */
+  async drain(): Promise<void> {
+    for (let i = 0; i < 4; i++) await Promise.resolve()
+  }
+  /** Nothing armed and nothing in flight: the document is at rest. */
+  get quiescent(): boolean {
+    return !this.timerArmed && !this.writeInFlight
+  }
+}
+
+const stats = { typed: 0, landedWrites: 0, editDuringWrite: 0, quiescentChecks: 0 }
+
+const step = fc.oneof(
+  { weight: 4, arbitrary: fc.constant('type' as const) },
+  { weight: 3, arbitrary: fc.constant('tick' as const) },
+  { weight: 3, arbitrary: fc.constant('settle-ok' as const) },
+  { weight: 1, arbitrary: fc.constant('settle-fail' as const) },
+  { weight: 1, arbitrary: fc.constant('leave' as const) },
+)
+
+describe('save scheduler under interleaved typing and writes', () => {
+  /**
+   * The shrunk counterexample, pinned before the fix. A write starts, an edit
+   * lands while it is in flight, and the write's success reports `saved` —
+   * over text that is not in it. The indicator then claims safety for as long
+   * as the next debounce takes.
+   *
+   * This is the root cause of the settle window `waitForMarkdownSaved` had to
+   * grow: that wait was compensating for an indicator that could say `saved`
+   * about an earlier write.
+   */
+  it('does not report saved for a write that started before the latest edit', async () => {
+    const h = new Harness()
+    h.type() //             edit 1, debounce armed
+    h.tick() //             timer fires; the write is only ENQUEUED here
+    await h.drain() //      the queue starts it, capturing edit 1
+    h.type() //             edit 2 lands while that write is still in flight
+    await h.settle('ok') // and the write, which does not contain it, succeeds
+    await h.drain()
+
+    if (h.state.kind === 'saved') expect(h.persisted).toBe(h.current)
+  })
+
+  fcTest.prop([fc.array(step, { minLength: 1, maxLength: 24 })], withDefaults({ numRuns: 300 }))(
+    'the indicator never reports `saved` over an edit that is not in the store',
+    async (steps) => {
+      const h = new Harness()
+      for (const s of steps) {
+        if (s === 'type') {
+          if (h.writeInFlight) stats.editDuringWrite += 1
+          stats.typed += 1
+          h.type()
+        } else if (s === 'tick') h.tick()
+        else if (s === 'leave') h.leave()
+        else await h.settle(s === 'settle-ok' ? 'ok' : 'fail')
+        await h.drain()
+
+        // S1 — the load-bearing one. "Saved" is a claim about the CURRENT
+        // text, not about some earlier write having succeeded. Anything
+        // weaker is what let a save wait settle on a partial body.
+        if (h.state.kind === 'saved' && h.persisted !== h.current) {
+          throw new Error(
+            `reported "saved" with edit ${h.current} unwritten (store holds ${h.persisted})`,
+          )
+        }
+      }
+      stats.landedWrites += h.landed
+
+      // S2 — convergence. Once nothing is armed and nothing is in flight,
+      // either the store has the last edit or the indicator says so.
+      if (h.quiescent) {
+        stats.quiescentChecks += 1
+        if (h.persisted !== h.current) expect(h.state.kind).not.toBe('saved')
+      }
+    },
+  )
+
+  afterAll(() => {
+    // The arrangement both defects needed is an edit arriving while a write
+    // is in flight. A run that never produced one has asserted nothing about
+    // the window this file exists for.
+    expect(
+      stats.editDuringWrite,
+      'no run typed while a write was in flight — the generator never reached the window',
+    ).toBeGreaterThan(0)
+    expect(stats.landedWrites, 'no write ever landed').toBeGreaterThan(0)
+    expect(stats.quiescentChecks, 'no run ever came to rest').toBeGreaterThan(0)
+  })
+})

--- a/apps/web/src/pages/save-scheduler.ts
+++ b/apps/web/src/pages/save-scheduler.ts
@@ -1,0 +1,136 @@
+/**
+ * When a markdown edit becomes a write, and what the save indicator says
+ * while that is in flight.
+ *
+ * Extracted from `use-markdown-document` so the POLICY can be modelled apart
+ * from React, IndexedDB and a real clock. It is worth separating because the
+ * same 500ms debounce has now produced two defects in two consecutive PRs,
+ * both of the same shape — a timer firing part-way through typing, and some
+ * downstream state settling on the partial value:
+ *
+ *   - a save wait settled on a partial write and reported it as the latest
+ *   - a document was named after a half-typed heading, permanently
+ *
+ * Neither is visible in a diff, and neither reproduces on an idle machine.
+ * What they have in common is an INTERLEAVING, which is exactly what a
+ * command-based model generates and a hand-written example does not.
+ */
+import type { Dispatch, SetStateAction } from 'react'
+import type { BrowserPersistenceState } from './use-browser-document-controller.js'
+
+/** Whatever the host's timer handle is; opaque here so a test can use its own. */
+export type SaveTimer = unknown
+
+export interface SaveSchedulerDeps {
+  /**
+   * Binds a write to whatever the document is attached to RIGHT NOW, or
+   * answers null when there is nothing to write through.
+   *
+   * Called when the write is ENQUEUED, never when it runs. The handle and
+   * the content are captured at different moments and both matter: by the
+   * time a queued write runs, the next document may already hold the handle,
+   * so resolving it late writes through the wrong one. Doing that is what
+   * broke `a reload sees the edits the unmount flush was still writing`.
+   * What the write CONTAINS is still whatever the containers hold when it
+   * runs, which is why `covers` below is read then and not here.
+   */
+  readonly beginSave: () => (() => Promise<void>) | null
+  /** Publishes the state a save indicator renders. */
+  readonly report: Dispatch<SetStateAction<BrowserPersistenceState>>
+  /**
+   * Runs `save` after whatever save is already in flight for this document.
+   * Injected because the real queue is keyed by document id and shared with
+   * the next load, which awaits it before reading.
+   */
+  readonly enqueue: (save: () => Promise<void>) => void
+  readonly setTimer: (fire: () => void, ms: number) => SaveTimer
+  readonly clearTimer: (timer: SaveTimer) => void
+  readonly debounceMs: number
+  /** The timestamp a landed write is stamped with. */
+  readonly now: () => string
+}
+
+export interface SaveScheduler {
+  /** An edit landed: unsaved from this instant, and the debounce restarts. */
+  edit(): void
+  /**
+   * FLUSH, not cancel. A pending debounce holds edits that are already in the
+   * document and already on screen; dropping it loses whatever was typed in
+   * the last debounce period before a switch or unmount.
+   */
+  flush(): void
+}
+
+/**
+ * Runs one write and reports what it means for the text ON SCREEN.
+ *
+ * `covers` is the load-bearing part. A write persists the document as it
+ * stood when it STARTED, so an edit arriving while it is in flight is not in
+ * it — and reporting `saved` on success then claims safety for text that is
+ * nowhere but memory, until the next debounce elapses. Found by the model in
+ * this file's companion test, on the sequence type / tick / type / settle.
+ *
+ * The write still landed, so its timestamp is still a fact and still
+ * advances; only the KIND stays `pending`, which is what the newer edit
+ * already made true and what its armed timer is about to resolve.
+ */
+async function reportingSave(
+  deps: SaveSchedulerDeps,
+  write: () => Promise<void>,
+  covers: () => boolean,
+): Promise<void> {
+  deps.report((p) => ({ kind: 'saving', lastSavedAt: p.lastSavedAt }))
+  try {
+    await write()
+    deps.report({ kind: covers() ? 'saved' : 'pending', lastSavedAt: deps.now() })
+  } catch (err) {
+    deps.report((p) => ({
+      kind: 'degraded',
+      reason: 'write-failed',
+      message: 'The last write to this browser failed. Your edits stay in memory for this session.',
+      lastSavedAt: p.lastSavedAt,
+    }))
+    throw err
+  }
+}
+
+export function createSaveScheduler(deps: SaveSchedulerDeps): SaveScheduler {
+  let timer: SaveTimer | null = null
+  // Counts edits, so a completed write can tell whether it contains the text
+  // that is on screen. Nothing reads the number itself.
+  let edits = 0
+  const run = () => {
+    const write = deps.beginSave()
+    if (write === null) return
+    // Read when the write RUNS, not here: it persists whatever the document
+    // holds at that moment, so that is the edit it covers.
+    let at: number | null = null
+    deps.enqueue(() => {
+      at = edits
+      return reportingSave(deps, write, () => at === edits)
+    })
+  }
+  return {
+    edit() {
+      edits += 1
+      if (timer !== null) deps.clearTimer(timer)
+      // Unsaved from this instant, not from when the timer fires: the window
+      // between the keystroke and the debounce is exactly when the old
+      // indicator claimed everything was safe.
+      deps.report((p) => ({ kind: 'pending', lastSavedAt: p.lastSavedAt }))
+      timer = deps.setTimer(() => {
+        // Cleared first, so a flush arriving after this point finds no timer
+        // and this save has to enqueue itself, or the next load has nothing
+        // to wait on.
+        timer = null
+        run()
+      }, deps.debounceMs)
+    },
+    flush() {
+      if (timer === null) return
+      deps.clearTimer(timer)
+      timer = null
+      run()
+    },
+  }
+}

--- a/apps/web/src/pages/use-markdown-document.ts
+++ b/apps/web/src/pages/use-markdown-document.ts
@@ -37,7 +37,6 @@ import {
 } from '@kamiazya/whiteboard-loro-adapter'
 import type { StoredCoreFacets } from '@kamiazya/whiteboard-model'
 import { Loro, type LoroText } from 'loro-crdt'
-import type { Dispatch, SetStateAction } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { isGeneratedDocumentPath } from '../components/workspace-files/new-document-path.js'
 import { getAppLogger } from '../lib/app-logger.js'
@@ -46,6 +45,7 @@ import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import { foldWorkspaceDocuments } from '../lib/fold-workspace.js'
 import { touchContentTimestamp } from '../lib/loro-store.js'
 import { titleFromMarkdownBody } from '../lib/title-from-body.js'
+import { createSaveScheduler, type SaveScheduler } from './save-scheduler.js'
 import type { BrowserPersistenceState, LoroStoreLike } from './use-browser-document-controller.js'
 
 const log = getAppLogger('markdown-document')
@@ -88,32 +88,6 @@ interface ContentHost {
  * Never rejects: a failed save is swallowed here exactly as a fire-and-forget
  * one was, so it cannot leave the queue permanently poisoned.
  */
-/**
- * One write, with the indicator told what happened to it.
- *
- * `queueSave` swallows failures so the queue cannot be poisoned, which also
- * means a failed write is invisible — the degraded branch here is the only
- * thing that surfaces it. The error is re-thrown so `queueSave` still absorbs
- * it exactly as before.
- */
-async function reportingSave(
-  host: ContentHost,
-  report: Dispatch<SetStateAction<BrowserPersistenceState>>,
-): Promise<void> {
-  report((p) => ({ kind: 'saving', lastSavedAt: p.lastSavedAt }))
-  try {
-    await host.save()
-    report({ kind: 'saved', lastSavedAt: new Date().toISOString() })
-  } catch (err) {
-    report((p) => ({
-      kind: 'degraded',
-      reason: 'write-failed',
-      message: 'The last write to this browser failed. Your edits stay in memory for this session.',
-      lastSavedAt: p.lastSavedAt,
-    }))
-    throw err
-  }
-}
 
 function queueSave(documentId: string, save: () => Promise<void>): Promise<void> {
   const previous = pendingFlushes.get(documentId)
@@ -282,7 +256,6 @@ export function useMarkdownDocument(
   const [coreFacets, setCoreMetaState] = useState<StoredCoreFacets | null>(null)
   const [doc, setDoc] = useState<Loro | null>(null)
   const hostRef = useRef<ContentHost | null>(null)
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const loroRef = useRef(loro)
   loroRef.current = loro
 
@@ -348,18 +321,10 @@ export function useMarkdownDocument(
       // title that is worse than lost text: `renameDocument` writes the
       // snapshot name immediately, so a cancelled facet save leaves the list
       // name and the OKF title disagreeing about what the document is called.
-      if (timerRef.current !== null) {
-        clearTimeout(timerRef.current)
-        timerRef.current = null
-        const host = hostRef.current
-        if (host !== null && documentId !== null) {
-          // Reports like any other write. The component is going away, so
-          // nothing renders the result — but this share the queue with the
-          // next load, and a silent branch here is how the two call sites
-          // drift apart later.
-          void queueSave(documentId, () => reportingSave(host, setSaveStateRef.current))
-        }
-      }
+      // Reports like any other write. The component is going away, so
+      // nothing renders the result — but this shares the queue with the next
+      // load, and a silent branch here is how the two call sites drift apart.
+      if (documentId !== null) schedulerRef.current?.scheduler.flush()
     }
   }, [documentId, enabled])
 
@@ -368,23 +333,40 @@ export function useMarkdownDocument(
   // ref from the doc subscription, which is created inside the load effect
   // before this binding initializes on the first render.
   const scheduleSaveRef = useRef<(() => void) | null>(null)
+  // Created per document rather than in an effect: the load effect's cleanup
+  // has to be able to FLUSH it, and effect cleanups run in reverse order —
+  // an effect owning the scheduler could be torn down first.
+  const schedulerRef = useRef<{ id: string; scheduler: SaveScheduler } | null>(null)
+  const schedulerFor = useCallback((id: string): SaveScheduler => {
+    if (schedulerRef.current?.id !== id) {
+      schedulerRef.current = {
+        id,
+        scheduler: createSaveScheduler({
+          debounceMs: SAVE_DEBOUNCE_MS,
+          now: () => new Date().toISOString(),
+          report: (update) => setSaveStateRef.current(update),
+          // Bound here, so the write goes through the handle this document
+          // had when the debounce elapsed — not whatever the next load has
+          // put in the ref by the time the queue reaches it.
+          beginSave: () => {
+            const host = hostRef.current
+            return host === null ? null : () => host.save()
+          },
+          enqueue: (save) => {
+            void queueSave(id, save)
+          },
+          setTimer: (fire, ms) => setTimeout(fire, ms),
+          clearTimer: (timer) => clearTimeout(timer as ReturnType<typeof setTimeout>),
+        }),
+      }
+    }
+    return schedulerRef.current.scheduler
+  }, [])
+
   const scheduleSave = useCallback(() => {
     if (documentId === null) return
-    if (timerRef.current !== null) clearTimeout(timerRef.current)
-    // Unsaved from this instant, not from when the timer fires: the window
-    // between the keystroke and the debounce is exactly when the old
-    // indicator claimed everything was safe.
-    setSaveStateRef.current((p) => ({ kind: 'pending', lastSavedAt: p.lastSavedAt }))
-    timerRef.current = setTimeout(() => {
-      // Clearing the ref first means a cleanup arriving after this point
-      // finds no timer to flush — so this save has to enqueue itself, or the
-      // next load has nothing to wait on.
-      timerRef.current = null
-      const host = hostRef.current
-      if (host === null) return
-      void queueSave(documentId, () => reportingSave(host, setSaveStateRef.current))
-    }, SAVE_DEBOUNCE_MS)
-  }, [documentId])
+    schedulerFor(documentId).edit()
+  }, [documentId, schedulerFor])
   scheduleSaveRef.current = scheduleSave
 
   const setBody = useCallback(


### PR DESCRIPTION
## Why this, and not something else

Picked by counting what actually caught defects across this run of work, rather than by guessing. The same 500ms debounce has now produced **three defects in three consecutive PRs**, all one shape — a timer fires part-way through typing, and some downstream state settles on the partial value:

| PR | what settled early |
|---|---|
| #1125 | a save wait, on a partial write |
| #1128 | a document's name, on a half-typed heading |
| this one | **the save indicator itself** |

None reproduced on an idle machine. All three needed an *interleaving*, which is what a model generates and a hand-written example has to guess.

## The defect

`reportingSave` reported `saved` on success, unconditionally. A write persists the document as it stood when it **started**, so an edit arriving while it is in flight is not in it — and reporting `saved` then claims safety for text that exists only in memory, until the next debounce elapses. Under typing that outruns the debounce, that is most of the time.

Found by the model, on its 28th case, shrunk to four steps:

```
type / tick / type / settle-ok
reported "saved" with edit 2 unwritten (store holds 1)
```

Pinned as an example before the fix. A completed write now reports `saved` only when no edit arrived since it began; otherwise the kind stays `pending`, which the newer edit already made true. The timestamp still advances, because the write did land.

This is also the root cause of the settle window I added to `waitForMarkdownSaved` in #1125 — that was compensating for an indicator that could say `saved` about an earlier write.

## The instrument

`save-scheduler.property.test.ts` generates sequences of `type` / `tick` / `leave` / `settle-ok` / `settle-fail` and states two invariants:

- **S1** the indicator never reports `saved` while the store lacks the current edit
- **S2** once nothing is armed and nothing is in flight, either the store has the last edit or the indicator says otherwise

Time is a *command*, not a clock: `tick` fires the armed timer, `settle` lands the in-flight write, and the generator is free to put an edit between them.

Mutation-checked — restoring the unconditional `saved` fails both the pinned example and the property.

## Two things the run got wrong first, both caught by guards rather than by me

**The harness could not reach its own subject.** `enqueue` defers through a promise, so a fired timer has not *begun* its write yet, and "an edit arrives while a write is in flight" was unreachable. The vacuity guard in `afterAll` read `editDuringWrite = 0` and said so. A step boundary now drains microtasks, which is what makes it a moment in time.

**The extraction introduced a second instance of the very class it was fixing.** Resolving the write handle late — `hostRef.current` at execution instead of at enqueue — broke `a reload sees the edits the unmount flush was still writing`, because by the time a queued write runs the next load may hold the ref. `beginSave` now binds the handle when the write is enqueued, so writing it the late way is not expressible rather than merely wrong. What the write *contains* is still read when it runs, which is what `covers` compares against.

I instrumented rather than guessed on that one: the probe showed `flush called, timerArmed=true` → `enqueue, host=true`, which ruled out the obvious explanations and pointed at *when* the handle was read.

## Test plan

- [x] New or updated tests added — `save-scheduler.property.test.ts` (1 property + the pinned counterexample + 3 vacuity guards)
- [x] `pnpm test` passes locally — 2904 passing; the only 9 failures are the standing objectURL/blob group that reproduces unchanged on a clean `origin/main` worktree in this container
- [x] Manual verification completed — n/a in the usual sense; this is a state machine, and the model *is* the verification. The existing 7 save-path tests plus 341 `web-jsdom` and 58 `web-browser` page tests pass unchanged, which is what pins the extraction as behaviour-preserving
- [ ] E2E coverage added or extended where applicable — not applicable; no routing, websocket or daemon composition involved

`pnpm knip`, `biome`, `pnpm -r typecheck` green.

## What is deliberately not here

`waitForMarkdownSaved`'s settle window **stays**. It covers a different window — an edit that has not reached `setBody` at all yet, through CodeMirror and the Loro subscription — and this fix does not close that one. Removing it because the other cause is gone would be exactly the kind of guard-weakening this work exists to prevent.

## Visual evidence

**Visual evidence: none — the only pixel change is the save chip holding "pending" for a beat longer, which is the fix.** There is no before/after picture worth taking: the old behaviour is a chip that reads "Saved" while text is unwritten, and a screenshot of it looks correct, which is precisely the problem. The evidence is the counterexample above.

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_