### PR TITLE
feat(model,loro-adapter): add the canvas comment annotation layer (ADR-0024)

### DIFF
--- a/docs/contributing/adr/0024-canvas-comments.md
+++ b/docs/contributing/adr/0024-canvas-comments.md
@@ -1,0 +1,154 @@
+# ADR-0024: Canvas comments — a first-class annotation layer
+
+**Status:** Accepted
+
+## Context
+
+The MCP Apps widget shipped an append-only "sticky note" (a plain text node
+added through `wb_canvas_edit`), and user feedback immediately redrew the
+target: what is wanted is a **comment** — point at a place on a view-only
+canvas, say something about it, and have that feedback reach the AI (or,
+later, another person) as a signal to act. Three properties follow that no
+existing mechanism has together:
+
+1. **Anchored, not placed.** A comment is ABOUT a spot or an object. It
+   carries an anchor point (and optionally a target node), while where its
+   bubble draws is a rendering decision — floating near the anchor, never
+   participating in content layout, never moved by `tidy`, never part of
+   what the document says.
+2. **Concurrent-safe.** The feature exists for collaboration — human⇄AI
+   today, human⇄human later — so two peers commenting at the same time must
+   both survive a CRDT merge.
+3. **Cross-surface.** Comments must be visible wherever the canvas renders:
+   the MCP Apps widget, `wb_scene_render`/PNG export, the viewer, and the
+   apps/web editor. Per ADR-0013 decision 8, that means SVG scene rendering,
+   not an HTML overlay.
+
+Each existing home fails at least one of these, measured against the real
+code rather than assumed:
+
+- **A facet payload** (ADR-0013) merges replace-whole-payload — two peers
+  appending to a `comment.threads` facet concurrently lose one side's
+  comment. Facets model attributes; comments accumulate.
+- **The canvas-level `x-whiteboard` envelope value** is stored whole-value
+  LWW in the Loro bridge (`canvas` map) — same concurrent loss.
+- **A text node with comment styling** pollutes content: it would be
+  exported as content, rearranged by `tidy`, counted by every consumer, and
+  its "floating" requirement contradicts a node's fixed geometry.
+- **An editor-side HTML overlay** vanishes from every non-editor surface
+  (the ADR-0013 argument, verified against `layoutSpatialCanvas`).
+
+## Decision
+
+### 1. A comment is a first-class object of the spatial document
+
+`canvasCommentSchema` (model):
+
+```
+{ id, x, y, text, author?, createdAt?, targetNodeId?, resolved? }
+```
+
+- `x`/`y` is the ANCHOR (JSON Canvas integer coordinates): the point the
+  comment is about. No width/height — a comment has no box of its own.
+- `targetNodeId` narrows the anchor to "about this node"; renderers follow
+  the node's current position and fall back to the anchor point. A dangling
+  target is VALID — a comment may outlive its subject, and the annotation
+  layer must never make the document unreadable. Deleting a node does NOT
+  cascade to its comments.
+- `author` is an OKF actor string (`human:<id>` / `process:<id>`, ADR-0016),
+  so the `human:` prefix keeps its trust meaning; `createdAt` is an OKF
+  timestamp. Both optional — identity is a keeper concern deferred with the
+  multi-user work.
+- `resolved` is the lifecycle: a resolved comment stays in the document (it
+  is the record of the conversation) and default rendering hides it.
+
+### 2. File format: under the canvas-level `x-whiteboard`, dropped by strict mode
+
+In the model type and the serialized JSON Canvas file, comments live at
+`x-whiteboard.comments`. This amends the canvas-level extension rule a
+second time (the first was ADR-0013's `facets` bucket): the rule's spirit —
+a consumer that drops the key still holds the complete document — HOLDS for
+comments, because what is lost is the conversation about the content, not
+the content. `x-whiteboard` stays the only non-standard key ever emitted;
+strict-mode export drops comments with the rest of the extension; the
+published `x-whiteboard.schema.json` carries the shape.
+
+### 3. Storage: one Loro map keyed per comment
+
+The bridge stores comments in a dedicated `comments` map, one entry per
+comment id — the same granularity as nodes and edges, and the reason
+decision 2's file placement does not decide the merge story.
+`writeSpatialCanvas` splits `comments` out of the envelope value on write;
+`readSpatialCanvas` reassembles, dropping a corrupt entry per comment
+rather than failing the layer. `writeCanvasComment` /
+`deleteCanvasComment` are the fine-grained paths (resolve = rewrite with
+`resolved: true`). The map joins `CONTENT_CONTAINER_KEYS` so tree-hosted
+documents pre-attach it (the undo/redo invariant). Measured cost: +31B per
+document at create time in the workspace-record scoreboard, and the
+shallow-snapshot reclaim is no longer byte-identical to create time (9B
+leaner at 10 documents) — both pinned where they are measured.
+
+### 4. Rendering: pins composed into the SVG scene, above content
+
+canvas-render composes comment markers AFTER nodes and edges in
+`layoutSpatialCanvas`'s emission, from existing scene-node kinds, so pins
+paint above content and appear in every surface that renders the scene.
+Comments are core model data — this is direct composition, not a plugin
+`RenderContribution`. Floating placement (near the anchor or the target
+node's current box, avoiding content where cheap) is owned by the renderer;
+resolved comments are not drawn.
+
+### 5. Delivery to the AI is a surface concern, not stored state
+
+The widget submits a comment through `wb_canvas_edit` AND, where the host
+supports it (`getHostCapabilities()?.message`), injects a user-role message
+via ext-apps `sendMessage` so the model responds to the feedback
+immediately. Hosts without the capability degrade to the document write
+alone — the comment still reaches the AI on its next read. Nothing about
+delivery is persisted; the document records the comment, not the
+notification.
+
+### 6. The sticky note is renamed, not kept beside this
+
+The widget's sticky-note affordance becomes comment creation (visually
+distinct pin, click-to-anchor). No compatibility surface: 0.0.x, no users
+(vocabulary.md's standing policy).
+
+## This increment
+
+Decisions 1-3 (model schema + published JSON schema, bridge storage with
+the concurrent-merge tests, the scoreboard re-measurement). Rendering
+(decision 4), the `wb_canvas_edit` comment ops, and the widget surface
+(decisions 5-6) land as their own increments; the apps/web editor's
+interactive comment UI follows after those.
+
+## Consequences
+
+- Comments merge per comment: concurrent human⇄AI or human⇄human
+  commenting cannot lose a side. Concurrent edits to the SAME comment are
+  whole-comment LWW, which is right for text nobody co-edits.
+- Every surface that renders the scene shows comments with zero extra
+  wiring, because they travel inside `SpatialCanvas` (`canvas_view`
+  already ships the whole canvas to the widget).
+- A strict JSON Canvas export loses the conversation. Accepted: strict
+  mode is interop with consumers that could not draw it anyway.
+- The envelope-purity rule (comments never stored inside the `canvas`
+  map's extension value) is load-bearing and pinned by a bridge test; a
+  writer that bypasses the bridge reopens the concurrent-loss bug.
+- Threads (replies), mentions, and per-user read state are all future
+  value-space extensions of the comment object, not new mechanisms.
+
+## Alternatives considered
+
+- **A `comment` plugin facet** — replace-whole-payload merge loses
+  concurrent comments; rejected on the CRDT ground above, not on taste.
+- **Comment as a styled text node** — pollutes content, export, and tidy;
+  contradicts floating placement.
+- **Editor-only HTML overlay** — invisible to the widget, exports, and the
+  viewer, which are the surfaces the feature was asked for.
+- **A separate comments document/store beside the canvas** — a second
+  thing to sync, version, and promote; the CRDT document already provides
+  exactly the merge and transport comments need.
+- **Top-level `comments` key in the file** — breaks the published
+  "`x-whiteboard` is the only non-standard key" contract for no modelling
+  gain.

--- a/docs/contributing/adr/README.md
+++ b/docs/contributing/adr/README.md
@@ -56,3 +56,4 @@ See [template.md](template.md) for the standard structure (MADR-lite: Title, Sta
 | [ADR-0021](0021-durability-boundary.md) | Durability is a property of each store, not an operation on a directory | Accepted (implemented) |
 | [ADR-0022](0022-variation-addressing.md) | A variation is not in the address, and the default one has no name to put there | Accepted — records the shipped shape; fixes the grammar for later |
 | [ADR-0023](0023-replica-model.md) | A workspace has one keeper; every other copy is a replica | Proposed — design of record for the demote/cache work |
+| [ADR-0024](0024-canvas-comments.md) | Canvas comments are a first-class annotation layer, keyed per comment | Accepted |

--- a/docs/reference/x-whiteboard.schema.json
+++ b/docs/reference/x-whiteboard.schema.json
@@ -28,6 +28,54 @@
           },
           "additionalProperties": false
         },
+        "comments": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "x": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "y": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "text": {
+                "type": "string",
+                "minLength": 1
+              },
+              "author": {
+                "type": "string",
+                "minLength": 1
+              },
+              "createdAt": {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})$"
+              },
+              "targetNodeId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "resolved": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "id",
+              "x",
+              "y",
+              "text"
+            ],
+            "additionalProperties": false
+          }
+        },
         "facets": {
           "type": "object",
           "propertyNames": {

--- a/packages/loro-adapter/src/index.ts
+++ b/packages/loro-adapter/src/index.ts
@@ -2,6 +2,7 @@ export { collectImageRefIds } from './image-refs.js'
 export type { DocumentContainers } from './loro-bridge.js'
 export {
   CONTENT_CONTAINER_KEYS,
+  deleteCanvasComment,
   deleteSpatialEdge,
   deleteSpatialNode,
   MARKDOWN_BODY_KEY,
@@ -18,6 +19,7 @@ export {
   setEdgeLock,
   setNodeLock,
   withSpatialBatch,
+  writeCanvasComment,
   writeCoreFacets,
   writeDocumentKind,
   writeFacets,

--- a/packages/loro-adapter/src/loro-bridge.test.ts
+++ b/packages/loro-adapter/src/loro-bridge.test.ts
@@ -1,4 +1,5 @@
 import type {
+  CanvasComment,
   CanvasEdge,
   ExtensionFacets,
   SpatialCanvas,
@@ -8,6 +9,7 @@ import type {
 import { LoroDoc, UndoManager } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
 import {
+  deleteCanvasComment,
   deleteSpatialEdge,
   deleteSpatialNode,
   readCoreFacets,
@@ -18,6 +20,7 @@ import {
   setEdgeLock,
   setNodeLock,
   withSpatialBatch,
+  writeCanvasComment,
   writeCoreFacets,
   writeDocumentKind,
   writeFacets,
@@ -960,5 +963,118 @@ describe('canvas-level extension', () => {
     a.import(b.export({ mode: 'snapshot' }))
 
     expect(readSpatialCanvas(a)['x-whiteboard']?.edgeRouting?.style).toBe('orthogonal')
+  })
+})
+
+// The annotation layer (ADR-0024). The one property everything below exists
+// for: two peers commenting CONCURRENTLY must both survive a merge, which is
+// why each comment lives under its own key in a dedicated map rather than
+// inside the canvas envelope value (whole-value LWW) or a facet payload
+// (replace-whole-payload).
+describe('canvas comments bridge', () => {
+  const COMMENT: CanvasComment = { id: 'c1', x: 10, y: 20, text: 'this box overlaps' }
+  const OTHER: CanvasComment = {
+    id: 'c2',
+    x: -40,
+    y: 5,
+    text: 'rename this',
+    author: 'human:reviewer',
+    createdAt: '2026-09-01T10:00:00+09:00',
+    targetNodeId: 'node-1',
+    resolved: false,
+  }
+
+  test('round-trips comments beside the rendering preferences', () => {
+    const doc = makeDoc()
+    writeSpatialCanvas(doc, {
+      nodes: [],
+      edges: [],
+      'x-whiteboard': { edgeRouting: { style: 'orthogonal' }, comments: [COMMENT, OTHER] },
+    })
+
+    const result = readSpatialCanvas(doc)
+    expect(result['x-whiteboard']?.edgeRouting).toEqual({ style: 'orthogonal' })
+    expect((result['x-whiteboard']?.comments ?? []).map((c) => c.id).sort()).toEqual(['c1', 'c2'])
+    expect(result['x-whiteboard']?.comments?.find((c) => c.id === 'c2')).toEqual(OTHER)
+  })
+
+  test('stores each comment under its own key, never inside the envelope value', () => {
+    const doc = makeDoc()
+    writeSpatialCanvas(doc, {
+      nodes: [],
+      edges: [],
+      'x-whiteboard': { edgeRouting: { style: 'orthogonal' }, comments: [COMMENT] },
+    })
+
+    // The envelope stays whole-value LWW and must not carry the comments —
+    // that is what would reintroduce the concurrent-loss this layout removes.
+    expect(doc.getMap('canvas').get('x-whiteboard')).toEqual({
+      edgeRouting: { style: 'orthogonal' },
+    })
+    expect(doc.getMap('comments').keys()).toEqual(['c1'])
+  })
+
+  test('CRDT merge: two peers comment concurrently and both survive', () => {
+    const base = makeDoc()
+    writeSpatialCanvas(base, { nodes: [TEXT_NODE], edges: [] })
+    const peer = makeDoc()
+    peer.import(base.export({ mode: 'snapshot' }))
+
+    writeCanvasComment(base, COMMENT)
+    writeCanvasComment(peer, OTHER)
+    base.import(peer.export({ mode: 'snapshot' }))
+
+    const merged = readSpatialCanvas(base)['x-whiteboard']?.comments ?? []
+    expect(merged.map((c) => c.id).sort()).toEqual(['c1', 'c2'])
+  })
+
+  test('a full resync deletes the comments the canvas no longer carries', () => {
+    const doc = makeDoc()
+    writeSpatialCanvas(doc, {
+      nodes: [],
+      edges: [],
+      'x-whiteboard': { comments: [COMMENT, OTHER] },
+    })
+    writeSpatialCanvas(doc, { nodes: [], edges: [], 'x-whiteboard': { comments: [OTHER] } })
+
+    expect(readSpatialCanvas(doc)['x-whiteboard']?.comments).toEqual([OTHER])
+  })
+
+  test('writeCanvasComment leaves every other comment untouched; delete removes exactly one', () => {
+    const doc = makeDoc()
+    writeSpatialCanvas(doc, { nodes: [], edges: [], 'x-whiteboard': { comments: [COMMENT] } })
+
+    writeCanvasComment(doc, OTHER)
+    expect(readSpatialCanvas(doc)['x-whiteboard']?.comments).toHaveLength(2)
+
+    deleteCanvasComment(doc, 'c1')
+    expect(readSpatialCanvas(doc)['x-whiteboard']?.comments).toEqual([OTHER])
+
+    // Absent id: a no-op, no commit — matching the bridge convention.
+    deleteCanvasComment(doc, 'never-existed')
+    expect(readSpatialCanvas(doc)['x-whiteboard']?.comments).toEqual([OTHER])
+  })
+
+  test('a corrupt stored comment is dropped on read, never the whole layer', () => {
+    const doc = makeDoc()
+    writeCanvasComment(doc, COMMENT)
+    doc.getMap('comments').set('bad', { nope: true })
+    doc.commit()
+
+    expect(readSpatialCanvas(doc)['x-whiteboard']?.comments).toEqual([COMMENT])
+  })
+
+  test('refuses a non-finite anchor loudly, matching the node geometry guard', () => {
+    const doc = makeDoc()
+    expect(() => writeCanvasComment(doc, { ...COMMENT, x: Number.NaN })).toThrow(TypeError)
+  })
+
+  test('comments alone produce an extension; no comments and no envelope produce none', () => {
+    const doc = makeDoc()
+    writeCanvasComment(doc, COMMENT)
+    expect(readSpatialCanvas(doc)['x-whiteboard']).toEqual({ comments: [COMMENT] })
+
+    deleteCanvasComment(doc, 'c1')
+    expect(readSpatialCanvas(doc)).not.toHaveProperty('x-whiteboard')
   })
 })

--- a/packages/loro-adapter/src/loro-bridge.ts
+++ b/packages/loro-adapter/src/loro-bridge.ts
@@ -1,5 +1,7 @@
 import {
+  type CanvasComment,
   type CanvasEdge,
+  canvasCommentSchema,
   canvasEdgeSchema,
   canvasExtensionSchema,
   type DocumentKind,
@@ -55,6 +57,15 @@ const EDGES_KEY = 'edges'
  */
 const CANVAS_KEY = 'canvas'
 const EXTENSION_FIELD = 'x-whiteboard'
+/**
+ * The comment annotation layer (ADR-0024), keyed per comment like nodes and
+ * edges — NOT stored inside the canvas envelope above, although the model
+ * type carries comments on `x-whiteboard`. The envelope is whole-value LWW,
+ * which is right for a preference and exactly wrong for comments: two peers
+ * commenting concurrently must both survive a merge. `writeSpatialCanvas`
+ * splits the field out on write and `readSpatialCanvas` reassembles it.
+ */
+const COMMENTS_KEY = 'comments'
 const FACETS_KEY = 'facets'
 // Editor state that is NOT canvas content: stored beside the canvas in the
 // same doc (so it survives reload and syncs to peers) but in its own map,
@@ -155,16 +166,51 @@ function edgeToFields(edge: CanvasEdge): Fields {
   return fields
 }
 
+function commentToFields(comment: CanvasComment): Fields {
+  // Same loud refusal as nodeToFields: readSpatialCanvas round-trips every
+  // comment through the Zod schema and silently drops failures, so a NaN
+  // anchor written here would delete the comment for every reader.
+  for (const [field, value] of [
+    ['x', comment.x],
+    ['y', comment.y],
+  ] as const) {
+    if (!Number.isFinite(value)) {
+      throw new TypeError(
+        `canvas comment "${comment.id}" has a non-finite ${field} (${value}); the anchor must be finite`,
+      )
+    }
+  }
+  const fields: Fields = { id: comment.id, x: comment.x, y: comment.y, text: comment.text }
+  if (comment.author !== undefined) fields.author = comment.author
+  if (comment.createdAt !== undefined) fields.createdAt = comment.createdAt
+  if (comment.targetNodeId !== undefined) fields.targetNodeId = comment.targetNodeId
+  if (comment.resolved !== undefined) fields.resolved = comment.resolved
+  return fields
+}
+
 export function writeSpatialCanvas(doc: DocumentContainers, canvas: SpatialCanvas): void {
   const nodesMap = doc.getMap(NODES_KEY)
   const edgesMap = doc.getMap(EDGES_KEY)
   // Deleted rather than left behind when the canvas drops it: a canvas that
   // returned to the default must stop rendering a preference the author
-  // turned off.
+  // turned off. Comments are split OUT of the envelope value first — see
+  // COMMENTS_KEY for why they must not ride the whole-value LWW write.
   const canvasMap = doc.getMap(CANVAS_KEY)
-  const extension = canvas[EXTENSION_FIELD]
-  if (extension === undefined) canvasMap.delete(EXTENSION_FIELD)
-  else canvasMap.set(EXTENSION_FIELD, extension)
+  const { comments, ...envelope } = canvas[EXTENSION_FIELD] ?? {}
+  if (Object.values(envelope).every((value) => value === undefined)) {
+    canvasMap.delete(EXTENSION_FIELD)
+  } else {
+    canvasMap.set(EXTENSION_FIELD, envelope)
+  }
+
+  const commentsMap = doc.getMap(COMMENTS_KEY)
+  const existingCommentIds = new Set<string>(commentsMap.keys())
+  for (const comment of comments ?? []) {
+    existingCommentIds.delete(comment.id)
+    commentsMap.set(comment.id, commentToFields(comment))
+  }
+  // A resync states the whole truth, comments included.
+  for (const id of existingCommentIds) commentsMap.delete(id)
 
   const existingNodeIds = new Set<string>(nodesMap.keys())
   const existingEdgeIds = new Set<string>(edgesMap.keys())
@@ -405,9 +451,53 @@ export function readSpatialCanvas(doc: DocumentContainers): SpatialCanvas {
 
   // Parsed, not trusted: the stored value came from another version or peer,
   // and model's own rule for this key is that an unreadable payload
-  // costs the preference, never the canvas.
-  const extension = canvasExtensionSchema.safeParse(doc.getMap(CANVAS_KEY).get(EXTENSION_FIELD))
-  return extension.success ? { nodes, edges, [EXTENSION_FIELD]: extension.data } : { nodes, edges }
+  // costs the preference, never the canvas. Any `comments` a buggy writer
+  // left INSIDE the envelope are discarded here — the comments map below is
+  // the single source of that field.
+  const parsedEnvelope = canvasExtensionSchema.safeParse(
+    doc.getMap(CANVAS_KEY).get(EXTENSION_FIELD),
+  )
+  const { comments: _strayComments, ...envelope } = parsedEnvelope.success
+    ? parsedEnvelope.data
+    : {}
+
+  const commentsMap = doc.getMap(COMMENTS_KEY)
+  const comments: CanvasComment[] = []
+  for (const commentId of commentsMap.keys()) {
+    const parsed = canvasCommentSchema.safeParse(commentsMap.get(commentId))
+    if (parsed.success) comments.push(parsed.data)
+  }
+
+  const hasEnvelope = Object.values(envelope).some((value) => value !== undefined)
+  if (!hasEnvelope && comments.length === 0) return { nodes, edges }
+  return {
+    nodes,
+    edges,
+    [EXTENSION_FIELD]: comments.length > 0 ? { ...envelope, comments } : envelope,
+  }
+}
+
+/**
+ * Writes exactly one comment's entry, leaving every other comment (and the
+ * canvas envelope) untouched — the comment-level counterpart of
+ * `writeSpatialNode`, and the write shape a "two peers comment concurrently"
+ * merge depends on. Also the UPDATE path: resolving a comment is a rewrite
+ * of the same id with `resolved: true`.
+ */
+export function writeCanvasComment(doc: DocumentContainers, comment: CanvasComment): void {
+  doc.getMap(COMMENTS_KEY).set(comment.id, commentToFields(comment))
+  doc.commit()
+}
+
+/**
+ * Removes exactly one comment. Idempotent and a no-op (no commit) for an id
+ * absent from the doc, matching `deleteSpatialEdge`.
+ */
+export function deleteCanvasComment(doc: DocumentContainers, commentId: string): void {
+  const commentsMap = doc.getMap(COMMENTS_KEY)
+  if (!commentsMap.keys().includes(commentId)) return
+  commentsMap.delete(commentId)
+  doc.commit()
 }
 
 /**
@@ -712,6 +802,7 @@ export const CONTENT_CONTAINER_KEYS: ReadonlyArray<{ key: string; kind: 'map' | 
   { key: NODES_KEY, kind: 'map' },
   { key: EDGES_KEY, kind: 'map' },
   { key: CANVAS_KEY, kind: 'map' },
+  { key: COMMENTS_KEY, kind: 'map' },
   { key: FACETS_KEY, kind: 'map' },
   { key: NODE_LOCKS_KEY, kind: 'map' },
   { key: EDGE_LOCKS_KEY, kind: 'map' },

--- a/packages/loro-adapter/src/workspace-record-growth.test.ts
+++ b/packages/loro-adapter/src/workspace-record-growth.test.ts
@@ -81,9 +81,9 @@ describe('workspace-record growth scoreboard', () => {
   })
 
   it('pins record size against document count (no edits)', () => {
-    expect(build(1, 0).afterCreateBytes).toBe(858)
-    expect(build(10, 0).afterCreateBytes).toBe(3002)
-    expect(build(50, 0).afterCreateBytes).toBe(12655)
+    expect(build(1, 0).afterCreateBytes).toBe(889)
+    expect(build(10, 0).afterCreateBytes).toBe(3166)
+    expect(build(50, 0).afterCreateBytes).toBe(13866)
   })
 
   it('pins oplog growth per edit and the shallow reclaim', () => {
@@ -92,10 +92,16 @@ describe('workspace-record growth scoreboard', () => {
     expect(n.updateBytes).toBe(178460)
     // The stored-snapshot price of the same history — Loro's snapshot
     // encoding compresses it to ~8B/edit.
-    expect(n.fullBytes).toBe(11348)
-    // The reclaim: a shallow cut at the current frontier is byte-identical
-    // to the record before any edit happened.
-    expect(n.shallowBytes).toBe(3002)
-    expect(n.shallowBytes).toBe(build(10, 0).afterCreateBytes)
+    expect(n.fullBytes).toBe(11428)
+    // The reclaim: a shallow cut at the current frontier collapses the whole
+    // edit history. It is no longer byte-IDENTICAL to the create-time record:
+    // since the comments container (ADR-0024) joined the pre-attached set, a
+    // container that has never been written encodes 9B leaner in a shallow
+    // snapshot than at create time (measured 3157 vs 3166), so the cut is
+    // pinned exactly AND bounded by the create-time size — the reclaim story
+    // ("compaction takes back everything the edits added") is the invariant,
+    // byte identity was only its strongest available form.
+    expect(n.shallowBytes).toBe(3157)
+    expect(n.shallowBytes).toBeLessThanOrEqual(build(10, 0).afterCreateBytes)
   })
 })

--- a/packages/model/src/spatial.test.ts
+++ b/packages/model/src/spatial.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   canvasColorSchema,
+  canvasCommentSchema,
   canvasEdgeSchema,
   spatialCanvasSchema,
   spatialNodeSchema,
@@ -382,5 +383,83 @@ describe('canvas-level x-whiteboard', () => {
       'x-whiteboard': 'not an object',
     })
     expect(parsed.nodes).toHaveLength(1)
+  })
+})
+
+// The annotation layer (ADR-0024): a comment is pinned AT an anchor point but
+// is not content — it must never cost the canvas, and a reader that cannot
+// interpret it still holds a complete document.
+describe('canvasCommentSchema', () => {
+  const minimal = { id: 'c1', x: 100, y: -40, text: 'this arrow points the wrong way' }
+
+  it('accepts the minimal shape: id + integer anchor + non-empty text', () => {
+    expect(canvasCommentSchema.safeParse(minimal).success).toBe(true)
+  })
+
+  it('accepts the full shape: OKF actor author, OKF timestamp, target node, resolved', () => {
+    const parsed = canvasCommentSchema.safeParse({
+      ...minimal,
+      author: 'human:yuuki',
+      createdAt: '2026-09-01T10:00:00+09:00',
+      targetNodeId: 'n1',
+      resolved: true,
+    })
+    expect(parsed.success).toBe(true)
+  })
+
+  it('rejects empty text — a comment with nothing to say is a caller bug', () => {
+    expect(canvasCommentSchema.safeParse({ ...minimal, text: '' }).success).toBe(false)
+  })
+
+  it('rejects a non-integer anchor, matching JSON Canvas geometry', () => {
+    expect(canvasCommentSchema.safeParse({ ...minimal, x: 1.5 }).success).toBe(false)
+  })
+
+  it('rejects a blank author and a timestamp without an explicit offset', () => {
+    expect(canvasCommentSchema.safeParse({ ...minimal, author: '  ' }).success).toBe(false)
+    expect(
+      canvasCommentSchema.safeParse({ ...minimal, createdAt: '2026-09-01T10:00:00' }).success,
+    ).toBe(false)
+  })
+})
+
+describe('canvas comments on the canvas-level extension', () => {
+  const comment = { id: 'c1', x: 10, y: 20, text: 'shrink this' }
+
+  it('carries comments beside the rendering preferences', () => {
+    const parsed = spatialCanvasSchema.parse({
+      nodes: [],
+      edges: [],
+      'x-whiteboard': { edgeRouting: { style: 'orthogonal' }, comments: [comment] },
+    })
+    expect(parsed['x-whiteboard']).toEqual({
+      edgeRouting: { style: 'orthogonal' },
+      comments: [comment],
+    })
+  })
+
+  it('a malformed comment costs the comments bucket only, never the sibling preferences', () => {
+    const parsed = spatialCanvasSchema.parse({
+      nodes: [],
+      edges: [],
+      'x-whiteboard': {
+        edgeRouting: { style: 'orthogonal' },
+        comments: [{ id: 'c1', x: 10, y: 20, text: '' }],
+      },
+    })
+    expect(parsed['x-whiteboard']).toEqual({ edgeRouting: { style: 'orthogonal' } })
+  })
+
+  // Deliberately UNLIKE an edge's endpoints: a comment may outlive the node it
+  // was left on (or arrive about one a concurrent peer deleted), and a
+  // renderer falls back to the anchor point. Rejecting would let the
+  // annotation layer make the document unreadable.
+  it('accepts a targetNodeId that names no existing node', () => {
+    const parsed = spatialCanvasSchema.safeParse({
+      nodes: [],
+      edges: [],
+      'x-whiteboard': { comments: [{ ...comment, targetNodeId: 'gone' }] },
+    })
+    expect(parsed.success).toBe(true)
   })
 })

--- a/packages/model/src/spatial.ts
+++ b/packages/model/src/spatial.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { extensionFacetsSchema } from './facets.js'
 import { documentIdSchema, nodeIdSchema } from './ids.js'
+import { okfActorSchema, okfTimestampSchema } from './trust.js'
 
 // JSON Canvas 1.0 (https://jsoncanvas.org/spec/1.0/): color is either one of
 // six numbered presets or a 6-digit hex string.
@@ -163,6 +164,36 @@ export const edgeRoutingSchema = z.object({
 })
 
 /**
+ * A comment pinned to the canvas — the annotation layer (ADR-0024).
+ *
+ * `x`/`y` is the ANCHOR: the point the comment is about, in JSON Canvas
+ * integer canvas coordinates. It is deliberately not a bounding box — where
+ * the comment's bubble draws is a renderer decision (floating near the
+ * anchor), never stored. `targetNodeId` narrows the anchor to "about this
+ * node"; a renderer follows the node's current position and falls back to
+ * the anchor point when the node is gone. A dangling `targetNodeId` is
+ * VALID: a comment may outlive its subject, and the annotation layer must
+ * never make the document unreadable.
+ *
+ * `author` is an OKF actor string (`human:<id>` / `process:<id>`, ADR-0016)
+ * so the `human:` prefix keeps its trust meaning across layers; `createdAt`
+ * is an OKF timestamp. Both optional: identity is a keeper concern this
+ * model does not solve.
+ */
+export const canvasCommentSchema = z.object({
+  id: nodeIdSchema,
+  x: z.number().int(),
+  y: z.number().int(),
+  text: z.string().min(1),
+  author: okfActorSchema.optional(),
+  createdAt: okfTimestampSchema.optional(),
+  targetNodeId: nodeIdSchema.optional(),
+  resolved: z.boolean().optional(),
+})
+
+export type CanvasComment = z.infer<typeof canvasCommentSchema>
+
+/**
  * `x-whiteboard` at the CANVAS level — separate from the node-level key of the
  * same name, and holding preferences rather than content.
  *
@@ -173,6 +204,21 @@ export const edgeRoutingSchema = z.object({
  */
 export const canvasExtensionSchema = z.object({
   edgeRouting: edgeRoutingSchema.optional(),
+  /**
+   * The comment annotation layer (ADR-0024). Lives under the canvas-level
+   * extension because a strict JSON Canvas consumer that drops the key still
+   * holds the complete CONTENT — what it loses is the conversation about it,
+   * which is exactly what an annotation is. The bucket carries its own catch
+   * for the same reason `facets` does: a malformed comment costs the
+   * comments, not the preferences beside them.
+   *
+   * NOTE the storage shape differs from this file shape: the Loro bridge
+   * stores each comment under its own key in a dedicated `comments` map
+   * (per-comment CRDT merge, so two peers commenting concurrently both
+   * survive), never inside the canvas envelope value — see loro-adapter's
+   * `writeSpatialCanvas`.
+   */
+  comments: z.array(canvasCommentSchema).optional().catch(undefined),
   /**
    * Canvas-target facets (ADR-0013 decision 5): the spatial counterpart of a
    * markdown document's `facets` bucket, carrying `{namespace}.{name}/v{n}`

--- a/packages/model/src/test-utils/arbitraries.ts
+++ b/packages/model/src/test-utils/arbitraries.ts
@@ -9,7 +9,7 @@ import type {
   MdastTableCell,
   MdastTableRow,
 } from '../mdast/index.js'
-import type { SpatialCanvas } from '../spatial.js'
+import type { CanvasComment, CanvasEdge, SpatialCanvas } from '../spatial.js'
 import { fc } from './fast-check.js'
 
 const CROCKFORD_CHARS = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
@@ -502,11 +502,30 @@ export function mdastRootArbitrary(maxDepth = 3): fc.Arbitrary<MdastRoot> {
  * and one of them had lost the node-id dedupe — a canvas the schema rejects,
  * asserted to round-trip.
  */
+// Valid-by-construction: text is non-empty, the anchor is integer, and the
+// optional author/timestamp use the shapes their schemas actually accept.
+// `targetNodeId` is free-standing on purpose — a dangling target is VALID
+// (a comment may outlive its subject), so the canvas arbitrary does not need
+// to correlate it with node ids the way edges must be.
+export const canvasCommentArbitrary: fc.Arbitrary<CanvasComment> = fc.record(
+  {
+    id: nodeIdArbitrary,
+    x: geometryArbitrary,
+    y: geometryArbitrary,
+    text: fc.string({ minLength: 1, maxLength: 40 }),
+    author: fc.constantFrom('human:reviewer', 'process:layout-agent'),
+    createdAt: fc.constant('2026-09-01T10:00:00+09:00'),
+    targetNodeId: nodeIdArbitrary,
+    resolved: fc.boolean(),
+  },
+  { requiredKeys: ['id', 'x', 'y', 'text'] },
+)
+
 export const spatialCanvasArbitrary: fc.Arbitrary<SpatialCanvas> = fc
   .uniqueArray(spatialNodeArbitrary, { maxLength: 4, selector: (node) => node.id })
-  .chain((nodes): fc.Arbitrary<SpatialCanvas> => {
+  .chain((nodes) => {
     const ids = nodes.map((node) => node.id)
-    if (ids.length < 2) return fc.constant({ nodes, edges: [] })
+    if (ids.length < 2) return fc.constant({ nodes, edges: [] as CanvasEdge[] })
     return fc
       .uniqueArray(
         fc
@@ -518,3 +537,15 @@ export const spatialCanvasArbitrary: fc.Arbitrary<SpatialCanvas> = fc
       )
       .map((edges) => ({ nodes, edges }))
   })
+  .chain(
+    (canvas): fc.Arbitrary<SpatialCanvas> =>
+      fc
+        .option(fc.uniqueArray(canvasCommentArbitrary, { maxLength: 3, selector: (c) => c.id }), {
+          nil: undefined,
+        })
+        .map((comments) =>
+          comments === undefined || comments.length === 0
+            ? canvas
+            : { ...canvas, 'x-whiteboard': { comments } },
+        ),
+  )


### PR DESCRIPTION
# Summary

The data half of ADR-0024 (new in this PR): a **comment** becomes a first-class annotation object of a spatial document — anchored at a point (optionally about a node), never part of content layout, safe under concurrent collaboration.

- **model**: `canvasCommentSchema` — `{id, x, y, text, author?, createdAt?, targetNodeId?, resolved?}` with an OKF actor author (`human:`/`process:` prefixes keep their trust meaning) and OKF timestamp. Carried as a `comments` bucket (own `.catch`) on the canvas-level `x-whiteboard`, so a strict JSON Canvas consumer that drops the key still holds the complete content, and `x-whiteboard` stays the only non-standard key. A dangling `targetNodeId` is deliberately VALID (a comment may outlive its subject). `docs/reference/x-whiteboard.schema.json` regenerated; the shared canvas arbitrary now generates comments, so codec's round-trip and extension-contract properties exercise them.
- **loro-adapter**: comments are stored in a dedicated per-comment map — the same CRDT granularity as nodes/edges — because both rejected homes lose a side under concurrency (facet payloads merge replace-whole-payload; the canvas envelope value is whole-value LWW). `writeSpatialCanvas` splits comments out of the envelope (pinned by an envelope-purity test and **mutation-checked**: re-storing the whole extension in the envelope fails exactly that test), `readSpatialCanvas` reassembles with per-comment drop tolerance, and `writeCanvasComment`/`deleteCanvasComment` are the fine-grained paths. The new `comments` container joins `CONTENT_CONTAINER_KEYS` (tree-host pre-attach / undo-redo invariant).
- **Measured cost** (workspace-record growth scoreboard, re-pinned): +31B per document at create time; the shallow-snapshot reclaim is now 9B leaner than the create-time record (no longer byte-identical), pinned exactly and bounded by the create-time size.
- **ADR-0024** records the decision, the rejected alternatives, and the follow-up increments: scene-composed pins (render), `wb_canvas_edit` comment ops, and the widget's click-to-comment with ext-apps `sendMessage` delivery to the AI.

`userReach`: foundation — wired by the follow-up increments above (render pins → comment ops → widget comment UI), each its own PR.

# Test plan

- `pnpm vitest run --project model-node --project codec-node --project loro-adapter-node --project server-core-node --project canvas-render-node --project arch-lint-node` → 2061 passed.
- `pnpm test --project mcp-node` → 4207 passed, 1 failed = `local-node-version.test.ts` (this container runs Node 22 vs the pinned 24; known environment baseline, CI runs Node 24).
- `pnpm check:local` → green.
- Mutation check: enveloping the whole extension (comments included) back into the `canvas` map fails the envelope-purity test; restored and re-verified green.

Visual evidence: none — data-layer only, no pixels move (rendering lands in the follow-up increment with its own before/after figure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for anchored canvas comments with optional authors, timestamps, node references, and resolution status.
  - Comments can be created, updated, deleted, and synchronized safely across collaborative sessions.
  - Added schema validation and graceful handling of malformed comment data.
  - Exposed canvas comment operations through the public API.

- **Documentation**
  - Documented the approved canvas comments design and added it to the architecture decision record index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->