### PR TITLE
refactor(web): assemble the spatial editor pane and page shell once for both document pages

### DIFF
--- a/apps/web/src/components/document-editor/DocumentPageShell.tsx
+++ b/apps/web/src/components/document-editor/DocumentPageShell.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode, Ref } from 'react'
+import { cn } from '@/lib/utils'
+
+/**
+ * The two-row grid shell both document pages stand in.
+ *
+ * Everything header-shaped stacks inside the `auto` row, and the editor owns
+ * `minmax(0,1fr)` — however many banner rows appear (or however tall they
+ * wrap), the editor row is always exactly the remaining viewport height,
+ * never clipped below it. Both pages carried this template and the sr-only
+ * `<h1>` landmark by hand; owning them here means a layout or a11y drift
+ * between the two modes cannot happen quietly.
+ *
+ * `mainRef` and `mainClassName` exist for one caller and one reason that
+ * travel together: the browser page fullscreens this element, and a
+ * fullscreened element without its own background is composited over black —
+ * so it passes the ref it fullscreens and `bg-background` to stand behind
+ * it. The daemon page has no fullscreen affordance and passes neither.
+ */
+export function DocumentPageShell({
+  srTitle,
+  header,
+  children,
+  mainRef,
+  mainClassName,
+}: {
+  /** The page's visually-hidden `<h1>` landmark text. */
+  srTitle: string
+  /** The header row's contents, after the landmark. */
+  header: ReactNode
+  /** The editor row, and any banner rows the page stacks above it. */
+  children: ReactNode
+  mainRef?: Ref<HTMLElement>
+  mainClassName?: string
+}) {
+  return (
+    <main
+      ref={mainRef}
+      className={cn('relative grid h-full w-full grid-rows-[auto_minmax(0,1fr)]', mainClassName)}
+    >
+      <div className="min-w-0">
+        <h1 className="sr-only">{srTitle}</h1>
+        {header}
+      </div>
+      {children}
+    </main>
+  )
+}

