### PR TITLE
test(web): make every screen in the scoped-state ledger account for its refs

### DIFF
--- a/apps/web/src/scoped-screen-state.test.ts
+++ b/apps/web/src/scoped-screen-state.test.ts
@@ -93,6 +93,12 @@ const PANEL_STATE: Record<string, ScopeCoverage> = {
   // only a real source change is a switch, and the effect's own note says why.
   folder: 'cleared on switch',
   columns: 'no subject: how you look, not what at; deliberately persisted across everything',
+  rootRef: 'no subject: the panel’s own DOM node',
+  onFolderChangeRef: 'no subject: mirrors the callback prop, reassigned every render',
+  onOpenDocumentRef: 'no subject: mirrors the callback prop, reassigned every render',
+  moveDocumentRef: 'no subject: mirrors the current handler, reassigned every render',
+  lastReadListRef:
+    'no subject: holds the PREVIOUS source’s identity so the reset block can tell a real switch from a StrictMode replay — clearing it would make every replay read as a switch, which is the trap the effect’s own note describes',
   createError:
     'no subject: a refused create, carrying a kind and the store’s words — no path of its own',
   creating: 'no subject: an in-flight flag for this screen’s own submit',
@@ -115,6 +121,15 @@ const DAEMON_INDEX_STATE: Record<string, ScopeCoverage> = {
   duplicateError: 'no subject: a refused duplicate; the path it was about is `duplicatingPath`',
   creating: 'no subject: an in-flight flag for this screen’s own submit',
   deleting: 'no subject: an in-flight flag; the path it is about is `pendingDelete`',
+  selectedWorkspaceRef:
+    'no subject: mirrors the selection, written during render so it is current within the very render that changes it',
+  addressedWorkspaceRef: 'no subject: mirrors the addressed workspace, written during render',
+  listGeneration:
+    'no subject: a monotonic stamp ordering list loads — resetting it would revive the stale-answer race it exists to close',
+  reportedWorkspaceRef:
+    'no subject: keyed BY the workspace it names; a switch changes the comparison, not the ref',
+  refetchedForRef:
+    'no subject: keyed BY the handle it names, the same shape as reportedWorkspaceRef',
 }
 
 /** An empty value, in any of the shapes these screens reset to. */
@@ -152,16 +167,20 @@ function stateNames(source: string): Slot[] {
 /**
  * Names every `const x = useRef` declares.
  *
- * Opt-in per case, and the reason it exists at all is that a REF held the
- * worst defect of the three this ledger has now covered: `hostRef` in
- * `use-markdown-document` kept the departed document's write handle through
- * the next one's load, so a keystroke under one document was saved into
- * another. Scanning only `useState` would never have asked about it.
+ * It exists because a REF held the worst defect this ledger has covered:
+ * `hostRef` in `use-markdown-document` kept the departed document's write
+ * handle through the next one's load, so a keystroke under one document was
+ * saved into another. Scanning only `useState` would never have asked about
+ * it.
  *
- * The four screen cases do not scan refs yet — 3 to 5 each, none of them read
- * closely enough here to classify honestly, and a wrong `no subject:` in a
- * guard people trust is worse than an absent one. Turning it on for them is a
- * one-word change per case and its own increment.
+ * What reading all 27 of them settled is WHICH refs are dangerous, and it is
+ * not "refs on a screen". Twenty-six are machinery that names no document —
+ * DOM nodes, mirrors rewritten every render, monotonic sequence stamps whose
+ * reset would REVIVE the race they exist to close, one-shot flags about the
+ * page's own lifetime, markers keyed by the value they hold. The one that bit
+ * is the one you could WRITE THROUGH, and it was in a hook rather than a
+ * screen. So the question to ask a new ref is not whether it survives a
+ * switch — most should — but whether anything can act through it afterwards.
  */
 function refNames(source: string): Slot[] {
   return [...source.matchAll(/const (\w+) = useRef/g)].map((m) => ({
@@ -211,6 +230,12 @@ const BRANCH_CHIP_STATE: Record<string, ScopeCoverage> = {
   newName:
     'no subject: free text for a variation that does not exist yet, so it cannot address the wrong one — creating it here creates it HERE',
   chipTooltipOpen: 'no subject: hover state on the chip itself',
+  prevRefreshSignalRef:
+    'no subject: only decides whether a refetch is REDUNDANT — useBranches already refetches on the document change itself',
+  suppressNextTooltipOpenRef:
+    'no subject: a one-shot about Radix’s return-focus rather than about the document, and the very next open request clears it',
+  pendingFocusInCleanupRef: 'no subject: holds a listener remover; unmount runs it',
+  chipButtonRef: 'no subject: the trigger’s DOM node',
 }
 
 const VERSION_TIMELINE_STATE: Record<string, ScopeCoverage> = {
@@ -220,6 +245,12 @@ const VERSION_TIMELINE_STATE: Record<string, ScopeCoverage> = {
   isRestoring: 'cleared on switch',
 
   loading: 'no subject: an in-flight flag for this screen’s own fetch',
+  pendingRestoreRef:
+    'no subject: mirrors pendingRestore, reassigned every render — so it is dropped with the state it mirrors',
+  fetchSeqRef:
+    'no subject: a monotonic dispatch stamp; resetting it would revive the stale-response race it exists to close',
+  prevRefreshSignalRef:
+    'no subject: only decides whether a refetch is REDUNDANT — the switch already refetches through refresh’s identity',
 }
 
 // Scoped on the DOCUMENT, and the one case that scans REFS too — see
@@ -256,17 +287,33 @@ const BROWSER_DOCUMENT_PAGE_STATE: Record<string, ScopeCoverage> = {
     'no subject: how you are looking at the page rather than what at — and the browser owns the real state, so a reset here would disagree with the `document.fullscreenElement` the label follows',
   documents:
     'no subject: the WORKSPACE’s list, which a document switch does not change; its own refresh effect keys on the document identity that belongs in it',
+  canvasOpsButtonRef: 'no subject: the kebab’s DOM node',
+  exitFullscreenRef: 'no subject: a DOM node',
+  mainRef: 'no subject: a DOM node',
+  wasFullscreenRef:
+    'no subject: the previous fullscreen state, for handing focus over — about the viewport, not a document',
+  listGenerationRef:
+    'no subject: a monotonic stamp ordering list loads — resetting it would revive the stale-resolution race it exists to close',
+  currentDocumentIdRef:
+    'no subject: mirrors the scope itself, reassigned every render — it is what an async handler outliving its document asks to find out whether its report still belongs on screen',
+  isFirstCanvasUrlSyncRef:
+    'no subject: whether this MOUNT has synced the URL once, which picks replace over push — resetting it per document would make every switch a replace and flatten the history it exists to keep',
+  documentsEnumeratedRef:
+    'no subject: whether listDocuments has answered at all, which is about the page’s lifetime rather than one document',
+  lastKnownCanvasIdRef:
+    'no subject: holds the previously loaded id ON PURPOSE, to tell an external navigation from this page’s own pending push — clearing it is exactly what breaks that',
+  shortcutHandledRef: 'no subject: a once-per-page-load flag for the ?new=canvas launcher param',
 }
 
 const CASES = [
-  { file: PANEL, ledger: PANEL_STATE, label: 'WorkspaceFilesPanel', scanRefs: false },
-  { file: DAEMON_INDEX, ledger: DAEMON_INDEX_STATE, label: 'DaemonIndexPage', scanRefs: false },
-  { file: BRANCH_CHIP, ledger: BRANCH_CHIP_STATE, label: 'HeaderBranchChip', scanRefs: false },
+  { file: PANEL, ledger: PANEL_STATE, label: 'WorkspaceFilesPanel', scanRefs: true },
+  { file: DAEMON_INDEX, ledger: DAEMON_INDEX_STATE, label: 'DaemonIndexPage', scanRefs: true },
+  { file: BRANCH_CHIP, ledger: BRANCH_CHIP_STATE, label: 'HeaderBranchChip', scanRefs: true },
   {
     file: VERSION_TIMELINE,
     ledger: VERSION_TIMELINE_STATE,
     label: 'VersionTimeline',
-    scanRefs: false,
+    scanRefs: true,
   },
   {
     file: MARKDOWN_DOCUMENT,
@@ -278,7 +325,7 @@ const CASES = [
     file: BROWSER_DOCUMENT_PAGE,
     ledger: BROWSER_DOCUMENT_PAGE_STATE,
     label: 'BrowserDocumentPage',
-    scanRefs: false,
+    scanRefs: true,
   },
 ] as const
 


### PR DESCRIPTION
## Summary

- `scanRefs` was on for one case out of six. The deferral said why: three to five refs each, none read closely enough to classify honestly, and a wrong `no subject:` in a guard people trust is worse than an absent one.
- All **27 are now read**. None of them is a defect — and that, plus what it settles about *which* refs are dangerous, is the point.

## No defects, and the reading is the deliverable

Every ref on these six screens is machinery that names no document:

| shape | examples | why a reset would be wrong or pointless |
|---|---|---|
| DOM nodes | `rootRef`, `chipButtonRef`, `mainRef` | nothing to clear |
| render-time mirrors | `selectedWorkspaceRef`, `onFolderChangeRef`, `pendingRestoreRef`, `currentDocumentIdRef` | rewritten every render; cleared with what they mirror |
| monotonic stamps | `listGeneration`, `fetchSeqRef`, `listGenerationRef` | a reset would **revive** the stale-answer race they exist to close |
| page-lifetime one-shots | `isFirstCanvasUrlSyncRef`, `documentsEnumeratedRef`, `shortcutHandledRef` | `isFirstCanvasUrlSyncRef` picks replace over push — resetting it per document would make **every** switch a replace and flatten the history it exists to keep |
| value-keyed markers | `reportedWorkspaceRef`, `lastKnownCanvasIdRef`, `lastReadListRef` | a switch changes the *comparison*, not the ref; clearing `lastReadListRef` makes every StrictMode replay read as a workspace switch |

## What this changes about the rule itself

The one ref that ever held a defect is the one you could **write through** — `hostRef`, which kept the departed document's write handle through the next one's load (#1144). And it was in a **hook**, not a screen.

So "refs on screens are risky" was the wrong generalisation, and `refNames`' docstring now says the right one: the question to ask a new ref is not whether it survives a switch — most should, and several must — but **whether anything can act through it afterwards**.

## Mutations

Each verified present in the file before its result was believed.

| mutation | result |
|---|---|
| a new `useRef` added to a screen | RED — the ledger names `['probeRef']` |
| a ledger entry renamed so it names a ref that no longer exists | RED from **both** directions at once — unclassified `['fetchSeqRef']` and stale `['fetchSeqRefGone']` |

## Test plan

- [x] Mutation-checked in both directions the refs added coverage for
- [x] `pnpm --filter @kamiazya/whiteboard-web test` — 291 files / **3007**, plus `web-node` 13 / 86, exit 0
- [x] `pnpm check:local` — exit 0
- [ ] Manual verification — n/a, test-only change with no production diff
- [ ] E2E — n/a

## Visual evidence

**Visual evidence: none — test-only, zero production lines changed.**

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — n/a
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for state handling when switching between workspaces and documents.
  * Added validation for retained references across all supported scoped screens.
  * Improved safeguards to ensure screen state is correctly classified for clearing or preservation during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->