### PR TITLE
chore(arch): accept ADR-0018 and make its allowlist actually ratchet

### DIFF
--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -51,9 +51,22 @@ tool registration under `server/mcp/**`) may not import a MECHANIC (anything
 under `server/store/`). The composition root's own wiring — `di/`, `app.ts`,
 `http-server.ts` — is deliberately out of scope, since knowing the mechanics
 is its job. `ADAPTERS_REACHING_MECHANICS` in `architecture-map.ts` records
-the 35 edges that exist today and may only SHRINK: an unlisted edge fails
-the build, and a listed edge that no longer exists fails it too, so an entry
-cannot outlive the debt it names. `corrupt-stored-data` is excluded and says
+the edges that exist today: an unlisted edge fails the build, and a listed
+edge that no longer exists fails it too, so an entry cannot outlive the debt
+it names.
+
+**Shrinking is a third check, and for a while it was only a sentence.** Those
+two guards reject a fabricated entry and a stale one; neither has anything to
+say about a real new edge added along with its allowlist line, which is the
+ordinary way the list grows. Measured: a genuine `routes/export.ts ->
+backup-in-progress` import, duly listed, passed all six assertions, and the
+list went 37 -> 36 -> 35 -> 36 -> 40 in a week while this paragraph and the
+test's own comment both said it could only shrink. `ADAPTERS_REACHING_MECHANICS_CEILING`
+now pins the count by equality — **39 today** — so adding an edge fails until
+someone raises it deliberately and paying one off fails until someone lowers
+it. ADR-0018 is **Accepted** as of 2026-08-31 and carries the burn-down order;
+the four adapters it schedules first (`restore.ts`, `live-doc.ts`,
+`workspace-document.ts`, `ws.ts`) hold 17 of the 39. `corrupt-stored-data` is excluded and says
 why — an error taxonomy an adapter reads to pick a status code is
 translation, which is an adapter's job, and listing it would put five
 permanently-unshrinkable entries in a list whose whole value is that it

--- a/docs/contributing/adr/0018-operation-vs-mechanic.md
+++ b/docs/contributing/adr/0018-operation-vs-mechanic.md
@@ -1,6 +1,6 @@
 # ADR-0018: An operation is a use case; the composition root holds only mechanics
 
-**Status:** Proposed
+**Status:** Accepted (2026-08-31)
 
 ## Context
 
@@ -152,6 +152,52 @@ executable rungs carry it:
 
 The guards land before the moves. A migration with no guard re-admits the
 thing it was migrating away from.
+
+## Burn-down
+
+Accepting this ADR without a schedule would leave a rule the codebase does
+not obey and nothing recording the gap, so the debt is counted and ratcheted.
+
+**Where it stands, measured on 2026-08-31:** `ADAPTERS_REACHING_MECHANICS`
+holds **39 edges across 17 adapters**. `ADAPTERS_REACHING_MECHANICS_CEILING`
+pins that number by equality — adding an edge fails the build until someone
+raises it deliberately, and paying one off fails until someone lowers it, so
+the figure keeps saying where the migration actually is.
+
+That ratchet is the half this ADR was missing. The allowlist's two existing
+checks reject a fabricated entry and a stale one; neither has anything to say
+about the ordinary way the list grows, which is a real new edge added along
+with its allowlist line. Measured before the ceiling existed: a genuine
+`routes/export.ts -> backup-in-progress` import, duly listed, passed all six
+assertions. The list went 37 -> 36 -> 35 -> 36 -> 40 across one week while
+both the map's doc comment and the test's own comment said it could only
+shrink.
+
+**Order.** Four adapters hold 17 of the 39, and they are the ones where a
+second surface most plausibly needs the same operation:
+
+| adapter | edges | the operation underneath |
+|---|---|---|
+| `routes/document/restore.ts` | 5 | restoring a version — three modes in one handler |
+| `routes/document/live-doc.ts` | 4 | reading and updating a document by path |
+| `routes/document/workspace-document.ts` | 4 | the workspace document's own snapshot/update |
+| `routes/ws.ts` | 4 | the sync surface's document access |
+
+Take them one at a time, each its own PR, lowering the ceiling in the same
+commit that removes the edges. `restore.ts` first: it is the largest cluster,
+its three restore modes are already tangled in a single 215-line handler, and
+it has no MCP twin yet — so it is the case where a second surface is most
+likely to arrive and find no operation to call.
+
+The remaining 22 edges across 13 adapters are mostly one or two apiece and
+are not scheduled here. They come along with whatever work next opens those
+files, under the standing "fix what you touch" rule.
+
+**What would make raising the ceiling right.** It is a decision, not a
+failure: an operation that genuinely belongs to this deployment, or a fix
+that cannot wait for the move. The requirement is only that the PR says which
+one it is, so a raised number is a recorded judgement rather than the list
+quietly resuming its drift.
 
 ## Alternatives considered
 

