### PR TITLE
test(server): pin that a handle resolves against the registry the route reads

### DIFF
--- a/packages/mcp-server/src/server/routes/document/handle-resolution-seam.test.ts
+++ b/packages/mcp-server/src/server/routes/document/handle-resolution-seam.test.ts
@@ -1,0 +1,90 @@
+/**
+ * A handle is resolved against the same registry the request then reads.
+ *
+ * This looks like two registries and is one. `workspaceIdFromHandle` reaches
+ * module-level `workspaceRegistry()`, while every route beside it takes
+ * `options.serverDeps` — so a router given deps of its own reads like it could
+ * resolve a segment against one store and mutate another.
+ *
+ * It cannot, and the reason is in `store-local.module.ts`: `DocumentIndex` is
+ * bound to `cacheBackedWorkspaceDocs()` and `workspaceRegistry()`, both
+ * module-level. `opts.db` reaches `DocumentStore` and NOT the index. That is
+ * deliberate — cache coherence is the point, every path operating on one live
+ * workspace doc — but it makes "the same registry" a property of the wiring
+ * rather than of anything the seam states, and wiring changes.
+ *
+ * So this pins the invariant rather than the mechanism: whatever registry
+ * resolution reads, it is the one the route's own index answers from. Give
+ * `DocumentIndex` a store of its own and this fails, which is the moment the
+ * seam becomes real and every call site would need the deps threaded through.
+ *
+ * Addressed BY SEGMENT deliberately: a canonical id passes through
+ * `resolveWorkspaceHandle` unchanged whichever registry answers, so a test
+ * using one would be green against either and assert nothing.
+ */
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { withTempDataDir } from '../_test-helpers.js'
+
+const tmp = withTempDataDir('whiteboard-handle-seam-')
+
+vi.mock('../../config.js', () => ({
+  get DATA_DIR() {
+    return tmp.dir
+  },
+  getDataDir: () => tmp.dir,
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+  REPO_ROOT: '/tmp',
+}))
+
+const { getDb } = await import('../../store/db/index.js')
+const { prepareDataDir } = await import('../../store/db/prepare.js')
+const { createContainer, resolveServerDeps } = await import('../../../di/container.js')
+const { createStoreLocalModule } = await import('../../../di/store-local.module.js')
+const { createWorkspacesRouter } = await import('./workspaces.js')
+
+const WS = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+const SEGMENT = 'design-team'
+
+describe('handle resolution and the request that follows it', () => {
+  beforeEach(async () => {
+    await prepareDataDir(tmp.dir)
+  })
+
+  it('reaches the route with the id the injected index knows the segment by', async () => {
+    // Built from a SECOND data dir, so the deps are as independent as the DI
+    // module lets them be. Today that changes only the blob store; if the
+    // index ever follows `db` too, this fixture is what makes the divergence
+    // show up here rather than in production.
+    const otherDir = await mkdtemp(join(tmpdir(), 'whiteboard-handle-seam-other-'))
+    await prepareDataDir(otherDir)
+    const deps = resolveServerDeps(
+      createContainer(createStoreLocalModule({ db: await getDb(otherDir), blobDir: otherDir })),
+    )
+
+    await deps.documentIndex.createWorkspace({ workspaceId: WS, segment: SEGMENT })
+
+    const asked: string[] = []
+    const realList = deps.documentIndex.listDocuments.bind(deps.documentIndex)
+    deps.documentIndex.listDocuments = async (input: never) => {
+      // What the route ASKED for, recorded before the index answers: the
+      // answer alone cannot tell "resolved wrongly" from "resolved right and
+      // the workspace is empty" — both are `{documents: []}`.
+      asked.push((input as unknown as { workspaceId: string }).workspaceId)
+      return realList(input)
+    }
+
+    const app = createWorkspacesRouter({ serverDeps: deps })
+    const res = await app.request(`/api/workspaces/${SEGMENT}/documents`)
+
+    expect(res.status).toBe(200)
+    // The subject is PRESENT: a run where the route refused before reaching
+    // the index would leave this empty and satisfy nothing.
+    expect(asked).toHaveLength(1)
+    // Resolved, not passed through. `SEGMENT` here would mean the address was
+    // handed on as if it were an id.
+    expect(asked[0]).toBe(WS)
+  })
+})


### PR DESCRIPTION
## Summary

- A review finding on #1129 said `workspaceIdFromHandle` could diverge from the route beside it. **Measured, it cannot** — and the reason is not where the finding pointed.
- That **retires the cross-cutting change** the finding implied (8 files, 13 call sites). This ships the guard that was actually worth having instead.

## What the finding said, and what is true

The finding: `workspaceIdFromHandle` reaches module-level `workspaceRegistry()` while every route beside it takes `options.serverDeps`, so a router given deps of its own could resolve a segment against one store and mutate another.

The wiring says otherwise — `di/store-local.module.ts`:

```ts
bind(TOKENS.DocumentIndex).toDynamicValue(() =>
  new CacheCoherentDocumentIndex(
    cacheBackedWorkspaceDocs(),   // module-level — ignores opts.db
    new FsBlobStore(opts.blobDir),
    workspaceRegistry(),          // module-level — ignores opts.db
  ))
```

`opts.db` reaches `DocumentStore` and **not** the index. Measured rather than read off the source: a workspace created through an index built on a *second* data dir's db shows up in the module registry. The two are one store by construction, not by coincidence.

That is deliberate. `CacheCoherent` is the point — every path operating on one live workspace doc.

## Why the cross-cutting change is not the answer

Threading deps through 13 call sites would be machinery for a divergence the wiring makes impossible, and it would collide with the reason the index is module-backed at all. So it is not done here, and the task is closed with this reasoning rather than left open as a standing "should do".

## What is worth keeping

"The same registry" is a property of the **wiring**, stated nowhere the seam itself can see — and wiring changes. So this pins the invariant instead of the mechanism:

> whatever registry resolution reads is the one the route's own index answers from.

Give `DocumentIndex` a store of its own and this fails, which is precisely the moment the seam becomes real and the threading would be warranted.

Addressed **by segment** deliberately: a canonical id passes through `resolveWorkspaceHandle` unchanged whichever registry answers, so a test using one would be green against either and assert nothing.

## The fixture is the whole test

The first version built its deps from the mocked config's own data dir — which gave both sides one store and **passed against unfixed code**. It is recorded in the file's comment, because that difference is what separates this guard from one that checks nothing. Two further guards against the same class are in the assertions: `asked` must have length 1 (a run refused before reaching the index would satisfy nothing), and the id must be the ULID rather than the segment passed through.

## Mutation check

Emptying the registry resolution reads makes the request 404 and fails the test; the restore was confirmed by re-running, not assumed.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [ ] `pnpm test` passes locally
- [x] Manual verification completed (describe above)
- [ ] E2E coverage added or extended where applicable

`pnpm check:local` → **exit 0** (exit code captured directly, not read through a pipe). The whole `routes/document` suite: **22 files / 184 tests passed**.

## Visual evidence

**Visual evidence: none — this adds one server-side test and changes no behaviour.** The evidence is the probe result quoted above, which is what refuted the premise.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — not applicable; the reasoning lives in the test's own docblock, where the next person to suspect this seam will be
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that document requests addressed through a workspace segment resolve correctly.
  * Confirmed successful responses use the resolved workspace identifier and the expected document index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->