### PR TITLE
fix(web): let the hand tool pan from a link node's embed, found by a property

### DIFF
--- a/apps/web/src/components/spatial-editor/LinkEmbedLayer.tsx
+++ b/apps/web/src/components/spatial-editor/LinkEmbedLayer.tsx
@@ -27,9 +27,20 @@ export interface LinkEmbedLayerProps {
   readonly canvas: SpatialCanvas
   /** The LOD gate: only link nodes this returns true for offer the facade. */
   readonly shouldOffer: (node: Extract<SpatialNode, { type: 'link' }>) => boolean
+  /**
+   * False while the editor's tool is navigation-only (the hand tool), where
+   * every press has to pan — including one that lands on this layer.
+   *
+   * `data-editor-overlay` alone cannot express that: it makes the root ignore
+   * the press, which is what a control wants and the opposite of what a
+   * navigation gesture wants. It also cannot help at all once the iframe is
+   * live, because an iframe consumes the pointer before any handler of ours
+   * runs. `pointer-events: none` is the only thing that answers both.
+   */
+  readonly interactive: boolean
 }
 
-export function LinkEmbedLayer({ canvas, shouldOffer }: LinkEmbedLayerProps) {
+export function LinkEmbedLayer({ canvas, shouldOffer, interactive }: LinkEmbedLayerProps) {
   // Activation order doubles as the LRU: first entry is the oldest.
   const [liveIds, setLiveIds] = useState<readonly string[]>([])
 
@@ -63,6 +74,7 @@ export function LinkEmbedLayer({ canvas, shouldOffer }: LinkEmbedLayerProps) {
               top: node.y,
               width: node.width,
               height: node.height,
+              pointerEvents: interactive ? undefined : 'none',
             }}
             className="overflow-hidden rounded-md border bg-background shadow-sm"
           >
@@ -112,6 +124,7 @@ export function LinkEmbedLayer({ canvas, shouldOffer }: LinkEmbedLayerProps) {
               top: node.y + node.height / 2 - 14 + 8,
               width: 28,
               height: 28,
+              pointerEvents: interactive ? undefined : 'none',
             }}
             className="flex items-center justify-center rounded-full border bg-background/95 text-muted-foreground shadow hover:text-foreground"
           >

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -3543,6 +3543,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               LOD gate mirrors the canvas-embed thresholds. */}
             <LinkEmbedLayer
               canvas={canvas}
