### PR TITLE
refactor(web): retire the never-wired webMcpMaxTier persisted setting

### DIFF
--- a/apps/web/src/lib/user-settings-store.test.ts
+++ b/apps/web/src/lib/user-settings-store.test.ts
@@ -394,7 +394,12 @@ describe('v1 -> v2 migration', () => {
     })
     // browserToDaemon is dropped by the chained v2->v3 step, not carried.
     expect(loaded.migration).toEqual({})
-    expect(loaded.capabilities).toEqual({ webMcpEnabled: true, webMcpMaxTier: 2 })
+    // webMcpMaxTier went IN this bump, not through it: declared speculative
+    // in the very first schema, never written or read by anything since. The
+    // v1 seed above still carries it, pinning that a payload holding the
+    // retired key MIGRATES (parse-tolerated) rather than being discarded by
+    // the strict parse.
+    expect(loaded.capabilities).toEqual({ webMcpEnabled: true })
     expect(loaded.appearance).toEqual({ faviconStyle: 'dot' })
   })
 

--- a/apps/web/src/lib/user-settings-store.ts
+++ b/apps/web/src/lib/user-settings-store.ts
@@ -209,6 +209,19 @@ const migrationSettingsSchema = z
 const capabilitySettingsSchema = z
   .object({
     webMcpEnabled: z.boolean().optional(),
+  })
+  .strict()
+
+/**
+ * The capability shape v1 and v2 stored, kept parse-only. `webMcpMaxTier`
+ * was declared speculative in the very first schema and never written or
+ * read by anything since — dropped from the live shape (a field nobody
+ * reads does not need to survive the bump), kept here so a payload holding
+ * the retired key migrates instead of being discarded by `.strict()`.
+ */
+const legacyCapabilitySettingsSchema = z
+  .object({
+    webMcpEnabled: z.boolean().optional(),
     webMcpMaxTier: z
       .union([z.literal(0), z.literal(1), z.literal(2), z.literal(3), z.literal(4)])
       .optional(),
@@ -311,7 +324,7 @@ const legacyV1SettingsSchema = z
       // through.
       .strict(),
     migration: legacyMigrationSettingsSchema,
-    capabilities: capabilitySettingsSchema,
+    capabilities: legacyCapabilitySettingsSchema,
     appearance: appearanceSettingsSchema.optional(),
   })
   .strict()
@@ -353,7 +366,7 @@ const legacyV2SettingsSchema = z
       })
       .strict(),
     migration: legacyMigrationSettingsSchema,
-    capabilities: capabilitySettingsSchema,
+    capabilities: legacyCapabilitySettingsSchema,
     appearance: appearanceSettingsSchema.optional(),
   })
   .strict()
@@ -414,10 +427,13 @@ function migrateV2(legacy: z.infer<typeof legacyV2SettingsSchema>): UserSettings
   return {
     version: 3,
     storage: legacy.storage,
-    // browserToDaemon goes IN the migration (dropped), not through it: a
-    // field nobody reads does not need to survive the bump.
+    // browserToDaemon and webMcpMaxTier go IN the migration (dropped), not
+    // through it: a field nobody reads does not need to survive the bump.
     migration: promotion === undefined ? {} : { promotion: normalizeLegacyPromotion(promotion) },
-    capabilities: legacy.capabilities,
+    capabilities:
+      legacy.capabilities.webMcpEnabled === undefined
+        ? {}
+        : { webMcpEnabled: legacy.capabilities.webMcpEnabled },
     ...(legacy.appearance === undefined ? {} : { appearance: legacy.appearance }),
   }
 }


### PR DESCRIPTION
## Summary

Audit backlog (MEDIUM / wiring): `webMcpMaxTier` was declared speculative in the very first `UserSettingsStore` schema (#112) and never written or read by anything since — verified by history (`git log -S`: only schema moves and one test seed ever touched it). The wire-or-delete call lands on **delete**, per the standing rule that a field nobody reads does not need to survive a bump.

- The live capability schema drops the field.
- A new parse-only `legacyCapabilitySettingsSchema` keeps it readable for v1/v2 payloads — the `.strict()` loader discards a **whole** payload on any unknown key, the measured defect class this store's own history documents (the `preferredProvider` sweep), so tolerance is load-bearing even for a field that was almost certainly never stored.
- `migrateV2` drops it on the way into the live shape, exactly the `browserToDaemon` precedent one line above it.

## Test plan

- [x] Red first — the v1-migration test's expectation tightened to `{ webMcpEnabled: true }` fails against the carrying code (`webMcpMaxTier: 2` still rode along); green after the drop. The v1 seed keeps carrying the retired key, so the test now pins BOTH halves: the payload migrates (tolerance) and the field does not (retirement)
- [x] Mutation-checked the tolerance half — removing the key from the LEGACY schema too fails 4 migration tests (the seeded payload is discarded to defaults); restore is green
- [x] `pnpm test` passes locally — user-settings-store (41) and both pages' webmcp suites (46 total with them); typecheck / lint / knip clean
- [x] E2E coverage — the migration tests are the standing regression lock for the settings store's parse-tolerance contract

## Visual evidence

Visual evidence: none — a persisted-settings schema retirement with no reader anywhere; no pixel or flow can change.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — no user-visible or published-contract change
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_