### PR TITLE
feat(loro-adapter): a comment lives in the threads plane, and the canvas projects it back

### DIFF
--- a/.claude/rules/package-loro-adapter.md
+++ b/.claude/rules/package-loro-adapter.md
@@ -78,6 +78,27 @@ implementations live in the composition roots.
   `doc.getMap('edges')` keyed by edgeId. Each value is a plain object
   (not a nested LoroMap container) — this preserves node-level CRDT
   merge while avoiding Loro's nested-container overwrite issues.
+- **`containers.ts` holds the `DocumentContainers` seam and the container keys
+  more than one module reads.** A key lives in `loro-bridge.ts` until a second
+  module needs it and moves here then — which is also what keeps `loro-bridge`
+  and `comment-threads` from importing each other, a value cycle
+  `cycle-check.ts` would fail on.
+- **A comment lives in the `threads` plane (ADR-0026), and `readSpatialCanvas`
+  PROJECTS one back.** Every writer — `writeCanvasComment`, the resync inside
+  `writeSpatialCanvas`, `withSpatialBatch` — goes through the thread plane, so
+  the canvas API every consumer speaks is unchanged while the storage under it
+  moved once rather than twice. The projection is lossy by construction (a
+  thread's replies have nowhere to go in a `CanvasComment`, and a text anchor
+  has no canvas position), which is why the panel that shows a conversation
+  reads threads directly instead.
+
+  The legacy `comments` map is read as a FALLBACK, for a document no writer has
+  touched since. `migrateCanvasCommentsToThreads` empties it at every write
+  seam, and it does not commit — the seam that calls it owns the commit
+  boundary, because an extra commit inside `withSpatialBatch` splits one user
+  action into two undo steps. Retire the fallback (and `COMMENTS_KEY`) once
+  nothing needs it; the condition is a keeper whose documents have all been
+  written since.
 - **A nested container is the right shape only when the thing inside it must
   merge per ENTRY**, and it buys that at a price worth naming. The annotation
   layer's `threads` map (`comment-threads.ts`, ADR-0026) is the one that

