### PR TITLE
test(mcp-server): pin the eviction guard on the path every agent write takes

### DIFF
--- a/packages/mcp-server/src/server/store/workspace-plane.test.ts
+++ b/packages/mcp-server/src/server/store/workspace-plane.test.ts
@@ -249,3 +249,47 @@ it('the index creates, renames and deletes on the tree', async () => {
   expect(resolveWorkspaceDocumentById(tree, entry.documentId)).toBeNull()
   expect(readTrashEntries(tree).map((t) => t.documentId)).toContain(entry.documentId)
 })
+
+it('does not keep serving an agent write whose persistence failed', async () => {
+  // A save mutates the LIVE projection before the record is persisted, so a
+  // failure in between leaves every cached reader ahead of durable state and
+  // the next read serves content that was never written. `saveWorkspaceDoc`
+  // is what prevents that, by evicting both caches in its catch — the choke
+  // point every durable workspace write funnels through, which is why this
+  // path inherits the guard without repeating it.
+  //
+  // The guard is load-bearing and was covered ONCE. Mutating that catch to
+  // rethrow without evicting turns 4210 mcp-node tests into exactly two
+  // failures, and before this test the only one was in `restore.test.ts` —
+  // a route-level test of a handler ADR-0018 schedules for removal. So the
+  // single guard on an invariant every agent write depends on
+  // (`wb_canvas_edit` -> saveDocumentSnapshot -> saveSnapshot) was going to
+  // be deleted by an unrelated refactor, silently.
+  //
+  // Asserted on what a reader GETS, not on whether some cache entry exists,
+  // so it keeps meaning the same thing if the caching changes.
+  const { routed } = await stores()
+  await saveDocument('ws-a', 'design', canvasDoc('persisted'), { kind: 'spatial' })
+  const rowId = await resolveDocumentIdAtPath('ws-a', 'design')
+  if (rowId === null) throw new Error('document missing from the tree')
+
+  const edited = canvasDoc('never-persisted')
+  const { manifest, chunks } = chunkSnapshot(
+    new Uint8Array(edited.export({ mode: 'snapshot' })),
+    1_000_000,
+  )
+  const saveSpy = vi
+    .spyOn(DocumentStoreWorkspaceDocs.prototype, 'save')
+    .mockRejectedValueOnce(new Error('simulated persistence failure'))
+  await expect(
+    routed.saveSnapshot({
+      docRef: { kind: 'document', workspaceId: 'ws-a', documentId: rowId },
+      manifest,
+      chunks,
+      frontier: new Uint8Array(edited.oplogVersion().encode()),
+    }),
+  ).rejects.toThrow('simulated persistence failure')
+  saveSpy.mockRestore()
+
+  expect(readText(await loadDocument('ws-a', 'design'))).toBe('persisted')
+})


### PR DESCRIPTION
## Summary

Preparation for [ADR-0018](docs/contributing/adr/0018-operation-vs-mechanic.md)'s restore move, and it exists because of something the migration nearly did by accident.

`saveWorkspaceDoc` evicts both caches when persistence fails, so a write durable storage refused is never served as though it succeeded:

```js
} catch (err) {
  // The live workspace doc now carries ops durable storage refused, and
  // every cached projection derives from it. Serving either as though
  // persisted would resurrect exactly the unpersisted-state bug eviction
  // exists to prevent — drop both so the next read reloads stored bytes.
  evictWorkspaceDocCache(workspaceId)
  evictWorkspaceDocs(workspaceId)
  throw err
}
```

**That guard was covered by exactly one test, and it is in a file ADR-0018 schedules for rewriting.** Mutating the catch to rethrow without evicting, then running all of `mcp-node`:

```
FAIL  workspace-plane.test.ts > does not keep serving an agent write whose persistence failed   ← this PR
FAIL  restore.test.ts > evicts the cached doc when saveDocument fails during in-place restore
Tests  2 failed | 4199 passed | 9 skipped (4210)
```

Two failures out of 4210. Before this PR only the second existed — a route-level test of the very handler that is about to become a server-core operation. Moving restore off that path would have deleted the only guard on an invariant **every agent write** depends on (`wb_canvas_edit` → `saveDocumentSnapshot` → `saveSnapshot`), silently, as a side effect of a refactor about something else.

This pins it where the invariant actually lives, and asserts on **what a reader gets back** rather than on whether a cache entry exists, so it keeps meaning the same thing if the caching changes.

## How this was found, including what I got wrong

Worth recording, because the first version of this investigation reached the opposite conclusion and would have shipped a fix for a bug that does not exist.

I grepped `workspace-plane.ts` for `evictDoc`, got `0`, and concluded the port path had no guard while the route path did. **That was absence in one file read as absence everywhere.** The guard is one layer down, in the choke point every durable workspace write funnels through.

The refutation came from running the failure rather than reading for it — forcing a persistence failure and probing all three readers:

```
PROBE loadDocument = persisted
PROBE getDoc       = persisted
PROBE peekDoc      = evicted
```

No leak. So there is no bug, and the restore move does not lose a guard — it inherits a stronger, more central one. What survived from the investigation is the coverage gap, which is real and measured above.

## Test plan

- [x] New or updated tests added — one `mcp-node` test on the agent-write path.
- [x] `pnpm test` passes locally — full `mcp-node` on unmutated code: **4201 passed, 9 skipped**; the touched file 8/8. `pnpm lint` clean.
- [x] Manual verification completed — **mutation-checked, and the mutation swept across the whole project** rather than only against the new test, which is what establishes that this adds coverage instead of duplicating it. Counts quoted above. The mutation was applied and reverted under a shell `trap` after an earlier sweep timed out mid-run and left the tree dirty.
- [ ] E2E coverage — n/a; this adds a regression test, no production code changes.

## Visual evidence

Visual evidence: none — a single added test, no production code. The observable output is the mutation sweep quoted above, in both its failing and passing forms.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — n/a
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_