### PR TITLE
refactor(tooling): single-source the vitest browser-mode project config

### DIFF
--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -2,12 +2,11 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
-import { playwright } from '@vitest/browser-playwright'
 import svgr from 'vite-plugin-svgr'
 import topLevelAwait from 'vite-plugin-top-level-await'
 import wasm from 'vite-plugin-wasm'
 import { defineConfig } from 'vitest/config'
-import { resolveBrowserLaunchOptions } from '../../packages/mcp-server/src/server/browser-test-config.js'
+import { sharedBrowserTestConfig } from '../../vitest.browser.shared.js'
 import { mcpSourceAlias } from './mcp-source-alias.js'
 import { workerSafeDepsAlias } from './worker-safe-deps-alias.js'
 
@@ -120,22 +119,6 @@ export default defineConfig({
     // Every browser test renders against the app's real stylesheet — see
     // browser-setup.ts for what silently breaks without it.
     setupFiles: ['./src/test-utils/browser-setup.ts'],
-    browser: {
-      enabled: true,
-      headless: true,
-      connectTimeout: 120_000,
-      screenshotFailures: false,
-      trace: {
-        mode: 'retain-on-failure',
-        tracesDir: './tmp/vitest-traces',
-        screenshots: true,
-        snapshots: true,
-      },
-      viewport: { width: 1280, height: 900 },
-      provider: playwright({
-        launchOptions: resolveBrowserLaunchOptions(process.env),
-      }),
-      instances: [{ browser: 'chromium' }],
-    },
+    browser: sharedBrowserTestConfig({ viewport: { width: 1280, height: 900 } }),
   },
 })

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "knip": "6.26.0",
     "lefthook": "^2.1.10",
     "secretlint": "13.0.2",
+    "@vitest/browser-playwright": "catalog:",
     "vitest": "catalog:"
   }
 }

--- a/packages/canvas-render/package.json
+++ b/packages/canvas-render/package.json
@@ -32,7 +32,6 @@
     "@fast-check/vitest": "^0.4.1",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/vitest-runner": "^9.6.1",
-    "@vitest/browser-playwright": "catalog:",
     "fast-check": "^4.7.0",
     "typescript": "catalog:",
     "vite": "catalog:",

--- a/packages/canvas-render/vitest.browser.config.ts
+++ b/packages/canvas-render/vitest.browser.config.ts
@@ -1,31 +1,10 @@
-import { playwright } from '@vitest/browser-playwright'
 import { defineProject } from 'vitest/config'
-// Import the source file directly rather than `@kamiazya/whiteboard-mcp/test-utils`:
-// that package export resolves to the built `dist/` output, which is gitignored
-// and not produced by a plain `pnpm install` on a clean checkout (CI's browser
-// job never builds packages/mcp-server before running Vitest).
-import { resolveBrowserLaunchOptions } from '../mcp-server/src/server/browser-test-config.js'
+import { sharedBrowserTestConfig } from '../../vitest.browser.shared.js'
 
 export default defineProject({
   test: {
     name: 'canvas-render-browser',
     include: ['src/**/*.browser.test.ts'],
-    browser: {
-      enabled: true,
-      headless: true,
-      connectTimeout: 120_000,
-      screenshotFailures: false,
-      trace: {
-        mode: 'retain-on-failure',
-        tracesDir: './tmp/vitest-traces',
-        screenshots: true,
-        snapshots: true,
-      },
-      viewport: { width: 800, height: 600 },
-      provider: playwright({
-        launchOptions: resolveBrowserLaunchOptions(process.env),
-      }),
-      instances: [{ browser: 'chromium' }],
-    },
+    browser: sharedBrowserTestConfig(),
   },
 })

--- a/packages/canvas-viewer/package.json
+++ b/packages/canvas-viewer/package.json
@@ -48,7 +48,6 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.5",
-    "@vitest/browser-playwright": "catalog:",
     "fast-check": "^4.7.0",
     "playwright": "1.61.1",
     "typescript": "catalog:",

--- a/packages/canvas-viewer/vitest.browser.config.ts
+++ b/packages/canvas-viewer/vitest.browser.config.ts
@@ -1,33 +1,12 @@
 import react from '@vitejs/plugin-react'
