### PR TITLE
refactor(web): extract the file-reference seam into useFileSeamScene

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -100,9 +100,7 @@ import {
   recordReconnection,
   writeClipboardFragment,
 } from '../../lib/clipboard-store.js'
-import { createSpatialContentCache } from '../../lib/content-cache.js'
 import { hapticTick } from '../../lib/haptics.js'
-import { composeReferenceSeam } from '../../lib/layout-worker-protocol.js'
 import { useKeyedSvg } from '../../lib/use-keyed-svg.js'
 import type { BoxMove } from './align.js'
 import {
@@ -195,6 +193,7 @@ import {
   ToolPalette,
 } from './ToolPalette.js'
 import { MINIMAP_MIN_ROOT_WIDTH_PX, useEditorMeasurements } from './use-editor-measurements.js'
+import { EXPAND_MIN_H, EXPAND_MIN_W, useFileSeamScene } from './use-file-seam-scene.js'
 import { useGestureCaptured } from './use-gesture-captured.js'
 import { useNativeCanvasListeners } from './use-native-canvas-listeners.js'
 import { useWorkerScene } from './use-worker-scene.js'
@@ -707,105 +706,19 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [canvas, externalVersion])
 
-    /**
-     * The LOD gate (embed spec v2, user decision 2026-08-08): a file node
-     * expands into an inline miniature only while its ON-SCREEN box is
-     * large enough to be legible. Hysteresis (expand at >=200x140, collapse
-     * below 160x110 CSS px) keeps pinch-zoom from flickering at the
-     * boundary, and a budget caps simultaneous miniatures at the largest
-     * candidates (deterministic tie-break by node id). The set is state so
-     * layout re-runs only when membership actually changes — never per
-     * zoom frame.
-     */
-    const EXPAND_MIN_W = 200
-    const EXPAND_MIN_H = 140
-    const COLLAPSE_MIN_W = 160
-    const COLLAPSE_MIN_H = 110
-    const EMBED_BUDGET = 8
-    const [expandedFileIds, setExpandedFileIds] = useState<ReadonlySet<string>>(new Set())
-    useEffect(() => {
-      if (resolveReference === undefined) return
-      const zoom = viewport.zoom
-      const candidates = canvas.nodes
-        .filter((node): node is Extract<SpatialNode, { type: 'file' }> => node.type === 'file')
-        .filter((node) => {
-          const w = node.width * zoom
-          const h = node.height * zoom
-          return expandedFileIds.has(node.id)
-            ? w >= COLLAPSE_MIN_W && h >= COLLAPSE_MIN_H
-            : w >= EXPAND_MIN_W && h >= EXPAND_MIN_H
-        })
-        .sort((a, b) => b.width * b.height - a.width * a.height || a.id.localeCompare(b.id))
-        .slice(0, EMBED_BUDGET)
-      const next = new Set(candidates.map((node) => node.id))
-      const unchanged =
-        next.size === expandedFileIds.size && [...next].every((id) => expandedFileIds.has(id))
-      if (!unchanged) setExpandedFileIds(next)
-    }, [canvas, viewport.zoom, resolveReference, expandedFileIds])
-    const expandFileNode = useMemo(
-      () =>
-        resolveReference === undefined
-          ? undefined
-          : (node: Extract<SpatialNode, { type: 'file' }>) => expandedFileIds.has(node.id),
-      [resolveReference, expandedFileIds],
-    )
-
-    // Opaque file references (canvas ids minted in the browser) become readable
-    // card labels through the host-supplied options list.
-    const fileRefLabelMap = useMemo(
-      () =>
-        fileRefOptions === undefined
-          ? undefined
-          : new Map(fileRefOptions.map((option) => [option.file, option.label])),
-      [fileRefOptions],
-    )
-    // The plain-data twin of the seam's `missing` field, so the worker path
-    // (which cannot take a function) sees the same missing set the
-    // synchronous and drag paths compute through the callback.
-    const missingRefSet = useMemo(() => {
-      if (missingFileRef === undefined) return undefined
-      const refs = new Set<string>()
-      for (const node of canvas.nodes) {
-        if (node.type === 'file' && missingFileRef(node.file)) refs.add(node.file)
-      }
-      return refs.size === 0 ? undefined : refs
-    }, [canvas, missingFileRef])
-    const missingFileRefs = useMemo(
-      () => (missingRefSet === undefined ? undefined : [...missingRefSet]),
-      [missingRefSet],
-    )
-    // ONE object for every render path below (committed scene, drag ghost,
-    // drag-static backdrop, resize preview). Four hand-listed copies is how a
-    // seam ends up wired into the committed render and missing from the drag
-    // overlay, which reads as content vanishing mid-gesture.
-    //
-    // `resolveReferenceContent` rides along UNCOMPOSED so the worker gate can
-    // still tell content (which cannot be serialized) from label/missing
-    // (which already cross as data).
-    // One text-node body memo per measure+theme (the cache's validity
-    // contract); rides fileSeamOptions so every synchronous render path in
-    // this component — the committed fallback, the drag backdrop, the live
-    // resize node — shares it. It never crosses to the layout worker
-    // (LayoutRequest carries plain data only); the worker keeps its own.
-    const contentCache = useMemo(
-      () => createSpatialContentCache(),
-      // eslint-disable-next-line react-hooks/exhaustive-deps -- theme and
-      // measure invalidate cached layout; nothing else does.
-      [resolvedMeasure, theme],
-    )
-    const fileSeamOptions = useMemo(
-      () => ({
-        resolveReference: composeReferenceSeam({
-          content: resolveReference,
-          labels: fileRefLabelMap,
-          missing: missingRefSet,
-        }),
-        resolveReferenceContent: resolveReference,
-        expandFileNode,
-        contentCache,
-      }),
-      [resolveReference, fileRefLabelMap, missingRefSet, expandFileNode, contentCache],
-    )
+    // The file-reference seam — the LOD gate, label/missing resolution and
+    // the content cache — built once in useFileSeamScene and spread into
+    // every scene-building call below (committed scene, drag ghost,
+    // drag-static backdrop, resize preview).
+    const { fileSeamOptions, missingFileRefs } = useFileSeamScene({
+      canvas,
+      zoom: viewport.zoom,
+      resolveReference,
+      fileRefOptions,
+      missingFileRef,
+      resolvedMeasure,
+      theme,
+    })
     // The COMMITTED scene, laid out in a worker when it can be. The drag
     // layers below keep their own synchronous paths: a gesture already has a
     // fast route through carried-side caching, and a round trip per frame

