### PR TITLE
feat(annotations): read the layer without a canvas, and hand it to the renderer

### DIFF
--- a/packages/canvas-render/src/layout/comments.test.ts
+++ b/packages/canvas-render/src/layout/comments.test.ts
@@ -99,6 +99,54 @@ function runsOf(nodes: readonly SceneNode[]): TextRunNode[] {
   })
 }
 
+describe('the comments option', () => {
+  // ADR-0026 decision 1b: the annotation layer is keeper-side, so it stops
+  // riding inside the canvas envelope and travels beside it. These pin the
+  // seam that lets a caller hand comments over directly — the step that
+  // makes a markdown document's threads renderable at all, since it has no
+  // envelope to put them in.
+  it('draws comments passed as an option, on a canvas whose envelope has none', () => {
+    const scene = layoutSpatialCanvas(
+      { nodes: [TEXT_NODE], edges: [] },
+      baseOptions({ comments: [{ id: 'c1', x: 400, y: 60, text: 'from beside the canvas' }] }),
+    )
+
+    expect(pinOf(scene.nodes, 'c1')).toBeDefined()
+    // Joined, because the body lays out through the markdown pipeline and a
+    // bubble-width wrap splits it across runs.
+    expect(
+      runsOf(scene.nodes)
+        .map((run) => run.text)
+        .join(' '),
+    ).toContain('from beside the canvas')
+  })
+
+  it('lets the option win over the envelope, so a migrating caller is never doubled', () => {
+    // Both populated is what a half-migrated call site looks like. Drawing
+    // the union would put two pins on one comment; preferring the argument
+    // makes the migration one call site at a time.
+    const scene = layoutSpatialCanvas(
+      canvasWith([{ id: 'stale', x: 10, y: 10, text: 'from the envelope' }]),
+      baseOptions({ comments: [{ id: 'fresh', x: 400, y: 60, text: 'from the option' }] }),
+    )
+
+    expect(pinOf(scene.nodes, 'fresh')).toBeDefined()
+    expect(pinOf(scene.nodes, 'stale')).toBeUndefined()
+  })
+
+  it('draws nothing for an empty option, rather than falling back to the envelope', () => {
+    // An empty array is an ANSWER — "this document has no conversations" —
+    // and a caller that has read the layer and found it empty must not get
+    // the envelope's stale copy back.
+    const scene = layoutSpatialCanvas(
+      canvasWith([{ id: 'stale', x: 10, y: 10, text: 'from the envelope' }]),
+      baseOptions({ comments: [] }),
+    )
+
+    expect(pinOf(scene.nodes, 'stale')).toBeUndefined()
+  })
+})
+
 describe('comment layer', () => {
   it('draws a pin centered on the anchor and a bubble holding the text, after all content', () => {
     const scene = layoutSpatialCanvas(

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -286,6 +286,25 @@ export interface SpatialLayoutOptions {
    * alone) and needing it placed exactly as the committed scene placed it.
    */
   readonly commentObstacles?: readonly BoundingBox[]
+  /**
+   * This document's annotation layer, handed over beside the canvas rather
+   * than read out of its envelope.
+   *
+   * ADR-0026 decision 1b makes the layer keeper-side: it is stored one level
+   * above content, so it no longer rides inside `x-whiteboard`. A markdown
+   * document has no envelope at all, which is the argument that decides it —
+   * there is nowhere in a canvas key to put a markdown document's comments.
+   *
+   * When present it REPLACES the envelope's copy rather than adding to it,
+   * and an empty array is an answer ("no conversations") rather than a
+   * missing one. Both matter while call sites migrate one at a time: the
+   * union would draw two pins on one comment, and a fallback would hand a
+   * caller that read the layer and found it empty the stale copy back.
+   *
+   * Absent, the envelope is read as before. That is what keeps every
+   * unmigrated caller byte-identical, and it goes once none is left.
+   */
+  readonly comments?: readonly CanvasComment[]
 }
 
 /**
@@ -1385,7 +1404,7 @@ function composeComments(
   canvas: SpatialCanvas,
   options: ResolvedLayoutOptions,
 ): readonly SceneNode[] {
-  const comments = canvas['x-whiteboard']?.comments
+  const comments = options.comments ?? canvas['x-whiteboard']?.comments
   if (comments === undefined || comments.length === 0) return []
 
   const chrome = options.appearance.resolveComment?.()

--- a/packages/loro-adapter/src/annotations.test.ts
+++ b/packages/loro-adapter/src/annotations.test.ts
@@ -1,0 +1,76 @@
+/**
+ * `readAnnotations` is the format-agnostic half of the annotation layer
+ * (ADR-0026 step 2): the plane is stored one level above content, so reading
+ * it must not require the document to have a canvas.
+ *
+ * `readSpatialCanvas` could never serve that — it is the canvas reader, and a
+ * markdown document's threads were unreachable rather than absent.
+ */
+import type { CommentThread } from '@kamiazya/whiteboard-model'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, it } from 'vitest'
+import { readAnnotations } from './annotations.js'
+import { writeCommentThread } from './comment-threads.js'
+import { writeMarkdownBody } from './loro-bridge.js'
+
+const THREAD: CommentThread = {
+  id: 't1',
+  anchor: { kind: 'spatial', nodeId: 'n1', x: 40, y: 50 },
+  status: 'open',
+  createdAt: '2026-09-03T00:00:00.000Z',
+  messages: [{ id: 'm1', body: 'tighten this' }],
+}
+
+/** Seeds the legacy `comments` map the way the pre-threads writer did. */
+function seedLegacy(doc: LoroDoc, comment: Record<string, unknown>): void {
+  doc.getMap('comments').set(String(comment.id), comment)
+  doc.commit()
+}
+
+describe('readAnnotations', () => {
+  it('reads a document that has no canvas at all', () => {
+    // The point of the whole reader. This document holds a markdown body and
+    // no `canvas` map, so `readSpatialCanvas` has nothing to project through.
+    const doc = new LoroDoc()
+    writeMarkdownBody(doc, '# a note')
+    writeCommentThread(doc, THREAD)
+    expect(readAnnotations(doc)).toEqual([THREAD])
+  })
+
+  it('lifts an un-migrated legacy comment into the one-message thread it always was', () => {
+    const doc = new LoroDoc()
+    seedLegacy(doc, { id: 'c1', x: 10, y: 20, text: 'from before threads' })
+    const [thread, ...rest] = readAnnotations(doc)
+    expect(rest).toEqual([])
+    expect(thread?.id).toBe('c1')
+    expect(thread?.anchor).toEqual({ kind: 'spatial', x: 10, y: 20 })
+    expect(thread?.messages.map((m) => m.body)).toEqual(['from before threads'])
+  })
+
+  it('prefers the thread over a legacy row that shares its id', () => {
+    // The migration clears the legacy map, but a replica that merged an old
+    // peer's write can hold both. The thread is the newer shape and the one
+    // a reply was written into.
+    const doc = new LoroDoc()
+    writeCommentThread(doc, THREAD)
+    seedLegacy(doc, { id: 't1', x: 0, y: 0, text: 'stale' })
+    expect(readAnnotations(doc)).toEqual([THREAD])
+  })
+
+  it('puts threads before legacy rows, because that order decides bubble placement', () => {
+    // `composeComments` fans a later bubble out around an earlier one, so the
+    // sequence is behaviour, not presentation. Ids are chosen so that sorting
+    // the union would interleave them and change what the canvas draws.
+    const doc = new LoroDoc()
+    writeCommentThread(doc, { ...THREAD, id: 'z-thread' })
+    seedLegacy(doc, { id: 'a-legacy', x: 1, y: 1, text: 'older shape' })
+    expect(readAnnotations(doc).map((t) => t.id)).toEqual(['z-thread', 'a-legacy'])
+  })
+
+  it('drops a legacy row the schema rejects rather than the rows beside it', () => {
+    const doc = new LoroDoc()
+    seedLegacy(doc, { id: 'bad', x: 'not a number', text: 'unreadable' })
+    seedLegacy(doc, { id: 'good', x: 5, y: 6, text: 'readable' })
+    expect(readAnnotations(doc).map((t) => t.id)).toEqual(['good'])
+  })
+})

--- a/packages/loro-adapter/src/annotations.ts
+++ b/packages/loro-adapter/src/annotations.ts
@@ -1,0 +1,74 @@
+/**
+ * Reading the annotation layer, for any document kind.
+ *
+ * The layer is stored one level above content (ADR-0026 decision 1) — a
+ * document-level `threads` map, a peer of `nodes`, `edges` and `body` rather
+ * than something inside the canvas envelope. This is the reader that says so:
+ * it takes a document's containers and answers its conversations, and it
+ * never mentions a canvas.
+ *
+ * Before it existed the union below sat inside `readSpatialCanvas`, which
+ * made a markdown document's threads *unreachable* rather than absent —
+ * stored correctly and readable by nothing.
+ */
+
+import type { CommentThread } from '@kamiazya/whiteboard-model'
+import {
+  type CanvasComment,
+  canvasCommentSchema,
+  threadFromCanvasComment,
+} from '@kamiazya/whiteboard-model'
+import { readCommentThreads } from './comment-threads.js'
+import { COMMENTS_KEY, type DocumentContainers } from './containers.js'
+
+/**
+ * Every conversation on this document: the threads plane, plus any legacy
+ * comment no writer has migrated yet, lifted into the one-message thread it
+ * always was.
+ *
+ * **Threads come first, and the legacy rows keep their map order after them.**
+ * That is not presentation: `composeComments` fans a later bubble out around
+ * an earlier one, so the sequence decides where a comment is drawn. Sorting
+ * the union by id would read more tidily and would move bubbles on any
+ * document that still holds both shapes.
+ *
+ * A read never migrates. Doing so would turn opening a document into a
+ * commit, and a reader may not even hold the write lock — the first WRITE
+ * empties the legacy map instead.
+ *
+ * A record the schema rejects costs that record and nothing beside it, the
+ * contract every reader in this package keeps.
+ */
+export function readAnnotations(doc: DocumentContainers): CommentThread[] {
+  const threads = readCommentThreads(doc)
+  const known = new Set(threads.map((thread) => thread.id))
+  const legacy: CommentThread[] = []
+  const commentsMap = doc.getMap(COMMENTS_KEY)
+  for (const commentId of commentsMap.keys()) {
+    // A replica that merged an old peer's write can hold both shapes for one
+    // id. The thread is the newer one, and the one a reply was written into.
+    if (known.has(commentId)) continue
+    const parsed = canvasCommentSchema.safeParse(commentsMap.get(commentId))
+    if (parsed.success) legacy.push(threadFromCanvasComment(parsed.data))
+  }
+  return [...threads, ...legacy]
+}
+
+/**
+ * The same layer as the flat comments the canvas renderer still takes.
+ *
+ * Lossy by construction — a thread's replies have nowhere to go in a shape
+ * that holds one `text` — which is why it is a projection with a name rather
+ * than something a caller does inline. It goes when the renderer takes
+ * threads (ADR-0026 step 3).
+ */
+export function readCanvasComments(doc: DocumentContainers): CanvasComment[] {
+  const comments: CanvasComment[] = []
+  for (const thread of readAnnotations(doc)) {
+    const projected = canvasCommentFromThread(thread)
+    if (projected !== undefined) comments.push(projected)
+  }
+  return comments
+}
+
+import { canvasCommentFromThread } from './comment-threads.js'

--- a/packages/loro-adapter/src/index.ts
+++ b/packages/loro-adapter/src/index.ts
@@ -1,3 +1,4 @@
+export { readAnnotations, readCanvasComments } from './annotations.js'
 export {
   migrateCanvasCommentsToThreads,
   readCommentThreads,

--- a/packages/loro-adapter/src/loro-bridge.ts
+++ b/packages/loro-adapter/src/loro-bridge.ts
@@ -1,7 +1,6 @@
 import {
   type CanvasComment,
   type CanvasEdge,
-  canvasCommentSchema,
   canvasEdgeSchema,
   canvasExtensionSchema,
   type DocumentKind,
@@ -18,12 +17,8 @@ import {
   trustFacetsSchema,
 } from '@kamiazya/whiteboard-model'
 import type { z } from 'zod'
-import {
-  canvasCommentFromThread,
-  migrateCanvasCommentsToThreads,
-  readCommentThreads,
-  writeThreadInto,
-} from './comment-threads.js'
+import { readCanvasComments } from './annotations.js'
+import { migrateCanvasCommentsToThreads, writeThreadInto } from './comment-threads.js'
 import { COMMENTS_KEY, type DocumentContainers, THREADS_KEY } from './containers.js'
 
 const NODES_KEY = 'nodes'
@@ -472,23 +467,11 @@ export function readSpatialCanvas(doc: DocumentContainers): SpatialCanvas {
     ? parsedEnvelope.data
     : {}
 
-  // Threads are where a comment lives (ADR-0026); the legacy map is read only
-  // for a document no writer has touched since, and the first write empties
-  // it. A read never migrates — it would turn opening a document into a
-  // commit, and a reader may not even hold the write lock.
-  const comments: CanvasComment[] = []
-  const threadIds = new Set<string>()
-  for (const thread of readCommentThreads(doc)) {
-    threadIds.add(thread.id)
-    const projected = canvasCommentFromThread(thread)
-    if (projected !== undefined) comments.push(projected)
-  }
-  const commentsMap = doc.getMap(COMMENTS_KEY)
-  for (const commentId of commentsMap.keys()) {
-    if (threadIds.has(commentId)) continue
-    const parsed = canvasCommentSchema.safeParse(commentsMap.get(commentId))
-    if (parsed.success) comments.push(parsed.data)
-  }
+  // The annotation layer is document-level and format-agnostic, so reading it
+  // is not this reader's job — `readAnnotations` answers it for a markdown
+  // document too. What stays here is only the lossy projection into the flat
+  // shape the canvas renderer still takes.
+  const comments = readCanvasComments(doc)
 
   const hasEnvelope = Object.values(envelope).some((value) => value !== undefined)
   if (!hasEnvelope && comments.length === 0) return { nodes, edges }


### PR DESCRIPTION
ADR-0026 step 2 (Readers), the two seams the rest of the plan needs. Behaviour-preserving: nothing calls either seam in anger yet.

## Summary

**`readAnnotations(doc)` — the format-agnostic reader.** The union it performs (the threads plane, plus any legacy comment no writer has migrated yet, lifted into the one-message thread it always was) used to sit inside `readSpatialCanvas`. That made a markdown document's threads **unreachable rather than absent** — stored correctly, at the document level, and readable by nothing. `readSpatialCanvas` now calls the extraction and keeps only the lossy projection into the flat shape the canvas renderer still takes.

**`layoutSpatialCanvas` gains a `comments` option.** ADR-0026 decision 1b makes the layer keeper-side, so it stops riding inside `x-whiteboard` and travels beside the canvas — the deciding argument being that a markdown document has no envelope to put comments in at all.

Two properties of the option are load-bearing while call sites migrate one at a time, and both are pinned:

- it **replaces** the envelope's copy rather than adding to it — the union would draw two pins on one comment;
- an **empty array is an answer**, not a missing one — a caller that read the layer and found it empty must not get the stale copy back.

Absent, the envelope is read as before, which is what keeps every unmigrated caller byte-identical.

**Order is behaviour, not presentation**, and now says so where it is decided: `composeComments` fans a later bubble out around an earlier one, so `readAnnotations` keeps threads first and legacy rows in map order after them. Sorting the union by id reads more tidily and would move bubbles on any document still holding both shapes.

## Test plan

- **Red first**, both halves: `readAnnotations` (5 cases, module absent) and the layout option (3 cases, all failing).
- The reader's headline case is a document with **no canvas at all** — a markdown body plus a thread — which `readSpatialCanvas` could not serve by construction.
- **Mutation checks**: making the option *supplement* the envelope fails two of the three renderer cases; sorting `readAnnotations`' union by id fails the order case.
- `loro-adapter-node` 14 files / 179 tests; `canvas-render-node` 108 files / 1087 tests; `mcp-node` + `model-node` + `server-core-node` 4920 passed / 10 skipped.
- `pnpm -r typecheck`, `pnpm check:local` — exit 0.

## Reach

`userReach: foundation` — deliberately. Wired by **2b-B** (apps/web and server-core move onto the seams); **2b-C** then removes the projection and the envelope fallback together, which is also where `canvas_view`'s published payload changes.

Visual evidence: none — no pixel moves. Every existing caller renders byte-identically, which is what the 1087-test canvas-render run is asserting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_