### PR TITLE
test(rules): pin the always-on context budget, and cut 15% of it

### DIFF
--- a/.claude/rules/dev-flow.md
+++ b/.claude/rules/dev-flow.md
@@ -78,58 +78,25 @@ TDD red-first; Zod single source of truth (`z.infer`, never a parallel hand-writ
 
 **Simplicity already has two executable rungs — reach for them before writing a prose rule.** `tools/arch-lint`'s allowed-third-party-dependency check fails the build on a dependency added outside a package's allowlist, and `pnpm knip` fails on the unused export a deleted feature left behind. Those are the "don't add a dependency" and "delete it" rungs made mechanical. What the `simplifier` agent and its `ponytail` ladder add on top is only the judgement-shaped rungs (does this need to exist, is this one line) — inherently prose, and the weakest rung by design.
 
-**Measure before you change what you cannot see in the diff.** A heuristic, a cost model, a search or an optimisation is correct-looking code whose worth is entirely in numbers nobody has taken — so the INSTRUMENT lands first, in its own commit, and the change is judged by it. Two exist: `edge-routing-quality.test.ts` (quality: a corpus plus aggregate counts pinned EXACTLY, so an improvement is as loud as a regression, with debt metrics separated from price metrics) and `pnpm bench` (performance: `vitest bench`, compared across INTERLEAVED paired runs because machine drift between separate runs exceeds the effect). For a behaviour-preserving optimisation the scoreboard NOT moving is the proof. This is not ceremony: the instruments rejected three changes that were obviously right on argument — per-blocker detours, a placement cache, and an excess-length penalty tier — and one cheap reachability probe (67 of 68 remaining defects had a clean path available) retired a planned task and redirected the work. They also **rescued** one: an aligned re-score was rejected in its first two shapes on cost (13x, then 4.5x layout time) and shipped in a third that reused machinery already in the file, at 2x — the measurement did not veto the idea, it priced each shape until one was worth paying for. Load the `measured-change` skill. When a change buys one metric with another, `PENALTY_RULES`' declared tier order decides it; when the currencies are genuinely different, that is a human decision worth interrupting for.
+**Three things you cannot see by reading a diff each have a skill, and the skill is where the
+worked measurements live.** Load it before the work, not after:
 
-**A guard that never reaches its subject passes, and reads exactly like a
-guard that checked.** Distinct from a vacuous PROPERTY (a generator too sparse
-to reach the interesting inputs) and from an empty `--project` filter: here the
-assertion is right, the subject is simply absent from the fixture, so nothing
-is wrong for it to find. Three instances in one session, each costing a real
-defect:
-
-- `route-scope-registry.test.ts` walked apps built WITHOUT `ServerDeps`, and
-  `/api/v1` mounts only when they are supplied — so nine routes were exempt
-  from the registry-wide guard by accident. Every `/api/v1/*` path resolved to
-  `null`, which server mode answers 500 to.
-- Nothing migrated the data dir before `http-server.ts` handed its ports a
-  handle. `/api/v1` had answered `no such table: workspaces` on a fresh dir
-  since the day it was mounted; no test saw it because every one of them
-  migrated through some legacy call first.
-- A route test's own helper pre-created the workspace, so `createWorkspace:
-  true` was pinned by nothing — removing it left every case green, on
-  behaviour the PR body claimed to preserve.
-
-The mutation check catches this ONLY if the mutation is on the production
-side; mutating a rule the fixture never exercises is green either way. So
-assert the subject is PRESENT, not merely that what is present passes —
-`expect(routes.some(r => r.path.startsWith('/api/v1/'))).toBe(true)` beside the
-walk, `expect(edges.length).toBeGreaterThan(20)` beside the allowlist. A count
-far below what the real surface holds is evidence the fixture missed, never
-good news.
-
-**The same scepticism applies one step earlier, to a DIAGNOSIS.** A failure message, a "not a
-regression", a mutation check, a hand-verified fix — each arrives looking like evidence while
-saying nothing about what was actually exercised. In one session that produced three published
-wrong conclusions: a cause read off an assertion string without checking which of two identical
-assertions failed; a regression denied by a property of the diff instead of an A/B of the
-behaviour; and a mutation check whose restore had already run, so eleven "mutated" runs used the
-original file. Each was one printed line away from being caught. Load the `diagnosis-evidence` skill before
-reporting ANY diagnostic or verification conclusion — a cause, a "not a regression", a mutation
-result, or a fix you are calling verified by hand.
-
-**Visual evidence for a change that moves pixels** is a repeatable procedure, not a screenshot of whatever was on screen: render the SAME canvas through the real pipeline before and after, side by side, chosen by the metric the change targets rather than by eye. Load the `visual-evidence` skill — its traps (a no-op `git stash` producing identical panels, unfilled rects rendering black) have each produced a misleading figure at least once.
-
-This rule was prose ONLY for a long time, and it hollowed out: the observed shape is a `## Visual repro` heading over a single "after" capture for a change that is a fix, which satisfies a reader skimming for the section while showing a reviewer nothing they could not have assumed. Two rungs now carry the parts a rule cannot.
-
-- **`node .claude/scripts/compose-figure.mjs --before <png> --after <png> --out <png>`** composes the labelled figure and **refuses two identical panels**, printing both digests for the PR body. Every way of getting the "before" wrong fails identically — a `git stash push` with nothing to stash, a revert that did not take, a second run overwriting the first — and the result is a figure showing one picture under both labels.
-- **A PreToolUse hook** (`hooks/pre-pr-visual-evidence.mjs`) blocks `gh pr create` when the diff touches a surface a human looks at and the body carries no figure. It cannot judge whether a figure is GOOD; it makes the ABSENCE a stated decision — `Visual evidence: none — <reason>` in the body passes, the same way `blastRadius: none:` does. The REASON is required, not decoration: a bare `none` is the same omission with a sentence in front of it. Fail-open for a body it cannot read.
+- **`measured-change`** — a heuristic, a cost model, a search or an optimisation is
+  correct-looking code whose worth is entirely in numbers nobody has taken, so the INSTRUMENT
+  lands first, in its own commit, and the change is judged by it. It rejected three changes that
+  were obviously right on argument, and priced a fourth through three shapes until one was worth
+  paying for.
+- **`diagnosis-evidence`** — before publishing ANY cause, "not a regression", mutation result, or
+  fix you are calling verified by hand. A number arrives looking like evidence while saying
+  nothing about what was actually exercised; the fix is to choose an observation that could
+  REFUTE the claim.
+- **`visual-evidence`** — for a change that moves pixels: the same canvas through the real
+  pipeline before and after, chosen by the metric the change targets rather than by eye. Two
+  executable rungs back it, because this rule was prose alone for a long time and hollowed out —
+  `compose-figure.mjs` refuses two identical panels, and a PreToolUse hook makes an absent figure
+  a stated decision (`Visual evidence: none — <reason>`) rather than an omission.
 
 **Docs sync**: a user-visible / API / contract / config change ships with its docs in the same increment (`technical-writer` + `docs-sync` skill; honesty — document the shipped state, never the aspiration). **`./docs/**` is USER docs (Diátaxis); developer docs are OSS-convention root files (README / SECURITY / CONTRIBUTING / CODE_OF_CONDUCT / .github). All project docs are in ENGLISH.** Marketing/release notes are drafts only (`marketing` agent), human ships.
-
-**Coverage ledgers** — the discipline that keeps a test honest about a surface that keeps growing
-— are governed by `.claude/rules/coverage-ledger.md` (path-scoped to `apps/web/**` and
-`packages/*/src/**`). Reach for it when adding a member to an editor's command set, event set,
-keyboard catalog or verb table, and when deciding whether a new surface earns a ledger at all.
 
 **Code placement and package boundaries** are governed by `.claude/rules/architecture-map.md` (always-on) and `.claude/rules/package-*.md` (path-scoped). Every PR that adds a package ships its path-scoped rule in the same increment.
 

--- a/.claude/rules/dev-flow.md
+++ b/.claude/rules/dev-flow.md
@@ -94,7 +94,9 @@ worked measurements live.** Load it before the work, not after:
   pipeline before and after, chosen by the metric the change targets rather than by eye. Two
   executable rungs back it, because this rule was prose alone for a long time and hollowed out —
   `compose-figure.mjs` refuses two identical panels, and a PreToolUse hook makes an absent figure
-  a stated decision (`Visual evidence: none — <reason>`) rather than an omission.
+  a stated decision (`Visual evidence: none — <reason>`) rather than an omission — for a body it
+  can read, which is a `--body`/`--body-file` argument; it fails open on stdin, an editor, or
+  `--fill`.
 
 **Docs sync**: a user-visible / API / contract / config change ships with its docs in the same increment (`technical-writer` + `docs-sync` skill; honesty — document the shipped state, never the aspiration). **`./docs/**` is USER docs (Diátaxis); developer docs are OSS-convention root files (README / SECURITY / CONTRIBUTING / CODE_OF_CONDUCT / .github). All project docs are in ENGLISH.** Marketing/release notes are drafts only (`marketing` agent), human ships.
 

--- a/.claude/skills/diagnosis-evidence/SKILL.md
+++ b/.claude/skills/diagnosis-evidence/SKILL.md
@@ -58,15 +58,19 @@ the duplicate:
   comparing to the same literal".
 - `grep 'setSystemTime'` reported clock-pinning absent from `docs-sync`, which says "pin the
   clock".
-- `grep -- '--ring'` reported the compose-figure invocation absent from `visual-evidence`, which
-  prints the whole command including that flag. (The pattern was also eaten as an option — a
-  second way to get a false negative from the same command.)
+- `grep '--ring'` reported the compose-figure invocation absent from `visual-evidence`, which
+  prints the whole command including that flag. This one was not a wording miss at all: `grep`
+  parsed `--ring` as an option and exited with an error, and the checking script branched on exit
+  status alone, so `grep: unrecognized option` and "no match" arrived as the same answer. Ending
+  option parsing (`grep -- '--ring'`) finds it. **A non-zero exit means "did not match" OR "did
+  not run"; a script that reads only the status cannot tell you which.**
 - `grep 'gh image'` reported the upload step absent from the same file, four lines further down.
 
 So a NEGATIVE from a text search is a hypothesis, not a finding. Confirm it by reading the section
 that would hold the claim, or by searching for the thing the claim is ABOUT — the identifier, the
-path, the number — rather than the sentence you expect around it. A positive is safe; only the
-absence needs the second look.
+path, the number — rather than the sentence you expect around it. Let the search PRINT rather than
+branching on its status, so a tool error cannot arrive dressed as a result. A positive is safe;
+only the absence needs the second look.
 
 ## Read the stack line before explaining the message
 

--- a/.claude/skills/diagnosis-evidence/SKILL.md
+++ b/.claude/skills/diagnosis-evidence/SKILL.md
@@ -44,6 +44,30 @@ This is also why a diagnosis is cheapest to check while it is still a sentence.
 Each of the three cost one extra command to settle, and each was published
 first.
 
+## A grep for a phrase is not a test for a claim
+
+Searching a document for the words you would have used answers whether it uses your wording, not
+whether it makes your claim — and a miss reads as proof of absence, which is the direction that
+does damage: it licenses writing the content again, or deleting the copy that had it.
+
+Four times in one session, while checking whether a skill already held something before cutting
+the duplicate:
+
+- `grep 'identical assertion'` reported the two-identical-assertions case absent from this file.
+  It is the **Read the stack line** section below, worded "a different assertion in the same test
+  comparing to the same literal".
+- `grep 'setSystemTime'` reported clock-pinning absent from `docs-sync`, which says "pin the
+  clock".
+- `grep -- '--ring'` reported the compose-figure invocation absent from `visual-evidence`, which
+  prints the whole command including that flag. (The pattern was also eaten as an option — a
+  second way to get a false negative from the same command.)
+- `grep 'gh image'` reported the upload step absent from the same file, four lines further down.
+
+So a NEGATIVE from a text search is a hypothesis, not a finding. Confirm it by reading the section
+that would hold the claim, or by searching for the thing the claim is ABOUT — the identifier, the
+path, the number — rather than the sentence you expect around it. A positive is safe; only the
+absence needs the second look.
+
 ## Read the stack line before explaining the message
 
 `expected '' to be 'Fast switch'` was diagnosed from the string alone, blamed on

--- a/.claude/skills/docs-sync/SKILL.md
+++ b/.claude/skills/docs-sync/SKILL.md
@@ -47,6 +47,14 @@ pnpm --filter @kamiazya/whiteboard-web docs:snapshots
 
 Add a `*.docs-snapshot.test.tsx`, pin the clock, save via `resolveDocAssetPath`, run, and commit the PNG with the markdown that references it.
 
+The project is excluded from the ordinary `pnpm test` run because it writes into the repo, so
+regenerate deliberately and commit the result. `docs:snapshots:check` generates TWICE before
+`git diff --exit-code`: Vite's first run after a config change can re-optimise dependencies and
+produce a one-off pixel drift, so the second run is the stable artifact. Diffs surviving a
+double run are a real UI change, not jitter. Cross-platform font rendering means a Linux CI
+capture is not byte-identical to a macOS one — this stays a developer-driven, regenerate-locally
+workflow.
+
 ## Discipline
 
 Update only doc files in a docs pass; commit them separately with a `docs:` message. Fix broken links you touch. Surface any user-visible change you could not find a doc home for.

--- a/.claude/skills/measured-change/SKILL.md
+++ b/.claude/skills/measured-change/SKILL.md
@@ -17,10 +17,24 @@ instrument rejected **three separate changes that were obviously right**:
   are a higher tier, so it was a bad trade in the project's own currency
 - a per-group placement cache — measured *slower* in all three rounds; the
   cached groups held two or three items and the key cost more than the work
-- an aligned re-score post-pass — targeted 9 layouts in 400 and would have
-  charged every layout an extra pass
+- an excess-length penalty tier — a new cost term that argued well and moved
+  no debt metric the corpus pins
 
 Every one of them would have shipped on argument alone.
+
+**And the instrument is not a veto — it prices.** An aligned re-score was
+rejected in its first shape (a bespoke repair loop scoring whole
+configurations, 13x layout time — it targeted 9 layouts in 400 and would have
+charged every layout an extra pass), rejected again in its second (the same
+loop reusing unchanged paths, 4.5x), and SHIPPED in a third that reused the search's
+own incremental trial machinery, at 2x — `assignEdgeAnchors` now hands the
+settled configuration back through the same search with `align: true`, and it
+buys own-endpoint violations 35 -> 14 and crossings 647 -> 500. A measurement
+that kills the first shape of an idea has not killed the idea.
+
+That distinction is worth the words because this list used to end with the
+re-score's FIRST verdict, as though it were the final one, while the third
+shape was already in `spatial-edges.ts`.
 
 ## Quality: a scoreboard
 

--- a/.claude/skills/test-layer-selection/SKILL.md
+++ b/.claude/skills/test-layer-selection/SKILL.md
@@ -75,6 +75,27 @@ solved with different machinery — exact BigInt rationals against the subject's
 cross-multiplication, cell-by-cell rasterisation against its interval algebra — is what makes the
 comparison mean anything. Calling the production helper from the test is the same code twice.
 
+**A guard that never reaches its subject passes, and reads exactly like a guard that checked.**
+The third sibling of the two above, and the one no mutation check finds: here the assertion is
+right and the subject is simply absent from the fixture, so there is nothing for it to find.
+Mutating the production side is green either way when the fixture never exercises that rule.
+
+Three instances in one session, each costing a real defect:
+
+- `route-scope-registry.test.ts` walked apps built WITHOUT `ServerDeps`, and `/api/v1` mounts
+  only when they are supplied — so nine routes were exempt from a registry-wide guard by
+  accident, every `/api/v1/*` path resolving to `null`, which server mode answers 500 to.
+- Nothing migrated the data dir before `http-server.ts` handed its ports a handle, so `/api/v1`
+  had answered `no such table: workspaces` on a fresh dir since the day it was mounted. No test
+  saw it, because every one of them migrated through some legacy call first.
+- A route test's own helper pre-created the workspace, so `createWorkspace: true` was pinned by
+  nothing — removing it left every case green, on behaviour a PR body claimed to preserve.
+
+So assert the subject is PRESENT, not merely that what is present passes:
+`expect(routes.some((r) => r.path.startsWith('/api/v1/'))).toBe(true)` beside the walk,
+`expect(edges.length).toBeGreaterThan(20)` beside the allowlist. A count far below what the real
+surface holds is evidence the fixture missed, never good news.
+
 **Coverage ledgers**, for a property modelling a surface that keeps growing (an editor's command
 set, its gesture events, its keyboard catalog, its verbs), are
 `.claude/rules/coverage-ledger.md` — path-scoped to `apps/web/**` and `packages/*/src/**`, so it

--- a/.claude/skills/test-layer-selection/SKILL.md
+++ b/.claude/skills/test-layer-selection/SKILL.md
@@ -59,3 +59,25 @@ properties are the most expensive per run (real browser + IndexedDB/etc.) — ke
   fixing production code, fix the implementation, then mutation-check (revert the fix, confirm the
   pinned example — and ideally the property — goes red, then restore).
 - Shared arbitraries belong in the owning package's `test-utils`, not copy-pasted per test file.
+- A generator too sparse to reach the interesting arrangements — boxes that rarely overlap,
+  sequences that rarely collide — passes **vacuously**. The mutation check is what catches a
+  property that asserts nothing, and the fix is a denser domain plus a reachability guard with a
+  measured floor, never more runs.
+
+**A differential oracle is blind to whatever it SHARES with its subject**, and this reads as the
+strongest kind of property rather than the weakest. `edge-crossing-sweep`'s oracle is the full
+O(E^2) scan its sweep claims exact equality with — but both sides called the same scoring helper,
+so a mutation inside that helper changed the oracle and the subject together and the property
+stayed green: 22 survivors in one function, under a property nobody would have doubted.
+
+So when you write an A-vs-B property, ask what B **imports**, not what it asserts. A reference
+solved with different machinery — exact BigInt rationals against the subject's floating-point
+cross-multiplication, cell-by-cell rasterisation against its interval algebra — is what makes the
+comparison mean anything. Calling the production helper from the test is the same code twice.
+
+**Coverage ledgers**, for a property modelling a surface that keeps growing (an editor's command
+set, its gesture events, its keyboard catalog, its verbs), are
+`.claude/rules/coverage-ledger.md` — path-scoped to `apps/web/**` and `packages/*/src/**`, so it
+loads itself when you are in those files. Worked examples: `editor-state.property.test.ts` (three
+union ledgers), `editor-verbs.property.test.ts` (one), `editor-state-surface.test.ts` (the source
+scan).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,105 +89,22 @@ pnpm run test:browser:trace  # same, with trace artifacts on failure
 
 ## MCP Development Mode
 
-When developing this repo's MCP server, prefer the daemon-hosted HTTP MCP endpoint over direct `stdio`.
+Develop this repo's MCP server against the **daemon-hosted HTTP endpoint**, not `stdio`:
+`pnpm mcp:http:dev` starts the local daemon in watch mode at `http://127.0.0.1:3099/mcp`, so a
+code change restarts the daemon rather than the whole client integration. `stdio` is reserved for
+packaged-distribution checks — validating `@kamiazya/whiteboard-mcp` as it ships. Debug in this
+order: MCP Inspector against that URL (`pnpm mcp:inspect`), then `initialize` and `tools/list`,
+then `MCP_HTTP_DEBUG=1` if capability negotiation or request flow is unclear, and only then
+compare against a specific client.
 
-Use:
+When changing transport, routing, or tool registration, add or update a nearest-layer automated
+test for `/mcp` behaviour and verify against the running endpoint with a real client, not only
+mocked unit tests.
 
-```bash
-pnpm mcp:http:dev
-pnpm mcp:inspect
-pnpm mcp:debug:http
-```
-
-- This starts the local daemon in watch mode and exposes MCP at `http://127.0.0.1:3099/mcp`.
-- Prefer connecting Codex or Claude Code to that URL during active MCP development so code changes only restart the daemon, not the whole MCP client integration.
-- Use `stdio` MCP only for packaged-distribution checks or when specifically validating the standalone entrypoint behavior.
-- Prefer the official MCP Inspector for first-pass debugging before switching to client-specific debugging.
-- If request flow is unclear, restart with `MCP_HTTP_DEBUG=1 pnpm mcp:http:dev` and inspect the `[mcp-http:init]` / `[mcp-http]` logs.
-- Keep the detailed checklist in `docs/contributing/mcp-debugging.md` in sync with actual repo workflow.
-
-Dev sessions reach the daemon through the stdio proxy
-`packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs`:
-
-- **Claude Code**: register it once per checkout at LOCAL scope (machine-
-  private `~/.claude.json`), which shadows the published `npx` definition
-  in `.mcp.json` (precedence: local > project). `.mcp.json` itself is the
-  PUBLIC plugin/team surface and stays pointed at the published package —
-  do not repoint it at dev tooling. Note `settings.json` has no
-  `mcpServers` field in its schema; a definition there is silently ignored.
-
-  ```bash
-  claude mcp add --scope local --transport stdio whiteboard --     node "$(git rev-parse --show-toplevel)/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs"
-  ```
-
-- **Codex**: `.codex/config.toml` registers the same proxy as
-  `whiteboard_dev` (repo-tracked; it already disables the plugin-provided
-  published server).
-
-The clients register the proxy as a stdio server rather than the HTTP URL
-directly: an MCP client attempts one HTTP connection at session start and
-never retries, so it can lose the race against the SessionStart hook
-spawning the daemon, and a watch restart mid-session strands the
-connection the same way. The stdio spawn always succeeds; the proxy runs
-the ensure hook, waits for readiness, and retries each request across
-watch restarts. This is sound because `/mcp` is stateless per request —
-one stdin line becomes one authenticated POST, with no protocol session
-to lose. Server-initiated notifications do not traverse the proxy;
-reload the client session to pick up a changed tool list.
-
-Both Claude Code (`.claude/settings.json`) and Codex
-(`.codex/config.toml`) wire a `SessionStart` hook to
-`packages/mcp-server/scripts/dev/ensure-http-dev-daemon.mjs`. The hook
-probes this checkout's derived dev port (3099 on the main checkout,
-a deterministic per-worktree port otherwise — see
-`docs/contributing/development.md`'s ".dev-data" section) and, if
-nothing is listening, spawns `pnpm mcp:http:dev` detached so the first
-MCP request can connect immediately. It is idempotent — if our
-authenticated daemon is already up **and its identity marker matches
-this worktree** it exits without touching anything; if a foreign
-service, or a different worktree's daemon that hash-collided on the
-same port, is on the port it fails loudly so the developer can
-investigate. Output goes to `tmp/logs/mcp-http-dev.log`. If hooks are
-disabled or the project is not trusted yet, run `pnpm mcp:http:dev`
-manually in another terminal before opening the repo.
-
-The probe-decide-spawn sequence is mutually exclusive across
-processes: two hooks starting close together (a new editor session
-plus a `new-worktree.mjs` run, say) acquire an exclusive, atomically-
-created lock file (`<dataDir>/dev-daemon-spawn.lock`, alongside the
-`dev-daemon.json` identity marker — per-worktree exactly like the
-derived port) before probing the port, so only one of them ever
-spawns. The loser doesn't exit or spawn a competitor — it waits for
-the winner's daemon to become reachable and exits 0 once it answers,
-because the developer's session just needs a working daemon regardless
-of who started it. A lock abandoned by a crashed hook self-heals: it
-is stolen once its recorded pid is dead, or once it exceeds
-`WHITEBOARD_DEV_SPAWN_LOCK_STALE_MS` (default 45s).
-
-With HTTP transport every client reload connects to the same long-lived
-daemon, picking up source changes immediately and avoiding the stale-daemon
-reuse that the old stdio + daemon-registry path was prone to.
-
-stdio is reserved for packaged-distribution checks (validating
-`@kamiazya/whiteboard-mcp` as it ships on npm). Day-to-day MCP development
-inside this repo always goes through HTTP.
-
-When changing MCP transport, routing, or tool registration:
-
-- Add or update a nearest-layer automated test for `/mcp` behavior.
-- Manually verify with a real MCP client against the running HTTP endpoint, not only via mocked unit tests.
-
-Preferred MCP debugging order:
-
-1. Reproduce with Inspector against `http://127.0.0.1:3099/mcp`
-2. Verify `initialize` and `tools/list`
-3. Enable `MCP_HTTP_DEBUG=1` if capability negotiation or request flow is unclear
-4. Only then compare with Codex / Claude Code specific behavior
-
-If the issue is client-specific:
-
-- Capture the mismatch between Inspector and the real client before changing server behavior.
-- Keep `docs/contributing/mcp-debugging.md` aligned with any new debugging workflow learned during the fix.
+Everything else — how each client registers the stdio proxy, the SessionStart hook that ensures
+the daemon, its per-worktree port and spawn lock, and the failure modes — is
+`docs/contributing/mcp-debugging.md` and `docs/contributing/development.md`, which carry it in
+more detail than a summary here could. Keep those in sync with the real workflow.
 
 ## Zod Schema Discipline
 
@@ -283,41 +200,10 @@ rather than passed as a structured field — do not do that.
 
 ## Doc Screenshots
 
-Images under `docs/assets/` that are produced from the running UI (canvas
-list, storage tab, etc.) are regenerated by Vitest browser-mode tests
-that render real components against deterministic mocked data and write
-PNGs straight to their final paths.
-
-```bash
-pnpm --filter @kamiazya/whiteboard-web docs:snapshots
-```
-
-Each `*.docs-snapshot.test.tsx` under `apps/web/src/docs-snapshots/`
-mounts a canonical apps/web component, waits for the post-fetch render
-to settle, then calls `page.screenshot({ path: … })`. To add a new doc
-image:
-
-1. Drop a new `<name>.docs-snapshot.test.tsx` file under that directory.
-2. Pin the system clock with `vi.setSystemTime(...)` so any "Xd ago"
-   labels stay stable across regenerations.
-3. Save to the canonical asset path with
-   `resolveDocAssetPath('foo.png')` from `_helpers.ts`.
-4. Run `pnpm --filter @kamiazya/whiteboard-web docs:snapshots` and commit
-   the resulting PNG alongside the markdown change that references it.
-
-The project is excluded from the regular `pnpm test` run because it
-writes into the repo. Cross-platform font rendering means snapshots
-generated on Linux CI will not be byte-identical to macOS / Windows
-captures, so for now treat this as a developer-driven workflow:
-regenerate locally, commit.
-
-`pnpm --filter @kamiazya/whiteboard-web docs:snapshots:check` invokes the generator twice before running
-`git diff --exit-code` because Vite's first run after a config change
-can re-optimise dependencies and produce a one-off pixel drift; the
-second run is the stable artifact. If a regeneration leaves
-unexpected diffs in `docs/assets/`, it almost always means a real UI
-change rather than residual jitter — re-run twice and inspect the
-remaining diff.
+Images under `docs/assets/` that come from the running UI are regenerated by vitest browser-mode
+tests that render real components against mocked data and write PNGs to their final paths:
+`pnpm --filter @kamiazya/whiteboard-web docs:snapshots`. Adding one, the clock-pinning that keeps
+"Xd ago" labels stable, and why the check runs twice are the `docs-sync` skill.
 
 ## Completion Checklist
 
@@ -351,33 +237,16 @@ pnpm build
 
 ## PR Visual Evidence
 
-When the change has a user-visible effect (canvas rendering, UI surface, MCP tool result that depends on state), attach the verification screenshot to the PR body. Reviewers should be able to see the bug and the fix without having to clone and reproduce.
+A change with a user-visible effect ships its verification figure in the PR body, so a reviewer
+sees the bug and the fix without cloning. For a FIX that means two panels — the same case before
+and after — not one capture of the result. **Say so when you skip**: `Visual evidence: none —
+<reason>` in the body, with a real reason; a PreToolUse hook blocks `gh pr create` otherwise, so
+the skip is a decision on the record rather than an omission. Other real evidence goes there too
+— a `pnpm test` paste for a browser-mode regression reads as a reason.
 
-Workflow:
-
-1. Capture screenshots while doing the manual verification step from the workflow above. Save them under `tmp/screenshots/` per the tmp-workspace rule. For a FIX that means two: the same case rendered by the code before and after.
-2. Compose the two into one figure:
-   ```
-   node .claude/scripts/compose-figure.mjs \
-     --before tmp/screenshots/before.png --after tmp/screenshots/after.png \
-     --out tmp/screenshots/figure.png \
-     [--before-label "…"] [--after-label "…"] [--ring x1,y1,x2,y2]
-   ```
-   It refuses two panels that are the same picture — which is what every failed attempt at producing a real "before" looks like — and prints both pixel signatures for the body. A new affordance has nothing to compare against; one capture of it is the whole figure, and this step is skipped.
-3. Upload the figure to GitHub via the `gh image` extension (`drogers0/gh-image`):
-   ```
-   gh extension install drogers0/gh-image  # one-time setup
-   gh image tmp/screenshots/figure.png
-   ```
-   This prints an `![figure.png](https://github.com/user-attachments/...)` line.
-4. Paste the markdown into the PR body under a `## Visual repro` (or similarly named) section, with one sentence naming what to look at — and say what the figure CANNOT show, when something about it is staged (a case only reachable behind a flag, a state supplied through a seam rather than by its real producer).
-5. Keep the PNGs in `tmp/screenshots/` until the PR merges; remove them afterward to keep the dir lean (the GitHub upload is the durable copy).
-
-Skip this rule for changes that are invisible to humans — purely backend, schema, internal helper, etc. — but lean toward attaching when in doubt.
-
-**Say so when you skip**, in the body: `Visual evidence: none — <reason>`. A PreToolUse hook blocks `gh pr create` when the diff touches a surface a human looks at and the body carries neither a figure nor that line, so the skip is a decision on the record rather than an omission — and the reason is required, because a bare "none" is the same omission with a sentence in front of it. Everything that is real evidence but not a picture goes there too: a `pnpm test` output paste for a `canvas-viewer-browser`/`web-browser` regression is a perfectly good reason, and reads as one.
-
-The hook exists because this section was prose alone for a long time and the practice decayed into a `## Visual repro` heading over an after-only capture — which satisfies a reader skimming for the section while showing a reviewer nothing.
+How to produce the figure — rendering both versions through the real pipeline, composing them
+with `compose-figure.mjs` (which refuses two identical panels), uploading it, and the traps that
+have each produced a misleading figure — is the `visual-evidence` skill.
 
 ## Source Comment Discipline
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,60 +9,18 @@ Use this repo's standard development loop for every feature, bug fix, or refacto
 
 ## Test Layer Selection
 
-- Use `mcp-node` for pure functions, stores, routes, server behavior, and persistence logic in `packages/mcp-server`.
-- Use `canvas-viewer-node` / `canvas-viewer-jsdom` for `packages/canvas-viewer` parsing, hooks, and components where browser layout and pointer behavior are not the core risk; use `canvas-viewer-browser` when they are.
-- Use the `apps/web` jsdom project (`apps/web/vitest.config.ts`) for React components and hooks when browser layout and pointer behavior are not the core risk.
-- Use `web-browser` for `apps/web` tests that require real browser APIs not available in jsdom: IndexedDB, OPFS, `window.showOpenFilePicker`. File suffix: `.browser.test.tsx`.
-- Promote to E2E when the bug depends on real routes, server composition, websocket timing, persistence order, or multi-step page flows.
+Start with the smallest failing test at the **nearest** layer, and do not jump to broad E2E when a
+smaller failing test can isolate the bug. Reach for a property or model-based test (fast-check)
+over an example-only one when the change touches a parser/serializer, a state machine with
+time/TTL/revocation semantics, a concurrent store, a CRDT or other mergeable structure, or a
+rounding/normalization transform with an algebraic invariant. Prefer example and browser tests for
+UI wiring, one-off integrations, and anything with no clean invariant to state.
 
-Do not jump to broad E2E first if a smaller failing test can isolate the bug.
-
-### Property-Based / Model-Based Testing (PBT)
-
-Prefer a property or model-based test (fast-check; shared wrappers in
-`packages/mcp-server/src/shared/test-utils/fast-check.ts` and
-`apps/web/src/test-utils/fast-check.ts`) over an example-only test when the change touches:
-
-- a parser/serializer (round-trip: `parse(serialize(x))` equals `x` or a well-defined normalization of `x`)
-- a state machine or store with time/TTL/revocation semantics (model-based: generate a random
-  command sequence, check invariants after each step)
-- a concurrent store (convergence: N concurrent operations settle on one agreed-upon result)
-- a CRDT or other mergeable structure (idempotence, commutativity, convergence under any merge order)
-- rounding, normalization, or other value transforms with an algebraic invariant
-
-When a property models a SURFACE that keeps growing — the editor's command set, its gesture
-events, its keyboard catalog, its editing verbs — pin that surface with a coverage ledger rather
-than trusting whoever adds the next feature to remember this file exists. A ledger is a
-`satisfies Record<TheUnion, SurfaceCoverage>` map guarded in four directions, two by the type
-system and two at runtime by the shared helper in
-`apps/web/src/test-utils/coverage-ledger.ts` — never a per-file re-implementation.
-
-**`.claude/rules/coverage-ledger.md` is the convention**: when a surface earns one and (the half
-that matters more) when it does not, the declare -> model -> pin order, the source-scan variant
-for a surface with no union behind it, and the traps. Worked examples are
-`editor-state.property.test.ts` (three union ledgers), `editor-verbs.property.test.ts` (one), and
-`editor-state-surface.test.ts` (the source scan).
-
-Prefer example/browser tests for UI wiring, one-off integrations, and anything without a clean
-invariant to state. When a property finds a real bug, pin the shrunk counterexample as an example
-test before fixing the implementation — the example is the regression guard, the property is the
-generator that found it. Mutation-check every NEW property before trusting it: temporarily revert
-the rule/fix it pins and confirm the property goes red. A generator too sparse to reach the
-interesting arrangements (boxes that rarely overlap, sequences that rarely collide) passes
-vacuously — the mutation check is what catches a property that asserts nothing, and the fix is a
-denser generator, not more runs. Never pin a fast-check seed to make a flaky property pass; treat repeat
-failures under load as a signal to reduce `numRuns`, not to fix the RNG. Put arbitraries shared
-across test files in the owning package's `test-utils`, not duplicated per file.
-
-**A differential oracle is blind to whatever it SHARES with its subject**, and this is the failure
-mode that reads as the strongest kind of property rather than the weakest. `edge-crossing-sweep`'s
-oracle is the full O(E^2) scan its sweep claims exact equality with — but both sides called the same
-scoring helper, so a mutation inside that helper changed the oracle and the subject together and the
-property stayed green: 22 survivors in one function, under a property nobody would have doubted. So
-when you write an A-vs-B property, ask what B IMPORTS, not what it asserts. A reference solved with
-different machinery (exact BigInt rationals against the subject's floating-point cross-multiplication,
-cell-by-cell rasterisation against its interval algebra) is what makes the comparison mean anything;
-calling the production helper from the test is the same code twice.
+Everything that follows from that choice is the **`test-layer-selection` skill**: which project
+serves which layer and the command for each, the per-layer `numRuns` budget, and the property
+disciplines — mutation-check every new property, answer a vacuous one with a denser generator
+rather than more runs, never pin a seed, and never build an oracle out of the code it is judging.
+Coverage ledgers are `.claude/rules/coverage-ledger.md`, which is path-scoped and loads itself.
 
 ## Required Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,7 +241,9 @@ A change with a user-visible effect ships its verification figure in the PR body
 sees the bug and the fix without cloning. For a FIX that means two panels — the same case before
 and after — not one capture of the result. **Say so when you skip**: `Visual evidence: none —
 <reason>` in the body, with a real reason; a PreToolUse hook blocks `gh pr create` otherwise, so
-the skip is a decision on the record rather than an omission. Other real evidence goes there too
+the skip is a decision on the record rather than an omission. The hook reads the body from
+`--body`/`--body-file` and fails open when it cannot — stdin, an editor, `--fill` — so it is a
+net under the rule, not the rule. Other real evidence goes there too
 — a `pnpm test` paste for a browser-mode regression reads as a reason.
 
 How to produce the figure — rendering both versions through the real pipeline, composing them

--- a/packages/mcp-server/src/server/dev-rules-budget.test.ts
+++ b/packages/mcp-server/src/server/dev-rules-budget.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+// Always-on rule prose is charged to EVERY session in this repo before any
+// work starts, and almost none of it is guarded: across the five files below,
+// the only content any test would notice losing is the 163 characters
+// `dev-rules-contract.test.ts` pins about the web-jsdom hazard — 0.15% of the
+// corpus. So the budget is not protected by the suite as a side effect of
+// anything else, and a section added in passing costs every future session
+// silently.
+//
+// This is the instrument, not a limit: the sizes are pinned so a change to
+// them is a decision someone makes in a diff rather than drift nobody
+// measures. Growth is legitimate — a rule that earns always-on status should
+// be always-on — and so is a cut.
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '../../../..')
+
+/**
+ * Buckets of 1000 characters, floored.
+ *
+ * Pinning the exact count is what this repo does for a list of modules, and
+ * it is wrong for prose: a typo fix would fail the test, and a test that
+ * fails on typos gets weakened until it means nothing. A coarse bucket keeps
+ * an improvement exactly as loud as a regression — the property that matters
+ * — while an ordinary clarification passes.
+ */
+const bucket = (chars: number): number => Math.floor(chars / 1000)
+
+function read(relativePath: string): string {
+  return readFileSync(join(REPO_ROOT, relativePath), 'utf8')
+}
+
+/** A rule file is PATH-SCOPED when its frontmatter declares `paths:`. */
+function isPathScoped(source: string): boolean {
+  const frontmatter = /^---\n(.*?)\n---\n/s.exec(source)?.[1] ?? ''
+  return frontmatter.includes('paths:')
+}
+
+function ruleFiles(): string[] {
+  return readdirSync(join(REPO_ROOT, '.claude/rules'))
+    .filter((name) => name.endsWith('.md'))
+    .map((name) => `.claude/rules/${name}`)
+    .sort()
+}
+
+/** Loaded in every session: AGENTS.md plus every rule file without `paths:`. */
+function alwaysOnFiles(): string[] {
+  return ['AGENTS.md', ...ruleFiles().filter((path) => !isPathScoped(read(path)))]
+}
+
+const ALWAYS_ON_BUDGET: Record<string, number> = {
+  'AGENTS.md': 27,
+  '.claude/rules/architecture-map.md': 17,
+  '.claude/rules/dev-flow.md': 32,
+  '.claude/rules/integrator-flow.md': 13,
+  '.claude/rules/vocabulary.md': 15,
+}
+
+/** Floored bucket of the SUM, which is not the sum of the buckets. */
+const ALWAYS_ON_TOTAL_BUDGET = 105
+
+/**
+ * The largest path-scoped file, tracked separately because it is not paid by
+ * every session — only by one that touches its package. It is listed alone
+ * because at more than thirteen times the median package rule it is a budget
+ * of its own; the rest are small enough that a total would hide them.
+ */
+const CANVAS_RENDER_BUDGET = 77
+
+describe('always-on rule context budget', () => {
+  it('charges every session exactly the files this budget names', () => {
+    // A new always-on rule file, or one that gains or loses `paths:`, moves
+    // between the two budgets — and has to say so in the diff rather than
+    // arriving as context nobody counted.
+    expect(alwaysOnFiles().sort()).toEqual(Object.keys(ALWAYS_ON_BUDGET).sort())
+  })
+
+  it('holds each always-on file at its pinned size', () => {
+    const drift = alwaysOnFiles()
+      .map((path) => ({ path, chars: read(path).length }))
+      .filter(({ path, chars }) => bucket(chars) !== ALWAYS_ON_BUDGET[path])
+      .map(({ path, chars }) => `${path}: ${chars} chars = bucket ${bucket(chars)}`)
+    expect(drift).toEqual([])
+  })
+
+  it('holds the always-on total at its pinned size', () => {
+    const chars = alwaysOnFiles().reduce((sum, path) => sum + read(path).length, 0)
+    expect(bucket(chars), `always-on corpus is ${chars} chars`).toBe(ALWAYS_ON_TOTAL_BUDGET)
+  })
+
+  it('holds package-canvas-render.md at its pinned size', () => {
+    const chars = read('.claude/rules/package-canvas-render.md').length
+    expect(bucket(chars), `package-canvas-render.md is ${chars} chars`).toBe(CANVAS_RENDER_BUDGET)
+  })
+})

