### PR TITLE
feat(web): model the editor's navigation gestures as a pure reducer

### DIFF
--- a/apps/web/src/components/spatial-editor/navigation.test.ts
+++ b/apps/web/src/components/spatial-editor/navigation.test.ts
@@ -1,0 +1,287 @@
+/**
+ * The navigation machine's behaviour, stated at the model level.
+ *
+ * These are a PORT's specification, not a discovery: every case here is
+ * behaviour `SpatialEditor.tsx` already ships and its browser tests already
+ * pin. Writing them at this layer is what makes the port checkable at all —
+ * a reducer whose only evidence is "the browser suite still passes" would
+ * tell you it broke without telling you where.
+ *
+ * The two most recent defects are restated here as model-level cases (a
+ * double press bounded in space, a stranded touch dropped on the next
+ * primary press) so that a future edit to the reducer fails HERE, in
+ * milliseconds and by name, rather than in a browser property that has to
+ * search for it.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  createIdleNavigation,
+  DOUBLE_PRESS_SLOP_PX,
+  DOUBLE_PRESS_WINDOW_MS,
+  NAVIGATION_MEMORY_KEYS,
+  type NavigationEvent,
+  type NavigationState,
+  type PressContext,
+  reduceNavigation,
+} from './navigation.js'
+
+const plainContext: PressContext = {
+  handMode: false,
+  spaceDown: false,
+  hitId: undefined,
+  anchorPrimaryId: null,
+  manipulating: false,
+}
+
+const handContext: PressContext = { ...plainContext, handMode: true }
+
+function down(
+  pointerId: number,
+  point: { x: number; y: number },
+  options: {
+    readonly context?: PressContext
+    readonly timeStamp?: number
+    readonly isPrimary?: boolean
+    readonly pointerType?: 'touch' | 'mouse'
+    readonly button?: number
+  } = {},
+): NavigationEvent {
+  return {
+    type: 'pointerdown',
+    pointerId,
+    pointerType: options.pointerType ?? 'touch',
+    isPrimary: options.isPrimary ?? pointerId === 1,
+    button: options.button ?? 0,
+    point,
+    timeStamp: options.timeStamp ?? 0,
+    context: options.context ?? handContext,
+  }
+}
+
+function move(pointerId: number, point: { x: number; y: number }): NavigationEvent {
+  return { type: 'pointermove', pointerId, pointerType: 'touch', point }
+}
+
+function up(pointerId: number): NavigationEvent {
+  return { type: 'pointerup', pointerId, pointerType: 'touch' }
+}
+
+/** Folds a sequence, keeping every effect in order alongside the final state. */
+function run(events: readonly NavigationEvent[], from = createIdleNavigation()) {
+  let state = from
+  const effects = []
+  let fallThrough = false
+  for (const event of events) {
+    const result = reduceNavigation(state, event)
+    state = result.state
+    effects.push(...result.effects)
+    fallThrough = result.fallThrough
+  }
+  return { state, effects, fallThrough }
+}
+
+describe('panning', () => {
+  it('a hand press then a move pans by the screen delta', () => {
+    const { state, effects } = run([down(1, { x: 100, y: 100 }), move(1, { x: 130, y: 80 })])
+    expect(effects).toContainEqual({ kind: 'pan', deltaScreen: { x: 30, y: -20 } })
+    expect(state.mode).toEqual({ kind: 'panning', pointerId: 1, last: { x: 130, y: 80 } })
+  })
+
+  it('a press with neither the hand tool nor Space falls through to the caller', () => {
+    const result = reduceNavigation(
+      createIdleNavigation(),
+      down(1, { x: 100, y: 100 }, { context: plainContext }),
+    )
+    expect(result.fallThrough).toBe(true)
+    expect(result.effects.filter((effect) => effect.kind === 'pan')).toEqual([])
+  })
+
+  it('the middle button pans whatever the tool is', () => {
+    const { effects } = run([
+      down(1, { x: 100, y: 100 }, { context: plainContext, button: 1, pointerType: 'mouse' }),
+      { type: 'pointermove', pointerId: 1, pointerType: 'mouse', point: { x: 110, y: 100 } },
+    ])
+    expect(effects).toContainEqual({ kind: 'pan', deltaScreen: { x: 10, y: 0 } })
+  })
+})
+
+describe('the hand double press', () => {
+  const first = down(1, { x: 100, y: 100 }, { timeStamp: 0 })
+
+  it('zooms when the second press is close in space and time', () => {
+    const { effects, state } = run([
+      first,
+      up(1),
+      down(1, { x: 100 + DOUBLE_PRESS_SLOP_PX - 1, y: 100 }, { timeStamp: 100 }),
+    ])
+    expect(effects).toContainEqual({
+      kind: 'zoom-at',
+      anchorScreen: { x: 100 + DOUBLE_PRESS_SLOP_PX - 1, y: 100 },
+      factor: 2,
+    })
+    // The press that zoomed does not also pan: nothing is dragging.
+    expect(state.mode).toEqual({ kind: 'idle' })
+  })
+
+  it('pans when the second press is far away, however close in time', () => {
+    const { effects, state } = run([
+      first,
+      up(1),
+      down(1, { x: 100 + DOUBLE_PRESS_SLOP_PX + 1, y: 100 }, { timeStamp: 1 }),
+    ])
+    expect(effects.filter((effect) => effect.kind === 'zoom-at')).toEqual([])
+    expect(state.mode.kind).toBe('panning')
+  })
+
+  it('pans when the second press is late, however close in space', () => {
+    const { effects, state } = run([
+      first,
+      up(1),
+      down(1, { x: 100, y: 100 }, { timeStamp: DOUBLE_PRESS_WINDOW_MS + 1 }),
+    ])
+    expect(effects.filter((effect) => effect.kind === 'zoom-at')).toEqual([])
+    expect(state.mode.kind).toBe('panning')
+  })
+})
+
+describe('two fingers', () => {
+  it('take the viewport, capture both, and abandon what one finger started', () => {
+    const { state, effects } = run([
+      down(1, { x: 100, y: 100 }),
+      // `manipulating` describes the moment the SECOND finger arrives, which
+      // is when the decision to abandon the node gesture is taken.
+      down(
+        2,
+        { x: 200, y: 100 },
+        {
+          context: { ...handContext, manipulating: true },
+          isPrimary: false,
+        },
+      ),
+    ])
+    expect(state.mode).toEqual({ kind: 'pinching' })
+    expect(effects).toContainEqual({ kind: 'capture', pointerIds: [1, 2] })
+    expect(effects).toContainEqual({ kind: 'cancel-manipulation' })
+  })
+
+  it('a move from either finger produces one pinch update', () => {
+    const { effects } = run([
+      down(1, { x: 100, y: 100 }),
+      down(2, { x: 200, y: 100 }, { isPrimary: false }),
+      move(1, { x: 80, y: 100 }),
+    ])
+    const pinches = effects.filter((effect) => effect.kind === 'pinch')
+    expect(pinches).toHaveLength(1)
+    // The fingers spread from 100px to 120px about a centroid that moved -10.
+    expect(pinches[0]).toMatchObject({ factor: 1.2, panDeltaScreen: { x: -10, y: 0 } })
+  })
+
+  it('a lone finger left behind by a pinch stays inert until it lifts', () => {
+    const { effects, state } = run([
+      down(1, { x: 100, y: 100 }),
+      down(2, { x: 200, y: 100 }, { isPrimary: false }),
+      up(2),
+      move(1, { x: 140, y: 100 }),
+    ])
+    expect(effects.filter((effect) => effect.kind === 'pan')).toEqual([])
+    expect(state.mode).toEqual({ kind: 'pinching' })
+  })
+})
+
+describe('a touch whose release never arrived', () => {
+  /** Down, and no up: exactly what a finger lifted outside the root leaves. */
+  const stranded = run([down(7, { x: 50, y: 50 }, { isPrimary: false })])
+
+  it('is dropped by the next primary press rather than read as a pinch', () => {
+    expect([...stranded.state.touches.keys()]).toEqual([7])
+    const next = reduceNavigation(stranded.state, down(1, { x: 300, y: 300 }))
+    expect([...next.state.touches.keys()]).toEqual([1])
+    expect(next.state.mode.kind).toBe('panning')
+  })
+
+  it('would otherwise make the next one-finger drag a pinch', () => {
+    // The same press WITHOUT the browser's primary flag — the shape the
+    // reconciliation above is guarding against.
+    const next = reduceNavigation(stranded.state, down(1, { x: 300, y: 300 }, { isPrimary: false }))
+    expect(next.state.mode).toEqual({ kind: 'pinching' })
+  })
+})
+
+describe('gathering', () => {
+  const gatherContext: PressContext = {
+    ...plainContext,
+    hitId: 'n2',
+    anchorPrimaryId: 'n1',
+    manipulating: true,
+  }
+
+  it('a second finger on a node extends the selection the first is holding', () => {
+    const { state, effects } = run([
+      down(1, { x: 100, y: 100 }, { context: { ...gatherContext, hitId: 'n1' } }),
+      down(2, { x: 200, y: 200 }, { context: gatherContext, isPrimary: false }),
+    ])
+    expect(effects).toContainEqual({ kind: 'gather', anchorPrimaryId: 'n1', hitId: 'n2' })
+    expect(state.mode).toMatchObject({ kind: 'gathering', anchorId: 1 })
+  })
+
+  it('cannot happen without a selection anchor, which is why hand mode never gathers', () => {
+    const { state, effects } = run([
+      down(1, { x: 100, y: 100 }),
+      down(2, { x: 200, y: 200 }, { context: { ...handContext, hitId: 'n2' }, isPrimary: false }),
+    ])
+    expect(effects.filter((effect) => effect.kind === 'gather')).toEqual([])
+    expect(state.mode).toEqual({ kind: 'pinching' })
+  })
+})
+
+describe('long press arming', () => {
+  it('is armed for a single finger outside hand mode', () => {
+    const { effects } = run([down(1, { x: 10, y: 20 }, { context: plainContext })])
+    expect(effects).toContainEqual({
+      kind: 'arm-long-press',
+      pointerId: 1,
+      screen: { x: 10, y: 20 },
+    })
+  })
+
+  it('is never armed in hand mode, where its teardown would strand a live pan', () => {
+    const { effects } = run([down(1, { x: 10, y: 20 })])
+    expect(effects.filter((effect) => effect.kind === 'arm-long-press')).toEqual([])
+  })
+})
+
+describe('the idle invariant', () => {
+  /**
+   * Every field except the ones NAVIGATION_MEMORY_KEYS names is
+   * gesture-scoped, so returning to idle must empty all of them. This is the
+   * whole reason the machine exists: the defect family it replaces is
+   * "a field outlived the gesture that set it", and in a twelve-ref
+   * component there was no single place to state this.
+   */
+  const emptied = (state: NavigationState) => ({
+    mode: state.mode.kind,
+    touches: state.touches.size,
+    down: state.down.size,
+  })
+
+  it('a cancel empties everything a gesture owns', () => {
+    const { state } = run([
+      down(1, { x: 100, y: 100 }),
+      down(2, { x: 200, y: 100 }, { isPrimary: false }),
+      { type: 'pointercancel', pointerId: 1, pointerType: 'touch' },
+      { type: 'pointercancel', pointerId: 2, pointerType: 'touch' },
+    ])
+    expect(emptied(state)).toEqual({ mode: 'idle', touches: 0, down: 0 })
+  })
+
+  it('a completed pan empties everything a gesture owns', () => {
+    const { state } = run([down(1, { x: 100, y: 100 }), move(1, { x: 120, y: 120 }), up(1)])
+    expect(emptied(state)).toEqual({ mode: 'idle', touches: 0, down: 0 })
+  })
+
+  it('keeps the press memory, which is the one thing that outlives a gesture', () => {
+    const { state } = run([down(1, { x: 100, y: 100 }, { timeStamp: 7 }), up(1)])
+    expect(NAVIGATION_MEMORY_KEYS).toEqual(['lastHandPress'])
+    expect(state.lastHandPress).toEqual({ at: 7, point: { x: 100, y: 100 } })
+  })
+})

