### PR TITLE
refactor(web): delete the unreachable Excalidraw-shaped export branch

### DIFF
--- a/apps/web/src/lib/document-sync-export.ts
+++ b/apps/web/src/lib/document-sync-export.ts
@@ -1,131 +1,21 @@
-import { SPATIAL_DARK_PALETTE, SPATIAL_LIGHT_PALETTE } from '@kamiazya/whiteboard-canvas-render'
 import type { ExportRequestPayload } from '@kamiazya/whiteboard-mcp/browser-contract'
 
-// Ported verbatim from the original daemon-served UI's useWhiteboardSync
-// helpers (since retired; buildWhiteboardWsProtocols/buildWhiteboardWsUrl and
-// applyRestoreComplete/RestoreCompleteDeps were intentionally excluded —
-// daemon-only / trivially inlined at the call site instead).
-//
-// document-sync-session.ts wires `api: null` permanently (SpatialEditor has no
-// Excalidraw-shaped imperative API), so `sendExportResponse` below is
-// unreachable today and only the queueing path in
-// handleIncomingExportRequest/flushPendingExportRequests ever runs.
-//
-// The element/files shapes are declared locally rather than imported from
-// `@excalidraw/excalidraw`: only `id`/`type`/`fontSize`/`frameId` are read
-// and `files` is passed through opaquely, so the structural declaration
-// carries the whole contract without the dependency.
-type ExportElement = {
-  id: string
-  type: string
-  fontSize: number
-  frameId?: string | null
-}
-
-type ExportFiles = Record<string, unknown>
-
-type ExportApi = {
-  getSceneElements: () => readonly ExportElement[]
-  getAppState: () => Record<string, unknown>
-  getFiles: () => ExportFiles
-}
-
+// The browser session has no imperative editor handle that could render an
+// export, so an incoming export request can only be QUEUED — the daemon's
+// export path renders headlessly on its own side, and nothing in the
+// browser answers these. The queue records the requests so a future editor
+// handle could serve them; until one exists there is deliberately no
+// serving branch here.
 type ExportRequestPayloadNoType = Omit<ExportRequestPayload, 'type'>
 
 export interface ExportRequestHandlerDeps {
-  api: ExportApi | null
   pending: ExportRequestPayloadNoType[]
-  send: (message: string) => void
-  exportToBlobFn: (args: {
-    elements: readonly ExportElement[]
-    appState: Record<string, unknown>
-    files: ExportFiles
-    exportPadding: number
-  }) => Promise<Blob>
-  blobToBase64Fn: (blob: Blob) => Promise<string>
 }
 
