### PR TITLE
feat(web): record every gesture decision, so a phone can hand over the crash

### DIFF
--- a/apps/web/src/components/settings/GestureTraceRow.browser.test.tsx
+++ b/apps/web/src/components/settings/GestureTraceRow.browser.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * The retrieval half of the gesture flight recorder: what leaves the device
+ * is the serialized trace, it leaves only on the button, and what arrives is
+ * replayable JSON rather than prose.
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { gestureTrace, type TraceEntry } from '@/components/spatial-editor/gesture-trace'
+import { GestureTraceRow } from './GestureTraceRow'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+it('copies the serialized trace: parseable, replayable entries plus the bundle identity', async () => {
+  // Scoped by a pointerId this test minted: the singleton deliberately
+  // outlives every test, so "the newest entry" would read a neighbour's.
+  gestureTrace.recordDocPointer({
+    at: 1,
+    type: 'pointerdown',
+    pointerId: 461,
+    pointerType: 'touch',
+    isPrimary: true,
+    x: 10,
+    y: 20,
+    insideRoot: true,
+    target: { tag: 'div' },
+  })
+  const written: string[] = []
+  vi.spyOn(navigator.clipboard, 'writeText').mockImplementation(async (text) => {
+    written.push(text)
+  })
+
+  render(<GestureTraceRow />)
+  await userEvent.click(screen.getByRole('button', { name: 'Copy trace' }))
+
+  expect(written).toHaveLength(1)
+  const parsed = JSON.parse(written[0] ?? '') as {
+    bundle: string
+    userAgent: string
+    entries: TraceEntry[]
+  }
+  expect(parsed.bundle.length).toBeGreaterThan(0)
+  expect(parsed.userAgent.length).toBeGreaterThan(0)
+  const mine = parsed.entries.filter(
+    (entry) => entry.kind === 'doc-pointer' && entry.pointerId === 461,
+  )
+  expect(mine).toHaveLength(1)
+  expect(await screen.findByText('copied')).toBeInTheDocument()
+})
+
+it('says so, rather than pretending, when the clipboard refuses', async () => {
+  vi.spyOn(navigator.clipboard, 'writeText').mockRejectedValue(new Error('denied'))
+  render(<GestureTraceRow />)
+  await userEvent.click(screen.getByRole('button', { name: 'Copy trace' }))
+  expect(await screen.findByText('copy failed')).toBeInTheDocument()
+})

--- a/apps/web/src/components/settings/GestureTraceRow.tsx
+++ b/apps/web/src/components/settings/GestureTraceRow.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+import { gestureTrace } from '@/components/spatial-editor/gesture-trace'
+
+const BUTTON_CLASS =
+  'shrink-0 rounded-md border border-primary px-3 py-1 text-xs font-semibold text-primary hover:bg-primary/5'
+
+/**
+ * The retrieval half of the gesture flight recorder (see
+ * `spatial-editor/gesture-trace.ts`). Recording is always on precisely
+ * because the failure it exists for is noticed only after it happens; this
+ * row is how a phone, with no devtools within reach, hands the last ~200
+ * pointer decisions to whoever is investigating. The trace holds event
+ * kinds, coordinates, element test-ids and mode names — no document
+ * content — and leaves the device only when this button is pressed.
+ */
+export function GestureTraceRow() {
+  const [copied, setCopied] = useState<'idle' | 'copied' | 'failed'>('idle')
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(gestureTrace.serialize())
+      setCopied('copied')
+    } catch {
+      setCopied('failed')
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div>
+        <p className="flex flex-wrap items-baseline gap-x-2 text-sm font-medium">
+          Gesture diagnostics
+          <span className="font-mono text-[11px] font-normal text-muted-foreground">
+            {copied === 'copied'
+              ? 'copied'
+              : copied === 'failed'
+                ? 'copy failed'
+                : `${gestureTrace.entries().length} events recorded`}
+          </span>
+        </p>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          The last pointer events and what the canvas decided — coordinates and control names, never
+          document content. Copy it when a touch or drag misbehaved.
+        </p>
+      </div>
+      <button type="button" className={BUTTON_CLASS} onClick={() => void copy()}>
+        Copy trace
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -133,6 +133,7 @@ import {
   scaleBoxWithin,
   unionBox,
 } from './geometry.js'
+import { describeTarget, gestureTrace } from './gesture-trace.js'
 import {
   type CarriedSideCache,
   canReuseCarriedSides,
@@ -1487,6 +1488,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           }
           setMarquee(null)
           navigationRef.current = createIdleNavigation()
+          gestureTrace.recordReset('long-press-menu', Math.round(performance.now()))
           lastPressRef.current = null
           doublePressRef.current = null
           // The native long-press this replaces gave a system haptic; keep
@@ -1504,9 +1506,15 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * asks for. Every effect maps to something this component already did at
      * the site the machine replaced; nothing new is invented here.
      */
-    const runNavigation = (root: HTMLElement, event: NavigationEvent): NavigationResult => {
-      const result = reduceNavigation(navigationRef.current, event)
+    const runNavigation = (
+      root: HTMLElement,
+      event: NavigationEvent,
+      at: number,
+    ): NavigationResult => {
+      const before = navigationRef.current
+      const result = reduceNavigation(before, event)
       navigationRef.current = result.state
+      gestureTrace.recordNavigation({ at: Math.round(at), event, before, result })
       for (const effect of result.effects) {
         switch (effect.kind) {
           case 'pan':
@@ -1563,10 +1571,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         // would be read as an ordinary handback and never recovered. Their
         // release does reach handlePointerUp, because capture redirects the
         // rest of the sequence to the root.
-        navigationRef.current = reduceNavigation(navigationRef.current, {
-          type: 'external-press',
-          pointerId: e.pointerId,
-        }).state
+        runNavigation(root, { type: 'external-press', pointerId: e.pointerId }, e.timeStamp)
         capturePointer(root, e.pointerId)
       }
       return root
@@ -1612,7 +1617,19 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     }
 
     const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-      if (isOverlayEvent(e)) return
+      if (isOverlayEvent(e)) {
+        // The one rejection that used to leave no trace at all: a press an
+        // overlay took never reaches the machine, so a dead zone made of
+        // chrome reads as nothing having happened. The recorder names what
+        // took it.
+        gestureTrace.recordOverlayRejected({
+          at: Math.round(e.timeStamp),
+          pointerId: e.pointerId,
+          pointerType: e.pointerType,
+          target: describeTarget(e.target),
+        })
+        return
+      }
       const root = rootRef.current
       if (root === null) return
       const screenPoint = clientPointToRootLocal(e, root)
@@ -1622,31 +1639,35 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // it owns — which finger is down, whether two of them are driving the
       // viewport, whether this press continues a gather — lives in one value
       // in `navigation.ts` rather than in the refs this used to read.
-      const navigation = runNavigation(root, {
-        type: 'pointerdown',
-        pointerId: e.pointerId,
-        pointerType: navigationPointerKind(e.pointerType),
-        isPrimary: e.isPrimary,
-        button: e.button,
-        point: screenPoint,
-        timeStamp: e.timeStamp,
-        context: {
-          handMode: tool === 'hand',
-          spaceDown: spaceDownRef.current,
-          hitId,
-          // The anchor a gather would extend. Mid-gather it is the standing
-          // selection; otherwise only a node this press could join to, which
-          // is why entering hand mode — which clears the selection — can
-          // never gather.
-          anchorPrimaryId:
-            navigationRef.current.mode.kind === 'gathering'
-              ? selectedId
-              : gestureState.kind === 'moving'
-                ? gestureState.nodeId
-                : null,
-          manipulating: gestureState.kind !== 'idle',
+      const navigation = runNavigation(
+        root,
+        {
+          type: 'pointerdown',
+          pointerId: e.pointerId,
+          pointerType: navigationPointerKind(e.pointerType),
+          isPrimary: e.isPrimary,
+          button: e.button,
+          point: screenPoint,
+          timeStamp: e.timeStamp,
+          context: {
+            handMode: tool === 'hand',
+            spaceDown: spaceDownRef.current,
+            hitId,
+            // The anchor a gather would extend. Mid-gather it is the standing
+            // selection; otherwise only a node this press could join to, which
+            // is why entering hand mode — which clears the selection — can
+            // never gather.
+            anchorPrimaryId:
+              navigationRef.current.mode.kind === 'gathering'
+                ? selectedId
+                : gestureState.kind === 'moving'
+                  ? gestureState.nodeId
+                  : null,
+            manipulating: gestureState.kind !== 'idle',
+          },
         },
-      })
+        e.timeStamp,
+      )
       if (navigation.preventDefault === true) e.preventDefault()
       if (!navigation.fallThrough) return
       if (e.button !== 0) return
@@ -1812,12 +1833,16 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       ) {
         capturePointer(root, e.pointerId)
       }
-      const navigation = runNavigation(root, {
-        type: 'pointermove',
-        pointerId: e.pointerId,
-        pointerType: navigationPointerKind(e.pointerType),
-        point: screenPoint,
-      })
+      const navigation = runNavigation(
+        root,
+        {
+          type: 'pointermove',
+          pointerId: e.pointerId,
+          pointerType: navigationPointerKind(e.pointerType),
+          point: screenPoint,
+        },
+        e.timeStamp,
+      )
       if (!navigation.fallThrough) return
       if (marquee !== null) {
         setMarquee({ start: marquee.start, current: screenToCanvas(screenPoint, viewport) })
@@ -1838,11 +1863,15 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
       const root = rootRef.current
       if (root === null) return
-      const navigation = runNavigation(root, {
-        type: 'pointerup',
-        pointerId: e.pointerId,
-        pointerType: navigationPointerKind(e.pointerType),
-      })
+      const navigation = runNavigation(
+        root,
+        {
+          type: 'pointerup',
+          pointerId: e.pointerId,
+          pointerType: navigationPointerKind(e.pointerType),
+        },
+        e.timeStamp,
+      )
       // A release the machine answered was navigation — a finger leaving a
       // gather or a pinch, or the end of a pan. None of them run the click
       // and marquee semantics below: the sequence was never a gesture on the
@@ -2010,11 +2039,15 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // The machine's own cancel arm emits the long-press clear, the capture
       // release and the gesture cancel, in that order — the three things
       // this handler used to do by hand across four refs.
-      runNavigation(root, {
-        type: 'pointercancel',
-        pointerId: e.pointerId,
-        pointerType: navigationPointerKind(e.pointerType),
-      })
+      runNavigation(
+        root,
+        {
+          type: 'pointercancel',
+          pointerId: e.pointerId,
+          pointerType: navigationPointerKind(e.pointerType),
+        },
+        e.timeStamp,
+      )
     }
 
     /**
@@ -2036,6 +2069,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      */
     const handleLostPointerCapture = (e: React.PointerEvent<HTMLDivElement>) => {
       if (!navigationRef.current.down.has(e.pointerId)) return
+      gestureTrace.recordLostCapture(e.pointerId, Math.round(e.timeStamp))
       handlePointerCancel(e)
     }
 
@@ -2627,6 +2661,40 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     // out) would otherwise leave the browser holding capture for a pointer
     // no element can any longer respond to. Best-effort/never-throw, same
     // reasoning as `trySetPointerCapture`.
+    // The flight recorder's document-side ear. The root's own handlers can
+    // only record presses that REACH them, and the report this recorder
+    // exists for is precisely a press that seems not to: an element outside
+    // the root — a portal, a stale overlay — consumes it before the editor
+    // sees anything. A capture-phase listener on the document sees every
+    // press first and records whether it was headed inside the root, which
+    // is the discriminator nothing else can supply. Down/up/cancel only:
+    // moves would flood the ring, and the missing-press question never
+    // needs them.
+    useEffect(() => {
+      const record = (e: PointerEvent) => {
+        const root = rootRef.current
+        gestureTrace.recordDocPointer({
+          at: Math.round(e.timeStamp),
+          type: e.type,
+          pointerId: e.pointerId,
+          pointerType: e.pointerType,
+          isPrimary: e.isPrimary,
+          x: Math.round(e.clientX),
+          y: Math.round(e.clientY),
+          insideRoot: root !== null && e.target instanceof Node && root.contains(e.target),
+          target: describeTarget(e.target),
+        })
+      }
+      document.addEventListener('pointerdown', record, true)
+      document.addEventListener('pointerup', record, true)
+      document.addEventListener('pointercancel', record, true)
+      return () => {
+        document.removeEventListener('pointerdown', record, true)
+        document.removeEventListener('pointerup', record, true)
+        document.removeEventListener('pointercancel', record, true)
+      }
+    }, [])
+
     useEffect(() => {
       // Capture the root HERE, at mount, rather than reading `rootRef.current`
       // inside the cleanup closure: React detaches the ref (sets it to

--- a/apps/web/src/components/spatial-editor/gesture-trace.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/gesture-trace.browser.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * The flight recorder's wiring: each of the three ways a press can vanish
+ * leaves a DIFFERENT trace, and telling them apart is the recorder's whole
+ * job — the phone report it exists for is "I pressed and nothing happened",
+ * which is one sentence describing three distinct mechanisms.
+ *
+ * Entries are scoped by a pointerId each test mints, never by counting the
+ * singleton's length: the recorder deliberately survives across tests, and
+ * an assertion on "the newest entry" would read a neighbour's press as its
+ * own (the global-counter flake shape).
+ */
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { gestureTrace, type TraceEntry } from './gesture-trace.js'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const board: SpatialCanvas = {
+  nodes: [{ id: 'n1', type: 'text', x: 60, y: 60, width: 200, height: 100, text: 'hello' }],
+  edges: [],
+}
+
+function Host() {
+  const [canvas, setCanvas] = useState(board)
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor defaultTool="hand" canvas={canvas} onChange={setCanvas} theme="light" />
+    </div>
+  )
+}
+
+function touch(target: Element, type: 'down' | 'move' | 'up', id: number, x: number, y: number) {
+  const init = {
+    pointerId: id,
+    pointerType: 'touch',
+    isPrimary: true,
+    button: 0,
+    buttons: type === 'up' ? 0 : 1,
+    clientX: x,
+    clientY: y,
+  }
+  if (type === 'down') fireEvent.pointerDown(target, init)
+  else if (type === 'move') fireEvent.pointerMove(target, init)
+  else fireEvent.pointerUp(target, init)
+}
+
+function entriesFor(pointerId: number): TraceEntry[] {
+  return gestureTrace.entries().filter((entry) => {
+    if (entry.kind === 'navigation')
+      return 'pointerId' in entry.event && entry.event.pointerId === pointerId
+    if (entry.kind === 'reset') return false
+    return entry.pointerId === pointerId
+  })
+}
+
+it('a hand drag records the machine answering: panning, then idle again', () => {
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const r = root.getBoundingClientRect()
+  touch(root, 'down', 71, r.left + 300, r.top + 300)
+  touch(root, 'move', 71, r.left + 340, r.top + 320)
+  touch(root, 'up', 71, r.left + 340, r.top + 320)
+
+  const modes = entriesFor(71).flatMap((entry) =>
+    entry.kind === 'navigation' ? [entry.modeAfter] : [],
+  )
+  expect(modes).toEqual(['panning', 'panning', 'idle'])
+  // The document-side ear heard the same press, headed inside the root.
+  const doc = entriesFor(71).filter((entry) => entry.kind === 'doc-pointer')
+  expect(doc.map((entry) => (entry.kind === 'doc-pointer' ? entry.insideRoot : false))).toEqual([
+    true,
+    true,
+  ])
+})
+
+it('a press the dock takes is recorded with the name of what took it', () => {
+  const { container } = render(<Host />)
+  const dock = container.querySelector('[aria-label="Canvas tools"]') as HTMLElement
+  const b = dock.getBoundingClientRect()
+  touch(dock, 'down', 72, b.left + 4, b.top + 4)
+  touch(dock, 'up', 72, b.left + 4, b.top + 4)
+
+  const mine = entriesFor(72)
+  const rejected = mine.filter((entry) => entry.kind === 'overlay-rejected')
+  expect(rejected).toHaveLength(1)
+  expect(rejected[0]?.kind === 'overlay-rejected' && rejected[0].target.overlay).toBe(
+    'tool-palette',
+  )
+  // The PRESS never consulted the machine: chrome answers for itself. The
+  // release did and should — a release is never overlay-filtered, so a
+  // control the press bubbled from still gets its click.
+  const consulted = mine.flatMap((entry) => (entry.kind === 'navigation' ? [entry.event.type] : []))
+  expect(consulted).toEqual(['pointerup'])
+})
+
+it('a press a portal element takes never reaches the editor, and the trace says so', () => {
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const r = root.getBoundingClientRect()
+  const portal = document.createElement('div')
+  portal.setAttribute('data-testid', 'trace-test-portal')
+  portal.style.cssText = `position:fixed;left:${r.left + 200}px;top:${r.top + 200}px;width:120px;height:120px;z-index:9999`
+  document.body.append(portal)
+  try {
+    touch(portal, 'down', 73, r.left + 240, r.top + 240)
+    touch(portal, 'up', 73, r.left + 240, r.top + 240)
+  } finally {
+    portal.remove()
+  }
+
+  const mine = entriesFor(73)
+  const doc = mine.filter((entry) => entry.kind === 'doc-pointer' && entry.type === 'pointerdown')
+  expect(doc).toHaveLength(1)
+  expect(doc[0]?.kind === 'doc-pointer' && doc[0].insideRoot).toBe(false)
+  expect(doc[0]?.kind === 'doc-pointer' && doc[0].target.testId).toBe('trace-test-portal')
+  // This is the whole discriminator: the document heard it, the editor never did.
+  expect(mine.filter((entry) => entry.kind === 'navigation')).toEqual([])
+  expect(mine.filter((entry) => entry.kind === 'overlay-rejected')).toEqual([])
+})

--- a/apps/web/src/components/spatial-editor/gesture-trace.test.ts
+++ b/apps/web/src/components/spatial-editor/gesture-trace.test.ts
@@ -1,0 +1,143 @@
+/**
+ * The gesture flight recorder's own behaviour: a bounded ring, coalesced
+ * moves, and a serialized form that replays through the navigation reducer
+ * deterministically.
+ *
+ * Replay is the point of the whole module. A phone reproduction arrives as
+ * pasted JSON, and because `reduceNavigation` is pure, folding it over the
+ * recorded events answers "what did the machine decide" without the phone,
+ * the browser, or the session that recorded it.
+ */
+import { describe, expect, it } from 'vitest'
+import { createGestureTrace, replayNavigation, type TraceEntry } from './gesture-trace.js'
+import {
+  createIdleNavigation,
+  type NavigationEvent,
+  type NavigationState,
+  reduceNavigation,
+} from './navigation.js'
+
+const HAND_CONTEXT = {
+  handMode: true,
+  spaceDown: false,
+  hitId: undefined,
+  anchorPrimaryId: null,
+  manipulating: false,
+}
+
+function down(pointerId: number, x: number, y: number, timeStamp = 0): NavigationEvent {
+  return {
+    type: 'pointerdown',
+    pointerId,
+    pointerType: 'touch',
+    isPrimary: true,
+    button: 0,
+    point: { x, y },
+    timeStamp,
+    context: HAND_CONTEXT,
+  }
+}
+
+function move(pointerId: number, x: number, y: number): NavigationEvent {
+  return { type: 'pointermove', pointerId, pointerType: 'touch', point: { x, y } }
+}
+
+function up(pointerId: number): NavigationEvent {
+  return { type: 'pointerup', pointerId, pointerType: 'touch' }
+}
+
+/**
+ * Drives the REAL reducer and records what it answered, the way
+ * `SpatialEditor` does: the recorder never reduces anything itself, so it
+ * cannot disagree with what the component actually performed.
+ */
+function makeRecorder(trace = createGestureTrace()) {
+  let state: NavigationState = createIdleNavigation()
+  return {
+    trace,
+    feed(event: NavigationEvent, at: number) {
+      const result = reduceNavigation(state, event)
+      trace.recordNavigation({ at, event, before: state, result })
+      state = result.state
+    },
+  }
+}
+
+function recordDrag(trace = createGestureTrace(), moves = 3) {
+  const recorder = makeRecorder(trace)
+  recorder.feed(down(1, 100, 100), 0)
+  for (let i = 1; i <= moves; i += 1) recorder.feed(move(1, 100 + i * 10, 100), i)
+  recorder.feed(up(1), moves + 1)
+  return trace
+}
+
+describe('the ring', () => {
+  it('keeps the newest entries once capacity is reached', () => {
+    const trace = createGestureTrace(3)
+    for (let i = 0; i < 10; i += 1) {
+      trace.recordDocPointer({
+        at: i,
+        type: 'pointerdown',
+        pointerId: i,
+        pointerType: 'touch',
+        isPrimary: true,
+        x: 0,
+        y: 0,
+        insideRoot: true,
+        target: { tag: 'div' },
+      })
+    }
+    const ids = trace
+      .entries()
+      .map((entry) => (entry.kind === 'doc-pointer' ? entry.pointerId : -1))
+    expect(ids).toEqual([7, 8, 9])
+  })
+
+  it('coalesces the moves of one continuing gesture instead of flooding', () => {
+    const trace = recordDrag(createGestureTrace(), 50)
+    const kinds = trace.entries().map((entry) => entry.kind)
+    // down, ONE move entry carrying a counter, up — not 52 entries.
+    expect(kinds).toEqual(['navigation', 'navigation', 'navigation'])
+    const moveEntry = trace.entries()[1]
+    if (moveEntry?.kind !== 'navigation') throw new Error('expected a navigation entry')
+    expect(moveEntry.coalescedMoves).toBe(49)
+    expect(moveEntry.modeAfter).toBe('panning')
+  })
+
+  it('does not coalesce across a mode change', () => {
+    const recorder = makeRecorder()
+    const trace = recorder.trace
+    recorder.feed(down(1, 100, 100), 0)
+    recorder.feed(move(1, 110, 100), 1)
+    recorder.feed(up(1), 2)
+    recorder.feed(down(1, 300, 300, 1000), 3)
+    const modes = trace
+      .entries()
+      .map((entry) => (entry.kind === 'navigation' ? entry.modeAfter : '?'))
+    expect(modes).toEqual(['panning', 'panning', 'idle', 'panning'])
+  })
+})
+
+describe('serialize and replay', () => {
+  it('round-trips: the replayed mode sequence is the recorded one', () => {
+    const trace = recordDrag()
+    // The component resets the machine outside the reducer in one place (the
+    // long-press menu firing); a recorded reset must replay as one, or every
+    // event after it replays against the wrong state.
+    trace.recordReset('long-press-menu', 99)
+    const recorder = makeRecorder(trace)
+    recorder.feed(down(1, 50, 50, 2000), 100)
+    const parsed = JSON.parse(trace.serialize()) as { entries: TraceEntry[] }
+    const recorded = parsed.entries.flatMap((entry) =>
+      entry.kind === 'navigation' ? [entry.modeAfter] : [],
+    )
+    expect(replayNavigation(parsed.entries)).toEqual(recorded)
+  })
+
+  it('carries the bundle identity and the device beside the entries', () => {
+    const parsed = JSON.parse(createGestureTrace().serialize()) as Record<string, unknown>
+    expect(typeof parsed.bundle).toBe('string')
+    expect((parsed.bundle as string).length).toBeGreaterThan(0)
+    expect(typeof parsed.userAgent).toBe('string')
+  })
+})

--- a/apps/web/src/components/spatial-editor/gesture-trace.ts
+++ b/apps/web/src/components/spatial-editor/gesture-trace.ts
@@ -1,0 +1,225 @@
+/**
+ * The gesture flight recorder: a bounded, always-on ring of what the pointer
+ * pipeline saw and what the navigation machine answered.
+ *
+ * It exists for the failure that cannot be reproduced on demand — "the hand
+ * tool sometimes does not respond" on a phone, noticed only after the press
+ * that died. A recorder the user has to arm first records nothing, so this
+ * one always runs; what makes that acceptable is what it holds: event kinds,
+ * coordinates, element test-ids and mode names. Never document content.
+ *
+ * Because `reduceNavigation` is pure and its events are plain data, a
+ * serialized trace REPLAYS: fold the reducer over the recorded events and
+ * the machine's decisions are reproduced away from the device that made
+ * them. That fold is `replayNavigation`, and it is the reason the recorder
+ * stores whole `NavigationEvent`s rather than a prose summary.
+ *
+ * The singleton below deliberately outlives every component — the exact
+ * lifetime this editor's state discipline forbids elsewhere. A flight
+ * recorder that unmounts with the crash it recorded is decoration; the ring
+ * is bounded, so surviving costs a fixed few KB.
+ */
+import {
+  createIdleNavigation,
+  type NavigationEvent,
+  type NavigationResult,
+  type NavigationState,
+  reduceNavigation,
+} from './navigation.js'
+
+/** Where a pointer landed, compressed to what a reader can act on. */
+export interface TargetDescriptor {
+  readonly tag: string
+  readonly testId?: string
+  readonly label?: string
+  /** The `data-editor-overlay` ancestor that would swallow a press, if any. */
+  readonly overlay?: string
+}
+
+export type TraceEntry =
+  | {
+      kind: 'navigation'
+      at: number
+      /** When the newest coalesced move landed; absent until one does. */
+      lastAt?: number
+      /** Further moves merged into this entry — see recordNavigation. */
+      coalescedMoves: number
+      event: NavigationEvent
+      modeBefore: string
+      modeAfter: string
+      effects: readonly string[]
+      fallThrough: boolean
+    }
+  | {
+      kind: 'doc-pointer'
+      at: number
+      type: string
+      pointerId: number
+      pointerType: string
+      isPrimary: boolean
+      x: number
+      y: number
+      /** False is the finding: a press some portal took before the editor could see it. */
+      insideRoot: boolean
+      target: TargetDescriptor
+    }
+  | {
+      kind: 'overlay-rejected'
+      at: number
+      pointerId: number
+      pointerType: string
+      target: TargetDescriptor
+    }
+  | { kind: 'lost-capture'; at: number; pointerId: number }
+  /** The one place the component resets the machine outside the reducer. */
+  | { kind: 'reset'; at: number; reason: string }
+
+export interface RecordedNavigation {
+  readonly at: number
+  readonly event: NavigationEvent
+  readonly before: NavigationState
+  readonly result: NavigationResult
+}
+
+export interface GestureTrace {
+  recordNavigation(record: RecordedNavigation): void
+  recordDocPointer(entry: Omit<Extract<TraceEntry, { kind: 'doc-pointer' }>, 'kind'>): void
+  recordOverlayRejected(
+    entry: Omit<Extract<TraceEntry, { kind: 'overlay-rejected' }>, 'kind'>,
+  ): void
+  recordLostCapture(pointerId: number, at: number): void
+  recordReset(reason: string, at: number): void
+  entries(): readonly TraceEntry[]
+  serialize(): string
+}
+
+/** Effects that mean "the same gesture, continuing" rather than a decision. */
+const CONTINUATION_EFFECTS = new Set(['pan', 'pinch'])
+
+export function createGestureTrace(capacity = 200): GestureTrace {
+  const ring: TraceEntry[] = []
+
+  const push = (entry: TraceEntry) => {
+    ring.push(entry)
+    if (ring.length > capacity) ring.splice(0, ring.length - capacity)
+  }
+
+  return {
+    recordNavigation(record) {
+      const { at, event, before, result } = record
+      const modeAfter = result.state.mode.kind
+      const effects = result.effects.map((effect) => effect.kind)
+      // One pan is a decision; the 200 moves that continue it are not, and
+      // at one entry each they would evict the press this recorder exists
+      // to keep. A move that changes nothing but the viewport merges into
+      // the entry that started it, counted rather than kept.
+      const last = ring[ring.length - 1]
+      if (
+        event.type === 'pointermove' &&
+        last !== undefined &&
+        last.kind === 'navigation' &&
+        // Only into a previous MOVE: a press's effect list can be empty, and
+        // an empty list passes the continuation check vacuously — measured,
+        // the first move of every drag merged into its press until this line.
+        last.event.type === 'pointermove' &&
+        last.modeAfter === modeAfter &&
+        !result.fallThrough &&
+        !last.fallThrough &&
+        effects.every((effect) => CONTINUATION_EFFECTS.has(effect)) &&
+        last.effects.every((effect) => CONTINUATION_EFFECTS.has(effect))
+      ) {
+        last.coalescedMoves += 1
+        last.lastAt = at
+        return
+      }
+      push({
+        kind: 'navigation',
+        at,
+        coalescedMoves: 0,
+        event,
+        modeBefore: before.mode.kind,
+        modeAfter,
+        effects,
+        fallThrough: result.fallThrough,
+      })
+    },
+    recordDocPointer(entry) {
+      push({ kind: 'doc-pointer', ...entry })
+    },
+    recordOverlayRejected(entry) {
+      push({ kind: 'overlay-rejected', ...entry })
+    },
+    recordLostCapture(pointerId, at) {
+      push({ kind: 'lost-capture', at, pointerId })
+    },
+    recordReset(reason, at) {
+      push({ kind: 'reset', at, reason })
+    },
+    entries() {
+      return ring.slice()
+    },
+    serialize() {
+      return JSON.stringify({
+        recordedAt: new Date().toISOString(),
+        // The recorder module's own URL: hash-named in a production build,
+        // which is what tells a trace from a stale service-worker bundle
+        // apart from one running the deploy it claims to.
+        bundle: import.meta.url,
+        userAgent: typeof navigator === 'undefined' ? 'unknown' : navigator.userAgent,
+        viewport:
+          typeof window === 'undefined'
+            ? undefined
+            : {
+                width: window.innerWidth,
+                height: window.innerHeight,
+                dpr: window.devicePixelRatio,
+              },
+        entries: ring,
+      })
+    },
+  }
+}
+
+/**
+ * Folds the reducer over a trace's navigation entries — one mode per entry,
+ * resets applied where they were recorded. Coalescing keeps only the first
+ * move of a run, so the fold sees fewer moves than the device did; every
+ * merged move left the mode unchanged by construction, which is why
+ * comparing MODE KINDS is sound and comparing pan positions would not be.
+ */
+export function replayNavigation(entries: readonly TraceEntry[]): string[] {
+  let state = createIdleNavigation()
+  const modes: string[] = []
+  for (const entry of entries) {
+    if (entry.kind === 'reset') {
+      state = createIdleNavigation()
+      continue
+    }
+    if (entry.kind !== 'navigation') continue
+    state = reduceNavigation(state, entry.event).state
+    modes.push(state.mode.kind)
+  }
+  return modes
+}
+
+/** Compresses an event target to the identity a trace reader can act on. */
+export function describeTarget(target: EventTarget | null): TargetDescriptor {
+  if (!(target instanceof Element)) return { tag: '?' }
+  const overlay = target.closest('[data-editor-overlay]')
+  const overlayName =
+    overlay === null
+      ? undefined
+      : (overlay.getAttribute('data-testid') ??
+        overlay.getAttribute('aria-label') ??
+        overlay.tagName.toLowerCase())
+  const carrier = target.closest('[data-testid]')
+  return {
+    tag: target.tagName.toLowerCase(),
+    testId: carrier?.getAttribute('data-testid') ?? undefined,
+    label: target.getAttribute('aria-label') ?? undefined,
+    overlay: overlayName,
+  }
+}
+
+/** The flight recorder. One per page on purpose — see the module docstring. */
+export const gestureTrace: GestureTrace = createGestureTrace()

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -13,6 +13,7 @@ import {
 import { useCallback, useEffect, useId, useRef, useState, useSyncExternalStore } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { AppVersionRow } from '@/components/settings/AppVersionRow'
+import { GestureTraceRow } from '@/components/settings/GestureTraceRow'
 import { PromoteWorkspaceSection } from '@/components/settings/PromoteWorkspaceSection'
 import type { PersistStepState } from '@/components/settings/SetupJourney'
 import { findVisibleJourneyBadge, SetupJourney } from '@/components/settings/SetupJourney'
@@ -326,6 +327,9 @@ function sectionContent(
           />
           <div className="mt-6 border-t pt-4">
             <AppVersionRow />
+          </div>
+          <div className="mt-4 border-t pt-4">
+            <GestureTraceRow />
           </div>
         </div>
       )

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -16,6 +16,8 @@ Guides:
   app and copy canvases kept in your browser onto it.
 - **[install-fonts-for-export](install-fonts-for-export.md)** — stop exports rendering Japanese,
   Chinese, Korean and other scripts as empty boxes.
+- **[report-a-gesture-problem](report-a-gesture-problem.md)** — copy the built-in pointer-event
+  trace from Settings when a touch or drag misbehaved.
 - **[view-canvas-in-chat](view-canvas-in-chat.md)** — render an interactive read-only canvas
   view inline in an MCP Apps-compatible AI chat client (currently unavailable — see the page's
   notice).

--- a/docs/how-to/report-a-gesture-problem.md
+++ b/docs/how-to/report-a-gesture-problem.md
@@ -1,0 +1,32 @@
+# Report a gesture problem
+
+When a touch or drag on the canvas misbehaves — a press that does not pan, a pinch that jumps —
+the app has already recorded what happened. The editor keeps a rolling record of the last ~200
+pointer events and what the canvas decided for each one, so you do not need to reproduce the
+problem on demand or attach a debugger to your phone.
+
+## Copy the trace
+
+1. Right after the misbehaving gesture, open **Settings**.
+2. Find **Gesture diagnostics** (under the app section, next to *App version*).
+3. Tap **Copy trace**.
+
+The trace is now on your clipboard as JSON. Paste it into a bug report, an issue, or a chat with
+whoever is investigating.
+
+Do this soon after the problem: the record is a rolling window, and roughly 40–60 later
+taps will push the interesting events out of it.
+
+## What the trace contains
+
+Event kinds, screen coordinates, the internal names of controls that were pressed, mode names
+(such as `panning`), your browser's user-agent string, the running bundle's file name, and the
+viewport size. It never contains document content — no text, no node data, no titles.
+
+Nothing is sent anywhere by itself. The trace leaves your device only when you copy and share it.
+
+## What an investigator can do with it
+
+The canvas's gesture decisions are made by a pure function over these events, so a pasted trace
+can be replayed exactly, away from your device — including whether a press ever reached the
+editor at all, or was consumed by another element in front of it.


### PR DESCRIPTION
## Summary

The report this serves cannot be reproduced on demand: *"the hand tool sometimes does not respond"*, on a phone, noticed only after the press that died. The instrumented search so far — a 6,231-point response map over the reporter's own board, two browser properties, a model-based one — found and fixed four real defects (#1157–#1164) and still cannot see the one dimension that matters: **what events the real device actually delivered**. This records that dimension, always, into a bounded ring of ~200 entries, and gives the phone a way to hand it over.

This is the payoff the navigation-reducer stack (#1160/#1162/#1164) was built toward: because `reduceNavigation` is pure and its events are plain data, a pasted trace **replays** — `replayNavigation` folds the reducer over the recorded events and reproduces the device's decisions away from the device. The round-trip is pinned by a unit test.

## The three seams, and the three ways a press vanishes

| seam | what it answers |
|---|---|
| `runNavigation` records every event + the machine's answer (modes, effects, `fallThrough`) | "the machine decided something surprising" |
| the `isOverlayEvent` rejection records **with the identity of what took the press** | the path that used to leave no trace at all — the family the link-embed dead zone (#1158) lived in |
| a document-level capture listener records every press with `insideRoot` | a press a portal element takes never reaches the root's handlers; **no component-side recording can see it**. `insideRoot: false` is the discriminator nothing else supplies |

The trace also carries the recorder module's own URL — hash-named in a production build — and the user agent, so a trace from a **stale service-worker bundle identifies itself** (the one live hypothesis for the phone report that no test can reach).

## Design decisions, argued

- **Always on.** A recorder the user must arm first records nothing, because the failure is noticed after it happens. What makes always-on acceptable: the ring holds event kinds, coordinates, element test-ids, mode names — never document content — and leaves the device only through the Settings row's Copy button.
- **Moves coalesce.** One drag emits hundreds of moves; at one entry each they would evict the press the recorder exists to keep. A move that changes nothing but the viewport merges into the entry that started the run, counted. Sound for replay because a merged move never changed the mode — the replay compares mode kinds, and the docstring says why positions would not be sound.
- **A deliberate singleton.** The exact lifetime this editor's state discipline forbids elsewhere, and the point: a flight recorder that unmounts with the crash it recorded is decoration. Bounded, so surviving costs a fixed few KB.

## A bug the red test caught before it shipped

The first coalescing merged a drag's first move into its **press** — a press's effect list can be empty, and `[].every(...)` passes the continuation check vacuously. The unit test measured it (2 entries where 3 belonged); the guard now requires the previous entry to be a move. The same vacuous-`every` shape as the guards this session kept finding, one layer down.

## Test plan

- [x] `gesture-trace.test.ts` — ring cap, coalescing, mode-change boundary, serialize→replay round-trip, bundle identity (5 tests, `web-jsdom`)
- [x] `gesture-trace.browser.test.tsx` — the three discriminators: a hand drag records `panning→panning→idle`; a dock press records `overlay-rejected` naming `tool-palette` and the machine sees only the release; a portal press records `insideRoot: false` and the editor records nothing (3 tests)
- [x] `GestureTraceRow.browser.test.tsx` — the copy writes parseable, replayable JSON with bundle + UA; a refused clipboard says `copy failed` rather than pretending (2 tests)
- [x] Mutation-checked seam by seam: removing the document listener fails the portal case + the drag's document assertions; removing the overlay recording fails the dock case; removing the navigation recording fails the drag + the dock's release expectation
- [x] Entries in the browser tests are scoped by pointerIds each test mints, never by counting the singleton — the global-counter flake shape from `integrator-flow.md`
- [x] Touched areas: spatial-editor + settings + pages browser files — **101 files / 490 tests** green
- [x] `tsc --noEmit`, `pnpm knip` clean; ledger scans (`editor-state-surface`, `scoped-screen-state`) unchanged and green
- [ ] Full `pnpm --filter @kamiazya/whiteboard-web test` + `pnpm test:browser` — running, reported before merge

Design checkpoints: `check-design.mjs` — all met (design in the session scratchpad).

**blastRadius:** SpatialEditor's pointer handlers (415 browser tests watch them); SettingsPage (its tests watch rendering); the singleton is additive observation — no existing behaviour reads it.

**userReach:** the Settings **Gesture diagnostics** row, shipped in this increment; recording itself is always on so the user does not have to arm it before the bug happens.

## Visual evidence

`Visual evidence: none — the recorder is observation with no pixel effect; the one visible surface is a Settings row whose two states (count / copied) are asserted by its browser test. The measurements that justify the feature are the discriminator table above.`

## Docs

`docs/how-to/report-a-gesture-problem.md` (+ index): copy soon (rolling window), what the trace contains, that nothing leaves the device on its own.

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_