### PR TITLE
docs(adr): record that a variation is not in the address and the default has no ref

### DIFF
--- a/docs/contributing/adr/0022-variation-addressing.md
+++ b/docs/contributing/adr/0022-variation-addressing.md
@@ -1,0 +1,101 @@
+# ADR-0022: A variation is not in the address, and the default one has no name to put there
+
+**Status:** Accepted — records the current shape and fixes the grammar for a later increment
+
+## Context
+
+Three things a session is "in" can be told apart by asking what names them:
+
+| layer | named by | where that name lives |
+|---|---|---|
+| Workspace | segment, or the canonical id | the URL ([ADR-0019](0019-workspace-identity.md)) |
+| Document | path | the URL |
+| **Variation** | branch name | **the daemon's HEAD for that document** |
+
+The first two follow ADR-0019's rule that the URL is the only runtime truth.
+The third does not, and this was never decided — it is what fell out of
+building variations on a branch API.
+
+What that means today, read off the code rather than assumed:
+
+- Switching a variation is `PUT` to the document's `head` route
+  (`useBranches`' `setHead`). It changes what the document IS, for everyone
+  looking at it, not what this reader is looking at.
+- No URL can name a variation. There is no way to link someone to one, and
+  no way for a reload to return to one — reload lands on whatever HEAD says
+  at that moment, which may be a variation this reader never chose.
+- Variations exist only under the daemon keeper. The browser keeper has no
+  branch API, which is why the connect copy offers "version history,
+  variations and merging" as things a daemon adds.
+
+The open question was the grammar: if a variation ever becomes addressable,
+does the DEFAULT one appear in the address?
+
+## Decision
+
+**A variation does not appear in the URL, and the default variation has no
+ref at all.**
+
+Two halves, and they are separate claims:
+
+1. **The default variation carries no ref.** It is the unnamed one. An
+   address with nothing said about variation means the default, the way
+   `/w/<workspace>/d/<path>` already reads. `main` is the identifier the
+   store happens to use; it is not a thing an address says.
+2. **No variation goes in the URL for now**, default or otherwise. The
+   address grammar stays `/w/<workspace>/d/<path>`, and the current
+   variation stays the daemon's HEAD.
+
+Decision 1 is the durable one: whatever addresses a variation later — a URL
+segment, a query parameter, something else — the default is never decorated.
+Decision 2 is a scope decision for now and may be revisited; decision 1
+constrains what revisiting it may look like.
+
+## Consequences
+
+Easier:
+
+- The common address stays short and stable. A document's URL does not
+  change when someone makes a variation, and does not need rewriting when a
+  variation is deleted or renamed.
+- There is one address for a document, so nothing has to decide whether two
+  URLs naming the same document through different variations are the same
+  page — for caching, for the service worker, for `documentPath`, or for a
+  reader.
+- No migration: this records the shape that already ships.
+
+Harder, and these are real:
+
+- **A variation cannot be shared or bookmarked.** Sending someone a link
+  sends them to the document, and they see whatever HEAD points at.
+- **Switching is a shared act.** One person switching moves the document for
+  everyone on it. That is a coordination property, not a viewing preference,
+  and the UI must keep saying so — the chip names the current variation
+  precisely because it is not private.
+- **Reload does not return to a variation.** Whatever a reader was looking
+  at is only theirs until someone moves HEAD.
+
+The second and third are the cost of decision 2, not of decision 1. If they
+become the wrong trade, the fix is to make a variation addressable — and
+decision 1 already says what that must look like for the default.
+
+## Alternatives considered
+
+**Put every variation in the URL, including the default**
+(`/w/<ws>/d/<path>/v/main`). Rejected: it decorates the overwhelmingly
+common case to serve the rare one, and it makes two spellings of the same
+page — `.../path` and `.../path/v/main` — which then have to be declared
+equivalent everywhere something keys on a URL. ADR-0019 rejected the same
+shape for workspaces, where a canonical id is a valid handle but the segment
+is what an address shows.
+
+**A per-reader variation, held client-side.** Rejected as a different
+product: variations here are a coordination feature with merging, and a
+reader privately on a variation nobody else can see would make "combine
+from another variation" mean something else. It is also not what the branch
+API implements — HEAD is one pointer per document.
+
+**Decide nothing until variations are addressable.** Rejected because the
+question is cheap to answer now and expensive later: by the time a URL
+carries variations, the default's spelling is already load-bearing in links
+people have sent each other.

--- a/docs/contributing/adr/README.md
+++ b/docs/contributing/adr/README.md
@@ -54,3 +54,4 @@ See [template.md](template.md) for the standard structure (MADR-lite: Title, Sta
 | [ADR-0019](0019-workspace-identity.md) | Workspace identity is three layers, in both keepers | Proposed |
 | [ADR-0020](0020-coordination-boundary.md) | The coordination boundary — a CRDT data plane and a compare-and-swap control plane | Proposed |
 | [ADR-0021](0021-durability-boundary.md) | Durability is a property of each store, not an operation on a directory | Accepted (implemented) |
+| [ADR-0022](0022-variation-addressing.md) | A variation is not in the address, and the default one has no name to put there | Accepted — records the shipped shape; fixes the grammar for later |


### PR DESCRIPTION
## Summary

- Records ADR-0022. Three things a session is "in" are told apart by what names them, and one of them was never decided:

| layer | named by | where that name lives |
|---|---|---|
| Workspace | segment, or the canonical id | the URL (ADR-0019) |
| Document | path | the URL |
| **Variation** | branch name | **the daemon's HEAD for that document** |

- The first two follow ADR-0019's rule that the URL is the only runtime truth. The third does not — that is what fell out of building variations on a branch API, not a decision anyone took.
- **The decision has two halves, and the ADR keeps them separate.** The durable one: the **default variation carries no ref** — an address that says nothing about variation means the default, and `main` is an identifier the store uses rather than something an address says. The scoped one: **no variation goes in the URL for now**, which may be revisited — and the first half constrains what revisiting may look like.

## What was read off the code, not assumed

- Switching a variation is a `PUT` to the document's `head` route (`useBranches`' `setHead`). It changes what the document **is**, for everyone looking at it — not what this reader is looking at.
- `app-routes.ts` builds `workspacePath` and `documentPath` and nothing else: there is no variation in the URL grammar today, so this records a shape that already ships and needs no migration.
- Variations exist only under the daemon keeper, which is why the connect copy offers "version history, variations and merging" as things a daemon adds.

The ADR states the costs rather than glossing them: a variation cannot be shared or bookmarked, switching is a shared act rather than a viewing preference, and a reload does not return to one. Those are the price of the *scoped* half, not the durable half — and if they become the wrong trade, the durable half already says what the fix must look like for the default.

## Test plan

- [ ] New or updated tests — none; this is a decision record with no code change
- [x] `pnpm check:local` passes (exit 0) — the full gate CI's `check` job runs, plus knip
- [ ] Manual verification — not applicable
- [ ] E2E coverage — not applicable

Two things checked rather than assumed about the gates: `biome` does not lint markdown under `docs/` (it reports the paths as ignored), and `intent:validate`'s `tanstack-intent` keyword warning reproduces on `main` with this change stashed, so it is pre-existing and unrelated.

## Visual evidence

Visual evidence: none — this is a documentation-only change with no user-visible surface.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — this **is** the docs change; the ADR index row is included
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_