### PR TITLE
docs: switch visual-evidence to gh --attach instead of gh image

### DIFF
--- a/.claude/scripts/compose-figure.mjs
+++ b/.claude/scripts/compose-figure.mjs
@@ -167,4 +167,7 @@ try {
 // panels were two different renders rather than one file used twice.
 console.log(`[compose-figure] wrote ${outPath}`)
 console.log(`  before ${beforeDigest}  after ${afterDigest}`)
-console.log(`  next: gh image ${outPath}   → paste under a "## Visual repro" heading`)
+console.log(
+  `  next: reference ![…](${outPath}) under a "## Visual repro" heading, then pass\n` +
+    `        --attach ${outPath} to \`gh pr create\`/\`gh pr comment\` (gh ≥2.99.0) to upload it`,
+)

--- a/.claude/scripts/hooks/pre-pr-visual-evidence.mjs
+++ b/.claude/scripts/hooks/pre-pr-visual-evidence.mjs
@@ -41,8 +41,9 @@ const VISUAL_PATHS = [
 const NOT_A_SURFACE = /\.(test|bench|spec|docs-snapshot)\.[cm]?[jt]sx?$/
 
 /**
- * A figure. Markdown image, HTML img, or a bare attachment URL — `gh image`
- * prints the first, and a body assembled by hand may carry any of them.
+ * A figure. Markdown image, HTML img, or a bare attachment URL — a body
+ * referencing a local screenshot path for `gh pr create --attach` to upload
+ * carries the first, and a body assembled by hand may carry any of them.
  */
 const HAS_FIGURE = /!\[[^\]]*\]\([^)]+\)|<img\s|https:\/\/github\.com\/user-attachments\//
 
@@ -111,7 +112,9 @@ try {
       `  • For a FIX, show the defect and the fix: render the same case both ways and compose with\n` +
       `      node .claude/scripts/compose-figure.mjs --before <a.png> --after <b.png> --out tmp/screenshots/figure.png\n` +
       `    (it refuses two identical panels, which is the trap that has produced a misleading figure before),\n` +
-      `    then \`gh image\` the result into a "## Visual repro" section. See the visual-evidence skill.\n` +
+      `    then reference it as ![…](tmp/screenshots/figure.png) under a "## Visual repro" section\n` +
+      `    and pass --attach tmp/screenshots/figure.png to \`gh pr create\` (gh ≥2.99.0) to upload it.\n` +
+      `    See the visual-evidence skill.\n` +
       `  • For a new affordance, one capture of it is enough.\n` +
       `  • If a picture is genuinely the wrong evidence, say so in one line: "Visual evidence: none — <reason>".`,
   )

--- a/.claude/skills/visual-evidence/SKILL.md
+++ b/.claude/skills/visual-evidence/SKILL.md
@@ -170,17 +170,37 @@ same face, or do not make the figure.
 **Read the PNG before uploading.** Half the failures above are invisible in
 the SVG text and obvious in the image.
 
-```bash
-gh image tmp/screenshots/figure.png     # prints the markdown
+Reference it under a `## Visual repro` heading with plain markdown image
+syntax, pointing at the local file:
+
+```markdown
+## Visual repro
+![before — 170px through B / after — clean path](tmp/screenshots/figure.png)
 ```
 
-Paste under a `## Visual repro` heading with one sentence naming what to look
-at, and say what the figure CANNOT show (a case only reachable behind a flag,
-a panel state supplied through a seam rather than by the real producer). Cite
-the two digests the script printed: they are what tells a reader the panels
-were two different renders. Delete the throwaway test and the intermediate
-`.svg` files; keep the PNG in `tmp/screenshots/` until the PR merges (the
-GitHub upload is the durable copy).
+Then pass it to `gh pr create` (or `gh pr comment`/`gh pr edit` on an
+existing PR) with `--attach`, which gh added in v2.99.0 (GitHub Changelog,
+2026-09-01) specifically to replace hand-uploading a screenshot and pasting
+its markdown back in:
+
+```bash
+gh pr create --title "…" --body-file body.md --attach tmp/screenshots/figure.png
+```
+
+`--attach` uploads the file, rewrites any local-path reference already in the
+body in place (alt text preserved), and appends the markdown for anything
+left unmatched. It is repeatable for more than one image, accepts
+`--attach 'path#alt text'` for custom alt text, and covers PNG/JPEG/GIF/WebP/
+SVG plus MP4/MOV/WebM (10 MB cap on images/GIFs). Confirm `gh --version` is
+2.99.0+ before relying on it — an older gh silently has no such flag.
+
+One sentence naming what to look at, and say what the figure CANNOT show (a
+case only reachable behind a flag, a panel state supplied through a seam
+rather than by the real producer). Cite the two digests the script printed:
+they are what tells a reader the panels were two different renders. Delete
+the throwaway test and the intermediate `.svg` files; keep the PNG in
+`tmp/screenshots/` until the PR merges (the GitHub upload is the durable
+copy).
 
 `gh pr create` is gated on this: a diff touching a surface a human looks at
 needs a figure in the body, or one line saying why a picture is the wrong


### PR DESCRIPTION
## Summary

- gh added a repeatable `--attach` flag in v2.99.0 (GitHub Changelog, 2026-09-01) for `gh issue/pr create|edit|comment`: it uploads a local image/video and rewrites a matching local-path reference already in the body, replacing the previous `gh image` extension + manual paste workflow.
- Updated the `visual-evidence` skill, the `pre-pr-visual-evidence.mjs` hook's guidance message, and `compose-figure.mjs`'s "next step" hint to reference `--attach` instead of `gh image`.
- Left the one `gh image` mention in `diagnosis-evidence/SKILL.md` alone — it documents a past search-tooling incident, not a current instruction.

## Test plan

- [ ] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [x] `pnpm test` passes locally (documentation-only change; ran the full pre-push gate instead — see below)
- [ ] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable

This is a docs/prose change to three `.claude/` files with no runtime code path, so no new test was added. The pre-push gate (`git-hooks`, `noconsole`, `mutation-lane`, `lint`, `typecheck`, `test-node` — 4203 tests) ran clean on Node 24 before pushing.

**Not manually verified end-to-end**: this session has no `gh` CLI / direct GitHub API access (GitHub interactions here go through the GitHub MCP server, which has no attach-equivalent tool), so `gh pr create --attach …` / `gh pr comment --attach …` could not be exercised against a real PR. The doc update is based on the official GitHub changelog rather than a local repro. Please spot-check `--attach` with a real `gh` ≥2.99.0 before treating `gh image` as fully retired.

## Visual evidence

Visual evidence: none — this is a prose/documentation change to workflow scripts and skill docs; nothing renders and there is no UI surface to screenshot.

## Checklist

- [x] Commit messages follow Conventional Commits (`docs: ...`)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract (this PR *is* the docs update)
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cENKD4WGbe2WjE3XgxJpQ