### PR TITLE
feat(model): the annotation layer's data shape — threads, selector anchors, per-message merge

### DIFF
--- a/.claude/rules/package-loro-adapter.md
+++ b/.claude/rules/package-loro-adapter.md
@@ -78,6 +78,22 @@ implementations live in the composition roots.
   `doc.getMap('edges')` keyed by edgeId. Each value is a plain object
   (not a nested LoroMap container) — this preserves node-level CRDT
   merge while avoiding Loro's nested-container overwrite issues.
+- **A nested container is the right shape only when the thing inside it must
+  merge per ENTRY**, and it buys that at a price worth naming. The annotation
+  layer's `threads` map (`comment-threads.ts`, ADR-0026) is the one that
+  qualifies: a thread's messages are a set two peers append to concurrently,
+  and stored as one value the second reply would erase the first, silently.
+  Nodes, edges and comments are each ONE value with one meaning, so a plain
+  object is right for them and a container would only add the hazard below.
+
+  The price, measured on loro-crdt 1.13.6: when two replicas create a
+  container under the same key with **no common ancestor for that key**, the
+  merge keeps one of them and every entry the other side put in it is gone —
+  no conflict, no marker. So only the CREATION path may open a thread
+  container (its id is minted, and cannot collide); a reply or a status change
+  to a thread this replica has not received writes nothing rather than opening
+  a rival. `setContainer` is banned here for the reason it is banned on tree
+  nodes, and `getOrCreateContainer` alone is not enough.
 - A third map, `doc.getMap('canvas')`, holds the canvas ENVELOPE —
   properties of the canvas rather than of anything on it (today
   `x-whiteboard`, the rendering preferences). Separate because the merge

--- a/.claude/rules/package-model.md
+++ b/.claude/rules/package-model.md
@@ -41,6 +41,14 @@ paths:
   the `human:` prefix (§5.3 keys trust tiers off it), and `isHumanActor` is the single place that
   check lives. `trustTier` is DERIVED on read and never stored — OKF's whole position is that a
   stored verdict is subjective, unportable and goes stale.
+- **The annotation layer (`annotation.ts`, ADR-0026) is format-agnostic except
+  for its anchor.** A thread carries where it points, whether it is open, and
+  its messages; only `annotationAnchorSchema` varies by document kind, and it
+  is a CLOSED discriminated union so every renderer's switch over it stays
+  exhaustive. Every arm has the same shape — an optional object reference plus
+  a positional fallback — because the reference is what survives the object
+  moving and the position is what survives it being deleted. Supporting a new
+  document format means adding an arm here, never widening an existing one.
 - A key joins `RESERVED_ROOT_KEYS` the moment something INTERPRETS it, and not before. Until then
   `facetsRaw` is the right home: preserved verbatim, never half-understood.
 

--- a/packages/loro-adapter/src/comment-threads.property.test.ts
+++ b/packages/loro-adapter/src/comment-threads.property.test.ts
@@ -1,0 +1,110 @@
+import { compareMessages } from '@kamiazya/whiteboard-model'
+import {
+  commentMessageArbitrary,
+  commentThreadArbitrary,
+} from '@kamiazya/whiteboard-model/test-utils'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect } from 'vitest'
+import {
+  readCommentThreads,
+  setCommentThreadStatus,
+  writeCommentThread,
+  writeThreadMessage,
+} from './comment-threads.js'
+import { fc, fcTest, withDefaults } from './test-utils/fast-check.js'
+
+function byId<T extends { id: string }>(items: readonly T[]): T[] {
+  return [...items].sort((a, b) => a.id.localeCompare(b.id))
+}
+
+/** Two replicas of the same document, synced up to the write just made. */
+function syncedPair(seed: (doc: LoroDoc) => void): [LoroDoc, LoroDoc] {
+  const a = new LoroDoc()
+  seed(a)
+  const b = LoroDoc.fromSnapshot(a.export({ mode: 'snapshot' }))
+  return [a, b]
+}
+
+function merge(a: LoroDoc, b: LoroDoc): void {
+  const fromA = a.export({ mode: 'update' })
+  const fromB = b.export({ mode: 'update' })
+  a.import(fromB)
+  b.import(fromA)
+}
+
+describe('comment thread storage properties', () => {
+  fcTest.prop([commentThreadArbitrary], withDefaults())(
+    'readCommentThreads(writeCommentThread(doc, thread)) deep-equals thread up to message order',
+    (thread) => {
+      const doc = new LoroDoc()
+      writeCommentThread(doc, thread)
+      const [stored] = readCommentThreads(doc)
+      expect(stored).toBeDefined()
+      expect({ ...stored, messages: byId(stored?.messages ?? []) }).toEqual({
+        ...thread,
+        messages: byId(thread.messages),
+      })
+    },
+  )
+
+  fcTest.prop([commentThreadArbitrary], withDefaults())(
+    'a thread reads back with its messages in comparator order',
+    (thread) => {
+      // The oracle is `compareMessages` applied to the INPUT, never to the
+      // output: sorting what came back and asserting it is sorted would pass
+      // against a read that does no sorting at all.
+      const doc = new LoroDoc()
+      writeCommentThread(doc, thread)
+      expect(readCommentThreads(doc)[0]?.messages).toEqual(
+        [...thread.messages].sort(compareMessages),
+      )
+    },
+  )
+
+  fcTest.prop(
+    [commentThreadArbitrary, commentMessageArbitrary, commentMessageArbitrary],
+    withDefaults(),
+  )(
+    'two peers replying to the same thread concurrently both survive the merge',
+    (thread, first, second) => {
+      // The invariant the whole shape exists for. A thread stored as one
+      // whole value would lose one of these replies to last-writer-wins, and
+      // the loss is silent: the surviving reply looks like the only one ever
+      // written.
+      fc.pre(first.id !== second.id)
+      fc.pre(!thread.messages.some((m) => m.id === first.id || m.id === second.id))
+
+      const [a, b] = syncedPair((doc) => writeCommentThread(doc, thread))
+      writeThreadMessage(a, thread.id, first)
+      writeThreadMessage(b, thread.id, second)
+      merge(a, b)
+
+      const expected = byId([...thread.messages, first, second])
+      for (const replica of [a, b]) {
+        const [merged] = readCommentThreads(replica)
+        expect(byId(merged?.messages ?? [])).toEqual(expected)
+      }
+    },
+  )
+
+  fcTest.prop([commentThreadArbitrary, commentMessageArbitrary], withDefaults())(
+    'a reply and a concurrent resolve do not cancel each other out',
+    (thread, reply) => {
+      // Resolving is a write to the thread's own field, replying a write to
+      // the messages beneath it. Storing the two in one value would make
+      // whichever landed second erase the other.
+      fc.pre(!thread.messages.some((m) => m.id === reply.id))
+
+      const [a, b] = syncedPair((doc) => writeCommentThread(doc, { ...thread, status: 'open' }))
+      writeThreadMessage(a, thread.id, reply)
+      setCommentThreadStatus(b, thread.id, 'resolved')
+      merge(a, b)
+
+      for (const replica of [a, b]) {
+        const [merged] = readCommentThreads(replica)
+        expect(merged?.status).toBe('resolved')
+        expect(byId(merged?.messages ?? [])).toEqual(byId([...thread.messages, reply]))
+      }
+    },
+  )
+})

