### PR TITLE
docs: record the decomposition measurement that rejected two component splits

### DIFF
--- a/.claude/skills/measured-change/SKILL.md
+++ b/.claude/skills/measured-change/SKILL.md
@@ -121,6 +121,54 @@ concrete counts, and recommend one. ("42% less ink through a box, 8% more
 crossings" was decided by a human in ten seconds; guessing it would have
 been a coin flip.)
 
+## A decomposition is a measured change too
+
+"This file is 700 lines" is an argument, not a measurement, and it is the
+one an audit reaches for when it has run out of defects. The number that
+decides a split is **how much body an extraction removes against how many
+identifiers cross its seam** — because a component whose extracted half
+needs fourteen props has moved lines without moving knowledge, and the
+reader still has to hold both files at once.
+
+Calibrate against the split this repo ACCEPTED rather than against a number
+you like. `CanvasContextMenu`'s four extractions measured, in lines per
+crossing identifier:
+
+| extraction | lines | seam | ratio |
+|---|---|---|---|
+| `color-row` | 73 | 3 | 24.3 |
+| `edge-menu-items` | 155 | 8 | 19.4 |
+| `node-menu-items` | 433 | 32 | 13.5 |
+| `canvas-menu-items` | 117 | 14 | 8.4 |
+
+So ~8 is the floor an accepted extraction has cleared, not a bar invented
+here. Measured against it, the two components a maintainability audit
+flagged next were both **rejected**:
+
+- `HeaderBranchChip` (663 lines) — rename dialog 43 lines / 10 crossing
+  identifiers = **4.3**, delete dialog 49 / 7 = **7.0**, both under the
+  floor. And the ratio is the smaller objection: its `SCOPE RESET` effect
+  clears eight state slices on `[workspaceId, path]`, so an extraction that
+  takes the state with it breaks the invariant, and one that leaves the
+  state behind is the prop-drilling those ratios are measuring. There is no
+  version that both pays and preserves.
+- `DaemonDetectedBanner` (741 lines) — only the LNA gate rows clear the bar
+  (57 lines / 3 = **19.0**); the port row is 7.8 and the failure notices
+  9.7. But its nine decision functions are ALREADY extracted into
+  `lib/` with their own tests (`decideConnectGate`, `explainProbeFailure`,
+  `deriveCapabilityTier`, `shouldShowDaemonCta`, …), so what is left is
+  wiring and copy. Of the 34 tests, 12 assert on those rows and every one
+  of them is about WHEN the row appears, not what it says — so the reader
+  the extraction would serve does not exist.
+
+Two things generalise. **Count the seam, not the props you would like to
+pass**: a fair count is every identifier the extracted body reads that is
+declared outside it, callbacks and setters included. And **ask what is left
+after the pure decisions are already extracted** — when the answer is
+wiring plus user-facing prose, a split relocates prose between files and
+reduces nothing a reader must hold. Both files are ~535 lines of code under
+a comment ratio of 15-22%; their size is where their explanations live.
+
 ## Before a big rewrite, ask whether the target is reachable
 
 Cheapest experiment in the batch: for every route still cutting through a

