### PR TITLE
feat(web): close the inspector on deselect, and drop its Done control

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -898,6 +898,18 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     // selection. Pinning it to the node the menu was opened on made it a
     // dialog you had to close before you could look at anything else.
     const [facetPanelOpen, setFacetPanelOpen] = useState(false)
+    // Deselecting CLOSES it, rather than leaving it standing with nothing to
+    // edit. It is the same act that dismisses the context menu, and on touch
+    // a press on blank canvas is how you put a surface away — one semantic
+    // instead of two, and no dismiss control for this panel to carry.
+    //
+    // Cleared during render rather than in an effect, the shape
+    // `DerivedFacetForm` uses for its draft: an effect would let the panel
+    // paint one frame with nothing in it. Clearing the FLAG (rather than
+    // rendering null and leaving it true) is what keeps a later re-open an
+    // ordinary open — the earlier version of this returned null and stranded
+    // the flag, which only a new selection could get out of.
+    if (facetPanelOpen && selectedId === null) setFacetPanelOpen(false)
     const boxes = useMemo(() => indexNodeBoxes(canvas), [canvas])
     /**
      * Lock only binds when the host wired the seam — an editor mounted
@@ -3905,26 +3917,17 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         {facetPanelOpen &&
           (() => {
             const target = canvas.nodes.find((entry) => entry.id === selectedId)
-            // Nothing selected: the inspector stays open and says so, rather
-            // than vanishing. Returning null here left `facetPanelOpen` true
-            // with nothing on screen and no Done to press — a state only a
-            // new selection could get out of.
-            if (target === undefined) {
-              return (
-                <FacetFormPanel
-                  node={undefined}
-                  registry={bundledFacetRegistry}
-                  onClose={() => setFacetPanelOpen(false)}
-                  variant={inspectorIsSheet ? 'sheet' : 'dock'}
-                  onWrite={() => {}}
-                />
-              )
-            }
+            // Nothing selected: the inspector is ABOUT a node, so there is
+            // nothing for it to be about. It closes rather than standing
+            // there saying so — the same thing a press on blank canvas does
+            // to the context menu, which is the semantic this matches. The
+            // flag is cleared during render just above, so re-opening it
+            // later is an ordinary open rather than a stuck true.
+            if (target === undefined) return null
             return (
               <FacetFormPanel
                 node={target}
                 registry={bundledFacetRegistry}
-                onClose={() => setFacetPanelOpen(false)}
                 variant={inspectorIsSheet ? 'sheet' : 'dock'}
                 onWrite={(key, payload) => {
                   // Applies to the whole selection, the semantics the menu

--- a/apps/web/src/components/spatial-editor/facet-panel.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/facet-panel.browser.test.tsx
@@ -68,8 +68,14 @@ it('the Facets entry opens the panel, and a pick there stores and draws', () => 
   })
   expect(container.querySelector('svg g[data-wb-key] polygon')).not.toBeNull()
 
-  // Done is the way out. Escape belongs to the canvas (deselect) — an
-  // inspector that never holds focus could not receive it anyway.
-  fireEvent.click(panel.querySelector('[aria-label="Close facets"]') as HTMLElement)
+  // DESELECTING is the way out, and the only one: the panel carries no
+  // dismiss control of its own, because it is about the selected node and a
+  // press on blank canvas is already how a surface is put away here.
+  expect(
+    panel.querySelector('[aria-label="Close facets"]'),
+    'the panel grew a dismiss control again — two ways to put one surface away',
+  ).toBeNull()
+  fireEvent.pointerDown(root, { clientX: 20, clientY: 400, button: 0, pointerId: 7 })
+  fireEvent.pointerUp(root, { clientX: 20, clientY: 400, button: 0, pointerId: 7 })
   expect(container.querySelector('[data-testid="facet-form-panel"]')).toBeNull()
 })

--- a/apps/web/src/components/spatial-editor/facet-widgets/FacetFormPanel.tsx
+++ b/apps/web/src/components/spatial-editor/facet-widgets/FacetFormPanel.tsx
@@ -40,8 +40,6 @@ export interface FacetFormPanelProps {
   readonly registry: FacetRegistry
   /** `undefined` payload clears the facet, matching set-node-facet. */
   readonly onWrite: (key: string, payload: unknown) => void
-  /** Present when mounted as an overlay; absent renders the bare body. */
-  readonly onClose?: () => void
   /**
    * Where the inspector sits: a column beside the canvas, or a sheet under
    * it. Decided from the EDITOR SHELL's width — the panel's own column comes
@@ -55,7 +53,6 @@ export function FacetFormPanel({
   node,
   registry,
   onWrite,
-  onClose,
   editors = NODE_FACET_EDITORS,
   variant = 'dock',
 }: FacetFormPanelProps) {
@@ -112,7 +109,6 @@ export function FacetFormPanel({
         ))}
       </div>
     )
-  if (onClose === undefined) return <div data-testid="facet-form-panel">{body}</div>
   // Same vessel convention as the other canvas overlays: hand-rolled and
   // inline-positioned, so it behaves identically where the app stylesheet
   // is absent (browser-mode component tests), and marked
@@ -148,16 +144,13 @@ export function FacetFormPanel({
             }
       }
     >
-      <div className="flex items-center justify-between gap-4 pb-2">
+      {/* No dismiss control of its own. The panel is ABOUT the selected node,
+          so deselecting is what closes it — the same thing a press on blank
+          canvas already does to the context menu, and one semantic instead of
+          two. Writes land as they are made, so there is nothing here to
+          confirm either. */}
+      <div className="pb-2">
         <span className="text-xs font-medium">Facets</span>
