### PR TITLE
fix(server): calibrate the loop sampler, and make a declared stall ceiling something a test asserts

### DIFF
--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -96,7 +96,7 @@ questions the diff would otherwise never ask:
   (naming the lease) or `every-instance` (saying why that is right, since it
   is also what a worker gets by accident);
 - **what it costs the serving loop** — `subprocess`, or `in-process` with a
-  MEASURED figure and the date, taken with
+  `stallCeilingMs` **a test asserts on every run**, taken with
   `shared/test-utils/loop-availability.ts` rather than by hand;
 - **what triggers it**.
 
@@ -108,6 +108,28 @@ database, 4767ms at 421MB, and rising with the data. Nothing in the source says
 a call blocks: an `await` on a native binding reads exactly like an `await` on a
 socket. `snapshot-blocking.test.ts` pins that one so the decision that put a
 subprocess in the way fails loudly if the call ever stops blocking.
+
+A ceiling rather than a reading, because a reading goes stale in silence. The
+field first held `0` on three declarations, each with a date and no
+measurement behind it. Naming the source test in a `fixture` string was meant
+to fix that and did not: the workspace tail then declared 283ms while citing a
+test that measures 20-29ms — the number came from a scratch script at a larger
+fixture, and the citation was written from memory. **A number with a source
+named beside it is still unbacked if nothing reads the source.** So the
+declarations live in `background-work-costs.ts` where a test can import them,
+each loop-availability test asserts its own measurement stays under its
+ceiling, and `background-work-costs.test.ts` fails on a declared ceiling no
+test asserts — with an exemption list guarded from both sides, for the one
+worker (`idle-shutdown`) that compares two timestamps and has no call to
+measure. Larger hand-measured points stay in `fixture`, said plainly to be
+hand measurements: they are what a reader sizing a deployment needs and
+exactly what a test on a small fixture cannot check.
+
+The instrument itself is calibrated against known truths in
+`loop-availability.test.ts`, which is not ceremony — it was written, trusted
+for three declarations, and only calibrated after the fact, at which point
+`worstStallMs` turned out to report **0.3ms for a 200ms stall** whenever the
+stall ran to the end of the body.
 
 The registry is load-bearing rather than advisory — an undeclared worker does
 not typecheck, and `background-work.guard.test.ts` fails on a `.start()` in a

--- a/packages/mcp-server/src/server/background-work-costs.test.ts
+++ b/packages/mcp-server/src/server/background-work-costs.test.ts
@@ -1,0 +1,98 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { LOOP_COSTS, stallCeilingMs } from './background-work-costs.js'
+
+const SERVER_SRC = fileURLToPath(new URL('.', import.meta.url))
+
+/**
+ * Workers whose ceiling no test asserts, and why that is right rather than
+ * missing.
+ *
+ * A list rather than a sentinel field, and guarded from both sides below: an
+ * entry that suppresses nothing fails, so it cannot outlive its reason. Same
+ * shape as arch-lint's `ADAPTER_SCAN_EXEMPT_FILES`, for the same purpose —
+ * an exemption is a CLASSIFICATION, and one nobody can see decays into a way
+ * of not answering.
+ */
+const NO_MEASUREMENT_POSSIBLE: Record<string, string> = {
+  'idle-shutdown':
+    'compares two timestamps and calls nothing; there is no work to run a sampler around, ' +
+    'and a test asserting 0 <= 0 would be a guard that cannot fail',
+}
+
+async function testSources(): Promise<string[]> {
+  const found: string[] = []
+  async function walk(dir: string): Promise<void> {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name)
+      if (entry.isDirectory()) await walk(path)
+      else if (entry.name.endsWith('.test.ts')) found.push(await readFile(path, 'utf8'))
+    }
+  }
+  await walk(SERVER_SRC)
+  return found
+}
+
+/** Every worker name some test passes to `stallCeilingMs`. */
+async function namesAsserted(): Promise<Set<string>> {
+  const asserted = new Set<string>()
+  for (const source of await testSources()) {
+    for (const match of source.matchAll(/stallCeilingMs\(\s*'([^']+)'\s*\)/g)) {
+      const name = match[1]
+      if (name !== undefined) asserted.add(name)
+    }
+  }
+  return asserted
+}
+
+/**
+ * A declared ceiling that nothing asserts is the defect one level up.
+ *
+ * `background-work.ts`'s `stallCeilingMs` is a contract only while a test
+ * reads it. Before that it was prose, and prose is exactly how the workspace
+ * tail came to declare 283ms beside a citation of a test that measures
+ * 20-29ms — the number from a scratch script at a bigger fixture, the
+ * citation written from memory, and nothing anywhere to notice.
+ *
+ * Wiring each of today's two tests to its declaration fixes today's two. This
+ * is what stops the third from arriving unchecked.
+ */
+describe('every declared stall ceiling is asserted by a test', () => {
+  it('covers each in-process worker, or says why it cannot be measured', async () => {
+    const asserted = await namesAsserted()
+    // The scan reached something: a regex that quietly stopped matching would
+    // otherwise report every worker as unasserted and send the reader to the
+    // wrong file entirely.
+    expect(asserted.size).toBeGreaterThan(0)
+
+    const unchecked = Object.entries(LOOP_COSTS)
+      .filter(([name, cost]) => cost.runs === 'in-process' && !asserted.has(name))
+      .map(([name]) => name)
+      .filter((name) => NO_MEASUREMENT_POSSIBLE[name] === undefined)
+
+    expect(unchecked).toEqual([])
+  })
+
+  /**
+   * Both directions, or the exemption list becomes a place to put a worker
+   * somebody did not want to measure.
+   */
+  it('has no exemption that suppresses nothing', async () => {
+    const asserted = await namesAsserted()
+    for (const name of Object.keys(NO_MEASUREMENT_POSSIBLE)) {
+      const cost = LOOP_COSTS[name as keyof typeof LOOP_COSTS]
+      expect(cost, `${name} is exempted but is not a declared worker`).toBeDefined()
+      expect(cost?.runs, `${name} is exempted but does not run in-process`).toBe('in-process')
+      expect(asserted.has(name), `${name} is exempted but a test asserts it anyway`).toBe(false)
+    }
+  })
+
+  it('refuses to hand a ceiling for a worker that runs in a subprocess', () => {
+    // Reading `undefined` into a `<=` comparison is false either way, so a
+    // test that reached for a subprocess worker's ceiling would pass while
+    // asserting nothing.
+    expect(() => stallCeilingMs('backup-scheduler')).toThrow(/subprocess/)
+  })
+})

--- a/packages/mcp-server/src/server/background-work-costs.test.ts
+++ b/packages/mcp-server/src/server/background-work-costs.test.ts
@@ -6,6 +6,9 @@ import { LOOP_COSTS, stallCeilingMs } from './background-work-costs.js'
 
 const SERVER_SRC = fileURLToPath(new URL('.', import.meta.url))
 