--- a/apps/web/src/components/HeaderBranchChip.tsx
+++ b/apps/web/src/components/HeaderBranchChip.tsx
@@ -221,6 +221,11 @@ export function HeaderBranchChip({
   // reason its own comment gives about a staged restore.
   //
   // Setters only, so this never re-runs for its own writes.
+  //
+  // It is also why the rename/delete/merge state stays in THIS component
+  // rather than in a dialog of its own: a reset that reaches eight slices
+  // cannot reach state a child owns, and a child that owns none is the
+  // prop-drilling instead.
   // SCOPE RESET — see scoped-screen-state.test.ts
   useEffect(() => {
     setPendingDelete(null)

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -87,6 +87,13 @@ interface DaemonDetectedBannerProps {
  * loopback fetches need no extra permission. On https: origins the browser's
  * Local Network Access prompt requires explicit user intent, so the probe
  * only runs from a click.
+ *
+ * Every decision it makes is a pure function in `lib/` with its own tests —
+ * `decideConnectGate`, `explainProbeFailure`, `deriveCapabilityTier`,
+ * `shouldShowDaemonCta`, `candidateBaseUrls`, `discoverDaemons`. What stays
+ * here is the wiring between them and the copy that explains the result to
+ * the user, which is why the file is long and why splitting the copy back
+ * out again reduces nothing a reader has to hold.
  */
 export function DaemonDetectedBanner({
   settingsStore,

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -88,12 +88,15 @@ interface DaemonDetectedBannerProps {
  * Local Network Access prompt requires explicit user intent, so the probe
  * only runs from a click.
  *
- * Every decision it makes is a pure function in `lib/` with its own tests —
- * `decideConnectGate`, `explainProbeFailure`, `deriveCapabilityTier`,
- * `shouldShowDaemonCta`, `candidateBaseUrls`, `discoverDaemons`. What stays
- * here is the wiring between them and the copy that explains the result to
- * the user, which is why the file is long and why splitting the copy back
- * out again reduces nothing a reader has to hold.
+ * The DOMAIN decisions — what a probe failure means, whether the browser can
+ * be asked, which tier a responder earns, whether the CTA is due — are pure
+ * functions in `lib/` with their own tests: `decideConnectGate`,
+ * `explainProbeFailure`, `deriveCapabilityTier`, `shouldShowDaemonCta`,
+ * `candidateBaseUrls`, `discoverDaemons`. What stays here is the orchestration
+ * between them (which row is showing, what the port field accepts, when to
+ * re-probe) and the copy that explains the outcome to the user. That is why
+ * the file is long, and why moving the copy into row components of its own
+ * reduces nothing a reader has to hold.
  */
 export function DaemonDetectedBanner({
   settingsStore,


### PR DESCRIPTION
## Summary

- A maintainability audit flagged `HeaderBranchChip` (663 lines) and `DaemonDetectedBanner` (741 lines) and explicitly deferred the decision to "the input-surface-vs-body measurement the rules require", which it had no budget to run. This is that measurement. The answer is **no** for both.
- Calibrated against the split this repo actually accepted rather than a bar invented for the occasion. `CanvasContextMenu`'s four extractions run **8.4 to 24.3** lines per crossing identifier (`canvas-menu-items` 117/14 = 8.4 is the floor an accepted extraction has cleared).
- The numbers, and the two rules they generalise into, go in the `measured-change` skill — where the next audit finds them instead of re-proposing. Each component keeps only the *enduring* half of the reason, at the place that would otherwise invite the split again.

### What the measurement said

| candidate | lines | seam | ratio | verdict |
|---|---|---|---|---|
| `DaemonDetectedBanner` LNA gate rows | 57 | 3 | 19.0 | clears the bar |
| `HeaderBranchChip` main dropdown | 168 | 16 | 10.5 | marginal |
| `DaemonDetectedBanner` failure notices | 58 | 6 | 9.7 | marginal |
| `DaemonDetectedBanner` banner rows | 88 | 10 | 8.8 | at the floor |
| `DaemonDetectedBanner` port row | 39 | 5 | 7.8 | under |
| `HeaderBranchChip` delete dialog | 49 | 7 | 7.0 | under |
| `HeaderBranchChip` rename dialog | 43 | 10 | 4.3 | well under |

`HeaderBranchChip`'s ratio is the *smaller* objection. Its `SCOPE RESET` effect clears eight state slices on `[workspaceId, path]`, so an extraction that takes the state with it breaks the invariant, and one that leaves the state behind is the prop-drilling those ratios are already measuring. There is no version that both pays and preserves.

`DaemonDetectedBanner` has one row that clears the bar, but its nine decision functions are **already** extracted into `lib/` with their own tests (`decideConnectGate`, `explainProbeFailure`, `deriveCapabilityTier`, `shouldShowDaemonCta`, `candidateBaseUrls`, `discoverDaemons`). What is left is wiring plus user-facing copy. Of its 34 tests, the 12 that touch those rows all assert **when** a row appears, not what it says — so the reader an extraction would serve does not exist.

### The two rules it generalises into

- **Count the seam, not the props you would like to pass** — every identifier the extracted body reads that is declared outside it, callbacks and setters included.
- **Ask what is left after the pure decisions are already extracted.** When the answer is wiring plus prose, a split relocates prose between files and reduces nothing a reader must hold. Both files are ~535 lines of *code* under a 15-22% comment ratio; their size is where their explanations live.

## Test plan

- [ ] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [x] `pnpm test` passes locally — no test changes; the two `.tsx` edits are comments only, and `pnpm biome check` reports no fixes on both.
- [x] Manual verification completed — n/a in the usual sense; the deliverable *is* the measurement, and every number above was taken by script against the real sources (seam counts from an identifier scan corrected by hand for prose and attribute false positives, comment ratios from a line classifier, test counts by splitting the suite per `it`).
- [ ] E2E coverage added or extended where applicable

`dev-rules-budget.test.ts` covers `.claude/rules/` only, not `.claude/skills/`, so the always-on context budget is untouched by the skill addition.

## Visual evidence

Visual evidence: none — no user-visible change. The diff is one skill document and two source comments; nothing rendered moves.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — n/a
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for evaluating component extractions using measurable criteria.
  - Clarified why branch rename, deletion, and merge state remains managed within the header component.
  - Expanded documentation for daemon detection banners, including their decision logic, wiring responsibilities, and displayed messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->