### PR TITLE
refactor(web): extract the spawn-at-a-point creation family into useNodeCreation

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -150,21 +150,6 @@ import {
   type PointerKind,
   reduceNavigation,
 } from './navigation.js'
-import {
-  DOCUMENT_NODE_HEIGHT,
-  DOCUMENT_NODE_WIDTH,
-  fileNodeDefaults,
-  GROUP_FRAME_HEIGHT,
-  GROUP_FRAME_WIDTH,
-  groupEnclosure,
-  groupNodeDefaults,
-  IMAGE_NODE_HEIGHT,
-  IMAGE_NODE_WIDTH,
-  imageNodeDefaults,
-  LINK_NODE_HEIGHT,
-  linkNodeDefaults,
-  resolveSpawnPoint,
-} from './node-factories.js'
 import { PendingCutChip } from './PendingCutChip.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
 import { renderCanvasToSvg, requiredTextNodeHeight } from './scene-render.js'
@@ -179,7 +164,6 @@ import { findShortcut, isTextEntryEvent, type ShortcutId } from './shortcuts.js'
 import { type SnapBox, snapBox, snapEdge } from './snap.js'
 import { TextNodeEditor } from './TextNodeEditor.js'
 import {
-  DOCK_OCCLUSION_PX,
   type DraggableCreation,
   draggedCreation,
   type EditorTool,
@@ -190,6 +174,7 @@ import { MINIMAP_MIN_ROOT_WIDTH_PX, useEditorMeasurements } from './use-editor-m
 import { EXPAND_MIN_H, EXPAND_MIN_W, useFileSeamScene } from './use-file-seam-scene.js'
 import { useGestureCaptured } from './use-gesture-captured.js'
 import { useNativeCanvasListeners } from './use-native-canvas-listeners.js'
+import { useNodeCreation } from './use-node-creation.js'
 import { useWorkerScene } from './use-worker-scene.js'
 import {
   canvasToScreen,
@@ -198,7 +183,6 @@ import {
   IDENTITY_VIEWPORT,
   type Point,
   panBy,
-  panToShowTarget,
   screenToCanvas,
   contentBounds as unionContentBounds,
   type Viewport,
@@ -2463,108 +2447,32 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       })
     }
 
-    const createLinkAtViewportCenter = (url: string, at?: Point) => {
-      const root = rootRef.current
-      const centerScreen =
-        root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
-      const preferred = screenToCanvas(centerScreen, viewport)
-      const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
-      const point = resolveSpawnPoint(
-        at,
-        preferred,
-        { width: NEW_NODE_WIDTH, height: LINK_NODE_HEIGHT },
-        occupied,
-        visibleCanvasRect(),
-      )
-      const id =
-        createId?.() ??
-        (typeof crypto !== 'undefined' && 'randomUUID' in crypto
-          ? crypto.randomUUID()
-          : String(Math.random()))
-      const node = linkNodeDefaults(id, point, url)
-      applyResult({
-        state: { kind: 'idle' },
-        commands: [{ kind: 'create-node', node }],
-        selectedId: id,
-      })
-      // Creation selects the new node EXCLUSIVELY — set-primary alone would
-      // keep the old extras riding along into the next move/delete.
-      applySelection({ type: 'collapse-extras' })
-      panToShow({ x: node.x, y: node.y, width: node.width, height: node.height })
-    }
-
-    /** File nodes are reference cards like links — same shorter default box. */
-    const createFileRefAtViewportCenter = (file: string, at?: Point) => {
-      // The picked option's kind decides the box: a markdown document
-      // renders its prose inside the node and needs room a one-line
-      // reference card does not have.
-      const kind = fileRefOptions?.find((option) => option.file === file)?.kind
-      const root = rootRef.current
-      const centerScreen =
-        root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
-      const preferred = screenToCanvas(centerScreen, viewport)
-      const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
-      const point = resolveSpawnPoint(
-        at,
-        preferred,
-        kind === 'markdown'
-          ? { width: DOCUMENT_NODE_WIDTH, height: DOCUMENT_NODE_HEIGHT }
-          : { width: NEW_NODE_WIDTH, height: LINK_NODE_HEIGHT },
-        occupied,
-        visibleCanvasRect(),
-      )
-      const id = newId()
-      const node = fileNodeDefaults(id, point, file, kind)
-      applyResult({
-        state: { kind: 'idle' },
-        commands: [{ kind: 'create-node', node }],
-        selectedId: id,
-      })
-      // Creation selects the new node EXCLUSIVELY — set-primary alone would
-      // keep the old extras riding along into the next move/delete.
-      applySelection({ type: 'collapse-extras' })
-      panToShow({ x: node.x, y: node.y, width: node.width, height: node.height })
-    }
+    const {
+      visibleCanvasRect,
+      panToShow,
+      createLinkAtViewportCenter,
+      createFileRefAtViewportCenter,
+      addImageFile,
+      createGroupAtViewportCenter,
+      groupSelection,
+    } = useNodeCreation({
+      rootRef,
+      canvasRef,
+      viewport,
+      setViewport,
+      createId,
+      fileRefOptions,
+      onAddImage,
+      applyResult,
+      collapseExtras: () => applySelection({ type: 'collapse-extras' }),
+      containerSizeOf,
+    })
 
     const imageInputRef = useRef<HTMLInputElement | null>(null)
     /** When set, the next picked image becomes this group's background instead of a new node. */
     const pendingBackgroundGroupIdRef = useRef<string | null>(null)
     /** Where the pending picker-created image should land; null = viewport center. */
     const pendingImagePointRef = useRef<Point | null>(null)
