### PR TITLE
refactor: move countAliveNodes out of store/, where it was never a mechanic

### DIFF
--- a/packages/mcp-server/src/server/routes/debug.ts
+++ b/packages/mcp-server/src/server/routes/debug.ts
@@ -1,6 +1,6 @@
+import { countAliveNodes, countLegacyTombstones } from '@kamiazya/whiteboard-server-core'
 import { Hono } from 'hono'
 import { isAuthorized } from '../security/bearer-token.js'
-import { countAliveNodes, countLegacyTombstones } from '../store/count-alive-nodes.js'
 import { getCacheKeys, peekDoc } from '../store/doc-cache.js'
 import { listDocuments, listWorkspaces, loadDocument } from '../store/document-store.js'
 

--- a/packages/mcp-server/src/server/routes/document/restore.test.ts
+++ b/packages/mcp-server/src/server/routes/document/restore.test.ts
@@ -20,7 +20,7 @@ const { clearCache, peekDoc } = await import('../../store/doc-cache.js')
 const { getDoc, saveDocument, getDocumentKind, loadDocument, onWorkspaceDocUpdated } = await import(
   '../../store/document-store.js'
 )
-const { countAliveNodes } = await import('../../store/count-alive-nodes.js')
+const { countAliveNodes } = await import('@kamiazya/whiteboard-server-core')
 const { createDocumentRouter } = await import('../document.js')
 // Pre-load ws.js before any restore call, mirroring restore-race.test.ts's
 // documented cycle workaround for document.ts's dynamic import.

--- a/packages/mcp-server/src/server/routes/document/restore.ts
+++ b/packages/mcp-server/src/server/routes/document/restore.ts
@@ -4,10 +4,10 @@ import {
   reconcileDocContent,
 } from '@kamiazya/whiteboard-loro-adapter'
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
+import { countAliveNodes } from '@kamiazya/whiteboard-server-core'
 import { Hono } from 'hono'
 import type { LoroDoc } from 'loro-crdt'
 import { restoreVersionRequestSchema } from '../../../shared/api-contracts/document.js'
-import { countAliveNodes } from '../../store/count-alive-nodes.js'
 import { evictDoc } from '../../store/doc-cache.js'
 import {
   ConflictError,

--- a/packages/mcp-server/src/server/store/version-store.ts
+++ b/packages/mcp-server/src/server/store/version-store.ts
@@ -4,6 +4,7 @@ import {
   projectWorkspaceDocument,
   resolveWorkspaceDocument,
 } from '@kamiazya/whiteboard-loro-adapter'
+import { countAliveNodes } from '@kamiazya/whiteboard-server-core'
 import { DocumentStoreWorkspaceDocs } from '@kamiazya/whiteboard-workspace-index'
 import type { Frontiers } from 'loro-crdt'
 import { decodeFrontiers, encodeFrontiers, LoroDoc } from 'loro-crdt'
@@ -17,7 +18,6 @@ import {
   validateWorkspaceId,
 } from '../validators.js'
 import { corruptStoredData, isMissingFileError } from './corrupt-stored-data.js'
-import { countAliveNodes } from './count-alive-nodes.js'
 import { getDb } from './db/index.js'
 import { prepareDataDir } from './db/prepare.js'
 import { DocumentNotFoundError } from './document-not-found-error.js'

--- a/packages/server-core/src/document-counts.test.ts
+++ b/packages/server-core/src/document-counts.test.ts
@@ -1,7 +1,20 @@
+import { writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { LoroDoc, LoroMap } from 'loro-crdt'
 import { describe, expect, it } from 'vitest'
-import { makeSpatialDoc } from '../../shared/test-utils/spatial-doc.js'
-import { countAliveNodes, countLegacyTombstones } from './count-alive-nodes.js'
+import { countAliveNodes, countLegacyTombstones } from './document-counts.js'
+
+// Built through the real `writeSpatialCanvas` bridge rather than by poking at
+// LoroDoc internals, so the fixture cannot drift from what a save actually
+// persists. mcp-server's `test-utils/spatial-doc.ts` says the same and is
+// shared by nine of its own tests; this needs only the one line of it, and
+// hauling that file across a package boundary to avoid two lines would be
+// the larger change.
+function makeSpatialDoc(canvas: SpatialCanvas): LoroDoc {
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, canvas)
+  return doc
+}
 
 function legacyElement(doc: LoroDoc, id: string, isDeleted = false): void {
   const list = doc.getMovableList('elements')

--- a/packages/server-core/src/document-counts.ts
+++ b/packages/server-core/src/document-counts.ts
@@ -19,8 +19,15 @@ function readLegacyElements(doc: LoroDoc): Array<z.infer<typeof legacyElementSch
   })
 }
 
