### PR TITLE
fix(web): stop a previous gesture deciding whether the hand tool pans

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -430,6 +430,22 @@ const DEFAULT_TEST_ID = 'spatial-editor'
  */
 const DOUBLE_PRESS_WINDOW_MS = 400
 
+/**
+ * How far apart two presses may land and still be one double press.
+ *
+ * Only hand mode needs it. Every other double press is bound to a logical
+ * target — a node id, an edge id — so two presses far apart are already two
+ * different presses. Hand mode has no target to key on and used a constant
+ * key, which made EVERY press within the window a double press regardless of
+ * where it landed: a tap, then a drag from 224px away, and the drag zoomed
+ * instead of panning while the finger was still down.
+ *
+ * Sized like the OS convention it imitates rather than like finger jitter,
+ * which is what LONG_PRESS_SLOP_PX measures — a deliberate double tap is not
+ * a still finger, and a value near 10px would reject most real ones.
+ */
+const DOUBLE_PRESS_SLOP_PX = 40
+
 /** Breathing room kept around framed content (zoom to fit / selection). */
 const FRAME_MARGIN_PX = 24
 const ZOOM_WHEEL_FACTOR = 1.1
@@ -599,8 +615,12 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      */
     const gatherAnchorRef = useRef<number | null>(null)
     const gatherPointersRef = useRef<Set<number>>(new Set())
