### PR TITLE
fix(web): stop the Storage tab calling a deleted route and rendering a category the daemon cannot report

### DIFF
--- a/apps/web/src/components/StorageReportCard.test.tsx
+++ b/apps/web/src/components/StorageReportCard.test.tsx
@@ -1,3 +1,4 @@
+import { storageCategorySchema } from '@kamiazya/whiteboard-mcp/api-contracts'
 import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DaemonApiContext } from '@/contexts/DaemonApiContext'
@@ -7,11 +8,16 @@ import { STATUS_CLEAR_MS, StorageReportCard } from './StorageReportCard.js'
 const PAYLOAD = {
   totalBytes: 4096,
   fileCount: 6,
+  // Every category the contract declares. It used to omit `exports` and
+  // `logs` and carry a `libraries` the daemon cannot report — a fixture
+  // describing a payload no server sends, which is how the component's rows
+  // were asserted against a shape nothing produced.
   byCategory: {
     blobs: { bytes: 1024, files: 2 },
     versions: { bytes: 2048, files: 1 },
     files: { bytes: 0, files: 0 },
-    libraries: { bytes: 0, files: 0 },
+    exports: { bytes: 0, files: 0 },
+    logs: { bytes: 0, files: 0 },
     db: { bytes: 1024, files: 1 },
     other: { bytes: 0, files: 2 },
   },
@@ -62,12 +68,21 @@ describe('StorageReportCard', () => {
     expect(daemonFetch).toHaveBeenCalledWith('/api/runtime/logs/prune', { method: 'POST' })
   })
 
-  it('renders each storage category as its own row so future actions can hang off objects', async () => {
+  it('renders exactly the categories the daemon can report, one row each', async () => {
     const { container } = render(<StorageReportCard />)
-    // Eight rows render synchronously from the static descriptor list:
-    // blobs, versions, files, exports, logs, db, other, libraries.
-    // Values fill in once fetch + the min-refresh timer settle.
-    expect(container.querySelectorAll('[data-storage-row]').length).toBe(8)
+    // Compared against the contract's own union rather than a count. The
+    // count was 8 and included `libraries`, a category the daemon lost the
+    // ability to report when that feature's server half was deleted — the row
+    // then showed a permanent 0 B, which reads as "nothing stored yet". A
+    // number cannot tell those apart; the set can.
+    //
+    // This is the direction `key: StorageCategory` in the component does not
+    // catch: that rejects a row for a category the contract does not have,
+    // while this catches a category the contract gained and nobody rendered.
+    const rendered = Array.from(container.querySelectorAll('[data-storage-row]')).map((row) =>
+      row.getAttribute('data-storage-row'),
+    )
+    expect([...rendered].sort()).toEqual([...storageCategorySchema.options].sort())
     await act(async () => {
       await vi.advanceTimersByTimeAsync(500)
     })
@@ -77,10 +92,6 @@ describe('StorageReportCard', () => {
     expect(versionsRow!.textContent).toMatch(/2\.0\s*KiB|2048/)
     // Reserved per-row action slot is the OOUI hook for future Optimize.
     expect(container.querySelector('[data-storage-actions="versions"]')).not.toBeNull()
-    // User libraries row is pinned to the bottom so management UI lives
-    // away from the hot maintenance buckets.
-    const allRows = Array.from(container.querySelectorAll('[data-storage-row]'))
-    expect(allRows[allRows.length - 1]?.getAttribute('data-storage-row')).toBe('libraries')
   })
 
   it('exposes Optimize all on the Canvas snapshots row and aggregates across workspaces', async () => {
@@ -364,202 +375,6 @@ describe('StorageReportCard', () => {
 
     setTimeoutSpy.mockRestore()
     clearTimeoutSpy.mockRestore()
-  })
-
-  it('opens the libraries dialog, fetches rows, and renders the "file missing" branch', async () => {
-    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
-    fetchMock.mockImplementation((input: RequestInfo | URL) => {
-      const url =
-        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
-      if (url === '/api/runtime/storage') {
-        return Promise.resolve(jsonResponse(PAYLOAD))
-      }
-      if (url === '/api/user-libraries') {
-        return Promise.resolve(
-          jsonResponse({
-            libraries: [
-              { name: 'shapes', path: '/data/shapes.excalidrawlib', itemCount: 3, bytes: 2048 },
-              { name: 'orphan', path: '/data/orphan.excalidrawlib', itemCount: 1, bytes: null },
-            ],
-          }),
-        )
-      }
-      return Promise.reject(new Error(`unexpected fetch: ${url}`))
-    })
-
-    vi.useRealTimers()
-    const { container } = render(<StorageReportCard />)
-    await waitFor(() => {
-      expect(container.querySelector('[data-storage-row="libraries"]')).not.toBeNull()
-    })
-
-    const manageButton = container.querySelector(
-      '[aria-label="Manage installed user libraries"]',
-    ) as HTMLButtonElement
-    expect(manageButton).not.toBeNull()
-    fireEvent.click(manageButton)
-
-    await waitFor(() => {
-      expect(document.querySelector('[data-user-library-row="shapes"]')).not.toBeNull()
-    })
-    const shapesRow = document.querySelector('[data-user-library-row="shapes"]')!
-    expect(shapesRow.textContent).toMatch(/3\s*items?/i)
-    expect(shapesRow.textContent).toMatch(/KiB|2048/)
-
-    const orphanRow = document.querySelector('[data-user-library-row="orphan"]')!
-    expect(orphanRow.textContent).toMatch(/file missing/i)
-  })
-
-  it('shows the fetch error instead of "No user libraries installed." when the list request fails', async () => {
-    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
-    fetchMock.mockImplementation((input: RequestInfo | URL) => {
-      const url =
-        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
-      if (url === '/api/runtime/storage') {
-        return Promise.resolve(jsonResponse(PAYLOAD))
-      }
-      if (url === '/api/user-libraries') {
-        return Promise.resolve(new Response('{}', { status: 500 }))
-      }
-      return Promise.reject(new Error(`unexpected fetch: ${url}`))
-    })
-
-    vi.useRealTimers()
-    const { container } = render(<StorageReportCard />)
-    await waitFor(() => {
-      expect(container.querySelector('[data-storage-row="libraries"]')).not.toBeNull()
-    })
-    fireEvent.click(container.querySelector('[aria-label="Manage installed user libraries"]')!)
-
-    await waitFor(() => {
-      expect(document.body.textContent).toMatch(/HTTP 500/)
-    })
-    // An empty list caused by a failed fetch must not masquerade as
-    // "no libraries installed".
-    expect(document.body.textContent).not.toMatch(/No user libraries installed/)
-  })
-
-  it('surfaces a network failure from remove as libsError instead of an unhandled rejection', async () => {
-    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
-    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
-      const url =
-        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
-      if (url === '/api/runtime/storage') {
-        return Promise.resolve(jsonResponse(PAYLOAD))
-      }
-      if (url === '/api/user-libraries' && !init?.method) {
-        return Promise.resolve(
-          jsonResponse({
-            libraries: [
-              { name: 'shapes', path: '/data/shapes.excalidrawlib', itemCount: 3, bytes: 2048 },
-            ],
-          }),
-        )
-      }
-      if (url.startsWith('/api/user-libraries/') && init?.method === 'DELETE') {
-        return Promise.reject(new Error('network down'))
-      }
-      return Promise.reject(new Error(`unexpected fetch: ${url}`))
-    })
-
-    vi.useRealTimers()
-    const { container } = render(<StorageReportCard />)
-    await waitFor(() => {
-      expect(container.querySelector('[data-storage-row="libraries"]')).not.toBeNull()
-    })
-    fireEvent.click(container.querySelector('[aria-label="Manage installed user libraries"]')!)
-    await waitFor(() => {
-      expect(document.querySelector('[data-user-library-row="shapes"]')).not.toBeNull()
-    })
-
-    fireEvent.click(document.querySelector('[aria-label="Remove user library shapes"]')!)
-    await waitFor(() => {
-      expect(document.body.textContent).toMatch(/network down/)
-    })
-  })
-
-  it('removes a user library optimistically and re-pulls the list on success', async () => {
-    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
-    let libraries = [
-      { name: 'shapes', path: '/data/shapes.excalidrawlib', itemCount: 3, bytes: 2048 },
-    ]
-    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
-      const url =
-        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
-      if (url === '/api/runtime/storage') {
-        return Promise.resolve(jsonResponse(PAYLOAD))
-      }
-      if (url === '/api/user-libraries') {
-        return Promise.resolve(jsonResponse({ libraries }))
-      }
-      if (init?.method === 'DELETE' && url === '/api/user-libraries/shapes') {
-        libraries = []
-        return Promise.resolve(new Response(null, { status: 204 }))
-      }
-      return Promise.reject(new Error(`unexpected fetch: ${url}`))
-    })
-
-    vi.useRealTimers()
-    const { container } = render(<StorageReportCard />)
-    await waitFor(() => {
-      expect(container.querySelector('[data-storage-row="libraries"]')).not.toBeNull()
-    })
-    fireEvent.click(
-      container.querySelector('[aria-label="Manage installed user libraries"]') as HTMLElement,
-    )
-    await waitFor(() => {
-      expect(document.querySelector('[data-user-library-row="shapes"]')).not.toBeNull()
-    })
-
-    fireEvent.click(document.querySelector('[aria-label="Remove user library shapes"]')!)
-
-    await waitFor(() => {
-      expect(document.querySelector('[data-user-library-row="shapes"]')).toBeNull()
-    })
-  })
-
-  it('surfaces a remove failure without dropping the row', async () => {
-    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
-    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
-      const url =
-        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
-      if (url === '/api/runtime/storage') {
-        return Promise.resolve(jsonResponse(PAYLOAD))
-      }
-      if (url === '/api/user-libraries') {
-        return Promise.resolve(
-          jsonResponse({
-            libraries: [
-              { name: 'shapes', path: '/data/shapes.excalidrawlib', itemCount: 3, bytes: 2048 },
-            ],
-          }),
-        )
-      }
-      if (init?.method === 'DELETE' && url === '/api/user-libraries/shapes') {
-        return Promise.resolve(new Response(null, { status: 500 }))
-      }
-      return Promise.reject(new Error(`unexpected fetch: ${url}`))
-    })
-
-    vi.useRealTimers()
-    const { container } = render(<StorageReportCard />)
-    await waitFor(() => {
-      expect(container.querySelector('[data-storage-row="libraries"]')).not.toBeNull()
-    })
-    fireEvent.click(
-      container.querySelector('[aria-label="Manage installed user libraries"]') as HTMLElement,
-    )
-    await waitFor(() => {
-      expect(document.querySelector('[data-user-library-row="shapes"]')).not.toBeNull()
-    })
-
-    fireEvent.click(document.querySelector('[aria-label="Remove user library shapes"]')!)
-
-    await waitFor(() => {
-      expect(document.body.textContent ?? '').toMatch(/Remove failed: HTTP 500/i)
-    })
-    // The row must still be there — a failed remove should not disappear.
-    expect(document.querySelector('[data-user-library-row="shapes"]')).not.toBeNull()
   })
 
   it('exposes Cleanup on the Versions row and aggregates sandwiched-auto-version prunes across workspaces', async () => {

--- a/apps/web/src/components/StorageReportCard.tsx
+++ b/apps/web/src/components/StorageReportCard.tsx
@@ -3,40 +3,15 @@ import {
   optimizeAllDocumentsResponseSchema,
   pruneSandwichedVersionsResponseSchema,
   purgeResultSchema,
+  type StorageCategory,
   type StorageReportPayload,
   storageReportPayloadSchema,
 } from '@kamiazya/whiteboard-mcp/api-contracts'
-import { Eraser, HardDrive, Library, RefreshCw, Sparkles, Trash2 } from 'lucide-react'
+import { Eraser, HardDrive, RefreshCw, Sparkles } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { z } from 'zod'
 import { Button } from '@/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
 import { useDaemonApi } from '@/contexts/DaemonApiContext'
 import { formatBytes } from '../lib/format-bytes.js'
-import { SquiggleLoader } from './SquiggleLoader.js'
-
-// Schema for the daemon's /api/v1/user-libraries response.
-// This is the sole definition — the former api-contracts/libraries.ts was
-// removed by the move to the document model.
-const userLibraryRowSchema = z.object({
-  name: z.string(),
-  path: z.string(),
-  itemCount: z.number().int().nonnegative(),
-  bytes: z.number().int().nonnegative().nullable().optional(),
-})
-
-const userLibrariesResponseSchema = z.object({
-  libraries: z.array(userLibraryRowSchema),
-})
-
-type UserLibraryRow = z.infer<typeof userLibraryRowSchema>
 
 // Storage starts as visibility-before-enforcement: rows expose where bytes are
 // accumulating before the app applies caps, LRU, or category-specific cleanup.
@@ -44,7 +19,11 @@ type UserLibraryRow = z.infer<typeof userLibraryRowSchema>
 // Optimize / Cleanup controls can target the exact object they act on.
 
 interface CategoryDescriptor {
-  key: string
+  // Keyed by the wire contract's own category union, so a row for something
+  // the daemon cannot report does not compile. It used to be `string`, and a
+  // `libraries` row survived the deletion of its server half by rendering a
+  // permanent 0 B — a value indistinguishable from "nothing stored yet".
+  key: StorageCategory
   label: string
   description: string
   // Optional soft cap. When the row's bytes pass this threshold the row
@@ -52,8 +31,6 @@ interface CategoryDescriptor {
   // component only makes growth visible before any cleanup policy runs.
   softCapBytes?: number
 }
-
-const USER_LIBRARIES_SOFT_CAP_BYTES = 50 * 1024 * 1024
 
 const CATEGORIES: CategoryDescriptor[] = [
   { key: 'blobs', label: 'Canvas snapshots', description: 'Latest Loro doc per canvas' },
@@ -67,14 +44,6 @@ const CATEGORIES: CategoryDescriptor[] = [
   { key: 'logs', label: 'Logs', description: 'Daemon stdout / stderr archives' },
   { key: 'db', label: 'Metadata DB', description: 'Workspaces, names, pins, branches' },
   { key: 'other', label: 'Other', description: 'Unclassified files in the data dir' },
-  // Pinned to the bottom — user libraries are explicit user data, not
-  // generated artefacts, and have their own management dialog.
-  {
-    key: 'libraries',
-    label: 'User libraries',
-    description: 'Library packs you installed',
-    softCapBytes: USER_LIBRARIES_SOFT_CAP_BYTES,
-  },
 ]
 
 // Show the spinner for at least this long even if fetch returns sooner —
@@ -258,62 +227,6 @@ export function StorageReportCard() {
       }
     }
   }, [refresh, scheduleStatusClear, fetchApi])
-
-  // User libraries management dialog. Surfaces installed libraries with
-  // per-pack size and item count, plus a per-row Remove that maps to the
-  // existing DELETE /api/user-libraries/:name endpoint.
-  const [libsOpen, setLibsOpen] = useState(false)
-  const [libsLoading, setLibsLoading] = useState(false)
-  const [libs, setLibs] = useState<UserLibraryRow[]>([])
-  const [libsError, setLibsError] = useState<string | null>(null)
-  const fetchLibs = useCallback(async () => {
-    setLibsLoading(true)
-    setLibsError(null)
-    try {
-      const res = await fetchApi('/api/user-libraries')
-      if (!mountedRef.current) return
-      if (!res.ok) {
-        setLibsError(`HTTP ${res.status}`)
-        return
-      }
-      const json = userLibrariesResponseSchema.parse(await res.json())
-      if (!mountedRef.current) return
-      setLibs(json.libraries)
-    } catch (err) {
-      if (mountedRef.current) {
-        setLibsError(err instanceof Error ? err.message : String(err))
-      }
-    } finally {
-      if (mountedRef.current) setLibsLoading(false)
-    }
-  }, [fetchApi])
-  const removeLib = useCallback(
-    async (name: string) => {
-      // Callers fire-and-forget this (void removeLib(...)), so a thrown fetch
-      // must be converted to state here or it becomes an unhandled rejection.
-      try {
-        const res = await fetchApi(`/api/user-libraries/${encodeURIComponent(name)}`, {
-          method: 'DELETE',
-        })
-        if (!mountedRef.current) return
-        if (!res.ok) {
-          setLibsError(`Remove failed: HTTP ${res.status}`)
-          return
-        }
-        // Optimistic update so the row disappears immediately, then re-pull
-        // from the server to stay consistent with whatever else changed
-        // (timestamps etc.).
-        setLibs((prev) => prev.filter((l) => l.name !== name))
-        void fetchLibs()
-        void refresh()
-      } catch (err) {
-        if (mountedRef.current) {
-          setLibsError(err instanceof Error ? err.message : String(err))
-        }
-      }
-    },
-    [fetchLibs, refresh, fetchApi],
-  )
 
   // Daemon-log rotation override. Logs are also pruned fire-and-forget
   // on every daemon startup; this button lets the user reclaim disk
@@ -606,100 +519,11 @@ export function StorageReportCard() {
                     )}
                   </>
                 )}