--- a/packages/loro-adapter/src/comment-threads.test.ts
+++ b/packages/loro-adapter/src/comment-threads.test.ts
@@ -1,0 +1,137 @@
+import type { CommentThread } from '@kamiazya/whiteboard-model'
+import { LoroDoc, type LoroMap } from 'loro-crdt'
+import { describe, expect, it } from 'vitest'
+import {
+  migrateCanvasCommentsToThreads,
+  readCommentThreads,
+  setCommentThreadStatus,
+  writeCommentThread,
+  writeThreadMessage,
+} from './comment-threads.js'
+import { writeCanvasComment } from './loro-bridge.js'
+
+const THREAD: CommentThread = {
+  id: 't1',
+  anchor: { kind: 'spatial', nodeId: 'n1', x: 40, y: 50 },
+  status: 'open',
+  createdAt: '2026-09-02T00:00:00.000Z',
+  messages: [{ id: 'm1', body: 'tighten this', author: 'human:yuki' }],
+}
+
+describe('comment threads storage', () => {
+  it('round-trips a thread', () => {
+    const doc = new LoroDoc()
+    writeCommentThread(doc, THREAD)
+    expect(readCommentThreads(doc)).toEqual([THREAD])
+  })
+
+  it('reads messages in comparator order, not in storage order', () => {
+    // Ids ascend while timestamps descend, so neither insertion order nor
+    // key order answers this — only the comparator does. A case where the
+    // three agree cannot tell whether the read sorts at all.
+    const doc = new LoroDoc()
+    writeCommentThread(doc, {
+      ...THREAD,
+      messages: [{ id: 'a', body: 'later', createdAt: '2026-09-02T00:00:00.000Z' }],
+    })
+    writeThreadMessage(doc, 't1', {
+      id: 'b',
+      body: 'earlier',
+      createdAt: '2026-09-01T00:00:00.000Z',
+    })
+    expect(readCommentThreads(doc)[0]?.messages.map((m) => m.id)).toEqual(['b', 'a'])
+  })
+
+  it('rewrites one message without disturbing its siblings, which is how an edit lands', () => {
+    const doc = new LoroDoc()
+    writeCommentThread(doc, THREAD)
+    writeThreadMessage(doc, 't1', { id: 'm2', body: 'reply' })
+    writeThreadMessage(doc, 't1', {
+      id: 'm1',
+      body: 'tightened',
+      author: 'human:yuki',
+      editedAt: '2026-09-02T01:00:00.000Z',
+    })
+    const messages = readCommentThreads(doc)[0]?.messages ?? []
+    expect(messages.map((m) => m.body).sort()).toEqual(['reply', 'tightened'])
+  })
+
+  it('never mints a rival thread container from a reply or a status change', () => {
+    // Measured on loro-crdt 1.13.6: when two peers create a container under
+    // the same key with no common ancestor, the merge keeps ONE of them and
+    // the other side's entries are gone. Creation mints its own id and cannot
+    // collide; a reply to a thread this replica has not seen would, so it
+    // writes nothing rather than opening a container the other side loses.
+    const doc = new LoroDoc()
+    writeThreadMessage(doc, 'absent', { id: 'm1', body: 'reply' })
+    setCommentThreadStatus(doc, 'absent', 'resolved')
+    expect(doc.getMap('threads').keys()).toEqual([])
+  })
+
+  it('closes a thread without rewriting its messages', () => {
+    const doc = new LoroDoc()
+    writeCommentThread(doc, THREAD)
+    setCommentThreadStatus(doc, 't1', 'resolved')
+    expect(readCommentThreads(doc)).toEqual([{ ...THREAD, status: 'resolved' }])
+  })
+
+  it('drops a thread whose stored anchor no longer parses, and keeps its siblings', () => {
+    // Same contract as every other read here: a record the schema rejects
+    // costs that record, never the ones beside it.
+    const doc = new LoroDoc()
+    writeCommentThread(doc, THREAD)
+    writeCommentThread(doc, { ...THREAD, id: 't2' })
+    const broken = doc.getMap('threads').get('t2') as LoroMap
+    broken.set('anchor', { kind: 'spatial', x: 1.5, y: 0 })
+    doc.commit()
+    expect(readCommentThreads(doc).map((t) => t.id)).toEqual(['t1'])
+  })
+})
+
+describe('migrateCanvasCommentsToThreads', () => {
+  it('turns each stored comment into a one-message thread', () => {
+    const doc = new LoroDoc()
+    writeCanvasComment(doc, {
+      id: 'c1',
+      x: 1,
+      y: 2,
+      text: 'tighten this',
+      targetNodeId: 'n1',
+      resolved: true,
+    })
+    expect(migrateCanvasCommentsToThreads(doc)).toBe(1)
+    expect(readCommentThreads(doc)).toEqual([
+      {
+        id: 'c1',
+        anchor: { kind: 'spatial', nodeId: 'n1', x: 1, y: 2 },
+        status: 'resolved',
+        messages: [{ id: 'c1', body: 'tighten this' }],
+      },
+    ])
+  })
+
+  it('leaves the comments plane in place, because its readers have not moved yet', () => {
+    const doc = new LoroDoc()
+    writeCanvasComment(doc, { id: 'c1', x: 1, y: 2, text: 'x' })
+    migrateCanvasCommentsToThreads(doc)
+    expect(doc.getMap('comments').keys()).toEqual(['c1'])
+  })
+
+  it('is idempotent, and a second pass does not clobber a reply added since', () => {
+    const doc = new LoroDoc()
+    writeCanvasComment(doc, { id: 'c1', x: 1, y: 2, text: 'x' })
+    migrateCanvasCommentsToThreads(doc)
+    writeThreadMessage(doc, 'c1', { id: 'm2', body: 'reply' })
+    expect(migrateCanvasCommentsToThreads(doc)).toBe(0)
+    expect(readCommentThreads(doc)[0]?.messages).toHaveLength(2)
+  })
+
+  it('skips a comment the schema rejects rather than failing the whole pass', () => {
+    const doc = new LoroDoc()
+    writeCanvasComment(doc, { id: 'c1', x: 1, y: 2, text: 'x' })
+    doc.getMap('comments').set('bad', { id: 'bad', x: 0, y: 0 })
+    doc.commit()
+    expect(migrateCanvasCommentsToThreads(doc)).toBe(1)
+    expect(readCommentThreads(doc).map((t) => t.id)).toEqual(['c1'])
+  })
+})

