### PR TITLE
feat(dev-flow): the second-occurrence rule gets a watcher, from annotations CI already emits

### DIFF
--- a/.claude/rules/integrator-flow.md
+++ b/.claude/rules/integrator-flow.md
@@ -65,7 +65,7 @@ imports. Start the run, then leave the working tree alone.
 
 ## CI flakes
 
-- A known-flake failure gets one `gh run rerun <id> --failed`. The second occurrence of the same flake in CI promotes it to a root-cause fix lane (own worktree + dev-loop); do not keep re-running.
+- A known-flake failure gets one `gh run rerun <id> --failed`. The second occurrence of the same flake in CI promotes it to a root-cause fix lane (own worktree + dev-loop); do not keep re-running. The second occurrence is WATCHED: `flake-watch.mjs` (a quiet SessionStart hook) reports any test failing >=2 distinct main runs in 14 days, from the annotations vitest already emits.
 - **Read the property test's MESSAGE before hunting a counterexample.**
   `@fast-check/vitest` prints the seed in the test NAME, so a plain per-test
   timeout arrives looking exactly like a property failure — `... (with

--- a/.claude/scripts/flake-watch-lib.mjs
+++ b/.claude/scripts/flake-watch-lib.mjs
@@ -1,0 +1,80 @@
+// Which tests have failed main CI more than once — the executable half of
+// integrator-flow.md's rule that a flake's SECOND occurrence promotes it to
+// a root-cause fix lane. The rule had no watcher: each recurrence was
+// noticed only when somebody chose to spend an afternoon classifying job
+// logs by hand.
+//
+// The data needs no new production: vitest's github-actions reporter (on
+// whenever GITHUB_ACTIONS is set) annotates every failure, and the
+// annotation TITLE carries `[project] file > suite > test` — readable back
+// through the check-runs API for every past run. So the identity key here
+// is `[project] file`, which groups a file's tests together (a file that
+// fails different cases on different days is one flake surface, not three).
+//
+// Pure and filesystem-free: `flake-watch.mjs` supplies the real window from
+// the GitHub API; the tests replay the actual 2026-08/09 window as a
+// fixture, where the expected answer is known because it was classified by
+// hand first.
+
+/**
+ * `[project] path > suite > case` -> `[project] path`, or null for an
+ * annotation that is not a vitest test failure (the runner's own
+ * "Process completed with exit code 1." carries an empty title).
+ */
+export function testIdFromTitle(title) {
+  const match = /^(\[[^\]]+\] \S+?\.test\.[a-z]+)(?: > |$)/.exec(title ?? '')
+  return match === null ? null : match[1]
+}
+
+/**
+ * @param window `{ runId, createdAt, titles }[]` — one entry per failed run,
+ *   `titles` the test-failure annotation titles that run produced.
+ * @returns recurrences (id seen in >= 2 DISTINCT runs, most-occurrences
+ *   first, ties broken by most recent), singles, and the runs that failed
+ *   with no test annotation at all — the infra-shaped family, counted
+ *   rather than dropped so a registry outage does not vanish from the
+ *   report entirely.
+ */
+export function clusterFailures(window) {
+  const byId = new Map()
+  const unattributedRuns = []
+  for (const run of window) {
+    const ids = new Set(
+      run.titles.map((title) => testIdFromTitle(title)).filter((id) => id !== null),
+    )
+    if (ids.size === 0) {
+      unattributedRuns.push({ runId: run.runId, createdAt: run.createdAt })
+      continue
+    }
+    for (const id of ids) {
+      const entry = byId.get(id) ?? { id, runIds: [], latest: '' }
+      entry.runIds.push(run.runId)
+      if (run.createdAt > entry.latest) entry.latest = run.createdAt
+      byId.set(id, entry)
+    }
+  }
+  const entries = [...byId.values()]
+  const recurrences = entries
+    .filter((entry) => entry.runIds.length >= 2)
+    .sort((a, b) => b.runIds.length - a.runIds.length || b.latest.localeCompare(a.latest))
+  const singles = entries.filter((entry) => entry.runIds.length === 1)
+  return { recurrences, singles, unattributedRuns }
+}
+
+/** One line per recurrence; silence when there is none is the caller's job. */
+export function formatReport({ recurrences, singles, unattributedRuns }, windowDays) {
+  if (recurrences.length === 0) return ''
+  const lines = [
+    `[flake-watch] ${recurrences.length} test(s) failed main CI more than once in ${windowDays} days — the second occurrence is the promotion signal (integrator-flow.md):`,
+    '',
+  ]
+  for (const entry of recurrences) {
+    lines.push(`  ${entry.runIds.length}x ${entry.id}`)
+    lines.push(`      runs: ${entry.runIds.join(', ')}`)
+  }
+  lines.push('')
+  lines.push(
+    `  (${singles.length} single-occurrence test failure(s) and ${unattributedRuns.length} run(s) with no test annotation — infra-shaped — not listed.)`,
+  )
+  return lines.join('\n')
+}

--- a/.claude/scripts/flake-watch-lib.test.mjs
+++ b/.claude/scripts/flake-watch-lib.test.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// Regression coverage for flake-watch-lib.mjs.
+// Run with: pnpm test:scripts (also wired into the CI "check" job).
+//
+// The fixture is the real thing: the sixteen main-CI failures of
+// 2026-08-28..09-04, as their annotation titles actually read. One session
+// classified that window by hand — downloading six job logs, stripping
+// escape codes, grepping for FAIL lines — and integrator-flow.md's rule
+// ("the second occurrence of the same flake promotes it to a root-cause fix
+// lane") had no watcher: the two clusters below were each noticed only
+// after someone chose to look. Run over this window, the clusterer must
+// flag exactly those two and none of the singles.
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { clusterFailures, testIdFromTitle } from './flake-watch-lib.mjs'
+
+/** run id -> the test-failure annotation titles that run produced. */
+const WINDOW = [
+  // edge-rules: three runs in one day (Aug 30), pre-#1146.
+  {
+    runId: '33304624859',
+    createdAt: '2026-08-30T09:40:13Z',
+    titles: [
+      '[canvas-render-node] src/layout/edges/edge-rules.properties.test.ts > PENALTY_RULES: each rule writes only its declared tier slot > the domain makes every penalty rule contribute a nonzero term',
+    ],
+  },
+  {
+    runId: '33313408933',
+    createdAt: '2026-08-30T13:09:29Z',
+    titles: [
+      '[canvas-render-node] src/layout/edges/edge-rules.properties.test.ts > PENALTY_RULES: each rule writes only its declared tier slot > the domain makes every penalty rule contribute a nonzero term',
+    ],
+  },
+  {
+    runId: '33321928991',
+    createdAt: '2026-08-30T16:15:11Z',
+    titles: [
+      '[canvas-render-node] src/layout/edges/edge-rules.properties.test.ts > PENALTY_RULES: each rule writes only its declared tier slot > the domain makes every penalty rule contribute a nonzero term',
+    ],
+  },
+  // backup-in-progress: twice, three days apart (Aug 30, Sep 2), pre-#1224.
+  {
+    runId: '33326341153',
+    createdAt: '2026-08-30T17:49:46Z',
+    titles: [
+      '[mcp-node] src/server/store/backup-in-progress.test.ts > the backup-in-progress marker > stays valid across a pass longer than its own lifetime',
+    ],
+  },
+  {
+    runId: '33583802709',
+    createdAt: '2026-09-02T02:35:50Z',
+    titles: [
+      '[mcp-node] src/server/store/backup-in-progress.test.ts > the backup-in-progress marker > stays valid across a pass longer than its own lifetime',
+    ],
+  },
+  // The singles, one run each.
+  {
+    runId: '33554108510',
+    createdAt: '2026-09-01T20:14:06Z',
+    titles: [
+      '[web-jsdom] src/pages/BrowserDocumentPage.dialog-outlives-document.test.tsx > a destructive dialog does not outlive its document',
+    ],
+  },
+  {
+    runId: '33696937710',
+    createdAt: '2026-09-02T23:50:59Z',
+    titles: [
+      '[web-jsdom] src/components/markdown-editor/editor-verbs.model.property.test.ts > markdown editor verbs as a state machine over the caret line',
+    ],
+  },
+  {
+    runId: '33296982894',
+    createdAt: '2026-08-30T06:28:51Z',
+    titles: [
+      '[web-jsdom] src/App.workspace-switch.test.tsx > browser workspace switch > rewrites an address the registry cannot resolve, and stays where it was',
+    ],
+  },
+  // One run failing two files at once (mcp-node under load, Aug 28): both
+  // are singles — a run is one occurrence, not two.
+  {
+    runId: '33173434367',
+    createdAt: '2026-08-28T12:59:59Z',
+    titles: [
+      '[mcp-node] src/server/routes/branches.test.ts > POST branches > initializes tipFrontiers through the index',
+      '[mcp-node] src/server/routes/ws.test.ts > handleWsUpgrade viewport replay > replays the most recent viewport_request',
+    ],
+  },
+  // Infra failures produce no test annotation at all: the audit timeout and
+  // the apt 403. They must be counted, separately, not dropped.
+  { runId: '33822259235', createdAt: '2026-09-04T00:33:17Z', titles: [] },
+  { runId: '33756341059', createdAt: '2026-09-03T12:38:11Z', titles: [] },
+]
+
+test('testIdFromTitle keys on project + file, dropping the case name', () => {
+  assert.equal(
+    testIdFromTitle(
+      '[mcp-node] src/server/store/backup-in-progress.test.ts > the backup-in-progress marker > stays valid',
+    ),
+    '[mcp-node] src/server/store/backup-in-progress.test.ts',
+  )
+  // A title that is not a vitest test annotation (the runner's own
+  // "Process completed with exit code 1" has an empty title) yields null.
+  assert.equal(testIdFromTitle(''), null)
+  assert.equal(testIdFromTitle('Process completed with exit code 1.'), null)
+})
+
+test('the real window clusters into exactly the two known recurrences', () => {
+  const { recurrences, singles, unattributedRuns } = clusterFailures(WINDOW)
+  assert.deepEqual(
+    recurrences.map((entry) => ({ id: entry.id, runs: entry.runIds.length })),
+    [
+      { id: '[canvas-render-node] src/layout/edges/edge-rules.properties.test.ts', runs: 3 },
+      { id: '[mcp-node] src/server/store/backup-in-progress.test.ts', runs: 2 },
+    ],
+  )
+  assert.equal(singles.length, 5)
+  assert.equal(unattributedRuns.length, 2)
+})
+
+test('recurrence counts distinct RUNS, so one bad run cannot promote itself', () => {
+  // The same file failing twice inside one run (two shards, or a second
+  // assertion) is one occurrence of the environment, not two of the flake.
+  const { recurrences, singles } = clusterFailures([
+    {
+      runId: 'r1',
+      createdAt: '2026-09-01T00:00:00Z',
+      titles: ['[p] src/a.test.ts > one', '[p] src/a.test.ts > two'],
+    },
+  ])
+  assert.deepEqual(recurrences, [])
+  assert.equal(singles.length, 1)
+})
+
+test('recurrences are ordered most-occurrences-first, ties by most recent', () => {
+  const { recurrences } = clusterFailures([
+    { runId: 'r1', createdAt: '2026-09-01T00:00:00Z', titles: ['[p] src/a.test.ts > x'] },
+    { runId: 'r2', createdAt: '2026-09-02T00:00:00Z', titles: ['[p] src/a.test.ts > x'] },
+    { runId: 'r3', createdAt: '2026-09-03T00:00:00Z', titles: ['[p] src/b.test.ts > y'] },
+    { runId: 'r4', createdAt: '2026-09-04T00:00:00Z', titles: ['[p] src/b.test.ts > y'] },
+    { runId: 'r5', createdAt: '2026-09-05T00:00:00Z', titles: ['[p] src/b.test.ts > y'] },
+  ])
+  assert.deepEqual(
+    recurrences.map((entry) => entry.id),
+    ['[p] src/b.test.ts', '[p] src/a.test.ts'],
+  )
+})
+
+test('an empty window reports nothing, not an empty-shaped something', () => {
+  const { recurrences, singles, unattributedRuns } = clusterFailures([])
+  assert.deepEqual(recurrences, [])
+  assert.deepEqual(singles, [])
+  assert.deepEqual(unattributedRuns, [])
+})

--- a/.claude/scripts/flake-watch.mjs
+++ b/.claude/scripts/flake-watch.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Report tests that failed main CI more than once in the window — the
+// watcher for integrator-flow.md's second-occurrence rule. Read-only,
+// silent when there is nothing to say, and fail-open: a machine without
+// `gh` or network must not make a session start red.
+//
+//   node .claude/scripts/flake-watch.mjs [--days 14] [--quiet]
+//
+// No CI-side production was added for this, measured before building:
+// vitest's github-actions reporter already annotates every failure with
+// `[project] file > suite > case` in the annotation title, retroactively
+// readable through the check-runs API. The one hand-classified window
+// (2026-08-28..09-04, sixteen failures) is pinned as the lib's fixture.
+//
+// Annotations of a completed run never change, so they are cached per run
+// id under tmp/flake-watch/ — a session start re-fetches only runs it has
+// not seen.
+
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { clusterFailures, formatReport } from './flake-watch-lib.mjs'
+
+const QUIET = process.argv.includes('--quiet')
+const daysArg = process.argv.indexOf('--days')
+const WINDOW_DAYS = daysArg === -1 ? 14 : Number(process.argv[daysArg + 1] ?? 14)
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '../..')
+const CACHE_DIR = join(ROOT, 'tmp', 'flake-watch')
+
+function gh(args) {
+  return JSON.parse(execFileSync('gh', args, { encoding: 'utf-8', timeout: 30_000 }))
+}
+
+function cached(runId, fetch) {
+  const file = join(CACHE_DIR, `${runId}.json`)
+  try {
+    return JSON.parse(readFileSync(file, 'utf-8'))
+  } catch {
+    const value = fetch()
+    mkdirSync(CACHE_DIR, { recursive: true })
+    writeFileSync(file, JSON.stringify(value))
+    return value
+  }
+}
+
+function main() {
+  const since = new Date(Date.now() - WINDOW_DAYS * 86_400_000).toISOString()
+  const runs = gh([
+    'run', 'list', '--branch', 'main', '--workflow', 'ci', '--status', 'failure',
+    '--limit', '100', '--json', 'databaseId,createdAt',
+  ]).filter((run) => run.createdAt >= since)
+
+  const window = runs.map((run) => ({
+    runId: String(run.databaseId),
+    createdAt: run.createdAt,
+    titles: cached(String(run.databaseId), () => {
+      const jobs = gh(['api', `repos/{owner}/{repo}/actions/runs/${run.databaseId}/jobs`, '--jq', '[.jobs[] | select(.conclusion=="failure") | .id]'])
+      const titles = []
+      for (const jobId of jobs) {
+        // A job IS a check run, so its annotations live at the same id.
+        for (const annotation of gh(['api', `repos/{owner}/{repo}/check-runs/${jobId}/annotations`])) {
+          if (annotation.title) titles.push(annotation.title)
+        }
+      }
+      return titles
+    }),
+  }))
+
+  const report = formatReport(clusterFailures(window), WINDOW_DAYS)
+  if (report !== '') process.stdout.write(`${report}\n`)
+  else if (!QUIET) {
+    process.stdout.write(
+      `[flake-watch] no recurring test failure on main in ${WINDOW_DAYS} days (${window.length} failed run(s) examined)\n`,
+    )
+  }
+}
+
+try {
+  main()
+} catch (error) {
+  // The daemon being down never blocked stale-issues; gh being absent,
+  // unauthenticated, or offline must not block this either.
+  if (!QUIET) process.stderr.write(`[flake-watch] skipped: ${error.message}\n`)
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,6 +28,11 @@
             "type": "command",
             "command": "node .claude/scripts/stale-issues.mjs --quiet",
             "_comment": "Reports open issues whose declared OKF `sources` moved since their `generated.at`. Read-only, fails open, and silent when it has nothing to say or the daemon is not up \u2014 so it never delays or blocks a session start. Ordering against the ensure hook above is not guaranteed, which is why the script retries a refused connection briefly."
+          },
+          {
+            "type": "command",
+            "command": "node .claude/scripts/flake-watch.mjs --quiet",
+            "_comment": "The watcher for integrator-flow.md\u2019s second-occurrence rule: reports tests that failed main CI in >= 2 distinct runs in 14 days, from the annotations vitest already emits. Read-only, cached per run id under tmp/flake-watch/, fail-open and silent without gh or network."
           }
         ]
       }

--- a/packages/mcp-server/src/server/dev-rules-budget.test.ts
+++ b/packages/mcp-server/src/server/dev-rules-budget.test.ts
@@ -68,7 +68,12 @@ const ALWAYS_ON_BUDGET: Record<string, number> = {
   // one bullet rather than by drift. The three worked cases live in the
   // `measured-change` skill, which is not always-on and costs nothing here.
   '.claude/rules/dev-flow.md': 26,
-  '.claude/rules/integrator-flow.md': 13,
+  // 14 since the CI-flakes section gained flake-watch's pointer — the
+  // watcher for the section's own second-occurrence rule, whose value is
+  // being discovered at session start rather than remembered. The file sat
+  // 33 characters under the boundary, so the bucket is bought by one
+  // sentence; the mechanism lives in the script's header, not here.
+  '.claude/rules/integrator-flow.md': 14,
   // 16 since the annotation layer's thread vocabulary (ADR-0026) landed in
   // the Comment row. It sat 23 characters under the boundary beforehand, so
   // this bucket bought about 200 characters of prose, not a thousand — a


### PR DESCRIPTION
## The gap

`integrator-flow.md` rules that a flake's **second occurrence** in CI promotes it to a root-cause fix lane — and nothing watched for the second occurrence. Classifying one eight-day window (16 failures) by hand took six job-log downloads, escape-code stripping and per-job grepping, and the two clusters it found had by then failed main three and two times.

## Measured before building, which deleted half the plan

The original proposal had two halves: produce machine-readable failure output in CI, then consume it. Measuring first showed **the production half already exists**: vitest's `github-actions` reporter (active whenever `GITHUB_ACTIONS` is set) annotates every failure, and the annotation *title* carries `[project] file > suite > case` — readable back through the check-runs API for every past run, retroactively. Verified on two real failed jobs before writing a line. So this PR adds no CI-side anything; the missing piece was consumption.

## The watcher

`flake-watch.mjs` — also a quiet SessionStart hook, same shape as `stale-issues.mjs`:

```
[flake-watch] 2 test(s) failed main CI more than once in 14 days — the second occurrence is the promotion signal (integrator-flow.md):

  3x [canvas-render-node] src/layout/edges/edge-rules.properties.test.ts
      runs: 33321928991, 33313408933, 33304624859
  2x [mcp-node] src/server/store/backup-in-progress.test.ts
      runs: 33583802709, 33326341153

  (11 single-occurrence test failure(s) and 8 run(s) with no test annotation — infra-shaped — not listed.)
