### PR TITLE
feat: references follow a document's move, in both keepers

### DIFF
--- a/apps/web/src/lib/local-files-source.ts
+++ b/apps/web/src/lib/local-files-source.ts
@@ -1,7 +1,16 @@
 import {
+  type DocumentMove,
+  movesForPathChange,
+  planReferenceRewrite,
+  rewriteCanvasReferences,
+  rewriteReferenceTargets,
+} from '@kamiazya/whiteboard-codec'
+import {
   readCoreFacets,
   readMarkdownBody,
   readSpatialCanvas,
+  writeMarkdownBody,
+  writeSpatialNode,
 } from '@kamiazya/whiteboard-loro-adapter'
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import { type DocumentIndex, WorkspaceNotFoundError } from '@kamiazya/whiteboard-ports'
@@ -69,6 +78,58 @@ export function createLocalFilesSource(
    * measured workspace makes the first search slow.
    */
   const corpus = new Map<string, { stamp: string; texts: string[] }>()
+
+  /**
+   * After a move, repoint references other documents wrote to the old path — the same codec plan the daemon's
+   * rename routes apply, so both keepers give one answer. Scans every
+   * document rather than keeping a reference index: a rename is a rare,
+   * user-initiated click, and the search corpus above already prices the
+   * full read (60 documents / 202KB = 176ms against real IndexedDB).
+   * ponytail: full scan per rename; share a facts cache with search if a
+   * measured workspace makes the click slow.
+   *
+   * One unreadable document must not abort the rest — the rename already
+   * stands, and every reference this CAN repair is one fewer silently
+   * broken link.
+   */
+  async function followReferences(
+    entriesBefore: readonly WorkspaceDocumentEntry[],
+    moves: readonly DocumentMove[],
+  ): Promise<void> {
+    const plan = planReferenceRewrite({
+      entries: entriesBefore.map((entry) => ({
+        id: entry.documentId,
+        path: entry.path,
+        ...(entry.name === undefined ? {} : { name: entry.name }),
+      })),
+      moves,
+    })
+    if (plan.size === 0) return
+    const entries = await index.listDocuments({ workspaceId: getBrowserWorkspaceId() })
+    for (const entry of entries) {
+      try {
+        const doc = await loadCurrentDoc(entry)
+        if (entry.kind === 'spatial') {
+          const result = rewriteCanvasReferences(readSpatialCanvas(doc), plan)
+          if (!result.changed) continue
+          // Targeted writes, never a whole-canvas resync: readSpatialCanvas
+          // drops records this build cannot parse, and writing the whole
+          // canvas back would DELETE them.
+          for (const node of result.changedNodes) writeSpatialNode(doc, node)
+        } else {
+          const body = readMarkdownBody(doc)
+          const next = rewriteReferenceTargets(body, plan)
+          if (next === body) continue
+          writeMarkdownBody(doc, next)
+        }
+        await loro.save(entry.documentId, doc.export({ mode: 'snapshot' }))
+        // The content moved, so the search corpus entry for it is stale.
+        corpus.delete(entry.documentId)
+      } catch {
+        // Unreadable or unsaveable: leave it; the reference stays as written.
+      }
+    }
+  }
 
   async function loadCurrentDoc(entry: WorkspaceDocumentEntry): Promise<Loro> {
     // The workspace document first — that is where the editor persists — and
@@ -163,7 +224,16 @@ export function createLocalFilesSource(
     },
 
     async renameDocumentPath(path: string, newPath: string): Promise<void> {
+      const entriesBefore = await this.listDocuments()
       await index.moveDocument({ workspaceId: getBrowserWorkspaceId(), from: path, to: newPath })
+      // Every path the SUBTREE carried, derived rather than written here.
+      // The move already stands: a follow failure repairs less, it must not
+      // turn a completed rename into a rejection.
+      try {
+        await followReferences(entriesBefore, movesForPathChange(entriesBefore, path, newPath))
+      } catch {
+        // References the pass could not reach stay as written.
+      }
     },
 
     async searchDocuments(query, limit = 20) {
@@ -219,7 +289,9 @@ export function createLocalFilesSource(
       await index.setDocumentName({
         workspaceId: getBrowserWorkspaceId(),
         documentId: entry.documentId,
-        // The port spells "clear" as absence, not empty string.
+        // The port spells "clear" as absence, not empty string. No follow
+        // pass here: name references are being retired from resolution, so
+        // a name change breaks nothing worth rewriting.
         ...(name === undefined ? {} : { name }),
       })
     },

--- a/apps/web/src/lib/local-follow-rename.browser.test.tsx
+++ b/apps/web/src/lib/local-follow-rename.browser.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * The browser keeper's half of reference-following: a move through the
+ * local files source repoints references other documents wrote to the old
+ * path — the same codec plan the daemon's route applies, so both modes give
+ * one answer.
+ */
+import {
+  readMarkdownBody,
+  readSpatialCanvas,
+  writeDocumentKind,
+  writeMarkdownBody,
+  writeSpatialCanvas,
+} from '@kamiazya/whiteboard-loro-adapter'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { Loro } from 'loro-crdt'
+import { describe, expect, it } from 'vitest'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
+import { IdbDocumentIndex } from './idb-document-index.js'
+import { ensureLocalWorkspace } from './local-document-summary.js'
+import { createLocalFilesSource } from './local-files-source.js'
+import { LoroStore } from './loro-store.js'
+
+claimIsolatedWhiteboardDb('local-follow-rename')
+
+async function seedMarkdown(
+  index: IdbDocumentIndex,
+  path: string,
+  body: string,
+  name?: string,
+): Promise<string> {
+  const entry = await index.createDocument({
+    workspaceId: getBrowserWorkspaceId(),
+    path,
+    kind: 'markdown',
+    ...(name === undefined ? {} : { name }),
+  })
+  const doc = new Loro()
+  writeDocumentKind(doc, 'markdown')
+  writeMarkdownBody(doc, body)
+  await new LoroStore().save(entry.documentId, doc.export({ mode: 'snapshot' }))
+  return entry.documentId
+}
+
+async function seedSpatial(index: IdbDocumentIndex, path: string, canvas: SpatialCanvas) {
+  const entry = await index.createDocument({
+    workspaceId: getBrowserWorkspaceId(),
+    path,
+    kind: 'spatial',
+  })
+  const doc = new Loro()
+  writeDocumentKind(doc, 'spatial')
+  writeSpatialCanvas(doc, canvas)
+  await new LoroStore().save(entry.documentId, doc.export({ mode: 'snapshot' }))
+  return entry.documentId
+}
+
+async function bodyOf(documentId: string): Promise<string> {
+  const loaded = await new LoroStore().load(documentId)
+  if (loaded.kind !== 'ok') throw new Error(`unreadable: ${loaded.kind}`)
+  const doc = new Loro()
+  doc.import(loaded.snapshot)
+  for (const delta of loaded.deltas ?? []) doc.import(delta)
+  return readMarkdownBody(doc)
+}
+
+describe('local rename follows references', () => {
+  it('a path move repoints markdown and spatial references to the old path', async () => {
+    const index = new IdbDocumentIndex()
+    await ensureLocalWorkspace(index)
+    await seedMarkdown(index, 'follow/design-login', 'the target')
+    const sourceId = await seedMarkdown(
+      index,
+      'follow/daily',
+      'see [[follow/design-login]] and [[unrelated]]',
+    )
+    const boardId = await seedSpatial(index, 'follow/board', {
+      nodes: [
+        {
+          id: 't1',
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 40,
+          type: 'text',
+          text: 'see [[follow/design-login]]',
+        },
+        {
+          id: 'f1',
+          x: 0,
+          y: 60,
+          width: 100,
+          height: 40,
+          type: 'file',
+          file: 'follow/design-login',
+        },
+      ],
+      edges: [],
+    })
+
+    const source = createLocalFilesSource({ index })
+    await source.renameDocumentPath('follow/design-login', 'follow/archive-login')
+
+    expect(await bodyOf(sourceId)).toBe('see [[follow/archive-login]] and [[unrelated]]')
+    const loaded = await new LoroStore().load(boardId)
+    if (loaded.kind !== 'ok') throw new Error('board unreadable')
+    const doc = new Loro()
+    doc.import(loaded.snapshot)
+    const canvas = readSpatialCanvas(doc)
+    expect(canvas.nodes.find((n) => n.id === 't1')).toMatchObject({
+      text: 'see [[follow/archive-login]]',
+    })
+    expect(canvas.nodes.find((n) => n.id === 'f1')).toMatchObject({
+      file: 'follow/archive-login',
+    })
+  })
+
+  it('a subtree move follows references to a descendant', async () => {
+    const index = new IdbDocumentIndex()
+    await ensureLocalWorkspace(index)
+    await seedMarkdown(index, 'tree/folder', 'the parent')
+    await seedMarkdown(index, 'tree/folder/child', 'the child')
+    const sourceId = await seedMarkdown(index, 'tree/daily', 'see [[tree/folder/child]]')
+
+    const source = createLocalFilesSource({ index })
+    await source.renameDocumentPath('tree/folder', 'tree/archive')
+
+    expect(await bodyOf(sourceId)).toBe('see [[tree/archive/child]]')
+  })
+})

--- a/apps/web/src/lib/local-follow-rename.property.browser.test.tsx
+++ b/apps/web/src/lib/local-follow-rename.property.browser.test.tsx
@@ -1,0 +1,282 @@
+/**
+ * Command-sequence model test for the BROWSER keeper's follow pass — the
+ * parity half of server-core's reference-semantics property: both keepers
+ * are held to one independent naive model of the follow semantics, so they
+ * cannot disagree with each other without one of them disagreeing with it.
+ *
+ * Markdown-only and small on purpose: this runs against real IndexedDB,
+ * where shrinking is slow, so the semantic depth (spatial nodes, subtree
+ * collisions, ambiguity clusters) lives in the daemon-side property and the
+ * example tests. What THIS one pins is the browser wiring: entriesBefore
+ * taken on the right side of the mutation, the plan applied to every
+ * candidate, the rewrite persisted.
+ */
+
+import { scanReferences } from '@kamiazya/whiteboard-codec'
+import {
+  readMarkdownBody,
+  writeDocumentKind,
+  writeMarkdownBody,
+} from '@kamiazya/whiteboard-loro-adapter'
+import { Loro } from 'loro-crdt'
+import { describe, expect } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
+import { IdbDocumentIndex } from './idb-document-index.js'
+import { ensureLocalWorkspace } from './local-document-summary.js'
+import { createLocalFilesSource } from './local-files-source.js'
+import { LoroStore } from './loro-store.js'
+
+claimIsolatedWhiteboardDb('local-follow-rename-property')
+
+const SLOTS = [0, 1, 2] as const
+// Suffixes; every run prefixes them, so runs sharing one IndexedDB cannot
+// claim each other's aliases (the plan is computed over the whole listing).
+const PATHS = ['alpha', 'alpha/leaf', 'beta', 'gamma'] as const
+
+type Cmd =
+  | { t: 'create'; slot: number; path: (typeof PATHS)[number]; name?: 'Plan' }
+  | { t: 'writeBody'; slot: number; refs: readonly (typeof PATHS | string)[number][] }
+  | { t: 'move'; slot: number; to: (typeof PATHS)[number] }
+  | { t: 'setName'; slot: number; name?: 'Plan' }
+
+const slotArb = fc.constantFrom(...SLOTS)
+const cmdArb: fc.Arbitrary<Cmd> = fc.oneof(
+  {
+    weight: 2,
+    arbitrary: fc.record({
+      t: fc.constant('create' as const),
+      slot: slotArb,
+      path: fc.constantFrom(...PATHS),
+      name: fc.constantFrom<'Plan' | undefined>('Plan', undefined),
+    }),
+  },
+  {
+    weight: 2,
+    arbitrary: fc.record({
+      t: fc.constant('writeBody' as const),
+      slot: slotArb,
+      refs: fc.array(fc.constantFrom<string>(...PATHS, 'Plan'), { minLength: 1, maxLength: 2 }),
+    }),
+  },
+  {
+    weight: 3,
+    arbitrary: fc.record({
+      t: fc.constant('move' as const),
+      slot: slotArb,
+      to: fc.constantFrom(...PATHS),
+    }),
+  },
+  {
+    weight: 1,
+    arbitrary: fc.record({
+      t: fc.constant('setName' as const),
+      slot: slotArb,
+      name: fc.constantFrom<'Plan' | undefined>('Plan', undefined),
+    }),
+  },
+)
+
+interface ModelDoc {
+  id: string
+  path: string
+  name?: string
+  tokens: string[]
+}
+
+/** Same independent oracle as the daemon-side property, markdown-only. */
+class Model {
+  docs = new Map<string, ModelDoc>()
+
+  byPath(path: string): ModelDoc | undefined {
+    for (const d of this.docs.values()) if (d.path === path) return d
+    return undefined
+  }
+
+  movedBy(from: string): ModelDoc[] {
+    return [...this.docs.values()].filter((d) => d.path === from || d.path.startsWith(`${from}/`))
+  }
+
+  followMove(from: string, to: string): void {
+    const rows = () =>
+      [...this.docs.values()].map((d) => ({ id: d.id, path: d.path, name: d.name }))
+    const ownersIn = (alias: string, table: { id: string; path: string; name?: string }[]) => {
+      const out = new Set<string>()
+      for (const r of table) if (r.path === alias || r.name === alias) out.add(r.id)
+      return out
+    }
+    const before = rows()
+    const moved = this.movedBy(from)
+    const moves = moved.map((d) => ({ id: d.id, from: d.path, to: to + d.path.slice(from.length) }))
+    for (const d of moved) d.path = to + d.path.slice(from.length)
+    const after = rows()
+    const plan = new Map<string, string>()
+    for (const m of moves) {
+      if (m.to === m.from) continue
+      if (before.some((e) => e.id === m.from)) continue
+      const ob = ownersIn(m.from, before)
+      if (!(ob.size === 1 && ob.has(m.id))) continue
+      const oa = ownersIn(m.to, after)
+      const unique = oa.size === 1 && oa.has(m.id) && !after.some((e) => e.id === m.to)
+      plan.set(m.from, unique ? m.to : m.id)
+    }
+    for (const d of this.docs.values()) d.tokens = d.tokens.map((t) => plan.get(t) ?? t)
+  }
+}
+
+async function writeBodyOf(documentId: string, body: string): Promise<void> {
+  const store = new LoroStore()
+  const doc = new Loro()
+  const loaded = await store.load(documentId)
+  if (loaded.kind === 'ok') {
+    doc.import(loaded.snapshot)
+    for (const delta of loaded.deltas ?? []) doc.import(delta)
+  } else {
+    writeDocumentKind(doc, 'markdown')
+  }
+  writeMarkdownBody(doc, body)
+  await store.save(documentId, doc.export({ mode: 'snapshot' }))
+}
+
+async function tokensOf(documentId: string): Promise<string[]> {
+  const loaded = await new LoroStore().load(documentId)
+  if (loaded.kind !== 'ok') throw new Error(`unreadable: ${loaded.kind}`)
+  const doc = new Loro()
+  doc.import(loaded.snapshot)
+  for (const delta of loaded.deltas ?? []) doc.import(delta)
+  return scanReferences(readMarkdownBody(doc)).map((m) => m.target)
+}
+
+let runSeq = 0
+
+describe('local rename follow parity', () => {
+  fcTest.prop([fc.array(cmdArb, { minLength: 1, maxLength: 6 })], withDefaults({ numRuns: 8 }))(
+    'the browser keeper agrees with the naive follow model',
+    async (cmds) => {
+      const prefix = `pr${runSeq++}`
+      const P = (suffix: string) => `${prefix}/${suffix}`
+      const NAME = `Plan-${prefix}`
+      const alias = (a: string) => (a === 'Plan' ? NAME : P(a))
+      const index = new IdbDocumentIndex()
+      await ensureLocalWorkspace(index)
+      const source = createLocalFilesSource({ index })
+      const model = new Model()
+      const slots: (string | null)[] = [null, null, null]
+
+      const create = async (path: string, name?: string): Promise<string> => {
+        const entry = await index.createDocument({
+          workspaceId: getBrowserWorkspaceId(),
+          path,
+          kind: 'markdown',
+          ...(name === undefined ? {} : { name }),
+        })
+        const doc = new Loro()
+        writeDocumentKind(doc, 'markdown')
+        await new LoroStore().save(entry.documentId, doc.export({ mode: 'snapshot' }))
+        return entry.documentId
+      }
+
+      // Seed: a target, a descendant, and a source referencing both — the
+      // state the follow pass exists for (without it the sequences almost
+      // never assemble one; measured daemon-side).
+      const targetId = await create(P('alpha'))
+      model.docs.set(targetId, { id: targetId, path: P('alpha'), tokens: [] })
+      slots[0] = targetId
+      const leafId = await create(P('alpha/leaf'))
+      model.docs.set(leafId, { id: leafId, path: P('alpha/leaf'), tokens: [] })
+      const seedBody = `see [[${P('alpha')}]] and [[${P('alpha/leaf')}]] and [[${NAME}]]`
+      const sourceId = await create(P('gamma'))
+      await writeBodyOf(sourceId, seedBody)
+      model.docs.set(sourceId, {
+        id: sourceId,
+        path: P('gamma'),
+        tokens: scanReferences(seedBody).map((m) => m.target),
+      })
+      slots[1] = sourceId
+
+      for (const cmd of cmds) {
+        switch (cmd.t) {
+          case 'create': {
+            if (model.byPath(P(cmd.path)) !== undefined) break
+            const id = await create(P(cmd.path), cmd.name === undefined ? undefined : NAME)
+            slots[cmd.slot] = id
+            model.docs.set(id, {
+              id,
+              path: P(cmd.path),
+              ...(cmd.name === undefined ? {} : { name: NAME }),
+              tokens: [],
+            })
+            break
+          }
+          case 'writeBody': {
+            const id = slots[cmd.slot]
+            const doc = id === null ? undefined : model.docs.get(id)
+            if (doc === undefined) break
+            const body = cmd.refs.map((r) => `mention [[${alias(r)}]] here.`).join('\n')
+            await writeBodyOf(doc.id, body)
+            doc.tokens = scanReferences(body).map((m) => m.target)
+            break
+          }
+          case 'move': {
+            const id = slots[cmd.slot]
+            const doc = id === null ? undefined : model.docs.get(id)
+            if (doc === undefined) break
+            const from = doc.path
+            const to = P(cmd.to)
+            // Error paths are the daemon property's job; parity only needs
+            // the moves that succeed, so invalid ones are skipped up front.
+            if (to === from || to.startsWith(`${from}/`)) break
+            const movedPaths = model.movedBy(from).map((d) => d.path)
+            const produced = (path: string) => to + path.slice(from.length)
+            const collides = movedPaths.some((path) => {
+              const holder = model.byPath(produced(path))
+              return holder !== undefined && !movedPaths.includes(holder.path)
+            })
+            if (collides) break
+            await source.renameDocumentPath(from, to)
+            model.followMove(from, to)
+            break
+          }
+          case 'setName': {
+            const id = slots[cmd.slot]
+            const doc = id === null ? undefined : model.docs.get(id)
+            if (doc === undefined) break
+            const entries = await index.listDocuments({ workspaceId: getBrowserWorkspaceId() })
+            const entry = entries.find((e) => e.documentId === doc.id)
+            if (entry === undefined) break
+            await source.setDocumentName(entry, cmd.name === undefined ? undefined : NAME)
+            if (cmd.name === undefined) delete doc.name
+            else doc.name = NAME
+            break
+          }
+        }
+
+        for (const doc of model.docs.values()) {
+          expect(await tokensOf(doc.id), `tokens of ${doc.path}`).toEqual(doc.tokens)
+        }
+      }
+
+      // Witness epilogue: one move that ALWAYS carries a reference, on
+      // off-pool paths the commands cannot disturb. The random sequences
+      // alone reach a followed move only probabilistically at this budget —
+      // measured: a dropped followReferences call survived a full pass.
+      const wTargetId = await create(P('wtarget'))
+      model.docs.set(wTargetId, { id: wTargetId, path: P('wtarget'), tokens: [] })
+      const wBody = `see [[${P('wtarget')}]]`
+      const wSourceId = await create(P('wsource'))
+      await writeBodyOf(wSourceId, wBody)
+      model.docs.set(wSourceId, {
+        id: wSourceId,
+        path: P('wsource'),
+        tokens: scanReferences(wBody).map((m) => m.target),
+      })
+      await source.renameDocumentPath(P('wtarget'), P('wdest'))
+      model.followMove(P('wtarget'), P('wdest'))
+      for (const doc of model.docs.values()) {
+        expect(await tokensOf(doc.id), `tokens of ${doc.path}`).toEqual(doc.tokens)
+      }
+    },
+    60_000,
+  )
+})

--- a/apps/web/src/lib/reference-survival.test.ts
+++ b/apps/web/src/lib/reference-survival.test.ts
@@ -1,21 +1,27 @@
 /**
- * What a `[[reference]]` survives, measured rather than assumed.
- *
- * Nothing rewrites a reference when a document moves or is renamed — there
- * is no backlink index and no rewriting pass anywhere. Whichever identifier
- * the author wrote has to keep being true, and the three accepted forms fail
- * in complementary ways:
+ * What a `[[reference]]` survives AT THE RESOLVER, measured rather than
+ * assumed. The three accepted forms fail in complementary ways:
  *
  *   | written as   | path move | display-name change |
  *   |--------------|-----------|---------------------|
  *   | the path     | breaks    | survives            |
- *   | the name     | survives  | breaks              |
+ *   | the name     | survives  | breaks               |
  *   | the id       | survives  | survives            |
  *
  * This is the contract, not a defect list: `daemonLinkEntries` accepts both
  * human forms on purpose, because both are identifiers a reader would type.
- * The table is here so a change to either resolver has to state which column
- * it is moving, and so anyone adding a move affordance knows what it costs.
+ *
+ * The two breaking cells are answered differently, and on purpose:
+ *
+ * - the PATH cell is repaired one layer up — a move rewrites references
+ *   written to the old path (codec's `planReferenceRewrite`, applied by the
+ *   daemon's move route and by `local-files-source`). The repair cannot
+ *   reach a body edited outside the workspace or pasted back in, so the
+ *   cell stays true here at the resolver.
+ * - the NAME cell is being RETIRED, not repaired: path + id become the only
+ *   written forms, with display names shown at render time instead (owner
+ *   decision, 2026-09-03). Following a form on its way out would have been
+ *   work spent propping up the fragility being removed.
  */
 
 import {

--- a/packages/codec/src/index.ts
+++ b/packages/codec/src/index.ts
@@ -17,6 +17,15 @@ export type { AliasResolver } from './references/resolve.js'
 export { resolveReferences } from './references/resolve.js'
 export type { DocumentPathResolver } from './references/resolve-for-export.js'
 export { resolveReferencesForExport } from './references/resolve-for-export.js'
+export {
+  type CanvasRewriteResult,
+  type DocumentMove,
+  movesForPathChange,
+  planReferenceRewrite,
+  type ReferenceRewritePlanInput,
+  rewriteCanvasReferences,
+  rewriteReferenceTargets,
+} from './references/rewrite.js'
 export { type ReferenceMatch, scanReferences } from './references/scan.js'
 export {
   createUniqueNameResolver,

--- a/packages/codec/src/references/rewrite.property.test.ts
+++ b/packages/codec/src/references/rewrite.property.test.ts
@@ -1,0 +1,110 @@
+/**
+ * The two invariants the rewrite pass exists for, held under randomly
+ * colliding naming tables:
+ *
+ *   FOLLOW    — a reference that uniquely resolved to the moved document
+ *               before the change still resolves to it after the change.
+ *   UNTOUCHED — a reference that did not is byte-identical.
+ *
+ * The independent model below re-implements resolution naively (flat alias
+ * space over paths and names, ambiguity resolves to nothing, a document id
+ * always resolves to itself) so the property cannot inherit a bug from the
+ * code under test.
+ *
+ * The generator draws every alias — paths, names, the new path — from ONE
+ * five-string pool, so collisions (an old name shared by
+ * two documents, a new name landing on someone else's path) are the common
+ * case rather than the 1-in-2^40 one. A uniform generator here would pass
+ * with the ambiguity rules deleted.
+ */
+import { canonicalUlidArbitrary } from '@kamiazya/whiteboard-model/test-utils'
+import { describe, expect } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { planReferenceRewrite, rewriteReferenceTargets } from './rewrite.js'
+import { scanReferences } from './scan.js'
+
+const ALIAS_POOL = ['alpha', 'beta', 'gamma', 'delta', 'epsilon'] as const
+const aliasArbitrary = fc.constantFrom(...ALIAS_POOL)
+
+interface TableEntry {
+  id: string
+  path: string
+  name?: string
+}
+
+const tableArbitrary = fc
+  .tuple(
+    fc.uniqueArray(canonicalUlidArbitrary, { minLength: 2, maxLength: 4 }),
+    fc.infiniteStream(aliasArbitrary),
+    fc.infiniteStream(fc.boolean()),
+  )
+  .map(([ids, aliases, hasName]) => {
+    const iter = aliases[Symbol.iterator]()
+    const flags = hasName[Symbol.iterator]()
+    const next = (): string => (iter.next() as IteratorYieldResult<string>).value
+    return ids.map(
+      (id): TableEntry => ({
+        id,
+        path: next(),
+        ...((flags.next() as IteratorYieldResult<boolean>).value ? { name: next() } : {}),
+      }),
+    )
+  })
+
+/**
+ * The naive model: what does `alias` resolve to under `table`? A direct id
+ * wins outright — which is why the plan reserves every live id as an owner.
+ */
+function modelResolve(alias: string, table: readonly TableEntry[]): string | null {
+  if (table.some((entry) => entry.id === alias)) return alias
+  const owners = table.filter((entry) => entry.path === alias || entry.name === alias)
+  return owners.length === 1 ? (owners[0] as TableEntry).id : null
+}
+
+function applyChange(
+  table: readonly TableEntry[],
+  movedId: string,
+  path: { from: string; to: string },
+): TableEntry[] {
+  return table.map((entry) => (entry.id === movedId ? { ...entry, path: path.to } : entry))
+}
+
+const bodyPieceArbitrary = fc.oneof(
+  fc.constant('plain text '),
+  aliasArbitrary.map((alias) => `[[${alias}]] `),
+  aliasArbitrary.map((alias) => `![[${alias}]] `),
+  aliasArbitrary.map((alias) => `[[${alias}|label]] `),
+)
+
+describe('rewrite invariants', () => {
+  fcTest.prop(
+    [tableArbitrary, fc.array(bodyPieceArbitrary, { minLength: 1, maxLength: 8 }), aliasArbitrary],
+    withDefaults(),
+  )('follow + untouched, under a colliding table', (table, pieces, newPath) => {
+    const moved = table[0] as TableEntry
+    const body = pieces.join('')
+    const path = { from: moved.path, to: newPath }
+
+    const plan = planReferenceRewrite({ entries: table, moves: [{ movedId: moved.id, ...path }] })
+    const after = rewriteReferenceTargets(body, plan)
+    const newTable = applyChange(table, moved.id, path)
+
+    const refsBefore = scanReferences(body)
+    const refsAfter = scanReferences(after)
+    expect(refsAfter.length).toBe(refsBefore.length)
+
+    for (let i = 0; i < refsBefore.length; i++) {
+      const before = refsBefore[i] as (typeof refsBefore)[number]
+      const rewritten = refsAfter[i] as (typeof refsBefore)[number]
+      if (modelResolve(before.target, table) === moved.id) {
+        // FOLLOW: still resolves to the moved document under the new table.
+        expect(modelResolve(rewritten.target, newTable)).toBe(moved.id)
+      } else {
+        // UNTOUCHED: byte-identical, label and embed marker included.
+        expect(rewritten.full).toBe(before.full)
+      }
+      expect(rewritten.isEmbed).toBe(before.isEmbed)
+      expect(rewritten.alias).toBe(before.alias)
+    }
+  })
+})

--- a/packages/codec/src/references/rewrite.test.ts
+++ b/packages/codec/src/references/rewrite.test.ts
@@ -1,0 +1,172 @@
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { describe, expect, it } from 'vitest'
+import {
+  movesForPathChange,
+  planReferenceRewrite,
+  rewriteCanvasReferences,
+  rewriteReferenceTargets,
+} from './rewrite.js'
+
+const MOVED = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+const OTHER = '01BX5ZZKBKACTAV9WEVGEMMVRZ'
+
+describe('rewriteReferenceTargets', () => {
+  const map = new Map([['design/login', 'archive/login']])
+
+  it('rewrites only the target slice, keeping brackets, bang and label', () => {
+    expect(rewriteReferenceTargets('see [[design/login]] here', map)).toBe(
+      'see [[archive/login]] here',
+    )
+    expect(rewriteReferenceTargets('![[design/login]]', map)).toBe('![[archive/login]]')
+    expect(rewriteReferenceTargets('[[design/login|the login flow]]', map)).toBe(
+      '[[archive/login|the login flow]]',
+    )
+  })
+
+  it('leaves every other target byte-identical', () => {
+    const body = '[[design/logout]] and [[Login flow]] and plain [[design/login-notes]]'
+    expect(rewriteReferenceTargets(body, map)).toBe(body)
+  })
+
+  it('leaves text that only LOOKS like a reference alone', () => {
+    // The scanner never matches these, so the rewriter must not either —
+    // what gets rewritten must equal what resolves (ADR-0014's bar).
+    const body = '[[design/login and [design/login] and [[]]'
+    expect(rewriteReferenceTargets(body, map)).toBe(body)
+  })
+
+  it('rewrites every occurrence, not just the first', () => {
+    expect(rewriteReferenceTargets('[[design/login]] twice [[design/login]]', map)).toBe(
+      '[[archive/login]] twice [[archive/login]]',
+    )
+  })
+})
+
+describe('rewriteCanvasReferences', () => {
+  const map = new Map([['design/login', 'archive/login']])
+  const canvas: SpatialCanvas = {
+    nodes: [
+      { id: 't1', x: 0, y: 0, width: 100, height: 40, type: 'text', text: 'see [[design/login]]' },
+      { id: 'f1', x: 0, y: 60, width: 100, height: 40, type: 'file', file: 'design/login' },
+      { id: 'f2', x: 0, y: 120, width: 100, height: 40, type: 'file', file: 'design/logout' },
+    ],
+    edges: [],
+  }
+
+  it('rewrites text-node wikilinks and file-node targets, and reports exactly which changed', () => {
+    const out = rewriteCanvasReferences(canvas, map)
+    expect(out.changed).toBe(true)
+    // The CHANGED list is what a caller writes back — one targeted write per
+    // node, never the whole canvas, so records the current schema cannot
+    // read are never deleted by a resync.
+    expect(out.changedNodes.map((n) => n.id)).toEqual(['t1', 'f1'])
+    const nodes = out.canvas.nodes
+    expect(nodes[0]).toMatchObject({ text: 'see [[archive/login]]' })
+    expect(nodes[1]).toMatchObject({ file: 'archive/login' })
+    // An untouched node keeps its identity, not just its value.
+    expect(nodes[2]).toBe(canvas.nodes[2])
+  })
+
+  it('answers changed: false — and the same canvas object — when nothing matches', () => {
+    const out = rewriteCanvasReferences(canvas, new Map([['nowhere', 'else']]))
+    expect(out.changed).toBe(false)
+    expect(out.canvas).toBe(canvas)
+  })
+})
+
+describe('planReferenceRewrite', () => {
+  const table = (docs: readonly { id: string; path: string; name?: string }[]) => docs
+
+  it('maps the old path to the new path on a move', () => {
+    const plan = planReferenceRewrite({
+      entries: table([
+        { id: MOVED, path: 'design/login', name: 'Login flow' },
+        { id: OTHER, path: 'notes/other' },
+      ]),
+      moves: [{ movedId: MOVED, from: 'design/login', to: 'archive/login' }],
+    })
+    expect(plan.get('design/login')).toBe('archive/login')
+    expect(plan.has('Login flow')).toBe(false)
+  })
+
+  it('falls back to the id when the NEW path would not resolve uniquely', () => {
+    // Paths are unique among paths, but names share the alias space: the
+    // destination collides with another document's display name, so
+    // rewriting path -> path would produce a reference that resolves to
+    // nothing. The id survives everything.
+    const plan = planReferenceRewrite({
+      entries: table([
+        { id: MOVED, path: 'a/one' },
+        { id: OTHER, path: 'b/two', name: 'archive/login' },
+      ]),
+      moves: [{ movedId: MOVED, from: 'a/one', to: 'archive/login' }],
+    })
+    expect(plan.get('a/one')).toBe(MOVED)
+  })
+
+  it('skips an old path that collided with another document display name', () => {
+    // Paths are unique among paths, but the alias space is shared with
+    // names: if another document is NAMED "design/login", the alias was
+    // ambiguous and never resolved — rewriting it would resurrect a dead
+    // reference as a live one.
+    const plan = planReferenceRewrite({
+      entries: table([
+        { id: MOVED, path: 'design/login' },
+        { id: OTHER, path: 'b/two', name: 'design/login' },
+      ]),
+      moves: [{ movedId: MOVED, from: 'design/login', to: 'archive/login' }],
+    })
+    expect(plan.has('design/login')).toBe(false)
+  })
+
+  it('never rewrites an alias that is also a live document id', () => {
+    // A path can legally spell 26 Crockford characters. The reader resolves
+    // a direct id FIRST, so [[<OTHER>]] points at OTHER even while it is
+    // the moved document's path — rewriting it would break OTHER's link.
+    const plan = planReferenceRewrite({
+      entries: table([
+        { id: MOVED, path: OTHER },
+        { id: OTHER, path: 'b/two' },
+      ]),
+      moves: [{ movedId: MOVED, from: OTHER, to: 'archive/login' }],
+    })
+    expect(plan.has(OTHER)).toBe(false)
+  })
+
+  it('plans every descendant of a subtree move', () => {
+    const CHILD = '01CX5ZZKBKACTAV9WEVGEMMVRA'
+    const entries = table([
+      { id: MOVED, path: 'folder' },
+      { id: CHILD, path: 'folder/child' },
+    ])
+    const moves = movesForPathChange(entries, 'folder', 'archive/folder')
+    expect(moves).toEqual([
+      { movedId: MOVED, from: 'folder', to: 'archive/folder' },
+      { movedId: CHILD, from: 'folder/child', to: 'archive/folder/child' },
+    ])
+    const plan = planReferenceRewrite({ entries, moves })
+    expect(plan.get('folder')).toBe('archive/folder')
+    expect(plan.get('folder/child')).toBe('archive/folder/child')
+  })
+
+  it('does not sweep a sibling whose path merely starts with the same word', () => {
+    const SIB = '01CX5ZZKBKACTAV9WEVGEMMVRB'
+    const moves = movesForPathChange(
+      table([
+        { id: MOVED, path: 'folder' },
+        { id: SIB, path: 'folder-notes' },
+      ]),
+      'folder',
+      'archive/folder',
+    )
+    expect(moves).toEqual([{ movedId: MOVED, from: 'folder', to: 'archive/folder' }])
+  })
+
+  it('produces no entry when nothing changed', () => {
+    const plan = planReferenceRewrite({
+      entries: table([{ id: MOVED, path: 'a/one', name: 'Login flow' }]),
+      moves: [{ movedId: MOVED, from: 'a/one', to: 'a/one' }],
+    })
+    expect(plan.size).toBe(0)
+  })
+})

--- a/packages/codec/src/references/rewrite.ts
+++ b/packages/codec/src/references/rewrite.ts
@@ -1,0 +1,212 @@
+/**
+ * Rewriting references when a document's ADDRESS changes — the follow half
+ * of the survival table in apps/web's `reference-survival.test.ts`: a
+ * reference written as the path breaks on a move, one written as the
+ * display name breaks on a rename, and nothing rewrote either. These
+ * helpers are that rewriting pass, shared by both keepers (the daemon's
+ * rename routes and the browser's local files source) so a move follows
+ * references identically in both modes.
+ *
+ * Two rules carry all the correctness:
+ *
+ * - **What gets rewritten must equal what resolves.** The rewriter walks
+ *   the same scanner grammar the reader and the reference index use
+ *   (ADR-0014's bar), and `planReferenceRewrite` only maps an alias that
+ *   UNIQUELY resolved to the moved document under the old naming table — a
+ *   `[[Name]]` the reader saw as literal bracket text stays literal.
+ * - **Correctness over form.** A path reference becomes the new path —
+ *   unless the new path would not resolve uniquely under the new table
+ *   (today a display name elsewhere can still collide with it, since names
+ *   share the alias space), in which case the reference is rewritten to the
+ *   document id, which survives everything.
+ *
+ * Only PATH moves are followed. Display-name references are being retired
+ * from resolution (path + id become the only written forms; names are shown
+ * at render time instead — owner decision, 2026-09-03), so a name change
+ * rewrites nothing rather than propping up a form on its way out.
+ */
+import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
+import { scanReferences } from './scan.js'
+
+/**
+ * `value` with every `[[target]]` / `![[target|label]]` whose target is a
+ * key of `replacements` pointed at the mapped alias instead. Only the
+ * target slice moves; the bang, brackets and label are kept byte-for-byte.
+ */
+export function rewriteReferenceTargets(
+  value: string,
+  replacements: ReadonlyMap<string, string>,
+): string {
+  if (replacements.size === 0) return value
+  let out = ''
+  let cursor = 0
+  for (const match of scanReferences(value)) {
+    const next = replacements.get(match.target)
+    if (next === undefined) continue
+    // The target slice starts after `[[` (and the `!` when present).
+    const targetStart = match.index + (match.isEmbed ? 3 : 2)
+    out += value.slice(cursor, targetStart) + next
+    cursor = targetStart + match.target.length
+  }
+  return cursor === 0 ? value : out + value.slice(cursor)
+}
+
+export interface CanvasRewriteResult {
+  readonly canvas: SpatialCanvas
+  /** Whether anything moved — `false` returns the input object untouched. */
+  readonly changed: boolean
+  /**
+   * Exactly the nodes that changed, for TARGETED writes. A caller must
+   * never answer this rewrite with a whole-canvas resync: `readSpatialCanvas`
+   * drops records the current schema cannot parse, and a whole-canvas write
+   * then DELETES them — so a document holding one record from another
+   * version would lose it to a rename. One `writeSpatialNode` per entry
+   * here touches nothing else.
+   */
+  readonly changedNodes: readonly SpatialNode[]
+}
+
+/**
+ * The spatial half of the same pass: wikilinks inside text nodes go through
+ * `rewriteReferenceTargets`, and a file node whose `file` IS an affected
+ * alias is repointed. Embed targets are document ids and ids survive both
+ * kinds of change, so embeds are never rewritten. Untouched nodes keep
+ * their identity so a caller (and Loro) can tell what actually moved.
+ */
+export function rewriteCanvasReferences(
+  canvas: SpatialCanvas,
+  replacements: ReadonlyMap<string, string>,
+): CanvasRewriteResult {
+  const changedNodes: SpatialNode[] = []
+  const nodes = canvas.nodes.map((node): SpatialNode => {
+    if (node.type === 'text') {
+      const text = rewriteReferenceTargets(node.text, replacements)
+      if (text === node.text) return node
+      const next = { ...node, text }
+      changedNodes.push(next)
+      return next
+    }
+    if (node.type === 'file') {
+      const target = replacements.get(node.file)
+      if (target === undefined) return node
+      const next = { ...node, file: target }
+      changedNodes.push(next)
+      return next
+    }
+    return node
+  })
+  return changedNodes.length > 0
+    ? { canvas: { ...canvas, nodes }, changed: true, changedNodes }
+    : { canvas, changed: false, changedNodes }
+}
+
+export interface DocumentMove {
+  readonly movedId: string
+  readonly from: string
+  readonly to: string
+}
+
+/**
+ * A path change is a SUBTREE move: `moveDocument({from: 'a', to: 'b'})`
+ * carries every descendant with it, so following only the root would leave
+ * `[[a/child]]` pointing at nothing. This derives one move per affected
+ * document from the pre-move listing, and both keepers derive through it so
+ * neither can forget the descendants. Prefix matching is per SEGMENT —
+ * `folder-notes` is a sibling of `folder`, not a descendant.
+ */
+export function movesForPathChange(
+  entries: readonly { readonly documentId?: string; readonly id?: string; readonly path: string }[],
+  from: string,
+  to: string,
+): DocumentMove[] {
+  const prefix = `${from}/`
+  const moves: DocumentMove[] = []
+  for (const entry of entries) {
+    const movedId = entry.documentId ?? entry.id
+    if (movedId === undefined) continue
+    if (entry.path === from) moves.push({ movedId, from, to })
+    else if (entry.path.startsWith(prefix)) {
+      moves.push({ movedId, from: entry.path, to: to + entry.path.slice(from.length) })
+    }
+  }
+  return moves
+}
+
+export interface ReferenceRewritePlanInput {
+  /**
+   * The naming table BEFORE the change: every document's path and name.
+   * Names still matter here even though name CHANGES are not followed —
+   * they share the alias space, so they decide whether an old path
+   * resolved at all and whether a new one will.
+   */
+  readonly entries: readonly {
+    readonly id: string
+    readonly path: string
+    readonly name?: string
+  }[]
+  readonly moves: readonly DocumentMove[]
+}
+
+/**
+ * Which aliases to rewrite to what, for one document's path move and/or
+ * display-name change. The one policy decision lives here so both keepers
+ * apply it identically; the mechanical rewriters above take the result.
+ */
+export function planReferenceRewrite(
+  input: ReferenceRewritePlanInput,
+): ReadonlyMap<string, string> {
+  const { entries, moves } = input
+  const newPathOf = new Map(moves.map((move) => [move.movedId, move.to]))
+
+  // The alias space is FLAT: paths and display names resolve through one
+  // table (reference-aggregate builds its resolver from both). "Uniquely
+  // resolved" counts OWNERS, not column occurrences: a document whose name
+  // equals its own path is one owner, not a collision with itself —
+  // daemonLinkEntries dedupes exactly that case before the resolver sees it,
+  // and the first property run caught this function double-counting it.
+  const owners = (
+    project: (entry: ReferenceRewritePlanInput['entries'][number]) => readonly string[],
+  ): Map<string, Set<string>> => {
+    const byAlias = new Map<string, Set<string>>()
+    const claim = (alias: string, ownerId: string): void => {
+      const set = byAlias.get(alias) ?? new Set<string>()
+      set.add(ownerId)
+      byAlias.set(alias, set)
+    }
+    for (const entry of entries) {
+      for (const alias of project(entry)) claim(alias, entry.id)
+      // Every live document's ID is a reserved alias: the reader resolves a
+      // direct id FIRST, so an alias spelling one — a path can legally be 26
+      // Crockford characters — resolves to THAT document no matter whose
+      // path or name it also is. Claiming it here makes such an alias
+      // ambiguous-by-construction on both sides of the plan.
+      claim(entry.id, `id:${entry.id}`)
+    }
+    return byAlias
+  }
+  const uniquelyOwned = (
+    byAlias: Map<string, Set<string>>,
+    alias: string,
+    ownerId: string,
+  ): boolean => {
+    const set = byAlias.get(alias)
+    return set !== undefined && set.size === 1 && set.has(ownerId)
+  }
+
+  const before = owners((entry) =>
+    entry.name === undefined ? [entry.path] : [entry.path, entry.name],
+  )
+  // The table AFTER the change, to test whether each new path will resolve.
+  const after = owners((entry) => {
+    const path = newPathOf.get(entry.id) ?? entry.path
+    return entry.name === undefined ? [path] : [path, entry.name]
+  })
+
+  const plan = new Map<string, string>()
+  for (const { movedId, from, to } of moves) {
+    if (to === from) continue
+    if (!uniquelyOwned(before, from, movedId)) continue
+    plan.set(from, uniquelyOwned(after, to, movedId) ? to : movedId)
+  }
+  return plan
+}

--- a/packages/codec/src/references/unique-name-resolver.test.ts
+++ b/packages/codec/src/references/unique-name-resolver.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { createUniqueNameResolver } from './unique-name-resolver.js'
+
+describe('createUniqueNameResolver', () => {
+  it('resolves an alias exactly one document claims', () => {
+    const resolve = createUniqueNameResolver([
+      { id: 'A', name: 'Plan' },
+      { id: 'B', name: 'Note' },
+    ])
+    expect(resolve('Plan')).toBe('A')
+    expect(resolve('missing')).toBe(null)
+  })
+
+  it('answers null for an alias two documents claim', () => {
+    const resolve = createUniqueNameResolver([
+      { id: 'A', name: 'Plan' },
+      { id: 'B', name: 'Plan' },
+    ])
+    expect(resolve('Plan')).toBe(null)
+  })
+
+  it('a document claiming one alias twice is ONE owner, not an ambiguity', () => {
+    // Callers feed a path entry AND a name entry per document, so a document
+    // NAMED exactly its own path arrives as two claims with one id. The
+    // reader navigates that link (daemonLinkEntries dedupes the row), so the
+    // resolver must resolve it too — found by the command-sequence property:
+    // backlinks dropped a link the preview renders live.
+    const resolve = createUniqueNameResolver([
+      { id: 'A', name: 'beta/leaf' },
+      { id: 'A', name: 'beta/leaf' },
+      { id: 'B', name: 'other' },
+    ])
+    expect(resolve('beta/leaf')).toBe('A')
+  })
+
+  it('a same-id claim does not resurrect an alias already ambiguous', () => {
+    const resolve = createUniqueNameResolver([
+      { id: 'A', name: 'Plan' },
+      { id: 'B', name: 'Plan' },
+      { id: 'A', name: 'Plan' },
+    ])
+    expect(resolve('Plan')).toBe(null)
+  })
+})

--- a/packages/codec/src/references/unique-name-resolver.ts
+++ b/packages/codec/src/references/unique-name-resolver.ts
@@ -20,7 +20,11 @@ export interface UniqueNameEntry {
 export function createUniqueNameResolver(entries: readonly UniqueNameEntry[]): AliasResolver {
   const byName = new Map<string, string | null>()
   for (const entry of entries) {
-    byName.set(entry.name, byName.has(entry.name) ? null : entry.id)
+    const prev = byName.get(entry.name)
+    // Uniqueness counts OWNERS, not claims: callers feed a path entry and a
+    // name entry per document, so a document named exactly its own path is
+    // one owner arriving twice — still a link, not an ambiguity.
+    byName.set(entry.name, prev === undefined || prev === entry.id ? entry.id : null)
   }
   return (alias) => byName.get(alias) ?? null
 }

--- a/packages/mcp-server/src/server/routes/document/follow-rename-routes.test.ts
+++ b/packages/mcp-server/src/server/routes/document/follow-rename-routes.test.ts
@@ -1,0 +1,74 @@
+/**
+ * The path-move route carries the follow pass: after a move, references
+ * other documents wrote to the OLD path are repointed (server-core's
+ * `followReferencesAfterRename`). Proven through the ROUTE, against real
+ * default deps in a temp data dir — the same surface the web app's Rename
+ * dialog reaches. Display-name changes deliberately rewrite nothing: name
+ * references are being retired from resolution.
+ */
+import { mkdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import {
+  readMarkdownBody,
+  writeDocumentKind,
+  writeMarkdownBody,
+} from '@kamiazya/whiteboard-loro-adapter'
+import { LoroDoc } from 'loro-crdt'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { withTempDataDir } from '../_test-helpers.js'
+
+const tmp = withTempDataDir('whiteboard-follow-rename-test-')
+
+const { createDocumentRouter } = await import('../document.js')
+const documentStore = await import('../../store/document-store.js')
+const { getDoc } = documentStore
+
+async function seedMarkdown(workspaceId: string, path: string, body: string) {
+  const doc = new LoroDoc()
+  writeDocumentKind(doc, 'markdown')
+  writeMarkdownBody(doc, body)
+  await documentStore.saveDocument(workspaceId, path, doc)
+}
+
+async function bodyAt(workspaceId: string, path: string): Promise<string> {
+  const doc = await getDoc(workspaceId, path)
+  return readMarkdownBody(doc)
+}
+
+describe('rename routes follow references', () => {
+  beforeEach(async () => {
+    await mkdir(join(tmp.dir, 'session1'), { recursive: true })
+  })
+
+  it('PUT :path/path repoints references written as the old path', async () => {
+    await seedMarkdown('session1', 'design/login', 'the target')
+    await seedMarkdown('session1', 'notes/daily', 'see [[design/login]] and [[unrelated]]')
+    const app = createDocumentRouter()
+
+    const res = await app.request('/api/workspaces/session1/documents/design%2Flogin/path', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: 'archive/login' }),
+    })
+    expect(res.status).toBe(200)
+
+    expect(await bodyAt('session1', 'notes/daily')).toBe('see [[archive/login]] and [[unrelated]]')
+  })
+
+  it('PUT :path/path follows references to a moved DESCENDANT too', async () => {
+    await mkdir(join(tmp.dir, 'session3'), { recursive: true })
+    await seedMarkdown('session3', 'folder', 'the parent')
+    await seedMarkdown('session3', 'folder/child', 'the child')
+    await seedMarkdown('session3', 'notes/daily', 'see [[folder/child]]')
+    const app = createDocumentRouter()
+
+    const res = await app.request('/api/workspaces/session3/documents/folder/path', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: 'archive/folder' }),
+    })
+    expect(res.status).toBe(200)
+
+    expect(await bodyAt('session3', 'notes/daily')).toBe('see [[archive/folder/child]]')
+  })
+})

--- a/packages/mcp-server/src/server/routes/document/workspaces.ts
+++ b/packages/mcp-server/src/server/routes/document/workspaces.ts
@@ -1,3 +1,4 @@
+import { movesForPathChange } from '@kamiazya/whiteboard-codec'
 import {
   deriveWorkspaceSegment,
   generateDocumentId,
@@ -13,6 +14,7 @@ import {
   WorkspaceSegmentTakenError,
 } from '@kamiazya/whiteboard-ports'
 import {
+  followReferencesAfterRename,
   type ServerDeps,
   wbDocumentCreate,
   wbDocumentDelete,
@@ -449,7 +451,37 @@ export function createWorkspacesRouter(options: WorkspacesRouterOptions = {}) {
       }
       try {
         const deps = options.serverDeps ?? (await getDefaultServerDeps())
+        // The listing BEFORE the move is the table the old path resolved
+        // against; the follow pass needs it and only this side of the
+        // mutation can take it.
+        const entriesBefore = await deps.documentIndex.listDocuments({ workspaceId })
         await deps.documentIndex.moveDocument({ workspaceId, from: path, to: newPath })
+        // References written to the old paths follow the move — every path
+        // the SUBTREE carried, not just the root, which is why the moves are
+        // derived rather than written here. The rename itself already
+        // stands, so a follow failure is a log line and a partially repaired
+        // workspace, never a failed rename.
+        const moves = movesForPathChange(entriesBefore, path, newPath)
+        if (moves.length > 0) {
+          try {
+            const follow = await followReferencesAfterRename(deps, {
+              workspaceId,
+              entriesBefore,
+              moves,
+            })
+            if (follow.failedDocumentIds.length > 0) {
+              getLogger('document').warning(
+                { workspaceId, from: path, to: newPath, failed: follow.failedDocumentIds },
+                'rename followed references, but some documents could not be rewritten',
+              )
+            }
+          } catch (err) {
+            getLogger('document').warning(
+              { workspaceId, from: path, to: newPath, err },
+              'rename succeeded but the reference follow pass failed',
+            )
+          }
+        }
         const response: RenameDocumentPathResponse = { path: newPath }
         return c.json(response)
       } catch (err) {

--- a/packages/server-core/src/index.ts
+++ b/packages/server-core/src/index.ts
@@ -13,6 +13,11 @@ export type {
   RestoreVersionResult,
 } from './operations/restore-version.js'
 export { restoreVersion } from './operations/restore-version.js'
+export {
+  type FollowRenameInput,
+  type FollowRenameResult,
+  followReferencesAfterRename,
+} from './references/follow-rename.js'
 export type { Embedder } from './search/embedder.js'
 export type { ConfidenceInterval, Judgments, PermutationResult } from './search/eval.js'
 export {

--- a/packages/server-core/src/references/follow-rename.test.ts
+++ b/packages/server-core/src/references/follow-rename.test.ts
@@ -1,0 +1,224 @@
+import { readMarkdownBody, readSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+import { describe, expect, it } from 'vitest'
+import type { ServerDeps } from '../server-deps.js'
+import { makeTestDeps } from '../test-utils/make-test-deps.js'
+import { createCanvasEditTool } from '../tools/canvas-edit.js'
+import { wbDocumentCreate } from '../tools/document-crud.js'
+import { loadOrCreateDocument, saveDocumentSnapshot } from '../tools/document-io.js'
+import { createDocumentSetTool } from '../tools/document-set.js'
+import { followReferencesAfterRename } from './follow-rename.js'
+
+const WS = 'ws-follow'
+
+async function seed(deps: ServerDeps) {
+  await deps.documentIndex.createWorkspace({ workspaceId: WS })
+  const create = (path: string, name?: string) =>
+    wbDocumentCreate(deps, {
+      workspaceId: WS,
+      path,
+      kind: 'markdown',
+      ...(name === undefined ? {} : { name }),
+    })
+  const set = createDocumentSetTool(deps)
+  const write = (documentId: string, body: string) =>
+    set.execute({ workspaceId: WS, documentId, markdown: `---\ntype: note\n---\n${body}` })
+  const bodyOf = async (documentId: string) =>
+    readMarkdownBody(await loadOrCreateDocument(deps, WS, documentId as never))
+  return { create, write, bodyOf }
+}
+
+const entriesBefore = (deps: ServerDeps) => deps.documentIndex.listDocuments({ workspaceId: WS })
+
+describe('followReferencesAfterRename', () => {
+  it('a path move repoints references written as the old path', async () => {
+    const deps = makeTestDeps()
+    const { create, write, bodyOf } = await seed(deps)
+    const target = await create('design/login', 'Login flow')
+    const source = await create('notes/daily')
+    await write(source.documentId, 'see [[design/login]] and [[Login flow]] and [[unrelated]]')
+
+    const before = await entriesBefore(deps)
+    await deps.documentIndex.moveDocument({
+      workspaceId: WS,
+      from: 'design/login',
+      to: 'archive/login',
+    })
+    const result = await followReferencesAfterRename(deps, {
+      workspaceId: WS,
+      entriesBefore: before,
+      moves: [{ movedId: target.documentId, from: 'design/login', to: 'archive/login' }],
+    })
+
+    expect(result.updatedDocumentIds).toEqual([source.documentId])
+    // The path form followed; the name form and the dead ref are untouched.
+    expect(await bodyOf(source.documentId)).toBe(
+      'see [[archive/login]] and [[Login flow]] and [[unrelated]]',
+    )
+  })
+
+  it('rewrites spatial text nodes and file nodes too', async () => {
+    const deps = makeTestDeps()
+    const { create } = await seed(deps)
+    const target = await create('design/login', 'Login flow')
+    const canvas = await wbDocumentCreate(deps, { workspaceId: WS, path: 'board', kind: 'spatial' })
+    await createCanvasEditTool(deps).execute({
+      workspaceId: WS,
+      documentId: canvas.documentId,
+      ops: [
+        {
+          op: 'node.add',
+          node: {
+            id: 't1',
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 40,
+            type: 'text',
+            text: 'see [[design/login]]',
+          },
+        },
+        {
+          op: 'node.add',
+          node: {
+            id: 'f1',
+            x: 0,
+            y: 60,
+            width: 100,
+            height: 40,
+            type: 'file',
+            file: 'design/login',
+          },
+        },
+      ],
+    })
+
+    const before = await entriesBefore(deps)
+    await deps.documentIndex.moveDocument({
+      workspaceId: WS,
+      from: 'design/login',
+      to: 'archive/login',
+    })
+    const result = await followReferencesAfterRename(deps, {
+      workspaceId: WS,
+      entriesBefore: before,
+      moves: [{ movedId: target.documentId, from: 'design/login', to: 'archive/login' }],
+    })
+
+    expect(result.updatedDocumentIds).toEqual([canvas.documentId])
+    const doc = await loadOrCreateDocument(deps, WS, canvas.documentId as never)
+    const spatial = readSpatialCanvas(doc)
+    expect(spatial.nodes.find((n) => n.id === 't1')).toMatchObject({
+      text: 'see [[archive/login]]',
+    })
+    expect(spatial.nodes.find((n) => n.id === 'f1')).toMatchObject({ file: 'archive/login' })
+  })
+
+  it('a subtree move follows references to a descendant', async () => {
+    const deps = makeTestDeps()
+    const { create, write, bodyOf } = await seed(deps)
+    const parent = await create('folder')
+    const child = await create('folder/child')
+    const source = await create('notes/daily')
+    await write(source.documentId, 'see [[folder/child]] and [[folder]]')
+
+    const before = await entriesBefore(deps)
+    await deps.documentIndex.moveDocument({ workspaceId: WS, from: 'folder', to: 'archive/folder' })
+    await followReferencesAfterRename(deps, {
+      workspaceId: WS,
+      entriesBefore: before,
+      moves: [
+        { movedId: parent.documentId, from: 'folder', to: 'archive/folder' },
+        { movedId: child.documentId, from: 'folder/child', to: 'archive/folder/child' },
+      ],
+    })
+
+    expect(await bodyOf(source.documentId)).toBe(
+      'see [[archive/folder/child]] and [[archive/folder]]',
+    )
+  })
+
+  it('a record the current schema cannot read survives the rewrite', async () => {
+    // readSpatialCanvas drops what it cannot parse and a whole-canvas write
+    // would then DELETE it — the rewrite must therefore write only the
+    // nodes it changed, and this is the test that fails if it ever goes
+    // back to a resync.
+    const deps = makeTestDeps()
+    const { create } = await seed(deps)
+    const target = await create('design/login', 'Login flow')
+    const board = await wbDocumentCreate(deps, { workspaceId: WS, path: 'board', kind: 'spatial' })
+    await createCanvasEditTool(deps).execute({
+      workspaceId: WS,
+      documentId: board.documentId,
+      ops: [
+        {
+          op: 'node.add',
+          node: {
+            id: 't1',
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 40,
+            type: 'text',
+            text: 'see [[design/login]]',
+          },
+        },
+      ],
+    })
+    // A record from "another version": a shape today's spatialNodeSchema
+    // rejects, planted straight into the nodes map.
+    {
+      const doc = await loadOrCreateDocument(deps, WS, board.documentId as never)
+      doc.getMap('nodes').set('from-the-future', { type: 'hologram', shimmer: true })
+      doc.commit()
+      await saveDocumentSnapshot(deps, WS, board.documentId as never, doc)
+    }
+
+    const before = await entriesBefore(deps)
+    await deps.documentIndex.moveDocument({
+      workspaceId: WS,
+      from: 'design/login',
+      to: 'archive/login',
+    })
+    const result = await followReferencesAfterRename(deps, {
+      workspaceId: WS,
+      entriesBefore: before,
+      moves: [{ movedId: target.documentId, from: 'design/login', to: 'archive/login' }],
+    })
+
+    expect(result.updatedDocumentIds).toEqual([board.documentId])
+    const doc = await loadOrCreateDocument(deps, WS, board.documentId as never)
+    expect(readSpatialCanvas(doc).nodes.find((n) => n.id === 't1')).toMatchObject({
+      text: 'see [[archive/login]]',
+    })
+    // The unreadable record is still there, byte-for-byte.
+    expect(doc.getMap('nodes').get('from-the-future')).toEqual({
+      type: 'hologram',
+      shimmer: true,
+    })
+  })
+
+  it('touches nothing when no reference named the moved document', async () => {
+    const deps = makeTestDeps()
+    const { create, write, bodyOf } = await seed(deps)
+    const target = await create('design/login', 'Login flow')
+    const source = await create('notes/daily')
+    await write(source.documentId, 'no references here, and [[somewhere/else]] is dead')
+
+    const before = await entriesBefore(deps)
+    await deps.documentIndex.moveDocument({
+      workspaceId: WS,
+      from: 'design/login',
+      to: 'archive/login',
+    })
+    const result = await followReferencesAfterRename(deps, {
+      workspaceId: WS,
+      entriesBefore: before,
+      moves: [{ movedId: target.documentId, from: 'design/login', to: 'archive/login' }],
+    })
+
+    expect(result.updatedDocumentIds).toEqual([])
+    expect(await bodyOf(source.documentId)).toBe(
+      'no references here, and [[somewhere/else]] is dead',
+    )
+  })
+})

--- a/packages/server-core/src/references/follow-rename.ts
+++ b/packages/server-core/src/references/follow-rename.ts
@@ -1,0 +1,119 @@
+/**
+ * The follow half of a MOVE: after a document's path changes, repoint the
+ * references other documents wrote to its old path. Display-name changes
+ * rewrite nothing — name references are being retired from resolution
+ * (path + id only; names become render-time display), so there is no name
+ * half to follow.
+ *
+ * Which aliases move, and to what, is `planReferenceRewrite` in codec — the
+ * same package whose scanner and resolver decide what a reference IS, so
+ * what gets rewritten cannot drift from what resolves (ADR-0014's bar).
+ * This module is only the server's application of that plan: find the
+ * documents whose content names an affected alias, load each, rewrite, save.
+ *
+ * Candidates come from the same stamp-validated `ContentFactsCache` that
+ * serves backlinks, whose per-document `refs` hold each target AS WRITTEN —
+ * so only documents that actually spell an old alias are ever loaded. A
+ * rename is a rare, user-initiated operation; the per-candidate load is the
+ * cheap part and the cache spares the scan.
+ *
+ * One candidate failing to load or save must not abort the rest: the rename
+ * itself has already happened, so every reference this pass CAN repair is
+ * one fewer silently broken link. The ids it could not repair are reported
+ * to the caller, who owns deciding whether that is worth a log line.
+ */
+import {
+  type DocumentMove,
+  planReferenceRewrite,
+  rewriteCanvasReferences,
+  rewriteReferenceTargets,
+} from '@kamiazya/whiteboard-codec'
+import {
+  readDocumentKind,
+  readMarkdownBody,
+  readSpatialCanvas,
+  writeMarkdownBody,
+  writeSpatialNode,
+} from '@kamiazya/whiteboard-loro-adapter'
+import type { DocumentId } from '@kamiazya/whiteboard-model'
+import type { ServerDeps } from '../server-deps.js'
+import { loadOrCreateDocument, saveDocumentSnapshot } from '../tools/document-io.js'
+import { ContentFactsCache } from './content-facts-cache.js'
+
+export interface FollowRenameInput {
+  readonly workspaceId: string
+  /**
+   * The workspace listing BEFORE the index mutation — the table the old
+   * aliases resolved against. The caller holds it because only the caller
+   * exists on both sides of the mutation.
+   */
+  readonly entriesBefore: readonly {
+    readonly documentId: string
+    readonly path: string
+    readonly name?: string
+  }[]
+  /**
+   * One entry per document the path change carried — a move is a SUBTREE
+   * move, so derive these with codec's `movesForPathChange` rather than
+   * passing the root alone.
+   */
+  readonly moves: readonly DocumentMove[]
+}
+
+export interface FollowRenameResult {
+  /** Documents whose content was rewritten and saved, in listing order. */
+  readonly updatedDocumentIds: readonly string[]
+  /** Candidates that failed to load or save; the rename itself stands. */
+  readonly failedDocumentIds: readonly string[]
+}
+
+export async function followReferencesAfterRename(
+  deps: ServerDeps,
+  input: FollowRenameInput,
+  cache: ContentFactsCache = new ContentFactsCache(),
+): Promise<FollowRenameResult> {
+  const plan = planReferenceRewrite({
+    entries: input.entriesBefore.map((entry) => ({
+      id: entry.documentId,
+      path: entry.path,
+      ...(entry.name === undefined ? {} : { name: entry.name }),
+    })),
+    moves: input.moves,
+  })
+  if (plan.size === 0) return { updatedDocumentIds: [], failedDocumentIds: [] }
+
+  const entries = await deps.documentIndex.listDocuments({ workspaceId: input.workspaceId })
+  const facts = await cache.factsFor(deps, input.workspaceId, entries)
+
+  const updated: string[] = []
+  const failed: string[] = []
+  for (const entry of entries) {
+    const refs = facts.get(entry.documentId)?.refs
+    if (refs === undefined || !refs.some((ref) => plan.has(ref.target))) continue
+    try {
+      const doc = await loadOrCreateDocument(
+        deps,
+        input.workspaceId,
+        entry.documentId as DocumentId,
+      )
+      if (readDocumentKind(doc) === 'spatial') {
+        const result = rewriteCanvasReferences(readSpatialCanvas(doc), plan)
+        if (!result.changed) continue
+        // Targeted writes, never a whole-canvas resync: readSpatialCanvas
+        // drops records the current schema cannot parse, and writing the
+        // whole canvas back would DELETE them.
+        for (const node of result.changedNodes) writeSpatialNode(doc, node)
+      } else {
+        const body = readMarkdownBody(doc)
+        const next = rewriteReferenceTargets(body, plan)
+        if (next === body) continue
+        writeMarkdownBody(doc, next)
+      }
+      await saveDocumentSnapshot(deps, input.workspaceId, entry.documentId as DocumentId, doc)
+      updated.push(entry.documentId)
+    } catch {
+      failed.push(entry.documentId)
+    }
+  }
+  return { updatedDocumentIds: updated, failedDocumentIds: failed }
+}

--- a/packages/server-core/src/references/reference-semantics.property.test.ts
+++ b/packages/server-core/src/references/reference-semantics.property.test.ts
@@ -9,12 +9,19 @@
  * a name collision introduced by a THIRD document, a rename that revives a
  * dangling path link, and a delete that takes its outgoing refs with it.
  *
+ * A path move also carries the FOLLOW pass, exactly as the daemon's route
+ * runs it (movesForPathChange -> followReferencesAfterRename), and the model
+ * rewrites its own tokens by an independent naive plan — so follow semantics
+ * hold under any interleaving, not just the single-move example tests.
+ *
  * The token scanner (codec's scanReferences) is deliberately shared with
  * the SUT: the bracket grammar is not under test here. Aggregation and
  * resolution — the semantics this file exists for — are written out
  * independently below.
  */
-import { scanReferences } from '@kamiazya/whiteboard-codec'
+import { movesForPathChange, scanReferences } from '@kamiazya/whiteboard-codec'
+import { readMarkdownBody, readSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+import type { DocumentId } from '@kamiazya/whiteboard-model'
 import { describe, expect } from 'vitest'
 import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
 import { createInMemoryDocumentStore } from '../test-utils/in-memory-document-store.js'
@@ -22,14 +29,18 @@ import { makeTestDeps } from '../test-utils/make-test-deps.js'
 import { computeBacklinks } from '../tools/backlinks.js'
 import { createCanvasEditTool } from '../tools/canvas-edit.js'
 import { wbDocumentCreate } from '../tools/document-crud.js'
+import { loadOrCreateDocument } from '../tools/document-io.js'
 import { createDocumentSearchTool } from '../tools/document-search.js'
 import { createDocumentSetTool } from '../tools/document-set.js'
 import { computeDocumentTags } from '../tools/document-tags.js'
 import { ContentFactsCache } from './content-facts-cache.js'
+import { followReferencesAfterRename } from './follow-rename.js'
 
 const WS = 'ws-pbt'
-const PATHS = ['alpha', 'beta', 'gamma', 'delta'] as const
-const NAMES = ['Plan', 'Note'] as const
+const PATHS = ['alpha', 'alpha/leaf', 'beta', 'beta/leaf', 'gamma'] as const
+// 'beta/leaf' as a NAME collides with a path in the pool — the states the
+// follow plan's ambiguity and fallback rules exist for.
+const NAMES = ['Plan', 'Note', 'beta/leaf'] as const
 const SLOTS = [0, 1, 2] as const
 
 // ---------------------------------------------------------------- commands
@@ -61,9 +72,15 @@ const slotArb = fc.constantFrom(...SLOTS)
 // undoing, and a uniform pool reaches them too rarely — the last-wins
 // mutation of the ambiguity rule SURVIVED this property until the
 // distribution was skewed this way. Density, not numRuns (AGENTS.md).
+// ... and toward PATH aliases with equal weight since the follow pass
+// landed: a moved document only drags references written as its PATH, so a
+// name-heavy pool never reaches the states the follow plan decides.
+// Measured: with paths at weight 1-in-8, a no-op'd followReferencesAfterRename
+// SURVIVED this property at numRuns 40.
 const aliasArb = fc.oneof(
-  { weight: 3, arbitrary: fc.constant<string>('Plan') },
-  { weight: 1, arbitrary: fc.constantFrom<string>(...NAMES, ...PATHS) },
+  { weight: 2, arbitrary: fc.constant<string>('Plan') },
+  { weight: 2, arbitrary: fc.constantFrom<string>(...PATHS) },
+  { weight: 1, arbitrary: fc.constantFrom<string>(...NAMES) },
 )
 const tokenArb: fc.Arbitrary<Token> = fc.oneof(
   { weight: 1, arbitrary: fc.record({ k: fc.constant('id' as const), slot: slotArb }) },
@@ -85,6 +102,7 @@ const cmdArb: fc.Arbitrary<Cmd> = fc.oneof(
         name: fc.oneof(
           { weight: 3, arbitrary: fc.constant<(typeof NAMES)[number] | undefined>('Plan') },
           { weight: 1, arbitrary: fc.constant<(typeof NAMES)[number] | undefined>('Note') },
+          { weight: 1, arbitrary: fc.constant<(typeof NAMES)[number] | undefined>('beta/leaf') },
           { weight: 1, arbitrary: fc.constant<(typeof NAMES)[number] | undefined>(undefined) },
         ),
       },
@@ -115,7 +133,7 @@ const cmdArb: fc.Arbitrary<Cmd> = fc.oneof(
     }),
   },
   {
-    weight: 2,
+    weight: 3,
     arbitrary: fc.record({
       t: fc.constant('renamePath' as const),
       slot: slotArb,
@@ -130,6 +148,7 @@ const cmdArb: fc.Arbitrary<Cmd> = fc.oneof(
       name: fc.oneof(
         { weight: 3, arbitrary: fc.constant<(typeof NAMES)[number] | undefined>('Plan') },
         { weight: 1, arbitrary: fc.constant<(typeof NAMES)[number] | undefined>('Note') },
+        { weight: 1, arbitrary: fc.constant<(typeof NAMES)[number] | undefined>('beta/leaf') },
         { weight: 1, arbitrary: fc.constant<(typeof NAMES)[number] | undefined>(undefined) },
       ),
     }),
@@ -157,21 +176,65 @@ class Model {
     return undefined
   }
 
-  /** The reader's alias table: one entry per path + one per display name. */
-  private resolveAlias(alias: string): string | null {
-    let found: string | null = null
-    let hits = 0
+  /**
+   * The reader's alias table: paths and display names share one space, and
+   * a document whose name equals its own path is ONE owner, not two — the
+   * real table dedupes that row before the resolver sees it.
+   */
+  private owners(alias: string): Set<string> {
+    const out = new Set<string>()
     for (const d of this.docs.values()) {
-      if (d.path === alias) {
-        hits++
-        found = d.id
-      }
-      if (d.name === alias) {
-        hits++
-        found = d.id
-      }
+      if (d.path === alias || d.name === alias) out.add(d.id)
     }
-    return hits === 1 ? found : null
+    return out
+  }
+
+  private resolveAlias(alias: string): string | null {
+    const owners = this.owners(alias)
+    const [only] = owners
+    return owners.size === 1 && only !== undefined ? only : null
+  }
+
+  /** Documents a subtree move at `from` carries, in listing order. */
+  movedBy(from: string): ModelDoc[] {
+    return [...this.docs.values()].filter((d) => d.path === from || d.path.startsWith(`${from}/`))
+  }
+
+  /**
+   * The intended follow semantics, written out independently of
+   * planReferenceRewrite: apply the subtree's path change, then rewrite
+   * every token that uniquely resolved to a moved document — to its new
+   * path when that resolves uniquely too, else to its id.
+   */
+  followMove(from: string, to: string): void {
+    const table = () =>
+      [...this.docs.values()].map((d) => ({ id: d.id, path: d.path, name: d.name }))
+    const ownersIn = (alias: string, rows: { id: string; path: string; name?: string }[]) => {
+      const out = new Set<string>()
+      for (const r of rows) if (r.path === alias || r.name === alias) out.add(r.id)
+      return out
+    }
+    const before = table()
+    const moved = this.movedBy(from)
+    const moves = moved.map((d) => ({ id: d.id, from: d.path, to: to + d.path.slice(from.length) }))
+    for (const d of moved) d.path = to + d.path.slice(from.length)
+    const after = table()
+    const plan = new Map<string, string>()
+    for (const m of moves) {
+      if (m.to === m.from) continue
+      // An alias that spells a live document id resolves to THAT id first
+      // and is never rewritten; a new path that spells one never wins.
+      if (before.some((e) => e.id === m.from)) continue
+      const ob = ownersIn(m.from, before)
+      if (!(ob.size === 1 && ob.has(m.id))) continue
+      const oa = ownersIn(m.to, after)
+      const toIsUnique = oa.size === 1 && oa.has(m.id) && !after.some((e) => e.id === m.to)
+      plan.set(m.from, toIsUnique ? m.to : m.id)
+    }
+    for (const d of this.docs.values()) {
+      d.bodyTokens = d.bodyTokens.map((t) => plan.get(t) ?? t)
+      d.fileRefs = d.fileRefs.map((t) => plan.get(t) ?? t)
+    }
   }
 
   /** sourceId -> reference count into `targetId`. Independent of the SUT. */
@@ -224,6 +287,97 @@ describe('reference semantics under command sequences', () => {
       // slot -> documentId of the doc created into it (dead ids stay, model ignores)
       const slots: (string | null)[] = [null, null, null]
       let nodeSeq = 0
+
+      // Every run OPENS on the state the follow pass exists for — a document
+      // and a reference spelling its path — and the commands then mutate it.
+      // Without this seed the sequences almost never assemble it themselves:
+      // measured at numRuns 40, zero runs held a path reference at move time,
+      // and a no-op'd followReferencesAfterRename survived the property.
+      const seedTarget = await wbDocumentCreate(deps, {
+        workspaceId: WS,
+        path: 'alpha',
+        kind: 'markdown',
+      })
+      slots[0] = seedTarget.documentId
+      model.docs.set(seedTarget.documentId, {
+        id: seedTarget.documentId,
+        path: 'alpha',
+        kind: 'markdown',
+        bodyTokens: [],
+        embedIds: [],
+        fileRefs: [],
+      })
+      const seedLeaf = await wbDocumentCreate(deps, {
+        workspaceId: WS,
+        path: 'alpha/leaf',
+        kind: 'markdown',
+      })
+      model.docs.set(seedLeaf.documentId, {
+        id: seedLeaf.documentId,
+        path: 'alpha/leaf',
+        kind: 'markdown',
+        bodyTokens: [],
+        embedIds: [],
+        fileRefs: [],
+      })
+      const seedSource = await wbDocumentCreate(deps, {
+        workspaceId: WS,
+        path: 'gamma',
+        kind: 'markdown',
+      })
+      slots[1] = seedSource.documentId
+      // A SHADOWED alias on non-pool paths: X's path is also Y's display
+      // name, so '[[shadowed]]' is ambiguous and must stay literal through
+      // any move of X. Off-pool so it never contends with command traffic;
+      // X sits in slot 2 so the commands can move it. With this absent,
+      // dropping the plan's old-alias ambiguity guard survived the property.
+      const seedShadowed = await wbDocumentCreate(deps, {
+        workspaceId: WS,
+        path: 'shadowed',
+        kind: 'markdown',
+      })
+      slots[2] = seedShadowed.documentId
+      model.docs.set(seedShadowed.documentId, {
+        id: seedShadowed.documentId,
+        path: 'shadowed',
+        kind: 'markdown',
+        bodyTokens: [],
+        embedIds: [],
+        fileRefs: [],
+      })
+      const seedShadowHolder = await wbDocumentCreate(deps, {
+        workspaceId: WS,
+        path: 'shadow-holder',
+        kind: 'markdown',
+        name: 'shadowed',
+      })
+      model.docs.set(seedShadowHolder.documentId, {
+        id: seedShadowHolder.documentId,
+        path: 'shadow-holder',
+        name: 'shadowed',
+        kind: 'markdown',
+        bodyTokens: [],
+        embedIds: [],
+        fileRefs: [],
+      })
+      // The DESCENDANT reference makes every successful move of 'alpha'
+      // exercise subtree derivation: with it absent, dropping descendants
+      // from movesForPathChange survived this property.
+      const seedBody =
+        'mention [[alpha]] here.\nmention [[alpha/leaf]] here.\nmention [[shadowed]] here.\nmention [[Plan]] here.'
+      await setTool.execute({
+        workspaceId: WS,
+        documentId: seedSource.documentId,
+        markdown: `---\ntype: markdown\n---\n${seedBody}`,
+      })
+      model.docs.set(seedSource.documentId, {
+        id: seedSource.documentId,
+        path: 'gamma',
+        kind: 'markdown',
+        bodyTokens: scanReferences(seedBody).map((m) => m.target),
+        embedIds: [],
+        fileRefs: [],
+      })
 
       for (const cmd of cmds) {
         switch (cmd.t) {
@@ -322,15 +476,35 @@ describe('reference semantics under command sequences', () => {
             const id = slots[cmd.slot]
             const doc = id === null || id === undefined ? undefined : model.docs.get(id)
             if (doc === undefined) break
-            if (doc.path === cmd.to) break // real moveDocument refuses from===to? skip both ways
-            if (model.byPath(cmd.to) !== undefined) {
-              await expect(
-                deps.documentIndex.moveDocument({ workspaceId: WS, from: doc.path, to: cmd.to }),
-              ).rejects.toThrow()
+            const from = doc.path
+            const attempt = () =>
+              deps.documentIndex.moveDocument({ workspaceId: WS, from, to: cmd.to })
+            if (cmd.to === from || cmd.to.startsWith(`${from}/`)) {
+              await expect(attempt()).rejects.toThrow()
               break
             }
-            await deps.documentIndex.moveDocument({ workspaceId: WS, from: doc.path, to: cmd.to })
-            doc.path = cmd.to
+            // A subtree move fails when any PRODUCED path is already taken
+            // by a document the move does not carry.
+            const movedPaths = model.movedBy(from).map((d) => d.path)
+            const produced = (path: string) => cmd.to + path.slice(from.length)
+            const collides = movedPaths.some((path) => {
+              const holder = model.byPath(produced(path))
+              return holder !== undefined && !movedPaths.includes(holder.path)
+            })
+            if (collides) {
+              await expect(attempt()).rejects.toThrow()
+              break
+            }
+            // The route's own glue, verbatim: list before, move, follow.
+            const entriesBefore = await deps.documentIndex.listDocuments({ workspaceId: WS })
+            await attempt()
+            const follow = await followReferencesAfterRename(deps, {
+              workspaceId: WS,
+              entriesBefore,
+              moves: movesForPathChange(entriesBefore, from, cmd.to),
+            })
+            expect(follow.failedDocumentIds).toEqual([])
+            model.followMove(from, cmd.to)
             break
           }
           case 'setName': {
@@ -350,14 +524,49 @@ describe('reference semantics under command sequences', () => {
             const id = slots[cmd.slot]
             const doc = id === null || id === undefined ? undefined : model.docs.get(id)
             if (doc === undefined) break
+            if (model.movedBy(doc.path).length > 1) {
+              // Descendants exist — the index refuses the delete.
+              await expect(
+                deps.documentIndex.deleteDocument({ workspaceId: WS, path: doc.path }),
+              ).rejects.toThrow()
+              break
+            }
             await deps.documentIndex.deleteDocument({ workspaceId: WS, path: doc.path })
             model.docs.delete(doc.id)
             break
           }
         }
 
-        // After EVERY command: the CACHED pipeline agrees with the model,
-        // and byte-for-byte with a fresh full scan (backlinks AND mentions).
+        // After EVERY command: what each document SAYS agrees with the model
+        // token-for-token — the follow pass rewrote exactly what the naive
+        // plan says it should, and nothing else.
+        for (const doc of model.docs.values()) {
+          const real = await loadOrCreateDocument(deps, WS, doc.id as DocumentId)
+          if (doc.kind === 'markdown') {
+            expect(
+              scanReferences(readMarkdownBody(real)).map((m) => m.target),
+              `body tokens of ${doc.path}`,
+            ).toEqual(doc.bodyTokens)
+          } else {
+            const canvas = readSpatialCanvas(real)
+            const textTokens = canvas.nodes
+              .filter((node) => node.type === 'text')
+              .flatMap((node) => scanReferences(node.text).map((m) => m.target))
+            expect([...textTokens].sort(), `text tokens of ${doc.path}`).toEqual(
+              [...doc.bodyTokens].sort(),
+            )
+            const plainFiles = canvas.nodes
+              .filter((node) => {
+                if (node.type !== 'file') return false
+                const ext = node['x-whiteboard']
+                return !(ext !== undefined && 'kind' in ext && ext.kind === 'embed')
+              })
+              .map((node) => (node.type === 'file' ? node.file : ''))
+            expect(plainFiles.sort(), `file refs of ${doc.path}`).toEqual([...doc.fileRefs].sort())
+          }
+        }
+        // And the CACHED pipeline agrees with the model, byte-for-byte with
+        // a fresh full scan (backlinks AND mentions).
         for (const doc of model.docs.values()) {
           const cached = await computeBacklinks(
             deps,
@@ -380,5 +589,10 @@ describe('reference semantics under command sequences', () => {
         }
       }
     },
+    // Budget, not numRuns: the seeded state + per-command full-content
+    // assertions price a 40-run pass at 3.5-6s on an idle machine (worst
+    // observed 7.3s under load), so the 5s default reads as a property
+    // failure that never happened.
+    30_000,
   )
 })

--- a/packages/server-core/src/tools/backlinks.test.ts
+++ b/packages/server-core/src/tools/backlinks.test.ts
@@ -43,6 +43,21 @@ async function backlinksOf(deps: ReturnType<typeof makeDeps>, documentId: string
 }
 
 describe('GET /backlinks', () => {
+  it('a document NAMED exactly its own path still receives backlinks', async () => {
+    // A path entry and a name entry both claim the alias — with ONE id, so
+    // it is unique, and the reader navigates it. The resolver used to count
+    // claims instead of owners and dropped the backlink the preview renders
+    // live. Found by the command-sequence property (seed -223444648).
+    const deps = makeDeps()
+    const { create, writeBody } = await seed(deps)
+    const twice = await create('beta/leaf', 'markdown', 'beta/leaf')
+    const source = await create('notes', 'markdown')
+    await writeBody(source.documentId, 'mention [[beta/leaf]] here.')
+
+    const out = await backlinksOf(deps, twice.documentId)
+    expect(out.backlinks.map((b) => b.documentId)).toEqual([source.documentId])
+  })
+
   it('reports an id wikilink, with a context snippet', async () => {
     const deps = makeDeps()
     const { create, target, writeBody } = await seed(deps)


### PR DESCRIPTION
## What this closes

The survival table (`reference-survival.test.ts`) records what a `[[reference]]` lives through:

| written as | path move | display-name change |
|---|---|---|
| the path | **breaks** → now followed | survives |
| the name | survives | breaks → **retired, not repaired** |
| the id | survives | survives |

A move quietly turned other documents' prose back into dead bracket text; now the move repoints them. The name cell is deliberately NOT followed: name references are being retired from resolution — **path + id become the only written forms, with the display name shown at render time instead** (owner decision, 2026-09-03; ADR-0014 amendment + migration are the follow-up increment). Following a form on its way out would have been work spent propping up the fragility being removed. An earlier revision of this PR carried the name-follow half; it was trimmed on that decision.

Visual evidence: none — the before/after figure WAS produced and verified through the real preview overlay (composed by `compose-figure.mjs`, panel digests before `5fb528b1` / after `bb5695e2`; before shows the reference decayed to dead bracket text, after shows it still a live link), but `gh image`'s browser-cookie upload has no GitHub session on this machine since the account change — the figure was handed to the repo owner directly for attachment.

## Where the policy lives, and why

`planReferenceRewrite` sits in **codec, beside the scanner and resolver that define what a reference IS** — so what gets rewritten cannot drift from what resolves (ADR-0014's own bar). Two rules carry the correctness:

- **Only a path that uniquely resolved to the moved document** under the old naming table is mapped. The alias space is shared with display names, so a path another document is *named* was ambiguous, resolved to nothing, and stays literal — rewriting it would resurrect a dead reference as a live one.
- **If the NEW path would not resolve uniquely either** (a display name elsewhere collides with it), the reference falls back to the document id, which survives everything.

The mechanical rewriters splice only the target slice (`!`, brackets and `|label` stay byte-for-byte) and cover the spatial half: text-node wikilinks and file-node targets. Embed targets are ids and are never touched.

Three additions from review (cb02e5f0, each red-first):

- **Subtree moves** — `moveDocument` carries descendants, so both keepers now derive the moves with codec's `movesForPathChange(entriesBefore, from, to)`: one `DocumentMove` per carried document, segment-aware (`folder-notes` is not swept by a `folder` move).
- **Id reservation** — the plan claims every live document id in the alias-owner table, so an alias that legally spells a live id (the reader resolves ids FIRST) is never rewritten, and an id fallback that would collide is never treated as unique.
- **Targeted spatial writes (CRITICAL)** — `readSpatialCanvas` silently drops records today's schema cannot parse, and a whole-canvas write-back would then DELETE them. `rewriteCanvasReferences` now reports `changedNodes` and every caller applies one `writeSpatialNode` per changed node. Pinned by a test that plants a `{type:'hologram'}` record and asserts it survives; mutation-checked — reverting to the resync turns exactly that test red.

## Both keepers, one plan

- **daemon** — `followReferencesAfterRename` (server-core) runs after `PUT :path/path`, finding candidates through the same `ContentFactsCache` that serves backlinks, so only documents that actually spell the old path are loaded. A follow failure is a log line, never a failed rename.
- **browser** — `local-files-source` does the same after `moveDocument`, scanning the store the way search already prices (`ponytail:` marker names the ceiling), and invalidating the search-corpus entry for every document it rewrites.

The MCP `workspace-edit` tool has no move op today, so the route and the local method are the complete set of path mutations.

## Command-sequence model tests (both keepers, one oracle)

The follow semantics are now held by **stateful command-based PBT** at both keepers, against one independent naive model (owner-set resolution + naive follow plan), so the keepers cannot diverge from each other without one of them diverging from it:

- **daemon** — `reference-semantics.property.test.ts` (the existing command-sequence model test) now carries the follow pass exactly as the route runs it, with the model rewriting its own tokens per move. Each run opens on seeded states the sequences almost never assemble on their own (measured: 0 followed moves in 40 unseeded runs, and a no-op'd `followReferencesAfterRename` SURVIVED): a live path reference, a descendant reference, and a shadowed alias (a path that is also another document's display name). Four production mutations all go red now: follow no-op'd, subtree derivation dropped, old-alias ambiguity guard dropped, id fallback dropped.
- **browser** — `local-follow-rename.property.browser.test.tsx`: the same command vocabulary against `local-files-source` over real IndexedDB (numRuns 8, per-run path prefixes), plus a deterministic witness move per run — measured, a dropped `followReferences` call survived the random sequences alone at that budget. Mutation-checked red.

**The property found a real bug on its first extended run** (seed -223444648): a document NAMED exactly its own path lost its backlinks — codec's `createUniqueNameResolver` counted *claims* instead of *owners*, so the path entry + name entry of one document read as an ambiguity. The reader (`daemonLinkEntries`) dedupes that case, so the preview rendered a live link that backlinks denied — precisely the drift ADR-0014's "one resolution rule" bar exists to prevent. Fixed at the resolver (owner-set counting), pinned as example tests in codec and `backlinks.test.ts`, both mutation-checked red.

## Tests — red-first at every layer

- **codec**: 13 examples + a two-invariant property against an independent naive model — FOLLOW (a ref that resolved to the moved doc still does under the new table) and UNTOUCHED (any other ref is byte-identical) — over a deliberately colliding five-alias pool. **Its first run caught a real bug**: `planReferenceRewrite` double-counted a document whose display name equals its own path, which `daemonLinkEntries` dedupes before the resolver ever sees it. Both property halves mutation-checked red, **re-checked after the trim** (planted-line counts verified, restores confirmed).
- **server-core**: 5 operation tests (move, spatial nodes, subtree, unknown-record survival, no-op).
- **daemon route**: 2 route-level tests against real default deps in a temp data dir (root move + descendant follow).
- **browser keeper**: 2 tests against real IndexedDB (markdown body + spatial text node + file node in one move; subtree descendant follow).

## Gates

`-r typecheck` all Done (0 errors) · codec-node 128/128 · server-core-node 472/472 · mcp-node 4216/4216 · arch-lint 119/119 · `pnpm --filter @kamiazya/whiteboard-web test` (CI's test-jsdom) 3212+89 · web-browser follow tests 3/3 · lint clean · knip clean.

Local `web-browser` full-suite carries 2 failures in `shaped-node-editing.browser.test.tsx`, which **fail identically on clean current main** (twice, plus after `pnpm install`, plus under CI's own `google-chrome-stable`) while **CI is green on main and on this PR's first run** — a local-only, main-side divergence in a file this diff never touches (`'shapedbod'` vs `'shapedbody'`, a one-character measurement truncation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoaNgqWUKbYJxk2azmRQKY
