### PR TITLE
fix(web): give /settings a workspace source so the mark opens onto something

### DIFF
--- a/apps/web/src/App.shell-workspaces-surface.test.ts
+++ b/apps/web/src/App.shell-workspaces-surface.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Every place the shell is rendered hands it a workspace source.
+ *
+ * The mark IS the switcher, and the shell states the invariant in its own
+ * words: it "opens on every page — the workspace is a fact everywhere, so
+ * there is always something for the popover to say". /settings broke that by
+ * omission. Every child of that popover is conditional, and on that one route
+ * all of them were false at once — no `workspaces` prop, and no shell status
+ * either, since only DOCUMENT pages publish it. Measured in a real browser:
+ * the trigger was there, the popover opened, `innerHTML.length` was 0. A
+ * control that opens onto nothing, with no error anywhere.
+ *
+ * So this reads the ROUTE-RENDERING SOURCE rather than a list of routes.
+ * A behavioural test can only cover the routes someone remembered to add to
+ * it, which is the same forgetting that caused the defect; a new render site
+ * shows up here whether or not anyone thought of this file.
+ *
+ * What it pins: every `<AppShellLazy>` site passes a `workspaces` source.
+ * What it does NOT pin: that the source resolves to anything, or that the
+ * popover is non-empty at runtime — App.test.tsx's own /settings case covers
+ * the rendered outcome for that route.
+ *
+ * There is deliberately no exemption list. Every site can supply one today,
+ * so a mechanism for skipping would be machinery for a case that does not
+ * exist — and a future site that genuinely cannot should fail here and be
+ * argued about, not waved through.
+ */
+import { describe, expect, it } from 'vitest'
+
+const SOURCES = import.meta.glob('./App.tsx', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+/** Each `<AppShellLazy … />` element, as the text between the tag and its close. */
+function shellRenderSites(source: string): string[] {
+  const sites: string[] = []
+  const TAG = '<AppShellLazy'
+  let from = 0
+  for (;;) {
+    const start = source.indexOf(TAG, from)
+    if (start === -1) break
+    const end = source.indexOf('/>', start)
+    // An unterminated element means the matcher is wrong, not that the file
+    // is — say so rather than silently taking the rest of the file.
+    expect(end, `unterminated ${TAG} at index ${start}`).toBeGreaterThan(start)
+    sites.push(source.slice(start, end + 2))
+    from = end + 2
+  }
+  return sites
+}
+
+const APP = SOURCES['./App.tsx'] ?? ''
+const SITES = shellRenderSites(APP)
+
+describe('every shell render site supplies a workspace source', () => {
+  it('found App.tsx and a plausible number of render sites', () => {
+    // Both halves, because a regex that stops matching would otherwise report
+    // itself as "every site is fine" — the failure mode this whole file
+    // exists to refuse, one level up.
+    expect(APP.length).toBeGreaterThan(1000)
+    expect(SITES.length).toBeGreaterThanOrEqual(4)
+  })
+
+  it('passes `workspaces` at every one of them', () => {
+    const missing = SITES.filter((site) => !/\bworkspaces=\{/.test(site))
+    expect(
+      missing,
+      'a shell rendered without a workspace source opens a popover onto nothing — ' +
+        'pass browserWorkspaces or daemonWorkspaces, keyed off the same value as `daemon`',
+    ).toEqual([])
+  })
+
+  it('never passes a literal undefined, which would satisfy the check and not the reader', () => {
+    const hollow = SITES.filter((site) => /\bworkspaces=\{\s*undefined\s*\}/.test(site))
+    expect(hollow).toEqual([])
+  })
+})

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1324,6 +1324,36 @@ describe('App /settings routing', () => {
     }
   })
 
+  it('opens a mark popover with something in it on /settings, in both keepers', async () => {
+    // The shell states this as an invariant: the mark "opens on every page —
+    // the workspace is a fact everywhere, so there is always something for
+    // the popover to say". /settings broke it. Every child of the popover is
+    // conditional, and on this route all of them were false at once: the
+    // route passed no `workspaces`, and only DOCUMENT pages publish shell
+    // status, so the connection was null too. The control opened onto
+    // nothing — measured at innerHTML.length === 0 in a real browser.
+    for (const state of [BROWSER_STATE, DAEMON_STATE]) {
+      renderAppWithRouter(state, '/settings')
+      await screen.findByTestId('settings-page')
+      fireEvent.click(await screen.findByTestId('shell-mark-trigger'))
+      const popover = await screen.findByTestId('shell-mark-popover')
+      // Emptiness is the defect, so emptiness is what this asserts against —
+      // not any particular wording, which would pin the copy instead of the
+      // invariant.
+      //
+      // What this does NOT pin, said plainly because the loop looks like it
+      // does: WHICH source each keeper gets. Both lists come back empty here,
+      // so both states render the identical "Switch to＋New workspace" —
+      // measured. Swapping the daemon arm for the browser one leaves this
+      // green. The two iterations still earn their place, since an absent or
+      // throwing source on either arm fails them; the source CHOICE is keyed
+      // off the same `settingsDaemon` as the `daemon` prop beside it, and
+      // that pairing is what keeps them from disagreeing.
+      expect(popover.textContent?.trim()).not.toBe('')
+      cleanup()
+    }
+  })
+
   it('does not rewrite /settings to the daemon route (the URL-sync guard)', async () => {
     const router = renderAppWithRouter(DAEMON_STATE, '/settings')
     await screen.findByTestId('settings-page')

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -680,7 +680,20 @@ export function App({ providerState }: AppProps) {
     return (
       <ErrorBoundary>
         <div className="flex h-dvh flex-col">
-          <AppShellLazy daemon={settingsDaemon !== undefined} />
+          {/* The switcher belongs here for the reason the shell states about
+              its own mark: it opens on every page, so there is always
+              something for the popover to say. Without a source this route
+              was the exception — every child of that popover is conditional,
+              and here they were all false at once, because only DOCUMENT
+              pages publish shell status so the connection is null too. The
+              control opened onto nothing.
+
+              Keyed off `settingsDaemon` exactly as `daemon` beside it is, so
+              the two cannot answer different keepers for one render. */}
+          <AppShellLazy
+            daemon={settingsDaemon !== undefined}
+            workspaces={settingsDaemon === undefined ? browserWorkspaces : daemonWorkspaces}
+          />
           <div className="min-h-0 flex-1">
             <Suspense fallback={<LazyPageFallback heightClass="h-full" message="Loading…" />}>
               <SettingsPage daemon={settingsDaemon} onDisconnected={() => setForcedBrowser(true)} />


### PR DESCRIPTION
## Summary

- Tapping the mark on the settings screen opened a popover with **nothing in it**. Reported by the user; reproduced in a real browser against a production build.
- Every child of that popover is conditional, and on `/settings` all of them were false at once: the route passed no `workspaces`, so the switcher was absent — and only **document** pages publish shell status, so `connection` was `null` too, which took the keeper and sync blocks with it. Nothing was left to draw.
- The shell states the opposite as an invariant, in its own words: the mark *"opens on every page — the workspace is a fact everywhere, so there is always something for the popover to say"*. `/settings` was the exception.
- A second commit adds a **route-crossing guard** so the class cannot come back silently.

The source is chosen by the same `settingsDaemon` the neighbouring `daemon` prop already reads, so the two cannot answer different keepers for one render.

**Not caused by the count work that landed just before it** (#1145). That commit added six lines to `App.tsx` and none of them here; `git log -L` puts this line's last change in August.

## The guard, and why it reads source instead of routes

`App.shell-workspaces-surface.test.ts` scans the route-rendering source for every `<AppShellLazy>` site and requires each to pass `workspaces`.

A behavioural test over a list of routes can only cover the routes someone remembered to add to it — **which is the same forgetting that caused this defect.** A new render site shows up in a source scan whether or not anyone thinks of the file.

There is deliberately **no exemption list**: all four sites can supply a source today, so a skip mechanism would be machinery for a case that does not exist, and a future site that genuinely cannot should fail here and be argued about rather than waved through.

What it pins: every site passes a source. What it does **not** pin: that the source resolves to anything, or that the popover is non-empty at runtime — the `/settings` behavioural case covers the rendered outcome for that route.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [x] `pnpm test` passes locally — with the documented Node-version exception below
- [x] Manual verification completed (see Visual evidence)
- [ ] E2E coverage added or extended where applicable — not applicable, no route or server behaviour changes

Red first: the behavioural test failed with `expected '' not to be ''`, the same emptiness the browser showed.

**Guard mutation-checked in four directions**, restore verified by re-running each time:

| mutation | result |
|---|---|
| remove `workspaces` from /settings (the original defect) | fails |
| remove it from a *different* site | fails — one site is not carrying the whole guard |
| `workspaces={undefined}` (satisfies a naive presence check, not a reader) | fails its own case |
| break the scan's tag so it matches nothing | fails the **count** case, `expected 0 to be >= 4` |

That last row is why the count is asserted at all: with the scan finding nothing, the other two cases pass vacuously and the guard reports every site as fine.

**What the behavioural test does not pin, stated in the test itself.** Its loop over both keeper states looks like more coverage than it is: under test both workspace lists come back empty, so both states render the identical `"Switch to＋New workspace"`. Swapping the daemon arm for the browser one leaves it green — found by mutation-checking, not assumed. The iterations still earn their place, since an absent or throwing source on either arm fails them.

`apps/web` typecheck, `biome check` and `pnpm knip` clean. `web-jsdom` locally reports 9 failures that are this container's Node 22 against the pinned 24 — the same `DocumentThumb` / `VersionThumbnail` / `MergeDialog` thumbnail set as before this change, none of them files this diff touches; the repo's own `local-node-version` guard names the count and the symptom. CI's `test-jsdom` was green on the fix commit.

## Visual evidence

**Visual evidence: none attachable — no image upload path exists in this environment.** The `gh` CLI is unavailable here (GitHub access is through MCP tools), so the `gh image` step this repo's rule depends on cannot run. The reproduction is quantitative anyway, which beats a picture of an empty box:

| | popover `innerText` | `innerHTML.length` |
|---|---|---|
| before | `""` | **0** |
| after | `"SWITCH TO / default / 0 / ＋ New workspace"` | **914** |

Driven in real Chromium against a production build served over HTTP, navigating to `/settings` and clicking `shell-mark-trigger` — the user's exact gesture. Nothing is staged.

One thing the same run turned up that this PR deliberately does **not** touch: `/w/<workspace>/settings` renders no mark at all. It is not a route — `settingsPath()` only ever builds `/settings` or `/settings/<section>`, and nothing in the app links to a workspace-scoped settings URL. It was a URL I typed in the reproduction, not a path a user can reach, so widening the fix to cover it would be scope I invented.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [ ] Docs updated — not needed; this restores documented behaviour rather than changing it
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2