### PR TITLE
test(server): say when the checkout is on the wrong Node, and skip what root cannot reach

### DIFF
--- a/.claude/rules/dev-flow.md
+++ b/.claude/rules/dev-flow.md
@@ -147,6 +147,41 @@ Native **Task list** = live board (in-flight / blocked / done; main session owns
 
 The hazard this project name closes is narrower than it sounds, and the general shape survives: **vitest only errors when a `--project` filter set is empty; a project name that matches nothing alongside a sibling name that DOES match is silent** — `--project web-jsdom --project web-browser` used to run only the browser project (unnamed `web-jsdom` matched nothing), reported its ~540 tests, and exited 0. That reads exactly like both suites passing. It let a real regression reach CI twice in one session before anyone noticed the count was too small. Naming this one project retires that one instance; any future typo'd or renamed `--project` value reopens the same class. Match the local command to the CI job, and treat a test count far below CI's as evidence the filter missed, not as good news.
 
+**Run the Node in `.node-version`, and let the guard tell you when you are not.**
+`local-node-version.test.ts` compares the running major against the pin (24
+today, which is what CI installs) and fails naming the consequence. The
+consequence is specific: on Node 22 **nine `web-jsdom` tests fail**, every one
+of them with a message about `Blob` — jsdom's own `Blob` implements `slice`,
+`text`, `arrayBuffer` and `bytes` and no `stream()` in BOTH majors, so what
+differs is undici's `new Response(blobLike)`, which reaches for `.stream()` on
+22 and does not on 24. What you see is
+`TypeError: object.stream is not a function` out of
+`node:internal/deps/undici`, pointing at a Blob the test wrote and at code the
+diff never touched.
+
+That is not a hypothetical either. A whole session read those nine as standing
+environment failures, said so in three PR bodies, and A/B-confirmed them
+against a clean `origin/main` — which is TRUE, and answers a different question
+than "why". Nothing said the checkout was on the wrong Node. Under the pin the
+same commands report **285 files / 2944 tests** and **358 / 4171 + 9 skipped**,
+digit-for-digit what CI's own logs say. `engines` in the published package is
+deliberately wider (`^22 || ^24 || >=26`) and is a different claim: that is
+what a CONSUMER may run the daemon on.
+
+**A test whose PREMISE this environment cannot establish skips, and says so —
+probed, never inferred.** Three EACCES tests need a file they cannot read, and
+`chmod 000` does not achieve that for root (nor on Windows, where the mode
+barely means anything); the code under test never receives the error it exists
+to handle, and the failure reads as a broken error path
+(`expected undefined to be an instance of Error` says nothing about uid).
+`CAN_DENY_FILE_READ` in `shared/test-utils` writes a file, closes it off and
+tries to read it, rather than asking `getuid() === 0` — which is a guess about
+a mechanism that capabilities, a read-only mount, a user namespace and Windows
+each decide independently. Guarded from both sides, because a skipped test
+reads exactly like a passing one: the probe is checked against a fresh
+mode-000 read, and on CI it MUST be true, so the skip cannot quietly disable
+those paths for everyone while every summary line stays green.
+
 The integrator's push is guarded on two sides. **Local (pre-push, `lefthook`)**: `pnpm -r typecheck` + `pnpm test --project mcp-node` + `pnpm lint:noconsole` run before the commit leaves the machine (pre-commit only formats staged files, to not slow the dev-loop's worktree commits). **`pnpm check:local` is the fuller local pass** — every gate CI's `check` job runs, plus `pnpm knip` from `verify` (seconds, and it catches the dead export a refactor leaves behind; the rest of `verify` builds and smokes the published artifacts and belongs in CI). It is DERIVED from `ci.yml`, not remembered: `local-gate-command.test.ts` fails when the job gains a step the script does not run. That guard exists because the remembered list actually drifted — a session's habitual five (`typecheck`, `lint`, `lint:noconsole`, `audit`, `knip`) was missing `intent:validate`, `secretlint` and `test:scripts`, and reported green for work whose CI `check` job had not been approximated at all. A local pass that is trusted and wrong is worse than none. **Cloud (post-push)**: GitHub Actions CI (`verify`) + CodeRabbit + AccessLint + WIP + CodeQL — monitor with the `Monitor` tool and triage with the `ci-triage` workflow/skill into Tasks / whiteboard canvases. **Cloud (mutation, report-only)**: `mutation.yml` runs Stryker over `canvas-render`'s property-covered modules — on a PR, scoped to the curated files that diff changed and posted as a sticky comment; weekly, the whole list into an artifact. It is deliberately NOT a gate — a mutation score belongs to the whole suite, not to whoever pushed last — and it exists because a property that asserts nothing passes every other gate there is. Its survivors are triaged like review findings, and each is verified by hand first (the tool can report a false survivor; see `package-canvas-render.md`).
 
 **PR merge gate.** `verify` + CodeQL are the authoritative gate. AI review is consulted **when it has actually run**, and its absence does not block a merge (user decision, 2026-08-02): CodeRabbit is on a plan whose per-developer rolling limit this repo's merge pace exhausts, so waiting on it serialises delivery behind a quota rather than behind a real signal. Batching several PRs at once is what burns the quota fastest — when a review matters for a specific change, open that PR alone and let it land. Before merging, still fetch **every bot's** PR review comments and triage each finding; the discipline below applies whenever there *are* comments. Fetch with `gh api repos/<owner>/<repo>/pulls/<n>/comments` + `gh pr view <n> --json reviews,comments`, then **read the comments from ALL bot authors — do not filter to a hardcoded reviewer list.** The surface currently includes **CodeRabbit** (`coderabbitai[bot]`, AI review — Free Plan so not guaranteed) and **`github-advanced-security[bot]`** (CodeQL code-scanning — its findings arrive as ordinary PR review comments on the plain `/pulls/<n>/comments` feed, no `security_events` scope needed, and are same-priority-or-higher security signal). (Gemini Code Assist is **sunset** as of 2026-07-27 — no longer reviews; do not wait on it.) Missing a bot because you scoped the sweep to two named reviewers is exactly the gap that let a CodeQL ReDoS comment slip past this gate — enumerate authors from the feed, don't assume. Triage each finding: (a) verify validity against the actual code (do not trust or dismiss blindly — check the claimed line/behavior; CodeQL security findings on untrusted-input paths get the same red-test-first + fix treatment as any CRITICAL, per the `ci-triage` skill's CodeQL rubric), (b) apply valid findings as commits on the PR branch, (c) for findings judged invalid/stale, record the reason (reply on the PR thread or note in the merge summary to the user). A reviewer skipping a PR (rate limits, plan limits) is acceptable to proceed past — note it when it happens, rather than waiting it out. **Dependabot** (dep-bump PRs + security alerts) has its own `dependabot-triage` workflow + `dependabot-review` skill. Hooks are a net, not the gate — CI is authoritative; `LEFTHOOK=0` / `--no-verify` bypass when justified.

--- a/packages/mcp-server/src/server/release/local-node-version.test.ts
+++ b/packages/mcp-server/src/server/release/local-node-version.test.ts
@@ -1,0 +1,61 @@
+// The suite is calibrated for the Node in `.node-version`, and running it on
+// a different major produces failures that name the wrong thing.
+//
+// Measured, on Node 22 against a pin of 24: nine `web-jsdom` tests fail, all
+// with a message about `Blob`. jsdom's own `Blob` implements `slice`, `text`,
+// `arrayBuffer` and `bytes` and NO `stream()` — the same in both majors — so
+// what differs is undici's `new Response(blobLike)`, which reaches for
+// `.stream()` on 22 and does not on 24. The failure surfaces as
+// `TypeError: object.stream is not a function` from deep inside
+// `node:internal/deps/undici`, pointing at a Blob the test wrote and at code
+// the diff never touched.
+//
+// A whole session read those nine as "standing environment failures", wrote
+// them off in three PR bodies, and A/B-confirmed them against a clean
+// `origin/main` — which is true, and answers a different question than "why".
+// Nothing anywhere said the checkout was on the wrong Node. That is the gap
+// this closes, and it is the same one `local-gate-command.test.ts` closes for
+// the gate command: a local result that is trusted and wrong is worse than no
+// local result.
+//
+// `engines` in the published package is deliberately wider (`^22 || ^24 ||
+// >=26`) and is not this. That says what a CONSUMER may run the daemon on;
+// `.node-version` says what this repo develops and tests on, and CI installs
+// exactly it.
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(__dirname, '../../../../..')
+
+function pinnedMajor(): string {
+  // `.node-version` may carry a bare major ("24"), a full version, or a "v"
+  // prefix depending on who wrote it; every reader in the wild takes the
+  // leading number, so this does too.
+  const raw = readFileSync(join(ROOT, '.node-version'), 'utf8').trim()
+  const major = /^v?(\d+)/.exec(raw)?.[1]
+  if (major === undefined) throw new Error(`.node-version is not a version: ${JSON.stringify(raw)}`)
+  return major
+}
+
+describe('the checkout runs the Node the suite is calibrated for', () => {
+  it('.node-version names a major', () => {
+    // Asserted separately so a malformed pin fails as itself rather than as a
+    // mismatch against whatever is running.
+    expect(pinnedMajor()).toMatch(/^\d+$/)
+  })
+
+  it('is running that major', () => {
+    const pinned = pinnedMajor()
+    const running = process.versions.node.split('.')[0]
+    expect(
+      running,
+      `This checkout is on Node ${process.versions.node} but .node-version pins ${pinned}, which is what CI installs. ` +
+        'Nine web-jsdom tests fail on the wrong major with a message about Blob that names neither Node nor this file — ' +
+        'so a run on the wrong major looks like nine real regressions. Switch (nvm/fnm/asdf use ' +
+        `${pinned}) and re-run before believing any red. See this file's header for the mechanism.`,
+    ).toBe(pinned)
+  })
+})