-async function sendExportResponse(
-  msg: ExportRequestPayloadNoType,
-  api: ExportApi,
-  deps: Omit<ExportRequestHandlerDeps, 'api' | 'pending'>,
-): Promise<void> {
-  const rawElements = api.getSceneElements()
-  // If frameId is set, keep only that frame's children (el.frameId === target) and the frame itself.
-  // A missing frameId resolves to an empty list.
-  const frameId = msg.frameId
-  const scoped: readonly ExportElement[] =
-    frameId !== undefined
-      ? rawElements.filter((el) => el.id === frameId || el.frameId === frameId)
-      : rawElements
-  const minFontPx = msg.minFontPx
-  const elements: readonly ExportElement[] =
-    minFontPx !== undefined
-      ? scoped.map((el) => {
-          if (el.type !== 'text' || el.fontSize >= minFontPx) {
-            return el
-          }
-          return { ...el, fontSize: minFontPx }
-        })
-      : scoped
-  const rawAppState = api.getAppState()
-  // Mirror the headless renderer: when the export request forces a theme
-  // we override appState.theme and viewBackgroundColor so the same canvas
-  // renders consistently across the browser and headless paths.
-  const themeOverride =
-    msg.theme !== undefined
-      ? {
-          theme: msg.theme,
-          viewBackgroundColor:
-            msg.theme === 'dark' ? SPATIAL_DARK_PALETTE.surface : SPATIAL_LIGHT_PALETTE.surface,
-        }
-      : null
-  const appState = {
-    ...rawAppState,
-    exportEmbedScene: true,
-    ...(msg.scale !== undefined ? { exportScale: msg.scale } : {}),
-    ...(themeOverride ?? {}),
-  }
-  const blob = await deps.exportToBlobFn({
-    elements,
-    appState,
-    files: api.getFiles(),
-    exportPadding: msg.padding ?? 10,
-  })
-  const base64 = await deps.blobToBase64Fn(blob)
-  deps.send(
-    JSON.stringify({
-      type: 'export_response',
-      requestId: msg.requestId,
-      data: base64,
-    }),
-  )
-}
-
-export async function handleIncomingExportRequest(
+export function handleIncomingExportRequest(
   msg: ExportRequestPayloadNoType,
   deps: ExportRequestHandlerDeps,
-): Promise<'queued' | 'sent'> {
-  if (!deps.api) {
-    deps.pending.push(msg)
-    return 'queued'
-  }
-  await sendExportResponse(msg, deps.api, deps)
-  return 'sent'
-}
-
-export async function flushPendingExportRequests(deps: ExportRequestHandlerDeps): Promise<number> {
-  if (!deps.api || deps.pending.length === 0) return 0
-  const queued = deps.pending.splice(0, deps.pending.length)
-  let sent = 0
-  try {
-    for (const msg of queued) {
-      await sendExportResponse(msg, deps.api, deps)
-      sent += 1
-    }
-    return sent
-  } catch (err) {
-    deps.pending.unshift(...queued.slice(sent))
-    throw err
-  }
+): 'queued' {
+  deps.pending.push(msg)
+  return 'queued'
 }

--- a/apps/web/src/lib/document-sync-session.ts
+++ b/apps/web/src/lib/document-sync-session.ts
@@ -26,15 +26,12 @@ import type {
 /** Why a backend read or write failed. The published contract's own union. */
 export type BackendErrorReason = Parameters<NonNullable<DocumentBackendHandlers['onError']>>[0]
 
-import { exportResponseMessageSchema } from '@kamiazya/whiteboard-mcp/browser-shared'
 import type { SpatialCanvas, StoredCoreFacets } from '@kamiazya/whiteboard-model'
 import { LoroDoc, UndoManager } from 'loro-crdt'
-import type { z } from 'zod'
 import type { EditorCommand, EditorLeafCommand } from '../components/spatial-editor/commands.js'
 import { getAppLogger } from './app-logger.js'
 import {
   type ExportRequestHandlerDeps,
-  flushPendingExportRequests,
   handleIncomingExportRequest,
 } from './document-sync-export.js'
 import {
@@ -466,38 +463,6 @@ export function createDocumentSyncSession(
     notify(canvas, 'external')
   }
 
-  // Bridges flushPendingExportRequests'/handleIncomingExportRequest's
-  // string-message `send` contract to DocumentBackend's typed
-  // sendExportResponse(requestId, data) method.
-  function sendExportResponseMessage(message: string): void {
-    let parsed: z.infer<typeof exportResponseMessageSchema>
-    try {
-      parsed = exportResponseMessageSchema.parse(JSON.parse(message))
-    } catch {
-      return
-    }
-    backend.sendExportResponse(parsed.requestId, parsed.data)
-  }
-
-  function buildExportDeps(): ExportRequestHandlerDeps {
-    return {
-      // lane B (document-sync-export.ts) owns replacing ExportRequestHandlerDeps's
-      // Excalidraw-shaped `api` entirely; this session has no imperative
-      // editor handle to supply, so every export request only ever queues —
-      // exportToBlobFn/blobToBase64Fn are consequently unreachable (they are
-      // only invoked once `api` is non-null).
-      api: null,
-      pending: pendingExportRequests,
-      send: sendExportResponseMessage,
-      exportToBlobFn: () => {
-        throw new Error('exportToBlobFn is unreachable while api stays null')
-      },
-      blobToBase64Fn: () => {
-        throw new Error('blobToBase64Fn is unreachable while api stays null')
-      },
-    }
-  }
-
   // Debounce window (ms): edits fired within this window of each other
   // coalesce into a single commit firing.
   const DEBOUNCE_MS = 300
@@ -745,13 +710,9 @@ export function createDocumentSyncSession(
         }
       },
 
-      async onExportRequest(payload) {
+      onExportRequest(payload) {
         if (isStale()) return
-        try {
-          await handleIncomingExportRequest(payload, buildExportDeps())
-        } catch (err) {
-          log.error('onExportRequest failed', err)
-        }
+        handleIncomingExportRequest(payload, { pending: pendingExportRequests })
       },
 
       onAuthError() {
@@ -846,9 +807,6 @@ export function createDocumentSyncSession(
 
   function onEditorReady(): void {
     backend.sendClientReady()
-    void flushPendingExportRequests(buildExportDeps()).catch((err: unknown) => {
-      log.error('flushPendingExportRequests failed', err)
-    })
   }
 
   function clearUndo(): void {


### PR DESCRIPTION
## Summary

Closes the audit's dead-code finding in `document-sync-export.ts` (−152 lines net). `document-sync-session.ts` wires `api: null` permanently — SpatialEditor has no Excalidraw-shaped imperative handle — so everything behind that guard was permanently dead:

- `sendExportResponse` and the `ExportApi`/`ExportElement`/`ExportFiles` shapes
- `exportToBlobFn`/`blobToBase64Fn` (wired as throw-if-called stubs)
- the string-message `send` bridge (`sendExportResponseMessage` + its `exportResponseMessageSchema` parse)
- `flushPendingExportRequests` (always answered 0)

knip couldn't see any of it because the functions were still called — always through the dead branch's guard.

`ExportRequestHandlerDeps` collapses to `{ pending }`; `handleIncomingExportRequest` is the synchronous queue write it always effectively was. The queue itself stays: it records incoming export requests for a future editor handle, and the daemon's export path renders headlessly on its own side. No published contract changes (`exportResponseMessageSchema` stays exported from the daemon's browser-shared subpath; only its unreachable browser call site is gone).

## Test plan

- [x] `useDocumentSync.test.ts` 36/36 — including the existing pin that an export request never reaches `backend.sendExportResponse`, which holds unchanged through the deletion
- [x] `document-sync-session.test.ts` 35/35
- [x] Full `pnpm --filter @kamiazya/whiteboard-web test`: 3103 passed; the 10 failures are this container's recorded environment baseline (9 Node-22 Blob/objectURL jsdom failures + the known load-dependent `BrowserDocumentPage.dialog-outlives-document` local flake), none reachable from this diff — CI runs Node 24
- [x] `pnpm knip` clean; apps/web typecheck green

## Visual evidence

Visual evidence: none — dead-code deletion with no reachable behavior change; the queue-only export behavior is pinned by the existing sync tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_