### PR TITLE
feat(web): tappable ✓/✕ exit pill on touch instead of keyboard chords, and enterkeyhint on finish-on-Enter inputs

### DIFF
--- a/apps/web/src/components/EditorExitHint.test.tsx
+++ b/apps/web/src/components/EditorExitHint.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { EditorExitHint } from './EditorExitHint.js'
 
@@ -35,5 +35,46 @@ describe('EditorExitHint', () => {
     expect(hint.textContent).toContain('Cancel')
     expect(hint.getAttribute('aria-hidden')).toBe('true')
     expect(hint.className).toContain('pointer-events-none')
+  })
+})
+
+/** jsdom has no matchMedia at all, so the fine-pointer cases above see none. */
+function stubCoarsePointer() {
+  vi.stubGlobal('matchMedia', (query: string) => ({ matches: query === '(pointer: coarse)' }))
+}
+
+describe('EditorExitHint on a coarse pointer', () => {
+  it('offers Done and Cancel as real buttons that route to the handlers', () => {
+    stubCoarsePointer()
+    const onDone = vi.fn()
+    const onCancel = vi.fn()
+    render(<EditorExitHint onDone={onDone} onCancel={onCancel} />)
+    const hint = screen.getByTestId('editor-exit-hint')
+    expect(hint.getAttribute('aria-hidden')).toBeNull()
+    expect(hint.className).not.toContain('pointer-events-none')
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onDone).toHaveBeenCalledTimes(1)
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    // No chord is named: a finger has none to press. And no words either —
+    // the verbs are icons with accessible names, like every other pill.
+    expect(hint.querySelector('kbd')).toBeNull()
+    expect(hint.textContent?.trim()).toBe('')
+    expect(hint.querySelectorAll('svg')).toHaveLength(2)
+  })
+
+  it('claims pointerdown so the editor keeps focus until the click lands', () => {
+    stubCoarsePointer()
+    render(<EditorExitHint onDone={vi.fn()} onCancel={vi.fn()} />)
+    const cancel = screen.getByRole('button', { name: 'Cancel' })
+    const event = new MouseEvent('pointerdown', { bubbles: true, cancelable: true })
+    cancel.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('stays the decorative strip when no handler is offered', () => {
+    stubCoarsePointer()
+    render(<EditorExitHint />)
+    expect(screen.getByTestId('editor-exit-hint').getAttribute('aria-hidden')).toBe('true')
   })
 })

--- a/apps/web/src/components/EditorExitHint.tsx
+++ b/apps/web/src/components/EditorExitHint.tsx
@@ -12,6 +12,9 @@ const KBD =
  * family: 24px slots, 6px radius, background fill, border-coloured edge,
  * muted 1.5px glyphs, no shadow. Visually 24px; the hit area is widened by
  * the pseudo-element below, since a 24px target is under the touch floor.
+ * The glyph stroke is ABSOLUTE: lucide's strokeWidth is in 24-unit viewBox
+ * units, so at 14px a nominal 1.5 draws 0.9px and reads thinner than the
+ * node-tools arrow beside it.
  */
 const SLOT_CLASS =
   'relative flex size-6 items-center justify-center rounded-[6px] text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring after:absolute after:-inset-y-2 after:content-[""]'
@@ -109,7 +112,7 @@ export function EditorExitHint({
           onClick={onDone}
           className={cn(SLOT_CLASS, 'after:right-0 after:-left-2')}
         >
-          <Check aria-hidden="true" className="size-3.5" strokeWidth={1.5} />
+          <Check aria-hidden="true" className="size-3.5" strokeWidth={1.5} absoluteStrokeWidth />
         </button>
         <span aria-hidden="true" className="bg-border h-3.5 w-px" />
         <button
@@ -120,7 +123,7 @@ export function EditorExitHint({
           onClick={onCancel}
           className={cn(SLOT_CLASS, 'after:left-0 after:-right-2')}
         >
-          <X aria-hidden="true" className="size-3.5" strokeWidth={1.5} />
+          <X aria-hidden="true" className="size-3.5" strokeWidth={1.5} absoluteStrokeWidth />
         </button>
       </div>
     )

--- a/apps/web/src/components/EditorExitHint.tsx
+++ b/apps/web/src/components/EditorExitHint.tsx
@@ -14,8 +14,10 @@ const KBD =
  * the pseudo-element below, since a 24px target is under the touch floor.
  * The glyph stroke is ABSOLUTE: lucide's strokeWidth is in 24-unit viewBox
  * units, so at 14px a nominal 1.5 draws 0.9px and reads thinner than the
- * node-tools arrow beside it.
+ * node-tools arrow beside it. `absoluteStrokeWidth` rescales against the
+ * `size` PROP, not a CSS class, so the size has to be given as the prop.
  */
+const GLYPH_PX = 14
 const SLOT_CLASS =
   'relative flex size-6 items-center justify-center rounded-[6px] text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring after:absolute after:-inset-y-2 after:content-[""]'
 
@@ -112,7 +114,7 @@ export function EditorExitHint({
           onClick={onDone}
           className={cn(SLOT_CLASS, 'after:right-0 after:-left-2')}
         >
-          <Check aria-hidden="true" className="size-3.5" strokeWidth={1.5} absoluteStrokeWidth />
+          <Check aria-hidden="true" size={GLYPH_PX} strokeWidth={1.5} absoluteStrokeWidth />
         </button>
         <span aria-hidden="true" className="bg-border h-3.5 w-px" />
         <button
@@ -123,7 +125,7 @@ export function EditorExitHint({
           onClick={onCancel}
           className={cn(SLOT_CLASS, 'after:left-0 after:-right-2')}
         >
-          <X aria-hidden="true" className="size-3.5" strokeWidth={1.5} absoluteStrokeWidth />
+          <X aria-hidden="true" size={GLYPH_PX} strokeWidth={1.5} absoluteStrokeWidth />
         </button>
       </div>
     )

--- a/apps/web/src/components/EditorExitHint.tsx
+++ b/apps/web/src/components/EditorExitHint.tsx
@@ -1,9 +1,38 @@
-import type { CSSProperties } from 'react'
+import { Check, X } from 'lucide-react'
+import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react'
 import { cn } from '@/lib/utils'
-import { isMacPlatform } from '../lib/platform.js'
+import { hasCoarsePointer, isMacPlatform } from '../lib/platform.js'
+import { DOCK_BUTTON_CLASS } from './ui/dock-button.js'
+
+/** Header-height icon button (32px) for the 40px full-screen editor bar. */
+const DENSE_ICON_BUTTON_CLASS =
+  'flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground'
 
 const KBD =
   'rounded border border-border bg-background px-1 py-px font-sans text-[10px] text-muted-foreground'
+
+interface EditorExitHintProps {
+  readonly className?: string
+  readonly style?: CSSProperties
+  /**
+   * Both handlers turn the strip into real controls on a coarse pointer. A
+   * finger has no chord to press, so naming one there is noise — and the
+   * keyboard it does have is the software one, which offers no Escape.
+   */
+  readonly onDone?: () => void
+  readonly onCancel?: () => void
+  /** Header-height controls (32px) for a strip that lives in a 40px bar. */
+  readonly dense?: boolean
+  /**
+   * The strip sits inside the spatial canvas root, which refuses native
+   * touch and captures pointers everywhere EXCEPT inside
+   * `[data-editor-overlay]` — a tap on an unmarked button there never
+   * becomes a click. The full-screen editor's header is outside that root
+   * and must NOT carry the marker: the overlay's own Escape handler treats
+   * any marked element as an open popup and stands down.
+   */
+  readonly canvasOverlay?: boolean
+}
 
 /**
  * A text-editor overlay's exit semantics, said where the typing happens:
@@ -12,16 +41,63 @@ const KBD =
  * question the shortcut catalog records someone failing to answer while an
  * editor was open (shortcuts.ts, `commit-text-edit`).
  *
- * Decoration by design: `aria-hidden` (the editors carry the same chord in
- * `aria-keyshortcuts`), no pointer target, never focusable.
+ * On a fine pointer it is decoration by design: `aria-hidden` (the editors
+ * carry the same chord in `aria-keyshortcuts`), no pointer target, never
+ * focusable. On a coarse pointer, given handlers, it is the two buttons.
  */
 export function EditorExitHint({
   className,
   style,
-}: {
-  readonly className?: string
-  readonly style?: CSSProperties
-}) {
+  onDone,
+  onCancel,
+  dense = false,
+  canvasOverlay = false,
+}: EditorExitHintProps) {
+  if (onDone !== undefined && onCancel !== undefined && hasCoarsePointer()) {
+    // The editors commit on blur. A tap that moved focus here would commit
+    // BEFORE the click could cancel, so Cancel would silently mean Done —
+    // cancelling pointerdown keeps focus in the editor until the click lands.
+    const keepEditorFocus = (event: ReactPointerEvent) => {
+      event.preventDefault()
+    }
+    // Icons, not words: the same pill language as the dock and the node
+    // toolbar. The verbs live in the accessible names.
+    const button = dense ? DENSE_ICON_BUTTON_CLASS : DOCK_BUTTON_CLASS
+    const icon = dense ? 'size-4' : 'size-5'
+    return (
+      <div
+        data-testid="editor-exit-hint"
+        data-editor-overlay={canvasOverlay ? true : undefined}
+        className={cn(
+          'bg-background border-border inline-flex items-center gap-0.5 rounded-lg border p-0.5 shadow-sm select-none',
+          className,
+        )}
+        style={style}
+      >
+        <button
+          type="button"
+          aria-label="Done"
+          title="Done"
+          onPointerDown={keepEditorFocus}
+          onClick={onDone}
+          className={cn(button, 'text-foreground')}
+        >
+          <Check aria-hidden="true" className={icon} />
+        </button>
+        <span aria-hidden="true" className="bg-border h-5 w-px" />
+        <button
+          type="button"
+          aria-label="Cancel"
+          title="Cancel"
+          onPointerDown={keepEditorFocus}
+          onClick={onCancel}
+          className={button}
+        >
+          <X aria-hidden="true" className={icon} />
+        </button>
+      </div>
+    )
+  }
   return (
     <span
       aria-hidden="true"

--- a/apps/web/src/components/EditorExitHint.tsx
+++ b/apps/web/src/components/EditorExitHint.tsx
@@ -2,18 +2,38 @@ import { Check, X } from 'lucide-react'
 import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react'
 import { cn } from '@/lib/utils'
 import { hasCoarsePointer, isMacPlatform } from '../lib/platform.js'
-import { DOCK_BUTTON_CLASS } from './ui/dock-button.js'
-
-/** Header-height icon button (32px) for the 40px full-screen editor bar. */
-const DENSE_ICON_BUTTON_CLASS =
-  'flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground'
 
 const KBD =
   'rounded border border-border bg-background px-1 py-px font-sans text-[10px] text-muted-foreground'
 
+/**
+ * One slot of the touch pill, in screen px — the node-tools pill's slot
+ * (SelectionOverlay), so the two clusters attached to a node read as one
+ * family: 24px slots, 6px radius, background fill, border-coloured edge,
+ * muted 1.5px glyphs, no shadow. Visually 24px; the hit area is widened by
+ * the pseudo-element below, since a 24px target is under the touch floor.
+ */
+const SLOT_CLASS =
+  'relative flex size-6 items-center justify-center rounded-[6px] text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring after:absolute after:-inset-y-2 after:content-[""]'
+
+/**
+ * Where the strip goes, in the coordinates of the layer it renders into.
+ * The touch pill right-aligns to `right` (mirroring node-tools, which hangs
+ * off the node's top-right corner); the decorative strip left-aligns to
+ * `left`. `scale` counter-scales a canvas-space layer's zoom so the pill
+ * keeps its screen size — a tap target has a screen size, not a canvas one.
+ */
+export interface EditorExitHintPlacement {
+  readonly left: number
+  readonly right: number
+  readonly top: number
+  readonly scale?: number
+}
+
 interface EditorExitHintProps {
   readonly className?: string
   readonly style?: CSSProperties
+  readonly placement?: EditorExitHintPlacement
   /**
    * Both handlers turn the strip into real controls on a coarse pointer. A
    * finger has no chord to press, so naming one there is noise — and the
@@ -21,8 +41,6 @@ interface EditorExitHintProps {
    */
   readonly onDone?: () => void
   readonly onCancel?: () => void
-  /** Header-height controls (32px) for a strip that lives in a 40px bar. */
-  readonly dense?: boolean
   /**
    * The strip sits inside the spatial canvas root, which refuses native
    * touch and captures pointers everywhere EXCEPT inside
@@ -43,16 +61,19 @@ interface EditorExitHintProps {
  *
  * On a fine pointer it is decoration by design: `aria-hidden` (the editors
  * carry the same chord in `aria-keyshortcuts`), no pointer target, never
- * focusable. On a coarse pointer, given handlers, it is the two buttons.
+ * focusable. On a coarse pointer, given handlers, it is the two buttons —
+ * icons, not words, in the node-tools pill language; the verbs live in the
+ * accessible names.
  */
 export function EditorExitHint({
   className,
   style,
+  placement,
   onDone,
   onCancel,
-  dense = false,
   canvasOverlay = false,
 }: EditorExitHintProps) {
+  const scale = placement?.scale === undefined ? undefined : `scale(${placement.scale})`
   if (onDone !== undefined && onCancel !== undefined && hasCoarsePointer()) {
     // The editors commit on blur. A tap that moved focus here would commit
     // BEFORE the click could cancel, so Cancel would silently mean Done —
@@ -60,19 +81,25 @@ export function EditorExitHint({
     const keepEditorFocus = (event: ReactPointerEvent) => {
       event.preventDefault()
     }
-    // Icons, not words: the same pill language as the dock and the node
-    // toolbar. The verbs live in the accessible names.
-    const button = dense ? DENSE_ICON_BUTTON_CLASS : DOCK_BUTTON_CLASS
-    const icon = dense ? 'size-4' : 'size-5'
-    return (
+    const pill = (
       <div
         data-testid="editor-exit-hint"
         data-editor-overlay={canvasOverlay ? true : undefined}
         className={cn(
-          'bg-background border-border inline-flex items-center gap-0.5 rounded-lg border p-0.5 shadow-sm select-none',
-          className,
+          'bg-background border-border inline-flex items-center rounded-[6px] border select-none',
+          placement === undefined && className,
         )}
-        style={style}
+        style={
+          placement === undefined
+            ? style
+            : {
+                position: 'absolute',
+                right: 0,
+                top: 0,
+                transform: scale,
+                transformOrigin: 'top right',
+              }
+        }
       >
         <button
           type="button"
@@ -80,21 +107,38 @@ export function EditorExitHint({
           title="Done"
           onPointerDown={keepEditorFocus}
           onClick={onDone}
-          className={cn(button, 'text-foreground')}
+          className={cn(SLOT_CLASS, 'after:right-0 after:-left-2')}
         >
-          <Check aria-hidden="true" className={icon} />
+          <Check aria-hidden="true" className="size-3.5" strokeWidth={1.5} />
         </button>
-        <span aria-hidden="true" className="bg-border h-5 w-px" />
+        <span aria-hidden="true" className="bg-border h-3.5 w-px" />
         <button
           type="button"
           aria-label="Cancel"
           title="Cancel"
           onPointerDown={keepEditorFocus}
           onClick={onCancel}
-          className={button}
+          className={cn(SLOT_CLASS, 'after:left-0 after:-right-2')}
         >
-          <X aria-hidden="true" className={icon} />
+          <X aria-hidden="true" className="size-3.5" strokeWidth={1.5} />
         </button>
+      </div>
+    )
+    if (placement === undefined) return pill
+    // A zero-size anchor at the node's right edge; the pill hangs off it
+    // leftwards, and scaling about its top-right corner keeps that edge put.
+    return (
+      <div
+        className={className}
+        style={{
+          position: 'absolute',
+          left: placement.right,
+          top: placement.top,
+          width: 0,
+          height: 0,
+        }}
+      >
+        {pill}
       </div>
     )
   }
@@ -106,7 +150,17 @@ export function EditorExitHint({
         'text-muted-foreground pointer-events-none inline-flex items-center gap-1 text-[11px] leading-none whitespace-nowrap select-none',
         className,
       )}
-      style={style}
+      style={
+        placement === undefined
+          ? style
+          : {
+              position: 'absolute',
+              left: placement.left,
+              top: placement.top,
+              transform: scale,
+              transformOrigin: 'top left',
+            }
+      }
     >
       <kbd className={KBD}>{isMacPlatform() ? '⌘↩' : 'Ctrl+↩'}</kbd>
       <span>Done</span>

--- a/apps/web/src/components/HeaderBranchChip.tsx
+++ b/apps/web/src/components/HeaderBranchChip.tsx
@@ -565,6 +565,7 @@ export function HeaderBranchChip({
           </DialogHeader>
           <Input
             autoFocus
+            enterKeyHint="done"
             value={renameDraft}
             onChange={(e) => setRenameDraft(e.target.value)}
             onKeyDown={(e) => {

--- a/apps/web/src/components/document-editor/NodeTextEditorOverlay.tsx
+++ b/apps/web/src/components/document-editor/NodeTextEditorOverlay.tsx
@@ -114,7 +114,7 @@ export function NodeTextEditorOverlay({
           Canvas
         </button>
         <span className="text-foreground truncate text-sm font-medium">{title}</span>
-        <EditorExitHint className="ml-auto" />
+        <EditorExitHint className="ml-auto" dense onDone={commitAndClose} onCancel={onClose} />
       </div>
       <div className="min-h-0 flex-1">
         <MarkdownEditor

--- a/apps/web/src/components/document-editor/NodeTextEditorOverlay.tsx
+++ b/apps/web/src/components/document-editor/NodeTextEditorOverlay.tsx
@@ -114,7 +114,7 @@ export function NodeTextEditorOverlay({
           Canvas
         </button>
         <span className="text-foreground truncate text-sm font-medium">{title}</span>
-        <EditorExitHint className="ml-auto" dense onDone={commitAndClose} onCancel={onClose} />
+        <EditorExitHint className="ml-auto" onDone={commitAndClose} onCancel={onClose} />
       </div>
       <div className="min-h-0 flex-1">
         <MarkdownEditor

--- a/apps/web/src/components/document-properties/DocumentProperties.test.tsx
+++ b/apps/web/src/components/document-properties/DocumentProperties.test.tsx
@@ -48,6 +48,15 @@ describe('DocumentProperties', () => {
     expect(textboxValue(/title/i)).toBe('Release plan')
   })
 
+  it("labels the software keyboard's Enter as Done on the title field", () => {
+    // The one keyboard extension point the web has: Enter finishes the edit
+    // here, so the key says so instead of showing a return arrow.
+    render(<DocumentProperties {...titleProps()} facets={meta()} onFacetsChange={vi.fn()} />)
+    expect(screen.getByRole('textbox', { name: /title/i }).getAttribute('enterkeyhint')).toBe(
+      'done',
+    )
+  })
+
   it('keeps type and tags behind the disclosure until it is opened', async () => {
     render(<DocumentProperties {...titleProps()} facets={meta()} onFacetsChange={vi.fn()} />)
     expect(screen.queryByRole('combobox', { name: /type/i })).toBeNull()

--- a/apps/web/src/components/document-properties/DocumentProperties.tsx
+++ b/apps/web/src/components/document-properties/DocumentProperties.tsx
@@ -123,6 +123,7 @@ export function DocumentProperties({
         </label>
         <input
           id={`${suggestionsId}-title`}
+          enterKeyHint="done"
           value={draftTitle ?? title}
           onChange={(event) => {
             if (onTitleChange === undefined) return

--- a/apps/web/src/components/markdown-editor/LinkPickerDialog.tsx
+++ b/apps/web/src/components/markdown-editor/LinkPickerDialog.tsx
@@ -114,6 +114,7 @@ export function LinkPickerDialog({
     >
       <input
         id="link-picker-search"
+        enterKeyHint="go"
         ref={inputRef}
         role="combobox"
         aria-expanded

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -624,6 +624,7 @@ export function DaemonDetectedBanner({
             data-testid="daemon-port-input"
             type="text"
             inputMode="numeric"
+            enterKeyHint="go"
             value={portInput}
             onChange={(event) => setPortInput(event.target.value)}
             onKeyDown={(event) => {

--- a/apps/web/src/components/shell/WorkspaceMenu.tsx
+++ b/apps/web/src/components/shell/WorkspaceMenu.tsx
@@ -328,6 +328,7 @@ export function WorkspaceMenu({
             </label>
             <input
               id={urlId}
+              enterKeyHint="done"
               value={urlDraft ?? active.segment ?? ''}
               readOnly={rename === undefined}
               placeholder={active.workspaceId}
@@ -416,6 +417,7 @@ export function WorkspaceMenu({
               </label>
               <input
                 id={`${nameId}-new`}
+                enterKeyHint="done"
                 ref={newNameRef}
                 value={newName}
                 onChange={(event) => setNewName(event.target.value)}

--- a/apps/web/src/components/spatial-editor/MarkdownNodeEditor.tsx
+++ b/apps/web/src/components/spatial-editor/MarkdownNodeEditor.tsx
@@ -229,12 +229,11 @@ export function MarkdownNodeEditor({
         }}
         onCancel={cancel}
         canvasOverlay
-        style={{
-          position: 'absolute',
+        placement={{
           left: box.x,
+          right: box.x + box.width,
           top: exitHintTop ?? box.y + box.height + 6,
-          transform: exitHintScale === undefined ? undefined : `scale(${exitHintScale})`,
-          transformOrigin: 'top left',
+          scale: exitHintScale,
         }}
       />
     </>

--- a/apps/web/src/components/spatial-editor/MarkdownNodeEditor.tsx
+++ b/apps/web/src/components/spatial-editor/MarkdownNodeEditor.tsx
@@ -60,6 +60,12 @@ export interface MarkdownNodeEditorProps {
    * under `box`.
    */
   readonly exitHintTop?: number
+  /**
+   * Screen-size correction for the exit strip: the strip is positioned in
+   * canvas coordinates and would otherwise scale with the zoom, and a tap
+   * target has a screen size, not a canvas size. Callers pass `1 / zoom`.
+   */
+  readonly exitHintScale?: number
   readonly style?: CSSProperties
   readonly testId?: string
   readonly onCommit: (text: string) => void
@@ -72,6 +78,7 @@ export function MarkdownNodeEditor({
   initialText,
   centerContent = false,
   exitHintTop,
+  exitHintScale,
   style,
   testId = 'text-node-editor',
   onCommit,
@@ -86,6 +93,17 @@ export function MarkdownNodeEditor({
   const callbacksRef = useRef({ onCommit, onCancel, onChange })
   callbacksRef.current = { onCommit, onCancel, onChange }
 
+  const commit = (view: EditorView) => {
+    if (!mountedRef.current || finishedRef.current) return
+    finishedRef.current = true
+    callbacksRef.current.onCommit(view.state.doc.toString())
+  }
+  const cancel = () => {
+    if (finishedRef.current) return
+    finishedRef.current = true
+    callbacksRef.current.onCancel()
+  }
+
   // useLayoutEffect, not useEffect: passive cleanups run AFTER React has
   // detached the host DOM, and detaching a focused contentDOM fires a
   // native blur while our handler is still attached and mountedRef is
@@ -95,17 +113,6 @@ export function MarkdownNodeEditor({
   useLayoutEffect(() => {
     const host = hostRef.current
     if (host === null) return
-
-    const commit = (view: EditorView) => {
-      if (!mountedRef.current || finishedRef.current) return
-      finishedRef.current = true
-      callbacksRef.current.onCommit(view.state.doc.toString())
-    }
-    const cancel = () => {
-      if (finishedRef.current) return
-      finishedRef.current = true
-      callbacksRef.current.onCancel()
-    }
 
     const state = EditorState.create({
       doc: initialText,
@@ -216,7 +223,19 @@ export function MarkdownNodeEditor({
         }}
       />
       <EditorExitHint
-        style={{ position: 'absolute', left: box.x, top: exitHintTop ?? box.y + box.height + 6 }}
+        onDone={() => {
+          const view = viewRef.current
+          if (view !== null) commit(view)
+        }}
+        onCancel={cancel}
+        canvasOverlay
+        style={{
+          position: 'absolute',
+          left: box.x,
+          top: exitHintTop ?? box.y + box.height + 6,
+          transform: exitHintScale === undefined ? undefined : `scale(${exitHintScale})`,
+          transformOrigin: 'top left',
+        }}
       />
     </>
   )

--- a/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
+++ b/apps/web/src/components/spatial-editor/SelectionOverlay.tsx
@@ -1,4 +1,5 @@
 /** Selection outline + resize handles + in-flight connect line, drawn in canvas space. */
+import { hasCoarsePointer } from '../../lib/platform.js'
 import type { Box, ResizeHandleKind } from './geometry.js'
 import { cornerHitBoxes, edgeBandBoxes, resizeHandleBoxes } from './geometry.js'
 import type { Point } from './viewport.js'
@@ -100,8 +101,7 @@ export function SelectionOverlay({
   // small nodes are not swallowed, while the transparent hit shapes below
   // meet WCAG 2.5.8's 24px floor — 32px where the pointer is a finger
   // (matchMedia is cheap and correct here; a resize re-render re-reads it).
-  const hitPx =
-    typeof matchMedia !== 'undefined' && matchMedia('(pointer: coarse)').matches ? 32 : 24
+  const hitPx = hasCoarsePointer() ? 32 : 24
   const cornerHits = cornerHitBoxes(box, zoom, hitPx)
   const edgeBands = edgeBandBoxes(box, zoom, hitPx / 2, hitPx)
   const connectHandleSize = 10 / zoom

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -90,6 +90,7 @@ import { writeLastTool } from '@/lib/initial-tool'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
 import { parseClipboardText } from '../../lib/clipboard-fragment.js'
 import { hapticTick } from '../../lib/haptics.js'
+import { hasCoarsePointer } from '../../lib/platform.js'
 import type { BoxMove } from './align.js'
 import {
   CanvasContextMenu,
@@ -1935,7 +1936,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           {pendingCut !== null && (
             <PendingCutChip
               count={pendingCut.snapshot.size}
-              coarse={typeof matchMedia !== 'undefined' && matchMedia('(pointer: coarse)').matches}
+              coarse={hasCoarsePointer()}
               onCancel={() => setPendingCut(null)}
             />
           )}
@@ -2374,6 +2375,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 if (mid === undefined) return null
                 return (
                   <TextNodeEditor
+                    exitHintScale={1 / viewport.zoom}
                     box={{
                       x: mid.x - EDGE_LABEL_EDITOR_WIDTH_PX / 2,
                       y: mid.y - EDGE_LABEL_EDITOR_HEIGHT_PX / 2,
@@ -2402,6 +2404,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 if (group === undefined || group.type !== 'group') return null
                 return (
                   <TextNodeEditor
+                    exitHintScale={1 / viewport.zoom}
                     // The label renders OUTSIDE, above the frame (container
                     // convention) — the editor sits on that band.
                     box={{ x: group.x, y: group.y - 44, width: group.width, height: 40 }}
@@ -2448,6 +2451,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                   })()}
                   initialText={selectedNode.text}
                   exitHintTop={selection.box.y + selection.box.height + 6}
+                  exitHintScale={1 / viewport.zoom}
                   centerContent={scene.nodes.some(
                     (entry) =>
                       entry.kind === 'shape' &&

--- a/apps/web/src/components/spatial-editor/TextNodeEditor.tsx
+++ b/apps/web/src/components/spatial-editor/TextNodeEditor.tsx
@@ -128,12 +128,11 @@ export function TextNodeEditor({
         onDone={commit}
         onCancel={cancel}
         canvasOverlay
-        style={{
-          position: 'absolute',
+        placement={{
           left: box.x,
+          right: box.x + box.width,
           top: box.y + box.height + 6,
-          transform: exitHintScale === undefined ? undefined : `scale(${exitHintScale})`,
-          transformOrigin: 'top left',
+          scale: exitHintScale,
         }}
       />
     </>

--- a/apps/web/src/components/spatial-editor/TextNodeEditor.tsx
+++ b/apps/web/src/components/spatial-editor/TextNodeEditor.tsx
@@ -27,6 +27,12 @@ export interface TextNodeEditorProps {
   /** Overrides the testid for non-node uses (e.g. the edge label editor). */
   readonly testId?: string
   /**
+   * Screen-size correction for the exit strip: the strip is positioned in
+   * canvas coordinates and would otherwise scale with the zoom, and a tap
+   * target has a screen size, not a canvas size. Callers pass `1 / zoom`.
+   */
+  readonly exitHintScale?: number
+  /**
    * Merged over the base style. Callers pass the edited object's own
    * rendered appearance (fill, font, padding) so entering edit mode reads
    * as "the text became editable" rather than a second box appearing —
@@ -45,6 +51,7 @@ export function TextNodeEditor({
   box,
   initialText,
   testId = 'text-node-editor',
+  exitHintScale,
   style,
   onCommit,
   onCancel,
@@ -117,7 +124,18 @@ export function TextNodeEditor({
           }
         }}
       />
-      <EditorExitHint style={{ position: 'absolute', left: box.x, top: box.y + box.height + 6 }} />
+      <EditorExitHint
+        onDone={commit}
+        onCancel={cancel}
+        canvasOverlay
+        style={{
+          position: 'absolute',
+          left: box.x,
+          top: box.y + box.height + 6,
+          transform: exitHintScale === undefined ? undefined : `scale(${exitHintScale})`,
+          transformOrigin: 'top left',
+        }}
+      />
     </>
   )
 }

--- a/apps/web/src/components/spatial-editor/touch-exit-controls.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/touch-exit-controls.browser.test.tsx
@@ -1,0 +1,109 @@
+// On a coarse pointer the exit strip under an editing node is two real
+// buttons. The trap this pins: the editors COMMIT ON BLUR, so a tap that
+// moved focus to the button would commit before the click could cancel —
+// Cancel would silently mean Done. The buttons claim pointerdown so focus
+// never leaves the editor, and the click then routes to the right verb.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { cleanup, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { MarkdownNodeEditor } from './MarkdownNodeEditor.js'
+import { nodeEditorContent } from './node-editor-test-utils.js'
+import { SpatialEditor } from './SpatialEditor.js'
+import { TextNodeEditor } from './TextNodeEditor.js'
+
+const BOX = { x: 20, y: 20, width: 240, height: 80 }
+const realMatchMedia = window.matchMedia
+
+beforeEach(() => {
+  // The runner cannot emulate the media feature, so the query is answered
+  // here; everything else about the pointer stays real.
+  window.matchMedia = (query: string) =>
+    query === '(pointer: coarse)'
+      ? ({ matches: true, media: query } as MediaQueryList)
+      : realMatchMedia.call(window, query)
+})
+
+afterEach(() => {
+  window.matchMedia = realMatchMedia
+  cleanup()
+})
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 60))
+
+it('tapping Cancel on a markdown node editor cancels, and never commits', async () => {
+  const onCommit = vi.fn()
+  const onCancel = vi.fn()
+  render(
+    <MarkdownNodeEditor box={BOX} initialText="hello" onCommit={onCommit} onCancel={onCancel} />,
+  )
+  await vi.waitFor(() => expect(document.activeElement?.closest('.cm-editor')).not.toBeNull())
+
+  await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+  await settle()
+  expect(onCancel).toHaveBeenCalledTimes(1)
+  expect(onCommit).not.toHaveBeenCalled()
+})
+
+it('tapping Done on a markdown node editor commits the text once', async () => {
+  const onCommit = vi.fn()
+  const onCancel = vi.fn()
+  render(
+    <MarkdownNodeEditor box={BOX} initialText="hello" onCommit={onCommit} onCancel={onCancel} />,
+  )
+  await vi.waitFor(() => expect(document.activeElement?.closest('.cm-editor')).not.toBeNull())
+  await userEvent.keyboard(' there')
+
+  await userEvent.click(screen.getByRole('button', { name: 'Done' }))
+  await settle()
+  expect(onCommit).toHaveBeenCalledTimes(1)
+  expect(onCommit).toHaveBeenCalledWith('hello there')
+  expect(onCancel).not.toHaveBeenCalled()
+})
+
+it('tapping Cancel on a plain text editor cancels, and never commits', async () => {
+  const onCommit = vi.fn()
+  const onCancel = vi.fn()
+  render(<TextNodeEditor box={BOX} initialText="label" onCommit={onCommit} onCancel={onCancel} />)
+  await vi.waitFor(() => expect(document.activeElement?.tagName).toBe('TEXTAREA'))
+
+  await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+  await settle()
+  expect(onCancel).toHaveBeenCalledTimes(1)
+  expect(onCommit).not.toHaveBeenCalled()
+})
+
+// Inside the canvas root the trap has a second half: the root refuses
+// native touch and captures the pointer on any press it does not recognise
+// as an overlay's, which retargets the click away from the button. The
+// strip carries `data-editor-overlay` so the root leaves the tap alone —
+// only a full editor mount can see that, which is why this test exists.
+function Host({ start }: { start: SpatialCanvas }) {
+  const [canvas, setCanvas] = useState<SpatialCanvas>(start)
+  return (
+    <div style={{ width: 800, height: 600 }}>
+      <SpatialEditor defaultTool="select" canvas={canvas} onChange={setCanvas} theme="light" />
+    </div>
+  )
+}
+
+it('inside the spatial editor, tapping Cancel drops the draft and closes the editor', async () => {
+  const start: SpatialCanvas = {
+    nodes: [{ id: 'n1', type: 'text', x: 100, y: 100, width: 200, height: 100, text: 'kept' }],
+    edges: [],
+  }
+  const { container } = render(<Host start={start} />)
+  const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+  await userEvent.dblClick(root, { position: { x: 200, y: 150 } })
+  await vi.waitFor(() => expect(nodeEditorContent(container)).not.toBeNull())
+  await userEvent.keyboard(' draft')
+
+  await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+  await vi.waitFor(() => expect(nodeEditorContent(container)).toBeNull())
+  const svgText = [...container.querySelectorAll('svg')]
+    .map((svg) => svg.textContent ?? '')
+    .join(' ')
+  expect(svgText).toContain('kept')
+  expect(svgText).not.toContain('draft')
+})

--- a/apps/web/src/components/spatial-editor/touch-exit-controls.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/touch-exit-controls.browser.test.tsx
@@ -98,6 +98,10 @@ it('inside the spatial editor, tapping Cancel drops the draft and closes the edi
   await userEvent.dblClick(root, { position: { x: 200, y: 150 } })
   await vi.waitFor(() => expect(nodeEditorContent(container)).not.toBeNull())
   await userEvent.keyboard(' draft')
+  // Mirrors node-tools: hangs off the node's bottom-RIGHT corner.
+  const pill = screen.getByTestId('editor-exit-hint').getBoundingClientRect()
+  expect(pill.right - root.getBoundingClientRect().left).toBeCloseTo(300, 0)
+  expect(pill.height).toBeCloseTo(26, 0)
 
   await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
   await vi.waitFor(() => expect(nodeEditorContent(container)).toBeNull())

--- a/apps/web/src/components/spatial-editor/use-keyboard-avoidance.ts
+++ b/apps/web/src/components/spatial-editor/use-keyboard-avoidance.ts
@@ -15,10 +15,10 @@ import { panToShowTarget } from './viewport.js'
 /**
  * Screen px kept visible below the edited node's box, so the exit strip
  * rendered just under it rises above the keyboard too. Sized for the strip's
- * touch form — the 44px Done/Cancel buttons a phone shows, plus their gap —
- * since a phone is where a keyboard occludes anything at all.
+ * touch form — the 24px ✓/✕ pill a phone shows, its 6px gap, and the pill's
+ * widened tap band — since a phone is where a keyboard occludes anything.
  */
-export const EXIT_HINT_ALLOWANCE_PX = 56
+export const EXIT_HINT_ALLOWANCE_PX = 40
 
 /**
  * How many px of the root's bottom the on-screen keyboard covers. Client

--- a/apps/web/src/components/spatial-editor/use-keyboard-avoidance.ts
+++ b/apps/web/src/components/spatial-editor/use-keyboard-avoidance.ts
@@ -13,10 +13,12 @@ import type { BBoxLike, ContainerSize, Viewport } from './viewport.js'
 import { panToShowTarget } from './viewport.js'
 
 /**
- * Screen px kept visible below the edited node's box, so the exit hint
- * ("⌘↩ to finish") rendered just under it rises above the keyboard too.
+ * Screen px kept visible below the edited node's box, so the exit strip
+ * rendered just under it rises above the keyboard too. Sized for the strip's
+ * touch form — the 44px Done/Cancel buttons a phone shows, plus their gap —
+ * since a phone is where a keyboard occludes anything at all.
  */
-export const EXIT_HINT_ALLOWANCE_PX = 36
+export const EXIT_HINT_ALLOWANCE_PX = 56
 
 /**
  * How many px of the root's bottom the on-screen keyboard covers. Client

--- a/apps/web/src/lib/platform.ts
+++ b/apps/web/src/lib/platform.ts
@@ -11,3 +11,15 @@
 export function isMacPlatform(): boolean {
   return typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform)
 }
+
+/**
+ * Whether the primary pointer is a finger. One definition for every surface
+ * that grows a touch target or swaps a keyboard chord for a tap — the two
+ * inline `matchMedia` reads this replaced were already identical, and a
+ * third would have drifted. Read at call time so a test can stub
+ * `matchMedia`; a runtime without it (jsdom) answers false, the fine-pointer
+ * default.
+ */
+export function hasCoarsePointer(): boolean {
+  return typeof matchMedia !== 'undefined' && matchMedia('(pointer: coarse)').matches
+}


### PR DESCRIPTION
# Summary

A phone cannot press `⌘↩` or `esc`, yet the strip under a node being edited (and the full-screen node editor's header) named exactly those chords — the one keyboard a phone has is the software one, which offers no Escape at all. The web platform cannot extend that keyboard (no accessory rows, no custom keys), so this lands the two things it can do:

- **Tappable exit controls on a coarse pointer.** `EditorExitHint` gains `onDone` / `onCancel`; when `(pointer: coarse)` matches it renders a ✓ / ✕ icon pill in the **node-tools language** — the same 24px slots, 6px radius, background fill, border edge, muted 1.5px glyphs and no shadow as the (↗ | …) cluster on the node's top-right, hung off the node's bottom-right corner as its mirror. No words on screen (the app's non-verbal iconography, per user direction); the verbs live in the accessible names. The 24px slots are under the touch floor, so each button widens its hit band with a pseudo-element instead of growing. Fine pointers are untouched.
  - The editors **commit on blur**, so a tap that moved focus to the button would commit before the click could cancel — Cancel would silently mean Done. The buttons cancel `pointerdown` to keep focus in the editor; mutation-checked (dropping the `preventDefault` turns exactly the two Cancel tests red).
  - Inside the spatial canvas root the strip carries `data-editor-overlay`, the root's existing opt-out: the root refuses native `touchstart` and pointer-captures every unmarked press, either of which stops a tap from ever becoming a click. This was invisible to the component-level test and found only in the running app under mobile emulation, so a full-`SpatialEditor` browser test now pins it (removing the marker turns it red). The full-screen header must NOT carry the marker — that overlay's Escape handler treats any marked element as an open popup.
  - Placement lives in `EditorExitHint` (`placement: { left, right, top, scale }`): the decorative strip left-aligns, the pill right-aligns and scales about its anchored corner by `1 / zoom`, since a tap target has a screen size, not a canvas size. `EXIT_HINT_ALLOWANCE_PX` is sized to the pill band so keyboard avoidance (#1225) keeps it above the keyboard.
- **`enterkeyhint`** — the one software-keyboard extension point the web has — on single-line inputs whose Enter finishes the edit: `done` on the document title, branch rename, workspace URL and new-workspace name; `go` on the daemon port check and the link picker.
- `hasCoarsePointer()` in `lib/platform.ts` replaces the two identical inline `matchMedia('(pointer: coarse)')` reads (SelectionOverlay, PendingCutChip) so a third copy could not drift.

UX direction (user decision): tappable exit controls first; a keyboard-docked accessory bar (Done/Cancel + formatting) is the named follow-up.

# Test plan

- `EditorExitHint.test.tsx` (web-jsdom): coarse + handlers → two icon buttons (accessible names Done/Cancel, no visible text, no `<kbd>`) routing to the handlers, `pointerdown` default-prevented; coarse without handlers and fine pointer → decorative strip unchanged.
- `touch-exit-controls.browser.test.tsx` (web-browser, real Chromium, `matchMedia` answered coarse): MarkdownNodeEditor Cancel → `onCancel` once and `onCommit` never; Done → commits the typed text once; TextNodeEditor Cancel likewise; full `SpatialEditor` mount → the pill's right edge sits on the node's right edge at node-tools height, and Cancel drops the draft and closes the editor.
- `DocumentProperties.test.tsx`: `enterkeyhint="done"` on the title field.
- Existing suites watching the touched code stay green: MarkdownNodeEditor / TextNodeEditor / SelectionOverlay (matchMedia-mocking) / NodeTextEditorOverlay / keyboard-avoidance (derives its expectation from the allowance constant) / text-edit-experience / shaped-node-editing / style-parity.
- Real app under Playwright mobile emulation (`isMobile` + `hasTouch`, so `(pointer: coarse)` matches natively): real `tap()` on ✕ closes the editor with the draft dropped; `tap()` on ✓ commits — the run that exposed the root-level touch suppression. On-device check by the author on a Pixel (dark theme) drove the resize to node-tools proportions.
- `pnpm check:local` gates, `pnpm test` (full suite green before each push), `pnpm --filter @kamiazya/whiteboard-web typecheck` green locally (the only local-only failure is the known `compose-figure` ImageMagick gap CI's `check` covers).

# Visual evidence

Same node, entering edit mode under mobile emulation (390×844): before, the kbd strip a phone cannot act on; after, the ✓ / ✕ pill mirroring node-tools at the node's bottom-right.

Visual evidence: none attached — this remote session has no image-upload path to GitHub (no `gh` CLI; the GitHub MCP surface has no asset upload). The before/after figure was rendered through the real app under Chromium mobile emulation and delivered to the author in-session (`tmp/screenshots/touch-exit-figure.png`): before, `Ctrl+↩ Done · esc Cancel` as a 14px kbd strip under the node; after, a 51×26px ✓ / ✕ pill right-aligned under the node, matching the node-tools cluster above it.

# Checklist

- [x] Nearest-layer automated test for the root cause (jsdom + browser, incl. the blur trap and the canvas-root marker)
- [x] Manual verification in a running app (mobile emulation, real taps) and on the author's device
- [x] Scenario preserved in `web-browser` regression coverage
- [x] `pnpm test` / `pnpm check:local`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added touch-friendly Done and Cancel buttons when editing on touch devices.
  * Cancel preserves editor focus and prevents unintended commits; Done commits edits.
  * Improved exit-hint positioning and scaling across zoom levels.
  * Added mobile keyboard action hints, including Done and Go, to relevant inputs.
  * Improved touch target sizing and keyboard avoidance for spatial editing.

* **Bug Fixes**
  * Fixed touch interactions so Cancel reliably discards edits without committing on blur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->