--- a/apps/web/src/components/document-editor/SpatialEditorPane.tsx
+++ b/apps/web/src/components/document-editor/SpatialEditorPane.tsx
@@ -1,0 +1,158 @@
+import type { ReactNode, Ref } from 'react'
+import type { DocumentFileSeams } from '../../hooks/use-document-file-seams.js'
+import { readLastTool, resolveInitialTool } from '../../lib/initial-tool.js'
+import {
+  HistoryCluster,
+  type HistoryClusterVersionsProps,
+} from '../history-cluster/HistoryCluster.js'
+import {
+  SpatialEditor,
+  type SpatialEditorHandle,
+  type SpatialEditorProps,
+} from '../spatial-editor/index.js'
+import { NodeTextEditorOverlay, type NodeTextEditorOverlayProps } from './NodeTextEditorOverlay.js'
+import type { NodeInEditor } from './use-node-in-editor.js'
+
+/**
+ * The spatial editor pane, assembled once for both document pages.
+ *
+ * The editor takes ~23 props, and each page used to spell the assembly out
+ * itself — 19 of them shared, 14 with byte-identical expressions. That is
+ * the arrangement that shipped the file-seam defect: a prop added to one
+ * call site and not the other diverges silently, because each page's tests
+ * only exercise its own mode. Here a new prop is added in one place or it
+ * does not compile. `useNodeInEditor` made the same move for the same
+ * reason, one hook earlier.
+ *
+ * Prop types are `Pick`ed from the components they reach rather than
+ * restated, so this file cannot drift from the editor's own contract.
+ */
+type PassedThrough = Pick<
+  SpatialEditorProps,
+  | 'canvas'
+  | 'onChange'
+  | 'externalVersion'
+  | 'theme'
+  | 'fileRefOptions'
+  | 'missingFileRef'
+  | 'lockedNodeIds'
+  | 'lockedEdgeIds'
+  | 'onToggleNodeLock'
+  | 'onToggleEdgeLock'
+  | 'agentTouchedNodeIds'
+>
+
+export interface SpatialEditorPaneProps extends PassedThrough {
+  /** Keys the editor on canvas identity — see the comment at the render. */
+  editorKey: string
+  /**
+   * Whether the document behind `canvas` has loaded. The initial tool is
+   * decided from the canvas's own shape, but only then — at mount every
+   * canvas still looks empty.
+   */
+  canvasLoaded: boolean
+  /** From `useDocumentFileSeams`; spread onto the editor here, once. */
+  fileSeams: DocumentFileSeams
+  /** From `useNodeInEditor`; wires the editor and the overlay coherently. */
+  nodeInEditor: NodeInEditor
+  /**
+   * One navigation for both surfaces that follow a document reference —
+   * the editor's file-ref cards and the overlay's links. The pages each
+   * passed the same function to both under two prop names.
+   */
+  onOpenDocument: (id: string) => void
+  history: {
+    onUndo: () => void
+    onRedo: () => void
+    canUndo: boolean
+    canRedo: boolean
+    versions?: HistoryClusterVersionsProps
+  }
+  overlayTitle: string
+  resolveAlias: NodeTextEditorOverlayProps['resolveAlias']
+  resolveEmbed: NodeTextEditorOverlayProps['resolveEmbed']
+  linkTargets: NodeTextEditorOverlayProps['linkTargets']
+  /** The container's classes — the two pages sit in different grid shells. */
+  className: string
+  editorRef?: Ref<SpatialEditorHandle>
+  /** Page-specific chrome inside the container (the agent presence chip). */
+  children?: ReactNode
+}
+
+export function SpatialEditorPane({
+  editorKey,
+  canvasLoaded,
+  fileSeams,
+  nodeInEditor,
+  onOpenDocument,
+  history,
+  overlayTitle,
+  resolveAlias,
+  resolveEmbed,
+  linkTargets,
+  className,
+  editorRef,
+  children,
+  canvas,
+  onChange,
+  externalVersion,
+  theme,
+  fileRefOptions,
+  missingFileRef,
+  lockedNodeIds,
+  lockedEdgeIds,
+  onToggleNodeLock,
+  onToggleEdgeLock,
+  agentTouchedNodeIds,
+}: SpatialEditorPaneProps) {
+  return (
+    <div data-testid="spatial-editor-container" className={className}>
+      {children}
+      {/* Keyed on canvas identity: the editor's pan/zoom, in-flight gesture
+          and open text editor all describe ONE canvas, and `SpatialCanvas`
+          carries no id for the editor to notice a switch by. Without the
+          key, switching documents silently inherits the previous canvas's
+          viewport. */}
+      <SpatialEditor
+        key={editorKey}
+        initialTool={
+          canvasLoaded
+            ? resolveInitialTool({
+                isEmpty: canvas.nodes.length === 0,
+                lastTool: readLastTool(),
+              })
+            : undefined
+        }
+        ref={editorRef}
+        agentTouchedNodeIds={agentTouchedNodeIds}
+        canvas={canvas}
+        onChange={onChange}
+        externalVersion={externalVersion}
+        theme={theme}
+        fileRefOptions={fileRefOptions}
+        onOpenFileRef={onOpenDocument}
+        missingFileRef={missingFileRef}
+        {...fileSeams}
+        lockedNodeIds={lockedNodeIds}
+        lockedEdgeIds={lockedEdgeIds}
+        onToggleNodeLock={onToggleNodeLock}
+        onOpenInEditor={nodeInEditor.open}
+        onToggleEdgeLock={onToggleEdgeLock}
+        paletteLeading={<HistoryCluster {...history} />}
+      />
+      {nodeInEditor.editing !== null && (
+        <NodeTextEditorOverlay
+          title={overlayTitle}
+          initialText={nodeInEditor.editing.text}
+          theme={theme}
+          resolveAlias={resolveAlias}
+          resolveEmbed={resolveEmbed}
+          linkTargets={linkTargets}
+          onCommit={nodeInEditor.commit}
+          onClose={nodeInEditor.close}
+          onOpenDocument={onOpenDocument}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -7,6 +7,7 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } fro
 import { useLocation, useNavigate } from 'react-router-dom'
 import { DocumentPageSkeleton } from '../components/DocumentPageSkeleton.js'
 import { DocumentEditorSurface } from '../components/document-editor/DocumentEditorSurface.js'
+import { DocumentPageShell } from '../components/document-editor/DocumentPageShell.js'
 import { SpatialEditorPane } from '../components/document-editor/SpatialEditorPane.js'
 import { useNodeInEditor } from '../components/document-editor/use-node-in-editor.js'
 import { DocumentProperties } from '../components/document-properties/DocumentProperties.js'
@@ -823,63 +824,62 @@ export function BrowserDocumentPage({
     // background no longer shows. Anything this element does not paint itself
     // falls through to the browser's default black backdrop — which turned
     // the canvas area black under a light theme.
-    <main
-      ref={mainRef}
-      className="relative grid h-full w-full grid-rows-[auto_minmax(0,1fr)] bg-background"
-    >
-      <div className="min-w-0">
-        {/* Visually-hidden heading landmark: WorkspaceTopBar's canvas switcher
-          is the visible title control, but the page keeps a real <h1> for
-          accessibility trees. */}
-        <h1 className="sr-only">{renderState.snapshot.name}</h1>
-        {/* Fullscreen means the CANVAS, maximised: the whole top-bar row —
+    <DocumentPageShell
+      srTitle={renderState.snapshot.name}
+      mainRef={mainRef}
+      mainClassName="bg-background"
+      header={
+        <>
+          {/* Fullscreen means the CANVAS, maximised: the whole top-bar row —
             switcher, rename, menus — steps aside. The floating control below
             replaces its exit path, Escape still works natively, and the dock
             stays because editing is what the extra space is FOR. */}
-        {!isFullscreen && (
-          <Suspense
-            fallback={
-              <div className={cn(TOP_BAR_FALLBACK_HEIGHT, 'shrink-0 border-b bg-background')} />
-            }
-          >
-            <WorkspaceTopBar
-              // Local mode names documents through its own store, not through
-              // the daemon's `/names`, so the identity the bar offers is unused
-              // here and `documentName`/`onTitleChange` stay the source.
-              titleSlot={() => documentTitleSlot}
-              dataMode="local"
-              workspaceId="local"
-              path={renderState.snapshot.path}
-              // The way out of the editor. This page had none until now —
-              // the app-shell brand mark was the only exit, and it says
-              // nothing about where it goes.
-              onNavigateBack={() => {
-                const handle = browserWorkspaceHandleOrNull()
-                navigate(handle === null ? indexPath() : workspacePath(handle))
-              }}
-              isFullscreen={isFullscreen}
-              onToggleFullscreen={() => {
-                // Entering hides this whole bar; the floating exit control and
-                // native Escape are the ways back out. requestFullscreen can
-                // REJECT (Permissions-Policy, an iframe without
-                // allow="fullscreen", no user activation) — a swallowed
-                // rejection is unhandled-rejection noise, so both directions log.
-                if (document.fullscreenElement)
-                  document.exitFullscreen().catch((err) => log.warn('exitFullscreen failed', err))
-                else
-                  mainRef.current
-                    ?.requestFullscreen()
-                    .catch((err) => log.warn('requestFullscreen rejected', err))
-              }}
-              capabilities={{
-                versions: capabilities.versions,
-                branches: capabilities.branches,
-                merge: capabilities.merge,
-              }}
-            />
-          </Suspense>
-        )}
-      </div>
+          {!isFullscreen && (
+            <Suspense
+              fallback={
+                <div className={cn(TOP_BAR_FALLBACK_HEIGHT, 'shrink-0 border-b bg-background')} />
+              }
+            >
+              <WorkspaceTopBar
+                // Local mode names documents through its own store, not through
+                // the daemon's `/names`, so the identity the bar offers is unused
+                // here and `documentName`/`onTitleChange` stay the source.
+                titleSlot={() => documentTitleSlot}
+                dataMode="local"
+                workspaceId="local"
+                path={renderState.snapshot.path}
+                // The way out of the editor. This page had none until now —
+                // the app-shell brand mark was the only exit, and it says
+                // nothing about where it goes.
+                onNavigateBack={() => {
+                  const handle = browserWorkspaceHandleOrNull()
+                  navigate(handle === null ? indexPath() : workspacePath(handle))
+                }}
+                isFullscreen={isFullscreen}
+                onToggleFullscreen={() => {
+                  // Entering hides this whole bar; the floating exit control and
+                  // native Escape are the ways back out. requestFullscreen can
+                  // REJECT (Permissions-Policy, an iframe without
+                  // allow="fullscreen", no user activation) — a swallowed
+                  // rejection is unhandled-rejection noise, so both directions log.
+                  if (document.fullscreenElement)
+                    document.exitFullscreen().catch((err) => log.warn('exitFullscreen failed', err))
+                  else
+                    mainRef.current
+                      ?.requestFullscreen()
+                      .catch((err) => log.warn('requestFullscreen rejected', err))
+                }}
+                capabilities={{
+                  versions: capabilities.versions,
+                  branches: capabilities.branches,
+                  merge: capabilities.merge,
+                }}
+              />
+            </Suspense>
+          )}
+        </>
+      }
+    >
       {/* The snapshot's kind picks the editor: markdown documents open the
           markdown editor (body and OKF core facets persisted as containers
           of one Loro document — see use-markdown-document.ts), everything
@@ -965,6 +965,6 @@ export function BrowserDocumentPage({
             already handles undo); the history group rides the spatial
             editor's dock via paletteLeading above. */}
       </div>
-    </main>
+    </DocumentPageShell>
   )
 }

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -7,13 +7,11 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } fro
 import { useLocation, useNavigate } from 'react-router-dom'
 import { DocumentPageSkeleton } from '../components/DocumentPageSkeleton.js'
 import { DocumentEditorSurface } from '../components/document-editor/DocumentEditorSurface.js'
-import { NodeTextEditorOverlay } from '../components/document-editor/NodeTextEditorOverlay.js'
+import { SpatialEditorPane } from '../components/document-editor/SpatialEditorPane.js'
 import { useNodeInEditor } from '../components/document-editor/use-node-in-editor.js'
 import { DocumentProperties } from '../components/document-properties/DocumentProperties.js'
-import { HistoryCluster } from '../components/history-cluster/HistoryCluster.js'
 import { SaveStatusChip } from '../components/SaveStatusChip.js'
 import { CanvasDisplaySettings } from '../components/spatial-editor/CanvasDisplaySettings.js'
-import { SpatialEditor } from '../components/spatial-editor/index.js'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -50,7 +48,6 @@ import { BROWSER_FILE_ADAPTER } from '../lib/document-embed-content.js'
 import { isDocumentReadFailure } from '../lib/document-read-failure.js'
 import { browserFaviconStatus, type FaviconStyle } from '../lib/favicon.js'
 import { sharedFoldingBrowserIndex } from '../lib/folding-browser-index.js'
-import { readLastTool, resolveInitialTool } from '../lib/initial-tool.js'
 import { kindNoun } from '../lib/kind-noun.js'
 import type { ContentClock, DefaultDocumentPointer } from '../lib/local-document-summary.js'
 import { ensurePersistentStorage } from '../lib/persistent-storage.js'
@@ -924,79 +921,43 @@ export function BrowserDocumentPage({
           }
           spatial={() => (
             <div className="flex h-full min-h-0 flex-col">
-              {/* The hook sits INSIDE the spatial slot, as it does on the
-                  daemon page, so `spatial-editor-container` means the same
-                  thing on both: a spatial editor is mounted. Outside the
-                  slot it was also present for a markdown document, so one
-                  identifier answered two different questions depending on
-                  which page a test was written against. */}
-              <div data-testid="spatial-editor-container" className="relative min-h-0 flex-1">
-                {/* Keyed on canvas identity: the editor's pan/zoom, in-flight
-                  gesture and open text editor all describe ONE canvas, and
-                  `SpatialCanvas` carries no id for the editor to notice a
-                  switch by. Without the key, switching documents silently
-                  inherits the previous canvas's viewport. (The markdown
-                  branch keys for the same reason.) */}
-                <SpatialEditor
-                  key={documentId ?? 'no-canvas'}
-                  // Decided from the canvas's own shape, but only once its
-                  // document has loaded — at mount every canvas still looks
-                  // empty.
-                  initialTool={
-                    canvasLoaded
-                      ? resolveInitialTool({
-                          isEmpty: canvas.nodes.length === 0,
-                          lastTool: readLastTool(),
-                        })
-                      : undefined
-                  }
-                  canvas={canvas}
-                  onChange={onChange}
-                  externalVersion={externalVersion}
-                  theme={resolvedTheme}
-                  // File-node reference = canvas id minted in the browser; the current
-                  // canvas is excluded (a self-reference card is pure noise).
-                  fileRefOptions={documents
-                    .filter((entry) => entry.documentId !== documentId)
-                    .map((entry) => ({
-                      file: entry.documentId,
-                      label: entry.name,
-                      kind: entry.kind,
-                    }))}
-                  // A file-node reference names a document id exactly like a
-                  // [[wikiLink]] does, so it follows through the same one
-                  // conversion rather than repeating it here.
-                  onOpenFileRef={navigateToDocument}
-                  missingFileRef={missingFileRef}
-                  {...fileSeams}
-                  lockedNodeIds={lockedNodeIds}
-                  lockedEdgeIds={lockedEdgeIds}
-                  onToggleNodeLock={setNodeLock}
-                  onOpenInEditor={nodeInEditor.open}
-                  onToggleEdgeLock={setEdgeLock}
-                  paletteLeading={
-                    <HistoryCluster
-                      onUndo={() => void undo()}
-                      onRedo={() => void redo()}
-                      canUndo={canUndo()}
-                      canRedo={canRedo()}
-                    />
-                  }
-                />
-                {nodeInEditor.editing !== null && (
-                  <NodeTextEditorOverlay
-                    title={documentName ?? 'Untitled'}
-                    initialText={nodeInEditor.editing.text}
-                    theme={resolvedTheme}
-                    resolveAlias={resolveAlias}
-                    resolveEmbed={resolveEmbed}
-                    linkTargets={linkTargets}
-                    onCommit={nodeInEditor.commit}
-                    onClose={nodeInEditor.close}
-                    onOpenDocument={(id) => navigateToDocument(id)}
-                  />
-                )}
-              </div>
+              <SpatialEditorPane
+                className="relative min-h-0 flex-1"
+                editorKey={documentId ?? 'no-canvas'}
+                canvasLoaded={canvasLoaded}
+                canvas={canvas}
+                onChange={onChange}
+                externalVersion={externalVersion}
+                theme={resolvedTheme}
+                // File-node reference = canvas id minted in the browser; the
+                // current canvas is excluded (a self-reference card is pure
+                // noise).
+                fileRefOptions={documents
+                  .filter((entry) => entry.documentId !== documentId)
+                  .map((entry) => ({
+                    file: entry.documentId,
+                    label: entry.name,
+                    kind: entry.kind,
+                  }))}
+                onOpenDocument={navigateToDocument}
+                missingFileRef={missingFileRef}
+                fileSeams={fileSeams}
+                lockedNodeIds={lockedNodeIds}
+                lockedEdgeIds={lockedEdgeIds}
+                onToggleNodeLock={setNodeLock}
+                onToggleEdgeLock={setEdgeLock}
+                nodeInEditor={nodeInEditor}
+                history={{
+                  onUndo: () => void undo(),
+                  onRedo: () => void redo(),
+                  canUndo: canUndo(),
+                  canRedo: canRedo(),
+                }}
+                overlayTitle={documentName ?? 'Untitled'}
+                resolveAlias={resolveAlias}
+                resolveEmbed={resolveEmbed}
+                linkTargets={linkTargets}
+              />
             </div>
           )}
         />

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -12,6 +12,7 @@ import type { ConnectionsBacklink } from '../components/connections/ConnectionsC
 import { ConnectionsChip } from '../components/connections/ConnectionsChip.js'
 import { DocumentPageSkeleton } from '../components/DocumentPageSkeleton.js'
 import { DocumentEditorSurface } from '../components/document-editor/DocumentEditorSurface.js'
+import { DocumentPageShell } from '../components/document-editor/DocumentPageShell.js'
 import { SpatialEditorPane } from '../components/document-editor/SpatialEditorPane.js'
 import { useNodeInEditor } from '../components/document-editor/use-node-in-editor.js'
 import { DocumentProperties } from '../components/document-properties/DocumentProperties.js'
@@ -601,97 +602,95 @@ export function DaemonDocumentPage({
 
   return (
     <DaemonApiContext.Provider value={daemonFetch}>
-      {/* Two-row grid shell: everything header-shaped stacks inside the
-          auto row, and the canvas owns minmax(0,1fr) — however many banner
-          rows appear (or however tall they wrap), the canvas row is always
-          exactly the remaining viewport height, never clipped below it. */}
-      <main className="relative grid h-full w-full grid-rows-[auto_minmax(0,1fr)]">
-        <div className="min-w-0">
-          <h1 className="sr-only">Whiteboard (daemon)</h1>
-          {canvas && (
-            <WorkspaceTopBar
-              // Document identity in the merged header row, mirroring the
-              // browser page. The NAME is the workspace's — the top bar
-              // hands it down from `/names`, the same surface the canvas
-              // dropdown renames through — never a `title` read out of the
-              // content, which ADR-0009 decision 2 forbids and
-              // `storedCoreFacetsSchema` has no room for.
-              titleSlot={(identity) => (
-                <>
-                  <DocumentProperties
-                    inline
-                    key={`${canvas.workspaceId}/${canvas.path}`}
-                    title={identity.name}
-                    onTitleChange={identity.onRename}
-                    // Facets are OKF frontmatter, so only a markdown document
-                    // has any — `readCoreFacets` answers `undefined` for a
-                    // spatial one (ADR-0009 decision 3), which is what decides
-                    // the disclosure here without a second flag to keep in sync.
-                    facets={coreFacets}
-                    onFacetsChange={setCoreFacets}
-                    // Canvas-level display settings, gated on kind the same
-                    // way the facet disclosure above is: a markdown document
-                    // has no canvas to configure. The browser page has placed
-                    // this since it existed and this one did not, which left
-                    // every `canvasSettings` contribution — today `visual`'s
-                    // `visual.edges/v0` — unreachable in daemon mode.
-                    settings={
-                      documentKind === 'spatial' ? (
-                        <CanvasDisplaySettings canvas={canvasValue} onChange={onChange} />
-                      ) : undefined
-                    }
-                    actions={
-                      <>
-                        {exportError && (
-                          <span className="text-destructive truncate text-xs" role="alert">
-                            {exportError}
-                          </span>
-                        )}
-                        <DocumentMenu onExport={(format) => void handleExport(format)} />
-                      </>
-                    }
-                  />
-                  <ConnectionsChip
-                    backlinks={connections === null ? null : connections.backlinks}
-                    mentions={connections?.unlinkedMentions}
-                    onOpen={(entry) => controller.switchDocument(entry.path)}
-                    onLinkify={(mention) => {
-                      if (controller.workspaceId === null || currentDocumentId === undefined) return
-                      void linkifyDocumentMentions(
-                        daemonFetch,
-                        daemonBaseUrl,
-                        controller.workspaceId,
-                        mention.documentId,
-                        currentDocumentId,
-                      )
-                        .then(() => setConnectionsRefresh((n) => n + 1))
-                        .catch(() => {
-                          // The panel simply keeps showing the mention; the
-                          // next open retries.
-                        })
-                    }}
-                  />
-                </>
-              )}
-              workspaceId={canvas.workspaceId}
-              path={canvas.path}
-              capabilities={{
-                versions: capabilities.versions,
-                branches: capabilities.branches,
-                merge: capabilities.merge,
-              }}
-              branchRefreshSignal={branchRefreshSignal}
-              onNavigateBack={onNavigateBack}
-              // Version thumbnails come from the same PNG export path the
-              // user can trigger by hand. Without this the save flow skips
-              // the upload entirely and latest-thumbnail stays 204 forever.
-              getThumbnailBlob={getThumbnailBlob}
-            />
-          )}
-          {capabilities.branches && canvas && (
-            <HeaderBranchBanner workspaceId={canvas.workspaceId} path={canvas.path} />
-          )}
-          {/* This row only exists when it carries something meaningful: a
+      <DocumentPageShell
+        srTitle="Whiteboard (daemon)"
+        header={
+          <>
+            {canvas && (
+              <WorkspaceTopBar
+                // Document identity in the merged header row, mirroring the
+                // browser page. The NAME is the workspace's — the top bar
+                // hands it down from `/names`, the same surface the canvas
+                // dropdown renames through — never a `title` read out of the
+                // content, which ADR-0009 decision 2 forbids and
+                // `storedCoreFacetsSchema` has no room for.
+                titleSlot={(identity) => (
+                  <>
+                    <DocumentProperties
+                      inline
+                      key={`${canvas.workspaceId}/${canvas.path}`}
+                      title={identity.name}
+                      onTitleChange={identity.onRename}
+                      // Facets are OKF frontmatter, so only a markdown document
+                      // has any — `readCoreFacets` answers `undefined` for a
+                      // spatial one (ADR-0009 decision 3), which is what decides
+                      // the disclosure here without a second flag to keep in sync.
+                      facets={coreFacets}
+                      onFacetsChange={setCoreFacets}
+                      // Canvas-level display settings, gated on kind the same
+                      // way the facet disclosure above is: a markdown document
+                      // has no canvas to configure. The browser page has placed
+                      // this since it existed and this one did not, which left
+                      // every `canvasSettings` contribution — today `visual`'s
+                      // `visual.edges/v0` — unreachable in daemon mode.
+                      settings={
+                        documentKind === 'spatial' ? (
+                          <CanvasDisplaySettings canvas={canvasValue} onChange={onChange} />
+                        ) : undefined
+                      }
+                      actions={
+                        <>
+                          {exportError && (
+                            <span className="text-destructive truncate text-xs" role="alert">
+                              {exportError}
+                            </span>
+                          )}
+                          <DocumentMenu onExport={(format) => void handleExport(format)} />
+                        </>
+                      }
+                    />
+                    <ConnectionsChip
+                      backlinks={connections === null ? null : connections.backlinks}
+                      mentions={connections?.unlinkedMentions}
+                      onOpen={(entry) => controller.switchDocument(entry.path)}
+                      onLinkify={(mention) => {
+                        if (controller.workspaceId === null || currentDocumentId === undefined)
+                          return
+                        void linkifyDocumentMentions(
+                          daemonFetch,
+                          daemonBaseUrl,
+                          controller.workspaceId,
+                          mention.documentId,
+                          currentDocumentId,
+                        )
+                          .then(() => setConnectionsRefresh((n) => n + 1))
+                          .catch(() => {
+                            // The panel simply keeps showing the mention; the
+                            // next open retries.
+                          })
+                      }}
+                    />
+                  </>
+                )}
+                workspaceId={canvas.workspaceId}
+                path={canvas.path}
+                capabilities={{
+                  versions: capabilities.versions,
+                  branches: capabilities.branches,
+                  merge: capabilities.merge,
+                }}
+                branchRefreshSignal={branchRefreshSignal}
+                onNavigateBack={onNavigateBack}
+                // Version thumbnails come from the same PNG export path the
+                // user can trigger by hand. Without this the save flow skips
+                // the upload entirely and latest-thumbnail stays 204 forever.
+                getThumbnailBlob={getThumbnailBlob}
+              />
+            )}
+            {capabilities.branches && canvas && (
+              <HeaderBranchBanner workspaceId={canvas.workspaceId} path={canvas.path} />
+            )}
+            {/* This row only exists when it carries something meaningful: a
             capability this keeper does not have. A daemon with full
             capabilities — the common local case — gets no extra header row
             at all (every header row costs canvas height on a phone).
@@ -702,21 +701,23 @@ export function DaemonDocumentPage({
             had gone stale: it deferred to a WorkspaceTopBar dropdown that no
             longer exists. The shell switcher names the workspace on every
             page, this one included, so it is the one carrier now. */}
-          {(!capabilities.versions || !capabilities.branches || !capabilities.merge) && (
-            <div className="flex flex-wrap items-center gap-2 border-b bg-background px-4 py-2">
-              {/* WorkspaceTopBar owns the real History/HeaderSaveDot/HeaderBranchChip
+            {(!capabilities.versions || !capabilities.branches || !capabilities.merge) && (
+              <div className="flex flex-wrap items-center gap-2 border-b bg-background px-4 py-2">
+                {/* WorkspaceTopBar owns the real History/HeaderSaveDot/HeaderBranchChip
               affordances once a canvas is selected; these page-level teasers only
               surface guidance while the capability itself is unavailable. */}
-              {!capabilities.versions && (
-                <CapabilityTeaser label="Version history" enabled={capabilities.versions} />
-              )}
-              {!capabilities.branches && (
-                <CapabilityTeaser label="Variations" enabled={capabilities.branches} />
-              )}
-              {!capabilities.merge && <CapabilityTeaser label="Combine" enabled={false} />}
-            </div>
-          )}
-        </div>
+                {!capabilities.versions && (
+                  <CapabilityTeaser label="Version history" enabled={capabilities.versions} />
+                )}
+                {!capabilities.branches && (
+                  <CapabilityTeaser label="Variations" enabled={capabilities.branches} />
+                )}
+                {!capabilities.merge && <CapabilityTeaser label="Combine" enabled={false} />}
+              </div>
+            )}
+          </>
+        }
+      >
         {canvas !== null &&
         controller.documents.length > 0 &&
         workspaceSyncDocumentId === undefined ? (
@@ -863,7 +864,7 @@ export function DaemonDocumentPage({
             onRestored={clearLocalUndo}
           />
         )}
-      </main>
+      </DocumentPageShell>
     </DaemonApiContext.Provider>
   )
 }

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -12,15 +12,13 @@ import type { ConnectionsBacklink } from '../components/connections/ConnectionsC
 import { ConnectionsChip } from '../components/connections/ConnectionsChip.js'
 import { DocumentPageSkeleton } from '../components/DocumentPageSkeleton.js'
 import { DocumentEditorSurface } from '../components/document-editor/DocumentEditorSurface.js'
-import { NodeTextEditorOverlay } from '../components/document-editor/NodeTextEditorOverlay.js'
+import { SpatialEditorPane } from '../components/document-editor/SpatialEditorPane.js'
 import { useNodeInEditor } from '../components/document-editor/use-node-in-editor.js'
 import { DocumentProperties } from '../components/document-properties/DocumentProperties.js'
 import { HeaderBranchBanner } from '../components/HeaderBranchBanner.js'
-import { HistoryCluster } from '../components/history-cluster/HistoryCluster.js'
 import { MergeToast } from '../components/MergeToast.js'
 import { CanvasDisplaySettings } from '../components/spatial-editor/CanvasDisplaySettings.js'
 import type { SpatialEditorHandle } from '../components/spatial-editor/index.js'
-import { SpatialEditor } from '../components/spatial-editor/index.js'
 import { Button } from '../components/ui/button.js'
 import WorkspaceTopBar from '../components/WorkspaceTopBar.js'
 import { DocumentMenu } from '../components/workspace-top-bar/DocumentMenu.js'
@@ -50,7 +48,6 @@ import { daemonLinkEntries, daemonLinkTargets } from '../lib/daemon-link-entries
 import { deriveNewDocumentPath } from '../lib/derive-new-document-path.js'
 import { devTransportOverride } from '../lib/dev-transport-override.js'
 import { daemonFaviconStatus, type FaviconStyle } from '../lib/favicon.js'
-import { readLastTool, resolveInitialTool } from '../lib/initial-tool.js'
 import { DAEMON_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
 import { setShellConnection } from '../lib/shell-status-store.js'
 import { createSharedSseStreamSource } from '../lib/sse-shared-stream-source.js'
@@ -804,85 +801,58 @@ export function DaemonDocumentPage({
               resolveEmbed,
             }}
             spatial={() => (
-              <div data-testid="spatial-editor-container" className="relative h-full min-h-0">
+              <SpatialEditorPane
+                className="relative h-full min-h-0"
+                editorKey={canvas ? `${canvas.workspaceId}/${canvas.path}` : 'no-canvas'}
+                canvasLoaded={canvasLoaded}
+                editorRef={spatialEditorRef}
+                agentTouchedNodeIds={agentActivity.touchedNodeIds}
+                canvas={canvasValue}
+                onChange={onChange}
+                externalVersion={externalVersion}
+                theme={resolvedTheme}
+                // File-node reference = the target's immutable id (rename-
+                // safe); the label shows its current path and the current
+                // canvas is excluded. Legacy documents still carry path refs,
+                // which resolveRefPath misses and switchDocument takes as-is.
+                fileRefOptions={controller.documents
+                  .filter((entry) => entry.path !== canvas?.path)
+                  .map((entry) => ({
+                    file: entry.id,
+                    label: entry.path,
+                    kind: entry.kind,
+                  }))}
+                onOpenDocument={(id) => controller.switchDocument(resolveRefPath(id) ?? id)}
+                missingFileRef={missingFileRef}
+                fileSeams={fileSeams}
+                lockedNodeIds={lockedNodeIds}
+                lockedEdgeIds={lockedEdgeIds}
+                onToggleNodeLock={setNodeLock}
+                onToggleEdgeLock={setEdgeLock}
+                nodeInEditor={nodeInEditor}
+                history={{
+                  onUndo: () => void undo(),
+                  onRedo: () => void redo(),
+                  canUndo: canUndo(),
+                  canRedo: canRedo(),
+                  versions:
+                    capabilities.versions && canvas
+                      ? {
+                          workspaceId: canvas.workspaceId,
+                          path: canvas.path,
+                          onRestored: clearLocalUndo,
+                          refreshSignal: versionRefreshSignal,
+                          versionPanelExtra,
+                        }
+                      : undefined,
+                }}
+                overlayTitle={canvas?.path ?? 'Untitled'}
+                resolveAlias={resolveAlias}
+                resolveEmbed={resolveEmbed}
+                linkTargets={linkTargets}
+              >
                 <AgentPresenceChip summary={agentActivity.summary} />
-                {/* Keyed on canvas identity: the editor's pan/zoom, in-flight
-                gesture and open text editor all describe ONE canvas, and
-                `SpatialCanvas` carries no id for the editor to notice a switch
-                by. Without the key, switching documents silently inherits the
-                previous canvas's viewport. */}
-                <SpatialEditor
-                  key={canvas ? `${canvas.workspaceId}/${canvas.path}` : 'no-canvas'}
-                  // Decided from the canvas's own shape, but only once its
-                  // document has loaded — at mount every canvas still looks
-                  // empty.
-                  initialTool={
-                    canvasLoaded
-                      ? resolveInitialTool({
-                          isEmpty: canvasValue.nodes.length === 0,
-                          lastTool: readLastTool(),
-                        })
-                      : undefined
-                  }
-                  ref={spatialEditorRef}
-                  agentTouchedNodeIds={agentActivity.touchedNodeIds}
-                  canvas={canvasValue}
-                  onChange={onChange}
-                  externalVersion={externalVersion}
-                  theme={resolvedTheme}
-                  // File-node reference = the target's immutable id (rename-
-                  // safe); the label shows its current path and the current
-                  // canvas is excluded. Legacy documents still carry path refs,
-                  // which resolveRefPath misses and switchDocument takes as-is.
-                  fileRefOptions={controller.documents
-                    .filter((entry) => entry.path !== canvas?.path)
-                    .map((entry) => ({
-                      file: entry.id,
-                      label: entry.path,
-                      kind: entry.kind,
-                    }))}
-                  onOpenFileRef={(file) => controller.switchDocument(resolveRefPath(file) ?? file)}
-                  missingFileRef={missingFileRef}
-                  {...fileSeams}
-                  lockedNodeIds={lockedNodeIds}
-                  lockedEdgeIds={lockedEdgeIds}
-                  onToggleNodeLock={setNodeLock}
-                  onOpenInEditor={nodeInEditor.open}
-                  onToggleEdgeLock={setEdgeLock}
-                  paletteLeading={
-                    <HistoryCluster
-                      onUndo={() => void undo()}
-                      onRedo={() => void redo()}
-                      canUndo={canUndo()}
-                      canRedo={canRedo()}
-                      versions={
-                        capabilities.versions && canvas
-                          ? {
-                              workspaceId: canvas.workspaceId,
-                              path: canvas.path,
-                              onRestored: clearLocalUndo,
-                              refreshSignal: versionRefreshSignal,
-                              versionPanelExtra,
-                            }
-                          : undefined
-                      }
-                    />
-                  }
-                />
-                {nodeInEditor.editing !== null && (
-                  <NodeTextEditorOverlay
-                    title={canvas?.path ?? 'Untitled'}
-                    initialText={nodeInEditor.editing.text}
-                    theme={resolvedTheme}
-                    resolveAlias={resolveAlias}
-                    resolveEmbed={resolveEmbed}
-                    linkTargets={linkTargets}
-                    onCommit={nodeInEditor.commit}
-                    onClose={nodeInEditor.close}
-                    onOpenDocument={(id) => controller.switchDocument(resolveRefPath(id) ?? id)}
-                  />
-                )}
-              </div>
+              </SpatialEditorPane>
             )}
           />
         )}

--- a/apps/web/src/pages/file-seam-conformance.test.ts
+++ b/apps/web/src/pages/file-seam-conformance.test.ts
@@ -21,6 +21,17 @@ const sources = import.meta.glob('./{BrowserDocumentPage,DaemonDocumentPage}.tsx
   import: 'default',
 })
 
