### PR TITLE
fix(web): make `spatial-editor-container` mean the same thing on both pages

### DIFF
--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -901,7 +901,7 @@ export function BrowserDocumentPage({
           <Minimize2 aria-hidden="true" className="size-4" />
         </Button>
       )}
-      <div data-testid="spatial-editor-container" className="relative h-full min-h-0">
+      <div className="relative h-full min-h-0">
         <DocumentEditorSurface
           kind={documentKind}
           documentKey={documentId ?? 'no-canvas'}
@@ -924,7 +924,13 @@ export function BrowserDocumentPage({
           }
           spatial={() => (
             <div className="flex h-full min-h-0 flex-col">
-              <div className="relative min-h-0 flex-1">
+              {/* The hook sits INSIDE the spatial slot, as it does on the
+                  daemon page, so `spatial-editor-container` means the same
+                  thing on both: a spatial editor is mounted. Outside the
+                  slot it was also present for a markdown document, so one
+                  identifier answered two different questions depending on
+                  which page a test was written against. */}
+              <div data-testid="spatial-editor-container" className="relative min-h-0 flex-1">
                 {/* Keyed on canvas identity: the editor's pan/zoom, in-flight
                   gesture and open text editor all describe ONE canvas, and
                   `SpatialCanvas` carries no id for the editor to notice a

--- a/apps/web/src/pages/file-seam-conformance.test.ts
+++ b/apps/web/src/pages/file-seam-conformance.test.ts
@@ -97,6 +97,40 @@ function renders(source: string, chrome: string): boolean {
   return new RegExp(`<${chrome}[\\s/>]`).test(source)
 }
 
+/**
+ * `spatial-editor-container` must sit INSIDE each page's spatial slot.
+ *
+ * It is the hook most page tests reach for, and it meant two different things:
+ * the daemon page placed it inside the slot, so it answered "a spatial editor
+ * is mounted", while the browser page placed it around `DocumentEditorSurface`,
+ * so it also appeared for a MARKDOWN document and answered "the editor surface
+ * is mounted". Measured — `DocumentEditorSurface` does not render its `spatial`
+ * slot for a markdown document, so the two placements cannot agree.
+ *
+ * One identifier answering two questions makes a test written against one page
+ * silently wrong against the other, which is the same defect as chrome one page
+ * renders and the other does not, one layer down.
+ *
+ * A scan rather than a render, for the reason the file-seam scan gives: the
+ * property is WHERE the attribute sits in the source, and a render can only see
+ * one kind at a time.
+ */
+describe('the spatial-editor-container hook means one thing', () => {
+  it.each(PAGES)('%s places it inside the spatial slot', async (page) => {
+    const source = await read(page)
+    const slot = source.indexOf('spatial={() => (')
+    expect(slot, `${page} has no spatial slot to place it in`).toBeGreaterThan(-1)
+
+    const at = source.indexOf('data-testid="spatial-editor-container"')
+    expect(at, `${page} does not expose the hook at all`).toBeGreaterThan(-1)
+    expect(
+      at,
+      'the hook sits before the spatial slot, so it is present for a markdown ' +
+        'document too and no longer means "a spatial editor is mounted".',
+    ).toBeGreaterThan(slot)
+  })
+})
+
 describe('document page canvas chrome', () => {
   it.each(SHARED_CANVAS_CHROME)('both pages render %s', async (chrome) => {
     const missing: string[] = []

--- a/apps/web/src/pages/file-seam-conformance.test.ts
+++ b/apps/web/src/pages/file-seam-conformance.test.ts
@@ -116,18 +116,54 @@ function renders(source: string, chrome: string): boolean {
  * one kind at a time.
  */
 describe('the spatial-editor-container hook means one thing', () => {
-  it.each(PAGES)('%s places it inside the spatial slot', async (page) => {
-    const source = await read(page)
-    const slot = source.indexOf('spatial={() => (')
-    expect(slot, `${page} has no spatial slot to place it in`).toBeGreaterThan(-1)
+  const HOOK = 'data-testid="spatial-editor-container"'
+  const SLOT = 'spatial={() => ('
 
-    const at = source.indexOf('data-testid="spatial-editor-container"')
-    expect(at, `${page} does not expose the hook at all`).toBeGreaterThan(-1)
+  /**
+   * The slot callback's [start, end) range, by matching the paren the marker
+   * opens. `first occurrence comes after the opener` was the original
+   * assertion and it has two holes review named: it never proves the hook is
+   * INSIDE the callback, and a second hook added after the callback closes —
+   * outside it, so rendered for a markdown document too — keeps it green.
+   */
+  function spatialSlotRange(source: string): [number, number] {
+    const open = source.indexOf(SLOT)
+    if (open === -1) return [-1, -1]
+    let depth = 0
+    let i = open + SLOT.length - 1
+    for (; i < source.length; i++) {
+      if (source[i] === '(') depth += 1
+      else if (source[i] === ')') {
+        depth -= 1
+        if (depth === 0) break
+      }
+    }
+    return [open, i]
+  }
+
+  function hookOffsets(source: string): number[] {
+    const out: number[] = []
+    for (let i = source.indexOf(HOOK); i !== -1; i = source.indexOf(HOOK, i + 1)) out.push(i)
+    return out
+  }
+
+  it.each(PAGES)('%s places every occurrence inside the spatial slot', async (page) => {
+    const source = await read(page)
+    const [start, end] = spatialSlotRange(source)
+    expect(start, `${page} has no spatial slot to place it in`).toBeGreaterThan(-1)
+    // A slot whose body bracket-matched to nothing would let the range check
+    // below pass vacuously in one direction and fail nonsensically in the
+    // other; either way the range itself is the first thing to distrust.
+    expect(end - start, `${page}'s spatial slot range collapsed`).toBeGreaterThan(500)
+
+    const offsets = hookOffsets(source)
+    expect(offsets.length, `${page} does not expose the hook at all`).toBeGreaterThan(0)
+    const outside = offsets.filter((at) => at < start || at > end)
     expect(
-      at,
-      'the hook sits before the spatial slot, so it is present for a markdown ' +
-        'document too and no longer means "a spatial editor is mounted".',
-    ).toBeGreaterThan(slot)
+      outside,
+      'a hook outside the spatial slot is present for a markdown document ' +
+        'too, so it no longer means "a spatial editor is mounted".',
+    ).toEqual([])
   })
 })
 


### PR DESCRIPTION
## Summary

Second slice of the ADR-0004 page collapse. Measuring the two pages' structure before extracting anything turned up a divergence in the test hook their suites reach for most — so this slice moves one attribute and pins where it lives, ahead of the component extraction it protects.

**The same identifier answered two different questions:**

| page | placement | `getByTestId('spatial-editor-container')` meant |
|---|---|---|
| daemon | inside its `spatial` slot | "a **spatial** editor is mounted" |
| browser | around `DocumentEditorSurface` | "the editor surface is mounted" — **present for a markdown document too** |

Measured, not inferred from the source: `DocumentEditorSurface` does not render its `spatial` slot for a markdown document, so the two placements cannot agree. The daemon meaning matches the name; the browser page had an element called `spatial-editor-container` wrapping a markdown editor.

A test written against one page is silently wrong against the other — the same defect as chrome one page renders and the other does not (#1166), one layer down, in the surface tests grab first. 13 files and ~36 call sites query this hook.

**The fix moves only the `data-testid` attribute** into the browser page's spatial slot (onto its existing inner div). Both wrapper divs keep their classes, so the DOM layout is unchanged; only where the hook sits moves. A new scan in `file-seam-conformance.test.ts` pins the placement on both pages: the attribute must sit *after* `spatial={() => (` in each source, with reach assertions that the slot and the attribute both exist at all.

### Why a scan and not a render

The property is *where the attribute sits*, and a render can only see one document kind at a time — a markdown render on the browser page before this change was exactly the case nothing was looking at. Same reasoning the file-seam scan in the same file already records.

### Measurements toward the next slice

Taken while here, for the extraction this protects:

- `SpatialEditor`: **23 props, 19 shared, 14 byte-identical expressions**; the 5 genuinely per-page ones are identity/navigation-shaped (`key`, `canvas`, `initialTool`, `fileRefOptions`, `onOpenFileRef`)
- `NodeTextEditorOverlay`: **9/9 props shared**
- The measurement script itself misreported `canRedo` as divergent (it was the last prop on one page, so the extractor swept trailing text); both pages read `canRedo={canRedo()}`. Recorded because the instrument being wrong before the code is a recurring shape.

## Test plan

- [x] New or updated tests — the placement scan in `file-seam-conformance.test.ts` (2 reach assertions + the placement assertion, per page)
- [x] `pnpm test` locally, with the environment caveats below
- [x] Regression coverage — every browser-mode test that queries the hook was run directly: **7 files, 29 tests, all pass**; jsdom page suites **40 files / 371 tests** pass on the merged base
- [ ] Manual verification — not applicable: a `data-testid` has no user-visible surface

**Mutation-checked, restore confirmed green:**

| mutation | result |
|---|---|
| the attribute moved back outside the slot (the pre-change state) | the placement scan fails, naming the page |

**Known-failing in this container, none in a touched file, each discriminated rather than assumed:**

- Nine `web-jsdom` failures (`DocumentThumb`/`VersionThumbnail`/`MergeDialog`/`VersionTimeline`/`daemon-file-adapter`): `object.stream is not a function`, the documented Node 22 signature (this sandbox runs 22 against the pin of 24).
- A full `web-browser` run here shows 8 failures across 3 untouched files plus 2 `ENAMETOOLONG` teardown aborts (which silently abandon the rest of a file — 153 files, 131 accounted for). **A/B'd**: those same 3 files run as a subset pass **43/43 both with this diff and against clean `origin/main`** — the load-dependent full-run shape `dev-flow.md` documents, on a container with Chromium 1194 against the pinned 1228. CI's Node 24 + pinned browser run is the authoritative check.

## Visual evidence

Visual evidence: none — the change moves a `data-testid` attribute; no pixel differs. The evidence is the scan and the 29 direct browser-mode tests above.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — not applicable; no user-visible behavior or published contract changes
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the spatial editor test identifier so it appears only when a spatial editor is actually mounted.
  * Aligned document page behavior for more reliable spatial editor detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->