### PR TITLE
refactor(web): store the promotion result as a discriminated union under a settings v3 migration

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -176,7 +176,7 @@ describe('silent renewal on a hosted origin', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 2,
+        version: 3,
         storage: { daemonBaseUrl: 'http://127.0.0.1:3099' },
         migration: {},
         capabilities: {},
@@ -209,7 +209,7 @@ describe('silent renewal on a hosted origin', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 2,
+        version: 3,
         storage: {
           daemonBaseUrl: 'http://127.0.0.1:3099',
           replicas: {
@@ -241,7 +241,7 @@ describe('silent renewal on a hosted origin', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 2,
+        version: 3,
         storage: { daemonBaseUrl: 'http://127.0.0.1:3099' },
         migration: {},
         capabilities: {},
@@ -263,7 +263,7 @@ describe('silent renewal on a hosted origin', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 2,
+        version: 3,
         storage: { daemonBaseUrl: 'http://127.0.0.1:3099' },
         migration: {},
         capabilities: {},
@@ -286,7 +286,7 @@ describe('silent renewal on a hosted origin', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 2,
+        version: 3,
         storage: { daemonBaseUrl: 'http://127.0.0.1:3099' },
         migration: {},
         capabilities: {},
@@ -1485,7 +1485,7 @@ describe('App /settings routing', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 2,
+        version: 3,
         storage: { daemonBaseUrl: 'http://127.0.0.1:3099' },
         migration: {},
         capabilities: {},

--- a/apps/web/src/components/AppShell.test.tsx
+++ b/apps/web/src/components/AppShell.test.tsx
@@ -362,6 +362,9 @@ describe('AppShell — the mark as the connection carrier', () => {
           sourceWorkspaceId: 'ws-src',
           ok: true,
           promotedCount: 2,
+          shadowedPaths: [],
+          blobsMissing: [],
+          blobsFailed: [],
         },
       },
     }))
@@ -423,6 +426,10 @@ describe('AppShell — the mark as the connection carrier', () => {
           workspaceId: 'ws-a',
           sourceWorkspaceId: 'ws-src',
           ok: true,
+          promotedCount: 2,
+          shadowedPaths: [],
+          blobsMissing: [],
+          blobsFailed: [],
         },
       },
     }))
@@ -449,6 +456,10 @@ describe('AppShell — the mark as the connection carrier', () => {
           daemonBaseUrl: 'http://127.0.0.1:3099',
           workspaceId: 'ws-a',
           ok: true,
+          promotedCount: 2,
+          shadowedPaths: [],
+          blobsMissing: [],
+          blobsFailed: [],
         },
       },
     }))
@@ -472,6 +483,10 @@ describe('AppShell — the mark as the connection carrier', () => {
           daemonBaseUrl: 'http://127.0.0.1:4200',
           workspaceId: 'ws-a',
           ok: true,
+          promotedCount: 2,
+          shadowedPaths: [],
+          blobsMissing: [],
+          blobsFailed: [],
         },
       },
     }))

--- a/apps/web/src/components/settings/PromoteWorkspaceSection.browser.test.tsx
+++ b/apps/web/src/components/settings/PromoteWorkspaceSection.browser.test.tsx
@@ -498,7 +498,9 @@ describe('PromoteWorkspaceSection', () => {
     const replica = await new BrowserWorkspaceDocs().open('ws-a')
     expect(replica).not.toBeNull()
     expect(readWorkspaceDocuments(replica!)).toHaveLength(2)
-    expect(createUserSettingsStore().load().migration.promotion?.replicaSyncedAt).toBeTruthy()
+    const promotion = createUserSettingsStore().load().migration.promotion
+    if (promotion?.ok !== true) throw new Error('expected an ok promotion record')
+    expect(promotion.replicaSyncedAt).toBeTruthy()
   })
 
   it('stays discoverable but disabled with no daemon connected', async () => {

--- a/apps/web/src/components/settings/PromoteWorkspaceSection.tsx
+++ b/apps/web/src/components/settings/PromoteWorkspaceSection.tsx
@@ -62,24 +62,24 @@ type PromoteFlow =
 
 function describeResult(result: PromotionResultRecord): string {
   if (!result.ok) {
-    return `Move to daemon workspace "${result.workspaceId}" failed: ${result.reason ?? 'unknown error'}`
+    return `Move to daemon workspace "${result.workspaceId}" failed: ${result.reason}`
   }
   const parts = [
-    `Moved ${result.promotedCount ?? 0} document${(result.promotedCount ?? 0) === 1 ? '' : 's'} to daemon workspace "${result.workspaceId}"`,
+    `Moved ${result.promotedCount} document${result.promotedCount === 1 ? '' : 's'} to daemon workspace "${result.workspaceId}"`,
   ]
-  if ((result.shadowedPaths?.length ?? 0) > 0) {
+  if (result.shadowedPaths.length > 0) {
     parts.push(
-      `${result.shadowedPaths?.length} path${result.shadowedPaths?.length === 1 ? '' : 's'} already existed there — both versions are kept, the earlier one marked shadowed: ${result.shadowedPaths?.join(', ')}`,
+      `${result.shadowedPaths.length} path${result.shadowedPaths.length === 1 ? '' : 's'} already existed there — both versions are kept, the earlier one marked shadowed: ${result.shadowedPaths.join(', ')}`,
     )
   }
-  if ((result.blobsMissing?.length ?? 0) > 0) {
+  if (result.blobsMissing.length > 0) {
     parts.push(
-      `${result.blobsMissing?.length} referenced image${result.blobsMissing?.length === 1 ? ' was' : 's were'} already missing from this browser and could not be moved`,
+      `${result.blobsMissing.length} referenced image${result.blobsMissing.length === 1 ? ' was' : 's were'} already missing from this browser and could not be moved`,
     )
   }
-  if ((result.blobsFailed?.length ?? 0) > 0) {
+  if (result.blobsFailed.length > 0) {
     parts.push(
-      `${result.blobsFailed?.length} image upload${result.blobsFailed?.length === 1 ? '' : 's'} failed — moving again retries them safely`,
+      `${result.blobsFailed.length} image upload${result.blobsFailed.length === 1 ? '' : 's'} failed — moving again retries them safely`,
     )
   }
   if (result.replicaSyncedAt !== undefined) {

--- a/apps/web/src/lib/user-settings-store.test.ts
+++ b/apps/web/src/lib/user-settings-store.test.ts
@@ -3,6 +3,7 @@ import {
   createUserSettingsStore,
   defaultUserSettings,
   LEGACY_V1_STORAGE_KEY,
+  LEGACY_V2_STORAGE_KEY,
   STORAGE_KEY,
 } from './user-settings-store.js'
 
@@ -12,7 +13,7 @@ describe('knownDaemonBaseUrls bound', () => {
     const oversized = Array.from({ length: 6 }, (_, i) => `http://127.0.0.1:${3099 + i}`)
     localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify({ version: 2, storage: { knownDaemonBaseUrls: oversized } }),
+      JSON.stringify({ version: 3, storage: { knownDaemonBaseUrls: oversized } }),
     )
     const store = createUserSettingsStore()
     // Consistent with the store's existing invalid-value semantics (e.g. a
@@ -107,7 +108,7 @@ describe('createUserSettingsStore', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 2,
+        version: 3,
         storage: { daemonBaseUrl: hostile, lastConnectedWorkspaceId: 'w1' },
         migration: {},
         capabilities: {},
@@ -124,7 +125,7 @@ describe('createUserSettingsStore', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 2,
+        version: 3,
         storage: { daemonBaseUrl: 'http://127.0.0.1:3099', lastConnectedWorkspaceId: 'w1' },
         migration: {},
         capabilities: {},
@@ -161,7 +162,7 @@ describe('createUserSettingsStore', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 2,
+        version: 3,
         storage: { daemonBaseUrl: 'http://127.0.0.1:3099', daemonToken: 'super-secret' },
         migration: {},
         capabilities: {},
@@ -204,7 +205,7 @@ describe('promotion result persistence', () => {
       // actionable only while connected to this same daemon.
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws-a',
-      ok: true,
+      ok: true as const,
       promotedCount: 3,
       shadowedPaths: ['contested'],
       blobsMissing: [],
@@ -222,7 +223,7 @@ describe('promotion result persistence', () => {
       at: '2026-08-28T12:00:00.000Z',
       daemonBaseUrl: 'http://127.0.0.1:3099',
       workspaceId: 'ws-a',
-      ok: false,
+      ok: false as const,
       reason: 'Could not reach the daemon (network error).',
     }
     createUserSettingsStore().update((current) => ({
@@ -263,7 +264,7 @@ describe('createUserSettingsStore — beta banner dismissal', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 2,
+        version: 3,
         storage: { daemonBaseUrl: 'http://127.0.0.1:3099', lastConnectedPath: 'abc' },
         migration: {},
         capabilities: {},
@@ -318,10 +319,10 @@ describe('appearance settings', () => {
   it('parses a stored payload from before the appearance section existed', () => {
     localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify({ version: 2, storage: {}, migration: {}, capabilities: {} }),
+      JSON.stringify({ version: 3, storage: {}, migration: {}, capabilities: {} }),
     )
     const settings = createUserSettingsStore().load()
-    expect(settings.version).toBe(2)
+    expect(settings.version).toBe(3)
     expect(settings.appearance?.faviconStyle).toBeUndefined()
   })
 
@@ -329,7 +330,7 @@ describe('appearance settings', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 2,
+        version: 3,
         storage: {},
         migration: {},
         capabilities: {},
@@ -391,7 +392,8 @@ describe('v1 -> v2 migration', () => {
       dismissedDaemonCtaAt: '2026-07-07T00:00:00.000Z',
       dismissedDaemonCtaInstanceId: 'inst-1',
     })
-    expect(loaded.migration).toEqual({ browserToDaemon: { lastImportedDocumentId: 'doc-1' } })
+    // browserToDaemon is dropped by the chained v2->v3 step, not carried.
+    expect(loaded.migration).toEqual({})
     expect(loaded.capabilities).toEqual({ webMcpEnabled: true, webMcpMaxTier: 2 })
     expect(loaded.appearance).toEqual({ faviconStyle: 'dot' })
   })
@@ -407,28 +409,28 @@ describe('v1 -> v2 migration', () => {
     expect(loaded.storage.daemonBaseUrl).toBe('http://127.0.0.1:3099')
   })
 
-  it('persists the migrated payload under the v2 key and removes the v1 one', () => {
+  it('persists the migrated payload under the current key and removes the v1 one', () => {
     writeV1()
     createUserSettingsStore().load()
     expect(localStorage.getItem(LEGACY_V1_STORAGE_KEY)).toBeNull()
     const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null')
-    expect(stored.version).toBe(2)
+    expect(stored.version).toBe(3)
     expect(stored.storage.daemonBaseUrl).toBe('http://127.0.0.1:3099')
   })
 
-  it('a v2 payload wins and no migration runs, so a stale v1 key cannot resurrect', () => {
+  it('a current payload wins and no migration runs, so a stale v1 key cannot resurrect', () => {
     writeV1()
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 2,
+        version: 3,
         storage: { daemonBaseUrl: 'http://127.0.0.1:4321' },
         migration: {},
         capabilities: {},
       }),
     )
     expect(createUserSettingsStore().load().storage.daemonBaseUrl).toBe('http://127.0.0.1:4321')
-    // untouched, because the v2 key answered
+    // untouched, because the current key answered
     expect(localStorage.getItem(LEGACY_V1_STORAGE_KEY)).not.toBeNull()
   })
 
@@ -461,6 +463,142 @@ describe('v1 -> v2 migration', () => {
     )
     const loaded = createUserSettingsStore().load()
     expect(loaded.storage).not.toHaveProperty('daemonBaseUrl')
-    expect(loaded.version).toBe(2)
+    expect(loaded.version).toBe(3)
+  })
+})
+
+describe('v2 -> v3 migration', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  // A full v2 payload as a real reader could be holding it: the retired
+  // browserToDaemon block plus a promotion record from before the counts
+  // became required.
+  function writeV2(migration: Record<string, unknown> = {}): void {
+    localStorage.setItem(
+      LEGACY_V2_STORAGE_KEY,
+      JSON.stringify({
+        version: 2,
+        storage: {
+          daemonBaseUrl: 'http://127.0.0.1:3099',
+          knownDaemonBaseUrls: ['http://127.0.0.1:3099'],
+          lastConnectedWorkspaceId: 'ws-1',
+        },
+        migration: {
+          browserToDaemon: { lastImportedDocumentId: 'doc-1' },
+          ...migration,
+        },
+        capabilities: { webMcpEnabled: true },
+        appearance: { faviconStyle: 'dot' },
+      }),
+    )
+  }
+
+  it('carries the payload across, persists it under the v3 key, and removes the v2 one', () => {
+    writeV2()
+    const loaded = createUserSettingsStore().load()
+    expect(loaded.version).toBe(3)
+    expect(loaded.storage.daemonBaseUrl).toBe('http://127.0.0.1:3099')
+    expect(loaded.capabilities).toEqual({ webMcpEnabled: true })
+    expect(loaded.appearance).toEqual({ faviconStyle: 'dot' })
+    expect(localStorage.getItem(LEGACY_V2_STORAGE_KEY)).toBeNull()
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null')
+    expect(stored.version).toBe(3)
+  })
+
+  // Written by the retired per-document import panel, read by nothing since.
+  // A field nobody reads goes IN the migration (dropped), not through it.
+  it('drops migration.browserToDaemon', () => {
+    writeV2()
+    const loaded = createUserSettingsStore().load()
+    expect(loaded.migration).not.toHaveProperty('browserToDaemon')
+  })
+
+  // The v2 promotion schema was all-optional, so a stored ok:true record may
+  // lack the counts the union now requires. The migration fills them once,
+  // which is where the old describeResult `??` fallbacks moved to.
+  it('normalizes a partial ok promotion record into the union shape', () => {
+    writeV2({
+      promotion: { at: '2026-08-01T00:00:00.000Z', workspaceId: 'ws-a', ok: true },
+    })
+    expect(createUserSettingsStore().load().migration.promotion).toEqual({
+      at: '2026-08-01T00:00:00.000Z',
+      workspaceId: 'ws-a',
+      ok: true,
+      promotedCount: 0,
+      shadowedPaths: [],
+      blobsMissing: [],
+      blobsFailed: [],
+    })
+  })
+
+  it('normalizes a reason-less failure record', () => {
+    writeV2({
+      promotion: { at: '2026-08-01T00:00:00.000Z', workspaceId: 'ws-a', ok: false },
+    })
+    expect(createUserSettingsStore().load().migration.promotion).toEqual({
+      at: '2026-08-01T00:00:00.000Z',
+      workspaceId: 'ws-a',
+      ok: false,
+      reason: 'unknown error',
+    })
+  })
+
+  it('a v3 payload wins and a stale v2 key cannot resurrect', () => {
+    writeV2()
+    createUserSettingsStore().save({
+      ...defaultUserSettings(),
+      storage: { daemonBaseUrl: 'http://127.0.0.1:4321' },
+    })
+    expect(createUserSettingsStore().load().storage.daemonBaseUrl).toBe('http://127.0.0.1:4321')
+  })
+
+  it('a v1 payload chains all the way to v3', () => {
+    localStorage.setItem(
+      LEGACY_V1_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        storage: { localDaemonBaseUrl: 'http://127.0.0.1:3099' },
+        migration: { browserToDaemon: { lastImportedAt: '2026-07-01T00:00:00.000Z' } },
+        capabilities: {},
+      }),
+    )
+    const loaded = createUserSettingsStore().load()
+    expect(loaded.version).toBe(3)
+    expect(loaded.storage.daemonBaseUrl).toBe('http://127.0.0.1:3099')
+    expect(loaded.migration).not.toHaveProperty('browserToDaemon')
+    expect(localStorage.getItem(LEGACY_V1_STORAGE_KEY)).toBeNull()
+  })
+
+  it('reset() clears the un-migrated v2 key too, so nothing resurrects', () => {
+    writeV2()
+    const store = createUserSettingsStore()
+    store.reset()
+    expect(store.load()).toEqual(defaultUserSettings())
+  })
+
+  // The stored shape is a discriminated union now: an ok record cannot claim
+  // a failure reason, and a failure cannot carry promoted counts. Such a
+  // payload is tampered/corrupt, and invalid means defaults.
+  it('rejects a stored v3 record mixing the two arms', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 3,
+        storage: {},
+        migration: {
+          promotion: {
+            at: '2026-08-01T00:00:00.000Z',
+            workspaceId: 'ws-a',
+            ok: false,
+            reason: 'x',
+            promotedCount: 3,
+          },
+        },
+        capabilities: {},
+      }),
+    )
+    expect(createUserSettingsStore().load()).toEqual(defaultUserSettings())
   })
 })

--- a/apps/web/src/lib/user-settings-store.ts
+++ b/apps/web/src/lib/user-settings-store.ts
@@ -8,17 +8,18 @@ import { z } from 'zod'
 // field, changing a type, or making a field required), AND ship a migration
 // in the same increment: bumping alone is the discard this comment warns
 // about, just spelled differently.
-export const STORAGE_KEY = 'whiteboard:user-settings:v2'
+export const STORAGE_KEY = 'whiteboard:user-settings:v3'
 
 /**
- * The key v2 migrates FROM, read once and then removed.
+ * The keys older versions wrote, each read once and then removed.
  *
- * Two keys rather than a version discriminator inside one, because that is
- * what makes a concurrently-open OLD tab harmless: it keeps reading and
- * writing v1, which this build no longer looks at once v2 exists, instead of
- * safeParse-failing on the bumped `version` and overwriting v2 with its
- * defaults.
+ * A new key per version rather than a version discriminator inside one,
+ * because that is what makes a concurrently-open OLD tab harmless: it keeps
+ * reading and writing its own key, which this build no longer looks at once
+ * the current one exists, instead of safeParse-failing on the bumped
+ * `version` and overwriting the current payload with its defaults.
  */
+export const LEGACY_V2_STORAGE_KEY = 'whiteboard:user-settings:v2'
 export const LEGACY_V1_STORAGE_KEY = 'whiteboard:user-settings:v1'
 
 // localStorage access itself can throw (SecurityError when the browser blocks
@@ -141,61 +142,66 @@ const storageSettingsSchema = z
  * One slot, overwritten by the next run — promotion is an idempotent merge,
  * so only the latest outcome is actionable.
  */
-const promotionResultSchema = z
-  .object({
-    at: z.string(),
-    /**
-     * The daemon the move targeted. The result surface renders a stored
-     * result as actionable only while connected to this same daemon —
-     * without the binding, a result from daemon A (and its reload offer)
-     * would keep showing after connecting to daemon B. Optional because
-     * records persisted before the field existed lack it; those simply
-     * never match and age out on the next move.
-     */
-    daemonBaseUrl: httpUrl.optional(),
-    /** The TARGET daemon workspace the record merged into. */
-    workspaceId: z.string(),
-    /**
-     * The SOURCE browser workspace the record came from. The move disclosure
-     * is a claim about one workspace's data, and this browser keeps many —
-     * without the source, the banner fires on whichever workspace is active.
-     * Optional because records persisted before the field existed lack it;
-     * those cannot say which workspace moved, so no disclosure renders.
-     */
-    sourceWorkspaceId: z.string().optional(),
-    /**
-     * When the demote pull that follows a successful move cached the daemon
-     * workspace's record back into this browser (ADR-0023 decision 2).
-     * Absent when the pull failed or predates the feature — the report then
-     * simply claims no cache.
-     */
-    replicaSyncedAt: z.string().optional(),
-    ok: z.boolean(),
-    promotedCount: z.number().optional(),
-    shadowedPaths: z.array(z.string()).optional(),
-    blobsMissing: z.array(z.string()).optional(),
-    blobsFailed: z.array(z.string()).optional(),
-    reason: z.string().optional(),
-  })
-  .strict()
+const promotionResultCommonFields = {
+  at: z.string(),
+  /**
+   * The daemon the move targeted. The result surface renders a stored
+   * result as actionable only while connected to this same daemon —
+   * without the binding, a result from daemon A (and its reload offer)
+   * would keep showing after connecting to daemon B. Optional because
+   * records persisted before the field existed lack it; those simply
+   * never match and age out on the next move.
+   */
+  daemonBaseUrl: httpUrl.optional(),
+  /** The TARGET daemon workspace the record merged into. */
+  workspaceId: z.string(),
+}
+
+// A discriminated union rather than one all-optional bag: the v2 shape could
+// represent states no run produces (ok with no counts, a failure carrying
+// shadowed paths), and every reader paid for that in `??` fallbacks. The
+// v2->v3 migration normalizes legacy partial records once, so each arm can
+// require what its writer always writes.
+const promotionResultSchema = z.discriminatedUnion('ok', [
+  z
+    .object({
+      ...promotionResultCommonFields,
+      ok: z.literal(true),
+      /**
+       * The SOURCE browser workspace the record came from. The move
+       * disclosure is a claim about one workspace's data, and this browser
+       * keeps many — without the source, the banner fires on whichever
+       * workspace is active. Optional because records persisted before the
+       * field existed lack it; those cannot say which workspace moved, so
+       * no disclosure renders.
+       */
+      sourceWorkspaceId: z.string().optional(),
+      /**
+       * When the demote pull that follows a successful move cached the
+       * daemon workspace's record back into this browser (ADR-0023
+       * decision 2). Absent when the pull failed or predates the feature —
+       * the report then simply claims no cache.
+       */
+      replicaSyncedAt: z.string().optional(),
+      promotedCount: z.number(),
+      shadowedPaths: z.array(z.string()),
+      blobsMissing: z.array(z.string()),
+      blobsFailed: z.array(z.string()),
+    })
+    .strict(),
+  z
+    .object({
+      ...promotionResultCommonFields,
+      ok: z.literal(false),
+      reason: z.string(),
+    })
+    .strict(),
+])
 
 export type PromotionResultRecord = z.infer<typeof promotionResultSchema>
 
 const migrationSettingsSchema = z
   .object({
-    // Written by the retired per-document import panel; nothing produces or
-    // reads it any more. Kept parse-only because every schema level is
-    // `.strict()` and the loader falls back to defaults on ANY failure — so
-    // dropping the key would discard the whole stored payload of anyone who
-    // ever used the old import. Removable only with a v3 migration.
-    browserToDaemon: z
-      .object({
-        lastExportedAt: z.string().optional(),
-        lastImportedAt: z.string().optional(),
-        lastImportedDocumentId: z.string().optional(),
-      })
-      .strict()
-      .optional(),
     promotion: promotionResultSchema.optional(),
   })
   .strict()
@@ -219,7 +225,7 @@ const appearanceSettingsSchema = z
 
 const userSettingsSchema = z
   .object({
-    version: z.literal(2),
+    version: z.literal(3),
     storage: storageSettingsSchema,
     migration: migrationSettingsSchema,
     capabilities: capabilitySettingsSchema,
@@ -241,6 +247,45 @@ const userSettingsSchema = z
  * the two shapes are only coincidentally similar — v2 is free to move without
  * silently changing what a v1 payload is allowed to contain.
  */
+/**
+ * The all-optional promotion shape v1 and v2 stored, kept parse-only. The
+ * live schema is a discriminated union; this one's job is to read whatever
+ * partial record an old payload holds so the v3 migration can normalize it.
+ */
+const legacyPromotionResultSchema = z
+  .object({
+    at: z.string(),
+    daemonBaseUrl: httpUrl.optional(),
+    workspaceId: z.string(),
+    sourceWorkspaceId: z.string().optional(),
+    replicaSyncedAt: z.string().optional(),
+    ok: z.boolean(),
+    promotedCount: z.number().optional(),
+    shadowedPaths: z.array(z.string()).optional(),
+    blobsMissing: z.array(z.string()).optional(),
+    blobsFailed: z.array(z.string()).optional(),
+    reason: z.string().optional(),
+  })
+  .strict()
+
+const legacyMigrationSettingsSchema = z
+  .object({
+    // Written by the retired per-document import panel and read by nothing
+    // since; v2 kept it parse-only because dropping the key under `.strict()`
+    // would have discarded the whole payload. The v3 migration is the
+    // version bump that lets it finally be dropped.
+    browserToDaemon: z
+      .object({
+        lastExportedAt: z.string().optional(),
+        lastImportedAt: z.string().optional(),
+        lastImportedDocumentId: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    promotion: legacyPromotionResultSchema.optional(),
+  })
+  .strict()
+
 const legacyV1SettingsSchema = z
   .object({
     version: z.literal(1),
@@ -261,10 +306,53 @@ const legacyV1SettingsSchema = z
         dismissedDaemonCtaAt: z.string().optional(),
         dismissedDaemonCtaInstanceId: z.string().optional(),
       })
-      // `.strict()` here for the same reason v2 has it: the migration must not
-      // become the hole a token-shaped key travels through.
+      // `.strict()` here for the same reason the live schema has it: the
+      // migration must not become the hole a token-shaped key travels
+      // through.
       .strict(),
-    migration: migrationSettingsSchema,
+    migration: legacyMigrationSettingsSchema,
+    capabilities: capabilitySettingsSchema,
+    appearance: appearanceSettingsSchema.optional(),
+  })
+  .strict()
+
+/**
+ * The shape v3 migrates FROM. Its storage half is spelled out rather than
+ * reusing `storageSettingsSchema`, for the same reason v1's is: the live
+ * schema is free to move without silently changing what a v2 payload is
+ * allowed to contain — a required field added to the live shape must not
+ * start failing this parse and discarding migrating users' payloads.
+ */
+const legacyV2SettingsSchema = z
+  .object({
+    version: z.literal(2),
+    storage: z
+      .object({
+        daemonBaseUrl: httpUrl.optional(),
+        lastConnectedWorkspaceId: z.string().optional(),
+        lastConnectedPath: z.string().optional(),
+        knownDaemonBaseUrls: z.array(httpUrl).max(5).optional(),
+        dismissedDaemonBaseUrls: z.array(httpUrl).max(5).optional(),
+        dismissedPersistenceWarningAt: z.string().optional(),
+        dismissedBetaBannerAt: z.string().optional(),
+        dismissedDaemonCtaAt: z.string().optional(),
+        dismissedDaemonCtaInstanceId: z.string().optional(),
+        replicas: z
+          .record(
+            z.string(),
+            z
+              .object({
+                daemonBaseUrl: httpUrl,
+                syncedAt: z.string(),
+                segment: z.string().optional(),
+                displayName: z.string().optional(),
+              })
+              .strict(),
+          )
+          .optional(),
+      })
+      .strict(),
+    migration: legacyMigrationSettingsSchema,
     capabilities: capabilitySettingsSchema,
     appearance: appearanceSettingsSchema.optional(),
   })
@@ -272,7 +360,9 @@ const legacyV1SettingsSchema = z
 
 export type UserSettings = z.infer<typeof userSettingsSchema>
 
-function migrateV1(legacy: z.infer<typeof legacyV1SettingsSchema>): UserSettings {
+function migrateV1(
+  legacy: z.infer<typeof legacyV1SettingsSchema>,
+): z.infer<typeof legacyV2SettingsSchema> {
   const { preferredProvider, lastBrowserCanvasId, localDaemonBaseUrl, ...carried } = legacy.storage
   return {
     version: 2,
@@ -289,9 +379,52 @@ function migrateV1(legacy: z.infer<typeof legacyV1SettingsSchema>): UserSettings
   }
 }
 
+/**
+ * The one-time home of the `??` fallbacks the union retired from readers:
+ * an old ok record may lack the counts its writer now always supplies, and
+ * an old failure may lack its reason.
+ */
+function normalizeLegacyPromotion(
+  legacy: z.infer<typeof legacyPromotionResultSchema>,
+): PromotionResultRecord {
+  const common = {
+    at: legacy.at,
+    ...(legacy.daemonBaseUrl === undefined ? {} : { daemonBaseUrl: legacy.daemonBaseUrl }),
+    workspaceId: legacy.workspaceId,
+  }
+  if (!legacy.ok) {
+    return { ...common, ok: false, reason: legacy.reason ?? 'unknown error' }
+  }
+  return {
+    ...common,
+    ok: true,
+    ...(legacy.sourceWorkspaceId === undefined
+      ? {}
+      : { sourceWorkspaceId: legacy.sourceWorkspaceId }),
+    ...(legacy.replicaSyncedAt === undefined ? {} : { replicaSyncedAt: legacy.replicaSyncedAt }),
+    promotedCount: legacy.promotedCount ?? 0,
+    shadowedPaths: legacy.shadowedPaths ?? [],
+    blobsMissing: legacy.blobsMissing ?? [],
+    blobsFailed: legacy.blobsFailed ?? [],
+  }
+}
+
+function migrateV2(legacy: z.infer<typeof legacyV2SettingsSchema>): UserSettings {
+  const { promotion } = legacy.migration
+  return {
+    version: 3,
+    storage: legacy.storage,
+    // browserToDaemon goes IN the migration (dropped), not through it: a
+    // field nobody reads does not need to survive the bump.
+    migration: promotion === undefined ? {} : { promotion: normalizeLegacyPromotion(promotion) },
+    capabilities: legacy.capabilities,
+    ...(legacy.appearance === undefined ? {} : { appearance: legacy.appearance }),
+  }
+}
+
 export function defaultUserSettings(): UserSettings {
   return {
-    version: 2,
+    version: 3,
     storage: {},
     migration: {},
     capabilities: {},
@@ -317,25 +450,39 @@ export function createUserSettingsStore(): UserSettingsStore {
     }
   }
 
-  /**
-   * Migrates only when the v2 key is ABSENT, never when it is merely invalid.
-   * A corrupt or tampered v2 payload keeps the store's existing
-   * invalid-means-defaults contract instead of quietly resurrecting settings
-   * the user may have since changed.
-   */
+  function migrateFromV2(): UserSettings | null {
+    const result = legacyV2SettingsSchema.safeParse(readJson(LEGACY_V2_STORAGE_KEY))
+    if (!result.success) return null
+    const migrated = migrateV2(result.data)
+    save(migrated)
+    safeRemoveItem(LEGACY_V2_STORAGE_KEY)
+    return migrated
+  }
+
   function migrateFromV1(): UserSettings | null {
     const result = legacyV1SettingsSchema.safeParse(readJson(LEGACY_V1_STORAGE_KEY))
     if (!result.success) return null
-    const migrated = migrateV1(result.data)
+    const migrated = migrateV2(migrateV1(result.data))
     save(migrated)
     safeRemoveItem(LEGACY_V1_STORAGE_KEY)
     return migrated
   }
 
+  /**
+   * Each step migrates only when every NEWER key is ABSENT, never when one
+   * is merely invalid. A corrupt or tampered payload keeps the store's
+   * existing invalid-means-defaults contract instead of quietly resurrecting
+   * settings the user may have since changed.
+   */
   function load(): UserSettings {
-    if (safeGetItem(STORAGE_KEY) === null) return migrateFromV1() ?? defaultUserSettings()
-    const result = userSettingsSchema.safeParse(readJson(STORAGE_KEY))
-    return result.success ? result.data : defaultUserSettings()
+    if (safeGetItem(STORAGE_KEY) !== null) {
+      const result = userSettingsSchema.safeParse(readJson(STORAGE_KEY))
+      return result.success ? result.data : defaultUserSettings()
+    }
+    if (safeGetItem(LEGACY_V2_STORAGE_KEY) !== null) {
+      return migrateFromV2() ?? defaultUserSettings()
+    }
+    return migrateFromV1() ?? defaultUserSettings()
   }
 
   function save(next: UserSettings): void {
@@ -350,9 +497,10 @@ export function createUserSettingsStore(): UserSettingsStore {
 
   function reset(): void {
     safeRemoveItem(STORAGE_KEY)
-    // Both keys, or a reset on a browser that has not migrated yet clears
-    // nothing that lasts: load() would find v2 absent, migrate v1 again, and
-    // hand back the settings the user just reset.
+    // Every key, or a reset on a browser that has not migrated yet clears
+    // nothing that lasts: load() would find the current key absent, migrate
+    // an old one again, and hand back the settings the user just reset.
+    safeRemoveItem(LEGACY_V2_STORAGE_KEY)
     safeRemoveItem(LEGACY_V1_STORAGE_KEY)
   }
 

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -148,7 +148,7 @@ describe('SettingsPage — General', () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        version: 2,
+        version: 3,
         storage: {},
         migration: {},
         capabilities: {},


### PR DESCRIPTION
## Summary

Resolves two audit findings against `apps/web/src/lib/user-settings-store.ts` in one version bump:

- **`promotion-result-discriminated-union`** (MEDIUM / schema-drift): the persisted `promotionResultSchema` was one all-optional bag, able to represent states no run produces (ok with no counts, a failure carrying shadowed paths) — the exact deviation the zod-schema-discipline rule warns about, paid for in `??` fallbacks in `describeResult`. The writer already writes exactly two shapes, so the schema now says so: `z.discriminatedUnion('ok', ...)` with `promotedCount`/`shadowedPaths`/`blobsMissing`/`blobsFailed` required on the ok arm and `reason` required on the fail arm. The `describeResult` fallbacks are gone; `AppShell`'s reader already narrowed on `promotion.ok` and needed no change.
- **`drop-browser-to-daemon-settings-field`**: `migration.browserToDaemon` (written by the retired per-document import panel, read by nothing) survived as a parse-only field because removing it under `.strict()` + defaults-fallback would discard the whole payload. Its own comment said "removable only with a v3 migration" — this is that migration, and the field is dropped in it.

Mechanics mirror the v1→v2 increment: `STORAGE_KEY` moves to `whiteboard:user-settings:v3`; v2 (and chained v1) payloads are read once through parse-only legacy schemas — spelled out rather than derived, so the live schema stays free to move — migrated, and their keys removed. Legacy partial promotion records are normalized once in the migration (counts/lists filled, reason defaulted): the one-time home of the retired fallbacks. A v3 record mixing the two arms is rejected as tampered (defaults win). `reset()` clears all three keys.

## Test plan

- Red-first `v2 -> v3 migration` describe block (8 tests): payload carried + v3 key written + v2 key removed; `browserToDaemon` dropped; partial ok record normalized; reason-less failure normalized; v3 wins over a stale v2 key; v1 chains all the way to v3; reset clears the un-migrated v2 key; a mixed-arm v3 record is rejected.
- Mutation check: mutating the reason fallback in `normalizeLegacyPromotion` failed exactly its test; restored 41/41.
- `user-settings-store.test.ts` 41/41, `AppShell.test.tsx` 31/31 (72 combined); `PromoteWorkspaceSection` web-browser suites 13/13; `pnpm --filter @kamiazya/whiteboard-web test` fails only the 9 known Node-22-environment Blob/objectURL tests (thumbnail suites untouched by this diff; CI runs Node 24); `pnpm check:local` exit 0; `pnpm --filter @kamiazya/whiteboard-web build` green.
- Manual verification against the real built app in Chromium (vite preview): a seeded v2 payload with a daemon connection, replica registry, `browserToDaemon`, and a partial ok promotion migrated on boot — v3 key written (`version: 3`, promotion normalized to `{ok:true, promotedCount:0, shadowedPaths:[], ...}`), v2 key removed, daemon connection/replicas/appearance carried, page renders normally.

## Visual evidence

Visual evidence: none — a stored-schema migration with no rendered-UI change; the Chromium migration transcript and the un-weakened UI suites above are the evidence.

## Checklist

- [x] Red test first, smallest failing layer (web-jsdom)
- [x] Mutation-checked the migration's normalization
- [x] Manual verification in the real built app
- [x] `pnpm check:local` green

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when loading existing saved settings through an automatic storage migration.
  * Preserved promotion details, including counts and failure information, when upgrading saved settings.
  * Reset now clears settings from older storage versions.

* **Tests**
  * Updated settings and promotion coverage for the new storage format and migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->