### PR TITLE
feat(web): show a document path as the URL fragment it becomes

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -186,6 +186,31 @@ one it is not in yet, `spinner` that same ring while the doing is in flight.
   Each layer is written on its own, never as a form submitting both: an
   unchanged URL sent back would put every name edit behind the one write that
   can be refused for a collision.
+- **A document's path is drawn as the URL too — but it keeps its label.** The
+  create and rename forms put the head of the document's address in front of
+  the box (`/w/<handle>/d/`), so the text a person types is visibly a URL and
+  not a loose string. That head is sliced from `app-routes`' own builders,
+  separators included: a literal written into the component would go on
+  reading correctly long after the grammar moved, and a form that shows the
+  wrong address confidently is worse than one showing none. With no handle
+  yet resolved it shows nothing, because `/w//d/` is not half an address, it
+  is a wrong one.
+
+  What does NOT carry over from the switcher is dropping the label. There the
+  whole popover is unlabelled and the layer's only name is `segment`, which is
+  not a word to put in front of somebody. Here the form has two labelled
+  fields, `Path` is the word ADR-0008 already uses, and stripping one label of
+  the pair reads as breakage rather than as consistency. The prefix is added
+  to what the field SAYS, not swapped in for it — and it is part of the
+  field's accessible description rather than `aria-hidden`, since it is the
+  only thing on the form stating that a path is an address.
+
+  The handle is the one part allowed to truncate. A workspace with no segment
+  is addressed by its 26-character canonical id, and that prefix measured
+  269px of a 398px row — enough to push the dialog's form past its own max
+  width and overflow on every viewport. Truncating the prefix as one string
+  would eat `/d/` off the end, which is the half that says where the text
+  lands; truncating only the handle keeps the grammar legible at any width.
 - **The switcher is offered even when the address names no workspace.** A
   daemon holding nothing serves `/`, and the switcher is the only place
   creation lives — so requiring a handle before rendering it left a fresh

--- a/apps/web/src/components/workspace-files/DocumentPathField.tsx
+++ b/apps/web/src/components/workspace-files/DocumentPathField.tsx
@@ -1,0 +1,92 @@
+import { useId } from 'react'
+import { documentPathPrefix, workspacePath } from '@/lib/app-routes'
+
+/**
+ * A document's path, edited as the tail of the URL it actually is.
+ *
+ * The two forms that write a path — create and rename — had this field
+ * twice, verbatim apart from one sentence of hint, which is the shape that
+ * lets two sites quietly stop agreeing. It is one component so the URL head
+ * in front of the box cannot appear on one of them alone.
+ *
+ * That head is READ from the router's own builders rather than written out
+ * here, down to the `/w/` and `/d/` separators. A literal would go on reading
+ * correctly for as long as it took somebody to move the grammar, and a form
+ * that shows the wrong address confidently is worse than one that shows none.
+ *
+ * Absent when the workspace is not known — a page renders this before its
+ * handle resolves, and `/w//d/` is not a truthful half of an address, it is
+ * a wrong one.
+ */
+export function DocumentPathField({
+  workspace,
+  value,
+  onChange,
+  hint,
+}: {
+  /** The handle the address carries, or undefined while it is unknown. */
+  workspace?: string | undefined
+  value: string
+  onChange: (next: string) => void
+  /** What this particular form's path change does. */
+  hint: string
+}) {
+  const inputId = useId()
+  const prefixId = useId()
+  const hintId = useId()
+  const known = workspace !== undefined && workspace !== ''
+  const prefix = known ? documentPathPrefix(workspace) : null
+
+  // Sliced from the builders' own output, never spelled out: `head` is what
+  // `workspacePath` puts before a handle, `handle` is that handle as the URL
+  // encodes it, and `tail` is whatever `documentPathPrefix` adds after.
+  const head = workspacePath('')
+  const handle = known ? workspacePath(workspace).slice(head.length) : ''
+  const tail = prefix === null ? '' : prefix.slice(head.length + handle.length)
+
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor={inputId} className="text-sm font-medium">
+        Path
+      </label>
+      {/* The border is on the ROW so the prefix reads as part of the field
+          rather than as a caption sitting beside it. */}
+      <div className="focus-within:ring-ring flex items-center rounded-md border bg-background px-2 py-1.5 font-mono text-sm focus-within:ring-1">
+        {prefix !== null && (
+          // Only the HANDLE gives way. A workspace with no segment is
+          // addressed by its 26-character canonical id, and an unshrinkable
+          // prefix at that length measured 269px of what had been a 398px
+          // row — pushing the row past the dialog's own max width, which on a
+          // narrow viewport is an overflow rather than a wide dialog.
+          // Truncating the prefix as one string would instead eat `/d/` off
+          // the end, which is the half that says where the text lands.
+          <span
+            id={prefixId}
+            title={prefix}
+            className="text-muted-foreground flex min-w-0 shrink items-center"
+          >
+            <span className="shrink-0">{head}</span>
+            <span className="min-w-0 truncate">{handle}</span>
+            <span className="shrink-0">{tail}</span>
+          </span>
+        )}
+        <input
+          id={inputId}
+          type="text"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          // The prefix is DESCRIBED, not aria-hidden. It is the only thing on
+          // the form saying a path is an address, so hiding it would leave
+          // that fact available to sighted readers alone.
+          aria-describedby={prefix === null ? hintId : `${prefixId} ${hintId}`}
+          // A floor, so a long handle cannot squeeze the box people type in
+          // down to nothing: past this the handle truncates instead.
+          className="min-w-[10ch] flex-1 bg-transparent outline-none"
+        />
+      </div>
+      <span id={hintId} className="text-muted-foreground text-xs">
+        {hint}
+      </span>
+    </div>
+  )
+}

