### PR TITLE
fix(web): give the LCP gate a bounded grace instead of a fixed bet

### DIFF
--- a/apps/web/scripts/measure-critical-path.mjs
+++ b/apps/web/scripts/measure-critical-path.mjs
@@ -131,6 +131,62 @@ export function parseFloorMs(raw) {
   }
   return { floor: parsed }
 }
+// The fixed settle after `load`, and the bounded grace that only a run which
+// LOSES that bet ever pays.
+//
+// The fixed beat is a bet on how long the app takes to mount, and a cold
+// first run loses it. Measured on CI: run 1 of 5 came back `mounted=false`,
+// and the gate did exactly what it should — a number taken over the boot
+// splash is not the shell's LCP, so it refused. The run was not wrong about
+// what it saw; the instrument had not waited long enough for there to be
+// anything else to see. That is a flake in the INSTRUMENT, and re-running it
+// is how a gate starts being ignored.
+//
+// The grace is deliberately not "wait longer". Raising the fixed beat would
+// widen the LCP observation window on every run, including the healthy ones,
+// and every median in the comment block above was taken through the 2000ms
+// window — the floor would then be stated against one measurement and
+// enforced against another. So the beat is untouched and the extra wait is
+// reached only when the first probe comes back unmounted: a healthy run's
+// timeline is byte-identical to what it was, and a slow run reports the LCP
+// it actually had instead of failing the gate over the splash.
+//
+// It stays BOUNDED and the probe still has the last word. An app that truly
+// never mounts must still fail, and fail with the gate's own diagnosis rather
+// than a Playwright timeout, which is why the expiry is swallowed here.
+//
+// Verified against a real browser by shortening the beat to 1ms, which
+// reproduces the lost bet on demand instead of waiting for a cold CI runner:
+//
+//   beat 1ms, no grace     3/3 never mounted, gate FAILED (exit 1)
+//   beat 1ms, grace 8s     3/3 mounted, grace 1931-1970ms, LCP median 504 ms
+//   beat 2000ms (healthy)  5/5 mounted, no grace paid,     LCP median 500 ms
+//   beat 1ms, grace 200ms  2/2 never mounted, gate FAILED (exit 1)
+//
+// The middle two rows are the claim that matters and the reason the beat is
+// left alone: a run that pays the grace reports the same LCP as one that does
+// not, inside the 2% band. The last row is the one that keeps this honest —
+// a grace long enough to rescue a slow run must still be short enough that a
+// build which never mounts is refused, with the message above rather than a
+// selector timeout.
+const SETTLE_MS = Number(process.env.MEASURE_SETTLE_MS ?? 2000)
+const MOUNT_GRACE_MS = Number(process.env.MEASURE_MOUNT_GRACE_MS ?? 8000)
+
+// Injected rather than closed over a `page`, so both branches are testable
+// without a browser — the same reason `parseFloorMs` is pure and exported.
+export async function settleForMount({ waitFixed, probe, waitForMount, now = Date.now }) {
+  await waitFixed()
+  const first = await probe()
+  if (first.shellMark) return { ...first, graceMs: 0 }
+  const started = now()
+  try {
+    await waitForMount()
+  } catch {
+    // Expiry is not the verdict. The probe below is.
+  }
+  return { ...(await probe()), graceMs: now() - started }
+}
+
 // A mid-range phone on a decent connection, fixed so two runs are comparable.
 // The absolute numbers are only meaningful against each other.
 const CPU_THROTTLE = Number(process.env.MEASURE_CPU_THROTTLE ?? 4)
@@ -201,25 +257,31 @@ async function measureOnce(browser, url) {
   await cdp.send('Network.emulateNetworkConditions', NETWORK)
   await cdp.send('Emulation.setCPUThrottlingRate', { rate: CPU_THROTTLE })
   await page.goto(url, { waitUntil: 'load' })
-  // The app dismisses its boot splash and mounts React after load; settle for
-  // a fixed beat so LCP has landed on real content rather than on the splash.
-  await page.waitForTimeout(2000)
-  // Did the APP render, or did this measure the boot splash?
-  //
-  // Not decoration. The first run of this script reported LCP identical to
-  // FCP in every single run, which is what a page whose largest paint is its
-  // own splash looks like — and also what a page that never mounted looks
-  // like. A 2% spread on a number that describes the wrong thing reads as
-  // "gateable" and is worse than no measurement. So the instrument states
-  // what it saw rather than leaving the reader to assume.
-  const mounted = await page.evaluate(() => {
-    const el = document.querySelector('[data-testid="shell-mark"]')
-    const root = document.getElementById('root')
-    return {
-      shellMark: el !== null,
-      rootChildren: root ? root.childElementCount : 0,
-      largestText: document.body.innerText.slice(0, 60).replace(/\s+/g, ' ').trim(),
-    }
+  const mounted = await settleForMount({
+    // The app dismisses its boot splash and mounts React after load; settle
+    // for a fixed beat so LCP has landed on real content rather than on the
+    // splash. This is the window every recorded median was taken through.
+    waitFixed: () => page.waitForTimeout(SETTLE_MS),
+    // Did the APP render, or did this measure the boot splash?
+    //
+    // Not decoration. The first run of this script reported LCP identical to
+    // FCP in every single run, which is what a page whose largest paint is
+    // its own splash looks like — and also what a page that never mounted
+    // looks like. A 2% spread on a number that describes the wrong thing
+    // reads as "gateable" and is worse than no measurement. So the instrument
+    // states what it saw rather than leaving the reader to assume.
+    probe: () =>
+      page.evaluate(() => {
+        const el = document.querySelector('[data-testid="shell-mark"]')
+        const root = document.getElementById('root')
+        return {
+          shellMark: el !== null,
+          rootChildren: root ? root.childElementCount : 0,
+          largestText: document.body.innerText.slice(0, 60).replace(/\s+/g, ' ').trim(),
+        }
+      }),
+    waitForMount: () =>
+      page.waitForSelector('[data-testid="shell-mark"]', { timeout: MOUNT_GRACE_MS }),
   })
   const m = await page.evaluate(() => window.__m)
   await context.close()
@@ -278,7 +340,7 @@ async function main() {
       const m = await measureOnce(browser, url)
       runs.push(m)
       process.stderr.write(
-        `run ${i + 1}/${RUNS}  lcp=${m.lcp.toFixed(0)}ms  fcp=${m.fcp.toFixed(0)}ms  longTasks=${m.longTasks.toFixed(0)}ms  cls=${m.cls.toFixed(4)}  mounted=${m.shellMark} rootKids=${m.rootChildren} text="${m.largestText}"\n`,
+        `run ${i + 1}/${RUNS}  lcp=${m.lcp.toFixed(0)}ms  fcp=${m.fcp.toFixed(0)}ms  longTasks=${m.longTasks.toFixed(0)}ms  cls=${m.cls.toFixed(4)}  mounted=${m.shellMark} rootKids=${m.rootChildren}${m.graceMs > 0 ? ` grace=${m.graceMs}ms` : ''} text="${m.largestText}"\n`,
       )
     }
   } finally {

--- a/apps/web/scripts/measure-critical-path.test.ts
+++ b/apps/web/scripts/measure-critical-path.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'node:child_process'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
-import { parseFloorMs } from './measure-critical-path.mjs'
+import { parseFloorMs, settleForMount } from './measure-critical-path.mjs'
 
 const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'measure-critical-path.mjs')
 
@@ -66,5 +66,65 @@ describe('the gate script itself', () => {
     }
     expect(status).toBe(1)
     expect(stderr).toContain('LCP_FLOOR_MS must be a positive number')
+  })
+})
+
+describe('settleForMount', () => {
+  // The flake this closes: the fixed settle is a BET on how long the app
+  // takes to mount, and a cold first run loses it — the probe reads
+  // `shellMark=false`, and the gate correctly refuses a number that
+  // describes the boot splash. The run was not wrong about what it saw; the
+  // instrument simply did not wait long enough to see anything else.
+  //
+  // The fix has to leave the HEALTHY measurement alone, because the fixed
+  // beat is the LCP window every recorded median was taken through. So the
+  // grace is not a longer wait, it is a wait that only happens when the
+  // first probe comes back unmounted.
+  it('does not wait past the fixed beat when the shell is already up', async () => {
+    let waits = 0
+    const result = await settleForMount({
+      waitFixed: async () => {},
+      probe: async () => ({ shellMark: true, rootChildren: 3, largestText: 'Workspace' }),
+      waitForMount: async () => {
+        waits++
+      },
+    })
+    expect(waits).toBe(0)
+    expect(result.graceMs).toBe(0)
+    expect(result.shellMark).toBe(true)
+  })
+
+  it('waits out a slow mount and reports what it cost, so a slow run is visible rather than silent', async () => {
+    const probes = [
+      { shellMark: false, rootChildren: 1, largestText: 'Loading' },
+      { shellMark: true, rootChildren: 3, largestText: 'Workspace' },
+    ]
+    let clock = 1_000
+    const result = await settleForMount({
+      waitFixed: async () => {},
+      probe: async () => probes.shift() ?? probes[0],
+      waitForMount: async () => {
+        clock += 1_400
+      },
+      now: () => clock,
+    })
+    expect(result.shellMark).toBe(true)
+    expect(result.graceMs).toBe(1400)
+  })
+
+  // A grace that THROWS on expiry would abort the whole measurement with a
+  // Playwright timeout, replacing the gate's own diagnosis ("N/5 runs never
+  // mounted the app") with a stack trace about a selector. The wait is a
+  // grace, not an assertion — the probe after it is what states the verdict.
+  it('swallows an expired grace and lets the probe state the verdict', async () => {
+    const result = await settleForMount({
+      waitFixed: async () => {},
+      probe: async () => ({ shellMark: false, rootChildren: 1, largestText: 'Loading' }),
+      waitForMount: async () => {
+        throw new Error('Timeout 8000ms exceeded waiting for selector')
+      },
+      now: () => 0,
+    })
+    expect(result.shellMark).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

- `measure-critical-path.mjs` waited a flat 2000ms after `load` and then probed for the shell mark. That beat is a **bet** on how long the app takes to mount, and a cold run loses it — CI reported run 1 of 5 as `mounted=false`, and the gate correctly refused a number taken over the boot splash. The run was not wrong about what it saw; the instrument had not waited long enough for there to be anything else to see. That is a flake in the **instrument**, and re-running it is how a gate starts being ignored.
- Raising the beat was the wrong fix: it would widen the LCP observation window on *every* run, and every median recorded in that file was taken through the 2000ms window — the floor would then be stated against one measurement and enforced against another. So the beat is untouched and a bounded grace is reached **only when the first probe comes back unmounted**. A healthy run's timeline is unchanged; a slow run reports the LCP it actually had.
- The grace stays bounded and the probe keeps the last word, so a build that never mounts still fails — with the gate's own diagnosis rather than a Playwright selector timeout. Without that, the fix would have made the gate unfailable, which is worse than the flake.

Honest framing on why now: this had **not** recurred. Over the last 14 `origin/main` commits `verify` was `success` ×10, `cancelled` ×2, `skipped` ×2 — no failure; the single occurrence was on a PR branch. This is not a second occurrence promoting itself to a fix lane, it is an explicitly requested one. That also removes the conflict of interest in touching a gate that was blocking my own PR: that PR is merged.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — three `web-node` tests for `settleForMount`, written red first, **each mutation-checked to exactly one failure**: dropping the early return (grace paid on every run) → test 1; letting the expiry throw → test 3; returning the stale first probe → test 2.
- [x] `pnpm test` passes locally — `pnpm --filter @kamiazya/whiteboard-web test` (the command matching CI's `test-jsdom`, both projects): **295 files / 3052 tests** `web-jsdom` + **13 files / 89 tests** `web-node`, exit 0. `pnpm lint` and `pnpm knip` clean.
- [x] Manual verification completed — the gate was run end to end against a real browser, both before and after, by shortening the beat to 1ms so the lost bet reproduces on demand instead of waiting for a cold CI runner:

  | configuration | result |
  |---|---|
  | beat 1ms, no grace (unfixed) | 3/3 never mounted, gate **FAILED** (exit 1) |
  | beat 1ms, grace 8s | 3/3 mounted, grace 1931–1970ms, **LCP median 504ms** |
  | beat 2000ms (healthy) | 5/5 mounted, no grace paid, **LCP median 500ms** |
  | beat 1ms, grace 200ms | 2/2 never mounted, gate **FAILED** (exit 1) |

  The middle two rows are the claim that matters: a run that pays the grace reports the same LCP as one that does not, **inside the 2% band** — the grace rescues the run without distorting the number it exists to measure. The last row is what keeps the gate failable.
- [ ] E2E coverage added or extended where applicable — n/a; this is the smoke gate itself, and the table above is its end-to-end exercise.

## Visual evidence

Visual evidence: none — this changes a CI smoke script's wait strategy. Nothing renders differently; the observable output is the gate's own stdout, quoted in the table above (including the two failing configurations, which are the half a single "after" capture would omit).

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — n/a for user docs; the measurements and the reasoning are recorded in the script's own comment block, which is where that file keeps them.
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_