### PR TITLE
feat(tooling): catch cross-package dependency cycles in arch-lint

### DIFF
--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -145,19 +145,21 @@ on the first read: `server-mode-http.ts` — the MULTI-INSTANCE root, the one th
 backup lease was built for — was starting no background work at all, so
 scheduled backups reached only the local daemon.
 
-**A cross-package cycle is caught by nothing, so the one that exists is
-guarded where it is.** `plugin-visual` imports `canvas-render`'s scene-node
-vocabulary to build the decorations `canvas-render` then uses as its default —
-a source-level loop closed only by the import being TYPE-ONLY. Nothing
-mechanical holds that: the cycle check is intra-package, and the direction
-check reads `dependencies` while this edge sits in `devDependencies`, which it
-documents as never inspected. Measured — turning the import into a value
-import left all 102 arch-lint tests green.
-`plugin-visual/src/canvas-render-type-only.test.ts` is what actually fails,
-naming the offending line. The honest fix is a package below both holding the
-scene vocabulary, since it is a contract between the renderer and every plugin
-rather than the renderer's private type; worth extracting when a second plugin
-needs it, and recorded on `decorations.ts` until then.
+**A cross-package cycle is caught at the MANIFEST level, and its type-only
+property by a hand guard.** `plugin-visual` imports `canvas-render`'s
+scene-node vocabulary to build the decorations `canvas-render` then uses as
+its default — a source-level loop closed only by the import being TYPE-ONLY.
+`package-cycle-check.ts` now reads every workspace manifest's `dependencies`
+AND `devDependencies` (the door the direction check never inspects) and
+fails on any package loop not in `KNOWN_PACKAGE_CYCLES`, which carries this
+one edge with its reason. What stays hand-guarded is the type-only property
+itself — the manifest cannot see it, and measured, turning the import into
+a value import leaves the rest of arch-lint green:
+`plugin-visual/src/canvas-render-type-only.test.ts` is what fails, naming
+the offending line. The honest dissolution is a package below both holding
+the scene vocabulary, since it is a contract between the renderer and every
+plugin rather than the renderer's private type; worth extracting when a
+second plugin needs it, and recorded on `decorations.ts` until then.
 
 `lowlight` is a DEFAULT, not an opt-in. `layoutSpatialCanvas` supplies this
 package's own tokeniser the way it already supplies codec's markdown parser,

--- a/.claude/rules/tool-arch-lint.md
+++ b/.claude/rules/tool-arch-lint.md
@@ -33,6 +33,16 @@ silently leave the graph.
 `KNOWN_IMPORT_CYCLES` is the allowlist for cycles found and not yet fixed. It
 is **currently empty**.
 
+`package-cycle-check.ts` is the cross-PACKAGE half: a graph over every
+workspace manifest (enumerated from pnpm-workspace's globs, so a new package
+joins unlisted) reading `dependencies` AND `devDependencies` — the latter is
+the door the direction check never inspects, and measured, the one real
+cycle (canvas-render <-> plugin-visual) enters through it.
+`KNOWN_PACKAGE_CYCLES` allowlists it, both-sides guarded; the type-only
+property of the closing edge stays with
+`plugin-visual/src/canvas-render-type-only.test.ts`, because a manifest
+cannot see how an import is spelled.
+
 ## What the composition roots do and do not get
 
 `mcp-server` and `apps/web` are registered for the dependency-direction guard,

