### PR TITLE
fix(web): give the daemon page the canvas settings gear the browser page has

### DIFF
--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -53,20 +53,8 @@ under `server/store/`). The composition root's own wiring — `di/`, `app.ts`,
 is its job. `ADAPTERS_REACHING_MECHANICS` in `architecture-map.ts` records
 the edges that exist today: an unlisted edge fails the build, and a listed
 edge that no longer exists fails it too, so an entry cannot outlive the debt
-it names.
-
-**Shrinking is a third check, and for a while it was only a sentence.** Those
-two guards reject a fabricated entry and a stale one; neither has anything to
-say about a real new edge added along with its allowlist line, which is the
-ordinary way the list grows. Measured: a genuine `routes/export.ts ->
-backup-in-progress` import, duly listed, passed all six assertions, and the
-list went 37 -> 36 -> 35 -> 36 -> 40 in a week while this paragraph and the
-test's own comment both said it could only shrink. `ADAPTERS_REACHING_MECHANICS_CEILING`
-now pins the count by equality — **39 today** — so adding an edge fails until
-someone raises it deliberately and paying one off fails until someone lowers
-it. ADR-0018 is **Accepted** as of 2026-08-31 and carries the burn-down order;
-the four adapters it schedules first (`restore.ts`, `live-doc.ts`,
-`workspace-document.ts`, `ws.ts`) hold 17 of the 39. `corrupt-stored-data` is excluded and says
+it names. Neither sees the list GROW, so `ADAPTERS_REACHING_MECHANICS_CEILING`
+pins the count by equality; ADR-0018 (Accepted) carries the burn-down. `corrupt-stored-data` is excluded and says
 why — an error taxonomy an adapter reads to pick a status code is
 translation, which is an adapter's job, and listing it would put five
 permanently-unshrinkable entries in a list whose whole value is that it

--- a/apps/web/src/pages/DaemonDocumentPage.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.test.tsx
@@ -195,6 +195,24 @@ describe('DaemonDocumentPage', () => {
     expect(createdBackends[0]?.connectCount).toBe(1)
   })
 
