### PR TITLE
refactor(server): extract the live-doc update operation into server-core over the LiveDocuments seam

### DIFF
--- a/.claude/rules/tool-arch-lint.md
+++ b/.claude/rules/tool-arch-lint.md
@@ -72,7 +72,7 @@ further down.
 
 **`ADAPTERS_REACHING_MECHANICS`** records the edges that exist today.
 
-**`ADAPTERS_REACHING_MECHANICS_CEILING` pins the count by equality — 33 today.**
+**`ADAPTERS_REACHING_MECHANICS_CEILING` pins the count by equality — 29 today.**
 It exists because the two both-sides guards reject a fabricated entry and a
 stale one and have nothing to say about a real new edge added along with its
 allowlist line, which is the ordinary way a list grows. Measured: a genuine
@@ -81,10 +81,10 @@ assertions, and the list went 37 -> 36 -> 35 -> 36 -> 40 in a week while the
 rule and the test's own comment both said it could only shrink. Adding an edge
 now fails until someone raises the ceiling deliberately, and paying one off
 fails until someone lowers it. ADR-0018 is **Accepted** (2026-08-31) and
-carries the burn-down order; `restore.ts`'s four edges are paid off (its
-operation lives in server-core behind the `LiveDocuments` seam), and the
-three remaining scheduled adapters (`live-doc.ts`, `workspace-document.ts`,
-`ws.ts`) hold 12 of the 33.
+carries the burn-down order; `restore.ts`'s and `live-doc.ts`'s four edges
+each are paid off (their operations live in server-core behind the
+`LiveDocuments` seam), and the two remaining scheduled adapters
+(`workspace-document.ts`, `ws.ts`) hold 8 of the 29.
 
 `corrupt-stored-data` is excluded and says why: an error taxonomy an adapter
 reads to pick a status code is translation, which is an adapter's job, and

--- a/packages/mcp-server/src/server/routes/document.ts
+++ b/packages/mcp-server/src/server/routes/document.ts
@@ -61,7 +61,13 @@ export function createDocumentRouter(options: DocumentRouterOptions = {}) {
   app.route('/', createWorkspacesRouter({ serverDeps: options.serverDeps }))
   app.route('/', createTrashRouter({ serverDeps: options.serverDeps }))
   app.route('/', createDocumentMetadataRouter())
-  app.route('/', createLiveDocRouter({ triggerAutoVersion }))
+  app.route(
+    '/',
+    createLiveDocRouter({
+      triggerAutoVersion,
+      ...(options.serverDeps === undefined ? {} : { serverDeps: options.serverDeps }),
+    }),
+  )
   app.route('/', createWorkspaceDocumentRouter({ triggerAutoVersion }))
   app.route('/', createVersionsRouter({ versionStore, getHeadBranch: options.getHeadBranch }))
   app.route('/', createMaintenanceRouter({ versionStore }))

--- a/packages/mcp-server/src/server/routes/document/live-doc-seam.test.ts
+++ b/packages/mcp-server/src/server/routes/document/live-doc-seam.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The live-doc routes operate through the ServerDeps they were given.
+ *
+ * `serverDeps` is an OPTIONAL router option, so a wiring bug — the field
+ * declared but never read, or document.ts forgetting to pass it on — compiles
+ * clean and passes every test that exercises only the getDefaultServerDeps
+ * fallback, which is all of live-doc.test.ts. Same bug class
+ * handle-resolution-seam.test.ts pins for handle resolution: the recorder on
+ * the INJECTED deps is what tells "went through the seam" apart from "went
+ * around it to module-level state", because both persist the same bytes.
+ */
+import { writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, it, vi } from 'vitest'
+import { withTempDataDir } from '../_test-helpers.js'
+
+const tmp = withTempDataDir('whiteboard-live-doc-seam-')
+
+vi.mock('../../config.js', () => ({
+  get DATA_DIR() {
+    return tmp.dir
+  },
+  getDataDir: () => tmp.dir,
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+  REPO_ROOT: '/tmp',
+}))
+
+const { getDefaultServerDeps } = await import('../../../di/default-server-deps.js')
+const { createDocumentRouter } = await import('../document.js')
+// Pre-load ws.js, mirroring the other route tests' documented cycle
+// workaround for document.ts's dynamic import.
+await import('../ws.js')
+
+function updateBytes(nodeIds: readonly string[]): Uint8Array {
+  const doc = new LoroDoc()
+  const vv0 = doc.version()
+  writeSpatialCanvas(doc, {
+    nodes: nodeIds.map((id) => ({
+      id,
+      type: 'text' as const,
+      text: id,
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+    })),
+    edges: [],
+  })
+  return doc.export({ mode: 'update', from: vv0 }) as Uint8Array
+}
+
+describe('live-doc routes and the deps they were handed', () => {
+  it('POST /update reads and writes through the INJECTED liveDocuments', async () => {
+    const deps = await getDefaultServerDeps()
+    const recorded: string[] = []
+    const real = deps.liveDocuments
+    deps.liveDocuments = {
+      ...real,
+      get: async (workspaceId, path) => {
+        recorded.push(`get ${workspaceId}/${path}`)
+        return real.get(workspaceId, path)
+      },
+      save: async (workspaceId, path, doc, options) => {
+        recorded.push(`save ${workspaceId}/${path}`)
+        return real.save(workspaceId, path, doc, options)
+      },
+    }
+
+    const app = createDocumentRouter({ serverDeps: deps, autoVersionIntervalMs: 60_000 })
+    const res = await app.request('/api/w/seam-ws/document/canvas-a/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: updateBytes(['n1']),
+    })
+
+    expect(res.status).toBe(200)
+    // The recorder on the injected deps is the discriminator: a route that
+    // went around the seam to module-level stores persists the same bytes
+    // and leaves this empty.
+    expect(recorded).toEqual(['get seam-ws/canvas-a', 'save seam-ws/canvas-a'])
+  })
+})

