### PR TITLE
fix(web): stop a dialog left open across a workspace switch writing into the wrong workspace

### DIFF
--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -313,7 +313,28 @@ export function WorkspaceFilesPanel({
     let cancelled = false
     setDocuments(null)
     setListStatus('ok')
+    // Everything here NAMES A DOCUMENT, and a document belongs to exactly one
+    // workspace. `submitRename` and the card menu's verbs close over the
+    // CURRENT source while holding a captured entry, so anything left behind
+    // addresses the departed workspace's path into the one now on screen —
+    // and paths collide freely across workspaces, `untitled` most of all.
+    // Measured before this: a rename dialog left open across a switch called
+    // `setDocumentName` on the new workspace's store.
     setSelected(null)
+    setCardMenu(null)
+    setRenaming(null)
+    setRenameError(null)
+    setRenameBusy(false)
+    // Results computed against the departed workspace's content, still
+    // clickable. The search effect does re-run on a source change, but only
+    // after its debounce — until then these rows name documents that are not
+    // here.
+    setHits(null)
+    setSearchDegraded(false)
+    // Both name a path, and their message is about a write that happened
+    // somewhere else.
+    setRefreshError(null)
+    setPinError(null)
     // Guarded by the source's IDENTITY, not by a first-run flag: an
     // `initialFolder` is a deliberate address and must survive mounting,
     // while StrictMode replays this effect with the SAME readList — which a

--- a/apps/web/src/components/workspace-files/panel-state-outlives-workspace.test.tsx
+++ b/apps/web/src/components/workspace-files/panel-state-outlives-workspace.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+/**
+ * State the panel holds ABOUT A DOCUMENT must not outlive the workspace that
+ * document belongs to.
+ *
+ * The panel already keeps this rule against a background refresh: the
+ * `revision` effect re-resolves `selected` and `cardMenu` from the fresh list
+ * and drops what is gone. A workspace SWITCH is the same hazard one level up
+ * and was not covered — the switch effect clears `selected` and nothing else,
+ * so a captured `WorkspaceDocumentEntry` survives it while `source` becomes
+ * the new workspace's.
+ *
+ * That combination is not inert. `submitRename` closes over the CURRENT
+ * source and is handed the CAPTURED entry, so it addresses the old
+ * workspace's path into the new workspace's store. Paths are per-workspace
+ * and collide freely — `untitled` exists in most of them — so the write
+ * lands on whatever happens to sit at that path here.
+ *
+ * A modal does not make this unreachable: ADR-0019 makes a workspace switch
+ * an in-SPA route change, and browser Back is not blocked by a Radix dialog.
+ */
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
+import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
+
+afterEach(cleanup)
+
+// The same path in both workspaces, which is the ordinary case rather than a
+// contrived one: every workspace's first document is `untitled`.
+const IN_FIRST = [
+  { documentId: 'a1', path: 'untitled', name: 'Quarterly plan', kind: 'markdown' as const },
+]
+const IN_SECOND = [
+  { documentId: 'b1', path: 'untitled', name: 'Someone else’s notes', kind: 'markdown' as const },
+]
+
+async function cardTitled(title: string): Promise<HTMLElement> {
+  await waitFor(() => {
+    expect(screen.getAllByTestId('card-title').some((el) => el.textContent === title)).toBe(true)
+  })
+  const el = screen.getAllByTestId('card-title').find((n) => n.textContent === title)
+  return el?.closest('button') as HTMLElement
+}
+
+describe('panel state does not outlive its workspace', () => {
+  it('a rename dialog left open across a workspace switch cannot write into the new workspace', async () => {
+    const first = fakeFilesSource({ listDocuments: () => Promise.resolve(IN_FIRST) })
+    const second = fakeFilesSource({ listDocuments: () => Promise.resolve(IN_SECOND) })
+
+    const { rerender } = render(<WorkspaceFilesPanel source={first} />)
+
+    fireEvent.contextMenu(await cardTitled('Quarterly plan'), { clientX: 20, clientY: 20 })
+    const menu = await screen.findByRole('menu', { name: 'Document actions' })
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Rename…' }))
+    const dialog = await screen.findByRole('dialog')
+    expect((within(dialog).getByLabelText(/^Path/) as HTMLInputElement).value).toBe('untitled')
+
+    // The switch: same panel, different workspace. Browser Back does this
+    // with the dialog still open.
+    rerender(<WorkspaceFilesPanel source={second} />)
+    await waitFor(() => expect(second.listDocuments).toHaveBeenCalled())
+
+    // Whatever the dialog does now, it must not be a write addressed at the
+    // workspace on screen using the one that left.
+    const stillOpen = screen.queryByRole('dialog')
+    if (stillOpen !== null) {
+      fireEvent.change(within(stillOpen).getByLabelText(/^Name/), {
+        target: { value: 'Renamed while away' },
+      })
+      fireEvent.click(within(stillOpen).getByRole('button', { name: 'Save' }))
+      await waitFor(() => expect(second.setDocumentName).not.toHaveBeenCalled())
+    }
+    expect(
+      second.setDocumentName,
+      'the rename was addressed into the workspace that is now on screen, using an entry from the one that left — `untitled` exists in both, so this renames a document nobody asked about',
+    ).not.toHaveBeenCalled()
+    expect(second.renameDocumentPath).not.toHaveBeenCalled()
+  })
+
+  it('a card menu left open across a workspace switch offers no verbs for the departed document', async () => {
+    const first = fakeFilesSource({ listDocuments: () => Promise.resolve(IN_FIRST) })
+    const second = fakeFilesSource({ listDocuments: () => Promise.resolve(IN_SECOND) })
+
+    const { rerender } = render(<WorkspaceFilesPanel source={first} />)
+    fireEvent.contextMenu(await cardTitled('Quarterly plan'), { clientX: 20, clientY: 20 })
+    await screen.findByRole('menu', { name: 'Document actions' })
+
+    rerender(<WorkspaceFilesPanel source={second} />)
+    await waitFor(() => expect(second.listDocuments).toHaveBeenCalled())
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('menu', { name: 'Document actions' }),
+        'the menu still names the departed workspace’s document, and every verb on it would act on the workspace now on screen',
+      ).toBeNull(),
+    )
+  })
+})

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -1421,6 +1421,56 @@ describe('DaemonIndexPage', () => {
     ).toBeTruthy()
   })
 