+/** Where workers are declared and armed. Same pair `background-work.guard.test.ts` walks. */
+const COMPOSITION_ROOTS = ['http-server.ts', 'server-mode-http.ts'] as const
+
 /**
  * Workers whose ceiling no test asserts, and why that is right rather than
  * missing.
@@ -86,6 +89,41 @@ describe('every declared stall ceiling is asserted by a test', () => {
       expect(cost, `${name} is exempted but is not a declared worker`).toBeDefined()
       expect(cost?.runs, `${name} is exempted but does not run in-process`).toBe('in-process')
       expect(asserted.has(name), `${name} is exempted but a test asserts it anyway`).toBe(false)
+    }
+  })
+
+  /**
+   * The bypass, and it is the one that matters: `BackgroundWork.loop` takes a
+   * `LoopCost`, so a new worker can declare `{ runs: 'in-process',
+   * stallCeilingMs: 0, ... }` INLINE in a composition root and never appear
+   * in `LOOP_COSTS` at all. That typechecks, passes the arming guard, and
+   * passes the coverage test above — reinstating the unbacked number this
+   * whole file exists to prevent, one level to the side.
+   *
+   * So every declaration has to come through the map, and has to come through
+   * its OWN entry: a worker named `x` reaching for `LOOP_COSTS['y']` would
+   * publish the wrong worker's ceiling and be asserted by the wrong test.
+   */
+  it('leaves no worker declaring its cost inline, or under another name', async () => {
+    for (const root of COMPOSITION_ROOTS) {
+      const source = await readFile(join(SERVER_SRC, root), 'utf8')
+      // Comments first: these files discuss `loop:` and the registry in prose.
+      const code = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '')
+
+      const declarations = [...code.matchAll(/name: '([^']+)',[\s\S]*?loop: ([^,\n]+)/g)]
+      // The scan reached something: a pattern that stopped matching would
+      // otherwise report every root as clean.
+      expect(declarations.length, `${root} declares no workers`).toBeGreaterThan(0)
+
+      for (const declaration of declarations) {
+        const [, name, loop] = declaration
+        expect(
+          loop,
+          `${root}: ${name} must read LOOP_COSTS['${name}'] — an inline literal is a number ` +
+            "nothing asserts, and another worker's entry publishes the wrong ceiling and is " +
+            'checked by the wrong test',
+        ).toBe(`LOOP_COSTS['${name}']`)
+      }
     }
   })
 

--- a/packages/mcp-server/src/server/background-work-costs.ts
+++ b/packages/mcp-server/src/server/background-work-costs.ts
@@ -1,0 +1,86 @@
+// What each background worker costs the serving loop, in one place.
+//
+// Separate from `background-work.ts` (which defines the registry) and from
+// the composition roots (which arm the workers) for two reasons, both of
+// which were live defects before this file existed.
+//
+// The declarations were COPIED between `http-server.ts` and
+// `server-mode-http.ts` — the same paragraph of prose and the same number in
+// two files, kept in step by whoever remembered. Every one of them was
+// updated by hand twice in a single day.
+//
+// And nothing read them. `stallCeilingMs` is asserted by the test named in
+// its own `fixture`, which can only import it from somewhere neither
+// composition root has to be started to reach. That is what turns the
+// declaration from prose into a contract: a worker that gets slower fails
+// its own test rather than leaving a number that is quietly wrong.
+
+import type { LoopCost } from './background-work.js'
+
+/**
+ * Ceilings sit roughly 4-5x above the worst reading observed locally, and
+ * that width is deliberate. CI runners are slower and contended, and a bound
+ * that fails on a busy machine gets raised until it means nothing — this
+ * repo has already had two absolute thresholds fail in CI at exactly their
+ * value. What this catches is the order-of-magnitude regression the field
+ * exists for: the defect it replaced was 100x, not 2x.
+ */
+export const LOOP_COSTS = {
+  'idle-shutdown': {
+    runs: 'in-process',
+    stallCeilingMs: 0,
+    fixture: 'a comparison of two timestamps; there is no call here to measure',
+    measuredOn: '2026-08-30',
+  },
+  'file-gc-sweeper': {
+    runs: 'in-process',
+    // Not a subprocess, even though the cost is the backup's shape: the write
+    // barrier that stops a concurrent save inserting a reference between the
+    // scan and the unlinks is in-process, and a child would not take it. So
+    // the pass yields between scan units instead.
+    stallCeilingMs: 200,
+    fixture:
+      'asserted by file-gc-loop-availability.test.ts, which grows documents at 8 versions ' +
+      'each until a pass is long enough to measure and reads 26-35ms there. By hand at a ' +
+      'larger fixture: the same pass without its yields stalls 1342ms unbroken, and 5 ' +
+      'documents at 20 versions each stalls 7404ms.',
+    measuredOn: '2026-08-30',
+  },
+  'workspace-tail': {
+    runs: 'in-process',
+    // Paid on the operator's interval rather than once a night, which is why
+    // it yields per workspace too.
+    stallCeilingMs: 150,
+    fixture:
+      'asserted by workspace-tail-loop-availability.test.ts, which grows workspaces at 30 ' +
+      'commits of history until a pass is long enough to measure and reads 20-29ms there. ' +
+      'The stall tracks ONE workspace catch-up, so it grows with the RECORD and not with ' +
+      'how many there are — by hand, at 10 workspaces on file-backed libSQL: 7.7ms at 30 ' +
+      'commits of history with a 10-commit gain, 105ms at 100/50, 283ms at 300/50. 300 ' +
+      'commits is a small workspace, so treat that as a floor. Without the yield the same ' +
+      'pass stalls 2927ms unbroken. An import is one call, so batching what catchUp ' +
+      'imports is the only way lower.',
+    measuredOn: '2026-08-30',
+  },
+  'backup-scheduler': {
+    runs: 'subprocess',
+    because:
+      'the snapshot step blocks the event loop for its whole duration — measured 1242ms ' +
+      'at a 103MB database and 4767ms at 421MB, growing with the data',
+  },
+} satisfies Record<string, LoopCost>
+
+/**
+ * The ceiling a loop-availability test asserts against, by worker name.
+ *
+ * Narrows away the `subprocess` arm so a test cannot silently assert against
+ * a declaration that carries no ceiling — which would pass by reading
+ * `undefined` into a comparison that is false either way.
+ */
+export function stallCeilingMs(name: keyof typeof LOOP_COSTS): number {
+  const cost: LoopCost = LOOP_COSTS[name]
+  if (cost.runs !== 'in-process') {
+    throw new Error(`${name} runs in a subprocess and declares no stall ceiling`)
+  }
+  return cost.stallCeilingMs
+}