-        <button
-          type="button"
-          aria-label="Close facets"
-          className="rounded px-2 text-xs text-muted-foreground hover:bg-accent"
-          onClick={onClose}
-        >
-          Done
-        </button>
       </div>
       {body}
     </aside>

--- a/apps/web/src/components/spatial-editor/inspector-follows-selection.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/inspector-follows-selection.browser.test.tsx
@@ -81,7 +81,7 @@ it('leaves focus on the canvas, so typing and shortcuts still reach it', async (
   expect(panel.contains(document.activeElement)).toBe(false)
 })
 
-it('stays dismissible when the selection empties, instead of vanishing', async () => {
+it('closes when the selection empties — deselecting is what puts it away', async () => {
   const { Host } = makeHost()
   const { container } = render(<Host />)
   const root = await openInspector(container, 120, 85)
@@ -92,12 +92,17 @@ it('stays dismissible when the selection empties, instead of vanishing', async (
   await userEvent.click(root, {
     position: { x: Math.round(root.clientWidth / 2), y: 400 },
   })
-  const panel = panelOf(container)
-  // It must still be on screen WITH its Done control — returning null here
-  // left `facetPanelOpen` true with nothing to press.
-  expect(panel).not.toBeNull()
-  const done = panel?.querySelector('[aria-label="Close facets"]') as HTMLElement
-  expect(done).not.toBeNull()
-  fireEvent.click(done)
+  // Gone, not standing there saying there is nothing to edit. The panel is
+  // ABOUT the selected node, so the act that empties the selection is the act
+  // that puts it away — the same one that dismisses the context menu.
   expect(panelOf(container)).toBeNull()
+
+  // And the flag went with it: re-selecting must not spring the panel back
+  // open on its own. Rendering null while leaving `facetPanelOpen` true is
+  // the earlier defect this replaced, one turn further on.
+  await userEvent.click(root, { position: { x: 120, y: 85 } })
+  expect(
+    panelOf(container),
+    'the inspector re-opened by itself on the next selection — the open flag outlived the panel',
+  ).toBeNull()
 })


### PR DESCRIPTION
## Summary

Reported from a phone: with the facets panel open, emptying the selection left it standing at the bottom of the screen reading **"Select a node to edit its facets."**

Everywhere else on touch, a press on blank canvas is how a surface is put away — the context menu already works that way. The inspector was the one surface with a second, different exit.

- **Deselecting closes it.** One semantic instead of two.
- **Done is gone.** There was nothing for it to confirm: every write in this panel lands as it is made, so the button offered to commit something already committed.

## Two things this had to avoid re-breaking

Both were recorded in the code it replaces, which is why the empty state existed at all:

1. Returning `null` once left `facetPanelOpen` **true** with nothing on screen and no way out but a new selection. So closing clears the **flag**, not just the render — and `inspector-follows-selection` now asserts that second half: after deselecting, re-selecting must **not** spring the panel back open.
2. The panel stays open **across** a selection change, which is what makes it an inspector rather than a dialog. Only an **empty** selection closes it; that case is untouched and still covered.

## A prop that meant two things

`onClose` was both "what Done does" and "render the aside chrome, rather than the bare body". The bare branch had no production caller — only unit tests reached it. Both meanings are gone; the aside is the only form.

## Tests

The two browser cases that pinned the old exit are **rewritten, not deleted** — this is a product decision changing, not a guard being weakened:

| case | was | is |
|---|---|---|
| `facet-panel` | "Done is the way out" | deselecting is the way out, **and** the panel must carry no dismiss control |
| `inspector-follows-selection` | "stays dismissible when the selection empties, instead of vanishing" | "closes when the selection empties", plus the flag-not-stranded half |

## Test plan

- [x] `pnpm --filter @kamiazya/whiteboard-web test` — 292 files / **3005**, plus `web-node` 13 / 86, exit 0
- [x] `pnpm vitest run --project web-browser` — 149 files / **846**, exit 0
- [x] `pnpm check:local` — exit 0
- [ ] Manual verification — the report came from the running app on a phone; I have no device here, and the preview URL is unreachable from this environment
- [ ] E2E — n/a

## Visual evidence

**Visual evidence: none from me — the "before" is the reporter's own screenshot** (the panel standing empty at the bottom of the screen after deselecting), and the "after" is its absence. Composing a figure whose second panel is *nothing there* would add no information over the sentence. I could not capture either state myself: this environment has no phone and cannot reach the preview deployment.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — no doc describes the Done control
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_