--- a/apps/web/src/components/workspace-files/NewDocumentDialog.tsx
+++ b/apps/web/src/components/workspace-files/NewDocumentDialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { DocumentPathField } from './DocumentPathField.js'
 import { DOCUMENT_KIND_CHOICES } from './document-kind-choice.js'
 
 /**
@@ -32,6 +33,7 @@ import { DOCUMENT_KIND_CHOICES } from './document-kind-choice.js'
  */
 export function NewDocumentDialog({
   open,
+  workspace,
   defaultPath,
   busy,
   error,
@@ -39,6 +41,8 @@ export function NewDocumentDialog({
   onSubmit,
 }: {
   open: boolean
+  /** The handle the new document's URL will carry, when the page knows it. */
+  workspace?: string | undefined
   /** Where a create with no opinion would have put it. */
   defaultPath: string
   busy?: boolean
@@ -81,6 +85,14 @@ export function NewDocumentDialog({
     <Dialog open={open} onOpenChange={(next) => (next ? undefined : onCancel())}>
       <DialogContent className="sm:max-w-md">
         <form
+          // `min-w-0`: this form is a GRID item of DialogContent, so its
+          // automatic minimum size is its min-content width — and the path
+          // field's URL prefix is unbreakable text. Measured without it, a
+          // segment-less workspace's 26-character handle pushed the form to
+          // 464px inside a 448px dialog, overflowing on every viewport
+          // including a phone. With it the row is bounded and the handle
+          // truncates instead.
+          className="min-w-0"
           onSubmit={(event) => {
             event.preventDefault()
             const trimmedPath = path.trim()
@@ -145,22 +157,15 @@ export function NewDocumentDialog({
                 path instead.
               </span>
             </label>
-            <label className="flex flex-col gap-1">
-              <span className="text-sm font-medium">Path</span>
-              <input
-                type="text"
-                value={path}
-                onChange={(event) => {
-                  setPath(event.target.value)
-                  setPathIssue(null)
-                }}
-                className="rounded-md border bg-background px-2 py-1.5 font-mono text-sm"
-              />
-              <span className="text-muted-foreground text-xs">
-                Where it lives in the workspace. Folders are the path, so design/login sits under
-                design.
-              </span>
-            </label>
+            <DocumentPathField
+              workspace={workspace}
+              value={path}
+              onChange={(next) => {
+                setPath(next)
+                setPathIssue(null)
+              }}
+              hint="Where it lives in the workspace. Folders are the path, so design/login sits under design."
+            />
             {/* The form's own refusal wins: it names the field the person is
                 looking at, while `error` describes a submission that has
                 already been superseded by whatever they typed next. */}

--- a/apps/web/src/components/workspace-files/NewDocumentMenu.tsx
+++ b/apps/web/src/components/workspace-files/NewDocumentMenu.tsx
@@ -37,6 +37,7 @@ import { NewDocumentDialog } from './NewDocumentDialog.js'
 export function NewDocumentMenu({
   onCreate,
   disabled,
+  workspace,
   defaultPath,
   createError,
   onDismiss,
@@ -58,6 +59,8 @@ export function NewDocumentMenu({
    * than a dead button does.
    */
   disabled?: boolean
+  /** The handle the new document's URL will carry, when the page knows it. */
+  workspace?: string | undefined
   /**
    * Where a create with no opinion would put the document. Its absence is
    * what hides the dialog entry: with nothing to pre-fill `Path` with, the
@@ -143,6 +146,7 @@ export function NewDocumentMenu({
       {defaultPath !== undefined && (
         <NewDocumentDialog
           open={dialogOpen}
+          workspace={workspace}
           defaultPath={defaultPath}
           busy={disabled}
           error={createError}

--- a/apps/web/src/components/workspace-files/RenameDocumentDialog.tsx
+++ b/apps/web/src/components/workspace-files/RenameDocumentDialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { DocumentPathField } from './DocumentPathField.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
 
 /**
@@ -21,6 +22,7 @@ import type { WorkspaceDocumentEntry } from './document-entry.js'
  */
 export function RenameDocumentDialog({
   document,
+  workspace,
   busy,
   error,
   onCancel,
@@ -28,6 +30,8 @@ export function RenameDocumentDialog({
 }: {
   /** The document being renamed, or null when the dialog is closed. */
   document: WorkspaceDocumentEntry | null
+  /** The handle its URL carries, so the path field can show where it lands. */
+  workspace?: string | undefined
   busy: boolean
   /** Shown verbatim — the server names the path that actually collided. */
   error: string | null
@@ -49,6 +53,14 @@ export function RenameDocumentDialog({
     <Dialog open={document !== null} onOpenChange={(open) => (open ? undefined : onCancel())}>
       <DialogContent className="sm:max-w-md">
         <form
+          // `min-w-0`: this form is a GRID item of DialogContent, so its
+          // automatic minimum size is its min-content width — and the path
+          // field's URL prefix is unbreakable text. Measured without it, a
+          // segment-less workspace's 26-character handle pushed the form to
+          // 464px inside a 448px dialog, overflowing on every viewport
+          // including a phone. With it the row is bounded and the handle
+          // truncates instead.
+          className="min-w-0"
           onSubmit={(event) => {
             event.preventDefault()
             const trimmedName = name.trim()
@@ -78,18 +90,12 @@ export function RenameDocumentDialog({
                 path instead.
               </span>
             </label>
-            <label className="flex flex-col gap-1">
-              <span className="text-sm font-medium">Path</span>
-              <input
-                type="text"
-                value={path}
-                onChange={(event) => setPath(event.target.value)}
-                className="rounded-md border bg-background px-2 py-1.5 font-mono text-sm"
-              />
-              <span className="text-muted-foreground text-xs">
-                Where it lives in the workspace. Moving it takes everything under it along.
-              </span>
-            </label>
+            <DocumentPathField
+              workspace={workspace}
+              value={path}
+              onChange={setPath}
+              hint="Where it lives in the workspace. Moving it takes everything under it along."
+            />
             {error !== null && (
               <p role="alert" className="text-destructive text-sm">
                 {error}

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -38,6 +38,16 @@ export interface WorkspaceFilesPanelProps {
    * which is what lets one browser serve both.
    */
   source: WorkspaceFilesSource
+  /**
+   * The handle this workspace's URLs carry, when the host knows it.
+   *
+   * Used only to draw the head of a document's URL in front of the path
+   * fields, so a person can see where their text lands. Absent while a page
+   * is still resolving its address, and on a host that has no address to
+   * give — the fields simply lose the prefix, which is why this is optional
+   * rather than something the panel refuses to render without.
+   */
+  workspace?: string | undefined
   /** Absent means the preview shows no way in — looking still works. */
   onOpenDocument?: (path: string) => void
   /**
@@ -138,6 +148,7 @@ const REFRESH_FAILURE_VERB: Record<'created' | 'pinned' | 'unpinned', string> = 
  */
 export function WorkspaceFilesPanel({
   source,
+  workspace,
   onOpenDocument,
   initialFolder,
   onFolderChange,
@@ -713,6 +724,7 @@ export function WorkspaceFilesPanel({
         </div>
         <NewDocumentMenu
           disabled={creating}
+          workspace={workspace}
           defaultPath={derivedNewPath}
           createError={createError?.reason ?? null}
           onCreate={createHere}
@@ -935,6 +947,7 @@ export function WorkspaceFilesPanel({
       )}
       <RenameDocumentDialog
         document={renaming}
+        workspace={workspace}
         busy={renameBusy}
         error={renameError}
         onCancel={() => {

--- a/apps/web/src/components/workspace-files/path-url-affordance.test.tsx
+++ b/apps/web/src/components/workspace-files/path-url-affordance.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { documentPathPrefix } from '../../lib/app-routes.js'
+import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
+import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
+
+// A path is not a loose string: it is the tail of the document's URL, one
+// URL segment per path segment. Both forms that edit one draw the head of
+// that URL in front of the box, the way the workspace switcher draws `/w/`
+// in front of a segment — so the field shows where the text lands instead of
+// requiring somebody to already know.
+//
+// The prefix is READ from the router's own builder. A literal written out
+// here, or in the component, would keep reading right long after the grammar
+// moved, which is the whole reason `documentPathPrefix` is exported.
+
+afterEach(cleanup)
+
+const WORKSPACE = 'design-team'
+
+const entry = {
+  documentId: 'd1',
+  path: 'design/login',
+  name: 'Login flow',
+  kind: 'spatial' as const,
+}
+
+// No default parameter: `renderPanel(undefined)` would then silently re-supply
+// the handle, and the unknown-workspace case below would assert against a
+// fixture that never reached it.
+function renderPanel(workspace: string | undefined) {
+  const source = fakeFilesSource({ listDocuments: async () => [entry] })
+  render(<WorkspaceFilesPanel source={source} workspace={workspace} onOpenDocument={() => {}} />)
+  return source
+}
+
+async function openFolder() {
+  fireEvent.click((await screen.findAllByRole('button', { name: 'Open folder design' }))[0]!)
+  await waitFor(() => {
+    expect(
+      screen.queryAllByTestId('card-title').some((el) => el.textContent === 'Login flow'),
+    ).toBe(true)
+  })
+}
+
+async function openRenameDialog() {
+  await openFolder()
+  const card = screen.getAllByTestId('card-title').find((n) => n.textContent === 'Login flow')
+  fireEvent.click(card?.closest('button') as HTMLElement)
+  fireEvent.click(await screen.findByRole('button', { name: /Rename/ }))
+  return screen.findByRole('dialog')
+}
+
+async function openNewDocumentDialog() {
+  await openFolder()
+  // Radix's DropdownMenuTrigger opens on pointerDown, not click.
+  fireEvent.pointerDown(screen.getByRole('button', { name: /new document/i }), { button: 0 })
+  fireEvent.click(await screen.findByRole('menuitem', { name: /Name and folder/ }))
+  return screen.findByRole('dialog')
+}
+
+// The prefix is three spans, not one — a segment-less workspace is addressed
+// by a 26-character id, and only the handle is allowed to truncate so that
+// `/w/` and `/d/` stay legible. So it is found by the `title` that carries the
+// untruncated value, and its rendered text is asserted separately: `getByText`
+// reads only an element's DIRECT text children and would see nothing here.
+function prefixOf(dialog: HTMLElement): HTMLElement {
+  return within(dialog).getByTitle(documentPathPrefix(WORKSPACE))
+}
+
+describe('the path field shows where in the URL its text lands', () => {
+  it('draws the real URL head in front of the rename form’s path box', async () => {
+    renderPanel(WORKSPACE)
+    const dialog = await openRenameDialog()
+    expect(prefixOf(dialog).textContent).toBe(documentPathPrefix(WORKSPACE))
+  })
+
+  it('draws it in front of the create form’s path box too', async () => {
+    renderPanel(WORKSPACE)
+    const dialog = await openNewDocumentDialog()
+    expect(prefixOf(dialog).textContent).toBe(documentPathPrefix(WORKSPACE))
+  })
+
+  // Not decoration a screen reader is told to skip: the prefix is the only
+  // thing on the form that says the path is an address, so it is part of the
+  // field's own description rather than an aria-hidden flourish.
+  it('names the prefix in the path field’s accessible description', async () => {
+    renderPanel(WORKSPACE)
+    const dialog = await openRenameDialog()
+    const input = within(dialog).getByLabelText(/^Path/)
+    const described = (input.getAttribute('aria-describedby') ?? '')
+      .split(/\s+/)
+      .filter((id) => id !== '')
+      .map((id) => document.getElementById(id)?.textContent ?? '')
+      .join(' ')
+    expect(described).toContain(documentPathPrefix(WORKSPACE))
+    expect(described).toContain('Where it lives in the workspace')
+  })
+
+  // The panel is rendered before its page knows the handle, and on a page
+  // that has none at all. Half a URL is worse than none: `/w//d/` reads as a
+  // real address and is not one.
+  it('shows no URL head at all when the workspace is not known yet', async () => {
+    renderPanel(undefined)
+    const dialog = await openRenameDialog()
+    expect(within(dialog).queryByTitle(/^\/w\//)).toBeNull()
+    expect(dialog.textContent ?? '').not.toContain('/w/')
+    // The field itself is unaffected — it still edits the same path.
+    expect((within(dialog).getByLabelText(/^Path/) as HTMLInputElement).value).toBe('design/login')
+  })
+})

--- a/apps/web/src/components/workspace-files/path-url-width.browser.test.tsx
+++ b/apps/web/src/components/workspace-files/path-url-width.browser.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { documentPathPrefix } from '../../lib/app-routes.js'
+import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
+import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
+
+// A real browser, because the subject is LAYOUT and jsdom computes none.
+//
+// The path field draws the head of the document's URL in front of the box.
+// That head is unbreakable text, and a workspace with no segment is addressed
+// by its 26-character canonical id — so on the widest handle the prefix is
+// most of the row. The dialog's form is a GRID item, whose automatic minimum
+// size is its min-content width, so without `min-w-0` that prefix widened the
+// form past the dialog's own max: measured at 464px inside a 448px dialog,
+// overflowing on every viewport including a phone.
+
+afterEach(cleanup)
+
+// The shape that provoked it: no segment, so the handle IS the canonical id.
+const ULID_HANDLE = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+
+const entry = {
+  documentId: 'd1',
+  path: 'design/login',
+  name: 'Login flow',
+  kind: 'spatial' as const,
+}
+
+async function openRenameDialog() {
+  render(
+    <WorkspaceFilesPanel
+      source={fakeFilesSource({ listDocuments: async () => [entry] })}
+      workspace={ULID_HANDLE}
+      onOpenDocument={() => {}}
+    />,
+  )
+  await userEvent.click((await screen.findAllByRole('button', { name: 'Open folder design' }))[0]!)
+  const card = (await screen.findAllByTestId('card-title')).find(
+    (n) => n.textContent === 'Login flow',
+  )
+  await userEvent.click(card?.closest('button') as HTMLElement)
+  await userEvent.click(await screen.findByRole('button', { name: /Rename/ }))
+  return screen.findByRole('dialog')
+}
+
+describe('path field at the widest handle', () => {
+  it('does not widen the dialog past its own bound', async () => {
+    const dialog = await openRenameDialog()
+    expect(dialog.scrollWidth).toBeLessThanOrEqual(dialog.clientWidth + 1)
+
+    // The subject is PRESENT: a run where the prefix failed to render would
+    // satisfy the bound above while proving nothing.
+    const prefix = within(dialog).getByTitle(documentPathPrefix(ULID_HANDLE))
+    expect(prefix.textContent).toBe(documentPathPrefix(ULID_HANDLE))
+    expect(prefix.getBoundingClientRect().width).toBeGreaterThan(100)
+  })
+
+  it('leaves a usable box to type in', async () => {
+    const dialog = await openRenameDialog()
+    const input = within(dialog).getByLabelText(/^Path/) as HTMLInputElement
+    // The `min-w-[10ch]` floor: past it the handle truncates instead of the
+    // field being squeezed away. 10ch of this mono face measured ~84px.
+    expect(input.getBoundingClientRect().width).toBeGreaterThanOrEqual(80)
+
+    // And it still edits the path, prefix or no prefix.
+    await userEvent.fill(input, 'archive/login')
+    expect(input.value).toBe('archive/login')
+  })
+})

--- a/apps/web/src/lib/app-routes.test.ts
+++ b/apps/web/src/lib/app-routes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   documentPath,
+  documentPathPrefix,
   indexPath,
   isKnownAppPath,
   parseSettingsRoute,
@@ -240,5 +241,21 @@ describe('parseSettingsRoute', () => {
   it('returns null for an unknown section or unrelated path', () => {
     expect(parseSettingsRoute('/settings/nope')).toBeNull()
     expect(parseSettingsRoute('/w/w1')).toBeNull()
+  })
+})
+
+describe('documentPathPrefix', () => {
+  // The form fields that edit a document's path draw this in front of the
+  // box, so a person can see the URL their text lands in. That only stays
+  // true if it is the SAME string the router builds — a hand-written `/w/…/d/`
+  // in a component would keep reading right long after the grammar moved.
+  it('is the literal head of the URL a document is addressed at', () => {
+    expect(documentPath('design-team', 'design/login')).toBe(
+      `${documentPathPrefix('design-team')}design/login`,
+    )
+  })
+
+  it('encodes the handle the same way the full URL does', () => {
+    expect(documentPathPrefix('w 1')).toBe('/w/w%201/d/')
   })
 })

--- a/apps/web/src/lib/app-routes.ts
+++ b/apps/web/src/lib/app-routes.ts
@@ -25,13 +25,25 @@ export function workspacePath(workspace: string): string {
   return `/w/${encodeURIComponent(workspace)}`
 }
 
+// Everything in a document's URL that its path does not decide.
+//
+// Exported because the forms that EDIT a path draw it in front of the box, so
+// the field reads as the URL the text lands in rather than as a bare string.
+// That affordance is only honest while it is the same value the router emits,
+// which is why it is derived here instead of written out at the two form
+// sites: a literal `/w/${w}/d/` in a component keeps looking right for as
+// long as it takes somebody to move the grammar.
+export function documentPathPrefix(workspace: string): string {
+  return `${workspacePath(workspace)}/d/`
+}
+
 // Nested under the workspace it belongs to, so the URL reads as placement.
 // The tail is the document's path, one URL segment per path segment: each
 // segment is encoded, the separators are not — encoding them would collapse
 // the hierarchy the workspace shows into one opaque URL segment.
 export function documentPath(workspace: string, path: string): string {
   const tail = path.split('/').map(encodeURIComponent).join('/')
-  return `${workspacePath(workspace)}/d/${tail}`
+  return `${documentPathPrefix(workspace)}${tail}`
 }
 
 export type WorkspaceRoute =

--- a/apps/web/src/pages/BrowserIndexPage.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.tsx
@@ -23,7 +23,7 @@ import {
 import { createLocalFilesSource } from '../lib/local-files-source.js'
 import { LoroStore } from '../lib/loro-store.js'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
-import { workspaceLabel } from '../lib/workspace-handle.js'
+import { workspaceHandle, workspaceLabel } from '../lib/workspace-handle.js'
 import { createSeededDocument, type LoroStoreLike } from './use-browser-document-controller.js'
 
 export interface BrowserIndexPageProps {
@@ -260,6 +260,10 @@ export function BrowserIndexPage({
       ) : snapshots !== null ? (
         <WorkspaceFilesPanel
           source={filesSource}
+          // Read from the subscribed identity rather than the address: this
+          // page stays mounted across an in-SPA workspace switch, and the
+          // identity is what moves with it.
+          workspace={activeWorkspace === null ? undefined : workspaceHandle(activeWorkspace)}
           initialFolder={routedFolder}
           onFolderChange={setRoutedFolder}
           onOpenDocument={onOpenDocument}

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -663,6 +663,9 @@ export function DaemonIndexPage({
           <div className="animate-in fade-in-0 duration-(--motion-duration-normal) ease-(--motion-ease-out)">
             <WorkspaceFilesPanel
               source={filesSource}
+              // The handle the address carries, which is exactly what a
+              // document's URL under this workspace is built from.
+              workspace={selectedWorkspace}
               initialFolder={routedFolder}
               onFolderChange={setRoutedFolder}
               onOpenDocument={(path) => onOpenDocument(selectedWorkspace, path)}


### PR DESCRIPTION
## Summary

- **A document's path is the tail of its URL, and the forms that edit one gave no sign of it.** Create and rename both presented `Path` as a bare string. The workspace switcher already solved this for its own layer by drawing `/w/` in front of the editable part; this carries the idea to the only other place a typed string becomes a URL position. All three such inputs were enumerated (`value={path}` / `value={segment}`) — the switcher's was already done, so the scope is exactly these two.
- **The prefix is sliced from `app-routes`' own builders, separators included.** `documentPathPrefix` is extracted from `documentPath` so the two cannot drift, and the visible `/w/` + handle + `/d/` split is sliced from those builders rather than written as literals. A literal in a component keeps reading correctly long after the grammar moves, and a form that shows the wrong address confidently is worse than one that shows none. With no handle resolved it shows nothing — `/w//d/` is not half an address, it is a wrong one.
- **The two identical `Path` blocks became one `DocumentPathField`,** so the affordance cannot appear on one form and not the other.

## What deliberately did NOT carry over: dropping the label

`DESIGN.md` records the switcher's rule as *"The URL is drawn as the URL — a `/w/` prefix and the editable part — and carries no visible label"*. The reason given there is specific: that popover is unlabelled throughout, and the layer's only name is `segment`, which is not a word to put in front of somebody.

Neither half holds here. This form has two labelled fields, and `Path` is the word ADR-0008 already uses — stripping one label of a pair reads as breakage, not as consistency. So the prefix is **added to** what the field says rather than swapped in for it.

It is also **described, not `aria-hidden`**: it is the only thing on the form stating that a path is an address, and hiding it would leave that fact available to sighted readers alone. `aria-describedby` carries the prefix and the hint together.

## Measured, not argued — and the design changed twice because of it

Driven in a real browser at two viewports. A workspace with no segment is addressed by its 26-character canonical id, and that prefix took **269px of a 398px row**. The dialog's `<form>` is a **grid item**, so its automatic minimum size is its min-content width — the row widened the form to **464px inside a 448px dialog**, overflowing on every viewport including a phone.

Two attempts before the working one, both recorded because both were **inert**:

| attempt | result | why |
|---|---|---|
| `min-w-0` on the truncating span alone | still 464 | a flex item's default `min-width:auto` blocks it |
| `overflow-hidden` on the row | still 464 | that rule is for flex/grid items, not a block box |

The cause was isolated by setting the form's `min-width` to `0` in the live page, which collapsed the row to 398 immediately. `min-w-0` on the form is the fix. Past that bound only the **handle** truncates, keeping `/w/` and `/d/` legible — truncating the prefix as one string would eat `/d/` off the end, which is the half that says where the text lands — and the input holds a `10ch` floor.

| case | row | prefix | input | overflow |
|---|---|---|---|---|
| desktop, short handle | 398 | 109 | 271 | no |
| desktop, 26-char ULID | 398 (was 464) | 269 | 111 | **no** (was yes) |
| phone 375px, short handle | 293 | 109 | 166 | no |
| phone 375px, 26-char ULID | 293 | 191 (truncated) | 84 (floor) | **no** (was yes) |

## Mutation checks

Every new guard was shown to fail against a broken implementation, each restore verified by re-running:

| mutation | result |
|---|---|
| always render a prefix, even with no workspace | 1 failed |
| `aria-hidden` the prefix (drop it from `describedby`) | 1 failed |
| panel stops passing `workspace` to the rename dialog | 2 failed |
| remove `min-w-0` from the form (`web-browser`) | 1 failed — `expected 488 to be less than or equal to 447` |

The layout fix is pinned in `web-browser` rather than jsdom, because jsdom computes no layout and the assertion would pass vacuously there.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [ ] `pnpm test` passes locally
- [x] Manual verification completed (describe above)
- [ ] E2E coverage added or extended where applicable

`pnpm check:local` → **exit 0** (exit code captured directly to a file, not read through a pipe). `pnpm test:browser` → **866/866 passed**, with the run's log grepped for `Re-optimizing` (0 hits) so the tree was quiet throughout.

`apps/web`'s full suite has **pre-existing failures this branch does not touch**, verified by running the same files at `origin/main` rather than inferred from the diff: 5 files / 9 tests, all in the jsdom-`Blob.stream()` family (`DocumentThumb`, `MergeDialog`, `VersionThumbnail`, `VersionTimeline`, `daemon-file-adapter`). `pnpm test` is therefore not claimed.

One further pre-existing failure appeared in one of two full runs and not the other: `editor-state.property.test.ts`. Its message is `Error: Test timed out in 5000ms.` — the property never failed, despite the seed printed in its name. It fails **3/3 at `origin/main` in isolation**, so it is a budget that no longer fits on this machine rather than anything from this branch, and it is the sole reason two runs of the same tree disagreed on the failing-file count. Filed separately; no seed pinned.

## Visual evidence

**Visual evidence: none attached — this session has no image upload path.** GitHub access here is through the MCP server rather than the `gh` CLI, so the `gh image` step `AGENTS.md` specifies cannot run.

What a figure would have shown is stated exactly instead: the path field now reads `/w/default/d/` in muted mono immediately left of the box, inside the same border, with the typed path continuing from it. This is a **new affordance**, so per `AGENTS.md` there is no "before" to compare against — one capture would have been the whole figure. The numeric half of the evidence is the measurement table above, which is what the design decisions actually turned on.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — `apps/web/DESIGN.md` records the rule, and specifically why the label is kept here, so a later sweep does not "fix" the asymmetry with the switcher
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Document creation and rename dialogs now display the workspace URL prefix alongside the path field.
  - URL prefixes appear once the workspace is available and are included in accessible descriptions.
  - Workspace handles are safely truncated when needed to keep dialogs usable without obscuring the path.
  - Path fields now preserve URL formatting and remain editable across workspace contexts.

- **Bug Fixes**
  - Prevented long workspace handles from overflowing document dialogs.
  - Ensured displayed prefixes remain consistent with generated document URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->