--- a/packages/loro-adapter/src/comment-threads.ts
+++ b/packages/loro-adapter/src/comment-threads.ts
@@ -1,0 +1,168 @@
+import {
+  type CanvasComment,
+  type CommentMessage,
+  type CommentThread,
+  type CommentThreadStatus,
+  canvasCommentSchema,
+  commentMessageSchema,
+  commentThreadSchema,
+  compareMessages,
+  threadFromCanvasComment,
+} from '@kamiazya/whiteboard-model'
+import { LoroMap } from 'loro-crdt'
+import { COMMENTS_KEY, type DocumentContainers, THREADS_KEY } from './loro-bridge.js'
+
+/** The nested map of messages inside one thread's container. */
+const MESSAGES_KEY = 'messages'
+const ANCHOR_FIELD = 'anchor'
+const STATUS_FIELD = 'status'
+const CREATED_AT_FIELD = 'createdAt'
+
+function threadContainer(doc: DocumentContainers, threadId: string): LoroMap | undefined {
+  const stored = doc.getMap(THREADS_KEY).get(threadId)
+  return stored instanceof LoroMap ? stored : undefined
+}
+
+function messageToFields(message: CommentMessage): Record<string, unknown> {
+  const fields: Record<string, unknown> = { id: message.id, body: message.body }
+  if (message.author !== undefined) fields.author = message.author
+  if (message.createdAt !== undefined) fields.createdAt = message.createdAt
+  if (message.editedAt !== undefined) fields.editedAt = message.editedAt
+  return fields
+}
+
+function assertFiniteAnchor(thread: CommentThread): void {
+  // Loud for the same reason `nodeToFields` is: the read below round-trips
+  // every thread through its Zod schema and silently drops what fails, so a
+  // non-finite anchor written here would delete the thread for every reader —
+  // every synced peer, with no signal anywhere.
+  if (thread.anchor.kind !== 'spatial') return
+  for (const [field, value] of [
+    ['x', thread.anchor.x],
+    ['y', thread.anchor.y],
+  ] as const) {
+    if (!Number.isFinite(value)) {
+      throw new TypeError(
+        `comment thread "${thread.id}" has a non-finite ${field} (${value}); the anchor must be finite`,
+      )
+    }
+  }
+}
+
+/**
+ * Creates or replaces one thread's own fields and writes its messages.
+ *
+ * `getOrCreateContainer` and not `setContainer`: the latter REPLACES the
+ * container, discarding whatever a peer put in it. Creating one is still the
+ * only path allowed to open a thread container at all — measured on
+ * loro-crdt 1.13.6, two replicas that create a container under the same key
+ * with no common ancestor merge to ONE of them and the other side's entries
+ * are gone. Creation mints its own id and cannot collide; every other write
+ * below therefore refuses to open a container it did not find.
+ */
+export function writeCommentThread(doc: DocumentContainers, thread: CommentThread): void {
+  assertFiniteAnchor(thread)
+  const container = doc.getMap(THREADS_KEY).getOrCreateContainer(thread.id, new LoroMap())
+  container.set(ANCHOR_FIELD, thread.anchor)
+  container.set(STATUS_FIELD, thread.status)
+  if (thread.createdAt !== undefined) container.set(CREATED_AT_FIELD, thread.createdAt)
+  const messages = container.getOrCreateContainer(MESSAGES_KEY, new LoroMap())
+  for (const message of thread.messages) messages.set(message.id, messageToFields(message))
+  doc.commit()
+}
+
+/**
+ * Writes exactly one message, leaving every other message and the thread's own
+ * fields untouched — the append path AND the edit path, since an edit is the
+ * same message id written again.
+ *
+ * A no-op for a thread this replica does not hold: see `writeCommentThread`
+ * for why replying must never be the write that opens a container.
+ */
+export function writeThreadMessage(
+  doc: DocumentContainers,
+  threadId: string,
+  message: CommentMessage,
+): void {
+  const container = threadContainer(doc, threadId)
+  if (container === undefined) return
+  container
+    .getOrCreateContainer(MESSAGES_KEY, new LoroMap())
+    .set(message.id, messageToFields(message))
+  doc.commit()
+}
+
+/**
+ * Closes or reopens a thread. One key, last-writer-wins, which is all a
+ * status needs: two peers resolving concurrently agree, and neither touches
+ * the messages beneath.
+ */
+export function setCommentThreadStatus(
+  doc: DocumentContainers,
+  threadId: string,
+  status: CommentThreadStatus,
+): void {
+  const container = threadContainer(doc, threadId)
+  if (container === undefined) return
+  container.set(STATUS_FIELD, status)
+  doc.commit()
+}
+
+/**
+ * Every thread the document holds, ordered by id and with each thread's
+ * messages in `compareMessages` order, so two replicas that merged the same
+ * writes render the same conversation.
+ *
+ * A record the schema rejects costs that record and nothing beside it — the
+ * same contract `readSpatialCanvas` already keeps for nodes and comments.
+ */
+export function readCommentThreads(doc: DocumentContainers): CommentThread[] {
+  const threadsMap = doc.getMap(THREADS_KEY)
+  const threads: CommentThread[] = []
+  for (const threadId of threadsMap.keys()) {
+    const container = threadContainer(doc, threadId)
+    if (container === undefined) continue
+    const messagesContainer = container.get(MESSAGES_KEY)
+    const messages: CommentMessage[] = []
+    if (messagesContainer instanceof LoroMap) {
+      for (const messageId of messagesContainer.keys()) {
+        const parsed = commentMessageSchema.safeParse(messagesContainer.get(messageId))
+        if (parsed.success) messages.push(parsed.data)
+      }
+    }
+    const createdAt = container.get(CREATED_AT_FIELD)
+    const parsed = commentThreadSchema.safeParse({
+      id: threadId,
+      anchor: container.get(ANCHOR_FIELD),
+      status: container.get(STATUS_FIELD),
+      ...(createdAt === undefined ? {} : { createdAt }),
+      messages: messages.sort(compareMessages),
+    })
+    if (parsed.success) threads.push(parsed.data)
+  }
+  return threads.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+}
+
+/**
+ * Reads every stored canvas comment as the one-message thread it always was,
+ * and returns how many it converted.
+ *
+ * NON-DESTRUCTIVE and idempotent: the `comments` map is left in place, because
+ * every reader still projects it (`readSpatialCanvas`), and a thread id that
+ * already exists is skipped rather than rewritten — a second pass must not
+ * clobber a reply written since the first. Retiring the legacy plane belongs
+ * with the readers that move off it, not here.
+ */
+export function migrateCanvasCommentsToThreads(doc: DocumentContainers): number {
+  const commentsMap = doc.getMap(COMMENTS_KEY)
+  const existing = new Set(doc.getMap(THREADS_KEY).keys())
+  let migrated = 0
+  for (const commentId of commentsMap.keys()) {
+    if (existing.has(commentId)) continue
+    const parsed = canvasCommentSchema.safeParse(commentsMap.get(commentId))
+    if (!parsed.success) continue
+    writeCommentThread(doc, threadFromCanvasComment(parsed.data satisfies CanvasComment))
+    migrated += 1
+  }
+  return migrated
+}

