### PR TITLE
docs(adr-0025): stop the test-plan bullet promising a toast the ADR retired

### DIFF
--- a/docs/contributing/adr/0025-comment-editor-ux.md
+++ b/docs/contributing/adr/0025-comment-editor-ux.md
@@ -153,7 +153,10 @@ look correct in every single-user test.
   interaction), with race cases stated per slice: a compose bubble whose
   anchor node is deleted by a remote peer mid-edit keeps the draft and falls
   back to the point anchor; a resolve/reopen whose bubble unmounts mid-write
-  still lands or reports failure via toast.
+  still lands, and a failed one leaves the document — and therefore the pin
+  — as it was. (This bullet named a toast, which the decision above says is
+  deliberately not built. A test written to it would have been asserting on
+  a mechanism that does not exist.)
 - User copy vocabulary: the feature is a **Comment** (the layer name
   "annotation layer" stays an internal term), and the lifecycle word is
   **Resolved** — never "History", "Archived", or "Done".


### PR DESCRIPTION
## Summary

ADR-0025 contradicted itself about a mechanism that does not exist.

The **decision** bullet (lines 64–73) says the toast-with-Undo is deliberately not built — the host's Undo already reverts the write, and a resolved comment is one toggle and one verb from being back — and that a failed write leaves the document, and therefore the pin, as it was.

The **test-plan** bullet sixty lines below still asked for a race case where a resolve "reports failure via toast". A test written to it would have been asserting on a mechanism that does not exist, which is the opposite of what a decision record is for.

It now states the behaviour the decision above actually landed, and says in one line *why* the toast is gone, so the next reader does not re-add it.

Found by CodeRabbit as an outside-diff comment on #1247 (the merge-risk blurb's unnamed "one ADR statement needs correction"). Verified against the file before acting — both passages are present and do contradict.

## Test plan

- `pnpm check:local` — exit 0.
- Prose only; no code path changes.

Visual evidence: none — a documentation correction to a decision record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_