--- a/apps/web/src/components/spatial-editor/navigation.ts
+++ b/apps/web/src/components/spatial-editor/navigation.ts
@@ -1,0 +1,524 @@
+/**
+ * Pure navigation state machine: pointer events in, next state plus the
+ * effects the caller must perform. The other half of this editor's gesture
+ * handling — moving, resizing, connecting, editing text — has lived in
+ * `gestures.ts` as a reducer for a long time; navigation (pan, pinch, the
+ * hand tool, the touch gather, long-press arming) stayed as loose refs in
+ * the component, and that is where every gesture defect this editor has
+ * shipped was found.
+ *
+ * What the refs could not express is a LIFETIME. Twelve of them are read and
+ * written across thirty-five early returns in four handlers, so "this
+ * gesture is over" is a fact nothing states and every branch has to
+ * remember. The two most recent defects were both that: a touch point that
+ * outlived the gesture that recorded it, and a press memory consulted long
+ * after the press it described. Here the whole of navigation is ONE value,
+ * and `NAVIGATION_MEMORY_KEYS` names the only field allowed to survive a
+ * return to idle.
+ *
+ * What this module deliberately does NOT own: the marquee, selection, node
+ * gestures, and the long-press TIMER. Those stay with the caller, which is
+ * why every event can answer `fallThrough` — "this was not navigation, run
+ * your own path". The seam is what lets the component adopt this reducer by
+ * wrapping its handlers rather than rewriting them.
+ *
+ * Screen points are ROOT-LOCAL throughout, the same convention
+ * `clientPointToRootLocal` produces; this module never sees a client
+ * coordinate or a canvas one.
+ */
+import { computePinchUpdate } from './touch-pinch.js'
+import type { Point } from './viewport.js'
+
+/**
+ * Window for double-press detection. Matches the common OS double-click
+ * interval; not user-configurable today.
+ */
+export const DOUBLE_PRESS_WINDOW_MS = 400
+
+/**
+ * How far apart two presses may land and still be one double press.
+ *
+ * Sized like the OS gesture it imitates rather than like finger jitter — a
+ * deliberate double tap is not a still finger, and a jitter-sized value
+ * would reject most real ones. Hand mode is what needs this: every other
+ * double press in this editor is bound to a logical target (a node id, an
+ * edge id) and so is already bounded in space; hand mode has no target to
+ * key on, and without a distance any two presses inside the window read as
+ * one gesture.
+ */
+export const DOUBLE_PRESS_SLOP_PX = 40
+
+/** How much closer a hand-mode double press gets. */
+export const DOUBLE_PRESS_ZOOM_FACTOR = 2
+
+/** The pointer kinds this machine distinguishes. Pen behaves as a mouse. */
+export type PointerKind = 'mouse' | 'pen' | 'touch'
+
+export type NavigationMode =
+  | { readonly kind: 'idle' }
+  /** One pointer is dragging the canvas: hand tool, middle button, or Space. */
+  | { readonly kind: 'panning'; readonly pointerId: number; readonly last: Point }
+  /** Two or more fingers own the viewport until every one of them lifts. */
+  | { readonly kind: 'pinching' }
+  /**
+   * A finger is holding a selection open while further taps add to it. The
+   * anchor is the finger that was already down; members are the taps.
+   */
+  | {
+      readonly kind: 'gathering'
+      readonly anchorId: number
+      readonly memberIds: ReadonlySet<number>
+    }
+
+/** What a press remembers about the press before it, for double-press detection. */
+export interface HandPressMemory {
+  readonly at: number
+  readonly point: Point
+}
+
+export interface NavigationState {
+  readonly mode: NavigationMode
+  /** Touches this machine believes are down, in arrival order. */
+  readonly touches: ReadonlyMap<number, Point>
+  /** Every pointer believed down, touch or not — what a capture handback is judged against. */
+  readonly down: ReadonlySet<number>
+  /**
+   * The only field that may outlive a gesture, and it is memory rather than
+   * state: a double press is by definition a fact about the PREVIOUS press.
+   */
+  readonly lastHandPress: HandPressMemory | null
+}
+
+/**
+ * The fields of `NavigationState` that survive a return to idle.
+ *
+ * Declared rather than implied so a test can state the invariant over the
+ * whole type: everything NOT named here is gesture-scoped and must be back
+ * to its empty value the moment the machine is idle. Adding a field without
+ * deciding which side it falls on is exactly how the last two defects got
+ * in.
+ */
+export const NAVIGATION_MEMORY_KEYS = ['lastHandPress'] as const
+
+export function createIdleNavigation(): NavigationState {
+  return { mode: { kind: 'idle' }, touches: new Map(), down: new Set(), lastHandPress: null }
+}
+
+/**
+ * Everything the caller knows that this machine cannot: which tool is
+ * selected, what is under the pointer, whether a manipulation is in flight.
+ * Passed per-press rather than held, because all of it can change between
+ * one press and the next.
+ */
+export interface PressContext {
+  /** The hand tool is selected: every plain press pans, nodes included. */
+  readonly handMode: boolean
+  /** Space is held: a plain press pans whatever the tool is. */
+  readonly spaceDown: boolean
+  /** The id of the node under this press, or undefined for empty canvas. */
+  readonly hitId: string | undefined
+  /**
+   * The selection anchor a gather would extend, or null when there is none.
+   * Null makes a gather impossible, which is why entering hand mode — which
+   * clears the selection — cannot gather.
+   */
+  readonly anchorPrimaryId: string | null
+  /** A node gesture (move/resize/connect) is in flight and would need cancelling. */
+  readonly manipulating: boolean
+}
+
+export type NavigationEvent =
+  | {
+      readonly type: 'pointerdown'
+      readonly pointerId: number
+      readonly pointerType: PointerKind
+      /** Only ever true for a touch when no other touch is down — see reducer. */
+      readonly isPrimary: boolean
+      readonly button: number
+      readonly point: Point
+      readonly timeStamp: number
+      readonly context: PressContext
+    }
+  | {
+      readonly type: 'pointermove'
+      readonly pointerId: number
+      readonly pointerType: PointerKind
+      readonly point: Point
+    }
+  | { readonly type: 'pointerup'; readonly pointerId: number; readonly pointerType: PointerKind }
+  | {
+      readonly type: 'pointercancel'
+      readonly pointerId: number
+      readonly pointerType: PointerKind
+    }
+
+export type NavigationEffect =
+  /** Move the viewport by a screen-space delta. */
+  | { readonly kind: 'pan'; readonly deltaScreen: Point }
+  /** Zoom about a screen point, holding the canvas point under it still. */
+  | { readonly kind: 'zoom-at'; readonly anchorScreen: Point; readonly factor: number }
+  /** A pinch step: pan, then zoom about the anchor. Ordered as written. */
+  | {
+      readonly kind: 'pinch'
+      readonly panDeltaScreen: Point
+      readonly anchorScreen: Point
+      readonly factor: number
+    }
+  | { readonly kind: 'capture'; readonly pointerIds: readonly number[] }
+  | { readonly kind: 'arm-long-press'; readonly pointerId: number; readonly screen: Point }
+  | { readonly kind: 'clear-long-press' }
+  /** Abandon whatever node gesture was in flight; the sequence became navigation. */
+  | { readonly kind: 'cancel-manipulation' }
+  | { readonly kind: 'clear-marquee' }
+  /** Add the pressed node to the selection the anchor is holding open. */
+  | { readonly kind: 'gather'; readonly anchorPrimaryId: string; readonly hitId: string }
+
+export interface NavigationResult {
+  readonly state: NavigationState
+  /** Ordered — performed left-to-right by the caller. */
+  readonly effects: readonly NavigationEffect[]
+  /**
+   * The event was not navigation's to answer: the caller runs its own
+   * handler (marquee, node gesture, click semantics) as if this machine had
+   * not been consulted.
+   */
+  readonly fallThrough: boolean
+}
+
+function withTouch(
+  touches: ReadonlyMap<number, Point>,
+  id: number,
+  point: Point,
+): ReadonlyMap<number, Point> {
+  const next = new Map(touches)
+  next.set(id, point)
+  return next
+}
+
+function withoutTouch(touches: ReadonlyMap<number, Point>, id: number): ReadonlyMap<number, Point> {
+  if (!touches.has(id)) return touches
+  const next = new Map(touches)
+  next.delete(id)
+  return next
+}
+
+function withDown(down: ReadonlySet<number>, id: number, present: boolean): ReadonlySet<number> {
+  if (down.has(id) === present) return down
+  const next = new Set(down)
+  if (present) next.add(id)
+  else next.delete(id)
+  return next
+}
+
+/**
+ * The gesture-scoped half of the state, emptied. `lastHandPress` is carried
+ * because it is memory, not state — see NAVIGATION_MEMORY_KEYS.
+ */
+function toIdle(state: NavigationState): NavigationState {
+  return {
+    mode: { kind: 'idle' },
+    touches: new Map(),
+    down: state.down,
+    lastHandPress: state.lastHandPress,
+  }
+}
+
+function isDoublePress(memory: HandPressMemory | null, at: number, point: Point): boolean {
+  if (memory === null) return false
+  if (at - memory.at > DOUBLE_PRESS_WINDOW_MS) return false
+  return Math.hypot(point.x - memory.point.x, point.y - memory.point.y) <= DOUBLE_PRESS_SLOP_PX
+}
+
+function reducePointerDown(
+  state: NavigationState,
+  event: Extract<NavigationEvent, { type: 'pointerdown' }>,
+): NavigationResult {
+  const { context } = event
+  const effects: NavigationEffect[] = []
+  let next: NavigationState = { ...state, down: withDown(state.down, event.pointerId, true) }
+
+  if (event.pointerType === 'touch') {
+    // A touch pointer is `isPrimary` only while no other touch is active
+    // (Pointer Events 3, sec. 4.2), so this is the browser stating that
+    // nothing else is down. Anything still tracked belongs to a gesture
+    // whose release never reached us — a finger lifted over an element
+    // outside the editor, a cancel delivered somewhere else. Left in place
+    // it is not inert: the next one-finger press would make the map size 2
+    // and be read as the second finger of a pinch.
+    if (event.isPrimary) next = { ...toIdle(next), down: next.down }
+
+    next = { ...next, touches: withTouch(next.touches, event.pointerId, event.point) }
+
+    // A pinch owns the viewport until every finger lifts; later fingers are
+    // tracked so their release is accounted for, and otherwise inert.
+    if (next.mode.kind === 'pinching') return { state: next, effects, fallThrough: false }
+
+    if (next.mode.kind === 'gathering') {
+      // Already gathering: a further finger is another tap, never a pinch
+      // participant, so it must not sit among the pinch candidates.
+      next = { ...next, touches: withoutTouch(next.touches, event.pointerId) }
+    }
+
+    if (next.touches.size === 2 || next.mode.kind === 'gathering') {
+      const gathered = context.anchorPrimaryId === null ? undefined : context.hitId
+      const anchorId =
+        next.mode.kind === 'gathering'
+          ? next.mode.anchorId
+          : ([...next.touches.keys()].find((id) => id !== event.pointerId) ?? null)
+      if (gathered !== undefined && anchorId !== null && context.anchorPrimaryId !== null) {
+        const beganNow = next.mode.kind !== 'gathering'
+        const memberIds = new Set(
+          next.mode.kind === 'gathering' ? next.mode.memberIds : new Set<number>(),
+        )
+        memberIds.add(event.pointerId)
+        // Gathering is a selection act, not a drag. Whatever the anchor had
+        // begun to move is abandoned: carrying a half-applied delta into the
+        // new multi-selection would jump every node gathered afterwards by
+        // an offset the user never gave it.
+        if (beganNow && context.manipulating) effects.push({ kind: 'cancel-manipulation' })
+        effects.push({ kind: 'clear-marquee' }, { kind: 'clear-long-press' })
+        effects.push({
+          kind: 'gather',
+          anchorPrimaryId: context.anchorPrimaryId,
+          hitId: gathered,
+        })
+        return {
+          state: {
+            ...next,
+            mode: { kind: 'gathering', anchorId, memberIds },
+            touches: withoutTouch(next.touches, event.pointerId),
+            lastHandPress: null,
+          },
+          effects,
+          fallThrough: false,
+        }
+      }
+    }
+
+    if (next.touches.size === 2) {
+      // The second finger converts whatever the first started — marquee,
+      // node move, double-press arming — into navigation.
+      if (context.manipulating) effects.push({ kind: 'cancel-manipulation' })
+      effects.push({ kind: 'clear-marquee' }, { kind: 'clear-long-press' })
+      // Capture BOTH fingers, not only the one that arrived second: an
+      // uncaptured first finger crossing outside the root would stop
+      // delivering its move and up events, leaving a stale entry that would
+      // misread a later one-finger press as a pinch participant.
+      effects.push({ kind: 'capture', pointerIds: [...next.touches.keys()] })
+      return {
+        state: { ...next, mode: { kind: 'pinching' }, lastHandPress: null },
+        effects,
+        fallThrough: false,
+      }
+    }
+
+    // Hand mode is navigation-only, so there is no menu for the timer to
+    // open — and arming it anyway is actively harmful: the press below
+    // starts a pan, and the timer's teardown would clear it mid-drag,
+    // stranding the pan under a finger that is still moving.
+    if (next.touches.size === 1 && !context.handMode) {
+      effects.push({ kind: 'clear-long-press' })
+      effects.push({ kind: 'arm-long-press', pointerId: event.pointerId, screen: event.point })
+    }
+  }
+
+  // Middle button (or Space held) drags from ANYWHERE — a plain left drag on
+  // empty space marquee-selects instead. The hand tool makes EVERY plain
+  // press a pan, nodes included: it is the one-handed touch navigation mode,
+  // where a second finger is not available to promote the gesture.
+  const pans = event.button === 1 || (event.button === 0 && (context.spaceDown || context.handMode))
+  if (!pans) return { state: next, effects, fallThrough: true }
+
+  if (context.handMode && event.button === 0 && !context.spaceDown) {
+    if (isDoublePress(next.lastHandPress, event.timeStamp, event.point)) {
+      effects.push({
+        kind: 'zoom-at',
+        anchorScreen: event.point,
+        factor: DOUBLE_PRESS_ZOOM_FACTOR,
+      })
+      return { state: { ...next, lastHandPress: null }, effects, fallThrough: false }
+    }
+    next = { ...next, lastHandPress: { at: event.timeStamp, point: event.point } }
+  }
+
+  return {
+    state: { ...next, mode: { kind: 'panning', pointerId: event.pointerId, last: event.point } },
+    effects,
+    fallThrough: false,
+  }
+}
+
+function reducePointerMove(
+  state: NavigationState,
+  event: Extract<NavigationEvent, { type: 'pointermove' }>,
+): NavigationResult {
+  // A gathering finger has already acted on its press, and the anchor's own
+  // gesture was cancelled when gathering began — neither may resume dragging
+  // while the other is still down.
+  if (state.mode.kind === 'gathering') {
+    const involved =
+      state.mode.anchorId === event.pointerId || state.mode.memberIds.has(event.pointerId)
+    if (involved) return { state, effects: [], fallThrough: false }
+  }
+
+  if (event.pointerType === 'touch' && state.touches.has(event.pointerId)) {
+    if (state.mode.kind === 'pinching' && state.touches.size >= 2) {
+      // The pair is the two longest-lived fingers (a Map preserves insertion
+      // order); later fingers are tracked but inert.
+      const [idA, idB] = [...state.touches.keys()]
+      if (
+        idA !== undefined &&
+        idB !== undefined &&
+        (event.pointerId === idA || event.pointerId === idB)
+      ) {
+        const a = state.touches.get(idA)
+        const b = state.touches.get(idB)
+        if (a !== undefined && b !== undefined) {
+          const update = computePinchUpdate(
+            { a, b },
+            {
+              a: event.pointerId === idA ? event.point : a,
+              b: event.pointerId === idB ? event.point : b,
+            },
+          )
+          return {
+            state: { ...state, touches: withTouch(state.touches, event.pointerId, event.point) },
+            effects: [
+              {
+                kind: 'pinch',
+                panDeltaScreen: update.panDelta,
+                anchorScreen: update.anchor,
+                factor: update.zoomFactor,
+              },
+            ],
+            fallThrough: false,
+          }
+        }
+      }
+    }
+    const tracked = { ...state, touches: withTouch(state.touches, event.pointerId, event.point) }
+    // A lone finger left behind by a pinch stays inert until it lifts.
+    if (state.mode.kind === 'pinching') {
+      return { state: tracked, effects: [], fallThrough: false }
+    }
+    return reducePanMove(tracked, event)
+  }
+
+  return reducePanMove(state, event)
+}
+
+function reducePanMove(
+  state: NavigationState,
+  event: Extract<NavigationEvent, { type: 'pointermove' }>,
+): NavigationResult {
+  if (state.mode.kind !== 'panning') return { state, effects: [], fallThrough: true }
+  const delta = {
+    x: event.point.x - state.mode.last.x,
+    y: event.point.y - state.mode.last.y,
+  }
+  return {
+    state: { ...state, mode: { ...state.mode, last: event.point } },
+    effects: [{ kind: 'pan', deltaScreen: delta }],
+    fallThrough: false,
+  }
+}
+
+function reducePointerUp(
+  state: NavigationState,
+  event: Extract<NavigationEvent, { type: 'pointerup' }>,
+): NavigationResult {
+  const down = withDown(state.down, event.pointerId, false)
+  const effects: NavigationEffect[] = [{ kind: 'clear-long-press' }]
+
+  if (state.mode.kind === 'gathering') {
+    // Gathering fingers act on the press, so their release carries no
+    // meaning — running the click/marquee logic here would re-collapse the
+    // very selection the gesture just built. The anchor lifting ends it.
+    if (state.mode.memberIds.has(event.pointerId)) {
+      const memberIds = new Set(state.mode.memberIds)
+      memberIds.delete(event.pointerId)
+      return {
+        state: { ...state, down, mode: { ...state.mode, memberIds } },
+        effects,
+        fallThrough: false,
+      }
+    }
+    if (state.mode.anchorId === event.pointerId) {
+      return {
+        state: {
+          ...state,
+          down,
+          mode: { kind: 'idle' },
+          touches: withoutTouch(state.touches, event.pointerId),
+        },
+        effects,
+        fallThrough: false,
+      }
+    }
+  }
+
+  if (event.pointerType === 'touch') {
+    const touches = withoutTouch(state.touches, event.pointerId)
+    if (state.mode.kind === 'pinching') {
+      // Fingers lifting out of a pinch never run the click/marquee release
+      // logic — the sequence was navigation, not a gesture.
+      return {
+        state: {
+          ...state,
+          down,
+          touches,
+          mode: touches.size === 0 ? { kind: 'idle' } : state.mode,
+        },
+        effects,
+        fallThrough: false,
+      }
+    }
+    if (state.mode.kind === 'panning' && state.mode.pointerId === event.pointerId) {
+      return {
+        state: { ...state, down, touches, mode: { kind: 'idle' } },
+        effects,
+        fallThrough: false,
+      }
+    }
+    return { state: { ...state, down, touches }, effects, fallThrough: true }
+  }
+
+  if (state.mode.kind === 'panning' && state.mode.pointerId === event.pointerId) {
+    return { state: { ...state, down, mode: { kind: 'idle' } }, effects, fallThrough: false }
+  }
+  return { state: { ...state, down }, effects, fallThrough: true }
+}
+
+function reducePointerCancel(
+  state: NavigationState,
+  event: Extract<NavigationEvent, { type: 'pointercancel' }>,
+): NavigationResult {
+  const down = withDown(state.down, event.pointerId, false)
+  const touches = withoutTouch(state.touches, event.pointerId)
+  // Pointer ids are reused, so anything this cancel leaves behind would
+  // silently deaden whichever later touch inherits its id.
+  const stillPinching = state.mode.kind === 'pinching' && touches.size > 0
+  return {
+    state: {
+      ...state,
+      down,
+      touches,
+      mode: stillPinching ? state.mode : { kind: 'idle' },
+    },
+    effects: [{ kind: 'clear-long-press' }, { kind: 'cancel-manipulation' }],
+    fallThrough: false,
+  }
+}
+
+export function reduceNavigation(state: NavigationState, event: NavigationEvent): NavigationResult {
+  switch (event.type) {
+    case 'pointerdown':
+      return reducePointerDown(state, event)
+    case 'pointermove':
+      return reducePointerMove(state, event)
+    case 'pointerup':
+      return reducePointerUp(state, event)
+    case 'pointercancel':
+      return reducePointerCancel(state, event)
+  }
+}