--- a/packages/loro-adapter/src/index.ts
+++ b/packages/loro-adapter/src/index.ts
@@ -1,3 +1,10 @@
+export {
+  migrateCanvasCommentsToThreads,
+  readCommentThreads,
+  setCommentThreadStatus,
+  writeCommentThread,
+  writeThreadMessage,
+} from './comment-threads.js'
 export { collectImageRefIds } from './image-refs.js'
 export type { DocumentContainers } from './loro-bridge.js'
 export {

--- a/packages/loro-adapter/src/loro-bridge.ts
+++ b/packages/loro-adapter/src/loro-bridge.ts
@@ -65,7 +65,19 @@ const EXTENSION_FIELD = 'x-whiteboard'
  * commenting concurrently must both survive a merge. `writeSpatialCanvas`
  * splits the field out on write and `readSpatialCanvas` reassembles it.
  */
-const COMMENTS_KEY = 'comments'
+export const COMMENTS_KEY = 'comments'
+/**
+ * The annotation layer's thread plane (ADR-0026), one level deeper than the
+ * comments map above: a map of thread containers, each holding its anchor and
+ * status beside a nested map of MESSAGES keyed by message id. The extra level
+ * is the whole point — a thread stored as one value would lose one of two
+ * concurrent replies to last-writer-wins, silently.
+ *
+ * Read and written by `comment-threads.ts`; the key lives here so this file
+ * stays the one place a container is named and `CONTENT_CONTAINER_KEYS` below
+ * cannot fall out of step with it.
+ */
+export const THREADS_KEY = 'threads'
 const FACETS_KEY = 'facets'
 // Editor state that is NOT canvas content: stored beside the canvas in the
 // same doc (so it survives reload and syncs to peers) but in its own map,
@@ -826,6 +838,7 @@ export const CONTENT_CONTAINER_KEYS: ReadonlyArray<{ key: string; kind: 'map' | 
   { key: EDGES_KEY, kind: 'map' },
   { key: CANVAS_KEY, kind: 'map' },
   { key: COMMENTS_KEY, kind: 'map' },
+  { key: THREADS_KEY, kind: 'map' },
   { key: FACETS_KEY, kind: 'map' },
   { key: NODE_LOCKS_KEY, kind: 'map' },
   { key: EDGE_LOCKS_KEY, kind: 'map' },

--- a/packages/loro-adapter/src/workspace-record-growth.test.ts
+++ b/packages/loro-adapter/src/workspace-record-growth.test.ts
@@ -81,27 +81,34 @@ describe('workspace-record growth scoreboard', () => {
   })
 
   it('pins record size against document count (no edits)', () => {
-    expect(build(1, 0).afterCreateBytes).toBe(889)
-    expect(build(10, 0).afterCreateBytes).toBe(3166)
-    expect(build(50, 0).afterCreateBytes).toBe(13866)
+    // Each pre-attached container costs a document ~16-30B here. The last
+    // move was the annotation layer's `threads` map (ADR-0026) joining
+    // `CONTENT_CONTAINER_KEYS`: 889 -> 919 at one document, 13866 -> 14860 at
+    // fifty. That is the price of pre-attaching — a container attached on
+    // first READ instead would cost nothing here and clear the UndoManager's
+    // redo stack, which is the trade the pre-attached set exists to refuse.
+    expect(build(1, 0).afterCreateBytes).toBe(919)
+    expect(build(10, 0).afterCreateBytes).toBe(3329)
+    expect(build(50, 0).afterCreateBytes).toBe(14860)
   })
 
   it('pins oplog growth per edit and the shallow reclaim', () => {
     const n = build(10, 100)
     // The delta LOG price of an edit — what accumulates between compactions.
-    expect(n.updateBytes).toBe(178460)
+    expect(n.updateBytes).toBe(178560)
     // The stored-snapshot price of the same history — Loro's snapshot
     // encoding compresses it to ~8B/edit.
-    expect(n.fullBytes).toBe(11428)
+    expect(n.fullBytes).toBe(11563)
     // The reclaim: a shallow cut at the current frontier collapses the whole
     // edit history. It is no longer byte-IDENTICAL to the create-time record:
     // since the comments container (ADR-0024) joined the pre-attached set, a
-    // container that has never been written encodes 9B leaner in a shallow
-    // snapshot than at create time (measured 3157 vs 3166), so the cut is
+    // container that has never been written encodes leaner in a shallow
+    // snapshot than at create time (measured 3302 vs 3329, and the gap grows
+    // with each such container — 9B when comments was the only one), so the cut is
     // pinned exactly AND bounded by the create-time size — the reclaim story
     // ("compaction takes back everything the edits added") is the invariant,
     // byte identity was only its strongest available form.
-    expect(n.shallowBytes).toBe(3157)
+    expect(n.shallowBytes).toBe(3302)
     expect(n.shallowBytes).toBeLessThanOrEqual(build(10, 0).afterCreateBytes)
   })
 })