```

That is the actual output against the live API — and it **reproduces the hand classification exactly**: the same two recurrences, the same run ids. The lib's test fixture *is* that hand-classified window, where the expected answer was known before the code existed.

Design points, each with a test:

- Recurrence counts **distinct runs** — one bad run (two shards failing the same file) cannot promote itself.
- Runs with **no test annotation** are counted separately as infra-shaped, not dropped — a registry outage does not vanish from the report.
- Keyed `[project] file`, so a file failing different cases on different days is one flake surface.
- Cached per run id under `tmp/flake-watch/` (annotations of a completed run never change); ~4.5s on today's window. Fail-open: no `gh`, no network → no report, never a red session start.

Mutation-checked in four places, each restored and re-run green: threshold→1 (2 red), per-run dedupe removed (red), infra runs dropped (red), ordering inverted (2 red).

## The budget gate fired on this PR, and the paper trail is in the diff

Adding the rule pointer tipped `integrator-flow.md` from 13,967 chars — **33 under its bucket boundary** — into bucket 14, and `dev-rules-budget.test.ts` blocked the push. That is the same test whose Aug-31 main failure the flake census flagged as "semantic-conflict-shaped, not flake-shaped". The pin is raised deliberately, with the reason in the table per its convention; the total stays 87 because the floored bucket of the sum is not the sum of the buckets (87,940 → 87). The pointer itself was first trimmed to one sentence — the mechanism lives in the script's header, not in always-on context.

Visual evidence: none — dev tooling; the evidence is the live run output above matching the hand classification, and the 6-test lib suite in `pnpm test:scripts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmbb1zNhiZitB7tn9LQ5f3