### PR TITLE
fix(web): stop reading the editor's own capture transfer as a capture loss

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -2068,6 +2068,19 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * inherits it.
      */
     const handleLostPointerCapture = (e: React.PointerEvent<HTMLDivElement>) => {
+      // Only the ROOT losing capture is a loss. A real touch implicitly
+      // captures the pointer to the element under the finger (Pointer
+      // Events, "implicit pointer capture") — over a node that is an SVG
+      // child, not this root — and the first move's own capturePointer()
+      // then TRANSFERS capture here, which fires `lostpointercapture` on
+      // that child a frame later, bubbling to this handler. Treating the
+      // transfer this component itself performed as a loss cancelled the
+      // pan under a still-moving finger: pressed over a node it died within
+      // two frames, pressed over empty canvas (implicit capture already on
+      // the root, transfer a no-op, no event) it lived. Synthetic pointer
+      // events get no implicit capture, so only a real device ever showed
+      // it — caught by the gesture flight recorder, not by a test.
+      if (e.target !== e.currentTarget) return
       if (!navigationRef.current.down.has(e.pointerId)) return
       gestureTrace.recordLostCapture(e.pointerId, Math.round(e.timeStamp))
       handlePointerCancel(e)

--- a/apps/web/src/components/spatial-editor/hand-pan-capture-echo.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/hand-pan-capture-echo.browser.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * The phone bug, reproduced from its own flight-recorder trace
+ * (2026-09-01, Android Chrome 151): a hand pan that starts ON A NODE dies
+ * within two frames, while the finger keeps dragging and every move still
+ * reaches the root.
+ *
+ * Mechanism: a REAL touch gives implicit pointer capture to the element
+ * under the finger (Pointer Events, "implicit pointer capture") — a node's
+ * SVG child, not the root. The editor then takes capture onto the root at
+ * the first move, which is a capture TRANSFER: the child's
+ * `lostpointercapture` bubbles to the root one frame later, and a handler
+ * that only asks "is this pointer still down?" reads the transfer it
+ * itself performed as a loss, cancels, and strands the pan under a moving
+ * finger. Over empty canvas the implicit capture already sits on the root,
+ * the transfer is a no-op, no event fires — which is why every report said
+ * empty space always panned and nodes sometimes did not.
+ *
+ * Synthetic events get NO implicit capture, which is why three sessions of
+ * simulation never saw this. The tests below dispatch the child's echo
+ * explicitly — the exact event pattern the trace recorded.
+ */
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+const board: SpatialCanvas = {
+  nodes: [{ id: 'n1', type: 'text', x: 60, y: 60, width: 240, height: 140, text: 'node' }],
+  edges: [],
+}
+
+function Host() {
+  const [canvas, setCanvas] = useState(board)
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor defaultTool="hand" canvas={canvas} onChange={setCanvas} theme="light" />
+    </div>
+  )
+}
+
+function translateOf(container: HTMLElement): { x: number; y: number } {
+  const css = (container.querySelector('[data-testid="viewport-transform"]') as HTMLElement).style
+    .transform
+  const m = css.match(/translate\(([-\d.e+]+)px, ([-\d.e+]+)px\)/)
+  if (m === null) throw new Error(`unexpected transform: ${css}`)
+  return { x: Number(m[1]), y: Number(m[2]) }
+}
+
+function touch(target: Element, type: 'down' | 'move' | 'up', x: number, y: number) {
+  const init = {
+    pointerId: 9,
+    pointerType: 'touch',
+    isPrimary: true,
+    button: 0,
+    buttons: type === 'up' ? 0 : 1,
+    clientX: x,
+    clientY: y,
+  }
+  if (type === 'down') fireEvent.pointerDown(target, init)
+  else if (type === 'move') fireEvent.pointerMove(target, init)
+  else fireEvent.pointerUp(target, init)
+}
+
+it('a pan pressed on a node survives the capture transfer its own first move performs', () => {
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const content = container.querySelector('[data-testid="canvas-content"]') as HTMLElement
+  const child = content.querySelector('svg') ?? content
+  const r = root.getBoundingClientRect()
+
+  const before = translateOf(container)
+  // Press ON the node's own element, as a finger over a node does.
+  touch(child, 'down', r.left + 150, r.top + 120)
+  touch(root, 'move', r.left + 160, r.top + 130)
+  // The echo of the editor's own root.setPointerCapture: the implicitly
+  // captured child loses capture TO the root, and its event bubbles up.
+  fireEvent(child, new PointerEvent('lostpointercapture', { pointerId: 9, bubbles: true }))
+  touch(root, 'move', r.left + 190, r.top + 160)
+  touch(root, 'up', r.left + 190, r.top + 160)
+
+  const after = translateOf(container)
+  // The finger travelled +40/+40 in total; the canvas must have followed all
+  // of it — on the trace this recorder caught, everything after the echo was
+  // dropped on the floor.
+  expect({ dx: after.x - before.x, dy: after.y - before.y }).toEqual({ dx: 40, dy: 40 })
+})
+
+it('the ROOT losing capture mid-pan still cancels: that one is a real loss', () => {
+  const { container } = render(<Host />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  const r = root.getBoundingClientRect()
+
+  const before = translateOf(container)
+  touch(root, 'down', r.left + 400, r.top + 400)
+  touch(root, 'move', r.left + 410, r.top + 410)
+  fireEvent(root, new PointerEvent('lostpointercapture', { pointerId: 9, bubbles: true }))
+  // Whatever arrives after a genuine loss must not pan: the browser owns
+  // the pointer now.
+  touch(root, 'move', r.left + 470, r.top + 470)
+  touch(root, 'up', r.left + 470, r.top + 470)
+
+  const after = translateOf(container)
+  expect({ dx: after.x - before.x, dy: after.y - before.y }).toEqual({ dx: 10, dy: 10 })
+})


### PR DESCRIPTION
## Summary

**The phone bug.** *"The hand tool sometimes does not respond"* — dense areas sometimes dead, empty canvas always fine, never reproducible on demand — was the editor **cancelling its own pan**.

Caught by the gesture flight recorder (#1171) on its **first field trace** (2026-09-01, Android Chrome 151). Two pans in that trace died identically:

```
pointerdown on canvas content → panning → ONE move pans
→ lost-capture 16ms / 101ms in → synthesized cancel
→ 30+ pointermoves from the still-dragging finger (x 138→326), all reaching
  the root, all fallThrough against an idle machine
```

Four pans in the same trace lived. **The one variable separating them, visible in the trace itself, is the press target**: the dead ones pressed `canvas-content` (a node under the finger — one carries `hitId` for a specific node), the live ones pressed the root div (empty canvas).

## Mechanism

A **real** touch implicitly captures the pointer to the element under the finger (Pointer Events, *implicit pointer capture*). Over a node, that is an SVG child; over empty canvas, the root itself. The first move's own `capturePointer(root)` is then a capture **transfer** — and the child's `lostpointercapture` bubbles to the root a frame later, where a handler that only asked *"is this pointer still down?"* read the transfer this component itself performed as a loss, and cancelled the pan under a moving finger.

Over empty canvas the transfer is a no-op (same element), no event fires, the pan lives — **exactly the region-correlation every report described**, including the original screenshots.

## Why three sessions of simulation never saw it

Synthetic pointer events receive **no implicit capture**, so the transfer, the echo, and the bug do not exist in a dispatched-event world. A 6,231-point response map over the reporter's own board, two browser properties, and a model-based property all measured a world without the mechanism. The flight recorder was built precisely to record the one dimension no simulation could deliver — what events the real device produced — and it named the killer in its first trace.

## Fix

One discriminator the handler was missing: **only the root losing capture is a loss.** A descendant's `lostpointercapture` arriving here can only mean capture *moved*, and the only place this component ever moves it to is the root.

```ts
if (e.target !== e.currentTarget) return
```

## Test plan

- [x] `hand-pan-capture-echo.browser.test.tsx` — dispatches the child's echo explicitly (the exact event pattern the trace recorded):
  - *a pan pressed on a node survives the capture transfer its own first move performs* — **red on the unfixed code with the trace's own signature** (`{dx:10}` — first move pans, everything after dropped; the field trace shows the same one-move-then-dead shape)
  - *the ROOT losing capture mid-pan still cancels* — the real-loss side, green before AND after, guarding the fix from over-reach
- [x] The red-first order doubles as the mutation check: without the one-line fix, exactly the first case fails and the second passes
- [x] Existing capture-loss coverage (`lost-pointer-capture.browser.test.tsx`, `SpatialEditor.browser.test.tsx`) dispatches on the root — compatible by construction, and green
- [x] Whole `spatial-editor` browser suite: **84 files / 420 tests** green
- [x] `tsc --noEmit` clean

**blastRadius:** one handler in `SpatialEditor.tsx`; every gesture path that runs through capture is watched by the 420 tests above.

**userReach:** the hand tool on real touch devices — the shipped path this fixes.

## Visual evidence

`Visual evidence: none — the defect is pointer-event bookkeeping with no still frame that distinguishes broken from fixed; what a figure would need to show is a stroke's response over time. The evidence is the field trace quoted above (press target correlating perfectly with survival across six pans) and the reproduction failing with the trace's own signature.`

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_