+              interactive={tool !== 'hand'}
               shouldOffer={(node) =>
                 node.width * viewport.zoom >= EXPAND_MIN_W &&
                 node.height * viewport.zoom >= EXPAND_MIN_H

--- a/apps/web/src/components/spatial-editor/hand-pan-dead-zone.property.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/hand-pan-dead-zone.property.browser.test.tsx
@@ -1,0 +1,278 @@
+/**
+ * Hand tool: every press on the canvas surface pans, wherever it lands and
+ * at whatever zoom.
+ *
+ * Reported from a phone as "some regions sometimes do not respond". Empty
+ * space always panned; areas with nodes sometimes did not; it would not
+ * reproduce on demand. That is the signature of a dead zone that RIDES the
+ * canvas — an interactive overlay positioned in canvas coordinates covers a
+ * different screen region at every pan/zoom, so whether a given finger lands
+ * on it is decided by the viewport, not by the finger.
+ *
+ * No example test can be written for it, because nobody knows where the zone
+ * is. So the viewport and the press point are generated and the invariant is
+ * stated instead: the drag delta reaches the viewport.
+ *
+ * Chrome (the dock, the overview, the history cluster) legitimately swallows
+ * a press, and is excluded by CONSTRUCTION rather than by name: it sits
+ * outside the viewport-transform container. Everything INSIDE that container
+ * rides the canvas, and hand mode is navigation-only — its tool-change
+ * handler already drops every edit affordance — so nothing in there may take
+ * a press.
+ */
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { createRef, useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { fc } from '@/test-utils/fast-check'
+import { SpatialEditor, type SpatialEditorHandle } from './SpatialEditor.js'
+import type { Viewport } from './viewport.js'
+
+afterEach(cleanup)
+
+const ROOT_W = 800
+const ROOT_H = 600
+
+/**
+ * A board with the density the report describes: overlapping notes, a group,
+ * a file node big enough to draw its referenced canvas inline, and link nodes
+ * big enough to offer their embed. Every kind of canvas-space layer the
+ * editor can put under a finger is represented, because the property's job is
+ * to find the one that takes a press — not to check a layer someone already
+ * suspected.
+ */
+const referenced: SpatialCanvas = {
+  nodes: [{ id: 'r1', type: 'text', x: 0, y: 0, width: 300, height: 150, text: 'inside' }],
+  edges: [],
+}
+
+const board: SpatialCanvas = {
+  nodes: [
+    { id: 'g1', type: 'group', x: 40, y: 40, width: 620, height: 460, label: 'cluster' },
+    { id: 't1', type: 'text', x: 80, y: 80, width: 220, height: 120, text: 'one' },
+    { id: 't2', type: 'text', x: 260, y: 140, width: 220, height: 120, text: 'two' },
+    { id: 't3', type: 'text', x: 120, y: 300, width: 240, height: 140, text: 'three' },
+    { id: 'f1', type: 'file', x: 380, y: 300, width: 320, height: 240, file: 'ref-1' },
+    {
+      id: 'l1',
+      type: 'link',
+      x: 700,
+      y: 60,
+      width: 400,
+      height: 300,
+      url: 'https://example.com/a',
+    },
+    {
+      id: 'l2',
+      type: 'link',
+      x: 700,
+      y: 420,
+      width: 400,
+      height: 300,
+      url: 'https://example.com/b',
+    },
+    {
+      id: 'l3',
+      type: 'link',
+      x: 60,
+      y: 560,
+      width: 400,
+      height: 300,
+      url: 'https://example.com/c',
+    },
+  ],
+  edges: [{ id: 'e1', fromNode: 't1', toNode: 't2' }],
+}
+
+function Host({ handle }: { handle: React.RefObject<SpatialEditorHandle | null> }) {
+  const [canvas, setCanvas] = useState<SpatialCanvas>(board)
+  return (
+    <div style={{ width: ROOT_W, height: ROOT_H }}>
+      <SpatialEditor
+        ref={handle}
+        defaultTool="hand"
+        canvas={canvas}
+        onChange={(next) => setCanvas(next)}
+        theme="light"
+        fileRefOptions={[{ file: 'ref-1', label: 'Referenced canvas' }]}
+        resolveReference={(ref) => (ref === 'ref-1' ? { canvas: referenced } : undefined)}
+      />
+    </div>
+  )
+}
+
+function transformLayer(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-testid="viewport-transform"]') as HTMLElement
+}
+
+function readViewport(container: HTMLElement): Viewport {
+  const css = transformLayer(container).style.transform
+  const m = css.match(/scale\(([-\d.e+]+)\) translate\(([-\d.e+]+)px, ([-\d.e+]+)px\)/)
+  if (m === null) throw new Error(`unexpected transform: ${css}`)
+  return { zoom: Number(m[1]), x: -Number(m[2]), y: -Number(m[3]) }
+}
+
+function touch(
+  target: Element,
+  type: 'pointerdown' | 'pointermove' | 'pointerup',
+  clientX: number,
+  clientY: number,
+) {
+  const init = {
+    pointerId: 1,
+    pointerType: 'touch',
+    isPrimary: true,
+    button: 0,
+    buttons: type === 'pointerup' ? 0 : 1,
+    clientX,
+    clientY,
+  }
+  if (type === 'pointerdown') fireEvent.pointerDown(target, init)
+  else if (type === 'pointermove') fireEvent.pointerMove(target, init)
+  else fireEvent.pointerUp(target, init)
+}
+
+/** Screen point (root-local) of a canvas point under the given viewport. */
+function toRootLocal(point: { x: number; y: number }, vp: Viewport) {
+  return { x: (point.x - vp.x) * vp.zoom, y: (point.y - vp.y) * vp.zoom }
+}
+
+interface Press {
+  readonly nodeIndex: number
+  /** Where the chosen node's centre sits on screen; fixes the viewport. */
+  readonly screenX: number
+  readonly screenY: number
+  /** Press offset from that centre, in CANVAS units, so it scales with zoom. */
+  readonly ax: number
+  readonly ay: number
+  readonly dx: number
+  readonly dy: number
+  readonly zoom: number
+}
+
+/**
+ * The viewport is derived from the node the press aims at rather than
+ * generated independently: an independent one puts the node off screen at
+ * most zooms, and the runs that reach anything at all are then too few for
+ * the property to mean much (measured: 31 of 120).
+ *
+ * The offset is a MIXTURE for the same reason. A canvas-space affordance is
+ * tens of canvas units across, so a uniform offset over a node-sized box
+ * lands on one a few percent of the time and the property passes without
+ * ever exercising the thing it exists to check.
+ */
+const offsetArb = fc.oneof(
+  { weight: 2, arbitrary: fc.integer({ min: -16, max: 16 }) },
+  { weight: 1, arbitrary: fc.integer({ min: -70, max: 70 }) },
+)
+
+const pressArb: fc.Arbitrary<Press> = fc.record({
+  nodeIndex: fc.integer({ min: 0, max: board.nodes.length - 1 }),
+  screenX: fc.integer({ min: 80, max: ROOT_W - 80 }),
+  screenY: fc.integer({ min: 80, max: ROOT_H - 80 }),
+  ax: offsetArb,
+  ay: offsetArb,
+  dx: fc.integer({ min: -70, max: 70 }),
+  dy: fc.integer({ min: -70, max: 70 }),
+  zoom: fc.integer({ min: 30, max: 400 }).map((n) => n / 100),
+})
+
+interface Stats {
+  asserted: number
+  /** Presses that landed on an interactive overlay riding the canvas. */
+  onCanvasSpaceOverlay: number
+}
+
+it('a hand-tool press pans from any point on the canvas, at any pan and zoom', async () => {
+  const stats: Stats = { asserted: 0, onCanvasSpaceOverlay: 0 }
+
+  await fc.assert(
+    fc.asyncProperty(pressArb, async (press) => {
+      const handle = createRef<SpatialEditorHandle>()
+      const { container } = render(<Host handle={handle} />)
+      try {
+        const node = board.nodes[press.nodeIndex]!
+        const centre = { x: node.x + node.width / 2, y: node.y + node.height / 2 }
+        const viewport = {
+          zoom: press.zoom,
+          x: centre.x - press.screenX / press.zoom,
+          y: centre.y - press.screenY / press.zoom,
+        }
+        await act(async () => {
+          handle.current?.setViewport(viewport)
+        })
+        // Let the level-of-detail effects (canvas embeds, link facades)
+        // settle at this zoom before anything is hit-tested.
+        await act(async () => {
+          await new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
+        })
+
+        const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+        const rect = root.getBoundingClientRect()
+        const before = readViewport(container)
+
+        const local = toRootLocal({ x: centre.x + press.ax, y: centre.y + press.ay }, before)
+        // Off-screen at this viewport: nothing to press.
+        if (local.x < 2 || local.x > rect.width - 2) return
+        if (local.y < 2 || local.y > rect.height - 2) return
+
+        const clientX = rect.left + local.x
+        const clientY = rect.top + local.y
+        const target = document.elementFromPoint(clientX, clientY)
+        if (target === null || !root.contains(target)) return
+
+        const overlay = target.closest('[data-editor-overlay]')
+        // Chrome floats ABOVE the canvas rather than riding it; a press on it
+        // is a press on a control, and pans nothing by design.
+        if (overlay !== null && !transformLayer(container).contains(overlay)) return
+
+        // Counted from GEOMETRY, not from the hit test. Once this defect is
+        // fixed the layer stops taking the pointer, so a counter that read
+        // `elementFromPoint` would fall to zero on the fixed code and report
+        // the generator as too sparse — measured, it did.
+        const ridesCanvas = [
+          ...transformLayer(container).querySelectorAll<HTMLElement>('[data-editor-overlay]'),
+        ].some((el) => {
+          const box = el.getBoundingClientRect()
+          return (
+            box.width > 0 &&
+            clientX >= box.left &&
+            clientX <= box.right &&
+            clientY >= box.top &&
+            clientY <= box.bottom
+          )
+        })
+        if (ridesCanvas) stats.onCanvasSpaceOverlay += 1
+
+        touch(target, 'pointerdown', clientX, clientY)
+        touch(root, 'pointermove', clientX + press.dx, clientY + press.dy)
+        touch(root, 'pointerup', clientX + press.dx, clientY + press.dy)
+
+        const after = readViewport(container)
+        stats.asserted += 1
+        // Compared in SCREEN pixels, which is both what the invariant means
+        // (the content follows the finger) and the unit the transform is
+        // serialised in — dividing back into canvas units at zoom 0.3 turns
+        // the CSS string's own rounding into a false counterexample.
+        expect({
+          // `+ 0` normalises -0, which reads as a counterexample against 0.
+          dx: Math.round((after.x - before.x) * before.zoom * 100) / 100 + 0,
+          dy: Math.round((after.y - before.y) * before.zoom * 100) / 100 + 0,
+          zoom: after.zoom,
+        }).toEqual({ dx: -press.dx + 0, dy: -press.dy + 0, zoom: before.zoom })
+      } finally {
+        cleanup()
+      }
+    }),
+    { numRuns: 120 },
+  )
+
+  // A property that never reached an overlay riding the canvas would pass
+  // whatever those overlays do with a press — the exact blindness this test
+  // exists to remove. Floors, not targets: measured at 106 asserted runs of
+  // 120 and 17 of them over a canvas-space affordance. The seed is random per
+  // run, so the floors sit well below the measurement; a count near them is
+  // evidence the board or the generator drifted, not good news.
+  expect(stats.asserted).toBeGreaterThan(80)
+  expect(stats.onCanvasSpaceOverlay).toBeGreaterThan(5)
+})

--- a/apps/web/src/components/spatial-editor/hand-pan-over-link-embed.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/hand-pan-over-link-embed.browser.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * The dead zone `hand-pan-dead-zone.property.browser.test.tsx` found,
+ * pinned as the two examples it shrank to.
+ *
+ * A link node offers an embed once its on-screen box is large enough, and the
+ * affordance is marked `data-editor-overlay` so a press on it reaches its own
+ * onClick instead of starting a canvas gesture. That is right for the Select
+ * tool and wrong for the hand tool, which is navigation-only: there the press
+ * has to pan like any other.
+ *
+ * On a phone it presents as a region that "sometimes" does not respond —
+ * sometimes, because the affordance rides the canvas (so which screen region
+ * it covers depends on the pan) and appears only above a zoom threshold.
+ */
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+// 400x300 at zoom 1 clears the embed LOD thresholds (200x140).
+const NODE = { id: 'l1', type: 'link', x: 60, y: 60, width: 400, height: 300 } as const
+// A port nothing listens on: the iframe element mounts and refuses at once,
+// so the live-embed case never leaves the machine.
+const board: SpatialCanvas = {
+  nodes: [{ ...NODE, url: 'http://127.0.0.1:1/' }],
+  edges: [],
+}
+
+function Host({ tool }: { tool: 'hand' | 'select' }) {
+  const [canvas, setCanvas] = useState<SpatialCanvas>(board)
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor
+        defaultTool={tool}
+        canvas={canvas}
+        onChange={(next) => setCanvas(next)}
+        theme="light"
+      />
+    </div>
+  )
+}
+
+function readTranslate(container: HTMLElement): { x: number; y: number } {
+  const css = (container.querySelector('[data-testid="viewport-transform"]') as HTMLElement).style
+    .transform
+  const m = css.match(/translate\(([-\d.e+]+)px, ([-\d.e+]+)px\)/)
+  if (m === null) throw new Error(`unexpected transform: ${css}`)
+  return { x: Number(m[1]), y: Number(m[2]) }
+}
+
+/** Presses at the given root-local point, on whatever element is really there. */
+function dragFrom(root: HTMLElement, at: { x: number; y: number }, by: { x: number; y: number }) {
+  const rect = root.getBoundingClientRect()
+  const clientX = rect.left + at.x
+  const clientY = rect.top + at.y
+  const target = document.elementFromPoint(clientX, clientY) ?? root
+  const init = { pointerId: 1, pointerType: 'touch', isPrimary: true, button: 0 }
+  fireEvent.pointerDown(target, { ...init, buttons: 1, clientX, clientY })
+  fireEvent.pointerMove(root, {
+    ...init,
+    buttons: 1,
+    clientX: clientX + by.x,
+    clientY: clientY + by.y,
+  })
+  fireEvent.pointerUp(root, {
+    ...init,
+    buttons: 0,
+    clientX: clientX + by.x,
+    clientY: clientY + by.y,
+  })
+}
+
+const CENTRE = { x: NODE.x + NODE.width / 2, y: NODE.y + NODE.height / 2 }
+// The facade sits on the node's centre, nudged 8px down (see LinkEmbedLayer).
+const FACADE = { x: CENTRE.x, y: CENTRE.y + 8 }
+
+it('hand tool pans from a press on a link node embed facade', async () => {
+  const { container } = render(<Host tool="hand" />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  await screen.findByTestId('link-embed-facade')
+
+  const before = readTranslate(container)
+  dragFrom(root, FACADE, { x: 40, y: -25 })
+  const after = readTranslate(container)
+
+  expect({ dx: after.x - before.x, dy: after.y - before.y }).toEqual({ dx: 40, dy: -25 })
+})
+
+it('hand tool pans from a press on a live link embed', async () => {
+  const { container } = render(<Host tool="select" />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  await userEvent.click(await screen.findByTestId('link-embed-facade'))
+  await screen.findByTestId('link-embed-frame')
+  await userEvent.click(screen.getByRole('button', { name: 'Hand (pan)' }))
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: 'Hand (pan)' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    ),
+  )
+
+  const before = readTranslate(container)
+  dragFrom(root, CENTRE, { x: -30, y: 20 })
+  const after = readTranslate(container)
+
+  expect({ dx: after.x - before.x, dy: after.y - before.y }).toEqual({ dx: -30, dy: 20 })
+})

