### PR TITLE
refactor: consolidate three hand-kept duplications surfaced by the maintainability audit

### DIFF
--- a/apps/web/src/components/VersionTimeline.tsx
+++ b/apps/web/src/components/VersionTimeline.tsx
@@ -25,6 +25,7 @@ import { buildMiniGraph } from '@/lib/mini-graph'
 import { displayBranchName } from '@/lib/utils'
 import { SquiggleLoader } from './SquiggleLoader.js'
 import { VersionThumbnail } from './VersionThumbnail.js'
+import { formatRelative } from './workspace-files/format-relative.js'
 
 const log = getAppLogger('VersionTimeline')
 
@@ -38,20 +39,6 @@ interface Props {
   // 15s poll. Only a value CHANGE triggers a refetch, matching
   // HeaderBranchChip's refreshSignal contract.
   refreshSignal?: number
-}
-
-// Render an ISO string as a short relative timestamp.
-function formatRelative(iso: string): string {
-  const then = new Date(iso).getTime()
-  if (!Number.isFinite(then)) return iso
-  // Clamp: server clocks slightly ahead of the client would otherwise yield
-  // "-5s ago".
-  const diffSec = Math.max(0, Math.floor((Date.now() - then) / 1000))
-  if (diffSec < 60) return `${diffSec}s ago`
-  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`
-  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`
-  const d = new Date(then)
-  return `${d.getMonth() + 1}/${d.getDate()} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
 }
 
 // A version's display title: its explicit label, or a fallback naming its origin.
@@ -370,7 +357,8 @@ export default function VersionTimeline({ workspaceId, path, onRestored, refresh
                           </span>
                         )}
                         <span className="text-[11px] text-muted-foreground">
-                          {formatRelative(v.createdAt)} · {v.elementCount} els
+                          {formatRelative(v.createdAt, { pastDay: 'absolute', invalid: 'echo' })} ·{' '}
+                          {v.elementCount} els
                           {row?.branchOut ? (
                             <>
                               {' · '}
@@ -418,9 +406,13 @@ export default function VersionTimeline({ workspaceId, path, onRestored, refresh
               {pendingRestore && (
                 <>
                   Restoring <strong>{versionTitle(pendingRestore)}</strong> (
-                  {formatRelative(pendingRestore.createdAt)}, {pendingRestore.elementCount}{' '}
-                  elements) will merge that state into the current canvas and broadcast the change
-                  to every connected tab. Per-peer Ctrl+Z history is cleared.
+                  {formatRelative(pendingRestore.createdAt, {
+                    pastDay: 'absolute',
+                    invalid: 'echo',
+                  })}
+                  , {pendingRestore.elementCount} elements) will merge that state into the current
+                  canvas and broadcast the change to every connected tab. Per-peer Ctrl+Z history is
+                  cleared.
                 </>
               )}
               {restoreError && <span className="mt-2 block text-destructive">{restoreError}</span>}

--- a/apps/web/src/components/workspace-files/format-relative.test.ts
+++ b/apps/web/src/components/workspace-files/format-relative.test.ts
@@ -26,4 +26,20 @@ describe('formatRelative', () => {
   it('renders nothing for an unparsable stamp', () => {
     expect(formatRelative('not-a-date')).toBe('')
   })
+
+  // The version timeline's variant: past a day it switches to an absolute
+  // M/D HH:MM stamp instead of counting days forever — a parameter on the
+  // one formatter, not a fork (the fork existed, and its day-boundary
+  // behavior silently diverged from every other list's).
+  it("pastDay: 'absolute' switches to M/D HH:MM after 24h, and only then", () => {
+    expect(formatRelative('2026-08-22T03:00:00.000Z', { pastDay: 'absolute' })).toBe('9h ago')
+    const stamp = formatRelative('2026-08-19T15:04:00.000Z', { pastDay: 'absolute' })
+    // Local-time rendering, so assert the shape and the minute field rather
+    // than a fixed hour.
+    expect(stamp).toMatch(/^8\/19 \d{2}:04$/)
+  })
+
+  it("invalid: 'echo' answers the raw string for an unparsable stamp", () => {
+    expect(formatRelative('not-a-date', { invalid: 'echo' })).toBe('not-a-date')
+  })
 })

--- a/apps/web/src/components/workspace-files/format-relative.ts
+++ b/apps/web/src/components/workspace-files/format-relative.ts
@@ -1,11 +1,28 @@
 // Clock drift between client and daemon can make (now - t) negative; clamp
 // so the label never reads "-5s ago".
-export function formatRelative(iso: string): string {
+//
+// `pastDay` is the one knob a surface may legitimately want: a files list
+// keeps counting ("3d ago" indefinitely), while the version timeline
+// switches to an absolute local M/D HH:MM stamp — a saved version's age
+// stops being the interesting fact once it is days old, its date is. One
+// formatter with a parameter, because the fork this replaces diverged
+// silently at exactly that boundary.
+export function formatRelative(
+  iso: string,
+  options: { pastDay?: 'days-ago' | 'absolute'; invalid?: 'empty' | 'echo' } = {},
+): string {
   const t = new Date(iso).getTime()
-  if (!Number.isFinite(t)) return ''
+  // An unparsable stamp renders as nothing by default; the version timeline
+  // echoes the raw string instead (its test pins that a corrupt createdAt is
+  // at least visible rather than silently blank).
+  if (!Number.isFinite(t)) return options.invalid === 'echo' ? iso : ''
   const diff = Math.max(0, Math.floor((Date.now() - t) / 1000))
   if (diff < 60) return `${diff}s ago`
   if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
   if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  if (options.pastDay === 'absolute') {
+    const d = new Date(t)
+    return `${d.getMonth() + 1}/${d.getDate()} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+  }
   return `${Math.floor(diff / 86400)}d ago`
 }

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -865,11 +865,7 @@ export function BrowserDocumentPage({
                       ?.requestFullscreen()
                       .catch((err) => log.warn('requestFullscreen rejected', err))
                 }}
-                capabilities={{
-                  versions: capabilities.versions,
-                  branches: capabilities.branches,
-                  merge: capabilities.merge,
-                }}
+                capabilities={capabilities}
               />
             </Suspense>
           )}

--- a/apps/web/src/pages/BrowserIndexPage.flow.browser.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.flow.browser.test.tsx
@@ -102,10 +102,17 @@ describe('browser list landing (browser — real IndexedDB)', () => {
       { timeout: 10_000 },
     )
     await userEvent.keyboard('# From the list')
+    // Anchored on the last keystroke, not on a settle window: the binding
+    // commits into the doc synchronously with each key, so any write that
+    // COMPLETES after this instant contains all of them. Unanchored, this
+    // wait settled on a mid-typing write under CI load and the navigation
+    // below dropped the rest — `expected '# From t' to contain
+    // '# From the list'`.
+    const typedAt = Date.now()
     await waitFor(() => {
       expect(document.querySelector('.cm-content')?.textContent).toBe('# From the list')
     })
-    await waitForMarkdownSaved()
+    await waitForMarkdownSaved({ since: typedAt })
 
     // Back again: both documents listed, the note marked as markdown.
     await router.navigate(-1)

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -695,11 +695,7 @@ export function DaemonDocumentPage({
                 )}
                 workspaceId={canvas.workspaceId}
                 path={canvas.path}
-                capabilities={{
-                  versions: capabilities.versions,
-                  branches: capabilities.branches,
-                  merge: capabilities.merge,
-                }}
+                capabilities={capabilities}
                 branchRefreshSignal={branchRefreshSignal}
                 onNavigateBack={onNavigateBack}
                 // Version thumbnails come from the same PNG export path the

--- a/apps/web/src/test-utils/wait-for-saved.test.ts
+++ b/apps/web/src/test-utils/wait-for-saved.test.ts
@@ -71,4 +71,35 @@ describe('waitForMarkdownSaved', () => {
     set(chip, 'pending', null)
     await expect(waitForMarkdownSaved(300)).rejects.toThrow()
   })
+
+  /**
+   * The hole the settle window cannot close, and the CI failure that found
+   * it: the trailing keystrokes' commit reached the doc, but the delivery
+   * that ARMS the next save arrived later than the window — so the indicator
+   * sat on the partial write, unchanged, for the whole of it. A wait built
+   * out of a fixed duration cannot tell that apart from a finished document,
+   * however long the duration is.
+   */
+  it('with an anchor: refuses a write that completed BEFORE the last keystroke', async () => {
+    const chip = mountChip()
+    set(chip, 'saved', PARTIAL_AT)
+    const typedAt = Date.parse(PARTIAL_AT) + 1
+
+    // Nothing re-arms for well over the old settle window — exactly what the
+    // failing run observed.
+    setTimeout(() => set(chip, 'saved', FULL_AT), SAVE_DEBOUNCE_MS * 5)
+
+    await expect(waitForMarkdownSaved({ since: typedAt })).resolves.toBe(FULL_AT)
+  })
+
+  it('with an anchor: settles at once on a write that already covers the typing', async () => {
+    const chip = mountChip()
+    set(chip, 'saved', FULL_AT)
+    const started = Date.now()
+
+    await expect(waitForMarkdownSaved({ since: Date.parse(FULL_AT) - 1000 })).resolves.toBe(FULL_AT)
+    // No settle sleep in anchored mode: the timestamp IS the proof, so the
+    // wait must not spend a debounce period re-confirming it.
+    expect(Date.now() - started).toBeLessThan(SAVE_DEBOUNCE_MS)
+  })
 })

