### PR TITLE
test(web): give the editor's composite-state property a budget it fits

### DIFF
--- a/apps/web/src/components/spatial-editor/editor-state.property.test.ts
+++ b/apps/web/src/components/spatial-editor/editor-state.property.test.ts
@@ -2421,6 +2421,20 @@ describe('editor composite state (command-based)', () => {
       }
       fc.modelRun(freshState, commands)
     },
+    // An explicit budget, sized on a measurement rather than left at
+    // vitest's 5000ms default, which this property has never fit inside.
+    // Measured with the budget lifted: 5.22-5.27s, and the SAME 5.23-5.26s
+    // at `5ceac722`, the commit that raised `numRuns` to 500 — so it was
+    // over from the day it was written, on a machine slower than CI's. CI
+    // passes it; what the default cost was a local full-suite run
+    // reporting a failure that is purely this machine's speed, and a
+    // failing-file count that changed between two runs of one tree.
+    //
+    // The lever is the budget, NOT `numRuns`: the coverage floors above
+    // record that 300 left two counters sitting exactly ON their floor,
+    // so cutting runs trades a spurious failure for a property that
+    // asserts less. A pinned seed would be worse than either.
+    15_000,
   )
 })
 


### PR DESCRIPTION
## Summary

- **The property has never fit vitest's 5000ms default**, so it fails locally on any machine slower than CI's. This gives it an explicit budget sized on a measurement.
- **It is not a cost regression** — measured at the commit that introduced `numRuns: 500`, it cost the same. It was over budget from the day it was written.
- **The lever is the budget, not `numRuns`**, and the file itself says why.

## Measured, not argued

All on one machine, the property run alone:

| condition | result |
|---|---|
| default 5000ms budget | **3/3 fail**, at 5018 / 5019 / 5021ms — the wall, not a counterexample |
| budget lifted to 120s (`HEAD`) | **5266 / 5223ms** — the true cost |
| budget lifted to 120s, at `5ceac722` (the commit that set `numRuns: 500`) | **5229 / 5256ms** |
| CI `test-jsdom` (#1136) | **green** |

`5ceac722` and `HEAD` are statistically identical, which is what rules out a regression in the code under the property. The file's own comment says the 300 → 500 bump "costs about three seconds"; that was the *increment*, on a faster machine, and nobody noticed the total had passed the default.

## What it actually cost, which is not what it looked like

CI passes, so no PR was ever blocked — the earlier framing of this as "fails unrelated PRs" was wrong and is corrected here.

The real cost was local: a full `apps/web` run reporting a failure that is purely this machine's speed, and reporting it **inconsistently**. Two runs of one tree disagreed on the failing-file count — 5 versus 6 — with this test the only difference, because at ~5% over the wall it lands on either side of it. A failure count that moves on its own is worse than a slow test: it makes every *other* pre-existing failure unreadable, which is exactly what happened while triaging #1136.

## Why not `numRuns`

The coverage floors in the same file record that 300 runs left two counters sitting **exactly on** their floor, which is why it went to 500. Cutting runs would trade a spurious failure for a property that asserts less — the vacuity the repo's PBT rules exist to prevent. A pinned seed would be worse than either. `15_000` is ~2.8x the slowest measurement observed, so it holds on a machine slower again than this one.

## Verification

- **Mutation check**: setting the budget back to `5_000` fails 1 of the 6 tests in the file; the restore was confirmed by re-running (6 passed), not assumed.
- **The claim itself**: two consecutive full `apps/web` runs now report an **identical** `5 files / 9 tests`, same file list both times. Those nine are the pre-existing jsdom-`Blob.stream()` family (`DocumentThumb`, `MergeDialog`, `VersionThumbnail`, `VersionTimeline`, `daemon-file-adapter`), unrelated to this change.
- `pnpm check:local` → **exit 0** (exit code captured directly, not read through a pipe).

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [ ] `pnpm test` passes locally
- [x] Manual verification completed (describe above)
- [ ] E2E coverage added or extended where applicable

`pnpm test` is not claimed, for the pre-existing failures named above.

## Visual evidence

**Visual evidence: none — this changes one test's timeout and nothing a human looks at.** The evidence that matters here is numeric and is in the tables above.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — not applicable; the reasoning and the measurements live in a comment at the budget itself, where the next reader of that number will be
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_