### PR TITLE
fix(search): find a document by the first character typed, and stop the row vanishing

### DIFF
--- a/.claude/rules/package-search.md
+++ b/.claude/rules/package-search.md
@@ -11,6 +11,17 @@ paths:
   character bigrams (`tokenize`). Dictionary-free by design — Japanese,
   Chinese and Korean all work with zero download, trading precision for
   recall the way every dictionary-free engine does.
+- **Indexing and querying are deliberately asymmetric.** `tokenizeForIndex`
+  emits every CJK character on its own as well as the bigrams; `tokenize`,
+  the query side, does not. Symmetric bigrams cannot answer a
+  one-character query at all — a name is one CJK run, so it yields bigrams
+  only and 「た」 matches none of them, which is the first keystroke of
+  nearly every Japanese query. Widening the QUERY instead would buy that
+  case at the price of 「検索」 matching anything containing 索. Widen what
+  a document is found by, not what a query demands (Lucene spells the same
+  choice `outputUnigrams`). The scoreboard's pinned per-category nDCG and
+  recall were unchanged by it — take that measurement again before
+  touching either side.
 - BM25 ranking over a caller-supplied corpus (`fullTextSearch`), plus the
   match excerpts a result row shows (`snippetAround`).
 - **The one definition of what text a document contributes**

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -18,7 +18,7 @@ import { NewDocumentMenu } from './NewDocumentMenu.js'
 import { newDocumentPathIn } from './new-document-path.js'
 import { RenameDocumentDialog } from './RenameDocumentDialog.js'
 import { SearchResults } from './SearchResults.js'
-import { searchDocuments } from './search-documents.js'
+import { searchDocuments, withNameMatches } from './search-documents.js'
 import { TrashSection } from './TrashSection.js'
 import { useBrowserColumns } from './use-browser-columns.js'
 import { useDebouncedDocumentSearch } from './use-debounced-document-search.js'
