### PR TITLE
ci(web): gate an absolute LCP floor, deliberately far from the measurement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,6 +300,13 @@ jobs:
       - name: Web app PWA precache gate
         run: pnpm --filter @kamiazya/whiteboard-web smoke:pwa-precache
 
+      # An ABSOLUTE floor, not a regression stop — the bundle-size gate above
+      # is the regression stop and is seven times finer. This one only refuses
+      # a shell that takes over a second to appear on a mid-range phone
+      # profile; the reasoning and the measurements are in the script.
+      - name: Web app LCP floor
+        run: pnpm --filter @kamiazya/whiteboard-web smoke:lcp-floor
+
       - name: Web app preview-origin behavioral smoke
         run: pnpm --filter @kamiazya/whiteboard-web smoke:preview-origin
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "smoke:artifact": "node scripts/smoke-artifact.mjs",
     "smoke:bundle-size": "node scripts/smoke-bundle-size.mjs",
     "measure:critical-path": "node scripts/measure-critical-path.mjs",
+    "smoke:lcp-floor": "LCP_FLOOR_MS=1000 MEASURE_RUNS=5 node scripts/measure-critical-path.mjs",
     "smoke:preview-origin": "node scripts/smoke-preview-origin.mjs",
     "smoke:pwa-precache": "node scripts/check-pwa-precache.mjs"
   },

--- a/apps/web/scripts/measure-critical-path.mjs
+++ b/apps/web/scripts/measure-critical-path.mjs
@@ -228,7 +228,18 @@ async function main() {
   }
   const { server, port } = await serveDist()
   const url = `http://127.0.0.1:${port}/`
