### PR TITLE
fix(arch-lint): scan the retired vocabulary once, in the collection phase

### DIFF
--- a/.claude/rules/tool-arch-lint.md
+++ b/.claude/rules/tool-arch-lint.md
@@ -110,7 +110,23 @@ also retires a name that said `session` about a workspace.
 The one part of `.claude/rules/vocabulary.md` that can be mechanical rather
 than prose: it fails on a retired word appearing anywhere under `apps/web/src`
 or `packages/*/src`. Only words with no legitimate meaning left qualify — today
-`slug`. `canvas` never will, because it is correct for the spatial surface and
+`slug` plus the three keeper-axis spellings, each with its own scan roots.
+`canvas` never will, because it is correct for the spatial surface and
 wrong only as the container noun, and telling those apart needs a reader.
 `migrations/` is excluded as history, and `EXEMPT_FILES` carries the one other
 file writing history, with its reason.
+
+**The scan runs at module scope, and each file is read exactly once.** Both
+halves were bought by the same CI flake: the four words share three scan roots
+between them, so a per-word walk read 4826 files to cover 2141, and the whole
+thing sat in a test body under vitest's 5000ms default. Warm it is ~255ms;
+under the full parallel suite it measured 6315ms and timed out, reporting
+`no source file says "slug"` and a five-second budget in one message — which
+reads as a violation that is not there. Module evaluation is not bounded by a
+per-test timeout, so the cost now lands in the collection phase, the same move
+`.claude/rules/integrator-flow.md` prescribes for a heavy in-body
+`await import()`. The read count is pinned by its own assertion rather than
+left to a reader, because the redundancy was invisible in the source and
+visible only as a timeout somewhere else. Directory WALKS are still repeated
+per word and deliberately so: deduping them saves 9ms of the 255, which does
+not buy a second thing to keep true.