@@ -771,11 +771,17 @@ export function WorkspaceFilesPanel({
                       // flight, the names and paths already in hand are a
                       // real answer rather than a blank pane.
                       searchDocuments(documents, query).map((document) => ({ document }))
-                    : hits.map((hit) => ({
-                        document: hit.document,
-                        contexts: hit.contexts,
-                        ...(hit.lexicalRank === undefined ? {} : { lexicalRank: hit.lexicalRank }),
-                      }))
+                    : withNameMatches(
+                        hits.map((hit) => ({
+                          document: hit.document,
+                          contexts: hit.contexts,
+                          ...(hit.lexicalRank === undefined
+                            ? {}
+                            : { lexicalRank: hit.lexicalRank }),
+                        })),
+                        documents,
+                        query,
+                      )
                 }
                 query={query}
                 searchedContents={activeTag === null && hits !== null}

--- a/apps/web/src/components/workspace-files/search-documents.ts
+++ b/apps/web/src/components/workspace-files/search-documents.ts
@@ -54,3 +54,34 @@ export function searchDocuments<T extends WorkspaceDocumentEntry>(
     .filter((entry) => documentMatchesSearch(query, entry))
     .sort(compareDocumentEntries)
 }
+
+/**
+ * The content answer, plus the documents that only their NAME or PATH
+ * matched.
+ *
+ * Both halves are real answers to different questions, and the panel used to
+ * show the second and then replace it with the first. A row that appears and
+ * then vanishes reads as the document being found and unfound — and it
+ * happens on the most ordinary input there is, a prefix: word-token search
+ * cannot match "roa" against "Roadmap", and bigram search cannot match a
+ * single CJK character against a longer name. Whatever the lexical layer
+ * produces, a document whose name contains what was typed stays listed.
+ *
+ * Appended rather than merged by rank: these are the matches the ranked
+ * search did NOT produce, so there is no score to interleave them with, and
+ * putting an unranked row above ranked ones would claim a relevance nothing
+ * measured.
+ */
+export function withNameMatches<R extends { readonly document: WorkspaceDocumentEntry }>(
+  rows: readonly R[],
+  documents: readonly WorkspaceDocumentEntry[],
+  query: string,
+): readonly (R | { document: WorkspaceDocumentEntry })[] {
+  const produced = new Set(rows.map((row) => row.document.documentId))
+  return [
+    ...rows,
+    ...searchDocuments(documents, query)
+      .filter((entry) => !produced.has(entry.documentId))
+      .map((document) => ({ document })),
+  ]
+}

--- a/apps/web/src/components/workspace-files/search-name-match-persists.test.tsx
+++ b/apps/web/src/components/workspace-files/search-name-match-persists.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
+import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
+
+// A row that is on screen and then vanishes is worse than one that never
+// appeared: it says the document was found and then unfound. That is what
+// the panel did while someone typed — names and paths answer the first
+// keystroke, and the content answer replaced them wholesale a moment later,
+// dropping every document only its NAME matched.
+
+afterEach(cleanup)
+
+const entries = [
+  { documentId: 'd1', path: 'notes/quota', name: 'Storage notes', kind: 'markdown' as const },
+  { documentId: 'd2', path: 'plans/roadmap', name: 'Roadmap', kind: 'markdown' as const },
+]
+
+async function search(text: string) {
+  await waitFor(() => expect(screen.getAllByTestId('card-title').length).toBeGreaterThan(0))
+  fireEvent.change(screen.getByLabelText('Search documents'), { target: { value: text } })
+}
+
+describe('a name match survives the content answer', () => {
+  it('still lists the document a prefix names once the content hits arrive', async () => {
+    // The content search answers with a DIFFERENT document, which is both
+    // the realistic case and the trigger this test needs: its excerpt is
+    // how we know the answer landed rather than assuming the debounce ran.
+    const source = fakeFilesSource({
+      listDocuments: async () => entries,
+      searchDocuments: async () => [
+        { document: entries[0] as (typeof entries)[number], contexts: ['…roa…'] },
+      ],
+    })
+    render(<WorkspaceFilesPanel source={source} onOpenDocument={() => {}} />)
+
+    // "roa" is a prefix of "Roadmap", so the name filter finds it and the
+    // word-token search structurally cannot.
+    await search('roa')
+    // Titles carry the match marked in place, so they are read whole rather
+    // than matched as one text node.
+    const titles = () =>
+      within(screen.getByTestId('search-results'))
+        .queryAllByTestId('result-title')
+        .map((el) => el.textContent)
+    expect(titles()).toContain('Roadmap')
+
+    // The trigger: the content answer is now on screen.
+    await screen.findByTestId('result-excerpt')
+    expect(titles()).toContain('Storage notes')
+    // The outcome: the name match did not vanish under it.
+    expect(titles()).toContain('Roadmap')
+  })
+})

--- a/apps/web/src/lib/local-search.browser.test.tsx
+++ b/apps/web/src/lib/local-search.browser.test.tsx
@@ -78,6 +78,26 @@ describe('local body search', () => {
     ])
   })
 