-  const browser = await chromium.launch()
+  // `WHITEBOARD_CHROME_PATH` when the environment supplies its own Chrome,
+  // exactly as `smoke-preview-origin.mjs` does. CI's `verify` job installs no
+  // Playwright browsers — it sets that variable to the system Chrome — so a
+  // bare launch there fails with "Executable doesn't exist", which is a
+  // missing browser and not a slow one. Measured: that is how this gate first
+  // failed on CI, having passed every local run.
+  const browser = await chromium.launch({
+    headless: true,
+    ...(process.env.WHITEBOARD_CHROME_PATH && {
+      executablePath: process.env.WHITEBOARD_CHROME_PATH,
+    }),
+  })
   const runs = []
   try {
     for (let i = 0; i < RUNS; i++) {

--- a/apps/web/scripts/measure-critical-path.mjs
+++ b/apps/web/scripts/measure-critical-path.mjs
@@ -107,7 +107,30 @@ const RUNS = Number(process.env.MEASURE_RUNS ?? 10)
 // Set by the GATE caller only. Absent, this script reports and fails nothing,
 // which is what it was built to be; the assertion belongs to whoever states a
 // floor, not to the instrument.
-const FLOOR_MS = process.env.LCP_FLOOR_MS === undefined ? null : Number(process.env.LCP_FLOOR_MS)
+//
+// A value that is PRESENT but not a positive finite number is refused rather
+// than tolerated, because tolerating it fails in the direction that reads as
+// success: `Number('1000ms')` is NaN, `NaN === null` is false so the gate
+// arms, and `median > NaN` is false so every run passes. A typo in the env
+// var would disable enforcement while the job stayed green — measured, and it
+// prints `LCP floor: OK ... floor NaNms`. That is the same
+// guard-that-never-reaches-its-subject shape the mount check below refuses,
+// one level up in the gate's own configuration.
+//
+// Pure and exported so both directions are testable without a browser: the
+// caller does the exiting.
+export function parseFloorMs(raw) {
+  if (raw === undefined || raw === '') return { floor: null }
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return {
+      error:
+        `LCP_FLOOR_MS must be a positive number of milliseconds; got ${JSON.stringify(raw)}.` +
+        ' Refusing to run, because an unparseable floor would arm the gate and pass everything.',
+    }
+  }
+  return { floor: parsed }
+}
 // A mid-range phone on a decent connection, fixed so two runs are comparable.
 // The absolute numbers are only meaningful against each other.
 const CPU_THROTTLE = Number(process.env.MEASURE_CPU_THROTTLE ?? 4)
@@ -220,6 +243,15 @@ function row(name, s, unit) {
 }
 
 async function main() {
+  // First, so a misconfigured gate costs nothing and cannot be mistaken for a
+  // measurement that ran.
+  const floor = parseFloorMs(process.env.LCP_FLOOR_MS)
+  if (floor.error !== undefined) {
+    console.error(floor.error)
+    process.exit(1)
+  }
+  const FLOOR_MS = floor.floor
+
   if (!existsSync(join(DIST, 'index.html'))) {
     console.error(
       'dist/index.html not found — run `pnpm --filter @kamiazya/whiteboard-web build` first',
@@ -293,4 +325,8 @@ async function main() {
   console.log(`\nLCP floor: OK — median ${lcp.median.toFixed(0)}ms, floor ${FLOOR_MS}ms`)
 }
 
-await main()
+// Importable for its own tests; runs only when executed directly, exactly as
+// `smoke-bundle-size.mjs` does.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}

--- a/apps/web/scripts/measure-critical-path.mjs
+++ b/apps/web/scripts/measure-critical-path.mjs
@@ -60,6 +60,41 @@ import { existsSync, readFileSync, statSync } from 'node:fs'
 // there is before the lazy page arrives. The mount check below is what
 // establishes that — it was added after the first run, where a 2% spread on
 // an unverified number read as "gateable".
+//
+// ## The floor, and why it is deliberately far away (decision 2026-08-30)
+//
+// `LCP_FLOOR_MS=1000` gates CI. Current median is 492 ms, so the floor sits at
+// roughly twice the measurement and catches only a serious accident — about
+// 100 KB gzipped of new critical path. That distance is the POINT, not slack
+// left over from picking a round number.
+//
+// The reason is what this rig actually measures. LCP here is dominated by
+// CDP-emulated transfer, and the response is linear at **4.9 ms per gzipped
+// KB** — so on this machine LCP is very nearly a function of bytes. Set close
+// to the measurement and it becomes a second byte budget, with 2.5 KB of
+// resolution against `smoke-bundle-size.mjs`'s 335 bytes, plus a noise band
+// the byte count does not have. Seven times coarser and less certain, for the
+// same question, is not a gate worth having.
+//
+// So the two are given different jobs rather than different numbers:
+// bytes DETECT CHANGE, this states an ABSOLUTE FLOOR — "a mid-range phone on
+// a decent connection sees the shell inside a second, whatever the code does".
+// A regression small enough to matter reaches the byte budget first, by
+// design; anything that reaches this one has gone badly wrong.
+//
+// What would make LCP an independent signal is the CPU-bound half — the
+// parse/execute cost bytes cannot see. `longTasks` is that quantity and it
+// carries a 14-70% spread here, measured twice: signal and noise are the same
+// size, so it gates nothing. Getting that half honestly needs a steadier
+// measurement (Lighthouse's lantern model, or real field data), which is a
+// separate piece of work and not a threshold choice.
+//
+// One measured caveat shaped the gate's mechanics rather than its number: a
+// COLD first run reads high. Two 10-run sets on the same build gave medians
+// of 492 ms both times, but the first set's opening run was 548 ms (+11%) and
+// the second set had no outlier at all. A single-shot gate would therefore
+// flake on an effect that has nothing to do with the code, which is why this
+// gates the MEDIAN of several runs and never one.
 import { createServer } from 'node:http'
 import { dirname, extname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -69,6 +104,10 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const DIST = resolve(ROOT, 'dist')
 
 const RUNS = Number(process.env.MEASURE_RUNS ?? 10)
+// Set by the GATE caller only. Absent, this script reports and fails nothing,
+// which is what it was built to be; the assertion belongs to whoever states a
+// floor, not to the instrument.
+const FLOOR_MS = process.env.LCP_FLOOR_MS === undefined ? null : Number(process.env.LCP_FLOOR_MS)
 // A mid-range phone on a decent connection, fixed so two runs are comparable.
 // The absolute numbers are only meaningful against each other.
 const CPU_THROTTLE = Number(process.env.MEASURE_CPU_THROTTLE ?? 4)
@@ -209,6 +248,38 @@ async function main() {
   console.log(row('FCP', stats(runs.map((r) => r.fcp)), 'ms'))
   console.log(row('long tasks', stats(runs.map((r) => r.longTasks)), 'ms'))
   console.log(row('CLS', stats(runs.map((r) => r.cls)), ''))
+
+  if (FLOOR_MS === null) return
+
+  // The mount check is part of the GATE, not decoration, and the numbers say
+  // so. Measured by replacing the entry chunk with a no-op, so the app never
+  // mounts and only the boot splash paints: LCP 460ms, against 492ms working.
+  // A broken build is FASTER, so a floor on its own would read it as an
+  // improvement and pass. This is the one way this gate can be satisfied while
+  // measuring nothing.
+  //
+  // Both halves are needed and only one of them fires: that same run reported
+  // `rootChildren=1`, because the splash is itself a child — so the child
+  // count alone would have missed it, and `shellMark` is what refuses it.
+  const unmounted = runs.filter((r) => !r.shellMark || r.rootChildren === 0)
+  if (unmounted.length > 0) {
+    console.error(
+      `\nLCP floor: FAILED — ${unmounted.length}/${runs.length} runs never mounted the app.` +
+        ' The number above describes the boot splash, not the shell.',
+    )
+    process.exitCode = 1
+    return
+  }
+
+  const lcp = stats(runs.map((r) => r.lcp))
+  if (lcp.median > FLOOR_MS) {
+    console.error(
+      `\nLCP floor: FAILED — median ${lcp.median.toFixed(0)}ms is over the ${FLOOR_MS}ms floor.`,
+    )
+    process.exitCode = 1
+    return
+  }
+  console.log(`\nLCP floor: OK — median ${lcp.median.toFixed(0)}ms, floor ${FLOOR_MS}ms`)
 }
 
 await main()

--- a/apps/web/scripts/measure-critical-path.test.ts
+++ b/apps/web/scripts/measure-critical-path.test.ts
@@ -1,0 +1,70 @@
+import { execFileSync } from 'node:child_process'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { parseFloorMs } from './measure-critical-path.mjs'
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'measure-critical-path.mjs')
+
+describe('parseFloorMs', () => {
+  it('reports no floor when the variable is absent or empty — the instrument mode this script was built as', () => {
+    expect(parseFloorMs(undefined)).toEqual({ floor: null })
+    expect(parseFloorMs('')).toEqual({ floor: null })
+  })
+
+  it('accepts a positive number of milliseconds', () => {
+    expect(parseFloorMs('1000')).toEqual({ floor: 1000 })
+    expect(parseFloorMs('492.5')).toEqual({ floor: 492.5 })
+  })
+
+  // Each of these would otherwise ARM the gate and pass every run, because
+  // `NaN === null` is false and `median > NaN` is false. Measured on the
+  // unfixed script: `LCP floor: OK — median 496ms, floor NaNms`, exit 0.
+  it.each([
+    'abc',
+    '1000ms',
+    'NaN',
+    '0',
+    '-5',
+    'Infinity',
+  ])('refuses %j rather than silently disabling the gate', (raw) => {
+    const result = parseFloorMs(raw)
+    expect(result.floor).toBeUndefined()
+    expect(result.error).toContain('LCP_FLOOR_MS must be a positive number')
+    expect(result.error).toContain(JSON.stringify(raw))
+  })
+})
+
+describe('the gate script itself', () => {
+  // Two things at once, and the second is why this is a subprocess rather
+  // than another call to `parseFloorMs`:
+  //
+  // 1. the refusal is WIRED — a bad floor exits non-zero, so CI goes red;
+  // 2. `main()` runs at all when the file is executed directly. It sits
+  //    behind an `import.meta.url === file://${process.argv[1]}` guard so
+  //    this test can import the module; break that expression and the CI
+  //    step measures nothing and exits 0 — a green job over a gate that no
+  //    longer exists. Then nothing is printed here and the exit code is 0,
+  //    which is what this case refuses.
+  //
+  // Asserting the MESSAGE is load-bearing, not decoration: a missing
+  // `dist/` also exits 1, so an exit-code-only assertion would pass on a
+  // machine that never reached the subject.
+  it('exits non-zero and names the variable when the floor is unparseable', () => {
+    let status: number | null = null
+    let stderr = ''
+    try {
+      execFileSync(process.execPath, [SCRIPT], {
+        env: { ...process.env, LCP_FLOOR_MS: 'abc' },
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+    } catch (err) {
+      const e = err as { status?: number; stderr?: string }
+      status = e.status ?? null
+      stderr = e.stderr ?? ''
+    }
+    expect(status).toBe(1)
+    expect(stderr).toContain('LCP_FLOOR_MS must be a positive number')
+  })
+})


### PR DESCRIPTION
## Summary

- `smoke-bundle-size.mjs` says the byte budget's four raises (108 → 114 → 126 → 138 KB) are "how a budget stops meaning anything", and that the real question is a **product call the gate file should not make silently**. This makes that call for the metric half.
- **LCP floor: 1000 ms**, against a current median of **492 ms**. The distance is the design, not slack.
- The instrument keeps its character — it asserts nothing unless a caller supplies a floor, so `measure:critical-path` still reports and fails nothing.

## Why the floor sits twice as far away as the measurement

On this rig LCP is dominated by CDP-emulated transfer and responds linearly at **4.9 ms per gzipped KB** — so it is very nearly a function of bytes. Placed near the measurement it becomes a second byte budget:

| | `smoke:bundle-size` | LCP on this rig |
|---|---|---|
| what it sees | transferred bytes | very nearly transferred bytes |
| resolution | **335 bytes** | ~2.5 KB (noise band ±2% ≈ ±10 ms) |
| variance | none (deterministic) | 2%, occasionally +11% cold |

Seven times coarser and less certain, for the same question, is not a gate worth having. So the two get **different jobs rather than different numbers**: bytes detect change, this states an absolute floor — *a mid-range phone sees the shell inside a second, whatever the code does*. A regression small enough to matter reaches the byte budget first, by design.

## What would make LCP independent, and why it is not available

The CPU-bound half — the parse/execute cost bytes cannot see. That quantity is `longTasks`, and it measured a **14–70% spread** across two 10-run sets. Signal and noise are the same size, so it gates nothing. Getting it honestly needs a steadier measurement than observed throttling (Lighthouse's lantern model, or field data), which is separate work and not a threshold choice.

## The mount check is part of the gate, and the numbers say why

Replacing the entry chunk with a no-op, so the app never mounts and only the boot splash paints:

```
run 1/3  lcp=460ms  mounted=false rootKids=1 text=""
```

**460 ms — faster than the working 492 ms.** A floor on its own would read a completely broken build as an improvement and pass. This is the one way this gate can be satisfied while measuring nothing, so it is refused explicitly.

Both halves of the check are needed and only one fires: that same run still reported `rootChildren=1`, because the splash is itself a child — so the child count alone would have missed it, and `shellMark` is what refuses it.

## Why the median of several runs, never one

Two 10-run sets on one build both gave a **492 ms median**, but the first set's opening run read **548 ms (+11%)** and the second set had no outlier at all. A cold-start effect that appears intermittently would flake a single-shot gate for reasons that have nothing to do with the code. The gate runs 5 and takes the median: one outlier cannot move it.

## Verification

| case | result |
|---|---|
| floor 1000 (as CI runs it) | **OK** — median 492 ms |
| floor 400 | **FAILED** — `496ms is over the 400ms floor` |
| entry chunk replaced with a no-op | **FAILED** — `3/3 runs never mounted the app` |
| restored | **OK** again — confirmed by re-running, not assumed |

`pnpm check:local` → **exit 0**. `local-gate-command.test.ts` still passes — it guards the `check` job, and this step joins `verify` alongside the other web smokes, so it is placed consistently with `smoke:bundle-size` and `smoke:pwa-precache`.

## What this does NOT fix

**The 108 → 114 → 126 → 138 ratchet.** That is the byte budget being set at "current + margin", and adding a metric gate does not change it. Fixing it means deciding what critical-path size is right as a product question — a separate decision from this one, and deliberately not smuggled in here.

## Test plan

- [ ] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [ ] `pnpm test` passes locally
- [x] Manual verification completed (describe above)
- [ ] E2E coverage added or extended where applicable

No unit test: the subject is a CI gate script, and its four cases above are exercised by running it, which is what a test would do less directly. `pnpm test` is not claimed, for the pre-existing `apps/web` failures recorded in #1136.

## Visual evidence

**Visual evidence: none — this adds a CI step and changes nothing a human looks at.** The evidence is the measurement tables above.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — the decision, its measurements and its limits live in the script's own docblock, where the next person to question the number will be
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Added automated checks to verify the web app loads successfully and maintains a fast Largest Contentful Paint (LCP).
  - Performance checks evaluate multiple runs to provide more reliable results and flag regressions before release.

- **Reliability**
  - Added validation to detect cases where the application fails to mount during loading checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->