-import { playwright } from '@vitest/browser-playwright'
 import { defineProject } from 'vitest/config'
-// Import the source file directly rather than `@kamiazya/whiteboard-mcp/test-utils`:
-// that package export resolves to the built `dist/` output, which is gitignored
-// and not produced by a plain `pnpm install` on a clean checkout (CI's browser
-// job never builds packages/mcp-server before running Vitest).
-import { resolveBrowserLaunchOptions } from '../mcp-server/src/server/browser-test-config.js'
+import { sharedBrowserTestConfig } from '../../vitest.browser.shared.js'
 
 export default defineProject({
   plugins: [react()],
   test: {
     name: 'canvas-viewer-browser',
     include: ['src/**/*.browser.test.tsx'],
-    browser: {
-      enabled: true,
-      headless: true,
-      connectTimeout: 120_000,
-      screenshotFailures: false,
-      trace: {
-        mode: 'retain-on-failure',
-        tracesDir: './tmp/vitest-traces',
-        screenshots: true,
-        snapshots: true,
-      },
-      viewport: { width: 800, height: 600 },
-      provider: playwright({
-        launchOptions: resolveBrowserLaunchOptions(process.env),
-      }),
-      instances: [{ browser: 'chromium' }],
-    },
+    browser: sharedBrowserTestConfig(),
   },
 })

--- a/packages/mcp-server/src/server/release/vitest-projects.test.ts
+++ b/packages/mcp-server/src/server/release/vitest-projects.test.ts
@@ -24,7 +24,9 @@ const RUN_SHARED_LAYER_TESTS_MODULE_PATH = join(ROOT, 'tools/checks/src/run-shar
 interface FixtureProject {
   configPath: string
   name?: string
-  browser?: boolean
+  /** true = the inline `enabled: true` literal; 'shared-helper' = the
+   *  `browser: sharedBrowserTestConfig()` shape the dedupe introduced. */
+  browser?: boolean | 'shared-helper'
 }
 
 interface VitestProjectsModule {
@@ -87,9 +89,12 @@ async function writeFixtureRepo(root: string, projects: FixtureProject[]): Promi
   for (const project of projects) {
     await mkdir(join(root, dirname(project.configPath)), { recursive: true })
     const nameField = project.name ? `      name: '${project.name}',\n` : ''
-    const browserField = project.browser
-      ? `      browser: {\n        enabled: true,\n      },\n`
-      : ''
+    const browserField =
+      project.browser === 'shared-helper'
+        ? `      browser: sharedBrowserTestConfig(),\n`
+        : project.browser
+          ? `      browser: {\n        enabled: true,\n      },\n`
+          : ''
     await writeFile(
       join(root, project.configPath),
       `import { defineConfig } from 'vitest/config'\nexport default defineConfig({\n  test: {\n${nameField}${browserField}  },\n})\n`,
@@ -124,6 +129,21 @@ describe('vitest-projects.mjs', () => {
     ])
 
     expect(deriveSharedLayerProjectNames(fixtureRoot)).toEqual(['alpha-node', 'zeta-node'])
+  })
+
+  it('detects the shared-helper browser shape, keeping it out of the derivation', async () => {
+    const { deriveSharedLayerProjectNames, readBrowserProjectNames } = await importVitestProjects()
+    await writeFixtureRepo(fixtureRoot, [
+      { configPath: 'packages/alpha/vitest.node.config.ts', name: 'alpha-node' },
+      {
+        configPath: 'packages/beta/vitest.browser.config.ts',
+        name: 'beta-browser',
+        browser: 'shared-helper',
+      },
+    ])
+
+    expect(readBrowserProjectNames(fixtureRoot)).toEqual(['beta-browser'])
+    expect(deriveSharedLayerProjectNames(fixtureRoot)).toEqual(['alpha-node'])
   })
 
   it('throws, naming the empty derivation, when every project is excluded or browser-mode', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       '@tanstack/intent':
         specifier: ^0.0.40
         version: 0.0.40
+      '@vitest/browser-playwright':
+        specifier: 'catalog:'
+        version: 4.1.10(msw@2.15.0(@types/node@24.13.1)(typescript@6.0.3))(playwright@1.61.1)(vite@8.2.0(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
       concurrently:
         specifier: ^9
         version: 9.2.1
@@ -367,9 +370,6 @@ importers:
       '@stryker-mutator/vitest-runner':
         specifier: ^9.6.1
         version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@24.13.1))(vitest@4.1.10)
-      '@vitest/browser-playwright':
-        specifier: 'catalog:'
-        version: 4.1.10(msw@2.15.0(@types/node@24.13.1)(typescript@6.0.3))(playwright@1.61.1)(vite@8.2.0(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
       fast-check:
         specifier: ^4.7.0
         version: 4.8.0
@@ -422,9 +422,6 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.5
         version: 6.0.5(vite@8.2.0(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))
-      '@vitest/browser-playwright':
-        specifier: 'catalog:'
-        version: 4.1.10(msw@2.15.0(@types/node@24.13.1)(typescript@6.0.3))(playwright@1.61.1)(vite@8.2.0(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
       fast-check:
         specifier: ^4.7.0
         version: 4.8.0
@@ -9460,7 +9457,7 @@ snapshots:
   '@fast-check/vitest@0.4.1(vitest@4.1.10)':
     dependencies:
       fast-check: 4.8.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(canvas@3.2.3))(msw@2.15.0(@types/node@24.12.2)(typescript@6.0.3))(vite@8.2.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(canvas@3.2.3))(msw@2.15.0(@types/node@24.13.1)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))
 
   '@floating-ui/core@1.8.0':
     dependencies:
@@ -11950,9 +11947,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(canvas@3.2.3))(msw@2.15.0(@types/node@24.12.2)(typescript@6.0.3))(vite@8.2.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(canvas@3.2.3))(msw@2.15.0(@types/node@24.13.1)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.10(msw@2.15.0(@types/node@24.12.2)(typescript@6.0.3))(vite@8.2.0(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(msw@2.15.0(@types/node@24.13.1)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
 
   '@vitest/expect@4.1.10':
     dependencies:

--- a/tools/arch-lint/src/repo-root-files.test.ts
+++ b/tools/arch-lint/src/repo-root-files.test.ts
@@ -55,6 +55,11 @@ const ALLOWED_ROOT_FILES: ReadonlySet<string> = new Set([
   'pnpm-workspace.yaml',
   'release-please-config.json',
   'server.json',
+  // The one definition of the browser-mode project config, spread by the
+  // three vitest.browser.config.ts files. Root on purpose: it sits beside
+  // vitest.config.ts (which registers those projects) and belongs to no
+  // single package.
+  'vitest.browser.shared.ts',
   'vitest.config.ts',
 ])
 

--- a/tools/checks/src/vitest-projects.mjs
+++ b/tools/checks/src/vitest-projects.mjs
@@ -34,7 +34,13 @@ export function readVitestProjects(repoRoot) {
     return {
       configPath,
       name: configContent.match(/name:\s*'([^']+)'/)?.[1],
-      isBrowser: /browser:\s*\{\s*\n?\s*enabled:\s*true/.test(configContent),
+      // Two shapes count as browser-enabled: the inline literal, and the
+      // shared factory every browser config spreads since the dedupe —
+      // sharedBrowserTestConfig() always sets enabled: true, so its call
+      // site is as reliable a marker as the literal it replaced.
+      isBrowser:
+        /browser:\s*\{\s*\n?\s*enabled:\s*true/.test(configContent) ||
+        /browser:\s*sharedBrowserTestConfig\(/.test(configContent),
     }
   })
 }

--- a/vitest.browser.shared.ts
+++ b/vitest.browser.shared.ts
@@ -1,0 +1,41 @@
+import { playwright } from '@vitest/browser-playwright'
+// Import the source file directly rather than `@kamiazya/whiteboard-mcp/test-utils`:
+// that package export resolves to the built `dist/` output, which is gitignored
+// and not produced by a plain `pnpm install` on a clean checkout (CI's browser
+// job never builds packages/mcp-server before running Vitest).
+import { resolveBrowserLaunchOptions } from './packages/mcp-server/src/server/browser-test-config.js'
+
+/**
+ * The one definition of how this repo runs a Vitest browser project —
+ * headless chromium via Playwright, launch options honouring
+ * WHITEBOARD_CHROME_PATH, failure traces retained under the package's
+ * `tmp/vitest-traces` (see AGENTS.md's browser-mode section). Three configs
+ * spread this; before it existed each carried its own copy, and a knob
+ * tuned in one (a trace setting, a connect timeout) silently missed the
+ * other two.
+ *
+ * `viewport` is the one knob that legitimately differs per project:
+ * component-scale projects render at 800x600, apps/web's page tests at
+ * 1280x900.
+ */
+export function sharedBrowserTestConfig(
+  options: { viewport?: { width: number; height: number } } = {},
+) {
+  return {
+    enabled: true,
+    headless: true,
+    connectTimeout: 120_000,
+    screenshotFailures: false,
+    trace: {
+      mode: 'retain-on-failure' as const,
+      tracesDir: './tmp/vitest-traces',
+      screenshots: true,
+      snapshots: true,
+    },
+    viewport: options.viewport ?? { width: 800, height: 600 },
+    provider: playwright({
+      launchOptions: resolveBrowserLaunchOptions(process.env),
+    }),
+    instances: [{ browser: 'chromium' as const }],
+  }
+}


### PR DESCRIPTION
## Summary

- The browser block (headless chromium via Playwright, `WHITEBOARD_CHROME_PATH` launch options, retain-on-failure traces under `tmp/vitest-traces`, connect timeout, instances) was **copied across the three browser configs** (canvas-render, canvas-viewer, apps/web) with only the viewport differing — a knob tuned in one silently missed the other two. `vitest.browser.shared.ts` at the repo root is now the one definition; each config spreads `sharedBrowserTestConfig()`, apps/web passing its 1280×900 viewport. Net −81/+85 with three configs collapsing to a few lines each.
- `@vitest/browser-playwright` moves to the **root devDependencies** (where the shared file that imports it lives — resolving it through the consuming package's context was a warning-level accident surfaced during the change); canvas-render and canvas-viewer drop their now-unused entries; apps/web keeps its own for `vitest.docs-snapshots.config.ts`.
- **The dedupe tripped the vitest-projects guards exactly as designed**: the dependency-free regex parser (`tools/checks/src/vitest-projects.mjs`) scanned for the inline `browser: { enabled: true }` literal, and five guard tests went red when the three projects stopped matching — the "browser-enabled project silently leaves the CI derivation" failure those guards exist to catch. The parser now also recognizes the `browser: sharedBrowserTestConfig(` call site (the helper always sets `enabled: true`), with a new fixture shape in `vitest-projects.test.ts` pinning it.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — new `vitest-projects.test.ts` fixture case for the shared-helper shape (`readBrowserProjectNames` detects it; the shared-layer derivation excludes it)
- [x] `pnpm test` passes locally — all three browser projects run against the shared config (`canvas-render-browser` + `canvas-viewer-browser` 23/23, a `web-browser` file 3/3), guard suites `vitest-projects` + `ci-verify-coverage` + `docs-contract` 25/25, full `mcp-node` 4,208 passed (only the known Node-22 environment guard fails locally; CI runs the pinned Node 24), `pnpm -r typecheck`, `pnpm lint`, `pnpm knip` green, `pnpm install --frozen-lockfile` clean
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable — not needed: config-only refactor, exercised by every browser-mode run

Mutation check: reverting the parser widening fails the new fixture test (`detects the shared-helper browser shape…`) while the other ten stay green; restored, 11/11.

Manual verification: ran each browser project end-to-end against the deduped config with real chromium (the launch-option, trace and viewport knobs all take effect through the shared path); confirmed the `Module not found` resolution warning for `@vitest/browser-playwright` disappears once the dependency lives beside its importer.

## Visual evidence

Visual evidence: none — test-tooling config refactor; no UI or pixel change.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — no user-visible or contract change
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_