### PR TITLE
test(web): make the editor property's floors say what else the run produced

### DIFF
--- a/apps/web/src/components/spatial-editor/editor-state.property.test.ts
+++ b/apps/web/src/components/spatial-editor/editor-state.property.test.ts
@@ -2308,6 +2308,26 @@ describe('editor composite state (command-based)', () => {
     assertLedger('GestureEvent type', GESTURE_EVENT_COVERAGE, stats.eventTypes)
     assertLedger('shortcut', SHORTCUT_COVERAGE, stats.shortcutIds)
 
+    // Every floor failure prints the WHOLE census, not only the counter
+    // that fell — because which one fell says almost nothing on its own.
+    // A counter that dropped while the one it shares a branch with stayed
+    // healthy is an unlucky ARRANGEMENT; a whole column that fell together
+    // is a run that simply did less work. Those want opposite fixes — a
+    // denser domain versus a bigger budget — and the message could not
+    // tell them apart, so the reader has to reconstruct the other numbers
+    // from somewhere else.
+    //
+    // Measured, on the run that occasioned this: separating those two
+    // readings took THIRTY local runs of this file, to recover numbers the
+    // failing run had already computed and thrown away.
+    const census = () =>
+      Object.entries(stats)
+        .filter(([, value]) => typeof value === 'number')
+        .map(([name, value]) => `${name}=${value}`)
+        .join(' ')
+    const atLeast = (actual: number, floor: number, wentWrong: string) =>
+      expect(actual, `${wentWrong}\ncensus: ${census()}`).toBeGreaterThan(floor)
+
     // Floors, not sentinels. `> 0` passes on a generator that reached an
     // arrangement once by luck, which is the shape this guard exists to
     // reject. Each sits at roughly a third of the minimum measured across
@@ -2318,7 +2338,7 @@ describe('editor composite state (command-based)', () => {
     // reorders 43-54 (of which forward/backward 16-24), locks applied
     // 15-28, select-alls 119-139, edge selections 83-95, edge deletes
     // 19-34, copies 33-46, cuts 53-72, cut-moves 13-20, paste-inserts
-    // 38-59, reconnections 8-13, marquee selections 23-30,
+    // 38-59, reconnections 5-19 (see below), marquee selections 23-30,
     // hand-swallowed presses 53-70, hand entries 43-56, connect arms
     // 44-68, tool switches 185-220, carried moves 57-80, group-or-multi
     // drags 57-80, group-frame drags 27-40, groups created 53-65.
@@ -2336,6 +2356,26 @@ describe('editor composite state (command-based)', () => {
     // dragged alongside a selection, which the extras kept green with
     // production containment disabled outright.
     //
+    // FIVE RUNS IS NOT A SAMPLE for a rare conjunction. Every range above
+    // was taken over five, which is ample for a counter in the hundreds
+    // and badly wrong for one in single digits. `reconnections` needs a
+    // cut whose selection straddles an edge, and then a paste — a deep
+    // conjunction the generator reaches only a few times per 500 runs.
+    // Re-measured over THIRTY runs it is 5-19 (mean 10.7), not the 8-13
+    // five runs reported, and the floor derived from that understated
+    // minimum was `> 2`. A CI run then produced 2 and went red.
+    //
+    // The floor is therefore re-derived by the SAME rule from the honest
+    // minimum — a third of 5 — rather than the guard being weakened by
+    // judgement. It still refuses the two states it exists to refuse: the
+    // arrangement never reached, and reached once by luck.
+    //
+    // What is NOT yet established is why CI produced 2 when thirty local
+    // runs produced nothing under 5. Both readings remain open — a run
+    // that did less work, or this conjunction alone being unlucky — and
+    // the census printed on failure is what will settle it the next time
+    // one fires, without another thirty runs.
+    //
     // Re-measure when adding a command, widening the document generator,
     // or making the model MORE faithful, because all three dilute every
     // existing counter. `numRuns` went 300 -> 500 when the command set
@@ -2343,49 +2383,44 @@ describe('editor composite state (command-based)', () => {
     // floor: the arrangements were still being reached, so that was
     // variance rather than vacuity, and more runs is the honest lever for
     // variance. It costs about three seconds.
-    expect(stats.moveCommits, 'moves barely committed').toBeGreaterThan(100)
-    expect(stats.resizeCommits, 'resizes barely committed').toBeGreaterThan(18)
-    expect(stats.connectCommits, 'edges barely connected').toBeGreaterThan(20)
-    expect(stats.deletes, 'nodes barely deleted').toBeGreaterThan(18)
-    expect(stats.textEditsOpened, 'text edits barely opened').toBeGreaterThan(40)
-    expect(stats.pendingTextHandoffs, 'open edits barely left with text in them').toBeGreaterThan(
-      12,
-    )
-    expect(
+    atLeast(stats.moveCommits, 100, 'moves barely committed')
+    atLeast(stats.resizeCommits, 18, 'resizes barely committed')
+    atLeast(stats.connectCommits, 20, 'edges barely connected')
+    atLeast(stats.deletes, 18, 'nodes barely deleted')
+    atLeast(stats.textEditsOpened, 40, 'text edits barely opened')
+    atLeast(stats.pendingTextHandoffs, 12, 'open edits barely left with text in them')
+    atLeast(
       stats.externalReplacementsMidGesture,
+      14,
       'external replacements barely landed mid-gesture',
-    ).toBeGreaterThan(14)
-    expect(stats.multiSelections, 'multi-selection barely reached').toBeGreaterThan(150)
-    expect(stats.nudges, 'arrow-key nudges barely reached').toBeGreaterThan(25)
-    expect(stats.duplicates, 'Cmd+D barely reached').toBeGreaterThan(6)
-    expect(stats.reordersEffective, 'z-order barely changed anything').toBeGreaterThan(15)
-    expect(
-      stats.stepReordersEffective,
-      'forward/backward never stepped over an overlapping node',
-    ).toBeGreaterThan(5)
-    expect(stats.locksApplied, 'Cmd+Shift+L barely locked anything').toBeGreaterThan(5)
-    expect(stats.selectAlls, 'Cmd+A barely reached').toBeGreaterThan(40)
-    expect(stats.edgeSelections, 'edges barely ever selected').toBeGreaterThan(28)
-    expect(stats.edgeDeletes, 'selected edges barely ever deleted').toBeGreaterThan(6)
-    expect(stats.copies, 'Cmd+C barely reached').toBeGreaterThan(11)
-    expect(stats.cuts, 'Cmd+X barely reached').toBeGreaterThan(18)
-    expect(stats.cutMoves, 'no paste resolved as a same-canvas move').toBeGreaterThan(4)
-    expect(stats.pasteInserts, 'no paste inserted a copy').toBeGreaterThan(12)
-    expect(stats.reconnections, 'no cut surface was ever reconnected').toBeGreaterThan(2)
-    expect(stats.marqueeSelections, 'no marquee ever gathered a node').toBeGreaterThan(7)
-    expect(stats.handPressesIgnored, 'hand mode never swallowed a press').toBeGreaterThan(17)
-    expect(stats.handEntries, 'hand mode was never entered').toBeGreaterThan(14)
-    expect(stats.connectArms, 'the connect tool never armed').toBeGreaterThan(14)
-    expect(stats.toolSwitches, 'the tool never changed').toBeGreaterThan(60)
-    expect(stats.carriedMoves, 'no drag ever carried a second node').toBeGreaterThan(18)
-    expect(stats.groupOrMultiDrags, 'no group or multi-selection was ever dragged').toBeGreaterThan(
-      18,
     )
-    expect(
-      stats.groupFrameDrags,
-      'a dragged group frame never carried anything it contained',
-    ).toBeGreaterThan(9)
-    expect(stats.groupsCreated, 'no group frame was ever made from a selection').toBeGreaterThan(17)
+    atLeast(stats.multiSelections, 150, 'multi-selection barely reached')
+    atLeast(stats.nudges, 25, 'arrow-key nudges barely reached')
+    atLeast(stats.duplicates, 6, 'Cmd+D barely reached')
+    atLeast(stats.reordersEffective, 15, 'z-order barely changed anything')
+    atLeast(
+      stats.stepReordersEffective,
+      5,
+      'forward/backward never stepped over an overlapping node',
+    )
+    atLeast(stats.locksApplied, 5, 'Cmd+Shift+L barely locked anything')
+    atLeast(stats.selectAlls, 40, 'Cmd+A barely reached')
+    atLeast(stats.edgeSelections, 28, 'edges barely ever selected')
+    atLeast(stats.edgeDeletes, 6, 'selected edges barely ever deleted')
+    atLeast(stats.copies, 11, 'Cmd+C barely reached')
+    atLeast(stats.cuts, 18, 'Cmd+X barely reached')
+    atLeast(stats.cutMoves, 4, 'no paste resolved as a same-canvas move')
+    atLeast(stats.pasteInserts, 12, 'no paste inserted a copy')
+    atLeast(stats.reconnections, 1, 'no cut surface was ever reconnected')
+    atLeast(stats.marqueeSelections, 7, 'no marquee ever gathered a node')
+    atLeast(stats.handPressesIgnored, 17, 'hand mode never swallowed a press')
+    atLeast(stats.handEntries, 14, 'hand mode was never entered')
+    atLeast(stats.connectArms, 14, 'the connect tool never armed')
+    atLeast(stats.toolSwitches, 60, 'the tool never changed')
+    atLeast(stats.carriedMoves, 18, 'no drag ever carried a second node')
+    atLeast(stats.groupOrMultiDrags, 18, 'no group or multi-selection was ever dragged')
+    atLeast(stats.groupFrameDrags, 9, 'a dragged group frame never carried anything it contained')
+    atLeast(stats.groupsCreated, 17, 'no group frame was ever made from a selection')
   })
 
   fcTest.prop(


### PR DESCRIPTION
## Summary

`test-jsdom` went red on `no cut surface was ever reconnected: expected 2 to be greater than 2` — once on #1202, and a sibling vacuity guard in the same suite went red **on `main` itself** at `51ca4639` three hours earlier. All 3142 tests passed in both; what failed was the `afterAll` coverage block.

- **The message named one counter and nothing else, and that is the defect ahead of the number.** Which counter fell says almost nothing alone: one that dropped while the counter it *shares a branch with* stayed healthy is an unlucky **arrangement**, whereas a whole column falling together is a run that **did less work**. Those want opposite fixes — a denser domain versus a bigger budget. Separating the two readings cost **thirty local runs of this file**, to recover numbers the failing run had already computed and thrown away. All thirty floors now go through `atLeast()`, which prints the whole census.
- **The recorded range was under-sampled.** Every range in that comment block came from five runs — ample for a counter in the hundreds, badly wrong for one in single digits. `reconnections` needs a cut whose selection straddles an edge *and then* a paste, a conjunction reached a handful of times per 500 runs. Over thirty runs it is **5–19 (mean 10.7)**, not the recorded 8–13.
- **The floor is re-derived by the file's own rule** — "roughly a third of the minimum measured" — from the honest minimum of 5 rather than the understated 8, giving `> 1`. This is the rule applied to a corrected measurement, **not** the guard weakened by judgement: it still refuses the two states it exists to refuse — never reached, and reached once by luck. CI's 2 would have passed.

Per `.claude/skills/steward/reference/failure-modes.md` ("a reachability/density guard fails intermittently → denser domain plus a measured floor — never a pinned seed, never fewer assertions"): **no pinned seed, no removed assertion, no widened budget.** Deliberately **no denser generator** either — this file warns that adding a command, widening the generator, or making the model more faithful all dilute every existing counter, so that change would force re-measuring all thirty floors. The census is what will say whether it is needed.

### What is not established

Why CI produced 2 when thirty local runs produced nothing below 5. I want that on the record rather than papered over, including a correction to my own earlier reasoning: I claimed a truncated run was ruled out because `pasteInserts` passed its floor, and **that does not hold** — the floor sits at about a quarter of the local mean, so a moderate truncation clears it. Both readings stay open in the comment, and the census settles it the next time one fires.

## Test plan

- [x] New or updated tests added — this *is* the test change; the guard's own diagnostic was verified by forcing it to fail.
- [x] `pnpm test` passes locally — `pnpm --filter @kamiazya/whiteboard-web test` (the command CI's `test-jsdom` runs): **303 files / 3142 tests** `web-jsdom` + **13 / 89** `web-node`, exit 0. Counts match CI's own reported totals, so this is the same surface. `pnpm lint` and `whiteboard-web typecheck` clean.
- [x] Manual verification completed — the diagnostic was **made to fire**, since a diagnostic nobody has seen fire is not a diagnostic:

  ```
  AssertionError: no cut surface was ever reconnected
  census: moveCommits=335 resizeCommits=75 connectCommits=63 deletes=79
  textEditsOpened=133 ... cuts=61 cutMoves=12 pasteInserts=48 reconnections=11
  marqueeSelections=26 ... groupsCreated=55: expected 11 to be greater than 999999
  ```

  `pasteInserts=48 reconnections=11` in one line is exactly what CI's failure lacked.

- [x] Measurement, n=30 (temporary copy of the file with a forced-failing assertion; the tracked file was never modified and the copy was deleted):

  ```
  5 6 6 8 8 8 9 9 9 9 10 10 10 10 10 11 11 11 11 12 12 13 13 13 13 13 14 14 15 19
  min 5   max 19   mean 10.7   none at or below 4
  ```

- [ ] E2E coverage — n/a; this changes a test's own guard, not product behaviour.

## Visual evidence

Visual evidence: none — a change to a property test's assertion helper and its recorded measurements. Nothing renders. The observable output is the assertion message, quoted above in both its failing and passing forms.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — n/a; the measurements and the open question are recorded in the test file itself, which is where that file keeps them
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

### Note

This branch previously carried #1202 (ADR-0018 slice 1, `countAliveNodes` reclassification). That PR is **parked, not withdrawn** — this session can push only one branch, and mixing two unrelated subjects into one diff was the alternative. Its commit is `fa14dd614ab21ab3c84f5ee6a0b907f10bbc0766`, reachable from closed PR #1202, and comes back on its own once this lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_