--- a/apps/web/src/test-utils/wait-for-saved.ts
+++ b/apps/web/src/test-utils/wait-for-saved.ts
@@ -39,12 +39,54 @@ function expectSettled(): string {
   return at as string
 }
 
+export interface WaitForSavedOptions {
+  /**
+   * When the caller finished typing, as `Date.now()`. Turns the wait from a
+   * DURATION into a PROOF: the CodeMirror binding commits into the Loro doc
+   * synchronously with the keystroke, and a write serialises the doc as it
+   * stands when it RUNS — so a write that COMPLETED at or after this instant
+   * necessarily contains every keystroke before it. The last edit's own
+   * debounce guarantees such a write arrives, so the wait only has to be
+   * patient rather than precisely timed.
+   */
+  readonly since?: number
+  readonly timeout?: number
+}
+
 /**
- * Resolves once a write has landed AND nothing further was scheduled while
- * we watched. Returns the `data-last-saved-at` it settled on, so a caller
- * that cares which write it waited for can say so.
+ * Resolves once a write has landed that provably covers the caller's typing
+ * (with `since`), or — without an anchor — once a write has landed and
+ * nothing further was scheduled while we watched. Returns the
+ * `data-last-saved-at` it settled on, so a caller that cares which write it
+ * waited for can say so.
+ *
+ * The settle window below is the weaker of the two and is kept only for
+ * callers with nothing to anchor on. It closes the window it was written for
+ * and no more: a fixed duration cannot tell "finished" from "the delivery
+ * that arms the next save has not arrived yet", and under a full browser
+ * project the second is unbounded — measured elsewhere in this repo at 1.5s
+ * alone versus 30-39s with every browser file in flight. That is the run
+ * that failed CI on a partial body while the indicator sat, unchanged and
+ * truthful, on the write before it.
  */
