### PR TITLE
feat(web): cross the state dot between tones instead of cutting

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -412,7 +412,15 @@ one it is not in yet, `spinner` that same ring while the doing is in flight.
   changes and small surfaces like popovers/toasts),
   `--motion-ease-out` (soft ease-out — never bouncy in chrome).
   Entrances are fade + small rise/scale (0.98→1); no entrance animation
-  without an explicit reason. `prefers-reduced-motion` is enforced
+  without an explicit reason. **Stateful colour is the one paint-property
+  exception**: where the colour IS the state (`StateDot`'s tone, a hover
+  affordance), it crosses with `transition-colors` on the normal token
+  rather than cutting. There is no transform/opacity encoding of "which
+  colour" that also works — stacking tones and fading between them breaks
+  the ring shape, whose transparent gap would reveal the layer beneath
+  instead of the background. Scoped to chrome-sized elements, where paint
+  is free; a full-surface colour transition is still a repaint per frame
+  and still belongs to the rule above. `prefers-reduced-motion` is enforced
   globally by the base-layer guard in `src/index.css` — component code
   must not assume an animation ran (never gate logic on motion).
 

--- a/apps/web/src/components/StateDot.browser.test.tsx
+++ b/apps/web/src/components/StateDot.browser.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * The dot's colour CROSSES rather than cuts, in the real stylesheet.
+ *
+ * A save cycle flips this dot every 500ms while someone types (the write
+ * debounce), and at an instant swap that reads as flicker beside a title
+ * the user is looking at — reported as the header being restless. The
+ * transition is the fix, and it also softens the case an instant swap makes
+ * worst: a write that completes in under the transition's own duration
+ * never reaches full amber at all, so a fast save shimmers instead of
+ * flashing.
+ *
+ * Asserted against COMPUTED style rather than a class string: the class is
+ * what was written, the computed duration is what the browser will actually
+ * do, and only the second one is what the reporter saw.
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, expect, it } from 'vitest'
+import { StateDot, type StateDotShape } from './StateDot'
+
+afterEach(cleanup)
+
+function dotStyle(shape?: StateDotShape) {
+  render(<StateDot tone="safe" shape={shape} />)
+  return getComputedStyle(screen.getByTestId('state-dot'))
+}
+
+/**
+ * The effective transition duration for one property, in milliseconds.
+ *
+ * Reads `transition-property` rather than trusting a class name, because
+ * the base stylesheet already computes to `all` with a duration of `0s` —
+ * a property list that LOOKS like it covers everything and transitions
+ * nothing. Duration is what decides the behaviour, so duration is what this
+ * returns.
+ */
+function crossFadeMs(style: CSSStyleDeclaration, property: string): number {
+  const props = style.transitionProperty.split(',').map((p) => p.trim())
+  const durations = style.transitionDuration.split(',').map((d) => d.trim())
+  const index = props.includes('all') ? 0 : props.indexOf(property)
+  if (index === -1) return 0
+  const raw = durations[Math.min(index, durations.length - 1)] ?? '0s'
+  return raw.endsWith('ms') ? Number.parseFloat(raw) : Number.parseFloat(raw) * 1000
+}
+
+it('crosses between tones instead of cutting, on the filled dot', () => {
+  expect(crossFadeMs(dotStyle(), 'background-color')).toBeGreaterThan(0)
+})
+
+it('crosses on the ring too, where the tone lives in the border', () => {
+  // The ring and the spinner say the same thing in stroke rather than fill,
+  // so a transition covering only `background-color` would leave two of the
+  // three shapes cutting — the per-carrier drift this component exists to
+  // prevent, one level down.
+  expect(crossFadeMs(dotStyle('ring'), 'border-color')).toBeGreaterThan(0)
+})

--- a/apps/web/src/components/StateDot.tsx
+++ b/apps/web/src/components/StateDot.tsx
@@ -83,6 +83,13 @@ export function StateDot({
         data-testid="state-dot"
         className={cn(
           'absolute inset-0 rounded-full',
+          // The tone CROSSES rather than cuts. A save cycle flips this dot
+          // every debounce period while someone types, and at an instant
+          // swap that reads as flicker beside the title being edited. It
+          // also softens the case an instant swap makes worst: a write
+          // faster than this duration never reaches the far colour at all,
+          // so a quick save shimmers instead of flashing.
+          'transition-colors duration-(--motion-duration-normal) ease-(--motion-ease-out)',
           shape === 'filled' && TONE_FILL[tone],
           shape !== 'filled' && cn('border-2', TONE_STROKE[tone]),
           // The ring's own gap is what reads as "not yet"; spinning it is the


### PR DESCRIPTION
## Summary

Reported as the header being restless while typing — the save dot's colour changes land too hard.

**Measured before changing anything.** The dot computes `transition-property: all` with `transition-duration: 0s` — a property list that *looks* like it covers everything and transitions nothing — while the markdown write debounce (`save-scheduler.ts`, 500ms) flips it amber↔emerald roughly twice a second. Half a second is exactly the cadence that reads as flicker beside a title someone is editing.

It crosses on `--motion-duration-normal` now.

Worth naming what that does to the case an instant swap makes *worst*: a write that completes faster than the transition never reaches the far colour at all, so a quick save shimmers instead of flashing, and a run of them settles rather than strobes. The calm is not just "slower", it is that brief states stop being spikes.

Applied to the ring and spinner too, where the tone lives in the border. A transition covering only `background-color` would leave two of the three shapes cutting — the per-carrier drift `StateDot` exists to prevent, one level down.

## The test asserts duration, not a class

```ts
crossFadeMs(style, 'background-color') > 0
```

resolved through the computed `transition-property` list (including `all`) to the matching entry in `transition-duration`. A class string is what was *written*; the computed duration is what the browser will *do*, and only the second one is what the reporter saw. **It fails on today's code** — which is how the `all` / `0s` combination above was found in the first place, rather than assumed.

## A documented rule, addressed rather than quietly broken

`DESIGN.md` said motion uses **compositor props only (`transform`, `opacity`)**. A colour transition is paint, so this does not comply as written.

The opacity-layered alternative was considered and **rejected on evidence**: cross-fading stacked tone layers breaks the `ring` shape, whose transparent gap would reveal the layer beneath instead of the background — and that gap is the entire meaning of the shape ("not yet"). There is no transform/opacity encoding of *which colour* that survives it.

So the exception is recorded in `DESIGN.md` with its reason and its scope: stateful colour on chrome-sized elements, where paint is free; a full-surface colour transition is still a repaint per frame and still belongs to the rule. The practice was already established — **23 `transition-colors` call sites in `components/`**, including the save chip's own button — and only the wording had not caught up.

## Test plan

- [x] `StateDot.browser.test.tsx` — 2 tests, red first on `0s`, green after; real stylesheet, computed style
- [x] Full `pnpm test:browser` — **163 files / 884 tests** green. `StateDot` is shared by the connection chip, the version dot, the shell mark and the save chip, so the whole browser surface is the check
- [x] `tsc --noEmit` clean

**blastRadius:** every `StateDot` carrier (`SaveStatusChip`, `HeaderVersionDot`, `ConnectionStatus` via the shell, `ShellMark`) — all four get the crossfade, which is the intent: the component owns the palette so its carriers cannot drift.

**userReach:** the save dot beside the document title, and the other three carriers, all shipped here.

## Visual evidence

`Visual evidence: none — the change is a 220ms transition between two colours the component already painted; a before/after still frame shows two identical dots, which compose-figure.mjs refuses on principle, and the difference exists only between frames. The measurement that stands in for it is the computed transition-duration going from 0s to non-zero, asserted by the test.`

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_