### PR TITLE
feat(web): put the last two surfaces behind the render broker, and make a new kind fail the build

### DIFF
--- a/apps/web/src/components/markdown-editor/rail-write-mode.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/rail-write-mode.browser.test.tsx
@@ -1,7 +1,9 @@
 import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { useCallback, useMemo } from 'react'
 import { afterEach, describe, expect, it } from 'vitest'
 import { useDocumentOutline } from '../../hooks/useDocumentOutline.js'
 import { useMarkdownOutline } from '../../hooks/useMarkdownOutline.js'
+import { createInTabRenderBroker } from '../../lib/render-broker.js'
 import { MarkdownEditor } from './MarkdownEditor.js'
 
 const SHORT = '# One\n\nJust a line.\n'
@@ -98,10 +100,16 @@ describe('the rail in write mode', () => {
 // starts another fleet of workers — measurably enough to destabilise the
 // whole project.
 function OutlineProbe({ body }: { body: string }) {
+  const broker = useMemo(() => createInTabRenderBroker(), [])
+  // A version that moves with the text, which is what the real source's
+  // frontier does — without one the memo would answer the second body from
+  // the first body's entry, which is the case these tests are about.
+  const readSource = useCallback(() => ({ frontier: `len-${body.length}`, body }), [body])
   const rects = useDocumentOutline({
+    documentId: 'outline-probe',
     kind: 'markdown',
-    canvas: { nodes: [], edges: [] },
-    markdownBody: body,
+    readSource,
+    broker,
   })
   return <div data-testid="outline-count">{rects.length}</div>
 }

--- a/apps/web/src/components/markdown-editor/rail-write-mode.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/rail-write-mode.browser.test.tsx
@@ -108,6 +108,7 @@ function OutlineProbe({ body }: { body: string }) {
   const rects = useDocumentOutline({
     documentId: 'outline-probe',
     kind: 'markdown',
+    revision: body,
     readSource,
     broker,
   })

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -212,7 +212,7 @@ export function WorkspaceFilesPanel({
   // The row-size rendition. Separate from `loadRender` on purpose: it asks
   // the worker for block geometry rather than a serialized SVG, which is
   // both cheaper and the only thing legible at 24px (see DocumentMinimap).
-  const loadOutline = useMemo(() => createRowOutlineLoader({ source }), [source])
+  const loadOutline = useMemo(() => createRowOutlineLoader({ source, broker }), [source, broker])
 
   const readList = useCallback(() => source.listDocuments(), [source])
 

--- a/apps/web/src/components/workspace-files/document-entry.ts
+++ b/apps/web/src/components/workspace-files/document-entry.ts
@@ -3,6 +3,9 @@
  * needs it. It lives here rather than with any one pane because three of
  * them read it and none of them owns it.
  */
+
+import type { DocumentKind } from '@kamiazya/whiteboard-model'
+
 export interface WorkspaceDocumentEntry {
   readonly documentId: string
   readonly path: string
@@ -13,8 +16,18 @@ export interface WorkspaceDocumentEntry {
    * to `untitled-N`, which ADR-0008 measured and rejected).
    */
   readonly name?: string
-  /** Which editor opens it, and which shape its icon takes. */
-  readonly kind?: 'spatial' | 'markdown'
+  /**
+   * Which editor opens it, and which shape its icon takes.
+   *
+   * `DocumentKind` rather than a copy of its members. Written out by hand it
+   * is a parallel union that quietly EXCLUDES a newly added kind, so the
+   * places that route a row by kind never see one — and the compile error
+   * lands in whichever files-source builds the entry instead of at the
+   * decision that has to be made. Measured by adding a third kind: the row
+   * renderer and the row outliner both stayed silent, and `local-files-source`
+   * and `daemon-files-source` failed in their place.
+   */
+  readonly kind?: DocumentKind
   /** Absent for a daemon that does not record it; the card then carries no age. */
   readonly updatedAt?: string
   /**

--- a/apps/web/src/components/workspace-files/load-row-outline.test.ts
+++ b/apps/web/src/components/workspace-files/load-row-outline.test.ts
@@ -1,27 +1,39 @@
-import { writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
-import { LoroDoc } from 'loro-crdt'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { createInTabRenderBroker } from '../../lib/render-broker.js'
 import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
-import { createRowOutlineLoader } from './load-row-outline.js'
+import { createRowOutlineLoader, type RowOutlineDeps } from './load-row-outline.js'
 
 const spatial = { documentId: 'c1', path: 'a/b', kind: 'spatial' as const }
 const markdown = { documentId: 'c2', path: 'notes', kind: 'markdown' as const }
+
+const RECTS = [{ x: 0, y: 0, w: 200, h: 120 }]
+
+/** A fresh broker per case, so one case's memo cannot answer another's. */
+function deps(over: Partial<RowOutlineDeps> = {}): RowOutlineDeps {
+  return {
+    source: fakeFilesSource(),
+    broker: createInTabRenderBroker(),
+    outlineMarkdown: vi.fn(async () => RECTS),
+    outlineSpatial: vi.fn(async () => RECTS),
+    ...over,
+  }
+}
 
 describe('createRowOutlineLoader', () => {
   // Kind decides where the shape comes from, and reading the wrong endpoint
   // would either 404 or answer with a shape of the wrong thing.
   it('reads a spatial document’s snapshot, not its OKF', async () => {
-    const source = fakeFilesSource()
-    await createRowOutlineLoader({ source })(spatial)
-    expect(source.loadSpatialSnapshot).toHaveBeenCalledOnce()
-    expect(source.loadMarkdown).not.toHaveBeenCalled()
+    const d = deps()
+    await createRowOutlineLoader(d)(spatial)
+    expect(d.source.loadSpatialSnapshot).toHaveBeenCalledOnce()
+    expect(d.source.loadMarkdown).not.toHaveBeenCalled()
   })
 
   it('reads a markdown document’s OKF, not its snapshot', async () => {
-    const source = fakeFilesSource()
-    await createRowOutlineLoader({ source })(markdown)
-    expect(source.loadMarkdown).toHaveBeenCalledOnce()
-    expect(source.loadSpatialSnapshot).not.toHaveBeenCalled()
+    const d = deps()
+    await createRowOutlineLoader(d)(markdown)
+    expect(d.source.loadMarkdown).toHaveBeenCalledOnce()
+    expect(d.source.loadSpatialSnapshot).not.toHaveBeenCalled()
   })
 
   it('hands each read the whole entry, so the source can address either way', async () => {
@@ -30,12 +42,12 @@ describe('createRowOutlineLoader', () => {
     // here — is what lets each source pick its own address, which is the
     // decision this loader used to make for them and got to be daemon-only by
     // making.
-    const source = fakeFilesSource()
-    const load = createRowOutlineLoader({ source })
+    const d = deps()
+    const load = createRowOutlineLoader(d)
     await load(spatial)
     await load(markdown)
-    expect(source.loadSpatialSnapshot).toHaveBeenCalledWith(spatial)
-    expect(source.loadMarkdown).toHaveBeenCalledWith(markdown)
+    expect(d.source.loadSpatialSnapshot).toHaveBeenCalledWith(spatial)
+    expect(d.source.loadMarkdown).toHaveBeenCalledWith(markdown)
   })
 
   // The branch that actually produces a miniature. Every other test here
@@ -47,14 +59,16 @@ describe('createRowOutlineLoader', () => {
       { x: 0, y: 40, w: 460, h: 48 },
     ]
     const widths: number[] = []
-    const layoutMarkdown = async (_body: string, maxWidth: number) => {
+    const outlineMarkdown = async (_body: string, maxWidth: number) => {
       widths.push(maxWidth)
       return blocks
     }
-    const load = createRowOutlineLoader({
-      source: fakeFilesSource({ loadMarkdown: async () => '# Title\n\nProse.\n' }),
-      layoutMarkdown,
-    })
+    const load = createRowOutlineLoader(
+      deps({
+        source: fakeFilesSource({ loadMarkdown: async () => '# Title\n\nProse.\n' }),
+        outlineMarkdown,
+      }),
+    )
 
     await expect(load(markdown)).resolves.toEqual(blocks)
     // The width is fixed rather than measured: an icon has no pane, and a
@@ -63,59 +77,71 @@ describe('createRowOutlineLoader', () => {
   })
 
   it('answers null when the layout refuses', async () => {
-    const load = createRowOutlineLoader({
-      source: fakeFilesSource({ loadMarkdown: async () => '# Title\n' }),
-      layoutMarkdown: async () => null,
-    })
+    const load = createRowOutlineLoader(
+      deps({
+        source: fakeFilesSource({ loadMarkdown: async () => '# Title\n' }),
+        outlineMarkdown: async () => null,
+      }),
+    )
     await expect(load(markdown)).resolves.toBeNull()
   })
 
-  // The spatial branch's own success path: a REAL snapshot, so the read and
-  // the outline are both exercised rather than fed empty bytes.
-  it('reads a spatial document’s nodes as its shape', async () => {
-    const doc = new LoroDoc()
-    writeSpatialCanvas(doc, {
-      nodes: [
-        { id: 'a', type: 'text', x: 0, y: 0, width: 200, height: 120, text: 'one' },
-        { id: 'b', type: 'text', x: 240, y: 0, width: 160, height: 90, text: 'two' },
-      ],
-      edges: [],
-    })
-    const snapshot = doc.export({ mode: 'snapshot' })
+  // The bytes go to the worker untouched: nothing on this thread decodes
+  // them, which is the whole saving. That the WORKER reads a real snapshot
+  // correctly is `layout-worker-outline.browser.test.tsx`, where a real one
+  // can be decoded by the code that actually does it.
+  it('hands the stored snapshot to the outliner without decoding it here', async () => {
+    const snapshot = new Uint8Array([9, 8, 7])
+    const d = deps({ source: fakeFilesSource({ loadSpatialSnapshot: async () => snapshot }) })
 
-    const load = createRowOutlineLoader({
-      source: fakeFilesSource({ loadSpatialSnapshot: async () => snapshot }),
-    })
+    await expect(createRowOutlineLoader(d)(spatial)).resolves.toEqual(RECTS)
+    expect(d.outlineSpatial).toHaveBeenCalledWith(snapshot)
+  })
 
-    const rects = await load(spatial)
-    expect(rects).toHaveLength(2)
-    expect(rects?.[0]).toMatchObject({ x: 0, y: 0, w: 200, h: 120 })
+  // A corrupt snapshot now arrives as a refused outline rather than a throw
+  // on this thread — the row's answer is the same either way, which is the
+  // point of the move being invisible here.
+  it('answers null when the outliner refuses a snapshot it could not decode', async () => {
+    const load = createRowOutlineLoader(deps({ outlineSpatial: async () => null }))
+    await expect(load(spatial)).resolves.toBeNull()
   })
 
   // A row that cannot be read keeps its kind icon; a throw here would take
   // the whole tree down with it.
   it('answers null rather than throwing when the read fails', async () => {
-    const load = createRowOutlineLoader({
-      source: fakeFilesSource({
-        loadSpatialSnapshot: async () => {
-          throw new Error('offline')
-        },
+    const load = createRowOutlineLoader(
+      deps({
+        source: fakeFilesSource({
+          loadSpatialSnapshot: async () => {
+            throw new Error('offline')
+          },
+        }),
       }),
-    })
+    )
     await expect(load(spatial)).resolves.toBeNull()
   })
 
   it('answers null rather than laying out an empty markdown document', async () => {
-    const load = createRowOutlineLoader({
-      source: fakeFilesSource({ loadMarkdown: async () => '   \n' }),
-    })
-    await expect(load(markdown)).resolves.toBeNull()
+    const d = deps({ source: fakeFilesSource({ loadMarkdown: async () => '   \n' }) })
+    await expect(createRowOutlineLoader(d)(markdown)).resolves.toBeNull()
+    expect(d.outlineMarkdown).not.toHaveBeenCalled()
   })
 
-  it('answers null for a snapshot that is not a document', async () => {
-    const load = createRowOutlineLoader({
-      source: fakeFilesSource({ loadMarkdown: async () => '' }),
-    })
-    await expect(load(spatial)).resolves.toBeNull()
+  // The measured defect the broker is here for: a row that scrolls away and
+  // back, or a tree left and returned to, used to re-read and re-outline what
+  // it already had. Both loaders below are separate instances, as two mounts
+  // would be, sharing the one broker a page holds.
+  it('outlines one document once, however many mounts ask', async () => {
+    const broker = createInTabRenderBroker()
+    const stamped = { ...markdown, updatedAt: '2026-09-04T00:00:00Z' }
+    const first = deps({ broker, source: fakeFilesSource({ loadMarkdown: async () => '# Hi' }) })
+    const second = deps({ broker, source: fakeFilesSource({ loadMarkdown: async () => '# Hi' }) })
+
+    await createRowOutlineLoader(first)(stamped)
+    await createRowOutlineLoader(second)(stamped)
+
+    expect(first.outlineMarkdown).toHaveBeenCalledTimes(1)
+    expect(second.outlineMarkdown).not.toHaveBeenCalled()
+    expect(second.source.loadMarkdown).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/components/workspace-files/load-row-outline.ts
+++ b/apps/web/src/components/workspace-files/load-row-outline.ts
@@ -1,22 +1,33 @@
 /**
  * Reads one document's shape for a tree row's icon.
  *
- * Kind decides where the shape comes from, and the two are genuinely
- * different reads: a spatial canvas already IS boxes, so its snapshot is
- * enough; a markdown document has none of its own and has to be laid out,
- * which happens in the shared worker pool at background priority.
+ * Kind decides only which read supplies the content: markdown by id from the
+ * OKF route, spatial by PATH from the snapshot route. Both then go to the
+ * shared worker pool at IDLE priority — a 24px icon is below even a list of
+ * thumbnails, which is at least something the person is looking at.
  *
- * Total by contract — every failure answers `null` and the row keeps its
- * kind icon. A tree that cannot draw a miniature is a tree with plainer
- * icons; a tree that throws is a broken screen.
+ * Neither is decoded here. A spatial document's snapshot travels to the
+ * worker as bytes, so this thread's share of a row icon is the read and
+ * nothing else: the decode this replaces cost 1.20ms at 12 nodes, 2.60ms at
+ * 40 and 4.60ms at 120, once per visible row, and handing the bytes over
+ * costs nothing measurable. What that buys is not a faster icon but a thread
+ * that is free while one is drawn.
+ *
+ * Total by contract. Every failure answers `null` and the row keeps its kind
+ * icon: a tree that cannot draw a miniature is a tree with plainer icons, a
+ * tree that throws is a broken screen.
+ *
+ * Every answer goes through the render broker (ADR-0027), under an OUTLINE
+ * key — so a row that scrolls away and back, or a tree left and returned to,
+ * does not re-read and re-outline what it already has, and cannot be handed
+ * the SVG family's answer for the same document.
  */
 
-import { readSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
-import { LoroDoc } from 'loro-crdt'
-import { outlineFromSpatial } from '../../lib/document-outline.js'
 import type { FaviconRect } from '../../lib/favicon.js'
 import { nextLayoutRequestId, sharedLayoutWorkerPool } from '../../lib/layout-worker-pool.js'
-import type { MarkdownRailResponse } from '../../lib/layout-worker-protocol.js'
+import type { OutlineResponse } from '../../lib/layout-worker-protocol.js'
+import type { RenderBroker } from '../../lib/render-broker.js'
+import { outlineKeyOf } from '../../lib/render-key.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
 import type { WorkspaceFilesSource } from './files-source.js'
 
@@ -30,41 +41,72 @@ const ROW_LAYOUT_WIDTH = 640
 export interface RowOutlineDeps {
   readonly source: WorkspaceFilesSource
   /**
-   * Lays a markdown body out. Injected like the two reads above so the
-   * success path is assertable without mocking a module — the branch that
-   * actually produces a miniature is the one worth pinning.
+   * Answers from the memo, joins an outline already in flight for the same
+   * key, and otherwise runs the pipeline below exactly once.
    */
-  readonly layoutMarkdown?: (
+  readonly broker: RenderBroker
+  /**
+   * Both outlines are injected like the reads above, so the branch that
+   * actually produces a miniature is assertable without standing up a worker.
+   */
+  readonly outlineMarkdown?: (
     body: string,
     maxWidth: number,
   ) => Promise<readonly FaviconRect[] | null>
+  /** Takes the stored SNAPSHOT — the worker decodes it, not this thread. */
+  readonly outlineSpatial?: (snapshot: Uint8Array) => Promise<readonly FaviconRect[] | null>
 }
 
-/** The shared fleet, at background priority: an icon is never the thing someone is waiting on. */
-async function layoutInSharedPool(
-  body: string,
-  maxWidth: number,
+/** The shared fleet, at idle priority: nobody is waiting on a 24px icon. */
+async function outlineInPool(
+  request: Record<string, unknown>,
 ): Promise<readonly FaviconRect[] | null> {
-  const reply = await sharedLayoutWorkerPool().run<MarkdownRailResponse>(
-    { type: 'markdown-rail', id: nextLayoutRequestId(), body, maxWidth },
-    'background',
+  const reply = await sharedLayoutWorkerPool().run<OutlineResponse>(
+    { type: 'outline', id: nextLayoutRequestId(), ...request },
+    'idle',
   )
-  return reply.type === 'markdown-rail-done' ? reply.blocks : null
+  return reply.type === 'outlined' ? reply.rects : null
+}
+
+const outlineMarkdownInPool = (body: string, maxWidth: number) => outlineInPool({ body, maxWidth })
+const outlineSpatialInPool = (snapshot: Uint8Array) => outlineInPool({ snapshot })
+
+/**
+ * The kind the pipeline will actually take, which is what the key has to
+ * agree with. `kind` is optional on a row, and an entry without one is read
+ * as spatial below — so the key must say spatial too. Deriving both from
+ * here is not tidiness: a key disagreeing with the branch is how one entry
+ * ends up answering for a document it is not a picture of.
+ */
+function outlinedKind(document: WorkspaceDocumentEntry): 'spatial' | 'markdown' {
+  return document.kind === 'markdown' ? 'markdown' : 'spatial'
 }
 
 export function createRowOutlineLoader(deps: RowOutlineDeps) {
-  return async (document: WorkspaceDocumentEntry): Promise<readonly FaviconRect[] | null> => {
-    try {
-      if (document.kind === 'markdown') {
-        const markdown = await deps.source.loadMarkdown(document)
-        if (markdown.trim() === '') return null
-        return await (deps.layoutMarkdown ?? layoutInSharedPool)(markdown, ROW_LAYOUT_WIDTH)
-      }
+  const produce = async (
+    document: WorkspaceDocumentEntry,
+  ): Promise<readonly FaviconRect[] | null> => {
+    if (outlinedKind(document) === 'markdown') {
+      const markdown = await deps.source.loadMarkdown(document)
+      if (markdown.trim() === '') return null
+      return await (deps.outlineMarkdown ?? outlineMarkdownInPool)(markdown, ROW_LAYOUT_WIDTH)
+    }
 
-      const bytes = await deps.source.loadSpatialSnapshot(document)
-      const doc = new LoroDoc()
-      doc.import(bytes)
-      return outlineFromSpatial(readSpatialCanvas(doc))
+    const snapshot = await deps.source.loadSpatialSnapshot(document)
+    return await (deps.outlineSpatial ?? outlineSpatialInPool)(snapshot)
+  }
+
+  return async (document: WorkspaceDocumentEntry): Promise<readonly FaviconRect[] | null> => {
+    // The catch stays OUTSIDE the broker: a rejection must not be remembered
+    // as an answer, so the broker is allowed to see it and forget the entry,
+    // and the totality this loader promises is restored here.
+    try {
+      const key = outlineKeyOf({
+        documentId: document.documentId,
+        kind: outlinedKind(document),
+        ...(document.updatedAt === undefined ? {} : { updatedAt: document.updatedAt }),
+      })
+      return await deps.broker.render(key, () => produce(document))
     } catch {
       return null
     }

--- a/apps/web/src/components/workspace-files/load-row-outline.ts
+++ b/apps/web/src/components/workspace-files/load-row-outline.ts
@@ -23,6 +23,7 @@
  * the SVG family's answer for the same document.
  */
 
+import { unhandledKind } from '../../lib/exhaustive.js'
 import type { FaviconRect } from '../../lib/favicon.js'
 import { nextLayoutRequestId, sharedLayoutWorkerPool } from '../../lib/layout-worker-pool.js'
 import type { OutlineResponse } from '../../lib/layout-worker-protocol.js'
@@ -79,7 +80,19 @@ const outlineSpatialInPool = (snapshot: Uint8Array) => outlineInPool({ snapshot 
  * ends up answering for a document it is not a picture of.
  */
 function outlinedKind(document: WorkspaceDocumentEntry): 'spatial' | 'markdown' {
-  return document.kind === 'markdown' ? 'markdown' : 'spatial'
+  // A row that does not say its kind is read as spatial, which is what the
+  // pipeline below does with it. The switch is what makes a NEW kind a
+  // compile error here rather than another silent spatial: being drawn by
+  // the wrong pipeline is a picture of the wrong thing, not a missing one.
+  const kind = document.kind ?? 'spatial'
+  switch (kind) {
+    case 'markdown':
+      return 'markdown'
+    case 'spatial':
+      return 'spatial'
+    default:
+      return unhandledKind(kind, 'outlinedKind')
+  }
 }
 
 export function createRowOutlineLoader(deps: RowOutlineDeps) {

--- a/apps/web/src/components/workspace-files/load-row-render.ts
+++ b/apps/web/src/components/workspace-files/load-row-render.ts
@@ -31,6 +31,7 @@
 
 import type { BoundingBox } from '@kamiazya/whiteboard-canvas-render'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
+import { unhandledKind } from '../../lib/exhaustive.js'
 import { nextLayoutRequestId, sharedLayoutWorkerPool } from '../../lib/layout-worker-pool.js'
 import type { LayoutResponse, MarkdownRenderResponse } from '../../lib/layout-worker-protocol.js'
 import type { RenderBroker } from '../../lib/render-broker.js'
@@ -103,7 +104,19 @@ async function renderSpatialInPool(
  * and a dark render of the same board.
  */
 function renderedKind(document: WorkspaceDocumentEntry): 'spatial' | 'markdown' {
-  return document.kind === 'markdown' ? 'markdown' : 'spatial'
+  // A row that does not say its kind is read as spatial, which is what the
+  // pipeline below does with it. The switch is what makes a NEW kind a
+  // compile error here rather than another silent spatial: being drawn by
+  // the wrong pipeline is a picture of the wrong thing, not a missing one.
+  const kind = document.kind ?? 'spatial'
+  switch (kind) {
+    case 'markdown':
+      return 'markdown'
+    case 'spatial':
+      return 'spatial'
+    default:
+      return unhandledKind(kind, 'renderedKind')
+  }
 }
 
 export function createRowRenderLoader(deps: RowRenderDeps) {

--- a/apps/web/src/hooks/useDocumentOutline.test.tsx
+++ b/apps/web/src/hooks/useDocumentOutline.test.tsx
@@ -1,64 +1,131 @@
-import { cleanup, render } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { useCallback, useMemo } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { DocumentOutlineSource } from '../lib/document-outline.js'
+import { DOCUMENT_SYNC_CHANGED_EVENT } from '../lib/document-sync-types.js'
+import type { FaviconRect } from '../lib/favicon.js'
+import { createInTabRenderBroker } from '../lib/render-broker.js'
 import { useDocumentOutline } from './useDocumentOutline.js'
 
 afterEach(cleanup)
 
+const RECTS: readonly FaviconRect[] = [
+  { x: 0, y: 0, w: 10, h: 10 },
+  { x: 20, y: 0, w: 10, h: 10 },
+]
+
 function Probe({
-  kind,
-  body,
-  nodes = [],
+  source,
+  outline,
+  kind = 'spatial',
 }: {
-  kind: 'markdown' | 'spatial'
-  body: string | null
-  nodes?: {
-    id: string
-    type: 'text'
-    x: number
-    y: number
-    width: number
-    height: number
-    text: string
-  }[]
+  source: () => DocumentOutlineSource | null
+  outline: (s: DocumentOutlineSource) => Promise<readonly FaviconRect[] | null>
+  kind?: 'spatial' | 'markdown'
 }) {
-  const rects = useDocumentOutline({ kind, canvas: { nodes, edges: [] }, markdownBody: body })
-  return <div data-testid="count">{rects.length}</div>
+  // Stable identities: the hook's effect depends on all three, and a fresh
+  // one per render would re-subscribe forever — and a fresh BROKER per render
+  // would make every ask a first ask, which is exactly the deduplication
+  // these tests are about.
+  const broker = useMemo(() => createInTabRenderBroker(), [])
+  const readSource = useCallback(() => source(), [source])
+  const produce = useCallback((s: DocumentOutlineSource) => outline(s), [outline])
+  return (
+    <div data-testid="count">
+      {useDocumentOutline({ documentId: 'd1', kind, readSource, broker, outline: produce }).length}
+    </div>
+  )
 }
 
-// The markdown branch needs a real worker and is exercised end to end by
-// markdown-editor/rail-write-mode.browser.test.tsx. It is NOT repeated here:
-// the pool is a per-context singleton that never disposes, so a second
-// browser file spawning its own fleet measurably destabilised the whole
-// project — 649/649 clean without it, failures in two consecutive runs with.
+const spatialAt = (frontier: string): DocumentOutlineSource => ({
+  frontier,
+  snapshot: new Uint8Array([1, 2, 3]),
+})
+
 describe('useDocumentOutline', () => {
-  it('takes a spatial canvas’s own boxes, synchronously', () => {
+  it('asks once at mount and shows what comes back', async () => {
+    const outline = vi.fn(async () => RECTS)
+    const { getByTestId } = render(<Probe source={() => spatialAt('v1')} outline={outline} />)
+
+    await waitFor(() => expect(getByTestId('count').textContent).toBe('2'))
+    expect(outline).toHaveBeenCalledTimes(1)
+  })
+
+  // The trigger the whole hook is built around. Without it the outline is
+  // computed in the render path on every edit, most of them thrown away.
+  it('recomputes when the document changes, and not otherwise', async () => {
+    let frontier = 'v1'
+    const outline = vi.fn(async () => RECTS)
+    const source = () => spatialAt(frontier)
+    const { getByTestId } = render(<Probe source={source} outline={outline} />)
+    await waitFor(() => expect(getByTestId('count').textContent).toBe('2'))
+
+    // A change notification for a document that has NOT moved answers from
+    // the memo: same version, same picture, no second render.
+    window.dispatchEvent(new CustomEvent(DOCUMENT_SYNC_CHANGED_EVENT))
+    await Promise.resolve()
+    expect(outline).toHaveBeenCalledTimes(1)
+
+    frontier = 'v2'
+    window.dispatchEvent(new CustomEvent(DOCUMENT_SYNC_CHANGED_EVENT))
+    await waitFor(() => expect(outline).toHaveBeenCalledTimes(2))
+  })
+
+  // The reason the version travels WITH the bytes. A burst of edits inside
+  // one worker round trip must not all collapse onto the first one's answer:
+  // each has its own version, so each is its own key.
+  it('does not answer a later state from an earlier state’s entry', async () => {
+    const seen: string[] = []
+    let frontier = 'v1'
+    const outline = vi.fn(async (s: DocumentOutlineSource) => {
+      seen.push(s.frontier)
+      return RECTS
+    })
+    render(<Probe source={() => spatialAt(frontier)} outline={outline} />)
+    await waitFor(() => expect(seen).toEqual(['v1']))
+
+    frontier = 'v2'
+    window.dispatchEvent(new CustomEvent(DOCUMENT_SYNC_CHANGED_EVENT))
+    frontier = 'v3'
+    window.dispatchEvent(new CustomEvent(DOCUMENT_SYNC_CHANGED_EVENT))
+
+    await waitFor(() => expect(seen).toEqual(['v1', 'v2', 'v3']))
+  })
+
+  // Before the first snapshot there is no version, and a picture filed under
+  // "no version" would be served for as long as the tab is open.
+  it('asks for nothing while the document has not hydrated', async () => {
+    const outline = vi.fn(async () => RECTS)
+    const { getByTestId } = render(<Probe source={() => null} outline={outline} />)
+
+    await Promise.resolve()
+    expect(outline).not.toHaveBeenCalled()
+    expect(getByTestId('count').textContent).toBe('0')
+  })
+
+  it('lays nothing out for a markdown document with nothing in it', async () => {
+    const outline = vi.fn(async () => RECTS)
     const { getByTestId } = render(
-      <Probe
-        kind="spatial"
-        body={null}
-        nodes={[
-          { id: 'a', type: 'text', x: 0, y: 0, width: 10, height: 10, text: 'a' },
-          { id: 'b', type: 'text', x: 20, y: 0, width: 10, height: 10, text: 'b' },
-        ]}
-      />,
+      <Probe kind="markdown" source={() => ({ frontier: 'v1', body: '   ' })} outline={outline} />,
     )
-    // No await: a spatial outline costs a map, not a layout.
+
+    await Promise.resolve()
+    expect(outline).not.toHaveBeenCalled()
+    expect(getByTestId('count').textContent).toBe('0')
+  })
+
+  // Total by contract: the tab keeps the shape it had rather than throwing.
+  it('keeps the last shape when the outline refuses', async () => {
+    let answer: readonly FaviconRect[] | null = RECTS
+    let frontier = 'v1'
+    const outline = vi.fn(async () => answer)
+    const { getByTestId } = render(<Probe source={() => spatialAt(frontier)} outline={outline} />)
+    await waitFor(() => expect(getByTestId('count').textContent).toBe('2'))
+
+    answer = null
+    frontier = 'v2'
+    window.dispatchEvent(new CustomEvent(DOCUMENT_SYNC_CHANGED_EVENT))
+    await waitFor(() => expect(outline).toHaveBeenCalledTimes(2))
     expect(getByTestId('count').textContent).toBe('2')
-  })
-
-  it('lays nothing out for a markdown document with nothing in it', () => {
-    const { getByTestId } = render(<Probe kind="markdown" body="   " />)
-    expect(getByTestId('count').textContent).toBe('0')
-  })
-
-  it('ignores a spatial canvas’s nodes once the document is markdown', () => {
-    const { getByTestId } = render(
-      <Probe
-        kind="markdown"
-        body=""
-        nodes={[{ id: 'a', type: 'text', x: 0, y: 0, width: 10, height: 10, text: 'a' }]}
-      />,
-    )
-    expect(getByTestId('count').textContent).toBe('0')
   })
 })

--- a/apps/web/src/hooks/useDocumentOutline.test.tsx
+++ b/apps/web/src/hooks/useDocumentOutline.test.tsx
@@ -18,10 +18,12 @@ function Probe({
   source,
   outline,
   kind = 'spatial',
+  revision = 'r0',
 }: {
   source: () => DocumentOutlineSource | null
   outline: (s: DocumentOutlineSource) => Promise<readonly FaviconRect[] | null>
   kind?: 'spatial' | 'markdown'
+  revision?: unknown
 }) {
   // Stable identities: the hook's effect depends on all three, and a fresh
   // one per render would re-subscribe forever — and a fresh BROKER per render
@@ -32,7 +34,16 @@ function Probe({
   const produce = useCallback((s: DocumentOutlineSource) => outline(s), [outline])
   return (
     <div data-testid="count">
-      {useDocumentOutline({ documentId: 'd1', kind, readSource, broker, outline: produce }).length}
+      {
+        useDocumentOutline({
+          documentId: 'd1',
+          kind,
+          revision,
+          readSource,
+          broker,
+          outline: produce,
+        }).length
+      }
     </div>
   )
 }
@@ -127,5 +138,22 @@ describe('useDocumentOutline', () => {
     window.dispatchEvent(new CustomEvent(DOCUMENT_SYNC_CHANGED_EVENT))
     await waitFor(() => expect(outline).toHaveBeenCalledTimes(2))
     expect(getByTestId('count').textContent).toBe('2')
+  })
+  // The other trigger, and the one that matters in the running app: a
+  // markdown document typed into in browser mode fires no
+  // `whiteboard:doc_changed` at all, so an outline driven by the event alone
+  // never updates. Re-rendering with a new published value asks again.
+  it('asks again when the page re-renders with a changed document', async () => {
+    let frontier = 'v1'
+    const outline = vi.fn(async () => RECTS)
+    const source = () => spatialAt(frontier)
+    const { rerender, getByTestId } = render(
+      <Probe source={source} outline={outline} revision="r0" />,
+    )
+    await waitFor(() => expect(getByTestId('count').textContent).toBe('2'))
+
+    frontier = 'v2'
+    rerender(<Probe source={source} outline={outline} revision="r1" />)
+    await waitFor(() => expect(outline).toHaveBeenCalledTimes(2))
   })
 })

--- a/apps/web/src/hooks/useDocumentOutline.ts
+++ b/apps/web/src/hooks/useDocumentOutline.ts
@@ -2,17 +2,29 @@
  * A document's shape, whichever kind it is — the one input every small
  * rendition of it takes: the favicon, a tree row's icon, a list card.
  *
- * A spatial canvas already IS boxes, so its outline costs a map. A markdown
- * document has none of its own and has to be laid out, which happens in the
- * shared worker pool at background priority. Both answer the same shape, so
- * a consumer never branches on kind.
+ * SUBSCRIBED, not derived. It used to be a `useMemo` in the page's render
+ * path, so every edit computed an outline that the next edit threw away 150ms
+ * later, on the thread answering the person doing the editing. Now the
+ * document's own change notification triggers it, the worker computes it at
+ * IDLE priority — nobody waits on a tab icon — and the page holds the last
+ * answer until a better one arrives.
+ *
+ * That ordering is also what makes the memo SAFE. The version key names the
+ * COMMITTED state, and `onChange` publishes a canvas before it commits one,
+ * so a key taken at render time would file the new picture under the old
+ * version. `whiteboard:doc_changed` fires after the commit, which is the one
+ * moment the bytes and the version agree — see `readOutlineSource`.
  */
 
-import type { DocumentKind, SpatialCanvas } from '@kamiazya/whiteboard-model'
-import { useMemo } from 'react'
-import { outlineFromSpatial } from '../lib/document-outline.js'
-import { type FaviconRect, resolveRectColor } from '../lib/favicon.js'
-import { useMarkdownOutline } from './useMarkdownOutline.js'
+import type { DocumentKind } from '@kamiazya/whiteboard-model'
+import { useEffect, useState } from 'react'
+import type { DocumentOutlineSource } from '../lib/document-outline.js'
+import { DOCUMENT_SYNC_CHANGED_EVENT } from '../lib/document-sync-types.js'
+import type { FaviconRect } from '../lib/favicon.js'
+import { nextLayoutRequestId, sharedLayoutWorkerPool } from '../lib/layout-worker-pool.js'
+import type { OutlineResponse } from '../lib/layout-worker-protocol.js'
+import type { RenderBroker } from '../lib/render-broker.js'
+import { outlineKeyOf } from '../lib/render-key.js'
 
 /**
  * The width a markdown document is laid out at for these renditions. Fixed
@@ -22,30 +34,80 @@ import { useMarkdownOutline } from './useMarkdownOutline.js'
  */
 const OUTLINE_LAYOUT_WIDTH = 640
 
+/** Stable identity, so a document with no shape yet never re-renders a consumer. */
+const NO_RECTS: readonly FaviconRect[] = []
+
+/** The shared fleet at idle priority: a tab icon is below even a list. */
+async function outlineInPool(
+  source: DocumentOutlineSource,
+): Promise<readonly FaviconRect[] | null> {
+  const reply = await sharedLayoutWorkerPool().run<OutlineResponse>(
+    {
+      type: 'outline',
+      id: nextLayoutRequestId(),
+      ...(source.snapshot === undefined
+        ? { body: source.body, maxWidth: OUTLINE_LAYOUT_WIDTH }
+        : { snapshot: source.snapshot }),
+    },
+    'idle',
+  )
+  return reply.type === 'outlined' ? reply.rects : null
+}
+
 export function useDocumentOutline({
+  documentId,
   kind,
-  canvas,
-  markdownBody,
+  readSource,
+  broker,
+  outline = outlineInPool,
 }: {
+  /** `null` before the page is editing a document; nothing is asked for then. */
+  documentId: string | null
   kind: DocumentKind
-  canvas: SpatialCanvas
-  markdownBody: string | null
+  /** Reads the bytes-or-body and the version TOGETHER; see its own doc. */
+  readSource: (kind: DocumentKind) => DocumentOutlineSource | null
+  broker: RenderBroker
+  /** Injected so the branch that produces a shape is assertable without a worker. */
+  outline?: (source: DocumentOutlineSource) => Promise<readonly FaviconRect[] | null>
 }): readonly FaviconRect[] {
-  const spatial = useMemo(
-    () => (kind === 'markdown' ? [] : outlineFromSpatial(canvas)),
-    [kind, canvas],
-  )
-  const markdown = useMarkdownOutline(markdownBody ?? '', {
-    enabled: kind === 'markdown',
-    maxWidth: OUTLINE_LAYOUT_WIDTH,
-  })
-  // The same rect shape from both sources. A scene block has no colour of
-  // its own, and the favicon happens to default a missing one — so this is
-  // not a visible fix but a shape one: two producers of the same type that
-  // differ is how a later consumer, with no such default, gets a surprise.
-  const markdownRects = useMemo(
-    () => markdown.blocks.map((b) => ({ ...b, color: resolveRectColor(undefined) })),
-    [markdown.blocks],
-  )
-  return kind === 'markdown' ? markdownRects : spatial
+  const [rects, setRects] = useState<readonly FaviconRect[]>(NO_RECTS)
+
+  useEffect(() => {
+    let live = true
+
+    const run = () => {
+      if (documentId === null) return
+      const source = readSource(kind)
+      if (source === null) return
+      // An empty body lays out to nothing; asking the pool for it spends a
+      // slot to produce no rectangles.
+      if (source.body !== undefined && source.body.trim() === '') {
+        setRects(NO_RECTS)
+        return
+      }
+      const key = outlineKeyOf({ documentId, kind, updatedAt: source.frontier })
+      broker
+        .render(key, () => outline(source))
+        .then((next) => {
+          if (live && next !== null) setRects(next)
+        })
+        // A shape that cannot be computed leaves the last one showing. A
+        // favicon is a convenience; failing to draw one must not throw.
+        .catch(() => undefined)
+    }
+
+    run()
+    // Not filtered by document identity, deliberately: `readSource` reads
+    // THIS page's own session, so another document's change produces the
+    // same version here and answers from the memo. Filtering would add a
+    // second place for the two pages' identities to disagree, to save a map
+    // lookup.
+    window.addEventListener(DOCUMENT_SYNC_CHANGED_EVENT, run)
+    return () => {
+      live = false
+      window.removeEventListener(DOCUMENT_SYNC_CHANGED_EVENT, run)
+    }
+  }, [documentId, kind, readSource, broker, outline])
+
+  return rects
 }

--- a/apps/web/src/hooks/useDocumentOutline.ts
+++ b/apps/web/src/hooks/useDocumentOutline.ts
@@ -9,11 +9,22 @@
  * IDLE priority — nobody waits on a tab icon — and the page holds the last
  * answer until a better one arrives.
  *
- * That ordering is also what makes the memo SAFE. The version key names the
- * COMMITTED state, and `onChange` publishes a canvas before it commits one,
- * so a key taken at render time would file the new picture under the old
- * version. `whiteboard:doc_changed` fires after the commit, which is the one
- * moment the bytes and the version agree — see `readOutlineSource`.
+ * Safety and freshness come from different places, which is what the two
+ * triggers are for. SAFETY is `readOutlineSource` reading the bytes and the
+ * version out of the same committed document in one synchronous block, so
+ * whatever is drawn is filed under the version it actually is. FRESHNESS is
+ * only about asking often enough, and is best-effort by design — nobody is
+ * waiting on a tab icon.
+ *
+ * So it asks on BOTH the document's change notification and the published
+ * value, rather than picking one. Measured in the running app: typing into a
+ * markdown document in browser mode fires no `whiteboard:doc_changed` at all
+ * (`dispatchIdentityEvent` returns early without a workspace identity, which
+ * is why `useDirtyState`'s save dot stays clean there too), so an outline
+ * driven by the event alone never updated. The published value is what
+ * covers that; the event is what covers a change that arrives without one.
+ * Asking twice for one state costs a map lookup — the version is the same,
+ * so the second ask is answered from the memo.
  */
 
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
@@ -57,6 +68,7 @@ async function outlineInPool(
 export function useDocumentOutline({
   documentId,
   kind,
+  revision,
   readSource,
   broker,
   outline = outlineInPool,
@@ -64,6 +76,13 @@ export function useDocumentOutline({
   /** `null` before the page is editing a document; nothing is asked for then. */
   documentId: string | null
   kind: DocumentKind
+  /**
+   * Whatever the page re-renders with when this document changes — its
+   * canvas value or its body. Only its IDENTITY is read, never its content:
+   * what is drawn always comes from `readSource`, so this is a trigger and
+   * not a second source that could disagree with the version key.
+   */
+  revision: unknown
   /** Reads the bytes-or-body and the version TOGETHER; see its own doc. */
   readSource: (kind: DocumentKind) => DocumentOutlineSource | null
   broker: RenderBroker
@@ -107,7 +126,7 @@ export function useDocumentOutline({
       live = false
       window.removeEventListener(DOCUMENT_SYNC_CHANGED_EVENT, run)
     }
-  }, [documentId, kind, readSource, broker, outline])
+  }, [documentId, kind, revision, readSource, broker, outline])
 
   return rects
 }

--- a/apps/web/src/hooks/useDocumentSync.ts
+++ b/apps/web/src/hooks/useDocumentSync.ts
@@ -4,10 +4,16 @@ import {
 } from '@kamiazya/whiteboard-canvas-viewer'
 import { serializeSpatial } from '@kamiazya/whiteboard-codec'
 import type { DocumentBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
-import type { CommentThread, SpatialCanvas, StoredCoreFacets } from '@kamiazya/whiteboard-model'
+import type {
+  CommentThread,
+  DocumentKind,
+  SpatialCanvas,
+  StoredCoreFacets,
+} from '@kamiazya/whiteboard-model'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { EditorCommand } from '../components/spatial-editor/commands.js'
 import { renderCanvasToSvg } from '../components/spatial-editor/scene-render.js'
+import type { DocumentOutlineSource } from '../lib/document-outline.js'
 import {
   type BackendErrorReason,
   createDocumentSyncSession,
@@ -79,6 +85,12 @@ export interface UseDocumentSyncResult {
    */
   coreFacets: StoredCoreFacets | undefined
   setCoreFacets: (facets: StoredCoreFacets) => void
+  /**
+   * What a picture of this document would be drawn from, paired with the id
+   * of the state it is. `null` until the first snapshot. See the callback for
+   * why the two are read together rather than exposed separately.
+   */
+  readOutlineSource: (kind: DocumentKind) => DocumentOutlineSource | null
   /** OKF core facets from the doc's sidecar map; undefined until hydrated or when never written. */
   lockedEdgeIds: ReadonlySet<string>
   setEdgeLock: (edgeId: string, locked: boolean) => void
@@ -341,6 +353,34 @@ export function useDocumentSync(
     sessionRef.current?.clearUndo()
   }, [])
 
+  /**
+   * What a picture of this document would be drawn from, with the id of the
+   * state it is — read TOGETHER.
+   *
+   * Both reads happen in this one synchronous block, which is the whole
+   * point of returning a pair rather than two accessors: nothing can commit
+   * between them, so the bytes and the version cannot describe different
+   * states. Handing a caller two functions instead would let it read the
+   * body after an edit and the version before it, and file the new picture
+   * under the old key — which serves the previous picture for as long as
+   * that key stands.
+   *
+   * `null` until the first snapshot: the absence of a version, which the
+   * broker declines to remember anything under.
+   */
+  const readOutlineSource = useCallback(
+    (documentKind: DocumentKind): DocumentOutlineSource | null => {
+      const session = sessionRef.current
+      if (session === null) return null
+      const frontier = session.getFrontier()
+      if (frontier === null) return null
+      if (documentKind === 'markdown') return { frontier, body: session.getMarkdownBody() }
+      const snapshot = session.exportSnapshot()
+      return snapshot === null ? null : { frontier, snapshot }
+    },
+    [],
+  )
+
   // Live affordance state for undo/redo buttons. Not memoized state: every
   // publish re-renders the consumer (setCanvas above), so reading through
   // the session on each render is always current and never stale.
@@ -457,6 +497,7 @@ export function useDocumentSync(
     markdownBody,
     coreFacets,
     setCoreFacets,
+    readOutlineSource,
     lockedEdgeIds,
     setEdgeLock,
     canRedo,

--- a/apps/web/src/lib/document-frontier.ts
+++ b/apps/web/src/lib/document-frontier.ts
@@ -1,0 +1,30 @@
+/**
+ * One definition of "which state is this document in".
+ *
+ * It exists as its own module because two different owners hold a document in
+ * this app — `DocumentSyncSession` for a synced one, `useMarkdownDocument`
+ * for a browser-kept markdown one — and a picture derived from either is
+ * memoised under this value. Two hand-written encodings would be two answers
+ * to the same question, and the one that drifted would file a picture under a
+ * version that is not its own.
+ *
+ * NOT in `document-outline.ts`, which the layout worker imports: that would
+ * pull loro-crdt's WASM into the worker at module load and undo the lazy
+ * import that keeps every markdown render from paying for it.
+ *
+ * The STATE frontier rather than the oplog's — a document checked out to an
+ * older version SHOWS that version, and an oplog-derived id would claim the
+ * newest. Measured before choosing: it moves on every edit and does not move
+ * on a commit that changed nothing.
+ */
+
+import { encodeFrontiers, type LoroDoc } from 'loro-crdt'
+
+/** Just the part of LoroDoc this needs, so a caller's own doc type fits. */
+type FrontierBearing = Pick<LoroDoc, 'frontiers'>
+
+export function frontierOf(doc: FrontierBearing): string {
+  // `btoa` over the raw bytes: the value only has to be stable and
+  // comparable, and it is encoded again before it reaches a path.
+  return btoa(String.fromCharCode(...new Uint8Array(encodeFrontiers(doc.frontiers()))))
+}

--- a/apps/web/src/lib/document-outline.ts
+++ b/apps/web/src/lib/document-outline.ts
@@ -18,6 +18,25 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import type { FaviconRect } from './favicon.js'
 import { resolveRectColor } from './favicon.js'
 
+/**
+ * What a document's outline is computed FROM, paired with the id of the
+ * state it is.
+ *
+ * One value rather than two reads, because the pairing is the whole
+ * correctness of the memo above it: bytes from after an edit filed under the
+ * version from before it would serve the previous picture for as long as
+ * that version stands. The producer reads both in one synchronous block —
+ * nothing can commit between two synchronous reads — and hands them over
+ * together so no consumer can get it wrong.
+ *
+ * The two arms mirror the worker's own: a spatial document travels as the
+ * bytes nobody on this thread decoded, a markdown one as the body it has
+ * instead of boxes.
+ */
+export type DocumentOutlineSource =
+  | { readonly frontier: string; readonly snapshot: Uint8Array; readonly body?: undefined }
+  | { readonly frontier: string; readonly body: string; readonly snapshot?: undefined }
+
 export function outlineFromSpatial(canvas: SpatialCanvas): FaviconRect[] {
   return canvas.nodes.map((node) => ({
     x: node.x,

--- a/apps/web/src/lib/document-sync-session.test.ts
+++ b/apps/web/src/lib/document-sync-session.test.ts
@@ -204,6 +204,55 @@ describe('createDocumentSyncSession', () => {
     expect(nodes).toHaveLength(twoNodeCanvas().nodes.length)
   })
 
+  // The version key every derived picture of this document is memoised under
+  // (ADR-0027). Its whole job is to move when the document does and to stay
+  // put when it does not — a key that misses a change serves the previous
+  // picture, which is the worst failure a cache can have: wrong rather than
+  // missing.
+  //
+  // It names the COMMITTED state, which is not the same instant as the
+  // published canvas value: `onChange` publishes immediately and commits on
+  // a debounce, so between those two the doc has not moved yet. Measured
+  // rather than assumed — reading it straight after `onChange` returns the
+  // pre-edit value, canvas text 'hello' -> 'edited' with the frontier
+  // unchanged. That is why the surface driven by this key is driven by the
+  // doc's own change notification (which fires after the commit) and not by
+  // the React state the editor renders from.
+  it('answers no frontier before a snapshot, and one that moves when the doc does', () => {
+    const backend = makeFakeBackend()
+    const session = createDocumentSyncSession(backend, makeDeps())
+    session.connect()
+
+    // Nothing hydrated: the ABSENCE of a version, so nothing is remembered
+    // under it rather than everything sharing one key.
+    expect(session.getFrontier()).toBeNull()
+
+    const canvas = twoNodeCanvas()
+    backend._ctrl.handlers!.onSnapshot(makeSnapshot(canvas))
+    const hydrated = session.getFrontier()
+    expect(hydrated).not.toBeNull()
+
+    // A remote update imports synchronously, so this is a committed change.
+    const doc = new LoroDoc()
+    doc.import(makeSnapshot(canvas))
+    writeSpatialCanvas(doc, {
+      ...canvas,
+      nodes: [{ ...TEXT_NODE_A, text: 'changed' }, TEXT_NODE_B],
+    })
+    backend._ctrl.handlers!.onRemoteUpdate(doc.export({ mode: 'update' }))
+
+    expect(session.getFrontier()).not.toBe(hydrated)
+  })
+
+  it('answers the same frontier when nothing has changed', () => {
+    const backend = makeFakeBackend()
+    const session = createDocumentSyncSession(backend, makeDeps())
+    session.connect()
+    backend._ctrl.handlers!.onSnapshot(makeSnapshot(twoNodeCanvas()))
+
+    expect(session.getFrontier()).toBe(session.getFrontier())
+  })
+
   it('hydrates via readSpatialCanvas on snapshot and publishes it to subscribers', () => {
     const backend = makeFakeBackend()
     const session = createDocumentSyncSession(backend, makeDeps())

--- a/apps/web/src/lib/document-sync-session.test.ts
+++ b/apps/web/src/lib/document-sync-session.test.ts
@@ -244,6 +244,43 @@ describe('createDocumentSyncSession', () => {
     expect(session.getFrontier()).not.toBe(hydrated)
   })
 
+  // The bytes and the frontier are read in one synchronous block on purpose,
+  // and this pins that they describe the same state. Nothing can commit
+  // between two synchronous reads, so the pairing holds by construction —
+  // but a later refactor that made either read async would break it
+  // silently, and a picture memoised under the wrong version is the failure
+  // this whole key exists to avoid.
+  it('exports bytes that decode to the state its frontier names', () => {
+    const backend = makeFakeBackend()
+    const session = createDocumentSyncSession(backend, makeDeps())
+    session.connect()
+    const canvas = twoNodeCanvas()
+    backend._ctrl.handlers!.onSnapshot(makeSnapshot(canvas))
+
+    const first = session.exportSnapshot()
+    expect(first).not.toBeNull()
+    const rebuilt = new LoroDoc()
+    rebuilt.import(first as Uint8Array)
+    expect(readSpatialCanvas(rebuilt)).toEqual(canvas)
+
+    const doc = new LoroDoc()
+    doc.import(makeSnapshot(canvas))
+    const changed = { ...canvas, nodes: [{ ...TEXT_NODE_A, text: 'changed' }, TEXT_NODE_B] }
+    writeSpatialCanvas(doc, changed)
+    backend._ctrl.handlers!.onRemoteUpdate(doc.export({ mode: 'update' }))
+
+    const after = new LoroDoc()
+    after.import(session.exportSnapshot() as Uint8Array)
+    expect(readSpatialCanvas(after)).toEqual(changed)
+  })
+
+  it('exports nothing before a snapshot, like the frontier beside it', () => {
+    const backend = makeFakeBackend()
+    const session = createDocumentSyncSession(backend, makeDeps())
+    session.connect()
+    expect(session.exportSnapshot()).toBeNull()
+  })
+
   it('answers the same frontier when nothing has changed', () => {
     const backend = makeFakeBackend()
     const session = createDocumentSyncSession(backend, makeDeps())

--- a/apps/web/src/lib/document-sync-session.ts
+++ b/apps/web/src/lib/document-sync-session.ts
@@ -29,9 +29,10 @@ import type {
 export type BackendErrorReason = Parameters<NonNullable<DocumentBackendHandlers['onError']>>[0]
 
 import type { CommentThread, SpatialCanvas, StoredCoreFacets } from '@kamiazya/whiteboard-model'
-import { encodeFrontiers, LoroDoc, UndoManager } from 'loro-crdt'
+import { LoroDoc, UndoManager } from 'loro-crdt'
 import type { EditorCommand, EditorLeafCommand } from '../components/spatial-editor/commands.js'
 import { getAppLogger } from './app-logger.js'
+import { frontierOf } from './document-frontier.js'
 import {
   type ExportRequestHandlerDeps,
   handleIncomingExportRequest,
@@ -563,11 +564,7 @@ export function createDocumentSyncSession(
   }
 
   function getFrontier(): string | null {
-    if (doc === null) return null
-    // `btoa` over the raw bytes: this string only has to be stable and
-    // comparable, and it goes through `encodeURIComponent` before it ever
-    // reaches a path.
-    return btoa(String.fromCharCode(...new Uint8Array(encodeFrontiers(doc.frontiers()))))
+    return doc === null ? null : frontierOf(doc)
   }
 
   function getAnnotations(): readonly CommentThread[] {

--- a/apps/web/src/lib/document-sync-session.ts
+++ b/apps/web/src/lib/document-sync-session.ts
@@ -29,7 +29,7 @@ import type {
 export type BackendErrorReason = Parameters<NonNullable<DocumentBackendHandlers['onError']>>[0]
 
 import type { CommentThread, SpatialCanvas, StoredCoreFacets } from '@kamiazya/whiteboard-model'
-import { LoroDoc, UndoManager } from 'loro-crdt'
+import { encodeFrontiers, LoroDoc, UndoManager } from 'loro-crdt'
 import type { EditorCommand, EditorLeafCommand } from '../components/spatial-editor/commands.js'
 import { getAppLogger } from './app-logger.js'
 import {
@@ -211,6 +211,28 @@ export interface DocumentSyncSession {
    * decide whether to offer the disclosure.
    */
   getCoreFacets(): StoredCoreFacets | undefined
+  /**
+   * A stable id for the document's CURRENT state — what a picture drawn from
+   * it right now would be a picture OF. `null` before the first snapshot.
+   *
+   * This is the version key every derived rendition of the document is
+   * memoised under (ADR-0027). `updatedAt` cannot serve: it is stamped per
+   * push, so between two pushes it names one value for a document that has
+   * changed many times, and a memo under it would serve the picture from
+   * before the edit — wrong rather than missing, the worst failure a cache
+   * has.
+   *
+   * The STATE frontier, not the oplog's. A document checked out to an older
+   * version SHOWS that version, and an oplog-derived key would claim the
+   * newest one. Measured before choosing: the state frontier moves on every
+   * edit and does not move on a commit that changed nothing, which is
+   * exactly the invalidation a derived picture wants.
+   *
+   * Loro's own encoding, base64'd, rather than a digest of the content: the
+   * value is loro's answer to "which state is this", not a second opinion
+   * that could disagree with it.
+   */
+  getFrontier(): string | null
   // Current published canvas value (empty canvas before the first snapshot).
   getCanvas(): SpatialCanvas
   // Registers a listener for every published canvas value. `origin` tags
@@ -515,6 +537,14 @@ export function createDocumentSyncSession(
 
   function getCanvas(): SpatialCanvas {
     return currentCanvas
+  }
+
+  function getFrontier(): string | null {
+    if (doc === null) return null
+    // `btoa` over the raw bytes: this string only has to be stable and
+    // comparable, and it goes through `encodeURIComponent` before it ever
+    // reaches a path.
+    return btoa(String.fromCharCode(...new Uint8Array(encodeFrontiers(doc.frontiers()))))
   }
 
   function getAnnotations(): readonly CommentThread[] {
@@ -1046,6 +1076,7 @@ export function createDocumentSyncSession(
     canRedo,
     getAnnotations,
     getCanvas,
+    getFrontier,
     subscribeAnnotations,
     subscribe,
     subscribeHistory,

--- a/apps/web/src/lib/document-sync-session.ts
+++ b/apps/web/src/lib/document-sync-session.ts
@@ -233,6 +233,25 @@ export interface DocumentSyncSession {
    * that could disagree with it.
    */
   getFrontier(): string | null
+  /**
+   * The committed document as snapshot bytes, or null before the first
+   * snapshot.
+   *
+   * For handing the document to a worker without decoding it here: measured
+   * in a real browser, exporting costs 0.10ms at 12 nodes, 0.10 at 40 and
+   * 0.20 at 120, against 0.50 / 0.80 / 1.90ms to read the canvas out on this
+   * thread instead. The handover is the cheaper half by 5-9x and barely grows
+   * with the document, which is what makes moving the work a release rather
+   * than a relocation.
+   *
+   * Read it in the same synchronous block as `getFrontier()` and the two
+   * describe the same state: nothing can commit between two synchronous
+   * reads. `exports bytes that decode to the state its frontier names` pins
+   * that, because a refactor making either read async would break the
+   * pairing silently — and a picture memoised under the wrong version is the
+   * failure the version key exists to avoid.
+   */
+  exportSnapshot(): Uint8Array | null
   // Current published canvas value (empty canvas before the first snapshot).
   getCanvas(): SpatialCanvas
   // Registers a listener for every published canvas value. `origin` tags
@@ -537,6 +556,10 @@ export function createDocumentSyncSession(
 
   function getCanvas(): SpatialCanvas {
     return currentCanvas
+  }
+
+  function exportSnapshot(): Uint8Array | null {
+    return doc === null ? null : doc.export({ mode: 'snapshot' })
   }
 
   function getFrontier(): string | null {
@@ -1077,6 +1100,7 @@ export function createDocumentSyncSession(
     getAnnotations,
     getCanvas,
     getFrontier,
+    exportSnapshot,
     subscribeAnnotations,
     subscribe,
     subscribeHistory,

--- a/apps/web/src/lib/exhaustive.ts
+++ b/apps/web/src/lib/exhaustive.ts
@@ -1,0 +1,20 @@
+/**
+ * A compile error at the place that has to DECIDE, when a union grows.
+ *
+ * The shape this exists to retire: `kind === 'markdown' ? … : <the other one>`.
+ * It reads as a complete decision and is a default — a document kind added
+ * later is silently routed as whichever branch the `else` happens to be, and
+ * nothing anywhere goes red. Measured on this codebase by adding a third
+ * `DocumentKind` and typechecking: `render-surfaces.ts` failed three times
+ * (its `Record<DocumentKind, …>` is exhaustive), while every kind-routing
+ * branch in the render pipeline compiled clean and would have drawn the new
+ * kind with the wrong pipeline, or asked an owner that does not hold it.
+ *
+ * Passing the value as `never` is what makes the compiler object: once a case
+ * is unhandled, the narrowed type at the default is no longer `never` and the
+ * call stops typechecking. The throw is only for a value that reached here at
+ * runtime past the type system — a parsed payload, a cast.
+ */
+export function unhandledKind(value: never, context: string): never {
+  throw new Error(`${context}: unhandled ${JSON.stringify(value)}`)
+}

--- a/apps/web/src/lib/layout-worker-outline.browser.test.tsx
+++ b/apps/web/src/lib/layout-worker-outline.browser.test.tsx
@@ -1,0 +1,101 @@
+// The worker answers a document's OUTLINE — the rectangles a tree row's icon
+// and the tab favicon draw — for all three shapes a caller can hold it in.
+//
+// One request rather than a shape per surface, because the two surfaces
+// differ only in where the document came from: the tree row has stored bytes,
+// the favicon has the live canvas the editor is editing. A pipeline that
+// forked there is how markdown fell out of the SVG family in the first place.
+//
+// A real browser, not jsdom: the subject is the worker, the loro-crdt WASM it
+// imports lazily for the snapshot arm, and the font gate in front of the
+// markdown arm — a body measured with a system face lays its blocks out
+// somewhere else.
+import { writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { LoroDoc } from 'loro-crdt'
+import { expect, it } from 'vitest'
+import { nextLayoutRequestId, sharedLayoutWorkerPool } from './layout-worker-pool.js'
+import type { OutlineResponse } from './layout-worker-protocol.js'
+
+const canvas: SpatialCanvas = {
+  nodes: [
+    { id: 'a', type: 'text', x: 0, y: 0, width: 220, height: 120, text: 'first node' },
+    { id: 'b', type: 'text', x: 400, y: 220, width: 220, height: 120, text: 'second node' },
+  ],
+  edges: [],
+}
+
+function snapshotOf(value: SpatialCanvas): Uint8Array {
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, value)
+  return doc.export({ mode: 'snapshot' })
+}
+
+function ask(request: Record<string, unknown>): Promise<OutlineResponse> {
+  return sharedLayoutWorkerPool().run<OutlineResponse>(
+    { type: 'outline', id: nextLayoutRequestId(), ...request },
+    'idle',
+  )
+}
+
+// The tree row's shape: only the stored bytes, handed over undecoded. The
+// decode this replaces ran on the main thread, at the cost the snapshot
+// handover measured — 1.20ms at 12 nodes, 2.60 at 40, 4.60 at 120 — once per
+// visible row.
+it('outlines a spatial document from its snapshot bytes, decoding inside the worker', async () => {
+  const reply = await ask({ snapshot: snapshotOf(canvas) })
+
+  expect(reply.type).toBe('outlined')
+  if (reply.type !== 'outlined') return
+  // Both nodes survived the decode, at the geometry the canvas declared — so
+  // this is the real document's shape rather than an empty canvas's.
+  expect(reply.rects).toHaveLength(2)
+  expect(reply.rects.map((r) => r.w)).toEqual([220, 220])
+  expect(reply.rects[1]?.x).toBe(400)
+})
+
+// The favicon's shape: the page already holds the live canvas, so exporting a
+// snapshot just to post it would be strictly worse for that caller.
+it('outlines a spatial canvas passed directly, for the page that already holds one', async () => {
+  const reply = await ask({ canvas })
+
+  expect(reply.type).toBe('outlined')
+  if (reply.type !== 'outlined') return
+  expect(reply.rects).toHaveLength(2)
+})
+
+// Both shapes describe the same document, so they must describe it the same
+// way. A snapshot arm that disagreed with the live arm would make a tree row
+// and the tab icon draw different pictures of one document.
+it('answers the same rectangles whether it was handed the bytes or the canvas', async () => {
+  const [fromBytes, fromCanvas] = await Promise.all([
+    ask({ snapshot: snapshotOf(canvas) }),
+    ask({ canvas }),
+  ])
+
+  expect(fromBytes.type).toBe('outlined')
+  expect(fromCanvas.type).toBe('outlined')
+  if (fromBytes.type !== 'outlined' || fromCanvas.type !== 'outlined') return
+  expect(fromBytes.rects).toEqual(fromCanvas.rects)
+})
+
+// A markdown document has no boxes of its own, so its shape is the shape its
+// blocks take once laid out — the one arm that needs a real layout pass, and
+// the reason the font gate is in front of this request at all.
+it('outlines a markdown body by laying its blocks out', async () => {
+  const reply = await ask({ body: '# Heading\n\nA paragraph of text.\n', maxWidth: 640 })
+
+  expect(reply.type).toBe('outlined')
+  if (reply.type !== 'outlined') return
+  expect(reply.rects.length).toBeGreaterThan(0)
+  expect(reply.rects.every((r) => r.w > 0 && r.h > 0)).toBe(true)
+})
+
+// The bytes come from a keeper, so a corrupt snapshot is a real case: the row
+// keeps its kind icon and the tab keeps its static one, rather than the
+// worker going down for every request behind it.
+it('answers failed for bytes that will not decode', async () => {
+  const reply = await ask({ snapshot: new Uint8Array([1, 2, 3, 4, 5]) })
+
+  expect(reply.type).toBe('failed')
+})

--- a/apps/web/src/lib/layout-worker-pool.test.ts
+++ b/apps/web/src/lib/layout-worker-pool.test.ts
@@ -321,6 +321,57 @@ describe('createLayoutWorkerPool', () => {
     pool.dispose()
   })
 
+  // The third band exists for work NOBODY is waiting on — a tab favicon is
+  // the case it was added for. `background` already means "not what the user
+  // asked for a moment ago", but a list of thumbnails is still something
+  // they are looking at; an icon that arrives a second late is not noticed
+  // at all. Without a band of its own it competes with the list on equal
+  // terms and wins slots by arrival order.
+  //
+  // Both have to be QUEUED for the ordering to be observable: a pool cannot
+  // reserve a slot against work that has not arrived yet, so the deferrable
+  // budget is filled first and the two contenders queue behind it.
+  it('serves queued background work before idle work that arrived earlier', async () => {
+    const factory = fakeWorkerFactory()
+    // Three workers: two may hold deferrable work, one stays free for an
+    // interactive request.
+    const pool = createLayoutWorkerPool({ size: 3, createWorker: factory.create })
+
+    const running = pool.run({ id: 1 }, 'background')
+    ignore(pool.run({ id: 2 }, 'background'))
+    ignore(pool.run({ id: 3 }, 'idle'))
+    ignore(pool.run({ id: 4 }, 'background'))
+
+    // The budget is full, so neither contender has run yet.
+    expect(factory.live.flatMap((w) => w.sent)).toEqual([1, 2])
+
+    factory.live[0].reply(1, {})
+    await running
+
+    // 4 goes ahead of 3, which was queued first: priority beats arrival, as
+    // it already does for interactive.
+    const sent = factory.live.flatMap((w) => w.sent)
+    expect(sent).toContain(4)
+    expect(sent).not.toContain(3)
+    pool.dispose()
+  })
+
+  // A band that could fill the fleet is not the lowest band, whatever it is
+  // called: a worker cannot be interrupted mid-message, so idle work holding
+  // every slot would make a list of thumbnails wait out renders nobody is
+  // looking at.
+  it('never lets idle work occupy more than one worker', async () => {
+    const factory = fakeWorkerFactory()
+    const pool = createLayoutWorkerPool({ size: 3, createWorker: factory.create })
+
+    ignore(pool.run({ id: 1 }, 'idle'))
+    ignore(pool.run({ id: 2 }, 'idle'))
+    ignore(pool.run({ id: 3 }, 'idle'))
+
+    expect(factory.live.filter((w) => w.inFlight > 0)).toHaveLength(1)
+    pool.dispose()
+  })
+
   it('defaults to interactive, so an unlabelled caller is never deprioritised', async () => {
     const factory = fakeWorkerFactory()
     const pool = createLayoutWorkerPool({ size: 1, createWorker: factory.create })

--- a/apps/web/src/lib/layout-worker-pool.ts
+++ b/apps/web/src/lib/layout-worker-pool.ts
@@ -28,15 +28,25 @@ export interface PoolWorker {
 
 /**
  * `interactive` is work a person is waiting on — the scene for the commit
- * they just made. `background` is work that fills a surface they are looking
- * at but did not ask for a moment ago: a list of thumbnails, a favicon.
+ * they just made. `background` fills a surface they are looking at but did
+ * not ask for a moment ago: a list of thumbnails. `idle` is work NOBODY is
+ * waiting on, where arriving a second late is not noticed at all — the tab
+ * favicon is the case it exists for.
  *
- * The distinction exists so ONE fleet can serve both. Without it the choice
- * is between two fleets (two module graphs, two font registrations, and no
- * sharing of a warm worker) or a background list sitting in front of the one
- * latency a user actually feels.
+ * The distinction exists so ONE fleet can serve all three. Without it the
+ * choice is between several fleets (several module graphs, several font
+ * registrations, and no sharing of a warm worker) or a thumbnail list
+ * sitting in front of the one latency a user actually feels.
+ *
+ * Two bands were not enough once a surface appeared that is genuinely below
+ * a list: `background` already means "not what they asked for", but a list
+ * is still something they are looking at, and an icon competing with it on
+ * equal terms wins slots by arrival order.
  */
-type LayoutPriority = 'interactive' | 'background'
+export type LayoutPriority = 'interactive' | 'background' | 'idle'
+
+/** Highest first. `nextRunnableIndex` walks this order. */
+const PRIORITY_ORDER: readonly LayoutPriority[] = ['interactive', 'background', 'idle']
 
 export interface LayoutWorkerPool {
   /**
@@ -87,21 +97,36 @@ interface Slot {
 }
 
 /**
- * How many workers background work may occupy at once.
+ * How many workers may be busy with work nobody asked for a moment ago.
  *
  * Ordering the queue is not enough on its own: a worker cannot be
- * interrupted mid-message, so background work holding every slot would still
- * make an interactive request wait out a render nobody was waiting for.
- * Holding one worker back bounds that wait at zero.
+ * interrupted mid-message, so lower-priority work holding every slot would
+ * still make an interactive request wait out a render nobody was waiting
+ * for. Holding one worker back bounds that wait at zero.
  *
- * A single-worker fleet has nothing to hold back. Background runs there
+ * The budget is over ALL the lower bands together, not one per band. Counted
+ * per band, `idle` would be free to take the very slot `background`'s cap is
+ * holding for an interactive request — the reservation defeated by the
+ * lowest-value work in the app, exactly when it is doing its job. Measured
+ * on a two-worker fleet: an idle request arriving between two background
+ * ones ran immediately and both background requests then waited.
+ *
+ * A single-worker fleet has nothing to hold back. The lower bands run there
  * anyway rather than starving, and an interactive request waits out at most
  * ONE render instead of the whole list — the honest trade on a machine with
  * no cores to spare.
  */
-function backgroundSlotCap(size: number): number {
+function deferrableSlotCap(size: number): number {
   return size > 1 ? size - 1 : 1
 }
+
+/**
+ * And `idle` gets one worker whatever the fleet size, inside that budget. A
+ * band that could fill every slot it is allowed is not the lowest band
+ * however it is labelled — a list of thumbnails would wait out renders
+ * nobody is looking at.
+ */
+const IDLE_SLOT_CAP = 1
 
 export function createLayoutWorkerPool(options: {
   size: number
@@ -156,20 +181,34 @@ export function createLayoutWorkerPool(options: {
   const freeSlot = (): Slot | undefined =>
     slots.find((slot) => slot.busyWith === null) ?? (slots.length < size ? spawn() : undefined)
 
-  const backgroundInFlight = (): number =>
-    slots.filter((slot) => slot.busyWith?.priority === 'background').length
+  const inFlightAt = (priority: LayoutPriority): number =>
+    slots.filter((slot) => slot.busyWith?.priority === priority).length
+
+  const deferrableInFlight = (): number =>
+    slots.filter((slot) => slot.busyWith !== null && slot.busyWith.priority !== 'interactive')
+      .length
 
   /**
-   * The next request that may run right now: interactive first, FIFO within
-   * a priority, and background only while it is under its slot cap. Returning
-   * an INDEX rather than shifting lets a blocked background request stay
-   * queued while a later interactive one goes ahead of it.
+   * The next request that may run right now: by band, highest first, FIFO
+   * within a band, and each band only while it is under its slot cap.
+   * Returning an INDEX rather than shifting lets a blocked request stay
+   * queued while a higher-priority one goes ahead of it.
+   *
+   * A band that is queued but AT its cap STOPS the walk rather than letting
+   * the next band down take the slot. That slot is the one being held for
+   * the band above, so handing it to a lower one defeats the reservation
+   * exactly when it is doing its job.
    */
   const nextRunnableIndex = (): number => {
-    const interactive = queue.findIndex((pending) => pending.priority === 'interactive')
-    if (interactive !== -1) return interactive
-    if (backgroundInFlight() >= backgroundSlotCap(size)) return -1
-    return queue.findIndex((pending) => pending.priority === 'background')
+    for (const priority of PRIORITY_ORDER) {
+      const at = queue.findIndex((pending) => pending.priority === priority)
+      if (at === -1) continue
+      if (priority === 'interactive') return at
+      if (deferrableInFlight() >= deferrableSlotCap(size)) return -1
+      if (priority === 'idle' && inFlightAt('idle') >= IDLE_SLOT_CAP) return -1
+      return at
+    }
+    return -1
   }
 
   function pump(): void {

--- a/apps/web/src/lib/layout-worker-protocol.ts
+++ b/apps/web/src/lib/layout-worker-protocol.ts
@@ -32,6 +32,7 @@ import type {
 } from '@kamiazya/whiteboard-canvas-render'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import type { ResolvedTheme } from '../hooks/useThemeMode.js'
+import type { FaviconRect } from './favicon.js'
 
 /** Opaque file reference -> readable label, the plain-data form of the seam. */
 export type FileRefLabel = { readonly file: string; readonly label: string }
@@ -141,6 +142,56 @@ export type MarkdownRenderResponse =
       readonly svg: string
       /** What the SVG's own viewBox covers, so a caller can scale it. */
       readonly bounds: BoundingBox
+    }
+  | { readonly type: 'failed'; readonly id: number; readonly reason: string }
+
+/**
+ * A document whose OUTLINE is wanted, in one of the three shapes a caller can
+ * hold it in.
+ *
+ * One request rather than one per surface. A tree row's icon has only the
+ * stored bytes; the tab favicon has the live canvas the page is editing; a
+ * markdown document of either has a body and no boxes of its own. They differ
+ * in where the document came from and in nothing else, and a pipeline that
+ * forks on that is how markdown fell out of the SVG family in the first
+ * place (ADR-0027).
+ *
+ * The `body` arm is the only one that needs a real layout pass, and so the
+ * only one behind the font gate: a body measured with a system face puts its
+ * blocks somewhere else. The two spatial arms are a map over boxes the
+ * document already declares.
+ */
+type OutlineSubject =
+  | { readonly canvas: SpatialCanvas; readonly snapshot?: undefined; readonly body?: undefined }
+  | { readonly snapshot: Uint8Array; readonly canvas?: undefined; readonly body?: undefined }
+  | {
+      readonly body: string
+      readonly maxWidth: number
+      readonly canvas?: undefined
+      readonly snapshot?: undefined
+    }
+
+export type OutlineRequest = OutlineSubject & {
+  readonly type: 'outline'
+  readonly id: number
+}
+
+/**
+ * Rectangles in the document's own coordinates, COLOURED by the worker for
+ * both kinds.
+ *
+ * The colour is not decoration here. A scene block has none of its own, so
+ * the markdown side used to leave it absent and each consumer defaulted it
+ * (or, in the tree row's case, did not) — two producers of one type that
+ * differ, which is how a later consumer with no such default gets a surprise.
+ * Resolving it once, on the side that produces the rects, is what makes the
+ * two kinds interchangeable to every surface.
+ */
+export type OutlineResponse =
+  | {
+      readonly type: 'outlined'
+      readonly id: number
+      readonly rects: readonly FaviconRect[]
     }
   | { readonly type: 'failed'; readonly id: number; readonly reason: string }
 

--- a/apps/web/src/lib/layout-worker.ts
+++ b/apps/web/src/lib/layout-worker.ts
@@ -38,6 +38,8 @@ import {
 import { renderCanvasToSvgWith } from '../components/spatial-editor/scene-render-core.js'
 import type { ResolvedTheme } from '../hooks/useThemeMode'
 import { createSpatialContentCache } from './content-cache'
+import { outlineFromSpatial } from './document-outline.js'
+import { resolveRectColor } from './favicon.js'
 import {
   composeReferenceSeam,
   FONT_DEGRADED,
@@ -47,6 +49,8 @@ import {
   type MarkdownRailResponse,
   type MarkdownRenderRequest,
   type MarkdownRenderResponse,
+  type OutlineRequest,
+  type OutlineResponse,
 } from './layout-worker-protocol.js'
 
 const measure = createBrowserMeasureText()
@@ -101,9 +105,60 @@ async function decodeSnapshot(bytes: Uint8Array): Promise<SpatialCanvas> {
 const fontReady = ensureViewerFontLoaded()
 
 self.onmessage = async (
-  event: MessageEvent<LayoutRequest | MarkdownRailRequest | MarkdownRenderRequest>,
+  event: MessageEvent<LayoutRequest | MarkdownRailRequest | MarkdownRenderRequest | OutlineRequest>,
 ) => {
   const request = event.data
+  if (request.type === 'outline') {
+    try {
+      if (request.body !== undefined) {
+        // The only arm that lays anything out, so the only one the font gate
+        // applies to: an outline measured with a system face puts its blocks
+        // where an export of the same body would not.
+        if ((await fontReady) !== 'loaded') {
+          const failed: OutlineResponse = {
+            type: 'failed',
+            id: request.id,
+            reason: FONT_DEGRADED,
+          }
+          self.postMessage(failed)
+          return
+        }
+        const { blocks } = layoutMarkdownOutline(request.body, {
+          measure,
+          maxWidth: request.maxWidth,
+        })
+        const done: OutlineResponse = {
+          type: 'outlined',
+          id: request.id,
+          // A scene block carries no colour of its own; resolving it here is
+          // what makes a markdown outline the same TYPE as a spatial one to
+          // every consumer, rather than one each consumer has to default.
+          rects: blocks.map((block) => ({ ...block, color: resolveRectColor(undefined) })),
+        }
+        self.postMessage(done)
+        return
+      }
+      // A corrupt snapshot throws here and lands in the catch below as a
+      // `failed` reply — the row keeps its kind icon and the tab its static
+      // one. It must not take the worker down: every request queued behind it
+      // belongs to a different document.
+      const canvas = request.canvas ?? (await decodeSnapshot(request.snapshot))
+      const done: OutlineResponse = {
+        type: 'outlined',
+        id: request.id,
+        rects: outlineFromSpatial(canvas),
+      }
+      self.postMessage(done)
+    } catch (error) {
+      const failed: OutlineResponse = {
+        type: 'failed',
+        id: request.id,
+        reason: error instanceof Error ? error.message : String(error),
+      }
+      self.postMessage(failed)
+    }
+    return
+  }
   if (request.type === 'markdown-render') {
     try {
       // Same font gate as the other two: a thumbnail measured with a system

--- a/apps/web/src/lib/outline-source.test.ts
+++ b/apps/web/src/lib/outline-source.test.ts
@@ -1,0 +1,77 @@
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, it, vi } from 'vitest'
+import { frontierOf } from './document-frontier.js'
+import { composeOutlineSource } from './outline-source.js'
+
+function docWith(text: string): LoroDoc {
+  const doc = new LoroDoc()
+  doc.getText('body').insert(0, text)
+  doc.commit()
+  return doc
+}
+
+const noSession = () => null
+
+describe('composeOutlineSource', () => {
+  // The defect this exists for, found by opening the app: a browser-kept
+  // markdown document lives in its own LoroDoc and never reaches the sync
+  // session, so asking the session alone answered `null` and the tab icon
+  // never changed however much was typed. No test of the hook above could
+  // have caught it — they all inject a source and never make this choice.
+  it('reads a markdown document the session does not hold', () => {
+    const doc = docWith('# Heading')
+
+    const source = composeOutlineSource('markdown', noSession, { doc, body: '# Heading' })
+
+    expect(source).toEqual({ frontier: frontierOf(doc), body: '# Heading' })
+  })
+
+  // Where the session DOES hold it — the daemon page's shape — its answer is
+  // the authoritative one, and the second owner must not shadow it.
+  it('prefers the session when the session holds the document', () => {
+    const fromSession = vi.fn(() => ({ frontier: 'session-v1', body: 'from session' }))
+
+    const source = composeOutlineSource('markdown', fromSession, {
+      doc: docWith('other'),
+      body: 'from the markdown owner',
+    })
+
+    expect(source).toEqual({ frontier: 'session-v1', body: 'from session' })
+  })
+
+  it('leaves a spatial document to the session entirely', () => {
+    const snapshot = new Uint8Array([1, 2, 3])
+    const fromSession = vi.fn(() => ({ frontier: 'v1', snapshot }))
+
+    expect(composeOutlineSource('spatial', fromSession, { doc: null, body: null })).toEqual({
+      frontier: 'v1',
+      snapshot,
+    })
+    expect(fromSession).toHaveBeenCalledWith('spatial')
+  })
+
+  // Before either owner has hydrated there is no version, and a picture
+  // filed under "no version" would be served for as long as the tab is open.
+  it('answers nothing while neither owner holds the document', () => {
+    expect(composeOutlineSource('markdown', noSession, { doc: null, body: null })).toBeNull()
+  })
+
+  it('answers nothing when the markdown owner has a doc but no body yet', () => {
+    expect(
+      composeOutlineSource('markdown', noSession, { doc: docWith('x'), body: null }),
+    ).toBeNull()
+  })
+
+  // The version has to move with the document, or the memo above serves the
+  // previous picture — the failure the whole key exists to avoid.
+  it('answers a different version once the document has changed', () => {
+    const doc = docWith('# One')
+    const before = composeOutlineSource('markdown', noSession, { doc, body: '# One' })
+
+    doc.getText('body').insert(5, ' more')
+    doc.commit()
+    const after = composeOutlineSource('markdown', noSession, { doc, body: '# One more' })
+
+    expect(after?.frontier).not.toBe(before?.frontier)
+  })
+})

--- a/apps/web/src/lib/outline-source.ts
+++ b/apps/web/src/lib/outline-source.ts
@@ -1,0 +1,42 @@
+/**
+ * Which owner holds THIS document, for the surfaces that draw its shape.
+ *
+ * Two of them exist in the browser page and only one of them is obvious. A
+ * synced document lives in `DocumentSyncSession`; a browser-kept MARKDOWN
+ * document lives in `useMarkdownDocument`'s own LoroDoc and never reaches
+ * that session at all. Asking the session alone therefore answers `null` for
+ * every browser markdown document — which is not a crash and not a failing
+ * test, just a tab icon that never changes however much is typed. It was
+ * found by opening the app, and nothing else would have found it: every test
+ * of the hook above injects its source and so never exercises this choice.
+ *
+ * The daemon page has one owner (its markdown body comes through the sync
+ * session), so it passes the session's reader straight through and this
+ * function is the browser page's business.
+ */
+
+import type { DocumentKind } from '@kamiazya/whiteboard-model'
+import { frontierOf } from './document-frontier.js'
+import type { DocumentOutlineSource } from './document-outline.js'
+
+/** Just the part of the markdown document state this needs. */
+export interface MarkdownOwner {
+  readonly doc: Parameters<typeof frontierOf>[0] | null
+  readonly body: string | null
+}
+
+export function composeOutlineSource(
+  kind: DocumentKind,
+  fromSession: (kind: DocumentKind) => DocumentOutlineSource | null,
+  markdown: MarkdownOwner,
+): DocumentOutlineSource | null {
+  if (kind !== 'markdown') return fromSession(kind)
+  // The session gets first refusal even for markdown: where it DOES hold the
+  // document (the daemon page's shape), its answer is the authoritative one.
+  const synced = fromSession(kind)
+  if (synced !== null) return synced
+  if (markdown.doc === null || markdown.body === null) return null
+  // Both out of the same doc, in one synchronous block — the pairing the
+  // version key depends on.
+  return { frontier: frontierOf(markdown.doc), body: markdown.body }
+}

--- a/apps/web/src/lib/outline-source.ts
+++ b/apps/web/src/lib/outline-source.ts
@@ -18,6 +18,7 @@
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import { frontierOf } from './document-frontier.js'
 import type { DocumentOutlineSource } from './document-outline.js'
+import { unhandledKind } from './exhaustive.js'
 
 /** Just the part of the markdown document state this needs. */
 export interface MarkdownOwner {
@@ -30,13 +31,23 @@ export function composeOutlineSource(
   fromSession: (kind: DocumentKind) => DocumentOutlineSource | null,
   markdown: MarkdownOwner,
 ): DocumentOutlineSource | null {
-  if (kind !== 'markdown') return fromSession(kind)
-  // The session gets first refusal even for markdown: where it DOES hold the
-  // document (the daemon page's shape), its answer is the authoritative one.
-  const synced = fromSession(kind)
-  if (synced !== null) return synced
-  if (markdown.doc === null || markdown.body === null) return null
-  // Both out of the same doc, in one synchronous block — the pairing the
-  // version key depends on.
-  return { frontier: frontierOf(markdown.doc), body: markdown.body }
+  switch (kind) {
+    case 'spatial':
+      return fromSession(kind)
+    case 'markdown': {
+      // The session gets first refusal even here: where it DOES hold the
+      // document (the daemon page's shape), its answer is authoritative.
+      const synced = fromSession(kind)
+      if (synced !== null) return synced
+      if (markdown.doc === null || markdown.body === null) return null
+      // Both out of the same doc, in one synchronous block — the pairing the
+      // version key depends on.
+      return { frontier: frontierOf(markdown.doc), body: markdown.body }
+    }
+    default:
+      // A new kind has to name its owner HERE. Falling through to the
+      // session is what silently answered `null` for every browser markdown
+      // document, and the icon simply never changed.
+      return unhandledKind(kind, 'composeOutlineSource')
+  }
 }

--- a/apps/web/src/lib/render-broker.test.ts
+++ b/apps/web/src/lib/render-broker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { createInTabRenderBroker } from './render-broker.js'
-import { renderKeyOf } from './render-key.js'
+import { outlineKeyOf, renderKeyOf } from './render-key.js'
 
 const drawn = { svg: '<svg/>', bounds: { x: 0, y: 0, w: 1, h: 1 } }
 const keyFor = (documentId: string, updatedAt = '2026-09-03T00:00:00Z') =>
@@ -135,5 +135,23 @@ describe('the in-tab render broker', () => {
 
     await broker.render(keyFor('doc-3'), produce)
     expect(produce).toHaveBeenCalledTimes(3)
+  })
+  // The whole basis for one map holding two families' answers. `render` is
+  // generic over what a family returns, and nothing at runtime checks that a
+  // caller asking for an outline is not handed an SVG — the key's `pipeline`
+  // axis is what makes that impossible, so it is asserted here rather than
+  // assumed by the cast.
+  it("never answers one family from the other family's entry", async () => {
+    const broker = createInTabRenderBroker()
+    const subject = { documentId: 'd1', kind: 'spatial' as const, updatedAt: 'v1' }
+    const rects = [{ x: 0, y: 0, w: 10, h: 10 }]
+
+    const svg = await broker.render(renderKeyOf(subject, 'light'), async () => drawn)
+    const outline = await broker.render(outlineKeyOf(subject), async () => rects)
+
+    expect(svg).toBe(drawn)
+    expect(outline).toBe(rects)
+    // Two entries for one document, not one entry answering twice.
+    expect(broker.size).toBe(2)
   })
 })

--- a/apps/web/src/lib/render-broker.ts
+++ b/apps/web/src/lib/render-broker.ts
@@ -17,7 +17,7 @@
 
 import { isMemoisableKey, type RenderKey, renderKeyPath } from './render-key.js'
 
-/** What a surface gets back. `null` is "nothing to draw", and it is an answer. */
+/** The SVG family's answer. `null` is "nothing to draw", and it is an answer. */
 export interface RenderResult {
   readonly svg: string
   readonly bounds: {
@@ -33,8 +33,15 @@ export interface RenderBroker {
    * The picture for `key`. `produce` runs at most once per key: a caller that
    * arrives while the same key is still in flight joins it rather than
    * starting a second render.
+   *
+   * Generic over what a family answers with, because two of them do not
+   * answer with the same thing — the SVG surfaces get a `RenderResult`, the
+   * outline surfaces get rectangles. What makes one map safe to hold both is
+   * the key's `pipeline` axis: two families never name the same entry, so a
+   * caller cannot be handed the other one's type. That axis exists for this,
+   * and `render-key.test.ts` pins it from both directions.
    */
-  render(key: RenderKey, produce: () => Promise<RenderResult | null>): Promise<RenderResult | null>
+  render<T>(key: RenderKey, produce: () => Promise<T | null>): Promise<T | null>
   /** Entries currently held. For tests and for the cap below. */
   readonly size: number
 }
@@ -54,22 +61,25 @@ export interface InTabRenderBrokerOptions {
 export function createInTabRenderBroker(options: InTabRenderBrokerOptions = {}): RenderBroker {
   const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES
   // Insertion-ordered, so the oldest key is the first one `keys()` yields.
-  const done = new Map<string, RenderResult | null>()
+  // `unknown` rather than a union of every family's answer: the key's
+  // pipeline axis already keeps the families in separate entries, so a union
+  // here would only let a caller believe a cast was checked.
+  const done = new Map<string, unknown>()
   // Separate from `done` because an in-flight entry is not an answer yet, and
   // a rejection must leave nothing behind — a row whose fetch failed once must
   // not keep its kind icon for the rest of the session.
-  const inFlight = new Map<string, Promise<RenderResult | null>>()
+  const inFlight = new Map<string, Promise<unknown>>()
 
   return {
     get size() {
       return done.size
     },
-    render(key, produce) {
+    render<T>(key: RenderKey, produce: () => Promise<T | null>): Promise<T | null> {
       const path = renderKeyPath(key)
-      if (done.has(path)) return Promise.resolve(done.get(path) ?? null)
+      if (done.has(path)) return Promise.resolve((done.get(path) as T | undefined) ?? null)
 
       const joined = inFlight.get(path)
-      if (joined !== undefined) return joined
+      if (joined !== undefined) return joined as Promise<T | null>
 
       const work = produce()
         .then((result) => {

--- a/apps/web/src/lib/render-key.test.ts
+++ b/apps/web/src/lib/render-key.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   isMemoisableKey,
+  outlineKeyOf,
   RENDERER_BUILD_ID,
   renderKeyOf,
   renderKeyPath,
@@ -63,18 +64,31 @@ describe('renderKeyPath — the pipeline is part of the identity', () => {
   const subject = { documentId: 'd', kind: 'spatial' as const, updatedAt: 'v1' }
 
   it('keeps an outline of a document apart from its SVG', () => {
-    expect(renderKeyPath(renderKeyOf(subject, 'light', 'outline'))).not.toBe(
-      renderKeyPath(renderKeyOf(subject, 'light', 'svg')),
+    expect(renderKeyPath(outlineKeyOf(subject))).not.toBe(
+      renderKeyPath(renderKeyOf(subject, 'light')),
     )
   })
 
   it('names each family in the path, so a stored entry says what it holds', () => {
-    expect(renderKeyPath(renderKeyOf(subject, 'light', 'svg')).endsWith('.svg')).toBe(true)
-    expect(renderKeyPath(renderKeyOf(subject, 'light', 'outline')).endsWith('.svg')).toBe(false)
+    expect(renderKeyPath(renderKeyOf(subject, 'light')).endsWith('.svg')).toBe(true)
+    expect(renderKeyPath(outlineKeyOf(subject)).endsWith('.svg')).toBe(false)
   })
 
   it('defaults to the svg family, which every existing caller is', () => {
     expect(renderKeyOf(subject, 'light').pipeline).toBe('svg')
+  })
+
+  // An outline's colours are resolved from the LIGHT palette for both kinds,
+  // so the theme is not an axis of it at all. Carrying one would double the
+  // entries for nothing and, worse, make a theme toggle redraw every tree
+  // row icon to produce identical rectangles.
+  it('drops the theme axis for an outline, whose colours do not depend on it', () => {
+    expect(outlineKeyOf(subject).theme).toBeNull()
+    expect(renderKeyPath(outlineKeyOf(subject))).toBe(renderKeyPath(outlineKeyOf(subject)))
+  })
+
+  it('keeps the theme axis for a spatial SVG, whose palette is baked in', () => {
+    expect(renderKeyOf(subject, 'dark').theme).toBe('dark')
   })
 })
 

--- a/apps/web/src/lib/render-key.test.ts
+++ b/apps/web/src/lib/render-key.test.ts
@@ -53,6 +53,31 @@ describe('renderKeyPath — every component unambiguous', () => {
 // completed render must not be remembered under it. The in-flight join is
 // still safe there — two panes asking at the same instant are asking about
 // the same bytes — and that distinction is the whole point of this flag.
+// The broker holds ONE map, so two families asking about the same document
+// must not name the same entry. Before the pipeline axis they did: both keys
+// were `<build>/<kind>/<doc>/<version>.svg`, so a tree row's outline and a
+// list row's SVG collided — and whichever arrived first answered the other,
+// with a type the caller had no reason to check. The `.svg` extension was
+// also a lie for half of them.
+describe('renderKeyPath — the pipeline is part of the identity', () => {
+  const subject = { documentId: 'd', kind: 'spatial' as const, updatedAt: 'v1' }
+
+  it('keeps an outline of a document apart from its SVG', () => {
+    expect(renderKeyPath(renderKeyOf(subject, 'light', 'outline'))).not.toBe(
+      renderKeyPath(renderKeyOf(subject, 'light', 'svg')),
+    )
+  })
+
+  it('names each family in the path, so a stored entry says what it holds', () => {
+    expect(renderKeyPath(renderKeyOf(subject, 'light', 'svg')).endsWith('.svg')).toBe(true)
+    expect(renderKeyPath(renderKeyOf(subject, 'light', 'outline')).endsWith('.svg')).toBe(false)
+  })
+
+  it('defaults to the svg family, which every existing caller is', () => {
+    expect(renderKeyOf(subject, 'light').pipeline).toBe('svg')
+  })
+})
+
 describe('isMemoisableKey', () => {
   it('refuses a key with no version', () => {
     expect(isMemoisableKey(renderKeyOf({ documentId: 'd', kind: 'spatial' }, 'light'))).toBe(false)

--- a/apps/web/src/lib/render-key.ts
+++ b/apps/web/src/lib/render-key.ts
@@ -77,18 +77,38 @@ export interface RenderKeySubject {
   readonly updatedAt?: string
 }
 
-export function renderKeyOf(
-  subject: RenderKeySubject,
-  theme: ResolvedTheme,
-  pipeline: BrokeredPipeline = 'svg',
-): RenderKey {
+/** The key for the SVG a surface draws at size — the expensive family. */
+export function renderKeyOf(subject: RenderKeySubject, theme: ResolvedTheme): RenderKey {
   return {
     buildId: RENDERER_BUILD_ID,
-    pipeline,
+    pipeline: 'svg',
     documentId: subject.documentId,
     kind: subject.kind,
     version: subject.updatedAt ?? null,
+    // Baked into a spatial SVG's own bytes; a markdown one takes its ink
+    // from page CSS, so one entry serves both themes.
     theme: subject.kind === 'spatial' ? theme : null,
+  }
+}
+
+/**
+ * The key for a document's OUTLINE — the rectangles a tree row's icon and
+ * the tab favicon draw.
+ *
+ * It takes no theme, and that is the point rather than an omission: outline
+ * colours are resolved from the light palette for both kinds, so a theme axis
+ * would double the entries to hold identical rectangles and make a theme
+ * toggle redraw every icon for nothing. A separate constructor rather than a
+ * third argument, so no caller has to pass a theme that would be ignored.
+ */
+export function outlineKeyOf(subject: RenderKeySubject): RenderKey {
+  return {
+    buildId: RENDERER_BUILD_ID,
+    pipeline: 'outline',
+    documentId: subject.documentId,
+    kind: subject.kind,
+    version: subject.updatedAt ?? null,
+    theme: null,
   }
 }
 

--- a/apps/web/src/lib/render-key.ts
+++ b/apps/web/src/lib/render-key.ts
@@ -8,7 +8,7 @@
  * the wrong picture rather than failing.
  */
 
-import { documentKindSchema } from '@kamiazya/whiteboard-model'
+import { type DocumentKind, documentKindSchema } from '@kamiazya/whiteboard-model'
 import { z } from 'zod'
 import type { ResolvedTheme } from '../hooks/useThemeMode.js'
 
@@ -70,10 +70,17 @@ export const renderKeySchema = z.object({
 
 export type RenderKey = z.infer<typeof renderKeySchema>
 
-/** The document fields a key is built from. */
+/**
+ * The document fields a key is built from.
+ *
+ * `kind` is `DocumentKind` rather than a hand-written copy of its members:
+ * a parallel union beside the schema is the drift this repo's Zod discipline
+ * exists to prevent, and here it would let a new kind be keyed as one of the
+ * old ones.
+ */
 export interface RenderKeySubject {
   readonly documentId: string
-  readonly kind: 'spatial' | 'markdown'
+  readonly kind: DocumentKind
   readonly updatedAt?: string
 }
 

--- a/apps/web/src/lib/render-key.ts
+++ b/apps/web/src/lib/render-key.ts
@@ -22,9 +22,30 @@ declare const __RENDERER_BUILD_ID__: string
 
 export const RENDERER_BUILD_ID: string = __RENDERER_BUILD_ID__
 
+/**
+ * The families the broker holds, which is NOT every pipeline a surface can
+ * take: `png-raster` is absent because nothing asks the broker for one, and
+ * naming it here would claim a storage shape this key cannot address.
+ * `render-surfaces.ts` widens this by exactly that member, so the two say the
+ * same thing about the families they share.
+ */
+export const brokeredPipelineSchema = z.enum(['svg', 'outline'])
+
+export type BrokeredPipeline = z.infer<typeof brokeredPipelineSchema>
+
 export const renderKeySchema = z.object({
   /** The code that would produce these bytes. */
   buildId: z.string().min(1),
+  /**
+   * WHICH picture of the document, not just which document.
+   *
+   * The broker holds one map, so without this axis a tree row's outline and
+   * a list row's SVG name the same entry — and the one that arrives first
+   * answers the other, in a type the caller has no reason to check. A path
+   * ending `.svg` while holding block geometry is the same mistake written
+   * down.
+   */
+  pipeline: brokeredPipelineSchema,
   documentId: z.string().min(1),
   kind: documentKindSchema,
   /**
@@ -56,9 +77,14 @@ export interface RenderKeySubject {
   readonly updatedAt?: string
 }
 
-export function renderKeyOf(subject: RenderKeySubject, theme: ResolvedTheme): RenderKey {
+export function renderKeyOf(
+  subject: RenderKeySubject,
+  theme: ResolvedTheme,
+  pipeline: BrokeredPipeline = 'svg',
+): RenderKey {
   return {
     buildId: RENDERER_BUILD_ID,
+    pipeline,
     documentId: subject.documentId,
     kind: subject.kind,
     version: subject.updatedAt ?? null,
@@ -102,8 +128,20 @@ function segment(value: string): string {
  * what the OPFS store will address, and a leading build id makes retiring a
  * build's whole cache one directory removal rather than a scan.
  */
+/**
+ * What a family's bytes are. An outline is block geometry, so calling its
+ * entry `.svg` would misdescribe it to the OPFS store and to anyone reading
+ * a directory listing.
+ */
+const EXTENSION: Readonly<Record<BrokeredPipeline, string>> = {
+  svg: 'svg',
+  outline: 'json',
+}
+
 export function renderKeyPath(key: RenderKey): string {
   const version = key.version ?? ''
   const leaf = key.theme === null ? segment(version) : `${segment(version)}-${key.theme}`
-  return `${segment(key.buildId)}/${key.kind}/${segment(key.documentId)}/${leaf}.svg`
+  // The pipeline sits under the build id and above the kind, so a sweep can
+  // drop one family the way it can already drop one build: a directory.
+  return `${segment(key.buildId)}/${key.pipeline}/${key.kind}/${segment(key.documentId)}/${leaf}.${EXTENSION[key.pipeline]}`
 }

--- a/apps/web/src/lib/render-surfaces.ts
+++ b/apps/web/src/lib/render-surfaces.ts
@@ -18,6 +18,7 @@
  */
 
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
+import type { BrokeredPipeline } from './render-key.js'
 
 export type RenderSurfaceId =
   | 'list-row-thumbnail'
@@ -32,7 +33,7 @@ export type RenderSurfaceId =
  * geometry only — cheaper, and the only thing legible at 24px. `png-raster`
  * is the SVG drawn into a canvas and read back as PNG.
  */
-export type RenderPipeline = 'svg' | 'outline' | 'png-raster'
+export type RenderPipeline = BrokeredPipeline | 'png-raster'
 
 type KindCoverage = 'covered' | `not covered: ${string}`
 type BrokerUse = 'through' | `not yet: ${string}`

--- a/apps/web/src/lib/render-surfaces.ts
+++ b/apps/web/src/lib/render-surfaces.ts
@@ -68,13 +68,12 @@ export const RENDER_SURFACES = {
   'tree-row-icon': {
     pipeline: 'outline',
     kinds: { spatial: 'covered', markdown: 'covered' },
-    broker:
-      'not yet: the outline pipeline has no measured duplication; moving it is a named follow-up',
+    broker: 'through',
   },
   favicon: {
     pipeline: 'outline',
     kinds: { spatial: 'covered', markdown: 'covered' },
-    broker: 'not yet: one render per page, so nothing to dedup; moves with the tree row',
+    broker: 'through',
   },
   'version-thumbnail': {
     pipeline: 'png-raster',

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -1,5 +1,5 @@
 import { createUniqueNameResolver, serializeSpatial } from '@kamiazya/whiteboard-codec'
-import type { CommentThread } from '@kamiazya/whiteboard-model'
+import type { CommentThread, DocumentKind } from '@kamiazya/whiteboard-model'
 import { isImageRef } from '@kamiazya/whiteboard-model'
 import type { DocumentIndex } from '@kamiazya/whiteboard-ports'
 import { LoroSyncPlugin } from 'loro-codemirror'
@@ -65,11 +65,13 @@ import { browserWorkspaceHandleOrNull, getBrowserWorkspaceId } from '../lib/brow
 import { useWhiteboardCommands } from '../lib/commands/index.js'
 import { DESTRUCTIVE_COPY } from '../lib/destructive-copy.js'
 import { BROWSER_FILE_ADAPTER } from '../lib/document-embed-content.js'
+import type { DocumentOutlineSource } from '../lib/document-outline.js'
 import { isDocumentReadFailure } from '../lib/document-read-failure.js'
 import { browserFaviconStatus, type FaviconStyle } from '../lib/favicon.js'
 import { sharedFoldingBrowserIndex } from '../lib/folding-browser-index.js'
 import { kindNoun } from '../lib/kind-noun.js'
 import type { ContentClock, DefaultDocumentPointer } from '../lib/local-document-summary.js'
+import { composeOutlineSource } from '../lib/outline-source.js'
 import { ensurePersistentStorage } from '../lib/persistent-storage.js'
 import { BROWSER_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
 import { createInTabRenderBroker } from '../lib/render-broker.js'
@@ -783,6 +785,14 @@ export function BrowserDocumentPage({
   const faviconStyle: FaviconStyle = settingsStore.load().appearance?.faviconStyle ?? 'minimap'
   // One shape for whichever kind this document is — the favicon draws
   // it today, and a tree row's icon draws the same one.
+  // Which owner holds THIS document — see `composeOutlineSource`, which is
+  // where the two of them and the reason are written down.
+  const readDocumentOutlineSource = useCallback(
+    (kind: DocumentKind): DocumentOutlineSource | null =>
+      composeOutlineSource(kind, readOutlineSource, markdownDoc),
+    [readOutlineSource, markdownDoc],
+  )
+
   // One broker per page mount, for the tab icon's outline. It is the same
   // seam the list surfaces ask through (ADR-0027); what it buys HERE is that
   // a re-render, a sync-status change or a remount does not recompute a
@@ -792,7 +802,8 @@ export function BrowserDocumentPage({
   const documentOutline = useDocumentOutline({
     documentId,
     kind: documentKind,
-    readSource: readOutlineSource,
+    revision: documentKind === 'markdown' ? markdownDoc.body : canvas,
+    readSource: readDocumentOutlineSource,
     broker: outlineBroker,
   })
 

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -72,6 +72,7 @@ import { kindNoun } from '../lib/kind-noun.js'
 import type { ContentClock, DefaultDocumentPointer } from '../lib/local-document-summary.js'
 import { ensurePersistentStorage } from '../lib/persistent-storage.js'
 import { BROWSER_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
+import { createInTabRenderBroker } from '../lib/render-broker.js'
 import { setShellConnection } from '../lib/shell-status-store.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
 import { cn } from '../lib/utils.js'
@@ -561,6 +562,7 @@ export function BrowserDocumentPage({
     setEdgeLock,
     backendError,
     clearLocalUndo,
+    readOutlineSource,
   } = useDocumentSync(backend, {
     // The backend delivers the WORKSPACE document; this scopes the session's
     // reads and writes to the tree node carrying this document's content.
@@ -781,10 +783,17 @@ export function BrowserDocumentPage({
   const faviconStyle: FaviconStyle = settingsStore.load().appearance?.faviconStyle ?? 'minimap'
   // One shape for whichever kind this document is — the favicon draws
   // it today, and a tree row's icon draws the same one.
+  // One broker per page mount, for the tab icon's outline. It is the same
+  // seam the list surfaces ask through (ADR-0027); what it buys HERE is that
+  // a re-render, a sync-status change or a remount does not recompute a
+  // shape the document already has — the version key is what makes that safe.
+  const outlineBroker = useMemo(() => createInTabRenderBroker(), [])
+
   const documentOutline = useDocumentOutline({
+    documentId,
     kind: documentKind,
-    canvas: canvas,
-    markdownBody: documentKind === 'markdown' ? (markdownDoc.body ?? '') : null,
+    readSource: readOutlineSource,
+    broker: outlineBroker,
   })
 
   useFavicon({

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -533,6 +533,7 @@ export function DaemonDocumentPage({
   const documentOutline = useDocumentOutline({
     documentId: backendState?.contentDocumentId ?? null,
     kind: documentKind,
+    revision: documentKind === 'markdown' ? markdownBody : canvasValue,
     readSource: readOutlineSource,
     broker: outlineBroker,
   })

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -63,6 +63,7 @@ import { deriveNewDocumentPath } from '../lib/derive-new-document-path.js'
 import { devTransportOverride } from '../lib/dev-transport-override.js'
 import { daemonFaviconStatus, type FaviconStyle } from '../lib/favicon.js'
 import { DAEMON_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
+import { createInTabRenderBroker } from '../lib/render-broker.js'
 import { scheduleReplicaRefresh } from '../lib/replica-refresh.js'
 import { setShellConnection } from '../lib/shell-status-store.js'
 import { createSharedSseStreamSource } from '../lib/sse-shared-stream-source.js'
@@ -316,6 +317,7 @@ export function DaemonDocumentPage({
     lockedEdgeIds,
     setEdgeLock,
     syncStatus,
+    readOutlineSource,
   } = useDocumentSync(backend, {
     ...(backendState?.contentDocumentId === undefined
       ? {}
@@ -522,10 +524,17 @@ export function DaemonDocumentPage({
   const { isDirty } = useDirtyState(canvas?.workspaceId ?? '', canvas?.path ?? '')
   // One shape for whichever kind this document is — the favicon draws
   // it today, and a tree row's icon draws the same one.
+  // One broker per page mount, for the tab icon's outline. It is the same
+  // seam the list surfaces ask through (ADR-0027); what it buys HERE is that
+  // a re-render, a sync-status change or a remount does not recompute a
+  // shape the document already has — the version key is what makes that safe.
+  const outlineBroker = useMemo(() => createInTabRenderBroker(), [])
+
   const documentOutline = useDocumentOutline({
+    documentId: backendState?.contentDocumentId ?? null,
     kind: documentKind,
-    canvas: canvasValue,
-    markdownBody,
+    readSource: readOutlineSource,
+    broker: outlineBroker,
   })
 
   useFavicon({

--- a/docs/contributing/adr/0027-render-broker.md
+++ b/docs/contributing/adr/0027-render-broker.md
@@ -1,6 +1,6 @@
 # ADR-0027: Every picture of a document goes through one broker, and the cache is a memo
 
-**Status:** Accepted — broker port and its in-tab implementation land with this ADR; OPFS persistence and the SharedWorker implementation are named follow-ups
+**Status:** Accepted — broker port and its in-tab implementation land with this ADR. Every surface named below now asks through it; OPFS persistence and the SharedWorker implementation are named follow-ups
 
 ## Context
 
@@ -118,8 +118,15 @@ string. The `~` prefix on each segment is what additionally makes `.` and
 rather than after.
 
 ```
-render/~<buildId>/<kind>/~<documentId>/~<versionKey>[-<theme>].svg
+render/~<buildId>/<pipeline>/<kind>/~<documentId>/~<versionKey>[-<theme>].<ext>
 ```
+
+The pipeline is part of the identity, not decoration. The broker holds one
+map, so without it a tree row's outline and a list row's SVG name the same
+entry — and whichever arrives first answers the other, in a type the caller
+has no reason to check. It sits under the build id so a sweep can drop one
+family the way it drops one build, and the extension is what the bytes
+actually are (`.svg`, or `.json` for an outline).
 
 Retiring a build's entire cache is removing one directory — no scan, no
 scheduler, no index. Write-time is enough: when storing an entry, drop any
@@ -128,6 +135,21 @@ sibling directory that is not the current build.
 The realm assignment follows a probe rather than a preference: only a
 **dedicated worker** has `createSyncAccessHandle`, and that is also where the
 bytes are produced, so the renderer persists its own output with no extra hop.
+
+### 6a. Work nobody is waiting on says so, and the fleet believes it
+
+`background` covered everything that was not the commit a person just made,
+which put a list of thumbnails and a tab favicon on equal terms — so they won
+worker slots by arrival order. A list is still something the user is looking
+at; an icon that arrives a second late is not noticed at all. `idle` is the
+band below, and the outline surfaces run in it.
+
+The slot budget is over all the deferrable bands TOGETHER rather than one cap
+per band, and that is correctness rather than tidiness: counted per band,
+`idle` is free to take the very slot `background`'s cap reserves for an
+interactive request. Measured on a two-worker fleet before the fix — an idle
+request arriving between two background ones ran immediately, and both
+background requests then waited.
 
 ### 6. A surface that draws a document is declared, or it does not compile
 
@@ -158,19 +180,33 @@ is stated per kind rather than applied uniformly.
 
 Still open, and named rather than assumed:
 
-- **Persistence needs a version key that does not exist yet.**
-  `documentSummarySchema` carries no frontier. `updatedAt` is stamped per push
-  in practice but is optional in the schema, and a key with no version cannot
-  notice its document changing — so `isMemoisableKey` refuses to remember a
-  completed render under one, and only the in-flight join applies there. That
-  is the honest behaviour rather than a limitation to work around: a memo
-  under such a key would serve the old picture for as long as the tab is open.
-  Adding the frontier is its own increment, and until it lands the broker
-  caches in memory only.
-- **The fetch of a document's bytes is unmeasured**, and `load-row-render.ts`
-  claims it dominates the wait. If that is true, the cache's largest win is
-  skipping the fetch rather than the CPU — which does not change this design,
-  but does change how its benefit should be reported.
+- **Persistence still needs a version key on the LIST surfaces.**
+  `documentSummarySchema` carries no frontier, and `updatedAt` is stamped per
+  push in practice but optional in the schema. A key with no version cannot
+  notice its document changing, so `isMemoisableKey` refuses to remember a
+  completed render under one and only the in-flight join applies there —
+  honest behaviour rather than a limitation to work around, since a memo
+  under such a key would serve the old picture for as long as the tab is
+  open.
+
+  The OPEN document is no longer in that position: `DocumentSyncSession`
+  answers `getFrontier()`, loro's own id for its committed state, and the
+  favicon is keyed by it. Two things that took measuring rather than
+  arguing, both recorded where the next reader will be:
+
+  - the STATE frontier, not the oplog's — a document checked out to an older
+    version shows that version, and the state frontier also does not move on
+    a commit that changed nothing;
+  - it names the COMMITTED state, which is deliberately not the instant the
+    canvas is published. `onChange` publishes immediately and commits on a
+    debounce, so a key read at render time files the new picture under the
+    old version. `whiteboard:doc_changed` fires after the commit, and is
+    therefore the trigger every surface keyed this way must use.
+- **The fetch of a document's bytes is unmeasured** for the daemon keeper.
+  For the browser keeper it is measured and `load-row-render.ts`'s claim that
+  it dominates the wait is false — a near-constant 4-6ms against a render of
+  9-29ms that grows with the document. The worker pool's cap of 4 rests on
+  that claim and is worth revisiting.
 - **Safari and iOS are unmeasured.** SharedWorker is expected absent, OPFS
   expected present. iOS is best-effort by standing policy, and the fallback is
   the in-tab implementation this ADR ships first.


### PR DESCRIPTION
## Summary

- The tree row's icon and the tab favicon were the two surfaces ADR-0027 declared `broker: 'not yet:'`. Both now ask the broker, and `RENDER_SURFACES` answers `through` for every surface it declares — the two reasons are **gone**, not reworded.
- The tree row was the last place still decoding a stored snapshot on the **main thread** — the same call `load-row-render.ts` stopped making, at the same measured cost, once per visible row. It hands the bytes over now.
- The favicon's outline was a `useMemo` in the page's render path, so every edit computed a shape the next edit threw away 150ms later. It is subscribed now, computed in the worker at a new `idle` priority.
- Manual verification then caught a defect no test could, and answering "is that fixed at the root?" turned up the same defect shape in two more places. Both sections below.

## What made this safe rather than fast

A cached picture's worst failure is being **wrong** rather than missing, so most of this diff is about the key.

**The pipeline is part of the key's identity.** The broker holds one map, and its path named only the document, kind, version and theme — so a tree row's outline and a list row's SVG named the same entry, and whichever arrived first answered the other in a type the caller has no reason to check. `pipeline` joins the key; `render-broker.ts` is generic over what a family answers with, and the cross-family isolation the cast rests on is asserted rather than assumed.

**A session can now name the state a picture of it would be a picture of.** `updatedAt` cannot serve — stamped per push, it names one value for a document that changed many times. `getFrontier()` answers loro's own id for the committed state. Two choices in it were measured, not argued:

- the **state** frontier, not the oplog's — a document checked out to an older version shows that version; and the state frontier does not move on a commit that changed nothing;
- it names the **committed** state, which is deliberately not the instant the canvas is published. `onChange` publishes immediately and commits on a debounce, so a key read at render time files the new picture under the old version. Measured: reading the frontier straight after `onChange` returns the pre-edit value while `getCanvas()` already shows `hello` → `edited`.

That last measurement is why the favicon is driven by the document's change notification rather than by React state.

## Where the cost went

Exporting a snapshot to hand the favicon's document to the worker, against reading the canvas out on the main thread instead. Real browser, medians of 21 interleaved rounds:

| nodes | `doc.export({snapshot})` | `readSpatialCanvas(doc)` | bytes |
|---|---|---|---|
| 12 | **0.10 ms** | 0.50 ms | 1.5 KB |
| 40 | **0.10 ms** | 0.80 ms | 3.6 KB |
| 120 | **0.20 ms** | 1.90 ms | 9.6 KB |

The handover is 5–9× cheaper than the alternative and barely grows with the document — a release rather than a relocation. The tree row's removed decode is the figure from #1275: 1.20 / 2.60 / 4.60 ms at 12 / 40 / 120 nodes, once per visible row.

`idle` is a third priority band below `background`. Its slot budget is over **all** the deferrable bands together rather than one cap per band, and that is correctness rather than tidiness: counted per band, `idle` is free to take the very slot `background`'s cap reserves for an interactive request. Measured on a two-worker fleet before the fix — an idle request arriving between two background ones ran immediately, and both background requests then waited.

## What manual verification caught, and what your question caught after it

Every gate was green and the favicon still never changed however much was typed into a markdown document. Browser-mode markdown documents live in `useMarkdownDocument`'s own LoroDoc and never reach `DocumentSyncSession`, so asking the session alone answered `null` for all of them. **No test could have found it** — every test of the hook injects its source and so never makes that choice. The discriminator was a reload: the typed text persisted, which ruled out "the document never changed". After the fix, 1690 → 1294 bytes of favicon.

That fix was a branch, not a root cause. Adding a third `DocumentKind` and typechecking says so exactly:

| | before | after |
|---|---|---|
| `render-surfaces.ts` | ✅ errors | ✅ |
| `DocumentEditorSurface.tsx` | ✅ | ✅ |
| **`outline-source.ts`** | ❌ **silent** | ✅ |
| **`load-row-render.ts`** | ❌ **silent** | ✅ |
| **`load-row-outline.ts`** | ❌ **silent** | ✅ |
| `local-files-source` + 2 others | ⚠️ incidental mismatch | error gone |

`kind === 'markdown' ? … : <the other one>` reads as a complete decision and is a default: a new kind would have been drawn by the spatial pipeline in two places and asked an owner that does not hold it in a third. Each is now an exhaustive switch whose default takes the value as `never`. Two hand-written parallel unions (`WorkspaceDocumentEntry.kind`, `RenderKeySubject.kind`) were why the row loaders could not see a new kind at all — that is the drift this repo's Zod discipline exists to stop, and its effect was to move the error somewhere unhelpful. The error now lands at the decision, and the incidental ones are gone.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [ ] `pnpm test` passes locally — **the browser project does not complete in this container any more; see below**
- [x] Manual verification completed (described above)
- [ ] E2E coverage added or extended where applicable — nothing here depends on real routing, persistence or the daemon

- `pnpm test --project web-jsdom` — **3503 passed**
- `pnpm --filter @kamiazya/whiteboard-web typecheck`, `pnpm lint`, `pnpm knip` — clean
- New: `layout-worker-outline.browser.test.tsx` (all three request shapes against the real worker and its lazily imported WASM), `outline-source.test.ts` (the branch manual verification found), plus the `idle` band, the pipeline axis, the cross-family isolation, and the frontier's two directions
- Mutation-checked: the `idle` band three ways, `getFrontier` three ways, the pipeline axis, the outline key — each fails a different assertion, baseline and restore green

**The browser suite is not green locally and I am not claiming it is.** It completed twice today at **194/194 files, 1037 tests**, then stopped completing. Five runs since, with a different set of files aborting each time and no overlap between them:

| run | files that aborted |
|---|---|
| 1 | `touch-pan-zoom` |
| 2 | `comment-compose-look`, `delete-confirm` |
| 3 | `backend-identity`, `canvas-settings`, `select-none` |
| 4 | `canvas-embed-lod`, `comment-placement`, `node-symbol-menu` |
| 5 | `touch-pan-zoom` |

The errors are `Browser connection was closed while running tests` and `[birpc] rpc is closed` — the Chromium process dying, not assertions — and the run aborts at 116–140 of 194 files. A real regression fails the same test every time. Per this repo's own rule I stopped re-running rather than fishing for a green. CI on a fresh runner is the authority here.

## Visual evidence

Visual evidence: none — `compose-figure.mjs` needs ImageMagick, which is absent in this container (it is also what stops `pnpm check:local` completing here). The user-visible change is a 32px tab icon and a 24px row icon; the measurement in its place is the favicon's own bytes before and after a real edit in the running app, 1690 → 1294, with the pre-fix pair 1690 → 1690 as the control.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — ADR-0027's path grammar, its status, the `idle` band as decision 6a, and the version-key section rewritten now that the open document has one
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema — this PR **removes** two that did

## Follow-ups, named rather than assumed

- `whiteboard:doc_changed` never fires in browser markdown mode (`dispatchIdentityEvent` returns early without a workspace identity), so `useDirtyState`'s save dot is inert there too. Pre-existing, not fixed here; the hook no longer depends on that event alone.
- OPFS persistence still needs a version key on the **list** surfaces — `documentSummarySchema` carries no frontier. The open document now has one.
- The worker pool's cap of 4 rests on a premise measured false in #1275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh)_