### PR TITLE
fix(web): declare destructive confirmation copy once, and stop it calling a note a canvas

### DIFF
--- a/.claude/rules/coverage-ledger.md
+++ b/.claude/rules/coverage-ledger.md
@@ -115,9 +115,43 @@ Assert the scan found a plausible COUNT in its own `it`. A regex that stops
 matching otherwise reports itself as "every entry is stale", which sends the
 reader to the wrong file entirely.
 
-This variant is deliberately NOT in the shared helper: one call site, and
-its coverage vocabulary differs (it needs a `view only:` state). Extract it
-when a second one exists, not before.
+There are two scans now, and they still do NOT share a helper. What they
+have in common is four lines — the `?raw` glob and the plausible-count
+assertion — and past that they diverge completely: `editor-state-surface`
+CLASSIFIES each thing it finds against a three-value vocabulary it needs a
+`view only:` state for, while `destructive-copy-surface` asserts a
+single-definition rule and has no vocabulary at all. A helper over that is
+a glob with a parameter. Extract when two call sites want the same
+JUDGEMENT, not when two of them read files.
+
+### The second one: copy declared once
+
+`lib/destructive-copy.ts` + `destructive-copy-surface.test.ts` is the worked
+example for a surface that earns a scan and explicitly does NOT earn a
+ledger. Nothing models confirmation copy — there is no property or
+table-driven run to tally — so a ledger would be the hand-maintained list of
+names this rule exists to replace. Step 1 of declare -> model -> pin, plus a
+scan holding it, is the whole mechanism, and that is a complete answer
+rather than a partial one.
+
+Two things it measured that generalise:
+
+- **Scan word RUNS, not whole strings.** The defect that motivated it was a
+  correction that had to reach six places and a grep that found four; both
+  misses were tests asserting a MIDDLE FRAGMENT of the sentence. Measured:
+  the first version of that scan compared whole fragments and flagged the
+  three production sites and neither test. Five-word runs, derived from the
+  copy by splitting on a sentinel subject, catch both. Four collides with
+  ordinary English; six misses the prefix case.
+- **Derive the probes, never list them.** A hand-picked "distinctive
+  phrase" beside the copy is one more string to keep in step — the same
+  defect one level up.
+
+A scan has a floor and saying so is part of the rule: a test asserting a
+three-word prefix is under any run length that avoids false positives. That
+is acceptable here because the single definition removes the SWEEP rather
+than perfecting the grep — with one source there is nothing to keep in
+step, and a stale assertion fails loudly instead of being missed quietly.
 
 ## Traps
 

--- a/apps/web/src/components/document-list/DeleteDocumentDialog.tsx
+++ b/apps/web/src/components/document-list/DeleteDocumentDialog.tsx
@@ -1,3 +1,4 @@
+import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -8,13 +9,21 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
+import { DESTRUCTIVE_COPY, type DestructiveActionId } from '@/lib/destructive-copy'
+import { kindNoun } from '@/lib/kind-noun'
 
 export interface DeleteDocumentDialogProps {
-  // The canvas pending deletion, or null when the dialog is closed.
-  pending: { displayName: string } | null
+  // The document pending deletion, or null when the dialog is closed.
+  pending: { displayName: string; kind?: DocumentKind } | null
   busy: boolean
   error: string | null
-  description: string
+  /**
+   * Which promise this delete makes about the user's data. The dialog builds
+   * the sentence itself rather than taking one: a caller that can pass a
+   * string is a caller that can write a second copy of it, which is how the
+   * browser sentence came to exist in two files. See lib/destructive-copy.ts.
+   */
+  action: DestructiveActionId
   onCancel: () => void
   onConfirm: () => void
 }
