### PR TITLE
fix(server): mint a canonical ULID for the workspace a fresh daemon bootstraps

### DIFF
--- a/packages/mcp-server/src/server/app.test.ts
+++ b/packages/mcp-server/src/server/app.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { deleteSpatialNode } from '@kamiazya/whiteboard-loro-adapter'
+import { workspaceCanonicalIdSchema } from '@kamiazya/whiteboard-model'
 import {
   Client,
   LATEST_PROTOCOL_VERSION,
@@ -750,7 +751,12 @@ describe('createApp daemon mutation auth', () => {
       .select(['value'])
       .where('key', '=', 'currentWorkspaceId')
       .executeTakeFirst()
-    expect(runtimeRow?.value).toMatch(/^[A-Za-z0-9_-]{21}$/)
+    // Concurrency is this test's subject — 32 initializes must settle on ONE
+    // id — and the shape is incidental to that. It asserts the canonical
+    // schema rather than a literal pattern so it does not quietly become a
+    // second place the id format is pinned; `current-workspace.test.ts` owns
+    // that.
+    expect(workspaceCanonicalIdSchema.safeParse(runtimeRow?.value).success).toBe(true)
   })
 
   it('protects newly added /api routes by default, GET included', async () => {

--- a/packages/mcp-server/src/server/current-workspace.test.ts
+++ b/packages/mcp-server/src/server/current-workspace.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { workspaceCanonicalIdSchema } from '@kamiazya/whiteboard-model'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { clearWorkspaceIdCache, ensureWorkspaceId } from './current-workspace.js'
 import { getDb } from './store/db/index.js'
@@ -27,6 +28,24 @@ describe('ensureWorkspaceId', () => {
     // ensureWorkspaceId again must return the same value.
     const cached = ids[0]
     await expect(ensureWorkspaceId(dataDir)).resolves.toBe(cached)
+  })
+
+  it('mints a canonical ULID, the shape migration 0019 re-keyed every other workspace to', async () => {
+    // ADR-0019 fixes the canonical workspace id as a bare ULID, and `0019`
+    // re-keys every workspace a daemon ALREADY holds to that shape. This is
+    // the other half: the writer that runs on a fresh install. It kept minting
+    // nanoids, so the migration corrected the data while the producer went on
+    // writing the old shape — a daemon created after 0019 shipped is never
+    // re-keyed by anything.
+    //
+    // Two consequences, both on every fresh install. The bootstrapped
+    // workspace has no segment, so its handle IS this id and the address reads
+    // `/w/<id>` — removing raw identifiers from that position is what ADR-0019
+    // is for. And segment-first resolution stays unambiguous only because a
+    // segment may not be ULID-shaped; a nanoid is not ULID-shaped either, so
+    // it lands in the same namespace segments occupy.
+    const id = await ensureWorkspaceId(dataDir)
+    expect(workspaceCanonicalIdSchema.safeParse(id).success).toBe(true)
   })
 
   it('returns the persisted id again after the in-memory cache is cleared', async () => {
@@ -80,6 +99,11 @@ describe('ensureWorkspaceId', () => {
     await expect(ensureWorkspaceId(blocked)).rejects.toBeDefined()
 
     await rm(blocked)
-    await expect(ensureWorkspaceId(blocked)).resolves.toMatch(/^[A-Za-z0-9_-]{21}$/)
+    // The subject is the eviction: the retry has to SUCCEED, and minting an
+    // id is how it shows that. Asserting the canonical shape rather than a
+    // literal pattern keeps this test out of the business of pinning the id
+    // format, which `mints a canonical ULID` above owns.
+    const retried = await ensureWorkspaceId(blocked)
+    expect(workspaceCanonicalIdSchema.safeParse(retried).success).toBe(true)
   })
 })

--- a/packages/mcp-server/src/server/current-workspace.ts
+++ b/packages/mcp-server/src/server/current-workspace.ts
@@ -1,4 +1,4 @@
-import { nanoid } from 'nanoid'
+import { generateDocumentId } from '@kamiazya/whiteboard-model'
 import { getDb } from './store/db/index.js'
 import { prepareDataDir } from './store/db/prepare.js'
 import { upsertWorkspaceRow } from './store/db/upsert-workspace.js'
@@ -19,7 +19,23 @@ async function resolveWorkspaceId(db: Awaited<ReturnType<typeof getDb>>): Promis
   // Fresh install — no row yet. Pick a new id and upsert atomically so
   // concurrent ensureWorkspaceId callers across worker threads cannot
   // diverge on the chosen id.
-  const id = nanoid()
+  //
+  // A canonical ULID, which is what ADR-0019 makes a workspace id and what
+  // migration `0019` re-keyed every workspace a daemon already held to. This
+  // is the writer on the OTHER side of that migration: while it minted
+  // nanoids, the migration corrected the data and the producer went on
+  // writing the old shape, so a daemon created after 0019 shipped was never
+  // re-keyed by anything.
+  //
+  // The bootstrapped workspace has no segment, so its handle IS this id and
+  // it is what the address shows. It also has to stay out of the namespace
+  // segments occupy: segment-first resolution is unambiguous only because a
+  // segment may not be ULID-shaped, and a nanoid is not ULID-shaped either.
+  //
+  // `generateDocumentId` despite the name — ADR-0019 gave both ids the same
+  // canonical shape deliberately, and the confusion guard is the pair of
+  // distinct Zod schemas, not a second generator.
+  const id = generateDocumentId()
   const now = Date.now()
   await db
     .insertInto('runtime')

--- a/packages/model/src/generate-document-id.ts
+++ b/packages/model/src/generate-document-id.ts
@@ -4,8 +4,13 @@ const TIME_CHARS = 10
 const RANDOM_CHARS = 16
 
 /**
- * Generates a canonical ULID matching model's `documentIdSchema`
- * (`/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/`). The 48-bit millisecond timestamp is
+ * Generates a canonical ULID matching model's `documentIdSchema` — and
+ * `workspaceCanonicalIdSchema`, which ADR-0019 gave the same shape on
+ * purpose. Both delegate to `ULID_PATTERN`, and the guard against confusing
+ * the two is those distinct schemas rather than distinct generators, so a
+ * caller minting a workspace id calls this one. (`/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/`.)
+ *
+ * The 48-bit millisecond timestamp is
  * encoded big-endian into the first 10 base32 characters; 80 bits of
  * cryptographic entropy fill the remaining 16.
  *


### PR DESCRIPTION
## Summary

- **A boot-time writer was undoing a migration.** `0019` re-keys every workspace a daemon already holds to a bare ULID — ADR-0019's canonical workspace id. `current-workspace.ts`'s `resolveWorkspaceId`, which mints the id on a **fresh install**, kept calling `nanoid()`. The migration corrected the data and the producer went on writing the old shape, so a daemon created after 0019 shipped is never re-keyed by anything. `vocabulary.md` names this trap outright: *"A boot-time writer can undo a migration."*
- **It is user-visible on every fresh install.** The bootstrapped workspace has no segment, so its handle IS that id and the address reads `/w/-j6-glMsEiosR84ZhnNkl`. Taking raw identifiers out of that position is what this initiative is for.
- **It also breaks ADR-0019's disambiguation.** Segment-first resolution is unambiguous only because a segment may not be ULID-shaped. A nanoid is not ULID-shaped either, so it lands in the very namespace segments occupy.

## Measured, not argued

Found by driving a real daemon on an empty data dir while verifying something else — reading the code would not have shown it, because the mint site says only `nanoid()` and nothing near it mentions ULIDs.

A/B against a real daemon, fresh `WHITEBOARD_DATA_DIR` each time:

```
before  -j6-glMsEiosR84ZhnNkl        len 21  canonical ULID: false
after   01M18Z415KGY7RYJH67EHFGDSA   len 26  canonical ULID: true
```

Checked mechanically against `workspaceCanonicalIdSchema`'s pattern, not by eye.

**The namespace collision is the common case, not a corner.** Generating 200,000 ids from nanoid's default alphabet and testing each against `workspaceSegmentSchema`: **96.9% of nanoids are valid workspace segments.** So for almost any bootstrapped daemon, some workspace could take its id as a segment, and `resolveWorkspaceHandle` — which matches segment before id — would resolve that address to the segment's owner rather than the id's.

## Why `generateDocumentId`, and not a second generator

ADR-0019 gave both ids the same canonical shape deliberately, and `package-model.md` records what guards the confusion: **the pair of distinct Zod schemas**, not distinct generators. Adding `generateWorkspaceId` would invent a guard the decision did not ask for and give one behaviour two names. `POST /api/workspaces` already mints this way; the boot path now agrees with it.

The generator's own docblock named only `documentIdSchema`, which was already understated — it now names both and says why they share a shape.

## Two tests pinned the retired shape

Neither had the id format as its subject: one is about cache eviction letting a retry succeed, the other about 32 concurrent initializes settling on one id. Both asserted `/^[A-Za-z0-9_-]{21}$/` incidentally, so the nanoid shape was pinned in three places and `current-workspace.test.ts`'s new case would have been contradicted by two of them.

Both now assert `workspaceCanonicalIdSchema`, leaving the format pinned in exactly one place. Found by grepping for the pattern rather than by waiting for CI — the second one lives in `app.test.ts`, a file this change otherwise had no reason to open.

## Mutation check

Reverting the mint to `nanoid()` fails **2** cases in `current-workspace.test.ts` — the new canonical-shape one and the retry one. The restore was verified by re-running, not assumed.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [ ] `pnpm test` passes locally
- [x] Manual verification completed (describe above)
- [ ] E2E coverage added or extended where applicable

`pnpm check:local` → **exit 0** (exit code captured directly to a file, not read through a pipe). `pnpm --filter @kamiazya/whiteboard-mcp typecheck` and `pnpm build` → clean, both run because this touches a published package.

Full `mcp-node`: **4169 passed | 3 failed**. The three are the pre-existing EACCES family (`0011-import-fs-blobs` ×2, `migrator`) — they `chmod 000` a path and assert the read is denied, which cannot happen in this container because it runs as **uid 0**, where `chmod` denies root nothing. Unrelated to a workspace-id change; `pnpm test` is therefore not claimed.

## Visual evidence

**Visual evidence: none — this changes an identifier a daemon mints at boot.** The only user-visible trace is the address bar reading a ULID instead of a nanoid, and that difference is stated exactly above as the two ids. There is also no image upload path in this session: GitHub access here is through the MCP server rather than the `gh` CLI, so the `gh image` step `AGENTS.md` specifies cannot run.

## Deliberately not done

**Daemons that already hold a nanoid id are not re-keyed.** That is a migration against existing data and wants its own decision, so this change only stops new ones being minted. Nothing here validates the stored id, so such a daemon keeps working exactly as it does today — this is strictly a reduction in how many daemons end up in that state, not a completion of the fix.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [ ] Docs updated if this changes user-visible behavior or a published contract — no doc states the minted shape; ADR-0019 already says it must be a canonical ULID, and this makes the code agree with it
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New workspaces now receive IDs in the standard canonical format.
  * Workspace ID validation is aligned across creation and connection flows.

* **Documentation**
  * Clarified the recommended method for generating canonical workspace IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->