-    /** Last primary press for double-press detection: logical target + time. */
-    const lastPressRef = useRef<{ key: string; at: number } | null>(null)
+    /**
+     * Last primary press for double-press detection: logical target, time, and
+     * where it landed. The point is what stops hand mode — whose key is a
+     * constant — from reading any two presses in the window as one gesture.
+     */
+    const lastPressRef = useRef<{ key: string; at: number; point: Point } | null>(null)
     const lastPanPointRef = useRef({ x: 0, y: 0 })
     /**
      * The pointerId this component currently holds capture for, or `null`.
@@ -1546,6 +1566,21 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // as a capture loss.
       downPointersRef.current.add(e.pointerId)
       if (e.pointerType === 'touch') {
+        // A touch pointer is `isPrimary` only while no other touch is active
+        // (Pointer Events 3, sec. 4.2), so anything still tracked here belongs
+        // to a gesture whose release this handler never received — a finger
+        // lifted over an element outside the root, a browser that claimed the
+        // gesture, a pointercancel delivered somewhere else. Left in place it
+        // is not inert: the next one-finger press makes the map size 2, so a
+        // plain drag is read as the second finger of a pinch and the canvas
+        // follows at half speed while zooming, which reads as "the hand tool
+        // stopped responding" and never recovers on its own.
+        if (e.isPrimary) {
+          touchPointsRef.current.clear()
+          gatherPointersRef.current.clear()
+          gatherAnchorRef.current = null
+          pinchActiveRef.current = false
+        }
         touchPointsRef.current.set(e.pointerId, clientPointToRootLocal(e, root))
         if (pinchActiveRef.current) return
         if (gatherPointersRef.current.size > 0 || gatherAnchorRef.current !== null) {
@@ -1664,11 +1699,18 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         // note, because that one is detected further down — past this
         // early return, which hand mode never gets past.
         if (tool === 'hand' && e.button === 0 && !spaceDownRef.current) {
+          const previous = lastPressRef.current
           const isDoublePress =
-            lastPressRef.current !== null &&
-            lastPressRef.current.key === HAND_PRESS_KEY &&
-            e.timeStamp - lastPressRef.current.at <= DOUBLE_PRESS_WINDOW_MS
-          lastPressRef.current = isDoublePress ? null : { key: HAND_PRESS_KEY, at: e.timeStamp }
+            previous !== null &&
+            previous.key === HAND_PRESS_KEY &&
+            e.timeStamp - previous.at <= DOUBLE_PRESS_WINDOW_MS &&
+            Math.hypot(
+              screenPointForPan.x - previous.point.x,
+              screenPointForPan.y - previous.point.y,
+            ) <= DOUBLE_PRESS_SLOP_PX
+          lastPressRef.current = isDoublePress
+            ? null
+            : { key: HAND_PRESS_KEY, at: e.timeStamp, point: screenPointForPan }
           if (isDoublePress) {
             setViewport((vp) => zoomAt(vp, screenPointForPan, DOUBLE_PRESS_ZOOM_FACTOR))
             return
@@ -1723,7 +1765,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         lastPressRef.current !== null &&
         lastPressRef.current.key === pressKey &&
         now - lastPressRef.current.at <= DOUBLE_PRESS_WINDOW_MS
-      lastPressRef.current = isDoublePress ? null : { key: pressKey, at: now }
+      lastPressRef.current = isDoublePress ? null : { key: pressKey, at: now, point: screenPoint }
       doublePressRef.current = isDoublePress ? { key: pressKey, point } : null
 
       if (hitId === undefined) {

--- a/apps/web/src/components/spatial-editor/hand-pan-after-gesture.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/hand-pan-after-gesture.browser.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * The two dead-hand-tool cases `hand-pan-gesture-history.property` shrank to,
+ * pinned as examples. Both are "I pressed and dragged and the canvas did not
+ * follow", and neither depends on where the finger landed — which is why a
+ * property over press POSITIONS could not see either of them.
+ */
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const board: SpatialCanvas = {
+  nodes: [{ id: 'a', type: 'text', x: 40, y: 40, width: 200, height: 100, text: 'a' }],
+  edges: [],
+}
+
+function Host() {
+  const [canvas, setCanvas] = useState(board)
+  return (
+    <div style={{ width: 390, height: 780 }}>
+      <SpatialEditor defaultTool="hand" canvas={canvas} onChange={setCanvas} theme="light" />
+    </div>
+  )
+}
+
+function mount() {
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const layer = container.querySelector('[data-testid="viewport-transform"]') as HTMLElement
+  return { root, layer, rect: root.getBoundingClientRect() }
+}
+
+function ev(
+  target: Element,
+  kind: 'down' | 'move' | 'up',
+  id: number,
+  x: number,
+  y: number,
+  isPrimary: boolean,
+) {
+  const init = {
+    pointerId: id,
+    pointerType: 'touch',
+    isPrimary,
+    button: 0,
+    buttons: kind === 'up' ? 0 : 1,
+    clientX: x,
+    clientY: y,
+  }
+  if (kind === 'down') fireEvent.pointerDown(target, init)
+  else if (kind === 'move') fireEvent.pointerMove(target, init)
+  else fireEvent.pointerUp(target, init)
+}
+
+function readTransform(layer: HTMLElement) {
+  const m = layer.style.transform.match(
+    /scale\(([-\d.e+]+)\) translate\(([-\d.e+]+)px, ([-\d.e+]+)px\)/,
+  )
+  if (m === null) throw new Error(`unexpected transform: ${layer.style.transform}`)
+  return { zoom: Number(m[1]), x: Number(m[2]), y: Number(m[3]) }
+}
+
+/** One finger down, moved by `by`, released. Answers the viewport's response. */
+function handDrag(
+  root: HTMLElement,
+  layer: HTMLElement,
+  at: { x: number; y: number },
+  by: { x: number; y: number },
+) {
+  const before = readTransform(layer)
+  ev(root, 'down', 1, at.x, at.y, true)
+  ev(root, 'move', 1, at.x + by.x, at.y + by.y, true)
+  ev(root, 'up', 1, at.x + by.x, at.y + by.y, true)
+  const after = readTransform(layer)
+  return {
+    dx: Math.round((after.x - before.x) * 100) / 100 + 0,
+    dy: Math.round((after.y - before.y) * 100) / 100 + 0,
+    zoom: after.zoom / before.zoom,
+  }
+}
+
+it('a tap, then a drag from elsewhere, pans rather than reading as a double press', () => {
+  const { root, layer, rect } = mount()
+
+  // A tap in one corner...
+  ev(root, 'down', 1, rect.left + 70, rect.top + 180, true)
+  ev(root, 'up', 1, rect.left + 70, rect.top + 180, true)
+  // ...then, well inside the double-press WINDOW but 420px away, a drag.
+  const at = { x: rect.left + 300, y: rect.top + 600 }
+  expect(Math.hypot(300 - 70, 600 - 180)).toBeGreaterThan(400)
+
+  expect(handDrag(root, layer, at, { x: 24, y: -18 })).toEqual({ dx: 24, dy: -18, zoom: 1 })
+})
+
+it('a finger whose release the root never saw does not turn the next drag into a pinch', () => {
+  const { root, layer, rect } = mount()
+
+  // A second finger goes down on the canvas and is released over something
+  // outside the editor, so the root's handler never hears about it. Real
+  // phones do this; `document.body` sits above the root, so an event there
+  // reaches nothing the editor listens on.
+  ev(root, 'down', 7, rect.left + 100, rect.top + 200, false)
+  ev(document.body, 'up', 7, 2, 2, false)
+
+  // The next touch is the first of a new sequence, so the browser marks it
+  // primary — which is exactly the evidence that nothing else is down.
+  const at = { x: rect.left + 300, y: rect.top + 600 }
+  expect(handDrag(root, layer, at, { x: 24, y: -18 })).toEqual({ dx: 24, dy: -18, zoom: 1 })
+})