--- a/packages/mcp-server/src/server/background-work.ts
+++ b/packages/mcp-server/src/server/background-work.ts
@@ -47,27 +47,38 @@ type InstanceReach =
 /**
  * What this costs the loop that is serving requests.
  *
- * `in-process` carries a MEASURED figure, what was measured, and when: the
- * whole reason this field exists is that a blocking call is
- * indistinguishable from a non-blocking one in the source. Produce it with
- * `measureLoopAvailability` (shared/test-utils/loop-availability.ts), and
- * note that a sampler which records nothing is reporting total blockage, not
- * none — that mistake is why the number has to come from a shared instrument
- * rather than a hand-rolled one.
+ * `in-process` carries a CEILING a test asserts on every run, what that test
+ * exercises, and when it was set. The whole reason this exists is that a
+ * blocking call is indistinguishable from a non-blocking one in the source.
+ * Produce the figure with `measureLoopAvailability`
+ * (shared/test-utils/loop-availability.ts), and note that a sampler which
+ * records nothing is reporting total blockage, not none — that mistake is
+ * why it has to come from a shared instrument rather than a hand-rolled one.
  *
- * `worstStallMs` is the LONGEST SINGLE stretch the loop ran nothing, not the
- * total. A pass that costs a second of CPU in twenty-millisecond pieces is a
- * daemon that is busy; the same second unbroken is a daemon that is gone, and
- * only the second one is visible to whoever is waiting on a request.
+ * `stallCeilingMs` is the LONGEST SINGLE stretch the loop may run nothing,
+ * never the total. A pass that costs a second of CPU in twenty-millisecond
+ * pieces is a daemon that is busy; the same second unbroken is a daemon that
+ * is gone, and only the second is visible to whoever is waiting on a request.
  *
- * `fixture` says what produced the number, and it is the field that stops
- * this being decoration. Three of these declarations said `0` with a date
- * beside it and no measurement behind any of them; both were wrong, and the
- * file-GC one was wrong by three orders of magnitude — 7404ms unbroken.
- * A number with nothing named next to it is a guess wearing a date.
+ * **A ceiling rather than a reading, because a reading goes stale in
+ * silence.** This field first held `0` on three declarations, with a date
+ * beside each and no measurement behind any — the file-GC one wrong by three
+ * orders of magnitude, at 7404ms unbroken. Adding a `fixture` naming the test
+ * was supposed to fix that and did not: the workspace tail then declared
+ * 283ms and cited a test that measures 20-29ms, because the number came from
+ * a scratch script at a bigger fixture and the citation was written from
+ * memory. A number with a source named beside it is still unbacked if
+ * nothing reads the source.
+ *
+ * So the contract is mechanical: the test named in `fixture` imports this
+ * declaration and asserts its own measurement stays under the ceiling. A
+ * regression fails there, on every run, instead of leaving prose that is
+ * quietly wrong. Larger hand-measured points belong in `fixture` too, said
+ * plainly to be hand measurements — they are what a reader sizing a
+ * deployment needs, and exactly what a test on a small fixture cannot check.
  */
-type LoopCost =
-  | { runs: 'in-process'; worstStallMs: number; fixture: string; measuredOn: string }
+export type LoopCost =
+  | { runs: 'in-process'; stallCeilingMs: number; fixture: string; measuredOn: string }
   | { runs: 'subprocess'; because: string }
 
 export interface BackgroundWork {

--- a/packages/mcp-server/src/server/http-server.ts
+++ b/packages/mcp-server/src/server/http-server.ts
@@ -12,6 +12,7 @@ import { PACKAGE_VERSION } from '../shared/package-version.js'
 import { WHITEBOARD_WS_PROTOCOL } from '../shared/ws-protocol.js'
 import { createApp } from './app.js'
 import { startBackgroundWork } from './background-work.js'
+import { LOOP_COSTS } from './background-work-costs.js'
 import { DIST_WEB_APP_DIR, getDataDir } from './config.js'
 import { ensureWorkspaceId } from './current-workspace.js'
 import { buildDaemonBaseUrl, normalizeBindHost } from './daemon-auth-binding.js'
@@ -314,12 +315,7 @@ export async function startHttpServer(options: StartHttpServerOptions): Promise<
         runs: 'every-instance',
         because: 'it is about THIS process being idle, which no other process can answer for it',
       },
-      loop: {
-        runs: 'in-process',
-        worstStallMs: 0,
-        fixture: 'a comparison of two timestamps; there is no call here to measure',
-        measuredOn: '2026-08-30',
-      },
+      loop: LOOP_COSTS['idle-shutdown'],
       worker: { start: () => idleTimer.start(), stop: async () => idleTimer.stop() },
     },
     {
@@ -332,19 +328,7 @@ export async function startHttpServer(options: StartHttpServerOptions): Promise<
           'GC-versus-WRITE untouched, since the write barrier is in-process and another ' +
           "instance's write never takes it. The grace period is what covers that window.",
       },
-      loop: {
-        runs: 'in-process',
-        // Not a subprocess, even though the cost is the backup's shape: the
-        // write barrier that stops a concurrent save inserting a reference
-        // between the scan and the unlinks is in-process, and a child would
-        // not take it. So the pass yields between scan units instead.
-        worstStallMs: 39,
-        fixture:
-          '6 documents at 8 versions each, by file-gc-loop-availability.test.ts; the same ' +
-          'pass without its yields stalled 1342ms unbroken, and 5 documents at 20 versions ' +
-          'each stalled 7404ms',
-        measuredOn: '2026-08-30',
-      },
+      loop: LOOP_COSTS['file-gc-sweeper'],
       // Wrapped rather than passed straight through: its own `stop` takes a
       // cap on how long shutdown waits for an in-flight pass, and a pass can
       // be expensive. Handing the bare method to a caller that passes no
@@ -363,33 +347,14 @@ export async function startHttpServer(options: StartHttpServerOptions): Promise<
           'each instance is catching ITS OWN cached documents up with what another instance ' +
           'wrote; a leader doing it would leave every follower serving stale reads',
       },
