### PR TITLE
fix(web): make FoldingBrowserIndex.createWorkspace write both registry and tree

### DIFF
--- a/apps/web/src/lib/folding-browser-index.conformance.browser.test.tsx
+++ b/apps/web/src/lib/folding-browser-index.conformance.browser.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * The production browser index, held to the port's own conformance suite —
+ * the same bar `IdbDocumentIndex` and `LoroWorkspaceDocumentIndex` already
+ * pass. Real IndexedDB on purpose: this class composes three IDB-backed
+ * collaborators, and the suite's transactional claims are about the real
+ * thing.
+ *
+ * Each case gets its OWN database (a counter-suffixed name passed to every
+ * collaborator through the constructor) rather than deleting one shared name
+ * between cases: the collaborators hold connections whose close timing this
+ * file does not own, and a blocked `deleteDatabase` would hand the next case
+ * the previous one's rows. A fresh name cannot be stale.
+ */
+import { describeDocumentIndexConformance } from '@kamiazya/whiteboard-ports/test-utils'
+import { describe } from 'vitest'
+import { FoldingBrowserIndex } from './folding-browser-index.js'
+
+let caseN = 0
+
+function deleteDb(name: string): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase(name)
+    // Best-effort: a blocked deletion is fine here because no later case
+    // reuses this name.
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+    req.onblocked = () => resolve()
+  })
+}
+
+describe('FoldingBrowserIndex', () => {
+  describeDocumentIndexConformance(async () => {
+    caseN += 1
+    const dbName = `whiteboard-folding-conformance-${caseN}`
+    await deleteDb(dbName)
+    const index = new FoldingBrowserIndex(dbName)
+    return {
+      index,
+      dispose: () => deleteDb(dbName),
+      // createWorkspace persists identity into the registry the class
+      // resolves against, so the port's own call is the seam.
+      seedWorkspace: (entry) => index.createWorkspace(entry),
+    }
+  })
+})

--- a/apps/web/src/lib/folding-browser-index.ts
+++ b/apps/web/src/lib/folding-browser-index.ts
@@ -136,8 +136,18 @@ export class FoldingBrowserIndex implements DocumentIndex {
     return this.folded
   }
 
+  /**
+   * Both halves of what a workspace IS: identity (segment, displayName) into
+   * the registry, placement into the tree. The tree index alone cannot do
+   * this — its `createWorkspace` deliberately never writes a registry row —
+   * so delegating only there created a workspace `listWorkspaces` could not
+   * report and `resolveWorkspace` could not address. The registry write is
+   * create-if-absent, so re-creating an existing workspace bare never
+   * clobbers identity it already carries.
+   */
   async createWorkspace(input: CreateWorkspaceInput): Promise<void> {
     await this.ensureFolded()
+    await this.legacy.createWorkspace(input)
     return this.inner.createWorkspace(input)
   }
 

--- a/apps/web/src/lib/idb-document-index.ts
+++ b/apps/web/src/lib/idb-document-index.ts
@@ -109,12 +109,11 @@ export class IdbDocumentIndex implements DocumentIndex {
       // blind `put` of the input let the bare `{ workspaceId }` call clear
       // whatever identity layers the row already carried.
       //
-      // No caller reaches that today: `FoldingBrowserIndex` routes
-      // `createWorkspace` to the tree index and keeps this one for
-      // `listWorkspaces`/`renameWorkspace`/`listDocuments`/`deleteDocument`
-      // only. It is fixed because the row it would clobber is the one
-      // `renameWorkspace` — right below, on this same store — writes, so the
-      // two halves of one registry sat one call apart from disagreeing.
+      // Load-bearing for `FoldingBrowserIndex`, whose `createWorkspace`
+      // writes its registry half through this call: `ensureLocalWorkspace`
+      // re-creates the browser workspace bare on every boot path, and an
+      // overwrite here would strip the identity `renameWorkspace` — right
+      // below, on this same store — had written.
       //
       // Read and return inside the SAME transaction, so the check and the
       // write cannot be split by a concurrent create.


### PR DESCRIPTION
## Summary

Audit backlog (MEDIUM / test): hold `FoldingBrowserIndex` — the browser's production `DocumentIndex` — to `describeDocumentIndexConformance`, the same bar `IdbDocumentIndex` and `LoroWorkspaceDocumentIndex` already pass. Doing so surfaced a real contract violation, which this PR fixes:

- **The gap**: `createWorkspace` delegated only to the tree index, whose `createWorkspace` deliberately never writes a registry row. A workspace created through the port was therefore one its own `listWorkspaces` could not report and `resolveWorkspace` could not address, and its `segment`/`displayName` were silently dropped. (No production flow hits it today — `browser-workspaces.ts` writes the registry directly — which is exactly the built-but-divergent state a conformance suite exists to catch before a caller does.)
- **The fix**: `createWorkspace` now writes the identity half through the legacy registry (create-if-absent, so re-creating an existing workspace bare never clobbers identity `renameWorkspace` wrote) and the placement half through the tree.
- **The suite**: a new conformance file runs all 38 port cases over the real IndexedDB composition. Each case gets its own counter-suffixed database rather than deleting a shared one — the collaborators hold connections whose close timing the test does not own, and a blocked `deleteDatabase` would hand the next case stale rows.
- The stale comment in `idb-document-index.ts` describing the old routing is corrected: its no-overwrite `createWorkspace` is now load-bearing for this class.

## Test plan

- [x] New or updated `web-browser` tests added — `folding-browser-index.conformance.browser.test.tsx` (38 cases)
- [x] Red first, measured: against the unfixed class, **12 of 38 cases failed** — the registry-visibility and identity-layer family, the rename cases among them (no row existed to rename). The one-line registry write turns all 12 green.
- [x] `pnpm test` passes locally — conformance 38 + existing folding 5, fold-workspace, idb-document-index (39), local-document-summary browser suites (90 browser tests total), Browser pages' jsdom suites (57); repo-wide typecheck / lint / knip clean
- [x] Manual verification completed — the red run IS the mutation evidence: the fix reverted is the measured 12-failure state
- [x] E2E coverage — the conformance suite is the standing regression lock for the port contract

## Visual evidence

Visual evidence: none — a port-contract fix with no pixel or flow change; production workspace creation goes through a different, already-correct path, and the hardened one is pinned by the new 38-case suite.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — no user-visible or published-contract change
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_