### PR TITLE
fix(web): hydrate IndexedDB document-index rows through documentEntrySchema

### DIFF
--- a/apps/web/src/lib/idb-document-index.browser.test.tsx
+++ b/apps/web/src/lib/idb-document-index.browser.test.tsx
@@ -12,9 +12,12 @@
 // fidelity contract (transaction/upgrade/abort semantics fake-indexeddb only
 // approximates). IndexedDB-only suites with no such stake run in jsdom via
 // fake-indexeddb instead — see e.g. local-document-summary.test.tsx.
+import { generateDocumentId } from '@kamiazya/whiteboard-model'
 import { describeDocumentIndexConformance } from '@kamiazya/whiteboard-ports/test-utils'
-import { describe } from 'vitest'
+import { describe, expect, it } from 'vitest'
+import { DOCUMENT_INDEX_STORE } from './browser-idb.js'
 import { IdbDocumentIndex } from './idb-document-index.js'
+import { inTransaction, request } from './idb-tx.js'
 
 // Its OWN database, not the app's. Browser tests share an origin, so deleting
 // `whiteboard` between conformance cases would tear it out from under whatever
@@ -37,6 +40,33 @@ async function deleteDb(): Promise<void> {
     req.onerror = () => reject(req.error)
   })
 }
+
+describe('IdbDocumentIndex row hydration', () => {
+  it('a malformed stored row fails the read loudly instead of flowing into the UI as a DocumentEntry', async () => {
+    await deleteDb()
+    try {
+      const index = new IdbDocumentIndex(DB_NAME)
+      await index.createWorkspace({ workspaceId: 'ws' })
+      // Plant a corrupt row through the same transaction helper the class
+      // uses, bypassing its own validated write path — the shape a buggy
+      // writer, a devtools edit, or a future schema drift would leave
+      // behind. `path` as a number is still a valid IndexedDB key, so
+      // nothing below the schema refuses it.
+      await inTransaction(DB_NAME, [DOCUMENT_INDEX_STORE], 'readwrite', async (tx) => {
+        await request(
+          tx
+            .objectStore(DOCUMENT_INDEX_STORE)
+            .put({ workspaceId: 'ws', documentId: generateDocumentId(), path: 42 }),
+        )
+      })
+      // A cast would answer this with `path: 42` inside a DocumentEntry —
+      // corrupt data wearing the contract's type. The schema names the field.
+      await expect(index.listDocuments({ workspaceId: 'ws' })).rejects.toThrow(/path/)
+    } finally {
+      await deleteDb()
+    }
+  })
+})
 
 describe('IdbDocumentIndex', () => {
   describeDocumentIndexConformance(async () => {

--- a/apps/web/src/lib/idb-document-index.ts
+++ b/apps/web/src/lib/idb-document-index.ts
@@ -23,6 +23,7 @@ import {
   DocumentMoveIntoSelfError,
   DocumentNotFoundError,
   DocumentPathTakenError,
+  documentEntrySchema,
   findDescendantPath,
   isSelfOrDescendant,
   type ListDocumentsInput,
@@ -38,22 +39,26 @@ import {
   WorkspaceSegmentTakenError,
   workspaceEntrySchema,
 } from '@kamiazya/whiteboard-ports'
+import { z } from 'zod'
 import { DOCUMENT_INDEX_STORE, WORKSPACES_STORE } from './browser-idb.js'
 import { inTransaction, request } from './idb-tx.js'
 
 /**
- * A row as stored. `name` and `kind` are absent rather than null when unset,
+ * A row as stored: the port's own entry shape plus the `workspaceId` the
+ * store keys on. `name` and `kind` are absent rather than null when unset,
  * matching `DocumentEntry` — IndexedDB round-trips `undefined` properties by
  * dropping them, so writing the entry shape directly keeps the read path free
  * of null-to-absent conversions the daemon's SQL twin has to perform.
+ *
+ * Derived from `documentEntrySchema` rather than written beside it, and
+ * every read below hydrates through it — the same discipline
+ * `listWorkspaces` applies with `workspaceEntrySchema.parse`. A cast here
+ * let a corrupt row (a devtools edit, a buggy writer, schema drift) flow
+ * into the UI wearing the contract's type; the parse fails loudly and names
+ * the field instead.
  */
-interface IndexRow {
-  readonly workspaceId: string
-  readonly documentId: string
-  readonly path: string
-  readonly kind?: DocumentEntry['kind']
-  readonly name?: string
-}
+const indexRowSchema = documentEntrySchema.extend({ workspaceId: z.string().min(1) })
+type IndexRow = z.infer<typeof indexRowSchema>
 
 function toEntry(row: IndexRow): DocumentEntry {
   return {
@@ -72,7 +77,13 @@ async function requireWorkspace(tx: IDBTransaction, workspaceId: string): Promis
 /** Every row in one workspace, unordered. */
 async function rowsIn(tx: IDBTransaction, workspaceId: string): Promise<IndexRow[]> {
   const range = IDBKeyRange.bound([workspaceId], [workspaceId, []])
-  return (await request(tx.objectStore(DOCUMENT_INDEX_STORE).getAll(range))) as IndexRow[]
+  const rows = await request(tx.objectStore(DOCUMENT_INDEX_STORE).getAll(range))
+  return rows.map((row) => indexRowSchema.parse(row))
+}
+
+/** Hydrates one stored value, passing an absent row through. */
+function parseRow(value: unknown): IndexRow | undefined {
+  return value === undefined ? undefined : indexRowSchema.parse(value)
 }
 
 export class IdbDocumentIndex implements DocumentIndex {
@@ -208,9 +219,9 @@ export class IdbDocumentIndex implements DocumentIndex {
     path,
   }: ResolveDocumentInput): Promise<DocumentEntry | null> {
     return this.tx([DOCUMENT_INDEX_STORE], 'readonly', async (tx) => {
-      const row = (await request(tx.objectStore(DOCUMENT_INDEX_STORE).get([workspaceId, path]))) as
-        | IndexRow
-        | undefined
+      const row = parseRow(
+        await request(tx.objectStore(DOCUMENT_INDEX_STORE).get([workspaceId, path])),
+      )
       return row === undefined ? null : toEntry(row)
     })
   }
@@ -223,9 +234,11 @@ export class IdbDocumentIndex implements DocumentIndex {
       // Keyed by [workspaceId, documentId], so an id from another workspace
       // misses rather than reaching across — the port calls an id a handle
       // within a workspace, not a capability.
-      const row = (await request(
-        tx.objectStore(DOCUMENT_INDEX_STORE).index('byId').get([workspaceId, documentId]),
-      )) as IndexRow | undefined
+      const row = parseRow(
+        await request(
+          tx.objectStore(DOCUMENT_INDEX_STORE).index('byId').get([workspaceId, documentId]),
+        ),
+      )
       return row === undefined ? null : toEntry(row)
     })
   }
@@ -280,9 +293,7 @@ export class IdbDocumentIndex implements DocumentIndex {
   async setDocumentName({ workspaceId, documentId, name }: SetDocumentNameInput): Promise<void> {
     await this.tx([DOCUMENT_INDEX_STORE], 'readwrite', async (tx) => {
       const store = tx.objectStore(DOCUMENT_INDEX_STORE)
-      const row = (await request(store.index('byId').get([workspaceId, documentId]))) as
-        | IndexRow
-        | undefined
+      const row = parseRow(await request(store.index('byId').get([workspaceId, documentId])))
       if (row === undefined) throw new DocumentNotFoundError(workspaceId, documentId)
       // Rebuilt rather than spread-with-undefined: a stored `name: undefined`
       // is not the same as an absent one to `'name' in entry`, which the


### PR DESCRIPTION
## Summary

Audit backlog (MEDIUM / contract): `IdbDocumentIndex`'s stored-row shape was a hand-written `IndexRow` interface and every read site an `as` cast — the exact persisted-JSON pattern the Zod discipline forbids, one file away from `listWorkspaces` doing it right with `workspaceEntrySchema.parse`.

- `IndexRow` is now `z.infer` of `documentEntrySchema.extend({ workspaceId })`, declared next to the reads it validates.
- All four read sites hydrate through the schema (the workspace `getAll`, both single-row `get`s, and `setDocumentName`'s read-back), so a corrupt row — a devtools edit, a buggy writer, schema drift — fails loudly naming the field instead of flowing into the UI wearing the contract's type.
- Writes were already shaped by the same type; valid rows parse byte-identically, so the happy path is unchanged.

## Test plan

- [x] New or updated `web-browser` test added — a red-first regression: planting a row with a numeric `path` through the real IndexedDB (bypassing the class's validated write path) made `listDocuments` **resolve with the corrupt entry** (measured: `promise resolved "[ { …(2) } ]" instead of rejecting`); with the schema it rejects naming `path`
- [x] `pnpm test` passes locally — the port's 38-case `describeDocumentIndexConformance` suite over `IdbDocumentIndex` (real browser IndexedDB), `folding-browser-index` browser suite, `fold-workspace` browser suite, and the Browser pages' jsdom suites all pass unchanged; repo-wide typecheck / lint / knip clean
- [x] Manual verification completed — mutation check: restoring the cast in `rowsIn` turns the new test red again; restore is green
- [x] E2E coverage — the conformance suite is the regression lock for the port contract; the new test locks the corrupt-row rejection

## Visual evidence

Visual evidence: none — no pixel or flow changes on valid data; the hardened path is only reachable by planting corrupt bytes, which the new browser test does through the real IndexedDB.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — no user-visible or published-contract change
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema — this PR deletes exactly one

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document index reliability by validating stored document data before it is used.
  * Invalid or corrupted document records now produce a clear error instead of appearing as valid documents.
  * Added coverage to verify malformed IndexedDB records are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->