### PR TITLE
refactor(web): share the both-sides check the two classifying scans re-derive

### DIFF
--- a/.claude/rules/coverage-ledger.md
+++ b/.claude/rules/coverage-ledger.md
@@ -115,16 +115,34 @@ Assert the scan found a plausible COUNT in its own `it`. A regex that stops
 matching otherwise reports itself as "every entry is stale", which sends the
 reader to the wrong file entirely.
 
-There are two scans now, and they still do NOT share a helper. What they
-have in common is four lines — the `?raw` glob and the plausible-count
-assertion — and past that they diverge completely: `editor-state-surface`
-CLASSIFIES each thing it finds against a three-value vocabulary it needs a
-`view only:` state for, while `destructive-copy-surface` asserts a
-single-definition rule and has no vocabulary at all. A helper over that is
-a glob with a parameter. Extract when two call sites want the same
-JUDGEMENT, not when two of them read files.
+There are **four** scans now, and they fall into two families that want
+different things:
 
-### The second one: copy declared once
+| family | scans | what it does with what it finds |
+|---|---|---|
+| **classify** | `editor-state-surface`, `scoped-screen-state` | every name found is entered in a `Record<string, Vocabulary>`, with a three-value vocabulary per surface |
+| **assert a rule** | `destructive-copy-surface`, `App.shell-workspaces-surface` | every occurrence found must satisfy one rule; no per-item entries, no vocabulary |
+
+The classify family shares a real JUDGEMENT — every scanned name is
+classified, and every entry still names something the source holds — so
+`assertScannedLedger` in `test-utils/coverage-ledger.ts` now holds it, beside
+`assertLedger`. That is the criterion working, not a change to it: **extract
+when two call sites want the same judgement, not when two of them read
+files.** The `?raw` glob and the plausible-count assertion are still four
+lines nobody should share, because a helper over those is a glob with a
+parameter.
+
+The MESSAGES stay at the call site. What a reader needs is the name of the
+actual table and the actual vocabulary — a shared wording would name neither.
+That is the opposite of `assertLedger`, where the wording IS the value; the
+two helpers differ because what they have to say differs.
+
+Why it earned an extraction at all: the union form gets two of its four
+directions from the type system, and a scanned surface has to do both by
+hand. Doing them by hand is how a scan ends up with only one — which reads
+exactly like a scan that checked. The helper makes them travel together.
+
+### The assert-a-rule family: copy declared once
 
 `lib/destructive-copy.ts` + `destructive-copy-surface.test.ts` is the worked
 example for a surface that earns a scan and explicitly does NOT earn a

--- a/apps/web/src/components/spatial-editor/editor-state-surface.test.ts
+++ b/apps/web/src/components/spatial-editor/editor-state-surface.test.ts
@@ -30,6 +30,7 @@
  * starts holding an element id.
  */
 import { describe, expect, it } from 'vitest'
+import { assertScannedLedger } from '../../test-utils/coverage-ledger.js'
 
 const sources = import.meta.glob('./SpatialEditor.tsx', {
   query: '?raw',
@@ -110,19 +111,10 @@ describe('SpatialEditor state surface', () => {
   })
 
   it('classifies every piece of state the component holds', () => {
-    const held = new Set(scanStateNames(source))
-    const declared = new Set(Object.keys(EDITOR_STATE_COVERAGE))
-
-    const undeclared = [...held].filter((name) => !declared.has(name))
-    expect(
-      undeclared,
-      'new SpatialEditor state is unclassified — add it to EDITOR_STATE_COVERAGE as "modelled", "view only: <reason>" or "not modelled: <reason>", and if it holds an element id, read what the two selection defects cost first',
-    ).toEqual([])
-
-    const stale = [...declared].filter((name) => !held.has(name))
-    expect(
-      stale,
-      'EDITOR_STATE_COVERAGE names state SpatialEditor no longer holds — drop the entry',
-    ).toEqual([])
+    assertScannedLedger(scanStateNames(source), EDITOR_STATE_COVERAGE, {
+      unclassified:
+        'new SpatialEditor state is unclassified — add it to EDITOR_STATE_COVERAGE as "modelled", "view only: <reason>" or "not modelled: <reason>", and if it holds an element id, read what the two selection defects cost first',
+      stale: 'EDITOR_STATE_COVERAGE names state SpatialEditor no longer holds — drop the entry',
+    })
   })
 })