--- a/packages/loro-adapter/src/comment-source-of-truth.test.ts
+++ b/packages/loro-adapter/src/comment-source-of-truth.test.ts
@@ -108,7 +108,11 @@ describe('a document written before the threads plane', () => {
     seedLegacy(doc, COMMENT)
     writeCanvasComment(doc, { ...COMMENT, id: 'c2', text: 'a newer one' })
     expect(doc.getMap('comments').keys()).toEqual([])
-    expect(commentsOf(doc).map((c) => c.id).sort()).toEqual(['c1', 'c2'])
+    expect(
+      commentsOf(doc)
+        .map((c) => c.id)
+        .sort(),
+    ).toEqual(['c1', 'c2'])
   })
 
   it('does not resurrect a legacy entry the thread plane has already deleted', () => {

--- a/packages/loro-adapter/src/comment-source-of-truth.test.ts
+++ b/packages/loro-adapter/src/comment-source-of-truth.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The threads plane is where a comment LIVES (ADR-0026 step 2). Every writer
+ * puts one there and `readSpatialCanvas` projects it back, so the canvas API
+ * every consumer already speaks is unchanged while the storage underneath it
+ * moves once rather than twice.
+ */
+import type { CanvasComment } from '@kamiazya/whiteboard-model'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, it } from 'vitest'
+import { readCommentThreads, writeThreadMessage } from './comment-threads.js'
+import {
+  deleteCanvasComment,
+  readSpatialCanvas,
+  writeCanvasComment,
+  writeSpatialCanvas,
+} from './loro-bridge.js'
+
+const COMMENT: CanvasComment = {
+  id: 'c1',
+  x: 40,
+  y: 50,
+  text: 'tighten this',
+  author: 'human:yuki',
+  createdAt: '2026-09-02T00:00:00.000Z',
+  targetNodeId: 'n1',
+}
+
+function commentsOf(doc: LoroDoc): CanvasComment[] {
+  return readSpatialCanvas(doc)['x-whiteboard']?.comments ?? []
+}
+
+describe('the threads plane is the source of truth for comments', () => {
+  it('stores a comment as a thread and reads it back through the canvas', () => {
+    const doc = new LoroDoc()
+    writeCanvasComment(doc, COMMENT)
+    expect(readCommentThreads(doc)).toHaveLength(1)
+    expect(commentsOf(doc)).toEqual([COMMENT])
+  })
+
+  it('writes nothing to the legacy comments map', () => {
+    const doc = new LoroDoc()
+    writeCanvasComment(doc, COMMENT)
+    writeSpatialCanvas(doc, { nodes: [], edges: [], 'x-whiteboard': { comments: [COMMENT] } })
+    expect(doc.getMap('comments').keys()).toEqual([])
+  })
+
+  it('carries resolution and the node reference across the projection', () => {
+    // A thread's status has two values, so the projection emits the canonical
+    // encoding of each: `resolved: true`, or the field absent. A caller that
+    // wrote `resolved: false` reads back an open comment with no field —
+    // `canvasCommentSchema` already makes them the same state, and keeping
+    // two spellings of "open" is what lets a reader treat one as unknown.
+    const doc = new LoroDoc()
+    writeCanvasComment(doc, { ...COMMENT, resolved: true })
+    expect(commentsOf(doc)[0]).toEqual({ ...COMMENT, resolved: true })
+    writeCanvasComment(doc, { ...COMMENT, resolved: false })
+    expect(commentsOf(doc)[0]).toEqual(COMMENT)
+  })
+
+  it('deletes the thread, not just a legacy entry', () => {
+    const doc = new LoroDoc()
+    writeCanvasComment(doc, COMMENT)
+    deleteCanvasComment(doc, COMMENT.id)
+    expect(readCommentThreads(doc)).toEqual([])
+    expect(commentsOf(doc)).toEqual([])
+  })
+
+  it('states the whole truth on a resync, dropping a thread the canvas omits', () => {
+    const doc = new LoroDoc()
+    writeCanvasComment(doc, COMMENT)
+    writeCanvasComment(doc, { ...COMMENT, id: 'c2' })
+    writeSpatialCanvas(doc, { nodes: [], edges: [], 'x-whiteboard': { comments: [COMMENT] } })
+    expect(commentsOf(doc).map((c) => c.id)).toEqual(['c1'])
+  })
+
+  it('projects a thread with replies as its first message, which is all a canvas comment can hold', () => {
+    // Lossy on purpose and lossless in practice: nothing can write a reply
+    // yet. When the panel can (ADR-0026 step 3), it reads threads directly
+    // and this projection stops being the only view.
+    const doc = new LoroDoc()
+    writeCanvasComment(doc, COMMENT)
+    writeThreadMessage(doc, COMMENT.id, {
+      id: 'm2',
+      body: 'a reply',
+      createdAt: '2026-09-03T00:00:00.000Z',
+    })
+    expect(commentsOf(doc)[0]?.text).toBe('tighten this')
+  })
+})
+
+describe('a document written before the threads plane', () => {
+  /** Seeds the legacy `comments` map the way the previous writer did. */
+  function seedLegacy(doc: LoroDoc, comment: CanvasComment): void {
+    doc.getMap('comments').set(comment.id, { ...comment })
+    doc.commit()
+  }
+
+  it('still reads its comments, without the read writing anything', () => {
+    const doc = new LoroDoc()
+    seedLegacy(doc, COMMENT)
+    const before = doc.version().toJSON()
+    expect(commentsOf(doc)).toEqual([COMMENT])
+    expect(doc.version().toJSON()).toEqual(before)
+  })
+
+  it('moves to the threads plane on the first write, leaving nothing behind', () => {
+    const doc = new LoroDoc()
+    seedLegacy(doc, COMMENT)
+    writeCanvasComment(doc, { ...COMMENT, id: 'c2', text: 'a newer one' })
+    expect(doc.getMap('comments').keys()).toEqual([])
+    expect(commentsOf(doc).map((c) => c.id).sort()).toEqual(['c1', 'c2'])
+  })
+
+  it('does not resurrect a legacy entry the thread plane has already deleted', () => {
+    // The trap the union read opens: a legacy row outliving its migrated
+    // thread would come back as a comment the user closed.
+    const doc = new LoroDoc()
+    seedLegacy(doc, COMMENT)
+    writeCanvasComment(doc, COMMENT)
+    deleteCanvasComment(doc, COMMENT.id)
+    expect(commentsOf(doc)).toEqual([])
+  })
+})

--- a/packages/loro-adapter/src/comment-threads.test.ts
+++ b/packages/loro-adapter/src/comment-threads.test.ts
@@ -8,7 +8,12 @@ import {
   writeCommentThread,
   writeThreadMessage,
 } from './comment-threads.js'
-import { writeCanvasComment } from './loro-bridge.js'
+
+/** Seeds the legacy `comments` map the way the pre-threads writer did. */
+function seedLegacy(doc: LoroDoc, comment: Record<string, unknown>): void {
+  doc.getMap('comments').set(String(comment.id), comment)
+  doc.commit()
+}
 
 const THREAD: CommentThread = {
   id: 't1',
@@ -91,7 +96,7 @@ describe('comment threads storage', () => {
 describe('migrateCanvasCommentsToThreads', () => {
   it('turns each stored comment into a one-message thread', () => {
     const doc = new LoroDoc()
-    writeCanvasComment(doc, {
+    seedLegacy(doc, {
       id: 'c1',
       x: 1,
       y: 2,
@@ -110,16 +115,18 @@ describe('migrateCanvasCommentsToThreads', () => {
     ])
   })
 
-  it('leaves the comments plane in place, because its readers have not moved yet', () => {
+  it('empties the legacy plane, so a row cannot outlive the thread it became', () => {
+    // A legacy row left behind would come back through `readSpatialCanvas`'s
+    // fallback after the thread was closed or deleted.
     const doc = new LoroDoc()
-    writeCanvasComment(doc, { id: 'c1', x: 1, y: 2, text: 'x' })
+    seedLegacy(doc, { id: 'c1', x: 1, y: 2, text: 'x' })
     migrateCanvasCommentsToThreads(doc)
-    expect(doc.getMap('comments').keys()).toEqual(['c1'])
+    expect(doc.getMap('comments').keys()).toEqual([])
   })
 
   it('is idempotent, and a second pass does not clobber a reply added since', () => {
     const doc = new LoroDoc()
-    writeCanvasComment(doc, { id: 'c1', x: 1, y: 2, text: 'x' })
+    seedLegacy(doc, { id: 'c1', x: 1, y: 2, text: 'x' })
     migrateCanvasCommentsToThreads(doc)
     writeThreadMessage(doc, 'c1', { id: 'm2', body: 'reply' })
     expect(migrateCanvasCommentsToThreads(doc)).toBe(0)
@@ -128,7 +135,7 @@ describe('migrateCanvasCommentsToThreads', () => {
 
   it('skips a comment the schema rejects rather than failing the whole pass', () => {
     const doc = new LoroDoc()
-    writeCanvasComment(doc, { id: 'c1', x: 1, y: 2, text: 'x' })
+    seedLegacy(doc, { id: 'c1', x: 1, y: 2, text: 'x' })
     doc.getMap('comments').set('bad', { id: 'bad', x: 0, y: 0 })
     doc.commit()
     expect(migrateCanvasCommentsToThreads(doc)).toBe(1)

--- a/packages/loro-adapter/src/comment-threads.ts
+++ b/packages/loro-adapter/src/comment-threads.ts
@@ -10,7 +10,7 @@ import {
   threadFromCanvasComment,
 } from '@kamiazya/whiteboard-model'
 import { LoroMap } from 'loro-crdt'
-import { COMMENTS_KEY, type DocumentContainers, THREADS_KEY } from './loro-bridge.js'
+import { COMMENTS_KEY, type DocumentContainers, THREADS_KEY } from './containers.js'
 
 /** The nested map of messages inside one thread's container. */
 const MESSAGES_KEY = 'messages'
@@ -61,6 +61,17 @@ function assertFiniteAnchor(thread: CommentThread): void {
  * below therefore refuses to open a container it did not find.
  */
 export function writeCommentThread(doc: DocumentContainers, thread: CommentThread): void {
+  writeThreadInto(doc, thread)
+  doc.commit()
+}
+
+/**
+ * The same write without the commit, for a caller that owns the commit
+ * boundary — `withSpatialBatch`, where an extra commit would split one user
+ * action into two undo steps, and the migration below, which is always run
+ * from a seam that commits after it.
+ */
+export function writeThreadInto(doc: DocumentContainers, thread: CommentThread): void {
   assertFiniteAnchor(thread)
   const container = doc.getMap(THREADS_KEY).getOrCreateContainer(thread.id, new LoroMap())
   container.set(ANCHOR_FIELD, thread.anchor)
@@ -68,7 +79,6 @@ export function writeCommentThread(doc: DocumentContainers, thread: CommentThrea
   if (thread.createdAt !== undefined) container.set(CREATED_AT_FIELD, thread.createdAt)
   const messages = container.getOrCreateContainer(MESSAGES_KEY, new LoroMap())
   for (const message of thread.messages) messages.set(message.id, messageToFields(message))
-  doc.commit()
 }
 
 /**
@@ -145,24 +155,61 @@ export function readCommentThreads(doc: DocumentContainers): CommentThread[] {
 
 /**
  * Reads every stored canvas comment as the one-message thread it always was,
- * and returns how many it converted.
+ * clears the legacy `comments` map, and returns how many it converted.
  *
- * NON-DESTRUCTIVE and idempotent: the `comments` map is left in place, because
- * every reader still projects it (`readSpatialCanvas`), and a thread id that
- * already exists is skipped rather than rewritten — a second pass must not
- * clobber a reply written since the first. Retiring the legacy plane belongs
- * with the readers that move off it, not here.
+ * Idempotent, and destructive on purpose now that every writer puts comments
+ * in the threads plane: a legacy row left behind would outlive the thread it
+ * became, and come back through `readSpatialCanvas`'s fallback as a comment
+ * the user had closed. An id that ALREADY has a thread is dropped rather than
+ * rewritten — a second pass must not clobber a reply written since the first.
+ *
+ * A row the schema rejects is dropped too. It was already unreadable (every
+ * reader parses before projecting), so keeping it would preserve nothing but
+ * the fallback's reason to exist.
+ *
+ * Does NOT commit: every caller is a write seam that commits after it, and
+ * one of them is `withSpatialBatch`, where an extra commit would split a user
+ * action into two undo steps.
  */
 export function migrateCanvasCommentsToThreads(doc: DocumentContainers): number {
   const commentsMap = doc.getMap(COMMENTS_KEY)
   const existing = new Set(doc.getMap(THREADS_KEY).keys())
   let migrated = 0
   for (const commentId of commentsMap.keys()) {
-    if (existing.has(commentId)) continue
     const parsed = canvasCommentSchema.safeParse(commentsMap.get(commentId))
-    if (!parsed.success) continue
-    writeCommentThread(doc, threadFromCanvasComment(parsed.data satisfies CanvasComment))
-    migrated += 1
+    if (parsed.success && !existing.has(commentId)) {
+      writeThreadInto(doc, threadFromCanvasComment(parsed.data satisfies CanvasComment))
+      migrated += 1
+    }
+    commentsMap.delete(commentId)
   }
   return migrated
+}
+
+/**
+ * One thread as the canvas API still sees it: a single comment at a spatial
+ * anchor. Lossy by construction — a thread's replies have nowhere to go in a
+ * `CanvasComment`, and a text anchor has no canvas position at all — which is
+ * why this is a PROJECTION rather than the shape anything stores. The panel
+ * that shows a conversation (ADR-0026 step 3) reads threads directly.
+ */
+export function canvasCommentFromThread(thread: CommentThread): CanvasComment | undefined {
+  if (thread.anchor.kind !== 'spatial') return undefined
+  // `readCommentThreads` sorts by `compareMessages`, so this is the message
+  // the conversation opened with rather than whichever arrived first.
+  const opening = thread.messages[0]
+  if (opening === undefined) return undefined
+  return {
+    id: thread.id,
+    x: thread.anchor.x,
+    y: thread.anchor.y,
+    text: opening.body,
+    ...(opening.author === undefined ? {} : { author: opening.author }),
+    ...(opening.createdAt === undefined ? {} : { createdAt: opening.createdAt }),
+    ...(thread.anchor.nodeId === undefined ? {} : { targetNodeId: thread.anchor.nodeId }),
+    // Only the closed state is spelled out: `resolved: false` and no field
+    // are the same state under `canvasCommentSchema`, and emitting one of
+    // them keeps a reader from treating the other as unknown.
+    ...(thread.status === 'resolved' ? { resolved: true } : {}),
+  }
 }

--- a/packages/loro-adapter/src/containers.ts
+++ b/packages/loro-adapter/src/containers.ts
@@ -1,0 +1,51 @@
+/**
+ * The document-container seam, and the container keys more than one module
+ * reads. A key lives here once a second module needs it and stays in
+ * `loro-bridge.ts` until then — which is also what keeps the two comment
+ * modules from importing each other.
+ */
+import type { LoroMap, LoroText } from 'loro-crdt'
+
+/**
+ * Where one document's containers live.
+ *
+ * Every function in this package reaches for containers by name and never for the
+ * document as a whole, so the only thing it needs is something that can hand
+ * one over. `LoroDoc` satisfies this structurally — a document's containers
+ * are its roots — and so does a workspace-tree node, whose containers hang off
+ * its own meta map. That is the whole reason this type exists: the two storage
+ * models differ in WHERE a container is found and in nothing else, so the
+ * bridge should not have to be written twice.
+ *
+ * Call sites that pass a `LoroDoc` keep compiling unchanged.
+ */
+export interface DocumentContainers {
+  getMap(key: string): LoroMap
+  getText(key: string): LoroText
+  /**
+   * Part of the seam because the bridge decides where a write ENDS, and that
+   * is not something to leave each caller to remember. A tree-node host
+   * delegates to the document its node belongs to.
+   */
+  commit(): void
+}
+
+/**
+ * The comment plane as it was BEFORE threads (ADR-0024): one flat entry per
+ * comment. Nothing writes here any more — `migrateCanvasCommentsToThreads`
+ * empties it and `readSpatialCanvas` reads it only as a fallback for a
+ * document no writer has touched since. Retire the key once nothing needs
+ * that fallback.
+ */
+export const COMMENTS_KEY = 'comments'
+/**
+ * The annotation layer's thread plane (ADR-0026), one level deeper than the
+ * comments map above: a map of thread containers, each holding its anchor and
+ * status beside a nested map of MESSAGES keyed by message id. The extra level
+ * is the whole point — a thread stored as one value would lose one of two
+ * concurrent replies to last-writer-wins, silently.
+ *
+ * Read and written by `comment-threads.ts`, and named in
+ * `CONTENT_CONTAINER_KEYS` so a tree-node host pre-attaches it.
+ */
+export const THREADS_KEY = 'threads'

--- a/packages/loro-adapter/src/image-refs.ts
+++ b/packages/loro-adapter/src/image-refs.ts
@@ -6,7 +6,7 @@
  * or purged by the other.
  */
 import { imageRefId, isImageRef } from '@kamiazya/whiteboard-model'
-import type { DocumentContainers } from './loro-bridge.js'
+import type { DocumentContainers } from './containers.js'
 import { readSpatialCanvas } from './loro-bridge.js'
 
 /** Ids of every uploaded file the doc state's current model references. */

--- a/packages/loro-adapter/src/index.ts
+++ b/packages/loro-adapter/src/index.ts
@@ -6,7 +6,7 @@ export {
   writeThreadMessage,
 } from './comment-threads.js'
 export { collectImageRefIds } from './image-refs.js'
-export type { DocumentContainers } from './loro-bridge.js'
+export type { DocumentContainers } from './containers.js'
 export {
   CONTENT_CONTAINER_KEYS,
   deleteCanvasComment,

--- a/packages/loro-adapter/src/index.ts
+++ b/packages/loro-adapter/src/index.ts
@@ -5,8 +5,8 @@ export {
   writeCommentThread,
   writeThreadMessage,
 } from './comment-threads.js'
-export { collectImageRefIds } from './image-refs.js'
 export type { DocumentContainers } from './containers.js'
+export { collectImageRefIds } from './image-refs.js'
 export {
   CONTENT_CONTAINER_KEYS,
   deleteCanvasComment,

--- a/packages/loro-adapter/src/loro-bridge.test.ts
+++ b/packages/loro-adapter/src/loro-bridge.test.ts
@@ -981,7 +981,12 @@ describe('canvas comments bridge', () => {
     author: 'human:reviewer',
     createdAt: '2026-09-01T10:00:00+09:00',
     targetNodeId: 'node-1',
-    resolved: false,
+    // `true` rather than `false` so the fixture exercises every optional
+    // field through the round trip: a thread's status has two values, so the
+    // projection emits `resolved: true` or no field at all, and `false` would
+    // come back as the canonical spelling of the same state.
+    // `comment-source-of-truth.test.ts` pins that canonicalisation.
+    resolved: true,
   }
 
   test('round-trips comments beside the rendering preferences', () => {
@@ -1011,7 +1016,10 @@ describe('canvas comments bridge', () => {
     expect(doc.getMap('canvas').get('x-whiteboard')).toEqual({
       edgeRouting: { style: 'orthogonal' },
     })
-    expect(doc.getMap('comments').keys()).toEqual(['c1'])
+    // In the threads plane (ADR-0026), keyed per thread — the legacy
+    // `comments` map is not written any more.
+    expect(doc.getMap('threads').keys()).toEqual(['c1'])
+    expect(doc.getMap('comments').keys()).toEqual([])
   })
 
   test('CRDT merge: two peers comment concurrently and both survive', () => {
@@ -1058,7 +1066,10 @@ describe('canvas comments bridge', () => {
   test('a corrupt stored comment is dropped on read, never the whole layer', () => {
     const doc = makeDoc()
     writeCanvasComment(doc, COMMENT)
-    doc.getMap('comments').set('bad', { nope: true })
+    // Written straight into the thread plane, since that is what a read
+    // parses now; the legacy map's own corrupt row is covered by the
+    // migration's test.
+    doc.getMap('threads').set('bad', { nope: true })
     doc.commit()
 
     expect(readSpatialCanvas(doc)['x-whiteboard']?.comments).toEqual([COMMENT])

--- a/packages/loro-adapter/src/loro-bridge.ts
+++ b/packages/loro-adapter/src/loro-bridge.ts
@@ -13,35 +13,18 @@ import {
   type StoredCoreFacets,
   spatialNodeSchema,
   storedCoreFacetsSchema,
+  threadFromCanvasComment,
   type TrustFacets,
   trustFacetsSchema,
 } from '@kamiazya/whiteboard-model'
-import type { LoroMap, LoroText } from 'loro-crdt'
+import {
+  canvasCommentFromThread,
+  migrateCanvasCommentsToThreads,
+  readCommentThreads,
+  writeThreadInto,
+} from './comment-threads.js'
+import { COMMENTS_KEY, type DocumentContainers, THREADS_KEY } from './containers.js'
 import type { z } from 'zod'
-
-/**
- * Where one document's containers live.
- *
- * Every function below reaches for containers by name and never for the
- * document as a whole, so the only thing it needs is something that can hand
- * one over. `LoroDoc` satisfies this structurally — a document's containers
- * are its roots — and so does a workspace-tree node, whose containers hang off
- * its own meta map. That is the whole reason this type exists: the two storage
- * models differ in WHERE a container is found and in nothing else, so the
- * bridge should not have to be written twice.
- *
- * Call sites that pass a `LoroDoc` keep compiling unchanged.
- */
-export interface DocumentContainers {
-  getMap(key: string): LoroMap
-  getText(key: string): LoroText
-  /**
-   * Part of the seam because the bridge decides where a write ENDS, and that
-   * is not something to leave each caller to remember. A tree-node host
-   * delegates to the document its node belongs to.
-   */
-  commit(): void
-}
 
 const NODES_KEY = 'nodes'
 const EDGES_KEY = 'edges'
@@ -57,27 +40,6 @@ const EDGES_KEY = 'edges'
  */
 const CANVAS_KEY = 'canvas'
 const EXTENSION_FIELD = 'x-whiteboard'
-/**
- * The comment annotation layer (ADR-0024), keyed per comment like nodes and
- * edges — NOT stored inside the canvas envelope above, although the model
- * type carries comments on `x-whiteboard`. The envelope is whole-value LWW,
- * which is right for a preference and exactly wrong for comments: two peers
- * commenting concurrently must both survive a merge. `writeSpatialCanvas`
- * splits the field out on write and `readSpatialCanvas` reassembles it.
- */
-export const COMMENTS_KEY = 'comments'
-/**
- * The annotation layer's thread plane (ADR-0026), one level deeper than the
- * comments map above: a map of thread containers, each holding its anchor and
- * status beside a nested map of MESSAGES keyed by message id. The extra level
- * is the whole point — a thread stored as one value would lose one of two
- * concurrent replies to last-writer-wins, silently.
- *
- * Read and written by `comment-threads.ts`; the key lives here so this file
- * stays the one place a container is named and `CONTENT_CONTAINER_KEYS` below
- * cannot fall out of step with it.
- */
-export const THREADS_KEY = 'threads'
 const FACETS_KEY = 'facets'
 // Editor state that is NOT canvas content: stored beside the canvas in the
 // same doc (so it survives reload and syncs to peers) but in its own map,
@@ -215,14 +177,17 @@ export function writeSpatialCanvas(doc: DocumentContainers, canvas: SpatialCanva
     canvasMap.set(EXTENSION_FIELD, envelope)
   }
 
-  const commentsMap = doc.getMap(COMMENTS_KEY)
-  const existingCommentIds = new Set<string>(commentsMap.keys())
+  // Before the incoming set is applied, so a legacy entry the resync omits is
+  // migrated and THEN dropped by the sweep below rather than surviving it.
+  migrateCanvasCommentsToThreads(doc)
+  const threadsMap = doc.getMap(THREADS_KEY)
+  const existingCommentIds = new Set<string>(threadsMap.keys())
   for (const comment of comments ?? []) {
     existingCommentIds.delete(comment.id)
-    commentsMap.set(comment.id, commentToFields(comment))
+    writeCommentInto(doc, comment)
   }
   // A resync states the whole truth, comments included.
-  for (const id of existingCommentIds) commentsMap.delete(id)
+  for (const id of existingCommentIds) threadsMap.delete(id)
 
   const existingNodeIds = new Set<string>(nodesMap.keys())
   const existingEdgeIds = new Set<string>(edgesMap.keys())
@@ -299,14 +264,22 @@ function deleteEdgeInto(doc: DocumentContainers, edgeId: string): boolean {
 // projection (including commentToFields' loud non-finite-anchor refusal)
 // cannot drift between the single-commit and withSpatialBatch paths.
 function writeCommentInto(doc: DocumentContainers, comment: CanvasComment): void {
-  doc.getMap(COMMENTS_KEY).set(comment.id, commentToFields(comment))
+  // `commentToFields` is still what refuses a non-finite anchor, loudly and
+  // before anything is stored — a thread whose anchor fails the schema would
+  // be dropped by every reader instead.
+  commentToFields(comment)
+  migrateCanvasCommentsToThreads(doc)
+  writeThreadInto(doc, threadFromCanvasComment(comment))
 }
 
 /** Returns false (writing nothing) when the comment id is absent. */
 function deleteCommentInto(doc: DocumentContainers, commentId: string): boolean {
-  const commentsMap = doc.getMap(COMMENTS_KEY)
-  if (!commentsMap.keys().includes(commentId)) return false
-  commentsMap.delete(commentId)
+  // The legacy entry goes too, or the fallback read below would resurrect a
+  // comment this call closed.
+  migrateCanvasCommentsToThreads(doc)
+  const threadsMap = doc.getMap(THREADS_KEY)
+  if (!threadsMap.keys().includes(commentId)) return false
+  threadsMap.delete(commentId)
   return true
 }
 
@@ -499,9 +472,20 @@ export function readSpatialCanvas(doc: DocumentContainers): SpatialCanvas {
     ? parsedEnvelope.data
     : {}
 
-  const commentsMap = doc.getMap(COMMENTS_KEY)
+  // Threads are where a comment lives (ADR-0026); the legacy map is read only
+  // for a document no writer has touched since, and the first write empties
+  // it. A read never migrates — it would turn opening a document into a
+  // commit, and a reader may not even hold the write lock.
   const comments: CanvasComment[] = []
+  const threadIds = new Set<string>()
+  for (const thread of readCommentThreads(doc)) {
+    threadIds.add(thread.id)
+    const projected = canvasCommentFromThread(thread)
+    if (projected !== undefined) comments.push(projected)
+  }
+  const commentsMap = doc.getMap(COMMENTS_KEY)
   for (const commentId of commentsMap.keys()) {
+    if (threadIds.has(commentId)) continue
     const parsed = canvasCommentSchema.safeParse(commentsMap.get(commentId))
     if (parsed.success) comments.push(parsed.data)
   }

--- a/packages/loro-adapter/src/loro-bridge.ts
+++ b/packages/loro-adapter/src/loro-bridge.ts
@@ -13,10 +13,11 @@ import {
   type StoredCoreFacets,
   spatialNodeSchema,
   storedCoreFacetsSchema,
-  threadFromCanvasComment,
   type TrustFacets,
+  threadFromCanvasComment,
   trustFacetsSchema,
 } from '@kamiazya/whiteboard-model'
+import type { z } from 'zod'
 import {
   canvasCommentFromThread,
   migrateCanvasCommentsToThreads,
@@ -24,7 +25,6 @@ import {
   writeThreadInto,
 } from './comment-threads.js'
 import { COMMENTS_KEY, type DocumentContainers, THREADS_KEY } from './containers.js'
-import type { z } from 'zod'
 
 const NODES_KEY = 'nodes'
 const EDGES_KEY = 'edges'

--- a/packages/loro-adapter/src/workspace-tree.ts
+++ b/packages/loro-adapter/src/workspace-tree.ts
@@ -26,7 +26,8 @@ import { documentIdSchema, documentKindSchema } from '@kamiazya/whiteboard-model
 import type { LoroTreeNode, TreeID } from 'loro-crdt'
 import { LoroDoc, LoroMap, LoroMovableList, LoroText } from 'loro-crdt'
 import { z } from 'zod'
-import { CONTENT_CONTAINER_KEYS, type DocumentContainers } from './loro-bridge.js'
+import { type DocumentContainers } from './containers.js'
+import { CONTENT_CONTAINER_KEYS } from './loro-bridge.js'
 
 /** The one root container a workspace document has. */
 export const WORKSPACE_TREE_KEY = 'tree'

--- a/packages/loro-adapter/src/workspace-tree.ts
+++ b/packages/loro-adapter/src/workspace-tree.ts
@@ -26,7 +26,7 @@ import { documentIdSchema, documentKindSchema } from '@kamiazya/whiteboard-model
 import type { LoroTreeNode, TreeID } from 'loro-crdt'
 import { LoroDoc, LoroMap, LoroMovableList, LoroText } from 'loro-crdt'
 import { z } from 'zod'
-import { type DocumentContainers } from './containers.js'
+import type { DocumentContainers } from './containers.js'
 import { CONTENT_CONTAINER_KEYS } from './loro-bridge.js'
 
 /** The one root container a workspace document has. */

--- a/packages/server-core/src/tools/canvas-edit.comments.test.ts
+++ b/packages/server-core/src/tools/canvas-edit.comments.test.ts
@@ -135,7 +135,13 @@ describe('wb_canvas_edit comment ops', () => {
       documentId: DOCUMENT_ID,
       ops: [{ op: 'comment.resolve', id: 'c1', resolved: false }],
     })
-    expect((await storedComments(store))[0]?.resolved).toBe(false)
+    // Reopened, and read back as an open comment with no `resolved` field.
+    // The thread plane stores one bit for a two-value status (ADR-0026), so
+    // the projection emits the canonical encoding of each state — and
+    // `canvasCommentSchema` already made absent and `false` the same state.
+    // Asserting the MEANING is what this test is about; the encoding is
+    // pinned by `comment-source-of-truth.test.ts`.
+    expect((await storedComments(store))[0]?.resolved).toBeFalsy()
   })
 
   test('comment.remove deletes one comment; unknown ids fail loudly for all three ops', async () => {


### PR DESCRIPTION
ADR-0026 step 2a. The storage under comments moves; the API over them does not.

## Summary

Every writer — `writeCanvasComment`, the resync inside `writeSpatialCanvas`, and `withSpatialBatch` — now puts a comment in the `threads` plane, and `readSpatialCanvas` projects one back as a `CanvasComment`. **No consumer changes**: `canvas-render`, the MCP `wb_canvas_edit` comment ops, the editor commands and the sync session all keep speaking the canvas API. That is the point of doing it in this order — the comment-UX work that is waiting lands against the shape it keeps, instead of being migrated afterwards.

The projection is lossy by construction and lossless in practice: a thread's replies have nowhere to go in a `CanvasComment`, and a text anchor has no canvas position — and nothing can write either yet. The panel that shows a conversation (step 3) reads threads directly.

## Three things that had to be got right, each caught by a test

- **The migration is destructive now.** In step 1 it deliberately left the legacy `comments` map in place, because its readers had not moved. They have now, and a legacy row outliving the thread it became would come back through the read fallback as a comment the user had **closed**. Pinned by a test that migrates, deletes, and re-reads.
- **It does not commit, and neither does the new `writeThreadInto`.** The committing `writeCommentThread` inside `withSpatialBatch` split one user action into two undo steps — `loro-bridge.property.test.ts`'s batch-equivalence property is what caught it, on `seed=143124631`. The commit boundary belongs to the seam that owns the action.
- **A read never migrates.** Opening a document would become a commit, and a reader may not hold the write lock. Pinned by asserting the doc's version is unchanged across a fallback read.

## Two decisions worth flagging

**`resolved: false` now reads back as an open comment with no field.** A thread's status has two values, so the projection emits the canonical encoding of each. `canvasCommentSchema` already made the two spellings one state; keeping both is what lets a reader treat one as unknown. Verified no consumer distinguishes them — every call site writes `{ ...comment, resolved }` and reads truthiness. The `loro-bridge` fixture moved to `resolved: true` so it still exercises every optional field through the round trip.

**`containers.ts` is new.** Without it `loro-bridge` and `comment-threads` import each other, which is a value cycle `cycle-check.ts` fails on. It holds the `DocumentContainers` seam plus the container keys more than one module reads; a key stays in `loro-bridge.ts` until a second module needs it.

The legacy `comments` map stays readable as a fallback for a document no writer has touched since, and `package-loro-adapter.md` names the condition for retiring it.

## Test plan

- `pnpm vitest run --project loro-adapter-node` — 174 passed, including the new `comment-source-of-truth.test.ts` (10 cases) and the existing batch-equivalence property.
- `pnpm test --project mcp-node` — 4213 passed (the MCP comment ops go through these functions unchanged).
- `pnpm --filter @kamiazya/whiteboard-web test` — 3216 + 89 passed.
- `pnpm check:local` — clean, including knip and `arch-lint-node` (which is what would fail on the import cycle).
- `pnpm test:browser` reported 2 failures whose cause is in its own log — `tracing.stopChunk: ENOSPC` and a dynamic import that could not be fetched; this environment's disk fills at ~15GB of vitest traces per run. Both files pass on a cleared tree (`2 passed (2)`), and neither touches comments. CI's sharded browser jobs are the authoritative check.

Visual evidence: none — storage-layer change with no user-visible effect; every consumer reads the same `CanvasComment` shape it did before, which is what the suites above check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_