--- a/packages/mcp-server/src/server/routes/document/live-doc.ts
+++ b/packages/mcp-server/src/server/routes/document/live-doc.ts
@@ -1,15 +1,14 @@
+import { applyDocumentUpdate, type ServerDeps } from '@kamiazya/whiteboard-server-core'
 import { Hono } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
 import type { LoroDoc } from 'loro-crdt'
+import { getDefaultServerDeps } from '../../../di/default-server-deps.js'
 import type {
   DocumentExistsResponse,
   UpdateDocumentResponse,
+  VersionEntry,
 } from '../../../shared/api-contracts/document.js'
 import { getLogger } from '../../log.js'
-import { evictDoc } from '../../store/doc-cache.js'
-import { documentExists, getDoc, saveDocument } from '../../store/document-store.js'
-import type { VersionEntry } from '../../store/version-store.js'
-import { withWorkspaceWriteLock } from '../../store/workspace-lock.js'
 import { onDocumentAction } from './path-route.js'
 
 // A Loro update embeds any attachment-affecting deltas since the client's
@@ -24,29 +23,43 @@ export interface LiveDocRouterOptions {
     path: string,
     doc: LoroDoc,
   ) => Promise<VersionEntry | null>
+  // The live-document seam the routes read and write through. Production
+  // wires this from document.ts; a router built without it falls back to the
+  // same wiring via getDefaultServerDeps.
+  serverDeps?: ServerDeps
 }
 
 // GET /api/w/:workspaceId/document/*/snapshot
 // GET /api/w/:workspaceId/document/*/exists
 // POST /api/w/:workspaceId/document/*/update
+//
+// Translation-only adapters (ADR-0018): the reads go through the
+// LiveDocuments seam, and the update path — lock bracket, import, persist,
+// evict-on-failure — lives in server-core's applyDocumentUpdate.
 export function createLiveDocRouter(options: LiveDocRouterOptions) {
   const app = new Hono()
+  const depsOf = async (): Promise<ServerDeps> =>
+    options.serverDeps ?? (await getDefaultServerDeps())
 
   onDocumentAction(app, 'get', 'exists', async (c, workspaceId, path) => {
-    const response: DocumentExistsResponse = { exists: await documentExists(workspaceId, path) }
+    const deps = await depsOf()
+    const response: DocumentExistsResponse = {
+      exists: await deps.liveDocuments.exists(workspaceId, path),
+    }
     return c.json(response)
   })
 
   onDocumentAction(app, 'get', 'snapshot', async (c, workspaceId, path) => {
-    // getDoc()'s lazy-create would otherwise silently hand back an empty
+    const deps = await depsOf()
+    // get()'s lazy-create would otherwise silently hand back an empty
     // doc for a canvas that does not exist — indistinguishable from a
     // never-created OR just-deleted canvas. Same problem-details { title }
     // shape as DELETE, deliberately not thumbnails/restore's { error,
     // message }: the client parses problem-details for both routes.
-    if (!(await documentExists(workspaceId, path))) {
+    if (!(await deps.liveDocuments.exists(workspaceId, path))) {
       return c.json({ title: `Canvas "${path}" not found` }, 404)
     }
-    const doc = await getDoc(workspaceId, path)
+    const doc = await deps.liveDocuments.get(workspaceId, path)
     const snapshot = doc.export({ mode: 'snapshot' }) as Uint8Array<ArrayBuffer>
     return c.body(snapshot, 200, {
       'Content-Type': 'application/octet-stream',
@@ -59,32 +72,10 @@ export function createLiveDocRouter(options: LiveDocRouterOptions) {
     'update',
     async (c, workspaceId, path) => {
       const bytes = new Uint8Array(await c.req.arrayBuffer())
+      const deps = await depsOf()
+      const doc = await applyDocumentUpdate(deps, { workspaceId, path, update: bytes })
 
-      // Resolve the doc AND persist it inside one lock hold. getDoc() alone is
-      // unlocked, so a rename that runs its whole lock-protected section
-      // between an unlocked read here and saveDocument()'s own later lock
-      // acquisition would find no row left at the old path (renameDocumentPath
-      // moved it) and silently insert a brand-new phantom canvas back at
-      // that path instead of erroring or landing on the renamed one. Sharing
-      // the workspace write lock across the read and the write closes that
-      // window: the two operations settle into one definite order instead of
-      // interleaving through a stale read.
-      const doc = await withWorkspaceWriteLock(workspaceId, async () => {
-        const resolved = await getDoc(workspaceId, path)
-        resolved.import(bytes)
-        try {
-          await saveDocument(workspaceId, path, resolved, { overwrite: true })
-        } catch (err) {
-          // doc.import() above already mutated the cached doc, so a failed save
-          // would otherwise leave the cache ahead of durable state. Evict it so
-          // the next read reloads the last successfully persisted snapshot.
-          evictDoc(workspaceId, path)
-          throw err
-        }
-        return resolved
-      })
-
-      // No explicit broadcast: saveDocument persisted through the workspace
+      // No explicit broadcast: the save persisted through the workspace
       // record, whose funnel already fanned the persisted bytes to every
       // subscriber (including the sender, whose re-import is a CRDT no-op).
 

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -2,6 +2,8 @@ export { createServer } from './create-server.js'
 export { countAliveNodes, countLegacyTombstones } from './document-counts.js'
 export type { Logger, LogSink } from './log.js'
 export { getLogger, setLogSink } from './log.js'
+export type { ApplyDocumentUpdateInput } from './operations/apply-document-update.js'
+export { applyDocumentUpdate } from './operations/apply-document-update.js'
 export type {
   RestoreProgress,
   RestoreProgressEvent,

--- a/packages/server-core/src/operations/apply-document-update.test.ts
+++ b/packages/server-core/src/operations/apply-document-update.test.ts
@@ -1,0 +1,132 @@
+import { readSpatialCanvas, writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, it } from 'vitest'
+import type { LiveDocuments } from '../server-deps.js'
+import { unusedLiveDocuments } from '../test-utils/unused-live-documents.js'
+import { applyDocumentUpdate } from './apply-document-update.js'
+
+const WS = 'ws-1'
+const PATH = 'canvas-a'
+
+function updateBytes(nodeIds: readonly string[]): Uint8Array {
+  const doc = new LoroDoc()
+  const vv0 = doc.version()
+  writeSpatialCanvas(doc, {
+    nodes: nodeIds.map((id) => ({
+      id,
+      type: 'text' as const,
+      text: id,
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+    })),
+    edges: [],
+  })
+  return doc.export({ mode: 'update', from: vv0 }) as Uint8Array
+}
+
+/**
+ * Spread over the REFUSING defaults so any call the operation makes beyond
+ * get/save/evict/withWriteLock fails loudly instead of passing silently.
+ * Lock depth is recorded per call — the property is not only "the right
+ * calls happen" but "none of them happens outside the one lock hold" (the
+ * rename race the route's own comment documents).
+ */
+function fakeLive(initial?: LoroDoc) {
+  const calls: { method: string; lockDepth: number; overwrite?: boolean }[] = []
+  const evicted: string[] = []
+  let lockDepth = 0
+  let stored = initial ?? null
+  let saved: LoroDoc | null = null
+  let failNextSave: Error | null = null
+  const live: LiveDocuments = {
+    ...unusedLiveDocuments(),
+    async get(_workspaceId, _path) {
+      calls.push({ method: 'get', lockDepth })
+      if (stored === null) stored = new LoroDoc()
+      return stored
+    },
+    async save(_workspaceId, _path, doc, options) {
+      calls.push({ method: 'save', lockDepth, overwrite: options?.overwrite ?? false })
+      if (failNextSave !== null) {
+        const err = failNextSave
+        failNextSave = null
+        throw err
+      }
+      saved = doc
+    },
+    evict(_workspaceId, path) {
+      calls.push({ method: 'evict', lockDepth })
+      evicted.push(path)
+    },
+    async withWriteLock<T>(_workspaceId: string, fn: () => Promise<T>): Promise<T> {
+      lockDepth += 1
+      try {
+        return await fn()
+      } finally {
+        lockDepth -= 1
+      }
+    },
+  }
+  return {
+    live,
+    calls,
+    evicted,
+    savedDoc: () => saved,
+    failNextSave: (err: Error) => {
+      failNextSave = err
+    },
+  }
+}
+
+describe('applyDocumentUpdate', () => {
+  it('imports the update into the live doc, saves with overwrite, and returns the SAME instance', async () => {
+    const existing = new LoroDoc()
+    const fake = fakeLive(existing)
+    const returned = await applyDocumentUpdate(
+      { liveDocuments: fake.live },
+      { workspaceId: WS, path: PATH, update: updateBytes(['n1', 'n2']) },
+    )
+    expect(returned).toBe(existing)
+    expect(fake.savedDoc()).toBe(existing)
+    expect(
+      readSpatialCanvas(existing)
+        .nodes.map((n) => n.id)
+        .sort(),
+    ).toEqual(['n1', 'n2'])
+    expect(fake.calls.find((c) => c.method === 'save')).toMatchObject({ overwrite: true })
+    for (const call of fake.calls) {
+      expect(call, `${call.method} ran outside the workspace write lock`).toMatchObject({
+        lockDepth: 1,
+      })
+    }
+  })
+
+  it('an unknown path lazy-creates rather than refusing (the WS/update-on-unknown-path behavior)', async () => {
+    const fake = fakeLive()
+    const returned = await applyDocumentUpdate(
+      { liveDocuments: fake.live },
+      { workspaceId: WS, path: PATH, update: updateBytes(['n1']) },
+    )
+    expect(readSpatialCanvas(returned).nodes.map((n) => n.id)).toEqual(['n1'])
+    expect(fake.savedDoc()).toBe(returned)
+  })
+
+  it('evicts the live doc when the save fails, then rethrows', async () => {
+    const fake = fakeLive(new LoroDoc())
+    fake.failNextSave(new Error('disk full'))
+    await expect(
+      applyDocumentUpdate(
+        { liveDocuments: fake.live },
+        { workspaceId: WS, path: PATH, update: updateBytes(['n1']) },
+      ),
+    ).rejects.toThrow('disk full')
+    expect(fake.evicted).toEqual([PATH])
+    for (const call of fake.calls) {
+      expect(call, `${call.method} ran outside the workspace write lock`).toMatchObject({
+        lockDepth: 1,
+      })
+    }
+  })
+})

--- a/packages/server-core/src/operations/apply-document-update.ts
+++ b/packages/server-core/src/operations/apply-document-update.ts
@@ -1,0 +1,52 @@
+import type { LoroDoc } from 'loro-crdt'
+import type { ServerDeps } from '../server-deps.js'
+
+export interface ApplyDocumentUpdateInput {
+  readonly workspaceId: string
+  readonly path: string
+  /** A Loro update (delta or full) as the client exported it. */
+  readonly update: Uint8Array
+}
+
+/**
+ * Applies a client's Loro update to the live doc at `path` and persists it —
+ * the write half of the live-document sync surface.
+ *
+ * An unknown path lazy-creates rather than refusing: the sync surface's
+ * update-on-a-path-nobody-made is how an empty document comes to exist, and
+ * the store stamps its default kind.
+ *
+ * THE OPERATION HOLDS THE LOCK: the read and the write run inside one
+ * `liveDocuments.withWriteLock` hold. `get` alone is unlocked at the store,
+ * so a rename that runs its whole lock-protected section between an unlocked
+ * read here and the save's own later lock acquisition would find no row left
+ * at the old path and silently insert a brand-new phantom document back at
+ * that path instead of erroring or landing on the renamed one. Holding it
+ * here means a second surface cannot forget it — same reasoning as
+ * `restoreVersion`.
+ *
+ * Returns the live cached doc instance (not a copy), so a caller can feed
+ * follow-up work — the HTTP route's auto-version trigger — without a second
+ * read racing other writers.
+ */
+export async function applyDocumentUpdate(
+  deps: Pick<ServerDeps, 'liveDocuments'>,
+  input: ApplyDocumentUpdateInput,
+): Promise<LoroDoc> {
+  const live = deps.liveDocuments
+  const { workspaceId, path, update } = input
+  return live.withWriteLock(workspaceId, async () => {
+    const doc = await live.get(workspaceId, path)
+    doc.import(update)
+    try {
+      await live.save(workspaceId, path, doc, { overwrite: true })
+    } catch (err) {
+      // doc.import() above already mutated the cached doc, so a failed save
+      // would otherwise leave the cache ahead of durable state. Evict it so
+      // the next read reloads the last successfully persisted snapshot.
+      live.evict(workspaceId, path)
+      throw err
+    }
+    return doc
+  })
+}

--- a/tools/arch-lint/src/architecture-map.ts
+++ b/tools/arch-lint/src/architecture-map.ts
@@ -311,10 +311,6 @@ export const ADAPTERS_REACHING_MECHANICS: readonly string[] = [
   'routes/document.ts -> version-store',
   'routes/document/auto-version.ts -> version-store',
   'routes/document/export-svg.ts -> document-store',
-  'routes/document/live-doc.ts -> doc-cache',
-  'routes/document/live-doc.ts -> document-store',
-  'routes/document/live-doc.ts -> version-store',
-  'routes/document/live-doc.ts -> workspace-lock',
   'routes/document/maintenance.ts -> doc-cache',
   'routes/document/maintenance.ts -> document-store',
   'routes/document/maintenance.ts -> version-store',
@@ -353,11 +349,11 @@ export const ADAPTERS_REACHING_MECHANICS: readonly string[] = [
  *
  * Raising it is a decision, not a fix. Do it only when the alternative is
  * worse than the debt, and say in the PR why the operation could not go to
- * server-core instead. The burn-down order is in the ADR; restore.ts's edges
- * are paid off, and the three remaining scheduled adapters (live-doc.ts,
- * workspace-document.ts, ws.ts) hold 12 of these 33.
+ * server-core instead. The burn-down order is in the ADR; restore.ts's and
+ * live-doc.ts's edges are paid off, and the two remaining scheduled adapters
+ * (workspace-document.ts, ws.ts) hold 8 of these 29.
  */
-export const ADAPTERS_REACHING_MECHANICS_CEILING = 33
+export const ADAPTERS_REACHING_MECHANICS_CEILING = 29
 
 /**
  * Modules under `store/` the adapter rule does NOT count.


### PR DESCRIPTION
## Summary

- **ADR-0018 burn-down step 2** (of 4): the live-doc routes (`exists` / `snapshot` / `update`) become translation-only adapters over the `LiveDocuments` seam #1224 landed — **no new seam, `ServerDeps` unchanged**, so no construction site anywhere is touched.
- server-core gains `operations/apply-document-update.ts`: resolve the live doc, import the client's Loro update and save with overwrite inside **one `withWriteLock` hold** (the phantom-canvas rename race the route's own comment documents), evict on save failure before rethrowing, and return the live doc instance so the adapter's auto-version trigger sees exactly what was persisted without a second read.
- `live-doc.ts` now imports **no `store/` module**: reads go through `deps.liveDocuments`, the update path calls the operation, and the `VersionEntry` type import moves to `shared/api-contracts` where #1220 single-sourced it. HTTP behavior is byte-compatible (response shapes, the 404 problem-details `{title}`, the 413 limit, the fire-and-forget auto-version trigger with its `ws.js` dynamic import — all verbatim).
- Because `serverDeps` is an **optional** router option a typecheck cannot notice going unread, the `document.ts` threading gets its own seam-injection test (`live-doc-seam.test.ts`, red against the old wiring): a recording double injected through `createDocumentRouter({serverDeps})` must observe the `/update` route's `get` and `save` — the discriminator between going through the seam and going around it to module-level state, per `handle-resolution-seam.test.ts`'s precedent. (PlanReview round 1 caught that this criterion had no test; this is the fix.)
- **arch-lint**: live-doc.ts's four `ADAPTERS_REACHING_MECHANICS` edges removed, `ADAPTERS_REACHING_MECHANICS_CEILING` **33 → 29**; the two remaining scheduled adapters (`workspace-document.ts`, `ws.ts`) hold 8 of the 29. `tool-arch-lint.md` figures updated.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — 3 new `server-core-node` tests over a refusing double that records write-lock depth on every call (red-first), plus the new `mcp-node` seam-injection test (red against the pre-change wiring)
- [x] `pnpm test` passes locally — `server-core-node` 461 passed, full `mcp-node` 4,203 passed (the only failure is the known Node-22 environment guard; CI runs the pinned Node 24), `arch-lint-node` 119 passed
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable — not needed: byte-compatible HTTP contract pinned by existing route tests against real stores

Mutation checks (each restored after confirming red): lock bracket removed → 3 fail; evict-on-failure dropped → 1 fail; `serverDeps` threading dropped from `document.ts` → seam-injection test fails.

Manual verification: server-side refactor with byte-compatible responses; verified via the full existing route suites (every suite that seeds documents through `POST /update`: live-doc, auto-version, promote-workspace, restore*, workspace-document, versions, ws) plus `pnpm build`, typecheck, lint and knip, all green.

## Visual evidence

Visual evidence: none — server-side refactor with no UI or pixel change; behavior is pinned by existing route tests plus the new operation and seam tests.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract (`.claude/rules/tool-arch-lint.md` figures; no user-visible change)
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema (the operation input/result are internal seam contracts, same as the restore operation's)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_