### PR TITLE
fix(search): stop snippets cutting a character in half

### DIFF
--- a/packages/search/src/snippet.test.ts
+++ b/packages/search/src/snippet.test.ts
@@ -1,0 +1,95 @@
+/**
+ * `snippetAround` cuts by UTF-16 CODE UNIT, and every character outside the
+ * BMP — emoji, and the rare CJK ideographs a Japanese document reaches for —
+ * is two of them. A radius landing between the two halves emitted a lone
+ * surrogate: a broken glyph at the edge of every search result and backlink
+ * context showing that document.
+ *
+ * The property below is written so the cut ALWAYS lands inside an astral run,
+ * with `k` deciding whether it lands between a character's halves or on the
+ * boundary between two. Leaving that to independently-arbitrary inputs is how
+ * this kind of property passes without ever reaching the case it names, so the
+ * tally below counts the runs that actually entered it.
+ */
+import { afterAll, describe, expect, it } from 'vitest'
+import { CONTEXT_RADIUS, snippetAround } from './snippet.js'
+import { fc, fcTest, withDefaults } from './test-utils/fast-check.js'
+
+/** How many unpaired surrogates a string carries. Zero is the contract. */
+function unpairedSurrogates(value: string): number {
+  let count = 0
+  for (let i = 0; i < value.length; i += 1) {
+    const unit = value.charCodeAt(i)
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(i + 1)
+      if (next >= 0xdc00 && next <= 0xdfff) i += 1
+      else count += 1
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) count += 1
+  }
+  return count
+}
+
+const NEEDLE = 'NEEDLE'
+/** Comfortably longer than the radius, so the cut cannot fall outside it. */
+const RUN = CONTEXT_RADIUS + 20
+
+/**
+ * Runs whose start boundary landed STRICTLY INSIDE a two-unit character —
+ * the arrangement the fix exists for. Asserted against a floor because a
+ * generator that never reaches it makes the surrogate assertion below
+ * vacuously true, which reads exactly like a thorough test.
+ */
+let enteredDefectZone = 0
+
+afterAll(() => {
+  expect(
+    enteredDefectZone,
+    'the generator never put a cut inside a character — the surrogate property proved nothing',
+  ).toBeGreaterThan(20)
+})
+
+describe('snippetAround', () => {
+  fcTest.prop([fc.integer({ min: 0, max: 7 }), fc.constantFrom('🎨', '𠮷', '😀')], withDefaults())(
+    'never cuts a character in half',
+    (k, astral) => {
+      const body = `${astral.repeat(RUN)}${'y'.repeat(k)}${NEEDLE}${astral.repeat(RUN)}`
+      const index = body.indexOf(NEEDLE)
+      const start = index - CONTEXT_RADIUS
+      // Inside a character exactly when the unit at the boundary is the second
+      // half of one — which is what `k`'s parity moves.
+      const unit = body.charCodeAt(start)
+      if (unit >= 0xdc00 && unit <= 0xdfff) enteredDefectZone += 1
+
+      expect(unpairedSurrogates(snippetAround(body, index, NEEDLE.length))).toBe(0)
+    },
+  )
+
+  // The measured reproduction, kept as a named companion to the property: the
+  // property says "for any of these", this says "this one, concretely".
+  it('does not leave a broken glyph where the radius falls between two halves', () => {
+    const body = `${'🎨'.repeat(40)}y${NEEDLE}${'🎨'.repeat(40)}`
+    const out = snippetAround(body, body.indexOf(NEEDLE), NEEDLE.length)
+    expect(unpairedSurrogates(out)).toBe(0)
+    expect(out).toContain(NEEDLE)
+  })
+
+  it('adds no ellipsis for a string that fits inside the radius', () => {
+    expect(snippetAround('a short body', 2, 5)).toBe('a short body')
+  })
+
+  it('marks only the end when the cut starts at the beginning', () => {
+    const body = `start ${'x'.repeat(400)}`
+    expect(snippetAround(body, 0, 5)).toMatch(/^start x+…$/)
+  })
+
+  it('marks only the start when the cut reaches the end', () => {
+    const body = `${'x'.repeat(400)} end`
+    const out = snippetAround(body, body.length - 3, 3)
+    expect(out.startsWith('…')).toBe(true)
+    expect(out.endsWith('…')).toBe(false)
+  })
+
+  it('collapses whitespace runs to a single space', () => {
+    expect(snippetAround('a  \n\t b', 0, 1)).toBe('a b')
+  })
+})

--- a/packages/search/src/snippet.ts
+++ b/packages/search/src/snippet.ts
@@ -1,4 +1,10 @@
-const CONTEXT_RADIUS = 60
+/**
+ * How much text either side of the match an excerpt carries, in UTF-16 code
+ * units. Exported so a test can place a character exactly on the cut boundary
+ * — duplicating the number there would let the generator silently stop
+ * aiming at anything the day this changes.
+ */
+export const CONTEXT_RADIUS = 60
 
 /**
  * A short plain-text excerpt around [index, index+length), whitespace
@@ -7,8 +13,31 @@ const CONTEXT_RADIUS = 60
  * from both surfaces.
  */
 export function snippetAround(value: string, index: number, length: number): string {
-  const start = Math.max(0, index - CONTEXT_RADIUS)
-  const end = Math.min(value.length, index + length + CONTEXT_RADIUS)
+  // Snapped to whole characters before slicing. `slice` indexes UTF-16 code
+  // UNITS, and everything outside the BMP — emoji, the rarer CJK ideographs —
+  // is two of them, so a radius landing between the halves used to emit a lone
+  // surrogate: a broken glyph at the edge of the excerpt, in every search
+  // result and backlink context for that document.
+  //
+  // Inward, so an excerpt can never grow past the radius it was asked for and
+  // the rule reads the same at both ends. This buys WHOLE CHARACTERS and not
+  // whole graphemes: a combining mark or a flag sequence can still be split,
+  // which needs `Intl.Segmenter` and is a larger question than the one
+  // measured here.
+  const start = snapForward(value, Math.max(0, index - CONTEXT_RADIUS))
+  const end = snapBack(value, Math.min(value.length, index + length + CONTEXT_RADIUS))
   const text = value.slice(start, end).replace(/\s+/g, ' ').trim()
   return `${start > 0 ? '…' : ''}${text}${end < value.length ? '…' : ''}`
+}
+
+/** Past the low half of a pair, when the cut landed between the two. */
+function snapForward(value: string, at: number): number {
+  const unit = value.charCodeAt(at)
+  return unit >= 0xdc00 && unit <= 0xdfff ? at + 1 : at
+}
+
+/** Before the high half of a pair, when the cut landed between the two. */
+function snapBack(value: string, at: number): number {
+  const unit = value.charCodeAt(at - 1)
+  return unit >= 0xd800 && unit <= 0xdbff ? at - 1 : at
 }


### PR DESCRIPTION
## Summary

`snippetAround` slices a fixed 60-unit radius with `String.slice`, which indexes UTF-16 code **units**. Everything outside the BMP — emoji, and the rarer CJK ideographs a Japanese document reaches for — is two of them, so a radius landing between the halves emitted a **lone surrogate**: a broken glyph at the edge of the excerpt.

It shows in three places, all user-facing: full-text search results (`packages/search/src/full-text.ts`) and both reference surfaces (`extract.ts`, `reference-aggregate.ts` in server-core).

### Reproduced before it was fixed

Four bodies differing only in how far the match sat into an emoji run:

| offset of the cut into the run | unpaired surrogates |
|---|---|
| 20 | 0 |
| **21** | **1** |
| 22 | 0 |
| **23** | **1** |

The defect is the **parity** of an offset. That is why this is a property and not an example — a hand-written case would have to guess the parity, and half of them guess wrong and pass.

### The fix, and what it deliberately does not buy

Both bounds snap **inward** to a whole character: an excerpt can never grow past the radius it was asked for, and the rule reads the same at both ends.

It buys whole **characters**, not whole **graphemes**. A combining mark or a flag sequence can still be split — that needs `Intl.Segmenter` and is a larger question than the one measured here. The source says so rather than implying a guarantee the code does not make.

### Why `CONTEXT_RADIUS` becomes an export

Of `snippet.ts` only — not of the package barrel, which nothing outside needs. The property has to place a character *exactly* on the computed cut boundary; a duplicated `60` in the test would let the generator silently stop aiming at anything the day the radius changes, which is precisely the vacuity this property exists to avoid.

## Test plan

- [x] New `search-node` tests — a property over both parities, the measured reproduction as a named example, and the ellipsis / whitespace-collapse behaviour that nothing pinned before. Written **red first**.
- [x] `pnpm test` passes locally — `search-node` 20/20, `server-core-node` 473/473 (the other two call sites), `pnpm -r typecheck`, `pnpm lint`, `pnpm knip` all clean.
- [x] Manual verification completed — the reproduction above *is* the measurement; a UI check would show the same broken glyph the property states in general.
- [x] E2E coverage — n/a; a pure string function whose contract lives at this layer.

### Mutation checks — and the second one is the one worth reading

| mutation | result |
|---|---|
| revert the inward snap | the property **and** the example fail |
| narrow the generator to the aligned parity only | **`Tests 20 passed (20)`** — the surrogate property goes green *vacuously*, and only the reachability tally's floor catches it |

The second is why the tally exists. With a generator that cannot reach the defect, the assertion everyone would look at passes whether or not the fix is present. Note also that vitest reported `20 passed` while the `afterAll` floor was failing — the exit code is the truth, exactly as `.claude/rules/coverage-ledger.md` records.

That failure also happened for real, not just as an experiment: the first run of the red test reported `expected 0 to be greater than 20` because `CONTEXT_RADIUS` was not exported yet, so the generator built an empty body. The tally caught a broken generator before it could pretend to be a passing property.

## Visual evidence

Visual evidence: none — the change is one character wide at the edge of a text excerpt, and a screenshot of `…🎨` beside `…�` would be a picture of a font's replacement glyph rather than evidence about this code. The measurement above counts the unpaired surrogates directly, which is the thing itself.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — n/a: the package's public surface is unchanged (`CONTEXT_RADIUS` is exported from `snippet.ts`, not from `index.ts`), so `package-search.md`'s "What belongs here" still describes it exactly.
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_