### PR TITLE
feat(server-core): declare the version-history seam an operation reads

### DIFF
--- a/packages/mcp-server/src/di/container.ts
+++ b/packages/mcp-server/src/di/container.ts
@@ -12,6 +12,7 @@ import { createOpentypeMeasureText } from '../server/export/measure-text.js'
 import { resolveSearchEmbedder } from '../server/search/search-embedder.js'
 import { documentTeardown } from '../server/store/document-store.js'
 import { documentWritten } from '../server/store/document-written.js'
+import { FileVersionStore } from '../server/store/version-store.js'
 import { storeMemoryModule } from './store-memory.module.js'
 
 export function createContainer(storeModule: ContainerModule = storeMemoryModule): Container {
@@ -86,5 +87,9 @@ export function resolveServerDeps(container: Container): ServerDeps {
     // than in the HTTP route registration, which is what confined the old
     // saved-listener to one deployment shape.
     documentWritten,
+    // The daemon's own version store satisfies the seam structurally: it has
+    // eleven methods and the seam names the three an operation reads, so no
+    // adapter class is needed to bridge them.
+    versions: new FileVersionStore(),
   }
 }

--- a/packages/server-core/src/server-deps.ts
+++ b/packages/server-core/src/server-deps.ts
@@ -2,6 +2,7 @@ import type { MeasureText } from '@kamiazya/whiteboard-canvas-render'
 import type { FacetRegistry } from '@kamiazya/whiteboard-facet-engine'
 import type { DocumentId } from '@kamiazya/whiteboard-model'
 import type { BlobStore, DocumentIndex, DocumentStore } from '@kamiazya/whiteboard-ports'
+import type { LoroDoc } from 'loro-crdt'
 import type { Embedder } from './search/embedder.js'
 
 /**
@@ -162,6 +163,48 @@ export interface ServerDeps {
    * than leaving it to a comment.
    */
   documentWritten: DocumentWritten
+  /**
+   * A document's saved history, as an OPERATION needs to read it.
+   *
+   * Three methods, not the eleven the daemon's own version store has. A
+   * seam states what the operation needs; the implementation is free to be
+   * larger, and structural typing lets it satisfy this without a wrapper.
+   * Thumbnails, pruning and branch rewriting are not read by any operation
+   * here, and publishing them would make this a second name for a mechanic
+   * rather than a seam.
+   *
+   * REQUIRED, for the reason `documentTeardown` is: a composition root that
+   * forgets it should be a compile error, not a server whose restore
+   * silently answers "no such version" for every version that exists.
+   *
+   * Not a `packages/ports` port, despite the shape. Ports may depend on
+   * model and zod only, and these answer with a `LoroDoc` — so this belongs
+   * beside the other seams, exactly as `documentTeardown` does.
+   */
+  versions: VersionHistory
+}
+
+/**
+ * `path` addresses the version LIST because a version belongs to a document
+ * at the name it had; `load` and `loadWorkspaceAt` take only the version's
+ * own id, which is already unique within the workspace.
+ */
+export interface VersionHistory {
+  /**
+   * The past state of ONE document, as an independent doc — the stored
+   * record checked out at this version's frontiers. Null only when the
+   * version does not exist.
+   */
+  load(workspaceId: string, id: string): Promise<LoroDoc | null>
+  /**
+   * The whole WORKSPACE at this version, which is what a subtree rollback
+   * walks. Null when the version exists but is not workspace-scoped, which
+   * is a real answer and not an error: a per-document version cannot say
+   * where its siblings were.
+   */
+  loadWorkspaceAt(workspaceId: string, id: string): Promise<LoroDoc | null>
+  /** Saved versions of the document at `path`, newest first. */
+  list(workspaceId: string, path: string): Promise<readonly { id: string; label?: string }[]>
 }
 
 // Carries the workspaceId because the tree is the address book: resolving a

--- a/packages/server-core/src/test-utils/make-test-deps.ts
+++ b/packages/server-core/src/test-utils/make-test-deps.ts
@@ -3,6 +3,7 @@ import type { ServerDeps } from '../server-deps.js'
 import { ignoredDocumentWrites } from './ignored-document-writes.js'
 import { createInMemoryDocumentStore } from './in-memory-document-store.js'
 import { unusedDocumentTeardown } from './unused-document-teardown.js'
