### PR TITLE
fix(web): disclose a move only on the workspace that was actually moved

### DIFF
--- a/apps/web/src/components/AppShell.test.tsx
+++ b/apps/web/src/components/AppShell.test.tsx
@@ -1,6 +1,10 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  resetBrowserWorkspaceIdForTests,
+  setBrowserWorkspaceIdForTests,
+} from '@/lib/browser-workspace-id'
 import { resetInstallPromptForTests } from '@/lib/install-prompt-store'
 import { resetShellStatusForTests, setShellConnection } from '@/lib/shell-status-store'
 import { createUserSettingsStore } from '@/lib/user-settings-store'
@@ -16,6 +20,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup()
+  resetBrowserWorkspaceIdForTests()
   Object.defineProperty(navigator, 'storage', { value: undefined, configurable: true })
 })
 
@@ -344,6 +349,7 @@ describe('AppShell — the mark as the connection carrier', () => {
   // silently would hide that edits made here diverge from the daemon copy —
   // so the browser popover discloses the move instead of claiming nothing.
   it('the browser popover discloses a recorded move to the still-configured daemon', async () => {
+    setBrowserWorkspaceIdForTests('ws-src')
     createUserSettingsStore().update((current) => ({
       ...current,
       storage: { ...current.storage, daemonBaseUrl: 'http://127.0.0.1:3099' },
@@ -353,6 +359,7 @@ describe('AppShell — the mark as the connection carrier', () => {
           at: '2026-08-28T12:00:00.000Z',
           daemonBaseUrl: 'http://127.0.0.1:3099',
           workspaceId: 'ws-a',
+          sourceWorkspaceId: 'ws-src',
           ok: true,
           promotedCount: 2,
         },
@@ -366,6 +373,58 @@ describe('AppShell — the mark as the connection carrier', () => {
     expect(notice.textContent).toMatch(/stay in this browser/i)
     // Reachability is unknown from here, so the copy must not claim it.
     expect(notice.textContent).not.toMatch(/unreachable|offline|cannot be reached/i)
+  })
+
+  it('a workspace that was not the one moved gets no move disclosure', async () => {
+    // The marker is per-workspace: since ADR-0019 this browser keeps many
+    // workspaces, and telling a never-promoted one "this workspace has been
+    // moved" is a false claim about ITS data.
+    setBrowserWorkspaceIdForTests('ws-other')
+    createUserSettingsStore().update((current) => ({
+      ...current,
+      storage: { ...current.storage, daemonBaseUrl: 'http://127.0.0.1:3099' },
+      migration: {
+        ...current.migration,
+        promotion: {
+          at: '2026-08-28T12:00:00.000Z',
+          daemonBaseUrl: 'http://127.0.0.1:3099',
+          workspaceId: 'ws-a',
+          sourceWorkspaceId: 'ws-src',
+          ok: true,
+        },
+      },
+    }))
+    setShellConnection({ state: { keeper: 'browser' } })
+    renderShell(false)
+    fireEvent.click(await screen.findByTestId('shell-mark-trigger'))
+    await screen.findByText(CTA)
+    expect(screen.queryByTestId('promoted-elsewhere-notice')).toBeNull()
+  })
+
+  it('a legacy record that never named its source shows no disclosure', async () => {
+    // Pre-per-workspace records cannot say WHICH browser workspace moved, so
+    // showing the banner on whichever is active would be the misfire this
+    // field exists to end. Staying silent about an unknown is the honest
+    // floor.
+    setBrowserWorkspaceIdForTests('ws-src')
+    createUserSettingsStore().update((current) => ({
+      ...current,
+      storage: { ...current.storage, daemonBaseUrl: 'http://127.0.0.1:3099' },
+      migration: {
+        ...current.migration,
+        promotion: {
+          at: '2026-08-28T12:00:00.000Z',
+          daemonBaseUrl: 'http://127.0.0.1:3099',
+          workspaceId: 'ws-a',
+          ok: true,
+        },
+      },
+    }))
+    setShellConnection({ state: { keeper: 'browser' } })
+    renderShell(false)
+    fireEvent.click(await screen.findByTestId('shell-mark-trigger'))
+    await screen.findByText(CTA)
+    expect(screen.queryByTestId('promoted-elsewhere-notice')).toBeNull()
   })
 
   it('no move disclosure without a matching promotion record', async () => {

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -4,6 +4,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { useSettingsNudge } from '@/hooks/useSettingsNudge'
 import { parseWorkspaceRoute, settingsPath } from '@/lib/app-routes'
+import { browserWorkspaceIdOrNull } from '@/lib/browser-workspace-id'
 import { beginPairingGrant } from '@/lib/pairing-grant'
 import { getShellConnection, subscribeShellStatus } from '@/lib/shell-status-store'
 import { createUserSettingsStore } from '@/lib/user-settings-store'
@@ -33,7 +34,11 @@ const DaemonDetectedBanner = lazy(() =>
  * when the recorded move targets the SAME daemon the browser still points
  * at: a move to a daemon this browser no longer uses is not this
  * connection's story. Reachability is unknown from here and deliberately
- * not claimed.
+ * not claimed. And only for the workspace that was actually MOVED: this
+ * browser keeps many workspaces, and the disclosure is a claim about one
+ * record's data — a legacy promotion record that never named its source
+ * cannot say which, so it discloses nothing rather than accusing whichever
+ * workspace happens to be active.
  */
 function PromotedElsewhereNotice({
   settingsStore,
@@ -47,7 +52,9 @@ function PromotedElsewhereNotice({
     promotion === undefined ||
     !promotion.ok ||
     storedDaemon === undefined ||
-    promotion.daemonBaseUrl !== storedDaemon
+    promotion.daemonBaseUrl !== storedDaemon ||
+    promotion.sourceWorkspaceId === undefined ||
+    promotion.sourceWorkspaceId !== browserWorkspaceIdOrNull()
   ) {
     return null
   }

--- a/apps/web/src/components/settings/PromoteWorkspaceSection.tsx
+++ b/apps/web/src/components/settings/PromoteWorkspaceSection.tsx
@@ -190,6 +190,7 @@ export function PromoteWorkspaceSection({
                 at: new Date().toISOString(),
                 daemonBaseUrl: daemon.baseUrl,
                 workspaceId: targetId,
+                sourceWorkspaceId: outcome.sourceWorkspaceId,
                 ok: true,
                 promotedCount: outcome.promotedDocumentIds.length,
                 shadowedPaths: outcome.shadowedPaths,

--- a/apps/web/src/lib/promote-workspace.browser.test.tsx
+++ b/apps/web/src/lib/promote-workspace.browser.test.tsx
@@ -152,6 +152,9 @@ describe('promoteWorkspace', () => {
 
     expect(result.kind).toBe('ok')
     if (result.kind !== 'ok') return
+    // The per-workspace moved marker keys off this: the transfer names the
+    // record it actually read, not whatever the caller believes is active.
+    expect(result.sourceWorkspaceId).toBe(getBrowserWorkspaceId())
     expect([...result.promotedDocumentIds].sort()).toEqual(
       [roadmap.documentId, contested.documentId].sort(),
     )

--- a/apps/web/src/lib/promote-workspace.ts
+++ b/apps/web/src/lib/promote-workspace.ts
@@ -63,6 +63,12 @@ export async function countBrowserWorkspaceDocuments(
 export type PromoteWorkspaceResult =
   | {
       kind: 'ok'
+      /**
+       * The browser workspace the record was read from — what a per-workspace
+       * moved marker needs, reported by the transfer itself rather than
+       * re-read by the caller, so the two cannot disagree.
+       */
+      sourceWorkspaceId: string
       /** Every documentId the record carried across — the same ids, by design. */
       promotedDocumentIds: string[]
       /** Paths the merge left contested; surfaced, never auto-resolved. */
@@ -136,7 +142,8 @@ async function promoteWorkspaceUnsafe(
   // the same claimed database, so tests seed through the production path.
   const fileStore = new DocumentFileStore()
 
-  const record = await workspaceDocs.open(getBrowserWorkspaceId())
+  const sourceWorkspaceId = getBrowserWorkspaceId()
+  const record = await workspaceDocs.open(sourceWorkspaceId)
   if (record === null) {
     return { kind: 'failed', reason: 'This browser keeps no workspace record to promote.' }
   }
@@ -190,5 +197,5 @@ async function promoteWorkspaceUnsafe(
     else blobs.failed.push(fileId)
   }
 
-  return { kind: 'ok', promotedDocumentIds, shadowedPaths, blobs }
+  return { kind: 'ok', sourceWorkspaceId, promotedDocumentIds, shadowedPaths, blobs }
 }

--- a/apps/web/src/lib/user-settings-store.ts
+++ b/apps/web/src/lib/user-settings-store.ts
@@ -127,6 +127,14 @@ const promotionResultSchema = z
     daemonBaseUrl: httpUrl.optional(),
     /** The TARGET daemon workspace the record merged into. */
     workspaceId: z.string(),
+    /**
+     * The SOURCE browser workspace the record came from. The move disclosure
+     * is a claim about one workspace's data, and this browser keeps many —
+     * without the source, the banner fires on whichever workspace is active.
+     * Optional because records persisted before the field existed lack it;
+     * those cannot say which workspace moved, so no disclosure renders.
+     */
+    sourceWorkspaceId: z.string().optional(),
     ok: z.boolean(),
     promotedCount: z.number().optional(),
     shadowedPaths: z.array(z.string()).optional(),


### PR DESCRIPTION
# Summary

- Fixes a live misfire found while mapping ADR-0023's ground: `settings.migration.promotion` is one global slot that never recorded WHICH browser workspace was moved, so `PromotedElsewhereNotice` told whichever browser workspace was active "this workspace has been moved to the daemon" — a false claim about a never-promoted workspace's data (possible since ADR-0019 made the browser multi-workspace).
- The record now names its source: `promoteWorkspace`'s ok result gains `sourceWorkspaceId` (the transfer reports the record it actually read, so the caller cannot disagree with it), `promotionResultSchema` stores it (optional — the schema is `.strict()` with a defaults fallback, so old payloads must keep parsing), and the notice renders only when the active browser workspace matches. A legacy record without a source discloses nothing rather than accusing whichever workspace is active.
- First ADR-0023 implementation increment: replica state is per-workspace, and this marker is the ground it stands on. Copy is unchanged — the "moved / stays in this browser" framing stays honest until real replica sync exists (R2).

# Test plan

- Red-first in `AppShell.test.tsx`: the misfire repro (promotion for `ws-src`, active `ws-other` → no notice) and the legacy-record case (no `sourceWorkspaceId` → no notice); the existing disclosure test updated to set a matching active workspace. 29/29 green.
- Guard mutation-checked: replacing the workspace-match condition with `false` leaves exactly the misfire test red (restore verified byte-identical by md5, then 29/29 green).
- `promote-workspace.browser.test.tsx` pins the new result field against `getBrowserWorkspaceId()`; promote + PromoteWorkspaceSection browser suites 15/15 green.
- `pnpm -r typecheck`, biome, `pnpm knip` clean.
- Manually verified in a real Chromium against the built dist (unreachable configured daemon → honest-detach fallback → real document page): with the minted workspace as source the popover shows the disclosure; reseeded with a different source id on the SAME document page (keeper section present both times, so the absence is not vacuous) it shows none.

# Visual evidence

Visual evidence: none attachable — no image upload path exists in this environment. The manual-verification captures (`tmp/screenshots/moved-marker-match.png` / `moved-marker-mismatch.png`, same document page, notice present vs absent) exist locally; the probe counts are in the test plan above.

# Checklist

- [x] Red test first at the nearest layer, mutation-checked
- [x] Manual verification in a running browser (both directions, non-vacuous)
- [x] `pnpm -r typecheck` / biome / knip green
- [x] No model identifier in repository artifacts

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_