--- a/tools/arch-lint/src/adapter-mechanic-check.test.ts
+++ b/tools/arch-lint/src/adapter-mechanic-check.test.ts
@@ -8,6 +8,7 @@ import { findAdapterMechanicEdges } from './adapter-mechanic-check.js'
 import {
   ADAPTER_SCAN_EXEMPT_FILES,
   ADAPTERS_REACHING_MECHANICS,
+  ADAPTERS_REACHING_MECHANICS_CEILING,
   MECHANICS_NOT_SCANNED,
 } from './architecture-map.js'
 
@@ -39,9 +40,9 @@ describe('ADR-0018: an adapter may not reach a mechanic directly', () => {
     ).toEqual([])
   })
 
-  // Guarded from both sides, so the list can only shrink. Without this, a
-  // migration that removed an edge would leave its entry behind and the
-  // allowlist would slowly stop describing anything.
+  // Guarded from both sides, so an entry cannot outlive its debt. Note this
+  // is NOT what keeps the list shrinking — that is the ceiling below, and the
+  // comment here claimed otherwise for as long as the claim was false.
   it('every allowlist entry is still a real edge', () => {
     const found = new Set(actual)
     const stale = ADAPTERS_REACHING_MECHANICS.filter((edge) => !found.has(edge))
@@ -56,6 +57,30 @@ describe('ADR-0018: an adapter may not reach a mechanic directly', () => {
   // The scan reaching nothing would make both assertions above pass while
   // checking nothing at all — the failure mode this repo has been bitten by
   // more than once.
+  // The ratchet. The two assertions above stop a fabricated entry and a stale
+  // one, and neither has anything to say about the ordinary way this list
+  // grows: a real new adapter -> mechanic edge added together with its
+  // allowlist line. Measured before this existed — a genuine
+  // `routes/export.ts -> backup-in-progress` import, duly listed, passed all
+  // six assertions, and the list had gone 35 -> 40 in a week under two
+  // comments asserting it could only shrink.
+  //
+  // Equality rather than an upper bound, so paying debt off is also a failure
+  // until the number comes down with it. A ceiling nobody lowers stops
+  // recording progress and turns into a budget.
+  it('holds the allowlist at its declared ceiling', () => {
+    expect(
+      ADAPTERS_REACHING_MECHANICS.length,
+      ADAPTERS_REACHING_MECHANICS.length > ADAPTERS_REACHING_MECHANICS_CEILING
+        ? 'a new adapter -> mechanic edge was added. ADR-0018 is Accepted, so ' +
+            'this is debt being taken on against a decision to pay it down: give ' +
+            'the operation a home in server-core, or raise the ceiling in the ' +
+            'same PR and say there why that was not possible.'
+        : 'an edge was paid off — lower ADAPTERS_REACHING_MECHANICS_CEILING to ' +
+            'match, so the number keeps recording where the migration is.',
+    ).toBe(ADAPTERS_REACHING_MECHANICS_CEILING)
+  })
+
   it('the scan actually reaches the adapter tree', () => {
     expect(actual.length).toBeGreaterThan(20)
   })

--- a/tools/arch-lint/src/architecture-map.ts
+++ b/tools/arch-lint/src/architecture-map.ts
@@ -256,15 +256,24 @@ export const KNOWN_IMPORT_CYCLES: readonly (readonly string[])[] = []
  * Mechanics an ADAPTER still reaches directly, pending ADR-0018's migration.
  *
  * Each entry is one `<adapter file> -> <mechanic module>` edge, relative to
- * `packages/mcp-server/src/server`. This list may only SHRINK: an edge that
- * is not here fails the build, and an entry that is no longer a real edge
- * fails it too, so an entry cannot outlive the debt it names. Same shape,
- * and the same reason, as {@link KNOWN_IMPORT_CYCLES}.
+ * `packages/mcp-server/src/server`. An edge that is not here fails the build,
+ * and an entry that is no longer a real edge fails it too, so an entry cannot
+ * outlive the debt it names. Same shape, and the same reason, as
+ * {@link KNOWN_IMPORT_CYCLES}.
  *
  * The rule could not land without it. Every one of these exists today, and
  * enforcing the invariant on an empty list would simply have failed the
  * build — so the debt is recorded rather than the guard postponed until
  * after the migration it is meant to verify.
+ *
+ * **Shrinking is what {@link ADAPTERS_REACHING_MECHANICS_CEILING} enforces,
+ * and the two checks above do not.** They stop a fabricated entry and a stale
+ * one; neither has anything to say about a real new edge added along with its
+ * allowlist line, which is the ordinary way this list grows. Measured before
+ * the ceiling existed: a genuine `routes/export.ts -> backup-in-progress`
+ * import, duly listed, passed all six assertions. The list went 37 -> 36 ->
+ * 35 -> 36 -> 40 over one week while both this doc comment and the test's own
+ * comment said it could only shrink.
  */
 export const ADAPTERS_REACHING_MECHANICS: readonly string[] = [
   'mcp/document-tools.ts -> workspace-lock',
@@ -310,6 +319,24 @@ export const ADAPTERS_REACHING_MECHANICS: readonly string[] = [
   'routes/ws.ts -> version-store',
   'routes/ws.ts -> workspace-lock',
 ]
+
+/**
+ * How many entries {@link ADAPTERS_REACHING_MECHANICS} may hold — a ratchet,
+ * not a budget.
+ *
+ * ADR-0018 is Accepted, so this debt is scheduled rather than tolerated, and
+ * the number is the only thing that makes "scheduled" mean anything a build
+ * can check. Pinned by equality on purpose: adding an edge fails until
+ * someone raises this line, and PAYING one off fails until someone lowers it.
+ * Both halves matter — a ceiling nobody lowers stops recording progress and
+ * becomes a budget, which is the thing it exists not to be.
+ *
+ * Raising it is a decision, not a fix. Do it only when the alternative is
+ * worse than the debt, and say in the PR why the operation could not go to
+ * server-core instead. The burn-down order is in the ADR; the four clusters
+ * it names are 17 of these 39.
+ */
+export const ADAPTERS_REACHING_MECHANICS_CEILING = 39
 
 /**
  * Modules under `store/` the adapter rule does NOT count.


### PR DESCRIPTION
## Summary

A user decision on a standing audit finding: advance ADR-0018 rather than leave it `Proposed` while the debt it describes drifts, and cap its allowlist numerically.

**Say plainly what this does not do: it pays off zero edges.** The ceiling of 39 ratifies the status quo. What changes is what happens *next time* — an edge added fails the build, and an edge paid off fails until the number comes down with it. Reading this as progress on the migration would be wrong; it is the thing that makes progress measurable.

### The list said it could only shrink, in two places, and neither was true

`ADAPTERS_REACHING_MECHANICS` had two guards: an unlisted edge fails, and a listed edge that no longer exists fails. Both are real. Neither has anything to say about the ordinary way such a list grows — **a genuine new adapter → mechanic edge, added together with its allowlist line.**

Measured rather than argued. A real `routes/export.ts -> backup-in-progress` import, duly listed, **passed all six assertions**. Over one week the list went `37 → 36 → 35 → 36 → 40` while both `architecture-map.ts`'s doc comment and the test's own comment said it could only shrink.

A first attempt at that demonstration used a *fabricated* edge, which the stale-entry check catches. That proves the wrong thing — the experiment had to plant a real import to mean anything.

### The ratchet

`ADAPTERS_REACHING_MECHANICS_CEILING` pins the count **by equality**, so adding an edge fails until someone raises it deliberately *and* paying one off fails until someone lowers it.

The second half is not symmetry for its own sake. A ceiling nobody lowers stops recording progress and becomes a budget, which is the thing it exists not to be.

Raising it stays a legitimate decision — an operation that really does belong to this deployment, or a fix that cannot wait for the move. The only requirement is that the PR says which, so a raised number is a recorded judgement rather than the list quietly resuming its drift.

### ADR-0018 → Accepted, with the burn-down order

Four adapters hold **17 of the 39** edges:

| adapter | edges | the operation underneath |
|---|---|---|
| `routes/document/restore.ts` | 5 | restoring a version — three modes in one handler |
| `routes/document/live-doc.ts` | 4 | reading and updating a document by path |
| `routes/document/workspace-document.ts` | 4 | the workspace document's snapshot/update |
| `routes/ws.ts` | 4 | the sync surface's document access |

`restore.ts` goes first: largest cluster, three restore modes already tangled in one 215-line handler, and no MCP twin yet — so it is where a second surface is most likely to arrive and find no operation to call. The remaining 22 edges across 13 adapters are deliberately not scheduled; they come along under the standing "fix what you touch" rule.

### Counting it was itself worth recording

Three numbers disagreed: the audit said **43**, `.claude/rules/architecture-map.md` said **35**, the file holds **39 across 17 adapters**.

Two attempts at the measurement were wrong before the third was right — an `awk` range that spanned into `ADAPTER_SCAN_EXEMPT_FILES`, then a bracket matcher that took `readonly string[]`'s brackets for the array's and answered **zero**. Both were caught by the answer being implausible, not by re-reading the script. The figure here is from bracket-matched extraction of entry lines only; no allowlist entry overlaps the exempt list.

That disagreement is the same phenomenon this PR is about: a number nobody re-reads drifts in silence.

## Test plan

- [x] New or updated `arch-lint-node` tests — one assertion added to `adapter-mechanic-check.test.ts`
- [x] `pnpm test` passes locally (one known-failing, below)
- [ ] Manual verification — not applicable; this is a build-time guard with no runtime surface
- [ ] E2E coverage — not applicable

**Mutation-checked, both directions, restore confirmed green:**

| mutation | result |
|---|---|
| the same real-edge experiment that passed **6/6** before | `1 failed` |
| an edge removed with the ceiling left stale | `2 failed` |

The first row is the load-bearing one: it is not a new test failing on new input, it is the *identical* experiment changing answer.

**Known-failing, pre-existing:** `local-node-version.test.ts` — this sandbox is Node 22 against the pin of 24. `mcp-node` + `arch-lint-node` otherwise: **4314 passed, 9 skipped**. `pnpm lint` and `pnpm knip` clean.

## Visual evidence

Visual evidence: none — a build-time architecture guard and two documents; nothing renders.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — ADR-0018 status and burn-down, and `.claude/rules/architecture-map.md`, whose "35 edges … may only SHRINK" was wrong on both counts
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_