### PR TITLE
docs: fix five doc-vs-reality drifts the codebase-health audit verified

### DIFF
--- a/.env.server.example
+++ b/.env.server.example
@@ -21,5 +21,6 @@ WHITEBOARD_SERVER_JWT_AUDIENCE=whiteboard
 # JWKS endpoint served by your identity provider (https://, no credentials, no query params).
 WHITEBOARD_SERVER_JWKS_URI=https://auth.example.com/.well-known/jwks.json
 
-# Comma-separated list of allowed origins for CORS (no wildcards).
+# Comma-separated list of allowed origins for CORS: exact https:// origins, or a
+# https://*.example.com leftmost-label wildcard subdomain pattern per entry (bare * is rejected).
 WHITEBOARD_SERVER_ALLOWED_ORIGINS=https://whiteboard.example.com

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,12 +63,12 @@ Do not stop at manual verification without preserving the scenario in automation
 
 ## Browser Mode And Trace
 
-`canvas-viewer-browser` is the default place for real browser regression tests in `packages/canvas-viewer`. Use `web-browser` for `apps/web` browser tests (IndexedDB, OPFS, etc.). `pnpm test:browser` runs both.
+`canvas-viewer-browser` is the default place for real browser regression tests in `packages/canvas-viewer`. Use `web-browser` for `apps/web` browser tests (IndexedDB, OPFS, etc.). `pnpm test:browser` runs all three browser projects: `canvas-viewer-browser`, `web-browser`, and `canvas-render-browser`.
 
 Use:
 
 ```bash
-pnpm run test:browser        # canvas-viewer-browser + web-browser
+pnpm run test:browser        # canvas-viewer-browser + web-browser + canvas-render-browser
 pnpm run test:browser:trace  # same, with trace artifacts on failure
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,8 @@ Thanks for considering a contribution. This repo is a pnpm monorepo for `@kamiaz
 ```bash
 git clone https://github.com/kamiazya/whiteboard.git
 cd whiteboard      # Node: match .node-version (currently 24) — use nvm / fnm / Volta
+                   # ImageMagick (convert/identify) is also required — pnpm test:scripts and pnpm check:local call it;
+                   # full prerequisites: docs/contributing/development.md
 pnpm install
 pnpm exec playwright install --with-deps chromium   # required for the browser test projects (canvas-viewer-browser / web-browser)
 pnpm test         # all 22 vitest projects (listed under Workflow below)

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Add to `~/.gemini/settings.json`:
 
 ### Verify
 
-In your agent session, ask it to call `wb_document_create({ workspaceId: "default", path: "smoke", kind: "spatial" })`. The call creates `~/.whiteboard/{workspaceId}/`; open `http://127.0.0.1:<port>/w/{workspaceId}/canvas/smoke` in a browser tab to see it.
+In your agent session, ask it to call `wb_document_create({ workspaceId: "default", path: "smoke", kind: "spatial" })`. The call creates `~/.whiteboard/{workspaceId}/`; open `http://127.0.0.1:<port>/w/{workspaceId}/d/smoke` in a browser tab to see it.
 
 ## Pair with your local daemon
 

--- a/skills/auditing-workspaces/SKILL.md
+++ b/skills/auditing-workspaces/SKILL.md
@@ -29,7 +29,7 @@ For the main drawing workflow, see the drawing-visuals skill in `skills/drawing-
 wb_document_list({ workspaceId })
 ```
 
-Returns `{ canvases: [{ documentId, path, name? }] }` — placement only, no content. An unknown
+Returns `{ documents: [{ documentId, path, name?, kind?, updatedAt?, shadowed? }] }` — placement only, no content. An unknown
 `workspaceId` is an error here, not an empty list, so a typo reads as a failure rather than "nothing
 found."
 


### PR DESCRIPTION
## Summary

The standing codebase-health audit surfaced a "documentation says X, reality is Y" cluster. Each item was verified against the code before editing:

- **README.md** — the Quick Install verify step linked `/w/{workspaceId}/canvas/smoke`; the real route grammar is `/w/:workspaceId/d/:path` (App.tsx), and `/canvas/` is the retired container sense.
- **skills/auditing-workspaces/SKILL.md** — documented `wb_document_list`'s response as `{ canvases: [...] }`; `wbDocumentListOutputSchema` says `{ documents: [{ documentId, path, name?, kind?, updatedAt?, shadowed? }] }`. (The rest of `skills/` was spot-checked for the same drift — this was the only occurrence of `canvases`.)
- **.env.server.example** — claimed `WHITEBOARD_SERVER_ALLOWED_ORIGINS` takes "no wildcards"; `server-mode-env-config.ts` accepts leftmost-label `https://*.example.com` wildcard-subdomain patterns (bare `*` stays rejected), matching `docs/reference/configuration.md`.
- **AGENTS.md** — said `pnpm test:browser` runs two projects; `package.json` runs three (`canvas-viewer-browser`, `web-browser`, `canvas-render-browser`) — the exact silent project-filter-shrinkage hazard AGENTS.md itself warns about.
- **CONTRIBUTING.md** — the Quick start omitted the ImageMagick prerequisite `pnpm test:scripts` (and so `pnpm check:local`) needs, and never linked `docs/contributing/development.md`'s fuller prerequisites.

## Test plan

- [x] `pnpm check:local` green (exit 0 — includes `intent:validate` over the edited skill file and `secretlint` over all edited files)
- [x] `pnpm test --project mcp-node`: 365/366 files green; the single failure is `local-node-version.test.ts` — the known guard for this container's Node 22 vs the pinned 24 (CI installs 24), unrelated to the diff
- [x] Greped tests for the corrected phrases (`runs both`, `canvas/smoke`, `no wildcards`) — no test pins the old wording

## Visual evidence

Visual evidence: none — documentation-only change with no runtime or pixel effect.

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CORS configuration guidance to support comma-separated exact origins and wildcard subdomains while rejecting bare wildcards.
  * Documented the additional browser test project and ImageMagick prerequisite.
  * Corrected the README verification URL.
  * Updated workspace auditing guidance to reflect the current document listing response format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->