--- a/apps/web/src/components/spatial-editor/hand-pan-over-link-embed.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/hand-pan-over-link-embed.browser.test.tsx
@@ -52,12 +52,20 @@ function readTranslate(container: HTMLElement): { x: number; y: number } {
   return { x: Number(m[1]), y: Number(m[2]) }
 }
 
-/** Presses at the given root-local point, on whatever element is really there. */
+/**
+ * Presses at the given root-local point, on whatever element is really there —
+ * which is the whole point, since the defect is an element taking a press.
+ *
+ * It THROWS rather than falling back to the root when nothing is at the point.
+ * The fallback is what a probe that missed its target looks like, and it makes
+ * the test pass while never touching the layer it exists to check.
+ */
 function dragFrom(root: HTMLElement, at: { x: number; y: number }, by: { x: number; y: number }) {
   const rect = root.getBoundingClientRect()
   const clientX = rect.left + at.x
   const clientY = rect.top + at.y
-  const target = document.elementFromPoint(clientX, clientY) ?? root
+  const target = document.elementFromPoint(clientX, clientY)
+  if (target === null) throw new Error(`nothing at (${clientX}, ${clientY}) to press`)
   const init = { pointerId: 1, pointerType: 'touch', isPrimary: true, button: 0 }
   fireEvent.pointerDown(target, { ...init, buttons: 1, clientX, clientY })
   fireEvent.pointerMove(root, {
@@ -78,10 +86,30 @@ const CENTRE = { x: NODE.x + NODE.width / 2, y: NODE.y + NODE.height / 2 }
 // The facade sits on the node's centre, nudged 8px down (see LinkEmbedLayer).
 const FACADE = { x: CENTRE.x, y: CENTRE.y + 8 }
 
+/**
+ * That the press point is over the embed layer, checked from GEOMETRY.
+ *
+ * Not from the hit test: once the fix lands the layer stops taking the
+ * pointer, so `elementFromPoint` answers with what is beneath it and a
+ * hit-test guard would fail on the fixed code. The geometry is the same
+ * before and after, and it is what "this probe reached its subject" means.
+ */
+function expectOver(root: HTMLElement, testId: string, at: { x: number; y: number }) {
+  const rect = root.getBoundingClientRect()
+  const box = screen.getByTestId(testId).getBoundingClientRect()
+  const x = rect.left + at.x
+  const y = rect.top + at.y
+  expect({
+    inside: x >= box.left && x <= box.right && y >= box.top && y <= box.bottom,
+    hasArea: box.width > 0 && box.height > 0,
+  }).toEqual({ inside: true, hasArea: true })
+}
+
 it('hand tool pans from a press on a link node embed facade', async () => {
   const { container } = render(<Host tool="hand" />)
   const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
   await screen.findByTestId('link-embed-facade')
+  expectOver(root, 'link-embed-facade', FACADE)
 
   const before = readTranslate(container)
   dragFrom(root, FACADE, { x: 40, y: -25 })
@@ -102,6 +130,8 @@ it('hand tool pans from a press on a live link embed', async () => {
       'true',
     ),
   )
+
+  expectOver(root, 'link-embed-frame', CENTRE)
 
   const before = readTranslate(container)
   dragFrom(root, CENTRE, { x: -30, y: 20 })


### PR DESCRIPTION
## Summary

- Reported from a phone: with the hand tool, some regions of the canvas *sometimes* did not respond. Empty space always panned; areas with nodes sometimes did not; it would not reproduce on demand.
- Cause: a link node offers an embed once its on-screen box clears the LOD thresholds (200×140), and the affordance is marked `data-editor-overlay` so a press reaches its own `onClick` instead of starting a canvas gesture. Right for Select, wrong for the hand tool — whose contract is that *every* press pans. The affordance rides the canvas, so which screen region it covers depends on the pan, and it only exists above a zoom threshold. Hence "sometimes", and hence empty space always working.
- `LinkEmbedLayer` now takes `interactive`, false in hand mode, and sets `pointer-events: none`. `data-editor-overlay` cannot express "inert here" — it makes the root *ignore* the press, which is what a control wants and the opposite of what a navigation gesture wants — and it cannot help at all once the iframe is live, since an iframe consumes the pointer before any handler of ours runs.

## How it was found

A browser-mode **property**, not by reading: no example test can be written for a dead zone whose location nobody knows. `hand-pan-dead-zone.property.browser.test.tsx` generates the viewport (pan + zoom) and the press point, presses **whatever element is really under that point** (`document.elementFromPoint`, which is what makes it able to see an overlay at all), and states the invariant — a hand press pans by the drag delta.

It shrank to a link node's centre at zoom 0.5, exactly the LOD threshold for that node's size:

```
Counterexample: [{"nodeIndex":5,"screenX":80,"screenY":80,"ax":0,"ay":0,"dx":0,"dy":-1,"zoom":0.5}]
```

That counterexample is pinned as an example in `hand-pan-over-link-embed.browser.test.tsx`, together with the live-iframe case the property does not reach (activating an embed needs a click in Select mode first).

Chrome — the dock, the overview, the history cluster — legitimately swallows a press and is excluded by **construction** rather than by name: it sits outside the viewport-transform container. Everything inside that container rides the canvas, so a future canvas-space affordance joins the property by existing.

## Vacuity guards

Measured, not guessed: **106 of 120 runs assert** (the rest fall off screen at their viewport) and **17 press over an affordance riding the canvas**. The floors in the test sit well below both.

The overlay counter is read from **geometry**, not from the hit test. A counter reading `elementFromPoint` falls to zero once the fix lands and then reports the generator as too sparse — measured, it did exactly that on the first fixed run.

## Test plan

- [x] New `web-browser` tests added (1 property + 2 pinned examples)
- [x] `pnpm test` passes locally
  - `pnpm test:browser` — **157 files / 872 tests passed**
  - `pnpm --filter @kamiazya/whiteboard-web test` — **292 files / 3005 tests** then **13 files / 86 tests**, all passed
- [x] Mutation-checked: with `interactive` pinned `true`, the property and both examples go red, each naming its own invariant (`Property failed after 3 tests`; `expected { dx: +0, dy: +0 } to deeply equal { dx: 40, dy: -25 }`; `… { dx: -30, dy: 20 }`)
- [ ] E2E coverage — not applicable; the defect is entirely in editor pointer handling

## Visual evidence

**No uploaded figure — this environment has no `gh` CLI, so `gh image` cannot upload one.** What the figure encodes is a measurement, and it is quoted here instead.

A throwaway browser test swept the whole 800×600 editor root on a 16px grid, pressing each point with the hand tool and recording whether the viewport moved, then painted the non-responding points red over the real editor. Same board, same viewport, before and after:

| | non-responding probe points |
|---|---|
| before | **4** — all four inside the link node's 28px embed button |
| after | **0** |

The generator was removed before this PR; the two committed tests are the durable form of the same measurement.

## Checklist

- [x] Commit message follows Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [ ] Docs — no user-visible contract changed; the hand tool now behaves as its existing documented contract already says
- [x] No `console.*` added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hand-tool navigation so dragging over link embeds pans the canvas instead of interacting with the embedded content.
  - Preserved normal link embed interaction when using other editor tools.

- **Tests**
  - Added browser coverage for panning over link embed facades and live embeds.
  - Added randomized touch-drag coverage across dense canvas layouts, zoom levels, and viewport positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->