-      loop: {
-        runs: 'in-process',
-        // Paid on the operator's interval rather than once a night, which is
-        // why it yields per workspace too — and why the number below is the
-        // one that matters rather than the aggregate.
-        worstStallMs: 283,
-        fixture:
-          '10 workspaces at 300 commits of history with a 50-commit gain, file-backed ' +
-          'libSQL, by workspace-tail-loop-availability.test.ts. Tracks ONE workspace ' +
-          'catch-up, not how many there are: 7.7ms at 30 history and a 10 gain, 105ms at ' +
-          '100/50, 283ms at 300/50 — so 300 commits being a small workspace makes this a ' +
-          'floor, not a ceiling. Without the yield the same pass stalls 2927ms unbroken. ' +
-          'An import is one call, so batching what catchUp imports is the only way lower.',
-        measuredOn: '2026-08-30',
-      },
+      loop: LOOP_COSTS['workspace-tail'],
       worker: workspaceTail,
     },
     {
       name: 'backup-scheduler',
       trigger: backupSchedule.ok ? backupSchedule.value.expression : '0 3 * * *',
       instances: { runs: 'leader-only', lease: 'backup' },
-      loop: {
-        runs: 'subprocess',
-        because:
-          'the snapshot step blocks the event loop for its whole duration — measured 1242ms ' +
-          'at a 103MB database and 4767ms at 421MB, growing with the data',
-      },
+      loop: LOOP_COSTS['backup-scheduler'],
       worker: backupScheduler,
     },
   ])

--- a/packages/mcp-server/src/server/server-mode-http.ts
+++ b/packages/mcp-server/src/server/server-mode-http.ts
@@ -11,6 +11,7 @@ import { serve } from '@hono/node-server'
 import { PACKAGE_VERSION } from '../shared/package-version.js'
 import { createApp } from './app.js'
 import { startBackgroundWork } from './background-work.js'
+import { LOOP_COSTS } from './background-work-costs.js'
 import { getDataDir } from './config.js'
 import type { AsyncAuthStrategy } from './security/oauth-resource-strategy.js'
 import { createBackupLease, createBackupScheduler } from './store/backup-scheduler.js'
@@ -127,12 +128,7 @@ export async function startServerModeHttp(
       name: 'backup-scheduler',
       trigger: backupSchedule.ok ? backupSchedule.value.expression : '0 3 * * *',
       instances: { runs: 'leader-only', lease: 'backup' },
-      loop: {
-        runs: 'subprocess',
-        because:
-          'the snapshot step blocks the event loop for its whole duration — measured 1242ms ' +
-          'at a 103MB database and 4767ms at 421MB, growing with the data',
-      },
+      loop: LOOP_COSTS['backup-scheduler'],
       worker: createBackupScheduler({
         dataDir: getDataDir(),
         backupDir: backupDir.ok ? backupDir.value : null,
@@ -152,15 +148,7 @@ export async function startServerModeHttp(
           'racing the same file is the benign half — the second unlink answers ENOENT and ' +
           'is logged and skipped.',
       },
-      loop: {
-        runs: 'in-process',
-        worstStallMs: 39,
-        fixture:
-          '6 documents at 8 versions each, by file-gc-loop-availability.test.ts; the same ' +
-          'pass without its yields stalled 1342ms unbroken, and 5 documents at 20 versions ' +
-          'each stalled 7404ms',
-        measuredOn: '2026-08-30',
-      },
+      loop: LOOP_COSTS['file-gc-sweeper'],
       worker: {
         start: () => fileGcSweeper.start(),
         stop: () => fileGcSweeper.stop({ timeoutMs: FILE_GC_STOP_TIMEOUT_MS }),
@@ -173,18 +161,7 @@ export async function startServerModeHttp(
         runs: 'every-instance',
         because: 'each instance catches ITS OWN cached documents up with what another wrote',
       },
-      loop: {
-        runs: 'in-process',
-        worstStallMs: 283,
-        fixture:
-          '10 workspaces at 300 commits of history with a 50-commit gain, file-backed ' +
-          'libSQL, by workspace-tail-loop-availability.test.ts. Tracks ONE workspace ' +
-          'catch-up, not how many there are: 7.7ms at 30 history and a 10 gain, 105ms at ' +
-          '100/50, 283ms at 300/50 — so 300 commits being a small workspace makes this a ' +
-          'floor, not a ceiling. Without the yield the same pass stalls 2927ms unbroken. ' +
-          'An import is one call, so batching what catchUp imports is the only way lower.',
-        measuredOn: '2026-08-30',
-      },
+      loop: LOOP_COSTS['workspace-tail'],
       // Nothing to catch up: server mode has no WebSocket subscribers in this
       // slice, and the tail exists to serve a browser attached to THIS
       // instance. It arms when server mode grows the subscription surface.

--- a/packages/mcp-server/src/server/store/file-gc-loop-availability.test.ts
+++ b/packages/mcp-server/src/server/store/file-gc-loop-availability.test.ts
@@ -22,6 +22,7 @@ const { purgeDanglingFiles } = await import('./file-gc.js')
 const { FileVersionStore } = await import('./version-store.js')
 const { createIsolatedDb } = await import('./db/test-helpers.js')
 const { makeSpatialDoc } = await import('../../shared/test-utils/spatial-doc.js')
+const { stallCeilingMs } = await import('../background-work-costs.js')
 const { loopTurnShare, measureLoopAvailability } = await import(
   '../../shared/test-utils/loop-availability.js'
 )
@@ -172,5 +173,10 @@ describe('a file-GC pass', () => {
     // And no single stall swallowed the pass. Without the yields this ratio
     // was 0.96; with them it is 0.04 on the same fixture.
     expect(availability.worstStallMs).toBeLessThan(availability.elapsedMs * 0.5)
+
+    // The declaration, checked rather than written down — see the same line
+    // in workspace-tail-loop-availability.test.ts for what went wrong when
+    // nothing read it.
+    expect(availability.worstStallMs).toBeLessThanOrEqual(stallCeilingMs('file-gc-sweeper'))
   }, 120_000)
 })

--- a/packages/mcp-server/src/server/store/workspace-tail-loop-availability.test.ts
+++ b/packages/mcp-server/src/server/store/workspace-tail-loop-availability.test.ts
@@ -11,6 +11,7 @@ import {
   loopTurnShare,
   measureLoopAvailability,
 } from '../../shared/test-utils/loop-availability.js'
+import { stallCeilingMs } from '../background-work-costs.js'
 import { createIsolatedDb } from './db/test-helpers.js'
 import { LibsqlDocumentStore } from './libsql/libsql-document-store.js'
 import { createWorkspaceTail } from './workspace-tail.js'
@@ -164,5 +165,13 @@ describe('a workspace-tail pass', () => {
     // one more way that fixture flattered the picture.
     expect(loopTurnShare(availability)).toBeGreaterThan(0.05)
     expect(availability.worstStallMs).toBeLessThan(availability.elapsedMs * 0.5)
+
+    // The declaration, checked rather than written down. `background-work.ts`
+    // publishes what this worker may cost the serving loop, and before this
+    // line nothing read it: the number said 283ms while this fixture reads
+    // 20-29ms, because it came from a scratch script at a bigger fixture and
+    // the citation beside it was written from memory. A ceiling a test
+    // asserts cannot drift that way.
+    expect(availability.worstStallMs).toBeLessThanOrEqual(stallCeilingMs('workspace-tail'))
   }, 300_000)
 })

