### PR TITLE
feat(canvas-render): tie comment pin to bubble with a dashed leader line

### DIFF
--- a/packages/canvas-render/src/layout/comments.test.ts
+++ b/packages/canvas-render/src/layout/comments.test.ts
@@ -5,7 +5,7 @@
 import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
 import type { MdastRoot } from '@kamiazya/whiteboard-model/mdast'
 import { describe, expect, it } from 'vitest'
-import type { SceneNode, ShapeSceneNode, TextRunNode } from '../scene-graph.js'
+import type { ResolvedEdgeNode, SceneNode, ShapeSceneNode, TextRunNode } from '../scene-graph.js'
 import { createFakeMeasure } from '../test-utils/fake-measure.js'
 import type { SpatialAppearanceResolver } from './nodes/spatial-appearance.js'
 import {
@@ -24,6 +24,7 @@ const fakeAppearance: SpatialAppearanceResolver = {
   resolveComment: () => ({
     pin: { fill: '#d97706' },
     bubble: { fill: '#fef3c7', stroke: '#d97706' },
+    leader: { stroke: '#d97706', strokeWidth: 1, strokeDasharray: '4 3' },
   }),
 }
 
@@ -107,6 +108,56 @@ describe('comment layer', () => {
     )
     const pinIndex = scene.nodes.indexOf(pin as ShapeSceneNode)
     expect(pinIndex).toBeGreaterThan(nodeChromeIndex)
+  })
+
+  it('ties pin to bubble with a dashed leader line drawn under both', () => {
+    const scene = layoutSpatialCanvas(
+      canvasWith([{ id: 'c1', x: 400, y: 60, text: 'move this left' }]),
+      baseOptions(),
+    )
+    const leader = scene.nodes.find(
+      (node): node is ResolvedEdgeNode => node.kind === 'edge' && node.id === 'c1/leader',
+    )
+    expect(leader).toBeDefined()
+    // From the anchor (the pin's center) to the bubble's near corner, so the
+    // relation still reads when a dense canvas separates the two.
+    expect(leader?.path).toEqual([
+      { x: 400, y: 60 },
+      { x: 400 + COMMENT_BUBBLE_OFFSET_PX, y: 60 + COMMENT_BUBBLE_OFFSET_PX },
+    ])
+    expect(leader?.fromEnd).toBe('none')
+    expect(leader?.toEnd).toBe('none')
+    expect(leader?.appearance).toEqual({
+      stroke: '#d97706',
+      strokeWidth: 1,
+      strokeDasharray: '4 3',
+    })
+
+    // Under the pin and bubble: both ends tuck beneath the chrome instead of
+    // striking through it.
+    const shapes = shapesOf(scene.nodes)
+    const pin = shapes.find((shape) => shape.bbox.w === COMMENT_PIN_SIZE_PX)
+    const bubble = shapes.find((shape) => shape.appearance?.fill === '#fef3c7')
+    const leaderIndex = scene.nodes.indexOf(leader as ResolvedEdgeNode)
+    expect(leaderIndex).toBeLessThan(scene.nodes.indexOf(pin as ShapeSceneNode))
+    expect(leaderIndex).toBeLessThan(scene.nodes.indexOf(bubble as ShapeSceneNode))
+  })
+
+  it('a bare resolver still gets the leader geometry, carrying no appearance', () => {
+    const bare: SpatialAppearanceResolver = {
+      resolveNode: () => ({}),
+      resolveEdge: () => undefined,
+      resolveLabel: () => ({}),
+    }
+    const scene = layoutSpatialCanvas(
+      canvasWith([{ id: 'c1', x: 5, y: 5, text: 'still tied' }]),
+      baseOptions({ appearance: bare }),
+    )
+    const leader = scene.nodes.find(
+      (node): node is ResolvedEdgeNode => node.kind === 'edge' && node.id === 'c1/leader',
+    )
+    expect(leader).toBeDefined()
+    expect(leader?.appearance).toBeUndefined()
   })
 
   it('follows the target node when it resolves, and falls back to the anchor when it is gone', () => {

--- a/packages/canvas-render/src/layout/comments.test.ts
+++ b/packages/canvas-render/src/layout/comments.test.ts
@@ -120,10 +120,13 @@ describe('comment layer', () => {
     )
     expect(leader).toBeDefined()
     // From the anchor (the pin's center) to the bubble's near corner, so the
-    // relation still reads when a dense canvas separates the two.
+    // relation still reads when a dense canvas separates the two. The end
+    // lands ON the rounded corner's arc (radius 8), not the bbox corner,
+    // which sits outside the rounded fill and would leave a gap.
+    const inset = 8 * (1 - Math.SQRT1_2)
     expect(leader?.path).toEqual([
       { x: 400, y: 60 },
-      { x: 400 + COMMENT_BUBBLE_OFFSET_PX, y: 60 + COMMENT_BUBBLE_OFFSET_PX },
+      { x: 400 + COMMENT_BUBBLE_OFFSET_PX + inset, y: 60 + COMMENT_BUBBLE_OFFSET_PX + inset },
     ])
     expect(leader?.fromEnd).toBe('none')
     expect(leader?.toEnd).toBe('none')

--- a/packages/canvas-render/src/layout/nodes/spatial-appearance.ts
+++ b/packages/canvas-render/src/layout/nodes/spatial-appearance.ts
@@ -51,4 +51,6 @@ export interface SpatialAppearanceResolver {
 export interface SpatialCommentAppearance {
   readonly pin: Appearance
   readonly bubble: Appearance
+  /** The dashed line tying pin to bubble, so the pair reads as one comment. */
+  readonly leader: Appearance
 }

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -1352,13 +1352,17 @@ function composeComments(
     // The leader FIRST, so pin and bubble paint over its ends: a dashed line
     // from the anchor to the bubble's near corner keeps the pair reading as
     // one comment when a dense canvas separates them. Geometry is composed
-    // for every resolver; only its paint is assigned.
+    // for every resolver; only its paint is assigned. The endpoint sits ON
+    // the rounded corner's arc, not the bbox corner — the corner point
+    // itself is outside the rounded fill, which leaves a visible gap
+    // between the dash end and the bubble border.
+    const leaderInsetPx = COMMENT_BUBBLE_RADIUS_PX * (1 - Math.SQRT1_2)
     out.push({
       kind: 'edge',
       id: `${comment.id}/leader`,
       path: [
         { x: anchor.x, y: anchor.y },
-        { x: bubbleX, y: bubbleY },
+        { x: bubbleX + leaderInsetPx, y: bubbleY + leaderInsetPx },
       ],
       fromSide: 'right',
       toSide: 'left',

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -1346,6 +1346,27 @@ function composeComments(
     if (comment.resolved === true) continue
     const anchor = commentAnchor(comment, canvas)
 
+    const bubbleX = anchor.x + COMMENT_BUBBLE_OFFSET_PX
+    const bubbleY = anchor.y + COMMENT_BUBBLE_OFFSET_PX
+
+    // The leader FIRST, so pin and bubble paint over its ends: a dashed line
+    // from the anchor to the bubble's near corner keeps the pair reading as
+    // one comment when a dense canvas separates them. Geometry is composed
+    // for every resolver; only its paint is assigned.
+    out.push({
+      kind: 'edge',
+      id: `${comment.id}/leader`,
+      path: [
+        { x: anchor.x, y: anchor.y },
+        { x: bubbleX, y: bubbleY },
+      ],
+      fromSide: 'right',
+      toSide: 'left',
+      fromEnd: 'none',
+      toEnd: 'none',
+      ...(appearance !== undefined ? { appearance: appearance.leader } : {}),
+    })
+
     out.push({
       kind: 'shape',
       bbox: {
@@ -1374,8 +1395,6 @@ function composeComments(
     const contentRight = Math.max(0, ...laid.nodes.map((node) => sceneRight(node)))
     const contentBottom = Math.max(0, ...laid.nodes.map((node) => sceneBottom(node)))
 
-    const bubbleX = anchor.x + COMMENT_BUBBLE_OFFSET_PX
-    const bubbleY = anchor.y + COMMENT_BUBBLE_OFFSET_PX
     out.push({
       kind: 'shape',
       bbox: {

--- a/packages/canvas-render/src/scene-graph.ts
+++ b/packages/canvas-render/src/scene-graph.ts
@@ -62,6 +62,14 @@ export interface Appearance {
    * the single-element output byte-identical.
    */
   readonly halo?: string
+  /**
+   * SVG `stroke-dasharray` value, verbatim ("4 3"). A dash pattern is paint
+   * the way a stroke color is — assigned by a resolver, never invented here.
+   * Deliberately NOT scaled by `scaleScene` (the svgFragment/arrowhead
+   * class): parsing and rescaling a pattern string buys visual fidelity only
+   * at scales where a dashed hairline is unreadable anyway.
+   */
+  readonly strokeDasharray?: string
 }
 
 /** A single styled run of inline text, positioned within its parent block. */

--- a/packages/canvas-render/src/svg/backend.test.ts
+++ b/packages/canvas-render/src/svg/backend.test.ts
@@ -540,6 +540,50 @@ describe('renderSceneToSvg — appearance on textRun and edge', () => {
     )
   })
 
+  it('emits stroke-dasharray presence-only, after the other paint attributes', () => {
+    const scene: Scene = {
+      nodes: [
+        {
+          kind: 'edge',
+          id: 'e1',
+          path: [
+            { x: 0, y: 0 },
+            { x: 10, y: 10 },
+          ],
+          fromSide: 'right',
+          toSide: 'left',
+          fromEnd: 'none',
+          toEnd: 'none',
+          appearance: { stroke: '#d97706', strokeWidth: 1, strokeDasharray: '4 3' },
+        },
+      ],
+    }
+    expect(renderSceneToSvg(scene)).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 10,10" fill="none" stroke="#d97706" stroke-width="1" stroke-dasharray="4 3" role="presentation"/></svg>',
+    )
+    // Empty string is unusable, so it is omitted — never emitted blank.
+    const blank: Scene = {
+      nodes: [
+        {
+          kind: 'edge',
+          id: 'e1',
+          path: [
+            { x: 0, y: 0 },
+            { x: 10, y: 10 },
+          ],
+          fromSide: 'right',
+          toSide: 'left',
+          fromEnd: 'none',
+          toEnd: 'none',
+          appearance: { stroke: '#d97706', strokeDasharray: '' },
+        },
+      ],
+    }
+    expect(renderSceneToSvg(blank)).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg"><polyline points="0,0 10,10" fill="none" stroke="#d97706" role="presentation"/></svg>',
+    )
+  })
+
   it('an appearance-free edge is byte-identical to before', () => {
     const scene: Scene = {
       nodes: [

--- a/packages/canvas-render/src/svg/backend.ts
+++ b/packages/canvas-render/src/svg/backend.ts
@@ -85,6 +85,9 @@ function appearanceAttrs(appearance?: Appearance): PaintAttrs {
   ) {
     attrs['stroke-opacity'] = appearance.strokeOpacity
   }
+  if (isNonEmptyString(appearance.strokeDasharray)) {
+    attrs['stroke-dasharray'] = appearance.strokeDasharray
+  }
   return attrs
 }
 

--- a/packages/canvas-render/src/svg/elements.ts
+++ b/packages/canvas-render/src/svg/elements.ts
@@ -39,6 +39,7 @@ export type PaintAttrs = {
   'font-size'?: number
   'fill-opacity'?: number
   'stroke-opacity'?: number
+  'stroke-dasharray'?: string
 }
 
 export type TextEmphasisAttrs = {

--- a/packages/canvas-render/src/theme/spatial-theme.test.ts
+++ b/packages/canvas-render/src/theme/spatial-theme.test.ts
@@ -189,4 +189,18 @@ describe('createSpatialTheme', () => {
     expect(theme.resolveEdge(edge())).toEqual({ stroke: SPATIAL_DARK_PALETTE.edgeStroke })
     expect(theme.resolveLabel().fill).toBe(SPATIAL_DARK_PALETTE.labelFill)
   })
+
+  it('gives the comment leader a dashed stroke in the amber ramp, both modes', () => {
+    for (const [mode, palette] of [
+      ['light', SPATIAL_LIGHT_PALETTE],
+      ['dark', SPATIAL_DARK_PALETTE],
+    ] as const) {
+      const leader = createSpatialTheme({ mode }).resolveComment?.().leader
+      expect(leader).toEqual({
+        stroke: palette.comment.bubble.stroke,
+        strokeWidth: 1,
+        strokeDasharray: '4 3',
+      })
+    }
+  })
 })

--- a/packages/canvas-render/src/theme/spatial-theme.ts
+++ b/packages/canvas-render/src/theme/spatial-theme.ts
@@ -46,6 +46,9 @@ export interface SpatialThemeOptions {
   readonly palette?: SpatialPalette
 }
 
+/** Dash pattern for the comment leader line (SVG stroke-dasharray). */
+const COMMENT_LEADER_DASH = '4 3'
+
 /** A numbered preset resolved through the palette; null for hex/unknown. */
 function presetAccent(color: CanvasColor | undefined, palette: SpatialPalette) {
   if (color === undefined || color.startsWith('#')) return null
@@ -82,6 +85,14 @@ function buildTheme(palette: SpatialPalette): SpatialAppearanceResolver {
     resolveComment: () => ({
       pin: { fill: palette.comment.pin.fill, stroke: palette.comment.pin.stroke },
       bubble: { fill: palette.comment.bubble.fill, stroke: palette.comment.bubble.stroke },
+      // The bubble's stroke color, dashed: the tie must read as comment
+      // chrome, not as an authored canvas edge, and dashing is what says so
+      // when a dense canvas separates pin from bubble.
+      leader: {
+        stroke: palette.comment.bubble.stroke,
+        strokeWidth: 1,
+        strokeDasharray: COMMENT_LEADER_DASH,
+      },
     }),
     resolveLabel: () => ({
       fill: palette.labelFill,


### PR DESCRIPTION
## Summary

On a dense canvas the comment layer's pin and its floating bubble read as two unrelated marks. This draws a dashed leader line from the anchor (the pin's center) to the bubble's near corner, UNDER both, so the pair reads as one comment even when they separate (user request, follow-up to the comment series #1204–#1207).

- `Appearance` gains `strokeDasharray` (verbatim SVG value). The backend emits it presence-only after the existing paint attributes, so every existing golden stays byte-identical; empty strings are omitted, never emitted blank. Deliberately not scaled by `scaleScene` (the svgFragment/arrowhead class, documented on the field).
- `composeComments` composes the leader as an existing `edge` scene node (`<comment id>/leader`, no arrowheads) first per comment, so pin and bubble paint over its ends. Geometry is composed for every resolver; only paint is assigned.
- `SpatialCommentAppearance` gains a required `leader`; `createSpatialTheme` supplies the amber ramp's bubble stroke, width 1, dash `4 3` in both modes (theme is the only `resolveComment` producer — verified by repo-wide grep).

## Test plan

- Red-first: 4 new assertions failed before the change — leader geometry/paint/z-order and bare-resolver degradation (`comments.test.ts`), presence-only + blank-string emission (`svg/backend.test.ts`), both palette modes (`spatial-theme.test.ts`).
- `canvas-render-node` 1059 passed, `canvas-render-browser` 9 passed (determinism goldens untouched), `pnpm -r typecheck`, `pnpm check:local` exit 0, `mcp-node` 4206 passed with only the known Node-22-container baseline failure (`local-node-version.test.ts`; CI runs Node 24 and is authoritative).

## Visual repro

Rendered through the real export pipeline (`renderSpatialCanvasToPng`, vendored Roboto + resvg), same canvas before (`e8b7f631`) and after (`acd48c13`): before, the amber pin and bubble float with nothing relating them; after, a short dashed amber leader ties each pair — visible on both the node-anchored comment (Timeline's corner) and the free-floating one.

Visual evidence: figure delivered to the user in-session (compose-figure digests above) — this environment has no gh CLI to upload an image attachment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comment pins now connect to their bubbles with dashed leader lines.
  * Leader lines use the comment bubble styling and remain visible in both light and dark themes.
  * SVG rendering now supports configurable dashed strokes for edges and other painted elements.
* **Bug Fixes**
  * Leader lines are rendered beneath pins and bubbles, keeping connection points visually clean.
  * Empty dash patterns are omitted from SVG output to prevent unnecessary attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->