### PR TITLE
refactor(web): declare ConnectedDaemon once instead of six inline copies

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -50,6 +50,7 @@ import {
   workspacePath,
   workspaceRoutePath,
 } from './lib/app-routes.js'
+import type { ConnectedDaemon } from './lib/daemon-auth-fetch.js'
 import {
   BROWSER_CAPABILITIES,
   type ProviderState,
@@ -660,7 +661,7 @@ export function App({ providerState }: AppProps) {
   // that only exists inside one of those branches' own scope.
   const grantPairedForSettings = grantConnection?.status === 'paired' ? grantConnection : null
   const providerStateForSettings = providerState ?? defaultProviderState
-  const settingsDaemon: { baseUrl: string; token: string | null } | undefined = forcedBrowser
+  const settingsDaemon: ConnectedDaemon | undefined = forcedBrowser
     ? undefined
     : daemonConnection.status === 'paired'
       ? {

--- a/apps/web/src/components/settings/PromoteWorkspaceSection.tsx
+++ b/apps/web/src/components/settings/PromoteWorkspaceSection.tsx
@@ -29,13 +29,14 @@ import {
 } from '@/components/ui/dialog'
 import { getAppLogger } from '@/lib/app-logger'
 import { createDaemonFetch, listWorkspaces } from '@/lib/daemon-api-client'
+import type { ConnectedDaemon } from '@/lib/daemon-auth-fetch'
 import type { PromotionResultRecord, UserSettings } from '@/lib/user-settings-store'
 import { type WorkspaceIdentity, workspaceLabel } from '@/lib/workspace-handle'
 
 const log = getAppLogger('promote-workspace-section')
 
 export interface PromoteWorkspaceSectionProps {
-  daemon?: { baseUrl: string; token: string | null }
+  daemon?: ConnectedDaemon
   settingsStore: {
     load: () => UserSettings
     update: (fn: (current: UserSettings) => UserSettings) => void

--- a/apps/web/src/lib/daemon-auth-fetch.ts
+++ b/apps/web/src/lib/daemon-auth-fetch.ts
@@ -9,6 +9,18 @@
  * context share the one implementation.
  */
 /**
+ * The daemon a session is connected to, as the pair every authorized call
+ * needs — exactly what `createDaemonFetch` consumes. One declaration rather
+ * than an inline literal per surface, because structural typing would let
+ * one site's copy drift (a token quietly becoming optional, say) without a
+ * single error anywhere.
+ */
+export interface ConnectedDaemon {
+  baseUrl: string
+  token: string | null
+}
+
+/**
  * Resolves an input (string/URL/Request) against `daemonBaseUrl` and returns
  * its final URL object. Relative string/URL inputs resolve against
  * daemonBaseUrl; absolute inputs and Request objects keep their own origin

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -26,6 +26,7 @@ import { useThemeMode } from '@/hooks/useThemeMode'
 import { parseSettingsRoute, type SettingsSection, settingsPath } from '@/lib/app-routes'
 import { celebrate } from '@/lib/celebrate'
 import { createDaemonFetch } from '@/lib/daemon-api-client'
+import type { ConnectedDaemon } from '@/lib/daemon-auth-fetch'
 import { disconnectFromDaemon } from '@/lib/disconnect-daemon'
 import type { FaviconStyle } from '@/lib/favicon'
 import { getInstallState, promptInstall, subscribeInstallState } from '@/lib/install-prompt-store'
@@ -41,7 +42,7 @@ import { PairedOriginsCard } from '../components/PairedOriginsCard.js'
 import { StorageReportCard } from '../components/StorageReportCard.js'
 
 export interface SettingsPageProps {
-  daemon?: { baseUrl: string; token: string | null }
+  daemon?: ConnectedDaemon
   /**
    * Called after this browser stops using the daemon, so the App branch can
    * follow the settings it just wrote. Without it the change only takes
@@ -206,7 +207,7 @@ function ConnectionsSection({
   daemon,
   onDisconnected,
 }: {
-  daemon?: { baseUrl: string; token: string | null }
+  daemon?: ConnectedDaemon
   onDisconnected?: () => void
 }) {
   if (!daemon) {
@@ -272,7 +273,7 @@ function stripScheme(baseUrl: string): string {
  * tofu (ADR-0012 decision 4). Without one there is nothing to install into,
  * and saying so beats an empty list.
  */
-function FontsSection({ daemon }: { daemon?: { baseUrl: string; token: string | null } }) {
+function FontsSection({ daemon }: { daemon?: ConnectedDaemon }) {
   if (!daemon) {
     return (
       <section>
@@ -309,7 +310,7 @@ function sectionContent(
     installStatus: 'installed' | 'installable' | 'not-captured'
     estimate: BrowserStorageEstimate | null
     daemonStorageBytes: number | null
-    daemon?: { baseUrl: string; token: string | null }
+    daemon?: ConnectedDaemon
     onDisconnected?: () => void
   },
 ) {


### PR DESCRIPTION
## Summary

Resolves the audit finding `daemon-handle-type-dedup` (LOW / architecture-debt): the `{ baseUrl: string; token: string | null }` daemon-handle type was written out independently six times (App.tsx ×1, SettingsPage.tsx ×4, PromoteWorkspaceSection.tsx ×1 — the finding counted 4; the surface had grown since). Structural typing would let one copy drift — a token quietly becoming optional, say — with no error anywhere, only a silent behavioral difference.

`ConnectedDaemon` is now declared once in `lib/daemon-auth-fetch.ts`, beside `createDaemonFetch` — exactly the pair the type describes — and all six sites import it. Type-only, behavior-preserving; no runtime diff.

## Test plan

- `pnpm --filter @kamiazya/whiteboard-web typecheck` clean; a repo grep for the inline literal outside tests comes back empty.
- Touched suites un-weakened: `SettingsPage.test.tsx` + `App.test.tsx` 108/108 (web-jsdom).
- `pnpm check:local` exit 0.

## Visual evidence

Visual evidence: none — type-only refactor with no runtime or rendered change; the un-weakened suites above are the evidence.

## Checklist

- [x] Behavior-preserving (existing tests un-weakened, 108/108)
- [x] `pnpm check:local` green

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_