### PR TITLE
fix(web): stop a delete confirmed after a switch taking the document that arrived

### DIFF
--- a/apps/web/src/pages/BrowserDocumentPage.dialog-outlives-document.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.dialog-outlives-document.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * A destructive dialog this page holds open must not outlive the document it
+ * was opened about.
+ *
+ * `confirmDelete` is a bare boolean, and `triggerCleanup()` acts on whatever
+ * document the controller currently holds. Nothing binds the two together —
+ * so a dialog opened on A and confirmed after a switch deletes B.
+ *
+ * The switch needs no unmount, and that is by design rather than by accident.
+ * `App.tsx` says it at the mount site: "The editor mounts only for a document
+ * route, whose in-editor switching it keeps owning." A URL that disagrees
+ * with the loaded document calls `switchDocument` in place, which is what
+ * browser Back does — and ADR-0019's route change is not blocked by a Radix
+ * dialog.
+ *
+ * The same shape has now been found on four screens. The panel's rename
+ * dialog (workspace scope), the branch chip's delete (document scope), the
+ * markdown hook's write handle, and this one — a document delete addressed at
+ * a document nobody asked about.
+ */
+
+// jsdom + fake-indexeddb: the subject is page wiring across a route-driven
+// switch, not browser layout — the spatial editor is mocked out entirely.
+import 'fake-indexeddb/auto'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import {
+  act,
+  cleanup,
+  configure,
+  fireEvent,
+  render as rtlRender,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { useEffect } from 'react'
+import { MemoryRouter, useNavigate } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { documentPath } from '../lib/app-routes.js'
+import { BROWSER_DEFAULT_SEGMENT } from '../lib/browser-idb.js'
+import { IdbDocumentIndex } from '../lib/idb-document-index.js'
+import { listLocalDocuments } from '../lib/local-document-summary.js'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { seedIdbDocument } from '../test-utils/seed-idb-document.js'
+// The lazy WorkspaceTopBar chunk, transformed in the collection phase so a
+// findBy* on its kebab never pays the load (integrator-flow.md's
+// lazy()-vs-findBy* family).
+import '../components/WorkspaceTopBar.js'
+
+claimIsolatedWhiteboardDb('browserdocumentpage-dialog-outlives-document')
+
+// Captured so a test can wait for the page to be fully WIRED, not merely
+// painted. It matters: the URL -> document effect drops a navigation that
+// lands before `listDocuments` has answered and never retries it (that
+// effect's own comment says why), so a switch issued too early is a silent
+// no-op — measured, ten samples over three seconds all still on the first
+// document.
+let editorMounted: (() => void) | null = null
+vi.mock('../components/spatial-editor/index.js', () => ({
+  SpatialEditor: (props: { canvas: SpatialCanvas; onChange?: () => void }) => {
+    editorMounted = props.onChange ?? null
+    return null
+  },
+}))
+
+const { BrowserDocumentPage } = await import('./BrowserDocumentPage.js')
+
+// Stands in for the document browser: the only thing it does to this page is
+// change the URL, which is exactly what picking a document there does.
+let navigateTo: ((to: string) => void) | null = null
+function NavigationProbe() {
+  const navigate = useNavigate()
+  useEffect(() => {
+    navigateTo = navigate
+    return () => {
+      navigateTo = null
+    }
+  }, [navigate])
+  return null
+}
+
+function render(ui: ReactElement) {
+  return rtlRender(
+    <div style={{ height: '100vh' }}>
+      <MemoryRouter initialEntries={['/']}>
+        <NavigationProbe />
+        {ui}
+      </MemoryRouter>
+    </div>,
+  )
+}
+
+async function openDeleteDialog(): Promise<HTMLElement> {
+  const kebab = await screen.findByRole('button', { name: 'More actions' })
+  fireEvent.pointerDown(kebab, { button: 0, ctrlKey: false })
+  const item = await screen.findByRole('menuitem', { name: /^delete$/i })
+  fireEvent.pointerUp(item)
+  return screen.findByRole('alertdialog')
+}
+
+// fake-indexeddb behind the DocumentStore port costs several round trips per
+// read; the sibling multi-document suite carries the same budgets for the
+// same reason.
+vi.setConfig({ testTimeout: 30_000 })
+configure({ asyncUtilTimeout: 15_000 })
+
+const OPENED_ABOUT = 'The document the dialog was opened about'
+const ARRIVED_AFTER = 'The document that arrived while it was open'
+
+describe('a destructive dialog does not outlive its document', () => {
+  beforeEach(async () => {
+    await clearWhiteboardDb()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('confirming a delete opened on one document does not delete the one now on screen', async () => {
+    const store = new IdbDocumentIndex()
+    await seedIdbDocument(store, {
+      path: 'opened-about',
+      name: OPENED_ABOUT,
+      kind: 'spatial',
+      makeDefault: true,
+    })
+    await seedIdbDocument(store, {
+      path: 'arrived-after',
+      name: ARRIVED_AFTER,
+      kind: 'spatial',
+    })
+
+    render(<BrowserDocumentPage store={store} />)
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { level: 1 }).textContent).toContain(OPENED_ABOUT),
+    )
+
+    await waitFor(() =>
+      expect(
+        editorMounted,
+        'the page is not wired yet; a switch now would be dropped',
+      ).not.toBeNull(),
+    )
+    await waitFor(async () => {
+      expect((await listLocalDocuments(store)).map((r) => r.path)).toHaveLength(2)
+    })
+
+    await openDeleteDialog()
+
+    // The switch. Browser Back does this with the dialog still open.
+    await act(async () => {
+      navigateTo?.(documentPath(BROWSER_DEFAULT_SEGMENT, 'arrived-after'))
+    })
+    // Polled OUTSIDE React's act scope, and read from the document text
+    // rather than by role. Both are measured rather than stylistic:
+    //
+    // - `waitFor` runs its whole body inside act, and the switch is a chain of
+    //   effect -> IndexedDB promise -> effect that does not advance there.
+    //   Ten act-wrapped samples across three seconds all stayed on the first
+    //   document; a plain unwrapped wait switched inside two.
+    // - the open dialog marks the page behind it aria-hidden, so every
+    //   heading on it leaves the accessibility tree while it stands, and a
+    //   role query reports "never switched" for a page that did.
+    for (let i = 0; i < 100 && !document.body.textContent?.includes(ARRIVED_AFTER); i++) {
+      await new Promise((r) => setTimeout(r, 50))
+    }
+    await act(async () => {})
+    expect(
+      document.body.textContent,
+      'the page never switched, so this case would pass without exercising anything',
+    ).toContain(ARRIVED_AFTER)
+
+    // The dialog named the document that left. It has no subject any more, so
+    // it must not still be standing over a document it was never about.
+    expect(
+      screen.queryAllByRole('alertdialog'),
+      'a confirmation opened about another document is still on screen, now reading as though it were about this one',
+    ).toHaveLength(0)
+
+    // And if some other fix leaves it open — rebinding it to a captured
+    // target, say — confirming it still must not take the document that
+    // arrived. That is the invariant; the assertion above is one way of
+    // meeting it.
+    const stillOpen = screen.queryByRole('alertdialog')
+    if (stillOpen !== null) {
+      within(stillOpen)
+        .getByRole('button', { name: /^delete$/i })
+        .click()
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 50))
+        if ((await listLocalDocuments(store)).length < 2) break
+      }
+      await act(async () => {})
+    }
+
+    const paths = (await listLocalDocuments(store)).map((row) => row.path)
+    expect(
+      paths,
+      'the delete was confirmed on a dialog opened about another document, and it took this one — the dialog said its name and the action never looked',
+    ).toContain('arrived-after')
+  })
+})

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -258,6 +258,22 @@ export function BrowserDocumentPage({
   const mainRef = useRef<HTMLElement | null>(null)
   // Stable canvas id from the loaded snapshot; null while not yet loaded.
   const documentId = pageState.kind === 'editing' ? pageState.snapshot.documentId : null
+
+  // Everything above NAMES A DOCUMENT, and this page keeps its own document
+  // switching rather than remounting (App.tsx says so at the mount site), so
+  // none of it may outlive the document it is about.
+  //
+  // `confirmDelete` is the one that bites: it is a bare boolean, and
+  // `triggerCleanup()` acts on whatever document the controller currently
+  // holds. Nothing binds them, so a dialog opened on one document and
+  // confirmed after a switch deletes the OTHER — measured, the document that
+  // arrived while the dialog stood was the one that went to the Trash.
+  // SCOPE RESET — see scoped-screen-state.test.ts
+  useEffect(() => {
+    setConfirmDelete(false)
+    setDuplicateError(null)
+    setIsDuplicating(false)
+  }, [documentId])
   // The loaded document's own path — the address the URL carries. Read off the
   // snapshot rather than looked up in the list, so it is known at the same
   // instant the id is, and so this effect does not re-fire every time the list

--- a/apps/web/src/scoped-screen-state.test.ts
+++ b/apps/web/src/scoped-screen-state.test.ts
@@ -46,6 +46,7 @@ const sources = import.meta.glob(
     './components/HeaderBranchChip.tsx',
     './components/VersionTimeline.tsx',
     './pages/use-markdown-document.ts',
+    './pages/BrowserDocumentPage.tsx',
   ],
   { query: '?raw', import: 'default', eager: true },
 ) as Record<string, string>
@@ -73,6 +74,7 @@ const DAEMON_INDEX = './pages/DaemonIndexPage.tsx'
 const BRANCH_CHIP = './components/HeaderBranchChip.tsx'
 const VERSION_TIMELINE = './components/VersionTimeline.tsx'
 const MARKDOWN_DOCUMENT = './pages/use-markdown-document.ts'
+const BROWSER_DOCUMENT_PAGE = './pages/BrowserDocumentPage.tsx'
 
 const PANEL_STATE: Record<string, ScopeCoverage> = {
   documents: 'cleared on switch',
@@ -239,6 +241,23 @@ const MARKDOWN_DOCUMENT_STATE: Record<string, ScopeCoverage> = {
     'no subject: keyed BY the document id — `schedulerFor` replaces it whenever the id differs, so it corrects itself rather than going stale',
 }
 
+// The page itself, not a panel inside it. It keeps its own document
+// switching rather than remounting — `App.tsx` says so at the mount site —
+// so everything it holds about a document has to be dropped by hand.
+const BROWSER_DOCUMENT_PAGE_STATE: Record<string, ScopeCoverage> = {
+  // The one that bit: a bare boolean over `triggerCleanup()`, which acts on
+  // whatever document the controller currently holds. Confirmed after a
+  // switch, it deleted the document that had arrived.
+  confirmDelete: 'cleared on switch',
+  duplicateError: 'cleared on switch',
+  isDuplicating: 'cleared on switch',
+
+  isFullscreen:
+    'no subject: how you are looking at the page rather than what at — and the browser owns the real state, so a reset here would disagree with the `document.fullscreenElement` the label follows',
+  documents:
+    'no subject: the WORKSPACE’s list, which a document switch does not change; its own refresh effect keys on the document identity that belongs in it',
+}
+
 const CASES = [
   { file: PANEL, ledger: PANEL_STATE, label: 'WorkspaceFilesPanel', scanRefs: false },
   { file: DAEMON_INDEX, ledger: DAEMON_INDEX_STATE, label: 'DaemonIndexPage', scanRefs: false },
@@ -254,6 +273,12 @@ const CASES = [
     ledger: MARKDOWN_DOCUMENT_STATE,
     label: 'useMarkdownDocument',
     scanRefs: true,
+  },
+  {
+    file: BROWSER_DOCUMENT_PAGE,
+    ledger: BROWSER_DOCUMENT_PAGE_STATE,
+    label: 'BrowserDocumentPage',
+    scanRefs: false,
   },
 ] as const
 


### PR DESCRIPTION
## Summary

- `confirmDelete` is a bare boolean and `triggerCleanup()` acts on whatever document the controller currently holds. Nothing binds the two — so a confirmation opened about one document and confirmed after a switch **deletes the other one**.
- The page joins `scoped-screen-state.test.ts` as a sixth case, so the next piece of state it grows has to answer the same question.

## The defect

The reproduction is unambiguous. The document the dialog was actually opened about survives; the one that **arrived while the dialog stood** is the one that went to the Trash:

```
paths: ["opened-about"]        ← "arrived-after" is gone
```

The switch needs no unmount, and that is by design rather than by accident. `App.tsx` says so at the mount site — the editor "keeps owning" its own document switching — and a URL that disagrees with the loaded document calls `switchDocument` in place. ADR-0019's route change is not blocked by a Radix dialog, so browser Back does exactly this.

This is the fourth screen with the same shape, and the second time it is a **destructive** verb:

| where | what it did |
|---|---|
| `WorkspaceFilesPanel` | a rename addressed at the workspace on screen using an entry from the one that left |
| `HeaderBranchChip` | `deleteBranch` on the document that arrived |
| `use-markdown-document` | a keystroke written into the document that left, then its save report landing on the next one |
| **this** | a document delete taking the document that arrived |

## Three things the reproduction had to establish, each after a wrong reading

Written out because each one first produced a confident, wrong answer, and only measuring separated them.

1. **"The page never switched."** A role query said the page was still on the first document. It was not — an open dialog marks the page behind it `aria-hidden`, so every heading on it leaves the accessibility tree. Reading `document.body.textContent` shows the switch plainly. A control run with **no dialog at all** is what ruled the dialog out as the cause.
2. **A navigation that lands before `listDocuments` has answered is dropped and never retried.** That is not a guess — the effect's own comment says it ("recovering the switch itself once the list lands needs this effect's own-push guard restructured first"). The test waits for the list before navigating.
3. **`waitFor` runs its body inside `act`, where the switch chain does not advance.** Ten act-wrapped samples across three seconds all stayed on the first document; a plain unwrapped wait switched inside two. The poll is outside `act` on purpose and says so.

The test asserts the switch happened before it asserts anything else, for the reason `dev-flow.md` gives: a guard that never reaches its subject passes, and reads exactly like a guard that checked.

### Mutations

Verified present in the file before the result was believed (`grep` count 0 with the mutation, 1 after restore).

| mutation | result |
|---|---|
| `setConfirmDelete(false)` removed from the scope reset | RED twice — the reproduction ("a confirmation opened about another document is still on screen") and the ledger naming `['confirmDelete']` |

## One thing recorded rather than fixed

`duplicateError` and `isDuplicating` are reset here, which covers the switch itself. What it does **not** cover is the same async residual `saveState` had in #1147: `handleDuplicate`'s `catch` runs after an `await`, so a duplicate that fails for the document that left can still print its error under the one on screen. A guard for it was written and then **removed from this PR**, because it needs the store's duplicate path to fail on demand and nothing here pins it — and an unpinned fix is how the last one came back.

Named so it is a task rather than a shrug: make `IdbDocumentIndex.createDocument` reject on demand, switch mid-flight, assert the error does not appear. Small, and its own increment.

## Test plan

- [x] Red-first reproduction, then mutation-checked by reverting the fix
- [x] `pnpm --filter @kamiazya/whiteboard-web test` — 290 files / **3002**, plus `web-node` 13 / 86, exit 0
- [x] `pnpm vitest run --project web-browser` — 149 files / **846**, exit 0
- [x] `pnpm check:local` — exit 0
- [ ] Manual verification — see below
- [ ] E2E — not applicable; the jsdom case drives the real route change over real (faked) IndexedDB, which is the mechanism

## Visual evidence

**Visual evidence: none — the bug is that the picture looks right.** The dialog on screen names the document you are looking at and offers to delete it; what a screenshot cannot show is that the button was bound to a different one. Before and after are the same image. The evidence is the store contents after confirming: `["opened-about"]` where both should stand.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — n/a
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_