+  it('finds a Japanese name by its first character', async () => {
+    // What a Japanese reader types first is one character. Bigram-only
+    // indexing answered nothing for it, and the panel had already shown the
+    // document from its name — so the row appeared and then vanished.
+    const index = new IdbDocumentIndex()
+    await ensureLocalWorkspace(index)
+    const id = await seedMarkdown(index, 'notes/kana', 'ひらがなだけの本文です。')
+    await index.setDocumentName({
+      workspaceId: getBrowserWorkspaceId(),
+      documentId: id,
+      name: 'たささたはな',
+    })
+    await seedMarkdown(index, 'notes/other', 'Nothing relevant here at all.')
+    const source = createLocalFilesSource()
+
+    expect((await source.searchDocuments('た')).map((h) => h.document.path)).toEqual(['notes/kana'])
+    // The control: the widening is a match, not a list of everything.
+    expect(await source.searchDocuments('ぬ')).toEqual([])
+  })
+
   it('answers nothing for an empty query', async () => {
     const index = new IdbDocumentIndex()
     await ensureLocalWorkspace(index)

--- a/docs/how-to/find-documents-from-chat.md
+++ b/docs/how-to/find-documents-from-chat.md
@@ -10,8 +10,9 @@ What it covers:
   meaning lives in its relations, so they are searchable content)
 - document names and paths
 
-Japanese (and other CJK) queries work without any dictionary or download.
-Results come back ranked, with a context excerpt around each match, and can
+Japanese (and other CJK) queries work without any dictionary or download,
+down to a single character — 「た」 finds 「たささたはな」, so a query answers
+while it is still being typed. Results come back ranked, with a context excerpt around each match, and can
 be narrowed by `kind` (markdown / spatial) or by tags.
 
 Example prompts:

--- a/packages/search/src/full-text.test.ts
+++ b/packages/search/src/full-text.test.ts
@@ -42,6 +42,24 @@ describe('fullTextSearch', () => {
     expect(results[0]?.contexts[0]).toContain('検索基盤')
   })
 
+  it('finds a document by a single CJK character — the first keystroke of a Japanese query', () => {
+    // What a Japanese reader types FIRST is one character, and a name is
+    // one CJK run: bigram-only indexing makes every such query answer
+    // nothing, however obviously the name contains it.
+    const results = fullTextSearch(
+      [DOC('a', [], { name: 'たささたはな' }), DOC('b', [], { name: 'unrelated' })],
+      'た',
+    )
+    expect(results.map((r) => r.documentId)).toEqual(['a'])
+  })
+
+  it('does not let a multi-character CJK query match a document sharing one character', () => {
+    // The other side of that: making the QUERY emit unigrams too would buy
+    // the case above at the cost of every longer query matching anything
+    // that shares a character.
+    expect(fullTextSearch([DOC('a', ['索引を作る'])], '検索')).toEqual([])
+  })
+
   it('matches latin queries case-insensitively', () => {
     const results = fullTextSearch([DOC('a', ['Tune the BM25 scoring constants.'])], 'bm25')
     expect(results.map((r) => r.documentId)).toEqual(['a'])

--- a/packages/search/src/full-text.ts
+++ b/packages/search/src/full-text.ts
@@ -7,11 +7,32 @@ import { snippetAround } from './snippet.js'
  * zero download, which is why stage 0 of the search plan starts here. A
  * lone CJK character (a run of length one) is its own token rather than
  * disappearing.
+ *
+ * This is the QUERY tokenizer, and it is deliberately narrower than
+ * `tokenizeForIndex`: a two-character query means the pair, so it must not
+ * also match every document that happens to share one of the two.
  */
 const CJK = /[぀-ヿ㐀-䶿一-鿿豈-﫿]/
 const WORD = /[\p{L}\p{N}]+/gu
 
 export function tokenize(text: string): string[] {
+  return tokenizeRuns(text, false)
+}
+
+/**
+ * The INDEX side, which additionally emits every CJK character on its own.
+ *
+ * Symmetric bigram tokenization cannot answer a one-character query at all:
+ * a name is a single CJK run, so it yields bigrams only, and 「た」 — the
+ * first keystroke of nearly every Japanese query — matches none of them.
+ * The asymmetry is the standard fix (Lucene spells it `outputUnigrams`):
+ * widen what a document is FOUND BY, not what a query demands.
+ */
+export function tokenizeForIndex(text: string): string[] {
+  return tokenizeRuns(text, true)
+}
+
+function tokenizeRuns(text: string, unigrams: boolean): string[] {
   const tokens: string[] = []
   for (const match of text.toLowerCase().matchAll(WORD)) {
     const run = match[0]
@@ -25,7 +46,7 @@ export function tokenize(text: string): string[] {
       latin = ''
     }
     const flushCjk = () => {
-      if (cjk.length === 1) tokens.push(cjk)
+      if (unigrams || cjk.length === 1) for (const char of cjk) tokens.push(char)
       for (let i = 0; i + 1 < cjk.length; i++) tokens.push(cjk.slice(i, i + 2))
       cjk = ''
     }
@@ -81,7 +102,7 @@ export function fullTextSearch(
     const counts = new Map<string, number>()
     let length = 0
     for (const text of [doc.path, doc.name ?? '', ...doc.texts]) {
-      for (const token of tokenize(text)) {
+      for (const token of tokenizeForIndex(text)) {
         counts.set(token, (counts.get(token) ?? 0) + 1)
         length++
       }

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -1,3 +1,9 @@
-export { fullTextSearch, type SearchableDocument, type SearchHit, tokenize } from './full-text.js'
+export {
+  fullTextSearch,
+  type SearchableDocument,
+  type SearchHit,
+  tokenize,
+  tokenizeForIndex,
+} from './full-text.js'
 export { type SearchableContent, searchableTexts } from './searchable-texts.js'
 export { snippetAround } from './snippet.js'

--- a/packages/server-core/src/search/search-quality.test.ts
+++ b/packages/server-core/src/search/search-quality.test.ts
@@ -20,7 +20,7 @@
 //     evidence, not a hunch. If the debt is small, the 120MB is not worth
 //     paying and stage 0 is the whole feature.
 
-import { tokenize } from '@kamiazya/whiteboard-search'
+import { tokenize, tokenizeForIndex } from '@kamiazya/whiteboard-search'
 import { beforeAll, describe, expect, it } from 'vitest'
 import type { ServerDeps } from '../server-deps.js'
 import { createInMemoryDocumentStore } from '../test-utils/in-memory-document-store.js'
@@ -139,7 +139,7 @@ describe('search corpus', () => {
             ...(doc?.groups ?? []).map((g) => g.label),
             ...(doc?.edges ?? []).map((e) => e.label),
           ].join(' ')
-          const shared = [...new Set(tokenize(indexed))].filter((t) => queryTokens.has(t))
+          const shared = [...new Set(tokenizeForIndex(indexed))].filter((t) => queryTokens.has(t))
           expect(shared, `"${judged.query}" shares tokens with ${path}`).toEqual([])
         }
       }


### PR DESCRIPTION
## Summary

Searching 「た」 in a workspace holding a document named 「たささたはな」 answered `Nothing matches “た” in the names, paths and contents of this workspace.` — after showing the document for a moment. Two independent causes, both reproduced against the running app:

- **A one-character CJK query could match nothing at all.** Bigram tokenization was symmetric: the name indexes as `たさ ささ さた たは はな`, the query produces `た`, and it is in none of them. `tokenizeForIndex` now also emits each CJK character on its own; the query tokenizer is unchanged, so 「検索」 still means the pair rather than anything containing 索. Widen what a document is *found by*, not what a query demands (Lucene spells the same choice `outputUnigrams`). One package, so both keepers get it.
- **That is why it flashed.** The panel answers the first keystroke from names and paths, then replaced the list wholesale with the content answer — dropping every document only its name matched. `withNameMatches` appends the matches the ranked search did not produce, so a row on screen is never unfound. The same defect hit latin prefixes: `roa` lost `Roadmap` identically.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [x] `pnpm test` passes locally
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable

Red-first at each layer: `search-node` (the single-character case, plus a guard that a two-character query must *not* match a document sharing one character), the panel in jsdom (`search-name-match-persists.test.tsx`, whose trigger assertion is the content answer's own excerpt on screen), and the browser keeper against real IndexedDB (`local-search.browser.test.tsx`). Mutation-checked: reverting the one-line unigram condition turns exactly the browser regression red and nothing else.

The search-quality scoreboard's pinned per-category nDCG and recall are unchanged by the widening — it is the instrument this change is judged by, not an argument about the diff. Its non-degeneracy guard now reads the indexed side with the index tokenizer, so it cannot go quietly looser than the thing it guards.

`pnpm test`: `11518 passed | 9 skipped`, one unrelated failure — `canvas-render-node`'s live-drag parity property, whose message is `Test timed out in 5000ms` rather than a counterexample (the documented load-dependent shape); the file passes 19/19 on a quiet machine. `pnpm typecheck`, `pnpm lint`, `pnpm knip`, `secretlint`, `test:scripts`, `intent:validate` all clean; `pnpm audit --prod` cannot reach registry.npmjs.org from this environment and this diff adds no dependency.

## Visual evidence

Driven through the real app (dev server, Playwright, one workspace holding 「たささたはな」 and `Roadmap`), toggling the fix by stashing it:

| query | before | after |
|---|---|---|
| 「た」 | `Nothing matches “た” …` | `たささたはな` |
| `roa` | `Nothing matches “roa” …` | `Roadmap` |
| 「たささ」 | `たささたはな` | `たささたはな` |

Each query returns one of the two documents, so the widening is a match rather than a list of everything. A composed before/after figure was produced locally (`compose-figure.mjs`, distinct panel hashes `e1883ed3` / `59a121ad`) but cannot be uploaded from this environment — no `gh` here to attach it — so the measured table above stands in for it.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved workspace file search so documents matching by name or path remain visible alongside content matches.
  * Enhanced Japanese and other CJK search, including single-character queries without additional downloads or dictionaries.
  * Preserved ranked contextual results and filtering options for document searches.

* **Bug Fixes**
  * Prevented unrelated multi-character CJK searches from matching documents based on only one shared character.

* **Documentation**
  * Clarified CJK search behavior and supported query patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->