### PR TITLE
refactor(web): split CanvasContextMenu into per-variant item builders

### DIFF
--- a/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
@@ -1,66 +1,18 @@
 /** Right-click menu: node, edge, and empty-canvas actions. */
 
-import type { SpatialPresetKey } from '@kamiazya/whiteboard-canvas-render'
-import {
-  SPATIAL_DARK_PALETTE,
-  SPATIAL_LIGHT_PALETTE,
-  tidyNodes,
-} from '@kamiazya/whiteboard-canvas-render'
 import type { FacetRegistry } from '@kamiazya/whiteboard-facet-engine'
-import type {
-  CanvasColor,
-  ClipboardFragment,
-  SpatialCanvas,
-  SpatialNode,
-} from '@kamiazya/whiteboard-model'
+import type { ClipboardFragment, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
 import { bundledFacetRegistry } from '@kamiazya/whiteboard-plugin-visual'
-import {
-  AlignCenterHorizontal,
-  AlignCenterVertical,
-  AlignEndHorizontal,
-  AlignEndVertical,
-  AlignHorizontalDistributeCenter,
-  AlignStartHorizontal,
-  AlignStartVertical,
-  AlignVerticalDistributeCenter,
-  BringToFront,
-  ChevronDown,
-  ChevronUp,
-  ClipboardPaste,
-  Copy as CopyIcon,
-  CopyPlus,
-  ExternalLink,
-  FileBox,
-  Frame,
-  Image as ImageIcon,
-  ImageOff,
-  Link,
-  Lock as LockIcon,
-  LockOpen,
-  PanelBottom,
-  PanelLeft,
-  PanelRight,
-  PanelTop,
-  Pencil,
-  Scissors,
-  SendToBack,
-  Sparkles,
-  SquareDashed,
-  StickyNote,
-  Tag,
-  Trash2,
-} from 'lucide-react'
 import type { MutableRefObject } from 'react'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
-import { hasClipboardFragment } from '../../lib/clipboard-store.js'
 import type { BoxMove } from './align.js'
-import { alignableBoxesOf, alignBoxes, distributeBoxes } from './align.js'
+import { alignableBoxesOf } from './align.js'
 import { ContextMenu, type ContextMenuItem } from './ContextMenu.js'
-import type { EditorCommand } from './commands.js'
-import { CREATION_LABELS } from './creation-labels.js'
+import { canvasMenuItems } from './context-menu-items/canvas-menu-items.js'
+import { edgeMenuItems } from './context-menu-items/edge-menu-items.js'
+import { nodeMenuItems } from './context-menu-items/node-menu-items.js'
 import type { FileRefOption } from './DocumentPickerDialog.js'
-import { nodePropertyItems } from './facet-widgets/index.js'
-import { type GestureResult, type GestureState, reduceGesture } from './gestures.js'
+import type { GestureResult, GestureState } from './gestures.js'
 import type { Point } from './viewport.js'
 
 /** Open right-click menu: screen position (root-relative) + hit target. */
@@ -201,583 +153,87 @@ export function CanvasContextMenu({
   // computes against a stale render closure.
   const selectedAlignableBoxes = () =>
     alignableBoxesOf(canvasRef.current.nodes, selectedId === null ? [] : [selectedId, ...extraIds])
+
+  const node =
+    contextMenu.nodeId === undefined
+      ? undefined
+      : canvas.nodes.find((n) => n.id === contextMenu.nodeId)
+  const edge =
+    contextMenu.edgeId === undefined
+      ? undefined
+      : canvas.edges.find((entry) => entry.id === contextMenu.edgeId)
+
+  const items: readonly ContextMenuItem[] =
+    node === undefined && edge !== undefined
+      ? edgeMenuItems({
+          edge,
+          theme,
+          isEdgeLocked,
+          edgeLockEnabled,
+          applyResult,
+          setEdgeLabelEditId,
+          setSelectedEdgeId,
+          onToggleEdgeLock,
+        })
+      : node === undefined
+        ? canvasMenuItems({
+            point: contextMenu.point,
+            canvas,
+            canvasRef,
+            isLocked,
+            fileRefOptions,
+            onAddImage,
+            pendingImagePointRef,
+            imageInputRef,
+            pasteClipboard,
+            createNodeAt,
+            setLinkDialog,
+            createGroupAtViewportCenter,
+            setDocumentPicker,
+            applyBoxMoves,
+          })
+        : nodeMenuItems({
+            node,
+            canvas,
+            canvasRef,
+            theme,
+            gestureState,
+            isLocked,
+            lockEnabled,
+            isEdgeLocked,
+            extraIds,
+            selectedId,
+            isImageFileRef,
+            missingFileRef,
+            fileRefOptions,
+            facetRegistry,
+            selectedAlignableBoxes,
+            pendingBackgroundGroupIdRef,
+            imageInputRef,
+            applyResult,
+            applyBoxMoves,
+            copySelection,
+            cutSelection,
+            duplicateSelection,
+            reorderSelection,
+            groupSelection,
+            openLinkNode,
+            onOpenFileRef,
+            onAddImage,
+            onToggleNodeLock,
+            setGroupLabelEditId,
+            setLinkDialog,
+            setDocumentPicker,
+            setFacetPanelOpen,
+          })
+
   return (
     <ContextMenu
       x={contextMenu.x}
       y={contextMenu.y}
       variant={contextMenu.variant}
       onClose={() => setContextMenu(null)}
-      items={(() => {
-        const node =
-          contextMenu.nodeId === undefined
-            ? undefined
-            : canvas.nodes.find((n) => n.id === contextMenu.nodeId)
-        const edge =
-          contextMenu.edgeId === undefined
-            ? undefined
-            : canvas.edges.find((entry) => entry.id === contextMenu.edgeId)
-        // The swatch chips preview the CURRENT mode's preset strokes so
-        // the picker shows what will actually render; the stored value
-        // stays the semantic slot ('1'..'6'), never a resolved hex.
-        const presetSwatches = (theme === 'dark' ? SPATIAL_DARK_PALETTE : SPATIAL_LIGHT_PALETTE)
-          .presets
-        const presetEntries: readonly {
-          readonly key: SpatialPresetKey
-          readonly name: string
-        }[] = [
-          { key: '1', name: 'Red' },
-          { key: '2', name: 'Orange' },
-          { key: '3', name: 'Yellow' },
-          { key: '4', name: 'Green' },
-          { key: '5', name: 'Cyan' },
-          { key: '6', name: 'Purple' },
-        ]
-        const colorRow = (
-          current: CanvasColor | undefined,
-          apply: (color: CanvasColor | undefined) => void,
-        ) => ({
-          kind: 'options' as const,
-          label: 'Color',
-          options: [
-            {
-              label: 'default',
-              ariaLabel: 'Default',
-              icon: <SquareDashed />,
-              selected: current === undefined,
-              onSelect: () => apply(undefined),
-            },
-            ...presetEntries.map((entry) => ({
-              label: entry.key,
-              ariaLabel: entry.name,
-              icon: (
-                // Paint-critical props are inline, not utility classes:
-                // a default-inline span ignores width/height entirely
-                // (it laid out 0x0 live), and the chip must also paint
-                // where the app stylesheet is absent.
-                <span
-                  style={{
-                    display: 'block',
-                    width: 14,
-                    height: 14,
-                    borderRadius: '50%',
-                    backgroundColor: presetSwatches[entry.key].stroke,
-                  }}
-                />
-              ),
-              selected: current === entry.key,
-              onSelect: () => apply(entry.key),
-            })),
-          ],
-          // The JSON Canvas color union is presets OR a 6-digit hex;
-          // the native color input covers the hex half the swatches
-          // cannot.
-          customColor: {
-            value: current?.startsWith('#') === true ? current : '#808080',
-            ariaLabel: 'Custom color',
-            selected: current?.startsWith('#') === true,
-            onPick: (hex: string) => apply(hex as CanvasColor),
-          },
-        })
-        if (node === undefined && edge !== undefined) {
-          // A locked edge offers exactly one action. Everything else in
-          // this branch — delete, label, arrowheads, sides, colour —
-          // is a mutation the lock exists to refuse.
-          if (isEdgeLocked(edge.id)) {
-            return [
-              {
-                label: 'Unlock',
-                icon: <LockOpen />,
-                onSelect: () => onToggleEdgeLock?.(edge.id, false),
-              },
-            ]
-          }
-          // Property pickers are inline option rows (one tap per
-          // choice, menu stays open) — a cycling item costs an
-          // open-tap-reopen per step. Sections group the menu:
-          // actions, then properties, then the destructive entry.
-          // Arrow direction reads the JSON Canvas defaults (fromEnd
-          // none, toEnd arrow).
-          const fromEnd = edge.fromEnd ?? 'none'
-          const toEnd = edge.toEnd ?? 'arrow'
-          const arrowStates = [
-            { label: '→', ariaLabel: 'Forward', fromEnd: 'none', toEnd: 'arrow' },
-            { label: '↔', ariaLabel: 'Both', fromEnd: 'arrow', toEnd: 'arrow' },
-            { label: '←', ariaLabel: 'Backward', fromEnd: 'arrow', toEnd: 'none' },
-            { label: '−', ariaLabel: 'None', fromEnd: 'none', toEnd: 'none' },
-          ] as const
-          const applyEdgeCommand = (command: EditorCommand) =>
-            applyResult({ state: { kind: 'idle' }, commands: [command] })
-          // Excel-border-style side pickers: a rectangle with the
-          // pinned side emphasized; dashed = unpinned (auto).
-          const SIDES = [
-            { label: 'auto', ariaLabel: 'Auto', icon: <SquareDashed />, side: undefined },
-            { label: 'top', ariaLabel: 'Top', icon: <PanelTop />, side: 'top' },
-            { label: 'right', ariaLabel: 'Right', icon: <PanelRight />, side: 'right' },
-            { label: 'bottom', ariaLabel: 'Bottom', icon: <PanelBottom />, side: 'bottom' },
-            { label: 'left', ariaLabel: 'Left', icon: <PanelLeft />, side: 'left' },
-          ] as const
-          const sideRow = (endpoint: 'from' | 'to') => {
-            const current = endpoint === 'from' ? edge.fromSide : edge.toSide
-            return {
-              kind: 'options' as const,
-              label: endpoint === 'from' ? 'From side' : 'To side',
-              options: SIDES.map((entry) => ({
-                label: entry.label,
-                icon: entry.icon,
-                ariaLabel: entry.ariaLabel,
-                selected: current === entry.side,
-                onSelect: () =>
-                  applyEdgeCommand({
-                    kind: 'set-edge-side',
-                    id: edge.id,
-                    endpoint,
-                    side: entry.side,
-                  }),
-              })),
-            }
-          }
-          return [
-            {
-              kind: 'options' as const,
-              label: 'Arrows',
-              options: arrowStates.map((state) => ({
-                label: state.label,
-                ariaLabel: state.ariaLabel,
-                selected: state.fromEnd === fromEnd && state.toEnd === toEnd,
-                onSelect: () =>
-                  applyEdgeCommand({
-                    kind: 'set-edge-ends',
-                    id: edge.id,
-                    fromEnd: state.fromEnd,
-                    toEnd: state.toEnd,
-                  }),
-              })),
-            },
-            sideRow('from'),
-            sideRow('to'),
-            colorRow(edge.color, (color) =>
-              applyEdgeCommand({ kind: 'set-edge-color', id: edge.id, color }),
-            ),
-            { kind: 'separator' as const },
-            {
-              label: 'Edit label',
-              icon: <Tag />,
-              onSelect: () => setEdgeLabelEditId(edge.id),
-            },
-            ...(edgeLockEnabled
-              ? [
-                  {
-                    label: 'Lock',
-                    icon: <LockIcon />,
-                    onSelect: () => {
-                      onToggleEdgeLock?.(edge.id, true)
-                      setSelectedEdgeId(null)
-                    },
-                  },
-                ]
-              : []),
-            { kind: 'separator' as const },
-            {
-              label: 'Delete',
-              icon: <Trash2 />,
-              danger: true,
-              onSelect: () => {
-                applyResult({
-                  state: { kind: 'idle' },
-                  commands: [{ kind: 'delete-edge', id: edge.id } as const],
-                })
-                setSelectedEdgeId(null)
-              },
-            },
-          ]
-        }
-        if (node === undefined) {
-          // The same creation set as the dock's + menu, anchored at
-          // the click point — "here" is exactly the information the
-          // bottom dock cannot express.
-          const emptyItems: ContextMenuItem[] = [
-            ...(hasClipboardFragment()
-              ? [
-                  {
-                    label: 'Paste here',
-                    icon: <ClipboardPaste />,
-                    onSelect: () => {
-                      pasteClipboard(contextMenu.point)
-                    },
-                  },
-                  { kind: 'separator' } as const,
-                ]
-              : []),
-            {
-              label: CREATION_LABELS.note,
-              icon: <StickyNote />,
-              onSelect: () => createNodeAt(contextMenu.point),
-            },
-            {
-              label: CREATION_LABELS.link,
-              icon: <Link />,
-              onSelect: () => setLinkDialog({ mode: 'create', point: contextMenu.point }),
-            },
-            {
-              label: CREATION_LABELS.group,
-              icon: <Frame />,
-              onSelect: () => createGroupAtViewportCenter(contextMenu.point),
-            },
-          ]
-          if (fileRefOptions !== undefined) {
-            emptyItems.push({
-              label: CREATION_LABELS.document,
-              icon: <FileBox />,
-              onSelect: () => setDocumentPicker({ mode: 'create', point: contextMenu.point }),
-            })
-          }
-          if (onAddImage !== undefined) {
-            emptyItems.push({
-              label: CREATION_LABELS.image,
-              icon: <ImageIcon />,
-              onSelect: () => {
-                pendingImagePointRef.current = contextMenu.point
-                imageInputRef.current?.click()
-              },
-            })
-          }
-          // Tidy needs a second node to tidy AGAINST — the item appears
-          // only once it can do something, like Align/Distribute above.
-          if (canvas.nodes.length >= 2) {
-            emptyItems.push({ kind: 'separator' })
-            emptyItems.push({
-              label: 'Tidy canvas',
-              icon: <Sparkles />,
-              onSelect: () =>
-                applyBoxMoves(tidyNodes(canvasRef.current.nodes, { locked: isLocked })),
-            })
-          }
-          return emptyItems
-        }
-        // The catalog's band order, shared by both vessels (list and grid):
-        // 1. properties (state pickers — the menu stays open),
-        // 2. verbs (one-shot — the menu closes),
-        // 3. the destructive entry, alone at the bottom.
-        const properties: ContextMenuItem[] = []
-        const verbs: ContextMenuItem[] = []
-        if (node.type === 'group') {
-          verbs.push({
-            label: 'Edit label',
-            icon: <Tag />,
-            onSelect: () => setGroupLabelEditId(node.id),
-          })
-          if (onAddImage !== undefined) {
-            verbs.push({
-              label: 'Set background image',
-              icon: <ImageIcon />,
-              onSelect: () => {
-                pendingBackgroundGroupIdRef.current = node.id
-                imageInputRef.current?.click()
-              },
-            })
-          }
-          if (node.background !== undefined) {
-            const background = node.background
-            const applyStyle = (backgroundStyle: 'cover' | 'ratio') =>
-              applyResult({
-                state: { kind: 'idle' },
-                commands: [
-                  { kind: 'set-group-background', id: node.id, background, backgroundStyle },
-                ],
-              })
-            properties.push({
-              kind: 'options',
-              label: 'Background',
-              options: [
-                {
-                  label: 'Cover',
-                  ariaLabel: 'Cover',
-                  selected: node.backgroundStyle !== 'ratio',
-                  onSelect: () => applyStyle('cover'),
-                },
-                {
-                  label: 'Fit',
-                  ariaLabel: 'Fit',
-                  selected: node.backgroundStyle === 'ratio',
-                  onSelect: () => applyStyle('ratio'),
-                },
-              ],
-            })
-            verbs.push({
-              label: 'Remove background',
-              icon: <ImageOff />,
-              onSelect: () =>
-                applyResult({
-                  state: { kind: 'idle' },
-                  commands: [{ kind: 'set-group-background', id: node.id }],
-                }),
-            })
-          }
-        }
-        // Framing an existing multi-selection is reached from any of
-        // its members — the frame encloses every selected node,
-        // including group frames: nesting is geometric in JSON Canvas,
-        // and containment moves already handle nested frames.
-        if (extraIds.size > 0) {
-          verbs.push({
-            label: 'Group selection',
-            icon: <Frame />,
-            onSelect: () => groupSelection([node.id, ...extraIds]),
-          })
-        }
-        if (node.type === 'file' && isImageFileRef?.(node.file) !== true) {
-          // A missing target makes Open a dead end (worse: the daemon's
-          // path routes lazily create, so following would mint an empty
-          // canvas under the dangling ref). Change target stays — it is
-          // the repair affordance.
-          if (onOpenFileRef !== undefined && missingFileRef?.(node.file) !== true) {
-            verbs.push({
-              label: 'Open canvas',
-              icon: <ExternalLink />,
-              onSelect: () => onOpenFileRef(node.file, node.subpath),
-            })
-          }
-          if (fileRefOptions !== undefined) {
-            verbs.push({
-              label: 'Change target',
-              icon: <FileBox />,
-              onSelect: () => setDocumentPicker({ mode: 'retarget', nodeId: node.id }),
-            })
-          }
-        }
-        if (node.type === 'link') {
-          verbs.push({
-            label: 'Open link',
-            icon: <ExternalLink />,
-            onSelect: () => openLinkNode(node),
-          })
-          verbs.push({
-            label: 'Edit URL',
-            icon: <Pencil />,
-            onSelect: () => setLinkDialog({ mode: 'edit', nodeId: node.id }),
-          })
-        }
-        if (node.type === 'text') {
-          verbs.push({
-            label: 'Edit text',
-            icon: <Pencil />,
-            onSelect: () => {
-              applyResult(
-                reduceGesture(gestureState, canvas, {
-                  type: 'start-text-edit',
-                  nodeId: node.id,
-                  text: node.text,
-                }),
-              )
-            },
-          })
-        }
-        // Touch path to Cmd/Ctrl+D (see shortcuts.ts). The menu's
-        // right-click already made this node the primary selection,
-        // so the shared handler clones the full multi-selection.
-        // A locked node's menu offers exactly one action: unlock.
-        // Showing Delete/Edit next to a lock the user deliberately
-        // set would make the lock read as decorative.
-        if (isLocked(node.id)) {
-          return [
-            {
-              label: 'Unlock',
-              icon: <LockOpen />,
-              onSelect: () => onToggleNodeLock?.(node.id, false),
-            },
-          ]
-        }
-        verbs.push({
-          label: 'Copy',
-          icon: <CopyIcon />,
-          onSelect: () => {
-            copySelection()
-          },
-        })
-        verbs.push({
-          label: 'Cut',
-          icon: <Scissors />,
-          onSelect: () => {
-            // The cut defers its delete: cutSelection holds the selection as
-            // a ghost until the paste resolves it.
-            cutSelection()
-          },
-        })
-        verbs.push({
-          label: 'Duplicate',
-          // Not CopyIcon: in the icon-only grid vessel, Copy and Duplicate
-          // with one glyph would be indistinguishable side by side.
-          icon: <CopyPlus />,
-          onSelect: () => {
-            duplicateSelection()
-          },
-        })
-        properties.push(
-          colorRow(node.color, (color) => {
-            // Recoloring FROM a multi-selection styles the whole
-            // selected AREA: every member, and every edge that runs
-            // between two members — the closest executable reading of
-            // "select a region, recolor it". An edge leaving the
-            // selection keeps its color (only one endpoint is inside),
-            // and a target outside the selection styles itself alone.
-            const members = new Set(selectedId !== null ? [selectedId, ...extraIds] : [])
-            const nodeTargets = members.has(node.id) ? [...members] : [node.id]
-            const edgeTargets =
-              nodeTargets.length > 1
-                ? canvas.edges.filter(
-                    (edge) =>
-                      !isEdgeLocked(edge.id) &&
-                      members.has(edge.fromNode) &&
-                      members.has(edge.toNode),
-                  )
-                : []
-            applyResult({
-              state: { kind: 'idle' },
-              commands: [
-                ...nodeTargets.map((id) => ({ kind: 'set-node-color' as const, id, color })),
-                ...edgeTargets.map((edge) => ({
-                  kind: 'set-edge-color' as const,
-                  id: edge.id,
-                  color,
-                })),
-              ],
-            })
-          }),
-        )
-        // Facets reach this surface as ONE doorway. This menu never names a
-        // plugin or facet key (facet-wiring-guard.test.ts keeps it that way),
-        // and now it does not carry their values either — an action menu runs
-        // an entry and closes; a facet is state you adjust repeatedly.
-        const facetItems = nodePropertyItems(facetRegistry, {
-          openPanel: () => setFacetPanelOpen(true),
-        })
-        // Z-order as one-tap options — the touch path to the [ / ]
-        // keyboard shortcuts (see shortcuts.ts). Not a picker: no
-        // option is ever "selected", each tap applies a move.
-        properties.push({
-          kind: 'options',
-          label: 'Order',
-          options: [
-            {
-              label: 'back',
-              ariaLabel: 'Send to back',
-              icon: <SendToBack />,
-              selected: false,
-              onSelect: () => reorderSelection('back'),
-            },
-            {
-              label: 'backward',
-              ariaLabel: 'Send backward',
-              icon: <ChevronDown />,
-              selected: false,
-              onSelect: () => reorderSelection('backward'),
-            },
-            {
-              label: 'forward',
-              ariaLabel: 'Bring forward',
-              icon: <ChevronUp />,
-              selected: false,
-              onSelect: () => reorderSelection('forward'),
-            },
-            {
-              label: 'front',
-              ariaLabel: 'Bring to front',
-              icon: <BringToFront />,
-              selected: false,
-              onSelect: () => reorderSelection('front'),
-            },
-          ],
-        })
-        // Align needs a second box to align TO, and distribute needs a
-        // middle one to place — so each row appears only once its
-        // action means something, rather than sitting there inert.
-        const alignableCount = extraIds.size + 1
-        if (alignableCount >= 2) {
-          properties.push({
-            kind: 'options',
-            label: 'Align',
-            options: (
-              [
-                ['left', 'Align left', <AlignStartVertical key="l" />],
-                ['center-x', 'Align centre horizontally', <AlignCenterVertical key="cx" />],
-                ['right', 'Align right', <AlignEndVertical key="r" />],
-                ['top', 'Align top', <AlignStartHorizontal key="t" />],
-                ['center-y', 'Align centre vertically', <AlignCenterHorizontal key="cy" />],
-                ['bottom', 'Align bottom', <AlignEndHorizontal key="b" />],
-              ] as const
-            ).map(([mode, ariaLabel, icon]) => ({
-              label: mode,
-              ariaLabel,
-              icon,
-              selected: false,
-              onSelect: () => applyBoxMoves(alignBoxes(selectedAlignableBoxes(), mode)),
-            })),
-          })
-        }
-        if (alignableCount >= 3) {
-          properties.push({
-            kind: 'options',
-            label: 'Distribute',
-            options: (
-              [
-                [
-                  'horizontal',
-                  'Distribute horizontally',
-                  <AlignHorizontalDistributeCenter key="h" />,
-                ],
-                ['vertical', 'Distribute vertically', <AlignVerticalDistributeCenter key="v" />],
-              ] as const
-            ).map(([axis, ariaLabel, icon]) => ({
-              label: axis,
-              ariaLabel,
-              icon,
-              selected: false,
-              onSelect: () => applyBoxMoves(distributeBoxes(selectedAlignableBoxes(), axis)),
-            })),
-          })
-        }
-        if (alignableCount >= 2) {
-          verbs.push({
-            label: 'Tidy',
-            icon: <Sparkles />,
-            onSelect: () =>
-              applyBoxMoves(
-                tidyNodes(canvasRef.current.nodes, {
-                  scope: new Set([node.id, ...extraIds]),
-                  locked: isLocked,
-                }),
-              ),
-          })
-        }
-        if (lockEnabled) {
-          verbs.push({
-            label: 'Lock',
-            icon: <LockIcon />,
-            onSelect: () => onToggleNodeLock?.(node.id, true),
-          })
-        }
-        return [
-          ...properties,
-          // Extensions come after every core row, behind their own fence.
-          ...facetItems,
-          { kind: 'separator' as const },
-          ...verbs,
-          { kind: 'separator' as const },
-          {
-            label: 'Delete',
-            icon: <Trash2 />,
-            danger: true,
-            onSelect: () => {
-              applyResult(
-                reduceGesture(gestureState, canvas, {
-                  type: 'delete-selection',
-                  nodeId: node.id,
-                }),
-              )
-            },
-          },
-        ]
-      })()}
+      items={items}
     />
   )
 }

--- a/apps/web/src/components/spatial-editor/context-menu-items/canvas-menu-items.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu-items/canvas-menu-items.test.tsx
@@ -1,0 +1,109 @@
+// The empty-canvas branch's composition rules: paste only with a clipboard
+// fragment, creation entries always, document/image only when the host wires
+// them, Tidy only once there is a second node to tidy against.
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearClipboardFragmentForTests,
+  writeClipboardFragment,
+} from '../../../lib/clipboard-store.js'
+import { canvasMenuItems } from './canvas-menu-items.js'
+
+const emptyCanvas: SpatialCanvas = { nodes: [], edges: [] }
+const twoNodeCanvas: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 0, y: 0, width: 10, height: 10, text: 'a' },
+    { id: 'b', type: 'text', x: 20, y: 0, width: 10, height: 10, text: 'b' },
+  ],
+  edges: [],
+}
+
+function baseInput(canvas: SpatialCanvas) {
+  return {
+    point: { x: 5, y: 5 },
+    canvas,
+    canvasRef: { current: canvas },
+    isLocked: () => false,
+    fileRefOptions: undefined,
+    onAddImage: undefined,
+    pendingImagePointRef: { current: null },
+    imageInputRef: { current: null },
+    pasteClipboard: vi.fn(),
+    createNodeAt: vi.fn(),
+    setLinkDialog: vi.fn(),
+    createGroupAtViewportCenter: vi.fn(),
+    setDocumentPicker: vi.fn(),
+    applyBoxMoves: vi.fn(),
+  }
+}
+
+describe('canvasMenuItems', () => {
+  afterEach(() => {
+    clearClipboardFragmentForTests()
+  })
+
+  it('offers only the creation entries when nothing extra is wired', () => {
+    const items = canvasMenuItems(baseInput(emptyCanvas))
+    expect(items.map((item) => (item as { label: string }).label)).toEqual([
+      'Note',
+      'Link',
+      'Group',
+    ])
+  })
+
+  it('prepends Paste here (and a separator) only when a clipboard fragment exists', () => {
+    const withoutFragment = canvasMenuItems(baseInput(emptyCanvas))
+    expect(
+      withoutFragment.some((item) => (item as { label?: string }).label === 'Paste here'),
+    ).toBe(false)
+
+    writeClipboardFragment({
+      type: 'whiteboard/clipboard',
+      version: 1,
+      nodes: [{ id: 'n', type: 'text', x: 0, y: 0, width: 1, height: 1, text: '' }],
+      edges: [],
+    })
+    const withFragment = canvasMenuItems(baseInput(emptyCanvas))
+    expect(withFragment[0]).toMatchObject({ label: 'Paste here' })
+    expect(withFragment[1]).toEqual({ kind: 'separator' })
+
+    const pasteClipboard = vi.fn()
+    const input = { ...baseInput(emptyCanvas), pasteClipboard }
+    const items = canvasMenuItems(input)
+    ;(items[0] as { onSelect: () => void }).onSelect()
+    expect(pasteClipboard).toHaveBeenCalledWith({ x: 5, y: 5 })
+  })
+
+  it('adds Document only when fileRefOptions is wired', () => {
+    const without = canvasMenuItems(baseInput(emptyCanvas))
+    expect(without.some((item) => (item as { label?: string }).label === 'Document')).toBe(false)
+
+    const withDocument = canvasMenuItems({ ...baseInput(emptyCanvas), fileRefOptions: [] })
+    expect(withDocument.some((item) => (item as { label?: string }).label === 'Document')).toBe(
+      true,
+    )
+  })
+
+  it('adds Image only when onAddImage is wired', () => {
+    const without = canvasMenuItems(baseInput(emptyCanvas))
+    expect(without.some((item) => (item as { label?: string }).label === 'Image')).toBe(false)
+
+    const withImage = canvasMenuItems({ ...baseInput(emptyCanvas), onAddImage: vi.fn() })
+    expect(withImage.some((item) => (item as { label?: string }).label === 'Image')).toBe(true)
+  })
+
+  it('adds a separator + Tidy canvas only once the canvas holds a second node', () => {
+    const withOne = canvasMenuItems(baseInput(emptyCanvas))
+    expect(withOne.some((item) => (item as { label?: string }).label === 'Tidy canvas')).toBe(false)
+
+    const applyBoxMoves = vi.fn()
+    const withTwo = canvasMenuItems({ ...baseInput(twoNodeCanvas), applyBoxMoves })
+    const tidyIndex = withTwo.findIndex(
+      (item) => (item as { label?: string }).label === 'Tidy canvas',
+    )
+    expect(tidyIndex).toBeGreaterThan(0)
+    expect(withTwo[tidyIndex - 1]).toEqual({ kind: 'separator' })
+    ;(withTwo[tidyIndex] as { onSelect: () => void }).onSelect()
+    expect(applyBoxMoves).toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/spatial-editor/context-menu-items/canvas-menu-items.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu-items/canvas-menu-items.tsx
@@ -1,0 +1,117 @@
+/**
+ * The empty-canvas branch: paste-with-fragment, creation entries, the
+ * conditional document/image entries, and Tidy at >=2 nodes.
+ */
+import { tidyNodes } from '@kamiazya/whiteboard-canvas-render'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import {
+  ClipboardPaste,
+  FileBox,
+  Frame,
+  Image as ImageIcon,
+  Link,
+  Sparkles,
+  StickyNote,
+} from 'lucide-react'
+import type { MutableRefObject } from 'react'
+import { hasClipboardFragment } from '../../../lib/clipboard-store.js'
+import type { CanvasCommands } from '../CanvasContextMenu.js'
+import type { ContextMenuItem } from '../ContextMenu.js'
+import { CREATION_LABELS } from '../creation-labels.js'
+import type { FileRefOption } from '../DocumentPickerDialog.js'
+import type { Point } from '../viewport.js'
+
+export interface CanvasMenuItemsInput {
+  readonly point: Point
+  readonly canvas: SpatialCanvas
+  readonly canvasRef: MutableRefObject<SpatialCanvas>
+  readonly isLocked: (nodeId: string) => boolean
+  readonly fileRefOptions?: readonly FileRefOption[]
+  readonly onAddImage: CanvasCommands['onAddImage']
+  readonly pendingImagePointRef: MutableRefObject<Point | null>
+  readonly imageInputRef: MutableRefObject<HTMLInputElement | null>
+  readonly pasteClipboard: CanvasCommands['pasteClipboard']
+  readonly createNodeAt: CanvasCommands['createNodeAt']
+  readonly setLinkDialog: CanvasCommands['setLinkDialog']
+  readonly createGroupAtViewportCenter: CanvasCommands['createGroupAtViewportCenter']
+  readonly setDocumentPicker: CanvasCommands['setDocumentPicker']
+  readonly applyBoxMoves: CanvasCommands['applyBoxMoves']
+}
+
+export function canvasMenuItems({
+  point,
+  canvas,
+  canvasRef,
+  isLocked,
+  fileRefOptions,
+  onAddImage,
+  pendingImagePointRef,
+  imageInputRef,
+  pasteClipboard,
+  createNodeAt,
+  setLinkDialog,
+  createGroupAtViewportCenter,
+  setDocumentPicker,
+  applyBoxMoves,
+}: CanvasMenuItemsInput): ContextMenuItem[] {
+  // The same creation set as the dock's + menu, anchored at
+  // the click point — "here" is exactly the information the
+  // bottom dock cannot express.
+  const emptyItems: ContextMenuItem[] = [
+    ...(hasClipboardFragment()
+      ? [
+          {
+            label: 'Paste here',
+            icon: <ClipboardPaste />,
+            onSelect: () => {
+              pasteClipboard(point)
+            },
+          },
+          { kind: 'separator' } as const,
+        ]
+      : []),
+    {
+      label: CREATION_LABELS.note,
+      icon: <StickyNote />,
+      onSelect: () => createNodeAt(point),
+    },
+    {
+      label: CREATION_LABELS.link,
+      icon: <Link />,
+      onSelect: () => setLinkDialog({ mode: 'create', point }),
+    },
+    {
+      label: CREATION_LABELS.group,
+      icon: <Frame />,
+      onSelect: () => createGroupAtViewportCenter(point),
+    },
+  ]
+  if (fileRefOptions !== undefined) {
+    emptyItems.push({
+      label: CREATION_LABELS.document,
+      icon: <FileBox />,
+      onSelect: () => setDocumentPicker({ mode: 'create', point }),
+    })
+  }
+  if (onAddImage !== undefined) {
+    emptyItems.push({
+      label: CREATION_LABELS.image,
+      icon: <ImageIcon />,
+      onSelect: () => {
+        pendingImagePointRef.current = point
+        imageInputRef.current?.click()
+      },
+    })
+  }
+  // Tidy needs a second node to tidy AGAINST — the item appears
+  // only once it can do something, like Align/Distribute above.
+  if (canvas.nodes.length >= 2) {
+    emptyItems.push({ kind: 'separator' })
+    emptyItems.push({
+      label: 'Tidy canvas',
+      icon: <Sparkles />,
+      onSelect: () => applyBoxMoves(tidyNodes(canvasRef.current.nodes, { locked: isLocked })),
+    })
+  }
+  return emptyItems
+}

--- a/apps/web/src/components/spatial-editor/context-menu-items/color-row.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu-items/color-row.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest'
+import { colorRow, presetEntries } from './color-row.js'
+
+describe('colorRow', () => {
+  it('offers default plus every preset, selecting the current value', () => {
+    const apply = vi.fn()
+    const row = colorRow('light', '3', apply)
+    expect(row.label).toBe('Color')
+    expect(row.options.map((o) => o.label)).toEqual(['default', ...presetEntries.map((p) => p.key)])
+    const yellow = row.options.find((o) => o.label === '3')
+    expect(yellow?.selected).toBe(true)
+    expect(row.options.find((o) => o.label === 'default')?.selected).toBe(false)
+  })
+
+  it('applies undefined for the default option and the preset key for a swatch', () => {
+    const apply = vi.fn()
+    const row = colorRow('light', undefined, apply)
+    row.options.find((o) => o.label === 'default')?.onSelect()
+    expect(apply).toHaveBeenCalledWith(undefined)
+    row.options.find((o) => o.label === '2')?.onSelect()
+    expect(apply).toHaveBeenCalledWith('2')
+  })
+
+  it('the custom color entry reflects a hex value and applies a picked hex', () => {
+    const apply = vi.fn()
+    const row = colorRow('light', '#112233', apply)
+    expect(row.customColor?.selected).toBe(true)
+    expect(row.customColor?.value).toBe('#112233')
+    row.customColor?.onPick('#445566')
+    expect(apply).toHaveBeenCalledWith('#445566')
+  })
+})

--- a/apps/web/src/components/spatial-editor/context-menu-items/color-row.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu-items/color-row.tsx
@@ -1,0 +1,73 @@
+/** Swatch/custom-hex color row shared by the edge and node context menus. */
+import type { SpatialPresetKey } from '@kamiazya/whiteboard-canvas-render'
+import { SPATIAL_DARK_PALETTE, SPATIAL_LIGHT_PALETTE } from '@kamiazya/whiteboard-canvas-render'
+import type { CanvasColor } from '@kamiazya/whiteboard-model'
+import { SquareDashed } from 'lucide-react'
+import type { ResolvedTheme } from '../../../hooks/useThemeMode.js'
+import type { ContextMenuOptionsItem } from '../ContextMenu.js'
+
+export const presetEntries: readonly {
+  readonly key: SpatialPresetKey
+  readonly name: string
+}[] = [
+  { key: '1', name: 'Red' },
+  { key: '2', name: 'Orange' },
+  { key: '3', name: 'Yellow' },
+  { key: '4', name: 'Green' },
+  { key: '5', name: 'Cyan' },
+  { key: '6', name: 'Purple' },
+]
+
+export function colorRow(
+  theme: ResolvedTheme,
+  current: CanvasColor | undefined,
+  apply: (color: CanvasColor | undefined) => void,
+): ContextMenuOptionsItem {
+  // The swatch chips preview the CURRENT mode's preset strokes so
+  // the picker shows what will actually render; the stored value
+  // stays the semantic slot ('1'..'6'), never a resolved hex.
+  const presetSwatches = (theme === 'dark' ? SPATIAL_DARK_PALETTE : SPATIAL_LIGHT_PALETTE).presets
+  return {
+    kind: 'options' as const,
+    label: 'Color',
+    options: [
+      {
+        label: 'default',
+        ariaLabel: 'Default',
+        icon: <SquareDashed />,
+        selected: current === undefined,
+        onSelect: () => apply(undefined),
+      },
+      ...presetEntries.map((entry) => ({
+        label: entry.key,
+        ariaLabel: entry.name,
+        icon: (
+          // Paint-critical props are inline, not utility classes:
+          // a default-inline span ignores width/height entirely
+          // (it laid out 0x0 live), and the chip must also paint
+          // where the app stylesheet is absent.
+          <span
+            style={{
+              display: 'block',
+              width: 14,
+              height: 14,
+              borderRadius: '50%',
+              backgroundColor: presetSwatches[entry.key].stroke,
+            }}
+          />
+        ),
+        selected: current === entry.key,
+        onSelect: () => apply(entry.key),
+      })),
+    ],
+    // The JSON Canvas color union is presets OR a 6-digit hex;
+    // the native color input covers the hex half the swatches
+    // cannot.
+    customColor: {
+      value: current?.startsWith('#') === true ? current : '#808080',
+      ariaLabel: 'Custom color',
+      selected: current?.startsWith('#') === true,
+      onPick: (hex: string) => apply(hex as CanvasColor),
+    },
+  }
+}

--- a/apps/web/src/components/spatial-editor/context-menu-items/edge-menu-items.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu-items/edge-menu-items.test.tsx
@@ -1,0 +1,100 @@
+// The edge branch's composition rules, pinned as plain function calls: items
+// are data, so presence/order/label assertions and handler-spy assertions
+// need no DOM.
+import type { CanvasEdge } from '@kamiazya/whiteboard-model'
+import { describe, expect, it, vi } from 'vitest'
+import type { ContextMenuItem } from '../ContextMenu.js'
+import { edgeMenuItems } from './edge-menu-items.js'
+
+const baseEdge: CanvasEdge = { id: 'e1', fromNode: 'a', toNode: 'b' }
+
+function labelsOf(items: readonly ContextMenuItem[]): string[] {
+  return items.map((item) => ('label' in item ? item.label : `<${item.kind}>`))
+}
+
+describe('edgeMenuItems', () => {
+  it('a locked edge offers exactly one action: Unlock, which releases the lock', () => {
+    const onToggleEdgeLock = vi.fn()
+    const items = edgeMenuItems({
+      edge: baseEdge,
+      theme: 'light',
+      isEdgeLocked: () => true,
+      edgeLockEnabled: true,
+      applyResult: vi.fn(),
+      setEdgeLabelEditId: vi.fn(),
+      setSelectedEdgeId: vi.fn(),
+      onToggleEdgeLock,
+    })
+    expect(labelsOf(items)).toEqual(['Unlock'])
+    ;(items[0] as { onSelect: () => void }).onSelect()
+    expect(onToggleEdgeLock).toHaveBeenCalledWith('e1', false)
+  })
+
+  it('an unlocked edge offers arrows/sides/color rows, then label, lock, and delete', () => {
+    const items = edgeMenuItems({
+      edge: baseEdge,
+      theme: 'light',
+      isEdgeLocked: () => false,
+      edgeLockEnabled: true,
+      applyResult: vi.fn(),
+      setEdgeLabelEditId: vi.fn(),
+      setSelectedEdgeId: vi.fn(),
+      onToggleEdgeLock: vi.fn(),
+    })
+    expect(items.map((item) => item.kind ?? 'action')).toEqual([
+      'options', // Arrows
+      'options', // From side
+      'options', // To side
+      'options', // Color
+      'separator',
+      'action', // Edit label
+      'action', // Lock
+      'separator',
+      'action', // Delete
+    ])
+    expect(items[0]).toMatchObject({ label: 'Arrows' })
+    expect(items[1]).toMatchObject({ label: 'From side' })
+    expect(items[2]).toMatchObject({ label: 'To side' })
+    expect(items[3]).toMatchObject({ label: 'Color' })
+    expect(items[5]).toMatchObject({ label: 'Edit label' })
+    expect(items[6]).toMatchObject({ label: 'Lock' })
+    expect(items[8]).toMatchObject({ label: 'Delete', danger: true })
+  })
+
+  it('omits Lock when no lock callback is wired (edgeLockEnabled false)', () => {
+    const items = edgeMenuItems({
+      edge: baseEdge,
+      theme: 'light',
+      isEdgeLocked: () => false,
+      edgeLockEnabled: false,
+      applyResult: vi.fn(),
+      setEdgeLabelEditId: vi.fn(),
+      setSelectedEdgeId: vi.fn(),
+      onToggleEdgeLock: undefined,
+    })
+    expect(items.some((item) => 'label' in item && item.label === 'Lock')).toBe(false)
+  })
+
+  it('Delete applies delete-edge and clears the selected edge', () => {
+    const applyResult = vi.fn()
+    const setSelectedEdgeId = vi.fn()
+    const items = edgeMenuItems({
+      edge: baseEdge,
+      theme: 'light',
+      isEdgeLocked: () => false,
+      edgeLockEnabled: false,
+      applyResult,
+      setEdgeLabelEditId: vi.fn(),
+      setSelectedEdgeId,
+      onToggleEdgeLock: undefined,
+    })
+    const deleteItem = items.find((item) => 'label' in item && item.label === 'Delete')
+    expect(deleteItem).toBeDefined()
+    ;(deleteItem as { onSelect: () => void }).onSelect()
+    expect(applyResult).toHaveBeenCalledWith({
+      state: { kind: 'idle' },
+      commands: [{ kind: 'delete-edge', id: 'e1' }],
+    })
+    expect(setSelectedEdgeId).toHaveBeenCalledWith(null)
+  })
+})

--- a/apps/web/src/components/spatial-editor/context-menu-items/edge-menu-items.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu-items/edge-menu-items.tsx
@@ -1,0 +1,155 @@
+/**
+ * The edge branch: the locked-edge [Unlock] short-circuit, then arrows/
+ * side/color rows, label/lock/delete.
+ */
+import type { CanvasEdge } from '@kamiazya/whiteboard-model'
+import {
+  Lock as LockIcon,
+  LockOpen,
+  PanelBottom,
+  PanelLeft,
+  PanelRight,
+  PanelTop,
+  SquareDashed,
+  Tag,
+  Trash2,
+} from 'lucide-react'
+import type { ResolvedTheme } from '../../../hooks/useThemeMode.js'
+import type { CanvasCommands } from '../CanvasContextMenu.js'
+import type { ContextMenuItem } from '../ContextMenu.js'
+import type { EditorCommand } from '../commands.js'
+import { colorRow } from './color-row.js'
+
+export interface EdgeMenuItemsInput {
+  readonly edge: CanvasEdge
+  readonly theme: ResolvedTheme
+  readonly isEdgeLocked: (edgeId: string) => boolean
+  readonly edgeLockEnabled: boolean
+  readonly applyResult: CanvasCommands['applyResult']
+  readonly setEdgeLabelEditId: CanvasCommands['setEdgeLabelEditId']
+  readonly setSelectedEdgeId: CanvasCommands['setSelectedEdgeId']
+  readonly onToggleEdgeLock: CanvasCommands['onToggleEdgeLock']
+}
+
+export function edgeMenuItems({
+  edge,
+  theme,
+  isEdgeLocked,
+  edgeLockEnabled,
+  applyResult,
+  setEdgeLabelEditId,
+  setSelectedEdgeId,
+  onToggleEdgeLock,
+}: EdgeMenuItemsInput): ContextMenuItem[] {
+  // A locked edge offers exactly one action. Everything else in
+  // this branch — delete, label, arrowheads, sides, colour —
+  // is a mutation the lock exists to refuse.
+  if (isEdgeLocked(edge.id)) {
+    return [
+      {
+        label: 'Unlock',
+        icon: <LockOpen />,
+        onSelect: () => onToggleEdgeLock?.(edge.id, false),
+      },
+    ]
+  }
+  // Property pickers are inline option rows (one tap per
+  // choice, menu stays open) — a cycling item costs an
+  // open-tap-reopen per step. Sections group the menu:
+  // actions, then properties, then the destructive entry.
+  // Arrow direction reads the JSON Canvas defaults (fromEnd
+  // none, toEnd arrow).
+  const fromEnd = edge.fromEnd ?? 'none'
+  const toEnd = edge.toEnd ?? 'arrow'
+  const arrowStates = [
+    { label: '→', ariaLabel: 'Forward', fromEnd: 'none', toEnd: 'arrow' },
+    { label: '↔', ariaLabel: 'Both', fromEnd: 'arrow', toEnd: 'arrow' },
+    { label: '←', ariaLabel: 'Backward', fromEnd: 'arrow', toEnd: 'none' },
+    { label: '−', ariaLabel: 'None', fromEnd: 'none', toEnd: 'none' },
+  ] as const
+  const applyEdgeCommand = (command: EditorCommand) =>
+    applyResult({ state: { kind: 'idle' }, commands: [command] })
+  // Excel-border-style side pickers: a rectangle with the
+  // pinned side emphasized; dashed = unpinned (auto).
+  const SIDES = [
+    { label: 'auto', ariaLabel: 'Auto', icon: <SquareDashed />, side: undefined },
+    { label: 'top', ariaLabel: 'Top', icon: <PanelTop />, side: 'top' },
+    { label: 'right', ariaLabel: 'Right', icon: <PanelRight />, side: 'right' },
+    { label: 'bottom', ariaLabel: 'Bottom', icon: <PanelBottom />, side: 'bottom' },
+    { label: 'left', ariaLabel: 'Left', icon: <PanelLeft />, side: 'left' },
+  ] as const
+  const sideRow = (endpoint: 'from' | 'to') => {
+    const current = endpoint === 'from' ? edge.fromSide : edge.toSide
+    return {
+      kind: 'options' as const,
+      label: endpoint === 'from' ? 'From side' : 'To side',
+      options: SIDES.map((entry) => ({
+        label: entry.label,
+        icon: entry.icon,
+        ariaLabel: entry.ariaLabel,
+        selected: current === entry.side,
+        onSelect: () =>
+          applyEdgeCommand({
+            kind: 'set-edge-side',
+            id: edge.id,
+            endpoint,
+            side: entry.side,
+          }),
+      })),
+    }
+  }
+  return [
+    {
+      kind: 'options' as const,
+      label: 'Arrows',
+      options: arrowStates.map((state) => ({
+        label: state.label,
+        ariaLabel: state.ariaLabel,
+        selected: state.fromEnd === fromEnd && state.toEnd === toEnd,
+        onSelect: () =>
+          applyEdgeCommand({
+            kind: 'set-edge-ends',
+            id: edge.id,
+            fromEnd: state.fromEnd,
+            toEnd: state.toEnd,
+          }),
+      })),
+    },
+    sideRow('from'),
+    sideRow('to'),
+    colorRow(theme, edge.color, (color) =>
+      applyEdgeCommand({ kind: 'set-edge-color', id: edge.id, color }),
+    ),
+    { kind: 'separator' as const },
+    {
+      label: 'Edit label',
+      icon: <Tag />,
+      onSelect: () => setEdgeLabelEditId(edge.id),
+    },
+    ...(edgeLockEnabled
+      ? [
+          {
+            label: 'Lock',
+            icon: <LockIcon />,
+            onSelect: () => {
+              onToggleEdgeLock?.(edge.id, true)
+              setSelectedEdgeId(null)
+            },
+          },
+        ]
+      : []),
+    { kind: 'separator' as const },
+    {
+      label: 'Delete',
+      icon: <Trash2 />,
+      danger: true,
+      onSelect: () => {
+        applyResult({
+          state: { kind: 'idle' },
+          commands: [{ kind: 'delete-edge', id: edge.id } as const],
+        })
+        setSelectedEdgeId(null)
+      },
+    },
+  ]
+}

--- a/apps/web/src/components/spatial-editor/context-menu-items/node-menu-items.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu-items/node-menu-items.test.tsx
@@ -1,0 +1,221 @@
+// The node branch's composition rules, pinned as plain function calls: items
+// are data, so presence/order/label assertions and handler-spy assertions
+// need no DOM. The one genuinely untested slice (per the design) is the last
+// case below: a LOCKED edge with both endpoints inside the multi-selection
+// must be excluded from the area recolor — the membership half (a selected
+// node/edge recolors, one leaving the selection does not) is already pinned
+// at context-menu.browser.test.tsx:462-508 and is not re-tested here.
+import { createFacetRegistry, defineFacet, definePlugin } from '@kamiazya/whiteboard-facet-engine'
+import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import type { NodeMenuItemsInput } from './node-menu-items.js'
+import { nodeMenuItems } from './node-menu-items.js'
+
+const textNode: SpatialNode = {
+  id: 'a',
+  type: 'text',
+  x: 0,
+  y: 0,
+  width: 10,
+  height: 10,
+  text: 'A',
+}
+const fileNode: SpatialNode = {
+  id: 'f',
+  type: 'file',
+  x: 0,
+  y: 0,
+  width: 10,
+  height: 10,
+  file: 'doc-1',
+}
+
+const emptyRegistry = createFacetRegistry([])
+const nodeFacetRegistry = createFacetRegistry([
+  definePlugin({
+    id: 'demo',
+    displayName: 'Demo',
+    facets: [
+      defineFacet({
+        name: 'one',
+        displayName: 'One',
+        version: 'v0',
+        targets: ['node' as const],
+        schema: z.object({}),
+      }),
+    ],
+  }),
+])
+
+function baseInput(
+  node: SpatialNode,
+  canvas: SpatialCanvas,
+  overrides: Partial<NodeMenuItemsInput> = {},
+): NodeMenuItemsInput {
+  return {
+    node,
+    canvas,
+    canvasRef: { current: canvas },
+    theme: 'light',
+    gestureState: { kind: 'idle' },
+    isLocked: () => false,
+    lockEnabled: false,
+    isEdgeLocked: () => false,
+    extraIds: new Set(),
+    selectedId: node.id,
+    isImageFileRef: undefined,
+    missingFileRef: undefined,
+    fileRefOptions: undefined,
+    facetRegistry: emptyRegistry,
+    selectedAlignableBoxes: () => [],
+    pendingBackgroundGroupIdRef: { current: null },
+    imageInputRef: { current: null },
+    applyResult: vi.fn(),
+    applyBoxMoves: vi.fn(),
+    copySelection: vi.fn(),
+    cutSelection: vi.fn(),
+    duplicateSelection: vi.fn(),
+    reorderSelection: vi.fn(),
+    groupSelection: vi.fn(),
+    openLinkNode: vi.fn(),
+    onOpenFileRef: undefined,
+    onAddImage: undefined,
+    onToggleNodeLock: undefined,
+    setGroupLabelEditId: vi.fn(),
+    setLinkDialog: vi.fn(),
+    setDocumentPicker: vi.fn(),
+    setFacetPanelOpen: vi.fn(),
+    ...overrides,
+  }
+}
+
+function labelOf(item: unknown): string | undefined {
+  return (item as { label?: string }).label
+}
+
+describe('nodeMenuItems', () => {
+  it('a locked node offers exactly one action: Unlock, which releases the lock', () => {
+    const onToggleNodeLock = vi.fn()
+    const canvas: SpatialCanvas = { nodes: [textNode], edges: [] }
+    const items = nodeMenuItems(
+      baseInput(textNode, canvas, { isLocked: () => true, onToggleNodeLock }),
+    )
+    expect(items.map(labelOf)).toEqual(['Unlock'])
+    ;(items[0] as { onSelect: () => void }).onSelect()
+    expect(onToggleNodeLock).toHaveBeenCalledWith('a', false)
+  })
+
+  it('offers Group selection only when a multi-selection exists (extraIds non-empty)', () => {
+    const canvas: SpatialCanvas = { nodes: [textNode], edges: [] }
+    const without = nodeMenuItems(baseInput(textNode, canvas))
+    expect(without.some((item) => labelOf(item) === 'Group selection')).toBe(false)
+
+    const groupSelection = vi.fn()
+    const withExtra = nodeMenuItems(
+      baseInput(textNode, canvas, { extraIds: new Set(['b']), groupSelection }),
+    )
+    const groupItem = withExtra.find((item) => labelOf(item) === 'Group selection')
+    expect(groupItem).toBeDefined()
+    ;(groupItem as { onSelect: () => void }).onSelect()
+    expect(groupSelection).toHaveBeenCalledWith(['a', 'b'])
+  })
+
+  it('offers Align at >=2 alignable boxes and Distribute at >=3, never before', () => {
+    const canvas: SpatialCanvas = { nodes: [textNode], edges: [] }
+    const solo = nodeMenuItems(baseInput(textNode, canvas))
+    expect(solo.some((item) => labelOf(item) === 'Align')).toBe(false)
+    expect(solo.some((item) => labelOf(item) === 'Distribute')).toBe(false)
+
+    const pair = nodeMenuItems(baseInput(textNode, canvas, { extraIds: new Set(['b']) }))
+    expect(pair.some((item) => labelOf(item) === 'Align')).toBe(true)
+    expect(pair.some((item) => labelOf(item) === 'Distribute')).toBe(false)
+
+    const trio = nodeMenuItems(baseInput(textNode, canvas, { extraIds: new Set(['b', 'c']) }))
+    expect(trio.some((item) => labelOf(item) === 'Align')).toBe(true)
+    expect(trio.some((item) => labelOf(item) === 'Distribute')).toBe(true)
+  })
+
+  it('hides Open canvas for a missing file ref, and offers it for a live one', () => {
+    const canvas: SpatialCanvas = { nodes: [fileNode], edges: [] }
+    const onOpenFileRef = vi.fn()
+    const missing = nodeMenuItems(
+      baseInput(fileNode, canvas, { onOpenFileRef, missingFileRef: () => true }),
+    )
+    expect(missing.some((item) => labelOf(item) === 'Open canvas')).toBe(false)
+
+    const live = nodeMenuItems(
+      baseInput(fileNode, canvas, { onOpenFileRef, missingFileRef: () => false }),
+    )
+    const openItem = live.find((item) => labelOf(item) === 'Open canvas')
+    expect(openItem).toBeDefined()
+    ;(openItem as { onSelect: () => void }).onSelect()
+    expect(onOpenFileRef).toHaveBeenCalledWith('doc-1', undefined)
+  })
+
+  it('contributes the facet doorway only when a plugin targets a node', () => {
+    const canvas: SpatialCanvas = { nodes: [textNode], edges: [] }
+    const withoutFacets = nodeMenuItems(
+      baseInput(textNode, canvas, { facetRegistry: emptyRegistry }),
+    )
+    expect(withoutFacets.some((item) => labelOf(item) === 'Facets…')).toBe(false)
+
+    const setFacetPanelOpen = vi.fn()
+    const withFacets = nodeMenuItems(
+      baseInput(textNode, canvas, { facetRegistry: nodeFacetRegistry, setFacetPanelOpen }),
+    )
+    const doorway = withFacets.find((item) => labelOf(item) === 'Facets…')
+    expect(doorway).toBeDefined()
+    ;(doorway as { onSelect: () => void }).onSelect()
+    expect(setFacetPanelOpen).toHaveBeenCalledWith(true)
+  })
+
+  it('excludes a LOCKED edge whose both endpoints are inside the multi-selection from the area recolor', () => {
+    const nodeA: SpatialNode = {
+      id: 'a',
+      type: 'text',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      text: 'A',
+    }
+    const nodeB: SpatialNode = {
+      id: 'b',
+      type: 'text',
+      x: 20,
+      y: 0,
+      width: 10,
+      height: 10,
+      text: 'B',
+    }
+    const canvas: SpatialCanvas = {
+      nodes: [nodeA, nodeB],
+      edges: [{ id: 'ab', fromNode: 'a', toNode: 'b' }],
+    }
+    const applyResult = vi.fn()
+    const items = nodeMenuItems(
+      baseInput(nodeA, canvas, {
+        extraIds: new Set(['b']),
+        selectedId: 'a',
+        isEdgeLocked: (id) => id === 'ab',
+        applyResult,
+      }),
+    )
+    const colorRow = items.find((item) => labelOf(item) === 'Color') as {
+      options: readonly { ariaLabel?: string; onSelect: () => void }[]
+    }
+    const red = colorRow.options.find((option) => option.ariaLabel === 'Red')
+    expect(red).toBeDefined()
+    red?.onSelect()
+    // Both selected nodes recolor; the edge between them, LOCKED, does not —
+    // only 'set-node-color' commands, no 'set-edge-color' for 'ab'.
+    expect(applyResult).toHaveBeenCalledWith({
+      state: { kind: 'idle' },
+      commands: [
+        { kind: 'set-node-color', id: 'a', color: '1' },
+        { kind: 'set-node-color', id: 'b', color: '1' },
+      ],
+    })
+  })
+})

--- a/apps/web/src/components/spatial-editor/context-menu-items/node-menu-items.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu-items/node-menu-items.tsx
@@ -1,0 +1,433 @@
+/**
+ * The node branch: group label/background, file/link/text verbs, the
+ * locked-node [Unlock] short-circuit, copy/cut/duplicate, recolor with
+ * multi-selection targeting, the facet doorway, order/align/distribute/
+ * tidy/lock, and the properties/facets/verbs/delete band order.
+ */
+import { tidyNodes } from '@kamiazya/whiteboard-canvas-render'
+import type { FacetRegistry } from '@kamiazya/whiteboard-facet-engine'
+import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
+import {
+  AlignCenterHorizontal,
+  AlignCenterVertical,
+  AlignEndHorizontal,
+  AlignEndVertical,
+  AlignHorizontalDistributeCenter,
+  AlignStartHorizontal,
+  AlignStartVertical,
+  AlignVerticalDistributeCenter,
+  BringToFront,
+  ChevronDown,
+  ChevronUp,
+  Copy as CopyIcon,
+  CopyPlus,
+  ExternalLink,
+  FileBox,
+  Frame,
+  Image as ImageIcon,
+  ImageOff,
+  Lock as LockIcon,
+  LockOpen,
+  Pencil,
+  Scissors,
+  SendToBack,
+  Sparkles,
+  Tag,
+  Trash2,
+} from 'lucide-react'
+import type { MutableRefObject } from 'react'
+import type { ResolvedTheme } from '../../../hooks/useThemeMode.js'
+import type { AlignableBox } from '../align.js'
+import { alignBoxes, distributeBoxes } from '../align.js'
+import type { CanvasCommands } from '../CanvasContextMenu.js'
+import type { ContextMenuItem } from '../ContextMenu.js'
+import type { FileRefOption } from '../DocumentPickerDialog.js'
+import { nodePropertyItems } from '../facet-widgets/index.js'
+import { type GestureState, reduceGesture } from '../gestures.js'
+import { colorRow } from './color-row.js'
+
+export interface NodeMenuItemsInput {
+  readonly node: SpatialNode
+  readonly canvas: SpatialCanvas
+  readonly canvasRef: MutableRefObject<SpatialCanvas>
+  readonly theme: ResolvedTheme
+  readonly gestureState: GestureState
+  readonly isLocked: (nodeId: string) => boolean
+  readonly lockEnabled: boolean
+  readonly isEdgeLocked: (edgeId: string) => boolean
+  readonly extraIds: ReadonlySet<string>
+  readonly selectedId: string | null
+  readonly isImageFileRef?: (file: string) => boolean
+  readonly missingFileRef?: (file: string) => boolean
+  readonly fileRefOptions?: readonly FileRefOption[]
+  readonly facetRegistry: FacetRegistry
+  readonly selectedAlignableBoxes: () => readonly AlignableBox[]
+  readonly pendingBackgroundGroupIdRef: MutableRefObject<string | null>
+  readonly imageInputRef: MutableRefObject<HTMLInputElement | null>
+  readonly applyResult: CanvasCommands['applyResult']
+  readonly applyBoxMoves: CanvasCommands['applyBoxMoves']
+  readonly copySelection: CanvasCommands['copySelection']
+  readonly cutSelection: CanvasCommands['cutSelection']
+  readonly duplicateSelection: CanvasCommands['duplicateSelection']
+  readonly reorderSelection: CanvasCommands['reorderSelection']
+  readonly groupSelection: CanvasCommands['groupSelection']
+  readonly openLinkNode: CanvasCommands['openLinkNode']
+  readonly onOpenFileRef: CanvasCommands['onOpenFileRef']
+  readonly onAddImage: CanvasCommands['onAddImage']
+  readonly onToggleNodeLock: CanvasCommands['onToggleNodeLock']
+  readonly setGroupLabelEditId: CanvasCommands['setGroupLabelEditId']
+  readonly setLinkDialog: CanvasCommands['setLinkDialog']
+  readonly setDocumentPicker: CanvasCommands['setDocumentPicker']
+  readonly setFacetPanelOpen: CanvasCommands['setFacetPanelOpen']
+}
+
+export function nodeMenuItems({
+  node,
+  canvas,
+  canvasRef,
+  theme,
+  gestureState,
+  isLocked,
+  lockEnabled,
+  isEdgeLocked,
+  extraIds,
+  selectedId,
+  isImageFileRef,
+  missingFileRef,
+  fileRefOptions,
+  facetRegistry,
+  selectedAlignableBoxes,
+  pendingBackgroundGroupIdRef,
+  imageInputRef,
+  applyResult,
+  applyBoxMoves,
+  copySelection,
+  cutSelection,
+  duplicateSelection,
+  reorderSelection,
+  groupSelection,
+  openLinkNode,
+  onOpenFileRef,
+  onAddImage,
+  onToggleNodeLock,
+  setGroupLabelEditId,
+  setLinkDialog,
+  setDocumentPicker,
+  setFacetPanelOpen,
+}: NodeMenuItemsInput): ContextMenuItem[] {
+  // The catalog's band order, shared by both vessels (list and grid):
+  // 1. properties (state pickers — the menu stays open),
+  // 2. verbs (one-shot — the menu closes),
+  // 3. the destructive entry, alone at the bottom.
+  const properties: ContextMenuItem[] = []
+  const verbs: ContextMenuItem[] = []
+  if (node.type === 'group') {
+    verbs.push({
+      label: 'Edit label',
+      icon: <Tag />,
+      onSelect: () => setGroupLabelEditId(node.id),
+    })
+    if (onAddImage !== undefined) {
+      verbs.push({
+        label: 'Set background image',
+        icon: <ImageIcon />,
+        onSelect: () => {
+          pendingBackgroundGroupIdRef.current = node.id
+          imageInputRef.current?.click()
+        },
+      })
+    }
+    if (node.background !== undefined) {
+      const background = node.background
+      const applyStyle = (backgroundStyle: 'cover' | 'ratio') =>
+        applyResult({
+          state: { kind: 'idle' },
+          commands: [{ kind: 'set-group-background', id: node.id, background, backgroundStyle }],
+        })
+      properties.push({
+        kind: 'options',
+        label: 'Background',
+        options: [
+          {
+            label: 'Cover',
+            ariaLabel: 'Cover',
+            selected: node.backgroundStyle !== 'ratio',
+            onSelect: () => applyStyle('cover'),
+          },
+          {
+            label: 'Fit',
+            ariaLabel: 'Fit',
+            selected: node.backgroundStyle === 'ratio',
+            onSelect: () => applyStyle('ratio'),
+          },
+        ],
+      })
+      verbs.push({
+        label: 'Remove background',
+        icon: <ImageOff />,
+        onSelect: () =>
+          applyResult({
+            state: { kind: 'idle' },
+            commands: [{ kind: 'set-group-background', id: node.id }],
+          }),
+      })
+    }
+  }
+  // Framing an existing multi-selection is reached from any of
+  // its members — the frame encloses every selected node,
+  // including group frames: nesting is geometric in JSON Canvas,
+  // and containment moves already handle nested frames.
+  if (extraIds.size > 0) {
+    verbs.push({
+      label: 'Group selection',
+      icon: <Frame />,
+      onSelect: () => groupSelection([node.id, ...extraIds]),
+    })
+  }
+  if (node.type === 'file' && isImageFileRef?.(node.file) !== true) {
+    // A missing target makes Open a dead end (worse: the daemon's
+    // path routes lazily create, so following would mint an empty
+    // canvas under the dangling ref). Change target stays — it is
+    // the repair affordance.
+    if (onOpenFileRef !== undefined && missingFileRef?.(node.file) !== true) {
+      verbs.push({
+        label: 'Open canvas',
+        icon: <ExternalLink />,
+        onSelect: () => onOpenFileRef(node.file, node.subpath),
+      })
+    }
+    if (fileRefOptions !== undefined) {
+      verbs.push({
+        label: 'Change target',
+        icon: <FileBox />,
+        onSelect: () => setDocumentPicker({ mode: 'retarget', nodeId: node.id }),
+      })
+    }
+  }
+  if (node.type === 'link') {
+    verbs.push({
+      label: 'Open link',
+      icon: <ExternalLink />,
+      onSelect: () => openLinkNode(node),
+    })
+    verbs.push({
+      label: 'Edit URL',
+      icon: <Pencil />,
+      onSelect: () => setLinkDialog({ mode: 'edit', nodeId: node.id }),
+    })
+  }
+  if (node.type === 'text') {
+    verbs.push({
+      label: 'Edit text',
+      icon: <Pencil />,
+      onSelect: () => {
+        applyResult(
+          reduceGesture(gestureState, canvas, {
+            type: 'start-text-edit',
+            nodeId: node.id,
+            text: node.text,
+          }),
+        )
+      },
+    })
+  }
+  // Touch path to Cmd/Ctrl+D (see shortcuts.ts). The menu's
+  // right-click already made this node the primary selection,
+  // so the shared handler clones the full multi-selection.
+  // A locked node's menu offers exactly one action: unlock.
+  // Showing Delete/Edit next to a lock the user deliberately
+  // set would make the lock read as decorative.
+  if (isLocked(node.id)) {
+    return [
+      {
+        label: 'Unlock',
+        icon: <LockOpen />,
+        onSelect: () => onToggleNodeLock?.(node.id, false),
+      },
+    ]
+  }
+  verbs.push({
+    label: 'Copy',
+    icon: <CopyIcon />,
+    onSelect: () => {
+      copySelection()
+    },
+  })
+  verbs.push({
+    label: 'Cut',
+    icon: <Scissors />,
+    onSelect: () => {
+      // The cut defers its delete: cutSelection holds the selection as
+      // a ghost until the paste resolves it.
+      cutSelection()
+    },
+  })
+  verbs.push({
+    label: 'Duplicate',
+    // Not CopyIcon: in the icon-only grid vessel, Copy and Duplicate
+    // with one glyph would be indistinguishable side by side.
+    icon: <CopyPlus />,
+    onSelect: () => {
+      duplicateSelection()
+    },
+  })
+  properties.push(
+    colorRow(theme, node.color, (color) => {
+      // Recoloring FROM a multi-selection styles the whole
+      // selected AREA: every member, and every edge that runs
+      // between two members — the closest executable reading of
+      // "select a region, recolor it". An edge leaving the
+      // selection keeps its color (only one endpoint is inside),
+      // and a target outside the selection styles itself alone.
+      const members = new Set(selectedId !== null ? [selectedId, ...extraIds] : [])
+      const nodeTargets = members.has(node.id) ? [...members] : [node.id]
+      const edgeTargets =
+        nodeTargets.length > 1
+          ? canvas.edges.filter(
+              (edge) =>
+                !isEdgeLocked(edge.id) && members.has(edge.fromNode) && members.has(edge.toNode),
+            )
+          : []
+      applyResult({
+        state: { kind: 'idle' },
+        commands: [
+          ...nodeTargets.map((id) => ({ kind: 'set-node-color' as const, id, color })),
+          ...edgeTargets.map((edge) => ({
+            kind: 'set-edge-color' as const,
+            id: edge.id,
+            color,
+          })),
+        ],
+      })
+    }),
+  )
+  // Facets reach this surface as ONE doorway. This menu never names a
+  // plugin or facet key (facet-wiring-guard.test.ts keeps it that way),
+  // and now it does not carry their values either — an action menu runs
+  // an entry and closes; a facet is state you adjust repeatedly.
+  const facetItems = nodePropertyItems(facetRegistry, {
+    openPanel: () => setFacetPanelOpen(true),
+  })
+  // Z-order as one-tap options — the touch path to the [ / ]
+  // keyboard shortcuts (see shortcuts.ts). Not a picker: no
+  // option is ever "selected", each tap applies a move.
+  properties.push({
+    kind: 'options',
+    label: 'Order',
+    options: [
+      {
+        label: 'back',
+        ariaLabel: 'Send to back',
+        icon: <SendToBack />,
+        selected: false,
+        onSelect: () => reorderSelection('back'),
+      },
+      {
+        label: 'backward',
+        ariaLabel: 'Send backward',
+        icon: <ChevronDown />,
+        selected: false,
+        onSelect: () => reorderSelection('backward'),
+      },
+      {
+        label: 'forward',
+        ariaLabel: 'Bring forward',
+        icon: <ChevronUp />,
+        selected: false,
+        onSelect: () => reorderSelection('forward'),
+      },
+      {
+        label: 'front',
+        ariaLabel: 'Bring to front',
+        icon: <BringToFront />,
+        selected: false,
+        onSelect: () => reorderSelection('front'),
+      },
+    ],
+  })
+  // Align needs a second box to align TO, and distribute needs a
+  // middle one to place — so each row appears only once its
+  // action means something, rather than sitting there inert.
+  const alignableCount = extraIds.size + 1
+  if (alignableCount >= 2) {
+    properties.push({
+      kind: 'options',
+      label: 'Align',
+      options: (
+        [
+          ['left', 'Align left', <AlignStartVertical key="l" />],
+          ['center-x', 'Align centre horizontally', <AlignCenterVertical key="cx" />],
+          ['right', 'Align right', <AlignEndVertical key="r" />],
+          ['top', 'Align top', <AlignStartHorizontal key="t" />],
+          ['center-y', 'Align centre vertically', <AlignCenterHorizontal key="cy" />],
+          ['bottom', 'Align bottom', <AlignEndHorizontal key="b" />],
+        ] as const
+      ).map(([mode, ariaLabel, icon]) => ({
+        label: mode,
+        ariaLabel,
+        icon,
+        selected: false,
+        onSelect: () => applyBoxMoves(alignBoxes(selectedAlignableBoxes(), mode)),
+      })),
+    })
+  }
+  if (alignableCount >= 3) {
+    properties.push({
+      kind: 'options',
+      label: 'Distribute',
+      options: (
+        [
+          ['horizontal', 'Distribute horizontally', <AlignHorizontalDistributeCenter key="h" />],
+          ['vertical', 'Distribute vertically', <AlignVerticalDistributeCenter key="v" />],
+        ] as const
+      ).map(([axis, ariaLabel, icon]) => ({
+        label: axis,
+        ariaLabel,
+        icon,
+        selected: false,
+        onSelect: () => applyBoxMoves(distributeBoxes(selectedAlignableBoxes(), axis)),
+      })),
+    })
+  }
+  if (alignableCount >= 2) {
+    verbs.push({
+      label: 'Tidy',
+      icon: <Sparkles />,
+      onSelect: () =>
+        applyBoxMoves(
+          tidyNodes(canvasRef.current.nodes, {
+            scope: new Set([node.id, ...extraIds]),
+            locked: isLocked,
+          }),
+        ),
+    })
+  }
+  if (lockEnabled) {
+    verbs.push({
+      label: 'Lock',
+      icon: <LockIcon />,
+      onSelect: () => onToggleNodeLock?.(node.id, true),
+    })
+  }
+  return [
+    ...properties,
+    // Extensions come after every core row, behind their own fence.
+    ...facetItems,
+    { kind: 'separator' as const },
+    ...verbs,
+    { kind: 'separator' as const },
+    {
+      label: 'Delete',
+      icon: <Trash2 />,
+      danger: true,
+      onSelect: () => {
+        applyResult(
+          reduceGesture(gestureState, canvas, {
+            type: 'delete-selection',
+            nodeId: node.id,
+          }),
+        )
+      },
+    },
+  ]
+}

--- a/apps/web/src/components/spatial-editor/facet-wiring-guard.test.ts
+++ b/apps/web/src/components/spatial-editor/facet-wiring-guard.test.ts
@@ -9,10 +9,22 @@
 import { describe, expect, it } from 'vitest'
 import contextMenuSource from './CanvasContextMenu.tsx?raw'
 import displaySettingsSource from './CanvasDisplaySettings.tsx?raw'
+import canvasMenuItemsSource from './context-menu-items/canvas-menu-items.tsx?raw'
+import colorRowSource from './context-menu-items/color-row.tsx?raw'
+import edgeMenuItemsSource from './context-menu-items/edge-menu-items.tsx?raw'
+import nodeMenuItemsSource from './context-menu-items/node-menu-items.tsx?raw'
 
 const CORE_SURFACES = [
   ['CanvasContextMenu.tsx', contextMenuSource],
   ['CanvasDisplaySettings.tsx', displaySettingsSource],
+  // The context menu's item builders — the facet doorway (nodePropertyItems)
+  // moved into node-menu-items.tsx, so a guard left scanning only the old
+  // file would go green while the rule it enforces is violated in the new
+  // one.
+  ['context-menu-items/color-row.tsx', colorRowSource],
+  ['context-menu-items/edge-menu-items.tsx', edgeMenuItemsSource],
+  ['context-menu-items/canvas-menu-items.tsx', canvasMenuItemsSource],
+  ['context-menu-items/node-menu-items.tsx', nodeMenuItemsSource],
 ] as const
 
 const DOMAIN_MARKS = [


### PR DESCRIPTION
## Summary

- Decomposes the 783-line `CanvasContextMenu.tsx` — one items-building IIFE dispatching three variants — into **pure item builders** under `context-menu-items/`: `color-row.tsx` (73), `edge-menu-items.tsx` (155), `canvas-menu-items.tsx` (117), `node-menu-items.tsx` (433). The component drops to **239 lines**: prop destructuring, derived flags, node/edge resolution, and dispatch. Every item's text, icon, handler, ordering and in-file rationale comment moved **verbatim**; only `colorRow` gained an explicit `theme` parameter in place of a closure capture.
- The menu's composition rules become **unit-testable data assertions** (18 new web-jsdom tests over `vi.fn()` command spies, red-first): locked edge → exactly `[Unlock]`; locked node → exactly `[Unlock]`; empty canvas offers Paste only with a clipboard fragment, document/image entries only when wired, Tidy only at ≥2 nodes; node menu offers Align at ≥2 / Distribute at ≥3 alignable, hides Open canvas for a missing file ref, offers Group selection only with a multi-selection — plus the one slice nothing pinned anywhere: **a locked edge with both endpoints inside the multi-selection is excluded from the area recolor** (the membership half was already browser-pinned at `context-menu.browser.test.tsx:462-508` and is deliberately not duplicated).
- **Guard co-movement** (PlanReview-gated): `facet-wiring-guard.test.ts`'s `CORE_SURFACES` gains all four new files in the same commit — the facet doorway (`nodePropertyItems`) moved into `node-menu-items.tsx`, and the guard left scanning only the old file would go green while the rule it enforces was violated in the new one. Mutation-checked by planting a `'visual.` literal in `node-menu-items.tsx` (guard red) and reverting (green). `purity-guard`'s recursive glob picks the new files up automatically (verified harmless — no raw-HTML sinks); `editor-state-surface` / `manipulation-tokens` glob explicit lists that never included this component.

Selection basis (why this component and not its siblings): CanvasContextMenu has zero hooks and no cross-flow state, so its builders take one cohesive input each — unlike `WorkspaceFilesPanel` / `HeaderBranchChip` / `DaemonDetectedBanner`, whose documented cross-cutting invariants (every action clears all transient reports; one scope-reset effect over many state slices) make each extraction's input surface exceed its body; those were measured and not split.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — 18 new web-jsdom unit tests (red-first: 4 files failed on missing modules before implementation), including the locked-edge recolor-exclusion slice
- [x] `pnpm test` passes locally — spatial-editor jsdom sweep 50 files / 529 tests, `context-menu.browser.test.tsx` **unmodified** 15/15 (re-run on a quiet tree), guard quartet 30/30, `arch-lint-node` 119/119, `tsc`/`lint`/`knip` clean; the full-repo run's only failures are the known Node-22 environment guard family (CI runs the pinned Node 24) with none touching this change's files
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable — not needed: the unmodified browser interaction suite exercises all four menu variants end-to-end

Mutation check: `'visual.` literal planted in `node-menu-items.tsx` → facet-wiring-guard fails naming the file; reverted → 6/6.

Manual verification: the unmodified `context-menu.browser.test.tsx` drives all four menu variants (node, edge, locked, empty canvas) through real right-clicks in real chromium, including the multi-selection recolor scenario — the exact flows a hand dogfood would repeat; behavior is byte-identical by construction (verbatim moves, single unchanged consumer `SpatialEditor.tsx`).

## Visual evidence

Visual evidence: none — pure refactor with byte-identical menu output pinned by the unmodified browser interaction suite; no pixel change.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — no user-visible or contract change
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_