### PR TITLE
fix(web): stop a read overtaking a name write the page has queued but not issued

### DIFF
--- a/apps/web/src/lib/idb-document-index.ts
+++ b/apps/web/src/lib/idb-document-index.ts
@@ -42,6 +42,7 @@ import {
 import { z } from 'zod'
 import { DOCUMENT_INDEX_STORE, WORKSPACES_STORE } from './browser-idb.js'
 import { inTransaction, request } from './idb-tx.js'
+import { indexWritesSettled, trackIndexWrite } from './pending-index-writes.js'
 
 /**
  * A row as stored: the port's own entry shape plus the `workspaceId` the
@@ -95,7 +96,15 @@ export class IdbDocumentIndex implements DocumentIndex {
     mode: IDBTransactionMode,
     body: (tx: IDBTransaction) => Promise<T>,
   ): Promise<T> {
-    return inTransaction(this.dbName, stores, mode, body)
+    // The one chokepoint for both directions, which is why the ordering rule
+    // lives here rather than in each caller: a write is registered as
+    // outstanding, and a read waits for the ones already issued. See
+    // pending-index-writes.ts for what transaction ordering alone does not
+    // cover. An empty set costs a read one microtask.
+    if (mode === 'readwrite') {
+      return trackIndexWrite(inTransaction(this.dbName, stores, mode, body))
+    }
+    return indexWritesSettled().then(() => inTransaction(this.dbName, stores, mode, body))
   }
 
   async createWorkspace({

--- a/apps/web/src/lib/pending-index-writes.ts
+++ b/apps/web/src/lib/pending-index-writes.ts
@@ -1,0 +1,46 @@
+/**
+ * Writes this tab has issued but whose IndexedDB transaction may not be open
+ * yet, so a read can be told to wait for them.
+ *
+ * IndexedDB serves transactions in creation order, which is all the ordering
+ * anyone needs — until a write is QUEUED rather than issued. A name edit is
+ * fire-and-forget: each keystroke queues a snapshot, and while one write is in
+ * flight the next only waits its turn, holding no transaction. A page that
+ * unmounts there still finishes the queued write (the loop is closed over its
+ * own refs), but any read that starts meanwhile — the workspace listing, or
+ * the page mounted in its place — opens a transaction first and is answered
+ * from before the last keystroke. Measured: a title typed and left immediately
+ * came back a character short, in the document AND in the workspace list.
+ *
+ * So the wait cannot live in either reader, and the queue cannot live in the
+ * index: only the writer knows about work it has not issued yet. This module
+ * is the one place both halves can see.
+ *
+ * A tracked promise must never READ through the index. Reads wait here, so a
+ * tracked promise that waited on one would wait on itself. Today's registrants
+ * are the index's own write transactions and the document controller's save
+ * loop, neither of which reads.
+ */
+const issued = new Set<Promise<unknown>>()
+
+/** Registers a write as outstanding until it settles. Returns it unchanged. */
+export function trackIndexWrite<T>(write: Promise<T>): Promise<T> {
+  issued.add(write)
+  void write
+    .catch(() => {})
+    .finally(() => {
+      issued.delete(write)
+    })
+  return write
+}
+
+/**
+ * Settles every write issued so far. Loops rather than awaiting once: a save
+ * loop that is finishing can register the next queued write, and a read let
+ * through between the two would land in exactly the gap this closes.
+ */
+export async function indexWritesSettled(): Promise<void> {
+  while (issued.size > 0) {
+    await Promise.allSettled([...issued])
+  }
+}

--- a/apps/web/src/pages/BrowserDocumentPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.markdown.browser.test.tsx
@@ -29,6 +29,23 @@ import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.
 
 claimIsolatedWhiteboardDb('browserdocumentpage-markdown')
 
+/**
+ * A real index whose name write takes a measurable moment, the way it does on
+ * a machine under load. Nothing else is faked: the rows, the transactions and
+ * their ordering are IndexedDB's own.
+ */
+class SlowNameWriteIndex extends IdbDocumentIndex {
+  constructor(private readonly delayMs: number) {
+    super()
+  }
+  override async setDocumentName(
+    input: Parameters<IdbDocumentIndex['setDocumentName']>[0],
+  ): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, this.delayMs))
+    return super.setDocumentName(input)
+  }
+}
+
 function render(ui: ReactElement) {
   return rtlRender(
     // Pages fill their allotted height (h-full) — the app shell owns the
@@ -340,7 +357,16 @@ describe('BrowserDocumentPage markdown 導線 (real IndexedDB)', () => {
   })
 
   it('flushes a title edit that is still debounced when the page goes away', async () => {
-    const store = new IdbDocumentIndex()
+    // Slowed deliberately, because the defect is an ORDERING one and an
+    // unslowed run only reaches it by luck. Each keystroke queues a name
+    // write; while one is in flight the next only WAITS, so it has not
+    // opened its IndexedDB transaction yet. IndexedDB orders transactions by
+    // creation, so the remount's read — whose transaction opens immediately —
+    // is served before the last keystroke's write ever starts, and comes back
+    // with the previous name. Measured unslowed under a full browser-project
+    // run: the final write completed, and the reload still showed the name
+    // from the write before it.
+    const store = new SlowNameWriteIndex(60)
     await seedIdbDocument(store, { path: 'note', kind: 'markdown', makeDefault: true })
     const first = render(<BrowserDocumentPage store={store} />)
 
@@ -369,6 +395,29 @@ describe('BrowserDocumentPage markdown 導線 (real IndexedDB)', () => {
       },
       { timeout: 10_000 },
     )
+  })
+
+  it('the workspace listing sees the last keystroke too, not only the reopened page', async () => {
+    // The second reader, and the one the fix first missed: leaving a document
+    // for the workspace shows the list, which reads the index on its own.
+    // Measured in the running app before this was closed — a title typed and
+    // left immediately read back a character short in the LIST while the
+    // reopened document was already correct.
+    const store = new SlowNameWriteIndex(60)
+    await seedIdbDocument(store, { path: 'note', kind: 'markdown', makeDefault: true })
+    const first = render(<BrowserDocumentPage store={store} />)
+
+    const title = await findMarkdownTitleInput()
+    await userEvent.click(title)
+    await userEvent.keyboard('Release plan')
+    await expectTitleValue('Release plan')
+    first.unmount()
+
+    // ONE read, taken the moment the page goes away — deliberately not a
+    // waitFor. Retrying would pass either way once the queued write lands,
+    // which is exactly the difference this is here to see.
+    const listed = await listLocalDocuments(store)
+    expect(listed.map((row) => row.name)).toContain('Release plan')
   })
 
   it('a spatial canvas gets the same properties bar, and its title round-trips', async () => {

--- a/apps/web/src/pages/use-browser-document-controller.ts
+++ b/apps/web/src/pages/use-browser-document-controller.ts
@@ -17,6 +17,7 @@ import {
 } from '../lib/local-document-summary.js'
 import { LoroStore, type LoroStoreLike } from '../lib/loro-store.js'
 import { mergeToSnapshot } from '../lib/merge-to-snapshot.js'
+import { trackIndexWrite } from '../lib/pending-index-writes.js'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
 import { seedWorkspaceDocumentContent, touchIfWorkspaceBacked } from '../lib/workspace-content.js'
 
@@ -214,7 +215,7 @@ export function useBrowserDocumentController(
   // savePromiseRef/pendingSnapshotRef so the second caller picks up and awaits
   // that newly-started save instead of returning true while it is still
   // in flight.
-  const flushSave = useCallback(async (): Promise<boolean> => {
+  const runFlush = useCallback(async (): Promise<boolean> => {
     for (;;) {
       if (savePromiseRef.current !== null) {
         const priorOk = await savePromiseRef.current
@@ -258,6 +259,15 @@ export function useBrowserDocumentController(
       // while this save was in flight.
     }
   }, [])
+
+  // Registered as outstanding for as long as the whole loop runs, not just
+  // the one write inside it: a caller that queued a snapshot the loop has not
+  // reached yet is exactly the case the barrier exists for.
+  // Registered for as long as the whole loop runs, not just the one write
+  // inside it: a keystroke whose snapshot the loop has not reached yet holds
+  // no transaction, and that is exactly the window a read must not slip
+  // through. See lib/pending-index-writes.ts.
+  const flushSave = useCallback((): Promise<boolean> => trackIndexWrite(runFlush()), [runFlush])
 
   useEffect(() => {
     let cancelled = false


### PR DESCRIPTION
## Summary

Typing a title and leaving the document immediately showed the name **one character short** — in the workspace list and in the document when reopened. Nothing was lost on disk: the write landed a moment later, with nobody left to read it.

- **The mechanism.** Each keystroke queues a name write, and while one is in flight the next only waits its turn, holding no IndexedDB transaction. IndexedDB serves transactions in creation order, so a read that starts in that window opens its transaction first and is answered from before the last keystroke.
- **The fix.** `lib/pending-index-writes.ts` is the one place both halves can see: the document controller registers its save loop (only the writer knows about work it has not issued yet), and every readonly transaction in `IdbDocumentIndex` waits for what is outstanding. The wait could not live in either reader — there are two, and scoping the first attempt to the controller left the workspace listing still reading a character short.

This was filed as a test flake ("the last title keystroke is sometimes lost"). It is not: the input was never lost, and the defect reproduces deterministically in the running app.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [x] `pnpm test` passes locally
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable

Two `web-browser` regressions, each mutation-checked (removing the barrier turns exactly that test red — `expected [ 'Releas' ] to include 'Release plan'`):

- The existing flush test now **slows the name write deliberately**. The defect is an ordering one, and an unslowed run only reaches it by luck — which is why it had been flaking as "the last input is lost" rather than failing as a bug.
- A new listing test takes **ONE read the moment the page goes away**, deliberately not a `waitFor`: retrying would pass either way once the queued write lands, which is exactly the difference it exists to see.

How the mechanism was established rather than argued — the trace from a full browser-project run, before any change:

```
write:start "Fast swit"
write:done  "Fast swit"
write:start "Fast switch"
write:done  "Fast switch"   ← the final write completed
restored="Fast swit"         ← and the reload still showed the one before it
```

That is what ruled out "the keystroke was lost" and pointed at read/write ordering instead.

`pnpm test`: `11549 passed | 9 skipped`, one unrelated failure — `canvas-render-node`'s live-drag parity property, whose message is `Test timed out in 5000ms` rather than a counterexample (the load-dependent shape documented in `integrator-flow.md`). It fails in `canvas-render`, which this diff cannot reach, and it failed the same way on a full run taken before this change. `pnpm check:local` passes in full, including `pnpm audit --prod`.

## Visual evidence

Driven through the real app (dev server + Playwright): create a note, type `Release plan`, and navigate to the workspace **without pausing for the save**.

| read | before | after |
|---|---|---|
| workspace list card | `"Release pla"` | `"Release plan"` |
| the document, reopened | `"Release pla"` | `"Release plan"` |

Deterministic on both sides — no load needed to reproduce it by hand. The middle row is what caught a wrong fix: with the barrier scoped to the document controller, the reopened document was already correct while the list still read `"Release pla"`.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_