-                {key === 'libraries' && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-7 gap-1.5"
-                    onClick={() => {
-                      setLibsOpen(true)
-                      void fetchLibs()
-                    }}
-                    aria-label="Manage installed user libraries"
-                  >
-                    <Library className="size-3.5" />
-                    <span className="text-xs">Manage</span>
-                  </Button>
-                )}
               </div>
             </li>
           )
         })}
       </ul>
-
-      <Dialog
-        open={libsOpen}
-        onOpenChange={(next) => {
-          setLibsOpen(next)
-          if (!next) setLibsError(null)
-        }}
-      >
-        <DialogContent className="sm:max-w-lg">
-          <DialogHeader>
-            <DialogTitle>User libraries</DialogTitle>
-            <DialogDescription>
-              Installed library packs. Removing a pack deletes its <code>.excalidrawlib</code> file
-              from disk and drops the registry row — documents that referenced it keep their
-              embedded copies of any item already inserted.
-            </DialogDescription>
-          </DialogHeader>
-          {libsLoading ? (
-            <SquiggleLoader label="Loading…" className="justify-start text-sm" />
-          ) : libs.length === 0 && !libsError ? (
-            // A failed fetch also leaves libs empty — that renders the error
-            // line below instead of masquerading as "no libraries installed".
-            <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
-              No user libraries installed.
-            </div>
-          ) : (
-            <ul className="rounded-md border divide-y max-h-[60vh] overflow-y-auto">
-              {libs.map((lib) => (
-                <li
-                  key={lib.name}
-                  className="flex items-center gap-3 px-3 py-2"
-                  data-user-library-row={lib.name}
-                >
-                  <div className="min-w-0 flex-1">
-                    <div className="text-sm font-medium truncate">{lib.name}</div>
-                    <div className="text-[11px] text-muted-foreground truncate">
-                      {lib.itemCount} item{lib.itemCount === 1 ? '' : 's'}
-                      {typeof lib.bytes === 'number'
-                        ? ` · ${formatBytes(lib.bytes)}`
-                        : lib.bytes === null
-                          ? ' · file missing'
-                          : ''}
-                    </div>
-                  </div>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 gap-1.5 text-destructive hover:text-destructive"
-                    onClick={() => void removeLib(lib.name)}
-                    aria-label={`Remove user library ${lib.name}`}
-                  >
-                    <Trash2 className="size-3.5" />
-                    <span className="text-xs">Remove</span>
-                  </Button>
-                </li>
-              ))}
-            </ul>
-          )}
-          {libsError && <div className="text-xs text-destructive">{libsError}</div>}
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={() => void fetchLibs()}
-              disabled={libsLoading}
-            >
-              Refresh
-            </Button>
-            <Button type="button" onClick={() => setLibsOpen(false)}>
-              Close
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   )
 }