--- a/packages/model/src/annotation.test.ts
+++ b/packages/model/src/annotation.test.ts
@@ -1,0 +1,179 @@
+// The annotation layer's shape (ADR-0026): a THREAD is the anchored unit and
+// comments are the messages in it, and the anchor is the only part that
+// varies by document format. These tests pin the three things a later reader
+// would otherwise have to infer — what belongs to the thread rather than to a
+// message, that every anchor arm is "an optional object reference plus a
+// positional fallback", and that today's flat comment is a one-message thread.
+import { describe, expect, it } from 'vitest'
+import {
+  type AnnotationAnchor,
+  annotationAnchorSchema,
+  commentMessageSchema,
+  commentThreadSchema,
+  compareMessages,
+  threadFromCanvasComment,
+} from './annotation.js'
+import type { CanvasComment } from './spatial.js'
+
+const SPATIAL: AnnotationAnchor = { kind: 'spatial', x: 10, y: 20 }
+
+function thread(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 't1',
+    anchor: SPATIAL,
+    status: 'open',
+    messages: [{ id: 'm1', body: 'first' }],
+    ...overrides,
+  }
+}
+
+describe('annotationAnchorSchema', () => {
+  it('accepts a spatial anchor with and without its object reference', () => {
+    expect(annotationAnchorSchema.safeParse({ kind: 'spatial', x: 1, y: 2 }).success).toBe(true)
+    expect(
+      annotationAnchorSchema.safeParse({ kind: 'spatial', nodeId: 'n1', x: 1, y: 2 }).success,
+    ).toBe(true)
+  })
+
+  it('requires integer spatial coordinates, because a reader drops a comment that fails the schema', () => {
+    // The same rule `canvasCommentSchema` already carries: a fractional
+    // anchor from a zoomed viewport survives the session and vanishes on the
+    // next read.
+    expect(annotationAnchorSchema.safeParse({ kind: 'spatial', x: 1.5, y: 2 }).success).toBe(false)
+  })
+
+  it('accepts a text anchor carrying both a quote and an offset', () => {
+    const anchor = {
+      kind: 'text',
+      quote: { prefix: 'the ', exact: 'launch plan', suffix: ' is' },
+      start: 4,
+      end: 15,
+    }
+    expect(annotationAnchorSchema.safeParse(anchor).success).toBe(true)
+  })
+
+  it('rejects a text anchor with no quote: an offset alone cannot survive an edit above it', () => {
+    expect(annotationAnchorSchema.safeParse({ kind: 'text', start: 4, end: 15 }).success).toBe(
+      false,
+    )
+  })
+
+  it('rejects an empty quote and a backwards range', () => {
+    const quote = { prefix: '', exact: '', suffix: '' }
+    expect(
+      annotationAnchorSchema.safeParse({ kind: 'text', quote, start: 0, end: 0 }).success,
+    ).toBe(false)
+    const ok = { prefix: '', exact: 'x', suffix: '' }
+    expect(
+      annotationAnchorSchema.safeParse({ kind: 'text', quote: ok, start: 9, end: 4 }).success,
+    ).toBe(false)
+  })
+
+  it('rejects an unknown format arm rather than passing it through', () => {
+    // The union is closed on purpose (ADR-0026 decision 3): a new format is a
+    // new arm here, which is what makes every renderer's switch exhaustive.
+    expect(annotationAnchorSchema.safeParse({ kind: 'audio', at: 3 }).success).toBe(false)
+  })
+})
+
+describe('commentThreadSchema', () => {
+  it('carries the anchor and the status, and at least one message', () => {
+    expect(commentThreadSchema.safeParse(thread()).success).toBe(true)
+    expect(commentThreadSchema.safeParse(thread({ messages: [] })).success).toBe(false)
+  })
+
+  it('has no resolved flag on a message: a conversation is what gets closed', () => {
+    // ADR-0026 decision 2. With `resolved` on a message and replies beside
+    // it, "which one's flag counts?" has no defensible answer.
+    expect(commentMessageSchema.safeParse({ id: 'm1', body: 'x', resolved: true }).success).toBe(
+      false,
+    )
+    expect(commentThreadSchema.safeParse(thread({ status: 'resolved' })).success).toBe(true)
+    expect(commentThreadSchema.safeParse(thread({ status: 'archived' })).success).toBe(false)
+  })
+
+  it('has no anchor on a message: a reply inherits the thread’s', () => {
+    expect(commentMessageSchema.safeParse({ id: 'm1', body: 'x', anchor: SPATIAL }).success).toBe(
+      false,
+    )
+  })
+})
+
+describe('compareMessages', () => {
+  it('orders by createdAt, then by id, so two peers reading the same thread see the same order', () => {
+    const a = { id: 'b', body: 'x', createdAt: '2026-09-02T00:00:00.000Z' }
+    const b = { id: 'a', body: 'x', createdAt: '2026-09-02T00:00:01.000Z' }
+    expect([b, a].sort(compareMessages).map((m) => m.id)).toEqual(['b', 'a'])
+  })
+
+  it('breaks a timestamp tie by id rather than leaving it to sort stability', () => {
+    const at = '2026-09-02T00:00:00.000Z'
+    const a = { id: 'a', body: 'x', createdAt: at }
+    const b = { id: 'b', body: 'x', createdAt: at }
+    expect([b, a].sort(compareMessages).map((m) => m.id)).toEqual(['a', 'b'])
+  })
+
+  it('sorts a message with no timestamp before one that has it, deterministically', () => {
+    // `createdAt` is optional (identity and time are keeper concerns), so the
+    // comparator must still be total: an absent timestamp is the earliest.
+    const none = { id: 'z', body: 'x' }
+    const dated = { id: 'a', body: 'x', createdAt: '2026-09-02T00:00:00.000Z' }
+    expect([dated, none].sort(compareMessages).map((m) => m.id)).toEqual(['z', 'a'])
+  })
+})
+
+describe('threadFromCanvasComment', () => {
+  it("turns today's flat comment into a one-message thread, keeping its id", () => {
+    const comment: CanvasComment = {
+      id: 'c1',
+      x: 40,
+      y: 50,
+      text: 'tighten this',
+      createdAt: '2026-09-02T00:00:00.000Z',
+      author: 'human:yuki',
+    }
+    expect(threadFromCanvasComment(comment)).toEqual({
+      id: 'c1',
+      anchor: { kind: 'spatial', x: 40, y: 50 },
+      status: 'open',
+      createdAt: '2026-09-02T00:00:00.000Z',
+      messages: [
+        {
+          id: 'c1',
+          body: 'tighten this',
+          createdAt: '2026-09-02T00:00:00.000Z',
+          author: 'human:yuki',
+        },
+      ],
+    })
+  })
+
+  it('carries the node reference into the anchor and resolution into the status', () => {
+    const migrated = threadFromCanvasComment({
+      id: 'c2',
+      x: 1,
+      y: 2,
+      text: 'done',
+      targetNodeId: 'n1',
+      resolved: true,
+    })
+    expect(migrated.anchor).toEqual({ kind: 'spatial', nodeId: 'n1', x: 1, y: 2 })
+    expect(migrated.status).toBe('resolved')
+  })
+
+  it('produces a thread that validates, for every comment that validated', () => {
+    // The migration is only mechanical if its output is always legal. A
+    // comment with nothing optional set is the case that would catch an
+    // over-required thread schema.
+    const bare = threadFromCanvasComment({ id: 'c3', x: 0, y: 0, text: 'x' })
+    expect(commentThreadSchema.safeParse(bare).success).toBe(true)
+  })
+
+  it('keeps the message id equal to the thread id for a migrated comment', () => {
+    // Deliberate: the comment's id is what every existing anchor, MCP call
+    // and test already names, so the THREAD keeps it. The single message
+    // borrowing it means a migrated record has no id nobody has seen before.
+    const migrated = threadFromCanvasComment({ id: 'c4', x: 0, y: 0, text: 'x' })
+    expect(migrated.messages[0]?.id).toBe(migrated.id)
+  })
+})

