### PR TITLE
feat(canvas-render): draw the comment annotation layer as pins and floating bubbles

### DIFF
--- a/packages/canvas-render/src/layout/comments.test.ts
+++ b/packages/canvas-render/src/layout/comments.test.ts
@@ -1,0 +1,184 @@
+// The comment annotation layer's rendering (ADR-0024 decision 4): pins and
+// bubbles composed into the SVG scene AFTER nodes and edges, so they paint
+// above content on every surface — widget, viewer, export — with no per-
+// surface wiring. Placement floats near the anchor; nothing here is stored.
+import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
+import type { MdastRoot } from '@kamiazya/whiteboard-model/mdast'
+import { describe, expect, it } from 'vitest'
+import type { SceneNode, ShapeSceneNode, TextRunNode } from '../scene-graph.js'
+import { createFakeMeasure } from '../test-utils/fake-measure.js'
+import type { SpatialAppearanceResolver } from './nodes/spatial-appearance.js'
+import {
+  COMMENT_BUBBLE_OFFSET_PX,
+  COMMENT_PIN_SIZE_PX,
+  layoutSpatialCanvas,
+  type SpatialLayoutOptions,
+} from './spatial-canvas.js'
+
+const measure = createFakeMeasure()
+
+const fakeAppearance: SpatialAppearanceResolver = {
+  resolveNode: () => ({ radius: 4 }),
+  resolveEdge: () => ({ stroke: '#606060', strokeWidth: 1.5 }),
+  resolveLabel: () => ({ fill: '#303030', fontFamily: 'sans-serif' }),
+  resolveComment: () => ({
+    pin: { fill: '#d97706' },
+    bubble: { fill: '#fef3c7', stroke: '#d97706' },
+  }),
+}
+
+function fakeParseBody(text: string): MdastRoot {
+  return {
+    type: 'root',
+    children: [{ type: 'paragraph', children: [{ type: 'text', value: text }] }],
+  }
+}
+
+function baseOptions(overrides: Partial<SpatialLayoutOptions> = {}): SpatialLayoutOptions {
+  return {
+    measure,
+    parseBody: fakeParseBody,
+    appearance: fakeAppearance,
+    geometry: { paddingPx: 8, labelFontSizePx: 14, minContentWidthPx: 1 },
+    ...overrides,
+  }
+}
+
+const TEXT_NODE: SpatialNode = {
+  id: 'n1',
+  type: 'text',
+  x: 0,
+  y: 0,
+  width: 200,
+  height: 100,
+  text: 'content',
+}
+
+function canvasWith(comments: NonNullable<SpatialCanvas['x-whiteboard']>['comments']) {
+  return {
+    nodes: [TEXT_NODE],
+    edges: [],
+    'x-whiteboard': { comments },
+  } satisfies SpatialCanvas
+}
+
+function shapesOf(nodes: readonly SceneNode[]): ShapeSceneNode[] {
+  return nodes.filter((node): node is ShapeSceneNode => node.kind === 'shape')
+}
+
+// Comment text lays out through the mdast pipeline, so its runs sit inside
+// paragraph/heading BLOCK nodes rather than at the top level.
+function runsOf(nodes: readonly SceneNode[]): TextRunNode[] {
+  return nodes.flatMap((node) => {
+    if (node.kind === 'textRun') return [node]
+    if (node.kind === 'paragraph' || node.kind === 'heading') return [...node.runs]
+    return []
+  })
+}
+
+describe('comment layer', () => {
+  it('draws a pin centered on the anchor and a bubble holding the text, after all content', () => {
+    const scene = layoutSpatialCanvas(
+      canvasWith([{ id: 'c1', x: 400, y: 60, text: 'move this left' }]),
+      baseOptions(),
+    )
+
+    const shapes = shapesOf(scene.nodes)
+    const pin = shapes.find((shape) => shape.bbox.w === COMMENT_PIN_SIZE_PX)
+    expect(pin).toBeDefined()
+    expect(pin?.bbox.x).toBe(400 - COMMENT_PIN_SIZE_PX / 2)
+    expect(pin?.bbox.y).toBe(60 - COMMENT_PIN_SIZE_PX / 2)
+    // A circle: the rect chrome with radius = half its side.
+    expect(pin?.radius).toBe(COMMENT_PIN_SIZE_PX / 2)
+    expect(pin?.appearance).toEqual({ fill: '#d97706' })
+
+    const bubble = shapes.find((shape) => shape.appearance?.fill === '#fef3c7')
+    expect(bubble).toBeDefined()
+    expect(bubble?.bbox.x).toBe(400 + COMMENT_BUBBLE_OFFSET_PX)
+    expect(bubble?.bbox.y).toBe(60 + COMMENT_BUBBLE_OFFSET_PX)
+
+    const texts = runsOf(scene.nodes).map((run) => run.text)
+    expect(texts).toContain('move this left')
+
+    // Painted ABOVE everything: the pin and bubble come after the node's own
+    // scene entries in the flat paint list.
+    const nodeChromeIndex = scene.nodes.findIndex(
+      (node) => node.kind === 'shape' && node.id === 'n1',
+    )
+    const pinIndex = scene.nodes.indexOf(pin as ShapeSceneNode)
+    expect(pinIndex).toBeGreaterThan(nodeChromeIndex)
+  })
+
+  it('follows the target node when it resolves, and falls back to the anchor when it is gone', () => {
+    const followed = layoutSpatialCanvas(
+      canvasWith([{ id: 'c1', x: 999, y: 999, text: 'about n1', targetNodeId: 'n1' }]),
+      baseOptions(),
+    )
+    const followedPin = shapesOf(followed.nodes).find(
+      (shape) => shape.bbox.w === COMMENT_PIN_SIZE_PX,
+    )
+    // Pinned to the node's top-right corner, not the stored anchor.
+    expect(followedPin?.bbox.x).toBe(200 - COMMENT_PIN_SIZE_PX / 2)
+    expect(followedPin?.bbox.y).toBe(0 - COMMENT_PIN_SIZE_PX / 2)
+
+    const dangling = layoutSpatialCanvas(
+      canvasWith([{ id: 'c1', x: 50, y: 70, text: 'about a deleted node', targetNodeId: 'gone' }]),
+      baseOptions(),
+    )
+    const danglingPin = shapesOf(dangling.nodes).find(
+      (shape) => shape.bbox.w === COMMENT_PIN_SIZE_PX,
+    )
+    expect(danglingPin?.bbox.x).toBe(50 - COMMENT_PIN_SIZE_PX / 2)
+    expect(danglingPin?.bbox.y).toBe(70 - COMMENT_PIN_SIZE_PX / 2)
+  })
+
+  it('does not draw a resolved comment — the record stays in the document, not on the canvas', () => {
+    const withoutComments = layoutSpatialCanvas({ nodes: [TEXT_NODE], edges: [] }, baseOptions())
+    const withResolved = layoutSpatialCanvas(
+      canvasWith([{ id: 'c1', x: 10, y: 10, text: 'done already', resolved: true }]),
+      baseOptions(),
+    )
+    expect(withResolved).toEqual(withoutComments)
+  })
+
+  it('a canvas without comments lays out exactly as before the layer existed', () => {
+    const plain = layoutSpatialCanvas({ nodes: [TEXT_NODE], edges: [] }, baseOptions())
+    const explicitEmpty = layoutSpatialCanvas(canvasWith([]), baseOptions())
+    expect(explicitEmpty).toEqual(plain)
+  })
+
+  it('renders pins without appearance when the resolver does not know comments', () => {
+    // A resolver predating the layer (or a caller's custom one) must not
+    // break layout — appearance is assigned, never invented, so the pins
+    // simply carry none.
+    const bare: SpatialAppearanceResolver = {
+      resolveNode: () => ({}),
+      resolveEdge: () => undefined,
+      resolveLabel: () => ({}),
+    }
+    const scene = layoutSpatialCanvas(
+      canvasWith([{ id: 'c1', x: 5, y: 5, text: 'still drawn' }]),
+      baseOptions({ appearance: bare }),
+    )
+    const pin = shapesOf(scene.nodes).find((shape) => shape.bbox.w === COMMENT_PIN_SIZE_PX)
+    expect(pin).toBeDefined()
+    expect(pin?.appearance).toBeUndefined()
+    expect(runsOf(scene.nodes).map((run) => run.text)).toContain('still drawn')
+  })
+
+  it('wraps long comment text within the bubble width instead of one endless line', () => {
+    const scene = layoutSpatialCanvas(
+      canvasWith([
+        {
+          id: 'c1',
+          x: 0,
+          y: 0,
+          text: 'a fairly long comment that certainly cannot fit on one narrow bubble line',
+        },
+      ]),
+      baseOptions(),
+    )
+    const runs = runsOf(scene.nodes).filter((run) => run.text !== 'content')
+    expect(runs.length).toBeGreaterThan(1)
+  })
+})

--- a/packages/canvas-render/src/layout/nodes/spatial-appearance.ts
+++ b/packages/canvas-render/src/layout/nodes/spatial-appearance.ts
@@ -38,4 +38,17 @@ export interface SpatialAppearanceResolver {
    * absence assigns no appearance rather than inventing one.
    */
   resolveSyntax?(): SpatialSyntaxPalette
+  /**
+   * Chrome for the comment annotation layer (ADR-0024): the anchor pin and
+   * the floating bubble behind the comment's text. Optional for the same
+   * reason `resolveSyntax` is — a resolver that predates the layer still
+   * lays comments out; they simply carry no appearance.
+   */
+  resolveComment?(): SpatialCommentAppearance
+}
+
+/** What a resolver decided for the comment layer's chrome. */
+export interface SpatialCommentAppearance {
+  readonly pin: Appearance
+  readonly bubble: Appearance
 }

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -27,6 +27,7 @@
 
 import { parseMarkdownBody } from '@kamiazya/whiteboard-codec'
 import type {
+  CanvasComment,
   CanvasEdge,
   EdgeRoutingStyle,
   SpatialCanvas,
@@ -1288,7 +1289,122 @@ function layoutSpatialCanvasInternal(
     ...composeDecorations(node, resolved),
   ])
   const { content, anchors } = composeEdgesAndLabels(canvas, resolved)
