### PR TITLE
refactor(web): give the editor's navigation gestures one state, not twelve refs

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -150,6 +150,7 @@ import { MemberOutlinesOverlay } from './MemberOutlinesOverlay.js'
 import { MinimapOverlay } from './MinimapOverlay.js'
 import {
   createIdleNavigation,
+  DOUBLE_PRESS_WINDOW_MS,
   type NavigationEvent,
   type NavigationResult,
   type NavigationState,
@@ -432,11 +433,6 @@ function navigationPointerKind(pointerType: string): PointerKind {
 
 const LONG_PRESS_SLOP_PX = 10
 const DEFAULT_TEST_ID = 'spatial-editor'
-/**
- * Window for OUR double-press detection (see handlePointerDown). Matches the
- * common OS double-click interval; not user-configurable today.
- */
-const DOUBLE_PRESS_WINDOW_MS = 400
 
 /** Breathing room kept around framed content (zoom to fit / selection). */
 const FRAME_MARGIN_PX = 24

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -149,6 +149,14 @@ import { MarkdownNodeEditor } from './MarkdownNodeEditor.js'
 import { MemberOutlinesOverlay } from './MemberOutlinesOverlay.js'
 import { MinimapOverlay } from './MinimapOverlay.js'
 import {
+  createIdleNavigation,
+  type NavigationEvent,
+  type NavigationResult,
+  type NavigationState,
+  type PointerKind,
+  reduceNavigation,
+} from './navigation.js'
+import {
   DOCUMENT_NODE_HEIGHT,
   DOCUMENT_NODE_WIDTH,
   fileNodeDefaults,
@@ -184,7 +192,6 @@ import {
   type EditorTool,
   ToolPalette,
 } from './ToolPalette.js'
-import { computePinchUpdate } from './touch-pinch.js'
 import { useGestureCaptured } from './use-gesture-captured.js'
 import { useWorkerScene } from './use-worker-scene.js'
 import {
@@ -226,16 +233,8 @@ const SNAP_THRESHOLD_SCREEN_PX = 6
 const SNAP_GRID_CANVAS_PX = 20
 
 /** Overview size. Big enough to aim at, small enough not to cover content. */
-/**
- * One step of hand mode's double-press zoom. Bigger than a wheel notch:
- * a tap that barely changed the view reads as a missed tap, and the way
- * back out is one press on zoom-to-fit rather than N reverse taps.
- */
-const DOUBLE_PRESS_ZOOM_FACTOR = 2
 /** One keyboard step of zoom — finer than the double press, which jumps. */
 const STEP_ZOOM_FACTOR = 1.25
-/** Press-pairing key for hand mode, where no node identity is involved. */
-const HAND_PRESS_KEY = 'hand'
 const MINIMAP_WIDTH_PX = 160
 const MINIMAP_HEIGHT_PX = 110
 
@@ -422,6 +421,15 @@ const EDGE_HIT_TOLERANCE_PX = 6
  * drag — past it the press is a drag and the menu must not interrupt.
  */
 const LONG_PRESS_MENU_MS = 500
+/**
+ * The navigation machine distinguishes touch from everything else; pen
+ * behaves as a mouse there, so this only has to be total, not faithful to
+ * every platform's spelling.
+ */
+function navigationPointerKind(pointerType: string): PointerKind {
+  return pointerType === 'touch' ? 'touch' : pointerType === 'pen' ? 'pen' : 'mouse'
+}
+
 const LONG_PRESS_SLOP_PX = 10
 const DEFAULT_TEST_ID = 'spatial-editor'
 /**
@@ -429,22 +437,6 @@ const DEFAULT_TEST_ID = 'spatial-editor'
  * common OS double-click interval; not user-configurable today.
  */
 const DOUBLE_PRESS_WINDOW_MS = 400
-
-/**
- * How far apart two presses may land and still be one double press.
- *
- * Only hand mode needs it. Every other double press is bound to a logical
- * target — a node id, an edge id — so two presses far apart are already two
- * different presses. Hand mode has no target to key on and used a constant
- * key, which made EVERY press within the window a double press regardless of
- * where it landed: a tap, then a drag from 224px away, and the drag zoomed
- * instead of panning while the finger was still down.
- *
- * Sized like the OS convention it imitates rather than like finger jitter,
- * which is what LONG_PRESS_SLOP_PX measures — a deliberate double tap is not
- * a still finger, and a value near 10px would reject most real ones.
- */
-const DOUBLE_PRESS_SLOP_PX = 40
 
 /** Breathing room kept around framed content (zoom to fit / selection). */
 const FRAME_MARGIN_PX = 24
@@ -577,51 +569,18 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * used to blur the just-mounted textarea when we opened at the press.
      */
     const doublePressRef = useRef<{ key: string; point: Point } | null>(null)
-    /**
-     * Every pointer currently down on the root, by id. Read by
-     * `handleLostPointerCapture` to tell a capture handed back with its own
-     * release from one lost out from under a pointer that is still down.
-     * A set, not a single slot: a pinch holds two at once and they end
-     * independently.
-     */
-    const downPointersRef = useRef<Set<number>>(new Set())
     /** In-flight marquee selection rect, in canvas space (Excalidraw
      * semantics: plain drag on empty space selects; pan is Space+drag,
      * middle-button drag, or wheel). */
     const [marquee, setMarquee] = useState<{ start: Point; current: Point } | null>(null)
     const spaceDownRef = useRef(false)
-    const isPanningRef = useRef(false)
-    // Two-finger touch navigation (`touch-action: none` disables the
-    // browser's own scrolling/zooming, so the editor must supply it):
-    // root-local positions per active touch pointer, and whether a pinch
-    // owns the touch sequence. The flag stays up until EVERY finger lifts,
-    // so the lone finger left behind after a pinch cannot fall through to
-    // the marquee/move path mid-air.
-    const touchPointsRef = useRef<Map<number, Point>>(new Map())
-    const pinchActiveRef = useRef(false)
     /**
-     * Touch multi-selection, the iOS "hold one, tap the rest" gesture.
-     *
-     * `gatherAnchorRef` is the finger holding the selection open; while it is
-     * down, a second finger's tap on a node collects that node instead of
-     * starting a pinch. Long press is NOT the trigger: the browser already
-     * synthesises `contextmenu` from it, and taking it would leave touch with
-     * no route to an object's menu.
-     *
-     * A second finger otherwise means pinch, so the two are separated by
-     * STATE rather than by timing — gathering needs a finger already holding
-     * a node, which a pinch never has. Fingers listed in `gatherPointersRef`
-     * have already done their job on the press and stay inert until they lift.
-     */
-    const gatherAnchorRef = useRef<number | null>(null)
-    const gatherPointersRef = useRef<Set<number>>(new Set())
-    /**
-     * Last primary press for double-press detection: logical target, time, and
-     * where it landed. The point is what stops hand mode — whose key is a
-     * constant — from reading any two presses in the window as one gesture.
+     * Last press for the SELECT tool's double press, keyed by what was under
+     * it — a node id, an edge id, or `'empty'`. Hand mode's own double press
+     * is not here: it has no target to key on, so the navigation machine
+     * holds it with the distance bound that keying cannot supply.
      */
     const lastPressRef = useRef<{ key: string; at: number; point: Point } | null>(null)
-    const lastPanPointRef = useRef({ x: 0, y: 0 })
     /**
      * The pointerId this component currently holds capture for, or `null`.
      * Tracked so unmount can best-effort release capture (see the teardown
@@ -630,6 +589,13 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * best-effort/never-throw reasoning.
      */
     const activePointerIdRef = useRef<number | null>(null)
+    /**
+     * Everything navigation owns, as one value: which fingers are down, what
+     * is driving the viewport, what the last hand press was. See
+     * `navigation.ts` — the refs this replaced could not say when a gesture
+     * was over, and twice shipped a field that outlived one.
+     */
+    const navigationRef = useRef<NavigationState>(createIdleNavigation())
 
     const canvasRef = useRef(canvas)
     const prevCanvasRef = useRef(canvas)
@@ -1500,6 +1466,95 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     }
 
     /**
+     * Arms the long-press menu for a single touch. Firing abandons whatever
+     * the press started (a node move's 'pressing' state, marquee arming):
+     * the press has become a menu invocation, not a drag.
+     *
+     * The navigation machine decides WHETHER to arm — hand mode never does,
+     * because the press below it starts a pan and this teardown would strand
+     * it mid-drag — and the timer itself stays here, where the menu, the
+     * haptic and the pulse live.
+     */
+    const armLongPress = (pointerId: number, screen: Point) => {
+      clearLongPress()
+      longPressRef.current = {
+        pointerId,
+        screen,
+        timer: setTimeout(() => {
+          longPressRef.current = null
+          if (gestureStateRef.current.kind !== 'idle') {
+            applyResult(
+              reduceGesture(gestureStateRef.current, canvasRef.current, {
+                type: 'pointercancel',
+              }),
+            )
+          }
+          setMarquee(null)
+          navigationRef.current = createIdleNavigation()
+          lastPressRef.current = null
+          doublePressRef.current = null
+          // The native long-press this replaces gave a system haptic; keep
+          // that cue so the menu opening under a still-down finger reads as
+          // deliberate, not glitchy.
+          hapticTick()
+          setLongPressPulse(screen)
+          openContextMenuAtRef.current(screen)
+        }, LONG_PRESS_MENU_MS),
+      }
+    }
+
+    /**
+     * Hands one pointer event to the navigation machine and performs what it
+     * asks for. Every effect maps to something this component already did at
+     * the site the machine replaced; nothing new is invented here.
+     */
+    const runNavigation = (root: HTMLElement, event: NavigationEvent): NavigationResult => {
+      const result = reduceNavigation(navigationRef.current, event)
+      navigationRef.current = result.state
+      for (const effect of result.effects) {
+        switch (effect.kind) {
+          case 'pan':
+            setViewport((vp) => panBy(vp, effect.deltaScreen))
+            break
+          case 'zoom-at':
+            setViewport((vp) => zoomAt(vp, effect.anchorScreen, effect.factor))
+            break
+          case 'pinch':
+            setViewport((vp) =>
+              zoomAt(panBy(vp, effect.panDeltaScreen), effect.anchorScreen, effect.factor),
+            )
+            break
+          case 'capture':
+            for (const pointerId of effect.pointerIds) capturePointer(root, pointerId)
+            break
+          case 'release-capture':
+            activePointerIdRef.current = null
+            break
+          case 'arm-long-press':
+            armLongPress(effect.pointerId, effect.screen)
+            break
+          case 'clear-long-press':
+            clearLongPress()
+            break
+          case 'clear-marquee':
+            setMarquee(null)
+            break
+          case 'clear-press-memory':
+            lastPressRef.current = null
+            doublePressRef.current = null
+            break
+          case 'cancel-manipulation':
+            applyResult(reduceGesture(gestureState, canvas, { type: 'pointercancel' }))
+            break
+          case 'gather':
+            toggleSelectionMember(effect.anchorPrimaryId, effect.hitId)
+            break
+        }
+      }
+      return result
+    }
+
+    /**
      * Shared prologue for the overlay's pointer handlers: take pointer capture
      * on the root and hand it back, or `null` when the root is not mounted.
      * (The overlay itself already stops propagation to the root's hit-test.)
@@ -1512,7 +1567,10 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         // would be read as an ordinary handback and never recovered. Their
         // release does reach handlePointerUp, because capture redirects the
         // rest of the sequence to the root.
-        downPointersRef.current.add(e.pointerId)
+        navigationRef.current = reduceNavigation(navigationRef.current, {
+          type: 'external-press',
+          pointerId: e.pointerId,
+        }).state
         capturePointer(root, e.pointerId)
       }
       return root
@@ -1561,165 +1619,40 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       if (isOverlayEvent(e)) return
       const root = rootRef.current
       if (root === null) return
-      // Before every early return below: what is down has to be recorded even
-      // for presses this handler goes on to ignore, or their handback is read
-      // as a capture loss.
-      downPointersRef.current.add(e.pointerId)
-      if (e.pointerType === 'touch') {
-        // A touch pointer is `isPrimary` only while no other touch is active
-        // (Pointer Events 3, sec. 4.2), so anything still tracked here belongs
-        // to a gesture whose release this handler never received — a finger
-        // lifted over an element outside the root, a browser that claimed the
-        // gesture, a pointercancel delivered somewhere else. Left in place it
-        // is not inert: the next one-finger press makes the map size 2, so a
-        // plain drag is read as the second finger of a pinch and the canvas
-        // follows at half speed while zooming, which reads as "the hand tool
-        // stopped responding" and never recovers on its own.
-        if (e.isPrimary) {
-          touchPointsRef.current.clear()
-          gatherPointersRef.current.clear()
-          gatherAnchorRef.current = null
-          pinchActiveRef.current = false
-        }
-        touchPointsRef.current.set(e.pointerId, clientPointToRootLocal(e, root))
-        if (pinchActiveRef.current) return
-        if (gatherPointersRef.current.size > 0 || gatherAnchorRef.current !== null) {
-          // Already gathering: any further finger is another tap, never a
-          // pinch participant, so it must not sit in touchPointsRef.
-          touchPointsRef.current.delete(e.pointerId)
-        }
-        if (touchPointsRef.current.size === 2 || gatherAnchorRef.current !== null) {
-          const anchorId =
-            gatherAnchorRef.current ??
-            [...touchPointsRef.current.keys()].find((id) => id !== e.pointerId) ??
-            null
-          const anchorPrimary =
-            gatherAnchorRef.current !== null
+      const screenPoint = clientPointToRootLocal(e, root)
+      const point = screenToCanvas(screenPoint, viewport)
+      const hitId = hitTest(selectableBoxes, point)
+      // Navigation answers first, and answers for its own state. Everything
+      // it owns — which finger is down, whether two of them are driving the
+      // viewport, whether this press continues a gather — lives in one value
+      // in `navigation.ts` rather than in the refs this used to read.
+      const navigation = runNavigation(root, {
+        type: 'pointerdown',
+        pointerId: e.pointerId,
+        pointerType: navigationPointerKind(e.pointerType),
+        isPrimary: e.isPrimary,
+        button: e.button,
+        point: screenPoint,
+        timeStamp: e.timeStamp,
+        context: {
+          handMode: tool === 'hand',
+          spaceDown: spaceDownRef.current,
+          hitId,
+          // The anchor a gather would extend. Mid-gather it is the standing
+          // selection; otherwise only a node this press could join to, which
+          // is why entering hand mode — which clears the selection — can
+          // never gather.
+          anchorPrimaryId:
+            navigationRef.current.mode.kind === 'gathering'
               ? selectedId
               : gestureState.kind === 'moving'
                 ? gestureState.nodeId
-                : null
-          const gathered =
-            anchorPrimary === null
-              ? undefined
-              : hitTest(selectableBoxes, screenToCanvas(clientPointToRootLocal(e, root), viewport))
-          if (gathered !== undefined && anchorId !== null) {
-            touchPointsRef.current.delete(e.pointerId)
-            gatherPointersRef.current.add(e.pointerId)
-            if (gatherAnchorRef.current === null) {
-              gatherAnchorRef.current = anchorId
-              // Gathering is a selection act, not a drag. Whatever the anchor
-              // had begun to move is abandoned here — carrying a half-applied
-              // delta into the new multi-selection would jump every node
-              // gathered afterwards by an offset the user never gave it.
-              if (gestureState.kind !== 'idle') {
-                applyResult(reduceGesture(gestureState, canvas, { type: 'pointercancel' }))
-              }
-            }
-            setMarquee(null)
-            isPanningRef.current = false
-            lastPressRef.current = null
-            doublePressRef.current = null
-            clearLongPress()
-            toggleSelectionMember(anchorPrimary, gathered)
-            return
-          }
-        }
-        if (touchPointsRef.current.size === 2) {
-          // The second finger converts whatever the first finger started
-          // (marquee, node move, double-press arming) into navigation:
-          // cancel it all, then pan/zoom until every finger lifts.
-          pinchActiveRef.current = true
-          setMarquee(null)
-          isPanningRef.current = false
-          lastPressRef.current = null
-          doublePressRef.current = null
-          if (gestureState.kind !== 'idle') {
-            applyResult(reduceGesture(gestureState, canvas, { type: 'pointercancel' }))
-          }
-          // Capture BOTH fingers, not just the one that arrived second: an
-          // uncaptured first finger crossing outside the root would stop
-          // delivering its move/up events here, leaving a stale entry in
-          // touchPointsRef that would misread a later one-finger press as
-          // a pinch participant.
-          for (const pointerId of touchPointsRef.current.keys()) {
-            trySetPointerCapture(root, pointerId)
-          }
-          activePointerIdRef.current = e.pointerId
-          clearLongPress()
-          return
-        }
-        // Hand mode is navigation-ONLY, so there is no menu for the timer
-        // to open — and arming it anyway is actively harmful: the press
-        // below starts a pan, and 500ms later the timer's teardown would
-        // clear isPanningRef mid-drag, stranding the pan under a finger
-        // that is still moving.
-        if (touchPointsRef.current.size === 1 && tool !== 'hand') {
-          // Arm the long-press menu. Firing abandons whatever the press
-          // started (a node move's 'pressing' state, marquee arming): the
-          // press has become a menu invocation, not a drag.
-          clearLongPress()
-          const screen = clientPointToRootLocal(e, root)
-          longPressRef.current = {
-            pointerId: e.pointerId,
-            screen,
-            timer: setTimeout(() => {
-              longPressRef.current = null
-              if (gestureStateRef.current.kind !== 'idle') {
-                applyResult(
-                  reduceGesture(gestureStateRef.current, canvasRef.current, {
-                    type: 'pointercancel',
-                  }),
-                )
-              }
-              setMarquee(null)
-              isPanningRef.current = false
-              lastPressRef.current = null
-              doublePressRef.current = null
-              // The native long-press this replaces gave a system haptic;
-              // keep that cue so the menu opening under a still-down finger
-              // reads as deliberate, not glitchy.
-              hapticTick()
-              setLongPressPulse(screen)
-              openContextMenuAtRef.current(screen)
-            }, LONG_PRESS_MENU_MS),
-          }
-        }
-      }
-      const screenPointForPan = clientPointToRootLocal(e, root)
-      // Middle-button (or Space-held) drag pans from ANYWHERE — Excalidraw
-      // semantics; a plain left drag on empty space marquee-selects instead.
-      // The hand tool makes EVERY plain press a pan (nodes included): it is
-      // the one-handed touch navigation mode, where a second finger is not
-      // available to promote the gesture.
-      if (e.button === 1 || (e.button === 0 && (spaceDownRef.current || tool === 'hand'))) {
-        e.preventDefault()
-        // Hand mode's own double press: get closer, anchored on what was
-        // pressed. It cannot collide with the double press that creates a
-        // note, because that one is detected further down — past this
-        // early return, which hand mode never gets past.
-        if (tool === 'hand' && e.button === 0 && !spaceDownRef.current) {
-          const previous = lastPressRef.current
-          const isDoublePress =
-            previous !== null &&
-            previous.key === HAND_PRESS_KEY &&
-            e.timeStamp - previous.at <= DOUBLE_PRESS_WINDOW_MS &&
-            Math.hypot(
-              screenPointForPan.x - previous.point.x,
-              screenPointForPan.y - previous.point.y,
-            ) <= DOUBLE_PRESS_SLOP_PX
-          lastPressRef.current = isDoublePress
-            ? null
-            : { key: HAND_PRESS_KEY, at: e.timeStamp, point: screenPointForPan }
-          if (isDoublePress) {
-            setViewport((vp) => zoomAt(vp, screenPointForPan, DOUBLE_PRESS_ZOOM_FACTOR))
-            return
-          }
-        }
-        isPanningRef.current = true
-        lastPanPointRef.current = screenPointForPan
-        return
-      }
+                : null,
+          manipulating: gestureState.kind !== 'idle',
+        },
+      })
+      if (navigation.preventDefault === true) e.preventDefault()
+      if (!navigation.fallThrough) return
       if (e.button !== 0) return
       // Deliberately NO pointer capture here. Capturing on the press
       // retargets the subsequent clicks to the capturing root, so a control
@@ -1728,9 +1661,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // press that turns into a drag still gets capture before it can
       // escape the element. Overlay handle/connect gestures are the
       // exception (beginOverlayGesture) — they want capture immediately.
-      const screenPoint = clientPointToRootLocal(e, root)
-      const point = screenToCanvas(screenPoint, viewport)
-      const hitId = hitTest(selectableBoxes, point)
 
       // Double-press detection is OURS, not the browser's `dblclick`: the
       // first press selects the node, which re-renders the DOM under the
@@ -1874,56 +1804,27 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           clearLongPress()
         }
       }
-      // A gathering finger has already acted on its press, and the anchor's
-      // own gesture was cancelled when gathering began — neither may resume
-      // dragging the canvas while the other is still down.
-      if (gatherPointersRef.current.has(e.pointerId) || gatherAnchorRef.current === e.pointerId) {
-        return
-      }
-      if (e.pointerType === 'touch' && touchPointsRef.current.has(e.pointerId)) {
-        const points = touchPointsRef.current
-        const nextPoint = clientPointToRootLocal(e, root)
-        if (pinchActiveRef.current && points.size >= 2) {
-          // The pinch pair is the two longest-lived fingers (Map preserves
-          // insertion order); later fingers are tracked but inert.
-          const [idA, idB] = points.keys()
-          if (e.pointerId === idA || e.pointerId === idB) {
-            const prev = { a: points.get(idA)!, b: points.get(idB)! }
-            const next = {
-              a: e.pointerId === idA ? nextPoint : prev.a,
-              b: e.pointerId === idB ? nextPoint : prev.b,
-            }
-            const { panDelta, zoomFactor, anchor } = computePinchUpdate(prev, next)
-            setViewport((vp) => zoomAt(panBy(vp, panDelta), anchor, zoomFactor))
-          }
-          points.set(e.pointerId, nextPoint)
-          return
-        }
-        points.set(e.pointerId, nextPoint)
-        // A lone finger left behind by a pinch stays inert until it lifts.
-        if (pinchActiveRef.current) return
-      }
+      const screenPoint = clientPointToRootLocal(e, root)
       // First movement of an in-flight gesture: take capture now (see the
       // handlePointerDown comment for why not at the press). Idempotent —
-      // re-capturing the same pointer is a no-op.
+      // re-capturing the same pointer is a no-op. Taken BEFORE the machine
+      // reduces this move, so it reads the pan that the PRESS started rather
+      // than the one this move is about to advance.
       if (
         activePointerIdRef.current === null &&
-        (isPanningRef.current || gestureState.kind !== 'idle')
+        (navigationRef.current.mode.kind === 'panning' || gestureState.kind !== 'idle')
       ) {
         capturePointer(root, e.pointerId)
       }
-      const screenPoint = clientPointToRootLocal(e, root)
+      const navigation = runNavigation(root, {
+        type: 'pointermove',
+        pointerId: e.pointerId,
+        pointerType: navigationPointerKind(e.pointerType),
+        point: screenPoint,
+      })
+      if (!navigation.fallThrough) return
       if (marquee !== null) {
         setMarquee({ start: marquee.start, current: screenToCanvas(screenPoint, viewport) })
-        return
-      }
-      if (isPanningRef.current) {
-        const screenDelta = {
-          x: screenPoint.x - lastPanPointRef.current.x,
-          y: screenPoint.y - lastPanPointRef.current.y,
-        }
-        lastPanPointRef.current = screenPoint
-        setViewport((vp) => panBy(vp, screenDelta))
         return
       }
       if (gestureState.kind === 'idle') return
@@ -1939,30 +1840,19 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     }
 
     const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
-      if (longPressRef.current?.pointerId === e.pointerId) clearLongPress()
-      // Ahead of the gather/pinch early returns: this pointer is up whatever
-      // the rest of the handler decides to do about it.
-      downPointersRef.current.delete(e.pointerId)
       const root = rootRef.current
-      // Gathering fingers act on the press, so their release carries no
-      // meaning — running the click/marquee logic here would re-collapse the
-      // very selection the gesture just built. The anchor lifting ends it.
-      if (gatherPointersRef.current.delete(e.pointerId)) return
-      if (gatherAnchorRef.current === e.pointerId) {
-        gatherAnchorRef.current = null
-        touchPointsRef.current.delete(e.pointerId)
-        return
-      }
-      if (e.pointerType === 'touch') {
-        touchPointsRef.current.delete(e.pointerId)
-        if (pinchActiveRef.current) {
-          if (touchPointsRef.current.size === 0) pinchActiveRef.current = false
-          // Fingers lifting out of a pinch never run the click/marquee
-          // release logic — the sequence was navigation, not a gesture.
-          return
-        }
-      }
-      activePointerIdRef.current = null
+      if (root === null) return
+      const navigation = runNavigation(root, {
+        type: 'pointerup',
+        pointerId: e.pointerId,
+        pointerType: navigationPointerKind(e.pointerType),
+      })
+      // A release the machine answered was navigation — a finger leaving a
+      // gather or a pinch, or the end of a pan. None of them run the click
+      // and marquee semantics below: the sequence was never a gesture on the
+      // canvas, and treating its release as one would re-collapse the very
+      // selection the gather just built.
+      if (!navigation.fallThrough) return
       const armed = doublePressRef.current
       doublePressRef.current = null
       if (marquee !== null) {
@@ -2023,10 +1913,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         // A drag that began on an edge line was a marquee, not an edge click
         // — drop the press-time edge selection so Delete acts on the nodes.
         setSelectedEdgeId(null)
-        return
-      }
-      if (isPanningRef.current) {
-        isPanningRef.current = false
         return
       }
       if (root === null) return
@@ -2123,19 +2009,16 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     }
 
     const handlePointerCancel = (e: React.PointerEvent<HTMLDivElement>) => {
-      if (longPressRef.current?.pointerId === e.pointerId) clearLongPress()
-      downPointersRef.current.delete(e.pointerId)
-      // Pointer ids are reused, so a gathering finger left in these refs by a
-      // cancel would silently deaden whichever later touch inherits its id.
-      gatherPointersRef.current.delete(e.pointerId)
-      if (gatherAnchorRef.current === e.pointerId) gatherAnchorRef.current = null
-      if (e.pointerType === 'touch') {
-        touchPointsRef.current.delete(e.pointerId)
-        if (touchPointsRef.current.size === 0) pinchActiveRef.current = false
-      }
-      isPanningRef.current = false
-      activePointerIdRef.current = null
-      applyResult(reduceGesture(gestureState, canvas, { type: 'pointercancel' }))
+      const root = rootRef.current
+      if (root === null) return
+      // The machine's own cancel arm emits the long-press clear, the capture
+      // release and the gesture cancel, in that order — the three things
+      // this handler used to do by hand across four refs.
+      runNavigation(root, {
+        type: 'pointercancel',
+        pointerId: e.pointerId,
+        pointerType: navigationPointerKind(e.pointerType),
+      })
     }
 
     /**
@@ -2156,7 +2039,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * inherits it.
      */
     const handleLostPointerCapture = (e: React.PointerEvent<HTMLDivElement>) => {
-      if (!downPointersRef.current.has(e.pointerId)) return
+      if (!navigationRef.current.down.has(e.pointerId)) return
       handlePointerCancel(e)
     }
 

--- a/apps/web/src/components/spatial-editor/navigation.property.test.ts
+++ b/apps/web/src/components/spatial-editor/navigation.property.test.ts
@@ -44,10 +44,12 @@ const EFFECT_COVERAGE = {
   'zoom-at': 'covered',
   pinch: 'covered',
   capture: 'covered',
+  'release-capture': 'covered',
   'arm-long-press': 'covered',
   'clear-long-press': 'covered',
   'cancel-manipulation': 'covered',
   'clear-marquee': 'covered',
+  'clear-press-memory': 'covered',
   gather: 'covered',
 } satisfies Record<NavigationEffect['kind'], SurfaceCoverage>
 
@@ -189,6 +191,11 @@ const stepArb = fc.record({
     // completes it. Steering toward an interesting state is what
     // `fc.commands`' own `check` does; the ORACLE stays independent.
     { weight: 3, arbitrary: fc.constant('reuse-mode-anchor' as const) },
+    // A press that reached an overlay control rather than this machine. It
+    // joins the down set without a touch, and its RELEASE does arrive here —
+    // so it is generated for the lifetime invariants, which would otherwise
+    // never see a pointer the machine believes down but never tracked.
+    { weight: 2, arbitrary: fc.constant('external-press' as const) },
   ),
   placement: pressPlacementArb,
   button: fc.constantFrom(0, 1),
@@ -285,6 +292,13 @@ function drive(sequence: Sequence, check: (observation: Observation) => void) {
       lastPoint = point
       platformDown.delete(id)
       apply({ type: 'pointerup', pointerId: id, pointerType: 'touch' })
+      continue
+    }
+
+    if (step.kind === 'external-press') {
+      if (platformDown.has(step.pointerId)) continue
+      platformDown.add(step.pointerId)
+      apply({ type: 'external-press', pointerId: step.pointerId })
       continue
     }
 

--- a/apps/web/src/components/spatial-editor/navigation.ts
+++ b/apps/web/src/components/spatial-editor/navigation.ts
@@ -30,8 +30,16 @@ import { computePinchUpdate } from './touch-pinch.js'
 import type { Point } from './viewport.js'
 
 /**
- * Window for double-press detection. Matches the common OS double-click
- * interval; not user-configurable today.
+ * Window for double-press detection, for BOTH of this editor's double
+ * presses — hand mode's zoom, which this module decides, and the select
+ * tool's edit-or-create, which the component decides past the `fallThrough`
+ * seam. Matches the common OS double-click interval; not user-configurable
+ * today.
+ *
+ * One definition because a user pressing twice quickly is performing one
+ * gesture whichever tool is selected. Two constants of the same value is how
+ * that stops being true silently: tuning the window for one leaves the other
+ * where it was, and nothing fails.
  */
 export const DOUBLE_PRESS_WINDOW_MS = 400
 

--- a/apps/web/src/components/spatial-editor/navigation.ts
+++ b/apps/web/src/components/spatial-editor/navigation.ts
@@ -146,6 +146,14 @@ export type NavigationEvent =
       readonly point: Point
     }
   | { readonly type: 'pointerup'; readonly pointerId: number; readonly pointerType: PointerKind }
+  /**
+   * A press that never reached this machine's handler — an overlay control
+   * taking the pointer and capturing it on the root. Its RELEASE does arrive
+   * here, because capture redirects the rest of the sequence, so without
+   * this the machine would see an up for a pointer it never saw go down and
+   * a capture handback would read as a loss.
+   */
+  | { readonly type: 'external-press'; readonly pointerId: number }
   | {
       readonly type: 'pointercancel'
       readonly pointerId: number
@@ -165,11 +173,28 @@ export type NavigationEffect =
       readonly factor: number
     }
   | { readonly kind: 'capture'; readonly pointerIds: readonly number[] }
+  /**
+   * This machine no longer holds capture for anything. Emitted on the
+   * releases that END a gesture and on a cancel — never on a finger lifting
+   * out of a gather or a pinch, where the others are still down and still
+   * captured. Deciding it from an editor-wide "is something active" flag is
+   * what let a lifted finger's ordinary handback answer for a finger that
+   * was still down.
+   */
+  | { readonly kind: 'release-capture' }
   | { readonly kind: 'arm-long-press'; readonly pointerId: number; readonly screen: Point }
   | { readonly kind: 'clear-long-press' }
   /** Abandon whatever node gesture was in flight; the sequence became navigation. */
   | { readonly kind: 'cancel-manipulation' }
   | { readonly kind: 'clear-marquee' }
+  /**
+   * Drop the caller's own armed double press. Navigation never sets it — the
+   * select-tool double press is decided past the `fallThrough` seam — but a
+   * gesture that becomes navigation has to abandon it, or the release that
+   * ends the pan would resolve as the second half of a press the user
+   * abandoned two fingers ago.
+   */
+  | { readonly kind: 'clear-press-memory' }
   /** Add the pressed node to the selection the anchor is holding open. */
   | { readonly kind: 'gather'; readonly anchorPrimaryId: string; readonly hitId: string }
 
@@ -183,6 +208,13 @@ export interface NavigationResult {
    * not been consulted.
    */
   readonly fallThrough: boolean
+  /**
+   * The caller must call `preventDefault` on the DOM event. Not an effect,
+   * because it acts on the event rather than on the app: a pan or a
+   * double-press zoom has to stop the browser's own drag and
+   * selection defaults, and only the caller holds the event to stop.
+   */
+  readonly preventDefault?: boolean
 }
 
 function withTouch(
@@ -276,7 +308,11 @@ function reducePointerDown(
         // new multi-selection would jump every node gathered afterwards by
         // an offset the user never gave it.
         if (beganNow && context.manipulating) effects.push({ kind: 'cancel-manipulation' })
-        effects.push({ kind: 'clear-marquee' }, { kind: 'clear-long-press' })
+        effects.push(
+          { kind: 'clear-marquee' },
+          { kind: 'clear-press-memory' },
+          { kind: 'clear-long-press' },
+        )
         effects.push({
           kind: 'gather',
           anchorPrimaryId: context.anchorPrimaryId,
@@ -299,7 +335,11 @@ function reducePointerDown(
       // The second finger converts whatever the first started — marquee,
       // node move, double-press arming — into navigation.
       if (context.manipulating) effects.push({ kind: 'cancel-manipulation' })
-      effects.push({ kind: 'clear-marquee' }, { kind: 'clear-long-press' })
+      effects.push(
+        { kind: 'clear-marquee' },
+        { kind: 'clear-press-memory' },
+        { kind: 'clear-long-press' },
+      )
       // Capture BOTH fingers, not only the one that arrived second: an
       // uncaptured first finger crossing outside the root would stop
       // delivering its move and up events, leaving a stale entry that would
@@ -336,7 +376,12 @@ function reducePointerDown(
         anchorScreen: event.point,
         factor: DOUBLE_PRESS_ZOOM_FACTOR,
       })
-      return { state: { ...next, lastHandPress: null }, effects, fallThrough: false }
+      return {
+        state: { ...next, lastHandPress: null },
+        effects,
+        fallThrough: false,
+        preventDefault: true,
+      }
     }
     next = { ...next, lastHandPress: { at: event.timeStamp, point: event.point } }
   }
@@ -345,6 +390,7 @@ function reducePointerDown(
     state: { ...next, mode: { kind: 'panning', pointerId: event.pointerId, last: event.point } },
     effects,
     fallThrough: false,
+    preventDefault: true,
   }
 }
 
@@ -482,6 +528,7 @@ function reducePointerUp(
         fallThrough: false,
       }
     }
+    effects.push({ kind: 'release-capture' })
     if (state.mode.kind === 'panning' && state.mode.pointerId === event.pointerId) {
       return {
         state: { ...state, down, touches, mode: { kind: 'idle' } },
@@ -492,6 +539,7 @@ function reducePointerUp(
     return { state: { ...state, down, touches }, effects, fallThrough: true }
   }
 
+  effects.push({ kind: 'release-capture' })
   if (state.mode.kind === 'panning' && state.mode.pointerId === event.pointerId) {
     return { state: { ...state, down, mode: { kind: 'idle' } }, effects, fallThrough: false }
   }
@@ -514,7 +562,11 @@ function reducePointerCancel(
       touches,
       mode: stillPinching ? state.mode : { kind: 'idle' },
     },
-    effects: [{ kind: 'clear-long-press' }, { kind: 'cancel-manipulation' }],
+    effects: [
+      { kind: 'clear-long-press' },
+      { kind: 'release-capture' },
+      { kind: 'cancel-manipulation' },
+    ],
     fallThrough: false,
   }
 }
@@ -529,5 +581,11 @@ export function reduceNavigation(state: NavigationState, event: NavigationEvent)
       return reducePointerUp(state, event)
     case 'pointercancel':
       return reducePointerCancel(state, event)
+    case 'external-press':
+      return {
+        state: { ...state, down: withDown(state.down, event.pointerId, true) },
+        effects: [],
+        fallThrough: false,
+      }
   }
 }

--- a/packages/mcp-server/src/server/dev-rules-budget.test.ts
+++ b/packages/mcp-server/src/server/dev-rules-budget.test.ts
@@ -59,7 +59,7 @@ const ALWAYS_ON_BUDGET: Record<string, number> = {
 }
 
 /** Floored bucket of the SUM, which is not the sum of the buckets. */
-const ALWAYS_ON_TOTAL_BUDGET = 91
+const ALWAYS_ON_TOTAL_BUDGET = 90
 
 /**
  * The largest path-scoped file, tracked separately because it is not paid by

--- a/packages/mcp-server/src/server/dev-rules-budget.test.ts
+++ b/packages/mcp-server/src/server/dev-rules-budget.test.ts
@@ -59,7 +59,7 @@ const ALWAYS_ON_BUDGET: Record<string, number> = {
 }
 
 /** Floored bucket of the SUM, which is not the sum of the buckets. */
-const ALWAYS_ON_TOTAL_BUDGET = 90
+const ALWAYS_ON_TOTAL_BUDGET = 91
 
 /**
  * The largest path-scoped file, tracked separately because it is not paid by

--- a/packages/mcp-server/src/server/routes/_test-helpers.ts
+++ b/packages/mcp-server/src/server/routes/_test-helpers.ts
@@ -15,7 +15,18 @@ export function withTempDataDir(prefix = 'whiteboard-test-'): { get dir(): strin
   })
 
   afterEach(async () => {
-    await rm(tempDir, { recursive: true, force: true })
+    // `recursive` is not enough on its own: a data dir a server is still
+    // shutting down can gain a file DURING the walk, and the rmdir at the
+    // end then raises ENOTEMPTY. It surfaces as a teardown failure attached
+    // to whichever test happened to run last, which names neither the writer
+    // nor the race — observed on CI as
+    // `ENOTEMPTY: directory not empty, rmdir '/tmp/whiteboard-app-test-…'`
+    // against a suite that passes 3/3 locally.
+    //
+    // `maxRetries` is what node supplies for exactly this. It makes the
+    // teardown robust to a writer that is on its way out; it would not
+    // rescue one that never stops, and is not meant to.
+    await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
   })
 
   return {


### PR DESCRIPTION
**Layer 3 of 3**, on top of #1160 (the reducer) and #1162 (its property and ledgers). `SpatialEditor.tsx` now asks `navigation.ts` what a pointer event means and performs what it answers.

> Not a `gh stack` — no `gh` CLI in the authoring environment, so the layers landed as sequential PRs. See #1160.

## What goes

Seven refs, all of them things a gesture owned and nothing could say were over:

`downPointersRef` · `isPanningRef` · `touchPointsRef` · `pinchActiveRef` · `gatherAnchorRef` · `gatherPointersRef` · `lastPanPointRef`

With them, three constants and the `computePinchUpdate` import — the arithmetic moved into the machine with the state it belongs to.

## What kept it small

`fallThrough`. Each of the four handlers now asks the machine, performs its effects, and falls through to **exactly the code it had before** when the answer is "not mine". The manipulation half — marquee, node gestures, selection, click semantics, the long-press timer — is untouched. This is a wrapping, not a rewrite of 570 lines, and that was the point of designing the seam in layer 1 rather than discovering the need for one here.

## What stays, and why it was never navigation's

- **`activePointerIdRef`** is what the unmount teardown releases capture from, and overlay gestures that never reach `handlePointerDown` set it too. The machine asks for it through `capture` / `release-capture` effects — which is also what keeps the old hazard closed: an editor-wide "is something active" flag let a lifted finger's ordinary handback answer for a finger that was still down.
- **`lastPressRef`** narrows to what it always was underneath: the **Select** tool's double press, keyed by what was under it. Hand mode's has no target to key on, which is exactly why it needed a distance bound (#1159), and it now lives with that bound in the machine. The two shared one slot and never shared a key.

"What is down" has **one** answer, not two: an overlay press joins the machine's set through the `external-press` event rather than a second ref beside it.

## One deliberate divergence

A gather now ends on its **anchor's** release rather than on a member's, carried from #1162 where the property found it. The two sets are disjoint in every ordinary gather; they collide only when a released anchor's id is reused, and the old order then left a gather holding a pointer that was not down.

## Test plan

Behaviour-preserving, and the oracle is the point of the stack's order — the instruments were built first precisely so this could be judged rather than argued.

| suite | result |
|---|---|
| `spatial-editor` browser files — **the subject** | **82 files / 415 tests** ✅ |
| `pnpm test:browser` (whole) | **159 files / 875 tests** ✅ |
| `web-jsdom` | **294 files / 3028 tests** ✅ |
| `web-node` | **13 files / 86 tests** ✅ |
| `tsc --noEmit`, `pnpm knip` | clean |
| `arch-lint-node` | 10 files / 111 tests ✅ |

Every pinch, hand-tool, gather, long-press, marquee and node-drag case passes unchanged, as do the two browser properties that found the defects this work began with.

The compiler did the completeness check for the deletions: after wiring, **every remaining error was an unused declaration** — the seven refs and three constants, and nothing else. That is a stronger statement than "the tests still pass": nothing else was still reading them.

## Visual evidence

`Visual evidence: none — a behaviour-preserving refactor whose whole claim is that the picture does not change. A before/after figure of an unchanged surface would show two identical panels, which compose-figure.mjs refuses on principle. The evidence is the suite table above, and specifically the 415 spatial-editor browser tests that exercise the surface this touches.`

## Checklist

- [x] Commit message follows Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [ ] Docs — no user-visible behaviour or published contract changes
- [x] No `console.*` added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

## What this stack did and did not buy

Stated plainly, since it was the reason for doing it. The lifetime family is now structurally closed: navigation is one value, and `NAVIGATION_MEMORY_KEYS` names the only field allowed to survive a return to idle. The **predicate** family (#1159's double press missing a dimension) and the **DOM-wiring** family (#1158's overlay eating a press) are untouched by this design — a reducer cannot see either. Of the four defects this session found, one becomes unrepresentable. The properties found all four.

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved spatial editor navigation for mouse, touch, and pen input.
  * Added smoother panning, pinch-to-zoom, two-finger gestures, touch multi-selection, and hand-mode activation.
  * Improved gesture handling when interacting with overlay controls, including more reliable pointer capture and release.
  * Enhanced long-press, double-press, and gesture cancellation behavior for more consistent editing interactions.
  * Improved handling of interrupted or overlapping gestures to help prevent unexpected navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->