-
-    const createImageNodeAt = (file: string, at?: Point) => {
-      const root = rootRef.current
-      const centerScreen =
-        root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
-      const preferred = screenToCanvas(centerScreen, viewport)
-      const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
-      const point = resolveSpawnPoint(
-        at,
-        preferred,
-        { width: IMAGE_NODE_WIDTH, height: IMAGE_NODE_HEIGHT },
-        occupied,
-        visibleCanvasRect(),
-      )
-      const id = newId()
-      const node = imageNodeDefaults(id, point, file)
-      applyResult({
-        state: { kind: 'idle' },
-        commands: [{ kind: 'create-node', node }],
-        selectedId: id,
-      })
-      // Creation selects the new node EXCLUSIVELY — set-primary alone would
-      // keep the old extras riding along into the next move/delete.
-      applySelection({ type: 'collapse-extras' })
-      panToShow({ x: node.x, y: node.y, width: node.width, height: node.height })
-    }
-
-    /** Stores the image via the host seam, then creates the node. */
-    const addImageFile = (file: File, at?: Point) => {
-      if (onAddImage === undefined || !file.type.startsWith('image/')) return
-      void onAddImage(file).then((ref) => {
-        if (ref !== undefined) createImageNodeAt(ref, at)
-      })
-    }
 
     /** The one place a stored URL is turned into navigation. noopener keeps
      * the canvas tab unreachable from the opened page, and the scheme guard
@@ -2574,83 +2482,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     const openLinkNode = (node: Extract<SpatialNode, { type: 'link' }>) => {
       if (!isFollowableUrl(node.url)) return
       window.open(node.url, '_blank', 'noopener,noreferrer')
-    }
-
-    /**
-     * The free-spot cascade can push a palette-created node outside the
-     * visible viewport, leaving the user staring at an unchanged canvas.
-     * When the created box does not fully fit on screen, pan (keeping the
-     * zoom) so it sits centered — creation is always visible feedback.
-     */
-    /**
-     * The canvas-space rectangle a person can actually see: the root, minus
-     * the strip the dock paints over. Creation places inside this before it
-     * places anywhere else, which is what keeps the view still.
-     */
-    const visibleCanvasRect = (): Box | undefined => {
-      const containerSize = containerSizeOf(rootRef.current)
-      if (containerSize === null) return undefined
-      const topLeft = screenToCanvas({ x: 0, y: 0 }, viewport)
-      return {
-        x: topLeft.x,
-        y: topLeft.y,
-        width: containerSize.width / viewport.zoom,
-        height: (containerSize.height - DOCK_OCCLUSION_PX) / viewport.zoom,
-      }
-    }
-
-    const panToShow = (box: Box) => {
-      const containerSize = containerSizeOf(rootRef.current)
-      if (containerSize === null) return
-      setViewport(
-        (vp) => panToShowTarget(box, vp, containerSize, { bottom: DOCK_OCCLUSION_PX }) ?? vp,
-      )
-    }
-
-    const newId = () =>
-      createId?.() ??
-      (typeof crypto !== 'undefined' && 'randomUUID' in crypto
-        ? crypto.randomUUID()
-        : String(Math.random()))
-
-    const createGroupAtViewportCenter = (at?: Point) => {
-      const root = rootRef.current
-      const centerScreen =
-        root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
-      const preferred = screenToCanvas(centerScreen, viewport)
-      const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
-      const point = resolveSpawnPoint(
-        at,
-        preferred,
-        { width: GROUP_FRAME_WIDTH, height: GROUP_FRAME_HEIGHT },
-        occupied,
-        visibleCanvasRect(),
-      )
-      const id = newId()
-      const node = groupNodeDefaults(id, point)
-      applyResult({
-        state: { kind: 'idle' },
-        commands: [{ kind: 'create-group', node }],
-        selectedId: id,
-      })
-      // Creation selects the new node EXCLUSIVELY — set-primary alone would
-      // keep the old extras riding along into the next move/delete.
-      applySelection({ type: 'collapse-extras' })
-      panToShow({ x: node.x, y: node.y, width: node.width, height: node.height })
-    }
-
-    /** Frames the current multi-selection: enclosing box + padding. */
-    const groupSelection = (memberIds: readonly string[]) => {
-      const members = canvasRef.current.nodes.filter((n) => memberIds.includes(n.id))
-      const frame = groupEnclosure(members)
-      if (frame === undefined) return
-      const id = newId()
-      applyResult({
-        state: { kind: 'idle' },
-        commands: [{ kind: 'create-group', node: { id, type: 'group', ...frame } }],
-        selectedId: id,
-      })
-      applySelection({ type: 'collapse-extras' })
     }
 
     return (

--- a/apps/web/src/components/spatial-editor/purity-guard.test.ts
+++ b/apps/web/src/components/spatial-editor/purity-guard.test.ts
@@ -156,7 +156,13 @@ describe('single content path (S10 guardrail)', () => {
     // command layer sync consumers replay.
     // The editor plus every hook its onChange call sites moved to — an
     // extraction moves a mutation site, not past the command boundary.
-    const MUTATING_SOURCES = ['./SpatialEditor.tsx', './use-clipboard-actions.ts']
+    const MUTATING_SOURCES = [
+      './SpatialEditor.tsx',
+      './use-clipboard-actions.ts',
+      // Creation goes through applyResult, so this one holds zero onChange
+      // calls today — scanned so a future direct write cannot slip in.
+      './use-node-creation.ts',
+    ]
     for (const path of MUTATING_SOURCES) {
       const source = modules[path] as string
       // String-level TRIPWIRE for the command boundary: every statement-level

--- a/apps/web/src/components/spatial-editor/use-node-creation.ts
+++ b/apps/web/src/components/spatial-editor/use-node-creation.ts
@@ -1,0 +1,209 @@
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import type { MutableRefObject, RefObject } from 'react'
+import type { FileRefOption } from './DocumentPickerDialog.js'
+import type { Box } from './geometry.js'
+import { indexNodeBoxes } from './geometry.js'
+import type { GestureResult } from './gestures.js'
+import { NEW_NODE_WIDTH } from './gestures.js'
+import {
+  DOCUMENT_NODE_HEIGHT,
+  DOCUMENT_NODE_WIDTH,
+  fileNodeDefaults,
+  GROUP_FRAME_HEIGHT,
+  GROUP_FRAME_WIDTH,
+  groupEnclosure,
+  groupNodeDefaults,
+  IMAGE_NODE_HEIGHT,
+  IMAGE_NODE_WIDTH,
+  imageNodeDefaults,
+  LINK_NODE_HEIGHT,
+  linkNodeDefaults,
+  resolveSpawnPoint,
+} from './node-factories.js'
+import { DOCK_OCCLUSION_PX } from './ToolPalette.js'
+import type { ContainerSize, Point, Viewport } from './viewport.js'
+import { panToShowTarget, screenToCanvas } from './viewport.js'
+
+export interface NodeCreationInputs {
+  readonly rootRef: RefObject<HTMLDivElement | null>
+  /** The editor's always-current canvas mirror. */
+  readonly canvasRef: MutableRefObject<SpatialCanvas>
+  readonly viewport: Viewport
+  readonly setViewport: (updater: (vp: Viewport) => Viewport) => void
+  readonly createId: (() => string) | undefined
+  readonly fileRefOptions: readonly FileRefOption[] | undefined
+  readonly onAddImage: ((file: File) => Promise<string | undefined>) | undefined
+  /**
+   * The command sink: the same applyResult every gesture goes through, so a
+   * palette/menu creation writes the canvas, the selection primary and the
+   * gesture state exactly as a pointer-driven one would.
+   */
+  readonly applyResult: (result: GestureResult) => void
+  /**
+   * Creation selects the new node EXCLUSIVELY — applyResult's selectedId
+   * sets the primary, and this drops the old extras that would otherwise
+   * ride along into the next move/delete.
+   */
+  readonly collapseExtras: () => void
+  readonly containerSizeOf: (root: HTMLDivElement | null) => ContainerSize | null
+}
+
+/**
+ * The spawn-at-a-point creation family — everything the palette, the
+ * context menu and drops create WITHOUT a gesture: link, file-reference,
+ * image and group nodes, plus the group-the-selection verb. The
+ * double-press note creator stays in the editor: it goes through the
+ * gesture reducer, not this family's idle-state results.
+ *
+ * The free-spot cascade can push a created node outside the visible
+ * viewport, leaving the user staring at an unchanged canvas. When the
+ * created box does not fully fit on screen, `panToShow` pans (keeping the
+ * zoom) so it sits centered — creation is always visible feedback.
+ */
+export function useNodeCreation({
+  rootRef,
+  canvasRef,
+  viewport,
+  setViewport,
+  createId,
+  fileRefOptions,
+  onAddImage,
+  applyResult,
+  collapseExtras,
+  containerSizeOf,
+}: NodeCreationInputs) {
+  /**
+   * The canvas-space rectangle a person can actually see: the root, minus
+   * the strip the dock paints over. Creation places inside this before it
+   * places anywhere else, which is what keeps the view still.
+   */
+  const visibleCanvasRect = (): Box | undefined => {
+    const containerSize = containerSizeOf(rootRef.current)
+    if (containerSize === null) return undefined
+    const topLeft = screenToCanvas({ x: 0, y: 0 }, viewport)
+    return {
+      x: topLeft.x,
+      y: topLeft.y,
+      width: containerSize.width / viewport.zoom,
+      height: (containerSize.height - DOCK_OCCLUSION_PX) / viewport.zoom,
+    }
+  }
+
+  const panToShow = (box: Box) => {
+    const containerSize = containerSizeOf(rootRef.current)
+    if (containerSize === null) return
+    setViewport(
+      (vp) => panToShowTarget(box, vp, containerSize, { bottom: DOCK_OCCLUSION_PX }) ?? vp,
+    )
+  }
+
+  const newId = () =>
+    createId?.() ??
+    (typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : String(Math.random()))
+
+  const spawnPoint = (at: Point | undefined, size: { width: number; height: number }): Point => {
+    const root = rootRef.current
+    const centerScreen =
+      root === null ? { x: 0, y: 0 } : { x: root.clientWidth / 2, y: root.clientHeight / 2 }
+    const preferred = screenToCanvas(centerScreen, viewport)
+    const occupied = indexNodeBoxes(canvasRef.current).map((b) => b.box)
+    return resolveSpawnPoint(at, preferred, size, occupied, visibleCanvasRect())
+  }
+
+  const createLinkAtViewportCenter = (url: string, at?: Point) => {
+    const point = spawnPoint(at, { width: NEW_NODE_WIDTH, height: LINK_NODE_HEIGHT })
+    const id = newId()
+    const node = linkNodeDefaults(id, point, url)
+    applyResult({
+      state: { kind: 'idle' },
+      commands: [{ kind: 'create-node', node }],
+      selectedId: id,
+    })
+    collapseExtras()
+    panToShow({ x: node.x, y: node.y, width: node.width, height: node.height })
+  }
+
+  /** File nodes are reference cards like links — same shorter default box. */
+  const createFileRefAtViewportCenter = (file: string, at?: Point) => {
+    // The picked option's kind decides the box: a markdown document
+    // renders its prose inside the node and needs room a one-line
+    // reference card does not have.
+    const kind = fileRefOptions?.find((option) => option.file === file)?.kind
+    const point = spawnPoint(
+      at,
+      kind === 'markdown'
+        ? { width: DOCUMENT_NODE_WIDTH, height: DOCUMENT_NODE_HEIGHT }
+        : { width: NEW_NODE_WIDTH, height: LINK_NODE_HEIGHT },
+    )
+    const id = newId()
+    const node = fileNodeDefaults(id, point, file, kind)
+    applyResult({
+      state: { kind: 'idle' },
+      commands: [{ kind: 'create-node', node }],
+      selectedId: id,
+    })
+    collapseExtras()
+    panToShow({ x: node.x, y: node.y, width: node.width, height: node.height })
+  }
+
+  const createImageNodeAt = (file: string, at?: Point) => {
+    const point = spawnPoint(at, { width: IMAGE_NODE_WIDTH, height: IMAGE_NODE_HEIGHT })
+    const id = newId()
+    const node = imageNodeDefaults(id, point, file)
+    applyResult({
+      state: { kind: 'idle' },
+      commands: [{ kind: 'create-node', node }],
+      selectedId: id,
+    })
+    collapseExtras()
+    panToShow({ x: node.x, y: node.y, width: node.width, height: node.height })
+  }
+
+  /** Stores the image via the host seam, then creates the node. */
+  const addImageFile = (file: File, at?: Point) => {
+    if (onAddImage === undefined || !file.type.startsWith('image/')) return
+    void onAddImage(file).then((ref) => {
+      if (ref !== undefined) createImageNodeAt(ref, at)
+    })
+  }
+
+  const createGroupAtViewportCenter = (at?: Point) => {
+    const point = spawnPoint(at, { width: GROUP_FRAME_WIDTH, height: GROUP_FRAME_HEIGHT })
+    const id = newId()
+    const node = groupNodeDefaults(id, point)
+    applyResult({
+      state: { kind: 'idle' },
+      commands: [{ kind: 'create-group', node }],
+      selectedId: id,
+    })
+    collapseExtras()
+    panToShow({ x: node.x, y: node.y, width: node.width, height: node.height })
+  }
+
+  /** Frames the current multi-selection: enclosing box + padding. */
+  const groupSelection = (memberIds: readonly string[]) => {
+    const members = canvasRef.current.nodes.filter((n) => memberIds.includes(n.id))
+    const frame = groupEnclosure(members)
+    if (frame === undefined) return
+    const id = newId()
+    applyResult({
+      state: { kind: 'idle' },
+      commands: [{ kind: 'create-group', node: { id, type: 'group', ...frame } }],
+      selectedId: id,
+    })
+    collapseExtras()
+  }
+
+  return {
+    visibleCanvasRect,
+    panToShow,
+    createLinkAtViewportCenter,
+    createFileRefAtViewportCenter,
+    createImageNodeAt,
+    addImageFile,
+    createGroupAtViewportCenter,
+    groupSelection,
+  }
+}


### PR DESCRIPTION
## Summary

PR 4 (final planned slice) of the SpatialEditor decomposition (3563 → 3382 lines, after #1192). Moves the gesture-free creators into `use-node-creation.ts`, behavior-preserving:

- `createLinkAtViewportCenter`, `createFileRefAtViewportCenter`, `createImageNodeAt`, `addImageFile`, `createGroupAtViewportCenter`, and the group-the-selection verb
- `visibleCanvasRect` (the dock-aware placement rect) and `panToShow` (creation is always visible feedback)

The seam is **`applyResult`** — the same command sink every gesture goes through — plus a `collapseExtras` callback, so creation still selects the new node exclusively through the selection reducer. The double-press note creator stays in the editor: it goes through the gesture reducer, not this family's idle-state results.

The four verbatim copies of the center/occupied/`resolveSpawnPoint` preamble collapse into one `spawnPoint` helper — same expressions, one spelling.

`purity-guard.test.ts`'s command-boundary scan also walks the new hook (zero `onChange` calls today, scanned so a future direct write cannot slip in).

After this slice the remaining editor is the parts the decomposition plan marked do-not-extract (the gesture reducer wiring, `applyResult`, the selection pair, pointer handlers) — the coupled core, not backlog.

## Test plan

- [x] spatial-editor jsdom suite: 43 files / 475 tests green
- [x] Creation-covering browser suites un-weakened: context-menu, group-node, image-node, file-node-markdown, SpatialEditor.browser — 5 files / 69 tests green
- [x] `pnpm knip` clean; typecheck green

## Visual evidence

Visual evidence: none — behavior-preserving code move with no pixel change; creation placement, pan-to-show and group framing are pinned by the real-browser suites listed in the Test plan.

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_