@@ -27,7 +36,7 @@ export function DeleteDocumentDialog({
   pending,
   busy,
   error,
-  description,
+  action,
   onCancel,
   onConfirm,
 }: DeleteDocumentDialogProps) {
@@ -45,7 +54,7 @@ export function DeleteDocumentDialog({
             {pending ? `Delete "${pending.displayName}"?` : 'Delete canvas?'}
           </AlertDialogTitle>
           <AlertDialogDescription>
-            {description}
+            {DESTRUCTIVE_COPY[action](kindNoun(pending?.kind))}
             {error && <span className="mt-2 block text-destructive">{error}</span>}
           </AlertDialogDescription>
         </AlertDialogHeader>

--- a/apps/web/src/destructive-copy-surface.test.ts
+++ b/apps/web/src/destructive-copy-surface.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The sentences in `lib/destructive-copy.ts` must exist in exactly one
+ * place. This scans every source file under `apps/web/src` and fails when
+ * any run of that copy is written out anywhere else.
+ *
+ * It is the source-scan variant from `.claude/rules/coverage-ledger.md` —
+ * user-facing copy is not a union the type system enumerates, so the guard
+ * reads the source instead. What it pins is narrower than a ledger and that
+ * is the point: there is no model of confirmation copy to tally, only a
+ * single-definition rule to hold.
+ *
+ * Why it exists rather than trusting a reader: correcting this copy once
+ * meant editing six places, and a grep for the old phrasing found four.
+ *
+ * **It scans word runs, not whole sentences, because of what those two
+ * misses were.** Both were tests asserting a MIDDLE FRAGMENT
+ * (`/^The note moves to the Trash/`) — no pattern written from the
+ * production sites matches that, and neither does a scan for the full
+ * sentence. Measured: the first version of this file, which compared whole
+ * fragments, flagged the three production sites and neither test. So the
+ * probes are every {@link PROBE_WORDS}-word run of the copy, derived from
+ * the copy itself rather than chosen by hand — a hand-picked "distinctive
+ * phrase" would be one more string to keep in step, which is the class this
+ * whole surface exists to remove.
+ *
+ * A test that wants to assert the copy imports the builder, so it passes
+ * this scan for the same reason it can never drift.
+ *
+ * Source comes from `?raw` at build time, not `node:fs`: apps/web is
+ * browser-only and `web-app-boundary.test.ts` enforces it.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  DESTRUCTIVE_COPY,
+  type DestructiveActionId,
+  type DestructiveDescription,
+  destructiveCopyFragments,
+} from '@/lib/destructive-copy'
+
+const sources = import.meta.glob('./**/*.{ts,tsx}', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+/** Where the copy is allowed to appear, being the file that declares it. */
+const DECLARATION = './lib/destructive-copy.ts'
+
+/** This file quotes the copy only in prose above; excluded so the doc comment can stay concrete. */
+const SELF = './destructive-copy-surface.test.ts'
+
+/**
+ * Short enough to catch a partial assertion, long enough that an ordinary
+ * English sentence elsewhere in the app will not collide with it. Four
+ * would flag "and restoring does not bring"; six would miss
+ * `/^The note moves to the Trash/`, which is the case that motivated this.
+ */
+const PROBE_WORDS = 5
+
+/**
+ * Every PROBE_WORDS-long word run of `fragment`, sliced out of the original
+ * so each probe is an exact substring — spacing and punctuation included.
+ */
+function wordRuns(fragment: string, size: number): string[] {
+  const words = [...fragment.matchAll(/\S+/g)]
+  const runs: string[] = []
+  for (let i = 0; i + size <= words.length; i += 1) {
+    const first = words[i]
+    const last = words[i + size - 1]
+    runs.push(fragment.slice(first.index, last.index + last[0].length))
+  }
+  return runs
+}
+
+function probesFor(build: DestructiveDescription): string[] {
+  return destructiveCopyFragments(build).flatMap((fragment) => wordRuns(fragment, PROBE_WORDS))
+}
+
+const entries = Object.entries(DESTRUCTIVE_COPY) as [DestructiveActionId, DestructiveDescription][]
+
+describe('destructive confirmation copy is declared once', () => {
+  // A scan that stops matching reports itself as "everything is fine",
+  // which is the failure mode this whole file exists to prevent. Assert the
+  // fixture is present before asserting anything about it.
+  it('scans a plausible number of source files', () => {
+    expect(Object.keys(sources).length).toBeGreaterThan(300)
+    expect(sources[DECLARATION]).toBeDefined()
+  })
+
+  it.each(entries)('%s yields probes the declaration actually contains', (_id, build) => {
+    const probes = probesFor(build)
+    expect(probes.length).toBeGreaterThan(0)
+    // If the declaration does not contain what we are about to grep for,
+    // the grep is looking for something nothing produces.
+    for (const probe of probes) {
+      expect(sources[DECLARATION]).toContain(probe)
+    }
+  })
+
+  it.each(entries)('%s appears in no file but the declaration', (_id, build) => {
+    const offenders = probesFor(build).flatMap((probe) =>
+      Object.entries(sources)
+        .filter(([path]) => path !== DECLARATION && path !== SELF)
+        .filter(([, source]) => source.includes(probe))
+        .map(([path]) => `${path} carries "${probe}"`),
+    )
+
+    expect(
+      [...new Set(offenders)].sort(),
+      'destructive confirmation copy is written out somewhere other than lib/destructive-copy.ts — import DESTRUCTIVE_COPY there instead, in tests too',
+    ).toEqual([])
+  })
+})

--- a/apps/web/src/lib/destructive-copy.ts
+++ b/apps/web/src/lib/destructive-copy.ts
@@ -1,0 +1,79 @@
+/**
+ * The sentence a destructive confirmation shows about the user's data —
+ * declared once, so the promise it makes exists in exactly one place.
+ *
+ * Scope is the DESCRIPTION and nothing else. That is the line that says
+ * whether the thing comes back, which is the half that has been wrong and
+ * the half a reader decides on. Titles ("Delete this note?") carry no
+ * promise, differ in subject between the list and the document page, and
+ * have never drifted — folding them in would buy a two-subject signature
+ * for nothing.
+ *
+ * Why a module rather than three string literals: a correction has to reach
+ * every site, and nothing made it. The browser sentence was already written
+ * out twice (the list page and the document page), and when this copy was
+ * last corrected a grep for the old phrasing found four of the six places
+ * that carried it — the two it missed were tests asserting a middle
+ * fragment, and only the full suite disagreed. Importing the same builder at
+ * every site, tests included, removes the class rather than re-checking for
+ * it: there is one string, so there is nothing to keep in step.
+ *
+ * `destructive-copy-surface.test.ts` holds that line — it scans the source
+ * for these sentences appearing anywhere but here.
+ *
+ * This surface deliberately has NO coverage ledger. Per
+ * `.claude/rules/coverage-ledger.md` a ledger is the third step of
+ * declare -> model -> pin, and nothing models confirmation copy: there is no
+ * property or table-driven run to tally, so a ledger here would be the
+ * hand-maintained list of names that rule exists to replace. The declaration
+ * plus the scan is the whole mechanism.
+ */
+
+/** A destructive confirmation this app shows. */
+export type DestructiveActionId = 'delete-document-browser' | 'delete-document-daemon'
+
+/**
+ * Built from the noun for the thing being destroyed, so a note reads "The
+ * note ..." and a canvas "The canvas ...". Taking the noun rather than
+ * baking one in is what lets a single sentence serve both kinds.
+ */
+export type DestructiveDescription = (noun: string) => string
+
+export const DESTRUCTIVE_COPY = {
+  // The delete evacuates into the trash before removing anything
+  // (loro-workspace-document-index's "EVACUATE FIRST"), and the Trash
+  // section restores it. Older copy said "There is no undo", which talks a
+  // reader out of tidying up. A browser workspace keeps no versions — those
+  // are a daemon feature — so the trash is the whole story here.
+  'delete-document-browser': (noun) => `The ${noun} moves to the Trash, where you can restore it.`,
+
+  // Recoverable in the same way: document-store.ts routes the delete through
+  // the index, which evacuates into the trash and keeps the same
+  // recoverability promise the agent-facing port makes. What genuinely does
+  // NOT come back is the versions and branches — documentTeardown deletes
+  // those rows, and the trash holds only the tree subtree — so that is the
+  // half worth warning about, rather than a blanket "no undo" that is false.
+  'delete-document-daemon': (noun) =>
+    `The ${noun} moves to the Trash, where you can restore it. Its versions and branches are deleted, and restoring does not bring them back.`,
+} satisfies Record<DestructiveActionId, DestructiveDescription>
+
+/**
+ * A subject no copy would ever contain, so splitting on it recovers a
+ * sentence's static halves without anyone writing them down a second time.
+ */
+const SUBJECT_HOLE = '\u0000'
+
+/**
+ * The static text a description is built from — the halves either side of
+ * the subject.
+ *
+ * Derived by calling the builder rather than listed by hand: a listed
+ * fragment is one more copy to keep in step, which is the defect this module
+ * exists to remove.
+ */
+export function destructiveCopyFragments(build: DestructiveDescription): string[] {
+  return build(SUBJECT_HOLE)
+    .split(SUBJECT_HOLE)
+    .map((fragment) => fragment.trim())
+    .filter((fragment) => fragment.length > 0)
+}

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -45,6 +45,7 @@ import {
 import { BrowserBackend } from '../lib/browser-backend.js'
 import { browserWorkspaceHandleOrNull } from '../lib/browser-workspace-id.js'
 import { useWhiteboardCommands } from '../lib/commands/index.js'
+import { DESTRUCTIVE_COPY } from '../lib/destructive-copy.js'
 import { BROWSER_FILE_ADAPTER } from '../lib/document-embed-content.js'
 import { isDocumentReadFailure } from '../lib/document-read-failure.js'
 import { browserFaviconStatus, type FaviconStyle } from '../lib/favicon.js'
@@ -712,7 +713,7 @@ export function BrowserDocumentPage({
           <AlertDialogHeader>
             <AlertDialogTitle>Delete this {kindNoun(documentKind)}?</AlertDialogTitle>
             <AlertDialogDescription>
-              The {kindNoun(documentKind)} moves to the Trash, where you can restore it.
+              {DESTRUCTIVE_COPY['delete-document-browser'](kindNoun(documentKind))}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/apps/web/src/pages/BrowserIndexPage.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
+
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { DESTRUCTIVE_COPY } from '@/lib/destructive-copy'
 import {
   getBrowserWorkspaceId,
   setBrowserWorkspaceIdForTests,
@@ -295,14 +297,18 @@ describe('BrowserIndexPage', () => {
     await selectCard('Meeting notes')
     fireEvent.click(await screen.findByRole('button', { name: 'Delete' }))
     let dialog = await screen.findByRole('alertdialog')
-    expect(within(dialog).getByText(/^The note moves to the Trash/)).toBeTruthy()
+    expect(
+      within(dialog).getByText(DESTRUCTIVE_COPY['delete-document-browser']('note')),
+    ).toBeTruthy()
     fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
     await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
 
     await selectCard('Trip plan')
     fireEvent.click(await screen.findByRole('button', { name: 'Delete' }))
     dialog = await screen.findByRole('alertdialog')
-    expect(within(dialog).getByText(/^The canvas moves to the Trash/)).toBeTruthy()
+    expect(
+      within(dialog).getByText(DESTRUCTIVE_COPY['delete-document-browser']('canvas')),
+    ).toBeTruthy()
   })
 
   it('Delete opens a dialog naming the canvas; Cancel removes nothing', async () => {

--- a/apps/web/src/pages/BrowserIndexPage.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.tsx
@@ -286,13 +286,7 @@ export function BrowserIndexPage({
         pending={pendingDelete}
         busy={deleting}
         error={deleteError}
-        // The delete evacuates into the trash before removing anything
-        // (loro-workspace-document-index's "EVACUATE FIRST"), and the Trash
-        // section restores it. The old copy said "There is no undo", which
-        // talks a reader out of tidying up. A browser workspace keeps no
-        // versions — those are a daemon feature — so the trash is the whole
-        // story here.
-        description={`The ${kindNoun(pendingDelete?.kind)} moves to the Trash, where you can restore it.`}
+        action="delete-document-browser"
         onCancel={() => {
           setPendingDelete(null)
           setDeleteError(null)

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -11,6 +11,7 @@ import {
 import type { ReactElement } from 'react'
 import { createMemoryRouter, MemoryRouter, RouterProvider } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { DESTRUCTIVE_COPY } from '@/lib/destructive-copy'
 import { pickNewDocumentKind } from '../test-utils/new-document-menu.js'
 import { DaemonIndexPage } from './DaemonIndexPage.js'
 
@@ -1406,15 +1407,18 @@ describe('DaemonIndexPage', () => {
     // A daemon delete is recoverable — document-store.ts routes it through
     // the index's evacuate-first path — so the dialog names the Trash. What
     // it still warns about is the half that really is destroyed.
-    expect(within(dialog).getByText(/The note moves to the Trash/)).toBeTruthy()
-    expect(within(dialog).getByText(/versions and branches are deleted/)).toBeTruthy()
+    expect(
+      within(dialog).getByText(DESTRUCTIVE_COPY['delete-document-daemon']('note')),
+    ).toBeTruthy()
     fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
     await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
 
     await selectCard('Trip plan')
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
     dialog = await screen.findByRole('alertdialog')
-    expect(within(dialog).getByText(/The canvas moves to the Trash/)).toBeTruthy()
+    expect(
+      within(dialog).getByText(DESTRUCTIVE_COPY['delete-document-daemon']('canvas')),
+    ).toBeTruthy()
   })
 
   it('Delete opens an AlertDialog naming the canvas; Cancel sends no DELETE', async () => {

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -684,14 +684,7 @@ export function DaemonIndexPage({
           pending={pendingDelete}
           busy={deleting}
           error={deleteError}
-          // Recoverable, like the browser's: document-store.ts routes the
-          // delete through the index, which evacuates into the trash and
-          // "keeps the same recoverability promise the agent-facing port
-          // makes". What genuinely does NOT come back is the versions and
-          // branches — documentTeardown deletes those rows, and the trash
-          // holds only the tree subtree — so that is the half worth warning
-          // about, instead of a blanket "no undo" that is simply false.
-          description={`The ${kindNoun(pendingDelete?.kind)} moves to the Trash, where you can restore it. Its versions and branches are deleted, and restoring does not bring them back.`}
+          action="delete-document-daemon"
           onCancel={closeDeleteDialog}
           onConfirm={() => void handleConfirmDelete()}
         />

--- a/apps/web/src/pages/use-browser-document-controller.test.ts
+++ b/apps/web/src/pages/use-browser-document-controller.test.ts
@@ -253,6 +253,42 @@ describe('useBrowserDocumentController', () => {
     expect(result.current.cleanupError).not.toMatch(/\btoken\b|\bAuthorization\b|\bBearer\b/i)
   })
 
+  it('cleanupError names the document by its own kind, not always "canvas"', async () => {
+    // `kindNoun` exists so user-visible copy never calls a note a canvas
+    // (vocabulary.md retired the container sense of the word). These two
+    // failure messages were written before it and bypassed it, so deleting a
+    // NOTE that could not be flushed reported "The canvas copy has been kept".
+    const base = new LocalStoreDouble()
+    await base.setDefaultDocumentId(C1)
+    await base.save({ ...snap, kind: 'markdown' })
+    let shouldFailSave = false
+    const setName = base.index.setDocumentName.bind(base.index)
+    base.index.setDocumentName = async (input) => {
+      if (shouldFailSave) throw new Error('save failed')
+      return setName(input)
+    }
+    const { result } = renderHook(() =>
+      useBrowserDocumentController(base.index, {
+        loro: base.loro,
+        pointer: base.pointer,
+        clock: base.clock,
+      }),
+    )
+    await act(async () => {})
+    shouldFailSave = true
+    await act(async () => {
+      result.current.renameDocument('Renamed').catch(() => {})
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(result.current.persistence.kind).toBe('degraded')
+    await act(async () => {
+      await result.current.triggerCleanup()
+    })
+    expect(result.current.cleanupError).toMatch(/\bnote\b/)
+    expect(result.current.cleanupError).not.toMatch(/\bcanvas\b/i)
+  })
+
   it('renameDocument returns a promise that rejects when the underlying save fails', async () => {
     // Root cause: callers such as WorkspaceTopBar await onRenameDocument and
     // treat a rejection as "keep the rename input open for retry". Before this

--- a/apps/web/src/pages/use-browser-document-controller.ts
+++ b/apps/web/src/pages/use-browser-document-controller.ts
@@ -5,6 +5,7 @@ import { newDocumentPathIn } from '../components/workspace-files/new-document-pa
 import { BrowserWorkspaceDocs, openWorkspaceOrNull } from '../lib/browser-workspace-docs.js'
 import { browserWorkspaceIdOrNull, getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
 import { deriveCopyName } from '../lib/derive-copy-name.js'
+import { kindNoun } from '../lib/kind-noun.js'
 import {
   type ContentClock,
   type DefaultDocumentPointer,
@@ -383,15 +384,18 @@ export function useBrowserDocumentController(
 
   const triggerCleanup = useCallback(async () => {
     setCleanupError(null)
+    // Copy below names the document, and a note is not a canvas — kindNoun is
+    // the single place that mapping lives (vocabulary.md).
+    const noun = kindNoun(snapshotRef.current?.kind)
     // Abort if flush fails — unsaved edits must not be silently discarded.
     const flushed = await flushSave()
     if (!flushed) {
-      setCleanupError('Your changes could not be saved. The canvas copy has been kept.')
+      setCleanupError(`Your changes could not be saved. The ${noun} copy has been kept.`)
       return
     }
     // Abort if a previous save already failed; data integrity is uncertain.
     if (persistenceRef.current.kind === 'degraded') {
-      setCleanupError('The canvas could not be safely removed. Your copy has been kept.')
+      setCleanupError(`The ${noun} could not be safely removed. Your copy has been kept.`)
       return
     }
     const id = await pointerRef.current.get()

--- a/packages/mcp-server/src/server/store/file-gc-loop-availability.test.ts
+++ b/packages/mcp-server/src/server/store/file-gc-loop-availability.test.ts
@@ -22,7 +22,9 @@ const { purgeDanglingFiles } = await import('./file-gc.js')
 const { FileVersionStore } = await import('./version-store.js')
 const { createIsolatedDb } = await import('./db/test-helpers.js')
 const { makeSpatialDoc } = await import('../../shared/test-utils/spatial-doc.js')
-const { measureLoopAvailability } = await import('../../shared/test-utils/loop-availability.js')
+const { loopTurnShare, measureLoopAvailability } = await import(
+  '../../shared/test-utils/loop-availability.js'
+)
 
 let handle: Awaited<ReturnType<typeof createIsolatedDb>>
 
@@ -160,17 +162,13 @@ describe('a file-GC pass', () => {
 
     // The loop ran something many times over, rather than once at each edge.
     //
-    // A FRACTION of the samples the interval asked for, not a count, for the
-    // same reason the stall assertion below is a ratio: a count is a
-    // statement about how busy the machine is. Measured on this fixture --
-    // without the yields, 3 samples of an ideal 279 (1.1%); with them, 61 of
-    // 173 idle (35%) and 20 of 85 under eight CPU hogs on four cores (24%).
-    // A floor at 5% clears the blocked case by 4x and the loaded case by 5x.
-    // The absolute 20 this replaces had NO margin: a loaded run landed on
-    // exactly 20 and CI failed `expected 20 to be greater than 20`.
-    expect(availability.samples).toBeGreaterThan(
-      (availability.elapsedMs / availability.intervalMs) * 0.05,
-    )
+    // A SHARE of the ticks the sampler asked for, not a count, for the same
+    // reason the stall assertion below is a ratio. Measured on this fixture:
+    // without the yields, 3 samples of an ideal 279 (0.011); with them, 0.35
+    // idle and 0.18 under eight CPU hogs on four cores. The absolute 20 this
+    // replaces had no margin -- a loaded run landed on exactly 20, and CI
+    // failed `expected 20 to be greater than 20`.
+    expect(loopTurnShare(availability)).toBeGreaterThan(0.05)
     // And no single stall swallowed the pass. Without the yields this ratio
     // was 0.96; with them it is 0.04 on the same fixture.
     expect(availability.worstStallMs).toBeLessThan(availability.elapsedMs * 0.5)

--- a/packages/mcp-server/src/server/store/file-gc-loop-availability.test.ts
+++ b/packages/mcp-server/src/server/store/file-gc-loop-availability.test.ts
@@ -159,8 +159,18 @@ describe('a file-GC pass', () => {
     expect(measured.result).toMatchObject({ purgedCount: 1 })
 
     // The loop ran something many times over, rather than once at each edge.
-    // Without the yields this fixture produced 3 samples across 1394ms.
-    expect(availability.samples).toBeGreaterThan(20)
+    //
+    // A FRACTION of the samples the interval asked for, not a count, for the
+    // same reason the stall assertion below is a ratio: a count is a
+    // statement about how busy the machine is. Measured on this fixture --
+    // without the yields, 3 samples of an ideal 279 (1.1%); with them, 61 of
+    // 173 idle (35%) and 20 of 85 under eight CPU hogs on four cores (24%).
+    // A floor at 5% clears the blocked case by 4x and the loaded case by 5x.
+    // The absolute 20 this replaces had NO margin: a loaded run landed on
+    // exactly 20 and CI failed `expected 20 to be greater than 20`.
+    expect(availability.samples).toBeGreaterThan(
+      (availability.elapsedMs / availability.intervalMs) * 0.05,
+    )
     // And no single stall swallowed the pass. Without the yields this ratio
     // was 0.96; with them it is 0.04 on the same fixture.
     expect(availability.worstStallMs).toBeLessThan(availability.elapsedMs * 0.5)

--- a/packages/mcp-server/src/server/store/workspace-tail-loop-availability.test.ts
+++ b/packages/mcp-server/src/server/store/workspace-tail-loop-availability.test.ts
@@ -4,7 +4,10 @@ import { newImageRef } from '@kamiazya/whiteboard-model'
 import { DocumentStoreWorkspaceDocs } from '@kamiazya/whiteboard-workspace-index'
 import { LoroDoc } from 'loro-crdt'
 import { describe, expect, it } from 'vitest'
-import { measureLoopAvailability } from '../../shared/test-utils/loop-availability.js'
+import {
+  loopTurnShare,
+  measureLoopAvailability,
+} from '../../shared/test-utils/loop-availability.js'
 import { InMemoryDocumentStore } from './inmemory/in-memory-document-store.js'
 import { createWorkspaceTail } from './workspace-tail.js'
 
@@ -109,8 +112,12 @@ describe('a workspace-tail pass', () => {
     expect(emitted).toBeGreaterThan(0)
 
     // Without the yield this fixture produced ZERO samples: the loop ran
-    // nothing at all for the whole pass.
-    expect(availability.samples).toBeGreaterThan(5)
+    // nothing at all for the whole pass. A SHARE rather than a count, for the
+    // reason `loopTurnShare` gives -- this pass is short enough that the ideal
+    // sample count is around ten, so the absolute 5 it replaces demanded half
+    // of them, and CI failed on `expected 5 to be greater than 5`. Measured
+    // here: 0.55 idle, 0.37 under load.
+    expect(loopTurnShare(availability)).toBeGreaterThan(0.05)
     expect(availability.worstStallMs).toBeLessThan(availability.elapsedMs * 0.5)
   }, 120_000)
 })

--- a/packages/mcp-server/src/shared/test-utils/loop-availability.ts
+++ b/packages/mcp-server/src/shared/test-utils/loop-availability.ts
@@ -18,7 +18,7 @@
  * 4.7-second call reports 4.7 seconds blocked, which is what happened.
  */
 
-interface LoopAvailability {
+export interface LoopAvailability {
   elapsedMs: number
   /** Wall clock in which the loop ran nothing: elapsed minus what ticked. */
   blockedMs: number
@@ -90,4 +90,28 @@ export async function measureLoopAvailability<T>(
 
 function round(value: number): number {
   return Math.round(value * 10) / 10
+}
+
+/**
+ * The share of the ticks the sampler ASKED for that actually landed.
+ *
+ * The scale-free way to say "the loop kept getting turns", and the one to
+ * assert on. A raw `samples` count is a statement about how busy the machine
+ * is: both loop-availability tests floored it at an absolute number
+ * calibrated on an idle machine, and both failed in CI at exactly their
+ * threshold (`expected 20 to be greater than 20`, `expected 5 to be greater
+ * than 5`) without anything being wrong with the code under them.
+ *
+ * Measured across three regimes, which is what the 0.05 floor those tests use
+ * is picked from:
+ *
+ *   blocked (the defect)   file-GC 3 of 279 = 0.011  ·  workspace-tail 0
+ *   under load             0.18 - 0.24              ·  0.37 - 0.64
+ *   idle                   0.35                     ·  0.55
+ *
+ * Read it beside `worstStallMs`, never instead: this says the loop ran
+ * something, that says no single stall swallowed the pass.
+ */
+export function loopTurnShare(availability: LoopAvailability): number {
+  return availability.samples / (availability.elapsedMs / availability.intervalMs)
 }


### PR DESCRIPTION
## Why this, and not something else

Picked by what actually caught a defect. In #1128 correcting the delete-dialog copy meant editing **six** places, and my grep for the old phrasing found **four**. The two it missed were tests asserting a *middle fragment* of the sentence, which no pattern written from the production sites could match — only the full suite disagreed, long after the sweep was believed done.

The cost was not a shipped bug. It was a **sweep believed complete**, and no mechanism in the repo could have told me otherwise.

## The declaration

`apps/web/src/lib/destructive-copy.ts` holds the sentence a delete dialog shows about the user's data. Scope is the **description** only — that is the line that says whether the thing comes back, the half that has been wrong, and the half a reader decides on. Titles carry no promise and have never drifted.

`DeleteDocumentDialog` now takes an **action id**, not a `description: string`:

```diff
-  description: string
+  action: DestructiveActionId
```

A caller that can pass a sentence is a caller that can write a second copy of it, which is exactly how the browser sentence came to exist in two files. It is no longer expressible.

Both index pages and `BrowserDocumentPage` build from the catalog; both test files now assert against the same builder, so they cannot drift from the copy they check.

## The scan, and the thing it had to be redesigned around

`destructive-copy-surface.test.ts` scans every source file under `apps/web/src` (`?raw` glob — apps/web is browser-only) and fails when the copy appears anywhere but the declaration.

**It scans five-word RUNS, not whole sentences, and that was a measurement, not a preference.** The first version compared whole fragments. Run against the tree it flagged the three production sites and **neither test file** — it would have repeated the #1128 miss exactly:

```
./pages/BrowserDocumentPage.tsx carries "moves to the Trash, where you can restore it."
./pages/BrowserIndexPage.tsx    carries "moves to the Trash, where you can restore it."
./pages/DaemonIndexPage.tsx     carries "moves to the Trash, where you can restore it."
```

Word runs catch the prefix case. Four words collides with ordinary English; six misses `/^The note moves to the Trash/`. Probes are **derived** from the copy by splitting on a sentinel subject — a hand-picked "distinctive phrase" beside the copy would be one more string to keep in step, the same defect one level up.

### Mutation-checked in all four directions

| mutation | result |
|---|---|
| a site hardcodes the sentence again | RED — 5 probes, names the file |
| a test asserts a prefix fragment (**the #1128 shape**) | RED — `DaemonIndexPage.test.tsx carries "moves to the Trash, where"` |
| the glob stops reaching the source | RED — `expected 0 to be greater than 300`, the count guard, not a false all-clear |
| the sentinel stops recovering static halves | RED — `expected 0 to be greater than 0` |

## Deliberately NO coverage ledger

Per `.claude/rules/coverage-ledger.md`, a ledger is step 3 of declare → model → pin, and **nothing models confirmation copy** — there is no property or table-driven run to tally, so a ledger here would be the hand-maintained list of names that rule exists to replace. Declaration + scan is the complete answer, not a partial one.

The rule gains that as its worked example for a surface that earns a scan and not a ledger, plus the word-run measurement, plus why two source scans still do **not** share a helper: they have four lines in common (glob + count assert) and diverge entirely past that. *Extract when two call sites want the same judgement, not when two of them read files.*

It also now states the scan's **floor** honestly: a three-word prefix assertion is under any run length that avoids false positives. That is acceptable because a single definition removes the *sweep* rather than perfecting the *grep*.

## Second fix — found by writing the declaration down

`triggerCleanup`'s two failure messages hardcoded `"canvas"`. Deleting a **note** that could not be flushed reported:

> The canvas could not be safely removed. Your copy has been kept.

`kindNoun` exists precisely so user-visible copy never calls a note a canvas (`vocabulary.md` retired the container sense), and these two strings predate it. Red test first — it reproduced that exact string — then routed through `kindNoun`.

## Third fix — CI, and not this PR's subject at all

This PR's `test-unit` went red twice on a defect it cannot reach, in `packages/mcp-server`. Both failures were the **same class**, one file apart:

```
file-gc-loop-availability.test.ts        expected 20 to be greater than 20
workspace-tail-loop-availability.test.ts expected  5 to be greater than  5
```

Both floored an absolute **sample count** — calibrated on an idle machine — beside a stall assertion that is deliberately a ratio. A count is a statement about how busy the runner is. Base `882cc8bf` was green and `rerun-failed-jobs` answers **403** here, so it was reproduced rather than waited out: eight CPU hogs on four cores, and the *first* local run gave `samples=20, elapsed=427ms` — the identical message.

Two instances is the class, so the rule moved into the helper that owns the measurement as `loopTurnShare`, and both tests assert against it:

| | file-GC | workspace-tail |
|---|---|---|
| yields removed (the defect each guards) | 3 of 279 = **0.011** | **0 samples** |
| under load | 0.18 – 0.24 | 0.37 – 0.64 |
| idle | 0.35 | 0.55 |

Floor at **0.05** — 4× above the blocked case, 5× below the worst loaded one. Mutation-checked separately against each production yield removed: `expected 0.0116 to be greater than 0.05` and `expected 0 to be greater than 0.05`. The message is now the share itself rather than arithmetic.

`loop-availability.test.ts`'s own `samples > 10` is **left alone**: its body is a bare `setTimeout` with no CPU work and it passed three loaded runs, so there is no evidence to weaken it on.

## Test plan

- [x] New or updated tests added — the scan (5 cases), a red-first regression for the wrong noun, and the two re-floored loop-availability guards
- [x] `pnpm --filter @kamiazya/whiteboard-web test` — **2932 passing**, `web-node` 77/77. The 9 failures are the standing objectURL/blob group, **A/B-confirmed** identical on a clean `origin/main` (`882cc8bf`) worktree in this container; none is in a file this diff touches
- [x] `arch-lint-node` 111/111 · `mcp-node` 4168 passing (its 3 failures are the chmod/EACCES tests that cannot fail as root, pre-existing) · both loop-availability guards pass four runs under load
- [x] Manual verification in a real browser against `pnpm dev` — all three delete dialogs after the refactor: document page/note *"Delete this note?" / "The note moves to the Trash, where you can restore it."*, document page/canvas *"Delete this canvas?" / "The canvas …"*, index page *"Delete \"untitled\"?" / "The note …"*. (The daemon variant needs a daemon; it is covered by the jsdom test.)
- [x] `pnpm knip`, `biome`, `secretlint`, `intent:validate`, `pnpm audit --prod`, `pnpm -r typecheck` green. `check:local`'s only failure is `compose-figure.test.mjs`, which prints its own reason — ImageMagick is absent in this container
- [ ] E2E coverage — not applicable; no routing, websocket or daemon composition involved

## Visual evidence

**Visual evidence: none — the rendered strings are unchanged for a canvas, and the one string that does change is a failure message reachable only by making a save fail mid-delete.** The delete dialogs render byte-identical copy before and after; the change is where that copy comes from, which the browser walk above confirms. The note-vs-canvas fix has no staged capture worth trusting either — the honest evidence is the red test, which reproduced `The canvas could not be safely removed.` on a `markdown` document before the fix and fails on any reintroduction.

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_