### PR TITLE
feat(web): let each setup-journey step carry its own storage evidence

### DIFF
--- a/apps/web/src/components/settings/SetupJourney.test.tsx
+++ b/apps/web/src/components/settings/SetupJourney.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { SetupJourney } from './SetupJourney.js'
+
+// The journey is the durability ladder AND the storage report: each step
+// carries its own measured evidence (user decision, 2026-09-01 — no separate
+// Storage tab; the step-form stays the one place).
+
+function renderJourney(over?: Partial<Parameters<typeof SetupJourney>[0]>) {
+  return render(
+    <MemoryRouter>
+      <SetupJourney
+        persist="todo"
+        protecting={false}
+        onProtect={() => {}}
+        install="not-captured"
+        onInstall={() => {}}
+        daemonConnected={false}
+        {...over}
+      />
+    </MemoryRouter>,
+  )
+}
+
+describe('SetupJourney — storage evidence on the steps', () => {
+  it('the Protect step states measured usage and quota when an estimate is available', () => {
+    renderJourney({ estimate: { usageBytes: 2_621_440, quotaBytes: 107_374_182_400 } })
+    const detail = document.querySelector('[data-journey-detail="protect"]')
+    expect(detail).not.toBeNull()
+    expect(detail?.textContent).toMatch(/2\.5 MiB used/)
+    expect(detail?.textContent).toMatch(/100\.0 GiB available/)
+  })
+
+  it('the Protect step keeps its evidence after the grant (done variant)', () => {
+    renderJourney({
+      persist: 'granted',
+      estimate: { usageBytes: 2_621_440, quotaBytes: 107_374_182_400 },
+    })
+    const detail = document.querySelector('[data-journey-detail="protect"]')
+    expect(detail?.textContent).toMatch(/2\.5 MiB used/)
+  })
+
+  it('renders no usage line when the estimate is unavailable', () => {
+    renderJourney({ estimate: null })
+    // Subject presence: the step itself rendered — absence on an empty page
+    // would prove nothing.
+    expect(screen.getByText('Protect your data')).toBeTruthy()
+    expect(document.querySelector('[data-journey-detail="protect"]')).toBeNull()
+  })
+
+  it('the connected companion step states what it keeps, linking to the breakdown', () => {
+    renderJourney({ daemonConnected: true, daemonStorageBytes: 108_003_328 })
+    const detail = document.querySelector('[data-journey-detail="daemon"]')
+    expect(detail).not.toBeNull()
+    expect(detail?.textContent).toMatch(/103\.0 MiB on this computer/)
+    const link = screen.getByRole('link', { name: /breakdown/i })
+    expect(link.getAttribute('href')).toBe('/settings/connections')
+  })
+
+  it('a connected step without a report shows plain connected, no dangling line', () => {
+    renderJourney({ daemonConnected: true, daemonStorageBytes: null })
+    expect(screen.getByText('connected')).toBeTruthy()
+    expect(document.querySelector('[data-journey-detail="daemon"]')).toBeNull()
+  })
+
+  it('shows no companion figure while disconnected even if a stale value is passed', () => {
+    renderJourney({ daemonConnected: false, daemonStorageBytes: 108_003_328 })
+    expect(document.querySelector('[data-journey-detail="daemon"]')).toBeNull()
+  })
+})

--- a/apps/web/src/components/settings/SetupJourney.tsx
+++ b/apps/web/src/components/settings/SetupJourney.tsx
@@ -2,7 +2,9 @@ import { Check } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { settingsPath } from '@/lib/app-routes'
+import { formatBytes } from '@/lib/format-bytes'
 import type { InstallState } from '@/lib/install-prompt-store'
+import type { BrowserStorageEstimate } from '@/lib/persistent-storage'
 
 export type PersistStepState = 'unknown' | 'granted' | 'browser-managed' | 'todo'
 
@@ -21,6 +23,14 @@ export interface SetupJourneyProps {
   install: InstallState['status']
   onInstall: () => void
   daemonConnected: boolean
+  /**
+   * Each step carries its own measured evidence (no separate storage
+   * report surface — the journey is the one place). null/undefined = no
+   * figure available; the step renders without one.
+   */
+  estimate?: BrowserStorageEstimate | null
+  /** Total bytes the connected companion app keeps; null/undefined = unknown. */
+  daemonStorageBytes?: number | null
 }
 
 type StepKind = 'done' | 'action' | 'blocked'
@@ -31,6 +41,8 @@ interface Step {
   title: string
   state: string
   desc?: string
+  /** Measured evidence for this step (usage figures), shown under the desc. */
+  detail?: ReactNode
   action?: ReactNode
   hint?: string
 }
@@ -52,7 +64,13 @@ export function SetupJourney({
   install,
   onInstall,
   daemonConnected,
+  estimate,
+  daemonStorageBytes,
 }: SetupJourneyProps) {
+  const usageDetail =
+    estimate == null
+      ? undefined
+      : `${formatBytes(estimate.usageBytes)} used · ${formatBytes(estimate.quotaBytes)} available`
   const steps: Step[] = [
     {
       key: 'draw',
@@ -67,12 +85,14 @@ export function SetupJourney({
           kind: 'done',
           title: 'Protect your data',
           state: persist === 'granted' ? 'granted' : 'managed by the browser',
+          detail: usageDetail,
         }
       : {
           key: 'protect',
           kind: 'action',
           title: 'Protect your data',
           state: persist === 'unknown' ? '…' : 'not granted yet',
+          detail: usageDetail,
           desc: 'Ask the browser to keep your documents even when it is running low on space — without this it may delete them to free up room.',
           action:
             persist === 'todo' ? (
@@ -112,7 +132,21 @@ export function SetupJourney({
             hint: 'Your browser’s menu may offer Install or Add to Home Screen.',
           },
     daemonConnected
-      ? { key: 'daemon', kind: 'done', title: 'Connect the companion app', state: 'connected' }
+      ? {
+          key: 'daemon',
+          kind: 'done',
+          title: 'Connect the companion app',
+          state: 'connected',
+          detail:
+            daemonStorageBytes == null ? undefined : (
+              <>
+                {`${formatBytes(daemonStorageBytes)} on this computer · `}
+                <Link to={settingsPath('connections')} className="underline">
+                  breakdown
+                </Link>
+              </>
+            ),
+        }
       : {
           key: 'daemon',
           kind: 'action',
@@ -166,6 +200,14 @@ export function SetupJourney({
             </p>
             {step.desc !== undefined && (
               <p className="mt-0.5 text-xs text-muted-foreground">{step.desc}</p>
+            )}
+            {step.detail !== undefined && (
+              <p
+                data-journey-detail={step.key}
+                className="mt-0.5 font-mono text-[11px] text-muted-foreground"
+              >
+                {step.detail}
+              </p>
             )}
             {step.action}
             {step.hint !== undefined && (

--- a/apps/web/src/lib/persistent-storage.test.ts
+++ b/apps/web/src/lib/persistent-storage.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { ensurePersistentStorage, queryPersistentStorage } from './persistent-storage.js'
+import {
+  ensurePersistentStorage,
+  queryPersistentStorage,
+  queryStorageEstimate,
+} from './persistent-storage.js'
 
 // jsdom has no navigator.storage — define/restore it per test.
 function withStorage(impl: Partial<StorageManager> | undefined) {
@@ -40,5 +44,28 @@ describe('ensurePersistentStorage', () => {
     withStorage(undefined)
     await expect(ensurePersistentStorage()).resolves.toBeNull()
     await expect(queryPersistentStorage()).resolves.toBeNull()
+  })
+})
+
+describe('queryStorageEstimate', () => {
+  it('reports usage and quota as bytes', async () => {
+    withStorage({ estimate: vi.fn().mockResolvedValue({ usage: 42, quota: 1024 }) })
+    await expect(queryStorageEstimate()).resolves.toEqual({ usageBytes: 42, quotaBytes: 1024 })
+  })
+
+  it('returns null where the API is unavailable', async () => {
+    withStorage(undefined)
+    await expect(queryStorageEstimate()).resolves.toBeNull()
+  })
+
+  it('returns null when the browser answers without numbers', async () => {
+    // StorageEstimate's fields are both optional in the spec.
+    withStorage({ estimate: vi.fn().mockResolvedValue({}) })
+    await expect(queryStorageEstimate()).resolves.toBeNull()
+  })
+
+  it('reports a throwing estimate as null, not a crash', async () => {
+    withStorage({ estimate: vi.fn().mockRejectedValue(new Error('denied')) })
+    await expect(queryStorageEstimate()).resolves.toBeNull()
   })
 })

--- a/apps/web/src/lib/persistent-storage.ts
+++ b/apps/web/src/lib/persistent-storage.ts
@@ -17,6 +17,28 @@ export async function queryPersistentStorage(): Promise<boolean | null> {
   }
 }
 
+export interface BrowserStorageEstimate {
+  usageBytes: number
+  quotaBytes: number
+}
+
+/**
+ * What this browser reports it is keeping for the app, and the room it
+ * offers. null = the API is absent (or answered without numbers), so the
+ * UI simply shows no figure rather than a zero that would read as "empty".
+ */
+export async function queryStorageEstimate(): Promise<BrowserStorageEstimate | null> {
+  const storage = navigator.storage
+  if (storage?.estimate === undefined) return null
+  try {
+    const { usage, quota } = await storage.estimate()
+    if (typeof usage !== 'number' || typeof quota !== 'number') return null
+    return { usageBytes: usage, quotaBytes: quota }
+  } catch {
+    return null
+  }
+}
+
 /** Request persistence if not yet granted. true/false = grant state, null = unsupported. */
 export async function ensurePersistentStorage(): Promise<boolean | null> {
   const storage = navigator.storage

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -545,3 +545,69 @@ describe('the back controls', () => {
     expect(link.textContent).toBe('')
   })
 })
+
+// Each journey step carries its own measured evidence (user decision,
+// 2026-09-01): the Protect step the browser's usage/quota, the companion
+// step what the daemon keeps. No separate storage surface.
+describe('SettingsPage — storage evidence wiring', () => {
+  afterEach(() => {
+    // jsdom has no navigator.storage; drop whatever a test defined.
+    Object.defineProperty(navigator, 'storage', { value: undefined, configurable: true })
+  })
+
+  it('feeds the journey the browser usage estimate', async () => {
+    Object.defineProperty(navigator, 'storage', {
+      value: { estimate: async () => ({ usage: 2_621_440, quota: 107_374_182_400 }) },
+      configurable: true,
+    })
+    renderAt('/settings/data')
+    const mobile = screen.getByTestId('settings-mobile')
+    expect(await within(mobile).findByText(/2\.5 MiB used/)).toBeTruthy()
+  })
+
+  it('feeds the journey the companion storage total when connected', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString()
+        if (url.includes('/api/runtime/storage')) {
+          // The contract requires ALL seven buckets — a partial byCategory is
+          // rejected by storageReportPayloadSchema (deliberately, see its doc).
+          const bucket = { bytes: 0, files: 0 }
+          return new Response(
+            JSON.stringify({
+              totalBytes: 108_003_328,
+              fileCount: 3,
+              byCategory: {
+                blobs: bucket,
+                versions: bucket,
+                files: bucket,
+                exports: bucket,
+                logs: bucket,
+                db: bucket,
+                other: bucket,
+              },
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          )
+        }
+        return new Response('{}', { status: 404, headers: { 'Content-Type': 'application/json' } })
+      }),
+    )
+    renderAt('/settings/data', { baseUrl: 'http://127.0.0.1:9999', token: 'tok' })
+    const mobile = screen.getByTestId('settings-mobile')
+    expect(await within(mobile).findByText(/103\.0 MiB on this computer/)).toBeTruthy()
+  })
+
+  it('shows no companion figure when the report fetch fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('nope', { status: 500 })),
+    )
+    renderAt('/settings/data', { baseUrl: 'http://127.0.0.1:9999', token: 'tok' })
+    const mobile = screen.getByTestId('settings-mobile')
+    // The step itself still reports connected — only the figure is absent.
+    expect(await within(mobile).findByText('connected')).toBeTruthy()
+    expect(mobile.querySelector('[data-journey-detail="daemon"]')).toBeNull()
+  })
+})

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,3 +1,4 @@
+import { storageReportPayloadSchema } from '@kamiazya/whiteboard-mcp/api-contracts'
 import {
   Cable,
   ChevronLeft,
@@ -28,7 +29,12 @@ import { createDaemonFetch } from '@/lib/daemon-api-client'
 import { disconnectFromDaemon } from '@/lib/disconnect-daemon'
 import type { FaviconStyle } from '@/lib/favicon'
 import { getInstallState, promptInstall, subscribeInstallState } from '@/lib/install-prompt-store'
-import { ensurePersistentStorage, queryPersistentStorage } from '@/lib/persistent-storage'
+import {
+  type BrowserStorageEstimate,
+  ensurePersistentStorage,
+  queryPersistentStorage,
+  queryStorageEstimate,
+} from '@/lib/persistent-storage'
 import { createUserSettingsStore } from '@/lib/user-settings-store'
 import { FontsCard } from '../components/FontsCard.js'
 import { PairedOriginsCard } from '../components/PairedOriginsCard.js'
@@ -301,6 +307,8 @@ function sectionContent(
     protectDeclined: boolean
     onProtect: () => void
     installStatus: 'installed' | 'installable' | 'not-captured'
+    estimate: BrowserStorageEstimate | null
+    daemonStorageBytes: number | null
     daemon?: { baseUrl: string; token: string | null }
     onDisconnected?: () => void
   },
@@ -328,6 +336,8 @@ function sectionContent(
             install={props.installStatus}
             onInstall={() => void promptInstall()}
             daemonConnected={props.daemon !== undefined}
+            estimate={props.estimate}
+            daemonStorageBytes={props.daemonStorageBytes}
           />
           <div className="mt-6 border-t pt-4">
             <AppVersionRow />
@@ -427,6 +437,45 @@ export function SettingsPage({ daemon, onDisconnected }: SettingsPageProps) {
 
   const installState = useSyncExternalStore(subscribeInstallState, getInstallState)
 
+  // Journey evidence: what this browser keeps (estimate) and what a
+  // connected companion keeps (report total). Queried once per visit — the
+  // figures are orders-of-magnitude context, not a live meter.
+  const [estimate, setEstimate] = useState<BrowserStorageEstimate | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    void queryStorageEstimate().then((value) => {
+      if (!cancelled) setEstimate(value)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const [daemonStorageBytes, setDaemonStorageBytes] = useState<number | null>(null)
+  const daemonBaseUrl = daemon?.baseUrl
+  const daemonToken = daemon?.token
+  useEffect(() => {
+    if (daemonBaseUrl === undefined) {
+      setDaemonStorageBytes(null)
+      return
+    }
+    let cancelled = false
+    const daemonFetch = createDaemonFetch(daemonBaseUrl, daemonToken ?? undefined)
+    void (async () => {
+      try {
+        const res = await daemonFetch('/api/runtime/storage')
+        if (!res.ok) return
+        const report = storageReportPayloadSchema.parse(await res.json())
+        if (!cancelled) setDaemonStorageBytes(report.totalBytes)
+      } catch {
+        // No figure — the step reads plain "connected".
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [daemonBaseUrl, daemonToken])
+
   const persistStep: PersistStepState = !persistedKnown
     ? 'unknown'
     : persisted === true
@@ -476,6 +525,8 @@ export function SettingsPage({ daemon, onDisconnected }: SettingsPageProps) {
     protectDeclined,
     onProtect: handleProtect,
     installStatus: installState.status,
+    estimate,
+    daemonStorageBytes,
     daemon,
     onDisconnected,
   }


### PR DESCRIPTION
# Summary

- The setup journey (Settings → Data & app) stays the one step-form place for data-safety actions — no separate Storage tab (user decision, 2026-09-01). Each step now carries its own measured evidence:
  - **Protect your data** shows what this browser keeps and offers: `X used · Y available` from `navigator.storage.estimate()`, which was previously called nowhere in the app — browser-kept data had zero usage visibility.
  - **Connect the companion app** (when connected) shows the daemon storage report's total with a `breakdown` link to the Connections card.
- New `queryStorageEstimate()` in `lib/persistent-storage.ts` beside its persist()/persisted() siblings: answers `null` for an absent API, a throwing call, or an estimate without numbers — the step then simply renders no figure, never a `0 B` that would read as "empty".
- The companion figure fails silent to plain `connected` on any fetch/parse failure. The wiring-test stub carries all seven `byCategory` buckets because `storageReportPayloadSchema` deliberately rejects a partial record (its doc comment says so; verified — a `byCategory: {}` stub fails parse, which is how the first version of the test caught it).

# Test plan

- Red-first: `SetupJourney.test.tsx` (new, 6 tests) pinned the evidence lines before they existed — usage/quota on the Protect step (action and done variants), companion total + breakdown link, and three absence guards (no estimate → no line; connected without a report → plain `connected`; disconnected → never a stale figure).
- `SettingsPage.test.tsx` +3 wiring tests: estimate reaches the journey; the companion total reaches it through `createDaemonFetch`; a 500 report leaves the step at plain `connected`.
- `persistent-storage.test.ts` +4 unit tests for `queryStorageEstimate` (numbers, absent API, number-less answer, throw).
- Full `web-jsdom`: 3056 passed / 9 failed — the 9 are the documented Node-22 environment set (`object.stream is not a function`, Blob/undici; `local-node-version.test.ts` names it); none touch this diff's files. CI runs the pinned Node 24.
- `pnpm -r typecheck`, biome (incl. noconsole), `pnpm knip` clean.
- Manually verified in a real Chromium against the built dist: `/settings/data` renders `13.6 MiB used · 1.0 GiB available` under the Protect step with no daemon involved.

# Visual evidence

Visual evidence: none attachable — no image upload path exists in this environment. The capture from the manual verification (real browser, built dist, live `storage.estimate()` values under the Protect step) is kept at `apps/web/tmp/screenshots/journey-evidence.png` locally; it is a new affordance, so there is no "before" panel to compose. The connected-companion figure was verified through the wiring tests (same `createDaemonFetch` path the Connections card uses), not a live pairing.

# Checklist

- [x] Red test first at the nearest layer (component, then wiring, then lib unit)
- [x] Manual verification in a running browser
- [x] `pnpm -r typecheck` / biome / knip green
- [x] No model identifier in repository artifacts

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added storage usage and quota details to the setup journey.
  * Connected companion steps now show stored data totals and link to a detailed breakdown.
  * Storage information remains available after setup actions when supported.

* **Bug Fixes**
  * Gracefully handles unavailable, invalid, or failed storage reports without disrupting setup status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->