### PR TITLE
fix(web): stop the departed document's save report landing on the one on screen

### DIFF
--- a/apps/web/src/pages/use-markdown-document.switch-race.test.ts
+++ b/apps/web/src/pages/use-markdown-document.switch-race.test.ts
@@ -122,3 +122,112 @@ describe('switching documents while the next one is still loading', () => {
     store.release()
   })
 })
+
+/**
+ * A store whose SAVE for one id never settles until the test releases it, so
+ * a test can stand between the outgoing document's flush being dispatched and
+ * its completion being reported.
+ */
+function heldSaveStore(
+  heldId: string,
+  opts: { fail?: boolean } = {},
+): LoroStoreLike & { dispatched: Promise<void>; release: () => void } {
+  let release = (): void => {}
+  const held = new Promise<void>((resolve) => {
+    release = () => {
+      resolve()
+    }
+  })
+  let markDispatched = (): void => {}
+  const dispatched = new Promise<void>((resolve) => {
+    markDispatched = resolve
+  })
+  return {
+    dispatched,
+    release: () => release(),
+    async save(id: string) {
+      if (id !== heldId) return
+      markDispatched()
+      await held
+      if (opts.fail === true) throw new Error('quota exceeded')
+    },
+    createEmptySnapshot() {
+      return new Uint8Array()
+    },
+    async load() {
+      return { kind: 'missing' } as never
+    },
+  } as LoroStoreLike & { dispatched: Promise<void>; release: () => void }
+}
+
+/**
+ * Who the save indicator is ABOUT while the outgoing document's flush is
+ * still in flight.
+ *
+ * The switch flushes the departed document's pending debounce — deliberately,
+ * so the last 500ms of typing is not lost. That write then reports through
+ * `setSaveStateRef`, which by the time it settles belongs to the NEXT
+ * document. So the indicator the user is reading answers about a document
+ * they are no longer looking at.
+ *
+ * It is not merely stale. `saved` is a durability claim, and it lands on a
+ * document whose own edit is still sitting in its debounce — the user reads
+ * "safe" over text that is not written yet. The failure branch is the same
+ * defect said out loud: a write that failed for the document that left
+ * accuses the one on screen.
+ */
+describe('the save indicator while the departed document is still writing', () => {
+  async function switchWithHeldSave(store: ReturnType<typeof heldSaveStore>) {
+    const view = renderHook(({ id }: { id: string }) => useMarkdownDocument(store, id, true), {
+      initialProps: { id: 'c1' },
+    })
+    await waitFor(() => expect(view.result.current.doc).not.toBeNull())
+    await act(async () => {
+      view.result.current.setBody('written in c1')
+    })
+
+    // The switch: the load effect's cleanup flushes c1's debounce, which
+    // dispatches the save this store holds open.
+    view.rerender({ id: 'c2' })
+    await store.dispatched
+    await waitFor(() => expect(view.result.current.doc).not.toBeNull())
+
+    // An edit under c2, still inside its own debounce — nothing about c2 has
+    // been written.
+    await act(async () => {
+      view.result.current.setBody('typed in c2')
+    })
+    await waitFor(() => expect(view.result.current.saveState.kind).toBe('pending'))
+    return view
+  }
+
+  it('does not call the new document saved because the old one finished writing', async () => {
+    const store = heldSaveStore('c1')
+    const view = await switchWithHeldSave(store)
+
+    await act(async () => {
+      store.release()
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    expect(
+      view.result.current.saveState.kind,
+      'c2’s own edit is still in its debounce, and the indicator says saved — the claim belongs to c1’s flush, and the user reads it as their text being safe',
+    ).toBe('pending')
+  })
+
+  it('does not accuse the new document of the old one’s failed write', async () => {
+    const store = heldSaveStore('c1', { fail: true })
+    const view = await switchWithHeldSave(store)
+
+    await act(async () => {
+      store.release()
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    expect(
+      view.result.current.saveState.kind,
+      'the write that failed was c1’s, and the error is on screen under c2 — a document with nothing wrong with it',
+    ).not.toBe('degraded')
+  })
+})

--- a/apps/web/src/pages/use-markdown-document.ts
+++ b/apps/web/src/pages/use-markdown-document.ts
@@ -110,6 +110,13 @@ function queueSave(documentId: string, save: () => Promise<void>): Promise<void>
  */
 export const DEFAULT_MARKDOWN_CORE_FACETS: StoredCoreFacets = { type: 'markdown' }
 
+/**
+ * What the indicator says about a document nothing has written yet: no
+ * unsaved edits, and no save this session. Named rather than written twice,
+ * so the initial value and the value a switch goes back to cannot drift.
+ */
+const INITIAL_SAVE_STATE: BrowserPersistenceState = { kind: 'saved', lastSavedAt: null }
+
 export interface MarkdownDocumentState {
   /** Null until the initial load resolves — render nothing editable before. */
   readonly body: string | null
@@ -245,14 +252,17 @@ export function useMarkdownDocument(
   enabled: boolean,
 ): MarkdownDocumentState {
   const [body, setBodyState] = useState<string | null>(null)
-  const [saveState, setSaveState] = useState<BrowserPersistenceState>({
-    kind: 'saved',
-    lastSavedAt: null,
-  })
+  const [saveState, setSaveState] = useState<BrowserPersistenceState>(INITIAL_SAVE_STATE)
   // Through a ref: the debounce closure and the unmount flush both report,
   // and neither may re-arm the timer by depending on the setter's identity.
   const setSaveStateRef = useRef(setSaveState)
   setSaveStateRef.current = setSaveState
+  // Mirrors the scope itself, rewritten every render: a scheduler outlives
+  // the document it was made for (its flush settles after the switch), so at
+  // report time it has to ask who the hook is about NOW, not who it was
+  // created for.
+  const currentDocumentIdRef = useRef(documentId)
+  currentDocumentIdRef.current = documentId
   const [coreFacets, setCoreMetaState] = useState<StoredCoreFacets | null>(null)
   const [doc, setDoc] = useState<Loro | null>(null)
   const hostRef = useRef<ContentHost | null>(null)
@@ -284,6 +294,11 @@ export function useMarkdownDocument(
     setDoc(null)
     setBodyState(null)
     setCoreMetaState(null)
+    // The indicator too. It reads `saved at 10:00` about the document that
+    // left, and left standing that becomes a claim about this one, which was
+    // never saved at all. Back to the initial value — no unsaved edits, no
+    // save yet this session — which is what a freshly loaded document is.
+    setSaveState(INITIAL_SAVE_STATE)
     if (!enabled || documentId === null) return
     let cancelled = false
     let unsubscribe: (() => void) | undefined
@@ -358,7 +373,18 @@ export function useMarkdownDocument(
         scheduler: createSaveScheduler({
           debounceMs: SAVE_DEBOUNCE_MS,
           now: () => new Date().toISOString(),
-          report: (update) => setSaveStateRef.current(update),
+          report: (update) => {
+            // The switch FLUSHES this document's debounce on purpose, so the
+            // last 500ms of typing is not lost — and that write reports after
+            // the hook has moved on. `saved` arriving then is a durability
+            // claim about the document now on screen, whose own edit may
+            // still be sitting in its debounce; `degraded` accuses it of a
+            // failure that was not its. Both answer about a document nobody
+            // is looking at, so they stop here. The write itself still
+            // completes; only its report is scoped.
+            if (currentDocumentIdRef.current !== id) return
+            setSaveStateRef.current(update)
+          },
           // Bound here, so the write goes through the handle this document
           // had when the debounce elapsed — not whatever the next load has
           // put in the ref by the time the queue reaches it.

--- a/apps/web/src/scoped-screen-state.test.ts
+++ b/apps/web/src/scoped-screen-state.test.ts
@@ -87,8 +87,9 @@ const PANEL_STATE: Record<string, ScopeCoverage> = {
   pinError: 'cleared on switch',
 
   listStatus: 'no subject: a load outcome for the list as a whole, reset by the same effect',
-  folder:
-    'no subject: an address WITHIN a workspace, reset separately and only on a real identity change — see the effect’s own note on StrictMode',
+  // Reset inside the block's identity check rather than beside the rest —
+  // only a real source change is a switch, and the effect's own note says why.
+  folder: 'cleared on switch',
   columns: 'no subject: how you look, not what at; deliberately persisted across everything',
   createError:
     'no subject: a refused create, carrying a kind and the store’s words — no path of its own',
@@ -105,9 +106,9 @@ const DAEMON_INDEX_STATE: Record<string, ScopeCoverage> = {
   workspaces: 'no subject: the list of workspaces, which a switch does not invalidate',
   workspacesLoaded: 'no subject: whether that list has settled',
   selectedWorkspace: 'no subject: it IS the workspace — the thing every clear is keyed on',
-  trashCount: 'no subject: a count, reset by the same effect',
-  loaded: 'no subject: whether this workspace’s documents have settled',
-  loadError: 'no subject: a load outcome for the workspace, reset by the same effect',
+  trashCount: 'cleared on switch',
+  loaded: 'cleared on switch',
+  loadError: 'cleared on switch',
   createError: 'no subject: a refused create; no path of its own',
   duplicateError: 'no subject: a refused duplicate; the path it was about is `duplicatingPath`',
   creating: 'no subject: an in-flight flag for this screen’s own submit',
@@ -115,7 +116,13 @@ const DAEMON_INDEX_STATE: Record<string, ScopeCoverage> = {
 }
 
 /** An empty value, in any of the shapes these screens reset to. */
-const EMPTY = '(null|\\[\\]|false|0|\'\'|"")'
+// What counts as putting a slot back. An empty value, or a SCREAMING_CASE
+// module constant — the neutral state of a slot is not always empty
+// (`saveState` goes back to a `{kind:'saved', lastSavedAt:null}` record, not
+// to null). A constant spelled that way is module-level by convention, so it
+// cannot be about the scope that just left; a lowercase identifier can be,
+// which is why `setFolder(landedIn)` must not read as a reset.
+const EMPTY = '(null|\\[\\]|false|0|\'\'|""|[A-Z][A-Z0-9_]*)'
 
 /**
  * What a name is called and how a reset to it would read.
@@ -221,12 +228,13 @@ const MARKDOWN_DOCUMENT_STATE: Record<string, ScopeCoverage> = {
   coreFacets: 'cleared on switch',
   hostRef: 'cleared on switch',
 
-  saveState:
-    'survives: it describes the DEPARTED document’s last save. Resetting it alone would not settle the question — the outgoing flush reports asynchronously through the same setter, so its result lands after any reset. Needs its own reproduction before a fix, the way the write path got one',
+  saveState: 'cleared on switch',
 
   loroRef: 'no subject: mirrors the `loro` prop, reassigned on every render',
   scheduleSaveRef: 'no subject: mirrors the current `scheduleSave`, reassigned on every render',
   setSaveStateRef: 'no subject: mirrors the state setter, reassigned on every render',
+  currentDocumentIdRef:
+    'no subject: mirrors the scope itself, reassigned on every render — it is what a scheduler outliving its document asks to find out whether its report still belongs on screen',
   schedulerRef:
     'no subject: keyed BY the document id — `schedulerFor` replaces it whenever the id differs, so it corrects itself rather than going stale',
 }
@@ -288,6 +296,33 @@ describe('scoped screen state is classified', () => {
       scopeResetBlock(sources[file]).length,
       `no ${SCOPE_RESET_MARKER} marker: the guard cannot tell what this screen drops when its scope changes`,
     ).toBeGreaterThan(0)
+  })
+
+  // The other side of the same claim, and the reason it exists is that this
+  // ledger already carried a `survives:` entry through the increment that
+  // FIXED it. `saveState` was reset and its report scoped, and nothing here
+  // went red — the entry would have gone on describing a debt that was paid.
+  // An exemption has to expire when the thing it excuses stops being true,
+  // or it decays into the decoration this ledger replaces.
+  it.each(CASES)('$label: nothing exempt is quietly reset there after all', ({
+    file,
+    ledger,
+    scanRefs,
+  }) => {
+    const block = scopeResetBlock(sources[file])
+    const exempt = new Set(
+      Object.entries(ledger)
+        .filter(([, scope]) => scope !== 'cleared on switch')
+        .map(([name]) => name),
+    )
+    const backed = scanned(sources[file], scanRefs)
+      .filter((slot) => exempt.has(slot.name))
+      .filter((slot) => slot.reset.test(block))
+      .map((slot) => slot.name)
+    expect(
+      backed,
+      'classified `no subject:` or `survives:` but the scope-reset effect resets it — the entry outlived what it described, so promote it to "cleared on switch"',
+    ).toEqual([])
   })
 
   it.each(CASES)('$label: everything marked cleared is reset IN that effect', ({


### PR DESCRIPTION
## Summary

- A document switch **flushes** the outgoing document's pending debounce, deliberately, so the last 500ms of typing is not lost. That write reports through `setSaveStateRef` — which by the time it settles belongs to the **next** document. The save indicator answers about a document the user is no longer looking at.
- Two halves, because a reset alone would not settle it: `saveState` goes back to its initial value in the scope-reset effect, **and** the scheduler's `report` is gated on the hook still being about the document that scheduler was made for. The write itself still completes; only its report is scoped.
- The coverage ledger gains the fourth direction it was missing — an exemption that has been paid off must expire.

## The defect

This is the item the previous increment recorded rather than fixed, as `survives: saveState`, saying it "needs its own reproduction before a fix, the way the write path got one". Here is that reproduction.

It is not merely stale. `saved` is a **durability claim**, and it lands on a document whose own edit is still sitting in its debounce — the user reads "safe" over text that is not written yet:

```
expected 'pending', received 'saved'
```

The failure branch is the same defect said out loud. A write that failed for the document that left puts *"The last write to this browser failed. Your edits stay in memory for this session."* on the document on screen — and unlike the first, that one **stays** until the next successful save:

```
expected 'degraded' not to be 'degraded'
```

Both come from one line, `report: (update) => setSaveStateRef.current(update)`, called from a scheduler that outlives the document it was created for.

## What was checked and found clean

Before writing anything, the same question was asked of the neighbours, because a fix that only covers the file you happened to open is the shape this class keeps taking.

- **`useDocumentSync`** (the spatial editor's half) does **not** have this hole. Its connect effect clears `canvas`, `loaded`, the locks, `markdownBody`, `coreFacets`, `backendError` and the restore state synchronously before the new session exists, each with a comment naming the consequence.
- **All 17 refs across the four screen cases** were read and classify cleanly — render-time mirrors, monotonic sequence stamps whose reset would *revive* a race, value-keyed markers, and DOM nodes. No defect there; the record is the value.

## The ledger's fourth direction

The ledger checked that a `cleared on switch` entry really is reset. It did **not** check the other way, and that gap is not hypothetical — it carried a `survives:` entry through the increment that fixed it and nothing would have gone red. An exemption has to expire with what it excuses, the way `KNOWN_IMPORT_CYCLES` does.

Its first run corrected **four entries whose own stated reason already admitted the reset they claimed exemption from**:

| entry | what it said | what it is |
|---|---|---|
| `trashCount` | `no subject: a count, reset by the same effect` | `cleared on switch` |
| `loaded` | `no subject: whether this workspace's documents have settled` | `cleared on switch` |
| `loadError` | `no subject: a load outcome for the workspace, reset by the same effect` | `cleared on switch` |
| `folder` | `no subject: an address WITHIN a workspace, reset separately` | `cleared on switch` |

`EMPTY` widens to accept a SCREAMING_CASE module constant, because a neutral state is not always an empty value — `saveState` goes back to a `{kind:'saved', lastSavedAt:null}` record. A lowercase identifier still must **not** read as a reset, or `setFolder(landedIn)` would count as one.

### Mutations

Each verified present in the file before its result was believed (`grep` count 0 with the mutation, 1 after restore).

| mutation | result |
|---|---|
| the `report` scope gate removed | RED — both reproductions, with their own messages |
| `setSaveState(INITIAL_SAVE_STATE)` removed from the switch | RED — the ledger names `['saveState']` |
| a `cleared on switch` entry downgraded to an exemption | RED — the new guard names `['trashCount']` |

## Test plan

- [x] Two red-first reproductions, then mutation-checked by reverting the fix
- [x] `pnpm --filter @kamiazya/whiteboard-web test` — 289 files / **2995**, plus `web-node` 13 / 86, exit 0
- [x] `pnpm vitest run --project web-browser` — 149 files / **846**, exit 0
- [x] `pnpm check:local` — exit 0
- [ ] Manual verification — see below
- [ ] E2E — not applicable; the switch is a prop change the hook's own suite models

## Visual evidence

**Visual evidence: none — the `saved` half is a sub-second indicator flip that a screenshot cannot tell from a real save, and the `degraded` half needs a failing IndexedDB write, which cannot be produced by hand.** Reaching either by driving the UI means winning the same race the tests hold open deliberately, so a capture would show the *absence* of a flicker and prove nothing. The evidence is the two assertions and their mutations. Said plainly: the `degraded` banner's persistence is read from the code and pinned by a test, **not** something observed on screen.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — n/a, no contract moved
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_