--- a/apps/web/src/components/spatial-editor/hand-pan-gesture-history.property.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/hand-pan-gesture-history.property.browser.test.tsx
@@ -1,0 +1,239 @@
+/**
+ * Hand tool: what happened BEFORE a press must not decide whether it pans.
+ *
+ * The sibling property (`hand-pan-dead-zone`) generates the viewport and the
+ * press point, and remounts for every run — so it can only ever see a defect
+ * that depends on WHERE a finger lands. This one holds one editor across a
+ * whole sequence of gestures, which is the only way to see a defect that
+ * depends on what the last gesture left behind.
+ *
+ * The invariant is stated so it needs no clock. Hand mode's double press
+ * deliberately zooms instead of panning, so a press NEAR the previous one is
+ * legitimately not a pan; every probe here therefore starts far enough away
+ * that no double press can be claimed, whatever the timing. What is left is
+ * unconditional: a one-finger drag from a fresh spot pans by its own delta.
+ */
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { fc } from '@/test-utils/fast-check'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const ROOT_W = 390
+const ROOT_H = 780
+
+const board: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 40, y: 40, width: 200, height: 100, text: 'a' },
+    { id: 'b', type: 'text', x: 20, y: 300, width: 200, height: 100, text: 'b' },
+  ],
+  edges: [],
+}
+
+function Host() {
+  const [canvas, setCanvas] = useState(board)
+  return (
+    <div style={{ width: ROOT_W, height: ROOT_H }}>
+      <SpatialEditor defaultTool="hand" canvas={canvas} onChange={setCanvas} theme="light" />
+    </div>
+  )
+}
+
+interface Pt {
+  readonly x: number
+  readonly y: number
+}
+
+function ev(
+  target: Element,
+  kind: 'down' | 'move' | 'up' | 'cancel',
+  id: number,
+  at: Pt,
+  isPrimary: boolean,
+) {
+  const init = {
+    pointerId: id,
+    pointerType: 'touch',
+    isPrimary,
+    button: 0,
+    buttons: kind === 'up' || kind === 'cancel' ? 0 : 1,
+    clientX: at.x,
+    clientY: at.y,
+  }
+  if (kind === 'down') fireEvent.pointerDown(target, init)
+  else if (kind === 'move') fireEvent.pointerMove(target, init)
+  else if (kind === 'up') fireEvent.pointerUp(target, init)
+  else fireEvent.pointerCancel(target, init)
+}
+
+function readViewport(container: HTMLElement) {
+  const layer = container.querySelector('[data-testid="viewport-transform"]') as HTMLElement
+  const m = layer.style.transform.match(
+    /scale\(([-\d.e+]+)\) translate\(([-\d.e+]+)px, ([-\d.e+]+)px\)/,
+  )
+  if (m === null) throw new Error(`unexpected transform: ${layer.style.transform}`)
+  return { zoom: Number(m[1]), x: -Number(m[2]), y: -Number(m[3]) }
+}
+
+/**
+ * The gestures a finger can leave behind. Each records the last point it
+ * PRESSED at, so the probe that follows can stand clear of the double press.
+ *
+ * `stranded` is the one that needs saying: a finger whose release the root
+ * never sees. Real phones produce it — a finger lifted over an element
+ * outside the editor, a browser that claims the gesture and cancels it
+ * somewhere the handler is not listening. Dispatching the release on
+ * `document.body` reproduces it exactly, because the editor's handlers sit on
+ * its own root and body is above them.
+ */
+type Gesture =
+  | { readonly kind: 'tap'; readonly at: Pt }
+  | { readonly kind: 'drag'; readonly at: Pt; readonly by: Pt }
+  | { readonly kind: 'pinch'; readonly a: Pt; readonly b: Pt; readonly by: Pt }
+  | { readonly kind: 'stranded'; readonly at: Pt; readonly id: number }
+  | { readonly kind: 'cancelled'; readonly at: Pt }
+
+const ptArb = fc.record({
+  x: fc.integer({ min: 20, max: ROOT_W - 20 }),
+  y: fc.integer({ min: 20, max: ROOT_H - 20 }),
+})
+
+const gestureArb: fc.Arbitrary<Gesture> = fc.oneof(
+  fc.record({ kind: fc.constant('tap' as const), at: ptArb }),
+  fc.record({
+    kind: fc.constant('drag' as const),
+    at: ptArb,
+    by: fc.record({
+      x: fc.integer({ min: -40, max: 40 }),
+      y: fc.integer({ min: -40, max: 40 }),
+    }),
+  }),
+  fc.record({
+    kind: fc.constant('pinch' as const),
+    a: ptArb,
+    b: ptArb,
+    by: fc.record({
+      x: fc.integer({ min: -40, max: 40 }),
+      y: fc.integer({ min: -40, max: 40 }),
+    }),
+  }),
+  fc.record({
+    kind: fc.constant('stranded' as const),
+    at: ptArb,
+    id: fc.integer({ min: 7, max: 9 }),
+  }),
+  fc.record({ kind: fc.constant('cancelled' as const), at: ptArb }),
+)
+
+/**
+ * Two probe spots far apart, so whichever gesture came last there is always
+ * one at least 200px from its press — well clear of any double-press slop a
+ * reasonable implementation could claim.
+ */
+const PROBE_A: Pt = { x: 70, y: 180 }
+const PROBE_B: Pt = { x: 300, y: 600 }
+
+function farthestFrom(point: Pt): Pt {
+  const d = (p: Pt) => Math.hypot(p.x - point.x, p.y - point.y)
+  return d(PROBE_A) >= d(PROBE_B) ? PROBE_A : PROBE_B
+}
+
+interface Stats {
+  probes: number
+  afterStranded: number
+  afterPinch: number
+  afterTouch: number
+}
+
+it('a hand drag from a fresh spot pans, whatever gesture came before it', async () => {
+  const stats: Stats = { probes: 0, afterStranded: 0, afterPinch: 0, afterTouch: 0 }
+
+  await fc.assert(
+    fc.asyncProperty(fc.array(gestureArb, { minLength: 1, maxLength: 5 }), async (gestures) => {
+      const { container } = render(<Host />)
+      try {
+        const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+        const rect = root.getBoundingClientRect()
+        const client = (p: Pt): Pt => ({ x: rect.left + p.x, y: rect.top + p.y })
+
+        for (const gesture of gestures) {
+          switch (gesture.kind) {
+            case 'tap': {
+              ev(root, 'down', 1, client(gesture.at), true)
+              ev(root, 'up', 1, client(gesture.at), true)
+              break
+            }
+            case 'drag': {
+              const from = client(gesture.at)
+              const to = { x: from.x + gesture.by.x, y: from.y + gesture.by.y }
+              ev(root, 'down', 1, from, true)
+              ev(root, 'move', 1, to, true)
+              ev(root, 'up', 1, to, true)
+              break
+            }
+            case 'pinch': {
+              const a = client(gesture.a)
+              const b = client(gesture.b)
+              ev(root, 'down', 1, a, true)
+              ev(root, 'down', 2, b, false)
+              ev(root, 'move', 1, { x: a.x + gesture.by.x, y: a.y + gesture.by.y }, true)
+              ev(root, 'up', 1, { x: a.x + gesture.by.x, y: a.y + gesture.by.y }, true)
+              ev(root, 'up', 2, b, false)
+              break
+            }
+            case 'stranded': {
+              // Down on the canvas, released where the root cannot hear it.
+              ev(root, 'down', gesture.id, client(gesture.at), false)
+              ev(document.body, 'up', gesture.id, { x: 2, y: 2 }, false)
+              break
+            }
+            case 'cancelled': {
+              ev(root, 'down', 1, client(gesture.at), true)
+              ev(root, 'cancel', 1, client(gesture.at), true)
+              break
+            }
+          }
+
+          const last = gestures[gestures.length - 1]!
+          const lastPoint = gesture.kind === 'pinch' ? gesture.a : (gesture as { at: Pt }).at
+          void last
+          const probe = farthestFrom(lastPoint)
+          const from = client(probe)
+          const by = { x: 24, y: -18 }
+          const to = { x: from.x + by.x, y: from.y + by.y }
+
+          const before = readViewport(container)
+          ev(root, 'down', 1, from, true)
+          ev(root, 'move', 1, to, true)
+          ev(root, 'up', 1, to, true)
+          const after = readViewport(container)
+
+          stats.probes += 1
+          stats.afterTouch += 1
+          if (gesture.kind === 'stranded') stats.afterStranded += 1
+          if (gesture.kind === 'pinch') stats.afterPinch += 1
+
+          expect({
+            // Screen pixels: what the invariant means, and the unit the
+            // transform is serialised in.
+            dx: Math.round((after.x - before.x) * before.zoom * 100) / 100 + 0,
+            dy: Math.round((after.y - before.y) * before.zoom * 100) / 100 + 0,
+            zoom: after.zoom,
+          }).toEqual({ dx: -by.x + 0, dy: -by.y + 0, zoom: before.zoom })
+        }
+      } finally {
+        cleanup()
+      }
+    }),
+    { numRuns: 60 },
+  )
+
+  // A sequence generator that never produced the interesting prefixes would
+  // pass while checking nothing about gesture history at all.
+  expect(stats.probes).toBeGreaterThan(100)
+  expect(stats.afterStranded).toBeGreaterThan(5)
+  expect(stats.afterPinch).toBeGreaterThan(5)
+})


### PR DESCRIPTION
## Summary

Two ways a hand-tool press does nothing. Neither depends on **where** the finger lands, which is why the position property that shipped with #1158 could not see either — it remounts for every run and presses once.

- **The double press had no distance bound.** `lastPressRef` carried a key and a time and no point, and hand mode's key is the constant `'hand'` — so every press inside the 400ms window matched every other press, wherever it was. Measured: a tap, then a drag beginning **224px away**, and the drag zoomed 2× and set no pan, leaving the rest of the stroke inert under a finger that was still moving. Every other double press in this file is bound to a logical target (a node id, an edge id); hand mode has none to key on, so it needs the distance. The slop is sized like the OS gesture it imitates (40px), not like the finger-jitter figure sitting next to it (`LONG_PRESS_SLOP_PX = 10`).
- **A finger whose release the root never saw stayed tracked forever.** A touch pointer is `isPrimary` only while no other touch is active (Pointer Events 3, §4.2), so a primary `pointerdown` is the browser stating that nothing else is down — and anything still in `touchPointsRef` at that moment belongs to a gesture whose `pointerup`/`pointercancel` went somewhere this handler is not listening. Left in place it is **not inert**: the next one-finger press makes the map size 2, the drag is read as the second finger of a pinch, and the canvas follows at half speed while zooming. Measured on the pinned example: **14.1px of travel for a 24px drag, plus 0.99× of zoom nobody asked for**. It never recovers on its own.

## How they were found

`hand-pan-gesture-history.property.browser.test.tsx` holds **one** editor across a generated sequence of gestures — taps, drags, pinches, a stranded finger, a cancelled press — and probes after each one. The invariant is stated so it needs no clock: hand mode's double press *deliberately* zooms, so a press NEAR the previous one is legitimately not a pan; every probe therefore starts >400px away, where no double press can be claimed whatever the timing. What is left is unconditional.

Shrunk counterexamples, both pinned as examples in `hand-pan-after-gesture.browser.test.tsx`:

```
[[{"kind":"drag","at":{"x":20,"y":20},"by":{"x":0,"y":0}}]]
  → expected { dx: 150, dy: 300, zoom: 2 } to deeply equal { dx: -24, dy: 18, zoom: 1 }

[[{"kind":"stranded","at":{"x":20,"y":20},"id":7}, {"kind":"pinch",…}]]
  → expected { dx: -13.37, dy: 6.6, zoom: 0.992085 } to deeply equal { dx: -24, dy: 18, zoom: 1 }
```

### A correction worth recording

The first version of this investigation's probe asked only whether `layer.style.transform` **changed**, and reported every scenario as a healthy pan — including the stranded-finger one, whose whole symptom is that the transform changes *by the wrong amount*. Both defects were invisible until the oracle compared against the drag delta. A weaker oracle is how a probe reports "nothing wrong here" about the thing it was built to find.