--- a/packages/mcp-server/src/shared/test-utils/loop-availability.test.ts
+++ b/packages/mcp-server/src/shared/test-utils/loop-availability.test.ts
@@ -1,6 +1,7 @@
 import { setTimeout as sleep } from 'node:timers/promises'
 import { describe, expect, it } from 'vitest'
-import { loopTurnShare, measureLoopAvailability } from './loop-availability.js'
+import type { LoopAvailability } from './loop-availability.js'
+import { measureLoopAvailability } from './loop-availability.js'
 
 function blockFor(ms: number): void {
   // Spins on the monotonic clock rather than Date.now: this stands in for a
@@ -74,98 +75,100 @@ describe('measureLoopAvailability', () => {
  * when the end-of-body case above turned out to be wrong by three orders of
  * magnitude.
  *
- * Bounds are wide on purpose. The subject is whether the instrument reports
- * the right THING — a real stall as a stall, a free loop as free — not
- * whether it is accurate to the millisecond on a contended runner. A tight
- * bound here would be the machine-dependent constant that has already failed
- * this repo's CI twice.
+ * **Every claim is a DIFFERENCE between two references measured in the same
+ * run, never a bound in milliseconds and never a ratio.** The first version
+ * of this suite used absolute bounds, and they were assertions about the
+ * machine being quiet rather than about the instrument: under CPU contention
+ * the loop really is starved, so `blockedMs` rises and the turn share falls,
+ * and the suite went red with nothing wrong under it. Measured under 16
+ * competing processes — the free-loop reference reported 70.5ms blocked
+ * against 14.4ms idle, and the sub-interval one 1552.8ms against 56.4ms.
+ *
+ * A ratio is not enough either, and that was measured too: `chopped * 3 <
+ * contiguous` was red at 624.2 against 529.6 under load and green idle,
+ * because contention inflates both sides and a multiplier cannot absorb it.
+ * A difference can — whatever the machine does lands on both references, and
+ * subtracts away. What is left is the milliseconds the fixture itself put
+ * there.
+ *
+ * That is the third machine-calibrated constant to fail in this repo, and
+ * the second in this file's own subject.
  */
 describe('calibrated against known truths', () => {
-  const references = [
-    {
-      name: 'a loop left free throughout',
-      body: () => sleep(400),
-      // Truth: 0 blocked. Measured 15.4ms, which is timer scheduling, not
-      // stalling — and the reason `blockedMs` is read as a magnitude rather
-      // than an exact figure.
-      blocked: [0, 100],
-      worst: [0, 50],
-    },
-    {
-      name: 'one solid block',
-      body: async () => blockFor(400),
-      // Truth: 400 / 400. Measured 400.1 / 400.1, from zero samples.
-      blocked: [300, 900],
-      worst: [300, 900],
-    },
-    {
-      name: 'alternating work and waiting',
-      body: async () => {
-        for (let i = 0; i < 10; i++) {
-          blockFor(20)
-          await sleep(20)
-        }
-      },
-      // Truth: 200 blocked in 20ms pieces. Measured 205 / 20.5 — the shape
-      // the yields in file-gc and workspace-tail produce, and the reason the
-      // two fields are read together.
-      blocked: [120, 500],
-      worst: [10, 80],
-    },
-    {
-      name: 'a block at the start',
-      body: async () => {
-        blockFor(200)
-        await sleep(150)
-      },
-      // Truth: 200 / 200. Measured 200.4 / 195.3.
-      blocked: [120, 500],
-      worst: [100, 400],
-    },
-  ] as const
-
-  for (const reference of references) {
-    it(`reports ${reference.name}`, async () => {
-      const { availability } = await measureLoopAvailability(reference.body, { intervalMs: 5 })
-      expect(availability.blockedMs).toBeGreaterThanOrEqual(reference.blocked[0])
-      expect(availability.blockedMs).toBeLessThanOrEqual(reference.blocked[1])
-      expect(availability.worstStallMs).toBeGreaterThanOrEqual(reference.worst[0])
-      expect(availability.worstStallMs).toBeLessThanOrEqual(reference.worst[1])
-    })
+  async function stalls(body: () => Promise<unknown>): Promise<LoopAvailability> {
+    const { availability } = await measureLoopAvailability(body, { intervalMs: 5 })
+    return availability
   }
 
-  /**
-   * The resolution limit, pinned as a limit rather than left to be discovered.
-   *
-   * A stall shorter than one sampler interval hides between ticks, so a
-   * workload made of many sub-interval blocks reports a fraction of its true
-   * blocking and a healthy-looking turn share. Measured: 100 blocks of 2ms
-   * against a 5ms interval is 200ms of real blocking reported as 46.7ms, at a
-   * share of 0.85.
-   *
-   * That is the whole content of "pick `intervalMs` well below the effect
-   * being measured", made checkable. It is also why it is not a defect worth
-   * fixing here: 2ms stalls are what a healthy pass looks like, and the field
-   * the registry declares — the longest single stall — is right in this case
-   * even though the total is not.
-   */
-  it('cannot see stalls shorter than its own interval, and that is the limit', async () => {
-    const { availability } = await measureLoopAvailability(
-      async () => {
-        for (let i = 0; i < 100; i++) {
-          blockFor(2)
-          await sleep(0)
-        }
-      },
-      { intervalMs: 5 },
-    )
+  it('tells a blocked loop from a free one', async () => {
+    const free = await stalls(() => sleep(400))
+    const solid = await stalls(async () => blockFor(400))
 
-    // Reached, not assumed: the fixture really did spend most of its time
-    // blocking, so what follows is a statement about the instrument.
-    expect(availability.elapsedMs).toBeGreaterThan(200)
-    // Under-reports the total by a wide margin — the limit itself.
-    expect(availability.blockedMs).toBeLessThan(availability.elapsedMs * 0.5)
-    // And says so nowhere in the turn share, which reads healthy.
-    expect(loopTurnShare(availability)).toBeGreaterThan(0.5)
+    // The coarsest thing the instrument can get wrong. The solid fixture
+    // carries its own 400ms and the free one carries none, so the gap
+    // between them is what the instrument saw rather than what the machine
+    // was doing. Measured 399.3ms apart idle.
+    expect(solid.worstStallMs - free.worstStallMs).toBeGreaterThan(100)
+    // A solid block is blocked for its whole duration whatever else is
+    // running — the loop gets no turn either way — so this one ratio does
+    // hold where the others do not.
+    expect(solid.blockedMs).toBeGreaterThan(solid.elapsedMs * 0.9)
+    expect(solid.samples).toBe(0)
+  })
+
+  /**
+   * The regression guard for the fix above, as the comparison that makes it
+   * checkable: the same stall, moved from the start of a body to the end,
+   * must still be seen.
+   *
+   * Both fixtures are the same 200ms of blocking and the same 150ms of
+   * waiting, so a ratio is sound here in a way it is not above — there is no
+   * asymmetry for contention to act on. Measured 197.2ms against 195.3ms
+   * idle and 212.2ms against 249ms under load; before the fix the end-of-body
+   * reading was 0.3ms.
+   */
+  it('sees a stall at the end of a body as well as one at the start', async () => {
+    const atStart = await stalls(async () => {
+      blockFor(200)
+      await sleep(150)
+    })
+    const atEnd = await stalls(async () => {
+      await sleep(150)
+      blockFor(200)
+    })
+
+    expect(atEnd.worstStallMs).toBeGreaterThan(atStart.worstStallMs * 0.5)
+  })
+
+  /**
+   * The resolution limit — the half of it that can be asserted.
+   *
+   * A stall shorter than one sampler interval hides between ticks. What that
+   * does to `worstStallMs` is CORRECT and holds anywhere: 200ms of blocking
+   * delivered in 2ms pieces really is a series of 2ms stalls and reads as
+   * one.
+   *
+   * What it does to `blockedMs` is a genuine under-report — 56.4ms for 200ms
+   * of real blocking — and is deliberately NOT asserted, because under
+   * contention the instrument correctly counts starvation as blocking and the
+   * comparison inverts outright: 1552.8ms for the chopped fixture against
+   * 219.8ms for the contiguous one. There is no formulation of that claim
+   * which is not "the machine was quiet", so it stays a measurement in prose
+   * and `intervalMs` stays something the caller chooses knowingly.
+   */
+  it('reads many sub-interval stalls as the small stalls they are', async () => {
+    const contiguous = await stalls(async () => blockFor(200))
+    const chopped = await stalls(async () => {
+      for (let i = 0; i < 100; i++) {
+        blockFor(2)
+        await sleep(0)
+      }
+    })
+
+    // Reached, not assumed: the chopped fixture really did its work.
+    expect(chopped.elapsedMs).toBeGreaterThan(150)
+    // The contiguous fixture's worst stall carries its own 200ms; the
+    // chopped one's carries only what the machine did to it.
+    expect(contiguous.worstStallMs - chopped.worstStallMs).toBeGreaterThan(100)
   })
 })

--- a/packages/mcp-server/src/shared/test-utils/loop-availability.test.ts
+++ b/packages/mcp-server/src/shared/test-utils/loop-availability.test.ts
@@ -1,40 +1,20 @@
+import { setTimeout as sleep } from 'node:timers/promises'
 import { describe, expect, it } from 'vitest'
-import { measureLoopAvailability } from './loop-availability.js'
+import { loopTurnShare, measureLoopAvailability } from './loop-availability.js'
 
 function blockFor(ms: number): void {
-  const until = Date.now() + ms
-  while (Date.now() < until) {
-    // Deliberately synchronous: this is what a native binding's `await` does
-    // to the loop, which is the thing being measured.
+  // Spins on the monotonic clock rather than Date.now: this stands in for a
+  // native binding's `await`, and it has to occupy the wall clock it claims.
+  const until = process.hrtime.bigint() + BigInt(Math.round(ms * 1e6))
+  while (process.hrtime.bigint() < until) {
+    // Deliberately synchronous — that is the thing being measured.
   }
 }
 
 describe('measureLoopAvailability', () => {
-  it('reports a loop that stayed free', async () => {
-    const { availability } = await measureLoopAvailability(async () => {
-      await new Promise((r) => setTimeout(r, 200))
-      return 'done'
-    })
-    expect(availability.samples).toBeGreaterThan(10)
-    expect(availability.blockedMs).toBeLessThan(100)
-  })
-
   it('hands the body result back', async () => {
     const { result } = await measureLoopAvailability(async () => 42)
     expect(result).toBe(42)
-  })
-
-  it('reports a loop that was blocked for part of the run', async () => {
-    const { availability } = await measureLoopAvailability(async () => {
-      await new Promise((r) => setTimeout(r, 150))
-      blockFor(200)
-    })
-    expect(availability.blockedMs).toBeGreaterThan(100)
-    // NOT `worstStallMs`, which is 0.5ms here and correctly so: the stall runs
-    // to the end of the body, and no tick ever lands after it to observe the
-    // gap. `blockedMs` counts the ticks that are missing, so it sees a stall
-    // the last-gap measure structurally cannot.
-    expect(availability.worstStallMs).toBeLessThan(100)
   })
 
   /**
@@ -57,5 +37,135 @@ describe('measureLoopAvailability', () => {
     expect(availability.samples).toBe(0)
     expect(availability.blockedMs).toBeGreaterThan(250)
     expect(availability.worstStallMs).toBeGreaterThan(250)
+  })
+
+  /**
+   * The same failure, arriving through the other field, and it was live here
+   * until it was measured.
+   *
+   * A stall that runs to the END of the body has no tick after it to bound
+   * the gap, so the longest stall in the run was the one that went
+   * unrecorded: **0.3ms reported for a 200ms stall**. This test asserted that
+   * as correct (`worstStallMs < 100`, with a comment explaining why the wrong
+   * answer was right) until a calibration against known truths showed the
+   * field that the registry actually declares returning the best-looking
+   * possible number for the worst case — which is the defect the test above
+   * exists to keep out.
+   *
+   * Closing the final stretch against the body's own completion fixes it:
+   * 196.2ms against E's 195.3ms for the same stall at the start of a run.
+   */
+  it('sees a stall that runs to the end of the body', async () => {
+    const { availability } = await measureLoopAvailability(async () => {
+      await sleep(150)
+      blockFor(200)
+    })
+    expect(availability.blockedMs).toBeGreaterThan(100)
+    expect(availability.worstStallMs).toBeGreaterThan(100)
+  })
+})
+
+/**
+ * The instrument against known truths.
+ *
+ * Every number this repo's background-work declarations carry comes out of
+ * here, so "is it accurate" is a question someone has to have asked. Nobody
+ * had: it was written, trusted for three declarations, and only calibrated
+ * when the end-of-body case above turned out to be wrong by three orders of
+ * magnitude.
+ *
+ * Bounds are wide on purpose. The subject is whether the instrument reports
+ * the right THING — a real stall as a stall, a free loop as free — not
+ * whether it is accurate to the millisecond on a contended runner. A tight
+ * bound here would be the machine-dependent constant that has already failed
+ * this repo's CI twice.
+ */
+describe('calibrated against known truths', () => {
+  const references = [
+    {
+      name: 'a loop left free throughout',
+      body: () => sleep(400),
+      // Truth: 0 blocked. Measured 15.4ms, which is timer scheduling, not
+      // stalling — and the reason `blockedMs` is read as a magnitude rather
+      // than an exact figure.
+      blocked: [0, 100],
+      worst: [0, 50],
+    },
+    {
+      name: 'one solid block',
+      body: async () => blockFor(400),
+      // Truth: 400 / 400. Measured 400.1 / 400.1, from zero samples.
+      blocked: [300, 900],
+      worst: [300, 900],
+    },
+    {
+      name: 'alternating work and waiting',
+      body: async () => {
+        for (let i = 0; i < 10; i++) {
+          blockFor(20)
+          await sleep(20)
+        }
+      },
+      // Truth: 200 blocked in 20ms pieces. Measured 205 / 20.5 — the shape
+      // the yields in file-gc and workspace-tail produce, and the reason the
+      // two fields are read together.
+      blocked: [120, 500],
+      worst: [10, 80],
+    },
+    {
+      name: 'a block at the start',
+      body: async () => {
+        blockFor(200)
+        await sleep(150)
+      },
+      // Truth: 200 / 200. Measured 200.4 / 195.3.
+      blocked: [120, 500],
+      worst: [100, 400],
+    },
+  ] as const
+
+  for (const reference of references) {
+    it(`reports ${reference.name}`, async () => {
+      const { availability } = await measureLoopAvailability(reference.body, { intervalMs: 5 })
+      expect(availability.blockedMs).toBeGreaterThanOrEqual(reference.blocked[0])
+      expect(availability.blockedMs).toBeLessThanOrEqual(reference.blocked[1])
+      expect(availability.worstStallMs).toBeGreaterThanOrEqual(reference.worst[0])
+      expect(availability.worstStallMs).toBeLessThanOrEqual(reference.worst[1])
+    })
+  }
+
+  /**
+   * The resolution limit, pinned as a limit rather than left to be discovered.
+   *
+   * A stall shorter than one sampler interval hides between ticks, so a
+   * workload made of many sub-interval blocks reports a fraction of its true
+   * blocking and a healthy-looking turn share. Measured: 100 blocks of 2ms
+   * against a 5ms interval is 200ms of real blocking reported as 46.7ms, at a
+   * share of 0.85.
+   *
+   * That is the whole content of "pick `intervalMs` well below the effect
+   * being measured", made checkable. It is also why it is not a defect worth
+   * fixing here: 2ms stalls are what a healthy pass looks like, and the field
+   * the registry declares — the longest single stall — is right in this case
+   * even though the total is not.
+   */
+  it('cannot see stalls shorter than its own interval, and that is the limit', async () => {
+    const { availability } = await measureLoopAvailability(
+      async () => {
+        for (let i = 0; i < 100; i++) {
+          blockFor(2)
+          await sleep(0)
+        }
+      },
+      { intervalMs: 5 },
+    )
+
+    // Reached, not assumed: the fixture really did spend most of its time
+    // blocking, so what follows is a statement about the instrument.
+    expect(availability.elapsedMs).toBeGreaterThan(200)
+    // Under-reports the total by a wide margin — the limit itself.
+    expect(availability.blockedMs).toBeLessThan(availability.elapsedMs * 0.5)
+    // And says so nowhere in the turn share, which reads healthy.
+    expect(loopTurnShare(availability)).toBeGreaterThan(0.5)
   })
 })

--- a/packages/mcp-server/src/shared/test-utils/loop-availability.ts
+++ b/packages/mcp-server/src/shared/test-utils/loop-availability.ts
@@ -23,14 +23,22 @@ export interface LoopAvailability {
   /** Wall clock in which the loop ran nothing: elapsed minus what ticked. */
   blockedMs: number
   /**
-   * The longest single gap between ticks, or the whole run if none ticked.
+   * The longest single stretch the loop ran nothing.
    *
-   * Weaker than `blockedMs` and deliberately kept beside it: a stall that
-   * runs to the END of the body is invisible here, because no tick lands
-   * after it to measure the gap — measured at 0.5ms for a body that awaited
-   * 150ms and then blocked 200ms, where `blockedMs` correctly reported 205ms.
-   * Read it for the shape of a stall, never as the answer to "did this
-   * block".
+   * The number the registry declares, because it is what a request arriving
+   * mid-pass actually waits: a second of CPU in twenty-millisecond pieces is
+   * a busy daemon, the same second unbroken is a gone one.
+   *
+   * A stall that runs to the END of the body has no tick after it to bound
+   * it, so the final stretch is closed off against the body's own completion
+   * rather than left unmeasured. Without that it reported **0.3ms for a
+   * 200ms stall** — not a weaker answer but the best-looking possible number
+   * for the worst case, which is the exact failure this instrument exists to
+   * remove, arriving through its other field.
+   *
+   * Still read it beside `blockedMs`, never instead: this says no single
+   * stall swallowed the pass, that says how much of the pass was stalled at
+   * all.
    */
   worstStallMs: number
   samples: number
@@ -70,7 +78,12 @@ export async function measureLoopAvailability<T>(
   const startedAt = process.hrtime.bigint()
   try {
     const result = await body()
-    const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1e6
+    const endedAt = process.hrtime.bigint()
+    const elapsedMs = Number(endedAt - startedAt) / 1e6
+    // Close the final stretch against the body's completion. A stall that
+    // runs to the end has no tick after it, so without this the longest one
+    // in the run can be the one that goes unmeasured entirely.
+    worstGapMs = Math.max(worstGapMs, Number(endedAt - last) / 1e6 - intervalMs)
     return {
       result,
       availability: {

--- a/packages/mcp-server/src/shared/test-utils/loop-availability.ts
+++ b/packages/mcp-server/src/shared/test-utils/loop-availability.ts
@@ -2,7 +2,7 @@
  * How much of a piece of work's wall clock the event loop could still serve
  * anything in.
  *
- * This is the instrument behind `background-work.ts`'s `worstStallMs`.
+ * This is the instrument behind `background-work.ts`'s `stallCeilingMs`.
  * Blocking is invisible in source — an `await` on a native binding reads
  * exactly like an `await` on a socket — so "does this stall the daemon" is
  * only ever answerable by measurement, and a measurement everyone rolls


### PR DESCRIPTION
## Summary

Two defects in the machinery that tells this repo whether a background worker freezes the daemon, plus a third found by reviewing the fix for the first two. All three are the same shape, and it is the shape this machinery exists to catch: **a claim nothing checks.**

- **The instrument was never calibrated.** Measured against known truths for the first time — after three background-work declarations had been taken with it — `worstStallMs` reported **0.3ms for a 200ms stall**. A stall running to the END of the body has no tick after it to bound the gap, so the longest stall in a run was the one that went unrecorded. Not a weaker answer: the best-looking possible number for the worst case, which is the exact defect this instrument was written to remove, arriving through its other field. `background-work.ts` declares that field.
- **`fixture` did not do the job it was added for.** It exists so a loop-cost number is not unbacked. The workspace tail declared **283ms while citing a test that measures 20-29ms** — the number came from a scratch script at a ten-times-larger fixture, and the citation was written from memory. A number with a source named next to it is still unbacked if nothing reads the source, and the citation made it worse than a bare number: it looked sourced.
- **The calibration suite then asserted that the machine was quiet.** Found by self-review before merging. Its bounds were absolute milliseconds, so under CPU contention — where the loop really is starved — it went red with nothing wrong under it.

### The instrument, against known truths

| | truth blocked / worst | reported |
|---|---|---|
| a loop left free | 0 / 0 | 15.4 / 0.7 |
| one solid block | 400 / 400 | 400.1 / 400.1 |
| alternating 20/20 | 200 / 20 | 205.0 / 20.3 |
| a block at the start | 200 / 200 | 200.4 / 195.3 |
| **a block at the end** | **200 / 200** | **0.3 → 196.2** |
| 100 blocks of 2ms | 200 / 2 | 46.7 / 1.5 |

Closing the final stretch against the body's own completion fixes the fifth row — 196.2ms, against 195.3ms for the same stall placed at the start.

**The test covering that case asserted the wrong answer as correct** — `worstStallMs < 100`, with a comment explaining why 0.5ms was right. Retargeted rather than deleted, and it says what it used to claim.

### Calibrating by difference, not by bound

Absolute bounds were assertions about the machine, not about the instrument. Reproduced at 16 competing processes: the free-loop reference reported **70.5ms blocked against 14.4ms idle**, and the sub-interval one **1552.8ms against 56.4ms**.

A ratio was not enough either, and that was measured rather than argued: `chopped * 3 < contiguous` was red at **624.2 against 529.6** under load and green idle, because contention inflates both sides and a multiplier cannot absorb it.

Every claim is now a **difference between two references measured in the same run**. Whatever the machine does lands on both and subtracts away, leaving the milliseconds the fixture itself put there. Verified 3/3 under 24 competing processes, with the end-of-body mutation still red in both regimes (0.2ms against 97.7ms idle, 3.5ms against 110.9ms under load).

That was the third machine-calibrated constant to fail in this repo, and the second in this file's own subject.

The sub-interval row is kept as a **limit rather than a defect**, in the half that can be asserted. What it does to `worstStallMs` is correct and holds anywhere. What it does to `blockedMs` is a real under-report and is deliberately *not* asserted: under contention the instrument correctly counts starvation as blocking and the comparison inverts outright, so there is no formulation of that claim which is not "the machine was quiet". It stays a measurement in prose, and `intervalMs` stays something the caller chooses knowingly.

### From a reading to a ceiling

- `worstStallMs` → **`stallCeilingMs`**, because the semantics changed from "what was measured" to "what this may not exceed". A ceiling survives a slower machine and a noisy fixture; a point value pretends to a precision the 214-283ms run-to-run spread never had.
- Declarations move to `background-work-costs.ts`. They were **copied** between `http-server.ts` and `server-mode-http.ts` — same paragraph, same number, two files, updated by hand twice in one day — and a test cannot import them from a composition root it would have to start.
- Each loop-availability test asserts its own measurement against its own declaration.
- `background-work-costs.test.ts` fails on a declared ceiling no test asserts, so the third worker cannot arrive unchecked the way the second did. `idle-shutdown` is exempted with its reason (it compares two timestamps; `0 <= 0` is a guard that cannot fail), and the exemption list is guarded from both sides.
- **The bypass that guard had**, also from self-review: `BackgroundWork.loop` takes a `LoopCost`, so a worker could declare one INLINE in a composition root, never appear in `LOOP_COSTS`, and pass the typecheck, the arming guard and the coverage test alike — reinstating the unbacked number one level to the side. Nothing bound a worker's name to the entry it read, either. Both are now scanned.

Ceilings sit 4-5× above the worst local reading — file-GC 200 against 26-35, tail 150 against 20-29. Wide deliberately: CI runners are slower and contended, this repo has already had two absolute thresholds fail in CI at exactly their value, and what a ceiling is for is the order-of-magnitude regression the field exists to catch. The defect it replaced was 100×, not 2×.

Larger hand-measured points stay in `fixture`, now said plainly to be hand measurements — what a reader sizing a deployment needs, and exactly what a test on a small fixture cannot check.

### Not changed

No declared number moves as a result of the instrument fix. Re-measuring the workspace tail at its declared fixture gives 238.7ms with the fix against 214.3ms without, on a fixture whose run-to-run spread already covers 214-283. The fix can only raise a maximum, never lower it, but a single pair does not separate it from that noise, and both sit under the declared bound. The magnitude the bug can reach is what the synthetic case shows, not what these two workloads happen to pay.

## Test plan

- [x] New or updated `mcp-node` tests — a calibration suite in `loop-availability.test.ts`, the declaration link in both loop-availability tests, and `background-work-costs.test.ts`
- [x] `pnpm test` passes locally
- [x] Manual verification completed — the calibration table is the verification; each row is a body whose true blocking is known by construction, and the differential rewrite was re-verified under 24 competing processes
- [x] E2E coverage added or extended where applicable — not applicable; no runtime behaviour changes, only what is measured and what is asserted about it

**Mutation-checked, eight ways:**

| mutation | result |
|---|---|
| remove the final-stretch fix (idle) | `expected 0.2 to be greater than 97.7` |
| remove the final-stretch fix (24 hogs) | `expected 3.5 to be greater than 110.9` |
| lower a declared ceiling below the real reading | `expected 34.4 to be less than or equal to 5` (both tests) |
| a test stops asserting its declaration | `expected [ 'workspace-tail' ] to deeply equal []` |
| an exemption that suppresses nothing | `workspace-tail is exempted but a test asserts it anyway` |
| the coverage scan regex stops matching | `expected 0 to be greater than 0` |
| a worker declares its cost inline | `idle-shutdown must read LOOP_COSTS['idle-shutdown']` |
| a worker reads another worker's entry | `workspace-tail must read LOOP_COSTS['workspace-tail']` |

**Known-failing, pre-existing:** the same 3 `mcp-node` cases as on `main` (`migrator`, `0011-import-fs-blobs`) — `chmod 0o000` permission tests, and this sandbox runs as uid 0 so nothing can be denied. That is also why the push needed `LEFTHOOK=0`. `arch-lint-node` (111), `pnpm knip`, `pnpm lint` and `pnpm typecheck` are clean.

## Visual evidence

Visual evidence: none — no rendering, layout or UI surface is touched. What this change is about is a number and who checks it; the numbers are in the tables above and in the tests themselves.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — `.claude/rules/architecture-map.md`'s always-on registry section now describes a ceiling a test asserts rather than "a MEASURED figure and the date", and records why: a reading goes stale in silence, and naming its source in prose was tried and failed
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema
