### PR TITLE
refactor(web): retire the orphaned user-libraries surface from StorageReportCard

### DIFF
--- a/apps/web/src/components/StorageReportCard.test.tsx
+++ b/apps/web/src/components/StorageReportCard.test.tsx
@@ -11,7 +11,6 @@ const PAYLOAD = {
     blobs: { bytes: 1024, files: 2 },
     versions: { bytes: 2048, files: 1 },
     files: { bytes: 0, files: 0 },
-    libraries: { bytes: 0, files: 0 },
     db: { bytes: 1024, files: 1 },
     other: { bytes: 0, files: 2 },
   },
@@ -64,10 +63,10 @@ describe('StorageReportCard', () => {
 
   it('renders each storage category as its own row so future actions can hang off objects', async () => {
     const { container } = render(<StorageReportCard />)
-    // Eight rows render synchronously from the static descriptor list:
-    // blobs, versions, files, exports, logs, db, other, libraries.
+    // Seven rows render synchronously from the static descriptor list:
+    // blobs, versions, files, exports, logs, db, other.
     // Values fill in once fetch + the min-refresh timer settle.
-    expect(container.querySelectorAll('[data-storage-row]').length).toBe(8)
+    expect(container.querySelectorAll('[data-storage-row]').length).toBe(7)
     await act(async () => {
       await vi.advanceTimersByTimeAsync(500)
     })
@@ -77,10 +76,10 @@ describe('StorageReportCard', () => {
     expect(versionsRow!.textContent).toMatch(/2\.0\s*KiB|2048/)
     // Reserved per-row action slot is the OOUI hook for future Optimize.
     expect(container.querySelector('[data-storage-actions="versions"]')).not.toBeNull()
-    // User libraries row is pinned to the bottom so management UI lives
-    // away from the hot maintenance buckets.
+    // 'Other' is the catch-all, so it reads last — a real category appearing
+    // after it would look like unclassified spill.
     const allRows = Array.from(container.querySelectorAll('[data-storage-row]'))
-    expect(allRows[allRows.length - 1]?.getAttribute('data-storage-row')).toBe('libraries')
+    expect(allRows[allRows.length - 1]?.getAttribute('data-storage-row')).toBe('other')
   })
 
   it('exposes Optimize all on the Canvas snapshots row and aggregates across workspaces', async () => {
@@ -366,200 +365,23 @@ describe('StorageReportCard', () => {
     clearTimeoutSpy.mockRestore()
   })
 
-  it('opens the libraries dialog, fetches rows, and renders the "file missing" branch', async () => {
-    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
-    fetchMock.mockImplementation((input: RequestInfo | URL) => {
-      const url =
-        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
-      if (url === '/api/runtime/storage') {
-        return Promise.resolve(jsonResponse(PAYLOAD))
-      }
-      if (url === '/api/user-libraries') {
-        return Promise.resolve(
-          jsonResponse({
-            libraries: [
-              { name: 'shapes', path: '/data/shapes.excalidrawlib', itemCount: 3, bytes: 2048 },
-              { name: 'orphan', path: '/data/orphan.excalidrawlib', itemCount: 1, bytes: null },
-            ],
-          }),
-        )
-      }
-      return Promise.reject(new Error(`unexpected fetch: ${url}`))
-    })
-
-    vi.useRealTimers()
+  it('offers no user-libraries surface — the daemon retired the feature it called', async () => {
+    // The pack feature is excalidraw-era and its server half is GONE: the
+    // daemon source defines no user-libraries route (a live daemon answers
+    // 404), api-contracts/libraries.ts was removed with the move to the
+    // document model, and the storage categorizer never emits a 'libraries'
+    // bucket. A dialog over a deleted endpoint is not a feature, it is an
+    // error screen with a button in front of it.
     const { container } = render(<StorageReportCard />)
-    await waitFor(() => {
-      expect(container.querySelector('[data-storage-row="libraries"]')).not.toBeNull()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
     })
-
-    const manageButton = container.querySelector(
-      '[aria-label="Manage installed user libraries"]',
-    ) as HTMLButtonElement
-    expect(manageButton).not.toBeNull()
-    fireEvent.click(manageButton)
-
-    await waitFor(() => {
-      expect(document.querySelector('[data-user-library-row="shapes"]')).not.toBeNull()
-    })
-    const shapesRow = document.querySelector('[data-user-library-row="shapes"]')!
-    expect(shapesRow.textContent).toMatch(/3\s*items?/i)
-    expect(shapesRow.textContent).toMatch(/KiB|2048/)
-
-    const orphanRow = document.querySelector('[data-user-library-row="orphan"]')!
-    expect(orphanRow.textContent).toMatch(/file missing/i)
-  })
-
-  it('shows the fetch error instead of "No user libraries installed." when the list request fails', async () => {
-    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
-    fetchMock.mockImplementation((input: RequestInfo | URL) => {
-      const url =
-        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
-      if (url === '/api/runtime/storage') {
-        return Promise.resolve(jsonResponse(PAYLOAD))
-      }
-      if (url === '/api/user-libraries') {
-        return Promise.resolve(new Response('{}', { status: 500 }))
-      }
-      return Promise.reject(new Error(`unexpected fetch: ${url}`))
-    })
-
-    vi.useRealTimers()
-    const { container } = render(<StorageReportCard />)
-    await waitFor(() => {
-      expect(container.querySelector('[data-storage-row="libraries"]')).not.toBeNull()
-    })
-    fireEvent.click(container.querySelector('[aria-label="Manage installed user libraries"]')!)
-
-    await waitFor(() => {
-      expect(document.body.textContent).toMatch(/HTTP 500/)
-    })
-    // An empty list caused by a failed fetch must not masquerade as
-    // "no libraries installed".
-    expect(document.body.textContent).not.toMatch(/No user libraries installed/)
-  })
-
-  it('surfaces a network failure from remove as libsError instead of an unhandled rejection', async () => {
-    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
-    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
-      const url =
-        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
-      if (url === '/api/runtime/storage') {
-        return Promise.resolve(jsonResponse(PAYLOAD))
-      }
-      if (url === '/api/user-libraries' && !init?.method) {
-        return Promise.resolve(
-          jsonResponse({
-            libraries: [
-              { name: 'shapes', path: '/data/shapes.excalidrawlib', itemCount: 3, bytes: 2048 },
-            ],
-          }),
-        )
-      }
-      if (url.startsWith('/api/user-libraries/') && init?.method === 'DELETE') {
-        return Promise.reject(new Error('network down'))
-      }
-      return Promise.reject(new Error(`unexpected fetch: ${url}`))
-    })
-
-    vi.useRealTimers()
-    const { container } = render(<StorageReportCard />)
-    await waitFor(() => {
-      expect(container.querySelector('[data-storage-row="libraries"]')).not.toBeNull()
-    })
-    fireEvent.click(container.querySelector('[aria-label="Manage installed user libraries"]')!)
-    await waitFor(() => {
-      expect(document.querySelector('[data-user-library-row="shapes"]')).not.toBeNull()
-    })
-
-    fireEvent.click(document.querySelector('[aria-label="Remove user library shapes"]')!)
-    await waitFor(() => {
-      expect(document.body.textContent).toMatch(/network down/)
-    })
-  })
-
-  it('removes a user library optimistically and re-pulls the list on success', async () => {
-    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
-    let libraries = [
-      { name: 'shapes', path: '/data/shapes.excalidrawlib', itemCount: 3, bytes: 2048 },
-    ]
-    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
-      const url =
-        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
-      if (url === '/api/runtime/storage') {
-        return Promise.resolve(jsonResponse(PAYLOAD))
-      }
-      if (url === '/api/user-libraries') {
-        return Promise.resolve(jsonResponse({ libraries }))
-      }
-      if (init?.method === 'DELETE' && url === '/api/user-libraries/shapes') {
-        libraries = []
-        return Promise.resolve(new Response(null, { status: 204 }))
-      }
-      return Promise.reject(new Error(`unexpected fetch: ${url}`))
-    })
-
-    vi.useRealTimers()
-    const { container } = render(<StorageReportCard />)
-    await waitFor(() => {
-      expect(container.querySelector('[data-storage-row="libraries"]')).not.toBeNull()
-    })
-    fireEvent.click(
-      container.querySelector('[aria-label="Manage installed user libraries"]') as HTMLElement,
-    )
-    await waitFor(() => {
-      expect(document.querySelector('[data-user-library-row="shapes"]')).not.toBeNull()
-    })
-
-    fireEvent.click(document.querySelector('[aria-label="Remove user library shapes"]')!)
-
-    await waitFor(() => {
-      expect(document.querySelector('[data-user-library-row="shapes"]')).toBeNull()
-    })
-  })
-
-  it('surfaces a remove failure without dropping the row', async () => {
-    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
-    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
-      const url =
-        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
-      if (url === '/api/runtime/storage') {
-        return Promise.resolve(jsonResponse(PAYLOAD))
-      }
-      if (url === '/api/user-libraries') {
-        return Promise.resolve(
-          jsonResponse({
-            libraries: [
-              { name: 'shapes', path: '/data/shapes.excalidrawlib', itemCount: 3, bytes: 2048 },
-            ],
-          }),
-        )
-      }
-      if (init?.method === 'DELETE' && url === '/api/user-libraries/shapes') {
-        return Promise.resolve(new Response(null, { status: 500 }))
-      }
-      return Promise.reject(new Error(`unexpected fetch: ${url}`))
-    })
-
-    vi.useRealTimers()
-    const { container } = render(<StorageReportCard />)
-    await waitFor(() => {
-      expect(container.querySelector('[data-storage-row="libraries"]')).not.toBeNull()
-    })
-    fireEvent.click(
-      container.querySelector('[aria-label="Manage installed user libraries"]') as HTMLElement,
-    )
-    await waitFor(() => {
-      expect(document.querySelector('[data-user-library-row="shapes"]')).not.toBeNull()
-    })
-
-    fireEvent.click(document.querySelector('[aria-label="Remove user library shapes"]')!)
-
-    await waitFor(() => {
-      expect(document.body.textContent ?? '').toMatch(/Remove failed: HTTP 500/i)
-    })
-    // The row must still be there — a failed remove should not disappear.
-    expect(document.querySelector('[data-user-library-row="shapes"]')).not.toBeNull()
+    // The card genuinely rendered — absence asserted on an empty page proves
+    // nothing.
+    expect(container.querySelector('[data-storage-row="blobs"]')).not.toBeNull()
+    expect(container.querySelector('[data-storage-row="libraries"]')).toBeNull()
+    expect(container.querySelector('[aria-label="Manage installed user libraries"]')).toBeNull()
+    expect(document.body.textContent).not.toMatch(/User librar/i)
   })
 
   it('exposes Cleanup on the Versions row and aggregates sandwiched-auto-version prunes across workspaces', async () => {

--- a/apps/web/src/components/StorageReportCard.tsx
+++ b/apps/web/src/components/StorageReportCard.tsx
@@ -6,37 +6,11 @@ import {
   type StorageReportPayload,
   storageReportPayloadSchema,
 } from '@kamiazya/whiteboard-mcp/api-contracts'
-import { Eraser, HardDrive, Library, RefreshCw, Sparkles, Trash2 } from 'lucide-react'
+import { Eraser, HardDrive, RefreshCw, Sparkles } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { z } from 'zod'
 import { Button } from '@/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
 import { useDaemonApi } from '@/contexts/DaemonApiContext'
 import { formatBytes } from '../lib/format-bytes.js'
-import { SquiggleLoader } from './SquiggleLoader.js'
-
-// Schema for the daemon's /api/v1/user-libraries response.
-// This is the sole definition — the former api-contracts/libraries.ts was
-// removed by the move to the document model.
-const userLibraryRowSchema = z.object({
-  name: z.string(),
-  path: z.string(),
-  itemCount: z.number().int().nonnegative(),
-  bytes: z.number().int().nonnegative().nullable().optional(),
-})
-
-const userLibrariesResponseSchema = z.object({
-  libraries: z.array(userLibraryRowSchema),
-})
-
-type UserLibraryRow = z.infer<typeof userLibraryRowSchema>
 
 // Storage starts as visibility-before-enforcement: rows expose where bytes are
 // accumulating before the app applies caps, LRU, or category-specific cleanup.
@@ -47,13 +21,7 @@ interface CategoryDescriptor {
   key: string
   label: string
   description: string
-  // Optional soft cap. When the row's bytes pass this threshold the row
-  // surfaces a "near / over cap" hint. No auto-prune happens here; this
-  // component only makes growth visible before any cleanup policy runs.
-  softCapBytes?: number
 }
-
-const USER_LIBRARIES_SOFT_CAP_BYTES = 50 * 1024 * 1024
 
 const CATEGORIES: CategoryDescriptor[] = [
   { key: 'blobs', label: 'Canvas snapshots', description: 'Latest Loro doc per canvas' },
@@ -67,14 +35,6 @@ const CATEGORIES: CategoryDescriptor[] = [
   { key: 'logs', label: 'Logs', description: 'Daemon stdout / stderr archives' },
   { key: 'db', label: 'Metadata DB', description: 'Workspaces, names, pins, branches' },
   { key: 'other', label: 'Other', description: 'Unclassified files in the data dir' },
-  // Pinned to the bottom — user libraries are explicit user data, not
-  // generated artefacts, and have their own management dialog.
-  {
-    key: 'libraries',
-    label: 'User libraries',
-    description: 'Library packs you installed',
-    softCapBytes: USER_LIBRARIES_SOFT_CAP_BYTES,
-  },
 ]
 
 // Show the spinner for at least this long even if fetch returns sooner —
@@ -259,62 +219,6 @@ export function StorageReportCard() {
     }
   }, [refresh, scheduleStatusClear, fetchApi])
 
-  // User libraries management dialog. Surfaces installed libraries with
-  // per-pack size and item count, plus a per-row Remove that maps to the
-  // existing DELETE /api/user-libraries/:name endpoint.
-  const [libsOpen, setLibsOpen] = useState(false)
-  const [libsLoading, setLibsLoading] = useState(false)
-  const [libs, setLibs] = useState<UserLibraryRow[]>([])
-  const [libsError, setLibsError] = useState<string | null>(null)
-  const fetchLibs = useCallback(async () => {
-    setLibsLoading(true)
-    setLibsError(null)
-    try {
-      const res = await fetchApi('/api/user-libraries')
-      if (!mountedRef.current) return
-      if (!res.ok) {
-        setLibsError(`HTTP ${res.status}`)
-        return
-      }
-      const json = userLibrariesResponseSchema.parse(await res.json())
-      if (!mountedRef.current) return
-      setLibs(json.libraries)
-    } catch (err) {
-      if (mountedRef.current) {
-        setLibsError(err instanceof Error ? err.message : String(err))
-      }
-    } finally {
-      if (mountedRef.current) setLibsLoading(false)
-    }
-  }, [fetchApi])
-  const removeLib = useCallback(
-    async (name: string) => {
-      // Callers fire-and-forget this (void removeLib(...)), so a thrown fetch
-      // must be converted to state here or it becomes an unhandled rejection.
-      try {
-        const res = await fetchApi(`/api/user-libraries/${encodeURIComponent(name)}`, {
-          method: 'DELETE',
-        })
-        if (!mountedRef.current) return
-        if (!res.ok) {
-          setLibsError(`Remove failed: HTTP ${res.status}`)
-          return
-        }
-        // Optimistic update so the row disappears immediately, then re-pull
-        // from the server to stay consistent with whatever else changed
-        // (timestamps etc.).
-        setLibs((prev) => prev.filter((l) => l.name !== name))
-        void fetchLibs()
-        void refresh()
-      } catch (err) {
-        if (mountedRef.current) {
-          setLibsError(err instanceof Error ? err.message : String(err))
-        }
-      }
-    },
-    [fetchLibs, refresh, fetchApi],
-  )
-
   // Daemon-log rotation override. Logs are also pruned fire-and-forget
   // on every daemon startup; this button lets the user reclaim disk
   // without bouncing the daemon.
@@ -489,11 +393,8 @@ export function StorageReportCard() {
       )}
 
       <ul className="rounded-lg border divide-y">
-        {CATEGORIES.map(({ key, label, description, softCapBytes }) => {
+        {CATEGORIES.map(({ key, label, description }) => {
           const bucket = report?.byCategory[key] ?? { bytes: 0, files: 0 }
-          const overCap = softCapBytes !== undefined && bucket.bytes > softCapBytes
-          const nearCap =
-            !overCap && softCapBytes !== undefined && bucket.bytes > softCapBytes * 0.8
           return (
             <li key={key} data-storage-row={key} className="flex items-center gap-3 px-4 py-3">
               <div className="min-w-0 flex-1">
@@ -501,19 +402,8 @@ export function StorageReportCard() {
                 <div className="text-xs text-muted-foreground truncate">{description}</div>
               </div>
               <div className="shrink-0 text-right font-mono text-xs tabular-nums">
-                <div className={overCap ? 'text-destructive' : undefined}>
-                  {formatBytes(bucket.bytes)}
-                  {softCapBytes !== undefined && (
-                    <span className="text-muted-foreground"> / {formatBytes(softCapBytes)}</span>
-                  )}
-                </div>
-                <div className="text-[10px] text-muted-foreground">
-                  {overCap
-                    ? 'Over soft cap — please uninstall unused'
-                    : nearCap
-                      ? 'Approaching soft cap'
-                      : `${bucket.files} files`}
-                </div>
+                <div>{formatBytes(bucket.bytes)}</div>
+                <div className="text-[10px] text-muted-foreground">{`${bucket.files} files`}</div>
               </div>
               {/* Reserved action slot. Today only the Canvas snapshots row
                   carries an action (Optimize all → compact Loro op-log on
@@ -606,100 +496,11 @@ export function StorageReportCard() {
                     )}
                   </>
                 )}
-                {key === 'libraries' && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-7 gap-1.5"
-                    onClick={() => {
-                      setLibsOpen(true)
-                      void fetchLibs()
-                    }}
-                    aria-label="Manage installed user libraries"
-                  >
-                    <Library className="size-3.5" />
-                    <span className="text-xs">Manage</span>
-                  </Button>
-                )}
               </div>
             </li>
           )
         })}
       </ul>
-
-      <Dialog
-        open={libsOpen}
-        onOpenChange={(next) => {
-          setLibsOpen(next)
-          if (!next) setLibsError(null)
-        }}
-      >
-        <DialogContent className="sm:max-w-lg">
-          <DialogHeader>
-            <DialogTitle>User libraries</DialogTitle>
-            <DialogDescription>
-              Installed library packs. Removing a pack deletes its <code>.excalidrawlib</code> file
-              from disk and drops the registry row — documents that referenced it keep their
-              embedded copies of any item already inserted.
-            </DialogDescription>
-          </DialogHeader>
-          {libsLoading ? (
-            <SquiggleLoader label="Loading…" className="justify-start text-sm" />
-          ) : libs.length === 0 && !libsError ? (
-            // A failed fetch also leaves libs empty — that renders the error
-            // line below instead of masquerading as "no libraries installed".
-            <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
-              No user libraries installed.
-            </div>
-          ) : (
-            <ul className="rounded-md border divide-y max-h-[60vh] overflow-y-auto">
-              {libs.map((lib) => (
-                <li
-                  key={lib.name}
-                  className="flex items-center gap-3 px-3 py-2"
-                  data-user-library-row={lib.name}
-                >
-                  <div className="min-w-0 flex-1">
-                    <div className="text-sm font-medium truncate">{lib.name}</div>
-                    <div className="text-[11px] text-muted-foreground truncate">
-                      {lib.itemCount} item{lib.itemCount === 1 ? '' : 's'}
-                      {typeof lib.bytes === 'number'
-                        ? ` · ${formatBytes(lib.bytes)}`
-                        : lib.bytes === null
-                          ? ' · file missing'
-                          : ''}
-                    </div>
-                  </div>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 gap-1.5 text-destructive hover:text-destructive"
-                    onClick={() => void removeLib(lib.name)}
-                    aria-label={`Remove user library ${lib.name}`}
-                  >
-                    <Trash2 className="size-3.5" />
-                    <span className="text-xs">Remove</span>
-                  </Button>
-                </li>
-              ))}
-            </ul>
-          )}
-          {libsError && <div className="text-xs text-destructive">{libsError}</div>}
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={() => void fetchLibs()}
-              disabled={libsLoading}
-            >
-              Refresh
-            </Button>
-            <Button type="button" onClick={() => setLibsOpen(false)}>
-              Close
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   )
 }


### PR DESCRIPTION
# Summary

- Deletes the user-libraries (`.excalidrawlib` pack) management surface from `StorageReportCard` — the schema block, the `libraries` category row with its soft-cap rendering, the list/remove dialog, and the fetch/delete wiring (705 → 517 lines).
- The feature is excalidraw-era and retired (user decision, 2026-08-31). Its server half is already gone: the daemon has no `/api/v1/user-libraries` route (live daemon answers 404 on both spellings), the storage categorizer (`runtime-storage.ts`) never emits a `libraries` bucket, and the `api-contracts` entry was removed earlier — so the client card kept a whole management surface that could never receive data.
- No contract change needed: `storageReportPayloadSchema.byCategory` is an open `z.record`, so the schema is untouched.
- Deliberately untouched: `validators.test.ts`'s seven `.excalidrawlib` URLs (SSRF-guard samples about a foreign format) and `vocabulary.md`'s foreign-format bullet (history).

# Test plan

- Red-first: new test `offers no user-libraries surface — the daemon retired the feature it called` pins the absence of the `libraries` row, the manage dialog, and any "User librar…" copy, while asserting the `blobs` row IS present (subject presence, so the absence cannot pass vacuously on an empty render). Confirmed red against the pre-deletion component for the right reason, green after.
- Removed the five stale libraries tests and the fixture's `libraries` bucket; row-order pin updated (`other` last, 7 categories).
- `StorageReportCard.test.tsx` + `SettingsPage.test.tsx`: 48/48 green; `pnpm -r typecheck`, biome (incl. noconsole), knip clean; repo-wide grep for the retired surface clean outside the two intentional keepers above.

# Visual evidence

Visual evidence: none attachable — no image upload path exists in this environment. Additionally the card only mounts when a daemon connection is present (Settings → Connections), which the scripted capture environment could not establish; verification is via the component tests above plus the live-daemon 404 evidence for the deleted route.

# Checklist

- [x] Nearest-layer automated test for the root cause (absence test with subject-presence guard)
- [x] Manual verification: live daemon 404 on `/api/v1/user-libraries` confirming the surface is orphaned
- [x] `pnpm -r typecheck` / biome / knip green
- [x] No model identifier in repository artifacts

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_