### PR TITLE
fix(deps): raise the fast-uri override past four new high advisories, and bound browser trace retention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,16 @@ pnpm run test:browser        # canvas-viewer-browser + web-browser + canvas-rend
 pnpm run test:browser:trace  # same, with trace artifacts on failure
 ```
 
-- Failure traces are stored under `<package>/tmp/vitest-traces`.
+- Failure traces are stored under `<package>/tmp/vitest-traces`, and are kept
+  for the **most recent run only** — `vitest.browser.shared.ts` clears the
+  directory as the config loads. Nothing else ever deleted them and each
+  retained trace carries screenshots and DOM snapshots: measured, one
+  session's failing runs left **19GB** under `apps/web/tmp/vitest-traces` and
+  filled the disk. What that looks like is worth knowing, because it names
+  nothing — browser runs stop producing output and hang until the per-test
+  timeout, with no error mentioning space. One run's worth is also all that
+  is useful: the traces you read are from the run that just failed, and a
+  second run at the same path would overwrite them anyway.
 - Check traces before adding temporary debug code.
 - **Keep a browser test's `describe` + `it` titles under 155 characters
   combined** (characters, not UTF-8 bytes: vitest replaces every

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,16 +72,7 @@ pnpm run test:browser        # canvas-viewer-browser + web-browser + canvas-rend
 pnpm run test:browser:trace  # same, with trace artifacts on failure
 ```
 
-- Failure traces are stored under `<package>/tmp/vitest-traces`, and are kept
-  for the **most recent run only** — `vitest.browser.shared.ts` clears the
-  directory as the config loads. Nothing else ever deleted them and each
-  retained trace carries screenshots and DOM snapshots: measured, one
-  session's failing runs left **19GB** under `apps/web/tmp/vitest-traces` and
-  filled the disk. What that looks like is worth knowing, because it names
-  nothing — browser runs stop producing output and hang until the per-test
-  timeout, with no error mentioning space. One run's worth is also all that
-  is useful: the traces you read are from the run that just failed, and a
-  second run at the same path would overwrite them anyway.
+- Failure traces are stored under `<package>/tmp/vitest-traces`.
 - Check traces before adding temporary debug code.
 - **Keep a browser test's `describe` + `it` titles under 155 characters
   combined** (characters, not UTF-8 bytes: vitest replaces every

--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -119,6 +119,9 @@ export default defineConfig({
     // Every browser test renders against the app's real stylesheet — see
     // browser-setup.ts for what silently breaks without it.
     setupFiles: ['./src/test-utils/browser-setup.ts'],
-    browser: sharedBrowserTestConfig({ viewport: { width: 1280, height: 900 } }),
+    browser: sharedBrowserTestConfig({
+      viewport: { width: 1280, height: 900 },
+      projectRoot: import.meta.dirname,
+    }),
   },
 })

--- a/packages/canvas-render/vitest.browser.config.ts
+++ b/packages/canvas-render/vitest.browser.config.ts
@@ -5,6 +5,6 @@ export default defineProject({
   test: {
     name: 'canvas-render-browser',
     include: ['src/**/*.browser.test.ts'],
-    browser: sharedBrowserTestConfig(),
+    browser: sharedBrowserTestConfig({ projectRoot: import.meta.dirname }),
   },
 })

--- a/packages/canvas-viewer/vitest.browser.config.ts
+++ b/packages/canvas-viewer/vitest.browser.config.ts
@@ -7,6 +7,6 @@ export default defineProject({
   test: {
     name: 'canvas-viewer-browser',
     include: ['src/**/*.browser.test.tsx'],
-    browser: sharedBrowserTestConfig(),
+    browser: sharedBrowserTestConfig({ projectRoot: import.meta.dirname }),
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,7 +69,7 @@ overrides:
   nanoid@<3.3.8: ^3.3.8
   nanoid@>=4.0.0 <5.0.9: ^5.0.9
   protobufjs@<8.6.6: ^8.6.6
-  fast-uri@<3.1.5: ^3.1.5
+  fast-uri@<3.1.6: ^3.1.6
   kysely@<0.28.17: ^0.28.17
   '@grpc/grpc-js@<1.14.4': ^1.14.4
   shell-quote@<1.9.0: ^1.9.0
@@ -81,6 +81,7 @@ overrides:
   body-parser@<2.3.0: ^2.3.0
   mermaid@<11.15.0: ^11.16.0
   dompurify@<3.4.12: ^3.4.12
+  '@xmldom/xmldom@<0.9.12': ^0.9.12
   immutable@<4.3.9: ^4.3.9
   '@opentelemetry/propagator-jaeger@<2.9.0': ^2.9.0
   sharp@<0.35.0: ^0.35.0
@@ -4527,10 +4528,9 @@ packages:
     peerDependencies:
       vitest: 4.1.10
 
-  '@xmldom/xmldom@0.9.10':
-    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+  '@xmldom/xmldom@0.9.12':
+    resolution: {integrity: sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==}
     engines: {node: '>=14.6'}
-    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -5454,8 +5454,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -12007,7 +12007,7 @@ snapshots:
       obug: 2.1.1
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(canvas@3.2.3))(msw@2.15.0(@types/node@24.13.1)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)(yaml@2.9.0))
 
-  '@xmldom/xmldom@0.9.10': {}
+  '@xmldom/xmldom@0.9.12': {}
 
   abbrev@3.0.1:
     optional: true
@@ -12040,14 +12040,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -13049,7 +13049,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -15484,7 +15484,7 @@ snapshots:
 
   speech-rule-engine@4.1.4:
     dependencies:
-      '@xmldom/xmldom': 0.9.10
+      '@xmldom/xmldom': 0.9.12
       commander: 13.1.0
       wicked-good-xpath: 1.3.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,7 +69,7 @@ overrides:
   nanoid@<3.3.8: ^3.3.8
   nanoid@>=4.0.0 <5.0.9: ^5.0.9
   protobufjs@<8.6.6: ^8.6.6
-  fast-uri@<3.1.5: ^3.1.5
+  fast-uri@<3.1.6: ^3.1.6
   kysely@<0.28.17: ^0.28.17
   "@grpc/grpc-js@<1.14.4": ^1.14.4
   shell-quote@<1.9.0: ^1.9.0
@@ -81,6 +81,7 @@ overrides:
   body-parser@<2.3.0: ^2.3.0
   mermaid@<11.15.0: ^11.16.0
   dompurify@<3.4.12: ^3.4.12
+  "@xmldom/xmldom@<0.9.12": ^0.9.12
   immutable@<4.3.9: ^4.3.9
   "@opentelemetry/propagator-jaeger@<2.9.0": ^2.9.0
   # Reached only through @huggingface/transformers, whose latest release

--- a/vitest.browser.shared.ts
+++ b/vitest.browser.shared.ts
@@ -1,9 +1,14 @@
+import { rmSync } from 'node:fs'
+import { join } from 'node:path'
 import { playwright } from '@vitest/browser-playwright'
 // Import the source file directly rather than `@kamiazya/whiteboard-mcp/test-utils`:
 // that package export resolves to the built `dist/` output, which is gitignored
 // and not produced by a plain `pnpm install` on a clean checkout (CI's browser
 // job never builds packages/mcp-server before running Vitest).
 import { resolveBrowserLaunchOptions } from './packages/mcp-server/src/server/browser-test-config.js'
+
+/** Where a project's failure traces land, relative to its own root. */
+const TRACES_DIR = 'tmp/vitest-traces'
 
 /**
  * The one definition of how this repo runs a Vitest browser project —
@@ -17,10 +22,33 @@ import { resolveBrowserLaunchOptions } from './packages/mcp-server/src/server/br
  * `viewport` is the one knob that legitimately differs per project:
  * component-scale projects render at 800x600, apps/web's page tests at
  * 1280x900.
+ *
+ * **Traces are kept for the MOST RECENT RUN ONLY**, cleared here as the
+ * config loads. Nothing else ever deleted them, and each retained trace
+ * carries screenshots and DOM snapshots: measured, one session's failing
+ * runs left **19GB** under `apps/web/tmp/vitest-traces` and filled the
+ * disk. What that looks like is worth stating, because it names nothing:
+ * browser runs stop producing output and hang until the per-test timeout,
+ * with no error mentioning space — the writes fail silently while `df`
+ * still reports plenty of "Used". One run's worth is also all that is
+ * useful: the traces you read are the ones from the run that just failed,
+ * and a second run at the same path would overwrite them anyway.
  */
 export function sharedBrowserTestConfig(
-  options: { viewport?: { width: number; height: number } } = {},
+  options: {
+    viewport?: { width: number; height: number }
+    /**
+     * The project's own root (`import.meta.dirname` at the call site), so
+     * the stale traces cleared are the ones this project is about to
+     * rewrite. Omitted, nothing is cleared — which is the old, unbounded
+     * behavior, so a config that wants the bound has to say where it lives.
+     */
+    projectRoot?: string
+  } = {},
 ) {
+  if (options.projectRoot !== undefined) {
+    rmSync(join(options.projectRoot, TRACES_DIR), { recursive: true, force: true })
+  }
   return {
     enabled: true,
     headless: true,
@@ -28,7 +56,7 @@ export function sharedBrowserTestConfig(
     screenshotFailures: false,
     trace: {
       mode: 'retain-on-failure' as const,
-      tracesDir: './tmp/vitest-traces',
+      tracesDir: `./${TRACES_DIR}`,
       screenshots: true,
       snapshots: true,
     },


### PR DESCRIPTION
Two changes, the second unplanned: an unrelated dependency advisory turned **main itself red** while this PR was in flight, and this branch is the session's only lane, so the unblock rides here rather than waiting behind a red gate.

## 1. `fast-uri` — the base-branch failure (why this PR grew)

`pnpm audit --prod --audit-level=high` (CI's `check` gate) went red on **four new `fast-uri` advisories** — host confusion via percent-encoded scheme normalization, host confusion via skipped IDN, and two SSRF — all patched in 3.1.6 while the overrides block pinned `^3.1.5`.

**Verified as not this branch's before touching anything**: a clean `origin/main` worktree fails the identical audit (7 vulnerabilities, 3 moderate | 4 high), so every PR in the repo is blocked until this lands. `fast-uri` is reached transitively (`@modelcontextprotocol/ext-apps` → sdk → `ajv`), so no Dependabot PR can fix it; bumping the entry `pnpm-workspace.yaml`'s overrides block already carries for exactly this purpose is the remedy that file was set up for. `@xmldom/xmldom` gets a new entry (0.9.10 → `^0.9.12`, XML fragment injection) since it was in the same report and installs cleanly.

The two remaining `qs` moderates are **left as they are, deliberately**: the patched 6.16.0 was published inside this repo's `minimumReleaseAge` window, and the supply-chain policy that holds a four-day-old package back outranks a moderate the gate does not fail on. They come back when the release ages past the cutoff.

## 2. Bounding vitest browser trace retention

- Failure traces accumulated **forever** — nothing ever deleted them, and each carries screenshots and DOM snapshots. Measured in one session of this repo's own work: **19GB** under `apps/web/tmp/vitest-traces`, which filled the disk.
- **The failure that produces names nothing**: browser runs stopped emitting output and hung until the per-test timeout, with no error mentioning space — trace writes fail silently while `df` still reports plenty of "Used". It cost most of an hour to attribute, and every suspect it invites first (a hung chromium, a bad config, the change under test) is wrong.
- `vitest.browser.shared.ts` now clears the project's trace directory as the config loads, so a checkout holds **one run's worth** — also all that is useful, since a second run at the same path would overwrite them anyway. Opt-in per config via `projectRoot`, so the helper never guesses which directory to delete.

A first pass also documented this in `AGENTS.md`, and **`dev-rules-budget.test.ts` refused it** — the always-on rule corpus sits within ~2 characters of its pinned bucket, so any note there costs every session context from then on. That guard is right and the note is reverted: a test-infra retention contract does not earn always-on budget, and the rationale it carried lives in `vitest.browser.shared.ts`, where someone touching traces will meet it.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — none: one is a dependency-range bump, the other three lines of `rmSync` in test infrastructure, both verified directly (below). A test that only restated either call would be worse than saying so.
- [x] `pnpm test` passes locally — full `mcp-node` 4,209 passed (only the known Node-22 environment guard fails on this container; CI's pinned Node 24 is authoritative), `canvas-viewer-browser` 14/14 and a `web-browser` file 3/3 against the changed configs, `arch-lint-node` 119/119, `dev-rules-budget` 4/4, `pnpm install --frozen-lockfile` / `-r typecheck` / `build` / `lint` / `knip` all clean
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable — not applicable: dependency + test-infrastructure change

Manual verification — audit: `pnpm audit --prod --audit-level=high` exits 0 after the override (7 findings → 2, both the deliberately-held `qs` moderates), and the same command on a clean `origin/main` worktree still fails, which is what establishes whose failure it was. Traces: seeded a `STALE-MARKER.txt` plus 11MB of prior traces into `packages/canvas-viewer/tmp/vitest-traces`, ran that project, and confirmed the marker was gone and only the new run's traces remained; the other two configs were exercised to confirm `projectRoot` resolves in each.

## Visual evidence

Visual evidence: none — dependency and test-infrastructure changes with no UI or pixel effect.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — no user-visible or contract change; the trace contract is documented at its own config, deliberately not in the always-on corpus
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema