### PR TITLE
fix(search): a canvas is findable by the url of a link node it holds

### DIFF
--- a/.claude/rules/package-search.md
+++ b/.claude/rules/package-search.md
@@ -14,8 +14,13 @@ paths:
 - BM25 ranking over a caller-supplied corpus (`fullTextSearch`), plus the
   match excerpts a result row shows (`snippetAround`).
 - **The one definition of what text a document contributes**
-  (`searchableTexts`): a markdown body, or a canvas's node texts, group
-  labels and edge labels.
+  (`searchableTexts`): a markdown body, or a canvas's node texts, link urls,
+  group labels and edge labels. A `file` node contributes NOTHING, and that
+  is a decision rather than a gap — its readable label is the RESOLVED
+  reference's, which needs a lookup this package deliberately does not take,
+  and the raw `node.file` is an opaque id. The node loop is an exhaustive
+  `switch` with a `satisfies never`, so a fifth `SpatialNode` kind fails the
+  build rather than being silently dropped from search.
 
 ## What does NOT belong here
 

--- a/packages/search/src/searchable-texts.test.ts
+++ b/packages/search/src/searchable-texts.test.ts
@@ -1,5 +1,6 @@
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { describe, expect, it } from 'vitest'
+import { fullTextSearch } from './full-text.js'
 import { searchableTexts } from './searchable-texts.js'
 
 describe('searchableTexts', () => {
@@ -22,11 +23,90 @@ describe('searchableTexts', () => {
     expect(searchableTexts({ kind: 'spatial', canvas })).toEqual(['Auth flow', 'Backlog', 'blocks'])
   })
 
+  // The url is exactly what canvas-render's `labelOf` draws for a link node,
+  // so it is content the reader can see and search for.
+  it('gives a canvas a link node’s url', () => {
+    const canvas: SpatialCanvas = {
+      nodes: [
+        {
+          id: 'l1',
+          type: 'link',
+          url: 'https://example.com/runbooks/oncall',
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 40,
+        },
+      ],
+      edges: [],
+    }
+    expect(searchableTexts({ kind: 'spatial', canvas })).toEqual([
+      'https://example.com/runbooks/oncall',
+    ])
+  })
+
+  // Not an oversight. A file node's readable label is `resolved?.label` —
+  // behind the reference resolver this package deliberately does not take —
+  // and the raw `node.file` is an opaque id, so indexing it would add noise
+  // rather than recall.
+  it('leaves a file node out, because its readable label is not in the content', () => {
+    const canvas: SpatialCanvas = {
+      nodes: [
+        {
+          id: 'f1',
+          type: 'file',
+          file: '01JBQ7Z2K3M4N5P6Q7R8S9T0V1',
+          x: 0,
+          y: 0,
+          width: 1,
+          height: 1,
+        },
+      ],
+      edges: [],
+    }
+    expect(searchableTexts({ kind: 'spatial', canvas })).toEqual([])
+  })
+
   it('leaves out what carries no label', () => {
     const canvas: SpatialCanvas = {
       nodes: [{ id: 'g1', type: 'group', x: 0, y: 0, width: 10, height: 10 }],
       edges: [{ id: 'e1', fromNode: 'g1', toNode: 'g1' }],
     }
     expect(searchableTexts({ kind: 'spatial', canvas })).toEqual([])
+  })
+})
+
+/**
+ * What the projection is FOR. `searchableTexts` returning a string proves
+ * only that the string is in an array; whether a user can find the document
+ * by it depends on the tokenizer, which splits on everything that is not a
+ * letter or a digit. Joining the two here is still the nearest layer — both
+ * halves live in this package — and it is the only place the recall claim is
+ * actually asserted.
+ */
+describe('a canvas through searchableTexts and into fullTextSearch', () => {
+  it('finds a document by the host of a link node it holds', () => {
+    const canvas: SpatialCanvas = {
+      nodes: [
+        {
+          id: 'l1',
+          type: 'link',
+          url: 'https://runbooks.example.com/oncall',
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 40,
+        },
+      ],
+      edges: [],
+    }
+    const results = fullTextSearch(
+      [
+        { documentId: 'a', path: 'a', texts: searchableTexts({ kind: 'spatial', canvas }) },
+        { documentId: 'b', path: 'b', texts: ['nothing to do with any of this'] },
+      ],
+      'runbooks',
+    )
+    expect(results.map((result) => result.documentId)).toEqual(['a'])
   })
 })

--- a/packages/search/src/searchable-texts.ts
+++ b/packages/search/src/searchable-texts.ts
@@ -10,8 +10,11 @@ export type SearchableContent =
  *
  * A canvas means through its RELATIONS, so edge labels are content rather
  * than decoration; group labels name a region the way a heading names a
