### PR TITLE
refactor(mcp-server): move version restore into a server-core operation

### DIFF
--- a/packages/mcp-server/src/server/routes/document.ts
+++ b/packages/mcp-server/src/server/routes/document.ts
@@ -67,7 +67,7 @@ export function createDocumentRouter(options: DocumentRouterOptions = {}) {
   app.route('/', createMaintenanceRouter({ versionStore }))
   app.route('/', createDocumentSvgExportRouter())
   app.route('/', createThumbnailsRouter({ versionStore }))
-  app.route('/', createRestoreRouter({ versionStore }))
+  app.route('/', createRestoreRouter({ serverDeps: options.serverDeps }))
 
   return app
 }

--- a/packages/mcp-server/src/server/routes/document/restore.test.ts
+++ b/packages/mcp-server/src/server/routes/document/restore.test.ts
@@ -733,4 +733,68 @@ describe('overwrite restore reconciles instead of replacing', () => {
     const body = (await restoreRes.json()) as { error: string }
     expect(body.error).toBe('output_exists')
   })
+
+  // The overlay a client shows while a restore runs is driven by these two
+  // messages, and until now nothing asserted the server SENDS them. The
+  // consumer side is well covered — `sse-backend`, `daemon-backend` and
+  // apps/web's sync hooks all test what happens when one ARRIVES — so a
+  // change that stopped emitting them would leave every one of those tests
+  // green while the overlay silently stopped appearing and, worse, stopped
+  // being dismissed.
+  it('brackets a restore with restore_started and restore_complete for a connected client', async () => {
+    const app = createDocumentRouter({ autoVersionIntervalMs: 60_000 })
+    const initial = new LoroDoc()
+    const vv0 = initial.version()
+    writeSpatialCanvas(initial, {
+      nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 80, height: 40, text: 'before' }],
+      edges: [],
+    })
+    initial.commit()
+    await app.request('/api/w/session1/document/canvas-a/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: initial.export({ mode: 'update', from: vv0 }),
+    })
+    const saveRes = await app.request('/api/workspaces/session1/documents/canvas-a/versions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label: 'v1' }),
+    })
+    const { version } = (await saveRes.json()) as { version: { id: string } }
+
+    const sent: string[] = []
+    const socket = {
+      send: (data: unknown) => {
+        if (typeof data === 'string') sent.push(data)
+      },
+      on: () => {},
+      close: () => {},
+    }
+    const { handleWsUpgrade } = await import('../ws.js')
+    await handleWsUpgrade(
+      { url: '/ws/session1/canvas-a', headers: { host: 'localhost:3099' } } as never,
+      socket as never,
+    )
+    sent.length = 0
+
+    const res = await app.request(
+      `/api/workspaces/session1/documents/canvas-a/versions/${version.id}/restore`,
+      { method: 'POST' },
+    )
+    expect(res.status).toBe(200)
+
+    const phases = sent
+      .flatMap((raw) => {
+        try {
+          return [JSON.parse(raw) as { type?: string }]
+        } catch {
+          return []
+        }
+      })
+      .map((m) => m.type)
+      .filter((t) => t === 'restore_started' || t === 'restore_complete')
+    // Both, and in that order: `complete` is what releases the overlay, so a
+    // restore that only announced its start would lock the client forever.
+    expect(phases).toEqual(['restore_started', 'restore_complete'])
+  })
 })

--- a/packages/mcp-server/src/server/routes/document/restore.test.ts
+++ b/packages/mcp-server/src/server/routes/document/restore.test.ts
@@ -35,8 +35,7 @@ afterEach(() => {
 
 describe('restore router', () => {
   it('returns a Hono instance', () => {
-    const versionStore = { listVersions: vi.fn(), saveVersion: vi.fn() }
-    const app = createRestoreRouter({ versionStore: versionStore as never })
+    const app = createRestoreRouter()
     expect(app).toBeInstanceOf(Hono)
   })
 })
@@ -320,8 +319,36 @@ describe('POST /api/workspaces/:workspaceId/documents/:path/versions/:id/restore
     expect(ids).toEqual(['added-after-v1', 'keep-me'])
   })
 
-  it('evicts the cached doc when reconcile/commit itself fails during in-place restore, not only when saveDocument fails', async () => {
-    const app = createDocumentRouter({ autoVersionIntervalMs: 60_000 })
+  // Previously this spied `commit` on the cached live doc and asserted the
+  // cache was EVICTED afterwards. That pinned a mechanism the restore no
+  // longer has: the operation reconciles a fresh copy and only the keeper's
+  // save touches the live projection, so a failure before that point leaves
+  // nothing to evict. The guarantee this now pins is the stronger one the
+  // design bought — a refused restore does not dirty the live document at
+  // all — asserted on what a reader gets, not on cache bookkeeping. The
+  // failure-DURING-persistence case, where the live doc is already mutated,
+  // is the test above this one.
+  it('a restore refused before persistence leaves the live document untouched and still served', async () => {
+    const { getDefaultServerDeps } = await import('../../../di/default-server-deps.js')
+    const deps = await getDefaultServerDeps()
+    const real = deps.documentStore
+    // Bound to the real store, not the proxy: the routed store keeps private
+    // fields, which a proxy receiver would break.
+    const refusing = new Proxy(real, {
+      get(target, key, receiver) {
+        if (key === 'saveSnapshot') {
+          return async () => {
+            throw new Error('simulated persistence refusal')
+          }
+        }
+        const value = Reflect.get(target, key, receiver)
+        return typeof value === 'function' ? value.bind(target) : value
+      },
+    })
+    const app = createDocumentRouter({
+      autoVersionIntervalMs: 60_000,
+      serverDeps: { ...deps, documentStore: refusing },
+    })
 
     const initial = new LoroDoc()
     const vv0 = initial.version()
@@ -352,26 +379,17 @@ describe('POST /api/workspaces/:workspaceId/documents/:path/versions/:id/restore
     })
 
     expect(peekDoc('session1', 'canvas-a')).toBeDefined()
-
-    // The reconcile has already mutated the live cached doc by the time its
-    // commit() runs, so a throw here must still evict the cache -- not only
-    // the saveDocument failure path further down. Spied on the cached
-    // INSTANCE, not the prototype: version machinery commits its own clones
-    // and projections first, and those must pass through.
-    const cachedLive = peekDoc('session1', 'canvas-a')!
-    const commitSpy = vi.spyOn(cachedLive, 'commit').mockImplementationOnce(() => {
-      throw new Error('simulated commit failure')
-    })
+    const before = peekDoc('session1', 'canvas-a')!
 
     const restoreRes = await app.request(
       `/api/workspaces/session1/documents/canvas-a/versions/${saveBody.version.id}/restore`,
       { method: 'POST' },
     )
-    commitSpy.mockRestore()
-
     expect(restoreRes.status).toBe(500)
-    expect(peekDoc('session1', 'canvas-a')).toBeUndefined()
 
+    // Still cached, and the SAME instance: nothing was dirtied, so nothing
+    // had to be thrown away.
+    expect(peekDoc('session1', 'canvas-a')).toBe(before)
     const reloaded = await getDoc('session1', 'canvas-a')
     const ids = (reloaded.getMovableList('elements').toJSON() as Array<{ id: string }>)
       .map((el) => el.id)

--- a/packages/mcp-server/src/server/routes/document/restore.ts
+++ b/packages/mcp-server/src/server/routes/document/restore.ts
@@ -1,120 +1,65 @@
+import type { ServerDeps } from '@kamiazya/whiteboard-server-core'
 import {
-  projectWorkspaceDocument,
-  readWorkspaceNodes,
-  reconcileDocContent,
-} from '@kamiazya/whiteboard-loro-adapter'
-import type { DocumentKind } from '@kamiazya/whiteboard-model'
-import { countAliveNodes } from '@kamiazya/whiteboard-server-core'
+  NoSuchVersionError,
+  NotWorkspaceScopedError,
+  RestoreTargetNotFoundError,
+  restoreVersion,
+  SubtreeTargetError,
+  TargetExistsError,
+} from '@kamiazya/whiteboard-server-core'
 import { Hono } from 'hono'
-import type { LoroDoc } from 'loro-crdt'
+import { getDefaultServerDeps } from '../../../di/default-server-deps.js'
 import { restoreVersionRequestSchema } from '../../../shared/api-contracts/document.js'
-import { evictDoc } from '../../store/doc-cache.js'
-import {
-  ConflictError,
-  deleteDocument,
-  documentExists,
-  getDoc,
-  getDocumentKind,
-  listDocuments,
-  renameDocumentPath,
-  saveDocument,
-} from '../../store/document-store.js'
-import type { VersionStore } from '../../store/version-store.js'
-import { withWorkspaceWriteLock } from '../../store/workspace-lock.js'
 import { validateDocumentPath, validateVersionId, validationErrorBody } from '../../validators.js'
 import { handleCorruptStoredData } from './_shared.js'
 import { onDocumentsRoute } from './path-route.js'
 
 export interface RestoreRouterOptions {
-  versionStore: VersionStore
-}
-
-// Reconciles `past` onto `doc` (the LIVE cached doc for workspaceId/targetPath),
-// commits, persists, and broadcasts the resulting update. Shared by both the
-// in-place restore and the overwrite-an-existing-canvas restore, because both
-// must mutate the same document instance any connected client already holds:
-// a delta broadcast only means something against the doc it was diffed from,
-// so "overwrite" cannot be a file swap without breaking every connected peer.
-async function reconcileCommitSaveBroadcast(
-  workspaceId: string,
-  targetPath: string,
-  doc: LoroDoc,
-  past: LoroDoc,
-  label: string | undefined,
-  kind: DocumentKind | null = null,
-): Promise<void> {
-  const { sendRestoreEvent } = await import('../ws.js')
-  sendRestoreEvent(workspaceId, targetPath, 'started', label)
-  try {
-    try {
-      // A DIFF, not an import: nothing rewinds in a CRDT, so restore is a
-      // NEW edit whose result equals the past state. The old
-      // `doc.import(past.export())` looked like that but was a measured
-      // no-op — a same-lineage checkout clone exports its full history, so
-      // the live doc already had every op — and a cross-lineage import
-      // (workspace-scoped versions project the past into a fresh doc) would
-      // lose to the live doc's later ops. reconcileDocContent makes the
-      // comment above this route true.
-      reconcileDocContent(doc, past)
-      await saveDocument(workspaceId, targetPath, doc, {
-        overwrite: true,
-        ...(kind !== null ? { kind } : {}),
-      })
-    } catch (err) {
-      // doc.import mutates the cached doc in place before commit/save
-      // run, so any failure in this block leaves the cache ahead of
-      // durable state. Evict it so the next read reloads the last
-      // successfully persisted snapshot.
-      evictDoc(workspaceId, targetPath)
-      throw err
-    }
-    // No per-document broadcast: saveDocument persisted through the
-    // workspace record, whose funnel already fanned the exact persisted
-    // bytes to every subscriber.
-  } finally {
-    // Always send complete, even on error, or the client overlay can stay locked forever.
-    sendRestoreEvent(workspaceId, targetPath, 'complete')
-  }
+  // The operation this route adapts onto (ADR-0018). Production wires it
+  // from app.ts; a caller that omits it gets `getDefaultServerDeps`, which
+  // is the same wiring over the same memoized connection, not a stand-in.
+  serverDeps?: ServerDeps
 }
 
 // POST /api/workspaces/:workspaceId/documents/:path/versions/:id/restore
 //
-// Two modes share this endpoint:
+// A translator, nothing more: it parses the request, calls the operation,
+// and maps the result and its refusals onto a response. Every decision
+// about what a restore MEANS — the three modes, why an existing target is
+// reconciled rather than swapped, why deletions run first in a subtree
+// rollback — lives in `restoreVersion` so a second surface gets the same
+// answer.
 //
-//   1. In-place reconcile (default; History panel uses this).
-//      CRDTs cannot forget history, so restore commits new ops that
-//      represent the past state:
-//        only in past    -> insert into current, or un-tombstone + restore fields
-//        only in current -> set isDeleted=true (tombstone)
-//        in both         -> copy differing fields from past onto current
+// Two modes share the endpoint, selected by the optional JSON body:
 //
-//   2. Restore into `targetPath` — body `{ targetPath, overwrite? }`.
-//      If `targetPath` does not yet exist, this writes the past doc as a
-//      brand-new canvas; the source canvas is untouched. If `targetPath`
-//      already exists, `overwrite: true` is required, and the restore goes
-//      through the SAME reconcile-onto-the-live-doc path as mode 1, applied
-//      to the target's live doc instead of the source's — never a straight
-//      file replacement. `targetPath === path` collapses into mode 1.
-//      Without `overwrite`, an existing target returns 409 `output_exists`.
-//      Replaces the deleted `checkpoint_restore` flow.
-export function createRestoreRouter(options: RestoreRouterOptions) {
+//   1. In-place reconcile (default; the History panel uses this). CRDTs
+//      cannot forget history, so the operation commits new ops whose
+//      result equals the past state.
+//   2. Restore into `targetPath` — body `{ targetPath, overwrite? }`. A new
+//      target is created; an existing one needs `overwrite: true` and is
+//      reconciled exactly as mode 1 is, onto the target's own live doc.
+//      `targetPath === path` collapses into mode 1. Without `overwrite`,
+//      an existing target answers 409 `output_exists`.
+//
+// `{ subtree: true }` rolls the document and every descendant back, and
+// needs a workspace-scoped version to do it.
+export function createRestoreRouter(options: RestoreRouterOptions = {}) {
   const app = new Hono()
-  const { versionStore } = options
 
   onDocumentsRoute(
     app,
     'post',
     ['versions', ':id', 'restore'],
     async (c, workspaceId, path, params) => {
-      const id = params.id as string
+      const versionId = params.id as string
       try {
-        validateVersionId(id)
+        validateVersionId(versionId)
       } catch (err) {
         const body = validationErrorBody(err)
         if (body) return c.json(body, 400)
         throw err
       }
-      // Body is optional. Empty body / non-JSON ⇒ in-place mode.
+      // Body is optional. Empty body / non-JSON => in-place mode.
       const rawText = await c.req.text()
       let targetPath: string | undefined
       let overwrite = false
@@ -134,187 +79,75 @@ export function createRestoreRouter(options: RestoreRouterOptions) {
         overwrite = parsed.data.overwrite === true
         subtree = parsed.data.subtree === true
       }
+      if (targetPath !== undefined) {
+        try {
+          validateDocumentPath(targetPath)
+        } catch (err) {
+          const body = validationErrorBody(err)
+          if (body) return c.json(body, 400)
+          throw err
+        }
+      }
+
+      const deps = options.serverDeps ?? (await getDefaultServerDeps())
+      // The version id belongs to the SOURCE document's history, so its
+      // label lives in the source's list whatever document the restore
+      // lands on. The overlay a client shows is addressed to the document
+      // being written, which is the target when one is named.
+      const eventPath = targetPath !== undefined && !subtree ? targetPath : path
+      const { sendRestoreEvent } = await import('../ws.js')
+
       try {
-        // Every doc read + save below runs inside one workspace-lock hold.
-        // getDoc() alone is unlocked, so a concurrent delete/rename that runs
-        // its whole lock-protected section between an unlocked read here and
-        // the eventual saveDocument() would find no row left at that path and
-        // silently insert a brand-new phantom canvas (or resurrect content
-        // onto a path the delete just cleared). Both the in-place branch and
-        // the targetPath-overwrite branch have that getDoc(path)->saveDocument(path)
-        // shape, so one lock around the whole handler body closes it for both
-        // — mirrors live-doc.ts's POST /update handler.
-        return await withWorkspaceWriteLock(workspaceId, async () => {
-          const doc = await getDoc(workspaceId, path)
-          const past = await versionStore.load(workspaceId, id)
-          if (!past) {
-            return c.json({ error: 'not_found' }, 404)
-          }
-
-          // Restore-as-new-canvas / overwrite-existing-canvas branch.
-          // targetPath === path is the same document as the in-place restore
-          // below, so route it there directly instead of forcing callers to
-          // pass overwrite:true against their own canvas.
-          if (targetPath !== undefined && targetPath !== path) {
-            try {
-              validateDocumentPath(targetPath)
-            } catch (err) {
-              const body = validationErrorBody(err)
-              if (body) return c.json(body, 400)
-              throw err
-            }
-
-            const targetAlreadyExists = await documentExists(workspaceId, targetPath)
-            if (targetAlreadyExists && !overwrite) {
-              return c.json(
-                {
-                  error: 'output_exists',
-                  message: `Target canvas "${targetPath}" already exists. Pass overwrite=true to replace it.`,
-                },
-                409,
-              )
-            }
-
-            if (targetAlreadyExists) {
-              // The version id belongs to the SOURCE canvas's history, so its
-              // label lives in the source's version list even though we are
-              // about to reconcile it onto the target.
-              const all = await versionStore.list(workspaceId, path)
-              const label = all.find((v) => v.id === id)?.label
-              const targetDoc = await getDoc(workspaceId, targetPath)
-              // The merged content is the source's own shape (spatial nodes/edges
-              // vs. a markdown body), same reasoning as the new-canvas branch
-              // below — the target's stored kind must follow it or a kind-aware
-              // consumer (editor routing) opens the overwritten canvas with the
-              // wrong editor.
-              const sourceKind = await getDocumentKind(workspaceId, path)
-              await reconcileCommitSaveBroadcast(
-                workspaceId,
-                targetPath,
-                targetDoc,
-                past,
-                label,
-                sourceKind,
-              )
+        const label = (await deps.versions.list(workspaceId, path)).find(
+          (v) => v.id === versionId,
+        )?.label
+        sendRestoreEvent(workspaceId, eventPath, 'started', label)
+        try {
+          const result = await restoreVersion(deps, {
+            workspaceId,
+            path,
+            versionId,
+            ...(targetPath !== undefined ? { targetPath } : {}),
+            ...(overwrite ? { overwrite } : {}),
+            ...(subtree ? { subtree } : {}),
+          })
+          switch (result.kind) {
+            case 'in-place':
+              return c.json({ ok: true })
+            case 'into-target':
               return c.json({
                 documentId: `${workspaceId}/${targetPath}`,
-                elementCount: countAliveNodes(targetDoc),
+                elementCount: result.elementCount,
               })
-            }
-
-            // Genuinely new canvas: no live doc and no connected clients, so
-            // there is nothing to reconcile against. The restored content is
-            // whatever the source canvas actually stores (spatial nodes/edges
-            // maps vs. a markdown 'body' text container), so the new row must
-            // carry the source's own kind rather than falling back to the
-            // saveDocument default.
-            try {
-              const sourceKind = await getDocumentKind(workspaceId, path)
-              await saveDocument(workspaceId, targetPath, past, {
-                overwrite: false,
-                ...(sourceKind !== null ? { kind: sourceKind } : {}),
-              })
-            } catch (err) {
-              if (err instanceof ConflictError) {
-                return c.json(
-                  {
-                    error: 'output_exists',
-                    message: `Target canvas "${targetPath}" already exists. Pass overwrite=true to replace it.`,
-                  },
-                  409,
-                )
-              }
-              throw err
-            }
-            // Guard against a stale cache entry from a since-deleted canvas at
-            // this path being served instead of the just-written snapshot.
-            evictDoc(workspaceId, targetPath)
-            return c.json({
-              documentId: `${workspaceId}/${targetPath}`,
-              elementCount: countAliveNodes(past),
-            })
+            case 'subtree':
+              return c.json({ ok: true, restoredCount: result.restoredCount })
           }
-
-          // Subtree rollback: the document and every descendant go back to
-          // this version's state — reverts, resurrections and deletions
-          // alike, each as ordinary new edits (nothing rewinds in a CRDT).
-          if (subtree) {
-            if (targetPath !== undefined && targetPath !== path) {
-              return c.json(
-                { error: 'invalid_body', message: 'subtree rollback cannot take a targetPath' },
-                400,
-              )
-            }
-            const pastWorkspace = await versionStore.loadWorkspaceAt(workspaceId, id)
-            if (pastWorkspace === null) {
-              return c.json(
-                {
-                  error: 'unsupported',
-                  message: 'subtree rollback needs a workspace-scoped version',
-                },
-                409,
-              )
-            }
-            const inSubtree = (p: string) => p === path || p.startsWith(`${path}/`)
-            const pastDocs = readWorkspaceNodes(pastWorkspace).flatMap((node) =>
-              node.type === 'document' && inSubtree(node.path) ? [node] : [],
-            )
-            const pastIds = new Set(pastDocs.map((node) => node.meta.documentId))
-            // The summary type leaves `id` optional; a row without one cannot
-            // be correlated to the version and is left alone.
-            const rows = (await listDocuments(workspaceId)).flatMap((row) =>
-              row.id === undefined ? [] : [{ id: row.id, path: row.path }],
-            )
-            const rowsById = new Map(rows.map((row) => [row.id, row]))
-            const { sendRestoreEvent } = await import('../ws.js')
-            const all = await versionStore.list(workspaceId, path)
-            sendRestoreEvent(workspaceId, path, 'started', all.find((v) => v.id === id)?.label)
-            try {
-              // Deletions first, so a past document whose path a later-born
-              // one occupies can land after the squatter is gone. The tree
-              // delete EVACUATES, so nothing here is unrecoverable.
-              for (const row of rows) {
-                if (inSubtree(row.path) && !pastIds.has(row.id)) {
-                  await deleteDocument(workspaceId, row.path)
-                }
-              }
-              for (const node of pastDocs) {
-                const past = projectWorkspaceDocument(pastWorkspace, node.meta.documentId)
-                if (past === null) continue
-                const live = rowsById.get(node.meta.documentId)
-                if (live !== undefined) {
-                  if (live.path !== node.path) {
-                    await renameDocumentPath(workspaceId, live.path, node.path)
-                  }
-                  const liveDoc = await getDoc(workspaceId, node.path)
-                  reconcileDocContent(liveDoc, past)
-                  await saveDocument(workspaceId, node.path, liveDoc, {
-                    overwrite: true,
-                    kind: node.meta.kind,
-                  })
-                  // The workspace record's funnel broadcasts the persisted
-                  // bytes; no per-document fan-out remains.
-                } else {
-                  // Deleted since the version: recreated under the SAME
-                  // documentId's row lineage as far as the tree is concerned
-                  // (the write-through places it by path + kind).
-                  await saveDocument(workspaceId, node.path, past, { kind: node.meta.kind })
-                  evictDoc(workspaceId, node.path)
-                }
-              }
-            } finally {
-              sendRestoreEvent(workspaceId, path, 'complete')
-            }
-            return c.json({ ok: true, restoredCount: pastDocs.length })
-          }
-
-          // In-place reconcile branch (default).
-          const all = await versionStore.list(workspaceId, path)
-          const label = all.find((v) => v.id === id)?.label
-          await reconcileCommitSaveBroadcast(workspaceId, path, doc, past, label)
-          return c.json({ ok: true })
-        })
+        } finally {
+          // Always, even on error, or the client overlay stays locked.
+          sendRestoreEvent(workspaceId, eventPath, 'complete')
+        }
       } catch (err) {
+        if (err instanceof NoSuchVersionError || err instanceof RestoreTargetNotFoundError) {
+          return c.json({ error: 'not_found' }, 404)
+        }
+        if (err instanceof TargetExistsError) {
+          return c.json(
+            {
+              error: 'output_exists',
+              message: `Target canvas "${err.targetPath}" already exists. Pass overwrite=true to replace it.`,
+            },
+            409,
+          )
+        }
+        if (err instanceof NotWorkspaceScopedError) {
+          return c.json(
+            { error: 'unsupported', message: 'subtree rollback needs a workspace-scoped version' },
+            409,
+          )
+        }
+        if (err instanceof SubtreeTargetError) {
+          return c.json({ error: 'invalid_body', message: err.message }, 400)
+        }
         const issue = handleCorruptStoredData(err)
         if (issue) return c.json(issue.body, issue.status)
         throw err

--- a/packages/mcp-server/src/server/store/version-store.ts
+++ b/packages/mcp-server/src/server/store/version-store.ts
@@ -261,84 +261,99 @@ export class FileVersionStore implements VersionStore {
     })
   }
 
+  // The three reads below open the STORED workspace record on the shared
+  // connection, and they take the same reentrant lock every writer holds.
+  // Not for the phantom-row hazard the write side guards against — a read
+  // cannot insert anything — but because a multi-statement read interleaved
+  // with a writer's COMMIT on one libsql connection fails the commit
+  // ("SQL statements in progress") and the read ("database is locked").
+  // The HTTP restore route used to hold this lock around the whole handler,
+  // which serialised these reads by accident; an operation expressed over
+  // the seam holds no lock, so the mechanic has to own its own safety.
   async load(workspaceId: string, id: string): Promise<LoroDoc | null> {
     validateWorkspaceId(workspaceId)
     validateVersionId(id)
-    const db = await dbReady()
-    const row = await db
-      .selectFrom('versions')
-      .select(['frontiers', 'documentId'])
-      .where('workspaceId', '=', workspaceId)
-      .where('id', '=', id)
-      .executeTakeFirst()
-    if (!row) return null
-    // Checked out against the STORED workspace document, whose oplog the
-    // frontiers were recorded in — never against a live per-document
-    // projection, whose fresh lineage does not contain them. The past state
-    // is then projected back out as a standalone doc, which is the shape
-    // every caller expects.
-    const storedWorkspace = await new DocumentStoreWorkspaceDocs(new LibsqlDocumentStore(db)).open(
-      workspaceId,
-    )
-    if (storedWorkspace === null) {
-      throw corruptStoredData(
-        `versions/${id}`,
-        'workspace-scoped version has no stored workspace document to check out against',
-      )
-    }
-    const clone = LoroDoc.fromSnapshot(storedWorkspace.export({ mode: 'snapshot' }))
-    try {
-      clone.checkout(decodeFrontiers(base64ToBytes(row.frontiers)))
-    } catch (error) {
-      throw corruptStoredData(
-        `versions/${id}`,
-        `frontiers could not be checked out against the workspace document (${errorMessage(error)})`,
-      )
-    }
-    return projectWorkspaceDocument(clone, row.documentId)
+    return withWorkspaceWriteLock(workspaceId, async () => {
+      const db = await dbReady()
+      const row = await db
+        .selectFrom('versions')
+        .select(['frontiers', 'documentId'])
+        .where('workspaceId', '=', workspaceId)
+        .where('id', '=', id)
+        .executeTakeFirst()
+      if (!row) return null
+      // Checked out against the STORED workspace document, whose oplog the
+      // frontiers were recorded in — never against a live per-document
+      // projection, whose fresh lineage does not contain them. The past state
+      // is then projected back out as a standalone doc, which is the shape
+      // every caller expects.
+      const storedWorkspace = await new DocumentStoreWorkspaceDocs(
+        new LibsqlDocumentStore(db),
+      ).open(workspaceId)
+      if (storedWorkspace === null) {
+        throw corruptStoredData(
+          `versions/${id}`,
+          'workspace-scoped version has no stored workspace document to check out against',
+        )
+      }
+      const clone = LoroDoc.fromSnapshot(storedWorkspace.export({ mode: 'snapshot' }))
+      try {
+        clone.checkout(decodeFrontiers(base64ToBytes(row.frontiers)))
+      } catch (error) {
+        throw corruptStoredData(
+          `versions/${id}`,
+          `frontiers could not be checked out against the workspace document (${errorMessage(error)})`,
+        )
+      }
+      return projectWorkspaceDocument(clone, row.documentId)
+    })
   }
 
   async loadWorkspaceAt(workspaceId: string, id: string): Promise<LoroDoc | null> {
     validateWorkspaceId(workspaceId)
     validateVersionId(id)
-    const db = await dbReady()
-    const row = await db
-      .selectFrom('versions')
-      .select(['frontiers'])
-      .where('workspaceId', '=', workspaceId)
-      .where('id', '=', id)
-      .executeTakeFirst()
-    if (!row) return null
-    const storedWorkspace = await new DocumentStoreWorkspaceDocs(new LibsqlDocumentStore(db)).open(
-      workspaceId,
-    )
-    if (storedWorkspace === null) return null
-    const clone = LoroDoc.fromSnapshot(storedWorkspace.export({ mode: 'snapshot' }))
-    try {
-      clone.checkout(decodeFrontiers(base64ToBytes(row.frontiers)))
-    } catch (error) {
-      throw corruptStoredData(
-        `versions/${id}`,
-        `frontiers could not be checked out against the workspace document (${errorMessage(error)})`,
-      )
-    }
-    return clone
+    return withWorkspaceWriteLock(workspaceId, async () => {
+      const db = await dbReady()
+      const row = await db
+        .selectFrom('versions')
+        .select(['frontiers'])
+        .where('workspaceId', '=', workspaceId)
+        .where('id', '=', id)
+        .executeTakeFirst()
+      if (!row) return null
+      const storedWorkspace = await new DocumentStoreWorkspaceDocs(
+        new LibsqlDocumentStore(db),
+      ).open(workspaceId)
+      if (storedWorkspace === null) return null
+      const clone = LoroDoc.fromSnapshot(storedWorkspace.export({ mode: 'snapshot' }))
+      try {
+        clone.checkout(decodeFrontiers(base64ToBytes(row.frontiers)))
+      } catch (error) {
+        throw corruptStoredData(
+          `versions/${id}`,
+          `frontiers could not be checked out against the workspace document (${errorMessage(error)})`,
+        )
+      }
+      return clone
+    })
   }
 
   async list(workspaceId: string, path: string): Promise<VersionEntry[]> {
     validateWorkspaceId(workspaceId)
     validateDocumentPath(path)
-    const db = await dbReady()
-    const documentId = await this.resolveDocumentId(db, workspaceId, path)
-    if (!documentId) return []
-    const rows = await db
-      .selectFrom('versions')
-      .selectAll()
-      .where('documentId', '=', documentId)
-      .orderBy('createdAt', 'desc')
-      .orderBy('id', 'desc')
-      .execute()
-    return rows.map((r) => rowToEntry({ ...r, path } as VersionRow))
+    return withWorkspaceWriteLock(workspaceId, async () => {
+      const db = await dbReady()
+      const documentId = await this.resolveDocumentId(db, workspaceId, path)
+      if (!documentId) return []
+      const rows = await db
+        .selectFrom('versions')
+        .selectAll()
+        .where('documentId', '=', documentId)
+        .orderBy('createdAt', 'desc')
+        .orderBy('id', 'desc')
+        .execute()
+      return rows.map((r) => rowToEntry({ ...r, path } as VersionRow))
+    })
   }
 
   async saveThumbnail(workspaceId: string, id: string, bytes: Uint8Array): Promise<void> {

--- a/packages/mcp-server/src/server/store/workspace-plane.test.ts
+++ b/packages/mcp-server/src/server/store/workspace-plane.test.ts
@@ -12,6 +12,7 @@ import {
   readSpatialCanvas,
   readTrashEntries,
   resolveWorkspaceDocumentById,
+  writeDocumentKind,
   writeSpatialCanvas,
 } from '@kamiazya/whiteboard-loro-adapter'
 import { chunkSnapshot, reassembleSnapshot } from '@kamiazya/whiteboard-ports'
@@ -292,4 +293,30 @@ it('does not keep serving an agent write whose persistence failed', async () => 
   saveSpy.mockRestore()
 
   expect(readText(await loadDocument('ws-a', 'design'))).toBe('persisted')
+})
+
+it("a tool save whose content declares a different kind moves the entry's kind with it", async () => {
+  // The restore route used to do this by hand, passing the source kind to
+  // saveDocument. Through the port the only channel is the document itself,
+  // which is also the channel every tool write already uses.
+  const { routed, index } = await stores()
+  await saveDocument('ws-a', 'design', canvasDoc('spatial-at-first'), { kind: 'spatial' })
+  const rowId = await resolveDocumentIdAtPath('ws-a', 'design')
+  if (rowId === null) throw new Error('document missing from the tree')
+
+  const restored = canvasDoc('markdown-now')
+  writeDocumentKind(restored, 'markdown')
+  const { manifest, chunks } = chunkSnapshot(
+    new Uint8Array(restored.export({ mode: 'snapshot' })),
+    1_000_000,
+  )
+  await routed.saveSnapshot({
+    docRef: { kind: 'document', workspaceId: 'ws-a', documentId: rowId },
+    manifest,
+    chunks,
+    frontier: new Uint8Array(restored.oplogVersion().encode()),
+  })
+
+  const entry = await index.resolveDocument({ workspaceId: 'ws-a', path: 'design' })
+  expect(entry?.kind).toBe('markdown')
 })

--- a/packages/mcp-server/src/server/store/workspace-plane.ts
+++ b/packages/mcp-server/src/server/store/workspace-plane.ts
@@ -11,7 +11,9 @@
  * (versions, branches and the fold still key off it).
  */
 import {
+  readDocumentKind,
   resolveWorkspaceDocumentById,
+  updateWorkspaceDocumentMeta,
   writeWorkspaceDocumentContent,
 } from '@kamiazya/whiteboard-loro-adapter'
 import type {
@@ -130,6 +132,17 @@ export class WorkspaceRoutedDocumentStore implements DocumentStore {
         // edit back out.
         const live = await getDoc(workspaceId, entry.path)
         live.import(doc.export({ mode: 'update' }))
+        // The entry's kind follows what the content DECLARES. Every tool
+        // write stamps its kind into the document (document-set, canvas-edit,
+        // document-crud), and a restore that lands markdown content on a
+        // spatial entry stamps the source's. Without this the tree would keep
+        // saying "spatial" over a markdown body and a kind-aware reader would
+        // open it under the wrong editor. A document that declares nothing
+        // changes nothing, so an ordinary edit cannot flip an entry.
+        const declared = readDocumentKind(live)
+        if (declared !== undefined && declared !== entry.kind) {
+          updateWorkspaceDocumentMeta(workspaceDoc, documentId, { kind: declared })
+        }
         if (!writeWorkspaceDocumentContent(workspaceDoc, documentId, live)) return false
         await saveWorkspaceDoc(workspaceId, workspaceDoc)
         return true

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -2,6 +2,17 @@ export { createServer } from './create-server.js'
 export { countAliveNodes, countLegacyTombstones } from './document-counts.js'
 export type { Logger, LogSink } from './log.js'
 export { getLogger, setLogSink } from './log.js'
+export type { RestoreVersionInput, RestoreVersionOutput } from './operations/restore-version.js'
+export {
+  NoSuchVersionError,
+  NotWorkspaceScopedError,
+  RestoreTargetNotFoundError,
+  restoreVersion,
+  restoreVersionInputSchema,
+  restoreVersionOutputSchema,
+  SubtreeTargetError,
+  TargetExistsError,
+} from './operations/restore-version.js'
 export type { Embedder } from './search/embedder.js'
 export type { ConfidenceInterval, Judgments, PermutationResult } from './search/eval.js'
 export {

--- a/packages/server-core/src/operations/restore-version.test.ts
+++ b/packages/server-core/src/operations/restore-version.test.ts
@@ -1,6 +1,8 @@
 import {
   createWorkspaceDocumentAtPath,
+  readDocumentKind,
   readSpatialCanvas,
+  writeDocumentKind,
   writeSpatialCanvas,
   writeWorkspaceDocumentContent,
 } from '@kamiazya/whiteboard-loro-adapter'
@@ -15,11 +17,11 @@ import {
 import { makeTestDeps } from '../test-utils/make-test-deps.js'
 import { loadDocument } from '../tools/document-io.js'
 import {
+  NoSuchVersionError,
   NotWorkspaceScopedError,
   restoreVersion,
   SubtreeTargetError,
   TargetExistsError,
-  VersionNotFoundError,
 } from './restore-version.js'
 
 const WORKSPACE_ID = 'ws-1'
@@ -103,7 +105,7 @@ describe('restoreVersion', () => {
 
     await expect(
       restoreVersion(deps, { workspaceId: WORKSPACE_ID, path: 'design', versionId: 'nope' }),
-    ).rejects.toBeInstanceOf(VersionNotFoundError)
+    ).rejects.toBeInstanceOf(NoSuchVersionError)
   })
 
   test('restores into a brand-new target, leaving the source untouched', async () => {
@@ -405,5 +407,42 @@ describe('restoreVersion', () => {
       documentId: OTHER_DOCUMENT_ID,
     })
     expect(moved?.path).toBe('design/where-it-was')
+  })
+
+  test('overwrite declares the source kind on the target, so it opens in the right editor', async () => {
+    const store = new FakeDocumentStore()
+    // Source is markdown; the seeded index entry says so.
+    await seedDoc(store, DOCUMENT_ID, (doc) => {
+      writeSpatialCanvas(doc, readSpatialCanvas(canvasWith(['keep-me'])))
+      writeDocumentKind(doc, 'markdown')
+    })
+    store.documentIndex.seed({
+      workspaceId: WORKSPACE_ID,
+      documentId: DOCUMENT_ID,
+      path: 'design',
+      kind: 'markdown',
+    })
+    // Target is spatial.
+    await seedDoc(store, OTHER_DOCUMENT_ID, (doc) => {
+      writeSpatialCanvas(doc, readSpatialCanvas(canvasWith(['occupied'])))
+      writeDocumentKind(doc, 'spatial')
+    })
+    await registerDocumentInWorkspace(store, WORKSPACE_ID, OTHER_DOCUMENT_ID, 'design-v1')
+    const deps: ServerDeps = makeTestDeps({
+      documentStore: store,
+      documentIndex: store.documentIndex,
+      versions: historyWith({ v1: canvasWith(['keep-me']) }),
+    })
+
+    await restoreVersion(deps, {
+      workspaceId: WORKSPACE_ID,
+      path: 'design',
+      versionId: 'v1',
+      targetPath: 'design-v1',
+      overwrite: true,
+    })
+
+    const { doc: target } = await loadDocument(deps, WORKSPACE_ID, OTHER_DOCUMENT_ID)
+    expect(readDocumentKind(target)).toBe('markdown')
   })
 })

--- a/packages/server-core/src/operations/restore-version.test.ts
+++ b/packages/server-core/src/operations/restore-version.test.ts
@@ -1,4 +1,9 @@
-import { readSpatialCanvas, writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+import {
+  createWorkspaceDocumentAtPath,
+  readSpatialCanvas,
+  writeSpatialCanvas,
+  writeWorkspaceDocumentContent,
+} from '@kamiazya/whiteboard-loro-adapter'
 import { LoroDoc } from 'loro-crdt'
 import { describe, expect, test } from 'vitest'
 import type { ServerDeps, VersionHistory } from '../server-deps.js'
@@ -9,7 +14,13 @@ import {
 } from '../test-utils/fake-document-store.js'
 import { makeTestDeps } from '../test-utils/make-test-deps.js'
 import { loadDocument } from '../tools/document-io.js'
-import { restoreVersion, TargetExistsError, VersionNotFoundError } from './restore-version.js'
+import {
+  NotWorkspaceScopedError,
+  restoreVersion,
+  SubtreeTargetError,
+  TargetExistsError,
+  VersionNotFoundError,
+} from './restore-version.js'
 
 const WORKSPACE_ID = 'ws-1'
 const DOCUMENT_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
@@ -224,5 +235,175 @@ describe('restoreVersion', () => {
     expect(result).toEqual({ kind: 'in-place' })
     const { doc } = await loadDocument(deps, WORKSPACE_ID, DOCUMENT_ID)
     expect(nodeIds(doc)).toEqual(['keep-me'])
+  })
+
+  test('subtree rollback refuses a version that is not workspace-scoped', async () => {
+    const store = new FakeDocumentStore()
+    await seedWorkspace(store, ['keep-me'])
+    const deps: ServerDeps = makeTestDeps({
+      documentStore: store,
+      documentIndex: store.documentIndex,
+      // `historyWith` answers null from loadWorkspaceAt, which is the seam's
+      // real answer for a per-document version: it cannot say where the
+      // document's siblings were, so it must not guess.
+      versions: historyWith({ v1: canvasWith(['keep-me']) }),
+    })
+
+    await expect(
+      restoreVersion(deps, {
+        workspaceId: WORKSPACE_ID,
+        path: 'design',
+        versionId: 'v1',
+        subtree: true,
+      }),
+    ).rejects.toBeInstanceOf(NotWorkspaceScopedError)
+  })
+
+  test('subtree rollback cannot take a targetPath', async () => {
+    const store = new FakeDocumentStore()
+    await seedWorkspace(store, ['keep-me'])
+    const deps: ServerDeps = makeTestDeps({
+      documentStore: store,
+      documentIndex: store.documentIndex,
+      versions: historyWith({ v1: canvasWith(['keep-me']) }),
+    })
+
+    // Rolling a subtree back to where it was, and copying it somewhere else,
+    // are different requests. Accepting both at once would have to silently
+    // pick one.
+    await expect(
+      restoreVersion(deps, {
+        workspaceId: WORKSPACE_ID,
+        path: 'design',
+        versionId: 'v1',
+        subtree: true,
+        targetPath: 'elsewhere',
+      }),
+    ).rejects.toBeInstanceOf(SubtreeTargetError)
+  })
+
+  test('subtree rollback reverts, resurrects and deletes in one pass', async () => {
+    // One version, three transitions, because they interact: the resurrected
+    // document's path is occupied by the one being deleted, so a pass that
+    // does not delete first cannot land it.
+    const GONE_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V9'
+    const store = new FakeDocumentStore()
+
+    // The past: `design` held keep-me, and `design/child` existed.
+    const pastWorkspace = new LoroDoc()
+    createWorkspaceDocumentAtPath(pastWorkspace, {
+      path: 'design',
+      documentId: DOCUMENT_ID,
+      kind: 'spatial',
+    })
+    createWorkspaceDocumentAtPath(pastWorkspace, {
+      path: 'design/child',
+      documentId: OTHER_DOCUMENT_ID,
+      kind: 'spatial',
+    })
+    writeWorkspaceDocumentContent(pastWorkspace, DOCUMENT_ID, canvasWith(['keep-me']))
+    writeWorkspaceDocumentContent(pastWorkspace, OTHER_DOCUMENT_ID, canvasWith(['child-past']))
+
+    // The present: `design` drifted, `design/child` was deleted, and a NEW
+    // document was born onto the path the child used to occupy.
+    await seedWorkspace(store, ['keep-me', 'added-after'])
+    await seedDoc(store, GONE_ID, (doc) => {
+      writeSpatialCanvas(doc, readSpatialCanvas(canvasWith(['squatter'])))
+    })
+    await registerDocumentInWorkspace(store, WORKSPACE_ID, GONE_ID, 'design/child')
+
+    const deps: ServerDeps = makeTestDeps({
+      documentStore: store,
+      documentIndex: store.documentIndex,
+      versions: {
+        load: async () => null,
+        loadWorkspaceAt: async () => pastWorkspace,
+        list: async () => [{ id: 'v1' }],
+      },
+    })
+
+    const result = await restoreVersion(deps, {
+      workspaceId: WORKSPACE_ID,
+      path: 'design',
+      versionId: 'v1',
+      subtree: true,
+    })
+
+    expect(result).toEqual({ kind: 'subtree', restoredCount: 2 })
+
+    // Reverted: the survivor is back at its past content.
+    const { doc: reverted } = await loadDocument(deps, WORKSPACE_ID, DOCUMENT_ID)
+    expect(nodeIds(reverted)).toEqual(['keep-me'])
+
+    // Deleted: the later-born squatter is gone from the subtree.
+    const squatter = await deps.documentIndex.resolveDocumentById({
+      workspaceId: WORKSPACE_ID,
+      documentId: GONE_ID,
+    })
+    expect(squatter).toBeNull()
+
+    // Resurrected: the child is back, at the path the squatter vacated.
+    const child = await deps.documentIndex.resolveDocument({
+      workspaceId: WORKSPACE_ID,
+      path: 'design/child',
+    })
+    expect(child).not.toBeNull()
+    if (child === null) return
+    const { doc: childDoc } = await loadDocument(deps, WORKSPACE_ID, child.documentId)
+    expect(nodeIds(childDoc)).toEqual(['child-past'])
+  })
+
+  test('subtree rollback moves a document back to the path it had at the version', async () => {
+    // Alive at both points but MOVED since. Reverting its content without
+    // moving it back leaves the subtree the right documents in the wrong
+    // shape, which reads as a successful rollback.
+    const store = new FakeDocumentStore()
+    const pastWorkspace = new LoroDoc()
+    createWorkspaceDocumentAtPath(pastWorkspace, {
+      path: 'design',
+      documentId: DOCUMENT_ID,
+      kind: 'spatial',
+    })
+    createWorkspaceDocumentAtPath(pastWorkspace, {
+      path: 'design/where-it-was',
+      documentId: OTHER_DOCUMENT_ID,
+      kind: 'spatial',
+    })
+    writeWorkspaceDocumentContent(pastWorkspace, DOCUMENT_ID, canvasWith(['keep-me']))
+    writeWorkspaceDocumentContent(pastWorkspace, OTHER_DOCUMENT_ID, canvasWith(['moved']))
+
+    await seedWorkspace(store, ['keep-me'])
+    await seedDoc(store, OTHER_DOCUMENT_ID, (doc) => {
+      writeSpatialCanvas(doc, readSpatialCanvas(canvasWith(['moved'])))
+    })
+    await registerDocumentInWorkspace(
+      store,
+      WORKSPACE_ID,
+      OTHER_DOCUMENT_ID,
+      'design/where-it-is-now',
+    )
+
+    const deps: ServerDeps = makeTestDeps({
+      documentStore: store,
+      documentIndex: store.documentIndex,
+      versions: {
+        load: async () => null,
+        loadWorkspaceAt: async () => pastWorkspace,
+        list: async () => [{ id: 'v1' }],
+      },
+    })
+
+    await restoreVersion(deps, {
+      workspaceId: WORKSPACE_ID,
+      path: 'design',
+      versionId: 'v1',
+      subtree: true,
+    })
+
+    const moved = await deps.documentIndex.resolveDocumentById({
+      workspaceId: WORKSPACE_ID,
+      documentId: OTHER_DOCUMENT_ID,
+    })
+    expect(moved?.path).toBe('design/where-it-was')
   })
 })

--- a/packages/server-core/src/operations/restore-version.test.ts
+++ b/packages/server-core/src/operations/restore-version.test.ts
@@ -1,0 +1,228 @@
+import { readSpatialCanvas, writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, test } from 'vitest'
+import type { ServerDeps, VersionHistory } from '../server-deps.js'
+import {
+  FakeDocumentStore,
+  registerDocumentInWorkspace,
+  seedDoc,
+} from '../test-utils/fake-document-store.js'
+import { makeTestDeps } from '../test-utils/make-test-deps.js'
+import { loadDocument } from '../tools/document-io.js'
+import { restoreVersion, TargetExistsError, VersionNotFoundError } from './restore-version.js'
+
+const WORKSPACE_ID = 'ws-1'
+const DOCUMENT_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V7'
+const OTHER_DOCUMENT_ID = '01H8XJZ9K5N4M3P2Q1R0S9T8V8'
+
+function canvasWith(ids: readonly string[]): LoroDoc {
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, {
+    nodes: ids.map((id, i) => ({
+      id,
+      type: 'text' as const,
+      x: i * 10,
+      y: 0,
+      width: 80,
+      height: 40,
+      text: id,
+    })),
+    edges: [],
+  })
+  return doc
+}
+
+function nodeIds(doc: LoroDoc): string[] {
+  return readSpatialCanvas(doc)
+    .nodes.map((n) => n.id)
+    .sort()
+}
+
+/**
+ * A history holding one version, keyed by id. Answers `null` for anything
+ * else, which is the seam's real "no such version" answer rather than a
+ * throw — the operation has to tell those apart.
+ */
+function historyWith(entries: Record<string, LoroDoc>): VersionHistory {
+  return {
+    load: async (_workspaceId, id) => entries[id] ?? null,
+    loadWorkspaceAt: async () => null,
+    list: async () => Object.keys(entries).map((id) => ({ id })),
+  }
+}
+
+async function seedWorkspace(store: FakeDocumentStore, ids: readonly string[]) {
+  await seedDoc(store, DOCUMENT_ID, (doc) => {
+    writeSpatialCanvas(doc, readSpatialCanvas(canvasWith(ids)))
+  })
+  await registerDocumentInWorkspace(store, WORKSPACE_ID, DOCUMENT_ID, 'design')
+}
+
+describe('restoreVersion', () => {
+  test('in-place restore reconciles the live document to the past state', async () => {
+    const store = new FakeDocumentStore()
+    await seedWorkspace(store, ['keep-me', 'added-after-v1'])
+    const deps: ServerDeps = makeTestDeps({
+      documentStore: store,
+      documentIndex: store.documentIndex,
+      versions: historyWith({ v1: canvasWith(['keep-me']) }),
+    })
+
+    const result = await restoreVersion(deps, {
+      workspaceId: WORKSPACE_ID,
+      path: 'design',
+      versionId: 'v1',
+    })
+
+    expect(result).toEqual({ kind: 'in-place' })
+    // A CRDT cannot rewind, so the restore is a NEW edit whose RESULT equals
+    // the past state — the node added after v1 is gone from the projection.
+    const { doc } = await loadDocument(deps, WORKSPACE_ID, DOCUMENT_ID)
+    expect(nodeIds(doc)).toEqual(['keep-me'])
+  })
+
+  test('refuses a version the history does not hold, rather than restoring nothing silently', async () => {
+    const store = new FakeDocumentStore()
+    await seedWorkspace(store, ['keep-me'])
+    const deps: ServerDeps = makeTestDeps({
+      documentStore: store,
+      documentIndex: store.documentIndex,
+      versions: historyWith({ v1: canvasWith(['keep-me']) }),
+    })
+
+    await expect(
+      restoreVersion(deps, { workspaceId: WORKSPACE_ID, path: 'design', versionId: 'nope' }),
+    ).rejects.toBeInstanceOf(VersionNotFoundError)
+  })
+
+  test('restores into a brand-new target, leaving the source untouched', async () => {
+    const store = new FakeDocumentStore()
+    await seedWorkspace(store, ['keep-me', 'added-after-v1'])
+    const deps: ServerDeps = makeTestDeps({
+      documentStore: store,
+      documentIndex: store.documentIndex,
+      versions: historyWith({ v1: canvasWith(['keep-me']) }),
+    })
+
+    const result = await restoreVersion(deps, {
+      workspaceId: WORKSPACE_ID,
+      path: 'design',
+      versionId: 'v1',
+      targetPath: 'design-v1',
+    })
+
+    expect(result.kind).toBe('into-target')
+    if (result.kind !== 'into-target') return
+    expect(result.elementCount).toBe(1)
+
+    // The new document holds the past state...
+    const created = await deps.documentIndex.resolveDocument({
+      workspaceId: WORKSPACE_ID,
+      path: 'design-v1',
+    })
+    expect(created).not.toBeNull()
+    if (created === null) return
+    // The restored content is whatever the SOURCE stores, so a kind-aware
+    // reader opening the copy must get the same editor. Without this the
+    // copy lands with no recorded kind and opens under the wrong one.
+    expect(created.kind).toBe('spatial')
+    const { doc: target } = await loadDocument(deps, WORKSPACE_ID, created.documentId)
+    expect(nodeIds(target)).toEqual(['keep-me'])
+
+    // ...and the SOURCE is untouched, which is what separates this mode from
+    // an in-place restore: a caller asking for a copy has not asked to lose
+    // the document they copied from.
+    const { doc: source } = await loadDocument(deps, WORKSPACE_ID, DOCUMENT_ID)
+    expect(nodeIds(source)).toEqual(['added-after-v1', 'keep-me'])
+  })
+
+  test('refuses an existing target without overwrite, rather than silently replacing it', async () => {
+    const store = new FakeDocumentStore()
+    await seedWorkspace(store, ['keep-me'])
+    await seedDoc(store, OTHER_DOCUMENT_ID, (doc) => {
+      writeSpatialCanvas(doc, readSpatialCanvas(canvasWith(['occupied'])))
+    })
+    await registerDocumentInWorkspace(store, WORKSPACE_ID, OTHER_DOCUMENT_ID, 'design-v1')
+    const deps: ServerDeps = makeTestDeps({
+      documentStore: store,
+      documentIndex: store.documentIndex,
+      versions: historyWith({ v1: canvasWith(['keep-me']) }),
+    })
+
+    await expect(
+      restoreVersion(deps, {
+        workspaceId: WORKSPACE_ID,
+        path: 'design',
+        versionId: 'v1',
+        targetPath: 'design-v1',
+      }),
+    ).rejects.toBeInstanceOf(TargetExistsError)
+
+    // Refusing means the occupant is still there, not merely that a promise
+    // rejected — the assertion that would catch a refusal issued too late.
+    const { doc: occupant } = await loadDocument(deps, WORKSPACE_ID, OTHER_DOCUMENT_ID)
+    expect(nodeIds(occupant)).toEqual(['occupied'])
+  })
+
+  test('overwrite reconciles the existing target onto the past state', async () => {
+    const store = new FakeDocumentStore()
+    await seedWorkspace(store, ['keep-me'])
+    await seedDoc(store, OTHER_DOCUMENT_ID, (doc) => {
+      writeSpatialCanvas(doc, readSpatialCanvas(canvasWith(['occupied'])))
+    })
+    await registerDocumentInWorkspace(store, WORKSPACE_ID, OTHER_DOCUMENT_ID, 'design-v1')
+    const deps: ServerDeps = makeTestDeps({
+      documentStore: store,
+      documentIndex: store.documentIndex,
+      versions: historyWith({ v1: canvasWith(['keep-me']) }),
+    })
+
+    const { doc: before } = await loadDocument(deps, WORKSPACE_ID, OTHER_DOCUMENT_ID)
+    const beforeVersion = before.oplogVersion()
+
+    const result = await restoreVersion(deps, {
+      workspaceId: WORKSPACE_ID,
+      path: 'design',
+      versionId: 'v1',
+      targetPath: 'design-v1',
+      overwrite: true,
+    })
+
+    expect(result.kind).toBe('into-target')
+    const { doc: target } = await loadDocument(deps, WORKSPACE_ID, OTHER_DOCUMENT_ID)
+    expect(nodeIds(target)).toEqual(['keep-me'])
+
+    // The projection alone cannot tell a reconcile from a wholesale swap —
+    // both end up showing the past state, which is why asserting only the
+    // node ids let a swap pass. The difference is LINEAGE: a reconcile
+    // appends new ops to the target's own history, so the restored doc still
+    // descends from what the target had. A swap installs `past`'s history
+    // instead, and a client holding the target would find its own ops gone.
+    expect(target.oplogVersion().compare(beforeVersion)).not.toBe(-1)
+    expect(target.oplogVersion().compare(beforeVersion)).not.toBeUndefined()
+  })
+
+  test('targetPath equal to the source path is the in-place restore, not a self-overwrite', async () => {
+    const store = new FakeDocumentStore()
+    await seedWorkspace(store, ['keep-me', 'added-after-v1'])
+    const deps: ServerDeps = makeTestDeps({
+      documentStore: store,
+      documentIndex: store.documentIndex,
+      versions: historyWith({ v1: canvasWith(['keep-me']) }),
+    })
+
+    // Without this collapse a caller restoring onto their own document would
+    // have to pass overwrite:true against themselves, or be refused for
+    // colliding with the document they are restoring.
+    const result = await restoreVersion(deps, {
+      workspaceId: WORKSPACE_ID,
+      path: 'design',
+      versionId: 'v1',
+      targetPath: 'design',
+    })
+
+    expect(result).toEqual({ kind: 'in-place' })
+    const { doc } = await loadDocument(deps, WORKSPACE_ID, DOCUMENT_ID)
+    expect(nodeIds(doc)).toEqual(['keep-me'])
+  })
+})

--- a/packages/server-core/src/operations/restore-version.ts
+++ b/packages/server-core/src/operations/restore-version.ts
@@ -1,4 +1,9 @@
-import { readDocumentKind, reconcileDocContent } from '@kamiazya/whiteboard-loro-adapter'
+import {
+  projectWorkspaceDocument,
+  readDocumentKind,
+  readWorkspaceNodes,
+  reconcileDocContent,
+} from '@kamiazya/whiteboard-loro-adapter'
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import { documentPathSchema, workspaceIdSchema } from '@kamiazya/whiteboard-model'
 import type { LoroDoc } from 'loro-crdt'
@@ -35,6 +40,12 @@ export const restoreVersionInputSchema = z
     targetPath: documentPathSchema.optional(),
     /** Required to replace a target that already exists. */
     overwrite: z.boolean().optional(),
+    /**
+     * Roll the document AND every descendant back to this version's state —
+     * reverts, resurrections and deletions alike, each as an ordinary new
+     * edit, since nothing rewinds in a CRDT.
+     */
+    subtree: z.boolean().optional(),
   })
   .strict()
 export type RestoreVersionInput = z.infer<typeof restoreVersionInputSchema>
@@ -52,6 +63,7 @@ export const restoreVersionOutputSchema = z.union([
       elementCount: z.number().int().min(0),
     })
     .strict(),
+  z.object({ kind: z.literal('subtree'), restoredCount: z.number().int().min(0) }).strict(),
 ])
 export type RestoreVersionOutput = z.infer<typeof restoreVersionOutputSchema>
 
@@ -82,6 +94,30 @@ export class TargetExistsError extends Error {
   }
 }
 
+/**
+ * A subtree rollback needs the whole workspace at that point, and this
+ * version does not carry it.
+ *
+ * Not a "not found": the version exists, it is simply per-document, and a
+ * per-document version cannot say where the document's SIBLINGS were. The
+ * seam answers `null` for exactly that, which is a real answer rather than
+ * a failure, so the refusal has to be its own condition.
+ */
+export class NotWorkspaceScopedError extends Error {
+  constructor(readonly versionId: string) {
+    super(`subtree rollback needs a workspace-scoped version: ${versionId}`)
+    this.name = 'NotWorkspaceScopedError'
+  }
+}
+
+/** A subtree rollback was asked to write somewhere other than where it rolls back. */
+export class SubtreeTargetError extends Error {
+  constructor() {
+    super('subtree rollback cannot take a targetPath')
+    this.name = 'SubtreeTargetError'
+  }
+}
+
 /** The document named by `path` is not in this workspace's index. */
 export class RestoreTargetNotFoundError extends Error {
   constructor(readonly path: string) {
@@ -94,11 +130,16 @@ export async function restoreVersion(
   deps: ServerDeps,
   input: RestoreVersionInput,
 ): Promise<RestoreVersionOutput> {
-  const { workspaceId, path, versionId, targetPath, overwrite } =
+  const { workspaceId, path, versionId, targetPath, overwrite, subtree } =
     restoreVersionInputSchema.parse(input)
 
   const entry = await deps.documentIndex.resolveDocument({ workspaceId, path })
   if (entry === null) throw new RestoreTargetNotFoundError(path)
+
+  if (subtree === true) {
+    if (targetPath !== undefined && targetPath !== path) throw new SubtreeTargetError()
+    return await rollBackSubtree(deps, { workspaceId, path, versionId })
+  }
 
   const past = await deps.versions.load(workspaceId, versionId)
   if (past === null) throw new VersionNotFoundError(versionId)
@@ -179,4 +220,66 @@ async function restoreIntoTarget(
     documentId: created.documentId,
     elementCount: countAliveNodes(past),
   }
+}
+
+/**
+ * Roll a document and every descendant back to a workspace-scoped version.
+ *
+ * DELETIONS RUN FIRST, and the order is load-bearing: a document that
+ * existed at the version may sit at a path some later-born document now
+ * occupies, and it cannot land until the squatter is gone. The index's
+ * delete evacuates rather than destroys, so nothing here is unrecoverable.
+ *
+ * A document alive at both points is RECONCILED in place rather than
+ * recreated, for the same reason the overwrite mode is: a client may be
+ * holding it, and a wholesale replacement would strand that client's own
+ * history. One that was deleted since the version has no holder, so it is
+ * written outright.
+ */
+async function rollBackSubtree(
+  deps: ServerDeps,
+  input: { workspaceId: string; path: string; versionId: string },
+): Promise<RestoreVersionOutput> {
+  const { workspaceId, path, versionId } = input
+  const pastWorkspace = await deps.versions.loadWorkspaceAt(workspaceId, versionId)
+  if (pastWorkspace === null) throw new NotWorkspaceScopedError(versionId)
+
+  const inSubtree = (candidate: string) => candidate === path || candidate.startsWith(`${path}/`)
+  const pastDocs = readWorkspaceNodes(pastWorkspace).flatMap((node) =>
+    node.type === 'document' && inSubtree(node.path) ? [node] : [],
+  )
+  const pastIds = new Set(pastDocs.map((node) => node.meta.documentId))
+  const live = await deps.documentIndex.listDocuments({ workspaceId })
+  const liveById = new Map(live.map((entry) => [entry.documentId, entry]))
+
+  for (const entry of live) {
+    if (inSubtree(entry.path) && !pastIds.has(entry.documentId)) {
+      await deps.documentIndex.deleteDocument({ workspaceId, path: entry.path })
+    }
+  }
+
+  for (const node of pastDocs) {
+    const pastDoc = projectWorkspaceDocument(pastWorkspace, node.meta.documentId)
+    // A node the workspace record holds but cannot project has no content to
+    // restore; skipping is the honest answer, not an error for the caller.
+    if (pastDoc === null) continue
+    const existing = liveById.get(node.meta.documentId)
+    if (existing === undefined) {
+      const created = await deps.documentIndex.createDocument({
+        workspaceId,
+        path: node.path,
+        kind: node.meta.kind ?? readDocumentKind(pastDoc) ?? 'spatial',
+      })
+      await saveDocumentSnapshot(deps, workspaceId, created.documentId, pastDoc)
+      continue
+    }
+    if (existing.path !== node.path) {
+      await deps.documentIndex.moveDocument({ workspaceId, from: existing.path, to: node.path })
+    }
+    const { doc } = await loadDocument(deps, workspaceId, existing.documentId)
+    reconcileDocContent(doc, pastDoc)
+    await saveDocumentSnapshot(deps, workspaceId, existing.documentId, doc)
+  }
+
+  return { kind: 'subtree', restoredCount: pastDocs.length }
 }

--- a/packages/server-core/src/operations/restore-version.ts
+++ b/packages/server-core/src/operations/restore-version.ts
@@ -3,9 +3,11 @@ import {
   readDocumentKind,
   readWorkspaceNodes,
   reconcileDocContent,
+  writeDocumentKind,
 } from '@kamiazya/whiteboard-loro-adapter'
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import { documentPathSchema, workspaceIdSchema } from '@kamiazya/whiteboard-model'
+import { isWorkspaceNotFoundError } from '@kamiazya/whiteboard-ports'
 import type { LoroDoc } from 'loro-crdt'
 import { z } from 'zod'
 import { countAliveNodes } from '../document-counts.js'
@@ -70,15 +72,24 @@ export type RestoreVersionOutput = z.infer<typeof restoreVersionOutputSchema>
 /**
  * The named version does not exist in this workspace's history.
  *
+ * Named for the history it answers about, because there are TWO. This
+ * operation reads the daemon's saved-version store through `deps.versions`
+ * — the History panel's versions. `wb_version_restore` reads a version
+ * record the document carries in its own `versions` map, and raises its own
+ * `VersionNotFoundError`. A version saved through one is invisible to the
+ * other. That is a standing second answer to what restoring means, of the
+ * kind ADR-0018 exists to retire; it predates this operation and is not
+ * resolved by it, only made visible.
+ *
  * A class rather than a `null` return, for the reason `SnapshotNotFoundError`
  * is one: every caller has to map it to a refusal, and a nullable result is
  * the shape a caller forgets to check. Distinct from the seam answering
  * `null`, which is the fact this is raised FROM.
  */
-export class VersionNotFoundError extends Error {
+export class NoSuchVersionError extends Error {
   constructor(readonly versionId: string) {
     super(`no such version: ${versionId}`)
-    this.name = 'VersionNotFoundError'
+    this.name = 'NoSuchVersionError'
   }
 }
 
@@ -133,7 +144,7 @@ export async function restoreVersion(
   const { workspaceId, path, versionId, targetPath, overwrite, subtree } =
     restoreVersionInputSchema.parse(input)
 
-  const entry = await deps.documentIndex.resolveDocument({ workspaceId, path })
+  const entry = await resolveOrNull(deps, workspaceId, path)
   if (entry === null) throw new RestoreTargetNotFoundError(path)
 
   if (subtree === true) {
@@ -142,7 +153,7 @@ export async function restoreVersion(
   }
 
   const past = await deps.versions.load(workspaceId, versionId)
-  if (past === null) throw new VersionNotFoundError(versionId)
+  if (past === null) throw new NoSuchVersionError(versionId)
 
   if (targetPath !== undefined && targetPath !== path) {
     return await restoreIntoTarget(deps, {
@@ -197,6 +208,11 @@ async function restoreIntoTarget(
     if (!overwrite) throw new TargetExistsError(targetPath)
     const { doc } = await loadDocument(deps, workspaceId, existing.documentId)
     reconcileDocContent(doc, past)
+    // The merged content is the SOURCE's shape, so the target has to declare
+    // the source's kind or a kind-aware reader opens it under the wrong
+    // editor. Declared in the document, the way every tool write declares
+    // kind, and the keeper's index follows the declaration on save.
+    if (sourceKind !== undefined) writeDocumentKind(doc, sourceKind)
     await saveDocumentSnapshot(deps, workspaceId, existing.documentId, doc)
     return {
       kind: 'into-target',
@@ -282,4 +298,19 @@ async function rollBackSubtree(
   }
 
   return { kind: 'subtree', restoredCount: pastDocs.length }
+}
+
+/**
+ * The index answers a missing DOCUMENT with `null` and a missing WORKSPACE
+ * with a throw — a typo'd workspace id must not materialise one. To this
+ * operation both are the same fact, "nothing to restore at that address",
+ * so the throw is folded into the null and every caller maps one error.
+ */
+async function resolveOrNull(deps: ServerDeps, workspaceId: string, path: string) {
+  try {
+    return await deps.documentIndex.resolveDocument({ workspaceId, path })
+  } catch (err) {
+    if (isWorkspaceNotFoundError(err)) return null
+    throw err
+  }
 }

--- a/packages/server-core/src/operations/restore-version.ts
+++ b/packages/server-core/src/operations/restore-version.ts
@@ -1,0 +1,182 @@
+import { readDocumentKind, reconcileDocContent } from '@kamiazya/whiteboard-loro-adapter'
+import type { DocumentKind } from '@kamiazya/whiteboard-model'
+import { documentPathSchema, workspaceIdSchema } from '@kamiazya/whiteboard-model'
+import type { LoroDoc } from 'loro-crdt'
+import { z } from 'zod'
+import { countAliveNodes } from '../document-counts.js'
+import type { ServerDeps } from '../server-deps.js'
+import { loadDocument, saveDocumentSnapshot } from '../tools/document-io.js'
+
+/**
+ * Restoring a document to a saved version — the operation, expressed over
+ * ports and seams so any surface can perform it.
+ *
+ * It is addressed by PATH on the way in, because that is what a caller
+ * names, and by documentId everywhere after. That is not incidental: the
+ * hazard the route-level implementation guards against at length — a
+ * concurrent delete or rename between the read and the save leaving the
+ * write to insert a phantom document at a path whose row is gone — is a
+ * property of addressing by PATH. An id is stable across a rename and
+ * absent after a delete, so resolving once and working by id is what
+ * removes the hazard rather than defending against it.
+ */
+export const restoreVersionInputSchema = z
+  .object({
+    workspaceId: workspaceIdSchema,
+    path: documentPathSchema,
+    versionId: z.string().min(1),
+    /**
+     * Restore into a DIFFERENT document instead of onto the source.
+     * Equal to `path` collapses to the in-place mode: a caller restoring
+     * onto their own document should not have to pass `overwrite` against
+     * themselves, nor be refused for colliding with the document they are
+     * restoring.
+     */
+    targetPath: documentPathSchema.optional(),
+    /** Required to replace a target that already exists. */
+    overwrite: z.boolean().optional(),
+  })
+  .strict()
+export type RestoreVersionInput = z.infer<typeof restoreVersionInputSchema>
+
+export const restoreVersionOutputSchema = z.union([
+  z.object({ kind: z.literal('in-place') }).strict(),
+  z
+    .object({
+      kind: z.literal('into-target'),
+      documentId: z.string(),
+      /**
+       * Nodes alive in the restored content — an advisory count for the
+       * caller's confirmation copy, not a contract about the document.
+       */
+      elementCount: z.number().int().min(0),
+    })
+    .strict(),
+])
+export type RestoreVersionOutput = z.infer<typeof restoreVersionOutputSchema>
+
+/**
+ * The named version does not exist in this workspace's history.
+ *
+ * A class rather than a `null` return, for the reason `SnapshotNotFoundError`
+ * is one: every caller has to map it to a refusal, and a nullable result is
+ * the shape a caller forgets to check. Distinct from the seam answering
+ * `null`, which is the fact this is raised FROM.
+ */
+export class VersionNotFoundError extends Error {
+  constructor(readonly versionId: string) {
+    super(`no such version: ${versionId}`)
+    this.name = 'VersionNotFoundError'
+  }
+}
+
+/**
+ * The target already holds a document and the caller did not pass
+ * `overwrite`. Raised BEFORE anything is written, so a refusal leaves the
+ * occupant exactly as it was.
+ */
+export class TargetExistsError extends Error {
+  constructor(readonly targetPath: string) {
+    super(`target already exists: ${targetPath}`)
+    this.name = 'TargetExistsError'
+  }
+}
+
+/** The document named by `path` is not in this workspace's index. */
+export class RestoreTargetNotFoundError extends Error {
+  constructor(readonly path: string) {
+    super(`no such document: ${path}`)
+    this.name = 'RestoreTargetNotFoundError'
+  }
+}
+
+export async function restoreVersion(
+  deps: ServerDeps,
+  input: RestoreVersionInput,
+): Promise<RestoreVersionOutput> {
+  const { workspaceId, path, versionId, targetPath, overwrite } =
+    restoreVersionInputSchema.parse(input)
+
+  const entry = await deps.documentIndex.resolveDocument({ workspaceId, path })
+  if (entry === null) throw new RestoreTargetNotFoundError(path)
+
+  const past = await deps.versions.load(workspaceId, versionId)
+  if (past === null) throw new VersionNotFoundError(versionId)
+
+  if (targetPath !== undefined && targetPath !== path) {
+    return await restoreIntoTarget(deps, {
+      workspaceId,
+      targetPath,
+      overwrite: overwrite === true,
+      sourceKind: entry.kind,
+      past,
+    })
+  }
+
+  const { doc } = await loadDocument(deps, workspaceId, entry.documentId)
+  // A DIFF, not an import: nothing rewinds in a CRDT, so a restore is a NEW
+  // edit whose RESULT equals the past state. Importing the past doc's
+  // history instead would be a no-op for a same-lineage checkout (the live
+  // doc already has every op) and would lose to the live doc's later ops
+  // across lineages.
+  reconcileDocContent(doc, past)
+  await saveDocumentSnapshot(deps, workspaceId, entry.documentId, doc)
+
+  return { kind: 'in-place' }
+}
+
+/**
+ * Restore into a document other than the source.
+ *
+ * The two branches are NOT the same operation with a flag. An existing
+ * target is RECONCILED, exactly as an in-place restore is, because a client
+ * may be holding it — a content swap would leave that client's document and
+ * the stored one disagreeing. A target that does not exist yet has no
+ * holder and no content to reconcile against, so it is created outright.
+ *
+ * Either way the target's kind follows the SOURCE's: the restored content
+ * is whatever the source stores (spatial nodes/edges vs. a markdown body),
+ * and a kind-aware reader opening it under the wrong kind gets the wrong
+ * editor.
+ */
+async function restoreIntoTarget(
+  deps: ServerDeps,
+  input: {
+    workspaceId: string
+    targetPath: string
+    overwrite: boolean
+    sourceKind: DocumentKind | undefined
+    past: LoroDoc
+  },
+): Promise<RestoreVersionOutput> {
+  const { workspaceId, targetPath, overwrite, sourceKind, past } = input
+  const existing = await deps.documentIndex.resolveDocument({ workspaceId, path: targetPath })
+
+  if (existing !== null) {
+    if (!overwrite) throw new TargetExistsError(targetPath)
+    const { doc } = await loadDocument(deps, workspaceId, existing.documentId)
+    reconcileDocContent(doc, past)
+    await saveDocumentSnapshot(deps, workspaceId, existing.documentId, doc)
+    return {
+      kind: 'into-target',
+      documentId: existing.documentId,
+      elementCount: countAliveNodes(doc),
+    }
+  }
+
+  // The same fallback chain the route-level save resolved: the source's
+  // recorded kind, else what the restored content itself declares, else
+  // spatial. A pre-kind source row has no recorded kind and still has to
+  // produce a copy that opens in the right editor.
+  const created = await deps.documentIndex.createDocument({
+    workspaceId,
+    path: targetPath,
+    kind: sourceKind ?? readDocumentKind(past) ?? 'spatial',
+  })
+  await saveDocumentSnapshot(deps, workspaceId, created.documentId, past)
+  return {
+    kind: 'into-target',
+    documentId: created.documentId,
+    elementCount: countAliveNodes(past),
+  }
+}

--- a/tools/arch-lint/src/architecture-map.ts
+++ b/tools/arch-lint/src/architecture-map.ts
@@ -319,10 +319,6 @@ export const ADAPTERS_REACHING_MECHANICS: readonly string[] = [
   'routes/document/maintenance.ts -> document-store',
   'routes/document/maintenance.ts -> version-store',
   'routes/document/metadata.ts -> names-store',
-  'routes/document/restore.ts -> doc-cache',
-  'routes/document/restore.ts -> document-store',
-  'routes/document/restore.ts -> version-store',
-  'routes/document/restore.ts -> workspace-lock',
   'routes/document/thumbnails.ts -> version-store',
   'routes/document/versions.ts -> document-store',
   'routes/document/versions.ts -> version-store',
@@ -360,7 +356,7 @@ export const ADAPTERS_REACHING_MECHANICS: readonly string[] = [
  * server-core instead. The burn-down order is in the ADR; the four clusters
  * it names are 17 of these 39.
  */
-export const ADAPTERS_REACHING_MECHANICS_CEILING = 37
+export const ADAPTERS_REACHING_MECHANICS_CEILING = 33
 
 /**
  * Modules under `store/` the adapter rule does NOT count.


### PR DESCRIPTION
## Summary

[ADR-0018](docs/contributing/adr/0018-operation-vs-mechanic.md)'s first scheduled cluster. `routes/document/restore.ts` — five adapter → mechanic edges when the ADR was accepted, four after #1211 — is now a **translator**: it parses the request, calls `restoreVersion`, and maps the result and its refusals onto a response. Every decision about what a restore *means* lives in `server-core`, where a second surface can reach it.

- **`operations/restore-version.ts`** carries all four modes: in-place reconcile, restore into a new target, overwrite an existing target, subtree rollback. Addressed by **path on the way in and documentId everywhere after** — which is what removes the hazard the old route guarded against at length (a concurrent delete/rename between read and save inserting a phantom row). That hazard is a property of path addressing; an id is stable across a rename and absent after a delete, so resolving once dissolves it rather than defending against it.
- **Four allowlist entries retired; `ADAPTERS_REACHING_MECHANICS_CEILING` 37 → 33.**
- Two mechanic-side fixes the move needed, each its own commit and each mutation-checked:
  - `FileVersionStore.load/loadWorkspaceAt/list` now take the (reentrant) workspace lock. They open the stored record on the shared libsql connection, and the old route's handler-wide lock had been serialising them against writers by accident. Without it, five route tests went 500 with `SQLITE_BUSY: cannot commit transaction - SQL statements in progress`; with it they went green.
  - `WorkspaceRoutedDocumentStore.saveSnapshot` moves the tree entry's kind when the saved content declares a different one — the channel every tool write already uses (`document-set`, `canvas-edit`, `document-crud` all stamp kind). The route used to do this by hand.

### Three premises refuted before writing this

The first estimate was ~1000 lines and four new seams. Reading the code refuted three of the four, which is why it is 341 insertions against 358 deletions:

| premise | finding |
|---|---|
| a `liveDocument` transaction seam is needed | **no** — the daemon's `documentStore` binding already holds the lock and merges into the live projection |
| a lock seam is needed for the phantom-insert hazard | **no** — the port resolves by documentId inside the lock |
| `saveSnapshot` lacks cache eviction on failure | **no** — `saveWorkspaceDoc` evicts both caches in its catch (#1223 pinned it) |

The one seam that was genuinely missing, `versions`, landed in #1216.

## Test plan

- [x] New or updated tests added — 12 operation-layer tests over the four modes; one mechanic test each for the lock and the kind sync; the route suite keeps 18.
- [x] `pnpm test` passes locally — `mcp-node` **366 files / 4205 passed, 9 skipped** (run alone, since its loop-availability tests are load-sensitive); `server-core-node` 52 / 455; `arch-lint-node` 119 / 119 at ceiling 33; `pnpm -r typecheck` 0 errors; `pnpm lint` and `pnpm knip` clean.
- [x] Manual verification completed — **mutation-checked rather than assumed**, and the checks did real work. Of the ten mutations run against the operation, **five survived the first version of its tests**, each because a behaviour the comments called important was never actually asserted:

  | mutation | first result | closed by |
  |---|---|---|
  | overwrite an existing target without being asked | caught | — |
  | **swap content instead of reconciling** an existing target | **survived** | asserting **lineage** (`oplogVersion().compare`), not node ids — both end showing the past state |
  | drop the `targetPath === path` collapse | caught | — |
  | **don't carry the source's kind** onto a new target | **survived** | asserting the created entry's kind |
  | delete *after* restoring in a subtree rollback | caught | — |
  | resurrect a document deleted since the version | caught | — |
  | **skip the rename** in a subtree rollback | **survived** — deleting the move left 10/10 green | a case for a document that moved while staying alive |
  | never announce `restore_started` / never send `restore_complete` | caught (once the test existed) | — |

  Also verified: dropping either version-store read lock reintroduces the 500s; dropping the kind sync fails its test.
- [ ] E2E coverage — **not run against a live daemon.** This container cannot drive the real History panel. The 18 HTTP-level route tests and the operation tests are the evidence; a manual restore from the History panel before merge would close that gap.

### One route test rewritten, not weakened

`evicts the cached doc when reconcile/commit itself fails` spied `commit` on the cached live doc and asserted eviction — a mechanism the operation no longer has (it reconciles a fresh copy; only the keeper's save touches the live projection). It now asserts the **stronger** guarantee the design bought: a restore refused before persistence leaves the live document untouched, the *same instance* still cached, and the reader still served the persisted state. The failure-*during*-persistence case, where the live doc is already mutated, keeps its own unchanged test.

### Surfaced, not resolved: two version histories

`wb_version_restore` (server-core) reads a version record the document carries in its own `versions` map. This operation, the HTTP route and the History panel read the daemon's `FileVersionStore`. **A version saved through one is invisible to the other** — confirmed: `wb_version_save` writes `doc.getMap('versions')` and nothing under `store/` reads that map. That is a standing second answer to what restoring means, of the kind ADR-0018 exists to retire. It predates this PR, is recorded on `NoSuchVersionError`'s doc comment, and which history is canonical is a product decision I have not made here.

## Visual evidence

Visual evidence: none — an HTTP route's internals moved behind an operation with the same request and response shapes. Nothing renders differently. The observable outputs are the gate counts and mutation table above.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — n/a; no contract changed, and the rationale is on the code
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema — input/output are `z.infer` of `restoreVersionInputSchema` / `restoreVersionOutputSchema`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_