### PR TITLE
docs(skills): correct ci-triage on what actually blocks a merge — measured, not assumed

### DIFF
--- a/.claude/skills/ci-triage/SKILL.md
+++ b/.claude/skills/ci-triage/SKILL.md
@@ -14,7 +14,7 @@ description: Monitor and triage the POST-PUSH automated-review surface for the w
 | **`verify`** | GitHub Actions CI (lint:noconsole + tests/typecheck/smoke per `.github/workflows/`) | `gh pr checks <PR>`; logs: `gh run view <run-id> --log-failed` |
 | **CodeRabbit** | AI PR review (line comments + summary). **Skips while the PR title contains `WIP`/draft** | `gh pr view <PR> --json reviews,comments`; `gh api repos/{owner}/{repo}/pulls/<PR>/comments` |
 | **AccessLint** | accessibility review app | its check + PR review comments |
-| **WIP** | blocks merge while the title says WIP | `gh pr checks` shows it pending; remove `WIP`/`(WIP)` from the title to release it + un-skip CodeRabbit |
+| **WIP** | reports work-in-progress from the title — **informational, measured not to block a merge** (#1201: with WIP the sole non-success check, `mergeable_state` read `unstable`, never `blocked`; Draft is the one mechanical merge block) | `gh pr checks` shows it pending; remove `WIP`/`(WIP)` from the title to settle it + un-skip CodeRabbit |
 | **CodeQL** | security code-scanning | **primary (scope-free):** its findings post as PR review comments by `github-advanced-security[bot]` — `gh api repos/{owner}/{repo}/pulls/<PR>/comments --jq '.[]\|select(.user.login=="github-advanced-security[bot]")'`. **enrichment (may 404 on scope / "no analysis"):** `gh api repos/{owner}/{repo}/code-scanning/alerts` (needs `security_events`/admin) for severity/state |
 | **Dependabot** | dependency-bump PRs + security alerts | **handled by its own flow** — the `dependabot-triage` workflow + `dependabot-review` skill (semver×ecosystem classify, conflict-cascade-safe merge, `pnpm audit --prod` gate). Don't triage it here. |
 


### PR DESCRIPTION
## Summary

- `ci-triage/SKILL.md` carried both halves of a contradiction about the WIP GitHub App: line 17 said it **"blocks merge while the title says WIP"**, while line 70 recommended a Draft PR for merge-blocking *because Draft blocks natively*. Both cannot be true. CodeRabbit proposed hardening the first half into an always-on rule during #1167's review (then withdrew it as unestablished), and the branch-protection API answers 403 to every reader here — so the question could not be settled by reading.
- Probe **#1201** settled it by observation: a wip-titled, **non-draft** PR with all 20 other checks green and the WIP check held `in_progress` read `mergeable_state: unstable` — mergeable, a non-required check unhappy — never `blocked`. De-wip the title, WIP flips to success, and it reads `clean`. **The WIP check is informational in this repo; Draft is the one mechanical merge block**, which is exactly what line 70 already said.
- Line 17 now states the measured behavior and cites the probe. Line 70 stands unchanged. A repo-wide sweep found no other file claiming WIP blocks (the `ci-triage.workflow.mjs` "unblocks" line is about CodeRabbit skipping, which is true and untouched).

## Test plan

- [ ] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — prose-only skill edit; the claim's evidence is the probe, not a test
- [x] `pnpm test` passes locally — `pnpm lint`, `secretlint`, and the `dev-rules-contract` / `dev-rules-budget` guards (12 passed) on the touched surface
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable

The verification IS #1201's two readings: `unstable` with WIP as the sole non-success check, `clean` after the title change with nothing else moving.

## Visual evidence

Visual evidence: none — one-line prose correction in a `.claude` skill; nothing rendered changes.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — this IS the doc fix
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh)_