- * section. Each string stays separate so a snippet can say WHICH source
- * matched instead of splicing two unrelated sentences together.
+ * section. The test for a node kind is whether the reader can SEE the text
+ * on the canvas — which is why a link contributes its url and a file
+ * contributes nothing (see the branches below). Each string stays separate
+ * so a snippet can say WHICH source matched instead of splicing two
+ * unrelated sentences together.
  *
  * It lives here, beside the ranking, because the daemon and the browser
  * must answer a query the same way: a second definition of "the text" is a
@@ -33,8 +36,31 @@ export function searchableTexts(content: SearchableContent): string[] {
   if (content.kind === 'markdown') return [content.body]
   const texts: string[] = []
   for (const node of content.canvas.nodes) {
-    if (node.type === 'text') texts.push(node.text)
-    if (node.type === 'group' && node.label !== undefined) texts.push(node.label)
+    switch (node.type) {
+      case 'text':
+        texts.push(node.text)
+        break
+      case 'link':
+        // The url IS the label canvas-render draws for a link node, so it is
+        // text the reader can see on the canvas and expects to find by.
+        texts.push(node.url)
+        break
+      case 'group':
+        if (node.label !== undefined) texts.push(node.label)
+        break
+      case 'file':
+        // Nothing, deliberately. A file node's readable label is the resolved
+        // reference's, and resolving needs a lookup this package does not take
+        // (see the note above about content already READ). The raw `node.file`
+        // is an opaque id: indexing it would add a token no one will ever
+        // query, and match a document for a string it does not display.
+        break
+      default:
+        // A fifth node kind has to answer this question rather than fall
+        // through it — an exhaustive switch is what makes forgetting one a
+        // build failure instead of a silent gap in search.
+        node satisfies never
+    }
   }
   for (const edge of content.canvas.edges) if (edge.label !== undefined) texts.push(edge.label)
   return texts


### PR DESCRIPTION
## Summary

- A `link` node's `url` is exactly the text `canvas-render`'s `labelOf` draws for it — the reader sees it on the canvas — and it is present in the content, yet `searchableTexts` contributed nothing for it. A canvas whose only content was a link could not be found by its url, in either keeper.
- A `file` node stays out, and that is now a decision on the record rather than a gap. Its readable label is the **resolved** reference's, behind a lookup this package deliberately does not take, and the raw `node.file` is an opaque id — indexing it would add a token nobody queries and match a document for a string it does not display.
- The two independent `if`s become one exhaustive `switch` with `satisfies never`, so a fifth `SpatialNode` kind has to answer the question instead of falling through it.

### Why a switch and not a coverage ledger

`.claude/rules/coverage-ledger.md` says it itself: *"If forgetting one already fails a typecheck ... that is a better guard than this and you are done."* The union is closed by JSON Canvas 1.0 rather than growing, and a build failure beats a table nobody reads.

### This function is also the embedding input, so it was measured

`package-search.md` warns that `searchableTexts` decides two things — BM25's tokens **and** what `ContentFactsCache.vectorsFor` embeds — so a change made with only lexical search in mind moves semantic results silently. Checked rather than argued: `packages/server-core/src/search/search-corpus.ts` contains zero `link` and zero `file` nodes (its `CorpusDocument` type cannot express them), so `search-quality.test.ts`'s exactly-pinned summary and miss list cannot move. Re-run: unchanged.

## Test plan

- [x] New or updated tests added — three in `search-node`: a link node contributes its url; a file node contributes nothing (with the reason in the test name); and a canvas driven **through `fullTextSearch`** is returned for a query naming the link's host. That third one exists because the first two only prove a string is in an array — whether a user can find the document by it depends on the tokenizer, which splits on everything that is not a letter or a digit.
- [x] `pnpm test` passes locally — `search-node` 14/14; `server-core-node` + `search-node` together 486/486; `pnpm lint` and `pnpm knip` clean; `@kamiazya/whiteboard-search`, `-server-core` and `-web` all typecheck.
- [x] Manual verification completed — see below; the end-to-end claim is discharged by the `fullTextSearch` test rather than by hand.
- [ ] E2E coverage added or extended where applicable

### Mutation checks

| mutation | what fails |
|---|---|
| delete the `link` case | both link tests |
| make `file` push `node.file` | the file test |
| add a fifth member to `spatialNodeSchema` | the **build**: `TS1360 ... does not satisfy the expected type 'never'` at `searchable-texts.ts:59` |

The third is a compile-time guard, so it is verified by `pnpm --filter @kamiazya/whiteboard-search typecheck` with a throwaway union member — running only `pnpm test --project search-node` would skip it entirely.

## Visual evidence

Visual evidence: none — this is a headless projection in a shared package with no UI of its own. Its user-visible effect is *more search results*, which a screenshot of a search box would show as a row that was not there; the `fullTextSearch` test asserts the same thing without depending on a fixture corpus staying put.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — `.claude/rules/package-search.md` said `searchableTexts` contributes "node texts, group labels and edge labels"; it now names link urls and records the `file` decision and the exhaustive switch.
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_