### PR TITLE
refactor(server): complete the ADR-0018 scheduled burn-down - ws.ts goes seam-only

### DIFF
--- a/.claude/rules/tool-arch-lint.md
+++ b/.claude/rules/tool-arch-lint.md
@@ -72,7 +72,7 @@ further down.
 
 **`ADAPTERS_REACHING_MECHANICS`** records the edges that exist today.
 
-**`ADAPTERS_REACHING_MECHANICS_CEILING` pins the count by equality — 25 today.**
+**`ADAPTERS_REACHING_MECHANICS_CEILING` pins the count by equality — 21 today.**
 It exists because the two both-sides guards reject a fabricated entry and a
 stale one and have nothing to say about a real new edge added along with its
 allowlist line, which is the ordinary way a list grows. Measured: a genuine
@@ -81,10 +81,11 @@ assertions, and the list went 37 -> 36 -> 35 -> 36 -> 40 in a week while the
 rule and the test's own comment both said it could only shrink. Adding an edge
 now fails until someone raises the ceiling deliberately, and paying one off
 fails until someone lowers it. ADR-0018 is **Accepted** (2026-08-31) and
-carries the burn-down order; `restore.ts`, `live-doc.ts` and
-`workspace-document.ts` are paid off (their operations live in server-core
-behind the `LiveDocuments`/`WorkspaceDocuments` seams), and the one
-remaining scheduled adapter (`ws.ts`) holds 4 of the 25.
+carried the burn-down order, and that scheduled burn-down is **COMPLETE**
+(2026-09-02): `restore.ts`, `live-doc.ts`, `workspace-document.ts` and
+`ws.ts` are all translation-only over the `LiveDocuments` /
+`WorkspaceDocuments` seams. The 21 edges left belong to the unscheduled
+adapters; paying one off still lowers the ceiling the same way.
 
 `corrupt-stored-data` is excluded and says why: an error taxonomy an adapter
 reads to pick a status code is translation, which is an adapter's job, and

--- a/docs/contributing/adr/0018-operation-vs-mechanic.md
+++ b/docs/contributing/adr/0018-operation-vs-mechanic.md
@@ -193,6 +193,22 @@ The remaining 22 edges across 13 adapters are mostly one or two apiece and
 are not scheduled here. They come along with whatever work next opens those
 files, under the standing "fix what you touch" rule.
 
+> **2026-09-02 — the scheduled burn-down is complete.** The four adapters
+> above landed one PR apiece in the listed order (restore.ts, live-doc.ts,
+> workspace-document.ts, ws.ts), each lowering the ceiling in the commit
+> that removed its edges: 37 → 33 → 29 → 25 → 21. Their operations live in
+> server-core (`restore-version`, `apply-document-update`,
+> `apply-workspace-document-update`) behind the `LiveDocuments` and
+> `WorkspaceDocuments` seams; ws.ts's update funnel became
+> `WorkspaceDocuments.onUpdated`, installed per transport by each
+> transport's own entry point. One count above was stale when written:
+> restore.ts held 4 edges, not 5, so the four adapters held 16 of the 39.
+> The "no MCP twin yet" premise also deserves a correction rather than a
+> rewrite: `wb_version_restore` existed, but restores the in-document Loro
+> versions map — a separate history system from the file-backed store
+> restore.ts wraps — so the second-surface argument stood, with the twin
+> still to come.
+
 **What would make raising the ceiling right.** It is a decision, not a
 failure: an operation that genuinely belongs to this deployment, or a fix
 that cannot wait for the move. The requirement is only that the PR says which