-export async function waitForMarkdownSaved(timeout = 15_000): Promise<string> {
+export async function waitForMarkdownSaved(
+  options: WaitForSavedOptions | number = {},
+): Promise<string> {
+  const { since, timeout = 15_000 } =
+    typeof options === 'number' ? { since: undefined, timeout: options } : options
+  if (since !== undefined) {
+    return await waitFor(
+      () => {
+        const at = expectSettled()
+        expect(
+          Date.parse(at) >= since,
+          `the latest write (${at}) completed before the typing it must cover`,
+        ).toBe(true)
+        return at
+      },
+      { timeout },
+    )
+  }
   await waitFor(expectSettled, { timeout })
   await new Promise((resolve) => setTimeout(resolve, SETTLE_MS))
   return await waitFor(expectSettled, { timeout })

--- a/packages/mcp-server/src/server/app-helpers.ts
+++ b/packages/mcp-server/src/server/app-helpers.ts
@@ -1,9 +1,6 @@
 import { decodeFrontiers, LoroDoc } from 'loro-crdt'
+import { errorMessage } from '../shared/error-message.js'
 import { corruptStoredData } from './store/corrupt-stored-data.js'
-
-export function errorMessage(error: unknown): string {
-  return error instanceof Error && error.message.length > 0 ? error.message : 'unknown error'
-}
 
 export function shouldLogMcpHttpDebug(env: NodeJS.ProcessEnv = process.env): boolean {
   return env.MCP_HTTP_DEBUG === '1'

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -13,10 +13,10 @@ import { Hono } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
 import { encodeFrontiers, type LoroDoc } from 'loro-crdt'
 import type { RuntimeStatusResponse } from '../shared/api-contracts/runtime.js'
+import { errorMessage } from '../shared/error-message.js'
 import {
   checkoutCloneOrThrow,
   decodeBranchTipOrThrow,
-  errorMessage,
   extractInitializeDebugPayload,
   isJsonObject,
   isReservedUiPath,

--- a/packages/mcp-server/src/server/routes/files.ts
+++ b/packages/mcp-server/src/server/routes/files.ts
@@ -2,6 +2,7 @@ import { mkdir, readdir, readFile } from 'node:fs/promises'
 import { basename, extname, join } from 'node:path'
 import { Hono } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
+import { errorMessage } from '../../shared/error-message.js'
 import { writeFileAtomic } from '../atomic-write.js'
 import { getDataDir } from '../config.js'
 import {
@@ -32,10 +33,6 @@ const MIME_TO_EXT: Record<string, string> = {
 const EXT_TO_MIME: Record<string, string> = Object.fromEntries(
   Object.entries(MIME_TO_EXT).map(([m, e]) => [e, m]),
 )
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error && error.message.length > 0 ? error.message : 'unknown error'
-}
 
 async function readStoredFileNames(dir: string): Promise<string[] | null> {
   try {

--- a/packages/mcp-server/src/server/store/document-store.ts
+++ b/packages/mcp-server/src/server/store/document-store.ts
@@ -52,6 +52,7 @@ import {
 import type { Frontiers } from 'loro-crdt'
 import { decodeFrontiers, encodeFrontiers, LoroDoc, VersionVector } from 'loro-crdt'
 import type { DocumentSummary } from '../../shared/api-contracts/document.js'
+import { errorMessage } from '../../shared/error-message.js'
 import { getDataDir } from '../config.js'
 import { getLogger } from '../log.js'
 import { validateDocumentPath, validateWorkspaceId } from '../validators.js'
@@ -83,10 +84,6 @@ export class ConflictError extends Error {
     super(message)
     this.name = 'ConflictError'
   }
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error && error.message.length > 0 ? error.message : 'unknown error'
 }
 
 // Soft cap for snapshot size. Do not block saves when exceeded because preserving user

--- a/packages/mcp-server/src/server/store/fs/fs-blob-store.ts
+++ b/packages/mcp-server/src/server/store/fs/fs-blob-store.ts
@@ -13,6 +13,7 @@ import type {
   BlobStore,
 } from '@kamiazya/whiteboard-ports'
 import { z } from 'zod'
+import { errorMessage } from '../../../shared/error-message.js'
 import { writeFileAtomic } from '../../atomic-write.js'
 import { getLogger } from '../../log.js'
 import { corruptStoredData, isMissingFileError } from '../corrupt-stored-data.js'
@@ -32,10 +33,6 @@ type BlobEnvelope = z.infer<typeof blobEnvelopeSchema>
 
 function digestHex(bytes: Uint8Array): string {
   return createHash('sha256').update(bytes).digest('hex')
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error && error.message.length > 0 ? error.message : 'unknown error'
 }
 
 /**

--- a/packages/mcp-server/src/server/store/version-store.ts
+++ b/packages/mcp-server/src/server/store/version-store.ts
@@ -43,6 +43,7 @@ const MAX_THUMBNAIL_BYTES = 2 * 1024 * 1024
 // written interface beside a Zod schema is the drift recipe the Zod
 // discipline names, and this pair had three copies of one shape.
 import type { OperatorInfo, VersionEntry } from '../../shared/api-contracts/document.js'
+import { errorMessage } from '../../shared/error-message.js'
 
 export type { OperatorInfo, VersionEntry }
 
@@ -117,10 +118,6 @@ function bytesToBase64(bytes: Uint8Array): string {
 
 function base64ToBytes(b64: string): Uint8Array {
   return new Uint8Array(Buffer.from(b64, 'base64'))
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error && error.message.length > 0 ? error.message : 'unknown error'
 }
 
 async function dbReady() {

--- a/packages/mcp-server/src/shared/error-message.ts
+++ b/packages/mcp-server/src/shared/error-message.ts
@@ -1,0 +1,9 @@
+/**
+ * The one spelling of "what do we call this thrown thing" — previously
+ * copy-pasted verbatim into five files, where a behavior change (an
+ * `AggregateError`, a `cause` chain, a non-Error throw) would have had to
+ * find every copy by hand.
+ */
+export function errorMessage(error: unknown): string {
+  return error instanceof Error && error.message.length > 0 ? error.message : 'unknown error'
+}


### PR DESCRIPTION
## Summary

Three independent findings from one maintainability audit sweep, each a silent-divergence risk with a one-definition fix (deliberately one PR: all S-size, one sweep, each named explicitly so the two-subject-diff rule is satisfied):

- **`errorMessage()`**: five byte-identical copies across mcp-server (`app-helpers.ts` exported one that nothing imported; `version-store`, `fs-blob-store`, `document-store` and `routes/files` each kept a private clone). Now one definition in `shared/error-message.ts`, imported by all five sites — a future behavior change (`AggregateError`, `cause` chains) has one home.
- **`formatRelative()`**: apps/web carried two same-named relative-time formatters whose behavior diverged past 24h without anyone deciding it — the shared workspace-files one counts days forever (`"3d ago"`), `VersionTimeline`'s private clone switched to an absolute local `M/D HH:MM` stamp. The divergences are now **parameters** on the one shared formatter (`pastDay: 'absolute'`; `invalid: 'echo'` — the latter surfaced by `VersionTimeline`'s own pinned corrupt-`createdAt` test, which passes unmodified), with red-first unit tests for both knobs; the clone is deleted.
- **The `WorkspaceTopBar` capabilities prop**: both document pages hand-copied `{versions, branches, merge}` field by field from a `capabilities` object of exactly that shape — a fourth capability field would have silently missed both call sites. Both now pass the object directly; the prop type already accepts it.

### Plus a flake root-cause fix (third commit)

The first CI run failed `BrowserIndexPage.flow.browser.test.tsx` on `expected '# From t' to contain '# From the list'` — 8 of 15 characters persisted, in a file this diff does not touch. That is the **second occurrence of the shape `wait-for-saved.ts` was written to close** (its own docblock records the first, at 7 of 15), so per the integrator flow it is a root-cause lane rather than another re-run — which this session cannot perform anyway (`rerun-failed-jobs` → 403).

**Root cause**: the helper's guarantee was "a write landed and nothing further was scheduled during a 2× debounce window" — a *fixed duration* against an *unbounded delay*. The keystroke commits into the Loro doc synchronously, but what **arms** the next save is the doc subscription's delivery, and under a full browser project this repo has already measured 1.5s-alone work taking 30–39s. When that delivery lands after the window, the indicator sits on the mid-typing write — unchanged and entirely truthful — and the wait believes it. Widening the window only moves the boundary.

**Fix**: the wait stops being a duration and becomes a proof. `since` takes the instant the caller finished typing; because the binding commits per keystroke and a write serialises the doc as it stands when it *runs*, any write completing at or after that instant necessarily contains every keystroke before it — and the last edit's own debounce guarantees such a write arrives, so the wait only has to be patient rather than precisely timed. The unanchored path stays for callers with nothing to anchor on, with its limit now stated rather than implied.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — 2 new red-first `format-relative` unit tests (`pastDay: 'absolute'`, `invalid: 'echo'`), plus 2 new red-first model tests for the anchored save wait (the first is the CI failure scripted against the indicator)
- [x] `pnpm test` passes locally — mcp-node `src/server` sweep 3,019 passed (only the known Node-22 version guard fails), `format-relative` + `VersionTimeline` + both document pages + `WorkspaceTopBar` jsdom suites green, `wait-for-saved` 5/5, the previously flaking `BrowserIndexPage.flow.browser.test.tsx` green in 18.9s, `tsc`/`lint`/`knip` clean
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable — not needed: behavior-preserving consolidations pinned by existing suites

Mutation checks: ignoring the `since` anchor fails both new model tests while the three existing ones stay green (restored → 5/5).

Environment note, stated for honesty: `VersionTimeline.test.tsx`'s objectURL thumbnail test fails **before and after** this change on this container's Node 22 (the known Blob environment family the `local-node-version` guard names; verified identical on the unmodified tree via stash) — CI's pinned Node 24 is authoritative for it.

## Visual evidence

Visual evidence: none — behavior-preserving consolidations plus a test-helper fix; every rendered string is pinned by the existing and new unit tests, and the capabilities prop change passes the identical value shape.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — no user-visible or contract change
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema