### PR TITLE
fix(dev-rules): the always-on total is 88, crossed by two merges neither CI saw

### DIFF
--- a/packages/mcp-server/src/server/dev-rules-budget.test.ts
+++ b/packages/mcp-server/src/server/dev-rules-budget.test.ts
@@ -81,8 +81,23 @@ const ALWAYS_ON_BUDGET: Record<string, number> = {
   '.claude/rules/vocabulary.md': 16,
 }
 
-/** Floored bucket of the SUM, which is not the sum of the buckets. */
-const ALWAYS_ON_TOTAL_BUDGET = 87
+/**
+ * Floored bucket of the SUM, which is not the sum of the buckets.
+ *
+ * 88 since two merges that were each green on their own base landed
+ * together. `integrator-flow.md` grew past its own boundary (13 -> 14) in
+ * one; `vocabulary.md` gained 204 characters in the other, which did not
+ * move ITS bucket (16 either way) and moved the total, 87940 -> 88144. So
+ * both per-file pins were correct and only this one was crossed, on a main
+ * neither PR's CI ever saw — the second PR was branched before the first
+ * landed, which is the one thing a per-PR check cannot cover.
+ *
+ * Worth knowing when this fails on a diff that touches no rule file: the
+ * total is the reading most likely to be stale, and the four `it`s below
+ * separate the cases — a per-file failure names the file that grew, this
+ * one names only the corpus.
+ */
+const ALWAYS_ON_TOTAL_BUDGET = 88
 
 /**
  * The largest path-scoped file, tracked separately because it is not paid by


### PR DESCRIPTION
## Summary

- **`test-unit` is red on `main` itself**, and therefore on every PR branched from it. `dev-rules-budget.test.ts` reports `always-on corpus is 88144 chars: expected 88 to be 87`, while all five per-file pins are correct — the signature of the one case a per-PR check cannot cover.
- Measured, not guessed. At **#1284**'s merge (`e166016c`) the total was **87940** (bucket 87, and its own `test-unit` was green). **#1283** (`242f6473`) then added **204 characters** to `.claude/rules/vocabulary.md` — which does not move *that file's* bucket (16096 and 16300 are both 16) and does move the total to **88144**. #1283 was branched before #1284 landed, so its CI weighed those 204 characters against a corpus that did not yet carry #1284's `integrator-flow.md` growth (13 → 14). Each was under the boundary on its own base; together they cross it.
- The pin is raised to 88, which is what this instrument is for — its own header says growth is legitimate and that the point is to make crossing a bucket *a decision in a diff* rather than drift nobody measures. The new comment records the mechanism, because the next reader to hit this will be staring at a diff that touches no rule file at all.

Not a flake and not a rerun candidate: the count is deterministic, and it reproduces on a checkout of `origin/main` with nothing else applied.

## Test plan

- [x] New or updated `mcp-node` tests — the existing budget test is the subject; no new case, the assertion it already makes is what was stale.
- [x] `pnpm test` passes locally — `pnpm vitest run --project mcp-node dev-rules-budget`: 4 passed. Verified red before the change with exactly the CI message.
- [x] Manual verification completed — read the corpus at both commits through the same JS measure the test uses (`.length`, not bytes): `e166016c` 87940 / bucket 87, `242f6473` 88144 / bucket 88; and confirmed through the check-runs API that `242f6473`'s own `test-unit (1)` is `failure` while `e166016c`'s is `success`.
- [ ] E2E coverage — not applicable.

**Mutation-checked**: pinned at 89 the total assertion fails naming the real count (88144), then restored green. The four cases still separate the diagnoses — a per-file failure names the file that grew, this one names only the corpus.

## Visual evidence

Visual evidence: none — a pinned integer in a test has no user-visible surface. The evidence is the two measurements above and the red-then-green on the assertion itself.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — neither changes.
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_