### PR TITLE
test(web): reach LoroStore's cross-tab fold refusal, and pin what it recovers

### DIFF
--- a/apps/web/src/lib/loro-store-compaction.browser.test.tsx
+++ b/apps/web/src/lib/loro-store-compaction.browser.test.tsx
@@ -7,10 +7,12 @@
  */
 import { readSpatialCanvas, writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
-import { COMPACT_DELTA_BYTES } from '@kamiazya/whiteboard-ports'
+import type { DocRef } from '@kamiazya/whiteboard-ports'
+import { COMPACT_DELTA_BYTES, chunkSnapshot, reassembleSnapshot } from '@kamiazya/whiteboard-ports'
 import { LoroDoc } from 'loro-crdt'
 import { expect, it } from 'vitest'
 import { resolveBrowserWorkspaceId } from './browser-workspace-id.js'
+import { IdbDocumentStore } from './idb-document-store.js'
 import { LoroStore } from './loro-store.js'
 
 function canvasWith(n: number, nudge = 0): SpatialCanvas {
@@ -98,4 +100,136 @@ it('keeps a log it cannot replay rather than dropping the edits', async () => {
   // load()'s deep validation refuses it — which is the point: the bytes are
   // still there to be refused, rather than silently gone.
   expect(loaded.kind).toBe('corrupt-delta')
+}, 120_000)
+
+/**
+ * The cross-tab arm of ADR-0020, at the layer that recovers from it.
+ *
+ * The port's own conformance suite proves the STORE refuses a fold whose
+ * generation another writer already replaced. What it cannot say is whether
+ * this CALLER does the right thing with that refusal — `appendDelta` answers
+ * it by re-issuing the delta as an ordinary append, so losing the race costs
+ * a fold and never an edit, and nothing exercised that branch.
+ *
+ * The arrangement is FORCED, not raced, and that is the whole design. Two
+ * instances started together do not reach the fence: measured on the daemon
+ * side, whose fold has the same shape, `Promise.all` leaves the second
+ * writer's read landing after the first writer's write, so its fold already
+ * contains the other's ops and disabling the fence changed nothing but the
+ * counters. So a wrapper puts a competing fold inside the window between
+ * this store's read and its own write, which is the ordering two real tabs
+ * produce and a single event loop will not.
+ */
+it('re-appends the edit when another tab folds first', async () => {
+  await resolveBrowserWorkspaceId()
+  const dbName = `race-${Math.trunc(performance.now() * 1000)}`
+  const id = 'doc'
+  const inner = new IdbDocumentStore(dbName)
+  const docRef: DocRef = {
+    kind: 'document',
+    workspaceId: await resolveBrowserWorkspaceId(),
+    documentId: id,
+  }
+
+  // What the subject's own saveCompactedSnapshot answered. The refusal is
+  // the reason this test exists, so it is asserted rather than assumed —
+  // without it a hook that silently failed to fire would leave a test that
+  // passes while exercising nothing.
+  const outcomes: boolean[] = []
+  let competeOnce: (() => Promise<void>) | undefined
+
+  const store = new LoroStore(dbName, {
+    ...inner,
+    saveSnapshot: (i) => inner.saveSnapshot(i),
+    loadSnapshot: (i) => inner.loadSnapshot(i),
+    loadDeltas: (i) => inner.loadDeltas(i),
+    appendDeltas: (i) => inner.appendDeltas(i),
+    readSnapshotManifest: (i) => inner.readSnapshotManifest(i),
+    readFrontier: (i) => inner.readFrontier(i),
+    deleteDoc: (i) => inner.deleteDoc(i),
+    async saveCompactedSnapshot(input) {
+      // Fires once, immediately before the fold's write reaches the store —
+      // the same placement the daemon's own model needs.
+      const compete = competeOnce
+      competeOnce = undefined
+      if (compete !== undefined) await compete()
+      const result = await inner.saveCompactedSnapshot(input)
+      outcomes.push(result.ok)
+      return result
+    },
+  })
+
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, canvasWith(20))
+  doc.commit()
+  await store.save(id, doc.export({ mode: 'snapshot' }))
+
+  // Armed BEFORE the first append, because the fold fires on whichever append
+  // first carries the log past the budget — arming later straddles nothing and
+  // the test passes on a fold that was never contested. That is not
+  // hypothetical: it is what the first version of this test did, and the
+  // refusal assertion below is the only thing that noticed.
+  competeOnce = async () => {
+    // Another tab folds the log AS IT STANDS — without this edit, which
+    // has not been written anywhere yet. Reading the generation here is
+    // what makes its own write succeed and the subject's stale.
+    const header = await inner.readSnapshotManifest({ docRef })
+    if (header === null) throw new Error('expected a stored snapshot')
+    const stored = await inner.loadSnapshot({ docRef })
+    if (stored === null) throw new Error('expected snapshot chunks')
+    const existing = (await inner.loadDeltas({ docRef, afterSeq: null })).updates
+    const other = new LoroDoc()
+    other.import(reassembleSnapshot(stored.manifest, stored.chunks))
+    for (const d of existing) other.import(d)
+    const folded = other.export({ mode: 'snapshot' })
+    const written = await inner.saveCompactedSnapshot({
+      docRef,
+      ...chunkSnapshot(folded, 1_000_000),
+      frontier: new Uint8Array(),
+      expectedGeneration: header.generation,
+      supersededDeltaCount: existing.length,
+    })
+    if (!written.ok) throw new Error('the competing fold was itself refused')
+  }
+
+  let version = doc.version()
+  let appended = 0
+  let lastDeltaBytes = 0
+  while (outcomes.length === 0) {
+    appended += 1
+    if (appended > 2000) throw new Error('never reached the budget')
+    writeSpatialCanvas(doc, canvasWith(20, appended))
+    doc.commit()
+    const delta = doc.export({ mode: 'update', from: version })
+    version = doc.version()
+    lastDeltaBytes = delta.byteLength
+    await store.appendDelta(id, delta)
+  }
+
+  // Exactly one refusal: the subject folded, the other tab had already
+  // replaced the snapshot, and the fence rejected the stale generation.
+  expect(outcomes, 'the subject never met a refusal — the straddle did not happen').toEqual([false])
+
+  const loaded = await store.load(id)
+  expect(loaded.kind).toBe('ok')
+  if (loaded.kind !== 'ok') return
+
+  // What went back into the log is the EDIT, not the fold. Re-appending the
+  // folded snapshot instead would also preserve the content — the fold
+  // contains it — so no content assertion can see the difference, and this is
+  // the only thing that does. It matters because the folded snapshot is the
+  // whole document: a store that re-appended it would permanently inflate the
+  // log of every document that ever lost a race, which is the opposite of
+  // what compaction is for.
+  const log = loaded.deltas ?? []
+  expect(log.at(-1)?.byteLength, 'the fallback re-appended the fold, not the edit').toBe(
+    lastDeltaBytes,
+  )
+
+  // The edit the subject was folding when it lost survived anyway, as an
+  // ordinary append. That is the whole guarantee.
+  const reopened = new LoroDoc()
+  reopened.import(loaded.snapshot)
+  for (const d of loaded.deltas ?? []) reopened.import(d)
+  expect(readSpatialCanvas(reopened).nodes[0]?.x).toBe(canvasWith(20, appended).nodes[0]?.x)
 }, 120_000)

--- a/apps/web/src/lib/loro-store.ts
+++ b/apps/web/src/lib/loro-store.ts
@@ -16,7 +16,7 @@
  *   this file's.
  */
 
-import type { DocRef } from '@kamiazya/whiteboard-ports'
+import type { DocRef, DocumentStore } from '@kamiazya/whiteboard-ports'
 import {
   chunkSnapshot,
   isStoredDocumentUnreadableError,
@@ -119,7 +119,7 @@ export async function touchContentTimestamp(documentId: string, dbName?: string)
 }
 
 export class LoroStore {
-  readonly #store: IdbDocumentStore
+  readonly #store: DocumentStore
 
   /**
    * Serialises this instance's read-modify-write sequences per document.
@@ -141,9 +141,24 @@ export class LoroStore {
    * Which database to talk to. Production never passes it; a browser test
    * does, so its fixtures cannot collide with another test FILE's — they
    * share an origin, and therefore one `whiteboard` database.
+   *
+   * `store` is the same kind of seam and exists for one reason a database
+   * name cannot serve: `appendDelta`'s compaction is fenced against another
+   * TAB folding first, and that arrangement cannot be reached by racing two
+   * instances. Measured on the daemon side, whose fold has the same shape —
+   * under microtask lockstep the second writer's read lands after the first
+   * writer's write, so its fold already contains the other's ops and
+   * disabling the fence changed nothing. Reaching the refusal needs a
+   * competing fold placed deliberately inside the window between this
+   * store's read and its write, which a wrapper around the port can do and
+   * nothing outside it can. Production passes nothing and gets the
+   * `IdbDocumentStore` it always had.
    */
-  constructor(private readonly dbName?: string) {
-    this.#store = new IdbDocumentStore(dbName)
+  constructor(
+    private readonly dbName?: string,
+    store?: DocumentStore,
+  ) {
+    this.#store = store ?? new IdbDocumentStore(dbName)
   }
 
   #serialise<T>(documentId: string, body: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
## Summary

`LoroStore.appendDelta` folds the delta log past the budget and writes it under ADR-0020's generation fence. When another tab folded first the write is refused, and `if (!written.ok)` re-issues the delta as an ordinary append — so losing the race costs a fold, never an edit. **Nothing drove `written.ok` to `false` against a real `LoroStore`**: both compaction tests use one instance, sequentially.

The port's own conformance suite proves the *store* will not drop a racing append. That says nothing about whether this *caller* does the right thing with a refusal, which is the branch a user editing one document in two tabs depends on.

### Why the arrangement is forced rather than raced

Two instances started together do not reach the fence. Measured on the daemon side, whose fold has the same shape: under microtask lockstep the second writer's read lands *after* the first writer's write, so its fold already contains the other's ops and disabling the fence changes nothing but the counters. So a wrapper puts a competing fold inside the window between this store's read and its own write — the ordering two real tabs produce and a single event loop will not.

That wrapper is the one production change: `#store` widens from `IdbDocumentStore` to the `DocumentStore` port (all seven methods it calls are declared there, and the file's own docblock already opens "a thin layer over the `DocumentStore` port"), plus an optional `store` constructor parameter beside the `dbName` seam this file already carries for the same reason. Production passes nothing.

### The red run is the finding

The first version armed the competing fold when the log passed twice the budget — but the fold fires on whichever append *first* carries it past the budget, so an uncontested fold had already happened. The test reported:

```
AssertionError: the subject never met a refusal — the straddle did not happen:
  expected [ true ] to deeply equal [ false ]
```

**With only a content assertion it would have passed**, because a fold that succeeds preserves the content perfectly well. The refusal assertion is the only thing that noticed the branch was never reached; the comment at the arming site says so, so the next reader does not re-introduce it.

## Test plan

- [x] New or updated `web-browser` test added — `loro-store-compaction.browser.test.tsx`, budgeted at `120_000`ms to match its two siblings; `describe`+`it` title is 47 characters.
- [x] `pnpm test` passes locally — the file 3/3; the **whole `web-browser` project 165 files / 929 tests, 0 failures**; `@kamiazya/whiteboard-web` typechecks.
- [x] Manual verification completed — n/a and deliberately so: a two-tab IndexedDB race is not reproducible by hand with any reliability, which is exactly why the test constructs the interleaving rather than hoping for it.
- [x] E2E coverage — not applicable; the guarantee lives entirely inside one document's store and `load()` is its observable.

### Mutation checks — each kills a *different* assertion

| mutation | assertion killed | message |
|---|---|---|
| never arm the competing fold | refusal | `expected [ true ] to deeply equal [ false ]` |
| delete the `if (!written.ok)` fallback | content | `expected 33 to be 34` |
| re-append the folded snapshot instead of the delta | log-entry size | `expected 6960 to be 1970` |

The third one is worth reading, because **the design predicted it would fail the content assertion and it did not**. The folded snapshot contains the edit, so no content assertion can tell the two apart. It is not an equivalent mutant though: the fold is the whole document, so a store that re-appended it would permanently inflate the log of every document that ever lost a race — the opposite of what compaction is for. The size assertion was added to catch exactly that, and re-running the mutation against it is where `expected 6960 to be 1970` comes from.

## Visual evidence

Visual evidence: none — no user-visible change. This is a regression test for an already-shipped recovery path plus a port-typed constructor seam; nothing rendered moves.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — n/a
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_