--- a/apps/web/src/scoped-screen-state.test.ts
+++ b/apps/web/src/scoped-screen-state.test.ts
@@ -38,6 +38,7 @@
  * browser-only and `web-app-boundary.test.ts` enforces it.
  */
 import { describe, expect, it } from 'vitest'
+import { assertScannedLedger } from './test-utils/coverage-ledger.js'
 
 const sources = import.meta.glob(
   [
@@ -342,20 +343,23 @@ describe('scoped screen state is classified', () => {
     expect(scanned(sources[file], scanRefs).length).toBeGreaterThan(4)
   })
 
-  it.each(CASES)('$label: every piece of state is classified', ({ file, ledger, scanRefs }) => {
-    const unclassified = scanned(sources[file], scanRefs)
-      .map((slot) => slot.name)
-      .filter((name) => !(name in ledger))
-    expect(
-      unclassified,
-      'new state or ref must say whether it is bound to this screen\'s SCOPE — the workspace for a browser, the document for the top bar and the markdown hook. If it is, reset it in the // SCOPE RESET effect and mark it "cleared on switch"; if it is not, say why; if it is and stays anyway, say `survives:` and what a fix would need. A path, an entry or a write handle always is',
-    ).toEqual([])
-  })
-
-  it.each(CASES)('$label: every classified name still exists', ({ file, ledger, scanRefs }) => {
-    const present = new Set(scanned(sources[file], scanRefs).map((slot) => slot.name))
-    const stale = Object.keys(ledger).filter((name) => !present.has(name))
-    expect(stale, 'these entries name state the screen no longer holds').toEqual([])
+  // Both directions in one `it`, through the shared helper: they are the same
+  // judgement, and a scan that ends up with only one of them reads exactly
+  // like a scan that checked.
+  it.each(CASES)('$label: every name is classified, and every entry still exists', ({
+    file,
+    ledger,
+    scanRefs,
+  }) => {
+    assertScannedLedger(
+      scanned(sources[file], scanRefs).map((slot) => slot.name),
+      ledger,
+      {
+        unclassified:
+          'new state or ref must say whether it is bound to this screen\'s SCOPE — the workspace for a browser, the document for the top bar and the markdown hook. If it is, reset it in the // SCOPE RESET effect and mark it "cleared on switch"; if it is not, say why; if it is and stays anyway, say `survives:` and what a fix would need. A path, an entry or a write handle always is',
+        stale: 'these entries name state the screen no longer holds',
+      },
+    )
   })
 
   // The half that makes this more than a list of names. An entry claiming to

--- a/apps/web/src/test-utils/coverage-ledger.ts
+++ b/apps/web/src/test-utils/coverage-ledger.ts
@@ -76,3 +76,39 @@ export function assertLedger<K extends string>(
     }
   }
 }
+
+/**
+ * The same both-sides check, for a ledger whose key set is SCANNED out of
+ * source rather than taken from a union.
+ *
+ * The union form above gets two of its four directions from the type system:
+ * a new member is a missing property, a removed one is an excess property. A
+ * scanned surface has no union, so both of those have to be done at runtime
+ * — and doing them by hand is how a scan ends up with only one of them, which
+ * reads exactly like a scan that checked.
+ *
+ * The MESSAGES stay at the call site, deliberately. What is shared here is
+ * the judgement — every scanned name is classified, every entry still names
+ * something the source holds — and not the wording, which has to name the
+ * actual table and the actual vocabulary or it helps nobody.
+ *
+ * Assert the scan found a plausible COUNT in its own `it` as well. A regex
+ * that stops matching reports itself here as "every entry is stale", which
+ * sends the reader to the wrong file entirely.
+ */
+export function assertScannedLedger(
+  scanned: readonly string[],
+  ledger: Record<string, unknown>,
+  messages: { readonly unclassified: string; readonly stale: string },
+): void {
+  const held = new Set(scanned)
+  const declared = new Set(Object.keys(ledger))
+  expect(
+    [...held].filter((name) => !declared.has(name)),
+    messages.unclassified,
+  ).toEqual([])
+  expect(
+    [...declared].filter((name) => !held.has(name)),
+    messages.stale,
+  ).toEqual([])
+}


### PR DESCRIPTION
## Summary

- Two scans want the same judgement and each derived it by hand. `assertScannedLedger` now holds it, beside `assertLedger`.
- `.claude/rules/coverage-ledger.md`'s own census was two increments behind: it says *"there are two scans now"* and there are **four**, in two families that want different things.

## The census the rule was carrying

| family | scans | what it does with what it finds |
|---|---|---|
| **classify** | `editor-state-surface`, `scoped-screen-state` | every name found is entered in a `Record<string, Vocabulary>`, three values per surface |
| **assert a rule** | `destructive-copy-surface`, `App.shell-workspaces-surface` | every occurrence must satisfy one rule; no entries, no vocabulary |

Naming the families is the part that will still be useful: the next scan needs to know which half it is joining, and the rule previously implied there was one shape.

## Why the classify family earned an extraction

This is the rule's own criterion applied, not a change to it — *"extract when two call sites want the same JUDGEMENT, not when two of them read files."* The `?raw` glob and the plausible-count assertion stay unshared, because a helper over those is a glob with a parameter.

What is shared is specific and load-bearing: **the union form of a ledger gets two of its four directions from the type system, and a scanned surface has to do both at runtime.** Doing them by hand is how a scan ends up with only one — which reads exactly like a scan that checked. The helper makes them travel together.

The **messages stay at the call site**, and the helper's docstring says why: a reader needs the name of the actual table and the actual vocabulary, and a shared wording would name neither. That is the opposite of `assertLedger`, whose wording *is* its value — the two helpers differ because what they have to say differs.

## Test count: 36 → 30, and why that is not a loss

Two `it`s per case become one call. Both assertions still run. Saying it explicitly because a smaller total is exactly what this repo's rules warn reads like good news.

## Mutations

Re-run **against the merged state**, not the branch they were first taken on. That distinction earned itself here: the first run of these mutations came back green and read as "the extraction broke the guard" — the real cause was that `scanRefs: true` and the ref entries lived in #1153, which had not merged yet, so the mutation's subject was not on the branch. Caught by checking the mutation had landed, which is the third time that check has stopped a wrong conclusion in this line of work.

| mutation | result |
|---|---|
| a new `useRef` on a screen | RED — `['probeRef']` |
| a ledger entry naming something gone | RED — `['goneRef']` |
| a new `useState` in `SpatialEditor`'s scan | RED — `['gestureState']` |
| a bogus entry in `EDITOR_STATE_COVERAGE` | RED — `['goneState']` |

Both directions, both call sites.

## Test plan

- [x] Four mutations, each verified present in the file before its result was believed
- [x] Verified after merging main that **both** sides survived — `assertScannedLedger` present, `scanRefs: true` ×6, the ref entries and the write-through docstring intact (an auto-merge that drops one side is silent)
- [x] `pnpm --filter @kamiazya/whiteboard-web test` — 291 files / **3001**, plus `web-node` 13 / 86, exit 0
- [x] `pnpm check:local` — exit 0
- [ ] Manual verification — n/a, test infrastructure and one rule file
- [ ] E2E — n/a

## Visual evidence

**Visual evidence: none — test helper plus a rule file; zero production lines changed.**

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — this PR *is* the docs update the last two increments owed
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_