--- a/packages/mcp-server/src/di/container.ts
+++ b/packages/mcp-server/src/di/container.ts
@@ -7,7 +7,6 @@ import {
 import type { ServerDeps } from '@kamiazya/whiteboard-server-core'
 import type { LoroWorkspaceDocumentIndex } from '@kamiazya/whiteboard-workspace-index'
 import { Container, type ContainerModule } from 'inversify'
-import { createCanvasClientNotifier } from '../server/canvas-client-notifier.js'
 import { createOpentypeMeasureText } from '../server/export/measure-text.js'
 import { resolveSearchEmbedder } from '../server/search/search-embedder.js'
 import { documentTeardown } from '../server/store/document-store.js'
@@ -68,10 +67,14 @@ export function resolveServerDeps(container: Container): ServerDeps {
     // line lands. Memoized inside the measurer, so this reference costs
     // nothing until a render actually asks for it.
     measure: createOpentypeMeasureText,
-    // Wired here rather than bound as a port: it is a bridge onto this
-    // package's own WebSocket routes, not an interchangeable implementation
-    // anyone would swap.
-    clientNotifier: createCanvasClientNotifier(documentIndex),
+    // clientNotifier is deliberately NOT wired here. It is a bridge onto
+    // this package's own WebSocket routes, and importing those from the di
+    // graph closes a value cycle (di -> canvas-client-notifier -> ws.ts ->
+    // di, now that the routes resolve their deps through
+    // getDefaultServerDeps). The field is optional by design — "absent
+    // means nobody is told anything" — so the two roots with a live-socket
+    // audience (http-server.ts, mcp/index.ts) attach it themselves, and the
+    // route-fallback deps correctly carry none.
     // undefined unless the user opted in, and even then the model loads on
     // the first search rather than here — a daemon that starts must not pay
     // a model download before it can answer anything.

--- a/packages/mcp-server/src/server/http-server.ts
+++ b/packages/mcp-server/src/server/http-server.ts
@@ -3,6 +3,7 @@ import { accessSync, existsSync, constants as fsConstants } from 'node:fs'
 import type { Socket } from 'node:net'
 import { join } from 'node:path'
 import { serve } from '@hono/node-server'
+import type { ServerDeps } from '@kamiazya/whiteboard-server-core'
 import { WebSocketServer } from 'ws'
 import { IdleTimer } from '../daemon/idle-timer.js'
 import { createContainer, resolveServerDeps } from '../di/container.js'
@@ -13,6 +14,7 @@ import { WHITEBOARD_WS_PROTOCOL } from '../shared/ws-protocol.js'
 import { createApp } from './app.js'
 import { startBackgroundWork } from './background-work.js'
 import { LOOP_COSTS } from './background-work-costs.js'
+import { createCanvasClientNotifier } from './canvas-client-notifier.js'
 import { DIST_WEB_APP_DIR, getDataDir } from './config.js'
 import { ensureWorkspaceId } from './current-workspace.js'
 import { buildDaemonBaseUrl, normalizeBindHost } from './daemon-auth-binding.js'
@@ -20,6 +22,7 @@ import { getLogger } from './log.js'
 import {
   getConnectionStats,
   handleWsUpgrade,
+  installWsUpdateFanout,
   setRuntimeTouchFn,
   subscribedWorkspaceIds,
 } from './routes/ws.js'
@@ -280,9 +283,21 @@ export async function startHttpServer(options: StartHttpServerOptions): Promise<
   // a state the document browser can select out of. Memoized per data dir, so
   // the per-request MCP callers below share this one resolve.
   await ensureWorkspaceId(dataDir)
-  const serverDeps = resolveServerDeps(
+  const resolvedDeps = resolveServerDeps(
     createContainer(createStoreLocalModule({ db: await getDb(dataDir), blobDir: dataDir })),
   )
+  // The WS-route bridge is attached HERE, not in resolveServerDeps: the di
+  // graph must not import the routes layer (value cycle), and this root is
+  // one of the two places a live-socket audience exists.
+  const serverDeps: ServerDeps = {
+    ...resolvedDeps,
+    clientNotifier: createCanvasClientNotifier(resolvedDeps.documentIndex),
+  }
+  // Eagerly, not only per-upgrade: an SSE-only audience (or a workspace-tail
+  // record arriving before any socket) must reach connected ws clients the
+  // moment the first one appears — and the ws fan-out listener costs nothing
+  // while nobody is connected.
+  installWsUpdateFanout(serverDeps)
 
   const app = createApp({
     authMode: 'local-daemon',
@@ -426,7 +441,7 @@ export async function startHttpServer(options: StartHttpServerOptions): Promise<
     }
     touch()
     wss.handleUpgrade(req, socket, head, (ws) => {
-      void handleWsUpgrade(req, ws, decision.scopes)
+      void handleWsUpgrade(req, ws, decision.scopes, serverDeps)
     })
   })
 

--- a/packages/mcp-server/src/server/mcp/index.ts
+++ b/packages/mcp-server/src/server/mcp/index.ts
@@ -5,6 +5,7 @@ import { z } from 'zod'
 import { createContainer, resolveServerDeps } from '../../di/container.js'
 import { createStoreLocalModule } from '../../di/store-local.module.js'
 import { PACKAGE_VERSION } from '../../shared/package-version.js'
+import { createCanvasClientNotifier } from '../canvas-client-notifier.js'
 import { getDataDir } from '../config.js'
 import { ensureWorkspaceId } from '../current-workspace.js'
 import { isDirectEntryPoint } from '../entrypoint.js'
@@ -113,7 +114,15 @@ export async function createMcpServer(options: CreateMcpServerOptions = {}) {
   const dataDir = getDataDir()
   const db = await getDb(dataDir)
   const container = createContainer(createStoreLocalModule({ db, blobDir: dataDir }))
-  registerDocumentTools(server, resolveServerDeps(container))
+  const deps = resolveServerDeps(container)
+  // The WS-route bridge is attached at the roots rather than in
+  // resolveServerDeps (the di graph must not import the routes layer); this
+  // stdio root serves the same daemon process, so its tools notify the same
+  // sockets the HTTP root serves.
+  registerDocumentTools(server, {
+    ...deps,
+    clientNotifier: createCanvasClientNotifier(deps.documentIndex),
+  })
 
   return server
 }

--- a/packages/mcp-server/src/server/routes/sync-sse.ts
+++ b/packages/mcp-server/src/server/routes/sync-sse.ts
@@ -147,10 +147,35 @@ export function resetSyncStreamsForTests(): void {
   streams.clear()
 }
 
+// This transport's own funnel subscription, installed by its own entry
+// point (stream-open) — an SSE-only audience must hear persisted updates
+// whether or not a websocket ever connected (ws.ts installs its own; see
+// installWsUpdateFanout). Subscribed through the WorkspaceDocuments seam
+// (ADR-0018) via the same wiring production resolves; memoized as a promise
+// so concurrent first opens install once, and a failed resolve retries on
+// the next open instead of poisoning the flag.
+let sseFanoutInstall: Promise<void> | null = null
+function ensureSseUpdateFanout(): Promise<void> {
+  sseFanoutInstall ??= (async () => {
+    // Dynamic for the same value-cycle reason ws.ts gives: the di wiring's
+    // import chain reaches back into the routes through canvas-client-notifier.
+    const { getDefaultServerDeps } = await import('../../di/default-server-deps.js')
+    const deps = await getDefaultServerDeps()
+    deps.workspaceDocuments.onUpdated((workspaceId, update) => {
+      sseBroadcastWorkspaceUpdate(workspaceId, update)
+    })
+  })().catch((err: unknown) => {
+    sseFanoutInstall = null
+    throw err
+  })
+  return sseFanoutInstall
+}
+
 export function createSyncSseRouter() {
   const app = new Hono()
 
-  app.get('/api/sync/stream', (c) => {
+  app.get('/api/sync/stream', async (c) => {
+    await ensureSseUpdateFanout()
     // The id is minted here and never accepted from the caller. A client-chosen
     // key into a server-side registry lets one client name another's stream —
     // displacing it on open, or adding and removing that client's

--- a/packages/mcp-server/src/server/routes/ws-seam.test.ts
+++ b/packages/mcp-server/src/server/routes/ws-seam.test.ts
@@ -1,0 +1,151 @@
+/**
+ * The ws routes operate through the ServerDeps they were given — the fourth
+ * instance of the optional-deps-going-unread bug class (data-dir-seam,
+ * handle-resolution-seam, live-doc-seam, workspace-document-seam precede
+ * it): an optional `deps` parameter that nothing reads compiles clean and
+ * passes every fallback-path test. The recorder on the INJECTED deps is the
+ * discriminator, because going around the seam persists the same bytes.
+ */
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+import { LoroDoc } from 'loro-crdt'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+
+let tempDir: string
+
+vi.mock('../config.js', () => ({
+  get DATA_DIR() {
+    return tempDir
+  },
+  getDataDir: () => tempDir,
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+  REPO_ROOT: '/tmp',
+}))
+
+const { clearCache } = await import('../store/doc-cache.js')
+const { saveDocument, _clearWorkspaceDocCacheForTests } = await import('../store/document-store.js')
+const { getDefaultServerDeps } = await import('../../di/default-server-deps.js')
+const { handleWsUpgrade } = await import('./ws.js')
+const { createIsolatedDb } = await import('../store/db/test-helpers.js')
+
+let handle: Awaited<ReturnType<typeof createIsolatedDb>>
+
+class FakeWebSocket {
+  sent: Array<string | Uint8Array> = []
+  closes: Array<{ code?: number; reason?: string }> = []
+  private listeners = new Map<string, Array<(...args: unknown[]) => void>>()
+
+  send(data: string | Uint8Array | ArrayBuffer): void {
+    this.sent.push(typeof data === 'string' ? data : new Uint8Array(data as ArrayBuffer))
+  }
+  on(event: string, handler: (...args: unknown[]) => void): void {
+    const handlers = this.listeners.get(event) ?? []
+    handlers.push(handler)
+    this.listeners.set(event, handlers)
+  }
+  close(code?: number, reason?: string): void {
+    this.closes.push({ code, reason })
+  }
+  async emitMessage(data: Buffer, isBinary: boolean): Promise<void> {
+    for (const handler of this.listeners.get('message') ?? []) {
+      await handler(data, isBinary)
+    }
+  }
+}
+
+function canvasDoc(ids: string[]): LoroDoc {
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, {
+    nodes: ids.map((id) => ({ id, type: 'text', text: id, x: 0, y: 0, width: 10, height: 10 })),
+    edges: [],
+  })
+  return doc
+}
+
+function updateFrame(): Buffer {
+  const doc = new LoroDoc()
+  const vv0 = doc.version()
+  writeSpatialCanvas(doc, {
+    nodes: [{ id: 'n-seam', type: 'text', text: 'seam', x: 0, y: 0, width: 10, height: 10 }],
+    edges: [],
+  })
+  return Buffer.from(doc.export({ mode: 'update', from: vv0 }))
+}
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'ws-seam-test-'))
+  handle = await createIsolatedDb({ dataDir: tempDir })
+  clearCache()
+  _clearWorkspaceDocCacheForTests()
+  await saveDocument('session1', 'c', canvasDoc(['n-a']), { kind: 'spatial' })
+})
+afterEach(async () => {
+  await handle.dispose()
+  await rm(tempDir, { recursive: true, force: true })
+  clearCache()
+  _clearWorkspaceDocCacheForTests()
+})
+
+it('a binary frame reads and writes through the INJECTED workspaceDocuments', async () => {
+  const deps = await getDefaultServerDeps()
+  const recorded: string[] = []
+  const real = deps.workspaceDocuments
+  deps.workspaceDocuments = {
+    ...real,
+    get: async (workspaceId) => {
+      recorded.push(`get ${workspaceId}`)
+      return real.get(workspaceId)
+    },
+    save: async (workspaceId, doc) => {
+      recorded.push(`save ${workspaceId}`)
+      return real.save(workspaceId, doc)
+    },
+  }
+
+  const ws = new FakeWebSocket()
+  await handleWsUpgrade(
+    { url: '/ws/session1/c', headers: { host: 'localhost:3099' } } as never,
+    ws as never,
+    undefined,
+    deps,
+  )
+  const baseline = recorded.length
+  await ws.emitMessage(updateFrame(), true)
+
+  expect(ws.closes).toEqual([])
+  expect(recorded.slice(baseline)).toEqual(['get session1', 'save session1'])
+})
+
+it('a persist failure lands its 1011 recovery on the INJECTED evictions', async () => {
+  const deps = await getDefaultServerDeps()
+  const recorded: string[] = []
+  const real = deps.workspaceDocuments
+  deps.workspaceDocuments = {
+    ...real,
+    save: async () => {
+      throw new Error('injected persist failure')
+    },
+    evictProjections: (workspaceId) => {
+      recorded.push(`evictProjections ${workspaceId}`)
+      real.evictProjections(workspaceId)
+    },
+    evict: (workspaceId) => {
+      recorded.push(`evict ${workspaceId}`)
+      real.evict(workspaceId)
+    },
+  }
+
+  const ws = new FakeWebSocket()
+  await handleWsUpgrade(
+    { url: '/ws/session1/c', headers: { host: 'localhost:3099' } } as never,
+    ws as never,
+    undefined,
+    deps,
+  )
+  await ws.emitMessage(updateFrame(), true)
+
+  expect(recorded).toEqual(['evictProjections session1', 'evict session1'])
+  expect(ws.closes).toEqual([{ code: 1011, reason: 'Failed to persist canvas update' }])
+})

--- a/packages/mcp-server/src/server/routes/ws.ts
+++ b/packages/mcp-server/src/server/routes/ws.ts
@@ -1,7 +1,9 @@
 import type { IncomingMessage } from 'node:http'
+import { applyWorkspaceDocumentUpdate, type ServerDeps } from '@kamiazya/whiteboard-server-core'
 import { SpanKind } from '@opentelemetry/api'
 import type { LoroDoc } from 'loro-crdt'
 import type { RawData, WebSocket } from 'ws'
+import type { VersionEntry } from '../../shared/api-contracts/document.js'
 import type { AgentActivityMessage, ServerTextMessage } from '../../shared/ws-messages.js'
 import { getLogger } from '../log.js'
 import { extractContextFromHeaders, getTracer } from '../observability/tracing.js'
@@ -11,24 +13,8 @@ import {
   requiredScopesForClientTextMessage,
   WS_BINARY_UPDATE_REQUIRED_SCOPES,
 } from '../security/ws-scope-registry.js'
-import { evictWorkspaceDocs } from '../store/doc-cache.js'
-import {
-  evictWorkspaceDocCache,
-  getDoc,
-  getWorkspaceDoc,
-  onWorkspaceDocUpdated,
-  saveWorkspaceDoc,
-  workspaceExists,
-} from '../store/document-store.js'
-import type { VersionEntry } from '../store/version-store.js'
-import { withWorkspaceWriteLock } from '../store/workspace-lock.js'
 import { resolveWorkspaceHandleToId } from '../workspace-handle.js'
-import {
-  setSyncSseHooks,
-  sseBroadcastText,
-  sseBroadcastTextToReady,
-  sseBroadcastWorkspaceUpdate,
-} from './sync-sse.js'
+import { setSyncSseHooks, sseBroadcastText, sseBroadcastTextToReady } from './sync-sse.js'
 import { parseWsClientTextMessage, parseWsTargetFromRequestUrl } from './ws-validation.js'
 
 // Connection registry: key = "workspaceId/path", value = Set<WebSocket>.
@@ -64,15 +50,24 @@ export function subscribedWorkspaceIds(): string[] {
 // save, a delete/rename, a restore — lands here once, with the exact bytes
 // the store persisted. No sender exclusion: a sender importing its own ops
 // back is a no-op by CRDT semantics.
-onWorkspaceDocUpdated((workspaceId, update) => {
-  const clients = workspaceConnections.get(workspaceId)
-  if (clients) {
-    for (const ws of clients) ws.send(update)
-  }
-  // The SSE transport is the same audience over a different pipe: a stream
-  // subscribed at workspace granularity gets the same persisted bytes.
-  sseBroadcastWorkspaceUpdate(workspaceId, update)
-})
+//
+// Subscribed through the WorkspaceDocuments seam rather than a store import
+// (ADR-0018), and installed by this transport's own entry points — every
+// upgrade, plus http-server at boot — because a subscription is only owed
+// where an audience can exist. The SSE transport installs its own (see
+// sync-sse.ts); each transport's fan-out is a property of its own call path
+// rather than of whichever one happened to load first.
+let wsFanoutInstalled = false
+export function installWsUpdateFanout(deps: ServerDeps): void {
+  if (wsFanoutInstalled) return
+  wsFanoutInstalled = true
+  deps.workspaceDocuments.onUpdated((workspaceId, update) => {
+    const clients = workspaceConnections.get(workspaceId)
+    if (clients) {
+      for (const ws of clients) ws.send(update)
+    }
+  })
+}
 
 // Sticky viewport state per canvas. The MCP `viewport_set` tool only fires the
 // `viewport_request` once and broadcasts to whoever is connected at that
@@ -258,6 +253,10 @@ export async function handleWsUpgrade(
   req: IncomingMessage,
   ws: WebSocket,
   scopes: readonly AuthScope[] = ALL_AUTH_SCOPES,
+  // The seams the connection reads and writes through. Production passes
+  // the deps http-server built; omitted, the same wiring resolves via
+  // getDefaultServerDeps.
+  deps?: ServerDeps,
 ): Promise<void> {
   let workspaceId = ''
   let path = ''
@@ -277,6 +276,13 @@ export async function handleWsUpgrade(
   // silent.
   workspaceId = await resolveWorkspaceHandleToId(workspaceId)
 
+  // Dynamic for the same reason document.ts imports ws.js dynamically: the
+  // di wiring's import chain reaches back into this module through
+  // canvas-client-notifier, and a static edge here closes a value cycle.
+  const resolvedDeps =
+    deps ?? (await (await import('../../di/default-server-deps.js')).getDefaultServerDeps())
+  installWsUpdateFanout(resolvedDeps)
+
   const key = `${workspaceId}/${path}`
 
   // Before anything is registered or served: a workspace this daemon has
@@ -290,7 +296,7 @@ export async function handleWsUpgrade(
   // keeps the lazy empty doc, which is how opening a just-deleted canvas
   // degrades. 4404 because RFC 6455 reserves 4000-4999 for application use
   // and no registered close code means "not found".
-  if (!(await workspaceExists(workspaceId))) {
+  if (!(await resolvedDeps.workspaceDocuments.exists(workspaceId))) {
     ws.close(4404, `Workspace "${workspaceId}" not found`)
     return
   }
@@ -309,7 +315,7 @@ export async function handleWsUpgrade(
 
   // On connect, send the workspace document's snapshot as binary for the
   // initial load. Every socket rides the workspace lineage.
-  const workspaceDoc = await getWorkspaceDoc(workspaceId)
+  const workspaceDoc = await resolvedDeps.workspaceDocuments.get(workspaceId)
   ws.send(workspaceDoc.export({ mode: 'snapshot' }))
 
   // Holds the most recent W3C trace-context the client announced via
@@ -426,43 +432,42 @@ export async function handleWsUpgrade(
       : getTracer('whiteboard.ws').startSpan('ws.message.binary', spanStartOptions)
     try {
       // Import into the live workspace document under the same lock every
-      // other mutation path holds. Fan-out to subscribers happens inside
-      // saveWorkspaceDoc's listener, with the exact persisted bytes.
-      const persisted = await withWorkspaceWriteLock(workspaceId, async () => {
-        const workspaceDoc = await getWorkspaceDoc(workspaceId)
-        // A second (or later) frame's handler can pass the `isClosing` check
-        // above before this frame's await resolves — both were still false
-        // at the top when they started. Recheck after the await so a frame
-        // that lost that race does not import, persist, or close a socket
-        // the earlier frame already tore down.
-        if (isClosing) return false
-        // `LoroDoc.import` throws synchronously (loro-crdt's wasm layer may
-        // throw a non-Error value) whenever the bytes are not a valid Loro
-        // update/snapshot. A write-scope credential is real authorization to
-        // send edits, not a guarantee the bytes are well-formed CRDT data, so
-        // this boundary must not be able to crash the daemon on one bad
-        // frame. Treat it as a protocol violation: discard the frame, never
-        // persist or broadcast it, and close 1003 (Unsupported Data) — the
-        // socket was authorized, only this frame's payload was not decodable.
-        try {
-          workspaceDoc.import(bytes)
-        } catch (err: unknown) {
-          getLogger('ws').warning(
-            { workspaceId, path, updateBytes: bytes.byteLength, err },
-            'ws binary update rejected: malformed Loro import data',
-          )
-          closeSocket(1003, 'Malformed workspace update')
-          return false
-        }
-        await saveWorkspaceDoc(workspaceId, workspaceDoc)
-        // Every cached per-document projection of this workspace is now
-        // stale; a stale one would diff old content back over this import
-        // on its next save. Dropped inside the lock so no reader grabs a
-        // stale projection between the import and the eviction.
-        evictWorkspaceDocs(workspaceId)
-        return true
-      })
-      if (!persisted) return
+      // other mutation path holds — the operation owns the lock, the
+      // import, the persist and the projection eviction (ADR-0018); this
+      // surface supplies only what is socket-shaped:
+      //
+      // abortIf: a second (or later) frame's handler can pass the
+      // `isClosing` check above before this frame's await resolves — both
+      // were still false at the top when they started. Rechecked inside the
+      // lock so a frame that lost that race does not import, persist, or
+      // close a socket the earlier frame already tore down.
+      //
+      // onMalformed: a write-scope credential is real authorization to send
+      // edits, not a guarantee the bytes are well-formed CRDT data, so this
+      // boundary must not crash the daemon on one bad frame. Close 1003
+      // (Unsupported Data) INSIDE the lock — the socket was authorized,
+      // only this frame's payload was not decodable, and closing while the
+      // lock still excludes other writers stops a queued valid frame from
+      // persisting onto a closing socket.
+      const result = await applyWorkspaceDocumentUpdate(
+        resolvedDeps,
+        { workspaceId, update: bytes },
+        {
+          abortIf: () => isClosing,
+          onMalformed: () => {
+            // The socket-shaped half of the refusal: the operation logged the
+            // seam-level rejection, but only this surface knows the PATH the
+            // socket is registered under, and only it may close. Never log
+            // the frame bytes themselves.
+            getLogger('ws').warning(
+              { workspaceId, path, updateBytes: bytes.byteLength },
+              'ws binary update rejected: malformed Loro import data',
+            )
+            closeSocket(1003, 'Malformed workspace update')
+          },
+        },
+      )
+      if (result !== 'applied') return
       // Isolated in its own try/catch: this hook exists only so tests can
       // await a deterministic "persisted" signal instead of polling. A
       // callback throwing must never be able to make an already-successful
@@ -476,7 +481,8 @@ export async function handleWsUpgrade(
         )
       }
       // Auto-version for the socket's own path over the fresh projection.
-      getDoc(workspaceId, path)
+      resolvedDeps.liveDocuments
+        .get(workspaceId, path)
         .then((doc) => autoVersionTrigger(workspaceId, path, doc))
         .then((entry) => {
           if (entry) sendVersionCreated(workspaceId, path, entry)
@@ -494,8 +500,8 @@ export async function handleWsUpgrade(
       // (Internal Error) so the client reconnects and resyncs from the
       // persisted state instead.
       getLogger('ws').error({ workspaceId, path, err }, 'ws binary update failed')
-      evictWorkspaceDocs(workspaceId)
-      evictWorkspaceDocCache(workspaceId)
+      resolvedDeps.workspaceDocuments.evictProjections(workspaceId)
+      resolvedDeps.workspaceDocuments.evict(workspaceId)
       closeSocket(1011, 'Failed to persist canvas update')
     } finally {
       wsSpan.end()

--- a/packages/mcp-server/src/server/store/live-documents.ts
+++ b/packages/mcp-server/src/server/store/live-documents.ts
@@ -5,10 +5,12 @@ import {
   ConflictError,
   deleteDocument,
   documentExists,
+  evictWorkspaceDocCache,
   getDoc,
   getDocumentKind,
   getWorkspaceDoc,
   listDocuments,
+  onWorkspaceDocUpdated,
   renameDocumentPath,
   saveDocument,
   saveWorkspaceDoc,
@@ -66,5 +68,7 @@ export function workspaceDocuments(): WorkspaceDocuments {
       await saveWorkspaceDoc(workspaceId, doc)
     },
     evictProjections: evictWorkspaceDocs,
+    evict: evictWorkspaceDocCache,
+    onUpdated: onWorkspaceDocUpdated,
   }
 }

--- a/packages/server-core/src/operations/apply-workspace-document-update.test.ts
+++ b/packages/server-core/src/operations/apply-workspace-document-update.test.ts
@@ -104,4 +104,56 @@ describe('applyWorkspaceDocumentUpdate', () => {
     expect(fake.wasSaved()).toBe(false)
     expect(fake.wasEvicted()).toBe(false)
   })
+
+  it('abortIf is consulted INSIDE the lock after the read, and aborted saves nothing', async () => {
+    const fake = fakes()
+    let observedInsideLock: boolean | null = null
+    const result = await applyWorkspaceDocumentUpdate(
+      { liveDocuments: fake.live, workspaceDocuments: fake.workspaceDocuments },
+      { workspaceId: WS, update: workspaceUpdateBytes('canvas-a') },
+      {
+        abortIf: () => {
+          // The frame-race guard only means anything inside the hold: a
+          // check taken before acquisition is the race it exists to close.
+          observedInsideLock = fake.calls.some((c) => c.method === 'get' && c.lockDepth === 1)
+          return true
+        },
+      },
+    )
+    expect(result).toBe('aborted')
+    expect(observedInsideLock).toBe(true)
+    expect(fake.wasSaved()).toBe(false)
+    expect(fake.wasEvicted()).toBe(false)
+  })
+
+  it('onMalformed fires INSIDE the lock before malformed-update returns', async () => {
+    const fake = fakes()
+    let malformedLockDepth: number | null = null
+    let lockDepthProbe = 0
+    const live = {
+      ...fake.live,
+      async withWriteLock<T>(workspaceId: string, fn: () => Promise<T>): Promise<T> {
+        lockDepthProbe += 1
+        try {
+          return await fake.live.withWriteLock(workspaceId, fn)
+        } finally {
+          lockDepthProbe -= 1
+        }
+      },
+    }
+    const result = await applyWorkspaceDocumentUpdate(
+      { liveDocuments: live, workspaceDocuments: fake.workspaceDocuments },
+      { workspaceId: WS, update: new Uint8Array([9, 9, 9]) },
+      {
+        onMalformed: () => {
+          malformedLockDepth = lockDepthProbe
+        },
+      },
+    )
+    expect(result).toBe('malformed-update')
+    // Fired while the lock still excludes other writers, so a surface can
+    // mark its socket closing before any queued frame acquires the hold.
+    expect(malformedLockDepth).toBe(1)
+    expect(fake.wasSaved()).toBe(false)
+  })
 })

--- a/packages/server-core/src/operations/apply-workspace-document-update.ts
+++ b/packages/server-core/src/operations/apply-workspace-document-update.ts
@@ -26,13 +26,32 @@ export interface ApplyWorkspaceDocumentUpdateInput {
  * projection between the import and the eviction would diff old content
  * back over this import on its next save.
  */
+export interface ApplyWorkspaceDocumentUpdateHooks {
+  /**
+   * Consulted INSIDE the lock, after the read: a surface whose frames queue
+   * (a websocket) uses this for its frame-race guard — a later frame can
+   * pass the surface's own pre-lock check before an earlier frame tears the
+   * socket down, and only a check taken under the hold closes that window.
+   */
+  readonly abortIf?: () => boolean
+  /**
+   * Called INSIDE the lock before `'malformed-update'` returns, so a
+   * surface can mark its socket closing while the lock still excludes
+   * other writers — a queued valid frame must not persist onto a socket
+   * the malformed frame is about to close.
+   */
+  readonly onMalformed?: () => void
+}
+
 export async function applyWorkspaceDocumentUpdate(
   deps: Pick<ServerDeps, 'liveDocuments' | 'workspaceDocuments'>,
   input: ApplyWorkspaceDocumentUpdateInput,
-): Promise<'applied' | 'malformed-update'> {
+  hooks: ApplyWorkspaceDocumentUpdateHooks = {},
+): Promise<'applied' | 'aborted' | 'malformed-update'> {
   const { workspaceId, update } = input
   return deps.liveDocuments.withWriteLock(workspaceId, async () => {
     const doc = await deps.workspaceDocuments.get(workspaceId)
+    if (hooks.abortIf?.() === true) return 'aborted'
     try {
       doc.import(update)
     } catch (err: unknown) {
@@ -41,6 +60,7 @@ export async function applyWorkspaceDocumentUpdate(
         updateBytes: update.byteLength,
         err,
       })
+      hooks.onMalformed?.()
       return 'malformed-update'
     }
     // Fan-out to subscribers happens inside save.

--- a/packages/server-core/src/server-deps.ts
+++ b/packages/server-core/src/server-deps.ts
@@ -233,6 +233,21 @@ export interface WorkspaceDocuments {
    * would diff old content back over the import on its next save.
    */
   evictProjections(workspaceId: string): void
+  /**
+   * Drops the cached workspace doc itself, so the next `get` reloads
+   * durable bytes — the recovery move when a failure may have left the
+   * in-memory doc ahead of what persisted.
+   */
+  evict(workspaceId: string): void
+  /**
+   * Subscribes to every persisted workspace-document update — the sync
+   * fan-out funnel. Listeners get the exact bytes the store persisted;
+   * importing them into a replica converges it. Best-effort and
+   * order-independent, the clientNotifier-shaped events carve-out: a
+   * listener throwing must never fail the save that fired it (the
+   * implementation guards this). Answers an unsubscribe.
+   */
+  onUpdated(listener: (workspaceId: string, update: Uint8Array) => void): () => void
 }
 
 /**

--- a/packages/server-core/src/test-utils/unused-workspace-documents.ts
+++ b/packages/server-core/src/test-utils/unused-workspace-documents.ts
@@ -17,5 +17,7 @@ export function unusedWorkspaceDocuments(): WorkspaceDocuments {
     get: refuse('get'),
     save: refuse('save'),
     evictProjections: refuse('evictProjections'),
+    evict: refuse('evict'),
+    onUpdated: refuse('onUpdated'),
   }
 }

--- a/tools/arch-lint/src/architecture-map.ts
+++ b/tools/arch-lint/src/architecture-map.ts
@@ -323,10 +323,6 @@ export const ADAPTERS_REACHING_MECHANICS: readonly string[] = [
   'routes/files.ts -> version-store',
   'routes/files.ts -> workspace-lock',
   'routes/runtime.ts -> document-store',
-  'routes/ws.ts -> doc-cache',
-  'routes/ws.ts -> document-store',
-  'routes/ws.ts -> version-store',
-  'routes/ws.ts -> workspace-lock',
 ]
 
 /**
@@ -342,11 +338,13 @@ export const ADAPTERS_REACHING_MECHANICS: readonly string[] = [
  *
  * Raising it is a decision, not a fix. Do it only when the alternative is
  * worse than the debt, and say in the PR why the operation could not go to
- * server-core instead. The burn-down order is in the ADR; restore.ts's,
- * live-doc.ts's and workspace-document.ts's edges are paid off, and the one
- * remaining scheduled adapter (ws.ts) holds 4 of these 25.
+ * server-core instead. The ADR's scheduled burn-down is COMPLETE
+ * (2026-09-02): restore.ts, live-doc.ts, workspace-document.ts and ws.ts
+ * are all translation-only over the LiveDocuments/WorkspaceDocuments
+ * seams. The 21 edges left are the unscheduled adapters — each still a
+ * candidate for the same treatment, none yet ordered.
  */
-export const ADAPTERS_REACHING_MECHANICS_CEILING = 25
+export const ADAPTERS_REACHING_MECHANICS_CEILING = 21
 
 /**
  * Modules under `store/` the adapter rule does NOT count.


### PR DESCRIPTION
## Summary

- **ADR-0018 burn-down step 4 (final)**: `ws.ts` — the last scheduled adapter — imports **no `store/` module**. `ADAPTERS_REACHING_MECHANICS_CEILING` drops **25 → 21**, completing the scheduled sequence **37 → 33 → 29 → 25 → 21** across four PRs (#1224, #1226, #1227, this one). All four ADR-ordered adapters are now translation-only over the `LiveDocuments` / `WorkspaceDocuments` seams.
- **The funnel becomes a seam, not a relocated file** (PlanReview round 1 rejected a file move as gaming the `store/**` path match): `WorkspaceDocuments` gains `onUpdated(listener)` — the `clientNotifier`-shaped events carve-out — plus `evict(workspaceId)`; the pub-sub stays in document-store untouched. **Each transport installs its own subscription from its own entry point** (round 2's catch): ws.ts a WS-clients-only broadcast at every upgrade + http-server boot; sync-sse its own SSE fan-out at stream-open. The SSE-only fan-out test now passes **in isolation** — under the old shared module-load listener it would have been test-order coincidence.
- The binary write path reuses `applyWorkspaceDocumentUpdate`, extended with two optional hooks that preserve the documented in-lock orderings verbatim: `abortIf` (the `isClosing` frame-race recheck, taken under the hold) and `onMalformed` (close 1003 while the lock still excludes other writers, plus the adapter's structured warning — only the socket surface knows the path). HTTP callers pass neither and stay pinned unchanged.
- `handleWsUpgrade` takes optional `deps` (fallback `getDefaultServerDeps`); http-server passes the deps it builds. Pinned by `ws-seam.test.ts` — the fourth instance of the optional-deps-going-unread bug class — covering the happy path **and** the 1011 recovery landing on the injected `evictProjections` + `evict` (round 1's third item).
- **A real value-import cycle surfaced and was dissolved at its root**: the di graph reached the routes layer through `canvas-client-notifier`, so `clientNotifier` wiring moves out of `resolveServerDeps` to the two roots with a live-socket audience (`http-server.ts`, `mcp/index.ts`). The field is optional by design ("absent means nobody is told anything"), so route-fallback deps correctly carry none.
- `tool-arch-lint.md` figures updated; ADR-0018 gains a dated completion note that also corrects its two stale claims (restore.ts held 4 edges, not 5; `wb_version_restore` existed but restores a different history system, so the no-twin argument stood).

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — 2 new `server-core-node` hook tests (red-first: `abortIf` observed inside the lock, `onMalformed` fired inside the lock) + `ws-seam.test.ts` (2 tests, red against the old wiring)
- [x] `pnpm test` passes locally — full `mcp-node` 4,206 passed (only the known Node-22 environment guard fails locally; CI runs the pinned Node 24), `server-core-node` 465 passed, `arch-lint-node` 119 passed; all 9 existing ws/sse/funnel suites (70 tests) pass **unmodified**, and the SSE-only fan-out test passes in isolation
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable — not needed: frame-compatible WS behavior pinned by the existing suites including a real-socket one

Mutation checks (each restored after confirming red): `abortIf` removed → 1 fail; `onMalformed` removed → 1 fail; injected deps ignored → ws-seam 2 fail; SSE stream-open install removed → isolated SSE test fails; upgrade-time install removed → 2 fan-out tests fail.

Manual verification: server-side refactor with frame/byte-compatible WS+SSE behavior (close codes 4404/1003/1008/1011, snapshot-on-connect, tracing, eviction recovery all verbatim); verified via the full suites above plus `pnpm build`, typecheck, lint, knip, lint:noconsole, all green.

## Visual evidence

Visual evidence: none — server-side refactor with no UI or pixel change; behavior is pinned by four existing ws test suites (real-socket included) plus the new operation-hook and seam tests.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract (`.claude/rules/tool-arch-lint.md`; ADR-0018 dated completion note)
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema (the seam and hook contracts are internal seams, same as the prior steps')

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_