+  it('offers the canvas display settings gear, so plugin canvasSettings are reachable here too', async () => {
+    // The source scan in file-seam-conformance.test.ts asserts the PROP is
+    // written; this asserts the surface actually appears, which is what a
+    // reader of the scan cannot tell. `CanvasDisplaySettings` owns the
+    // `canvasSettings` contribution point — `visual.edges/v0` is contributed
+    // there today — and only the browser page placed it, so those settings
+    // were unreachable in daemon mode with nothing failing.
+    await act(async () => {
+      render(
+        <DaemonDocumentPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
+        { container: document.body },
+      )
+    })
+
+    await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
+    expect(screen.getByTestId('canvas-settings-button')).toBeTruthy()
+  })
+
   it('shows the Connections chip with the backlink count and switches to a source on click', async () => {
     mockGetDocumentBacklinks.mockResolvedValue({
       backlinks: [

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -18,6 +18,7 @@ import { DocumentProperties } from '../components/document-properties/DocumentPr
 import { HeaderBranchBanner } from '../components/HeaderBranchBanner.js'
 import { HistoryCluster } from '../components/history-cluster/HistoryCluster.js'
 import { MergeToast } from '../components/MergeToast.js'
+import { CanvasDisplaySettings } from '../components/spatial-editor/CanvasDisplaySettings.js'
 import type { SpatialEditorHandle } from '../components/spatial-editor/index.js'
 import { SpatialEditor } from '../components/spatial-editor/index.js'
 import { Button } from '../components/ui/button.js'
@@ -631,6 +632,17 @@ export function DaemonDocumentPage({
                     // the disclosure here without a second flag to keep in sync.
                     facets={coreFacets}
                     onFacetsChange={setCoreFacets}
+                    // Canvas-level display settings, gated on kind the same
+                    // way the facet disclosure above is: a markdown document
+                    // has no canvas to configure. The browser page has placed
+                    // this since it existed and this one did not, which left
+                    // every `canvasSettings` contribution — today `visual`'s
+                    // `visual.edges/v0` — unreachable in daemon mode.
+                    settings={
+                      documentKind === 'spatial' ? (
+                        <CanvasDisplaySettings canvas={canvasValue} onChange={onChange} />
+                      ) : undefined
+                    }
                     actions={
                       <>
                         {exportError && (

--- a/apps/web/src/pages/file-seam-conformance.test.ts
+++ b/apps/web/src/pages/file-seam-conformance.test.ts
@@ -57,19 +57,44 @@ const SHARED_CANVAS_CHROME = ['CanvasDisplaySettings', 'WorkspaceTopBar'] as con
  * `SaveStatusChip` in the properties row, so the two presentations differ
  * while the capability does not.
  */
-const MODE_SPECIFIC_CHROME: Readonly<Record<string, string>> = {
+const MODE_SPECIFIC_CHROME = {
   // Not a substitute for a save indicator the other mode lacks: BOTH pages
   // render WorkspaceTopBar, whose dot comes from its own `useDirtyState` and
   // means "no manual version named yet" rather than "unsaved". The browser
   // page adds this finer chip because its markdown path has two writers — the
   // controller and the body's debounced save — and one dot reported `Saved`
   // over unwritten text.
-  SaveStatusChip: 'browser only; a second, finer indicator its markdown path needs',
-  HeaderBranchBanner: 'daemon only; branches are a daemon concept (ADR-0004)',
-  MergeToast: 'daemon only; merge is a daemon concept (ADR-0004)',
-  AgentPresenceChip: 'daemon only; no agents connect in browser mode',
-  ConnectionsChip: 'daemon only; backlinks come from the daemon index',
-  CapabilityTeaser: 'daemon only; it teases daemon capabilities',
+  SaveStatusChip: {
+    page: './BrowserDocumentPage.tsx',
+    why: 'a second, finer indicator its markdown path needs',
+  },
+  HeaderBranchBanner: {
+    page: './DaemonDocumentPage.tsx',
+    why: 'branches are a daemon concept (ADR-0004)',
+  },
+  MergeToast: { page: './DaemonDocumentPage.tsx', why: 'merge is a daemon concept (ADR-0004)' },
+  AgentPresenceChip: {
+    page: './DaemonDocumentPage.tsx',
+    why: 'no agents connect in browser mode',
+  },
+  ConnectionsChip: {
+    page: './DaemonDocumentPage.tsx',
+    why: 'backlinks come from the daemon index',
+  },
+  CapabilityTeaser: { page: './DaemonDocumentPage.tsx', why: 'it teases daemon capabilities' },
+} satisfies Record<string, { page: (typeof PAGES)[number]; why: string }>
+
+/**
+ * Does this page render that component?
+ *
+ * A word boundary after the name, because `includes('<Foo')` also matches
+ * `<FooPanel` — so a component RENAMED to a longer name reads as still
+ * rendered, and every assertion here keeps passing over chrome that is gone.
+ * Found by a mutation that renamed `<AgentPresenceChip` to
+ * `<AgentPresenceChipX` and did not turn the scan red.
+ */
+function renders(source: string, chrome: string): boolean {
+  return new RegExp(`<${chrome}[\\s/>]`).test(source)
 }
 
 describe('document page canvas chrome', () => {
@@ -77,7 +102,7 @@ describe('document page canvas chrome', () => {
     const missing: string[] = []
     for (const page of PAGES) {
       const source = await read(page)
-      if (!source.includes(`<${chrome}`)) missing.push(page)
+      if (!renders(source, chrome)) missing.push(page)
     }
 
     expect(
@@ -89,23 +114,27 @@ describe('document page canvas chrome', () => {
     ).toEqual([])
   })
 
-  // The exemption list is a claim about the code, so it is checked against it.
-  // An entry naming chrome that both pages render is stale — it would quietly
-  // excuse a real divergence if one appeared there later.
-  it('every mode-specific exemption is still one-sided', async () => {
-    const both: string[] = []
-    for (const [chrome] of Object.entries(MODE_SPECIFIC_CHROME)) {
-      const rendered = await Promise.all(
-        PAGES.map(async (page) => (await read(page)).includes(`<${chrome}`)),
-      )
-      if (rendered.every(Boolean)) both.push(chrome)
+  // The exemption list is a claim about the code, so it is checked against it —
+  // and against the exact page, not merely against "not shared". Naming only
+  // the sharing case leaves three ways to be wrong silently: chrome NEITHER
+  // page renders any more (a stale entry excusing nothing), chrome whose
+  // ownership has flipped, and chrome that quietly became shared. Asserting
+  // the owner covers all three with one comparison.
+  it.each(
+    Object.entries(MODE_SPECIFIC_CHROME),
+  )('%s is rendered by its documented page and no other', async (chrome, { page: owner }) => {
+    const renderedBy: string[] = []
+    for (const page of PAGES) {
+      if (renders(await read(page), chrome)) renderedBy.push(page)
     }
 
     expect(
-      both,
-      'these are rendered by both pages now — move them to SHARED_CANVAS_CHROME ' +
-        'so the scan holds them there.',
-    ).toEqual([])
+      renderedBy,
+      `${chrome} is exempt as ${owner}-only (${MODE_SPECIFIC_CHROME[chrome as keyof typeof MODE_SPECIFIC_CHROME].why}). ` +
+        'Rendered by both means it is shared now — move it to SHARED_CANVAS_CHROME. ' +
+        'Rendered by neither means the entry outlived its subject. Rendered by ' +
+        'the other page means the exemption is describing the wrong one.',
+    ).toEqual([owner])
   })
 
   // Neither assertion above means anything if the sources did not load.

--- a/apps/web/src/pages/file-seam-conformance.test.ts
+++ b/apps/web/src/pages/file-seam-conformance.test.ts
@@ -1,5 +1,5 @@
 /**
- * Both canvas pages must hand the editor the same file seams.
+ * Both document pages must offer the same document-level chrome.
  *
  * This exists because they did not: the seams were written inline in
  * BrowserDocumentPage, so DaemonDocumentPage shipped passing none of them and
@@ -26,6 +26,95 @@ async function read(page: string): Promise<string> {
   expect(loader, `no source loader for ${page}`).toBeDefined()
   return (await loader?.()) as string
 }
+
+/**
+ * Canvas-level chrome each page must place, and why a page cannot be trusted
+ * to remember it.
+ *
+ * These are surfaces the PAGE positions rather than the editor — the same
+ * arrangement that produced the file-seam defect above. `CanvasDisplaySettings`
+ * says so in its own docblock: "Standalone from SpatialEditor so the PAGE
+ * places it with the other canvas-level chrome", and it owns the
+ * `canvasSettings` contribution point, so a page that does not render it makes
+ * every plugin contributing there unreachable in that mode.
+ *
+ * Measured when this was added: `resolveFacetContributions(bundledFacetRegistry,
+ * 'canvasSettings')` answers one group — `visual` contributing
+ * `visual.edges/v0` — and only BrowserDocumentPage rendered the gear. A grep
+ * for the string `canvasSettings` in plugin-visual finds nothing, because the
+ * contribution is declared through the facet definition rather than spelled
+ * at a call site; resolving the registry is what shows it is real.
+ */
+const SHARED_CANVAS_CHROME = ['CanvasDisplaySettings', 'WorkspaceTopBar'] as const
+
+/**
+ * Chrome one mode has and the other cannot, per ADR-0004 — capability-gated
+ * by design, not drift.
+ *
+ * Listed rather than left implicit so the scan above stays a statement about
+ * what SHOULD agree. Save state is the interesting entry: the daemon page does
+ * show it, through `WorkspaceTopBar`'s dirty dot rather than a
+ * `SaveStatusChip` in the properties row, so the two presentations differ
+ * while the capability does not.
+ */
+const MODE_SPECIFIC_CHROME: Readonly<Record<string, string>> = {
+  // Not a substitute for a save indicator the other mode lacks: BOTH pages
+  // render WorkspaceTopBar, whose dot comes from its own `useDirtyState` and
+  // means "no manual version named yet" rather than "unsaved". The browser
+  // page adds this finer chip because its markdown path has two writers — the
+  // controller and the body's debounced save — and one dot reported `Saved`
+  // over unwritten text.
+  SaveStatusChip: 'browser only; a second, finer indicator its markdown path needs',
+  HeaderBranchBanner: 'daemon only; branches are a daemon concept (ADR-0004)',
+  MergeToast: 'daemon only; merge is a daemon concept (ADR-0004)',
+  AgentPresenceChip: 'daemon only; no agents connect in browser mode',
+  ConnectionsChip: 'daemon only; backlinks come from the daemon index',
+  CapabilityTeaser: 'daemon only; it teases daemon capabilities',
+}
+
+describe('document page canvas chrome', () => {
+  it.each(SHARED_CANVAS_CHROME)('both pages render %s', async (chrome) => {
+    const missing: string[] = []
+    for (const page of PAGES) {
+      const source = await read(page)
+      if (!source.includes(`<${chrome}`)) missing.push(page)
+    }
+
+    expect(
+      missing,
+      `${chrome} is placed by the PAGE, so a page that omits it drops the ` +
+        'surface in that mode entirely. This is the shape that shipped canvas ' +
+        'embeds and image nodes doing nothing in daemon mode; a per-page test ' +
+        'cannot catch it, because each page only ever exercises its own mode.',
+    ).toEqual([])
+  })
+
+  // The exemption list is a claim about the code, so it is checked against it.
+  // An entry naming chrome that both pages render is stale — it would quietly
+  // excuse a real divergence if one appeared there later.
+  it('every mode-specific exemption is still one-sided', async () => {
+    const both: string[] = []
+    for (const [chrome] of Object.entries(MODE_SPECIFIC_CHROME)) {
+      const rendered = await Promise.all(
+        PAGES.map(async (page) => (await read(page)).includes(`<${chrome}`)),
+      )
+      if (rendered.every(Boolean)) both.push(chrome)
+    }
+
+    expect(
+      both,
+      'these are rendered by both pages now — move them to SHARED_CANVAS_CHROME ' +
+        'so the scan holds them there.',
+    ).toEqual([])
+  })
+
+  // Neither assertion above means anything if the sources did not load.
+  it('reads both page sources', async () => {
+    for (const page of PAGES) {
+      expect((await read(page)).length, `${page} is empty`).toBeGreaterThan(10_000)
+    }
+  })
+})
 
 describe('canvas page file seams', () => {
   it.each(PAGES)('%s passes the shared seams to SpatialEditor', async (page) => {


### PR DESCRIPTION
## Summary

**Two subjects, the second one deliberate.** The first is the change the PR was opened for; the second is that `main` is currently red and this reclaims my share of why. Flagged here because a reviewer reading a diff that touches two subjects needs to know the second was intentional.

### 1. The daemon page had no canvas settings gear

**Scope, stated up front: this does not collapse the two pages.** The audit item is "collapse `BrowserDocumentPage`/`DaemonDocumentPage` onto ADR-0004's shared page" (L). This is the first slice — a guard, and the defect the guard found.

That order is not mine; ADR-0018 (Accepted last week) states it: *"The guards land before the moves. A migration with no guard re-admits the thing it was migrating away from."* So before touching 1,890 lines across two pages, measure what actually diverges.

**73 props shared, 17 divergent.** Most of the 17 are capability-gated by design and ADR-0004 says so — `versions`, `agentTouchedNodeIds`, `summary` are daemon concepts. One was not.

`CanvasDisplaySettings` was placed by the browser page and by nothing else. Its own docblock says why that matters:

> Standalone from SpatialEditor so the PAGE places it with the other canvas-level chrome […] This surface OWNS the `canvasSettings` contribution point

So in daemon mode the gear did not exist, and every plugin contributing to `canvasSettings` was unreachable — with nothing failing.

**Not a latent gap.** Resolving the registry answers one group: `visual` contributing `visual.edges/v0`. A grep gets this wrong in the other direction — `canvasSettings` appears nowhere in `plugin-visual`'s source because the contribution is declared through the facet definition, so searching for the string says "no contributors" and resolving says otherwise.

Second instance of the class `file-seam-conformance.test.ts` was written for, whose comment already stated the rule this PR is evidence for:

> each page's own tests only ever exercised its own mode, which is exactly why a per-page test cannot catch this class

The fix is one prop, gated on kind the same way the facet disclosure beside it already is.

**Two guards, measured to be non-redundant.** A source scan (both pages render the shared chrome) and a render test (the gear actually appears). With the prop written but gated to never render, **the scan passes 8/8 and only the render test fails**.

**The exemption list caught its own author, twice.** I listed `WorkspaceTopBar` as daemon-only from reading the import block — both pages render it. And the reason I first wrote against `SaveStatusChip` ("the daemon shows save state via the top bar's dirty dot") is wrong twice over: both pages render that bar, and its dot comes from `useDirtyState` meaning *"no manual version named yet"*, not *"unsaved"*. Both corrected against what the code does.

### 2. main is red on its own budget test, and 875 of those chars are mine

`dev-rules-budget.test.ts` (#1163) pins the always-on rule corpus at bucket 90. Run against a clean `origin/main` worktree it answers **91723 chars → bucket 91**. So main fails it and every branch inherits that; this PR contributes zero chars to the corpus and was red for that reason alone.

**A stale base, measured not inferred:**

| | |
|---|---|
| #1165 (mine) | merged 14:59, added **875 chars** to `.claude/rules/architecture-map.md` |
| #1163 | merged 16:30, but from `base_sha` `e7b4a621` — which predates #1165 |

#1163 pinned 90 against a corpus it had never measured. Both halves are true: it landed on a base it had not caught up with, and my 875 chars are the whole of what it could not see.

Reclaiming them needs nobody's decision and restores #1163's stated intent — it cut 15% of this corpus deliberately, and raising the pin a day later would undo that. Nothing is lost: the reasoning lives where a reader of the ceiling actually looks, in `architecture-map.ts`'s doc comment and ADR-0018's burn-down section. An always-on rule needs the pointer, not the argument — the same judgement #1163 was applying.

Corpus is now **90965 → bucket 90**, budget test 4/4.

**I measured this wrong twice first, in the direction that produces a false conclusion.** I sized the corpus with `wc -c`; the test counts JS string length and these files are full of em dashes and arrows, so bytes overstate it. On the byte figure I concluded *"removing my addition still leaves bucket 91"* — i.e. not my problem. In the test's own units it is 90848 → bucket 90, the opposite answer. A first attempt at sizing my own delta also compared against the wrong ref and answered 0.

**Headroom is now 35 chars.** That is not a stable place to leave it, and whether to raise the pin, cut further, or accept the margin is a call for whoever owns the 15% cut — not something this PR should decide.

## Test plan

- [x] New or updated tests — `file-seam-conformance.test.ts` (scan + both-sides exemption guard), `DaemonDocumentPage.test.tsx` (render)
- [x] `pnpm test` passes locally (standing Node 22 set below)
- [ ] Manual verification — not performed; see **Visual evidence**
- [x] Regression coverage preserved — the render test pins the outcome, the scan pins the class

**Mutation-checked, restores confirmed green:**

| mutation | scan | render |
|---|---|---|
| the fix reverted | fails, naming `DaemonDocumentPage.tsx` | fails |
| the prop kept but gated to never render | **passes 8/8** | fails |

The second row is what shows the two tests are not the same test twice.

**Known-failing, pre-existing:** nine `web-jsdom` failures in `DocumentThumb` / `VersionThumbnail` / `MergeDialog` / `VersionTimeline` — `TypeError: object.stream is not a function`, the documented Node 22 signature. None in a file this diff touches; this exact set was A/B'd against a clean tree and confirmed green on CI's Node 24 earlier in this branch's history. apps/web otherwise: **3024 passed**.

## Visual evidence

Visual evidence: none — **this environment cannot produce or attach a figure.** `.claude/scripts/compose-figure.mjs` needs ImageMagick (absent) and there is no `gh` CLI for `gh image`; both confirmed while attaching evidence to #1161.

What a figure would show is one gear icon appearing in the daemon page's document-properties row for a spatial document. The render test asserts exactly that (`canvas-settings-button` present after the editor mounts), in jsdom rather than a real browser — so the assertion is on the element, not on how it looks.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — `.claude/rules/architecture-map.md` trimmed as above; ADR-0004 already prescribes the shared page this moves toward
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema


---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_