-  return { scene: { nodes: [...nodeContent, ...content] }, anchors }
+  // Comments LAST: the annotation layer paints above every node and edge,
+  // which a flat document-order paint list can only express by position.
+  const commentContent = composeComments(canvas, resolved)
+  return { scene: { nodes: [...nodeContent, ...content, ...commentContent] }, anchors }
+}
+
+/** Pin diameter (px). Fixed like badge geometry — a mark, not content. */
+export const COMMENT_PIN_SIZE_PX = 20
+/** Gap (px) from the anchor point to the bubble's top-left corner. */
+export const COMMENT_BUBBLE_OFFSET_PX = 14
+const COMMENT_TEXT_MAX_WIDTH_PX = 200
+const COMMENT_BUBBLE_PADDING_PX = 8
+const COMMENT_BUBBLE_RADIUS_PX = 8
+
+/**
+ * Where a comment points: the target node's top-right corner while the node
+ * exists (the pin FOLLOWS the node), the stored anchor otherwise. The
+ * fallback is what makes a dangling `targetNodeId` harmless, per the model's
+ * contract that a comment may outlive its subject.
+ */
+function commentAnchor(
+  comment: CanvasComment,
+  canvas: SpatialCanvas,
+): { readonly x: number; readonly y: number } {
+  if (comment.targetNodeId !== undefined) {
+    const target = canvas.nodes.find((node) => node.id === comment.targetNodeId)
+    if (target !== undefined) return { x: target.x + target.width, y: target.y }
+  }
+  return { x: comment.x, y: comment.y }
+}
+
+/**
+ * The comment annotation layer (ADR-0024 decision 4): one pin (a circle on
+ * the anchor) plus one bubble (rounded rect holding the text, floating
+ * offset from the anchor) per unresolved comment, composed from existing
+ * scene kinds so no consumer of the closed union changes. Resolved comments
+ * stay in the document and are deliberately not drawn. Appearance comes
+ * from the resolver's optional `resolveComment` — assigned, never invented —
+ * so a resolver that predates the layer still lays comments out, bare.
+ *
+ * ponytail: placement is a fixed down-right offset with no collision
+ * avoidance; overlapping bubbles on clustered comments are the ceiling, and
+ * a greedy占-region placer over sceneBounds is the upgrade path.
+ */
+function composeComments(
+  canvas: SpatialCanvas,
+  options: ResolvedLayoutOptions,
+): readonly SceneNode[] {
+  const comments = canvas['x-whiteboard']?.comments
+  if (comments === undefined || comments.length === 0) return []
+
+  const appearance = options.appearance.resolveComment?.()
+  const out: SceneNode[] = []
+  for (const comment of comments) {
+    if (comment.resolved === true) continue
+    const anchor = commentAnchor(comment, canvas)
+
+    out.push({
+      kind: 'shape',
+      bbox: {
+        x: anchor.x - COMMENT_PIN_SIZE_PX / 2,
+        y: anchor.y - COMMENT_PIN_SIZE_PX / 2,
+        w: COMMENT_PIN_SIZE_PX,
+        h: COMMENT_PIN_SIZE_PX,
+      },
+      radius: COMMENT_PIN_SIZE_PX / 2,
+      ...(appearance !== undefined ? { appearance: appearance.pin } : {}),
+    })
+
+    // The text goes through the same mdast pipeline as a text node's body,
+    // so wrapping (CJK included) and theming have one producer. A parse
+    // failure degrades to the single-line label run, like a body's does.
+    let laid: Scene
+    try {
+      laid = layoutMdastBlocks(
+        options.parseBody(comment.text),
+        mdastOptionsFor(COMMENT_TEXT_MAX_WIDTH_PX, options),
+      )
+    } catch (err) {
+      options.onDegrade?.({ kind: 'body-parse-failed', nodeId: comment.id, err })
+      laid = { nodes: [labelRun(comment.text, options, COMMENT_TEXT_MAX_WIDTH_PX)] }
+    }
+    const contentRight = Math.max(0, ...laid.nodes.map((node) => sceneRight(node)))
+    const contentBottom = Math.max(0, ...laid.nodes.map((node) => sceneBottom(node)))
+
+    const bubbleX = anchor.x + COMMENT_BUBBLE_OFFSET_PX
+    const bubbleY = anchor.y + COMMENT_BUBBLE_OFFSET_PX
+    out.push({
+      kind: 'shape',
+      bbox: {
+        x: bubbleX,
+        y: bubbleY,
+        w: contentRight + 2 * COMMENT_BUBBLE_PADDING_PX,
+        h: contentBottom + 2 * COMMENT_BUBBLE_PADDING_PX,
+      },
+      radius: COMMENT_BUBBLE_RADIUS_PX,
+      ...(appearance !== undefined ? { appearance: appearance.bubble } : {}),
+    })
+    out.push(
+      ...translateScene(
+        laid,
+        bubbleX + COMMENT_BUBBLE_PADDING_PX,
+        bubbleY + COMMENT_BUBBLE_PADDING_PX,
+      ).nodes,
+    )
+  }
+  return out
+}
+
+/** Right/bottom extents of a laid-out block at origin, for sizing a bubble. */
+function sceneRight(node: SceneNode): number {
+  return node.kind === 'edge' ? 0 : node.bbox.x + node.bbox.w
+}
+
+function sceneBottom(node: SceneNode): number {
+  return node.kind === 'edge' ? 0 : node.bbox.y + node.bbox.h
 }
 
 function composeEdgesAndLabels(

--- a/packages/canvas-render/src/theme/spatial-palette.ts
+++ b/packages/canvas-render/src/theme/spatial-palette.ts
@@ -73,6 +73,13 @@ export interface SpatialPalette {
   readonly presets: Readonly<Record<SpatialPresetKey, SpatialPresetAccent>>
   /** Fills for syntax-highlighted code runs. */
   readonly syntax: SpatialSyntaxPalette
+  /**
+   * The comment annotation layer's chrome (ADR-0024): the anchor pin and
+   * the bubble behind the comment text. Amber on both modes — the one hue
+   * the node presets reserve for warm emphasis — so a comment reads as
+   * distinct from every content node at a glance.
+   */
+  readonly comment: { readonly pin: SpatialNodeStyle; readonly bubble: SpatialNodeStyle }
 }
 
 // Quiet-tool direction (apps/web/DESIGN.md): node and edge strokes sit at
@@ -113,6 +120,12 @@ export const SPATIAL_LIGHT_PALETTE: SpatialPalette = {
     number: '#c2410c',
     comment: '#5b6472',
   },
+  // The preset-3 amber pair: stroke 4.5:1 on white, labelFill 9.3:1 on the
+  // tint — the same contrast-tested ramp the presets pin.
+  comment: {
+    pin: { fill: '#d97706', stroke: '#b45309' },
+    bubble: { fill: '#fef3c7', stroke: '#d97706' },
+  },
 }
 
 // Seeded from the pre-theme editor's dark palette (EDITOR_DARK_PALETTE) — a