--- a/packages/mcp-server/src/server/release/web-api-paths-mounted.test.ts
+++ b/packages/mcp-server/src/server/release/web-api-paths-mounted.test.ts
@@ -1,0 +1,218 @@
+// Every `/api/...` path apps/web asks for must be a route the daemon mounts.
+//
+// Nothing checked this, and the gap was live: `StorageReportCard` fetched
+// `/api/user-libraries` and offered a Remove button posting DELETE to
+// `/api/user-libraries/:name`, for a feature whose server half had been
+// deleted with the move to the document model. Both could only ever 404. The
+// component's own comment acknowledged the contract was gone and redefined
+// the request schema locally rather than following it, so the client kept
+// calling a route that no longer existed.
+//
+// Its tests could not catch it: they mock `fetchApi`, so they assert the
+// client against a server that answers whatever the fixture says. That is the
+// right thing for a component test to do and the reason this guard has to
+// live somewhere else — against the routes the daemon really mounts.
+//
+// Reading apps/web source from this package follows web-app-boundary.test.ts:
+// the daemon owns the contract, so the daemon's suite is where a client's
+// use of it is checked.
+
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterAll, describe, expect, it } from 'vitest'
+import { createContainer, resolveServerDeps } from '../../di/container.js'
+import { createApp } from '../app.js'
+import { DOCUMENT_WILDCARD, DOCUMENTS_WILDCARD } from '../routes/document/path-route.js'
+import { createDaemonIdentity } from '../security/daemon-identity.js'
+import { createPairingGrantStore } from '../security/pairing-grant-store.js'
+import { createPairingCodeStore, createPairingTokenStore } from '../security/pairing-session.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(__dirname, '../../../../..')
+const WEB_SRC = join(ROOT, 'apps/web/src')
+
+const tempDirs: string[] = []
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'web-api-paths-'))
+  tempDirs.push(dir)
+  return dir
+}
+afterAll(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true })
+})
+
+/**
+ * Paths a literal can carry that are not a request target.
+ *
+ * Kept tiny and each one reasoned about — an exclusion list is how a guard
+ * stops reaching its subject. `/api/...` is prose inside a doc comment;
+ * `/api/v1` is a prefix a caller concatenates onto, never fetched whole.
+ */
+const NOT_A_REQUEST_TARGET = new Set(['/api/...', '/api/v1'])
+
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name !== 'node_modules') sourceFiles(full, out)
+    } else if (/\.tsx?$/.test(entry.name) && !/\.test\./.test(entry.name)) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+/** `${...}` interpolations and `:name` segments both stand for one segment. */
+function normalize(path: string): string {
+  return path
+    .replace(/\$\{[^}]*\}/g, ':p')
+    .replace(/:[A-Za-z_][\w]*/g, ':p')
+    .replace(/\/+$/, '')
+}
+
+interface WebPath {
+  raw: string
+  normalized: string
+  file: string
+}
+
+function webApiPaths(): WebPath[] {
+  const seen = new Map<string, WebPath>()
+  for (const file of sourceFiles(WEB_SRC)) {
+    const text = readFileSync(file, 'utf-8')
+    for (const match of text.matchAll(/['`](\/api\/[^'`]*)['`]/g)) {
+      const raw = match[1]
+      if (NOT_A_REQUEST_TARGET.has(raw)) continue
+      // A literal broken across an interpolation boundary is not a whole path.
+      if (raw.includes('${') && !raw.includes('}')) continue
+      const normalized = normalize(raw)
+      if (!seen.has(normalized)) {
+        seen.set(normalized, { raw, normalized, file: file.replace(`${ROOT}/`, '') })
+      }
+    }
+  }
+  return [...seen.values()]
+}
+
+/**
+ * Every /api route the daemon can mount, across BOTH supported modes.
+ *
+ * Neither mode alone is the surface: `/api/v1` mounts only when ServerDeps are
+ * supplied (server-mode), and `/api/pairing` only under local-daemon with
+ * pairing stores. A guard built on one mode would report the other's routes as
+ * missing — which is the same failure as not checking at all, only louder and
+ * wrong. The reach assertions below pin that both halves are present.
+ */
+function mountedApiRoutes(): string[] {
+  const serverMode = createApp({
+    authMode: 'server-mode',
+    publicBaseUrl: 'https://example.com',
+    allowedOrigins: ['https://example.com'],
+    authStrategy: () => ({ ok: false as const, status: 401 as const, error: 'denied' }),
+    touch: () => {},
+    getStatus: () => ({}) as never,
+    shutdown: () => Promise.resolve(),
+    serverDeps: resolveServerDeps(createContainer()),
+  })
+
+  const pairingDir = tempDir()
+  const localDaemon = createApp({
+    authMode: 'local-daemon',
+    token: 'test-token',
+    publicBaseUrl: 'http://127.0.0.1:3099',
+    allowedOrigins: ['http://127.0.0.1:3099'],
+    touch: () => {},
+    getStatus: () => ({}) as never,
+    shutdown: () => Promise.resolve(),
+    identity: createDaemonIdentity({ dataDir: pairingDir }),
+    pairing: {
+      grants: createPairingGrantStore(pairingDir),
+      codes: createPairingCodeStore(),
+      tokens: createPairingTokenStore(),
+    },
+  })
+
+  return [
+    ...new Set(
+      [...serverMode.routes, ...localDaemon.routes]
+        .map((route) => route.path)
+        .filter((path) => path.startsWith('/api/')),
+    ),
+  ]
+}
+
+/**
+ * The only mounted patterns whose `*` really serves the paths beneath it.
+ *
+ * Hono's `app.routes` gives middleware registered with `app.use(pattern)` and
+ * endpoints the same shape, so a wildcard entry is not evidence of a mount
+ * that serves anything. Most of them are middleware: `/api/*` is the auth and
+ * host-guard chain over the whole API, `/api/runtime/*` a runtime guard, and
+ * `/api/v1/workspaces/:workspaceId/*` server-core's own `app.use` — the v1
+ * endpoints beneath it are listed concretely and match on their own.
+ *
+ * What is left is the two path-addressed document patterns, where the
+ * wildcard IS the endpoint mechanism because a document path is many
+ * segments. They are imported rather than restated: a copy here is a second
+ * list to keep in step, which is the defect this guard exists for.
+ *
+ * Treating any other wildcard as a mount is not a small error. `/api/*` covers
+ * the entire API, so accepting it makes EVERY path resolve — a guard that
+ * cannot fail, reading exactly like one that checked. The first version of
+ * this file did precisely that (its `/api/*` case sat after the wildcard
+ * branch, unreachable) and reported `/api/user-libraries` as mounted. The
+ * control cases below are what catch that class; reading the function again
+ * is not.
+ */
+const WILDCARD_ENDPOINTS = [DOCUMENT_WILDCARD, DOCUMENTS_WILDCARD].map(normalize)
+
+function isMounted(webPath: string, routes: readonly string[]): boolean {
+  return routes.some((route) => {
+    const pattern = normalize(route)
+    if (pattern.endsWith('/*')) {
+      if (!WILDCARD_ENDPOINTS.includes(pattern)) return false
+      return webPath.startsWith(pattern.slice(0, -1))
+    }
+    return pattern === webPath
+  })
+}
+
+describe('apps/web only asks for /api routes the daemon mounts', () => {
+  const routes = mountedApiRoutes()
+  const paths = webApiPaths()
+
+  // Both scans are asserted to reach their subject first. A scan that stops
+  // matching reports every path as fine, which is the shape of a pass.
+  it('finds the routes the daemon mounts, in both modes', () => {
+    expect(routes.length).toBeGreaterThan(20)
+    expect(routes.some((route) => route.startsWith('/api/v1/'))).toBe(true)
+    expect(routes.some((route) => route.startsWith('/api/pairing'))).toBe(true)
+  })
+
+  it('finds the paths apps/web asks for', () => {
+    expect(paths.length).toBeGreaterThan(8)
+  })
+
+  // The matcher's own control. Everything above can be right while `isMounted`
+  // answers true for anything, and then the assertion below passes over a real
+  // defect. A path no route serves must come back unmounted.
+  it('every wildcard endpoint it trusts is actually mounted', () => {
+    const mounted = routes.map(normalize)
+    expect(WILDCARD_ENDPOINTS.filter((pattern) => !mounted.includes(pattern))).toEqual([])
+  })
+
+  it('does not report an unserved path as mounted', () => {
+    expect(isMounted('/api/definitely-not-a-route', routes)).toBe(false)
+    expect(isMounted('/api/runtime/not-a-real-endpoint', routes)).toBe(false)
+  })
+
+  it('every one of them resolves', () => {
+    const unmounted = paths.filter((path) => !isMounted(path.normalized, routes))
+    expect(
+      unmounted.map((path) => `${path.raw} (${path.file})`),
+      'apps/web requests a route the daemon does not mount',
+    ).toEqual([])
+  })
+})