--- a/tools/arch-lint/src/vocabulary-check.test.ts
+++ b/tools/arch-lint/src/vocabulary-check.test.ts
@@ -174,6 +174,26 @@ const BANNED = [
 ] as const
 
 /**
+ * How many times a file's bytes were actually pulled off disk. Four retired
+ * words share three scan roots between them, so a per-word walk reads most of
+ * the tree several times over; `scannedFileCount` is what that work SHOULD
+ * cost. Asserted below, because the difference is not visible in the source
+ * and only shows up as a load-dependent timeout on CI.
+ */
+let fileReadCount = 0
+let scannedFileCount = 0
+const lineCache = new Map<string, string[]>()
+
+function linesOf(file: string): string[] {
+  const cached = lineCache.get(file)
+  if (cached !== undefined) return cached
+  fileReadCount += 1
+  const lines = readFileSync(file, 'utf-8').split('\n')
+  lineCache.set(file, lines)
+  return lines
+}
+
+/**
  * Throws rather than skipping when a scan root is gone: a silently-missing
  * directory turns this guard into one that passes by scanning nothing, which
  * is the failure mode a rename is most likely to cause.
@@ -205,28 +225,55 @@ function listSourceFiles(dir: string): string[] {
   return files
 }
 
-describe('retired vocabulary', () => {
-  for (const entry of BANNED) {
-    const { pattern, word, instead } = entry
-    // A word retired only within one package scans only that package, so the
-    // guard never claims coverage it does not have.
-    const dirs: readonly string[] = 'dirs' in entry ? entry.dirs : SCAN_DIRS
-    // Per-word, never per-file: exempting a file for one retired word must
-    // not quietly stop another word being checked in it.
-    const exempt: readonly string[] = 'exempt' in entry ? entry.exempt : []
-    it(`no source file says "${word}" — use ${instead}`, () => {
-      const hits: string[] = []
-      for (const dir of dirs) {
-        for (const file of listSourceFiles(join(REPO_ROOT, dir))) {
-          const relativePath = relative(REPO_ROOT, file).split(sep).join('/')
-          if (relativePath in EXEMPT_FILES || exempt.includes(relativePath)) continue
-          const lines = readFileSync(file, 'utf-8').split('\n')
-          for (const [index, line] of lines.entries()) {
-            if (pattern.test(line)) hits.push(`${relativePath}:${index + 1}: ${line.trim()}`)
-          }
-        }
+/**
+ * The scan runs HERE, at module scope, rather than inside each `it`.
+ *
+ * It is filesystem-bound work whose wall clock is set by how much else the
+ * machine is doing: ~255ms with the tree in page cache, 6315ms measured under
+ * the full parallel suite — past vitest's 5000ms default. A per-test timeout
+ * does not bound module evaluation, so the cost lands in the collection phase
+ * where nothing is racing it, the same reason `.claude/rules/integrator-flow.md`
+ * says to hoist a heavy `await import()` out of a test body.
+ *
+ * It also fixes what the failure SAID. A timed-out `it` named `no source file
+ * says "slug"` reports a retired word and a five-second budget in one message,
+ * and reads as a vocabulary violation that is not there.
+ */
+const hitsByWord = BANNED.map((entry) => {
+  const { pattern } = entry
+  // A word retired only within one package scans only that package, so the
+  // guard never claims coverage it does not have.
+  const dirs: readonly string[] = 'dirs' in entry ? entry.dirs : SCAN_DIRS
+  // Per-word, never per-file: exempting a file for one retired word must not
+  // quietly stop another word being checked in it.
+  const exempt: readonly string[] = 'exempt' in entry ? entry.exempt : []
+  const hits: string[] = []
+  for (const dir of dirs) {
+    for (const file of listSourceFiles(join(REPO_ROOT, dir))) {
+      const relativePath = relative(REPO_ROOT, file).split(sep).join('/')
+      if (relativePath in EXEMPT_FILES || exempt.includes(relativePath)) continue
+      scannedFileCount += 1
+      for (const [index, line] of linesOf(file).entries()) {
+        if (pattern.test(line)) hits.push(`${relativePath}:${index + 1}: ${line.trim()}`)
       }
-      expect(hits).toEqual([])
+    }
+  }
+  return hits
+})
+
+describe('retired vocabulary', () => {
+  for (const [index, { word, instead }] of BANNED.entries()) {
+    it(`no source file says "${word}" — use ${instead}`, () => {
+      expect(hitsByWord[index]).toEqual([])
     })
   }
+
+  it('reads each scanned file once, however many words share its directory', () => {
+    // Measured with the cache removed: 4826 reads over 2141 distinct files,
+    // because `apps/web/src` alone is a scan root for all four words. The
+    // redundancy is invisible in the source and shows up only as a
+    // load-dependent timeout, so it is pinned rather than left to a reader.
+    expect(scannedFileCount).toBeGreaterThan(lineCache.size)
+    expect(fileReadCount).toBe(lineCache.size)
+  })
 })


### PR DESCRIPTION
## Summary

`vocabulary-check` timed out on CI under the full parallel suite, reporting `no source file says "slug"` alongside a 5000ms budget — which reads as a vocabulary violation when there is none. Two causes, both measured:

- **The scan was redundant.** The four retired words share three scan roots between them (`apps/web/src` is a root for all four), so a per-word walk read **4826 files to cover 2141**. Reads are now memoized. The directory *walks* are deliberately left repeated: deduping them saves 9ms of 255, which does not buy a second thing to keep true.
- **The scan sat inside a test body**, where vitest's 5000ms default applies. Warm it costs ~255ms; under the full parallel suite it measured **6315ms**. It now runs at module scope, which no per-test timeout bounds — the same move `.claude/rules/integrator-flow.md` already prescribes for a heavy in-body `await import()`.

A new assertion pins the read count against the distinct-file count, because the redundancy is invisible in the source and shows up only as a timeout somewhere else. `.claude/rules/tool-arch-lint.md` records the shape and the measurements.

## Test plan

- `pnpm vitest run --project arch-lint-node` — 11 files / 120 tests, green. The four word assertions report `tests 4ms` where the scan used to be charged to them.
- **Mutation check**: removing the memoization (the shape before this change) fails the new assertion with `- 2141 / + 4826`, then restored.
- `pnpm check:local` — exit 0 (every gate CI's `check` job runs, plus `knip`).

Visual evidence: none — a test-only change to a filesystem scan; the change is a cost and a failure *message*, neither of which is a pixel. The measurements above are the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_