--- a/tools/arch-lint/src/architecture-map.ts
+++ b/tools/arch-lint/src/architecture-map.ts
@@ -253,6 +253,32 @@ export const ARCHITECTURE_MAP: Readonly<Record<string, PackageArchEntry>> = {
 export const KNOWN_IMPORT_CYCLES: readonly (readonly string[])[] = []
 
 /**
+ * Cross-PACKAGE dependency cycles found and not yet dissolved — the
+ * manifest-level companion to {@link KNOWN_IMPORT_CYCLES}, over
+ * `dependencies` AND `devDependencies` (package-cycle-check.ts). Same
+ * both-sides contract: a cycle not listed here fails the build, and an
+ * entry whose cycle no longer exists fails it too.
+ *
+ * A listed cycle is not thereby safe at the SOURCE level: the manifest edge
+ * only says the loop could be closed, and whatever keeps the closing import
+ * type-only needs its own guard, named in the reason.
+ */
+export const KNOWN_PACKAGE_CYCLES: readonly {
+  readonly packages: readonly string[]
+  readonly reason: string
+}[] = [
+  {
+    packages: ['@kamiazya/whiteboard-canvas-render', '@kamiazya/whiteboard-plugin-visual'],
+    reason:
+      'plugin-visual imports canvas-render scene-node vocabulary TYPE-ONLY (devDependency) while ' +
+      'canvas-render consumes plugin-visual decorations at runtime. The type-only property is ' +
+      "guarded by plugin-visual's canvas-render-type-only.test.ts; the honest dissolution is a " +
+      'package below both holding the scene vocabulary, worth extracting when a second plugin ' +
+      'needs it (see architecture-map.md).',
+  },
+]
+
+/**
  * Mechanics an ADAPTER still reaches directly, pending ADR-0018's migration.
  *
  * Each entry is one `<adapter file> -> <mechanic module>` edge, relative to

--- a/tools/arch-lint/src/package-cycle-check.test.ts
+++ b/tools/arch-lint/src/package-cycle-check.test.ts
@@ -1,0 +1,90 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { KNOWN_PACKAGE_CYCLES } from './architecture-map.js'
+import { findPackageCycles } from './package-cycle-check.js'
+
+function manifest(
+  name: string,
+  deps: Record<string, string> = {},
+  devDeps: Record<string, string> = {},
+) {
+  return { name, dependencies: deps, devDependencies: devDeps }
+}
+
+describe('findPackageCycles', () => {
+  it('answers [] for an acyclic workspace graph, third-party deps ignored', () => {
+    expect(
+      findPackageCycles([
+        manifest('a', { b: 'workspace:*', zod: '^3' }),
+        manifest('b', { react: '^19' }),
+      ]),
+    ).toEqual([])
+  })
+
+  it('finds a cycle carried by dependencies', () => {
+    expect(
+      findPackageCycles([manifest('a', { b: 'workspace:*' }), manifest('b', { a: 'workspace:*' })]),
+    ).toEqual([['a', 'b']])
+  })
+
+  it('finds a cycle CLOSED through devDependencies — the edge the direction check never inspects', () => {
+    // The documented blind spot: direction-check.ts reads `dependencies`
+    // only, so a devDependency is the door a cross-package loop walks in
+    // through. This check exists for exactly this edge.
+    expect(
+      findPackageCycles([
+        manifest('a', { b: 'workspace:*' }),
+        manifest('b', {}, { a: 'workspace:*' }),
+      ]),
+    ).toEqual([['a', 'b']])
+  })
+
+  it('reports each cycle once, members sorted, deterministically', () => {
+    const cycles = findPackageCycles([
+      manifest('z', { a: 'workspace:*' }),
+      manifest('a', { z: 'workspace:*' }),
+      manifest('lonely'),
+    ])
+    expect(cycles).toEqual([['a', 'z']])
+  })
+})
+
+describe('the real workspace', () => {
+  // Enumerated from the same globs pnpm-workspace.yaml declares
+  // (packages/*, apps/*, tools/*), so a new package joins this scan the
+  // moment it exists — no list to keep in step.
+  const REPO_ROOT = join(__dirname, '../../..')
+  const manifests = ['packages', 'apps', 'tools'].flatMap((group) =>
+    readdirSync(join(REPO_ROOT, group), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .flatMap((entry) => {
+        try {
+          return [
+            JSON.parse(readFileSync(join(REPO_ROOT, group, entry.name, 'package.json'), 'utf-8')),
+          ]
+        } catch {
+          return []
+        }
+      }),
+  )
+
+  it('enumerates a plausible manifest count', () => {
+    // A scan over zero manifests would report "no cycles" while checking
+    // nothing; the workspace holds 13+ packages today.
+    expect(manifests.length).toBeGreaterThanOrEqual(10)
+  })
+
+  it('holds no cross-package dependency cycle beyond the allowlisted ones', () => {
+    const found = findPackageCycles(manifests)
+    expect(found).toEqual(KNOWN_PACKAGE_CYCLES.map((entry) => [...entry.packages].sort()).sort())
+  })
+
+  it('every allowlisted cycle still exists — an entry cannot outlive the debt it names', () => {
+    const found = findPackageCycles(manifests).map((cycle) => cycle.join(' <-> '))
+    for (const entry of KNOWN_PACKAGE_CYCLES) {
+      expect(found).toContain([...entry.packages].sort().join(' <-> '))
+      expect(entry.reason.length).toBeGreaterThan(20)
+    }
+  })
+})

--- a/tools/arch-lint/src/package-cycle-check.ts
+++ b/tools/arch-lint/src/package-cycle-check.ts
@@ -1,0 +1,38 @@
+// Cross-PACKAGE dependency-cycle check, over workspace manifests. The
+// source-level cycle check (cycle-check.ts) is intra-package by design, and
+// the direction check reads `dependencies` only — so a loop closed through a
+// devDependency was caught by nothing mechanical. This check reads BOTH
+// dependency objects: a type-only edge legitimately lives in
+// devDependencies, and that is precisely the door a cross-package loop
+// walks in through.
+//
+// Filesystem-free (pure functions over supplied manifests) like every other
+// check here; the repo wiring lives in the test. Cycle detection reuses
+// cycle-check.ts's Tarjan SCC — a graph is a graph.
+
+import { findImportCycles } from './cycle-check.js'
+import type { PackageManifest } from './direction-check.js'
+
+/**
+ * Directed graph over the supplied manifests' names: an edge for every
+ * dependency OR devDependency that names another supplied package.
+ * Third-party dependencies fall out via set membership, so the caller
+ * decides the workspace universe by what it passes in.
+ */
+function buildPackageGraph(manifests: readonly PackageManifest[]): Map<string, string[]> {
+  const names = new Set(manifests.map((m) => m.name))
+  const graph = new Map<string, string[]>()
+  for (const m of manifests) {
+    const targets = [
+      ...Object.keys(m.dependencies ?? {}),
+      ...Object.keys(m.devDependencies ?? {}),
+    ].filter((dep) => names.has(dep))
+    graph.set(m.name, [...new Set(targets)].sort())
+  }
+  return graph
+}
+
+/** Every package-level cycle, each sorted, the list sorted — deterministic. */
+export function findPackageCycles(manifests: readonly PackageManifest[]): string[][] {
+  return findImportCycles(buildPackageGraph(manifests))
+}


### PR DESCRIPTION
## Summary

Audit backlog (MEDIUM / architecture): the source-level cycle check is intra-package by design and the direction check reads `dependencies` only — so a package loop closed through a **devDependency** was caught by nothing mechanical. `architecture-map.md` carried this as a documented blind spot with one hand guard.

- **`package-cycle-check.ts`** builds a graph over every workspace manifest — enumerated from pnpm-workspace's globs (`packages/*`, `apps/*`, `tools/*`), so a new package joins the scan unlisted — reading `dependencies` AND `devDependencies`, and reuses `cycle-check.ts`'s Tarjan SCC (a graph is a graph).
- **Red first, measured**: with an empty allowlist the repo test fails naming exactly the one real cycle — `canvas-render ⇄ plugin-visual`, whose closing edge is the type-only devDependency. Nothing else in the workspace cycles.
- **`KNOWN_PACKAGE_CYCLES`** allowlists that cycle with a reason naming `canvas-render-type-only.test.ts` as the guard of the type-only property a manifest cannot see, under the tool's standing both-sides contract: an unlisted cycle fails the equality check, and a stale entry fails the still-exists check.
- `.claude/rules/architecture-map.md` and `tool-arch-lint.md` now say the loop is caught at the manifest level rather than "by nothing"; the always-on rules budget guard stays green.

## Test plan

- [x] New or updated tests added — `package-cycle-check.test.ts` (7 cases: acyclic passthrough with third-party deps ignored, a `dependencies` cycle, **the devDependency-closed cycle that is the whole point**, determinism, a plausible manifest count floor, and the two repo-level both-sides assertions)
- [x] `pnpm test` passes locally — full `arch-lint-node` project 11 files / 119 tests; `dev-rules-budget` guard green after the rules edits; typecheck / lint / knip clean
- [x] Manual verification completed — mutation checks, each red-then-restored-green:
  - empty allowlist against the real workspace → equality check fails naming `canvas-render ⇄ plugin-visual` (the red run)
  - fabricated allowlist entry (`model ⇄ codec`) → both the equality check and the still-exists guard fail
- [x] E2E coverage — the check runs in the `arch-lint-node` vitest project CI's `check` job already executes; it IS the standing regression lock

## Visual evidence

Visual evidence: none — a build-time developer guard with no user-visible surface.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — the two contributor rules files ship in this increment
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema — internal tool types, no process boundary

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_