-// Shared "how many elements does this doc have" reader for the daemon's
-// advisory UI counts (History panel / restore response / /api/debug).
+// The one "how many elements does this doc have" reader, for advisory counts
+// (History panel / restore response / /api/debug).
+//
+// It lives in the shared layer rather than beside a store because it answers
+// a question about the DOCUMENT, not about how a deployment keeps one — the
+// question ADR-0018 uses to tell an operation from a mechanic. Filed under
+// the daemon's `server/store/` it read as a mechanic to `adapter-mechanic-
+// check.ts`, which classifies by directory, so two routes that legitimately
+// ask a document its size were counted as ADR-0018 debt.
 //
 // - Edges are excluded: the bridge's edge-cascade invariant (an edge is
 //   deleted whenever either endpoint node is removed) means an edge can

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -1,4 +1,5 @@
 export { createServer } from './create-server.js'
+export { countAliveNodes, countLegacyTombstones } from './document-counts.js'
 export type { Logger, LogSink } from './log.js'
 export { getLogger, setLogSink } from './log.js'
 export type { Embedder } from './search/embedder.js'

--- a/tools/arch-lint/src/architecture-map.ts
+++ b/tools/arch-lint/src/architecture-map.ts
@@ -279,7 +279,6 @@ export const ADAPTERS_REACHING_MECHANICS: readonly string[] = [
   'mcp/document-tools.ts -> workspace-lock',
   'routes/branches.ts -> branch-merge',
   'routes/branches.ts -> branches-store',
-  'routes/debug.ts -> count-alive-nodes',
   'routes/debug.ts -> doc-cache',
   'routes/debug.ts -> document-store',
   'routes/document.ts -> auto-compact',
@@ -294,7 +293,6 @@ export const ADAPTERS_REACHING_MECHANICS: readonly string[] = [
   'routes/document/maintenance.ts -> document-store',
   'routes/document/maintenance.ts -> version-store',
   'routes/document/metadata.ts -> names-store',
-  'routes/document/restore.ts -> count-alive-nodes',
   'routes/document/restore.ts -> doc-cache',
   'routes/document/restore.ts -> document-store',
   'routes/document/restore.ts -> version-store',
@@ -336,7 +334,7 @@ export const ADAPTERS_REACHING_MECHANICS: readonly string[] = [
  * server-core instead. The burn-down order is in the ADR; the four clusters
  * it names are 17 of these 39.
  */
-export const ADAPTERS_REACHING_MECHANICS_CEILING = 39
+export const ADAPTERS_REACHING_MECHANICS_CEILING = 37
 
 /**
  * Modules under `store/` the adapter rule does NOT count.


### PR DESCRIPTION
## Summary

First slice of [ADR-0018](docs/contributing/adr/0018-operation-vs-mechanic.md)'s burn-down, which names `routes/document/restore.ts` as the cluster to pay off first (5 of the 39 allowlisted adapter → mechanic edges). **Two of those five turn out not to be debt at all.**

- `count-alive-nodes.ts` is a **pure function over a `LoroDoc`** — depends on loro-adapter, loro-crdt and zod; touches no store, cache, lock or scheduler; and answers *"how many elements does this doc have"*. By ADR-0018's own deciding question — *could a second surface need this?* — that is plainly an operation-side reader. It was classified as a mechanic **only because `adapter-mechanic-check.ts` classifies by directory and the file sat under `server/store/`**, so two routes that legitimately ask a document its size were counted as ADR-0018 debt.
- Moved to `server-core` as `document-counts.ts` — where a shared reader belongs, and where the second surface the ADR is about can actually reach it. `version-store.ts` keeps using it; a mechanic importing shared code is the allowed direction.
- Removes both `-> count-alive-nodes` edges (`routes/debug.ts`, `routes/document/restore.ts`) and lowers `ADAPTERS_REACHING_MECHANICS_CEILING` **39 → 37**.

**What this deliberately does not do.** The remaining four edges on `restore.ts` (`doc-cache`, `document-store`, `version-store`, `workspace-lock`) are genuine mechanics. Removing them means moving the restore operation itself into server-core, and that needs new **required** seams on `ServerDeps`: server-core reaches documents through the snapshot port, whereas `reconcileCommitSaveBroadcast` must mutate *the same live doc instance a connected client already holds* (a delta broadcast only means something against the doc it was diffed from). The ADR says to land a required-field change on its own small PR — it measured three CI failures from merge races alone during #1035 — so that is a follow-up, not this PR.

## Test plan

- [x] New or updated tests added — the module's existing test moved with it and is unchanged in substance.
- [x] `pnpm test` passes locally — `server-core-node` + `mcp-node`: **416 files / 4644 passed, 9 skipped**, exit 0. `arch-lint-node` 112/112. `pnpm -r typecheck` exit 0 across all packages; `pnpm lint` and `pnpm knip` clean.
- [x] Manual verification completed — red-first, and **the ratchet was mutation-checked in both directions**, since a guard that only fires one way reads exactly like one that checked:

  | state | result |
  |---|---|
  | ceiling lowered to 37, edges still present | **red** — `reports no adapter -> mechanic edge outside the allowlist` |
  | edges paid off, ceiling put back to 39 | **red** — `an edge was paid off — lower ADAPTERS_REACHING_MECHANICS_CEILING to match`, `expected 37 to be 39` |
  | edges paid off, ceiling 37 | green, 112/112 |

- [ ] E2E coverage added or extended where applicable — n/a; behaviour-preserving move, no surface changed.

### Rebased and re-verified, not just re-applied

This change was previously opened as #1202 and closed unmerged while an unrelated `test-jsdom` vacuity flake was fixed first (that fix is now on main as #1208). Re-applying it onto today's main was treated as a fresh change rather than assumed safe, because it pins a **count** and main had moved 20+ commits:

- `git diff` of `tools/arch-lint/src/architecture-map.ts` between the original base and current main is **empty** — main neither added nor paid off an adapter → mechanic edge, so 39 → 37 is still the right arithmetic.
- No new importer of the moved module appeared on main; all four importers resolve to `@kamiazya/whiteboard-server-core`.

Both were checked because this session already had one carried fix **invert** when main fixed the same breakage in the opposite direction.

### Note on the moved test

It inlines its two-line `makeSpatialDoc` over the real `writeSpatialCanvas` bridge rather than importing mcp-server's `shared/test-utils/spatial-doc.ts`. Nine mcp-server tests share that file; hauling it across a package boundary to avoid two lines would be the larger change. The fixture is still built through the real bridge, which is that helper's own stated reason for existing.

## Visual evidence

Visual evidence: none — a module move plus an allowlist ratchet. Nothing renders. The observable output is the arch-lint verdict, quoted in the table above, including both failing directions.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — n/a; the reclassification's rationale is recorded on the moved file, replacing a doc comment whose "the daemon's" framing came from the old location
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_