### PR TITLE
fix(web): stop a keystroke during a document load being written into the document that left

### DIFF
--- a/apps/web/src/components/settings/PromoteWorkspaceSection.browser.test.tsx
+++ b/apps/web/src/components/settings/PromoteWorkspaceSection.browser.test.tsx
@@ -38,6 +38,8 @@ const DAEMON = { baseUrl: BASE, token: 'tok-1' }
 interface StubOptions {
   updateDelayMs?: number
   putDelayMs?: number
+  /** An update that stays in flight until the test releases it. */
+  updateGate?: Promise<void>
   failUpdateStatus?: number
   workspaces?: { workspaceId: string; segment?: string; displayName?: string }[]
 }
@@ -53,6 +55,7 @@ function daemonStub(target: LoroDoc, opts: StubOptions = {}): typeof globalThis.
     }
     if (url.endsWith('/workspace-document/update') && init?.method === 'POST') {
       if (opts.updateDelayMs) await new Promise((r) => setTimeout(r, opts.updateDelayMs))
+      if (opts.updateGate) await opts.updateGate
       if (opts.failUpdateStatus) {
         return Response.json(
           { title: `Workspace "ws-a" not found` },
@@ -137,6 +140,28 @@ async function seedPreFoldDocument(path: string): Promise<string> {
   doc.commit()
   await new LoroStore().save(entry.documentId, doc.export({ mode: 'snapshot' }))
   return entry.documentId
+}
+
+/**
+ * An update the test releases, rather than one that finishes on a timer.
+ *
+ * A test that has to observe the RUNNING phase is racing the flow it started:
+ * the progress element is on screen only until the update resolves, and the
+ * driver round trip that `userEvent.click` waits out afterwards is charged to
+ * that same window. A delay makes the window wide, not certain — and it is a
+ * wall-clock number sitting next to a cost that grows with the run (the same
+ * file's tests were measured at 1.5s alone and 30s+ with the whole browser
+ * project in flight). Held instead, nothing about the machine can close the
+ * window early.
+ */
+function heldUpdate(): { gate: Promise<void>; release: () => void } {
+  let release = (): void => {}
+  const gate = new Promise<void>((resolve) => {
+    release = () => {
+      resolve()
+    }
+  })
+  return { gate, release: () => release() }
 }
 
 const NO_INTERNAL_VOCABULARY = /loro|crdt|oplog|snapshot/i
@@ -272,18 +297,24 @@ describe('PromoteWorkspaceSection', () => {
     failing.unmount()
 
     localStorage.removeItem(STORAGE_KEY)
+    const running = heldUpdate()
     render(
       <PromoteWorkspaceSection
         daemon={DAEMON}
         settingsStore={createUserSettingsStore()}
-        baseFetch={daemonStub(new LoroDoc(), { updateDelayMs: 120 })}
+        baseFetch={daemonStub(new LoroDoc(), { updateGate: running.gate })}
         reload={vi.fn()}
       />,
     )
     await userEvent.click(screen.getByTestId('promote-workspace-open'))
     await userEvent.click(await screen.findByTestId('promote-confirm'))
     await screen.findByTestId('promote-progress')
+    expect(
+      screen.queryByTestId('promote-last-result'),
+      'the update is still held, so the running phase is what is being read here — if the flow has already finished, this case is back to racing it',
+    ).toBeNull()
     expect(document.body.textContent).not.toMatch(NO_INTERNAL_VOCABULARY)
+    running.release()
     await screen.findByTestId('promote-last-result')
     expect(document.body.textContent).not.toMatch(NO_INTERNAL_VOCABULARY)
   })

--- a/apps/web/src/pages/use-markdown-document.switch-race.test.ts
+++ b/apps/web/src/pages/use-markdown-document.switch-race.test.ts
@@ -26,10 +26,7 @@ import { renderHook, waitFor } from '@testing-library/react'
 import { act } from 'react'
 import { describe, expect, it } from 'vitest'
 import type { LoroStoreLike } from './use-browser-document-controller.js'
-import { useMarkdownDocument } from './use-markdown-document.js'
-
-/** Debounce the hook's scheduler uses; waited out rather than faked. */
-const SAVE_DEBOUNCE_MS = 500
+import { SAVE_DEBOUNCE_MS, useMarkdownDocument } from './use-markdown-document.js'
 
 interface GatedStore extends LoroStoreLike {
   /** Every save, with the id it was addressed to. */

--- a/apps/web/src/pages/use-markdown-document.switch-race.test.ts
+++ b/apps/web/src/pages/use-markdown-document.switch-race.test.ts
@@ -40,6 +40,12 @@ interface GatedStore extends LoroStoreLike {
   requested: Promise<void>
 }
 
+/**
+ * A store whose load for ONE id never settles until released, so a test can
+ * stand inside the window where the next document is still loading and the
+ * hook is still holding the previous one. Every other id loads immediately,
+ * which is what lets the first document arrive normally.
+ */
 function gatedStore(heldId: string): GatedStore {
   const saves: { id: string; snapshot: Uint8Array }[] = []
   let release = (): void => {}

--- a/apps/web/src/pages/use-markdown-document.switch-race.test.ts
+++ b/apps/web/src/pages/use-markdown-document.switch-race.test.ts
@@ -1,0 +1,121 @@
+/**
+ * What the markdown editor is bound to while the NEXT document is still
+ * loading.
+ *
+ * The load effect guards its own result with `cancelled`, flushes the
+ * outgoing document's debounce on cleanup, and unsubscribes — all correct.
+ * What it does not do is clear what is on screen BEFORE the async load: `doc`
+ * and `body` are reset only when `documentId` becomes null, never when it
+ * changes from one document to another. `hostRef.current` is the same story —
+ * the cleanup sets `cancelled`, not the ref.
+ *
+ * So for the whole duration of the next document's load, the hook is still
+ * holding the previous document's host and content under the new document's
+ * address. `setBody` writes through `hostRef.current`, and `scheduleSave`
+ * keys its scheduler on the NEW id, so a keystroke in that window is written
+ * into the previous document and queued under the next one's name.
+ *
+ * Both sibling screens already keep the opposite rule and say why:
+ * `DaemonIndexPage` clears rows "synchronously BEFORE the async load ...
+ * leaving the previous workspace's rows visible during the switch lets a
+ * click pair the new workspace id with an old workspace's path", and
+ * `VersionTimeline` drops its rows "immediately on canvas change so a stale
+ * row ... never renders under the new canvas while the refetch is in flight".
+ */
+import { renderHook, waitFor } from '@testing-library/react'
+import { act } from 'react'
+import { describe, expect, it } from 'vitest'
+import type { LoroStoreLike } from './use-browser-document-controller.js'
+import { useMarkdownDocument } from './use-markdown-document.js'
+
+/** Debounce the hook's scheduler uses; waited out rather than faked. */
+const SAVE_DEBOUNCE_MS = 500
+
+interface GatedStore extends LoroStoreLike {
+  /** Every save, with the id it was addressed to. */
+  saves: { id: string; snapshot: Uint8Array }[]
+  /** Lets the held-open load for `heldId` finish. */
+  release: () => void
+  /** Resolves once that load has actually been requested. */
+  requested: Promise<void>
+}
+
+function gatedStore(heldId: string): GatedStore {
+  const saves: { id: string; snapshot: Uint8Array }[] = []
+  let release = (): void => {}
+  let markRequested = (): void => {}
+  const requested = new Promise<void>((resolve) => {
+    markRequested = resolve
+  })
+  const gate = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  return {
+    saves,
+    release: () => release(),
+    requested,
+    async save(id, snapshot) {
+      saves.push({ id, snapshot })
+    },
+    createEmptySnapshot() {
+      return new Uint8Array()
+    },
+    async load(id) {
+      if (id === heldId) {
+        markRequested()
+        await gate
+      }
+      return { kind: 'missing' } as never
+    },
+  } as GatedStore
+}
+
+describe('switching documents while the next one is still loading', () => {
+  it('does not keep showing the previous document under the new address', async () => {
+    const store = gatedStore('c2')
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useMarkdownDocument(store, id, true),
+      { initialProps: { id: 'c1' } },
+    )
+    await waitFor(() => expect(result.current.doc).not.toBeNull())
+    await act(async () => {
+      result.current.setBody('written in c1')
+    })
+    await waitFor(() => expect(result.current.body).toBe('written in c1'))
+
+    rerender({ id: 'c2' })
+    await store.requested
+
+    expect(
+      result.current.body,
+      'c2 is the document on screen, and this is c1’s prose — the editor is bound to the document that left',
+    ).not.toBe('written in c1')
+  })
+
+  it('does not write a keystroke into the document that left', async () => {
+    const store = gatedStore('c2')
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useMarkdownDocument(store, id, true),
+      { initialProps: { id: 'c1' } },
+    )
+    await waitFor(() => expect(result.current.doc).not.toBeNull())
+
+    rerender({ id: 'c2' })
+    await store.requested
+    store.saves.length = 0
+
+    // A keystroke under c2's address, while c2 is still loading.
+    await act(async () => {
+      result.current.setBody('typed while c2 was loading')
+    })
+    await new Promise((r) => setTimeout(r, SAVE_DEBOUNCE_MS * 2))
+
+    const intoC1 = store.saves.filter((s) => s.id === 'c1')
+    expect(
+      intoC1,
+      'the keystroke was addressed at c1 — the hook still held its host while c2 loaded, so text typed under one document was written into another',
+    ).toEqual([])
+
+    store.release()
+  })
+})

--- a/apps/web/src/pages/use-markdown-document.ts
+++ b/apps/web/src/pages/use-markdown-document.ts
@@ -263,14 +263,28 @@ export function useMarkdownDocument(
   // for this document before reading the store.
   const pending = pendingFlushes
 
+  // SCOPE RESET — see scoped-screen-state.test.ts
   useEffect(() => {
-    if (!enabled || documentId === null) {
-      hostRef.current = null
-      setDoc(null)
-      setBodyState(null)
-      setCoreMetaState(null)
-      return
-    }
+    // Cleared synchronously, BEFORE the async load below — the same rule
+    // `DaemonIndexPage` states for its rows ("leaving the previous
+    // workspace's rows visible during the switch lets a click pair the new
+    // workspace id with an old workspace's path") and `VersionTimeline` for
+    // its versions. Unconditional, because a switch from one document to
+    // another is the case that was missing: the `cancelled` guard below stops
+    // a stale load from LANDING, and does nothing about what is still held
+    // while the next one is in flight.
+    //
+    // `hostRef` is the half that matters. `setBody` writes through it and
+    // returns early when it is null, while `scheduleSave` keys its scheduler
+    // on the NEW id — so without this, a keystroke during the next document's
+    // load is written into the previous document and queued under a name that
+    // is not its own. Measured: typing under c2 while c2 loaded produced
+    // `save('c1', …)`.
+    hostRef.current = null
+    setDoc(null)
+    setBodyState(null)
+    setCoreMetaState(null)
+    if (!enabled || documentId === null) return
     let cancelled = false
     let unsubscribe: (() => void) | undefined
     void Promise.resolve(pending.get(documentId))

--- a/apps/web/src/scoped-screen-state.test.ts
+++ b/apps/web/src/scoped-screen-state.test.ts
@@ -45,6 +45,7 @@ const sources = import.meta.glob(
     './pages/DaemonIndexPage.tsx',
     './components/HeaderBranchChip.tsx',
     './components/VersionTimeline.tsx',
+    './pages/use-markdown-document.ts',
   ],
   { query: '?raw', import: 'default', eager: true },
 ) as Record<string, string>
@@ -52,6 +53,14 @@ const sources = import.meta.glob(
 type ScopeCoverage =
   /** Dropped when the scope changes, because it names something inside it. */
   | 'cleared on switch'
+  /**
+   * IS scope-bound and knowingly still survives. A first-class permanent
+   * answer, like `not modelled:` in the other ledgers — what it forbids is
+   * the UNDECIDED member, not the uncleared one. The reason has to say what
+   * would be needed, because "we'll get to it" is the omission with a
+   * sentence in front of it.
+   */
+  | `survives: ${string}`
   /**
    * Names no document, so it survives a switch harmlessly. The reason has to
    * say WHY — "it's only a boolean" is exactly what was true of
@@ -63,6 +72,7 @@ const PANEL = './components/workspace-files/WorkspaceFilesPanel.tsx'
 const DAEMON_INDEX = './pages/DaemonIndexPage.tsx'
 const BRANCH_CHIP = './components/HeaderBranchChip.tsx'
 const VERSION_TIMELINE = './components/VersionTimeline.tsx'
+const MARKDOWN_DOCUMENT = './pages/use-markdown-document.ts'
 
 const PANEL_STATE: Record<string, ScopeCoverage> = {
   documents: 'cleared on switch',
@@ -104,9 +114,52 @@ const DAEMON_INDEX_STATE: Record<string, ScopeCoverage> = {
   deleting: 'no subject: an in-flight flag; the path it is about is `pendingDelete`',
 }
 
-/** Names every `const [x, setX] = useState` declares, in source order. */
-function stateNames(source: string): string[] {
-  return [...source.matchAll(/const \[(\w+), set\w+\]\s*=\s*useState/g)].map((m) => m[1])
+/** An empty value, in any of the shapes these screens reset to. */
+const EMPTY = '(null|\\[\\]|false|0|\'\'|"")'
+
+/**
+ * What a name is called and how a reset to it would read.
+ *
+ * The setter is taken from the DECLARATION rather than derived as
+ * `set${Name}`, because that convention does not hold: `use-markdown-document`
+ * declares `[body, setBodyState]` and `[coreFacets, setCoreMetaState]`, since
+ * `setBody` is already the hook's public writer. A guard that assumed the
+ * convention would have reported both as unbacked claims and sent the reader
+ * looking for a bug in the fix.
+ */
+interface Slot {
+  name: string
+  reset: RegExp
+}
+
+/** Every `const [x, setX] = useState` a source declares, in source order. */
+function stateNames(source: string): Slot[] {
+  return [...source.matchAll(/const \[(\w+), (set\w+)\]\s*=\s*useState/g)].map((m) => ({
+    name: m[1],
+    reset: new RegExp(`${m[2]}\\(${EMPTY}\\)`),
+  }))
+}
+
+/**
+ * Names every `const x = useRef` declares.
+ *
+ * Opt-in per case, and the reason it exists at all is that a REF held the
+ * worst defect of the three this ledger has now covered: `hostRef` in
+ * `use-markdown-document` kept the departed document's write handle through
+ * the next one's load, so a keystroke under one document was saved into
+ * another. Scanning only `useState` would never have asked about it.
+ *
+ * The four screen cases do not scan refs yet — 3 to 5 each, none of them read
+ * closely enough here to classify honestly, and a wrong `no subject:` in a
+ * guard people trust is worse than an absent one. Turning it on for them is a
+ * one-word change per case and its own increment.
+ */
+function refNames(source: string): Slot[] {
+  return [...source.matchAll(/const (\w+) = useRef/g)].map((m) => ({
+    name: m[1],
+    // A ref has no setter: clearing one is an assignment to `.current`.
+    reset: new RegExp(`${m[1]}\\.current\\s*=\\s*${EMPTY}`),
+  }))
 }
 
 /**
@@ -160,31 +213,67 @@ const VERSION_TIMELINE_STATE: Record<string, ScopeCoverage> = {
   loading: 'no subject: an in-flight flag for this screen’s own fetch',
 }
 
+// Scoped on the DOCUMENT, and the one case that scans REFS too — see
+// `refNames` for why.
+const MARKDOWN_DOCUMENT_STATE: Record<string, ScopeCoverage> = {
+  doc: 'cleared on switch',
+  body: 'cleared on switch',
+  coreFacets: 'cleared on switch',
+  hostRef: 'cleared on switch',
+
+  saveState:
+    'survives: it describes the DEPARTED document’s last save. Resetting it alone would not settle the question — the outgoing flush reports asynchronously through the same setter, so its result lands after any reset. Needs its own reproduction before a fix, the way the write path got one',
+
+  loroRef: 'no subject: mirrors the `loro` prop, reassigned on every render',
+  scheduleSaveRef: 'no subject: mirrors the current `scheduleSave`, reassigned on every render',
+  setSaveStateRef: 'no subject: mirrors the state setter, reassigned on every render',
+  schedulerRef:
+    'no subject: keyed BY the document id — `schedulerFor` replaces it whenever the id differs, so it corrects itself rather than going stale',
+}
+
 const CASES = [
-  { file: PANEL, ledger: PANEL_STATE, label: 'WorkspaceFilesPanel' },
-  { file: DAEMON_INDEX, ledger: DAEMON_INDEX_STATE, label: 'DaemonIndexPage' },
-  { file: BRANCH_CHIP, ledger: BRANCH_CHIP_STATE, label: 'HeaderBranchChip' },
-  { file: VERSION_TIMELINE, ledger: VERSION_TIMELINE_STATE, label: 'VersionTimeline' },
+  { file: PANEL, ledger: PANEL_STATE, label: 'WorkspaceFilesPanel', scanRefs: false },
+  { file: DAEMON_INDEX, ledger: DAEMON_INDEX_STATE, label: 'DaemonIndexPage', scanRefs: false },
+  { file: BRANCH_CHIP, ledger: BRANCH_CHIP_STATE, label: 'HeaderBranchChip', scanRefs: false },
+  {
+    file: VERSION_TIMELINE,
+    ledger: VERSION_TIMELINE_STATE,
+    label: 'VersionTimeline',
+    scanRefs: false,
+  },
+  {
+    file: MARKDOWN_DOCUMENT,
+    ledger: MARKDOWN_DOCUMENT_STATE,
+    label: 'useMarkdownDocument',
+    scanRefs: true,
+  },
 ] as const
 
+/** Everything a case's ledger has to account for. */
+function scanned(source: string, scanRefs: boolean): Slot[] {
+  return scanRefs ? [...stateNames(source), ...refNames(source)] : stateNames(source)
+}
+
 describe('scoped screen state is classified', () => {
-  it.each(CASES)('$label: the scan reaches a plausible amount of state', ({ file }) => {
+  it.each(CASES)('$label: the scan reaches a plausible amount of state', ({ file, scanRefs }) => {
     // A regex that stops matching reports every entry as stale, which sends
     // the reader to the wrong file entirely.
     expect(sources[file], `${file} was not globbed`).toBeDefined()
-    expect(stateNames(sources[file]).length).toBeGreaterThan(4)
+    expect(scanned(sources[file], scanRefs).length).toBeGreaterThan(4)
   })
 
-  it.each(CASES)('$label: every piece of state is classified', ({ file, ledger }) => {
-    const unclassified = stateNames(sources[file]).filter((name) => !(name in ledger))
+  it.each(CASES)('$label: every piece of state is classified', ({ file, ledger, scanRefs }) => {
+    const unclassified = scanned(sources[file], scanRefs)
+      .map((slot) => slot.name)
+      .filter((name) => !(name in ledger))
     expect(
       unclassified,
-      'new screen state must say whether it NAMES A DOCUMENT. If it does, clear it in the workspace-switch effect and mark it "cleared on switch"; if it does not, say why — a path or an entry always does',
+      'new state or ref must say whether it is bound to this screen\'s SCOPE — the workspace for a browser, the document for the top bar and the markdown hook. If it is, reset it in the // SCOPE RESET effect and mark it "cleared on switch"; if it is not, say why; if it is and stays anyway, say `survives:` and what a fix would need. A path, an entry or a write handle always is',
     ).toEqual([])
   })
 
-  it.each(CASES)('$label: every classified name still exists', ({ file, ledger }) => {
-    const present = new Set(stateNames(sources[file]))
+  it.each(CASES)('$label: every classified name still exists', ({ file, ledger, scanRefs }) => {
+    const present = new Set(scanned(sources[file], scanRefs).map((slot) => slot.name))
     const stale = Object.keys(ledger).filter((name) => !present.has(name))
     expect(stale, 'these entries name state the screen no longer holds').toEqual([])
   })
@@ -204,19 +293,18 @@ describe('scoped screen state is classified', () => {
   it.each(CASES)('$label: everything marked cleared is reset IN that effect', ({
     file,
     ledger,
+    scanRefs,
   }) => {
     const block = scopeResetBlock(sources[file])
-    const unbacked = Object.entries(ledger)
-      .filter(([, scope]) => scope === 'cleared on switch')
-      .map(([name]) => name)
-      .filter((name) => {
-        const setter = `set${name[0].toUpperCase()}${name.slice(1)}`
-        // A reset to the empty value, in any of the shapes these screens use.
-        // `''` is here because leaving it out is what this guard caught on its
-        // own first run: `setRenameDraft('')` is a reset, and a rule that only
-        // knows `null` reads it as an unbacked claim.
-        return !new RegExp(`${setter}\\((null|\\[\\]|false|0|''|"")\\)`).test(block)
-      })
+    const cleared = new Set(
+      Object.entries(ledger)
+        .filter(([, scope]) => scope === 'cleared on switch')
+        .map(([name]) => name),
+    )
+    const unbacked = scanned(sources[file], scanRefs)
+      .filter((slot) => cleared.has(slot.name))
+      .filter((slot) => !slot.reset.test(block))
+      .map((slot) => slot.name)
     expect(
       unbacked,
       'marked "cleared on switch" but the scope-reset effect does not reset it — either clear it there or reclassify',


### PR DESCRIPTION
## The defect

`use-markdown-document`'s load effect is careful in three ways — it guards its result with `cancelled`, flushes the outgoing debounce on cleanup, and unsubscribes. What it did **not** do is clear what it *holds* before the async load: `doc`, the body and `hostRef` were reset only when `documentId` became `null`, never when it changed from one document to another.

So for the whole of the next document's load, the hook still held the previous one's **write handle** and content under the new one's address:

- `setBody` writes through `hostRef.current`
- `scheduleSave` keys its scheduler on the **new** id

which makes a keystroke in that window a write into the previous document, queued under a name that is not its own.

Reproduced before touching anything, both halves:

```
expected 'written in c1' not to be 'written in c1'    ← c1's prose rendered under c2
expected [ { id: 'c1', … } ] to deeply equal []       ← save('c1', …)
```

The second is the severe one: **text typed under one document was saved into another.** Unlike #1140's stray delete there is no trash to undo it — it is a content write.

## The fix, and the rule it restores

Clear synchronously *before* the load. Both sibling screens already state this rule in their own comments:

> `DaemonIndexPage`: "Clear synchronously BEFORE the async load: leaving the previous workspace's rows visible during the switch lets a click pair the new workspace id with an old workspace's path — a mismatched identity."

> `VersionTimeline`: "Clear the previously loaded canvas's versions immediately on canvas change so a stale row … never renders under the new canvas while the refetch is in flight."

The `cancelled` guard stops a stale load from **landing**. It says nothing about what is still held while the next one is **in flight**, and that gap is the whole defect.

## The ledger gains refs — because a ref held this one

`scoped-screen-state.test.ts` scanned only `useState`. `hostRef` is a `useRef`, so the guard from #1143 would never have asked about it. The hook is added as a fifth case with ref scanning on.

Two things that made that guard wrong for this file, **both surfaced by it failing rather than by me reading it**:

| what | why it was wrong |
|---|---|
| it derived the setter as `set${Name}` | does not hold here — `[body, setBodyState]`, because `setBody` is the hook's *public writer*. The setter now comes from the declaration, and a ref's reset is recognised as an assignment to `.current` |
| its "unclassified" message still said *workspace-switch* | stale since #1143 gave the ledger a second scope |

The four screen cases keep ref scanning **off**, and the reason is on the function: 3–5 refs each, none read closely enough here to classify honestly, and a wrong `no subject:` in a guard people trust is worse than an absent one. Turning it on is a one-word change per case and its own increment.

### Mutations

| mutation | result |
|---|---|
| a new **ref** on the hook, unclassified | RED — `expected [ 'strayRef' ] to deeply equal []` |
| `hostRef` no longer cleared in the effect | RED — `expected [ 'hostRef' ] to deeply equal []` |
| a `survives:` entry downgraded to a bare `cleared on switch` | RED — names `saveState` |
| the fix reverted (clearing made conditional again) | RED — both reproductions, with their own messages |

Each was verified present in the file before its result was believed.

## One thing recorded rather than fixed

`saveState` is classified `survives:`, not quietly cleared. It **is** scope-bound — it describes the departed document's last save — but a reset alone would not settle the question: the outgoing flush reports asynchronously through the same setter, so its result lands *after* any reset. That needs its own reproduction, the way the write path got one, and the entry says so.

That is the third value in the classification, added here:

```ts
type ScopeCoverage = 'cleared on switch' | `no subject: ${string}` | `survives: ${string}`
```

A first-class permanent answer, like `not modelled:` elsewhere: what the ledger forbids is the **undecided** member, not the uncleared one.

## Test plan

- [x] Two red-first reproductions, then mutation-checked by reverting the fix
- [x] `pnpm --filter @kamiazya/whiteboard-web test` — 289 files / **2981** + `web-node` 13 / 86, zero failures
- [x] `pnpm test --project web-browser` — 148 files / **844**, zero failures
- [x] `pnpm check:local` — **exit 0**
- [x] All four mutations above
- [ ] E2E — not applicable; the switch is a prop change the hook's own suite models

## Visual evidence

**Visual evidence: none — the visible half is a brief empty editor where there used to be the wrong document's prose.** A screenshot of the fix is an editor with nothing in it for the length of a load, which is indistinguishable from a slow load. The evidence is the two assertions above; the half that matters was never visible at all, since a save into another document leaves no mark on the screen you are looking at.

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Switching documents now immediately clears stale content and editing state.
  - Disabled document loading and missing-document states reset cleanly without displaying data from a previously selected document.
  - Prevented keystrokes made while a new document is loading from being saved to the previously active document.

- **Tests**
  - Added regression coverage for document switching during loading.
  - Expanded state-reset checks to verify document-related state is cleared correctly when changing scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->