### PR TITLE
refactor(server): extract the workspace-document update operation behind a WorkspaceDocuments seam

### DIFF
--- a/.claude/rules/tool-arch-lint.md
+++ b/.claude/rules/tool-arch-lint.md
@@ -72,7 +72,7 @@ further down.
 
 **`ADAPTERS_REACHING_MECHANICS`** records the edges that exist today.
 
-**`ADAPTERS_REACHING_MECHANICS_CEILING` pins the count by equality — 29 today.**
+**`ADAPTERS_REACHING_MECHANICS_CEILING` pins the count by equality — 25 today.**
 It exists because the two both-sides guards reject a fabricated entry and a
 stale one and have nothing to say about a real new edge added along with its
 allowlist line, which is the ordinary way a list grows. Measured: a genuine
@@ -81,10 +81,10 @@ assertions, and the list went 37 -> 36 -> 35 -> 36 -> 40 in a week while the
 rule and the test's own comment both said it could only shrink. Adding an edge
 now fails until someone raises the ceiling deliberately, and paying one off
 fails until someone lowers it. ADR-0018 is **Accepted** (2026-08-31) and
-carries the burn-down order; `restore.ts`'s and `live-doc.ts`'s four edges
-each are paid off (their operations live in server-core behind the
-`LiveDocuments` seam), and the two remaining scheduled adapters
-(`workspace-document.ts`, `ws.ts`) hold 8 of the 29.
+carries the burn-down order; `restore.ts`, `live-doc.ts` and
+`workspace-document.ts` are paid off (their operations live in server-core
+behind the `LiveDocuments`/`WorkspaceDocuments` seams), and the one
+remaining scheduled adapter (`ws.ts`) holds 4 of the 25.
 
 `corrupt-stored-data` is excluded and says why: an error taxonomy an adapter
 reads to pick a status code is translation, which is an adapter's job, and

--- a/packages/mcp-server/src/di/container.ts
+++ b/packages/mcp-server/src/di/container.ts
@@ -12,7 +12,7 @@ import { createOpentypeMeasureText } from '../server/export/measure-text.js'
 import { resolveSearchEmbedder } from '../server/search/search-embedder.js'
 import { documentTeardown } from '../server/store/document-store.js'
 import { documentWritten } from '../server/store/document-written.js'
-import { liveDocuments } from '../server/store/live-documents.js'
+import { liveDocuments, workspaceDocuments } from '../server/store/live-documents.js'
 import { FileVersionStore } from '../server/store/version-store.js'
 import { storeMemoryModule } from './store-memory.module.js'
 
@@ -96,5 +96,6 @@ export function resolveServerDeps(container: Container): ServerDeps {
     // lock, bundled once so operations reach them through the seam instead
     // of any adapter importing a mechanic.
     liveDocuments: liveDocuments(),
+    workspaceDocuments: workspaceDocuments(),
   }
 }

--- a/packages/mcp-server/src/server/routes/document.ts
+++ b/packages/mcp-server/src/server/routes/document.ts
@@ -68,7 +68,13 @@ export function createDocumentRouter(options: DocumentRouterOptions = {}) {
       ...(options.serverDeps === undefined ? {} : { serverDeps: options.serverDeps }),
     }),
   )
-  app.route('/', createWorkspaceDocumentRouter({ triggerAutoVersion }))
+  app.route(
+    '/',
+    createWorkspaceDocumentRouter({
+      triggerAutoVersion,
+      ...(options.serverDeps === undefined ? {} : { serverDeps: options.serverDeps }),
+    }),
+  )
   app.route('/', createVersionsRouter({ versionStore, getHeadBranch: options.getHeadBranch }))
   app.route('/', createMaintenanceRouter({ versionStore }))
   app.route('/', createDocumentSvgExportRouter())