--- a/packages/mcp-server/src/server/dev-rules-budget.test.ts
+++ b/packages/mcp-server/src/server/dev-rules-budget.test.ts
@@ -51,7 +51,7 @@ function alwaysOnFiles(): string[] {
 }
 
 const ALWAYS_ON_BUDGET: Record<string, number> = {
-  'AGENTS.md': 23,
+  'AGENTS.md': 16,
   '.claude/rules/architecture-map.md': 17,
   '.claude/rules/dev-flow.md': 28,
   '.claude/rules/integrator-flow.md': 13,
@@ -59,7 +59,7 @@ const ALWAYS_ON_BUDGET: Record<string, number> = {
 }
 
 /** Floored bucket of the SUM, which is not the sum of the buckets. */
-const ALWAYS_ON_TOTAL_BUDGET = 98
+const ALWAYS_ON_TOTAL_BUDGET = 90
 
 /**
  * The largest path-scoped file, tracked separately because it is not paid by

--- a/packages/mcp-server/src/server/dev-rules-budget.test.ts
+++ b/packages/mcp-server/src/server/dev-rules-budget.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
@@ -51,7 +51,7 @@ function alwaysOnFiles(): string[] {
 }
 
 const ALWAYS_ON_BUDGET: Record<string, number> = {
-  'AGENTS.md': 27,
+  'AGENTS.md': 23,
   '.claude/rules/architecture-map.md': 17,
   '.claude/rules/dev-flow.md': 32,
   '.claude/rules/integrator-flow.md': 13,
@@ -59,7 +59,7 @@ const ALWAYS_ON_BUDGET: Record<string, number> = {
 }
 
 /** Floored bucket of the SUM, which is not the sum of the buckets. */
-const ALWAYS_ON_TOTAL_BUDGET = 105
+const ALWAYS_ON_TOTAL_BUDGET = 102
 
 /**
  * The largest path-scoped file, tracked separately because it is not paid by

--- a/packages/mcp-server/src/server/dev-rules-budget.test.ts
+++ b/packages/mcp-server/src/server/dev-rules-budget.test.ts
@@ -53,13 +53,13 @@ function alwaysOnFiles(): string[] {
 const ALWAYS_ON_BUDGET: Record<string, number> = {
   'AGENTS.md': 23,
   '.claude/rules/architecture-map.md': 17,
-  '.claude/rules/dev-flow.md': 32,
+  '.claude/rules/dev-flow.md': 28,
   '.claude/rules/integrator-flow.md': 13,
   '.claude/rules/vocabulary.md': 15,
 }
 
 /** Floored bucket of the SUM, which is not the sum of the buckets. */
-const ALWAYS_ON_TOTAL_BUDGET = 102
+const ALWAYS_ON_TOTAL_BUDGET = 98
 
 /**
  * The largest path-scoped file, tracked separately because it is not paid by


### PR DESCRIPTION
## Summary

- Every session in this repo pays for the always-on rules before any work starts. Nothing counted them: **105,930 characters, about 26,500 tokens**, across `AGENTS.md` and the four `.claude/rules/` files with no `paths:` frontmatter.
- Adds the instrument that counts them, **in its own commit, before any cut** — the effect of this work is invisible in a diff and its failure mode is silent.
- Then cuts three sections whose detail already lives in a skill or a contributor doc, verified claim by claim first. **Always-on corpus 106,203 → 90,570 characters, roughly 3,900 tokens off every session.**

### Why an instrument first

The cheap reachability probe `measured-change` asks for, run before deciding anything: **how much of the always-on corpus would any test notice losing?** Measured — **0.15%**. The only guarded content is the 163 characters `dev-rules-contract.test.ts` pins about the web-jsdom hazard. The other 99.85% can be deleted and the suite stays green, so "the tests will catch a bad cut" is not available here and the safety has to be built.

`dev-rules-budget.test.ts` derives the always-on set from `paths:` frontmatter rather than a hardcoded list, so a rule file that gains or loses path scoping moves between budgets and has to say so in the diff. `package-canvas-render.md` gets its own line: at 77,606 characters it is thirteen times the median package rule, and a total would hide it.

Sizes are pinned in **1000-character buckets**, not exactly. An exact pin is right for a list of modules and wrong for prose — a typo fix would fail the test, and a test that fails on typos gets weakened until it means nothing. A bucket keeps the property that matters (a cut is exactly as loud as growth) while an ordinary clarification passes.

### What was cut, and how it was checked

Every cut was preceded by comparing the always-on text against its destination **claim by claim**, and anything the destination lacked was moved there rather than dropped.

| section | before | after | destination |
|---|---:|---:|---|
| `AGENTS.md` Test Layer Selection | 4,465 | 1,062 | `test-layer-selection` skill |
| `AGENTS.md` MCP Development Mode | 5,407 | 1,188 | `mcp-debugging.md`, `development.md` |
| `AGENTS.md` PR Visual Evidence | 2,797 | 840 | `visual-evidence` skill |
| `AGENTS.md` Doc Screenshots | 1,739 | 386 | `docs-sync` skill |
| `dev-flow.md` Disciplines | 9,042 | 4,340 | the three skills it already pointed at |

Moved rather than lost: the vacuous-generator rule and the independent-oracle rule (into `test-layer-selection`); "a guard that never reaches its subject" with all three worked instances (same skill — it is the third sibling of those two, and they are worth reading together); and why `docs:snapshots` is excluded from `pnpm test` and generates twice (into `docs-sync`).

Two paragraphs were dropped rather than moved, both announcements of `coverage-ledger.md` — which is path-scoped to the files where the decision arises and loads itself, so the always-on copy was a second announcement of a rule that already arrives on its own.

### Two corrections found on the way

- **`measured-change` was stale.** It listed an aligned re-score post-pass among the changes the instrument REJECTED, using the first shape's verdict as if it were final — while the third shape is in `spatial-edges.ts` today, running the search a second time with `align: true`. Verified three ways: the code, `package-canvas-render.md`'s record of the two discarded shapes at 13x and 4.5x, and `dev-flow.md`'s record of the 2x that shipped. The skill now says an instrument prices rather than vetoes, which is both more useful and true.
- **The instrument's first finding was its own commit.** It was written and verified green on one base, then rebased onto a newer `origin/main` where #1149 had added 273 characters to `vocabulary.md` — so its total pin said 105 where the tree said 106. The pre-push gate would have caught it; it was skipped with `LEFTHOOK=0` while working around an unrelated push failure. Corrected here.

## Test plan

- [x] New or updated tests added (`mcp-node`)
- [x] `pnpm test` passes locally
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable

The budget instrument was mutation-checked five ways before any cut relied on it:

| mutation | result |
|---|---|
| +1000 chars on an always-on file | per-file and total fail |
| a new always-on rule file | file set fails |
| removing `paths:` from a scoped file | file set fails |
| **−1000 chars** on `package-canvas-render.md` | only its own line fails |
| a 20-character edit | nothing moves |

The fourth is the one that matters: a cut is as loud as growth. The fifth is what makes the bucket unit honest rather than a dodge.

Verified on **Node 24** (`.node-version`; this container defaults to 22, which `local-node-version.test.ts` catches and names): **365 files, 4,202 passed, 9 skipped, 0 failed**, matching what `dev-flow.md` records CI reporting. `pnpm lint`, `pnpm knip`, `pnpm secretlint` and `pnpm typecheck` are clean.

### A method failure worth recording

Checking "does the skill already say this?" with `grep <phrase>` produced **four false ABSENTs** in this work — `diagnosis-evidence`'s own "read the stack line" section, `docs-sync`'s "pin the clock", and `visual-evidence`'s compose-figure invocation and its `gh image` line. Each claim was there in different words. The direction is what makes it dangerous: a false absence licenses writing the content again, or deleting the copy that had it. Recorded in `diagnosis-evidence` — a negative from a text search is a hypothesis, only a positive is safe.

## Visual evidence

Visual evidence: none — the diff is rule prose, skill prose and one guard test. It moves no pixels and changes no rendered surface.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — no behaviour changes; `docs/contributing/` is unchanged and is now the single home for the MCP dev-mode detail
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined development guidance and moved detailed workflows into focused skill documents.
  * Added clearer guidance for validating diagnoses, selecting test layers, and avoiding vacuous test results.
  * Documented measured optimization trade-offs and improved evidence-based review practices.
  * Clarified documentation snapshot checks, cross-platform differences, and local regeneration steps.
  * Added coverage-ledger guidance and expanded examples of common testing pitfalls.

* **Tests**
  * Added safeguards to track the size of always-on development guidance and prevent unexpected growth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->