### PR TITLE
fix(web): make the error screen's Reload able to change the bundle

### DIFF
--- a/apps/web/src/components/status/ErrorFallback.test.tsx
+++ b/apps/web/src/components/status/ErrorFallback.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * The recovery action has to be able to recover.
+ *
+ * "Try again" resets the boundary in place, which is right for a transient
+ * render failure. "Reload" is for the other kind — the bundle itself is
+ * wrong — and under a `prompt`-registered worker that means it must drop the
+ * worker, not merely navigate.
+ */
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, expect, it, vi } from 'vitest'
+
+const reloadFresh = vi.hoisted(() => vi.fn(() => Promise.resolve()))
+vi.mock('../../pwa/reload-fresh.js', () => ({ reloadFresh }))
+
+const { ErrorFallback } = await import('./ErrorFallback.js')
+
+// The spy is module-level, so a call from the previous test would otherwise
+// be counted as this one's.
+beforeEach(() => reloadFresh.mockClear())
+
+it('reloads through the worker-dropping path, not a plain navigation', () => {
+  const onRetry = vi.fn()
+  render(<ErrorFallback onRetry={onRetry} />)
+
+  fireEvent.click(screen.getByRole('button', { name: 'Reload' }))
+
+  expect(reloadFresh).toHaveBeenCalledTimes(1)
+  expect(onRetry).not.toHaveBeenCalled()
+})
+
+it('keeps Try again as the in-place retry, which must not reload anything', () => {
+  const onRetry = vi.fn()
+  render(<ErrorFallback onRetry={onRetry} />)
+
+  fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+  expect(onRetry).toHaveBeenCalledTimes(1)
+  expect(reloadFresh).not.toHaveBeenCalled()
+})

--- a/apps/web/src/components/status/ErrorFallback.tsx
+++ b/apps/web/src/components/status/ErrorFallback.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from 'react'
 import ErrorMark from '../../brand/error-mark.svg?react'
+import { reloadFresh } from '../../pwa/reload-fresh.js'
 import { StatusPageButton, StatusPageLayout } from './StatusPageLayout.js'
 
 /**
@@ -18,7 +19,12 @@ export function ErrorFallback({ onRetry }: { onRetry: () => void }): JSX.Element
       actions={
         <>
           <StatusPageButton label="Try again" onClick={onRetry} primary />
-          <StatusPageButton label="Reload" onClick={() => window.location.reload()} />
+          {/* `reloadFresh`, not `location.reload()`: under the worker's
+              `prompt` registration a plain reload re-runs the SAME cached
+              bundle, so for the failure this screen is most often reached by
+              — chunks that no longer agree with each other — the button
+              would return the user to the identical error. */}
+          <StatusPageButton label="Reload" onClick={() => void reloadFresh()} />
         </>
       }
     />