--- a/packages/mcp-server/src/server/routes/document/workspace-document-seam.test.ts
+++ b/packages/mcp-server/src/server/routes/document/workspace-document-seam.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The workspace-document routes operate through the ServerDeps they were
+ * given — the same optional-serverDeps-threading bug class live-doc-seam
+ * and handle-resolution-seam pin, proven twice now: a declared-but-unread
+ * `serverDeps` field compiles clean and passes every fallback-path test.
+ */
+import { createWorkspaceDocumentAtPath } from '@kamiazya/whiteboard-loro-adapter'
+import { generateDocumentId } from '@kamiazya/whiteboard-model'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, it, vi } from 'vitest'
+import { withTempDataDir } from '../_test-helpers.js'
+
+const tmp = withTempDataDir('whiteboard-workspace-doc-seam-')
+
+vi.mock('../../config.js', () => ({
+  get DATA_DIR() {
+    return tmp.dir
+  },
+  getDataDir: () => tmp.dir,
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+  REPO_ROOT: '/tmp',
+}))
+
+const { getDefaultServerDeps } = await import('../../../di/default-server-deps.js')
+const { seedWorkspaceRow } = await import('../_test-helpers.js')
+const { createDocumentRouter } = await import('../document.js')
+// Pre-load ws.js, mirroring the other route tests' documented cycle
+// workaround for document.ts's dynamic import.
+await import('../ws.js')
+
+const WS = 'seam-ws'
+
+function workspaceUpdateBytes(path: string): Uint8Array {
+  const doc = new LoroDoc()
+  const vv0 = doc.version()
+  createWorkspaceDocumentAtPath(doc, { path, documentId: generateDocumentId(), kind: 'spatial' })
+  doc.commit()
+  return doc.export({ mode: 'update', from: vv0 }) as Uint8Array
+}
+
+describe('workspace-document routes and the deps they were handed', () => {
+  it('POST /update reads and writes through the INJECTED workspaceDocuments', async () => {
+    await seedWorkspaceRow(tmp.dir, WS)
+    const deps = await getDefaultServerDeps()
+    const recorded: string[] = []
+    const real = deps.workspaceDocuments
+    deps.workspaceDocuments = {
+      ...real,
+      get: async (workspaceId) => {
+        recorded.push(`get ${workspaceId}`)
+        return real.get(workspaceId)
+      },
+      save: async (workspaceId, doc) => {
+        recorded.push(`save ${workspaceId}`)
+        return real.save(workspaceId, doc)
+      },
+    }
+
+    const app = createDocumentRouter({ serverDeps: deps, autoVersionIntervalMs: 60_000 })
+    const res = await app.request(`/api/w/${WS}/workspace-document/update`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: workspaceUpdateBytes('canvas-a'),
+    })
+
+    expect(res.status).toBe(200)
+    // The recorder on the injected deps is the discriminator: a route that
+    // went around the seam to module-level stores persists the same bytes
+    // and leaves this empty.
+    expect(recorded).toEqual([`get ${WS}`, `save ${WS}`])
+  })
+})

--- a/packages/mcp-server/src/server/routes/document/workspace-document.ts
+++ b/packages/mcp-server/src/server/routes/document/workspace-document.ts
@@ -1,18 +1,14 @@
 import { resolveWorkspaceDocumentById } from '@kamiazya/whiteboard-loro-adapter'
+import { applyWorkspaceDocumentUpdate, type ServerDeps } from '@kamiazya/whiteboard-server-core'
 import { Hono } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
 import type { LoroDoc } from 'loro-crdt'
-import type { UpdateDocumentResponse } from '../../../shared/api-contracts/document.js'
+import { getDefaultServerDeps } from '../../../di/default-server-deps.js'
+import type {
+  UpdateDocumentResponse,
+  VersionEntry,
+} from '../../../shared/api-contracts/document.js'
 import { getLogger } from '../../log.js'
-import { evictWorkspaceDocs } from '../../store/doc-cache.js'
-import {
-  getDoc,
-  getWorkspaceDoc,
-  saveWorkspaceDoc,
-  workspaceExists,
-} from '../../store/document-store.js'
-import type { VersionEntry } from '../../store/version-store.js'
-import { withWorkspaceWriteLock } from '../../store/workspace-lock.js'
 import { validateWorkspaceId, validationErrorBody } from '../../validators.js'
 import { workspaceIdFromHandle } from '../../workspace-handle.js'
 