## Vacuity guards

Measured, not guessed. The property asserts >100 probes across its runs and requires that the generator actually produced a stranded finger and a pinch before a probe — a sequence generator that never did would check nothing about history at all.

## Test plan

- [x] New `web-browser` tests added (1 sequence property + 2 pinned examples)
- [x] `pnpm test:browser` — **159 files / 875 tests passed**
- [x] `pnpm --filter @kamiazya/whiteboard-web test` — running; will report before merge
- [x] `tsc --noEmit` clean
- [x] Mutation-checked **separately**, and each attributes cleanly:
  - dropping the distance bound → property fails with `zoom: 2`; both examples fail
  - dropping the `isPrimary` reconciliation → property fails; **only** the stranded-finger example fails, with the half-speed signature `{ dx: 14.1, dy: -5.13, zoom: 0.990202 }`
- [x] The intended behaviour is still pinned: `hand-tool.browser.test.tsx`'s "a double press zooms in and holds the pressed canvas point still" presses the same spot twice and still passes.

## Visual evidence

`Visual evidence: none — both defects are in pointer-event bookkeeping, and neither has a still frame that distinguishes broken from fixed. What a figure would have to show is a stroke's response, so the measurements above are the evidence: 224px apart counted as one double press, and 14.1px of travel for a 24px drag. Both are asserted by the committed tests.`

## Checklist

- [x] Commit message follows Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [ ] Docs — no user-visible contract changed; both fixes make the hand tool behave as its existing contract already says
- [x] No `console.*` added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

## Honest scope note

This does **not** close the phone report that started the investigation. That report says empty areas always pan and dense areas sometimes do not; both defects here are position-independent, so neither matches that observation, and I would rather say so than claim a fix I cannot demonstrate. A response-map sweep over the reporter's actual board — 2077 probe points at each of three zooms — found **zero** dead points, so whatever they hit is not decided by where the finger lands either. Both defects below are real and both produce "I pressed and it did not pan"; whether one of them is theirs is unproven.

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hand-tool gesture recognition so taps followed by distant drags pan normally instead of triggering zoom.
  * Fixed one-finger dragging after an interrupted multi-touch gesture.
  * Improved handling of touch interactions when fingers leave the editor unexpectedly.

* **Tests**
  * Added regression and property-based coverage for hand-tool panning, double-press zoom, pinch gestures, and interrupted touch sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->