--- a/packages/mcp-server/src/server/store/db/migrations/0011-import-fs-blobs.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrations/0011-import-fs-blobs.test.ts
@@ -6,6 +6,7 @@ import { Kysely, type MigrationProvider, Migrator, SqliteDialect, sql } from 'ky
 import LibsqlNativeDatabase from 'libsql'
 import { encodeFrontiers, LoroDoc } from 'loro-crdt'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CAN_DENY_FILE_READ } from '../../../../shared/test-utils/can-deny-file-read.js'
 import type { DatabaseSchema } from '../schema.js'
 
 let dataDir = ''
@@ -391,35 +392,41 @@ describe('0011-import-fs-blobs', () => {
     await db.destroy()
   })
 
-  it('warns and skips a blob that fails to read (e.g. permission denied) without aborting the rest of the import', async () => {
-    const db = await memoryDb()
-    expect((await migratorFor(db).migrateTo(BEFORE)).error).toBeUndefined()
-    await seedWorkspace(db, 'ws-1')
+  // Skipped where this process cannot be denied read access to its own
+  // files -- root, or a filesystem that ignores the mode. `shared/test-utils/can-deny-file-read.ts`
+  // PROBES that rather than inferring it from the uid, and says why.
+  it.skipIf(!CAN_DENY_FILE_READ)(
+    'warns and skips a blob that fails to read (e.g. permission denied) without aborting the rest of the import',
+    async () => {
+      const db = await memoryDb()
+      expect((await migratorFor(db).migrateTo(BEFORE)).error).toBeUndefined()
+      await seedWorkspace(db, 'ws-1')
 
-    const unreadablePath = await writeBlob(dataDir, 'ws-1', 'doc-unreadable', snapshotBytes('x'))
-    const { chmod } = await import('node:fs/promises')
-    await chmod(unreadablePath, 0o000)
+      const unreadablePath = await writeBlob(dataDir, 'ws-1', 'doc-unreadable', snapshotBytes('x'))
+      const { chmod } = await import('node:fs/promises')
+      await chmod(unreadablePath, 0o000)
 
-    const okBytes = snapshotBytes('the sibling document')
-    await writeBlob(dataDir, 'ws-1', 'doc-ok', okBytes)
+      const okBytes = snapshotBytes('the sibling document')
+      await writeBlob(dataDir, 'ws-1', 'doc-ok', okBytes)
 
-    const capture = captureLogsForTests()
-    try {
-      expect((await migratorFor(db).migrateTo(THIS_ONE)).error).toBeUndefined()
-      const warnings = capture.records.filter(
-        (r) => r.level === 'warning' && r.data?.documentId === 'doc-unreadable',
-      )
-      expect(warnings).toHaveLength(1)
-    } finally {
-      capture.restore()
-      await chmod(unreadablePath, 0o644)
-    }
+      const capture = captureLogsForTests()
+      try {
+        expect((await migratorFor(db).migrateTo(THIS_ONE)).error).toBeUndefined()
+        const warnings = capture.records.filter(
+          (r) => r.level === 'warning' && r.data?.documentId === 'doc-unreadable',
+        )
+        expect(warnings).toHaveLength(1)
+      } finally {
+        capture.restore()
+        await chmod(unreadablePath, 0o644)
+      }
 
-    expect(await reassembledRow(db, 'canvas:doc-unreadable')).toBeNull()
-    expect(await reassembledRow(db, 'canvas:doc-ok')).toEqual(okBytes)
+      expect(await reassembledRow(db, 'canvas:doc-unreadable')).toBeNull()
+      expect(await reassembledRow(db, 'canvas:doc-ok')).toEqual(okBytes)
 
-    await db.destroy()
-  })
+      await db.destroy()
+    },
+  )
 
   it('backfills a missing documentFrontiers row when the snapshot+chunks pair already matches the FS blob', async () => {
     const db = await memoryDb()
@@ -472,26 +479,32 @@ describe('0011-import-fs-blobs', () => {
     await db.destroy()
   })
 
-  it('rethrows an unexpected readdir error (e.g. permission denied on a canvas directory) so the whole migration aborts', async () => {
-    const db = await memoryDb()
-    expect((await migratorFor(db).migrateTo(BEFORE)).error).toBeUndefined()
-    await seedWorkspace(db, 'ws-1')
+  // Skipped where this process cannot be denied read access to its own
+  // files -- root, or a filesystem that ignores the mode. `shared/test-utils/can-deny-file-read.ts`
+  // PROBES that rather than inferring it from the uid, and says why.
+  it.skipIf(!CAN_DENY_FILE_READ)(
+    'rethrows an unexpected readdir error (e.g. permission denied on a canvas directory) so the whole migration aborts',
+    async () => {
+      const db = await memoryDb()
+      expect((await migratorFor(db).migrateTo(BEFORE)).error).toBeUndefined()
+      await seedWorkspace(db, 'ws-1')
 
-    const canvasDir = join(dataDir, 'blobs', 'ws-1', 'canvas')
-    await writeBlob(dataDir, 'ws-1', 'doc-a', snapshotBytes('unreachable'))
-    const { chmod } = await import('node:fs/promises')
-    await chmod(canvasDir, 0o000)
+      const canvasDir = join(dataDir, 'blobs', 'ws-1', 'canvas')
+      await writeBlob(dataDir, 'ws-1', 'doc-a', snapshotBytes('unreachable'))
+      const { chmod } = await import('node:fs/promises')
+      await chmod(canvasDir, 0o000)
 
-    try {
-      const result = await migratorFor(db).migrateTo(THIS_ONE)
-      expect(result.error).toBeInstanceOf(Error)
-      expect((result.error as NodeJS.ErrnoException).code).toBe('EACCES')
-    } finally {
-      await chmod(canvasDir, 0o755)
-    }
+      try {
+        const result = await migratorFor(db).migrateTo(THIS_ONE)
+        expect(result.error).toBeInstanceOf(Error)
+        expect((result.error as NodeJS.ErrnoException).code).toBe('EACCES')
+      } finally {
+        await chmod(canvasDir, 0o755)
+      }
 
-    await db.destroy()
-  })
+      await db.destroy()
+    },
+  )
 
   it('exports the migration object wrapping the same routine', () => {
     expect(typeof migration.up).toBe('function')

--- a/packages/mcp-server/src/server/store/db/migrator.test.ts
+++ b/packages/mcp-server/src/server/store/db/migrator.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Migrator } from 'kysely'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CAN_DENY_FILE_READ } from '../../../shared/test-utils/can-deny-file-read.js'
 
 let tempDir: string
 
@@ -113,21 +114,27 @@ describe('runMigrations', () => {
   // errno error. runMigrations must reframe it the same way it reframes
   // the corrupted-migrations case, instead of surfacing the bare
   // "EACCES ... scandir '<path>'" message with no recovery guidance.
-  it('reframes an EACCES readdir failure during migration into an actionable message', async () => {
-    const canvasDir = join(tempDir, 'blobs', 'ws-1', 'canvas')
-    await mkdir(canvasDir, { recursive: true })
-    await writeFile(join(canvasDir, 'doc-a.loro'), 'irrelevant')
-    await chmod(canvasDir, 0o000)
+  // Skipped where this process cannot be denied read access to its own
+  // files -- root, or a filesystem that ignores the mode. `shared/test-utils/can-deny-file-read.ts`
+  // PROBES that rather than inferring it from the uid, and says why.
+  it.skipIf(!CAN_DENY_FILE_READ)(
+    'reframes an EACCES readdir failure during migration into an actionable message',
+    async () => {
+      const canvasDir = join(tempDir, 'blobs', 'ws-1', 'canvas')
+      await mkdir(canvasDir, { recursive: true })
+      await writeFile(join(canvasDir, 'doc-a.loro'), 'irrelevant')
+      await chmod(canvasDir, 0o000)
 
-    try {
-      const db = await getDb(tempDir)
-      await expect(runMigrations(db)).rejects.toThrow(/permission|blobs/i)
-      const err = await runMigrations(db).catch((e: unknown) => e)
-      expect((err as { cause?: unknown }).cause).toMatchObject({ code: 'EACCES' })
-    } finally {
-      await chmod(canvasDir, 0o755)
-    }
-  })
+      try {
+        const db = await getDb(tempDir)
+        await expect(runMigrations(db)).rejects.toThrow(/permission|blobs/i)
+        const err = await runMigrations(db).catch((e: unknown) => e)
+        expect((err as { cause?: unknown }).cause).toMatchObject({ code: 'EACCES' })
+      } finally {
+        await chmod(canvasDir, 0o755)
+      }
+    },
+  )
 
   it('exposes the expected workspaces + branches + versions schema after init, with no documents row required (0016/0017)', async () => {
     await prepareDataDir(tempDir)

--- a/packages/mcp-server/src/shared/test-utils/can-deny-file-read.test.ts
+++ b/packages/mcp-server/src/shared/test-utils/can-deny-file-read.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Both sides of the skip this probe gates, because a skipped test reads
+ * exactly like a passing one in the summary line.
+ *
+ * A capability probe is the honest way to skip a test whose PREMISE cannot be
+ * established here — but it is also the easy way to lose coverage for good:
+ * flip the probe to `false` and three EACCES tests quietly stop running
+ * everywhere, and nothing goes red. So the probe is checked for honesty, and
+ * CI is required to have the capability.
+ */
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { CAN_DENY_FILE_READ } from './can-deny-file-read.js'
+
+describe('CAN_DENY_FILE_READ', () => {
+  it('agrees with what a mode-000 file actually does here', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wb-deny-check-'))
+    const file = join(dir, 'closed-off')
+    try {
+      writeFileSync(file, 'x')
+      chmodSync(file, 0o000)
+      let denied: boolean
+      try {
+        readFileSync(file)
+        denied = false
+      } catch {
+        denied = true
+      }
+      expect(
+        denied,
+        'the probe and a fresh mode-000 read disagree, so every skip it gates is decided on a stale answer',
+      ).toBe(CAN_DENY_FILE_READ)
+    } finally {
+      try {
+        chmodSync(file, 0o644)
+      } catch {
+        // Already gone; the rm is what matters.
+      }
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  // The half that stops the skip becoming permanent. CI is the run whose
+  // green is load-bearing, so the EACCES paths must be genuinely exercised
+  // there — a probe that answered `false` on the runner would disable them
+  // for everyone while every summary line stayed green.
+  it.runIf(process.env.CI)('is true on CI, where these paths must run for real', () => {
+    expect(
+      CAN_DENY_FILE_READ,
+      'CI can no longer make a file unreadable, so every EACCES test is being skipped there — find out why before trusting this run',
+    ).toBe(true)
+  })
+})

--- a/packages/mcp-server/src/shared/test-utils/can-deny-file-read.ts
+++ b/packages/mcp-server/src/shared/test-utils/can-deny-file-read.ts
@@ -1,0 +1,52 @@
+/**
+ * Whether this process can be denied read access to a file it owns.
+ *
+ * A test that asserts EACCES handling has to make something unreadable
+ * first, and `chmod 000` does not do that for every process: root reads it
+ * anyway (and so does Windows, where the mode is close to meaningless). The
+ * test then fails on its own premise — the code under it never gets the error
+ * it exists to handle — and the failure reads as a broken error path.
+ *
+ * Measured in one container: three `mcp-node` tests failed for a whole
+ * session and were written off as "environment", which was true and useless.
+ * `expected undefined to be an instance of Error` says nothing about uid.
+ *
+ * PROBED, never inferred. `process.getuid?.() === 0` is the tempting version
+ * and it is a guess about a mechanism — capabilities, a read-only mount, a
+ * container's user namespace and Windows all decide this independently of the
+ * uid. So this actually writes a file, closes it off, and tries to read it.
+ *
+ * Resolved once at module load: the answer cannot change during a run, and
+ * `it.skipIf` needs it at collection time.
+ */
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+function probe(): boolean {
+  const dir = mkdtempSync(join(tmpdir(), 'wb-deny-read-'))
+  const file = join(dir, 'closed-off')
+  try {
+    writeFileSync(file, 'x')
+    chmodSync(file, 0o000)
+    try {
+      readFileSync(file)
+      // The mode was set and the read still succeeded, so nothing here can be
+      // made unreadable to us.
+      return false
+    } catch {
+      return true
+    }
+  } finally {
+    // Restore before removing: a directory holding a mode-000 file is fine to
+    // unlink, but leaving one behind in tmp is rude either way.
+    try {
+      chmodSync(file, 0o644)
+    } catch {
+      // Already gone, or never created — rm below is what matters.
+    }
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+export const CAN_DENY_FILE_READ = probe()


### PR DESCRIPTION
## The thing this is actually about

Twelve tests failed locally all session. I wrote them off as "standing environment failures" in **three** PR bodies, and A/B-confirmed them against a clean `origin/main` worktree.

That A/B was true. It was also useless — it answered *"is this mine?"* and never *"why?"*. Root-causing them found **two different things**, and only one of them was environmental at all.

## Nine were the wrong Node

`.node-version` pins **24**, which is what CI installs. This checkout ran **22**.

The mechanism is worth stating because the symptom points somewhere else entirely. jsdom's own `Blob` implements `slice` / `text` / `arrayBuffer` / `bytes` and **no `stream()`** — verified in the installed source, and true in *both* majors. What differs is undici's `new Response(blobLike)`, which reaches for `.stream()` on 22 and does not on 24. So the failure arrives as:

```
TypeError: object.stream is not a function
  at extractBody (node:internal/deps/undici/undici:5629:25)
  at new Response (node:internal/deps/undici/undici:9350:41)
```

— naming a `Blob` the test wrote, and code the diff never touched. Nothing anywhere said "wrong Node".

Under the pin, the same commands now report exactly what CI's own logs report:

| | local, Node 24 | CI |
|---|---|---|
| `web-jsdom` | 285 files / **2944** | 285 files / **2944** |
| `web-node` | 12 / **77** | 12 / **77** |
| `mcp-node` | 358 / **4171** + 9 skipped | green |
| `pnpm check:local` | **exit 0** | — |

`local-node-version.test.ts` compares the running major against the pin and fails naming that consequence — the same shape as `local-gate-command.test.ts`, and for the same stated reason: *a local pass that is trusted and wrong is worse than none.*

```
This checkout is on Node 22.22.2 but .node-version pins 24, which is what CI installs.
Nine web-jsdom tests fail on the wrong major with a message about Blob that names
neither Node nor this file — so a run on the wrong major looks like nine real
regressions. Switch (nvm/fnm/asdf use 24) and re-run before believing any red.
```

`engines` in the published package stays wider (`^22 || ^24 || >=26`) and is deliberately a different claim: that is what a **consumer** may run the daemon on.

## Three genuinely cannot run here

They need a file they cannot read, and `chmod 000` does not achieve that for root — nor on Windows, where the mode barely means anything. The code under test never receives the error it exists to handle, so the failure reads as a broken error path: `expected undefined to be an instance of Error` says nothing about uid.

`CAN_DENY_FILE_READ` **probes**: it writes a file, closes it off, and tries to read it. Not `getuid() === 0`, which is a guess about a mechanism that capabilities, a read-only mount, a user namespace and Windows each decide independently.

### Guarded from both sides, because a skipped test reads exactly like a passing one

| guard | what it stops |
|---|---|
| the probe is checked against a fresh mode-000 read | a stale answer silently deciding every skip |
| on CI the probe **must** be true | the three EACCES paths quietly never running for anyone, with every summary line green |

Mutation-checked:

| mutation | result |
|---|---|
| probe lies (`true`) as root | honesty check RED — *"the probe and a fresh mode-000 read disagree"* — **and the three gated tests run again**, so the gate is demonstrably what suppresses them |
| `CI=1` with the probe false | RED — *"CI can no longer make a file unreadable, so every EACCES test is being skipped there"* |
| Node guard on 22 / on 24 | RED with the message above / green |

## Test plan

- [x] `pnpm --filter @kamiazya/whiteboard-web test` — 2944 + 77, **zero failures** (was 9)
- [x] `pnpm test --project mcp-node` — 358 files, 4171 passed, 9 skipped, **zero failures** (was 3)
- [x] `pnpm check:local` — **exit 0**, every step
- [x] All three mutations above
- [ ] E2E — not applicable; this is test-harness and gate machinery

## What is deliberately not here

`compose-figure.test.mjs` still **fails** rather than skipping when ImageMagick is absent, and that is correct: unlike root, a missing tool is *installable*, the test already prints `apt: imagemagick, brew: imagemagick`, and AGENTS.md requires a figure for a visual change — a skip there would let someone believe they can produce one when they cannot. The distinction the probe encodes is *premise unreachable*, not *tool missing*.

## Visual evidence

**Visual evidence: none — no rendered surface is touched.** This is test-harness and gate machinery; the observable change is the numbers in the Test plan table above, and CI's own log is the control they are compared against.

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_