### PR TITLE
fix(deps): raise the fast-uri override to the patched range

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,7 +69,7 @@ overrides:
   nanoid@<3.3.8: ^3.3.8
   nanoid@>=4.0.0 <5.0.9: ^5.0.9
   protobufjs@<8.6.6: ^8.6.6
-  fast-uri@<3.1.5: ^3.1.5
+  fast-uri@<3.1.6: ^3.1.6
   kysely@<0.28.17: ^0.28.17
   '@grpc/grpc-js@<1.14.4': ^1.14.4
   shell-quote@<1.9.0: ^1.9.0
@@ -5454,8 +5454,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -12040,14 +12040,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -13049,7 +13049,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,7 +69,7 @@ overrides:
   nanoid@<3.3.8: ^3.3.8
   nanoid@>=4.0.0 <5.0.9: ^5.0.9
   protobufjs@<8.6.6: ^8.6.6
-  fast-uri@<3.1.5: ^3.1.5
+  fast-uri@<3.1.6: ^3.1.6
   kysely@<0.28.17: ^0.28.17
   "@grpc/grpc-js@<1.14.4": ^1.14.4
   shell-quote@<1.9.0: ^1.9.0


### PR DESCRIPTION
**Unblocks every PR in the repo.** `pnpm audit --prod --audit-level=high` — the CI `check` gate — is red on `main` and on every open PR, including ones whose diff touches no dependency at all.

## Summary

Four advisories, all one package: **`fast-uri`**, reached through `@modelcontextprotocol/sdk > ajv` (and `ajv-formats > ajv`), all patched at `>=3.1.6`.

The repo already carried an override for this package — `fast-uri@<3.1.5: ^3.1.5` in `pnpm-workspace.yaml`, from a previous round of the same advisory family. 3.1.5 is itself in the vulnerable range now, so the entry moves to `fast-uri@<3.1.6: ^3.1.6` and resolves **3.1.7**. A patch bump inside the same major, in a transitive dependency.

**Established as not any one PR's before fixing**, rather than assumed: the diff of an unrelated docs-only PR (#1250) against `main` changes neither `package.json` nor `pnpm-lock.yaml`, and the same four advisories reproduce on that untouched lockfile.

The three remaining **moderate** advisories (`nanoid`, `tar`, `browserslist`, `qs`) sit below `--audit-level=high` and do not gate. Left alone rather than swept in — a dependency change is judged by what it fixes, and widening this one would put four more resolutions under one review.

## Test plan

- [x] `pnpm audit --prod --audit-level=high`: **4 high → 0** (3 moderate remain, ungated)
- [x] `pnpm install --frozen-lockfile` — clean, so CI's install matches
- [x] `pnpm -r typecheck` — clean
- [x] `pnpm test --project mcp-node` — 371 files, **4211 passed** | 10 skipped (the suite that exercises the MCP SDK, i.e. the consumer of the bumped package)
- [x] `pnpm build` — green, including the published `@kamiazya/whiteboard-mcp` artifacts

Visual evidence: none — a transitive dependency resolution; no user-visible pixels change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_