### PR TITLE
docs(adr): ADR-0025 — comment editor UX decisions

### DIFF
--- a/.claude/rules/vocabulary.md
+++ b/.claude/rules/vocabulary.md
@@ -18,7 +18,7 @@ this rule is how it converges without anyone scheduling a big-bang rename.
 | **Scene** | the laid-out projection of a spatial document (what `composeCanvasScene` produces) | stored content |
 | **Version** | a saved point in a document's history | a branch |
 | **Browser** / **Daemon** | who KEEPS a workspace — the browser's own storage, or the whiteboard daemon | a claim about network locality; both run on the same machine |
-| **Comment** | the annotation layer's unit (ADR-0024/0025): anchored feedback ABOUT a spot or node, floating above content; its lifecycle word in user copy is **Resolved** | content (never exported as content, never moved by tidy); "annotation layer" in USER copy (internal term only); "History" / "Archived" / "Done" for the resolved state |
+| **Comment** | the annotation layer's unit (ADR-0024/0025): anchored feedback about a spot or node, floating above content. User-copy lifecycle word: **Resolved** | content (never exported, never tidied); "annotation layer" in user copy; "History"/"Archived"/"Done" for resolved |
 
 Two consequences that catch people out:
 

--- a/.claude/rules/vocabulary.md
+++ b/.claude/rules/vocabulary.md
@@ -18,6 +18,7 @@ this rule is how it converges without anyone scheduling a big-bang rename.
 | **Scene** | the laid-out projection of a spatial document (what `composeCanvasScene` produces) | stored content |
 | **Version** | a saved point in a document's history | a branch |
 | **Browser** / **Daemon** | who KEEPS a workspace — the browser's own storage, or the whiteboard daemon | a claim about network locality; both run on the same machine |
+| **Comment** | the annotation layer's unit (ADR-0024/0025): anchored feedback ABOUT a spot or node, floating above content; its lifecycle word in user copy is **Resolved** | content (never exported as content, never moved by tidy); "annotation layer" in USER copy (internal term only); "History" / "Archived" / "Done" for the resolved state |
 
 Two consequences that catch people out:
 

--- a/docs/contributing/adr/0025-comment-editor-ux.md
+++ b/docs/contributing/adr/0025-comment-editor-ux.md
@@ -1,0 +1,148 @@
+# ADR-0025: Comment editor UX — lifecycle, visibility, identity, and AI delivery
+
+**Status:** Accepted
+
+## Context
+
+ADR-0024 shipped the comment layer's data model, per-comment CRDT storage,
+scene-composed rendering, `wb_canvas_edit` ops (`comment.add` /
+`comment.resolve` / `comment.remove`), snapshot exposure, and the MCP Apps
+widget's click-to-anchor + `sendMessage` flow (PRs #1204–#1212). It
+explicitly deferred the apps/web editor's interactive UI.
+
+Building that UI forces decisions ADR-0024 did not take, and taking them
+piecemeal risks a stored-shape migration later or an editor that promises
+things the system does not do (a comment "sent to the AI" that no AI was
+told about). A multi-perspective design pass (product / UX / architecture /
+security / prior-art research over Figma, Miro, Google Docs, Linear) was run
+first; the human decisions below were taken on 2026-09-02 with the full
+option set in front of the user.
+
+Two facts frame every choice:
+
+- **Zero real usage evidence exists** for editor comments — the editor has
+  never had a create path — so every speculative surface (threads, identity,
+  push notification, dense-canvas clustering) would be built on argument
+  alone. This repo's standing rule is instrument first, and here the
+  instrument is a shipped minimal lifecycle loop plus dogfooding.
+- **Stored-shape changes are cheap now** (0.0.x, no external users, and
+  `canvasCommentSchema`'s optional fields are additive), so pre-provisioning
+  structure "for SaaS" buys nothing that adding it later would not.
+
+## Decision
+
+### 1. Creation enters through the context menu, and only there (v1)
+
+- Node band: **"Comment on this"** — creates with `targetNodeId`, anchored
+  by the existing top-right-corner rule. This verb is exempt from the
+  locked-node collapse-to-Unlock-only precedent, explicitly: a comment does
+  not mutate the node.
+- Empty-canvas band: **"Comment here"** — creates at the clicked canvas
+  point.
+- Both open an **inline, anchored, non-modal compose bubble** (autofocus
+  textarea; Enter/Add commits, Esc cancels; a failed write keeps the text
+  and the anchor). An optional `C` shortcut may accompany the menu verbs,
+  but the menu is the discoverable path and the keyboard path exists
+  regardless of pointer (accessibility floor).
+- A comment TOOL (Figma-style mode) is rejected for v1: it adds a tool-mode
+  state machine and a dock surface for no evidence-backed gain. Revisit only
+  with dogfooding evidence that menu entry is too slow.
+
+### 2. Resolved comments are a show/hide toggle, not a panel (v1)
+
+- One toggle — "Show resolved" — wired to a `showResolved` layout option in
+  `composeComments`. ON draws resolved pins/bubbles (visually muted per the
+  theme), each individually reopenable.
+- The toggle's state is **per-user local view state, never written to the
+  shared CRDT document** — a future multi-user keeper must not let one
+  person's toggle change what another person sees.
+- A persistent Comments panel (list + jump-to) is the named upgrade if
+  dogfooding shows the toggle insufficient on dense canvases. It is not
+  built now; the keyboard-reachable create/resolve paths carry the
+  accessibility requirement the panel would otherwise have carried.
+- Resolve/reopen ship with **no confirmation dialog** (resolve is reversible
+  by design — ADR-0024 keeps the record) and a toast with Undo. A failed
+  resolve/reopen write keeps the bubble's visible state unchanged and says
+  so in the toast — the pin never optimistically flips to a state the
+  document does not hold.
+- `comment.remove` stays an MCP-op-only affordance in v1. The editor ships
+  resolve-only, matching the ticketing rule one level down: deletion is for
+  a comment that was never worth keeping, and the editor should not make
+  destroying the conversation easier than closing it.
+
+### 3. Comments ship authorless in the editor (v1)
+
+The editor writes no `author`. The field already carries OKF actor strings
+(`human:` / `process:`, ADR-0016) written by MCP clients, so AI-authored
+comments are already distinguishable where an author exists; a real identity
+model arrives with a keeper that can vouch for one (SaaS/daemon accounts).
+Minting a browser-local display label now was considered and rejected: it
+would de facto reverse ADR-0016's refusal to mint local identity, and a
+label nobody can trust is worse than an honest blank. When identity lands,
+it fills an optional field — no migration.
+
+### 4. AI delivery is pull-by-convention (v1); no new push surface
+
+- The documented convention: **an AI collaborator sees new and resolved
+  comments on its next `wb_canvas_snapshot` read** (the snapshot already
+  returns all comments, resolved included). A how-to records this so agent
+  authors build the habit of checking open comments.
+- Editor copy must never claim real-time AI delivery — "Comment saved",
+  never "sent to the AI". The MCP Apps widget's `sendMessage` remains the
+  one proven push channel and keeps its wording.
+- MCP `resources/subscribe` (or any push/notification machinery) is out of
+  scope pending a client-support verification, filed as its own follow-up.
+  Security's position is recorded: a new delivery mechanism is new attack
+  surface and gets its own threat-model pass when it comes.
+
+### 5. Comment chrome stays out of `sceneDigest`
+
+The editor needs hit-testable pin/bubble geometry, which means those shapes
+gain ids (suffixed, mirroring the shipped `${commentId}/leader` convention:
+`/pin`, `/bubble`). `sceneDigest` reports one entry per addressable node id,
+so without a rule those ids would surface comments as phantom nodes in
+`wb_scene_digest` — repeating the three-nodes/six-entries mistake the
+digest's design note records, and double-reporting what
+`wb_canvas_snapshot.comments` already publishes. Decision: **suffixed comment
+chrome ids are excluded from the digest's addressable set**, pinned by a
+test, so the digest keeps answering "what content is on this canvas".
+
+### 6. Editor writes ride the fine-grained path, gated before any UI
+
+`document-sync-session.ts`'s command fallback commits a whole
+`writeSpatialCanvas` resync, which deletes any comment id not present in the
+in-memory canvas — exactly the concurrent-loss failure ADR-0024's
+per-comment map exists to prevent. Every comment `EditorCommand` therefore
+gets an explicit fine-grained write case (via the bridge's
+`writeCanvasComment` / `deleteCanvasComment`), and a property test pins that
+two peers writing different comments concurrently both survive. This lands
+as a spike BEFORE any UI slice, because a UI wired to the fallback would
+look correct in every single-user test.
+
+### Explicitly deferred (each needs evidence, not argument)
+
+| Deferred | Trigger to revisit |
+|---|---|
+| Threads / `parentId` replies | dogfooding shows single-text comments forcing awkward node-edit conversations |
+| Identity minting / per-author styling | a keeper that can vouch for identity (daemon accounts / SaaS) |
+| Push notification to AI (`resources/subscribe` etc.) | client-support verification + a real latency complaint against pull |
+| Dense-canvas collision avoidance / clustering | dogfooding pain at real comment densities (the fixed-offset ponytail stands) |
+| Resolve/remove authorization (author-only? role?) | real identity; named here so it is not decided by omission — today's boundary is "anyone with document write access" |
+| Comments panel / history surface | toggle proves insufficient on dense canvases |
+| `text` length cap + snapshot truncation treatment | first oversized-comment incident or measured snapshot bloat |
+
+## Consequences
+
+- The v1 loop is create → read → resolve/reopen, entirely inside the editor,
+  with resolved history one toggle away — and nothing in it writes a shape
+  that a later identity, thread, or notification feature would have to
+  migrate.
+- Editor UI slices route their interaction tests to `web-browser` (pointer /
+  keyboard / focus behavior — jsdom alone is disallowed by AGENTS.md for
+  interaction), with race cases stated per slice: a compose bubble whose
+  anchor node is deleted by a remote peer mid-edit keeps the draft and falls
+  back to the point anchor; a resolve/reopen whose bubble unmounts mid-write
+  still lands or reports failure via toast.
+- User copy vocabulary: the feature is a **Comment** (the layer name
+  "annotation layer" stays an internal term), and the lifecycle word is
+  **Resolved** — never "History", "Archived", or "Done".

--- a/docs/contributing/adr/README.md
+++ b/docs/contributing/adr/README.md
@@ -57,3 +57,4 @@ See [template.md](template.md) for the standard structure (MADR-lite: Title, Sta
 | [ADR-0022](0022-variation-addressing.md) | A variation is not in the address, and the default one has no name to put there | Accepted — records the shipped shape; fixes the grammar for later |
 | [ADR-0023](0023-replica-model.md) | A workspace has one keeper; every other copy is a replica | Proposed — design of record for the demote/cache work |
 | [ADR-0024](0024-canvas-comments.md) | Canvas comments are a first-class annotation layer, keyed per comment | Accepted |
+| [ADR-0025](0025-comment-editor-ux.md) | Comment editor UX: context-menu create, resolved toggle, authorless v1, pull-by-convention AI delivery | Accepted |


### PR DESCRIPTION
## Summary

Phase 0 of the editor comment UI initiative: record the design decisions BEFORE any implementation slice, per the user's direction to settle the whole comment UX (SaaS future, AI interaction, delete/resolve semantics, resolved-comment visibility) first. Decisions were prepared by a multi-perspective planning pass (product/UX/architecture/security + prior-art research over Figma/Miro/Google Docs/Linear) and each of the four write-scope-changing questions was put to the user with the full option set; all four resolved on 2026-09-02.

- **ADR-0025** (new, Accepted): context-menu creation with an inline compose bubble; show/hide-resolved toggle held as per-user LOCAL view state (never the shared CRDT); authorless v1 (no local identity minting — keeps ADR-0016 intact); pull-by-convention AI delivery with honest copy ("Comment saved", never "sent to the AI"). Plus two cross-cutting rules plan review surfaced: comment chrome ids stay out of `sceneDigest`'s addressable set, and comment EditorCommands must ride the fine-grained Loro write path (spike lands before any UI — the full-resync fallback would silently delete a remote peer's comment). Every deferred bet (threads, identity, push delivery, dense-canvas clustering, remove-in-editor, panel, text caps, authz) is named with its revisit trigger rather than dropped.
- **ADR README** gains the 0025 row.
- **vocabulary.md** gains the Comment row: canonical noun in user copy is Comment, lifecycle word is Resolved (never History/Archived/Done); "annotation layer" stays internal.

## Test plan

Docs + always-on rule only — no production code. `pnpm check:local` exit 0; `arch-lint-node` vocabulary-check 4 passed (the new vocabulary row spells no retired word).

Visual evidence: none — a decision record moves no pixels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance defining comments as anchored feedback annotations, with “Resolved” as the user-facing status.
  * Documented the accepted comment-editor experience, including context-menu creation, inline compose bubbles, resolved-comment visibility, and AI comment delivery.
  * Added the comment-editor UX decision record to the contributing documentation index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->