### PR TITLE
feat(web): route every rendered picture through one broker, and cache it

### DIFF
--- a/apps/web/renderer-build-id.ts
+++ b/apps/web/renderer-build-id.ts
@@ -1,0 +1,46 @@
+import { execFileSync } from 'node:child_process'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+/**
+ * Identifies the code that produced a rendered picture, for the render
+ * cache's key (ADR-0027 decision 2).
+ *
+ * Derived from the build rather than typed by hand: a version someone has to
+ * remember to bump is a guard that looks like a guard. It must also come from
+ * the ARTIFACT and never from the service worker's update state — under
+ * `registerType: 'prompt'` a new worker installs while the page keeps running
+ * the old bundle, so a key taken from the worker would claim the new identity
+ * while the old code writes the bytes. A compile-time constant travels with
+ * the code that produced them and cannot drift from it.
+ *
+ * Every build gets a fresh id even when the renderer did not change. That
+ * over-invalidates, which costs a lazy refill on the first visit after a
+ * deploy; the alternative is hashing the render chunk, which is fragile for
+ * what it buys.
+ */
+function rendererBuildId(): string {
+  try {
+    return execFileSync('git', ['rev-parse', '--short=12', 'HEAD'], {
+      cwd: here,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+  } catch {
+    // A tarball or a checkout with no git available: the timestamp still
+    // changes per build, which is the only property the key needs.
+    return `t${Date.now().toString(36)}`
+  }
+}
+
+/**
+ * Spread into every vite/vitest config's `define`. Shared rather than
+ * repeated because there are four of them, and `render-key.ts` reads the
+ * global with no fallback — a config that forgets this throws on the first
+ * key it builds instead of quietly keying every deploy the same.
+ */
+export const rendererBuildDefine = {
+  __RENDERER_BUILD_ID__: JSON.stringify(rendererBuildId()),
+}

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -3,6 +3,7 @@ import { Columns2, List, Search } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useThemeMode } from '../../hooks/useThemeMode.js'
+import { createInTabRenderBroker } from '../../lib/render-broker.js'
 import { ContextMenu } from '../spatial-editor/ContextMenu.js'
 import { DocumentMinimap } from './DocumentMinimap.js'
 import { DocumentPreview } from './DocumentPreview.js'
@@ -194,11 +195,18 @@ export function WorkspaceFilesPanel({
   }, [documents])
   const activeTag = query.trim().startsWith('#') ? query.trim().slice(1) : null
 
+  // One broker for the whole panel. Deliberately NOT keyed on the theme the
+  // loader below is: a markdown render is theme-independent (its ink comes
+  // from CSS), so its entries survive a theme toggle, and a spatial render
+  // carries the theme in its own key. Rebuilding the broker per theme would
+  // throw both away — which is the measured "dark mode re-renders every row".
+  const broker = useMemo(() => createInTabRenderBroker(), [source])
+
   // One loader for the whole panel, so a re-render does not hand every card
   // a new function and re-trigger its render.
   const loadRender = useMemo(
-    () => createRowRenderLoader({ source, theme: resolvedTheme }),
-    [source, resolvedTheme],
+    () => createRowRenderLoader({ source, theme: resolvedTheme, broker }),
+    [source, resolvedTheme, broker],
   )
 
   // The row-size rendition. Separate from `loadRender` on purpose: it asks

--- a/apps/web/src/components/workspace-files/load-row-render.test.ts
+++ b/apps/web/src/components/workspace-files/load-row-render.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { createInTabRenderBroker } from '../../lib/render-broker.js'
 import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
 import { createRowRenderLoader, type RowRenderDeps } from './load-row-render.js'
 
@@ -9,6 +10,8 @@ function deps(over: Partial<RowRenderDeps> = {}): RowRenderDeps {
   return {
     source: fakeFilesSource({ loadMarkdown: vi.fn(async () => '# Hi') }),
     theme: 'light',
+    // A fresh broker per case, so one case's memo cannot answer another's.
+    broker: createInTabRenderBroker(),
     renderMarkdown: vi.fn(async () => ({ svg: SVG, bounds: BOUNDS })),
     renderSpatial: vi.fn(async () => ({ svg: SVG, bounds: BOUNDS })),
     readCanvas: vi.fn(() => ({ nodes: [], edges: [] })),
@@ -17,6 +20,60 @@ function deps(over: Partial<RowRenderDeps> = {}): RowRenderDeps {
 }
 
 describe('createRowRenderLoader', () => {
+  // The measured defect this loader was routed through a broker to fix: the
+  // row's thumbnail and the preview pane beside it are separate components
+  // asking separately, so the second arrives while the first is still in the
+  // worker. Both must come back with one render behind them.
+  it('renders one document once, however many surfaces ask', async () => {
+    const d = deps()
+    const load = createRowRenderLoader(d)
+    const entry = { documentId: 'd1', path: 'a', kind: 'markdown' as const }
+
+    const [row, preview] = await Promise.all([load(entry), load(entry)])
+
+    expect(row).toEqual(preview)
+    expect(d.renderMarkdown).toHaveBeenCalledTimes(1)
+    expect(d.source.loadMarkdown).toHaveBeenCalledTimes(1)
+  })
+
+  // `kind` is optional on a row, and an entry without one is rendered
+  // SPATIALLY — so its key has to carry the theme. Keying it as markdown
+  // would drop that axis and let one entry answer for a light and a dark
+  // render of the same board, which is the worst failure a cache can have:
+  // a picture that is wrong rather than missing.
+  it('keys a kind-less row the way it actually renders it — spatially, with the theme', async () => {
+    const broker = createInTabRenderBroker()
+    const entry = { documentId: 'k1', path: 'k' }
+
+    const light = deps({ broker, theme: 'light' })
+    await createRowRenderLoader(light)(entry)
+    const dark = deps({ broker, theme: 'dark' })
+    await createRowRenderLoader(dark)(entry)
+
+    expect(light.renderSpatial).toHaveBeenCalledTimes(1)
+    expect(dark.renderSpatial).toHaveBeenCalledTimes(1)
+    expect(dark.renderMarkdown).not.toHaveBeenCalled()
+  })
+
+  // A theme toggle rebuilds the loader (the palette is a spatial render's
+  // input) but must not rebuild a markdown picture, whose ink comes from CSS.
+  it('keeps a markdown render across a theme change, and redraws a spatial one', async () => {
+    const broker = createInTabRenderBroker()
+    const note = { documentId: 'n1', path: 'n', kind: 'markdown' as const }
+    const board = { documentId: 'b1', path: 'b', kind: 'spatial' as const }
+
+    const light = deps({ broker, theme: 'light' })
+    await createRowRenderLoader(light)(note)
+    await createRowRenderLoader(light)(board)
+
+    const dark = deps({ broker, theme: 'dark' })
+    await createRowRenderLoader(dark)(note)
+    await createRowRenderLoader(dark)(board)
+
+    expect(dark.renderMarkdown).not.toHaveBeenCalled()
+    expect(dark.renderSpatial).toHaveBeenCalledTimes(1)
+  })
+
   // The picture in the row is the picture the preview draws, so both kinds
   // have to arrive as an SVG — not as boxes for one and a render for the
   // other, which is what made the two panes disagree about what a document

--- a/apps/web/src/components/workspace-files/load-row-render.test.ts
+++ b/apps/web/src/components/workspace-files/load-row-render.test.ts
@@ -27,7 +27,12 @@ describe('createRowRenderLoader', () => {
   it('renders one document once, however many surfaces ask', async () => {
     const d = deps()
     const load = createRowRenderLoader(d)
-    const entry = { documentId: 'd1', path: 'a', kind: 'markdown' as const }
+    const entry = {
+      documentId: 'd1',
+      path: 'a',
+      kind: 'markdown' as const,
+      updatedAt: '2026-09-03T00:00:00Z',
+    }
 
     const [row, preview] = await Promise.all([load(entry), load(entry)])
 
@@ -43,7 +48,9 @@ describe('createRowRenderLoader', () => {
   // a picture that is wrong rather than missing.
   it('keys a kind-less row the way it actually renders it — spatially, with the theme', async () => {
     const broker = createInTabRenderBroker()
-    const entry = { documentId: 'k1', path: 'k' }
+    // Stamped, so the two renders below are separated by the THEME axis
+    // rather than by a version-less key refusing to be remembered at all.
+    const entry = { documentId: 'k1', path: 'k', updatedAt: '2026-09-03T00:00:00Z' }
 
     const light = deps({ broker, theme: 'light' })
     await createRowRenderLoader(light)(entry)
@@ -59,8 +66,11 @@ describe('createRowRenderLoader', () => {
   // input) but must not rebuild a markdown picture, whose ink comes from CSS.
   it('keeps a markdown render across a theme change, and redraws a spatial one', async () => {
     const broker = createInTabRenderBroker()
-    const note = { documentId: 'n1', path: 'n', kind: 'markdown' as const }
-    const board = { documentId: 'b1', path: 'b', kind: 'spatial' as const }
+    // Both carry a version: without one nothing is remembered at all (see
+    // isMemoisableKey), and the axis under test here is the THEME.
+    const stamped = { updatedAt: '2026-09-03T00:00:00Z' }
+    const note = { documentId: 'n1', path: 'n', kind: 'markdown' as const, ...stamped }
+    const board = { documentId: 'b1', path: 'b', kind: 'spatial' as const, ...stamped }
 
     const light = deps({ broker, theme: 'light' })
     await createRowRenderLoader(light)(note)

--- a/apps/web/src/components/workspace-files/load-row-render.ts
+++ b/apps/web/src/components/workspace-files/load-row-render.ts
@@ -16,6 +16,11 @@
  * Total by contract. Every failure answers `null` and the row keeps its kind
  * icon: a list that cannot draw a miniature is a plainer list, a list that
  * throws is a broken screen.
+ *
+ * Every answer goes through the render broker (ADR-0027), which is why the
+ * preview pane beside a row no longer redraws what the row just drew: both
+ * ask for the same key, and the second one joins the first rather than
+ * starting a second render.
  */
 
 import type { BoundingBox } from '@kamiazya/whiteboard-canvas-render'
@@ -25,6 +30,8 @@ import { LoroDoc } from 'loro-crdt'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
 import { nextLayoutRequestId, sharedLayoutWorkerPool } from '../../lib/layout-worker-pool.js'
 import type { LayoutResponse, MarkdownRenderResponse } from '../../lib/layout-worker-protocol.js'
+import type { RenderBroker } from '../../lib/render-broker.js'
+import { renderKeyOf } from '../../lib/render-key.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
 import type { WorkspaceFilesSource } from './files-source.js'
 
@@ -45,6 +52,11 @@ export interface RowRenderDeps {
   readonly source: WorkspaceFilesSource
   /** Spatial rendering resolves its palette from this; markdown takes its ink from CSS. */
   readonly theme: ResolvedTheme
+  /**
+   * Answers from the memo, joins a render already in flight for the same key,
+   * and otherwise runs the pipeline below exactly once.
+   */
+  readonly broker: RenderBroker
   /**
    * The two renders and the snapshot decode are injected like the reads
    * above, so the branch that actually produces a picture is assertable
@@ -86,18 +98,45 @@ function decodeCanvas(bytes: Uint8Array): SpatialCanvas {
   return readSpatialCanvas(doc)
 }
 
-export function createRowRenderLoader(deps: RowRenderDeps) {
-  return async (document: WorkspaceDocumentEntry): Promise<DocumentRender | null> => {
-    try {
-      if (document.kind === 'markdown') {
-        const markdown = await deps.source.loadMarkdown(document)
-        if (markdown.trim() === '') return null
-        return await (deps.renderMarkdown ?? renderMarkdownInPool)(markdown, ROW_LAYOUT_WIDTH)
-      }
+/**
+ * The kind the pipeline will actually take, which is what the key has to
+ * agree with. `kind` is optional on a row, and an entry without one is read
+ * as spatial below — so the key must say spatial too. Deriving both from
+ * here is not tidiness: a key that said `markdown` for a spatially rendered
+ * document would drop the theme axis, and one entry would then serve a light
+ * and a dark render of the same board.
+ */
+function renderedKind(document: WorkspaceDocumentEntry): 'spatial' | 'markdown' {
+  return document.kind === 'markdown' ? 'markdown' : 'spatial'
+}
 
-      const bytes = await deps.source.loadSpatialSnapshot(document)
-      const canvas = (deps.readCanvas ?? decodeCanvas)(bytes)
-      return await (deps.renderSpatial ?? renderSpatialInPool)(canvas, deps.theme)
+export function createRowRenderLoader(deps: RowRenderDeps) {
+  const produce = async (document: WorkspaceDocumentEntry): Promise<DocumentRender | null> => {
+    if (renderedKind(document) === 'markdown') {
+      const markdown = await deps.source.loadMarkdown(document)
+      if (markdown.trim() === '') return null
+      return await (deps.renderMarkdown ?? renderMarkdownInPool)(markdown, ROW_LAYOUT_WIDTH)
+    }
+
+    const bytes = await deps.source.loadSpatialSnapshot(document)
+    const canvas = (deps.readCanvas ?? decodeCanvas)(bytes)
+    return await (deps.renderSpatial ?? renderSpatialInPool)(canvas, deps.theme)
+  }
+
+  return async (document: WorkspaceDocumentEntry): Promise<DocumentRender | null> => {
+    // The catch stays OUTSIDE the broker: a rejection must not be remembered
+    // as an answer, so the broker is allowed to see it and forget the entry,
+    // and the totality this loader promises is restored here.
+    try {
+      const key = renderKeyOf(
+        {
+          documentId: document.documentId,
+          kind: renderedKind(document),
+          ...(document.updatedAt === undefined ? {} : { updatedAt: document.updatedAt }),
+        },
+        deps.theme,
+      )
+      return await deps.broker.render(key, () => produce(document))
     } catch {
       return null
     }

--- a/apps/web/src/components/workspace-files/panel-one-render.browser.test.tsx
+++ b/apps/web/src/components/workspace-files/panel-one-render.browser.test.tsx
@@ -1,0 +1,48 @@
+// The panel hands ONE broker to a row's thumbnail and to the preview pane
+// beside it, so two panes showing the same document cost one trip through the
+// pipeline (ADR-0027).
+//
+// A real browser rather than jsdom, and not for layout: the pipeline has to
+// SUCCEED for the memo to hold anything. In jsdom the worker pool is absent,
+// the render rejects, and a rejection is deliberately not memoised — so both
+// panes retry and the count is 2 for a reason that has nothing to do with the
+// broker. The premise this test needs is a working renderer.
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
+import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
+
+afterEach(cleanup)
+
+it('draws a document once, however many panes show it', async () => {
+  const entry = {
+    documentId: 'd1',
+    path: 'note',
+    kind: 'markdown' as const,
+    updatedAt: '2026-09-03T00:00:00Z',
+  }
+  const loadMarkdown = vi.fn(async () => '# Hello\n\nsome body to give it a shape')
+  const source = fakeFilesSource({ listDocuments: async () => [entry], loadMarkdown })
+
+  render(<WorkspaceFilesPanel source={source} />)
+
+  // The row's own thumbnail, drawn by the real renderer. `data-kind` marks
+  // the PLACEHOLDER icon, which is itself an <svg> — so its absence, not the
+  // presence of an svg, is what says the render landed.
+  const card = (await screen.findAllByTestId('card-title'))[0] as HTMLElement
+  const thumbnail = () => document.querySelector('[data-testid="document-thumbnail"]')
+  await waitFor(() => expect(thumbnail()?.querySelector('[data-kind]')).toBeNull(), {
+    timeout: 15_000,
+  })
+  expect(loadMarkdown).toHaveBeenCalledTimes(1)
+
+  // Selecting opens the preview pane over the document the row already drew.
+  await userEvent.click(card.closest('button') ?? card)
+  await waitFor(
+    () => expect(document.querySelector('[data-testid="preview-render"] svg')).not.toBeNull(),
+    { timeout: 15_000 },
+  )
+
+  expect(loadMarkdown).toHaveBeenCalledTimes(1)
+})

--- a/apps/web/src/components/workspace-files/row-render.browser.test.tsx
+++ b/apps/web/src/components/workspace-files/row-render.browser.test.tsx
@@ -11,6 +11,7 @@ import { writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { LoroDoc } from 'loro-crdt'
 import { expect, it } from 'vitest'
+import { createInTabRenderBroker } from '../../lib/render-broker.js'
 import { createRowRenderLoader } from './load-row-render.js'
 
 const canvas: SpatialCanvas = {
@@ -31,6 +32,7 @@ it('renders a spatial document from its snapshot bytes through the pool', async 
   const bytes = snapshotBytes()
   const load = createRowRenderLoader({
     theme: 'light',
+    broker: createInTabRenderBroker(),
     source: {
       listDocuments: async () => [],
       createDocument: async () => {},

--- a/apps/web/src/lib/render-broker.test.ts
+++ b/apps/web/src/lib/render-broker.test.ts
@@ -46,6 +46,39 @@ describe('the in-tab render broker', () => {
     expect(produce).toHaveBeenCalledTimes(1)
   })
 
+  // A version-less document is one the key cannot notice changing, so a
+  // completed render is NOT remembered under it — otherwise a row would show
+  // the same picture for the life of the tab however often the list refreshed.
+  it('does not remember a completed render for a document with no version', async () => {
+    const produce = vi.fn().mockResolvedValue(drawn)
+    const broker = createInTabRenderBroker()
+    const key = renderKeyOf({ documentId: 'no-stamp', kind: 'spatial' as const }, 'light')
+
+    expect(await broker.render(key, produce)).toEqual(drawn)
+    expect(await broker.render(key, produce)).toEqual(drawn)
+
+    expect(produce).toHaveBeenCalledTimes(2)
+    expect(broker.size).toBe(0)
+  })
+
+  // ...but two panes asking at the same instant are asking about the same
+  // bytes, so the join still applies. This is the half that keeps the
+  // measured double render fixed for a keeper that stamps no time.
+  it('still joins concurrent callers for a document with no version', async () => {
+    const pending = deferred()
+    const produce = vi.fn().mockReturnValue(pending.promise)
+    const broker = createInTabRenderBroker()
+    const key = renderKeyOf({ documentId: 'no-stamp', kind: 'spatial' as const }, 'light')
+
+    const first = broker.render(key, produce)
+    const second = broker.render(key, produce)
+    pending.release()
+
+    expect(await first).toEqual(drawn)
+    expect(await second).toEqual(drawn)
+    expect(produce).toHaveBeenCalledTimes(1)
+  })
+
   it('keeps different keys apart', async () => {
     const produce = vi.fn().mockResolvedValue(drawn)
     const broker = createInTabRenderBroker()

--- a/apps/web/src/lib/render-broker.test.ts
+++ b/apps/web/src/lib/render-broker.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createInTabRenderBroker } from './render-broker.js'
+import { renderKeyOf } from './render-key.js'
+
+const drawn = { svg: '<svg/>', bounds: { x: 0, y: 0, w: 1, h: 1 } }
+const keyFor = (documentId: string, updatedAt = '2026-09-03T00:00:00Z') =>
+  renderKeyOf({ documentId, kind: 'spatial' as const, updatedAt }, 'light')
+
+/** A producer that does not settle until the test says so. */
+function deferred() {
+  let release: (value: typeof drawn | null) => void = () => {}
+  const promise = new Promise<typeof drawn | null>((resolve) => {
+    release = resolve
+  })
+  return { promise, release: (value: typeof drawn | null = drawn) => release(value) }
+}
+
+describe('the in-tab render broker', () => {
+  it('produces once per key and answers the second caller from the memo', async () => {
+    const produce = vi.fn().mockResolvedValue(drawn)
+    const broker = createInTabRenderBroker()
+    const key = keyFor('doc-1')
+
+    expect(await broker.render(key, produce)).toEqual(drawn)
+    expect(await broker.render(key, produce)).toEqual(drawn)
+
+    expect(produce).toHaveBeenCalledTimes(1)
+  })
+
+  // The measured defect: a row's thumbnail and the preview beside it ask
+  // independently, and the second arrives while the first is still in the
+  // worker. Memoising the RESULT is not enough — the join has to happen while
+  // the work is in flight, or the second caller starts a second render.
+  it('joins a caller that arrives while the same key is still rendering', async () => {
+    const pending = deferred()
+    const produce = vi.fn().mockReturnValue(pending.promise)
+    const broker = createInTabRenderBroker()
+    const key = keyFor('doc-1')
+
+    const first = broker.render(key, produce)
+    const second = broker.render(key, produce)
+    pending.release()
+
+    expect(await first).toEqual(drawn)
+    expect(await second).toEqual(drawn)
+    expect(produce).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps different keys apart', async () => {
+    const produce = vi.fn().mockResolvedValue(drawn)
+    const broker = createInTabRenderBroker()
+
+    await broker.render(keyFor('doc-1'), produce)
+    await broker.render(keyFor('doc-2'), produce)
+
+    expect(produce).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-renders when a document changes, because the key changed with it', async () => {
+    const produce = vi.fn().mockResolvedValue(drawn)
+    const broker = createInTabRenderBroker()
+
+    await broker.render(keyFor('doc-1', '2026-09-03T00:00:00Z'), produce)
+    await broker.render(keyFor('doc-1', '2026-09-03T01:00:00Z'), produce)
+
+    expect(produce).toHaveBeenCalledTimes(2)
+  })
+
+  // A failure must not be remembered as an answer. A row whose fetch failed
+  // once keeps its kind icon; it must not keep it for the rest of the session.
+  it('does not memoise a rejection', async () => {
+    const produce = vi.fn().mockRejectedValueOnce(new Error('offline')).mockResolvedValueOnce(drawn)
+    const broker = createInTabRenderBroker()
+    const key = keyFor('doc-1')
+
+    await expect(broker.render(key, produce)).rejects.toThrow('offline')
+    expect(await broker.render(key, produce)).toEqual(drawn)
+    expect(produce).toHaveBeenCalledTimes(2)
+  })
+
+  // `null` is this pipeline's "nothing to draw" (an empty body, a failed
+  // decode), and it IS an answer — remembering it is what stops an empty note
+  // being re-fetched on every scroll.
+  it('memoises a null answer', async () => {
+    const produce = vi.fn().mockResolvedValue(null)
+    const broker = createInTabRenderBroker()
+    const key = keyFor('doc-1')
+
+    expect(await broker.render(key, produce)).toBeNull()
+    expect(await broker.render(key, produce)).toBeNull()
+    expect(produce).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops the oldest entries past its cap rather than growing without bound', async () => {
+    const produce = vi.fn().mockResolvedValue(drawn)
+    const broker = createInTabRenderBroker({ maxEntries: 2 })
+
+    await broker.render(keyFor('doc-1'), produce)
+    await broker.render(keyFor('doc-2'), produce)
+    await broker.render(keyFor('doc-3'), produce)
+    expect(broker.size).toBeLessThanOrEqual(2)
+
+    await broker.render(keyFor('doc-3'), produce)
+    expect(produce).toHaveBeenCalledTimes(3)
+  })
+})

--- a/apps/web/src/lib/render-broker.ts
+++ b/apps/web/src/lib/render-broker.ts
@@ -15,7 +15,7 @@
  * what will make two tabs racing to fill one persistent entry harmless.
  */
 
-import { type RenderKey, renderKeyPath } from './render-key.js'
+import { isMemoisableKey, type RenderKey, renderKeyPath } from './render-key.js'
 
 /** What a surface gets back. `null` is "nothing to draw", and it is an answer. */
 export interface RenderResult {
@@ -73,6 +73,11 @@ export function createInTabRenderBroker(options: InTabRenderBrokerOptions = {}):
 
       const work = produce()
         .then((result) => {
+          // A key that cannot notice its document changing must not remember
+          // an answer: it would serve the old picture for as long as the tab
+          // is open. Joining the in-flight work above is still right there —
+          // the callers are asking in the same instant, about the same bytes.
+          if (!isMemoisableKey(key)) return result
           if (done.size >= maxEntries) {
             const oldest = done.keys().next()
             if (oldest.done !== true) done.delete(oldest.value)

--- a/apps/web/src/lib/render-broker.ts
+++ b/apps/web/src/lib/render-broker.ts
@@ -1,0 +1,90 @@
+/**
+ * The one seam every surface asks for a picture through (ADR-0027 decision 1).
+ *
+ * The broker owns DECISIONS — what is already drawn, what is being drawn right
+ * now, and who joins whom. It owns no pipeline: the caller passes the producer
+ * for its own kind, and the worker pool stays exactly where it was. That is
+ * what makes this additive rather than a rewrite, and it is what lets a
+ * SharedWorker or a daemon become another implementation of this port instead
+ * of a second path through the app.
+ *
+ * Why a producer per call is sound rather than sloppy: the key fully
+ * determines the bytes. `renderSceneToSvg` is pinned byte-for-byte against the
+ * same committed golden string in the node and browser projects, so two
+ * producers for one key are interchangeable by construction. The same fact is
+ * what will make two tabs racing to fill one persistent entry harmless.
+ */
+
+import { type RenderKey, renderKeyPath } from './render-key.js'
+
+/** What a surface gets back. `null` is "nothing to draw", and it is an answer. */
+export interface RenderResult {
+  readonly svg: string
+  readonly bounds: {
+    readonly x: number
+    readonly y: number
+    readonly w: number
+    readonly h: number
+  }
+}
+
+export interface RenderBroker {
+  /**
+   * The picture for `key`. `produce` runs at most once per key: a caller that
+   * arrives while the same key is still in flight joins it rather than
+   * starting a second render.
+   */
+  render(key: RenderKey, produce: () => Promise<RenderResult | null>): Promise<RenderResult | null>
+  /** Entries currently held. For tests and for the cap below. */
+  readonly size: number
+}
+
+/**
+ * A memory backstop, not an eviction policy. A list touches every visible key
+ * on each pass, so by the time the cap trips the map is dominated by keys from
+ * documents nobody is looking at any more; dropping the oldest costs one
+ * re-render of something a scroll would rebuild anyway.
+ */
+const DEFAULT_MAX_ENTRIES = 200
+
+export interface InTabRenderBrokerOptions {
+  readonly maxEntries?: number
+}
+
+export function createInTabRenderBroker(options: InTabRenderBrokerOptions = {}): RenderBroker {
+  const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES
+  // Insertion-ordered, so the oldest key is the first one `keys()` yields.
+  const done = new Map<string, RenderResult | null>()
+  // Separate from `done` because an in-flight entry is not an answer yet, and
+  // a rejection must leave nothing behind — a row whose fetch failed once must
+  // not keep its kind icon for the rest of the session.
+  const inFlight = new Map<string, Promise<RenderResult | null>>()
+
+  return {
+    get size() {
+      return done.size
+    },
+    render(key, produce) {
+      const path = renderKeyPath(key)
+      if (done.has(path)) return Promise.resolve(done.get(path) ?? null)
+
+      const joined = inFlight.get(path)
+      if (joined !== undefined) return joined
+
+      const work = produce()
+        .then((result) => {
+          if (done.size >= maxEntries) {
+            const oldest = done.keys().next()
+            if (oldest.done !== true) done.delete(oldest.value)
+          }
+          done.set(path, result)
+          return result
+        })
+        .finally(() => {
+          inFlight.delete(path)
+        })
+      inFlight.set(path, work)
+      return work
+    },
+  }
+}

--- a/apps/web/src/lib/render-key.test.ts
+++ b/apps/web/src/lib/render-key.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { RENDERER_BUILD_ID, renderKeyOf, renderKeyPath, renderKeySchema } from './render-key.js'
+import {
+  isMemoisableKey,
+  RENDERER_BUILD_ID,
+  renderKeyOf,
+  renderKeyPath,
+  renderKeySchema,
+} from './render-key.js'
 
 const spatial = { documentId: 'doc-1', kind: 'spatial' as const, updatedAt: '2026-09-03T00:00:00Z' }
 const markdown = {
@@ -7,6 +13,55 @@ const markdown = {
   kind: 'markdown' as const,
   updatedAt: '2026-09-03T00:00:00Z',
 }
+
+// The daemon contract declares `id` opaque and deliberately not
+// pattern-bound, and `updatedAt` is a plain string beside it. So path syntax
+// inside either is not excluded by anything upstream, and the path is both
+// this cache's map key and the address the OPFS store will use.
+describe('renderKeyPath — every component unambiguous', () => {
+  const md = (documentId: string, updatedAt: string) =>
+    renderKeyOf({ documentId, kind: 'markdown' as const, updatedAt }, 'light')
+
+  it('keeps two documents apart when a separator moves between id and version', () => {
+    // Unencoded, both of these join to `<build>/markdown/a/b/c.svg` — two
+    // different documents, one entry, and the second row shows the first
+    // one's picture.
+    expect(renderKeyPath(md('a', 'b/c'))).not.toBe(renderKeyPath(md('a/b', 'c')))
+  })
+
+  it('keeps a document whose id contains a separator apart from its neighbour', () => {
+    expect(renderKeyPath(md('x/y', 'v'))).not.toBe(renderKeyPath(md('x', 'y/v')))
+  })
+
+  // `.` and `..` are ordinary strings to a Map and directory traversal to a
+  // filesystem. The encoding has to make them impossible as whole segments
+  // before the OPFS store exists, not after.
+  it('never emits a dot or dot-dot segment', () => {
+    for (const id of ['.', '..', 'a/../b']) {
+      const segments = renderKeyPath(md(id, '..')).split('/')
+      expect(segments).not.toContain('.')
+      expect(segments).not.toContain('..')
+    }
+  })
+
+  it('is still one path per key — the same key twice is the same path', () => {
+    expect(renderKeyPath(md('a/b', 'c'))).toBe(renderKeyPath(md('a/b', 'c')))
+  })
+})
+
+// A key with no version cannot notice that its document changed, so a
+// completed render must not be remembered under it. The in-flight join is
+// still safe there — two panes asking at the same instant are asking about
+// the same bytes — and that distinction is the whole point of this flag.
+describe('isMemoisableKey', () => {
+  it('refuses a key with no version', () => {
+    expect(isMemoisableKey(renderKeyOf({ documentId: 'd', kind: 'spatial' }, 'light'))).toBe(false)
+  })
+
+  it('accepts a key that carries one', () => {
+    expect(isMemoisableKey(renderKeyOf(spatial, 'light'))).toBe(true)
+  })
+})
 
 describe('renderKeyOf', () => {
   it('carries the theme for a spatial document, whose palette is baked into the SVG', () => {
@@ -47,9 +102,10 @@ describe('renderKeyOf', () => {
   })
 
   it('leads the path with the build id, so retiring a build is one directory', () => {
-    expect(renderKeyPath(renderKeyOf(spatial, 'light')).startsWith(`${RENDERER_BUILD_ID}/`)).toBe(
-      true,
-    )
+    // The first segment, decoded — the encoding is reversible on purpose, so
+    // a sweep can still recognise which build a directory belongs to.
+    const [first] = renderKeyPath(renderKeyOf(spatial, 'light')).split('/')
+    expect(decodeURIComponent((first ?? '').replace(/^~/, ''))).toBe(RENDERER_BUILD_ID)
   })
 
   it('is a valid key by its own schema', () => {

--- a/apps/web/src/lib/render-key.test.ts
+++ b/apps/web/src/lib/render-key.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { RENDERER_BUILD_ID, renderKeyOf, renderKeyPath, renderKeySchema } from './render-key.js'
+
+const spatial = { documentId: 'doc-1', kind: 'spatial' as const, updatedAt: '2026-09-03T00:00:00Z' }
+const markdown = {
+  documentId: 'doc-2',
+  kind: 'markdown' as const,
+  updatedAt: '2026-09-03T00:00:00Z',
+}
+
+describe('renderKeyOf', () => {
+  it('carries the theme for a spatial document, whose palette is baked into the SVG', () => {
+    expect(renderKeyOf(spatial, 'light').theme).toBe('light')
+    expect(renderKeyOf(spatial, 'dark').theme).toBe('dark')
+  })
+
+  // The whole reason a markdown row survives a theme toggle: its ink comes
+  // from CSS, so the same bytes serve both themes and the axis is absent
+  // rather than set to something.
+  it('omits the theme for a markdown document, whose ink comes from CSS', () => {
+    expect(renderKeyOf(markdown, 'light').theme).toBeNull()
+    expect(renderKeyPath(renderKeyOf(markdown, 'light'))).toBe(
+      renderKeyPath(renderKeyOf(markdown, 'dark')),
+    )
+  })
+
+  it('separates two themes of the SAME spatial document', () => {
+    expect(renderKeyPath(renderKeyOf(spatial, 'light'))).not.toBe(
+      renderKeyPath(renderKeyOf(spatial, 'dark')),
+    )
+  })
+
+  it('changes when the document does', () => {
+    const later = { ...spatial, updatedAt: '2026-09-03T01:00:00Z' }
+    expect(renderKeyPath(renderKeyOf(later, 'light'))).not.toBe(
+      renderKeyPath(renderKeyOf(spatial, 'light')),
+    )
+  })
+
+  // A keeper that does not stamp updatedAt still gets a key; what it loses is
+  // the ability to notice a change, which is a persistence concern and not a
+  // reason to render the same document twice inside one sitting.
+  it('accepts a document with no version stamp', () => {
+    const key = renderKeyOf({ documentId: 'doc-3', kind: 'spatial' }, 'light')
+    expect(key.version).toBeNull()
+    expect(renderKeySchema.safeParse(key).success).toBe(true)
+  })
+
+  it('leads the path with the build id, so retiring a build is one directory', () => {
+    expect(renderKeyPath(renderKeyOf(spatial, 'light')).startsWith(`${RENDERER_BUILD_ID}/`)).toBe(
+      true,
+    )
+  })
+
+  it('is a valid key by its own schema', () => {
+    expect(renderKeySchema.safeParse(renderKeyOf(spatial, 'dark')).success).toBe(true)
+  })
+})

--- a/apps/web/src/lib/render-key.ts
+++ b/apps/web/src/lib/render-key.ts
@@ -29,10 +29,14 @@ export const renderKeySchema = z.object({
   kind: documentKindSchema,
   /**
    * What the document was when it was drawn, or null from a keeper that
-   * stamps no time. Null keeps the entry usable within one sitting — the
-   * list re-reads on mount, so a changed document arrives under a new
-   * entry — and is what stops persistence being safe until a real frontier
-   * reaches this surface.
+   * stamps no time.
+   *
+   * Null is not a version that happens to be missing — it is the absence of
+   * any way to notice a change, so a key carrying it is NOT memoisable (see
+   * `isMemoisableKey`). A re-read of the list produces the identical key, so
+   * remembering a completed render under it would serve the old picture for
+   * as long as the tab is open. It is also what stops persistence being safe
+   * until a real frontier reaches this surface.
    */
   version: z.string().nullable(),
   /**
@@ -63,6 +67,35 @@ export function renderKeyOf(subject: RenderKeySubject, theme: ResolvedTheme): Re
 }
 
 /**
+ * Whether a completed render may be remembered under this key.
+ *
+ * Only a key that can NOTICE a change may be: with `version: null` the key a
+ * re-read produces is byte-identical to the one before it, so a memo would
+ * answer with the old picture until the tab closes. A caller may still join
+ * work already in flight for such a key — two panes asking in the same
+ * instant are asking about the same bytes — which is why this is a property
+ * of the memo and not of the whole broker.
+ */
+export function isMemoisableKey(key: RenderKey): boolean {
+  return key.version !== null
+}
+
+/**
+ * One path segment, unambiguous whatever the value contains.
+ *
+ * Both `documentId` and the version are opaque strings from a keeper — the
+ * daemon's document contract says so explicitly and is deliberately not
+ * pattern-bound — so a `/` in either would otherwise move the boundary
+ * between segments and let two different documents join to one path.
+ * `encodeURIComponent` is reversible and escapes the separator; the `~`
+ * prefix is what makes `.` and `..` impossible as whole segments, which
+ * matters before the OPFS store exists rather than after.
+ */
+function segment(value: string): string {
+  return `~${encodeURIComponent(value)}`
+}
+
+/**
  * The key as a path, build id first (ADR-0027 decision 5).
  *
  * Today it is the in-memory map's key; it is shaped as a path because that is
@@ -70,9 +103,7 @@ export function renderKeyOf(subject: RenderKeySubject, theme: ResolvedTheme): Re
  * build's whole cache one directory removal rather than a scan.
  */
 export function renderKeyPath(key: RenderKey): string {
-  const leaf =
-    key.theme === null
-      ? (key.version ?? 'unversioned')
-      : `${key.version ?? 'unversioned'}-${key.theme}`
-  return `${key.buildId}/${key.kind}/${key.documentId}/${leaf}.svg`
+  const version = key.version ?? ''
+  const leaf = key.theme === null ? segment(version) : `${segment(version)}-${key.theme}`
+  return `${segment(key.buildId)}/${key.kind}/${segment(key.documentId)}/${leaf}.svg`
 }

--- a/apps/web/src/lib/render-key.ts
+++ b/apps/web/src/lib/render-key.ts
@@ -1,0 +1,78 @@
+/**
+ * What identifies one rendered picture of one document (ADR-0027 decision 2).
+ *
+ * The key crosses a worker boundary — and, once persistence lands, a storage
+ * boundary — so it is a declared value type rather than a string built at each
+ * call site, per this repo's Zod discipline. Three call sites concatenating
+ * their own key is three chances to disagree, and the two that disagree serve
+ * the wrong picture rather than failing.
+ */
+
+import { documentKindSchema } from '@kamiazya/whiteboard-model'
+import { z } from 'zod'
+import type { ResolvedTheme } from '../hooks/useThemeMode.js'
+
+/**
+ * Stamped into the bundle by every vite/vitest config (see
+ * `renderer-build-id.ts`). Read with NO fallback on purpose: a config that
+ * forgets the define throws here, loudly, instead of quietly keying every
+ * deploy the same and serving a picture the current renderer would not draw.
+ */
+declare const __RENDERER_BUILD_ID__: string
+
+export const RENDERER_BUILD_ID: string = __RENDERER_BUILD_ID__
+
+export const renderKeySchema = z.object({
+  /** The code that would produce these bytes. */
+  buildId: z.string().min(1),
+  documentId: z.string().min(1),
+  kind: documentKindSchema,
+  /**
+   * What the document was when it was drawn, or null from a keeper that
+   * stamps no time. Null keeps the entry usable within one sitting — the
+   * list re-reads on mount, so a changed document arrives under a new
+   * entry — and is what stops persistence being safe until a real frontier
+   * reaches this surface.
+   */
+  version: z.string().nullable(),
+  /**
+   * Set for a spatial document, whose palette is baked into the SVG, and
+   * NULL for markdown, whose ink comes from CSS. That asymmetry is the whole
+   * reason a markdown row survives a theme toggle: one entry serves both.
+   */
+  theme: z.enum(['light', 'dark']).nullable(),
+})
+
+export type RenderKey = z.infer<typeof renderKeySchema>
+
+/** The document fields a key is built from. */
+export interface RenderKeySubject {
+  readonly documentId: string
+  readonly kind: 'spatial' | 'markdown'
+  readonly updatedAt?: string
+}
+
+export function renderKeyOf(subject: RenderKeySubject, theme: ResolvedTheme): RenderKey {
+  return {
+    buildId: RENDERER_BUILD_ID,
+    documentId: subject.documentId,
+    kind: subject.kind,
+    version: subject.updatedAt ?? null,
+    theme: subject.kind === 'spatial' ? theme : null,
+  }
+}
+
+/**
+ * The key as a path, build id first (ADR-0027 decision 5).
+ *
+ * Today it is the in-memory map's key; it is shaped as a path because that is
+ * what the OPFS store will address, and a leading build id makes retiring a
+ * build's whole cache one directory removal rather than a scan.
+ */
+export function renderKeyPath(key: RenderKey): string {
+  const leaf =
+    key.theme === null
+      ? (key.version ?? 'unversioned')
+      : `${key.version ?? 'unversioned'}-${key.theme}`
+  return `${key.buildId}/${key.kind}/${key.documentId}/${leaf}.svg`
+}

--- a/apps/web/src/lib/render-surfaces.test.ts
+++ b/apps/web/src/lib/render-surfaces.test.ts
@@ -1,0 +1,49 @@
+import { documentKindSchema } from '@kamiazya/whiteboard-model'
+import { describe, expect, it } from 'vitest'
+import { RENDER_SURFACES, type RenderSurfaceId } from './render-surfaces.js'
+
+const entries = Object.entries(RENDER_SURFACES) as [
+  RenderSurfaceId,
+  (typeof RENDER_SURFACES)[RenderSurfaceId],
+][]
+
+describe('the render surface registry', () => {
+  // The type says every kind is answered; this says the answers are readable.
+  // An exemption whose reason is empty is the omission with a word in front.
+  it('gives every uncovered kind a reason someone can act on', () => {
+    for (const [id, surface] of entries) {
+      for (const [kind, coverage] of Object.entries(surface.kinds)) {
+        if (coverage === 'covered') continue
+        const reason = coverage.slice('not covered:'.length).trim()
+        expect(reason.length, `${id}/${kind} needs a reason`).toBeGreaterThan(10)
+      }
+    }
+  })
+
+  it('gives every surface outside the broker a reason', () => {
+    for (const [id, surface] of entries) {
+      if (surface.broker === 'through') continue
+      const reason = surface.broker.slice('not yet:'.length).trim()
+      expect(reason.length, `${id} needs a reason`).toBeGreaterThan(10)
+    }
+  })
+
+  // The registry's whole claim is that it names the kinds exhaustively. If
+  // the model's union and this table's key set ever diverge, the type check
+  // catches it — this pins that the type being relied on is the real one.
+  it('answers exactly the document kinds the model declares', () => {
+    const declared = new Set(documentKindSchema.options)
+    for (const [id, surface] of entries) {
+      expect(new Set(Object.keys(surface.kinds)), `${id}`).toEqual(declared)
+    }
+  })
+
+  // The measured defect this table exists for: the SVG family serves both
+  // kinds, and the surfaces that do not are each a stated decision.
+  it('has every svg surface answering for markdown', () => {
+    for (const [id, surface] of entries) {
+      if (surface.pipeline !== 'svg') continue
+      expect(surface.kinds.markdown, `${id}`).toBe('covered')
+    }
+  })
+})

--- a/apps/web/src/lib/render-surfaces.ts
+++ b/apps/web/src/lib/render-surfaces.ts
@@ -1,0 +1,87 @@
+/**
+ * Every place this app draws a picture of a document, and what each one does
+ * about each document kind (ADR-0027 decision 6).
+ *
+ * This table exists because of a specific failure: markdown documents arrived
+ * after the thumbnail paths did, the outline family absorbed them, and the SVG
+ * family did not — nobody was forced to enumerate the surfaces the new kind
+ * also had to reach. `kinds` is a `Record<DocumentKind, …>`, so adding a kind
+ * to the model fails the type check here until every surface has an answer.
+ * That is the direction that actually broke.
+ *
+ * The surface direction is weaker on purpose: a new component that renders
+ * without asking the broker cannot be caught by a type, only by a reader with
+ * this list in front of them. It is a list to review against, not a wall.
+ *
+ * `not covered:` and `not yet:` both take a reason. A bare exemption is the
+ * omission with a word in front of it.
+ */
+
+import type { DocumentKind } from '@kamiazya/whiteboard-model'
+
+export type RenderSurfaceId =
+  | 'list-row-thumbnail'
+  | 'list-preview-pane'
+  | 'editor-preview-pane'
+  | 'tree-row-icon'
+  | 'favicon'
+  | 'version-thumbnail'
+
+/**
+ * `svg` is layout plus serialisation, the expensive one. `outline` is block
+ * geometry only — cheaper, and the only thing legible at 24px. `png-raster`
+ * is the SVG drawn into a canvas and read back as PNG.
+ */
+export type RenderPipeline = 'svg' | 'outline' | 'png-raster'
+
+type KindCoverage = 'covered' | `not covered: ${string}`
+type BrokerUse = 'through' | `not yet: ${string}`
+
+export interface RenderSurface {
+  readonly pipeline: RenderPipeline
+  readonly kinds: Readonly<Record<DocumentKind, KindCoverage>>
+  readonly broker: BrokerUse
+}
+
+export const RENDER_SURFACES = {
+  'list-row-thumbnail': {
+    pipeline: 'svg',
+    kinds: { spatial: 'covered', markdown: 'covered' },
+    broker: 'through',
+  },
+  'list-preview-pane': {
+    pipeline: 'svg',
+    kinds: { spatial: 'covered', markdown: 'covered' },
+    broker: 'through',
+  },
+  'editor-preview-pane': {
+    pipeline: 'svg',
+    kinds: {
+      spatial:
+        'not covered: a spatial document opens in the canvas editor, which has no preview pane',
+      markdown: 'covered',
+    },
+    broker:
+      'not yet: renders on the main thread per keystroke, so it wants a live seam rather than a memo',
+  },
+  'tree-row-icon': {
+    pipeline: 'outline',
+    kinds: { spatial: 'covered', markdown: 'covered' },
+    broker:
+      'not yet: the outline pipeline has no measured duplication; moving it is a named follow-up',
+  },
+  favicon: {
+    pipeline: 'outline',
+    kinds: { spatial: 'covered', markdown: 'covered' },
+    broker: 'not yet: one render per page, so nothing to dedup; moves with the tree row',
+  },
+  'version-thumbnail': {
+    pipeline: 'png-raster',
+    kinds: {
+      spatial:
+        'not covered: written on every save and read by nothing — DocumentThumb has no call site',
+      markdown: 'not covered: the route predates markdown documents entirely',
+    },
+    broker: 'not yet: whether this surface should exist at all is open (ADR-0027)',
+  },
+} satisfies Record<RenderSurfaceId, RenderSurface>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -8,6 +8,7 @@ import svgr from 'vite-plugin-svgr'
 import topLevelAwait from 'vite-plugin-top-level-await'
 import wasm from 'vite-plugin-wasm'
 import { mcpSourceAlias } from './mcp-source-alias.js'
+import { rendererBuildDefine } from './renderer-build-id.js'
 import { cloudflareDevHeadersPlugin } from './vite-dev-headers.js'
 import { stripWasmSourceMapPlugin } from './vite-plugin-strip-wasm-sourcemap.js'
 import { pwaOptions } from './vite-pwa-options.js'
@@ -16,6 +17,7 @@ import { workerSafeDepsAlias } from './worker-safe-deps-alias.js'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
+  define: { ...rendererBuildDefine },
   // Both workers are constructed with `type: 'module'`, but Vite's default
   // worker output is `iife` — which happened to run anyway, since a module
   // worker executes IIFE code fine. It stops being harmless the moment a

--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -8,11 +8,13 @@ import wasm from 'vite-plugin-wasm'
 import { defineConfig } from 'vitest/config'
 import { sharedBrowserTestConfig } from '../../vitest.browser.shared.js'
 import { mcpSourceAlias } from './mcp-source-alias.js'
+import { rendererBuildDefine } from './renderer-build-id.js'
 import { workerSafeDepsAlias } from './worker-safe-deps-alias.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
+  define: { ...rendererBuildDefine },
   resolve: {
     alias: {
       ...mcpSourceAlias,

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -6,10 +6,12 @@ import topLevelAwait from 'vite-plugin-top-level-await'
 import wasm from 'vite-plugin-wasm'
 import { defineConfig } from 'vitest/config'
 import { mcpSourceAlias } from './mcp-source-alias.js'
+import { rendererBuildDefine } from './renderer-build-id.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
+  define: { ...rendererBuildDefine },
   plugins: [react(), svgr(), wasm(), topLevelAwait()],
   resolve: {
     alias: {

--- a/apps/web/vitest.docs-snapshots.config.ts
+++ b/apps/web/vitest.docs-snapshots.config.ts
@@ -20,6 +20,7 @@ import wasm from 'vite-plugin-wasm'
 import { defineConfig } from 'vitest/config'
 import { resolveBrowserLaunchOptions } from '../../packages/mcp-server/src/server/browser-test-config.js'
 import { mcpSourceAlias } from './mcp-source-alias.js'
+import { rendererBuildDefine } from './renderer-build-id.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 // Absolute path so test files can ship a single string literal to
@@ -30,6 +31,7 @@ const DOCS_ASSETS_DIR = resolve(__dirname, '..', '..', 'docs', 'assets')
 
 export default defineConfig({
   define: {
+    ...rendererBuildDefine,
     __DOCS_ASSETS_DIR__: JSON.stringify(DOCS_ASSETS_DIR),
   },
   // The doc-snapshot tests need to read existing scene fixtures (e.g.

--- a/apps/web/vitest.node.config.ts
+++ b/apps/web/vitest.node.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitest/config'
+import { rendererBuildDefine } from './renderer-build-id.js'
 
 // Node-environment guards for build/deploy config that never reaches the
 // browser: the PWA plugin options object and the static `public/_headers`
@@ -6,6 +7,7 @@ import { defineConfig } from 'vitest/config'
 // silently reopen the daemon/LNA fetch-interception hole (see
 // vite-pwa-options.ts) or the CSP worker-src gap.
 export default defineConfig({
+  define: { ...rendererBuildDefine },
   test: {
     name: 'web-node',
     environment: 'node',

--- a/docs/contributing/adr/0027-render-broker.md
+++ b/docs/contributing/adr/0027-render-broker.md
@@ -107,10 +107,18 @@ evidence instead of blocking the first increment.
 
 ### 5. Persistence is OPFS, and the path is the invalidation strategy
 
-The key derives the path deterministically, with the build id leading:
+The key derives the path deterministically, with the build id leading, and
+every component the keeper supplied is **encoded** — the document contract
+declares `id` opaque and deliberately not pattern-bound, so a `/` in an id or
+a timestamp would otherwise move the boundary between segments and let two
+different documents join to one path. Verified rather than argued: unencoded,
+`{id: 'a', version: 'b/c'}` and `{id: 'a/b', version: 'c'}` produce the same
+string. The `~` prefix on each segment is what additionally makes `.` and
+`..` impossible as whole segments, which matters before the store exists
+rather than after.
 
 ```
-render/<buildId>/<documentId>/<versionKey>[-<theme>].svg
+render/~<buildId>/<kind>/~<documentId>/~<versionKey>[-<theme>].svg
 ```
 
 Retiring a build's entire cache is removing one directory — no scan, no
@@ -125,10 +133,16 @@ bytes are produced, so the renderer persists its own output with no extra hop.
 
 The surfaces are a table keyed by a union — the way this repo already pins its
 background workers and its editor verbs — and each entry names the pipeline it
-takes and the kinds it answers for. Adding a document kind fails the type check
-until every surface has an answer; adding a surface fails until it names a
-pipeline. The missing markdown thumbnail is the evidence this mechanism exists
-for, and a comment listing surfaces is the thing it replaces.
+takes and the kinds it answers for. `kinds` is a `Record<DocumentKind, …>`, so
+**adding a document kind fails the type check** until every surface has an
+answer. That is the direction that actually broke, and it is the mechanical
+half.
+
+The surface direction is weaker, and saying so is part of the decision: a new
+component that renders without asking the broker cannot be caught by a type,
+only by a reader with this list in front of them. It is a list to review
+against rather than a wall, and the honest alternative — a source scan for
+"anything that draws a document" — has no reliable shape to match on.
 
 ## Consequences
 
@@ -146,9 +160,13 @@ Still open, and named rather than assumed:
 
 - **Persistence needs a version key that does not exist yet.**
   `documentSummarySchema` carries no frontier. `updatedAt` is stamped per push
-  in practice but is optional in the schema, so a keeper that omits it would
-  silently make entries uncacheable. Adding the frontier is its own increment,
-  and until it lands the broker caches in memory only.
+  in practice but is optional in the schema, and a key with no version cannot
+  notice its document changing — so `isMemoisableKey` refuses to remember a
+  completed render under one, and only the in-flight join applies there. That
+  is the honest behaviour rather than a limitation to work around: a memo
+  under such a key would serve the old picture for as long as the tab is open.
+  Adding the frontier is its own increment, and until it lands the broker
+  caches in memory only.
 - **The fetch of a document's bytes is unmeasured**, and `load-row-render.ts`
   claims it dominates the wait. If that is true, the cache's largest win is
   skipping the fetch rather than the CPU — which does not change this design,

--- a/docs/contributing/adr/0027-render-broker.md
+++ b/docs/contributing/adr/0027-render-broker.md
@@ -1,0 +1,197 @@
+# ADR-0027: Every picture of a document goes through one broker, and the cache is a memo
+
+**Status:** Accepted — broker port and its in-tab implementation land with this ADR; OPFS persistence and the SharedWorker implementation are named follow-ups
+
+## Context
+
+`apps/web` renders a document to SVG in several places — a list row's thumbnail,
+the preview beside it, the editor's preview pane — and throws the result away
+every time. Nothing caches it. What does exist is three mechanisms that are not
+that:
+
+| mechanism | holds | lifetime |
+|---|---|---|
+| `renderSceneToKeyedSvg` | keyed `<g>` groups for DOM patching | one mount, editor only |
+| `contentCache` | one text node's laid-out body | worker lifetime, per theme |
+| version thumbnail | a PNG of a saved version | durable, unrelated to live documents |
+
+### What a render costs, measured before designing
+
+`clusteredLayout` corpus, arithmetic measurer, warmed then 21 interleaved
+rounds, median:
+
+| document | layout + serialize | layout | serialize | warm `contentCache` | SVG |
+|---|---|---|---|---|---|
+| 12 nodes, 8 edges | 2.8 ms | 2.2 | 0.6 | 2.3 | 4.0 KB |
+| 40 nodes, 34 edges | 32.8 ms | 29.8 | 3.0 | 31.5 | 13.2 KB |
+| 120 nodes, 113 edges | 66.6 ms | 64.5 | 2.1 | 64.3 | 40.7 KB |
+
+Two things follow, and both are the opposite of the obvious guess. Caching the
+**SVG** is worth having not because serialising is expensive — it is 0.6–3 ms —
+but because holding the string lets a caller skip the layout behind it. And the
+`contentCache` that already exists returns 2–18% here, because edge routing
+dominates and it memoises only text bodies. Cost is super-linear: 3.3x the
+nodes cost 11.7x the time.
+
+### The repeated work is real, and none of it is speculative
+
+Three shapes, all confirmed in the source rather than imagined:
+
+- A row's thumbnail and the preview pane beside it call the same loader
+  independently, so selecting a row renders it a **second** time. There is no
+  in-flight dedup between them.
+- `loadRender` is memoised on `[source, resolvedTheme]`, so a dark-mode toggle
+  re-renders every visible row.
+- The result lives in component state, so leaving the list and returning
+  rebuilds it.
+
+### Markdown fell out of some surfaces, and nothing caught it
+
+Markdown documents arrived after the thumbnail paths existed. The outline
+family absorbed them — `useDocumentOutline` answers "a document's shape,
+whichever kind it is", and the favicon and the tree row never branch on kind.
+The SVG family never got the same treatment, and version thumbnails are worse
+than kind-specific: the page uploads a PNG on every save, and `DocumentThumb`,
+the only component that reads one back, is referenced by nothing but its own
+test. Writes with no reader, for canvases only.
+
+Prose does not hold that line. The worker pool's own doc comment lists a
+favicon among the surfaces it serves, and the favicon has never gone through
+it — a surface list written in a comment had already gone stale.
+
+## Decision
+
+### 1. One seam: a `RenderBroker` port, with the pool as its backend
+
+Every surface that wants a picture asks the broker, which owns the memo, the
+in-flight dedup and the priority. Today's worker pool becomes its backend
+unchanged, so the change is additive rather than a rewrite. A daemon-rendered
+future is another implementation of the same port, not a second path.
+
+### 2. The key is a declared value type, and renderer identity comes from the build
+
+The key crosses a worker boundary, which makes it a process boundary, which
+makes it a Zod schema under this repo's existing discipline. A key assembled by
+string concatenation at three call sites will disagree at two of them.
+
+Renderer identity is a build-time constant compiled into the bundle, never a
+hand-maintained version and never the service worker's update state. Under
+`registerType: 'prompt'` a new worker installs while the page keeps running the
+old bundle — a divergence this repo has already been bitten by (see
+`.claude/rules/integrator-flow.md`). A key taken from the service worker would
+say "v2" while v1's code writes the bytes, poisoning the new key with old
+output, invisibly. A compile-time constant travels with the code that produced
+the bytes and cannot drift from it.
+
+Over-invalidation on a deploy that did not touch the renderer is accepted:
+deploys are rare against page views, and precision would mean hashing the
+render chunk — fragile, for little.
+
+### 3. Kind is a parameter of the key, never a fork in the pipeline
+
+Both kinds cache. One axis differs: spatial rendering bakes its palette while
+markdown takes its ink from CSS, so **theme belongs in a spatial key and not in
+a markdown one**. Markdown therefore caches harder, not less — one entry serves
+both themes, and half of the measured dark-mode problem disappears from getting
+the key right rather than from caching more.
+
+### 4. Determinism makes this a memo, not a coordination problem
+
+`renderSceneToSvg` is pinned byte-for-byte against the same committed golden
+string in both the node and the browser test projects. Same key therefore means
+same bytes, so two tabs racing to fill one entry is harmless — the loser of the
+OPFS exclusive lock stops, because the winner is writing what it would have
+written. **Cross-tab leader election is an optimisation, never a correctness
+requirement.** That is what lets the SharedWorker implementation wait for
+evidence instead of blocking the first increment.
+
+### 5. Persistence is OPFS, and the path is the invalidation strategy
+
+The key derives the path deterministically, with the build id leading:
+
+```
+render/<buildId>/<documentId>/<versionKey>[-<theme>].svg
+```
+
+Retiring a build's entire cache is removing one directory — no scan, no
+scheduler, no index. Write-time is enough: when storing an entry, drop any
+sibling directory that is not the current build.
+
+The realm assignment follows a probe rather than a preference: only a
+**dedicated worker** has `createSyncAccessHandle`, and that is also where the
+bytes are produced, so the renderer persists its own output with no extra hop.
+
+### 6. A surface that draws a document is declared, or it does not compile
+
+The surfaces are a table keyed by a union — the way this repo already pins its
+background workers and its editor verbs — and each entry names the pipeline it
+takes and the kinds it answers for. Adding a document kind fails the type check
+until every surface has an answer; adding a surface fails until it names a
+pipeline. The missing markdown thumbnail is the evidence this mechanism exists
+for, and a comment listing surfaces is the thing it replaces.
+
+## Consequences
+
+Easier: a new surface that wants a picture has one place to ask and inherits
+dedup, priority and (later) persistence; a new document kind cannot silently
+miss a surface; the daemon-rendered and multi-tab futures are implementations
+rather than paths.
+
+Harder, and accepted: the key gains axes that must all be right, and a wrong
+key is the worst failure this design can have — a stale picture that every test
+still passes. That is why renderer identity is derived and why the theme axis
+is stated per kind rather than applied uniformly.
+
+Still open, and named rather than assumed:
+
+- **Persistence needs a version key that does not exist yet.**
+  `documentSummarySchema` carries no frontier. `updatedAt` is stamped per push
+  in practice but is optional in the schema, so a keeper that omits it would
+  silently make entries uncacheable. Adding the frontier is its own increment,
+  and until it lands the broker caches in memory only.
+- **The fetch of a document's bytes is unmeasured**, and `load-row-render.ts`
+  claims it dominates the wait. If that is true, the cache's largest win is
+  skipping the fetch rather than the CPU — which does not change this design,
+  but does change how its benefit should be reported.
+- **Safari and iOS are unmeasured.** SharedWorker is expected absent, OPFS
+  expected present. iOS is best-effort by standing policy, and the fallback is
+  the in-tab implementation this ADR ships first.
+- **The version-thumbnail PNG path is left alone here.** Its read side is dead,
+  so the question is whether the feature exists at all, and that is a product
+  decision rather than a caching one.
+
+## Alternatives considered
+
+**A Service Worker owning the cache.** It is killed when idle, so it hosts
+neither coordination nor compute. It is also unnecessary for storage: `caches`
+and `indexedDB` are present in every realm probed, including the SharedWorker.
+It earns a place only once a daemon serves SVG over HTTP, where a real URL and
+real cache headers exist.
+
+**The Cache API as the store.** URL-keyed, storing Responses, against a tuple
+key. Its payoff would be serving `<img src>` through a service worker, and
+markdown thumbnails cannot be images — they inherit their ink from page CSS.
+
+**A SharedWorker owning the worker fleet.** Measured impossible: a SharedWorker
+has no `Worker` constructor (`Worker is not defined`). The realm probe, run in
+Chromium against the repo's own font loader and measurer:
+
+| realm | `Worker` | `SharedWorker` | `indexedDB` | `caches` | `navigator.locks` | OPFS `getDirectory` | `createSyncAccessHandle` |
+|---|---|---|---|---|---|---|---|
+| window | yes | yes | — | yes | yes | yes | no |
+| dedicated worker | yes | no | yes | yes | yes | yes | **yes** |
+| SharedWorker | **no** | no | yes | yes | yes | yes | no |
+
+The font pipeline itself does work in every realm, which is what made the
+SharedWorker worth probing at all: `ensureViewerFontLoaded` +
+`createBrowserMeasureText` reported `loaded` and an identical 277.578125 px
+advance in all three. The control in that measurement is what makes it
+evidence — the SharedWorker's *fallback* font differs from the other two
+(296.578125 vs 268.5078125), so a Roboto match to the bit is the registered
+face being applied, not a coincidence of falling back to the same thing.
+
+**PNG thumbnails.** A row and the preview are the same SVG at two sizes, so a
+raster serves neither well. The one surviving PNG path is an Excalidraw-era
+contract that outlived its exporter: the app renders its own SVG and then
+rasterises it through an `<img>` and a canvas purely because the storage
+contract says PNG.

--- a/docs/contributing/adr/README.md
+++ b/docs/contributing/adr/README.md
@@ -59,3 +59,4 @@ See [template.md](template.md) for the standard structure (MADR-lite: Title, Sta
 | [ADR-0024](0024-canvas-comments.md) | Canvas comments are a first-class annotation layer, keyed per comment | Accepted |
 | [ADR-0025](0025-comment-editor-ux.md) | Comment editor UX: context-menu create, resolved toggle, authorless v1, pull-by-convention AI delivery | Accepted |
 | [ADR-0026](0026-annotation-layer.md) | The annotation layer — one plane per document, threads, and selector anchors | Proposed — design of record for comments beyond the canvas |
+| [ADR-0027](0027-render-broker.md) | Every picture of a document goes through one broker, and the cache is a memo | Accepted — in-tab broker landed; OPFS persistence and the SharedWorker implementation are follow-ups |


### PR DESCRIPTION
## Summary

- Rendered SVG was **not cached anywhere**. This adds a `RenderBroker` port with its in-tab implementation — memo plus in-flight dedup — and routes the list's row thumbnails and preview pane through it. The existing worker pool becomes its backend unchanged, so the change is additive.
- **ADR-0027** records the decision, the realm probes behind it, and what was rejected with why. It is in this PR rather than ahead of it because the decision and its first increment read together.
- Adds a **surface registry** keyed by `DocumentKind`, so adding a document kind fails the type check until all six picture-drawing surfaces answer for it. That is the direction that actually broke: markdown arrived after the thumbnail paths existed and quietly fell out of some of them.

### Measured before designing

`clusteredLayout` corpus, arithmetic measurer, warmed then 21 interleaved rounds, median:

| document | layout + serialize | layout | serialize | warm `contentCache` | SVG |
|---|---|---|---|---|---|
| 12 nodes, 8 edges | 2.8 ms | 2.2 | 0.6 | 2.3 | 4.0 KB |
| 40 nodes, 34 edges | 32.8 ms | 29.8 | 3.0 | 31.5 | 13.2 KB |
| 120 nodes, 113 edges | 66.6 ms | 64.5 | 2.1 | 64.3 | 40.7 KB |

Caching the SVG is worth having **not** because serialising is expensive — it is 0.6–3 ms — but because holding the string skips the layout behind it. The `contentCache` that already exists returns 2–18% here, because edge routing dominates and it memoises only text bodies.

### Measured in the real app

Same script, same flow, one line different (broker vs. direct call), driving the real dev server under Chromium and counting `layout` / `markdown-render` messages posted to the worker pool:

| | extra renders caused by selecting a row |
|---|---|
| direct call | **1** — the preview redraws a document the row beside it had already drawn |
| through the broker | **0** |

### Three decisions worth a reviewer's attention

**Renderer identity comes from the build, never from the service worker.** A version someone has to remember to bump is a guard that looks like a guard, so it is a compile-time constant shared by all four vite/vitest configs. It must come from the *artifact*: under `registerType: 'prompt'` a new worker installs while the page keeps running the old bundle, so a key taken from the worker would claim the new identity while old code writes the bytes — poisoning the new key, invisibly. `render-key.ts` reads the global with **no fallback**, so a config that forgets the define throws loudly instead of keying every deploy the same.

**Theme is a spatial-only axis.** Spatial rendering bakes its palette; markdown takes its ink from CSS. So a markdown entry serves both themes and a markdown row survives a theme toggle — half of the measured "dark mode re-renders everything" falls out of getting the key right rather than caching more.

**Determinism makes this a memo, not a coordination problem.** `renderSceneToSvg` is pinned byte-for-byte against the same golden string in the node and browser projects, so same key means same bytes. That is what lets persistence and the cross-tab implementation wait for evidence instead of blocking this increment.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [x] `pnpm test` passes locally
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable — the browser test mounts the real panel and drives a real click; nothing here depends on routing, persistence or the daemon

New:

- `render-key.test.ts` — the theme axis per kind, the path leading with the build id, a version-less document.
- `render-broker.test.ts` — memo, in-flight join, rejection not memoised, `null` memoised, the cap.
- `render-surfaces.test.ts` — every uncovered kind and every non-broker surface carries a reason; every `svg` surface answers for markdown.
- `load-row-render.test.ts` — one render however many surfaces ask; a markdown render survives a theme change while a spatial one redraws; a kind-less row keys the way it renders.
- `panel-one-render.browser.test.tsx` — the panel-level flow, in a real browser.

**Why that last one is a browser test and not jsdom**, because it is not about layout: the pipeline has to *succeed* for the memo to hold anything. In jsdom the worker pool is absent, the render rejects, and a rejection is deliberately not memoised — so both panes retry and the count is 2 for a reason that has nothing to do with the broker. The premise the test needs is a working renderer.

Mutation-checked, each reverted and restored:

| mutation | caught by |
|---|---|
| put the theme in a markdown key | the key test and the theme-survival test |
| bypass the broker in the loader | the dedup test, and the browser test (1 → 2) |
| key a kind-less row as markdown | the kind-agreement test |

Manual verification, real app under Chromium at 1400×900: a note created, back to the list, the row's thumbnail drawn as SVG by the real renderer, the row selected, the preview pane drawn as SVG — and the worker asked for **zero** additional renders.

### Two real defects found while verifying, both fixed here

- **A kind-less row was keyed as markdown but rendered spatially.** `kind` is optional on a list row, and `produce` branches `=== 'markdown'` while the key said `?? 'markdown'`. A markdown key drops the theme axis, so a light and a dark render of the same board would have shared one entry and served the wrong palette — a picture that is *wrong* rather than missing, which is the worst failure this design can have. Both now derive from one `renderedKind()`.
- **A duplicate `define` key** in `vitest.docs-snapshots.config.ts`, from adding the shared define mechanically to a config that already had one. Caught by lint; one of the two blocks was being silently dropped.

### Local runs, reported as they happened

- `pnpm --filter @kamiazya/whiteboard-web test`: 318 files / 3306 tests, plus 13 / 89 — exit 0.
- `pnpm test:browser`, run 1: 183/184 files, 992/993 tests. One failure, `expected 'Fast switc' to be 'Fast switch'`, in `BrowserDocumentPage.markdown.browser.test.tsx`.
- `pnpm test:browser`, run 2: that failure **did not recur**; the run aborted at 129/184 on a vitest browser-orchestrator iframe error (`Failed to fetch dynamically imported module`, `Cannot connect to the iframe`). Every test that ran passed: 867/867.
- The three files involved in those two runs, plus the new browser test: 4/4 files, 23/23 tests.

I read the first failure as not this PR's: `WorkspaceFilesPanel` is mounted only by the two Index pages, so none of this code executes on `BrowserDocumentPage` at all — the diff's only contribution to that page's bundle is a compile-time string constant. The symptom is a single dropped keystroke in a plain `<input>`, which is the load-dependent shape `.claude/rules/integrator-flow.md` already documents. Run 2's failure is harness infrastructure, not a test. Saying so here rather than in a summary line, because CI is the authority and I will drive it to green.

## Visual evidence

Visual evidence: none — this change draws no different pixels, by construction. The renderer is byte-deterministic and the broker returns the same bytes it would have produced; what changed is how many times they are produced. The evidence for that is the render-count measurement above, taken through the real app rather than a mock.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — ADR-0027 plus its row in the ADR index; no user-facing doc describes how a thumbnail is produced
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema — the render key is `z.infer`-derived

## Follow-ups, named in the ADR rather than assumed

- **OPFS persistence** is blocked on a version key the list contract does not carry: `documentSummarySchema` has no frontier, and `updatedAt` is optional in the schema even though it is stamped per push in practice.
- **The SharedWorker implementation** waits for evidence that people keep several tabs of one workspace open. Nobody has gathered it.
- **The tree row and the favicon** already share the outline pipeline and move behind the broker together; neither has measured duplication today.
- **The version-thumbnail PNG path** writes on every save and is read by nothing — `DocumentThumb` has no call site. Whether that surface should exist at all is a product question, not a caching one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added render-result reuse so repeated requests for the same document avoid duplicate rendering.
  - Added theme-aware handling: spatial previews refresh with theme changes, while markdown renders remain reusable.
  - Added build-aware render identification to prevent stale results across builds.
  - Added a registry documenting supported rendering surfaces and document types.

- **Bug Fixes**
  - Failed renders are no longer retained for future requests.

- **Documentation**
  - Added an architecture decision record describing the rendering and caching approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->