### PR TITLE
test(mcp-server): exercise wb_document_delete and wb_document_resolve in the e2e smoke

### DIFF
--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -334,6 +334,35 @@ async function main() {
   }
   console.log('[e2e] wb_document_create/list → name round-trips, unnamed stays unnamed')
 
+  // wb_document_resolve: id → placement, through the real outputSchema.
+  const resolved = await callTool('wb_document_resolve', {
+    workspaceId: WORKSPACE_ID,
+    documentId: named.documentId,
+  })
+  if (resolved.documentId !== named.documentId || resolved.path !== named.path) {
+    throw new Error(`wb_document_resolve returned unexpected shape: ${JSON.stringify(resolved)}`)
+  }
+  console.log(`[e2e] wb_document_resolve → ${resolved.documentId} at ${resolved.path}`)
+
+  // wb_document_delete: a throwaway document, deleted and gone from the list.
+  const doomed = await callTool('wb_document_create', {
+    workspaceId: WORKSPACE_ID,
+    path: 'doomed',
+    kind: 'spatial',
+  })
+  const deletion = await callTool('wb_document_delete', {
+    workspaceId: WORKSPACE_ID,
+    documentId: doomed.documentId,
+  })
+  if (deletion.deleted !== true) {
+    throw new Error(`wb_document_delete returned unexpected shape: ${JSON.stringify(deletion)}`)
+  }
+  const afterDelete = await callTool('wb_document_list', { workspaceId: WORKSPACE_ID })
+  if (afterDelete.documents.some((doc) => doc.documentId === doomed.documentId)) {
+    throw new Error('wb_document_delete left the document in the listing')
+  }
+  console.log('[e2e] wb_document_delete → deleted and gone from the list')
+
   // A facet is OKF frontmatter, so it belongs to the markdown document; the
   // spatial one refuses it.
   const facets = await callTool('wb_facet_set', {

--- a/packages/mcp-server/src/server/mcp/mcp-smoke-coverage.ts
+++ b/packages/mcp-server/src/server/mcp/mcp-smoke-coverage.ts
@@ -83,6 +83,8 @@ export const COVERED_TOOLS = [
   'wb_scene_render',
   'wb_document_get',
   'wb_document_list',
+  'wb_document_resolve',
+  'wb_document_delete',
 ] as const
 
 // wb_pairing_link_create's smoke coverage is deliberately its error path
@@ -105,7 +107,7 @@ export const ERROR_PATH_ONLY_TOOLS = ['wb_pairing_link_create'] as const
 // be a claim nobody checks.
 export const UI_LINKED_TOOLS = ['canvas_view'] as const
 
-export const UNIT_ONLY_TOOLS = ['wb_document_delete', 'wb_document_resolve'] as const
+export const UNIT_ONLY_TOOLS = [] as const satisfies readonly string[]
 
 export type DeferredTool = {
   name: string


### PR DESCRIPTION
## Summary

Closes the audit's zod-schema-discipline gap: `wb_document_delete` and `wb_document_resolve` were unit-tested only — never called through the MCP JSON-RPC boundary where the SDK validates `structuredContent` against `outputSchema`, the runtime drift the type system can't see (AGENTS.md calls the smoke the "last line of defense" for exactly this).

- The smoke now resolves a created document's id back to its placement (`wb_document_resolve` → documentId + path echo).
- Then creates a throwaway document, deletes it (`wb_document_delete` → `{ deleted: true }`), and asserts it is gone from the next `wb_document_list`.
- Both tools move from `UNIT_ONLY_TOOLS` (now empty) to `COVERED_TOOLS`; the parity guards (`smoke-tool-list-parity.test.ts`, `tool-structured-content.property.test.ts`) pin the move — 27/27 green.

## Test plan

- [x] `pnpm smoke:e2e` against a freshly built daemon: **ALL OK**, including the two new steps
- [x] `pnpm vitest run --project mcp-node src/server/mcp/smoke-tool-list-parity.test.ts src/server/mcp/tool-structured-content.property.test.ts` — 27/27
- [x] `pnpm --filter @kamiazya/whiteboard-mcp typecheck` green

## Visual evidence

Visual evidence: none — smoke/test-only change with no user-visible effect.

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_