### PR TITLE
test(web): reach the navigation double press on purpose, and count that it was reached

### DIFF
--- a/apps/web/src/components/spatial-editor/navigation.property.test.ts
+++ b/apps/web/src/components/spatial-editor/navigation.property.test.ts
@@ -73,19 +73,37 @@ const modeTally = emptyTally(MODE_COVERAGE)
  */
 let anchorReusedCount = 0
 
+/**
+ * How often the generator reached a double press the machine ACCEPTED.
+ * Counted for the same reason as the line above, and because this one was
+ * measured at 4-8 per run against siblings in the thousands — the ledger
+ * entry below passed on a margin of four, and reported `zoom-at` uncovered
+ * on about one run in sixteen. A ledger that fails at random teaches the
+ * reader to re-run it, which is the opposite of what it is for.
+ */
+let doublePressZoomCount = 0
+
 afterAll(() => {
   assertLedger('NavigationEffect kind', EFFECT_COVERAGE, effectTally)
   assertLedger('NavigationMode kind', MODE_COVERAGE, modeTally)
   expect(
     anchorReusedCount,
     'the generator never reached a gather whose anchor id was reused — the invariant about a mode holding a pointer that is not down has nothing to check',
-    // A floor, not a target: measured 100, 107 and 107 across three runs, and
-    // this sits at roughly a third of the lowest. The number matters because
+    // A floor, not a target: measured 100, 107 and 107 when it was written,
+    // and 68-73 once `double-press` took a share of the step draw — still
+    // twice the floor, which is why the number below did not move with it.
+    // The number matters because
     // it MOVED — a uniform draw of the step kinds reached this arrangement 4
     // times in 12000 sequences and the mutation check came back green, which
     // is exactly what a guard that never reaches its subject looks like from
     // the outside.
   ).toBeGreaterThan(30)
+  expect(
+    doublePressZoomCount,
+    'the generator never reached an accepted double press — the zoom-at ledger entry below is passing on luck',
+    // A floor, not a target, sized the same way: measured 556, 567 and 556
+    // across three runs with the `double-press` step, against 4-8 without it.
+  ).toBeGreaterThan(180)
 })
 
 const rawPointArb = fc.record({
@@ -191,6 +209,16 @@ const stepArb = fc.record({
     // completes it. Steering toward an interesting state is what
     // `fc.commands`' own `check` does; the ORACLE stays independent.
     { weight: 3, arbitrary: fc.constant('reuse-mode-anchor' as const) },
+    // A compound step, like the one above: press, release, press again, with
+    // hand mode on and the plain button both times. Every part is something
+    // a one-handed touch user does; what the generator supplies is the
+    // ARRANGEMENT, which is what a uniform draw almost never reaches —
+    // `handMode && !spaceDown && button === 0` on two consecutive presses is
+    // 1 in 64 before the interval and the distance are asked about, and the
+    // first press's pointer has to be released in between or the second one
+    // promotes to a pinch instead. Measured: 4-8 accepted double presses per
+    // run without this step, 556-567 with it.
+    { weight: 1, arbitrary: fc.constant('double-press' as const) },
     // A press that reached an overlay control rather than this machine. It
     // joins the down set without a touch, and its RELEASE does arrive here —
     // so it is generated for the lifetime invariants, which would otherwise
@@ -198,6 +226,17 @@ const stepArb = fc.record({
     { weight: 2, arbitrary: fc.constant('external-press' as const) },
   ),
   placement: pressPlacementArb,
+  /**
+   * Where the second press of a `double-press` lands relative to the first.
+   * Sized just outside the slop on each axis, so the step generates the
+   * ACCEPT and the REJECT case in roughly equal measure — a compound step
+   * that always satisfied the rule would leave "never claims a double press
+   * across more than the slop" with nothing to reject.
+   */
+  rePressOffset: fc.record({
+    x: fc.integer({ min: -50, max: 50 }),
+    y: fc.integer({ min: -50, max: 50 }),
+  }),
   button: fc.constantFrom(0, 1),
   isPrimary: fc.boolean(),
   context: contextArb,
@@ -254,7 +293,10 @@ function drive(sequence: Sequence, check: (observation: Observation) => void) {
     const result = reduceNavigation(before, event)
     expect(snapshot(before), 'the reducer mutated the state it was handed').toBe(beforeSnapshot)
     modeTally[result.state.mode.kind] += 1
-    for (const effect of result.effects) effectTally[effect.kind] += 1
+    for (const effect of result.effects) {
+      effectTally[effect.kind] += 1
+      if (effect.kind === 'zoom-at') doublePressZoomCount += 1
+    }
     if (
       result.state.mode.kind === 'gathering' &&
       result.state.mode.memberIds.has(result.state.mode.anchorId)
@@ -292,6 +334,39 @@ function drive(sequence: Sequence, check: (observation: Observation) => void) {
       lastPoint = point
       platformDown.delete(id)
       apply({ type: 'pointerup', pointerId: id, pointerType: 'touch' })
+      continue
+    }
+
+    if (step.kind === 'double-press') {
+      // Only from a quiet hand: a second pointer still down would make the
+      // re-press a pinch, which is a real arrangement the plain draw already
+      // produces and not the one this step exists to reach.
+      if (platformDown.size > 0) continue
+      const id = step.pointerId
+      const type = sequence.types[String(id)] ?? 'touch'
+      // Hand mode with the plain button and no Space is the whole precondition
+      // the reducer checks; everything else about the context stays generated.
+      const context = { ...step.context, handMode: true, spaceDown: false }
+      const second = { x: point.x + step.rePressOffset.x, y: point.y + step.rePressOffset.y }
+      for (const at of [point, second]) {
+        platformDown.add(id)
+        apply({
+          type: 'pointerdown',
+          pointerId: id,
+          pointerType: type,
+          isPrimary: true,
+          button: 0,
+          point: at,
+          timeStamp: clock,
+          context,
+        })
+        lastPoint = at
+        platformDown.delete(id)
+        apply({ type: 'pointerup', pointerId: id, pointerType: type })
+        // `dt` again, as the INTERVAL between the two presses — the same
+        // 0-600 draw the window at 400ms splits either side of.
+        clock += step.dt
+      }
       continue
     }
 


### PR DESCRIPTION
## Summary

`navigation.property.test.ts`'s `zoom-at` ledger entry failed about **one run in sixteen** on `main` (measured: 15 pass / 1 fail in 16 local runs on the same commit), taking unrelated PRs down with it.

It is not a timing flake. Instrumenting the tally showed the generator reached an accepted double press **4–8 times per run** across 8 runs — against siblings in the thousands — so zero is an ordinary draw, not a rare one:

```
zoom-at: 7, 4, 4, 5, 5, 8, 8, 7        pan: ~2700   clear-long-press: ~8000
```

The arrangement is rare because it is specific: `handMode && !spaceDown && button === 0` on **two consecutive presses** is 1 in 64 before the 400ms window and the 40px slop are asked about, and the first press's pointer has to be released in between or the second one promotes to a pinch instead.

## What changed

- A **`double-press` compound step**, beside the existing `reuse-mode-anchor`, on the same principle the file already states: every part is something a one-handed touch user does, and what the generator supplies is the **order**. Weight 1 — at 3 it drowned the other kinds (`zoom-at` 1616, `pinch` down to 9).
- Its second press is offset ±50px on each axis, so the step produces the **reject** case about as often as the accept one and *"never claims a double press across more than the slop"* keeps something to reject. It runs only from a quiet hand (no other pointer down), since a second pointer makes the re-press a pinch — a real arrangement the plain draw already reaches, and not the one this step is for.
- A **counted floor** beside `anchorReusedCount`. The ledger only asks for more than zero, and that is exactly what was passing on luck.

## Measured

| | before | after |
|---|---|---|
| accepted double presses / run | 4, 5, 8 | 556, 567, 556 |
| `pinch` / run | 14, 15, 16 | 14, 15, 16 |
| `anchorReusedCount` / run | 100, 107, 107 | 68, 73, 69 |

`anchorReusedCount` fell as the new step took its share of the draw — still more than twice its floor of 30, so that number stands, and its comment now carries both measurements instead of the stale one.

## Test plan

- 6 consecutive runs of the file: 6/6 green (it was 15/16 before).
- Mutation-checked: with the `double-press` step removed from the draw, the new floor fails — `expected 1 to be greater than 180`. The guard is load-bearing rather than decorative.
- `pnpm --filter @kamiazya/whiteboard-web test` (the command CI's `test-jsdom` job runs, both projects): 3216 + 89 passed.

Visual evidence: none — a test-only change with no user-visible surface; the measurements above are the evidence this one has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_