### PR TITLE
docs(adr): 0023 — a workspace has one keeper; every other copy is a replica

### DIFF
--- a/docs/contributing/adr/0023-replica-model.md
+++ b/docs/contributing/adr/0023-replica-model.md
@@ -1,0 +1,157 @@
+# ADR-0023: A workspace has one keeper; every other copy is a replica
+
+**Status:** Proposed — design of record for the demote/cache work; nothing here is implemented yet except where a paragraph says so
+
+## Context
+
+The keeper axis names who KEEPS a workspace — the browser's own storage or
+the whiteboard daemon (`.claude/rules/vocabulary.md`, "The keeper axis").
+The intended model was stated when the axis was named: connecting a daemon
+PROMOTES a workspace's source of truth to it, *with everything below
+becoming a replica*. Half of that model shipped and half did not:
+
+- **The move half is implemented.** Settings > Connections' "This
+  workspace" section transfers the browser's whole workspace record into a
+  daemon workspace as a CRDT merge — identity, history and referenced
+  images survive. A moved-disclosure marker stops the browser copy silently
+  resuming as its own keeper.
+- **The demote half is not.** After the move, the browser record remains an
+  independent store rather than a subscribed replica. Continuing from the
+  daemon is a narrated reload the user takes; the bytes of the old copy
+  stay where they were.
+
+So duplication is not a risk, it is the current behaviour: every promoted
+workspace exists twice, and the browser copy is a frozen fork that only a
+disclosure banner distinguishes from live data.
+
+Three user requests arrived together (2026-09-01) and are all, on
+inspection, this missing half:
+
+1. *"Choose a cache strategy — keep data in the browser, or assume the
+   daemon and keep it there."* The choice of where data authoritatively
+   lives is the keeper, and the keeper is already a per-workspace property
+   with a move action. What cannot be chosen today is the other option:
+   "assume the daemon" — because without demote the browser never stops
+   being a second full copy.
+2. *"A transparent mode: the PWA accesses a directory the OS owns, so data
+   is not duplicated."* The goal (no duplicate authoritative copies) is
+   right; the mechanism cannot work. The daemon's record is SQLite, and a
+   second writer on the same files corrupts it — the same reason
+   ADR-0020's scale-out work made the database location configurable
+   instead of sharing the file. What "transparent" actually wants is a
+   copy that is *not authoritative*: a replica.
+3. *"Storage visibility in the browser too."* Shipped separately (the setup
+   journey's per-step evidence); it matters here because replica semantics
+   are only trustworthy when the user can see what is where.
+
+### What the data plane already guarantees
+
+[ADR-0020](0020-coordination-boundary.md) established that the edit path is
+multi-writer safe: Loro ops carry their own identity, deltas append rather
+than overwrite, and two writers appending concurrently converge. A browser
+holding a stale copy of a daemon workspace is therefore a *visibility*
+problem, not a correctness one. That is the load-bearing fact of this ADR:
+a replica that keeps taking edits offline and appends them later is safe
+**on the data plane** without any new machinery.
+
+The same ADR lists where convergence stops covering: compaction,
+control-plane rows (names, placement, versions, branches), anything
+read-modify-write. A replica must not perform those against a keeper it
+cannot reach.
+
+## Decision
+
+Five decisions, ordered so each builds on the previous.
+
+### 1. The keeper is exclusive, and it is a property of each workspace
+
+Exactly one keeper per workspace at a time. Every other holder of the
+record is a replica: readable, overwritten by sync, never authoritative.
+There is consequently **no global "cache strategy" setting** — the choice
+surfaces per workspace as what it already is (this workspace is kept in
+this browser / kept by the daemon) plus the move action. A mode toggle
+would name a mechanism users cannot evaluate; the keeper names the thing
+they actually decide about.
+
+### 2. Demote completes promote
+
+Promote's missing second half: after a successful move, the browser record
+becomes a **subscribed replica** of the daemon workspace instead of a
+moved-marked independent store. Concretely:
+
+- The replica serves reads: warm start, and offline availability when the
+  daemon is unreachable.
+- Sync overwrites it; it never wins an argument with the keeper.
+- The moved-disclosure banner is replaced by replica state ("kept by the
+  daemon · cached here"), because the honest description changed.
+
+The reload after promote stays narrated (the user takes it); what changes
+is what they come back to.
+
+### 3. Replica edits are data-plane only
+
+While the keeper is unreachable, a replica MAY keep taking document edits:
+they are CRDT deltas appended locally and shipped as ordinary ops when the
+keeper returns, which ADR-0020 shows is convergent. It MUST NOT perform
+control-plane operations offline — create/rename/move/delete of documents
+or workspaces, version saves, branch operations, compaction — because those
+are the operations convergence does not cover. v1 may ship read-only
+replicas first; the edit capability is an extension inside the same
+boundary, not a different design.
+
+### 4. Transparent mode is rejected as specified, and its goal is met here
+
+No shared OS directory. A browser writing the daemon's SQLite files — via
+the File System Access API, OPFS mounts, or anything else — is a two-writer
+corruption and is rejected permanently, not deferred. OS-directory access
+appears in the design in exactly one legitimate shape: the daemon writing a
+**one-writer export mirror** (ADR-0021's append-only blob mirror is the
+precedent), which a later increment can offer for users who want plain
+files on disk. Deduplication — the actual goal behind "transparent mode" —
+is achieved by decision 2: the browser copy stops being a second
+authoritative store.
+
+### 5. Daemon-kept workspaces gain a browser cache by the same mechanism
+
+Once demote exists, the same replica machinery applies in the other
+direction of arrival: a workspace that was born on the daemon can be
+cached in the browser for warm start and offline reads. This is the
+"assume the daemon" cache strategy of request 1, obtained as a consequence
+rather than as a separate feature. It is explicitly later work; nothing in
+decisions 1–4 depends on it.
+
+## Consequences
+
+- Promote stops leaving a fork behind; "where is my data" has one answer
+  per workspace plus a visible cache.
+- Offline reading of daemon workspaces becomes possible without new
+  storage concepts — the replica is IndexedDB, where browser workspaces
+  already live.
+- The control-plane boundary (decision 3) becomes UI copy: offline, a
+  replica shows documents and takes edits but greys out rename/version/
+  branch actions with the reason. That is more honest than queuing
+  control-plane intents, and enormously simpler.
+- Two copies still exist on disk (a cache is a copy). The change is that
+  only one is authoritative and the other says so. True single-copy
+  storage was the rejected transparent mode.
+- The sync scheduling, retry, and staleness display are new work with real
+  cost; nothing here prices them. Each implementation increment must bring
+  its own measurements per the measured-change discipline.
+
+## Alternatives considered
+
+- **Shared data directory ("transparent mode" literally).** Rejected:
+  SQLite two-writer corruption; also couples the browser to the daemon's
+  storage layout, which ADR-0021 is actively decoupling even for the
+  daemon's own backups.
+- **A global storage-mode setting.** Rejected: the keeper is per-workspace
+  state with a per-workspace move action already shipped; a global mode
+  would sit beside it answering the same question differently.
+- **Queued offline control-plane operations.** Rejected for v1: ADR-0020
+  shows exactly why those operations need the keeper (CAS, not
+  convergence); a queue reintroduces the conflict cases the CRDT plane
+  exists to avoid, for operations rare enough to wait.
+- **Deleting the browser copy after promote (no replica at all).** Simpler,
+  and rejected: it trades the duplication complaint for a cold-start and
+  offline regression, and the moved-marker UX it would need is what we
+  have today — the state this ADR exists to finish.

--- a/docs/contributing/adr/README.md
+++ b/docs/contributing/adr/README.md
@@ -55,3 +55,4 @@ See [template.md](template.md) for the standard structure (MADR-lite: Title, Sta
 | [ADR-0020](0020-coordination-boundary.md) | The coordination boundary — a CRDT data plane and a compare-and-swap control plane | Proposed |
 | [ADR-0021](0021-durability-boundary.md) | Durability is a property of each store, not an operation on a directory | Accepted (implemented) |
 | [ADR-0022](0022-variation-addressing.md) | A variation is not in the address, and the default one has no name to put there | Accepted — records the shipped shape; fixes the grammar for later |
+| [ADR-0023](0023-replica-model.md) | A workspace has one keeper; every other copy is a replica | Proposed — design of record for the demote/cache work |


### PR DESCRIPTION
# Summary

- Adds ADR-0023 (Proposed) recording the storage-direction decisions of 2026-09-01, design-first: nothing is implemented by this change.
- Five decisions: (1) the keeper is exclusive and per-workspace — no global "cache strategy" setting; (2) demote-to-replica completes the promote flow (the browser copy becomes a subscribed replica instead of a moved-marked fork); (3) replica edits are data-plane only, per ADR-0020's convergence boundary — control-plane operations require the keeper; (4) the literal shared-directory "transparent mode" is rejected permanently (SQLite two-writer corruption), with the daemon-written one-writer export mirror as the only legitimate OS-directory shape; (5) a browser cache of daemon-kept workspaces falls out of the same mechanism as later work.
- Alternatives section records why the shared directory, a global mode toggle, queued offline control-plane operations, and delete-after-promote were each rejected.
- README index row added.

# Test plan

- Docs-only. `pnpm intent:validate` passes (pre-existing unrelated warning about a keywords array). ADR cross-references checked against ADR-0020/0021 and `vocabulary.md`'s keeper-axis text, which this ADR quotes rather than changes — vocabulary.md's "demotion is not implemented" statement remains true while this is Proposed.

# Visual evidence

Visual evidence: none — docs-only change with no rendered surface.

# Checklist

- [x] Conventional Commit title (release-please)
- [x] No model identifier in repository artifacts

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_