### PR TITLE
perf(test): stop a browser run writing 23GB of trace scratch

### DIFF
--- a/.claude/skills/test-layer-selection/SKILL.md
+++ b/.claude/skills/test-layer-selection/SKILL.md
@@ -18,7 +18,7 @@ Start with the smallest failing test at the **nearest** layer. Do not jump to br
 | E2E | real routes, server composition, websocket timing, persistence order, multi-step page flows | promote only when needed |
 
 Notes:
-- Browser suites together: `pnpm run test:browser` (`canvas-viewer-browser` + `web-browser`); traces land under `<package>/tmp/vitest-traces` and are kept for FAILING tests only. That trace carries the action log, stacks and screenshots but no DOM view — recording the DOM means recording every resource vite served (302MB against 7.5MB on `apps/web`'s 16 page files; 22GB over a whole run). `pnpm run test:browser:trace` turns it on, and traces every test including passing ones, so point it at the one failing file.
+- Browser suites together: `pnpm run test:browser` (`canvas-viewer-browser` + `web-browser` + `canvas-render-browser`); traces land under `<package>/tmp/vitest-traces` and are kept for FAILING tests only. That trace carries the action log, stacks and screenshots but no DOM view — recording the DOM means recording every resource vite served (302MB against 7.5MB on `apps/web`'s 16 page files; 23GB over a whole run). `pnpm run test:browser:trace` turns it on, and traces every test including passing ones, so point it at the one failing file.
 - After the targeted test passes, run the broader suite covering the touched area, then `pnpm test`.
 - Runtime is the source of truth: if behavior disagrees with a test, fix the test or implementation to match real behavior.
 - Passing tests alone are not sufficient — manually verify the real behavior (Playwright/Chrome MCP) before locking the scenario into regression coverage.

--- a/.claude/skills/test-layer-selection/SKILL.md
+++ b/.claude/skills/test-layer-selection/SKILL.md
@@ -18,7 +18,7 @@ Start with the smallest failing test at the **nearest** layer. Do not jump to br
 | E2E | real routes, server composition, websocket timing, persistence order, multi-step page flows | promote only when needed |
 
 Notes:
-- Browser suites together: `pnpm run test:browser` (`canvas-viewer-browser` + `web-browser`); `pnpm run test:browser:trace` for trace artifacts on failure (under `<package>/tmp/vitest-traces`).
+- Browser suites together: `pnpm run test:browser` (`canvas-viewer-browser` + `web-browser`); traces land under `<package>/tmp/vitest-traces` and are kept for FAILING tests only. That trace carries the action log, stacks and screenshots but no DOM view — recording the DOM means recording every resource vite served (302MB against 7.5MB on `apps/web`'s 16 page files; 22GB over a whole run). `pnpm run test:browser:trace` turns it on, and traces every test including passing ones, so point it at the one failing file.
 - After the targeted test passes, run the broader suite covering the touched area, then `pnpm test`.
 - Runtime is the source of truth: if behavior disagrees with a test, fix the test or implementation to match real behavior.
 - Passing tests alone are not sufficient — manually verify the real behavior (Playwright/Chrome MCP) before locking the scenario into regression coverage.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,11 +69,16 @@ Use:
 
 ```bash
 pnpm run test:browser        # canvas-viewer-browser + web-browser + canvas-render-browser
-pnpm run test:browser:trace  # same, with trace artifacts on failure
+pnpm run test:browser:trace  # same, plus a trace for EVERY test and its DOM snapshots
 ```
 
 - Failure traces are stored under `<package>/tmp/vitest-traces`.
 - Check traces before adding temporary debug code.
+- **The default trace has no DOM view** — actions, stacks and screenshots
+  only, because recording the DOM records every resource vite serves: 23GB
+  a run, filling the disk and reporting a test count short of the real one.
+  Re-run the ONE failing file under `test:browser:trace` for it — that
+  traces every test, so never point it at the suite.
 - **Keep a browser test's `describe` + `it` titles under 155 characters
   combined** (characters, not UTF-8 bytes: vitest replaces every
   non-alphanumeric character with one ASCII `-` before the name reaches the

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -173,8 +173,16 @@ There are three real-browser Vitest projects:
 
 ```bash
 pnpm run test:browser         # canvas-viewer-browser + web-browser + canvas-render-browser
-pnpm run test:browser:trace   # same, with trace artifacts on failure
+pnpm run test:browser:trace   # same, plus a trace for EVERY test and its DOM snapshots
 ```
+
+The default run retains a trace only for a FAILING test, and that trace has
+no DOM view — action log, stacks and screenshots, but no time-travel through
+the page. Recording the DOM means recording every resource vite served, which
+measured 302MB against 7.5MB on `apps/web`'s 16 page files and 22GB over a
+whole `web-browser` run. When you need the DOM, re-run the one failing file
+under `test:browser:trace`; it traces every test including passing ones, so
+it is a per-file tool rather than a suite-wide one.
 
 **jsdom exclude policy**: apps/web's jsdom config must exclude `.browser.test.ts` and `.browser.test.tsx` files. Tests that depend on IndexedDB or other real browser APIs belong in `web-browser`, not jsdom. Mixing them causes silent no-op failures or missing-API errors.
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -30,7 +30,7 @@ pnpm --filter @kamiazya/whiteboard-web test   # apps/web jsdom, when the change 
 
 # 2. After targeted test passes, run the broader gate for the touched area
 pnpm test
-pnpm test:browser        # for browser-mode changes (canvas-viewer-browser + apps/web web-browser)
+pnpm test:browser        # for browser-mode changes (canvas-viewer-browser + web-browser + canvas-render-browser)
 pnpm smoke:e2e           # for MCP tool / route / protocol changes
 pnpm test:e2e:distribution # for packaged daemon / tarball / binary behavior
 ```

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:web-jsdom": "vitest run --project web-jsdom",
     "test:distribution": "pnpm --filter @kamiazya/whiteboard-mcp test:distribution",
     "test:browser": "vitest run --project web-browser --project canvas-viewer-browser --project canvas-render-browser",
-    "test:browser:trace": "vitest run --project web-browser --project canvas-viewer-browser --project canvas-render-browser --browser.trace=on",
+    "test:browser:trace": "WHITEBOARD_TRACE_SNAPSHOTS=1 vitest run --project web-browser --project canvas-viewer-browser --project canvas-render-browser --browser.trace=on",
     "test:watch": "vitest --project mcp-node",
     "check:local": "pnpm lint && pnpm secretlint && pnpm test:scripts && pnpm knip && pnpm intent:validate && pnpm audit --prod --audit-level=high && pnpm typecheck",
     "check:pr-title": "pnpm --filter @kamiazya/whiteboard-mcp check:pr-title",

--- a/packages/mcp-server/src/server/release/vitest-projects.test.ts
+++ b/packages/mcp-server/src/server/release/vitest-projects.test.ts
@@ -15,6 +15,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { sharedBrowserTestConfig } from '../../../../../vitest.browser.shared.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(__dirname, '../../../../..')
@@ -337,22 +338,17 @@ describe('sharedBrowserTestConfig trace budget', () => {
     else process.env[VAR] = before
   })
 
-  async function load(): Promise<{ trace: { snapshots: boolean } }> {
-    // Cache-busted: the config is read at module scope in the real configs,
-    // and this suite needs a fresh read per env-var setting.
-    const mod = await import(
-      `${pathToFileURL(join(ROOT, 'vitest.browser.shared.ts')).href}?t=${Date.now()}`
-    )
-    return mod.sharedBrowserTestConfig() as { trace: { snapshots: boolean } }
-  }
-
-  it('records no DOM snapshots by default', async () => {
+  // Statically imported, and the env var read PER CALL rather than at module
+  // load, so no dynamic import is needed to see a changed value. An in-body
+  // `await import()` would also trip `test-lazy-import-check` — which is how
+  // the first version of this suite was written, and what caught it.
+  it('records no DOM snapshots by default', () => {
     delete process.env[VAR]
-    expect((await load()).trace.snapshots).toBe(false)
+    expect(sharedBrowserTestConfig().trace.snapshots).toBe(false)
   })
 
-  it('records them when the trace script asks for them', async () => {
+  it('records them when the trace script asks for them', () => {
     process.env[VAR] = '1'
-    expect((await load()).trace.snapshots).toBe(true)
+    expect(sharedBrowserTestConfig().trace.snapshots).toBe(true)
   })
 })

--- a/packages/mcp-server/src/server/release/vitest-projects.test.ts
+++ b/packages/mcp-server/src/server/release/vitest-projects.test.ts
@@ -305,3 +305,54 @@ describe('run-shared-layer-tests.mjs (CLI)', () => {
     expect(stderr.chunks.join('')).toMatch(/pnpm could not start/)
   })
 })
+
+/**
+ * `sharedBrowserTestConfig`'s trace budget.
+ *
+ * The default browser run must not record DOM snapshots. Measured on
+ * `apps/web`'s 16 page files (63 tests, all passing): with snapshots on, the
+ * run writes 302MB of trace scratch, 284MB of it the `.network` file that
+ * carries every resource body vite served so the viewer can replay the DOM.
+ * With them off, the same subset writes 7.5MB and a `.network` of zero. A
+ * whole `web-browser` run measured 22GB and exhausted this container's disk
+ * MID-RUN — reported not as "no space" but as `Failed to fetch dynamically
+ * imported module`, `Cannot connect to the iframe`, and a summary of
+ * `774 passed` against a true total of 929. 155 tests silently never ran and
+ * the smaller total read like good news.
+ *
+ * Fidelity is not lost, only moved: `pnpm test:browser:trace` sets the env
+ * var and gets the full trace back. That escape hatch is why the default is
+ * allowed to be lean, so it is pinned here too — a CLI `--browser.trace=on`
+ * cannot restore snapshots on its own (measured: a config carrying
+ * `snapshots: false` still produced a zero-byte `.network` under that flag,
+ * because vitest MERGES the override rather than replacing the object), so
+ * this env var is the only thing that can.
+ */
+describe('sharedBrowserTestConfig trace budget', () => {
+  const VAR = 'WHITEBOARD_TRACE_SNAPSHOTS'
+  const before = process.env[VAR]
+
+  afterEach(() => {
+    if (before === undefined) delete process.env[VAR]
+    else process.env[VAR] = before
+  })
+
+  async function load(): Promise<{ trace: { snapshots: boolean } }> {
+    // Cache-busted: the config is read at module scope in the real configs,
+    // and this suite needs a fresh read per env-var setting.
+    const mod = await import(
+      `${pathToFileURL(join(ROOT, 'vitest.browser.shared.ts')).href}?t=${Date.now()}`
+    )
+    return mod.sharedBrowserTestConfig() as { trace: { snapshots: boolean } }
+  }
+
+  it('records no DOM snapshots by default', async () => {
+    delete process.env[VAR]
+    expect((await load()).trace.snapshots).toBe(false)
+  })
+
+  it('records them when the trace script asks for them', async () => {
+    process.env[VAR] = '1'
+    expect((await load()).trace.snapshots).toBe(true)
+  })
+})

--- a/vitest.browser.shared.ts
+++ b/vitest.browser.shared.ts
@@ -11,6 +11,17 @@ import { resolveBrowserLaunchOptions } from './packages/mcp-server/src/server/br
 const TRACES_DIR = 'tmp/vitest-traces'
 
 /**
+ * Set by `pnpm test:browser:trace` to record DOM snapshots as well.
+ *
+ * It is an env var rather than a CLI flag because a CLI flag cannot do it.
+ * `--browser.trace=on` MERGES into the object below rather than replacing it
+ * (measured: a config carrying `snapshots: false` still produced a zero-byte
+ * `.network` under that flag), so once the default is off, nothing on the
+ * command line can turn it back on. This is the switch that can.
+ */
+const SNAPSHOTS_VAR = 'WHITEBOARD_TRACE_SNAPSHOTS'
+
+/**
  * The one definition of how this repo runs a Vitest browser project —
  * headless chromium via Playwright, launch options honouring
  * WHITEBOARD_CHROME_PATH, failure traces retained under the package's
@@ -33,6 +44,30 @@ const TRACES_DIR = 'tmp/vitest-traces'
  * still reports plenty of "Used". One run's worth is also all that is
  * useful: the traces you read are the ones from the run that just failed,
  * and a second run at the same path would overwrite them anyway.
+ *
+ * **DOM snapshots are off unless asked for**, which is a separate bound and
+ * the one that stops a SINGLE run filling the disk — the clear above only
+ * stops runs accumulating on each other. `snapshots: true` makes Playwright
+ * record every resource body it served so the viewer can replay the DOM, and
+ * under vitest browser mode vite serves the whole module graph of every page
+ * under test. Measured on `apps/web`'s 16 page files (63 tests, all passing):
+ * 302MB, of which the `.network` file is 284MB; the same subset with
+ * snapshots off writes 7.5MB and a `.network` of zero. A whole `web-browser`
+ * run measured 22GB.
+ *
+ * That is worth a paragraph because of how it fails rather than how big it
+ * is. The disk runs out MID-RUN, and `tracing.stopChunk: ENOSPC` appears
+ * once while what a reader actually sees is `Failed to fetch dynamically
+ * imported module`, `Cannot connect to the iframe`, and a summary of
+ * `774 passed` — against a true total of 929. 155 tests silently never ran,
+ * and the smaller total reads like good news. Same shape as a mis-filtered
+ * `--project`, reached by a different route.
+ *
+ * A failure's trace stays useful without them: the retained `.trace.zip` is
+ * self-contained and still carries the screenshots, the action log and the
+ * stacks (measured: 7 entries, 4 screenshots, 80KB against 96KB). What is
+ * lost is DOM time-travel and the resource bodies, and it is one command
+ * away — `pnpm test:browser:trace`, which is what that script is for.
  */
 export function sharedBrowserTestConfig(
   options: {
@@ -58,7 +93,7 @@ export function sharedBrowserTestConfig(
       mode: 'retain-on-failure' as const,
       tracesDir: `./${TRACES_DIR}`,
       screenshots: true,
-      snapshots: true,
+      snapshots: process.env[SNAPSHOTS_VAR] !== undefined,
     },
     viewport: options.viewport ?? { width: 800, height: 600 },
     provider: playwright({


### PR DESCRIPTION
## Summary

`trace.snapshots: true` makes Playwright record every resource body it served, so the viewer can replay the DOM. Under vitest browser mode vite serves the whole module graph of every page under test — so that is the app, recorded, every run.

**Matched full runs of `pnpm test:browser`, both on a cleaned disk:**

| | files | tests | duration | trace scratch |
|---|---|---|---|---|
| `snapshots: true` (today) | 180/180 | 985 | 270s | **23GB** |
| `snapshots: false` (this PR) | 180/180 | 985 | **130s** | **39MB** |

Same coverage, half the wall clock, ~600× less disk.

### How it fails matters more than how big it is

The disk runs out **mid-run**. `tracing.stopChunk: ENOSPC` appears once; what a reader actually sees is `Failed to fetch dynamically imported module`, `Cannot connect to the iframe`, and a summary of `774 passed` against a true total of 985. Tests silently never ran, and the smaller total reads like good news — the same shape AGENTS.md already records for a mis-filtered `--project`, reached by a different route.

The existing pre-run clear does not touch this. It bounds what runs accumulate on *each other*; this is what *one* run writes.

### Why an env var and not a CLI flag

Measured, after a plan review predicted the opposite from reading vitest's `mergeConfig`: `--browser.trace=on` **merges** into the trace object rather than replacing it, so a config carrying `snapshots: false` still produced a zero-byte `.network` under that flag. Once the default is off, nothing on the command line turns it back on — the env var is the only thing that can. Verified end to end afterwards: the trace script's own archive carries three resource bodies, two of them non-image.

### The trade, stated rather than buried

Debug fidelity against run reliability. **Give up**: the default run's failure trace loses DOM time-travel. **Keep**: the action log, the stacks and the screenshots — the retained `.trace.zip` is self-contained and still carries them (7 entries, 4 screenshots, 80KB against 96KB). **Recover**: `pnpm test:browser:trace` on the one failing file, which is what that script is for.

Taken rather than escalated because the loss is one command away, and because CI's `test-browser` job runs the default script — so this is exactly where the exhaustion happens.

A companion post-run prune of non-zip scratch was designed alongside this and is **dropped on the measurement**: at 39MB a run there is nothing left to prune.

## Test plan

- [x] New `mcp-node` tests — `sharedBrowserTestConfig()` returns `snapshots: false` by default and `true` under the env var. Written **red first**: the default-value assertion failed against the hardcoded `snapshots: true` before the change.
- [x] `pnpm test` passes locally — `pnpm test:browser` 180 files / 985 tests / 0 failures; `mcp-node` 4225 with the one known environmental failure below; `pnpm -r typecheck`, `pnpm lint`, `pnpm knip` all clean.
- [x] Manual verification completed — the substance of this change; every number above was taken, not argued.
- [x] E2E coverage — n/a, test-runner configuration.

### Mutation check

Removing the env-var read (hardcoding `false`) fails `records them when the trace script asks for them` with `expected false to be true`. Both assertions are load-bearing: today's code passes the second one for the wrong reason, which is why it is pinned.

### A measurement that had to be redone, because the first one was wrong

Three intermediate runs under-reported (99–150 of 180 files) and I initially read that as evidence against this change. It was not. Those runs were competing with the **disk aftermath of the 23GB baseline run I was comparing them to** — one of them hit ENOSPC while writing only 38MB of traces. Cleaned properly and re-run, the modified tree completes 180/180 with 985 tests, identical to baseline. The comparison in the table is the redone one; the earlier numbers are not in it.

### Known environmental failure, not from this PR

`local-node-version.test.ts` fails in my container (Node 22 vs the pinned 24). CI installs 24. That guard exists precisely so a wrong-major run is not mistaken for real regressions.

## Visual evidence

Visual evidence: none — no user-visible change. This is test-runner configuration and its documentation; nothing rendered moves, and the pixel goldens would say so if it did.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — all three copies of the wrong "trace artifacts on failure" claim (`AGENTS.md`, `docs/contributing/testing.md`, `.claude/skills/test-layer-selection/SKILL.md`), found by grep after a review caught that fixing one would leave the others contradicting it. `test:browser:trace` records **every** test, passing ones included. Re-grep returns nothing.
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

`dev-rules-budget.test.ts` fired on the AGENTS.md addition and the note was trimmed to fit rather than the bucket raised — always-on context is paid by every session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified browser test tracing behavior, including trace locations, retained failures, action logs, screenshots, and DOM snapshot availability.
  * Documented resource considerations and recommended targeting individual failing files when collecting detailed traces.

* **Tests**
  * Added coverage verifying that DOM snapshots are disabled by default and enabled when requested.

* **Bug Fixes**
  * Reduced disk usage during standard browser test runs by making DOM snapshot recording opt-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->