### PR TITLE
ci: unchain the jobs whose needs carried no artifact, halving the wall clock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,18 @@ jobs:
         run: pnpm --filter @kamiazya/whiteboard-canvas-viewer smoke:widget
 
   verify:
-    needs: [check, test-unit, test-jsdom, test-browser, widget-smoke]
+    # No `needs` on the test jobs, deliberately — measured 2026-09-04, that
+    # chain WAS the wall clock: pickup ~2min -> test-jsdom 5min -> verify
+    # 3min -> dry-run-docker 5min ≈ 14min for a 5-minute-max job graph.
+    # verify consumes nothing from the test jobs (fresh checkout + install),
+    # and the "a release tag points at a commit where the tests ran"
+    # property is carried by branch protection, which requires every test
+    # job INDIVIDUALLY (check, test-unit 1+2, test-jsdom, test-browser 1+2,
+    # widget-smoke — verified via the branch-protection API; the Actions
+    # token cannot read it, so no test can pin this and the settings page is
+    # the source of truth). What unchaining costs is only compute on a red
+    # run: verify's smokes run even when a test job fails, which on a free
+    # public repo is minutes, not money.
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -367,7 +378,10 @@ jobs:
           if-no-files-found: error
 
   dry-run-docker:
-    needs: verify
+    # No `needs: verify`, deliberately: unlike dry-run-npm this job downloads
+    # no artifact from verify — it checks out and builds the image from
+    # source — so the edge was pure ordering, and it serialized the two
+    # longest jobs in the workflow back to back.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/packages/mcp-server/src/server/release/ci-verify-coverage.test.ts
+++ b/packages/mcp-server/src/server/release/ci-verify-coverage.test.ts
@@ -111,16 +111,30 @@ describe('ci.yml verify coverage of removed publish-gate correctness projects', 
     expect(flaggedProjects).toEqual(expect.arrayContaining(browserProjectNames))
   })
 
-  it('the verify job gates on all four test jobs, so a release tag always points at a commit where they ran', () => {
-    const verifyIdx = text.indexOf('\n  verify:')
-    expect(verifyIdx, 'verify job must exist').toBeGreaterThanOrEqual(0)
-    const verifySection = text.slice(verifyIdx, verifyIdx + 400)
-    const needsMatch = verifySection.match(/needs:\s*\[([^\]]+)\]/)
-    expect(needsMatch, 'verify job must declare needs: [...]').not.toBeNull()
-    const needs = needsMatch![1].split(',').map((s) => s.trim())
-    expect(needs).toEqual(
-      expect.arrayContaining(['check', 'test-unit', 'test-jsdom', 'test-browser']),
-    )
+  it('dry-run-npm still rides the verify dist, the one needs edge that carries an artifact', () => {
+    // verify's `needs` on the test jobs was removed deliberately (measured
+    // 2026-09-04: that chain was the whole wall clock — see the comment in
+    // ci.yml). The "a release tag points at a commit where the tests ran"
+    // property this test used to pin moved to branch protection, which
+    // requires every test job individually and which no in-repo test can
+    // read — the Actions token cannot see it, so the settings page is the
+    // source of truth and this comment is the pointer. What remains
+    // assertable in-repo is the one dependency that is REAL: dry-run-npm
+    // downloads the dist verify built, so losing that edge would hand it a
+    // stale or absent artifact.
+    const npmIdx = text.indexOf('\n  dry-run-npm:')
+    expect(npmIdx, 'dry-run-npm job must exist').toBeGreaterThanOrEqual(0)
+    const npmSection = text.slice(npmIdx, npmIdx + 400)
+    // Anchored to a line START so a comment SAYING "needs: verify" (which
+    // dry-run-docker's why-not comment does) can never satisfy or trip it.
+    expect(npmSection).toMatch(/^\s*needs:\s*verify/m)
+    // And the inverse guard: dry-run-docker must NOT grow the edge back by
+    // reflex — it consumes no artifact, and the edge serialized the two
+    // longest jobs in the workflow.
+    const dockerIdx = text.indexOf('\n  dry-run-docker:')
+    expect(dockerIdx, 'dry-run-docker job must exist').toBeGreaterThanOrEqual(0)
+    const dockerSection = text.slice(dockerIdx, text.indexOf('steps:', dockerIdx))
+    expect(dockerSection).not.toMatch(/^\s*needs:\s*verify/m)
   })
 
   // Which browser CI runs is not a detail: local runs use Playwright's Chromium


### PR DESCRIPTION
Groundwork for the merge queue: its per-merge latency is one required-checks round, so the wall clock is the price of every merge once it is on.

## Measured

Five green main runs: **wall 13–14.3 min against a 5-minute longest job.** The difference is one chain, read off the job timeline:

```
0 ──► ~2.0   runner pickup
2.0 ──► 6.3  test-jsdom            (longest gate job)
6.4 ──► 9.3  verify                needs: [check, test-unit, test-jsdom, test-browser, widget-smoke]
9.4 ──► 14.2 dry-run-docker        needs: verify
```

Neither of the last two edges carries data:

| edge | what it actually transfers |
|---|---|
| test jobs → `verify` | **nothing** — verify checks out and installs fresh |
| `verify` → `dry-run-docker` | **nothing** — it builds the image from source |
| `verify` → `dry-run-npm` | **the dist artifact** — this one is real and stays |

## Safety moved nowhere, verified before cutting

The removed `verify` needs carried one property: "a release tag points at a commit where the tests ran." That property is held by **branch protection**, which requires every test job *individually* (`check`, `test-unit (1)(2)`, `test-jsdom`, `test-browser (1)(2)`, `widget-smoke`, `verify`) — read via the branch-protection API before editing. A PR cannot merge with a red test job regardless of verify's own state.

The Actions token cannot read that setting, so no in-repo test can pin it; the ci.yml comment says so and names the settings page as the source of truth. `ci-verify-coverage.test.ts` now asserts what **is** assertable in-repo: the artifact edge stays, and dry-run-docker's edge does not grow back by reflex. Both assertions are anchored to line starts — the first version matched its own why-not comment, the grep-for-a-phrase trap in miniature. Mutation-checked: regrowing the docker edge turns the guard red; restored, 14/14.

## Cost

On a red run, verify's smokes now spend their minutes anyway — compute, not money, on a public repo.

## Expected → this PR measures it

Expected wall ≈ pickup + max(test-jsdom, dry-run-docker) ≈ **6.5 min**. This PR's own CI run is the measurement; compare its wall clock against the 13–14.3 baseline above.

Remaining lever if this is not enough for the queue: shard `test-jsdom` ×2 like unit/browser (~1 more minute off), left out deliberately — one change per measurement.

Visual evidence: none — CI graph surgery; the evidence is the job timeline above and this run's own wall clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmbb1zNhiZitB7tn9LQ5f3