--- a/packages/model/src/annotation.ts
+++ b/packages/model/src/annotation.ts
@@ -1,0 +1,162 @@
+import { z } from 'zod'
+import { nodeIdSchema } from './ids.js'
+import type { CanvasComment } from './spatial.js'
+import { okfActorSchema, okfTimestampSchema } from './trust.js'
+
+/**
+ * The annotation layer's identifiers (ADR-0026). Same deliberate looseness as
+ * `nodeIdSchema` and for the same reason — they are nanoid-style strings and
+ * the alphabet may be swapped — but a separate schema, because a thread is not
+ * a node and the two must be free to diverge.
+ */
+export const annotationIdSchema = z.string().min(1, 'annotation id must not be empty')
+
+/**
+ * A quote-based text selector, after the W3C Web Annotation Data Model's
+ * `TextQuoteSelector`: the exact string the annotation is about, plus enough
+ * surrounding context to disambiguate a repeated phrase.
+ *
+ * `prefix`/`suffix` are optional because a producer may have none to give (an
+ * anchor at the very start or end of a body); `exact` is not, because it is
+ * the only part that can re-find the passage after an edit.
+ */
+export const textQuoteSelectorSchema = z
+  .object({
+    prefix: z.string().optional(),
+    exact: z.string().min(1, 'a text anchor must quote at least one character'),
+    suffix: z.string().optional(),
+  })
+  .strict()
+
+export type TextQuoteSelector = z.infer<typeof textQuoteSelectorSchema>
+
+/**
+ * Where an annotation points. This is the ONLY part of the layer that varies
+ * by document kind, which is what lets one thread shape serve the spatial
+ * canvas, the markdown body, and whatever format comes next.
+ *
+ * Every arm has the same shape: an OPTIONAL object reference plus a positional
+ * fallback. The reference is what survives the object moving; the position is
+ * what survives the object being deleted, and is what an orphaned annotation
+ * is still drawn from.
+ *
+ * The union is closed on purpose — a new format is a new arm here, so every
+ * renderer's switch over it stays exhaustive rather than silently ignoring a
+ * kind it has never seen.
+ */
+export const annotationAnchorSchema = z.discriminatedUnion('kind', [
+  z
+    .object({
+      kind: z.literal('spatial'),
+      nodeId: nodeIdSchema.optional(),
+      // Integer, matching JSON Canvas geometry and `canvasCommentSchema`: a
+      // fractional anchor taken from a zoomed viewport survives the session
+      // and then vanishes, because the next read drops what fails the schema.
+      x: z.number().int(),
+      y: z.number().int(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('text'),
+      quote: textQuoteSelectorSchema,
+      start: z.number().int().nonnegative(),
+      end: z.number().int().nonnegative(),
+    })
+    .strict()
+    .refine((anchor) => anchor.end >= anchor.start, {
+      message: 'a text anchor must not end before it starts',
+    }),
+])
+
+export type AnnotationAnchor = z.infer<typeof annotationAnchorSchema>
+
+/**
+ * One message in a thread. Deliberately carries NEITHER an anchor nor a
+ * resolution flag: a reply inherits the thread's anchor, and it is the
+ * conversation that gets closed, not an individual remark. With `resolved` on
+ * a message and replies beside it, "which one's flag counts?" has no
+ * defensible answer.
+ *
+ * `author` and `createdAt` are optional because identity and time are keeper
+ * concerns — a browser-kept workspace has no signed-in author to record.
+ */
+export const commentMessageSchema = z
+  .object({
+    id: annotationIdSchema,
+    body: z.string().min(1, 'a comment message must not be empty'),
+    author: okfActorSchema.optional(),
+    createdAt: okfTimestampSchema.optional(),
+    editedAt: okfTimestampSchema.optional(),
+  })
+  .strict()
+
+export type CommentMessage = z.infer<typeof commentMessageSchema>
+
+export const commentThreadStatusSchema = z.enum(['open', 'resolved'])
+
+export type CommentThreadStatus = z.infer<typeof commentThreadStatusSchema>
+
+/**
+ * The anchored unit of the annotation layer: one thread, holding where it
+ * points, whether it is still open, and the messages that make up the
+ * conversation. At least one message, because a thread with none is an anchor
+ * nobody can read and nothing would ever draw.
+ */
+export const commentThreadSchema = z
+  .object({
+    id: annotationIdSchema,
+    anchor: annotationAnchorSchema,
+    status: commentThreadStatusSchema,
+    createdAt: okfTimestampSchema.optional(),
+    messages: z.array(commentMessageSchema).min(1, 'a thread has at least one message'),
+  })
+  .strict()
+
+export type CommentThread = z.infer<typeof commentThreadSchema>
+
+/**
+ * The one order two peers reading the same thread agree on. `createdAt` first,
+ * then id as the tie-break — left to sort stability, two peers that received
+ * the same two messages in different orders would render them differently.
+ *
+ * A message with no timestamp sorts earliest, which keeps the comparator total
+ * rather than leaving an undefined pair to compare as `NaN`.
+ */
+export function compareMessages(a: CommentMessage, b: CommentMessage): number {
+  const at = a.createdAt ?? ''
+  const bt = b.createdAt ?? ''
+  if (at !== bt) return at < bt ? -1 : 1
+  if (a.id !== b.id) return a.id < b.id ? -1 : 1
+  return 0
+}
+
+/**
+ * Today's flat canvas comment, read as the one-message thread it always was.
+ *
+ * The THREAD keeps the comment's id: that id is what every existing anchor,
+ * MCP call and test already names. The single message borrows it, so a
+ * migrated record introduces no identifier nobody has seen before.
+ */
+export function threadFromCanvasComment(comment: CanvasComment): CommentThread {
+  const anchor: AnnotationAnchor = {
+    kind: 'spatial',
+    ...(comment.targetNodeId === undefined ? {} : { nodeId: comment.targetNodeId }),
+    x: comment.x,
+    y: comment.y,
+  }
+  return {
+    id: comment.id,
+    anchor,
+    status: comment.resolved === true ? 'resolved' : 'open',
+    ...(comment.createdAt === undefined ? {} : { createdAt: comment.createdAt }),
+    messages: [
+      {
+        id: comment.id,
+        body: comment.text,
+        ...(comment.createdAt === undefined ? {} : { createdAt: comment.createdAt }),
+        ...(comment.author === undefined ? {} : { author: comment.author }),
+      },
+    ],
+  }
+}

--- a/packages/model/src/index.ts
+++ b/packages/model/src/index.ts
@@ -1,3 +1,4 @@
+export * from './annotation.js'
 export * from './asset-ref.js'
 export * from './clipboard.js'
 // The mdast subset is intentionally NOT re-exported here — it is

--- a/packages/model/src/test-utils/arbitraries.ts
+++ b/packages/model/src/test-utils/arbitraries.ts
@@ -1,3 +1,4 @@
+import type { AnnotationAnchor, CommentMessage, CommentThread } from '../annotation.js'
 import { RESERVED_ROOT_KEYS } from '../facets.js'
 import { DOCUMENT_PATH_SEGMENT_PATTERN } from '../ids.js'
 import type {
@@ -519,6 +520,77 @@ export const canvasCommentArbitrary: fc.Arbitrary<CanvasComment> = fc.record(
     resolved: fc.boolean(),
   },
   { requiredKeys: ['id', 'x', 'y', 'text'] },
+)
+
+/**
+ * The annotation layer's generators (ADR-0026). Valid-by-construction against
+ * `annotationAnchorSchema` / `commentThreadSchema`, and deliberately covering
+ * BOTH anchor arms: a property that only ever saw the spatial arm would say
+ * nothing about the shape's whole reason for existing.
+ */
+export const annotationAnchorArbitrary: fc.Arbitrary<AnnotationAnchor> = fc.oneof(
+  fc.record(
+    {
+      kind: fc.constant('spatial' as const),
+      nodeId: nodeIdArbitrary,
+      x: geometryArbitrary,
+      y: geometryArbitrary,
+    },
+    { requiredKeys: ['kind', 'x', 'y'] },
+  ),
+  fc
+    .record(
+      {
+        kind: fc.constant('text' as const),
+        quote: fc.record(
+          {
+            prefix: fc.string({ maxLength: 8 }),
+            exact: fc.string({ minLength: 1, maxLength: 24 }),
+            suffix: fc.string({ maxLength: 8 }),
+          },
+          { requiredKeys: ['exact'] },
+        ),
+        start: fc.nat({ max: 4000 }),
+        length: fc.nat({ max: 200 }),
+      },
+      { requiredKeys: ['kind', 'quote', 'start', 'length'] },
+    )
+    // `end` is derived rather than generated so the range is never backwards —
+    // the schema rejects that, and a filter would just discard half the runs.
+    .map(({ length, ...anchor }) => ({ ...anchor, end: anchor.start + length })),
+)
+
+export const commentMessageArbitrary: fc.Arbitrary<CommentMessage> = fc.record(
+  {
+    id: nodeIdArbitrary,
+    body: fc.string({ minLength: 1, maxLength: 40 }),
+    author: fc.constantFrom('human:reviewer', 'process:layout-agent'),
+    createdAt: fc.constantFrom(
+      '2026-09-01T10:00:00+09:00',
+      '2026-09-01T11:30:00Z',
+      '2026-09-02T09:15:00Z',
+    ),
+  },
+  { requiredKeys: ['id', 'body'] },
+)
+
+export const commentThreadArbitrary: fc.Arbitrary<CommentThread> = fc.record(
+  {
+    id: nodeIdArbitrary,
+    anchor: annotationAnchorArbitrary,
+    status: fc.constantFrom('open' as const, 'resolved' as const),
+    createdAt: fc.constant('2026-09-01T10:00:00+09:00'),
+    // Unique ids for the same reason the canvas arbitrary dedupes node ids:
+    // `nodeIdArbitrary` collides often enough at small sizes to pass hundreds
+    // of runs and then fail on someone else's seed, and a thread whose two
+    // messages share an id is not a thread the storage can represent.
+    messages: fc.uniqueArray(commentMessageArbitrary, {
+      minLength: 1,
+      maxLength: 4,
+      selector: (message) => message.id,
+    }),
+  },
+  { requiredKeys: ['id', 'anchor', 'status', 'messages'] },
 )
 
 export const spatialCanvasArbitrary: fc.Arbitrary<SpatialCanvas> = fc


### PR DESCRIPTION
ADR-0026 step 1 — the data layer, ahead of the readers and the UI. Sequencing was a human decision: the data shape lands first and the seven-PR comment-UX stack waits, so it is moved onto this shape before it lands rather than migrated afterwards.

## Summary

A **thread** is the anchored unit and comments are the **messages** in it. The anchor is the only part that varies by document format, so one shape serves the spatial canvas today and a markdown body next.

**`packages/model/src/annotation.ts`**

- `annotationAnchorSchema` — a **closed** discriminated union. Every arm has the same shape: an optional object reference plus a positional fallback. The reference is what survives the object moving; the position is what survives it being deleted. Two arms today: `spatial` (integer coordinates, the same rule `canvasCommentSchema` already carries) and `text` (a W3C Web Annotation `TextQuoteSelector` plus offsets — a quote is required, because an offset alone cannot survive an edit above it). Closed on purpose: a new format is a new arm, which is what keeps every renderer's switch exhaustive.
- `commentMessageSchema` / `commentThreadSchema` — a message carries **neither** an anchor nor a resolution flag. A reply inherits the thread's anchor, and it is the conversation that closes: with `resolved` on a message and replies beside it, "which one's flag counts?" has no defensible answer.
- `compareMessages` — total, `createdAt` then id. Two peers that merged the same writes must render the same order, and sort stability does not promise that.
- `threadFromCanvasComment` — today's flat comment read as the one-message thread it always was. The **thread** keeps the comment's id, because that id is what every existing anchor, MCP call and test already names; the single message borrows it, so a migrated record introduces no identifier nobody has seen before.

**`packages/loro-adapter/src/comment-threads.ts`** — a `threads` map of thread containers, each holding its anchor and status beside a nested `messages` map keyed by message id. The extra level is the whole point: a thread stored as one value loses one of two concurrent replies to last-writer-wins, silently.

`migrateCanvasCommentsToThreads` is **non-destructive and idempotent** — the `comments` map stays, because every reader still projects it, and an existing thread id is skipped so a second pass cannot clobber a reply written since the first. Retiring the legacy plane belongs with the readers that move off it (ADR-0026 step 2).

## Measured

**Only the creation path may open a thread container.** On loro-crdt 1.13.6, two replicas that create a container under the same key with *no common ancestor for that key* merge to ONE of them, and the other side's entries are gone — no conflict, no marker:

```
a: {"t1":{"messages":{"mB":…},"anchor":…}}   // mA is simply not there
b: {"t1":{"messages":{"mB":…},"anchor":…}}
```

Creation mints its own id and cannot collide; a reply or a status change to a thread this replica has not received therefore writes **nothing** rather than opening a rival. A test pins that, and `.claude/rules/package-loro-adapter.md` now carries the measurement.

**The growth scoreboard moved, and the diff says why.** `threads` joining `CONTENT_CONTAINER_KEYS` costs a document ~16–30B of pre-attached container: 889 → 919 bytes at one document, 13866 → 14860 at fifty. Re-pinned exactly, with the cause named; the shallow-reclaim invariant (`shallowBytes <= afterCreateBytes`) still holds at 3302 ≤ 3329.

## Test plan

- `pnpm vitest run --project model-node annotation` — 16 passed.
- `pnpm vitest run --project loro-adapter-node comment-threads` — 14 passed, including the two properties this shape exists for: **two peers replying concurrently both survive**, and **a reply and a concurrent resolve do not cancel each other out**.
- Mutation-checked, four ways: opening a rival container from a reply (1 fails), `setContainer` on the messages map (5 fail), dropping the comparator sort (2 fail), and dropping the migration's already-migrated skip (1 fails). The sort's first test did **not** discriminate — storage order happened to agree with comparator order — so it was replaced with a case where ids ascend while timestamps descend, and re-checked.
- `pnpm check:local` — clean (typecheck, lint, `lint:noconsole`, audit, `intent:validate`, secretlint, `test:scripts`, knip).
- `pnpm test --project mcp-node` — 4211 passed. Full `pnpm test` filled the disk mid-run (19GB of vitest traces); after clearing them, every failure it reported re-ran green, and the remaining `dist/` artifact-smoke failures are the missing local build that CI does for itself.

Visual evidence: none — no user-visible surface. Nothing reads threads yet (`userReach: foundation`); the readers are ADR-0026 step 2 and the comment-UX stack, which is held for exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_