--- a/apps/web/src/components/spatial-editor/editor-state-surface.test.ts
+++ b/apps/web/src/components/spatial-editor/editor-state-surface.test.ts
@@ -35,11 +35,10 @@ import { assertScannedLedger } from '../../test-utils/coverage-ledger.js'
 // The editor plus the hooks its state moved to: an extraction moves state,
 // not away, so a moved useState must stay scanned. A new hook that declares
 // state joins this list in the same commit that moves it.
-const sources = import.meta.glob(['./SpatialEditor.tsx', './use-editor-measurements.ts'], {
-  query: '?raw',
-  import: 'default',
-  eager: true,
-}) as Record<string, string>
+const sources = import.meta.glob(
+  ['./SpatialEditor.tsx', './use-editor-measurements.ts', './use-file-seam-scene.ts'],
+  { query: '?raw', import: 'default', eager: true },
+) as Record<string, string>
 
 type StateCoverage =
   /** The composite-state property drives this and asserts about it. */

--- a/apps/web/src/components/spatial-editor/purity-guard.test.ts
+++ b/apps/web/src/components/spatial-editor/purity-guard.test.ts
@@ -86,8 +86,13 @@ describe('file seams reach every render path', () => {
     // drag-static backdrop, resize preview. When each listed the seams by
     // hand, adding one meant remembering four places, and the failure mode
     // is silent: content that renders committed and vanishes mid-gesture.
+    // The single build site lives in useFileSeamScene; the editor must take
+    // the shared object from there rather than assembling a second one.
+    const hookSource = modules['./use-file-seam-scene.ts'] as string
+    expect(hookSource.match(/const fileSeamOptions = useMemo\(/g) ?? []).toHaveLength(1)
     const source = modules['./SpatialEditor.tsx'] as string
-    expect(source.match(/const fileSeamOptions = useMemo\(/g) ?? []).toHaveLength(1)
+    expect(source.match(/const fileSeamOptions = useMemo\(/g) ?? []).toHaveLength(0)
+    expect(source.match(/useFileSeamScene\(/g) ?? []).toHaveLength(1)
     // Two entry points build scenes now, not one: the committed path goes
     // through `useWorkerScene` (which lays out in a worker and falls back to
     // `renderCanvasToSvg` itself), while the gesture overlays still call the

--- a/apps/web/src/components/spatial-editor/use-file-seam-scene.test.ts
+++ b/apps/web/src/components/spatial-editor/use-file-seam-scene.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Nearest-layer coverage for the LOD gate the seam hook owns. The browser
+ * suites (canvas-embed-lod, drag-ghost-embed) pin what an expanded file
+ * node RENDERS as; this file pins the gate's own decisions — hysteresis
+ * and the budget — at the layer they live, where each case is a zoom
+ * number instead of a mounted editor.
+ */
+import type { MeasureText } from '@kamiazya/whiteboard-canvas-render'
+import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useFileSeamScene } from './use-file-seam-scene.js'
+
+const measure: MeasureText = () => ({ advanceWidth: 0, ascent: 0, descent: 0, lineGap: 0 })
+const resolveReference = () => undefined
+
+function fileNode(
+  id: string,
+  width: number,
+  height: number,
+): Extract<SpatialNode, { type: 'file' }> {
+  return { id, type: 'file', file: `doc-${id}`, x: 0, y: 0, width, height }
+}
+
+function canvasOf(nodes: readonly SpatialNode[]): SpatialCanvas {
+  return { nodes: [...nodes], edges: [] }
+}
+
+function renderSeam(canvas: SpatialCanvas, zoom: number) {
+  return renderHook(
+    ({ c, z }) =>
+      useFileSeamScene({
+        canvas: c,
+        zoom: z,
+        resolveReference,
+        fileRefOptions: undefined,
+        missingFileRef: undefined,
+        resolvedMeasure: measure,
+        theme: 'light',
+      }),
+    { initialProps: { c: canvas, z: zoom } },
+  )
+}
+
+const expands = (
+  result: { current: ReturnType<typeof useFileSeamScene> },
+  node: Extract<SpatialNode, { type: 'file' }>,
+) => result.current.fileSeamOptions.expandFileNode?.(node) ?? false
+
+describe('useFileSeamScene LOD gate', () => {
+  it('expands a file node only once its on-screen box reaches 200x140', async () => {
+    const big = fileNode('big', 220, 150)
+    const small = fileNode('small', 180, 120)
+    const { result } = renderSeam(canvasOf([big, small]), 1)
+    await waitFor(() => expect(expands(result, big)).toBe(true))
+    expect(expands(result, small)).toBe(false)
+  })
+
+  it('keeps an expanded node until it shrinks below 160x110 (hysteresis), then collapses it', async () => {
+    const node = fileNode('h', 220, 150)
+    const { result, rerender } = renderSeam(canvasOf([node]), 1)
+    await waitFor(() => expect(expands(result, node)).toBe(true))
+
+    // 220x150 at zoom 0.8 is 176x120 — under the expand threshold, above
+    // the collapse one. An expanded node must ride through it.
+    rerender({ c: canvasOf([node]), z: 0.8 })
+    await waitFor(() => expect(expands(result, node)).toBe(true))
+
+    // At zoom 0.6 (132x90) the collapse floor is crossed.
+    rerender({ c: canvasOf([node]), z: 0.6 })
+    await waitFor(() => expect(expands(result, node)).toBe(false))
+
+    // And 0.8 again does NOT re-expand: hysteresis is one-directional.
+    rerender({ c: canvasOf([node]), z: 0.8 })
+    await waitFor(() => expect(expands(result, node)).toBe(false))
+  })
+
+  it('caps simultaneous miniatures at the 8 largest candidates, tie-broken by id', async () => {
+    const nodes = Array.from({ length: 10 }, (_, i) =>
+      // n0 is largest, n9 smallest; all clear the expand threshold.
+      fileNode(`n${i}`, 400 - i * 10, 300),
+    )
+    const { result } = renderSeam(canvasOf(nodes), 1)
+    await waitFor(() => expect(expands(result, nodes[7]!)).toBe(true))
+    expect(nodes.map((node) => expands(result, node))).toEqual([
+      ...Array.from({ length: 8 }, () => true),
+      false,
+      false,
+    ])
+  })
+
+  it('offers no expansion gate at all without a reference resolver', () => {
+    const { result } = renderHook(() =>
+      useFileSeamScene({
+        canvas: canvasOf([fileNode('a', 400, 300)]),
+        zoom: 1,
+        resolveReference: undefined,
+        fileRefOptions: undefined,
+        missingFileRef: undefined,
+        resolvedMeasure: measure,
+        theme: 'light',
+      }),
+    )
+    expect(result.current.fileSeamOptions.expandFileNode).toBeUndefined()
+  })
+})

--- a/apps/web/src/components/spatial-editor/use-file-seam-scene.ts
+++ b/apps/web/src/components/spatial-editor/use-file-seam-scene.ts
@@ -1,0 +1,136 @@
+import type { MeasureText, ResolvedReference } from '@kamiazya/whiteboard-canvas-render'
+import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
+import { useEffect, useMemo, useState } from 'react'
+import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
+import { createSpatialContentCache } from '../../lib/content-cache.js'
+import { composeReferenceSeam } from '../../lib/layout-worker-protocol.js'
+import type { FileRefOption } from './DocumentPickerDialog.js'
+
+/**
+ * The LOD gate (embed spec v2, user decision 2026-08-08): a file node
+ * expands into an inline miniature only while its ON-SCREEN box is
+ * large enough to be legible. Hysteresis (expand at >=200x140, collapse
+ * below 160x110 CSS px) keeps pinch-zoom from flickering at the
+ * boundary, and a budget caps simultaneous miniatures at the largest
+ * candidates (deterministic tie-break by node id). The set is state so
+ * layout re-runs only when membership actually changes — never per
+ * zoom frame.
+ */
+// Exported because LinkEmbedLayer's shouldOffer mirrors the canvas-embed
+// thresholds: a link iframe is offered at exactly the size a file miniature
+// would expand, so the two LOD gates stay one decision.
+export const EXPAND_MIN_W = 200
+export const EXPAND_MIN_H = 140
+const COLLAPSE_MIN_W = 160
+const COLLAPSE_MIN_H = 110
+const EMBED_BUDGET = 8
+
+export interface FileSeamSceneInputs {
+  readonly canvas: SpatialCanvas
+  /** The live viewport zoom — the LOD gate compares on-screen pixel size. */
+  readonly zoom: number
+  readonly resolveReference: ((ref: string) => ResolvedReference | undefined) | undefined
+  readonly fileRefOptions: readonly FileRefOption[] | undefined
+  readonly missingFileRef: ((file: string) => boolean) | undefined
+  readonly resolvedMeasure: MeasureText
+  readonly theme: ResolvedTheme
+}
+
+/**
+ * The file-reference seam, built once for every render path.
+ *
+ * ONE object for every scene-building call in the editor (committed scene,
+ * drag ghost, drag-static backdrop, resize preview). Four hand-listed
+ * copies is how a seam ends up wired into the committed render and missing
+ * from the drag overlay, which reads as content vanishing mid-gesture.
+ *
+ * `resolveReferenceContent` rides along UNCOMPOSED so the worker gate can
+ * still tell content (which cannot be serialized) from label/missing
+ * (which already cross as data). `missingFileRefs` is the plain-data twin
+ * of the seam's `missing` field for the same reason: the worker path
+ * cannot take a function.
+ */
+export function useFileSeamScene({
+  canvas,
+  zoom,
+  resolveReference,
+  fileRefOptions,
+  missingFileRef,
+  resolvedMeasure,
+  theme,
+}: FileSeamSceneInputs) {
+  const [expandedFileIds, setExpandedFileIds] = useState<ReadonlySet<string>>(new Set())
+  useEffect(() => {
+    if (resolveReference === undefined) return
+    const candidates = canvas.nodes
+      .filter((node): node is Extract<SpatialNode, { type: 'file' }> => node.type === 'file')
+      .filter((node) => {
+        const w = node.width * zoom
+        const h = node.height * zoom
+        return expandedFileIds.has(node.id)
+          ? w >= COLLAPSE_MIN_W && h >= COLLAPSE_MIN_H
+          : w >= EXPAND_MIN_W && h >= EXPAND_MIN_H
+      })
+      .sort((a, b) => b.width * b.height - a.width * a.height || a.id.localeCompare(b.id))
+      .slice(0, EMBED_BUDGET)
+    const next = new Set(candidates.map((node) => node.id))
+    const unchanged =
+      next.size === expandedFileIds.size && [...next].every((id) => expandedFileIds.has(id))
+    if (!unchanged) setExpandedFileIds(next)
+  }, [canvas, zoom, resolveReference, expandedFileIds])
+  const expandFileNode = useMemo(
+    () =>
+      resolveReference === undefined
+        ? undefined
+        : (node: Extract<SpatialNode, { type: 'file' }>) => expandedFileIds.has(node.id),
+    [resolveReference, expandedFileIds],
+  )
+
+  // Opaque file references (canvas ids minted in the browser) become readable
+  // card labels through the host-supplied options list.
+  const fileRefLabelMap = useMemo(
+    () =>
+      fileRefOptions === undefined
+        ? undefined
+        : new Map(fileRefOptions.map((option) => [option.file, option.label])),
+    [fileRefOptions],
+  )
+  const missingRefSet = useMemo(() => {
+    if (missingFileRef === undefined) return undefined
+    const refs = new Set<string>()
+    for (const node of canvas.nodes) {
+      if (node.type === 'file' && missingFileRef(node.file)) refs.add(node.file)
+    }
+    return refs.size === 0 ? undefined : refs
+  }, [canvas, missingFileRef])
+  const missingFileRefs = useMemo(
+    () => (missingRefSet === undefined ? undefined : [...missingRefSet]),
+    [missingRefSet],
+  )
+  // One text-node body memo per measure+theme (the cache's validity
+  // contract); rides fileSeamOptions so every synchronous render path in
+  // the editor — the committed fallback, the drag backdrop, the live
+  // resize node — shares it. It never crosses to the layout worker
+  // (LayoutRequest carries plain data only); the worker keeps its own.
+  const contentCache = useMemo(
+    () => createSpatialContentCache(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- theme and
+    // measure invalidate cached layout; nothing else does.
+    [resolvedMeasure, theme],
+  )
+  const fileSeamOptions = useMemo(
+    () => ({
+      resolveReference: composeReferenceSeam({
+        content: resolveReference,
+        labels: fileRefLabelMap,
+        missing: missingRefSet,
+      }),
+      resolveReferenceContent: resolveReference,
+      expandFileNode,
+      contentCache,
+    }),
+    [resolveReference, fileRefLabelMap, missingRefSet, expandFileNode, contentCache],
+  )
+
+  return { fileSeamOptions, missingFileRefs }
+}


### PR DESCRIPTION
## Summary

PR 2 of the SpatialEditor decomposition (3789 → 3703 lines, after #1190). Moves the file-reference seam into `use-file-seam-scene.ts`, behavior-preserving:

- the LOD gate (`expandedFileIds` state, hysteresis thresholds, embed budget) and `expandFileNode`
- `fileRefLabelMap`, `missingRefSet`/`missingFileRefs` (the worker path's plain-data twin)
- the `contentCache` (one text-node body memo per measure+theme)
- the single `fileSeamOptions` build that every scene-building call spreads

The hook returns `{ fileSeamOptions, missingFileRefs }`. `EXPAND_MIN_W`/`EXPAND_MIN_H` are exported because `LinkEmbedLayer`'s `shouldOffer` mirrors the canvas-embed thresholds — the two LOD gates stay one decision.

Pinned scans move with the code:
- `purity-guard.test.ts` now asserts the single `fileSeamOptions` build site lives in the hook and that SpatialEditor builds none of its own; mutation-checked — reintroducing a second build in the editor fails the guard naming it. The every-scene-call-carries-the-seam check and the `resolveReference`-at-call-site anti-pattern check are unchanged.
- `editor-state-surface.test.ts` globs the new hook, so the moved `expandedFileIds` `useState` stays on the ledger.

New nearest-layer coverage the extraction makes possible: `use-file-seam-scene.test.ts` pins the LOD gate's own decisions at the hook layer — the 200x140 expand threshold, one-directional hysteresis down to the 160x110 collapse floor, and the 8-miniature budget — mutation-checked in both directions (collapsed hysteresis band and widened budget each go red naming the case).

## Test plan

- [x] spatial-editor jsdom suite: 42 files / 469 tests green (+ the 4 new LOD gate cases)
- [x] Seam-covering browser suites un-weakened: canvas-embed-lod, canvas-ref-node, drag-ghost-embed, SpatialEditor.browser — 4 files / 45 tests green
- [x] purity-guard mutation check: a second `fileSeamOptions = useMemo(` in SpatialEditor → red naming the guard
- [x] `pnpm check:local` green (exit 0)

CI note: the first run's `test-browser (2)` failed on `BrowserIndexPage.flow.browser.test.tsx` — typed input truncated (`"# From the"` vs `"# From the list"`), the documented lost-keystrokes-under-load flake shape. This PR's diff touches only `spatial-editor` files and cannot reach that markdown-typing flow; the file passes 1/1 in isolation on this branch. First CI occurrence recorded; a second occurrence promotes it to a root-cause lane.

## Visual evidence

Visual evidence: none — behavior-preserving code move with no pixel change; the seam's rendering behavior is pinned by the browser suites listed in the Test plan.