+const paneSource = import.meta.glob('../components/document-editor/SpatialEditorPane.tsx', {
+  query: '?raw',
+  import: 'default',
+})
+
+async function readPane(): Promise<string> {
+  const loader = paneSource['../components/document-editor/SpatialEditorPane.tsx']
+  expect(loader, 'no source loader for SpatialEditorPane').toBeDefined()
+  return (await loader?.()) as string
+}
+
 async function read(page: string): Promise<string> {
   const loader = sources[page]
   expect(loader, `no source loader for ${page}`).toBeDefined()
@@ -115,54 +126,93 @@ function renders(source: string, chrome: string): boolean {
  * property is WHERE the attribute sits in the source, and a render can only see
  * one kind at a time.
  */
-describe('the spatial-editor-container hook means one thing', () => {
-  const HOOK = 'data-testid="spatial-editor-container"'
-  const SLOT = 'spatial={() => ('
+const HOOK = 'data-testid="spatial-editor-container"'
+const SLOT = 'spatial={() => ('
 
-  /**
-   * The slot callback's [start, end) range, by matching the paren the marker
-   * opens. `first occurrence comes after the opener` was the original
-   * assertion and it has two holes review named: it never proves the hook is
-   * INSIDE the callback, and a second hook added after the callback closes —
-   * outside it, so rendered for a markdown document too — keeps it green.
-   */
-  function spatialSlotRange(source: string): [number, number] {
-    const open = source.indexOf(SLOT)
-    if (open === -1) return [-1, -1]
-    let depth = 0
-    let i = open + SLOT.length - 1
-    for (; i < source.length; i++) {
-      if (source[i] === '(') depth += 1
-      else if (source[i] === ')') {
-        depth -= 1
-        if (depth === 0) break
-      }
+/**
+ * The slot callback's [start, end) range, by matching the paren the marker
+ * opens. `first occurrence comes after the opener` was the original
+ * assertion and it has two holes review named: it never proves the hook is
+ * INSIDE the callback, and a second hook added after the callback closes —
+ * outside it, so rendered for a markdown document too — keeps it green.
+ */
+function spatialSlotRange(source: string): [number, number] {
+  const open = source.indexOf(SLOT)
+  if (open === -1) return [-1, -1]
+  let depth = 0
+  let i = open + SLOT.length - 1
+  for (; i < source.length; i++) {
+    if (source[i] === '(') depth += 1
+    else if (source[i] === ')') {
+      depth -= 1
+      if (depth === 0) break
     }
-    return [open, i]
   }
+  return [open, i]
+}
 
-  function hookOffsets(source: string): number[] {
-    const out: number[] = []
-    for (let i = source.indexOf(HOOK); i !== -1; i = source.indexOf(HOOK, i + 1)) out.push(i)
-    return out
-  }
+function hookOffsets(source: string): number[] {
+  const out: number[] = []
+  for (let i = source.indexOf(HOOK); i !== -1; i = source.indexOf(HOOK, i + 1)) out.push(i)
+  return out
+}
 
-  it.each(PAGES)('%s places every occurrence inside the spatial slot', async (page) => {
+/**
+ * The spatial editor pane is assembled ONCE, in `SpatialEditorPane`.
+ *
+ * The editor takes ~23 props and the two pages used to spell them out
+ * independently — 19 shared, 14 byte-identical — which is the arrangement
+ * that shipped the file-seam defect: a prop added to one call site and not
+ * the other diverges silently, because each page's tests only exercise its
+ * own mode. With one component owning the assembly, a new prop is added in
+ * one place or it does not compile.
+ *
+ * So a page may not render `<SpatialEditor` directly, and the pane it
+ * renders instead must sit inside the `spatial` slot — outside it, the pane
+ * (which carries the `spatial-editor-container` hook) would mount for a
+ * markdown document too.
+ */
+describe('the spatial editor pane is built once', () => {
+  it.each(PAGES)('%s renders SpatialEditorPane, never SpatialEditor directly', async (page) => {
     const source = await read(page)
-    const [start, end] = spatialSlotRange(source)
-    expect(start, `${page} has no spatial slot to place it in`).toBeGreaterThan(-1)
-    // A slot whose body bracket-matched to nothing would let the range check
-    // below pass vacuously in one direction and fail nonsensically in the
-    // other; either way the range itself is the first thing to distrust.
-    expect(end - start, `${page}'s spatial slot range collapsed`).toBeGreaterThan(500)
-
-    const offsets = hookOffsets(source)
-    expect(offsets.length, `${page} does not expose the hook at all`).toBeGreaterThan(0)
-    const outside = offsets.filter((at) => at < start || at > end)
     expect(
-      outside,
-      'a hook outside the spatial slot is present for a markdown document ' +
-        'too, so it no longer means "a spatial editor is mounted".',
+      /<SpatialEditor[\s/>]/.test(source),
+      'a direct <SpatialEditor> render reintroduces the second copy of its ' +
+        'prop assembly — add props through SpatialEditorPane instead.',
+    ).toBe(false)
+
+    const [start, end] = spatialSlotRange(source)
+    expect(start, `${page} has no spatial slot`).toBeGreaterThan(-1)
+    const offsets: number[] = []
+    for (
+      let i = source.indexOf('<SpatialEditorPane');
+      i !== -1;
+      i = source.indexOf('<SpatialEditorPane', i + 1)
+    ) {
+      offsets.push(i)
+    }
+    expect(offsets.length, `${page} renders no SpatialEditorPane`).toBeGreaterThan(0)
+    expect(
+      offsets.filter((at) => at < start || at > end),
+      'a pane outside the spatial slot mounts for a markdown document too.',
+    ).toEqual([])
+  })
+})
+
+describe('the spatial-editor-container hook means one thing', () => {
+  // The pane owns the hook, and the "built once" scan above holds the pane
+  // inside each page's spatial slot — together they keep the old guarantee
+  // (the hook only ever means "a spatial editor is mounted") with the
+  // ownership the extraction moved.
+  it('the pane carries it exactly once', async () => {
+    expect(hookOffsets(await readPane())).toHaveLength(1)
+  })
+
+  it.each(PAGES)('%s does not spell it a second time', async (page) => {
+    expect(
+      hookOffsets(await read(page)),
+      'a page-level hook is one the pane does not position — for a markdown ' +
+        'document it would answer the wrong question again.',
     ).toEqual([])
   })
 })
@@ -216,18 +266,26 @@ describe('document page canvas chrome', () => {
 })
 
 describe('canvas page file seams', () => {
-  it.each(PAGES)('%s passes the shared seams to SpatialEditor', async (page) => {
+  it.each(PAGES)('%s hands the shared seams to the pane', async (page) => {
     const source = await read(page)
 
-    // The spread is the point: enumerating the four props per page is how
-    // they drifted apart in the first place, so a page that spells them out
-    // individually should fail here even if it happens to pass all four.
-    expect(source).toContain('{...fileSeams}')
+    // The page builds its seams from the shared hook and hands the OBJECT
+    // over; the single spread lives in the pane. Enumerating the four props
+    // per page is how they drifted apart in the first place.
+    expect(source).toContain('fileSeams={fileSeams}')
     expect(source).toContain('useDocumentFileSeams(')
   })
 
-  it.each(PAGES)('%s builds its seams from an adapter, not inline loading', async (page) => {
-    const source = await read(page)
+  it('the pane spreads them, once', async () => {
+    const source = await readPane()
+    expect(source.split('{...fileSeams}')).toHaveLength(2)
+  })
+
+  it.each([
+    ...PAGES,
+    'pane',
+  ])('%s builds its seams from an adapter, not inline loading', async (page) => {
+    const source = page === 'pane' ? await readPane() : await read(page)
 
     // Caching (staleness stamps, the same-instance guard, URL revocation)
     // belongs to the shared hook. A page reaching for these again means the

--- a/apps/web/src/pages/file-seam-conformance.test.ts
+++ b/apps/web/src/pages/file-seam-conformance.test.ts
@@ -56,7 +56,15 @@ async function read(page: string): Promise<string> {
  * contribution is declared through the facet definition rather than spelled
  * at a call site; resolving the registry is what shows it is real.
  */
-const SHARED_CANVAS_CHROME = ['CanvasDisplaySettings', 'WorkspaceTopBar'] as const
+const SHARED_CANVAS_CHROME = [
+  'CanvasDisplaySettings',
+  'WorkspaceTopBar',
+  // The two-row grid <main> shell: everything header-shaped stacks in the
+  // auto row and the editor owns minmax(0,1fr). Both pages carried the same
+  // grid template and the same sr-only <h1> landmark by hand; the shell owns
+  // them once, so a layout or a11y drift between modes cannot happen quietly.
+  'DocumentPageShell',
+] as const
 
 /**
  * Chrome one mode has and the other cannot, per ADR-0004 — capability-gated


### PR DESCRIPTION
## Summary

Two stacked slices of the ADR-0004 page collapse (audit #3), both behavior-preserving:

- **Slice 3 — `SpatialEditorPane`** (`components/document-editor/SpatialEditorPane.tsx`): the spatial-editor assembly (`SpatialEditor` + `HistoryCluster` + `NodeTextEditorOverlay` + the `fileSeams` spread + `resolveInitialTool`) now exists once, consumed by both `BrowserDocumentPage` and `DaemonDocumentPage`. Of `SpatialEditor`'s 23 props, 14 were byte-identical between the pages and 5 more identical after the shared hooks; the genuinely per-page ones (`editorKey`, `canvas`, `fileRefOptions`, navigation, history wiring, overlay title, container classes, the daemon's `AgentPresenceChip` child) stay props/children.
- **Slice 4 — `DocumentPageShell`** (`components/document-editor/DocumentPageShell.tsx`): both pages stand in one two-row `<main>` shell (`grid-rows-[auto_minmax(0,1fr)]`, sr-only `<h1>`, header slot). The browser page's `mainRef` + `bg-background` survive as props because they are load-bearing for fullscreen: `requestFullscreen` targets the `<main>`, and a fullscreened element without its own background composits over black.
- The `file-seam-conformance` suite grows to 21 tests: the pane is the only place `<SpatialEditor` is rendered and `{...fileSeams}` is spread (bracket-matched slot ranges, word-boundary matching so `<SpatialEditorPane` doesn't satisfy `<SpatialEditor`), `DocumentPageShell` joins the shared-chrome list with exact-ownership assertions for mode-specific chrome.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — `file-seam-conformance.test.ts` 21/21
- [x] `pnpm test` passes locally — jsdom pages + document-editor: 43 files / 391 tests; the 7 hook-querying `web-browser` files: 29/29 (standing Node-22 `Blob` set and the load-dependent full-browser-run set are the environment's known failures; CI's Node 24 is authoritative)
- [x] Manual verification completed — mutation checks, each red-then-restored-green:
  - drop `{...fileSeams}` from the pane → conformance scan fails (**and `DaemonDocumentPage.file-refs.test.tsx` stays green** — the scan is load-bearing, not decorative)
  - render `<SpatialEditor` directly on a page → "built once" test fails
  - peel `DaemonDocumentPage` back to a raw `<main>` → shared-chrome scan fails
- [ ] E2E coverage added or extended where applicable — not applicable: no user flow changes; the conformance suite is the regression lock

## Visual evidence

Visual evidence: none — a behavior-preserving refactor; no pixel differs, and this environment cannot compose or upload figures (no ImageMagick for `compose-figure.mjs`, no `gh` CLI).

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — no user-visible or contract change
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_