### PR TITLE
fix(web): route comment EditorCommands through the fine-grained Loro write path

### DIFF
--- a/apps/web/src/components/spatial-editor/commands.test.ts
+++ b/apps/web/src/components/spatial-editor/commands.test.ts
@@ -675,7 +675,7 @@ describe('comment commands', () => {
   it('set-comment-resolved flips only the target comment; a missing id is a no-op', () => {
     const canvas: SpatialCanvas = {
       ...baseCanvas(),
-      'x-whiteboard': { comments: [COMMENT, OTHER] },
+      'x-whiteboard': { edgeRouting: { style: 'orthogonal' }, comments: [COMMENT, OTHER] },
     }
     const next = applyCommand(canvas, {
       kind: 'set-comment-resolved',
@@ -687,6 +687,7 @@ describe('comment commands', () => {
       resolved: true,
     })
     expect(next['x-whiteboard']?.comments?.find((c) => c.id === 'c2')).toEqual(OTHER)
+    expect(next['x-whiteboard']?.edgeRouting).toEqual({ style: 'orthogonal' })
 
     expect(
       applyCommand(canvas, { kind: 'set-comment-resolved', id: 'ghost', resolved: true }),
@@ -706,6 +707,21 @@ describe('comment commands', () => {
     expect(spatialCanvasSchema.safeParse(afterBoth).success).toBe(true)
 
     expect(applyCommand(afterBoth, { kind: 'delete-comment', id: 'ghost' })).toBe(afterBoth)
+  })
+
+  it('delete-comment preserves a sibling extension field (edgeRouting), including once the last comment is removed', () => {
+    const withBoth: SpatialCanvas = {
+      ...baseCanvas(),
+      'x-whiteboard': { edgeRouting: { style: 'orthogonal' }, comments: [COMMENT, OTHER] },
+    }
+    const afterOne = applyCommand(withBoth, { kind: 'delete-comment', id: 'c1' })
+    expect(afterOne['x-whiteboard']?.comments).toEqual([OTHER])
+    expect(afterOne['x-whiteboard']?.edgeRouting).toEqual({ style: 'orthogonal' })
+
+    const afterBoth = applyCommand(afterOne, { kind: 'delete-comment', id: 'c2' })
+    expect(afterBoth['x-whiteboard']).not.toHaveProperty('comments')
+    expect(afterBoth['x-whiteboard']?.edgeRouting).toEqual({ style: 'orthogonal' })
+    expect(spatialCanvasSchema.safeParse(afterBoth).success).toBe(true)
   })
 })
 

--- a/apps/web/src/components/spatial-editor/commands.test.ts
+++ b/apps/web/src/components/spatial-editor/commands.test.ts
@@ -1,4 +1,4 @@
-import type { ClipboardFragment, SpatialCanvas } from '@kamiazya/whiteboard-model'
+import type { CanvasComment, ClipboardFragment, SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { spatialCanvasSchema } from '@kamiazya/whiteboard-model'
 import { describe, expect, it } from 'vitest'
 import { applyCommand, buildFragmentInsertCommand } from './commands.js'
@@ -637,6 +637,75 @@ describe('create-edge', () => {
         edge: { ...fullEdge, id: 'y', fromNode: 'a', toNode: 'a' },
       }),
     ).toBe(canvas)
+  })
+})
+
+// The comment annotation layer (ADR-0024). These commands ride the same
+// x-whiteboard.comments envelope loro-adapter's writeCanvasComment/
+// deleteCanvasComment split out into their own per-comment CRDT keys — see
+// commands.ts's withComments doc comment for the canonicality rules pinned
+// below.
+describe('comment commands', () => {
+  const COMMENT: CanvasComment = { id: 'c1', x: 10, y: 20, text: 'looks off' }
+  const OTHER: CanvasComment = { id: 'c2', x: -5, y: 0, text: 'nice', resolved: false }
+
+  const withComment = (canvas: SpatialCanvas, comment: CanvasComment): SpatialCanvas => ({
+    ...canvas,
+    'x-whiteboard': { ...canvas['x-whiteboard'], comments: [comment] },
+  })
+
+  it('create-comment appends under x-whiteboard.comments, preserving other envelope fields', () => {
+    const canvas: SpatialCanvas = {
+      ...baseCanvas(),
+      'x-whiteboard': { edgeRouting: { style: 'orthogonal' }, comments: [OTHER] },
+    }
+    const next = applyCommand(canvas, { kind: 'create-comment', comment: COMMENT })
+    expect(next['x-whiteboard']?.comments?.map((c) => c.id).sort()).toEqual(['c1', 'c2'])
+    expect(next['x-whiteboard']?.edgeRouting).toEqual({ style: 'orthogonal' })
+    expect(next.nodes).toBe(canvas.nodes)
+  })
+
+  it('create-comment with a colliding id is a no-op returning the input canvas reference', () => {
+    const canvas = withComment(baseCanvas(), COMMENT)
+    expect(applyCommand(canvas, { kind: 'create-comment', comment: { ...COMMENT, x: 99 } })).toBe(
+      canvas,
+    )
+  })
+
+  it('set-comment-resolved flips only the target comment; a missing id is a no-op', () => {
+    const canvas: SpatialCanvas = {
+      ...baseCanvas(),
+      'x-whiteboard': { comments: [COMMENT, OTHER] },
+    }
+    const next = applyCommand(canvas, {
+      kind: 'set-comment-resolved',
+      id: 'c1',
+      resolved: true,
+    })
+    expect(next['x-whiteboard']?.comments?.find((c) => c.id === 'c1')).toEqual({
+      ...COMMENT,
+      resolved: true,
+    })
+    expect(next['x-whiteboard']?.comments?.find((c) => c.id === 'c2')).toEqual(OTHER)
+
+    expect(
+      applyCommand(canvas, { kind: 'set-comment-resolved', id: 'ghost', resolved: true }),
+    ).toBe(canvas)
+  })
+
+  it('delete-comment removes exactly one comment; the last removal drops the comments key and an empty extension disappears', () => {
+    const withBoth: SpatialCanvas = {
+      ...baseCanvas(),
+      'x-whiteboard': { comments: [COMMENT, OTHER] },
+    }
+    const afterOne = applyCommand(withBoth, { kind: 'delete-comment', id: 'c1' })
+    expect(afterOne['x-whiteboard']?.comments).toEqual([OTHER])
+
+    const afterBoth = applyCommand(afterOne, { kind: 'delete-comment', id: 'c2' })
+    expect(afterBoth).not.toHaveProperty('x-whiteboard')
+    expect(spatialCanvasSchema.safeParse(afterBoth).success).toBe(true)
+
+    expect(applyCommand(afterBoth, { kind: 'delete-comment', id: 'ghost' })).toBe(afterBoth)
   })
 })
 

--- a/apps/web/src/components/spatial-editor/commands.ts
+++ b/apps/web/src/components/spatial-editor/commands.ts
@@ -21,6 +21,7 @@
 
 import type {
   CanvasColor,
+  CanvasComment,
   CanvasEdge,
   ClipboardFragment,
   EdgeRoutingStyle,
@@ -161,6 +162,24 @@ export type EditorLeafCommand =
       readonly endpoint: 'from' | 'to'
       // undefined returns the endpoint to derived (auto) routing.
       readonly side: 'top' | 'right' | 'bottom' | 'left' | undefined
+    }
+  | {
+      // Appends one comment verbatim (ADR-0024's annotation layer). A
+      // colliding id is a no-op, like create-node/create-edge.
+      readonly kind: 'create-comment'
+      readonly comment: CanvasComment
+    }
+  | {
+      // Rewrites one comment's `resolved` field. A missing target id is a
+      // no-op, matching every other single-field write in this union.
+      readonly kind: 'set-comment-resolved'
+      readonly id: string
+      readonly resolved: boolean
+    }
+  | {
+      // Removes one comment. A missing id is a no-op.
+      readonly kind: 'delete-comment'
+      readonly id: string
     }
 
 /**
@@ -538,6 +557,52 @@ function setEdgeLabel(canvas: SpatialCanvas, id: string, label: string): Spatial
   }
 }
 
+/**
+ * Rewrites the canvas's `x-whiteboard.comments` array via `update`, which
+ * receives the CURRENT comments (empty when none) and returns either the
+ * next array or `undefined` to signal a no-op (matching every other
+ * command's totality contract: a missing/colliding target id returns the
+ * input canvas reference unchanged). Same envelope-canonicality discipline
+ * as `withEdgeStyle`/`setNodeFacet`: an empty `comments` result drops the
+ * key, an empty extension disappears entirely, and sibling extension fields
+ * (edgeRouting, facets) survive untouched.
+ */
+function withComments(
+  canvas: SpatialCanvas,
+  update: (comments: readonly CanvasComment[]) => CanvasComment[] | undefined,
+): SpatialCanvas {
+  const { 'x-whiteboard': extension, ...rest } = canvas
+  const nextComments = update(extension?.comments ?? [])
+  if (nextComments === undefined) return canvas
+  const { comments: _previous, ...otherExtension } = extension ?? {}
+  const nextExtension = {
+    ...otherExtension,
+    ...(nextComments.length > 0 ? { comments: nextComments } : {}),
+  }
+  return Object.keys(nextExtension).length === 0 ? rest : { ...rest, 'x-whiteboard': nextExtension }
+}
+
+function createComment(canvas: SpatialCanvas, comment: CanvasComment): SpatialCanvas {
+  return withComments(canvas, (comments) => {
+    if (comments.some((existing) => existing.id === comment.id)) return undefined
+    return [...comments, comment]
+  })
+}
+
+function setCommentResolved(canvas: SpatialCanvas, id: string, resolved: boolean): SpatialCanvas {
+  return withComments(canvas, (comments) => {
+    if (!comments.some((comment) => comment.id === id)) return undefined
+    return comments.map((comment) => (comment.id === id ? { ...comment, resolved } : comment))
+  })
+}
+
+function deleteComment(canvas: SpatialCanvas, id: string): SpatialCanvas {
+  return withComments(canvas, (comments) => {
+    if (!comments.some((comment) => comment.id === id)) return undefined
+    return comments.filter((comment) => comment.id !== id)
+  })
+}
+
 export function applyCommand(canvas: SpatialCanvas, command: EditorCommand): SpatialCanvas {
   switch (command.kind) {
     case 'move-node':
@@ -592,6 +657,12 @@ export function applyCommand(canvas: SpatialCanvas, command: EditorCommand): Spa
       return reorderNodes(canvas, command.ids, command.placement)
     case 'create-edge':
       return createEdge(canvas, command.edge)
+    case 'create-comment':
+      return createComment(canvas, command.comment)
+    case 'set-comment-resolved':
+      return setCommentResolved(canvas, command.id, command.resolved)
+    case 'delete-comment':
+      return deleteComment(canvas, command.id)
     case 'batch':
       // Pure fold; a batch of no-ops folds back to the input reference,
       // preserving the union-wide "nothing changed → same object" contract.

--- a/apps/web/src/components/spatial-editor/editor-state.property.test.ts
+++ b/apps/web/src/components/spatial-editor/editor-state.property.test.ts
@@ -309,10 +309,11 @@ const COMMAND_COVERAGE = {
   'set-group-label': 'not modelled: group label editor, single-field write',
   'set-group-background': 'not modelled: group inspector, single-field write',
   'create-comment':
-    'not modelled: no comment UI is wired yet (ADR-0025 slice); the command has no gesture or selection coupling to model here — covered at the applyCommand/session layers instead',
+    "not modelled: no comment UI is wired yet (ADR-0024's apps/web interactive-comment-UI follow-up increment, named in its 'This increment' section); the command has no gesture or selection coupling to model here — covered at the applyCommand/session layers instead",
   'set-comment-resolved':
-    'not modelled: no comment UI is wired yet (ADR-0025 slice), single-field write',
-  'delete-comment': 'not modelled: no comment UI is wired yet (ADR-0025 slice)',
+    "not modelled: no comment UI is wired yet (ADR-0024's apps/web interactive-comment-UI follow-up increment), single-field write",
+  'delete-comment':
+    "not modelled: no comment UI is wired yet (ADR-0024's apps/web interactive-comment-UI follow-up increment)",
 } satisfies Record<EditorCommand['kind'], SurfaceCoverage>
 
 /** Every event the gesture state machine accepts. All of them are driven. */

--- a/apps/web/src/components/spatial-editor/editor-state.property.test.ts
+++ b/apps/web/src/components/spatial-editor/editor-state.property.test.ts
@@ -308,6 +308,11 @@ const COMMAND_COVERAGE = {
   'create-group': 'covered',
   'set-group-label': 'not modelled: group label editor, single-field write',
   'set-group-background': 'not modelled: group inspector, single-field write',
+  'create-comment':
+    'not modelled: no comment UI is wired yet (ADR-0025 slice); the command has no gesture or selection coupling to model here — covered at the applyCommand/session layers instead',
+  'set-comment-resolved':
+    'not modelled: no comment UI is wired yet (ADR-0025 slice), single-field write',
+  'delete-comment': 'not modelled: no comment UI is wired yet (ADR-0025 slice)',
 } satisfies Record<EditorCommand['kind'], SurfaceCoverage>
 
 /** Every event the gesture state machine accepts. All of them are driven. */

--- a/apps/web/src/lib/document-sync-session.test.ts
+++ b/apps/web/src/lib/document-sync-session.test.ts
@@ -375,8 +375,8 @@ describe('createDocumentSyncSession', () => {
 
     const localComment: CanvasComment = { id: 'local-c', x: 1, y: 1, text: 'local note' }
     const next: SpatialCanvas = { ...emptyCanvas(), 'x-whiteboard': { comments: [localComment] } }
-    const command = { kind: 'create-comment', comment: localComment }
-    session.onChange(next, command as unknown as EditorCommand)
+    const command: EditorCommand = { kind: 'create-comment', comment: localComment }
+    session.onChange(next, command)
     await vi.advanceTimersByTimeAsync(300)
 
     // The fallback's tell: if the comment command fell through to the full
@@ -389,6 +389,106 @@ describe('createDocumentSyncSession', () => {
     for (const bytes of backend._ctrl.pushLocalUpdateCalls) merged.import(bytes)
     const comments = readSpatialCanvas(merged)['x-whiteboard']?.comments ?? []
     expect(comments.map((c) => c.id).sort()).toEqual(['local-c', 'remote-c'])
+  })
+
+  it('debounce coalescing: create-comment then set-comment-resolved for the same id dedupes to a single write of the final comment value', async () => {
+    const backend = makeFakeBackend()
+    const session = createDocumentSyncSession(backend, makeDeps())
+    session.connect()
+    const snapshotBytes = makeSnapshot(emptyCanvas())
+    backend._ctrl.handlers!.onSnapshot(snapshotBytes)
+
+    const comment: CanvasComment = { id: 'c-1', x: 0, y: 0, text: 'first pass' }
+    const createCmd: EditorCommand = { kind: 'create-comment', comment }
+    const afterCreate = applyCommand(emptyCanvas(), createCmd)
+    session.onChange(afterCreate, createCmd)
+
+    const resolveCmd: EditorCommand = { kind: 'set-comment-resolved', id: 'c-1', resolved: true }
+    const afterResolve = applyCommand(afterCreate, resolveCmd)
+    session.onChange(afterResolve, resolveCmd)
+
+    await vi.advanceTimersByTimeAsync(300)
+
+    // commandTargetKey maps both commands to `comment:c-1` — proof the
+    // comment case is not falling into the default arm's fresh-key-per-call
+    // behavior, which would push twice.
+    expect(backend._ctrl.pushLocalUpdateCalls).toHaveLength(1)
+    const doc = new LoroDoc()
+    doc.import(snapshotBytes)
+    doc.import(backend._ctrl.pushLocalUpdateCalls[0]!)
+    const comments = readSpatialCanvas(doc)['x-whiteboard']?.comments ?? []
+    expect(comments).toEqual([{ ...comment, resolved: true }])
+  })
+
+  it('debounce coalescing: set-comment-resolved then delete-comment for the same id dedupes to the delete; an unrelated comment survives', async () => {
+    const backend = makeFakeBackend()
+    const session = createDocumentSyncSession(backend, makeDeps())
+    const comment: CanvasComment = { id: 'c-1', x: 0, y: 0, text: 'going away' }
+    const other: CanvasComment = { id: 'c-2', x: 5, y: 5, text: 'stays' }
+    const initial: SpatialCanvas = {
+      ...emptyCanvas(),
+      'x-whiteboard': { comments: [comment, other] },
+    }
+    session.connect()
+    const snapshotBytes = makeSnapshot(initial)
+    backend._ctrl.handlers!.onSnapshot(snapshotBytes)
+
+    const resolveCmd: EditorCommand = { kind: 'set-comment-resolved', id: 'c-1', resolved: true }
+    const afterResolve = applyCommand(initial, resolveCmd)
+    session.onChange(afterResolve, resolveCmd)
+
+    const deleteCmd: EditorCommand = { kind: 'delete-comment', id: 'c-1' }
+    const afterDelete = applyCommand(afterResolve, deleteCmd)
+    session.onChange(afterDelete, deleteCmd)
+
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(backend._ctrl.pushLocalUpdateCalls).toHaveLength(1)
+    const doc = new LoroDoc()
+    doc.import(snapshotBytes)
+    doc.import(backend._ctrl.pushLocalUpdateCalls[0]!)
+    const comments = readSpatialCanvas(doc)['x-whiteboard']?.comments ?? []
+    expect(comments.map((c) => c.id)).toEqual(['c-2'])
+  })
+
+  it('a batch containing a comment command plus a node command commits fine-grained: a remote comment survives, one undo step', async () => {
+    const backend = makeFakeBackend()
+    const session = createDocumentSyncSession(backend, makeDeps())
+    session.connect()
+    const snapshotBytes = makeSnapshot(twoNodeCanvas())
+    backend._ctrl.handlers!.onSnapshot(snapshotBytes)
+
+    const remoteComment: CanvasComment = { id: 'remote-c', x: -5, y: 3, text: 'remote note' }
+    const remoteDoc = new LoroDoc()
+    remoteDoc.import(snapshotBytes)
+    writeCanvasComment(remoteDoc, remoteComment)
+    backend._ctrl.handlers!.onRemoteUpdate(remoteDoc.export({ mode: 'update' }))
+
+    const localComment: CanvasComment = { id: 'local-c', x: 1, y: 1, text: 'local note' }
+    const batch: EditorCommand = {
+      kind: 'batch',
+      commands: [
+        { kind: 'create-comment', comment: localComment },
+        { kind: 'move-node', id: 'n-a', x: 42, y: 42 },
+      ],
+    }
+    const next: SpatialCanvas = {
+      ...applyCommand(twoNodeCanvas(), { kind: 'move-node', id: 'n-a', x: 42, y: 42 }),
+      'x-whiteboard': { comments: [localComment] },
+    }
+    session.onChange(next, batch)
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(appLoggerSpies.warn).not.toHaveBeenCalled()
+    expect(backend._ctrl.pushLocalUpdateCalls).toHaveLength(1)
+    const merged = new LoroDoc()
+    merged.import(snapshotBytes)
+    merged.import(remoteDoc.export({ mode: 'update' }))
+    merged.import(backend._ctrl.pushLocalUpdateCalls[0]!)
+    const result = readSpatialCanvas(merged)
+    const comments = result['x-whiteboard']?.comments ?? []
+    expect(comments.map((c) => c.id).sort()).toEqual(['local-c', 'remote-c'])
+    expect(result.nodes.find((n) => n.id === 'n-a')).toMatchObject({ x: 42, y: 42 })
   })
 
   it('debounce coalescing: create-node then move-node for the same id dedupes to a single write of the final node value', async () => {

--- a/apps/web/src/lib/document-sync-session.test.ts
+++ b/apps/web/src/lib/document-sync-session.test.ts
@@ -12,13 +12,14 @@ import {
   readMarkdownBody,
   readSpatialCanvas,
   setNodeLock,
+  writeCanvasComment,
   writeSpatialCanvas,
 } from '@kamiazya/whiteboard-loro-adapter'
 import type {
   DocumentBackend,
   DocumentBackendHandlers,
 } from '@kamiazya/whiteboard-mcp/browser-contract'
-import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
+import type { CanvasComment, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
 import { LoroDoc } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { EditorCommand } from '../components/spatial-editor/commands.js'
@@ -354,6 +355,40 @@ describe('createDocumentSyncSession', () => {
     const result = readSpatialCanvas(doc)
     expect(result.nodes.map((n) => n.id)).toEqual(['n-b'])
     expect(result.edges).toEqual([])
+  })
+
+  it('a local create-comment commit does not delete a comment a remote peer wrote concurrently (fine-grained comment write, not full resync)', async () => {
+    const backend = makeFakeBackend()
+    const session = createDocumentSyncSession(backend, makeDeps())
+    session.connect()
+    const snapshotBytes = makeSnapshot(emptyCanvas())
+    backend._ctrl.handlers!.onSnapshot(snapshotBytes)
+
+    // A remote peer wrote this comment directly into the shared doc — never
+    // reflected in this editor's own `next` canvas below, exactly as a
+    // remote update racing a local edit would arrive.
+    const remoteComment: CanvasComment = { id: 'remote-c', x: -5, y: 3, text: 'remote note' }
+    const remoteDoc = new LoroDoc()
+    remoteDoc.import(snapshotBytes)
+    writeCanvasComment(remoteDoc, remoteComment)
+    backend._ctrl.handlers!.onRemoteUpdate(remoteDoc.export({ mode: 'update' }))
+
+    const localComment: CanvasComment = { id: 'local-c', x: 1, y: 1, text: 'local note' }
+    const next: SpatialCanvas = { ...emptyCanvas(), 'x-whiteboard': { comments: [localComment] } }
+    const command = { kind: 'create-comment', comment: localComment }
+    session.onChange(next, command as unknown as EditorCommand)
+    await vi.advanceTimersByTimeAsync(300)
+
+    // The fallback's tell: if the comment command fell through to the full
+    // resync, this fires — see commitToDoc's doc comment.
+    expect(appLoggerSpies.warn).not.toHaveBeenCalled()
+
+    const merged = new LoroDoc()
+    merged.import(snapshotBytes)
+    merged.import(remoteDoc.export({ mode: 'update' }))
+    for (const bytes of backend._ctrl.pushLocalUpdateCalls) merged.import(bytes)
+    const comments = readSpatialCanvas(merged)['x-whiteboard']?.comments ?? []
+    expect(comments.map((c) => c.id).sort()).toEqual(['local-c', 'remote-c'])
   })
 
   it('debounce coalescing: create-node then move-node for the same id dedupes to a single write of the final node value', async () => {

--- a/apps/web/src/lib/document-sync-session.test.ts
+++ b/apps/web/src/lib/document-sync-session.test.ts
@@ -491,6 +491,55 @@ describe('createDocumentSyncSession', () => {
     expect(result.nodes.find((n) => n.id === 'n-a')).toMatchObject({ x: 42, y: 42 })
   })
 
+  it('a batch containing set-comment-resolved and delete-comment commits fine-grained: a remote comment survives, one undo step', async () => {
+    const backend = makeFakeBackend()
+    const session = createDocumentSyncSession(backend, makeDeps())
+    session.connect()
+    const toResolve: CanvasComment = { id: 'c-1', x: 0, y: 0, text: 'resolve me' }
+    const toDelete: CanvasComment = { id: 'c-2', x: 5, y: 5, text: 'delete me' }
+    const initial: SpatialCanvas = {
+      ...twoNodeCanvas(),
+      'x-whiteboard': { comments: [toResolve, toDelete] },
+    }
+    const snapshotBytes = makeSnapshot(initial)
+    backend._ctrl.handlers!.onSnapshot(snapshotBytes)
+
+    // A remote peer's concurrent comment — the fine-grained-write tell, same
+    // as the create-comment batch test above.
+    const remoteComment: CanvasComment = { id: 'remote-c', x: -5, y: 3, text: 'remote note' }
+    const remoteDoc = new LoroDoc()
+    remoteDoc.import(snapshotBytes)
+    writeCanvasComment(remoteDoc, remoteComment)
+    backend._ctrl.handlers!.onRemoteUpdate(remoteDoc.export({ mode: 'update' }))
+
+    const batch: EditorCommand = {
+      kind: 'batch',
+      commands: [
+        { kind: 'set-comment-resolved', id: 'c-1', resolved: true },
+        { kind: 'delete-comment', id: 'c-2' },
+        { kind: 'move-node', id: 'n-a', x: 42, y: 42 },
+      ],
+    }
+    const next: SpatialCanvas = {
+      ...applyCommand(initial, { kind: 'move-node', id: 'n-a', x: 42, y: 42 }),
+      'x-whiteboard': { comments: [{ ...toResolve, resolved: true }] },
+    }
+    session.onChange(next, batch)
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(appLoggerSpies.warn).not.toHaveBeenCalled()
+    expect(backend._ctrl.pushLocalUpdateCalls).toHaveLength(1)
+    const merged = new LoroDoc()
+    merged.import(snapshotBytes)
+    merged.import(remoteDoc.export({ mode: 'update' }))
+    merged.import(backend._ctrl.pushLocalUpdateCalls[0]!)
+    const result = readSpatialCanvas(merged)
+    const comments = result['x-whiteboard']?.comments ?? []
+    expect(comments.map((c) => c.id).sort()).toEqual(['c-1', 'remote-c'])
+    expect(comments.find((c) => c.id === 'c-1')).toMatchObject({ resolved: true })
+    expect(result.nodes.find((n) => n.id === 'n-a')).toMatchObject({ x: 42, y: 42 })
+  })
+
   it('debounce coalescing: create-node then move-node for the same id dedupes to a single write of the final node value', async () => {
     const backend = makeFakeBackend()
     const session = createDocumentSyncSession(backend, makeDeps())

--- a/apps/web/src/lib/document-sync-session.ts
+++ b/apps/web/src/lib/document-sync-session.ts
@@ -1,4 +1,5 @@
 import {
+  deleteCanvasComment,
   type DocumentContainers,
   deleteSpatialNode,
   documentContainers,
@@ -12,6 +13,7 @@ import {
   withSpatialBatch,
   setEdgeLock as workspaceSetEdgeLock,
   setNodeLock as workspaceSetNodeLock,
+  writeCanvasComment,
   writeCoreFacets,
   writeMarkdownBody,
   writeSpatialCanvas,
@@ -71,6 +73,11 @@ function commandTargetKey(command: EditorCommand): string {
       return `edge:${command.edgeId}`
     case 'create-node':
       return `node:${command.node.id}`
+    case 'create-comment':
+      return `comment:${command.comment.id}`
+    case 'set-comment-resolved':
+    case 'delete-comment':
+      return `comment:${command.id}`
     case 'set-body':
       // One key for the whole body: `text` is always the complete document,
       // so a burst of keystrokes inside one debounce window collapses to the
@@ -248,6 +255,19 @@ function writeCommandTarget(
       writeSpatialNode(doc, node)
       return true
     }
+    case 'create-comment':
+    case 'set-comment-resolved': {
+      const id = command.kind === 'create-comment' ? command.comment.id : command.id
+      const comment = next['x-whiteboard']?.comments?.find((c) => c.id === id)
+      if (!comment) return false
+      writeCanvasComment(doc, comment)
+      return true
+    }
+    case 'delete-comment':
+      // Always "handled", matching delete-node: deleteCanvasComment is a
+      // documented no-op for an already-absent id.
+      deleteCanvasComment(doc, command.id)
+      return true
     case 'set-body':
       // Always "handled", and it MUST be: the fallback below writes the
       // whole SpatialCanvas, which would leave the body container untouched
@@ -300,8 +320,13 @@ function isBatchWritable(command: EditorLeafCommand, next: SpatialCanvas): boole
       return next.edges.some((e) => e.id === command.edgeId)
     case 'create-edge':
       return next.edges.some((e) => e.id === command.edge.id)
+    case 'create-comment':
+      return next['x-whiteboard']?.comments?.some((c) => c.id === command.comment.id) ?? false
+    case 'set-comment-resolved':
+      return next['x-whiteboard']?.comments?.some((c) => c.id === command.id) ?? false
     case 'delete-node':
     case 'delete-edge':
+    case 'delete-comment':
       // Deletes are no-ops for absent ids — always writable.
       return true
     default:
@@ -337,6 +362,19 @@ function writeSubCommand(
       if (edge) writer.writeEdge(edge)
       return
     }
+    case 'create-comment': {
+      const comment = next['x-whiteboard']?.comments?.find((c) => c.id === command.comment.id)
+      if (comment) writer.writeComment(comment)
+      return
+    }
+    case 'set-comment-resolved': {
+      const comment = next['x-whiteboard']?.comments?.find((c) => c.id === command.id)
+      if (comment) writer.writeComment(comment)
+      return
+    }
+    case 'delete-comment':
+      writer.deleteComment(command.id)
+      return
     case 'delete-node':
       writer.deleteNode(command.id)
       return

--- a/apps/web/src/lib/document-sync-session.ts
+++ b/apps/web/src/lib/document-sync-session.ts
@@ -362,13 +362,10 @@ function writeSubCommand(
       if (edge) writer.writeEdge(edge)
       return
     }
-    case 'create-comment': {
-      const comment = next['x-whiteboard']?.comments?.find((c) => c.id === command.comment.id)
-      if (comment) writer.writeComment(comment)
-      return
-    }
+    case 'create-comment':
     case 'set-comment-resolved': {
-      const comment = next['x-whiteboard']?.comments?.find((c) => c.id === command.id)
+      const id = command.kind === 'create-comment' ? command.comment.id : command.id
+      const comment = next['x-whiteboard']?.comments?.find((c) => c.id === id)
       if (comment) writer.writeComment(comment)
       return
     }

--- a/apps/web/src/lib/document-sync-session.ts
+++ b/apps/web/src/lib/document-sync-session.ts
@@ -1,6 +1,6 @@
 import {
-  deleteCanvasComment,
   type DocumentContainers,
+  deleteCanvasComment,
   deleteSpatialNode,
   documentContainers,
   readCoreFacets,

--- a/packages/loro-adapter/src/loro-bridge.property.test.ts
+++ b/packages/loro-adapter/src/loro-bridge.property.test.ts
@@ -1,15 +1,18 @@
 import {
+  canvasCommentArbitrary,
   extensionFacetsArbitrary,
   spatialCanvasArbitrary,
 } from '@kamiazya/whiteboard-model/test-utils'
 import { LoroDoc, UndoManager } from 'loro-crdt'
 import { describe, expect } from 'vitest'
 import {
+  deleteCanvasComment,
   deleteSpatialEdge,
   deleteSpatialNode,
   readFacets,
   readSpatialCanvas,
   withSpatialBatch,
+  writeCanvasComment,
   writeFacets,
   writeSpatialCanvas,
   writeSpatialNode,
@@ -57,14 +60,99 @@ describe('loro-bridge properties', () => {
   )
 })
 
+// The annotation layer's one reason to exist (ADR-0024): two peers must be
+// able to touch DIFFERENT comments — or different FIELDS of the comment
+// annotation layer's state — concurrently and have both effects survive a
+// merge. `spatialCanvasArbitrary` already attaches 0-3 comments of its own
+// (via canvasCommentArbitrary), which would collide with a freshly-generated
+// pair's ids at low but nonzero probability and pollute the exact-membership
+// assertions below — so these properties seed a clean base canvas (nodes and
+// edges only) and add comments only through the fine-grained writer under
+// test.
+describe('comment concurrency properties (ADR-0024)', () => {
+  fcTest.prop(
+    [
+      spatialCanvasArbitrary,
+      fc.uniqueArray(canvasCommentArbitrary, { minLength: 2, maxLength: 2, selector: (c) => c.id }),
+    ],
+    withDefaults(),
+  )(
+    'two peers each writeCanvasComment a DIFFERENT comment concurrently: both survive a bidirectional merge',
+    (canvas, pair) => {
+      const [commentA, commentB] = pair
+      const clean = { nodes: canvas.nodes, edges: canvas.edges }
+      const base = new LoroDoc()
+      writeSpatialCanvas(base, clean)
+      const peer = new LoroDoc()
+      peer.import(base.export({ mode: 'snapshot' }))
+
+      writeCanvasComment(base, commentA)
+      writeCanvasComment(peer, commentB)
+
+      const peerUpdate = peer.export({ mode: 'update' })
+      const baseUpdate = base.export({ mode: 'update' })
+      base.import(peerUpdate)
+      peer.import(baseUpdate)
+
+      const idsOn = (doc: LoroDoc) =>
+        (readSpatialCanvas(doc)['x-whiteboard']?.comments ?? []).map((c) => c.id).sort()
+      const expected = [commentA.id, commentB.id].sort()
+      expect(idsOn(base)).toEqual(expected)
+      expect(idsOn(peer)).toEqual(expected)
+    },
+  )
+
+  fcTest.prop(
+    [
+      spatialCanvasArbitrary,
+      canvasCommentArbitrary,
+      fc.uniqueArray(canvasCommentArbitrary, { minLength: 1, maxLength: 1, selector: (c) => c.id }),
+    ],
+    withDefaults(),
+  )(
+    'peer 1 resolves comment A concurrent with peer 2 creating comment B: after bidirectional sync, both effects survive',
+    (canvas, seedA, otherPair) => {
+      const [commentB] = otherPair
+      // commentB must be a different id from A, or the "create" side is
+      // silently the exact same rewrite the "resolve" side already made.
+      if (commentB.id === seedA.id) return
+      const commentA = { ...seedA, resolved: false }
+      const clean = { nodes: canvas.nodes, edges: canvas.edges }
+      const base = new LoroDoc()
+      writeSpatialCanvas(base, clean)
+      writeCanvasComment(base, commentA)
+      const peer = new LoroDoc()
+      peer.import(base.export({ mode: 'snapshot' }))
+
+      writeCanvasComment(base, { ...commentA, resolved: true })
+      writeCanvasComment(peer, commentB)
+
+      const peerUpdate = peer.export({ mode: 'update' })
+      const baseUpdate = base.export({ mode: 'update' })
+      base.import(peerUpdate)
+      peer.import(baseUpdate)
+
+      const check = (doc: LoroDoc) => {
+        const comments = readSpatialCanvas(doc)['x-whiteboard']?.comments ?? []
+        expect(comments.find((c) => c.id === commentA.id)?.resolved).toBe(true)
+        expect(comments.some((c) => c.id === commentB.id)).toBe(true)
+      }
+      check(base)
+      check(peer)
+    },
+  )
+})
+
 // withSpatialBatch equivalence (editor-completeness slice 1): for ANY
-// command list drawn from the writer's four operations, one batch produces
+// command list drawn from the writer's operations, one batch produces
 // the same readSpatialCanvas state as the sequential committing helpers,
 // and (when anything was written) exactly one undo step.
 type BatchOp =
   | { readonly kind: 'writeNode'; readonly index: number }
   | { readonly kind: 'deleteNode'; readonly index: number }
   | { readonly kind: 'deleteEdge'; readonly index: number }
+  | { readonly kind: 'writeComment'; readonly index: number }
+  | { readonly kind: 'deleteComment'; readonly index: number }
 
 describe('withSpatialBatch equivalence property', () => {
   fcTest.prop(
@@ -72,11 +160,9 @@ describe('withSpatialBatch equivalence property', () => {
       spatialCanvasArbitrary,
       fc.array(
         fc.record({
-          kind: fc.constantFrom<'writeNode' | 'deleteNode' | 'deleteEdge'>(
-            'writeNode',
-            'deleteNode',
-            'deleteEdge',
-          ),
+          kind: fc.constantFrom<
+            'writeNode' | 'deleteNode' | 'deleteEdge' | 'writeComment' | 'deleteComment'
+          >('writeNode', 'deleteNode', 'deleteEdge', 'writeComment', 'deleteComment'),
           index: fc.nat({ max: 7 }),
         }),
         { maxLength: 6 },
@@ -87,10 +173,13 @@ describe('withSpatialBatch equivalence property', () => {
     'one batch ≡ sequential helpers on state, and at most one undo step',
     async (canvas, opSpecs) => {
       const ops: BatchOp[] = opSpecs
+      const comments = canvas['x-whiteboard']?.comments ?? []
       const apply = {
         writeNode: (index: number) => canvas.nodes[index % Math.max(1, canvas.nodes.length)],
         deleteNode: (index: number) => canvas.nodes[index % Math.max(1, canvas.nodes.length)]?.id,
         deleteEdge: (index: number) => canvas.edges[index % Math.max(1, canvas.edges.length)]?.id,
+        writeComment: (index: number) => comments[index % Math.max(1, comments.length)],
+        deleteComment: (index: number) => comments[index % Math.max(1, comments.length)]?.id,
       }
 
       const sequential = new LoroDoc()
@@ -105,9 +194,15 @@ describe('withSpatialBatch equivalence property', () => {
         } else if (op.kind === 'deleteNode') {
           const id = apply.deleteNode(op.index)
           if (id !== undefined) deleteSpatialNode(sequential, id)
-        } else {
+        } else if (op.kind === 'deleteEdge') {
           const id = apply.deleteEdge(op.index)
           if (id !== undefined) deleteSpatialEdge(sequential, id)
+        } else if (op.kind === 'writeComment') {
+          const comment = apply.writeComment(op.index)
+          if (comment !== undefined) writeCanvasComment(sequential, { ...comment, resolved: true })
+        } else {
+          const id = apply.deleteComment(op.index)
+          if (id !== undefined) deleteCanvasComment(sequential, id)
         }
       }
 
@@ -120,9 +215,15 @@ describe('withSpatialBatch equivalence property', () => {
           } else if (op.kind === 'deleteNode') {
             const id = apply.deleteNode(op.index)
             if (id !== undefined) writer.deleteNode(id)
-          } else {
+          } else if (op.kind === 'deleteEdge') {
             const id = apply.deleteEdge(op.index)
             if (id !== undefined) writer.deleteEdge(id)
+          } else if (op.kind === 'writeComment') {
+            const comment = apply.writeComment(op.index)
+            if (comment !== undefined) writer.writeComment({ ...comment, resolved: true })
+          } else {
+            const id = apply.deleteComment(op.index)
+            if (id !== undefined) writer.deleteComment(id)
           }
         }
       })
@@ -132,6 +233,9 @@ describe('withSpatialBatch equivalence property', () => {
         return {
           nodes: [...value.nodes].sort((a, b) => a.id.localeCompare(b.id)),
           edges: [...value.edges].sort((a, b) => a.id.localeCompare(b.id)),
+          comments: [...(value['x-whiteboard']?.comments ?? [])].sort((a, b) =>
+            a.id.localeCompare(b.id),
+          ),
         }
       }
       expect(stateOf(batched)).toEqual(stateOf(sequential))

--- a/packages/loro-adapter/src/loro-bridge.property.test.ts
+++ b/packages/loro-adapter/src/loro-bridge.property.test.ts
@@ -246,3 +246,46 @@ describe('withSpatialBatch equivalence property', () => {
     },
   )
 })
+
+// The equivalence property above skips its undo-step assertion whenever
+// `undo.canUndo()` is false, which is also the correct outcome for a value-
+// identical rewrite (Loro dedupes a `.set()` to unchanged content into no
+// diff even though a commit happens) — so that property alone cannot tell
+// "batch forgot to commit" apart from "batch committed a no-op". These two
+// properties close that gap for the comment writer specifically, each built
+// so the write is UNAMBIGUOUSLY a real value change: a brand-new id (the
+// base canvas below carries no comments to collide with) or a delete of an
+// id already present. Mutation-checked: dropping `wrote = true` from
+// `withSpatialBatch`'s `writeComment`/`deleteComment` handlers makes both
+// fail (`undo.canUndo()` stays `false` after the batch), and restoring it
+// makes both pass again.
+describe('withSpatialBatch comment ops always commit (ADR-0024)', () => {
+  fcTest.prop([spatialCanvasArbitrary, canvasCommentArbitrary], withDefaults())(
+    'a batch that only writes one brand-new comment produces exactly one undo step',
+    (canvas, comment) => {
+      const clean = { nodes: canvas.nodes, edges: canvas.edges }
+      const doc = new LoroDoc()
+      writeSpatialCanvas(doc, clean)
+      const undo = new UndoManager(doc, { mergeInterval: 0 })
+      withSpatialBatch(doc, (writer) => writer.writeComment(comment))
+      expect(undo.canUndo()).toBe(true)
+      undo.undo()
+      expect(undo.canUndo()).toBe(false)
+    },
+  )
+
+  fcTest.prop([spatialCanvasArbitrary, canvasCommentArbitrary], withDefaults())(
+    'a batch that only deletes one comment present in the doc produces exactly one undo step',
+    (canvas, comment) => {
+      const clean = { nodes: canvas.nodes, edges: canvas.edges }
+      const doc = new LoroDoc()
+      writeSpatialCanvas(doc, clean)
+      writeCanvasComment(doc, comment)
+      const undo = new UndoManager(doc, { mergeInterval: 0 })
+      withSpatialBatch(doc, (writer) => writer.deleteComment(comment.id))
+      expect(undo.canUndo()).toBe(true)
+      undo.undo()
+      expect(undo.canUndo()).toBe(false)
+    },
+  )
+})

--- a/packages/loro-adapter/src/loro-bridge.test.ts
+++ b/packages/loro-adapter/src/loro-bridge.test.ts
@@ -1069,6 +1069,38 @@ describe('canvas comments bridge', () => {
     expect(() => writeCanvasComment(doc, { ...COMMENT, x: Number.NaN })).toThrow(TypeError)
   })
 
+  test('the non-finite-anchor refusal also propagates through withSpatialBatch, and the batch commits NOTHING (no undo step)', () => {
+    const doc = makeDoc()
+    writeCanvasComment(doc, COMMENT)
+    const undoManager = new UndoManager(doc, { mergeInterval: 0 })
+    expect(undoManager.canUndo()).toBe(false)
+
+    // A batch that swallowed this would let a NaN anchor delete the comment
+    // for every reader — the same failure commentToFields' loud refusal
+    // exists to prevent on the committing path. The throw happens before
+    // the poisoned comment is ever written, so it never reaches the doc at
+    // all — only OTHER (written before the throw) is pending, uncommitted.
+    expect(() =>
+      withSpatialBatch(doc, (writer) => {
+        writer.writeComment(OTHER)
+        writer.writeComment({ ...COMMENT, x: Number.NaN })
+      }),
+    ).toThrow(TypeError)
+    // No undo step — commit is an undo/sync boundary, not a visibility
+    // boundary, matching the node/edge error-contract test above.
+    expect(undoManager.canUndo()).toBe(false)
+    expect(
+      readSpatialCanvas(doc)
+        ['x-whiteboard']?.comments?.map((c) => c.id)
+        .sort(),
+    ).toEqual(['c1', 'c2'])
+    // The session-layer fallback converges exactly as it does for a
+    // node/edge batch throw: one committing writeCanvasComment absorbs the
+    // pending op into a single undo step.
+    writeCanvasComment(doc, COMMENT)
+    expect(undoManager.canUndo()).toBe(true)
+  })
+
   test('comments alone produce an extension; no comments and no envelope produce none', () => {
     const doc = makeDoc()
     writeCanvasComment(doc, COMMENT)
@@ -1076,5 +1108,62 @@ describe('canvas comments bridge', () => {
 
     deleteCanvasComment(doc, 'c1')
     expect(readSpatialCanvas(doc)).not.toHaveProperty('x-whiteboard')
+  })
+
+  describe('withSpatialBatch writeComment/deleteComment', () => {
+    test('a batch of one writeComment is byte-identical to writeCanvasComment', () => {
+      const a = new LoroDoc()
+      a.setPeerId(1n)
+      const b = new LoroDoc()
+      b.setPeerId(1n)
+      writeCanvasComment(a, COMMENT)
+      withSpatialBatch(b, (w) => w.writeComment(COMMENT))
+      expect(b.export({ mode: 'update' })).toEqual(a.export({ mode: 'update' }))
+    })
+
+    test('a batch of one deleteComment is byte-identical to deleteCanvasComment; an absent id is a no-op', () => {
+      const base = new LoroDoc()
+      base.setPeerId(9n)
+      writeCanvasComment(base, COMMENT)
+      writeCanvasComment(base, OTHER)
+      const snapshot = base.export({ mode: 'snapshot' })
+
+      const a = new LoroDoc()
+      a.import(snapshot)
+      a.setPeerId(1n)
+      const b = new LoroDoc()
+      b.import(snapshot)
+      b.setPeerId(1n)
+      deleteCanvasComment(a, COMMENT.id)
+      withSpatialBatch(b, (w) => w.deleteComment(COMMENT.id))
+      expect(b.export({ mode: 'update' })).toEqual(a.export({ mode: 'update' }))
+
+      const undoManager = new UndoManager(b, { mergeInterval: 0 })
+      expect(undoManager.canUndo()).toBe(false)
+      withSpatialBatch(b, (w) => w.deleteComment('never-existed'))
+      expect(undoManager.canUndo()).toBe(false)
+      expect(readSpatialCanvas(b)['x-whiteboard']?.comments).toEqual([OTHER])
+    })
+
+    test('one batch of a comment write + a node write is exactly one undo step', () => {
+      const doc = makeDoc()
+      writeCanvasComment(doc, COMMENT)
+      const undoManager = new UndoManager(doc, { mergeInterval: 0 })
+      expect(undoManager.canUndo()).toBe(false)
+      withSpatialBatch(doc, (w) => {
+        w.writeComment(OTHER)
+        w.writeNode(TEXT_NODE)
+      })
+      expect(
+        readSpatialCanvas(doc)
+          ['x-whiteboard']?.comments?.map((c) => c.id)
+          .sort(),
+      ).toEqual(['c1', 'c2'])
+      expect(readSpatialCanvas(doc).nodes.map((n) => n.id)).toContain(TEXT_NODE.id)
+      undoManager.undo()
+      expect(readSpatialCanvas(doc)['x-whiteboard']?.comments).toEqual([COMMENT])
+      expect(readSpatialCanvas(doc).nodes).toEqual([])
+      expect(undoManager.canUndo()).toBe(false)
+    })
   })
 })

--- a/packages/loro-adapter/src/loro-bridge.ts
+++ b/packages/loro-adapter/src/loro-bridge.ts
@@ -283,6 +283,21 @@ function deleteEdgeInto(doc: DocumentContainers, edgeId: string): boolean {
   return true
 }
 
+// Shared with writeCanvasComment/deleteCanvasComment below, so field
+// projection (including commentToFields' loud non-finite-anchor refusal)
+// cannot drift between the single-commit and withSpatialBatch paths.
+function writeCommentInto(doc: DocumentContainers, comment: CanvasComment): void {
+  doc.getMap(COMMENTS_KEY).set(comment.id, commentToFields(comment))
+}
+
+/** Returns false (writing nothing) when the comment id is absent. */
+function deleteCommentInto(doc: DocumentContainers, commentId: string): boolean {
+  const commentsMap = doc.getMap(COMMENTS_KEY)
+  if (!commentsMap.keys().includes(commentId)) return false
+  commentsMap.delete(commentId)
+  return true
+}
+
 /**
  * Writes exactly one node's LoroMap entry, leaving every other node/edge in
  * the doc untouched. This is the node-level CRDT merge granularity a full
@@ -333,6 +348,10 @@ export interface SpatialBatchWriter {
   /** Same edge-cascade as `deleteSpatialNode`; absent ids write nothing. */
   deleteNode(nodeId: string): void
   deleteEdge(edgeId: string): void
+  /** Comment counterpart of writeNode/writeEdge — create AND update (an
+   * id-keyed rewrite), matching `writeCanvasComment`. */
+  writeComment(comment: CanvasComment): void
+  deleteComment(commentId: string): void
 }
 
 /**
@@ -373,6 +392,13 @@ export function withSpatialBatch(
     },
     deleteEdge(edgeId) {
       if (deleteEdgeInto(doc, edgeId)) wrote = true
+    },
+    writeComment(comment) {
+      writeCommentInto(doc, comment)
+      wrote = true
+    },
+    deleteComment(commentId) {
+      if (deleteCommentInto(doc, commentId)) wrote = true
     },
   }
   fn(writer)
@@ -485,7 +511,7 @@ export function readSpatialCanvas(doc: DocumentContainers): SpatialCanvas {
  * of the same id with `resolved: true`.
  */
 export function writeCanvasComment(doc: DocumentContainers, comment: CanvasComment): void {
-  doc.getMap(COMMENTS_KEY).set(comment.id, commentToFields(comment))
+  writeCommentInto(doc, comment)
   doc.commit()
 }
 
@@ -494,10 +520,7 @@ export function writeCanvasComment(doc: DocumentContainers, comment: CanvasComme
  * absent from the doc, matching `deleteSpatialEdge`.
  */
 export function deleteCanvasComment(doc: DocumentContainers, commentId: string): void {
-  const commentsMap = doc.getMap(COMMENTS_KEY)
-  if (!commentsMap.keys().includes(commentId)) return
-  commentsMap.delete(commentId)
-  doc.commit()
+  if (deleteCommentInto(doc, commentId)) doc.commit()
 }
 
 /**


### PR DESCRIPTION
## Summary

ADR-0025 decision 6, landed BEFORE any comment UI slice: the editor's `commitToDoc` falls back to a full `writeSpatialCanvas` resync for unmapped command kinds, and that resync deletes any comment id absent from the local `next` canvas — so a remote peer's comment (an AI via the daemon, the MCP Apps widget, another tab) that merged into the CRDT doc but not yet into the editor's in-memory canvas would be silently destroyed. A UI wired to the fallback looks correct in every single-user test, which is why this ships first.

- Three comment `EditorLeafCommand` kinds (`create-comment` / `set-comment-resolved` / `delete-comment`) with pure, total `applyCommand` cases — envelope canonicality preserved (empty comments array drops the key; an emptied `x-whiteboard` disappears; sibling fields like `edgeRouting` survive). No UI is wired (deliberate foundation; the ADR-0025 create-gesture slice wires it).
- `document-sync-session.ts` routes all three fine-grained: `commandTargetKey` maps to `comment:<id>` (per-comment debounce coalescing — two edits to one comment in a window commit once, proven by dedicated tests), `writeCommandTarget`/`isBatchWritable`/`writeSubCommand` go through the bridge.
- `SpatialBatchWriter` gains `writeComment`/`deleteComment` via shared non-committing `writeCommentInto`/`deleteCommentInto` internals (the file's existing `writeNodeInto` pattern) so field projection cannot drift between paths; the non-finite-anchor `TypeError` refuses loudly on BOTH paths and an aborted batch commits nothing (test-pinned).
- fast-check concurrency properties (reusing `canvasCommentArbitrary`): two peers creating different comments both survive bidirectional sync; resolve(A) ∥ create(B) preserves both effects. The batch-equivalence property's op set extends with the new writer methods.

## Test plan

- Red-first, mutation-checked: the session regression test (remote comment seeded directly into the doc + local `create-comment` committed through the session) failed on the unfixed code exactly via the resync deletion; removing the write cases re-reddens it. Both concurrency properties mutation-checked by swapping the fine-grained write for a stale whole-canvas rewrite.
- The dev-loop's independent review gate: 0 confirmed findings, QA smoke pass; a review fix round added batch-survival and sibling-field coverage.
- Verified by the integrator on Node 24 (`/opt/nvm`): `loro-adapter-node` + `web-jsdom` 3334 passed on the folded branch; CI-matching `pnpm --filter @kamiazya/whiteboard-web test` 3178+89 passed; `pnpm -r typecheck` and `pnpm check:local` exit 0.
- Existing guards un-weakened: `writeSpatialCanvas` resync still deletes comments the canvas no longer carries (the fallback stays a full-truth statement — safety comes from routing, not from softening it).

Visual evidence: none — no pixel moves; the changed surface is a pure command reducer plus CRDT write routing, and the observable is the fallback's warn log plus doc state, both test-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_