### PR TITLE
test(mcp-server): pin GET /api/workspaces counting its rows sequentially

### DIFF
--- a/packages/mcp-server/src/server/routes/document/workspaces.test.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.test.ts
@@ -138,6 +138,62 @@ describe('GET /api/workspaces', () => {
     expect('segment' in (bare ?? {})).toBe(false)
     expect('displayName' in (bare ?? {})).toBe(false)
   })
+
+  // SEQUENTIAL, and that is the load-bearing part (the route's own comment):
+  // `Promise.all` over the rows opens N workspace records at once against
+  // the one SQLite file, and on a real daemon holding real workspaces that
+  // 500ed every row with SQLITE_BUSY. That contention cannot be reproduced
+  // deterministically here — each test gets a fresh, idle database — so this
+  // pins the DECISION instead of the symptom: the per-row document listings
+  // never overlap. Reverting the loop to `Promise.all` drives the observed
+  // peak concurrency to the row count and fails the last assertion.
+  it('counts each workspace sequentially — the per-row listings never overlap', async () => {
+    const db = await getDb(tmp.dir)
+    const deps = resolveServerDeps(
+      createContainer(createStoreLocalModule({ db, blobDir: tmp.dir })),
+    )
+    for (const workspaceId of ['workspace-a', 'workspace-b', 'workspace-c']) {
+      await deps.documentIndex.createWorkspace({ workspaceId })
+    }
+    let inFlight = 0
+    let peak = 0
+    const inner = deps.documentIndex
+    const index = new Proxy(inner, {
+      get(target, key) {
+        if (key === 'listDocuments') {
+          return async (...args: unknown[]) => {
+            inFlight += 1
+            peak = Math.max(peak, inFlight)
+            // Long enough that a Promise.all shape reliably overlaps all
+            // three rows before the first listing resolves.
+            await new Promise((resolve) => setTimeout(resolve, 5))
+            try {
+              return await (inner.listDocuments as (...a: unknown[]) => Promise<unknown>).apply(
+                target,
+                args,
+              )
+            } finally {
+              inFlight -= 1
+            }
+          }
+        }
+        const value = Reflect.get(target, key, target)
+        return typeof value === 'function'
+          ? (value as (...a: unknown[]) => unknown).bind(target)
+          : value
+      },
+    }) as typeof deps.documentIndex
+
+    const app = createWorkspacesRouter({ serverDeps: { ...deps, documentIndex: index } })
+    const res = await app.request('/api/workspaces')
+    expect(res.status).toBe(200)
+    const parsed = listWorkspacesResponseSchema.parse(await res.json())
+    expect(parsed.workspaces).toHaveLength(3)
+    expect(
+      peak,
+      'GET /api/workspaces overlapped its per-row document listings — the Promise.all shape that 500ed a real daemon with SQLITE_BUSY',
+    ).toBe(1)
+  })
 })
 
 describe('POST /api/workspaces/:workspaceId/documents', () => {

--- a/packages/mcp-server/src/server/routes/document/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.ts
@@ -136,8 +136,10 @@ export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
       // and on a real daemon holding real workspaces that made the whole
       // listing fail with `SQLITE_BUSY: database is locked` — a 500 for every
       // row because of contention this route introduced. A/B against a live
-      // daemon: concurrent 500, sequential 200. No test here reaches it; each
-      // one gets a fresh temp database with nothing else touching it.
+      // daemon: concurrent 500, sequential 200. The contention itself is not
+      // reproducible here (each test gets a fresh, idle database), so the
+      // DECISION is pinned instead: workspaces.test.ts asserts the per-row
+      // listings never overlap, and a Promise.all revert fails it.
       //
       // The cost that buys: measured end-to-end over HTTP against that same
       // daemon — 11 workspaces, 38 documents — best of 7 is 4.2ms, on a


### PR DESCRIPTION
## Summary

Closes the HIGH test-gap the codebase-health audit verified: the `GET /api/workspaces` handler counts documents per workspace in a **sequential** loop on purpose — `Promise.all` over the rows opens N workspace records at once against the one SQLite file and 500ed a real daemon with `SQLITE_BUSY` — but nothing failed if the loop was reverted (the route's own comment admitted "No test here reaches it").

The contention itself is not deterministically reproducible in tests (each gets a fresh, idle database), so the new case pins the **decision** instead of the symptom: an injected `documentIndex` (same Proxy pattern as the file's `depsWithFailing`) measures peak in-flight `listDocuments` concurrency through the real route and asserts it never exceeds 1, with a per-call delay long enough that a `Promise.all` shape reliably overlaps.

The route comment's stale sentence now points at the guard.

## Test plan

- [x] `pnpm vitest run --project mcp-node src/server/routes/document/workspaces.test.ts` — 52/52 green
- [x] Mutation check: reverting the loop to `Promise.all` → the new test fails with peak = row count, naming the SQLITE_BUSY history; restore → green
- [x] `pnpm --filter @kamiazya/whiteboard-mcp typecheck` green

## Visual evidence

Visual evidence: none — server-side test-only change with no user-visible effect.

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_