### PR TITLE
fix(web): close the body surface when the document under it changes

### DIFF
--- a/apps/web/src/components/document-editor/use-node-in-editor.test.tsx
+++ b/apps/web/src/components/document-editor/use-node-in-editor.test.tsx
@@ -11,7 +11,7 @@ const canvas: SpatialCanvas = {
 describe('useNodeInEditor', () => {
   it('opens on a node, writes the edit, and closes', () => {
     const onChange = vi.fn()
-    const { result } = renderHook(() => useNodeInEditor(canvas, onChange))
+    const { result } = renderHook(() => useNodeInEditor(canvas, onChange, 'doc-a'))
     expect(result.current.editing).toBeNull()
 
     act(() => result.current.open('n1', 'before'))
@@ -28,7 +28,7 @@ describe('useNodeInEditor', () => {
 
   it('writes nothing when the edit changes nothing', () => {
     const onChange = vi.fn()
-    const { result } = renderHook(() => useNodeInEditor(canvas, onChange))
+    const { result } = renderHook(() => useNodeInEditor(canvas, onChange, 'doc-a'))
     act(() => result.current.open('n1', 'before'))
     act(() => result.current.commit('before'))
     expect(onChange).not.toHaveBeenCalled()
@@ -38,8 +38,51 @@ describe('useNodeInEditor', () => {
   // not write on the strength of a stale callback either.
   it('writes nothing when nothing is open', () => {
     const onChange = vi.fn()
-    const { result } = renderHook(() => useNodeInEditor(canvas, onChange))
+    const { result } = renderHook(() => useNodeInEditor(canvas, onChange, 'doc-a'))
     act(() => result.current.commit('after'))
     expect(onChange).not.toHaveBeenCalled()
+  })
+  /**
+   * The surface is opened against a node, and the node belongs to one
+   * document. Both pages that mount it keep their own document switching —
+   * `BrowserDocumentPage` says so at its mount site — so an edit left open
+   * has to be dropped when the document under it changes.
+   *
+   * Left standing it is worse than stale. The overlay is full-screen and
+   * takes its title from the CURRENT document, so it reads as "Editing
+   * <the document you just arrived at>" while holding the other one's node.
+   * And `commit` resolves the node in the CURRENT canvas: `withNodeText`
+   * returns the same canvas for a node it cannot find, and the caller drops
+   * a no-op write — so everything typed into it after the switch is
+   * discarded with no error and no indication.
+   */
+  it('drops an open edit when the document under it changes', () => {
+    const onChange = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useNodeInEditor(canvas, onChange, id),
+      { initialProps: { id: 'doc-a' } },
+    )
+    act(() => result.current.open('n1', 'before'))
+    expect(result.current.editing).not.toBeNull()
+
+    rerender({ id: 'doc-b' })
+    expect(
+      result.current.editing,
+      'the editor is still open over a document that does not hold this node, and anything typed into it now is discarded on commit',
+    ).toBeNull()
+  })
+
+  it('leaves an open edit alone while the document stays the same', () => {
+    const onChange = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useNodeInEditor(canvas, onChange, id),
+      { initialProps: { id: 'doc-a' } },
+    )
+    act(() => result.current.open('n1', 'before'))
+    rerender({ id: 'doc-a' })
+    expect(
+      result.current.editing,
+      'a re-render that did not change the document must not close the surface under the caret',
+    ).toEqual({ id: 'n1', text: 'before' })
   })
 })

--- a/apps/web/src/components/document-editor/use-node-in-editor.tsx
+++ b/apps/web/src/components/document-editor/use-node-in-editor.tsx
@@ -21,12 +21,39 @@ export interface NodeInEditor {
  * identical and the prop that carries them is OPTIONAL — a page that stopped
  * wiring it would compile clean and silently lose the feature, and only that
  * page's own test would notice. One hook means one place to get it right.
+ *
+ * @param documentKey Anything that changes exactly when the document does —
+ * the id where a page has one, the addressed path where that is what its own
+ * mount is keyed on. REQUIRED rather than optional for the reason above: a
+ * caller that forgot it would keep an edit open across a switch and lose
+ * what was typed into it, silently.
  */
 export function useNodeInEditor(
   canvas: SpatialCanvas,
   onChange: (next: SpatialCanvas, command: EditorCommand) => void,
+  documentKey: string | null,
 ): NodeInEditor {
   const [editing, setEditing] = useState<{ id: string; text: string } | null>(null)
+  // An open edit belongs to the document it was opened against, and both
+  // pages keep their own document switching rather than remounting — so the
+  // surface has to be dropped here rather than by a mount boundary.
+  //
+  // Left standing it is worse than stale: the overlay is full-screen and
+  // titles itself from the CURRENT document, so it reads as "Editing <the
+  // one you just arrived at>" while holding the other one's node. And
+  // `commit` resolves the node in the CURRENT canvas, where it is not
+  // found — `withNodeText` answers with the same canvas and the write is
+  // dropped as a no-op, so everything typed after the switch is discarded
+  // with nothing said.
+  //
+  // Reset during RENDER rather than in an effect, the same shape
+  // `DerivedFacetForm` uses for its draft: an effect would let the surface
+  // paint once under the new document's name before it goes.
+  const [scope, setScope] = useState(documentKey)
+  if (scope !== documentKey) {
+    setScope(documentKey)
+    setEditing(null)
+  }
   return {
     editing,
     open: (id, text) => setEditing({ id, text }),

--- a/apps/web/src/pages/BrowserDocumentPage.dialog-outlives-document.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.dialog-outlives-document.test.tsx
@@ -151,6 +151,13 @@ const ARRIVED_AFTER = 'The document that arrived while it was open'
 
 describe('a destructive dialog does not outlive its document', () => {
   beforeEach(async () => {
+    // Both captures are MODULE state, so they outlive the test that filled
+    // them — the same shape this file exists to refuse, one level up in the
+    // test itself. Left standing, `waitFor(editorMounted !== null)` is
+    // satisfied by the PREVIOUS test's callback and the wait proves nothing
+    // about this page; `openInEditor` would then be the departed page's.
+    editorMounted = null
+    openInEditor = null
     await clearWhiteboardDb()
   })
 

--- a/apps/web/src/pages/BrowserDocumentPage.dialog-outlives-document.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.dialog-outlives-document.test.tsx
@@ -58,9 +58,16 @@ claimIsolatedWhiteboardDb('browserdocumentpage-dialog-outlives-document')
 // no-op — measured, ten samples over three seconds all still on the first
 // document.
 let editorMounted: (() => void) | null = null
+/** The editor's own way in to the full-screen body surface. */
+let openInEditor: ((nodeId: string, text: string) => void) | null = null
 vi.mock('../components/spatial-editor/index.js', () => ({
-  SpatialEditor: (props: { canvas: SpatialCanvas; onChange?: () => void }) => {
+  SpatialEditor: (props: {
+    canvas: SpatialCanvas
+    onChange?: () => void
+    onOpenInEditor?: (nodeId: string, text: string) => void
+  }) => {
     editorMounted = props.onChange ?? null
+    openInEditor = props.onOpenInEditor ?? null
     return null
   },
 }))
@@ -202,7 +209,7 @@ describe('a destructive dialog does not outlive its document', () => {
     await act(async () => {})
     expect(
       document.body.textContent,
-      'the page never switched, so this case would pass without exercising anything',
+      'the page never switched, so the DELETE case would pass without exercising anything',
     ).toContain(ARRIVED_AFTER)
 
     // The dialog named the document that left. It has no subject any more, so
@@ -274,7 +281,7 @@ describe('a destructive dialog does not outlive its document', () => {
     await act(async () => {})
     expect(
       document.body.textContent,
-      'the page never switched, so this case would pass without exercising anything',
+      'the page never switched, so the DUPLICATE case would pass without exercising anything',
     ).toContain(ARRIVED_AFTER)
 
     store.releaseFailure()
@@ -287,6 +294,61 @@ describe('a destructive dialog does not outlive its document', () => {
     expect(
       screen.queryByText(/refused the write/i),
       'the duplicate that failed was the other document’s, and its error is on screen under this one — which has nothing wrong with it',
+    ).toBeNull()
+  })
+  it('a body surface opened on one document does not stay open over the next', async () => {
+    const store = new IdbDocumentIndex()
+    await seedIdbDocument(store, {
+      path: 'opened-about',
+      name: OPENED_ABOUT,
+      kind: 'spatial',
+      makeDefault: true,
+    })
+    await seedIdbDocument(store, {
+      path: 'arrived-after',
+      name: ARRIVED_AFTER,
+      kind: 'spatial',
+    })
+
+    render(<BrowserDocumentPage store={store} />)
+    await waitFor(() =>
+      expect(
+        editorMounted,
+        'the page is not wired yet; a switch now would be dropped',
+      ).not.toBeNull(),
+    )
+    await waitFor(async () => {
+      expect((await listLocalDocuments(store)).map((r) => r.path)).toHaveLength(2)
+    })
+
+    await act(async () => {
+      openInEditor?.('n1', 'typed against a node in the first document')
+    })
+    expect(
+      screen.queryByTestId('node-text-overlay'),
+      'the surface did not open, so the switch below would prove nothing',
+    ).not.toBeNull()
+
+    await act(async () => {
+      navigateTo?.(documentPath(BROWSER_DEFAULT_SEGMENT, 'arrived-after'))
+    })
+    for (let i = 0; i < 100 && !document.body.textContent?.includes(ARRIVED_AFTER); i++) {
+      await new Promise((r) => setTimeout(r, 50))
+    }
+    await act(async () => {})
+    expect(
+      document.body.textContent,
+      'the page never switched, so the BODY SURFACE case would pass without exercising anything',
+    ).toContain(ARRIVED_AFTER)
+
+    // It titles itself from the CURRENT document, so left open it reads as
+    // "Editing <the one that arrived>" while holding the other one's node —
+    // and its commit resolves that node in THIS canvas, does not find it,
+    // and drops the write. Everything typed into it after this point would
+    // go nowhere, with nothing said.
+    expect(
+      screen.queryByTestId('node-text-overlay'),
+      'the body surface is still open over a document that does not hold the node it was opened on',
     ).toBeNull()
   })
 })

--- a/apps/web/src/pages/BrowserDocumentPage.dialog-outlives-document.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.dialog-outlives-document.test.tsx
@@ -332,7 +332,12 @@ describe('a destructive dialog does not outlive its document', () => {
     await act(async () => {
       navigateTo?.(documentPath(BROWSER_DEFAULT_SEGMENT, 'arrived-after'))
     })
-    for (let i = 0; i < 100 && !document.body.textContent?.includes(ARRIVED_AFTER); i++) {
+    // Longer than the other two cases here, and measured rather than guessed:
+    // with the surface open this page also holds a CodeMirror instance, and
+    // under the full suite the switch did not land inside their 5s. Still
+    // well inside this file's 30s per-test budget, so a real failure lands on
+    // an assertion rather than turning into a timeout that names nothing.
+    for (let i = 0; i < 300 && !document.body.textContent?.includes(ARRIVED_AFTER); i++) {
       await new Promise((r) => setTimeout(r, 50))
     }
     await act(async () => {})

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -551,7 +551,7 @@ export function BrowserDocumentPage({
     isDocumentReadFailure(backendError) ? backendError : null,
   )
 
-  const nodeInEditor = useNodeInEditor(canvas, onChange)
+  const nodeInEditor = useNodeInEditor(canvas, onChange, documentId)
 
   const documentOpsFilenameBase = sanitizeExportFilenameBase(documentName ?? 'canvas')
   const { exportError, handleExport } = useSceneExport({

--- a/apps/web/src/pages/DaemonDocumentPage.surface-outlives-document.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.surface-outlives-document.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * The body surface on the DAEMON page, across a document switch this page
+ * makes without its props moving.
+ *
+ * The sibling case on the browser page is
+ * `BrowserDocumentPage.dialog-outlives-document.test.tsx`. This one exists
+ * separately because the switch arrives differently and the difference is the
+ * whole defect: `useDaemonDocumentController` owns its own `path` and
+ * `switchDocument`, and five call sites here move the document while
+ * `workspaceId`/`path` — the props, and what this page's own mount in
+ * App.tsx is keyed on — never change. Scoping the surface to the props reads
+ * correct and holds nothing.
+ *
+ * Both seams driven here are real props of the editor rather than test
+ * hooks: `onOpenInEditor` is how a node's body is opened, and
+ * `onOpenFileRef` is how following a file-node reference switches document.
+ */
+
+import { writeDocumentKind } from '@kamiazya/whiteboard-loro-adapter'
+import type {
+  DocumentBackend,
+  DocumentBackendHandlers,
+} from '@kamiazya/whiteboard-mcp/browser-contract'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { act, cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import { LoroDoc } from 'loro-crdt'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as daemonApiClient from '../lib/daemon-api-client.js'
+
+function render(ui: ReactElement) {
+  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>, {
+    container: document.body,
+  })
+}
+
+vi.mock('../lib/daemon-api-client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/daemon-api-client.js')>()
+  return { ...actual, listWorkspaces: vi.fn(), listDocuments: vi.fn(), createDocument: vi.fn() }
+})
+
+let openInEditor: ((nodeId: string, text: string) => void) | null = null
+let openFileRef: ((file: string) => void) | null = null
+vi.mock('../components/spatial-editor/index.js', () => ({
+  SpatialEditor: (props: {
+    canvas: SpatialCanvas
+    onOpenInEditor?: (nodeId: string, text: string) => void
+    onOpenFileRef?: (file: string) => void
+  }) => {
+    openInEditor = props.onOpenInEditor ?? null
+    openFileRef = props.onOpenFileRef ?? null
+    return null
+  },
+}))
+
+const { DaemonDocumentPage } = await import('./DaemonDocumentPage.js')
+
+const mockListWorkspaces = vi.mocked(daemonApiClient.listWorkspaces)
+const mockListDocuments = vi.mocked(daemonApiClient.listDocuments)
+
+function spatialSnapshot(): Uint8Array {
+  const doc = new LoroDoc()
+  writeDocumentKind(doc, 'spatial')
+  return doc.export({ mode: 'snapshot' })
+}
+
+class FakeBackend implements DocumentBackend {
+  connect(handlers: DocumentBackendHandlers): void {
+    handlers.onConnected()
+    handlers.onSnapshot(spatialSnapshot())
+  }
+  disconnect(): void {}
+  pushLocalUpdate(): void {}
+  getFile(): Promise<Blob | null> {
+    return Promise.resolve(null)
+  }
+  putFile(): Promise<void> {
+    return Promise.resolve()
+  }
+  sendClientReady(): void {}
+  sendExportResponse(): void {}
+}
+
+const DAEMON_BASE_URL = 'http://127.0.0.1:3099'
+
+describe('the body surface does not outlive its document (daemon)', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString()
+        if (url.includes('/names')) {
+          return new Response(
+            JSON.stringify({ documents: { 'doc-a': 'Doc A', 'doc-b': 'Doc B' }, pinned: [] }),
+            { status: 200 },
+          )
+        }
+        return new Response('{}', { status: 404 })
+      }),
+    )
+    mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
+    mockListDocuments.mockResolvedValue({
+      documents: [
+        { path: 'doc-a', id: 'id-a', updatedAt: '2026-01-01', kind: 'spatial' },
+        { path: 'doc-b', id: 'id-b', updatedAt: '2026-01-01', kind: 'spatial' },
+      ],
+    })
+  })
+  afterEach(() => {
+    cleanup()
+    window.localStorage.clear()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+    openInEditor = null
+    openFileRef = null
+  })
+
+  it('following a file reference closes a surface opened on the document being left', async () => {
+    await act(async () => {
+      render(
+        <DaemonDocumentPage
+          daemonBaseUrl={DAEMON_BASE_URL}
+          workspaceId="w1"
+          path="doc-a"
+          createBackend={() => new FakeBackend()}
+        />,
+      )
+    })
+    await waitFor(() => expect(openInEditor).not.toBeNull())
+    await waitFor(() => expect(openFileRef).not.toBeNull())
+
+    await act(async () => {
+      openInEditor?.('n1', 'typed against a node in doc-a')
+    })
+    expect(
+      screen.queryByTestId('node-text-overlay'),
+      'the surface did not open, so the switch below would prove nothing',
+    ).not.toBeNull()
+
+    // The switch this page makes by itself: the props never move.
+    await act(async () => {
+      openFileRef?.('id-b')
+    })
+    // Bounded well inside the per-test budget on purpose: the reset happens
+    // during RENDER, so the surface is gone by the commit that follows the
+    // switch. A longer wait would turn a failure into a timeout, which says
+    // nothing about which invariant broke — measured, it did exactly that.
+    for (let i = 0; i < 20 && screen.queryByTestId('node-text-overlay') !== null; i++) {
+      await new Promise((r) => setTimeout(r, 25))
+    }
+    await act(async () => {})
+
+    expect(
+      screen.queryByTestId('node-text-overlay'),
+      'the body surface is still open after this page switched document under it — scoped to the props, which a controller-driven switch never moves',
+    ).toBeNull()
+  })
+})

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -360,11 +360,17 @@ export function DaemonDocumentPage({
   // and local-update forwarding as every other change, with no second write
   // pipeline. `set-body` carries the WHOLE body, so it needs no canvas: the
   // value passed alongside is the unchanged one this command does not touch.
-  // The same identity this page's own mount is keyed on in App.tsx. Passing
-  // it is belt-and-braces here — the key already rebuilds the page on a
-  // switch — but the hook's contract is the hook's, not a caller's mount
-  // strategy, and the browser page next door has no key at all.
-  const nodeInEditor = useNodeInEditor(canvasValue, onChange, `${workspaceId}:${path}`)
+  // The CONTROLLER's identity, not this page's props. They are not the same
+  // thing: the controller owns its own `path` and `switchDocument`, and five
+  // call sites here move the document without the props ever changing — one
+  // of them is this very surface's own link-following
+  // (`onOpenDocument` below). Keying on the props would leave the surface
+  // open across exactly the switch it is most likely to be part of.
+  const nodeInEditor = useNodeInEditor(
+    canvasValue,
+    onChange,
+    `${controller.workspaceId}:${controller.path}`,
+  )
   const canvasValueRef = useRef(canvasValue)
   canvasValueRef.current = canvasValue
   const setMarkdownBody = useCallback(

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -360,7 +360,11 @@ export function DaemonDocumentPage({
   // and local-update forwarding as every other change, with no second write
   // pipeline. `set-body` carries the WHOLE body, so it needs no canvas: the
   // value passed alongside is the unchanged one this command does not touch.
-  const nodeInEditor = useNodeInEditor(canvasValue, onChange)
+  // The same identity this page's own mount is keyed on in App.tsx. Passing
+  // it is belt-and-braces here — the key already rebuilds the page on a
+  // switch — but the hook's contract is the hook's, not a caller's mount
+  // strategy, and the browser page next door has no key at all.
+  const nodeInEditor = useNodeInEditor(canvasValue, onChange, `${workspaceId}:${path}`)
   const canvasValueRef = useRef(canvasValue)
   canvasValueRef.current = canvasValue
   const setMarkdownBody = useCallback(


### PR DESCRIPTION
## Summary

- `useNodeInEditor` holds the open edit as plain state and knows nothing about which document it belongs to. Both pages that mount it keep their own document switching, so an edit opened against a node in one document **stays open over the next**.
- The consequence is not cosmetic: everything typed into it after the switch is **discarded with nothing said**.

## Measured

```
{ switched: true, stillOpen: true, label: "Editing Elsewhere" }
```

and the DOM under the switch, before the fix:

```
"The document that arrived while it was open · Title · Canvas ·
 The document that arrived while it was open · 8 words ·
 typed against a node in the first document"
```

A **full-screen** surface, titled from the **current** document — so it reads as *"Editing &lt;the one you just arrived at&gt;"* — holding the **other** document's node body.

Then `commit` resolves that node in the current canvas and does not find it. `withNodeText` answers with the same canvas (its own docstring says so for a missing node), and the caller drops the write as a no-op:

```ts
const next = withNodeText(canvas, editing.id, text)
if (next === canvas) return          // no revision for a no-op
```

So the user keeps typing into a surface that says it is editing this document, presses Canvas, and the text is gone. No error, no indicator.

**The way in is the surface's own affordance**: a `[[link]]` inside it calls `navigateToDocument`.

## The fix

Reset during **render**, not in an effect — the shape `DerivedFacetForm` already uses for its draft. An effect would let the surface paint once under the new document's name before it went.

`documentKey` is **required**, not optional, for exactly the reason the hook's own docstring gives about the prop that carries it: *"a page that stopped wiring it would compile clean and silently lose the feature."* It caught three existing test call sites on the way in.

## What was checked first and found clean

This scope has been swept before, and most of it holds. Reported because "I looked and it was already right" is the half that stops the next person re-deriving it:

| surface | why it is safe |
|---|---|
| `SpatialEditor`'s four id-pinned states | each resolves its element in the render; the two dialogs are pinned by `dialog-target-vanishes.browser.test.tsx` |
| the inspector's `DerivedFacetForm` | `key={`${node.id}:${facet.key}`}` — and the comment there already describes the exact defect I went looking for |
| the inline `MarkdownNodeEditor` | measured: a right-click on another node blurs it, which commits and unmounts it, so the reducer's `editing-text(A) → editing-text(B)` arm is never reached with it mounted |

That last one is safe **by blur ordering, not by design** — `MarkdownNodeEditor` is mount-once (`[]` deps, "initialText is the seed") while the reducer transitions directly between nodes. Nothing pins the ordering today. Recorded rather than fixed, because the transition is not reachable from the UI: a test for it would assert on a path no user can take.

## Mutations

| mutation | result |
|---|---|
| the render-phase reset removed from the hook | RED at the hook (`expected { id: 'n1', text: 'before' } to be null`) and RED at the page (`the body surface is still open over a document that does not hold the node it was opened on`) |

Landing verified (`grep -c setScope` = 0 with it, 2 after restore), and **attributed per test** — the first combined run reported a failure whose message belonged to a different case, and only re-running the page file alone with `--reporter=verbose` showed the delete-dialog test had flaked while mine passed. That is why this PR also **renames the three "never switched" guard messages** so each names its own case: two of them were identical, which is the mistake `dev-flow.md` records under diagnosis evidence — a cause read off an assertion string without checking which of two identical assertions failed.

## Test plan

- [x] Red-first at two layers (the hook, and the page driving a real route change), then mutation-checked
- [x] `pnpm --filter @kamiazya/whiteboard-web test` — 291 files / **3004**, plus `web-node` 13 / 86, exit 0
- [x] `pnpm vitest run --project web-browser` — 149 files / **846**, exit 0
- [x] `pnpm check:local` — exit 0
- [ ] Manual verification — see below
- [ ] E2E — n/a; the jsdom case drives the real route change through the page's own switch effect

## Visual evidence

**Visual evidence: none — the defect is a surface that looks entirely correct.** It is full-screen, titled with the document you are on, and shows a body; a screenshot cannot show that the body belongs to a different document and that Save will discard it. The evidence is the DOM measured above, quoted verbatim, and the two assertions.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — n/a
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented document editing dialogs and in-progress edits from persisting when switching to a different document.
  * Ensured stale edits cannot accidentally overwrite content in the newly opened document.
  * Preserved active edits when re-rendering the same document.

* **Tests**
  * Added coverage for document switching, dialog behavior, and stale edit protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->