@@ -151,5 +164,10 @@ export const SPATIAL_DARK_PALETTE: SpatialPalette = {
     string: '#34d399',
     number: '#fb923c',
     comment: '#9ba3af',
+  },
+  // The preset-3 dark pair (Tailwind 400 over 950), same ramp as above.
+  comment: {
+    pin: { fill: '#fbbf24', stroke: '#f59e0b' },
+    bubble: { fill: '#451a03', stroke: '#fbbf24' },
   },
 }

--- a/packages/canvas-render/src/theme/spatial-theme.ts
+++ b/packages/canvas-render/src/theme/spatial-theme.ts
@@ -79,6 +79,10 @@ function buildTheme(palette: SpatialPalette): SpatialAppearanceResolver {
       stroke: presetAccent(edge.color, palette)?.stroke ?? rawHex(edge.color) ?? palette.edgeStroke,
     }),
     resolveSyntax: () => palette.syntax,
+    resolveComment: () => ({
+      pin: { fill: palette.comment.pin.fill, stroke: palette.comment.pin.stroke },
+      bubble: { fill: palette.comment.bubble.fill, stroke: palette.comment.bubble.stroke },
+    }),
     resolveLabel: () => ({
       fill: palette.labelFill,
       fontFamily: SPATIAL_THEME_FONT_FAMILY,


### PR DESCRIPTION
# Summary

ADR-0024 decision 4 — the rendering half of canvas comments (data layer landed in #1204):

- `layoutSpatialCanvas` composes each **unresolved** comment as a pin (a circle centered on the anchor) plus a floating bubble (rounded rect + the comment text), **after nodes and edges** in the flat paint list, so comments paint above all content. Built from existing scene kinds — the closed scene-node union is untouched, so `sceneBounds`/`translateScene`/`scaleScene`/the SVG backend need no edits, and every surface that renders the scene (widget, viewer, `wb_scene_render`, PNG export) shows comments with zero per-surface wiring.
- A node-targeted comment **follows its node's top-right corner** and falls back to the stored anchor when the node is gone (the model's dangling-target contract); `resolved: true` comments stay in the document and are deliberately not drawn.
- Comment text goes through the same mdast pipeline as a text node's body (`layoutMdastBlocks` + the caller's `parseBody`) — one wrapping producer, CJK/kinsoku included; a parse failure degrades to the single-line label run via `onDegrade`, like a body's.
- Appearance stays assigned, never invented: `SpatialAppearanceResolver` gains an **optional** `resolveComment()`, produced by `createSpatialTheme` from a new `comment` palette entry (the preset-3 amber pair on both modes, same contrast-tested ramp as the presets). A resolver that predates the layer still lays comments out, bare.
- `ponytail:` placement is a fixed down-right offset with no collision avoidance — overlapping bubbles on clustered comments are the ceiling; a placer over `sceneBounds` is the upgrade path.

`userReach`: foundation — comments can only enter a document via `writeCanvasComment`/a full canvas write today; the `wb_canvas_edit` `comment.*` ops and the widget's click-to-comment (ext-apps `sendMessage` delivery) are the next two increments per ADR-0024.

# Test plan

- New `layout/comments.test.ts` (6 tests): pin centered on anchor + paint-above ordering, node-follow + dangling fallback, resolved hidden, no-comments scene byte-equal to before the layer existed, resolver-without-`resolveComment` degradation, wrapping within the bubble width.
- `pnpm vitest run --project canvas-render-node --project arch-lint-node` → 1167 passed (goldens + determinism + both scoreboards untouched).
- `pnpm -r typecheck`, `pnpm check:local` → green.

# Visual repro

Rendered through the real export pipeline (`renderSpatialCanvasToPng`, real Roboto measurer + resvg), same canvas before/after; compose-figure digests `before 213f2513` / `after f5b1163b` (the script refuses identical panels). The canvas holds a free-anchored comment (wraps over 4 lines), a comment targeting the "Daemon" node (pin rides its top-right corner), and a resolved comment (absent from the after panel by design).

This environment has no `gh` CLI or image-upload path to GitHub, so the PNG cannot be attached here; the figure was delivered to the reviewer in the working session (`tmp/screenshots/comment-layer-figure.png` in the worktree until merge). What the figure cannot show: the dark-mode palette pair (unit-asserted only) and the editor surface (comments reach it via the shared pipeline; interactive UI is a later increment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_