@@ -26,6 +22,10 @@ export interface WorkspaceDocumentRouterOptions {
     path: string,
     doc: LoroDoc,
   ) => Promise<VersionEntry | null>
+  // The workspace-document seam the routes read and write through.
+  // Production wires this from document.ts; a router built without it falls
+  // back to the same wiring via getDefaultServerDeps.
+  serverDeps?: ServerDeps
 }
 
 // The workspace-granularity sync surface (order 7 of the workspace-document
@@ -33,10 +33,17 @@ export interface WorkspaceDocumentRouterOptions {
 // protocol already carried a docRef per message; what changes here is only
 // the granularity of the subscription.
 //
+// Translation-only adapters (ADR-0018): the reads go through the
+// WorkspaceDocuments seam, and the update path — lock bracket, import,
+// persist, projection eviction — lives in server-core's
+// applyWorkspaceDocumentUpdate.
+//
 // GET  /api/w/:workspaceId/workspace-document/snapshot
 // POST /api/w/:workspaceId/workspace-document/update?documentId=<ulid>
 export function createWorkspaceDocumentRouter(options: WorkspaceDocumentRouterOptions) {
   const app = new Hono()
+  const depsOf = async (): Promise<ServerDeps> =>
+    options.serverDeps ?? (await getDefaultServerDeps())
 
   app.get('/api/w/:workspaceId/workspace-document/snapshot', async (c) => {
     const handle = c.req.param('workspaceId')
@@ -48,14 +55,15 @@ export function createWorkspaceDocumentRouter(options: WorkspaceDocumentRouterOp
       throw err
     }
     const workspaceId = await workspaceIdFromHandle(c, handle)
+    const deps = await depsOf()
     // Same honesty rule as the per-document snapshot: an unregistered
     // workspace is a refusal, not a phantom. Inside a registered workspace,
     // a missing workspace document is minted empty — the workspace is real,
     // it just has no tree-plane documents yet.
-    if (!(await workspaceExists(workspaceId))) {
+    if (!(await deps.workspaceDocuments.exists(workspaceId))) {
       return c.json({ title: `Workspace "${workspaceId}" not found` }, 404)
     }
-    const doc = await getWorkspaceDoc(workspaceId)
+    const doc = await deps.workspaceDocuments.get(workspaceId)
     const snapshot = doc.export({ mode: 'snapshot' }) as Uint8Array<ArrayBuffer>
     return c.body(snapshot, 200, { 'Content-Type': 'application/octet-stream' })
   })
@@ -83,35 +91,14 @@ export function createWorkspaceDocumentRouter(options: WorkspaceDocumentRouterOp
         throw err
       }
       const workspaceId = await workspaceIdFromHandle(c, handle)
-      if (!(await workspaceExists(workspaceId))) {
+      const deps = await depsOf()
+      if (!(await deps.workspaceDocuments.exists(workspaceId))) {
         return c.json({ title: `Workspace "${workspaceId}" not found` }, 404)
       }
       const bytes = new Uint8Array(await c.req.arrayBuffer())
 
-      // Import + persist under the workspace write lock so a concurrent
-      // per-document save (which projects, diffs, and writes through the
-      // same live workspace document) settles into a definite order.
-      const imported = await withWorkspaceWriteLock(workspaceId, async () => {
-        const doc = await getWorkspaceDoc(workspaceId)
-        try {
-          doc.import(bytes)
-        } catch (err: unknown) {
-          getLogger('document').warning(
-            { workspaceId, updateBytes: bytes.byteLength, err },
-            'workspace-document update rejected: malformed Loro import data',
-          )
-          return false
-        }
-        // Fan-out to subscribers happens inside saveWorkspaceDoc.
-        await saveWorkspaceDoc(workspaceId, doc)
-        // Every cached per-document projection of this workspace is now
-        // stale; a stale one would diff old content back over this import
-        // on its next save. Dropped inside the lock so no reader can grab
-        // a stale projection between the import and the eviction.
-        evictWorkspaceDocs(workspaceId)
-        return true
-      })
-      if (!imported) {
+      const result = await applyWorkspaceDocumentUpdate(deps, { workspaceId, update: bytes })
+      if (result === 'malformed-update') {
         return c.json({ title: 'Malformed workspace-document update' }, 400)
       }
 
@@ -120,10 +107,10 @@ export function createWorkspaceDocumentRouter(options: WorkspaceDocumentRouterOp
       const documentId = c.req.query('documentId')
       if (documentId !== undefined) {
         void (async () => {
-          const workspaceDoc = await getWorkspaceDoc(workspaceId)
+          const workspaceDoc = await deps.workspaceDocuments.get(workspaceId)
           const entry = resolveWorkspaceDocumentById(workspaceDoc, documentId)
           if (entry === null) return
-          const doc = await getDoc(workspaceId, entry.path)
+          const doc = await deps.liveDocuments.get(workspaceId, entry.path)
           const version = await options.triggerAutoVersion(workspaceId, entry.path, doc)
           if (!version) return
           const { sendVersionCreated } = await import('../ws.js')

--- a/packages/mcp-server/src/server/store/live-documents.ts
+++ b/packages/mcp-server/src/server/store/live-documents.ts
@@ -1,15 +1,18 @@
 import { DocumentPathTakenError } from '@kamiazya/whiteboard-ports'
-import type { LiveDocuments } from '@kamiazya/whiteboard-server-core'
-import { evictDoc } from './doc-cache.js'
+import type { LiveDocuments, WorkspaceDocuments } from '@kamiazya/whiteboard-server-core'
+import { evictDoc, evictWorkspaceDocs } from './doc-cache.js'
 import {
   ConflictError,
   deleteDocument,
   documentExists,
   getDoc,
   getDocumentKind,
+  getWorkspaceDoc,
   listDocuments,
   renameDocumentPath,
   saveDocument,
+  saveWorkspaceDoc,
+  workspaceExists,
 } from './document-store.js'
 import { withWorkspaceWriteLock } from './workspace-lock.js'
 
@@ -44,5 +47,24 @@ export function liveDocuments(): LiveDocuments {
     },
     evict: evictDoc,
     withWriteLock: withWorkspaceWriteLock,
+  }
+}
+
+/**
+ * The workspace-granularity half of the same seam, in the same bundle file
+ * (one mechanic bundle per composition, not one per axis). `save`'s
+ * subscriber fan-out lives inside `saveWorkspaceDoc`, which is what lets
+ * the seam promise callers never broadcast separately.
+ */
+export function workspaceDocuments(): WorkspaceDocuments {
+  return {
+    exists: workspaceExists,
+    get: getWorkspaceDoc,
+    async save(workspaceId, doc) {
+      // saveWorkspaceDoc answers the update bytes it fanned out; the seam
+      // promises only persistence, so the value is deliberately dropped.
+      await saveWorkspaceDoc(workspaceId, doc)
+    },
+    evictProjections: evictWorkspaceDocs,
   }
 }

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -4,6 +4,8 @@ export type { Logger, LogSink } from './log.js'
 export { getLogger, setLogSink } from './log.js'
 export type { ApplyDocumentUpdateInput } from './operations/apply-document-update.js'
 export { applyDocumentUpdate } from './operations/apply-document-update.js'
+export type { ApplyWorkspaceDocumentUpdateInput } from './operations/apply-workspace-document-update.js'
+export { applyWorkspaceDocumentUpdate } from './operations/apply-workspace-document-update.js'
 export type {
   RestoreProgress,
   RestoreProgressEvent,
@@ -34,6 +36,7 @@ export type {
   ServerDeps,
   VersionHistory,
   ViewportRequest,
+  WorkspaceDocuments,
 } from './server-deps.js'
 export type { BacklinksInput, BacklinksOutput } from './tools/backlinks.js'
 export { backlinksInputSchema, backlinksOutputSchema, computeBacklinks } from './tools/backlinks.js'

--- a/packages/server-core/src/operations/apply-workspace-document-update.test.ts
+++ b/packages/server-core/src/operations/apply-workspace-document-update.test.ts
@@ -1,0 +1,107 @@
+import {
+  createWorkspaceDocumentAtPath,
+  readWorkspaceDocuments,
+} from '@kamiazya/whiteboard-loro-adapter'
+import { generateDocumentId } from '@kamiazya/whiteboard-model'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, it } from 'vitest'
+import type { LiveDocuments, WorkspaceDocuments } from '../server-deps.js'
+import { unusedLiveDocuments } from '../test-utils/unused-live-documents.js'
+import { unusedWorkspaceDocuments } from '../test-utils/unused-workspace-documents.js'
+import { applyWorkspaceDocumentUpdate } from './apply-workspace-document-update.js'
+
+const WS = 'ws-1'
+
+/** An update that creates one document node in a workspace tree. */
+function workspaceUpdateBytes(path: string): Uint8Array {
+  const doc = new LoroDoc()
+  const vv0 = doc.version()
+  createWorkspaceDocumentAtPath(doc, { path, documentId: generateDocumentId(), kind: 'spatial' })
+  doc.commit()
+  return doc.export({ mode: 'update', from: vv0 }) as Uint8Array
+}
+
+/**
+ * Refusing defaults + lock-depth recording, the idiom the restore and
+ * live-doc operation tests established. The lock is liveDocuments' — the
+ * seam deliberately has no second lock spelling — so the double shares one
+ * depth counter across both seams.
+ */
+function fakes() {
+  const calls: { method: string; lockDepth: number }[] = []
+  let lockDepth = 0
+  const workspaceDoc = new LoroDoc()
+  let saved = false
+  let evicted = false
+  let evictedBeforeUnlock = false
+  const live: LiveDocuments = {
+    ...unusedLiveDocuments(),
+    async withWriteLock<T>(_workspaceId: string, fn: () => Promise<T>): Promise<T> {
+      lockDepth += 1
+      try {
+        return await fn()
+      } finally {
+        evictedBeforeUnlock = evicted
+        lockDepth -= 1
+      }
+    },
+  }
+  const workspaceDocuments: WorkspaceDocuments = {
+    ...unusedWorkspaceDocuments(),
+    async get(_workspaceId) {
+      calls.push({ method: 'get', lockDepth })
+      return workspaceDoc
+    },
+    async save(_workspaceId, _doc) {
+      calls.push({ method: 'save', lockDepth })
+      saved = true
+    },
+    evictProjections(_workspaceId) {
+      calls.push({ method: 'evictProjections', lockDepth })
+      evicted = true
+    },
+  }
+  return {
+    live,
+    workspaceDocuments,
+    calls,
+    workspaceDoc,
+    wasSaved: () => saved,
+    wasEvicted: () => evicted,
+    wasEvictedBeforeUnlock: () => evictedBeforeUnlock,
+  }
+}
+
+describe('applyWorkspaceDocumentUpdate', () => {
+  it('imports a valid update, saves, and evicts projections before the lock releases', async () => {
+    const fake = fakes()
+    const result = await applyWorkspaceDocumentUpdate(
+      { liveDocuments: fake.live, workspaceDocuments: fake.workspaceDocuments },
+      { workspaceId: WS, update: workspaceUpdateBytes('canvas-a') },
+    )
+    expect(result).toBe('applied')
+    expect(fake.wasSaved()).toBe(true)
+    expect(readWorkspaceDocuments(fake.workspaceDoc).map((d) => d.path)).toEqual(['canvas-a'])
+    // Dropped INSIDE the lock: a reader grabbing a stale per-document
+    // projection between import and eviction would diff old content back
+    // over this import on its next save.
+    expect(fake.wasEvictedBeforeUnlock()).toBe(true)
+    expect(fake.calls.map((c) => c.method)).toEqual(['get', 'save', 'evictProjections'])
+    for (const call of fake.calls) {
+      expect(call, `${call.method} ran outside the workspace write lock`).toMatchObject({
+        lockDepth: 1,
+      })
+    }
+  })
+
+  it('answers malformed-update for garbage bytes, saving and evicting NOTHING', async () => {
+    const fake = fakes()
+    const result = await applyWorkspaceDocumentUpdate(
+      { liveDocuments: fake.live, workspaceDocuments: fake.workspaceDocuments },
+      { workspaceId: WS, update: new Uint8Array([1, 2, 3, 4]) },
+    )
+    expect(result).toBe('malformed-update')
+    expect(fake.wasSaved()).toBe(false)
+    expect(fake.wasEvicted()).toBe(false)
+  })
+})

--- a/packages/server-core/src/operations/apply-workspace-document-update.ts
+++ b/packages/server-core/src/operations/apply-workspace-document-update.ts
@@ -1,0 +1,51 @@
+import { getLogger } from '../log.js'
+import type { ServerDeps } from '../server-deps.js'
+
+const log = getLogger('workspace-document')
+
+export interface ApplyWorkspaceDocumentUpdateInput {
+  readonly workspaceId: string
+  /** A workspace-granularity Loro update as the client exported it. */
+  readonly update: Uint8Array
+}
+
+/**
+ * Applies a client's workspace-granularity Loro update and persists it — the
+ * write half of the workspace-document sync surface.
+ *
+ * `'malformed-update'` is a real answer, not a crash: a client can send
+ * garbage bytes, and a throwing import must reach the surface as a 400
+ * rather than a 500 — and must mutate nothing durable (no save, no
+ * eviction; the in-memory import either applied atomically or threw).
+ *
+ * THE OPERATION HOLDS THE LOCK — `liveDocuments.withWriteLock`, because the
+ * workspace write lock is one lock however many seams touch the workspace.
+ * Import, save AND projection eviction all run inside the hold: a
+ * concurrent per-document save projects, diffs and writes through the same
+ * live workspace document, and a reader grabbing a stale per-document
+ * projection between the import and the eviction would diff old content
+ * back over this import on its next save.
+ */
+export async function applyWorkspaceDocumentUpdate(
+  deps: Pick<ServerDeps, 'liveDocuments' | 'workspaceDocuments'>,
+  input: ApplyWorkspaceDocumentUpdateInput,
+): Promise<'applied' | 'malformed-update'> {
+  const { workspaceId, update } = input
+  return deps.liveDocuments.withWriteLock(workspaceId, async () => {
+    const doc = await deps.workspaceDocuments.get(workspaceId)
+    try {
+      doc.import(update)
+    } catch (err: unknown) {
+      log.warning('workspace-document update rejected: malformed Loro import data', {
+        workspaceId,
+        updateBytes: update.byteLength,
+        err,
+      })
+      return 'malformed-update'
+    }
+    // Fan-out to subscribers happens inside save.
+    await deps.workspaceDocuments.save(workspaceId, doc)
+    deps.workspaceDocuments.evictProjections(workspaceId)
+    return 'applied'
+  })
+}

--- a/packages/server-core/src/server-deps.ts
+++ b/packages/server-core/src/server-deps.ts
@@ -198,6 +198,41 @@ export interface ServerDeps {
    * `unusedLiveDocuments()`, which refuses.
    */
   liveDocuments: LiveDocuments
+  /**
+   * The workspace-granularity half of the live-document surface: ONE Loro
+   * doc per workspace holding the tree and every document's content plane.
+   * The axis the restore increment named and deferred; ws.ts's migration
+   * (the last scheduled adapter) reuses it.
+   *
+   * Deliberately has NO lock method: the workspace write lock is
+   * `liveDocuments.withWriteLock`, and it is the SAME lock — a second
+   * spelling would let two surfaces each hold "the" lock and interleave.
+   *
+   * REQUIRED, like `liveDocuments`, and for the same reason.
+   */
+  workspaceDocuments: WorkspaceDocuments
+}
+
+export interface WorkspaceDocuments {
+  /** Whether the workspace is registered at all — a refusal, not a mint. */
+  exists(workspaceId: string): Promise<boolean>
+  /**
+   * The live workspace doc. Inside a registered workspace a missing record
+   * is minted empty: the workspace is real, it just has no tree-plane
+   * documents yet.
+   */
+  get(workspaceId: string): Promise<LoroDoc>
+  /**
+   * Persists the workspace doc. Fan-out to update subscribers happens
+   * INSIDE the implementation, so a caller never broadcasts separately.
+   */
+  save(workspaceId: string, doc: LoroDoc): Promise<void>
+  /**
+   * Drops every cached per-document projection of this workspace. After a
+   * workspace-granularity import each projection is stale, and a stale one
+   * would diff old content back over the import on its next save.
+   */
+  evictProjections(workspaceId: string): void
 }
 
 /**

--- a/packages/server-core/src/test-utils/make-test-deps.ts
+++ b/packages/server-core/src/test-utils/make-test-deps.ts
@@ -5,6 +5,7 @@ import { createInMemoryDocumentStore } from './in-memory-document-store.js'
 import { unusedDocumentTeardown } from './unused-document-teardown.js'
 import { unusedLiveDocuments } from './unused-live-documents.js'
 import { unusedVersionHistory } from './unused-version-history.js'
+import { unusedWorkspaceDocuments } from './unused-workspace-documents.js'
 
 /**
  * The `ServerDeps` a server-core test builds when its subject is something
@@ -47,6 +48,7 @@ export function makeTestDeps(overrides: Partial<ServerDeps> = {}): ServerDeps {
     documentWritten: ignoredDocumentWrites(),
     versions: unusedVersionHistory(),
     liveDocuments: unusedLiveDocuments(),
+    workspaceDocuments: unusedWorkspaceDocuments(),
     ...overrides,
   }
 }

--- a/packages/server-core/src/test-utils/unused-workspace-documents.ts
+++ b/packages/server-core/src/test-utils/unused-workspace-documents.ts
@@ -1,0 +1,21 @@
+import type { WorkspaceDocuments } from '../server-deps.js'
+
+/**
+ * A `WorkspaceDocuments` that REFUSES rather than answers — the same idiom
+ * and reasoning as `unusedLiveDocuments`: a no-op double would let a test
+ * that accidentally reaches the workspace doc pass while asserting nothing.
+ */
+export function unusedWorkspaceDocuments(): WorkspaceDocuments {
+  const refuse = (method: string) => (): never => {
+    throw new Error(
+      `WorkspaceDocuments.${method} was called by a test that passed unusedWorkspaceDocuments().` +
+        ' Pass a real implementation if the test is about the workspace doc.',
+    )
+  }
+  return {
+    exists: refuse('exists'),
+    get: refuse('get'),
+    save: refuse('save'),
+    evictProjections: refuse('evictProjections'),
+  }
+}

--- a/tools/arch-lint/src/architecture-map.ts
+++ b/tools/arch-lint/src/architecture-map.ts
@@ -318,13 +318,6 @@ export const ADAPTERS_REACHING_MECHANICS: readonly string[] = [
   'routes/document/thumbnails.ts -> version-store',
   'routes/document/versions.ts -> document-store',
   'routes/document/versions.ts -> version-store',
-  // The workspace-granularity twin of live-doc.ts, carrying the same four
-  // edges for the same reasons — it retires WITH live-doc's when the sync
-  // surface gets its server-core home.
-  'routes/document/workspace-document.ts -> doc-cache',
-  'routes/document/workspace-document.ts -> document-store',
-  'routes/document/workspace-document.ts -> version-store',
-  'routes/document/workspace-document.ts -> workspace-lock',
   'routes/export.ts -> document-store',
   'routes/files.ts -> file-gc',
   'routes/files.ts -> version-store',
@@ -349,11 +342,11 @@ export const ADAPTERS_REACHING_MECHANICS: readonly string[] = [
  *
  * Raising it is a decision, not a fix. Do it only when the alternative is
  * worse than the debt, and say in the PR why the operation could not go to
- * server-core instead. The burn-down order is in the ADR; restore.ts's and
- * live-doc.ts's edges are paid off, and the two remaining scheduled adapters
- * (workspace-document.ts, ws.ts) hold 8 of these 29.
+ * server-core instead. The burn-down order is in the ADR; restore.ts's,
+ * live-doc.ts's and workspace-document.ts's edges are paid off, and the one
+ * remaining scheduled adapter (ws.ts) holds 4 of these 25.
  */
-export const ADAPTERS_REACHING_MECHANICS_CEILING = 29
+export const ADAPTERS_REACHING_MECHANICS_CEILING = 25
 
 /**
  * Modules under `store/` the adapter rule does NOT count.


### PR DESCRIPTION
## Summary

- **ADR-0018 burn-down step 3** (of 4): the workspace-granularity sync routes (`/workspace-document/snapshot` + `/update`) become translation-only adapters, and `ServerDeps` gains the **`WorkspaceDocuments`** seam the restore increment (#1224) named and deliberately deferred — `exists` / `get` / `save` / `evictProjections`, REQUIRED like `liveDocuments`. It deliberately has **no lock method**: the workspace write lock is `liveDocuments.withWriteLock` and it is the *same* lock — a second spelling would let two surfaces each hold "the" lock and interleave. `save`'s subscriber fan-out stays inside the mechanic (stated in the seam doc), so `ws.ts`'s existing subscription keeps working unchanged through this PR.
- server-core gains `operations/apply-workspace-document-update.ts`: get + import + save + **projection eviction inside one lock hold, eviction before the lock releases** — a reader grabbing a stale per-document projection between import and eviction would diff old content back over the import on its next save (the route's own documented race). A throwing import answers `'malformed-update'` (→ the same 400 `{title}` body), logged through server-core's own logger, mutating nothing durable.
- `workspace-document.ts` keeps handle validation, the 404 refusals, the 413 limit and the fire-and-forget `documentId` auto-version tail verbatim, reads through the seams, and moves the `VersionEntry` type import to `shared/api-contracts` — after which it imports **no `store/` module**.
- `document.ts` threads `options.serverDeps` through, pinned by a new seam-injection test (`workspace-document-seam.test.ts`, red against the old wiring) — the optional-`serverDeps`-going-unread bug class is invisible to typecheck, per `live-doc-seam` / `handle-resolution-seam` precedents.
- **arch-lint**: workspace-document.ts's four `ADAPTERS_REACHING_MECHANICS` edges removed, `ADAPTERS_REACHING_MECHANICS_CEILING` **29 → 25**; the one remaining scheduled adapter (`ws.ts`) holds 4 of the 25. `tool-arch-lint.md` figures updated.
- Known coverage gap stated rather than hidden (PlanReview round-1 finding): apps/web's `replica-cache.ts` and `promote-workspace.ts` call these exact routes with **stubbed fetch** in their own browser tests. Accepted for this server-side-only refactor because the contract's server half is pinned by `workspace-document.test.ts` (real router, real stores, real snapshot/update bytes decoded and asserted) running **unmodified**; a cross-layer browser↔daemon E2E for the replica sync surface is a standing pre-existing gap, noted for the backlog.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — 2 new `server-core-node` tests over refusing doubles recording lock depth (red-first; valid update applies+saves+evicts **before unlock**, malformed update mutates nothing), plus the new `mcp-node` seam-injection test (red against the pre-change wiring)
- [x] `pnpm test` passes locally — `server-core-node` 463 passed, full `mcp-node` 4,204 passed (the only failure is the known Node-22 environment guard; CI runs the pinned Node 24), `arch-lint-node` 119 passed
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable — not needed for this refactor: byte-compatible HTTP contract pinned by the real-router/real-store route tests; the browser↔daemon E2E gap is pre-existing and noted above

Mutation checks (each restored after confirming red): lock bracket removed → 2 fail; projection eviction dropped → 1 fail; `serverDeps` threading dropped from `document.ts` → seam-injection test fails.

Manual verification: server-side refactor with byte-compatible responses; verified via the full existing suites (`workspace-document.test.ts`, `promote-workspace.test.ts` and every workspace-granularity sync consumer) plus `pnpm build`, typecheck, lint and knip, all green.

## Visual evidence

Visual evidence: none — server-side refactor with no UI or pixel change; behavior is pinned by existing route tests plus the new operation and seam tests.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract (`.claude/rules/tool-arch-lint.md` figures; no user-visible change)
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema (the seam and operation contracts are internal seams, same as `LiveDocuments`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved workspace document synchronization for more reliable updates and persistence.
  - Workspace changes now remain consistent when multiple document updates occur concurrently.
  - Invalid workspace updates are handled gracefully with a clear client error instead of an unexpected server failure.

- **Tests**
  - Added coverage for successful workspace updates, invalid update handling, and consistency during concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->