+  // State that NAMES A DOCUMENT must not outlive the workspace it names.
+  // `pendingDelete` holds a path, and `handleConfirmDelete` reads
+  // `selectedWorkspace` at CONFIRM time rather than at open time — so a
+  // switch with the dialog still open addresses the departed workspace's
+  // path into the one now on screen. Paths are per-workspace and collide
+  // freely, so the DELETE lands on whatever sits at that path here.
+  //
+  // A modal does not make this unreachable: ADR-0019 makes the switch an
+  // in-SPA route change, and browser Back is not blocked by a dialog.
+  it('a delete dialog left open across a workspace switch sends no DELETE into the new workspace', async () => {
+    const deleted: Array<{ workspaceId: string; path: string }> = []
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }, { workspaceId: 'ws-b' }],
+      documentsByWorkspace: {
+        // The SAME path in both, which is the ordinary case rather than a
+        // contrived one: every workspace's first document is `untitled`.
+        'ws-a': [{ path: 'untitled', displayName: 'Mine', updatedAt: new Date().toISOString() }],
+        'ws-b': [
+          { path: 'untitled', displayName: 'Someone else', updatedAt: new Date().toISOString() },
+        ],
+      },
+      onDeleteCanvas: (workspaceId, path) => {
+        deleted.push({ workspaceId, path })
+        return undefined
+      },
+    })
+    const { rerender } = render(
+      <DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} workspace="ws-a" onOpenDocument={vi.fn()} />,
+    )
+
+    await selectCard('Mine')
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await screen.findByRole('alertdialog')
+
+    switchWorkspace(rerender, 'ws-b')
+    await waitFor(() => expect(screen.queryByText('Someone else')).toBeTruthy())
+
+    const dialog = screen.queryByRole('alertdialog')
+    if (dialog !== null) {
+      const confirm = within(dialog).getAllByRole('button', { name: 'Delete' }).at(-1)
+      if (confirm) fireEvent.click(confirm)
+      await waitFor(() => expect(deleted.length).toBe(0))
+    }
+
+    expect(
+      deleted,
+      'the confirm was addressed at the workspace now on screen using a path from the one that left — `untitled` exists in both, so this deletes a document nobody asked about',
+    ).toEqual([])
+  })
+
   it('Delete opens an AlertDialog naming the canvas; Cancel sends no DELETE', async () => {
     const deleted: string[] = []
     installFetchMock({

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -398,6 +398,17 @@ export function DaemonIndexPage({
     setTrashCount(0)
     setLoaded(false)
     setLoadError(null)
+    // Same rule, one level up: a DIALOG holding a path is the mismatched
+    // identity the rows-clear above exists to prevent, and it outlives the
+    // switch that the rows do not. `handleConfirmDelete` reads
+    // `selectedWorkspace` when the button is pressed, not when the dialog
+    // opened, so confirming after a switch sends the departed workspace's
+    // path to the one now on screen. Measured before this line existed:
+    // opening Delete on ws-a's `untitled`, switching to ws-b and confirming
+    // sent `DELETE ws-b/untitled` — a document nobody selected.
+    setPendingDelete(null)
+    setDeleteError(null)
+    setDuplicatingPath(null)
     void loadWorkspace(selectedWorkspace, () => cancelled)
     return () => {
       cancelled = true

--- a/apps/web/src/workspace-scoped-state.test.ts
+++ b/apps/web/src/workspace-scoped-state.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Every piece of React state on a workspace-scoped screen, classified
+ * against one question: **does it name a document?**
+ *
+ * A document belongs to exactly one workspace, and paths collide freely
+ * across them — `untitled` is the first document in most. So state that
+ * names one, held across a workspace switch, pairs a departed path with the
+ * store now on screen. Both screens already knew this in part:
+ * `DaemonIndexPage`'s switch effect says in its own comment that leaving old
+ * rows visible "lets a click pair the new workspace id with an old
+ * workspace's path", and `WorkspaceFilesPanel`'s `revision` effect
+ * re-resolves `selected` and `cardMenu` against a fresh list. Neither list
+ * was complete, and nothing made the next one complete.
+ *
+ * What that cost, measured before the clears were added:
+ *
+ *   - a delete dialog left open across a switch sent
+ *     `DELETE ws-b/untitled` — a document nobody selected, in a workspace
+ *     the person had navigated away from the one they chose it in
+ *   - a rename dialog left open across a switch called `setDocumentName`
+ *     on the NEW workspace's store with the OLD workspace's entry
+ *
+ * A modal does not make either unreachable: ADR-0019 makes a workspace
+ * switch an in-SPA route change, and browser Back is not blocked by a Radix
+ * dialog.
+ *
+ * This is the source-scan variant from `.claude/rules/coverage-ledger.md`:
+ * `useState` calls are not a union, so the key set comes from the source.
+ * The classification is what a new piece of state cannot avoid answering —
+ * adding one fails this file until someone says which it is.
+ *
+ * Source comes from `?raw` at build time, not `node:fs`: apps/web is
+ * browser-only and `web-app-boundary.test.ts` enforces it.
+ */
+import { describe, expect, it } from 'vitest'
+
+const sources = import.meta.glob(
+  ['./components/workspace-files/WorkspaceFilesPanel.tsx', './pages/DaemonIndexPage.tsx'],
+  { query: '?raw', import: 'default', eager: true },
+) as Record<string, string>
+
+type WorkspaceScope =
+  /** Dropped when the workspace changes, because it names a document. */
+  | 'cleared on switch'
+  /**
+   * Names no document, so it survives a switch harmlessly. The reason has to
+   * say WHY — "it's only a boolean" is exactly what was true of
+   * `duplicatingPath` until you notice it is a path.
+   */
+  | `no document: ${string}`
+
+const PANEL = './components/workspace-files/WorkspaceFilesPanel.tsx'
+const DAEMON_INDEX = './pages/DaemonIndexPage.tsx'
+
+const PANEL_STATE: Record<string, WorkspaceScope> = {
+  documents: 'cleared on switch',
+  selected: 'cleared on switch',
+  cardMenu: 'cleared on switch',
+  renaming: 'cleared on switch',
+  renameError: 'cleared on switch',
+  renameBusy: 'cleared on switch',
+  hits: 'cleared on switch',
+  searchDegraded: 'cleared on switch',
+  refreshError: 'cleared on switch',
+  pinError: 'cleared on switch',
+
+  listStatus: 'no document: a load outcome for the list as a whole, reset by the same effect',
+  folder:
+    'no document: an address WITHIN a workspace, reset separately and only on a real identity change — see the effect’s own note on StrictMode',
+  columns: 'no document: how you look, not what at; deliberately persisted across everything',
+  createError:
+    'no document: a refused create, carrying a kind and the store’s words — no path of its own',
+  creating: 'no document: an in-flight flag for this screen’s own submit',
+  query: 'no document: what was typed; the results it produces are `hits`, which IS cleared',
+}
+
+const DAEMON_INDEX_STATE: Record<string, WorkspaceScope> = {
+  rows: 'cleared on switch',
+  pendingDelete: 'cleared on switch',
+  deleteError: 'cleared on switch',
+  duplicatingPath: 'cleared on switch',
+
+  workspaces: 'no document: the list of workspaces, which a switch does not invalidate',
+  workspacesLoaded: 'no document: whether that list has settled',
+  selectedWorkspace: 'no document: it IS the workspace — the thing every clear is keyed on',
+  trashCount: 'no document: a count, reset by the same effect',
+  loaded: 'no document: whether this workspace’s documents have settled',
+  loadError: 'no document: a load outcome for the workspace, reset by the same effect',
+  createError: 'no document: a refused create; no path of its own',
+  duplicateError: 'no document: a refused duplicate; the path it was about is `duplicatingPath`',
+  creating: 'no document: an in-flight flag for this screen’s own submit',
+  deleting: 'no document: an in-flight flag; the path it is about is `pendingDelete`',
+}
+
+/** Names every `const [x, setX] = useState` declares, in source order. */
+function stateNames(source: string): string[] {
+  return [...source.matchAll(/const \[(\w+), set\w+\]\s*=\s*useState/g)].map((m) => m[1])
+}
+
+const CASES = [
+  { file: PANEL, ledger: PANEL_STATE, label: 'WorkspaceFilesPanel' },
+  { file: DAEMON_INDEX, ledger: DAEMON_INDEX_STATE, label: 'DaemonIndexPage' },
+] as const
+
+describe('workspace-scoped screen state is classified', () => {
+  it.each(CASES)('$label: the scan reaches a plausible amount of state', ({ file }) => {
+    // A regex that stops matching reports every entry as stale, which sends
+    // the reader to the wrong file entirely.
+    expect(sources[file], `${file} was not globbed`).toBeDefined()
+    expect(stateNames(sources[file]).length).toBeGreaterThan(8)
+  })
+
+  it.each(CASES)('$label: every piece of state is classified', ({ file, ledger }) => {
+    const unclassified = stateNames(sources[file]).filter((name) => !(name in ledger))
+    expect(
+      unclassified,
+      'new screen state must say whether it NAMES A DOCUMENT. If it does, clear it in the workspace-switch effect and mark it "cleared on switch"; if it does not, say why — a path or an entry always does',
+    ).toEqual([])
+  })
+
+  it.each(CASES)('$label: every classified name still exists', ({ file, ledger }) => {
+    const present = new Set(stateNames(sources[file]))
+    const stale = Object.keys(ledger).filter((name) => !present.has(name))
+    expect(stale, 'these entries name state the screen no longer holds').toEqual([])
+  })
+
+  // The half that makes this more than a list of names. An entry claiming to
+  // be cleared must have its setter called somewhere — a claim nothing backs
+  // is the decoration this ledger exists to replace.
+  it.each(CASES)('$label: everything marked cleared has a setter that clears it', ({
+    file,
+    ledger,
+  }) => {
+    const source = sources[file]
+    const unbacked = Object.entries(ledger)
+      .filter(([, scope]) => scope === 'cleared on switch')
+      .map(([name]) => name)
+      .filter((name) => {
+        const setter = `set${name[0].toUpperCase()}${name.slice(1)}`
+        // A reset to the empty value, in any of the shapes these screens use.
+        return !new RegExp(`${setter}\\((null|\\[\\]|false|0)\\)`).test(source)
+      })
+    expect(
+      unbacked,
+      'marked "cleared on switch" but no reset call exists for it — either clear it or reclassify',
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
## The defect

Screen state that **names a document** was outliving the workspace that document belongs to. Paths are per-workspace and collide freely — `untitled` is the first document in most of them — so a captured entry plus the store now on screen is a write addressed at whatever happens to sit at that path *here*.

Reproduced, not argued. Open Delete on `ws-a`'s `untitled`, switch to `ws-b`, confirm:

```
[probe] DELETE went to [{"workspaceId":"ws-b","path":"untitled"}]
```

A document nobody selected, in a workspace the person had navigated away from the one they chose it in.

The rename dialog is the same shape one severity down: left open across a switch, **Save** called `setDocumentName` on the *new* workspace's store with the *old* workspace's entry. The card menu survived too, offering Rename / Duplicate / Delete / Pin for a document that is not here.

A modal does not make any of these unreachable: [ADR-0019](docs/contributing/adr) makes a workspace switch an in-SPA route change, and **browser Back is not blocked by a Radix dialog**.

## Why it is a missed piece, not a missing idea

Both screens already knew the rule — that is what makes this worth a guard rather than just a patch.

| screen | what it already said / did | what it missed |
|---|---|---|
| `DaemonIndexPage` | its switch effect comments that leaving old rows visible *"lets a click pair the new workspace id with an old workspace's path — a mismatched identity"* | cleared the rows, not the **dialog holding one** |
| `WorkspaceFilesPanel` | its `revision` effect re-resolves `selected` **and** `cardMenu` against a fresh list, dropping what is gone | its **workspace-switch** effect cleared only `selected` |

## The fix

Cleared on a workspace switch:

- **index page** — `pendingDelete`, `deleteError`, `duplicatingPath`
- **panel** — `cardMenu`, `renaming` (+ `renameBusy`, `renameError`), `hits` (+ `searchDegraded`), `refreshError`, `pinError`

`hits` earns its place independently: the search effect *does* re-run on a source change, but only after its debounce — until then the departed workspace's results are on screen **and clickable**, and each row carries the same context menu.

## What makes the next one answer

`workspace-scoped-state.test.ts` scans both screens for `useState` and requires every name to be classified:

```ts
type WorkspaceScope = 'cleared on switch' | `no document: ${string}`
```

The source-scan variant from `.claude/rules/coverage-ledger.md`, because `useState` is not a union the type system enumerates. The reason string is required for the same purpose `blastRadius: none:` requires one — `duplicatingPath` reads like an in-flight flag until you notice it is a *path*.

### Mutation-checked in four directions

| mutation | result |
|---|---|
| a new `useState` arrives unclassified | RED — `expected [ 'pendingThing' ] to deeply equal []` |
| a ledger entry outlives the state it names | RED — `these entries name state the screen no longer holds` |
| `cleared on switch` claimed with no reset call | RED — `marked "cleared on switch" but no reset call exists for it` |
| the scan stops matching | RED — `expected 0 to be greater than 8`, the count assert, so the message names the right file |

The fourth **came back green the first time**, on a `sed` whose escaping meant the mutation never landed. Re-applied and verified present in the file before believing the result — the trap the repo's own rules name.

## Test plan

- [x] Three red-first reproductions: the stray `DELETE`, the stray `setDocumentName`, and the surviving card menu
- [x] `pnpm --filter @kamiazya/whiteboard-web test` — **288 files / 2962** + `web-node` 12 / 77, zero failures
- [x] `pnpm test --project web-browser` — 148 files / **843**, zero failures
- [x] `pnpm check:local` — **exit 0**, every step
- [x] All four mutations above
- [ ] E2E — not applicable; the switch is a prop/route change both screens already model in-suite

## Scope I did not widen into

`HeaderBranchChip` and `VersionTimeline` hold the analogous state (`renameTarget`, `pendingDelete`, `pendingMerge`, `pendingRestore`) keyed on a **document**, not a workspace. `HeaderBranchChip.renameTarget` is a *deliberate* snapshot and says so in its own comment, so the same reflex applied there would be wrong without first establishing which of them are captures-on-purpose. Worth its own pass; the ledger here covers the two workspace-scoped screens only, and says so.

## Visual evidence

**Visual evidence: none — the change is what a dialog does when you are not looking at it.** The panel and index page render identically; what differs is that a dialog carried over from another workspace is no longer there to press. A screenshot of the correct behaviour is an absent dialog, which is indistinguishable from not having opened one. The evidence is the probe line above, and the three tests that fail on any reintroduction.

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_