--- a/apps/web/src/pwa/reload-fresh.test.ts
+++ b/apps/web/src/pwa/reload-fresh.test.ts
@@ -1,0 +1,95 @@
+/**
+ * The app's own Reload has to do more than the browser's.
+ *
+ * `apps/web` registers a Workbox worker with `registerType: 'prompt'`, so a
+ * plain `location.reload()` re-runs the SAME cached bundle — the worker keeps
+ * serving it until something calls `skipWaiting`. That is exactly the state
+ * the error screen is reached in when the page is running chunks that no
+ * longer agree with each other, and offering a reload that cannot change the
+ * bundle is offering a button that does nothing.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { reloadFresh } from './reload-fresh.js'
+
+interface Recorder {
+  unregistered: number
+  deletedCaches: string[]
+  reloaded: number
+}
+
+function install(overrides: { serviceWorker?: boolean; caches?: boolean } = {}): Recorder {
+  const rec: Recorder = { unregistered: 0, deletedCaches: [], reloaded: 0 }
+  if (overrides.serviceWorker !== false) {
+    vi.stubGlobal('navigator', {
+      ...globalThis.navigator,
+      serviceWorker: {
+        getRegistrations: () =>
+          Promise.resolve([
+            {
+              unregister: () => {
+                rec.unregistered += 1
+                return Promise.resolve(true)
+              },
+            },
+          ]),
+      },
+    })
+  } else {
+    vi.stubGlobal('navigator', { ...globalThis.navigator, serviceWorker: undefined })
+  }
+  if (overrides.caches !== false) {
+    vi.stubGlobal('caches', {
+      keys: () => Promise.resolve(['workbox-precache', 'assets']),
+      delete: (key: string) => {
+        rec.deletedCaches.push(key)
+        return Promise.resolve(true)
+      },
+    })
+  } else {
+    vi.stubGlobal('caches', undefined)
+  }
+  return rec
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('reloadFresh', () => {
+  it('drops every worker and every cache before reloading', async () => {
+    const rec = install()
+    await reloadFresh(() => {
+      rec.reloaded += 1
+    })
+    expect(rec).toEqual({
+      unregistered: 1,
+      deletedCaches: ['workbox-precache', 'assets'],
+      reloaded: 1,
+    })
+  })
+
+  it('still reloads where there is no worker and no cache API', async () => {
+    // A private window, an unsupported browser, or the dev server. The button
+    // must not become a no-op just because the clearing has nothing to clear.
+    const rec = install({ serviceWorker: false, caches: false })
+    await reloadFresh(() => {
+      rec.reloaded += 1
+    })
+    expect(rec.reloaded).toBe(1)
+  })
+
+  it('reloads even when clearing THROWS', async () => {
+    // Storage access can throw outright (blocked site data), and a reload the
+    // user cannot reach is worse than a reload that skipped its cleaning.
+    vi.stubGlobal('navigator', {
+      ...globalThis.navigator,
+      serviceWorker: {
+        getRegistrations: () => Promise.reject(new Error('site data blocked')),
+      },
+    })
+    vi.stubGlobal('caches', undefined)
+    let reloaded = 0
+    await reloadFresh(() => {
+      reloaded += 1
+    })
+    expect(reloaded).toBe(1)
+  })
+})

--- a/apps/web/src/pwa/reload-fresh.ts
+++ b/apps/web/src/pwa/reload-fresh.ts
@@ -1,0 +1,41 @@
+import { getAppLogger } from '../lib/app-logger.js'
+
+const log = getAppLogger('reload-fresh')
+
+/**
+ * Reload onto whatever the SERVER now serves, rather than onto the bundle
+ * this page is already running.
+ *
+ * The distinction is not pedantic here. `apps/web` registers its Workbox
+ * worker with `registerType: 'prompt'`, so a waiting worker holds its cached
+ * chunks until something calls `skipWaiting` — and a plain
+ * `location.reload()` never does. A page that reached the error screen
+ * because the chunks it holds no longer agree with each other therefore
+ * reloads straight back into the same broken bundle, which is the one thing
+ * a recovery action must not do.
+ *
+ * Clearing is best-effort and never blocks the reload: storage access throws
+ * outright in a browser set to block site data, and a reload the user cannot
+ * reach is worse than a reload that skipped its cleaning.
+ *
+ * The reload itself is injected so a test can observe it — a real
+ * `location.reload()` in jsdom navigates the test's own environment.
+ */
+export async function reloadFresh(
+  reload: () => void = () => window.location.reload(),
+): Promise<void> {
+  try {
+    const registrations = await navigator.serviceWorker?.getRegistrations()
+    for (const registration of registrations ?? []) await registration.unregister()
+  } catch (err) {
+    log.warn('could not drop the service worker before reloading', err)
+  }
+  try {
+    // `caches` is absent in a private window and in browsers without the API.
+    const keys = await globalThis.caches?.keys()
+    for (const key of keys ?? []) await globalThis.caches.delete(key)
+  } catch (err) {
+    log.warn('could not clear the caches before reloading', err)
+  }
+  reload()
+}


### PR DESCRIPTION
The error screen's recovery action could not recover.

## The defect

`apps/web` registers its Workbox worker with `registerType: 'prompt'`, so a waiting worker keeps serving its cached chunks until something calls `skipWaiting`. `ErrorFallback`'s Reload was a plain `location.reload()`, which never does — it reloads onto **the same bundle the page is already running**.

That matters most for the failure this screen is most often reached by: a page holding chunks that no longer agree with each other. React reports it as error #130 (`element type is invalid: got undefined`) when a symbol one chunk imports is not in the chunk that now answers. Pressing Reload returns the user to the identical error, and the only way out is DevTools — which `.claude/rules/integrator-flow.md` already documents as the manual recipe for exactly this.

## The change

`pwa/reload-fresh.ts` drops every service-worker registration and every cache, then reloads. Two properties it is tested for, because both are how this kind of helper usually breaks:

- it **still reloads** when there is no worker and no `caches` (a private window, an unsupported browser, the dev server) — the button must not become a no-op just because the clearing had nothing to clear;
- it **still reloads when clearing throws**. Storage access throws outright in a browser set to block site data, and a reload the user cannot reach is worse than a reload that skipped its cleaning.

"Try again" is unchanged and stays the in-place boundary reset, which is right for a transient render failure. A test pins that it reloads nothing, so the two actions cannot quietly collapse into one.

## What this does NOT claim

It does not diagnose any particular crash, and it is not offered as the fix for one. It makes the button do what it says. A report of a kebab-menu crash on a preview is what led me here; that crash is still unattributed, and this change would only have made the user's escape from it work.

## Test plan

- **Red first**: three `reload-fresh` cases against an absent module, then two on `ErrorFallback`.
- **Mutation-checked**: reverting the button to `location.reload()` fails the wiring test and nothing else.
- The reload is injected rather than called directly, so the test can observe it — a real `location.reload()` in jsdom navigates the test's own environment.
- `pnpm --filter @kamiazya/whiteboard-web test` — 315 files / 3283 tests, plus web-node 13 / 89. Exit 0.
- `pnpm check:local` — exit 0.

Visual evidence: none — the screen's markup and copy are unchanged; what changed is what one button does, which a screenshot cannot show. The behaviour is pinned by the two tests above instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_