### PR TITLE
feat(web): finish single-line edits on Enter without breaking IME, and say the editors' exit chords

### DIFF
--- a/apps/web/src/components/EditorExitHint.test.tsx
+++ b/apps/web/src/components/EditorExitHint.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { EditorExitHint } from './EditorExitHint.js'
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+function stubPlatform(platform: string) {
+  vi.stubGlobal('navigator', { ...window.navigator, platform })
+}
+
+describe('EditorExitHint', () => {
+  it('names the Mac command glyph on a Mac-family platform', () => {
+    stubPlatform('MacIntel')
+    render(<EditorExitHint />)
+    expect(screen.getByTestId('editor-exit-hint').textContent).toContain('⌘↩')
+  })
+
+  it('names Ctrl everywhere else', () => {
+    stubPlatform('Win32')
+    render(<EditorExitHint />)
+    const hint = screen.getByTestId('editor-exit-hint')
+    expect(hint.textContent).toContain('Ctrl+↩')
+    expect(hint.textContent).not.toContain('⌘')
+  })
+
+  it('says both exits, and stays decoration (hidden, no pointer target)', () => {
+    stubPlatform('MacIntel')
+    render(<EditorExitHint />)
+    const hint = screen.getByTestId('editor-exit-hint')
+    expect(hint.textContent).toContain('Done')
+    expect(hint.textContent).toContain('Cancel')
+    expect(hint.getAttribute('aria-hidden')).toBe('true')
+    expect(hint.className).toContain('pointer-events-none')
+  })
+})

--- a/apps/web/src/components/EditorExitHint.tsx
+++ b/apps/web/src/components/EditorExitHint.tsx
@@ -1,0 +1,42 @@
+import type { CSSProperties } from 'react'
+import { cn } from '@/lib/utils'
+import { isMacPlatform } from '../lib/platform.js'
+
+const KBD =
+  'rounded border border-border bg-background px-1 py-px font-sans text-[10px] text-muted-foreground'
+
+/**
+ * A text-editor overlay's exit semantics, said where the typing happens:
+ * mod+Enter commits, Escape cancels. Blur also commits, but blur is what a
+ * hand finds by accident — this strip answers "how do I say done?", the
+ * question the shortcut catalog records someone failing to answer while an
+ * editor was open (shortcuts.ts, `commit-text-edit`).
+ *
+ * Decoration by design: `aria-hidden` (the editors carry the same chord in
+ * `aria-keyshortcuts`), no pointer target, never focusable.
+ */
+export function EditorExitHint({
+  className,
+  style,
+}: {
+  readonly className?: string
+  readonly style?: CSSProperties
+}) {
+  return (
+    <span
+      aria-hidden="true"
+      data-testid="editor-exit-hint"
+      className={cn(
+        'text-muted-foreground pointer-events-none inline-flex items-center gap-1 text-[11px] leading-none whitespace-nowrap select-none',
+        className,
+      )}
+      style={style}
+    >
+      <kbd className={KBD}>{isMacPlatform() ? '⌘↩' : 'Ctrl+↩'}</kbd>
+      <span>Done</span>
+      <span className="opacity-60">·</span>
+      <kbd className={KBD}>esc</kbd>
+      <span>Cancel</span>
+    </span>
+  )
+}

--- a/apps/web/src/components/HeaderBranchChip.tsx
+++ b/apps/web/src/components/HeaderBranchChip.tsx
@@ -43,6 +43,7 @@ import type { MergeResult } from '@/hooks/useBranches'
 import { useBranches } from '@/hooks/useBranches'
 import { safeErrorCopy } from '@/lib/error-copy'
 import { cn, displayBranchName } from '@/lib/utils'
+import { isImeComposingKeydown } from '../lib/ime-keydown.js'
 
 // MergeDialog pulls in its own thumbnail-fetch effect and a second Dialog
 // surface; loading it on demand keeps it out of the daemon-canvas chunk