--- a/packages/mcp-server/src/server/release/web-api-paths-mounted.test.ts
+++ b/packages/mcp-server/src/server/release/web-api-paths-mounted.test.ts
@@ -82,8 +82,13 @@ function webApiPaths(): WebPath[] {
   const seen = new Map<string, WebPath>()
   for (const file of sourceFiles(WEB_SRC)) {
     const text = readFileSync(file, 'utf-8')
-    for (const match of text.matchAll(/['`](\/api\/[^'`]*)['`]/g)) {
-      const raw = match[1]
+    // All three quotings, matched with a backreference so the closing quote is
+    // the opening one. Double quotes are not hypothetical here: biome.json sets
+    // `jsxQuoteStyle: "double"`, so a JSX `src="/api/…"` is the style the
+    // linter ENFORCES — a scan blind to it would miss the one place a path is
+    // most likely to be written inline.
+    for (const match of text.matchAll(/(['"`])(\/api\/[^'"`]*)\1/g)) {
+      const raw = match[2]
       if (NOT_A_REQUEST_TARGET.has(raw)) continue
       // A literal broken across an interpolation boundary is not a whole path.
       if (raw.includes('${') && !raw.includes('}')) continue

--- a/packages/mcp-server/src/server/routes/runtime-storage.ts
+++ b/packages/mcp-server/src/server/routes/runtime-storage.ts
@@ -13,33 +13,26 @@
 import type { Dirent } from 'node:fs'
 import { readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
+import type {
+  StorageBucket,
+  StorageCategory,
+  StorageReportPayload,
+} from '../../shared/api-contracts/document.js'
 
-export interface StorageReport {
-  totalBytes: number
-  fileCount: number
-  byCategory: {
-    blobs: { bytes: number; files: number }
-    versions: { bytes: number; files: number }
-    files: { bytes: number; files: number }
-    db: { bytes: number; files: number }
-    // PNG / JSON exports the user produced via export_canvas.
-    // Kept separate from "other" because they are
-    // legitimate user data the UI should not invite to delete.
-    exports: { bytes: number; files: number }
-    // Daemon log files. Operational data — typically safe to clean up
-    // periodically, surfaced separately so the user can tell what is
-    // actually growing.
-    logs: { bytes: number; files: number }
-    other: { bytes: number; files: number }
-  }
-}
+// Derived from the wire schema rather than written alongside it. A
+// hand-written interface beside a Zod schema is the shape that shipped the
+// `create_frame` `assignedMembers` bug, and here the two had already drifted
+// in the direction nobody sees: the schema's `byCategory` was an open
+// `z.record(z.string(), …)`, so the Storage tab could ask for a category this
+// walk never produces and get a permanent 0 B row instead of a failure.
+//
+// `exports` holds the PNG / JSON files a user exported. It is kept out of
+// "other" because it is legitimate user data the UI must not invite them to
+// delete. `logs` is daemon operational data, usually safe to clean up, split
+// out so a user can tell what is actually growing.
+export type StorageReport = StorageReportPayload
 
-interface Bucket {
-  bytes: number
-  files: number
-}
-
-function emptyBucket(): Bucket {
+function emptyBucket(): StorageBucket {
   return { bytes: 0, files: 0 }
 }
 
@@ -52,7 +45,7 @@ function emptyBucket(): Bucket {
 //   logs/                                        — daemon log files
 //   whiteboard.db / .db-wal / .db-shm            — metadata SQLite
 //   daemon.json                                   — port + token registry
-function categorize(relPath: string): keyof StorageReport['byCategory'] {
+function categorize(relPath: string): StorageCategory {
   const segments = relPath.split('/').filter(Boolean)
   const head = segments[0] ?? ''
   if (head === 'blobs') {

--- a/packages/mcp-server/src/shared/api-contracts/document.ts
+++ b/packages/mcp-server/src/shared/api-contracts/document.ts
@@ -312,13 +312,45 @@ export const storageBucketSchema = z.object({
   files: z.number(),
 })
 
+/**
+ * The categories the walk in `routes/runtime-storage.ts` can put a file in.
+ *
+ * Enumerated rather than left as `z.record(z.string(), …)`, because a loose
+ * record makes a category the server can never emit indistinguishable from one
+ * it simply has not filled in yet. The Storage tab read it that way and
+ * rendered a `libraries` row — a feature whose server half was deleted — as a
+ * permanent 0 B instead of failing, which is what a contract with no key
+ * constraint buys.
+ *
+ * `runtime-storage.ts` derives its report type from this, and the client
+ * derives its row list from it, so all three cannot disagree.
+ *
+ * Note this makes the payload exhaustive at RUNTIME too, not only in the
+ * types: `z.record` over an enum requires every key, so a report missing a
+ * category is rejected rather than parsed with that bucket absent. Measured
+ * — a payload carrying only `blobs` fails with six `invalid_type` issues.
+ * That is the intent. The walk initialises all seven buckets on every run, so
+ * a missing one means the producer changed, and failing loudly beats a client
+ * rendering 0 B for a category that is no longer being counted.
+ */
+export const storageCategorySchema = z.enum([
+  'blobs',
+  'versions',
+  'files',
+  'exports',
+  'logs',
+  'db',
+  'other',
+])
+
 export const storageReportPayloadSchema = z.object({
   totalBytes: z.number(),
   fileCount: z.number(),
-  byCategory: z.record(z.string(), storageBucketSchema),
+  byCategory: z.record(storageCategorySchema, storageBucketSchema),
   lastAutoCompactedAt: z.number().nullable().optional(),
 })
 
+export type StorageCategory = z.infer<typeof storageCategorySchema>
 export type StorageBucket = z.infer<typeof storageBucketSchema>
 export type StorageReportPayload = z.infer<typeof storageReportPayloadSchema>
 


### PR DESCRIPTION
## Summary

Two findings from the same `audit-triage` sweep, in the same component, with the same cause: **a contract that stopped being enforced at the point it crossed a boundary.**

- **Settings offered a Remove button that could only 404.** `StorageReportCard` fetched `/api/user-libraries` and sent DELETE to `/api/user-libraries/:name`. Neither route exists — the user-libraries feature was removed server-side with the move to the document model, along with its `api-contracts/libraries.ts`. The component's own comment *acknowledged* the contract was gone ("the former `api-contracts/libraries.ts` was removed") and then redefined the request schema locally and kept calling the route.
- **The Storage tab showed a `libraries` row at a permanent 0 B.** `storageReportPayloadSchema.byCategory` was `z.record(z.string(), …)`, so a category the daemon can never emit was indistinguishable from one that is simply empty.

### Why nothing caught either

Five tests covered that dialog thoroughly — the list, the empty state, the error branch, optimistic removal, remove failure. They mock `fetchApi`, so they asserted the client against a server that answers whatever the fixture says. That is correct for a component test, and exactly why it could not notice; the guard has to live where the routes are.

`runtime-storage.ts` also carried a hand-written `StorageReport` interface beside the schema — the shape that shipped the `create_frame` `assignedMembers` bug — and the two had already drifted.

### The fix

The category set is a `z.enum` declared once in the contract. The server's report type is `z.infer` of it, and the component's row descriptors are keyed by it, so **a row for a category the daemon cannot report no longer compiles**.

**Measured consequence, stated in the schema:** `z.record` over an enum requires every key, so this makes the payload exhaustive at *runtime* too — a report missing a category is rejected rather than parsed with that bucket absent. A payload carrying only `blobs` fails with six `invalid_type` issues. That is the intent: the walk initialises all seven buckets on every run, so a missing one means the producer changed, and failing loudly beats rendering 0 B for a category nobody is counting any more.

It immediately caught the component's own fixture, which omitted `exports` and `logs` and carried a `libraries` — a payload no server sends.

### The guard, and the failure writing it produced

`web-api-paths-mounted.test.ts` scans apps/web for `/api/...` literals and resolves each against the routes really mounted, following `web-app-boundary.test.ts` in reading apps/web from the package that owns the contract.

It unions **both modes**: `/api/v1` mounts only with `ServerDeps` (server-mode) and `/api/pairing` only under local-daemon with pairing stores, so either mode alone reports the other's routes as missing. Reach assertions pin that both halves are present.

Worth recording, because it is this repo's own documented failure mode: **the first version of the guard could not fail.** It treated every wildcard in `app.routes` as a mount serving what is beneath it. `/api/*` is the auth middleware over the entire API, so every path resolved — it reported `/api/user-libraries` as mounted and passed. Re-reading the function did not find it; the control case did. The wildcards that really are endpoints are the two path-addressed document patterns, imported as constants rather than restated.

## Test plan

- [x] New or updated tests — `web-api-paths-mounted.test.ts` (new), `StorageReportCard.test.tsx` (row assertion now derived from the contract's union rather than a hardcoded count of 8)
- [x] `pnpm test` passes locally (see the two known-failing sets below)
- [x] Manual verification completed — the component rendered in a real browser against a full payload, before and after; see **Visual evidence**
- [ ] E2E coverage added or extended — not applicable; the deleted surface had no E2E, and the new guard is static

**Mutation-checked, eight ways, all red, restores confirmed green:**

| mutation | result |
|---|---|
| a web path naming an unmounted route | the resolve check fails, naming it |
| the matcher trusting `/api/*` again (the original bug) | the control case fails |
| the web-path scan stops matching | its reach assertion fails |
| only server-mode built | the pairing reach assertion fails |
| a category added to the contract, unrendered | the row-set test fails |
| a category dropped from the rendered rows | the row-set test fails |
| an undeclared category in the server's buckets | `TS2353` |
| a declared category missing from them | `TS2741` |

**Known-failing, pre-existing, neither this diff's:**

- `local-node-version.test.ts` — this sandbox is Node 22 against the pin of 24. `mcp-node` + `arch-lint-node` otherwise: **4313 passed, 9 skipped**.
- Nine `web-jsdom` failures in `DocumentThumb` / `VersionThumbnail` / `MergeDialog`: `TypeError: object.stream is not a function`, the documented Node 22 signature where undici reaches for `Blob.stream()`. **A/B'd rather than assumed** — those three files report `7 failed | 32 passed` identically with this change applied and reverted.

`pnpm lint`, `pnpm knip`, and both typechecks are clean.

## Visual evidence

Captured from the real component in a real browser (`web-browser`), same mocked payload both times, the only difference being this diff.

- **before** — the bottom row reads `User libraries · Library packs you installed · 0 B / 50.0 MiB · 0 files` with a **Manage** button. That button opens the dialog that can only 404, and the `0 B` is not "nothing stored yet" — it is a category the daemon lost the ability to report.
- **after** — seven rows, exactly the categories the daemon can emit. No Manage button.

**The figure could not be composed or uploaded from this environment**, so the two PNGs are not embedded here: `.claude/scripts/compose-figure.mjs` needs ImageMagick (absent — the prerequisite documented in #1149), and there is no `gh` CLI for `gh image`. The captures exist and were inspected; what they show is described above rather than asserted. Reproduce with `WHITEBOARD_CHROME_PATH=… pnpm vitest run --project web-browser` over a temporary render of `StorageReportCard`.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — the contract change is documented at the schema; no user doc describes the removed row
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema — this PR removes one

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Storage reports now use a consistent set of categories, including exports and logs.
  - Storage reports validate that all expected categories are present, improving reliability and completeness.
  - Storage usage categorization is now aligned across the web interface and service.
- **Changes**
  - User-library management has been removed from the storage report view, including its management controls and dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->