### PR DESCRIPTION
**Layer 1 of 3.** 2 is the model-based property + coverage ledger; 3 wires this into `SpatialEditor.tsx` and deletes the refs.

> Not a `gh stack`: the environment this was authored in has no `gh` CLI, so the layers land as ordinary sequential PRs. Chaining PR bases by hand looks like a stack and is not — `gh stack merge` rejects it and each squash rewrites the layer below into a commit the upper branch has never seen. Each layer here is still its own reviewable diff; only parallel review and atomic merge are missing.

## Summary

The other half of this editor's gesture handling has been a pure reducer for a long time — `gestures.ts`, 499 lines with 721 lines of tests, owning move, resize, connect and text editing. Navigation stayed as loose refs in the component. Measured:

```
SpatialEditor.tsx                  3997 lines
gesture/pointer useRefs              12  (26 refs in the file overall)
the four pointer handlers          1560–2125  (~570 lines)
early returns among them             35
```

That asymmetry is where the defects live. Every gesture defect this editor shipped recently came out of the ref half and none out of the reducer half, and the last two (#1159) were the same shape: **a field that outlived the gesture that set it**. In twelve refs there is no place to say "this gesture is over" — each branch has to remember, and one of them will not.

Here the whole of navigation is one value, and `NAVIGATION_MEMORY_KEYS` names the only field allowed to survive a return to idle. `lastHandPress` is on that list because a double press is *by definition* a fact about the previous press; everything else is gesture-scoped, and the idle invariant says so in a form a test can read.

## Scope, and the seam

Deliberately narrower than "the navigation handlers". This module owns the touch bookkeeping, pinch, pan, the hand tool's double press, the gather, and the long-press **arming** decision. It does **not** own the marquee, selection, node gestures, or the long-press timer — which is why every event can answer `fallThrough`: *"this was not navigation, run your own path"*.

That seam is the point. It lets layer 3 adopt the reducer by **wrapping** the existing handlers rather than rewriting them, leaving the manipulation code and its tests untouched — a much smaller blast radius than a 570-line rewrite would have.

## What this does not claim

A state machine kills the **lifetime** family. It does not kill the **predicate** family (#1159's double-press bug was an `isDoublePress` expression missing a dimension) or the **DOM-wiring** family (#1158's overlay eating a press is invisible to any reducer). Of the three defects found this session, this design would have made one unrepresentable. The properties found all three. This PR is a complexity and lifetime win, not a "bugs stop happening" one.

## Honest note on TDD order

The reducer was written before its tests, because it is a **port**: every case in `navigation.test.ts` is behaviour `SpatialEditor.tsx` already ships and its browser suite already pins. The tests are the port's specification, not a discovery, and they say so in the file. Two of them restate #1159's fixes at the model level so a future edit fails *here*, in milliseconds and by name, rather than in a browser property that has to search for it.

## Test plan

- [x] `navigation.test.ts` — 18 tests, `web-jsdom`
- [x] Mutation-checked, each failure naming the rule removed:
  - drop the double-press distance bound → *"pans when the second press is far away"* fails (and the stranded-touch case too, correctly — its probe is 250px away inside the window)
  - drop the primary-press reconciliation → *"is dropped by the next primary press rather than read as a pinch"* fails
  - drop the cancel's cleanup → *"a cancel empties everything a gesture owns"* fails
- [x] `pnpm knip` clean, `tsc --noEmit` clean, `arch-lint-node` 10 files / 111 tests passing
- [ ] Full `pnpm test` — running; nothing else imports this module, so the risk is confined to compilation

**blastRadius:** `none:` — a new module with no importer. `knip` is what would have caught it being dead, and it passes because the tests use it; layer 3 is what gives it a production caller.

**userReach:** `foundation:` — a pure module with no caller, wired by layer 3 of this stack. The follow-up is a named PR, not a hope.

## Visual evidence

`Visual evidence: none — a pure module with no caller renders nothing. The measurements that justify it are the ref/return counts quoted above.`

## Checklist

- [x] Commit message follows Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [ ] Docs — nothing user-visible or published changes
- [x] No `console.*` added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema (no contract crosses a process boundary here)

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_