@@ -567,7 +568,7 @@ export function HeaderBranchChip({
             value={renameDraft}
             onChange={(e) => setRenameDraft(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') {
+              if (e.key === 'Enter' && !isImeComposingKeydown(e.nativeEvent)) {
                 e.preventDefault()
                 void submitRename()
               }

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -4,6 +4,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { useDaemonApi } from '@/contexts/DaemonApiContext'
 import { useDirtyState } from '@/hooks/useDirtyState'
 import { getAppLogger } from '@/lib/app-logger'
+import { isMacPlatform } from '../lib/platform.js'
 import { HeaderBranchChip } from './HeaderBranchChip'
 import { HeaderVersionDot } from './HeaderVersionDot'
 import { TopBarSecondaryActions } from './workspace-top-bar/TopBarSecondaryActions'
@@ -127,7 +128,7 @@ export default function WorkspaceTopBar({
     log,
   })
   useQuickSaveShortcut(versionsEnabled, saveVersion)
-  const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform)
+  const isMac = isMacPlatform()
   const shortcutHint = isMac ? '⌘S' : 'Ctrl+S'
 
   const canvasCustomName = effectiveNames.documents[path]

--- a/apps/web/src/components/document-editor/NodeTextEditorOverlay.browser.test.tsx
+++ b/apps/web/src/components/document-editor/NodeTextEditorOverlay.browser.test.tsx
@@ -58,6 +58,14 @@ describe('the node text overlay (real browser)', () => {
   })
 
   // Same grammar as the inline node editor, so nothing new has to be learned.
+  it('says its exit chords in the header, for the hand asking how to finish', async () => {
+    const { container } = renderOverlay()
+    await waitFor(() => expect(container.querySelector('.cm-content')).not.toBeNull())
+    const hint = container.querySelector('[data-testid="editor-exit-hint"]')
+    expect(hint?.textContent).toContain('Done')
+    expect(hint?.textContent).toContain('Cancel')
+  })
+
   it('discards the edit on Escape', async () => {
     const { container, onCommit, onClose } = renderOverlay()
     await waitFor(() => expect(container.querySelector('.cm-content')).not.toBeNull())

--- a/apps/web/src/components/document-editor/NodeTextEditorOverlay.tsx
+++ b/apps/web/src/components/document-editor/NodeTextEditorOverlay.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { EditorExitHint } from '../EditorExitHint.js'
 import type { MarkdownEditorProps } from '../markdown-editor/MarkdownEditor.js'
 import { MarkdownEditor } from '../markdown-editor/MarkdownEditor.js'
 
@@ -113,6 +114,7 @@ export function NodeTextEditorOverlay({
           Canvas
         </button>
         <span className="text-foreground truncate text-sm font-medium">{title}</span>
+        <EditorExitHint className="ml-auto" />
       </div>
       <div className="min-h-0 flex-1">
         <MarkdownEditor

--- a/apps/web/src/components/document-properties/DocumentProperties.test.tsx
+++ b/apps/web/src/components/document-properties/DocumentProperties.test.tsx
@@ -131,6 +131,22 @@ describe('DocumentProperties', () => {
     expect(onChange).toHaveBeenLastCalledWith({ type: 'markdown' })
   })
 
+  it('does not commit a tag on the Enter that confirms an IME composition', () => {
+    const onChange = vi.fn()
+    render(
+      <DocumentProperties
+        {...titleProps()}
+        facets={meta({ tags: [] })}
+        onFacetsChange={onChange}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /properties/i }))
+    const box = screen.getByRole('textbox', { name: /add tag/i })
+    fireEvent.change(box, { target: { value: '\u4f01\u753b' } })
+    fireEvent.keyDown(box, { key: 'Enter', isComposing: true })
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
   it('ignores a duplicate or blank tag instead of storing it', () => {
     const onChange = vi.fn()
     render(
@@ -304,6 +320,51 @@ describe('DocumentProperties title typing (controlled-input round trip)', () => 
     fireEvent.keyDown(screen.getByRole('textbox', { name: /title/i }), { key: 'Delete' })
 
     expect(onAncestorKeyDown).not.toHaveBeenCalled()
+  })
+
+  // Enter is the universal "I'm done" for a single-line field, and every other
+  // single-line input in this app already treats it that way. Here every
+  // keystroke is already committed, so finishing means BLURRING — the focus
+  // ring goes away and the save dot is the receipt. Without it the caret just
+  // sits there and nothing says the name was kept.
+  it('finishes the edit on Enter: the field blurs and keeps the typed name', () => {
+    const onChange = vi.fn()
+    render(
+      <DocumentProperties
+        {...titleProps({ title: 'Draft', onTitleChange: onChange })}
+        facets={meta()}
+        onFacetsChange={vi.fn()}
+      />,
+    )
+    const box = screen.getByRole('textbox', { name: /title/i }) as HTMLInputElement
+    box.focus()
+    fireEvent.change(box, { target: { value: 'Release plan' } })
+    fireEvent.keyDown(box, { key: 'Enter' })
+
+    expect(document.activeElement).not.toBe(box)
+    // Finishing must not revert: the typed name stands (Escape is the revert).
+    expect(onChange).toHaveBeenLastCalledWith('Release plan')
+  })
+
+  // The Enter that CONFIRMS a Japanese/Chinese/Korean conversion is not "I am
+  // done with the field" — swallowing it into a blur would end the edit in
+  // the middle of typing a word. Both spellings of "an IME is active" must
+  // hold the field open (see lib/ime-keydown.ts).
+  it('stays focused on the Enter that confirms an IME composition', () => {
+    render(
+      <DocumentProperties
+        {...titleProps({ title: 'Draft' })}
+        facets={meta()}
+        onFacetsChange={vi.fn()}
+      />,
+    )
+    const box = screen.getByRole('textbox', { name: /title/i }) as HTMLInputElement
+    box.focus()
+    fireEvent.keyDown(box, { key: 'Enter', isComposing: true })
+    expect(document.activeElement).toBe(box)
+
+    fireEvent.keyDown(box, { key: 'Enter', keyCode: 229 })
+    expect(document.activeElement).toBe(box)
   })
 
   it('drops the draft on blur so the box shows the canonical name', () => {

--- a/apps/web/src/components/document-properties/DocumentProperties.tsx
+++ b/apps/web/src/components/document-properties/DocumentProperties.tsx
@@ -2,6 +2,7 @@ import type { StoredCoreFacets } from '@kamiazya/whiteboard-model'
 import { Info, X } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { useId, useRef, useState } from 'react'
+import { isImeComposingKeydown } from '../../lib/ime-keydown.js'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js'
 
 export interface DocumentPropertiesProps {
@@ -139,6 +140,17 @@ export function DocumentProperties({
           // bindings (Cmd+S) are unaffected by it.
           onKeyDown={(event) => {
             event.stopPropagation()
+            // Enter finishes the edit. Every keystroke is already committed
+            // (there is no Save button), so finishing means BLURRING: the
+            // focus ring goes away and the save dot is the receipt. Never on
+            // the Enter that confirms an IME conversion — that one means
+            // "accept this word", and the field must stay open under it.
+            if (event.key === 'Enter') {
+              if (isImeComposingKeydown(event.nativeEvent)) return
+              event.preventDefault()
+              event.currentTarget.blur()
+              return
+            }
             if (event.key !== 'Escape' || onTitleChange === undefined) return
             event.preventDefault()
             setDraftTitle(null)
@@ -355,6 +367,9 @@ function FacetDisclosure({
             onChange={(event) => setDraftTag(event.target.value)}
             onKeyDown={(event) => {
               if (event.key !== 'Enter' && event.key !== ',') return
+              // The Enter that confirms an IME conversion is "accept this
+              // word", not "finish this tag" — let it pass untouched.
+              if (isImeComposingKeydown(event.nativeEvent)) return
               // Enter would submit an enclosing form and `,` would land in
               // the box; both mean "finish this tag" here.
               event.preventDefault()

--- a/apps/web/src/components/history-cluster/HistoryCluster.tsx
+++ b/apps/web/src/components/history-cluster/HistoryCluster.tsx
@@ -19,11 +19,13 @@
  * Marked `data-editor-overlay` so the canvas root's gesture handlers
  * ignore presses originating here (see SpatialEditor's isOverlayEvent).
  */
+
 import { History, Redo2, Undo2 } from 'lucide-react'
 import { type ReactNode, useEffect, useRef, useState } from 'react'
 import { DOCK_BUTTON_CLASS } from '@/components/ui/dock-button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { isMacPlatform } from '../../lib/platform.js'
 import { VersionPanel } from '../workspace-top-bar/VersionPanel.js'
 
 export interface HistoryClusterVersionsProps {
@@ -43,7 +45,7 @@ export interface HistoryClusterProps {
   readonly versions?: HistoryClusterVersionsProps
 }
 
-const IS_MAC = typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform)
+const IS_MAC = isMacPlatform()
 const MOD_LABEL = IS_MAC ? '⌘' : 'Ctrl+'
 const MOD_KEY = IS_MAC ? 'Meta' : 'Control'
 

--- a/apps/web/src/components/markdown-editor/LinkPickerDialog.tsx
+++ b/apps/web/src/components/markdown-editor/LinkPickerDialog.tsx
@@ -1,5 +1,6 @@
 import { FileSymlink, SquareArrowOutUpRight } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { isImeComposingKeydown } from '../../lib/ime-keydown.js'
 import { cn } from '../../lib/utils.js'
 import {
   externalLinkMarkup,
@@ -105,6 +106,7 @@ export function LinkPickerDialog({
           return
         }
         if (event.key === 'Enter') {
+          if (isImeComposingKeydown(event.nativeEvent)) return
           event.preventDefault()
           commit(activeIndex)
         }

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -16,6 +16,7 @@ import {
   type ProbeDaemonOptions,
   probeDaemon,
 } from '../../lib/daemon-probe.js'
+import { isImeComposingKeydown } from '../../lib/ime-keydown.js'
 import {
   decideConnectGate,
   explainProbeFailure,
@@ -626,7 +627,8 @@ export function DaemonDetectedBanner({
             value={portInput}
             onChange={(event) => setPortInput(event.target.value)}
             onKeyDown={(event) => {
-              if (event.key === 'Enter') void checkNow()
+              if (event.key !== 'Enter' || isImeComposingKeydown(event.nativeEvent)) return
+              void checkNow()
             }}
             placeholder="3099"
             className="w-16 rounded border px-1 py-0.5"

--- a/apps/web/src/components/shell/WorkspaceMenu.test.tsx
+++ b/apps/web/src/components/shell/WorkspaceMenu.test.tsx
@@ -157,6 +157,19 @@ describe('WorkspaceMenu — creating', () => {
     expect(create).toHaveBeenCalledTimes(1)
   })
 
+  it('does not create on the Enter that confirms an IME composition', async () => {
+    // A workspace named in Japanese is typed through an IME, and the Enter
+    // that accepts the conversion arrives at this same handler. Only the
+    // shared guard (lib/ime-keydown.ts) separates it from "create now".
+    const create = vi.fn(() => Promise.resolve({ workspaceId: NOTES, segment: 'kikaku' }))
+    renderMenu([{ workspaceId: DESIGN, segment: 'design' }], { create })
+    fireEvent.click(screen.getByRole('menuitem', { name: /new workspace/i }))
+    const input = screen.getByLabelText(/new workspace name/i)
+    fireEvent.change(input, { target: { value: '\u4f01\u753b' } })
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: true })
+    expect(create).not.toHaveBeenCalled()
+  })
+
   it('closes the create form once the workspace exists, rather than leaving it disabled', async () => {
     // `onSwitch` is an in-SPA route change for the browser keeper, so the
     // shell does NOT remount — the same menu instance survives the

--- a/apps/web/src/components/shell/WorkspaceMenu.tsx
+++ b/apps/web/src/components/shell/WorkspaceMenu.tsx
@@ -14,6 +14,7 @@
 import type { RenameWorkspaceInput, WorkspaceEntry } from '@kamiazya/whiteboard-ports'
 import { useEffect, useId, useRef, useState } from 'react'
 import { workspaceHandle, workspaceLabel } from '@/lib/workspace-handle'
+import { isImeComposingKeydown } from '../../lib/ime-keydown.js'
 
 /**
  * Where the workspaces come from and how one is made or renamed — the half
@@ -337,6 +338,7 @@ export function WorkspaceMenu({
               onKeyDown={(event) => {
                 event.stopPropagation()
                 if (event.key === 'Enter') {
+                  if (isImeComposingKeydown(event.nativeEvent)) return
                   event.preventDefault()
                   commitUrl()
                   return
@@ -418,7 +420,8 @@ export function WorkspaceMenu({
                 value={newName}
                 onChange={(event) => setNewName(event.target.value)}
                 onKeyDown={(event) => {
-                  if (event.key === 'Enter') submitCreate()
+                  if (event.key !== 'Enter' || isImeComposingKeydown(event.nativeEvent)) return
+                  submitCreate()
                 }}
                 className="rounded-md border bg-background px-2 py-1 text-sm"
               />

--- a/apps/web/src/components/spatial-editor/MarkdownNodeEditor.test.tsx
+++ b/apps/web/src/components/spatial-editor/MarkdownNodeEditor.test.tsx
@@ -1,0 +1,20 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MarkdownNodeEditor } from './MarkdownNodeEditor.js'
+
+afterEach(cleanup)
+
+const BOX = { x: 40, y: 60, width: 200, height: 80 }
+
+describe('MarkdownNodeEditor exit hint', () => {
+  it('shows the exit hint below the editing box while open', () => {
+    render(
+      <MarkdownNodeEditor box={BOX} initialText="hello" onCommit={vi.fn()} onCancel={vi.fn()} />,
+    )
+    const hint = screen.getByTestId('editor-exit-hint')
+    expect(hint.textContent).toContain('Done')
+    expect(hint.style.top).toBe(`${BOX.y + BOX.height + 6}px`)
+    expect(hint.style.left).toBe(`${BOX.x}px`)
+  })
+})

--- a/apps/web/src/components/spatial-editor/MarkdownNodeEditor.tsx
+++ b/apps/web/src/components/spatial-editor/MarkdownNodeEditor.tsx
@@ -25,6 +25,7 @@
  * the rendered SVG); an OPAQUE background is load-bearing — it is what
  * hides the committed render underneath while editing.
  */
+
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
 import { markdown } from '@codemirror/lang-markdown'
 import { syntaxHighlighting } from '@codemirror/language'
@@ -32,6 +33,7 @@ import { EditorState, Prec } from '@codemirror/state'
 import { EditorView, keymap } from '@codemirror/view'
 import { GFM } from '@lezer/markdown'
 import { type CSSProperties, useLayoutEffect, useRef } from 'react'
+import { EditorExitHint } from '../EditorExitHint.js'
 import { markdownStyleKeymap } from '../markdown-editor/editor-verbs.js'
 import { exitEmptyListItem } from '../markdown-editor/exit-empty-list-item.js'
 import { markdownHighlightStyle } from '../markdown-editor/SourcePane.js'
@@ -159,26 +161,30 @@ export function MarkdownNodeEditor({
   }, [])
 
   return (
-    <div
-      ref={hostRef}
-      data-testid={testId}
-      data-editor-overlay
-      // Caret placement must not bubble into the root's hit-test and turn
-      // into a move gesture that unmounts this editor mid-edit.
-      onPointerDown={(e) => e.stopPropagation()}
-      style={{
-        position: 'absolute',
-        left: box.x,
-        top: box.y,
-        width: box.width,
-        height: box.height,
-        boxSizing: 'border-box',
-        overflow: 'hidden',
-        // Explicit, because the canvas root turns selection OFF and this
-        // inherits from it.
-        userSelect: 'text',
-        ...style,
-      }}
-    />
+    <>
+      <div
+        ref={hostRef}
+        aria-keyshortcuts="Meta+Enter Control+Enter"
+        data-testid={testId}
+        data-editor-overlay
+        // Caret placement must not bubble into the root's hit-test and turn
+        // into a move gesture that unmounts this editor mid-edit.
+        onPointerDown={(e) => e.stopPropagation()}
+        style={{
+          position: 'absolute',
+          left: box.x,
+          top: box.y,
+          width: box.width,
+          height: box.height,
+          boxSizing: 'border-box',
+          overflow: 'hidden',
+          // Explicit, because the canvas root turns selection OFF and this
+          // inherits from it.
+          userSelect: 'text',
+          ...style,
+        }}
+      />
+      <EditorExitHint style={{ position: 'absolute', left: box.x, top: box.y + box.height + 6 }} />
+    </>
   )
 }

--- a/apps/web/src/components/spatial-editor/TextNodeEditor.test.tsx
+++ b/apps/web/src/components/spatial-editor/TextNodeEditor.test.tsx
@@ -48,6 +48,15 @@ describe('TextNodeEditor', () => {
     expect(onCancel).not.toHaveBeenCalled()
   })
 
+  it('shows the exit hint below the editing box while open', () => {
+    render(<TextNodeEditor box={BOX} initialText="hello" onCommit={vi.fn()} onCancel={vi.fn()} />)
+    const hint = screen.getByTestId('editor-exit-hint')
+    expect(hint.textContent).toContain('Done')
+    // Rides the same canvas-space coordinates as the editor, just under it.
+    expect(hint.style.top).toBe(`${BOX.y + BOX.height + 6}px`)
+    expect(hint.style.left).toBe(`${BOX.x}px`)
+  })
+
   it('a blur after Escape does not resurrect the cancelled edit as a commit', () => {
     const onCommit = vi.fn()
     const onCancel = vi.fn()

--- a/apps/web/src/components/spatial-editor/TextNodeEditor.tsx
+++ b/apps/web/src/components/spatial-editor/TextNodeEditor.tsx
@@ -16,7 +16,9 @@
  * `onCancel` unmounting synchronously is not guaranteed, so `mountedRef`
  * alone cannot prevent either.
  */
+
 import { type CSSProperties, useEffect, useRef, useState } from 'react'
+import { EditorExitHint } from '../EditorExitHint.js'
 import type { Box } from './geometry.js'
 
 export interface TextNodeEditorProps {
@@ -78,40 +80,44 @@ export function TextNodeEditor({
   }
 
   return (
-    <textarea
-      ref={textareaRef}
-      data-testid={testId}
-      value={value}
-      style={{
-        position: 'absolute',
-        left: box.x,
-        top: box.y,
-        width: box.width,
-        height: box.height,
-        resize: 'none',
-        boxSizing: 'border-box',
-        // Explicit, because the canvas root turns selection OFF and this
-        // inherits from it — without this the caret cannot select the text it
-        // is editing.
-        userSelect: 'text',
-        ...style,
-      }}
-      onChange={(e) => {
-        setValue(e.target.value)
-        onChange?.(e.target.value)
-      }}
-      data-editor-overlay
-      onPointerDown={(e) => e.stopPropagation()}
-      onBlur={commit}
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') {
-          e.preventDefault()
-          cancel()
-        } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-          e.preventDefault()
-          commit()
-        }
-      }}
-    />
+    <>
+      <textarea
+        ref={textareaRef}
+        aria-keyshortcuts="Meta+Enter Control+Enter"
+        data-testid={testId}
+        value={value}
+        style={{
+          position: 'absolute',
+          left: box.x,
+          top: box.y,
+          width: box.width,
+          height: box.height,
+          resize: 'none',
+          boxSizing: 'border-box',
+          // Explicit, because the canvas root turns selection OFF and this
+          // inherits from it — without this the caret cannot select the text it
+          // is editing.
+          userSelect: 'text',
+          ...style,
+        }}
+        onChange={(e) => {
+          setValue(e.target.value)
+          onChange?.(e.target.value)
+        }}
+        data-editor-overlay
+        onPointerDown={(e) => e.stopPropagation()}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.preventDefault()
+            cancel()
+          } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+            e.preventDefault()
+            commit()
+          }
+        }}
+      />
+      <EditorExitHint style={{ position: 'absolute', left: box.x, top: box.y + box.height + 6 }} />
+    </>
   )
 }

--- a/apps/web/src/lib/ime-keydown.test.ts
+++ b/apps/web/src/lib/ime-keydown.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { isImeComposingKeydown } from './ime-keydown.js'
+
+// A single-line input that commits on Enter must ignore the Enter that
+// CONFIRMS an IME composition — for a Japanese typist that key means "accept
+// this conversion", not "I am done with the field". Two spellings reach us:
+// `isComposing` (the spec'd flag, set in Chrome/Firefox), and the legacy
+// `keyCode === 229` WebKit emits for keydowns fired while an IME is active.
+describe('isImeComposingKeydown', () => {
+  it('is true while the spec flag says a composition is active', () => {
+    expect(isImeComposingKeydown({ isComposing: true, keyCode: 13 })).toBe(true)
+  })
+
+  it('is true for the WebKit 229 keydown even when the flag is unset', () => {
+    expect(isImeComposingKeydown({ isComposing: false, keyCode: 229 })).toBe(true)
+  })
+
+  it('is false for a plain keydown outside composition', () => {
+    expect(isImeComposingKeydown({ isComposing: false, keyCode: 13 })).toBe(false)
+  })
+})

--- a/apps/web/src/lib/ime-keydown.ts
+++ b/apps/web/src/lib/ime-keydown.ts
@@ -1,0 +1,20 @@
+/**
+ * Is this keydown part of an IME composition — the Enter that confirms a
+ * Japanese conversion rather than the Enter that means "I am done"?
+ *
+ * Every single-line input that commits or blurs on Enter must check this
+ * first, or a CJK typist loses the field mid-word: the conversion-confirming
+ * keypress would submit a half-typed value. Two spellings reach the handler:
+ * `isComposing` (the UI Events flag, set by Chrome/Firefox on the confirming
+ * keydown) and the legacy `keyCode === 229` WebKit/older engines emit for any
+ * keydown fired while an IME is active.
+ *
+ * Takes the NATIVE event's fields — React callers pass `event.nativeEvent`
+ * (the synthetic event does not carry `isComposing`), window-capture
+ * listeners pass the event itself.
+ */
+export function isImeComposingKeydown(
+  event: Pick<KeyboardEvent, 'isComposing' | 'keyCode'>,
+): boolean {
+  return event.isComposing || event.keyCode === 229
+}

--- a/apps/web/src/lib/platform.ts
+++ b/apps/web/src/lib/platform.ts
@@ -1,0 +1,13 @@
+/**
+ * One definition of "is this a Mac-family platform", for chrome that names
+ * the command modifier. Two components had already grown their own copy of
+ * this regex before it moved here (the StateDot lesson: private copies of
+ * the same literal drift).
+ *
+ * `navigator.platform` is deprecated-but-stable and remains the practical
+ * signal for keyboard-modifier display; `userAgentData.platform` is not on
+ * Firefox/Safari. Read at call time so a test can stub the navigator.
+ */
+export function isMacPlatform(): boolean {
+  return typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform)
+}

--- a/apps/web/src/pages/BrowserDocumentPage.rename.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.rename.browser.test.tsx
@@ -64,6 +64,25 @@ describe('BrowserDocumentPage rename (real IndexedDB)', () => {
     cleanup()
   })
 
+  it('Enter ends the title edit; a composing Enter keeps it open', async () => {
+    await renderLoaded()
+    const titleInput = await titleField()
+    titleInput.focus()
+    fireEvent.change(titleInput, { target: { value: '\u4f01\u753b' } })
+    // The Enter that confirms an IME conversion must hold the field open.
+    fireEvent.keyDown(titleInput, { key: 'Enter', isComposing: true })
+    expect(document.activeElement).toBe(titleInput)
+
+    // The plain Enter is "I am done": the field blurs, the name stands, and
+    // the save chip is the receipt.
+    fireEvent.keyDown(titleInput, { key: 'Enter' })
+    expect(document.activeElement).not.toBe(titleInput)
+    await waitForTitle('\u4f01\u753b')
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Saved' })).toBeInTheDocument(), {
+      timeout: 5000,
+    })
+  })
+
   it('reload: edited title survives an unmount + fresh-store remount', async () => {
     await renderLoaded()
     const titleInput = await titleField()


### PR DESCRIPTION
## Summary

- **The document title now finishes its edit on Enter.** The field commits every keystroke already, but Enter was swallowed silently — the caret just sat there and nothing said the name was kept. Enter (outside IME composition) now blurs the field: the focus ring goes away and the save dot is the receipt. This also aligns the title with every other single-line input in the app, where plain Enter already commits. Escape keeps its revert-and-close meaning.
- **A shared IME guard, applied everywhere Enter commits.** No keydown handler in `apps/web` looked at composition state, so the Enter that *confirms a Japanese conversion* fired the commit mid-word at six existing sites (tag input, both WorkspaceMenu fields, branch rename, daemon port, link picker). `lib/ime-keydown.ts` (`isComposing`, plus WebKit's legacy `keyCode === 229`) now holds Enter back during composition at all of them and at the title.
- **The text-editing overlays say their exit chords.** All three (edge/group label, markdown node editor, full-screen node editor) commit on mod+Enter and cancel on Escape, and nothing on screen said so — the shortcut catalog's own comment records someone opening an editor and failing to find "how do I save?". `EditorExitHint` now sits just below the editing box (and in the full-screen editor's header): `⌘↩ Done · esc Cancel`, with the platform's own modifier, `aria-hidden` while the editors carry the chord in `aria-keyshortcuts`. `lib/platform.ts` consolidates the two pre-existing private copies of the Mac-platform regex.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [x] `pnpm test` passes locally
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable

New coverage: the guard helper's contract; title Enter-blurs / composing-Enter-stays / Escape-reverts and the tag input's composing case (jsdom); the workspace-create composing case, **mutation-checked** — removing that one guard fails exactly that test; hint presence and placement for both node editors (jsdom) and the full-screen overlay (real browser); and a real-browser regression on the rename flow covering both the composing and the plain Enter.

Manual verification drove the real dev app in the container's Chromium **with a real IME path**: CDP `Input.imeSetComposition` composing きかく, then Enter — the title field stayed open with the composition intact; `企画` confirmed, plain Enter ended the edit and the name persisted. The node-editor hint was verified visible and placed below the box in light and dark themes, and mod+Enter committed as advertised.

Local gates on the merged head: `web-jsdom` 3,088 passed; `web-node` 86; `web-browser` 861 (pre-merge full run; post-merge full run repeated locally); `mcp-node` 4,207; `pnpm lint` / `knip` / `secretlint` / `intent:validate` / `audit --prod` / `pnpm -r typecheck` clean. (`test:scripts`'s `compose-figure` test cannot run in this container — no ImageMagick; `.claude/scripts` is untouched and CI's `check` job covers it.)

## Visual evidence

Visual evidence: none — the composed before/after figure cannot be produced here (the container lacks ImageMagick for `compose-figure.mjs`, and the "before" of an additive hint is an empty region). In its place: the hint was verified in the running app in both themes and the screenshots were handed to the reviewer directly in session; presence, text, and box-relative placement are pinned by `web-jsdom` and `web-browser` tests in this diff.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — keyboard affordances now describe themselves in the UI; no published contract changed
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh)_