### PR TITLE
fix(web): stop a failed duplicate reporting under the document that arrived

### DIFF
--- a/apps/web/src/pages/BrowserDocumentPage.dialog-outlives-document.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.dialog-outlives-document.test.tsx
@@ -100,6 +100,39 @@ async function openDeleteDialog(): Promise<HTMLElement> {
   return screen.findByRole('alertdialog')
 }
 
+/**
+ * An index whose duplicate-time create never settles until the test releases
+ * it, so a test can stand between a duplicate failing for one document and
+ * its error being reported.
+ *
+ * Only the duplicate's create is held. Seeding goes through the same method,
+ * so the switch is armed explicitly rather than by counting calls.
+ */
+class HeldDuplicateIndex extends IdbDocumentIndex {
+  holdNextCreate = false
+  private release: () => void = () => {}
+  private readonly gate = new Promise<void>((resolve) => {
+    this.release = resolve
+  })
+  private markAttempted: () => void = () => {}
+  readonly attempted = new Promise<void>((resolve) => {
+    this.markAttempted = resolve
+  })
+
+  releaseFailure(): void {
+    this.release()
+  }
+
+  override async createDocument(
+    input: Parameters<IdbDocumentIndex['createDocument']>[0],
+  ): ReturnType<IdbDocumentIndex['createDocument']> {
+    if (!this.holdNextCreate) return super.createDocument(input)
+    this.markAttempted()
+    await this.gate
+    throw new Error('the browser refused the write')
+  }
+}
+
 // fake-indexeddb behind the DocumentStore port costs several round trips per
 // read; the sibling multi-document suite carries the same budgets for the
 // same reason.
@@ -200,5 +233,60 @@ describe('a destructive dialog does not outlive its document', () => {
       paths,
       'the delete was confirmed on a dialog opened about another document, and it took this one — the dialog said its name and the action never looked',
     ).toContain('arrived-after')
+  })
+  it('a duplicate that fails for one document does not report under the one now on screen', async () => {
+    const store = new HeldDuplicateIndex()
+    await seedIdbDocument(store, {
+      path: 'opened-about',
+      name: OPENED_ABOUT,
+      kind: 'spatial',
+      makeDefault: true,
+    })
+    await seedIdbDocument(store, {
+      path: 'arrived-after',
+      name: ARRIVED_AFTER,
+      kind: 'spatial',
+    })
+
+    render(<BrowserDocumentPage store={store} />)
+    await waitFor(() =>
+      expect(
+        editorMounted,
+        'the page is not wired yet; a switch now would be dropped',
+      ).not.toBeNull(),
+    )
+    await waitFor(async () => {
+      expect((await listLocalDocuments(store)).map((r) => r.path)).toHaveLength(2)
+    })
+
+    store.holdNextCreate = true
+    const kebab = await screen.findByRole('button', { name: 'More actions' })
+    fireEvent.pointerDown(kebab, { button: 0, ctrlKey: false })
+    fireEvent.pointerUp(await screen.findByRole('menuitem', { name: /^duplicate$/i }))
+    await store.attempted
+
+    await act(async () => {
+      navigateTo?.(documentPath(BROWSER_DEFAULT_SEGMENT, 'arrived-after'))
+    })
+    for (let i = 0; i < 100 && !document.body.textContent?.includes(ARRIVED_AFTER); i++) {
+      await new Promise((r) => setTimeout(r, 50))
+    }
+    await act(async () => {})
+    expect(
+      document.body.textContent,
+      'the page never switched, so this case would pass without exercising anything',
+    ).toContain(ARRIVED_AFTER)
+
+    store.releaseFailure()
+    for (let i = 0; i < 40; i++) {
+      await new Promise((r) => setTimeout(r, 50))
+      if (screen.queryByRole('alert') !== null) break
+    }
+    await act(async () => {})
+
+    expect(
+      screen.queryByText(/refused the write/i),
+      'the duplicate that failed was the other document’s, and its error is on screen under this one — which has nothing wrong with it',
+    ).toBeNull()
   })
 })

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -176,16 +176,26 @@ export function BrowserDocumentPage({
   const [duplicateError, setDuplicateError] = useState<string | null>(null)
   const handleDuplicate = async () => {
     if (isDuplicating) return
+    // The document this run is about, fixed before the first await. The page
+    // stays mounted across a switch, so by the time the catch below runs the
+    // one on screen may be a different document — and reading `documentId`
+    // there would answer with this closure's own render either way.
+    const startedOn = documentId
     setIsDuplicating(true)
     setDuplicateError(null)
     try {
       await duplicateDocument()
     } catch (err) {
+      // Resetting on the switch is not enough on its own: this runs AFTER the
+      // reset, so without the guard the failed duplicate of the document that
+      // left prints its error under a document that has nothing wrong with
+      // it. Same residual the save indicator had, same shape of fix.
+      if (currentDocumentIdRef.current !== startedOn) return
       setDuplicateError(
         err instanceof Error ? err.message : `Failed to duplicate ${kindNoun(documentKind)}.`,
       )
     } finally {
-      setIsDuplicating(false)
+      if (currentDocumentIdRef.current === startedOn) setIsDuplicating(false)
     }
   }
 
@@ -258,6 +268,12 @@ export function BrowserDocumentPage({
   const mainRef = useRef<HTMLElement | null>(null)
   // Stable canvas id from the loaded snapshot; null while not yet loaded.
   const documentId = pageState.kind === 'editing' ? pageState.snapshot.documentId : null
+
+  // Mirrors the scope itself, rewritten every render: an async handler that
+  // started under one document has to ask who is on screen NOW, and its own
+  // closure can only answer with the render it was created in.
+  const currentDocumentIdRef = useRef(documentId)
+  currentDocumentIdRef.current = documentId
 
   // Everything above NAMES A DOCUMENT, and this page keeps its own document
   // switching rather than remounting (App.tsx says so at the mount site), so


### PR DESCRIPTION
## Summary

- The residual #1150 recorded rather than fixed, now with the reproduction it was waiting for. `handleDuplicate`'s `catch` runs after an `await`, so resetting `duplicateError` on the switch does **not** settle it — the reset happens first and the catch writes afterwards.
- Fixed the way the save indicator's was in #1147: the run fixes the document it started on before its first await, and the catch (and the in-flight flag's release) only reach the screen while that is still the document on it.

## The reproduction it was waiting for

#1150 said what it would take: *"make `IdbDocumentIndex.createDocument` reject on demand, switch mid-flight, assert the error does not appear."* That is what this is. An index whose duplicate-time create is held open makes the window standable, and the failure is unambiguous:

```
expected <div role="alert" …> to be null
```

The duplicate failed for the document that **left**, and its error is printed under a document that has nothing wrong with it.

Mutation (verified present in the file before the result was believed — `grep` count 0 with it, 1 after restore):

| mutation | result |
|---|---|
| the `catch`'s `startedOn` guard removed | RED, with the reproduction's own message |

## Also checked, and NOT a defect

`DaemonDocumentPage` **cannot hold this class at all**, and I had it wrong before checking.

Its state reads like it should: `saveVersionMessage` ("Version saved." / "Save failed. Please try again.") and `savingVersion` have no reset effect anywhere on the page. But both of its mount sites in `App.tsx` carry `key={`${daemonView.workspace}:${daemonView.path}`}` — a document switch changes the key, so React unmounts and rebuilds the page and every piece of that state goes with it.

That asymmetry is exactly why only the browser page could have any of these bugs:

| page | on a document switch |
|---|---|
| `BrowserDocumentPage` | **no key** — its own mount site says the editor "keeps owning" its document switching, so state survives |
| `DaemonDocumentPage` | **keyed** — rebuilt from scratch, nothing survives |

Recorded here rather than dropped, because "these three pieces of state are never reset" is a true reading of that file that leads nowhere, and the next person to notice deserves the second half of it.

## Test plan

- [x] Red-first reproduction, then mutation-checked by reverting the fix
- [x] `pnpm --filter @kamiazya/whiteboard-web test` — 291 files / **3007**, plus `web-node` 13 / 86, exit 0
- [x] `pnpm vitest run --project web-browser` — 149 files / **846**, exit 0
- [x] `pnpm check:local` — exit 0
- [ ] Manual verification — see below
- [ ] E2E — not applicable; the jsdom case drives the real route change and the real duplicate path

## Visual evidence

**Visual evidence: none — reaching the state by hand needs a browser write that fails on demand, which is what the test's held index exists to provide.** A screenshot of the fixed page shows an error banner that is absent, which is indistinguishable from a page where nothing was ever tried. The evidence is the assertion and its mutation.

## Note

The branch was pushed once under an earlier name (`claude/version-message-outlives-document`, from when this lane was expected to be about `DaemonDocumentPage`). Deleting that remote branch is refused by this environment's git proxy, so it is stale but harmless — identical content, no PR.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — n/a
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_