+import { unusedVersionHistory } from './unused-version-history.js'
 
 /**
  * The `ServerDeps` a server-core test builds when its subject is something
@@ -43,6 +44,7 @@ export function makeTestDeps(overrides: Partial<ServerDeps> = {}): ServerDeps {
     documentIndex: new InMemoryDocumentIndex(),
     documentTeardown: unusedDocumentTeardown(),
     documentWritten: ignoredDocumentWrites(),
+    versions: unusedVersionHistory(),
     ...overrides,
   }
 }

--- a/packages/server-core/src/test-utils/unused-version-history.ts
+++ b/packages/server-core/src/test-utils/unused-version-history.ts
@@ -1,0 +1,28 @@
+import type { VersionHistory } from '../server-deps.js'
+
+/**
+ * A `VersionHistory` that REFUSES rather than answers, for a test whose
+ * subject is something else.
+ *
+ * Throwing, not `null`-returning, and the distinction is the whole point:
+ * `null` is a real answer from this seam — "no such version", "not a
+ * workspace-scoped version" — so a null-returning double would let a test
+ * that accidentally reaches history pass while asserting nothing, and read
+ * exactly like one that never reached it. Same reasoning as
+ * `unusedDocumentTeardown`.
+ *
+ * A test that means to exercise history passes its own.
+ */
+export function unusedVersionHistory(): VersionHistory {
+  const refuse = (method: string) => (): never => {
+    throw new Error(
+      `VersionHistory.${method} was called by a test that passed unusedVersionHistory().` +
+        ' Pass a real history if the test is about saved versions.',
+    )
+  }
+  return {
+    load: refuse('load'),
+    loadWorkspaceAt: refuse('loadWorkspaceAt'),
+    list: refuse('list'),
+  }
+}


### PR DESCRIPTION
## Summary

[ADR-0018](docs/contributing/adr/0018-operation-vs-mechanic.md)'s burn-down needs exactly one thing server-core cannot express before the restore operation can leave the daemon's route layer: **a document's saved history**. Everything else `restore.ts` reaches for turned out to be covered already (see *What this replaced* below), which is why this is the only seam here.

- **Three methods, not the eleven** the daemon's own version store has. A seam states what an *operation reads*; thumbnails, pruning and branch rewriting are read by no operation, and publishing them would make this a second name for a mechanic. `FileVersionStore` satisfies it **structurally**, so the composition root needs no adapter class.
- **Not a `packages/ports` port**, despite the shape — ports may depend on model and zod only, and these answer with a `LoroDoc`. So it sits beside `documentTeardown` and `documentWritten`: same file, same reason.
- **Required, not optional**, per the ADR: a composition root that forgets it should be a compile error, not a server whose restore silently answers "no such version" for every version that exists.

### The refusing default throws rather than returning null

`unusedVersionHistory()` throws. That distinction is the point and not a style choice: **`null` is a real answer from this seam** — no such version, or a version that is not workspace-scoped. A null-returning double would let a test that accidentally reaches history pass while asserting nothing, reading exactly like one that never reached it. Same reasoning `unused-document-teardown.ts` gives for existing.

### Landed alone, and #1215 is why that is cheap

The ADR asks for a required-field change on its own small PR — it measured three CI failures from merge races alone during #1035. #1215 made that nearly free: this field broke **exactly one file**, `make-test-deps.ts`. Before #1215 the same field broke **26 files with 310 errors**. That prediction was made in #1215's body and is confirmed here.

## Test plan

- [x] New or updated tests added — `unusedVersionHistory()` is itself test infrastructure; no existing test's subject changed.
- [x] `pnpm test` passes locally — `server-core-node` + `mcp-node`: **416 files / 4644 passed, 9 skipped**, exit 0. `pnpm lint`, `pnpm knip`, and a full `pnpm -r typecheck` (0 errors, all packages) clean.
- [x] Manual verification completed — the required-field cost was measured rather than assumed: applying the seam to today's main produced errors in one file only, and `FileVersionStore` type-checked against the seam with no wrapper.
- [ ] E2E coverage — n/a; nothing executes differently yet, by design.

## Foundation-only, with its follow-up named

Nothing reads `deps.versions` yet. Stating that plainly rather than letting it look wired: this is a foundation slice, and the follow-up is the one ADR-0018 schedules — moving `restore.ts`'s four modes into a server-core operation addressed by **documentId**, which removes its remaining `doc-cache` / `document-store` / `version-store` / `workspace-lock` edges and lowers `ADAPTERS_REACHING_MECHANICS_CEILING` from 37. That is the next PR on this branch.

## What this replaced

Two earlier design premises for the restore move were **refuted by reading the code**, which is why this PR is 78 lines rather than the ~1000 first estimated:

- A `liveDocument` transaction seam is **not** needed. `WorkspaceRoutedDocumentStore.saveSnapshot` — what the daemon binds `documentStore` to — already takes the workspace write lock and merges into *the same live projection* connected clients hold.
- A lock seam is **not** needed either. The phantom-insert hazard `restore.ts` guards against at length is specific to **path** addressing; the port resolves by **documentId** inside the lock, so a concurrent rename is followed and a concurrent delete declines to invent a placement.

## Visual evidence

Visual evidence: none — a type-level seam plus its wiring and a test double. Nothing renders and nothing executes differently.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — n/a; the rationale lives on the seam declaration itself
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema — `VersionHistory` is a seam over `LoroDoc`, which has no Zod counterpart

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_