### PR TITLE
test(web): the verb model learns to type, which its marks were starving without

### DIFF
--- a/apps/web/src/components/markdown-editor/editor-verbs.model.property.test.ts
+++ b/apps/web/src/components/markdown-editor/editor-verbs.model.property.test.ts
@@ -408,6 +408,40 @@ class Rule extends Press {
   }
 }
 
+/**
+ * Not a verb: the user typing the line's first word. The machine needs it
+ * because `Rule` opens a fresh empty line and every mark's meaning starts at
+ * a word — without typing, the first `rule` in a sequence closes the inline
+ * verbs for the REST of it (`Inline.check` gates on a non-empty line, and
+ * nothing else ever put text back). Measured before this command existed:
+ * across five full executions the six marks were driven 0–13 times each
+ * while every structure verb was driven ~400–480, and the ledger failure CI
+ * saw — `code` marked covered but never produced — is that distribution's
+ * tail. The word is inserted at the caret, so it lands inside whatever
+ * structure the presses have built; `judge` holds it to the model like any
+ * press.
+ */
+class Type implements fc.Command<Model, Real> {
+  check(model: Readonly<Model>): boolean {
+    return model.line.text === ''
+  }
+  run(model: Model, real: Real): void {
+    const head = real.state.selection.main.head
+    real.state = real.state.update({
+      changes: { from: head, insert: 'milk' },
+      selection: EditorSelection.cursor(head + 'milk'.length),
+    }).state
+    // `Line.text` is readonly because no VERB writes it, and typing is not a
+    // verb — the line is replaced rather than the field assigned, so that
+    // statement stays checked by the compiler.
+    model.line = { ...model.line, text: 'milk' }
+    judge(model, real)
+  }
+  toString(): string {
+    return 'type'
+  }
+}
+
 // ------------------------------------------------------------ the generator
 
 const mark = fc.constantFrom<Mark>('bold', 'italic', 'strikethrough', 'code', 'link', 'math')
@@ -439,6 +473,7 @@ const presses = fc.commands(
     fc.constant(new Task()),
     mark.map((id) => new Inline(id)),
     fc.constant(new Rule()),
+    fc.constant(new Type()),
   ],
   { size: '+1' },
 )
@@ -481,5 +516,21 @@ describe('markdown editor verbs as a state machine over the caret line', () => {
 
   afterAll(() => {
     assertLedger('editing verb', VERB_COVERAGE, drives)
+    // A FLOOR for the marks, not only the ledger's "at least once" — the
+    // same guard-of-the-guard edge-rules.properties.test.ts carries, for the
+    // same reason. Without `Type` in the pool the marks were driven 0–13
+    // times per execution against ~400+ for every structure verb, and the
+    // ledger failed only on the tail of that distribution: a red build
+    // pointing at a file nobody had changed. With `Type`, measured over five
+    // executions, every mark lands 18–46. The floor sits well below that
+    // without pinning a distribution; a generator change that thins the
+    // marks back out fails HERE, every run, naming the thin mark.
+    const MARK_DRIVE_FLOOR = 8
+    for (const id of ['bold', 'italic', 'strikethrough', 'code', 'link', 'math'] as const) {
+      expect(
+        drives[id],
+        `mark "${id}" was driven ${drives[id]} time(s); the generator has gone sparse (see Type)`,
+      ).toBeGreaterThanOrEqual(MARK_DRIVE_FLOOR)
+    }
   })
 })


### PR DESCRIPTION
## The flake, measured to its mechanism

CI failed `editor-verbs.model.property.test.ts` on Sep 2 with the **property green and the ledger red**: `Tests 3273 passed (3273)`, one failed *file* — 60 runs completed and the covered mark `code` was never once driven.

Five instrumented executions show that is the distribution, not a tail accident:

| | per execution |
|---|---|
| each structure verb (heading, quote, rule, lists, task) | **~400–480** |
| each of the six inline marks | **0–13** (one local run: `link=0`) |

Three things conspire, each individually correct:

- `Rule.move` replaces the model line with `freshLine()` — text empty, faithful to the editor.
- `Inline.check` gates on a non-empty line — also right; a wrap with no word is typing-ahead, deliberately not modelled.
- **Nothing ever put text back.** So the first `rule` in a sequence (P=1/7 per press, expected within ~7) closes the inline verbs for the rest of that ~40-press run, and 25% of runs start with an empty line — closed from the first press.

So beyond the flake, the property was barely testing marks at all: ~6 presses per mark out of ~2500.

## The fix adds what the machine was missing, not less of what the ledger asks

A `Type` command — the user typing the line's first word. Gated to an empty line, held to the model by `judge` like any press, **not a verb** so it does not tally, and `Line.text` stays `readonly`: the line is replaced rather than assigned, keeping "no verb writes text" compiler-checked.

Re-measured over five executions: every mark lands **18–46**.

## The guard-of-the-guard

`MARK_DRIVE_FLOOR = 8` in `afterAll` — the same shape `edge-rules.properties.test.ts` carries for the same reason (#1146). A generator change that thins the marks back out fails **every run, naming the thin mark**, instead of failing one CI run a week on the tail and pointing at a file nobody changed.

Mutation-checked with the state printed: `Type` removed from the pool → `mark "bold" was driven 5 time(s) … expected ≥ 8` and `driven 4` across two runs; restored (`Type in pool = 1`) → green.

## Verification

markdown-editor suite 212 passed · web typecheck clean · lint clean.

Visual evidence: none — a test-only change; the evidence is the before/after tally table above, measured on five executions each side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmbb1zNhiZitB7tn9LQ5f3