### PR TITLE
perf(web): apply react-best-practices audit fixes across seven hot paths

### DIFF
--- a/apps/web/src/components/MergeDialog.tsx
+++ b/apps/web/src/components/MergeDialog.tsx
@@ -4,6 +4,7 @@ import {
   listVersionsResponseSchema,
   type MergeRequest,
   type MergeResponse,
+  type VersionEntry,
 } from '@kamiazya/whiteboard-mcp/api-contracts'
 import {
   AlertTriangle,
@@ -55,6 +56,28 @@ interface BadgeView {
   label: string
   tone: 'danger' | 'warning' | 'info'
   title: string
+}
+
+/**
+ * The most recent thumbnail-bearing version on a branch, or null.
+ *
+ * Single pass with a strictly-greater comparison, rather than filter+sort+[0]
+ * (an O(n log n) sort to read one extreme): a strictly-greater `createdAt`
+ * only replaces the running pick on a genuine improvement, so the FIRST
+ * array entry wins a tie — the same result `.sort((a, b) =>
+ * b.createdAt.localeCompare(a.createdAt))[0]` gave, since `Array.sort` is
+ * stable and a tie there keeps original order too.
+ */
+export function latestThumbnailVersion(
+  versions: readonly VersionEntry[],
+  branchName: string,
+): VersionEntry | null {
+  let latest: VersionEntry | null = null
+  for (const v of versions) {
+    if (!v.hasThumbnail || v.branchName !== branchName) continue
+    if (latest === null || v.createdAt.localeCompare(latest.createdAt) > 0) latest = v
+  }
+  return latest
 }
 
 function badgeLabel(badge: Record<string, unknown>): BadgeView {
@@ -273,14 +296,8 @@ export function MergeDialog({
           setThumbs({ target: null, source: null })
           return
         }
-        const latestFor = (name: string) => {
-          const matches = parsed.data.versions
-            .filter((v) => v.hasThumbnail && v.branchName === name)
-            .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
-          return matches[0] ?? null
-        }
-        const tgt = latestFor(target.name)
-        const src = latestFor(source.name)
+        const tgt = latestThumbnailVersion(parsed.data.versions, target.name)
+        const src = latestThumbnailVersion(parsed.data.versions, source.name)
         setThumbs({
           target: tgt?.id ?? null,
           source: src?.id ?? null,

--- a/apps/web/src/components/VersionTimeline.render-memo.test.tsx
+++ b/apps/web/src/components/VersionTimeline.render-memo.test.tsx
@@ -1,0 +1,109 @@
+// miniGraphRows/miniGraphById were rebuilt in the component body on every
+// render, even for state churn unrelated to head/branches/versions
+// (previewing, isRestoring, restoreError, stale, loading) — buildMiniGraph
+// is O(versions) and every keystroke of unrelated UI state paid for it again.
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import VersionTimeline from './VersionTimeline.js'
+
+const mockLog = vi.hoisted(() => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+}))
+
+vi.mock('@/lib/app-logger', () => ({
+  getAppLogger: () => mockLog,
+}))
+
+const buildMiniGraphSpy = vi.fn()
+
+vi.mock('@/lib/mini-graph', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/mini-graph')>()
+  return {
+    ...actual,
+    buildMiniGraph: (...args: Parameters<typeof actual.buildMiniGraph>) => {
+      buildMiniGraphSpy(...args)
+      return actual.buildMiniGraph(...args)
+    },
+  }
+})
+
+type FetchArgs = [RequestInfo | URL, RequestInit?]
+
+function mkBranchesResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      head: 'main',
+      branches: [
+        { name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '2026-04-23T00:00:00Z' },
+      ],
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+function mkVersionDocumentResponse(): Response {
+  return new Response(JSON.stringify({ kind: 'spatial', canvas: { nodes: [], edges: [] } }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function mkVersionsResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      versions: [
+        {
+          id: 'v-new',
+          path: 'canvas-a',
+          createdAt: '2026-04-23T02:00:00Z',
+          elementCount: 5,
+          auto: true,
+          hasThumbnail: false,
+          branchName: 'main',
+        },
+      ],
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+beforeEach(() => {
+  buildMiniGraphSpy.mockClear()
+  const fetchMock = vi.fn<(...args: FetchArgs) => Promise<Response>>((input) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+    if (url.includes('/branches')) return Promise.resolve(mkBranchesResponse())
+    if (url.endsWith('/document')) return Promise.resolve(mkVersionDocumentResponse())
+    if (url.includes('/versions')) return Promise.resolve(mkVersionsResponse())
+    return Promise.resolve(new Response('{}', { status: 200 }))
+  })
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  cleanup()
+})
+
+it('does not recompute the mini-graph when only preview/restore state changes', async () => {
+  render(<VersionTimeline workspaceId="sess_1" path="canvas-a" />)
+  const row = await screen.findByTestId('version-row')
+  const baseline = buildMiniGraphSpy.mock.calls.length
+  expect(baseline).toBeGreaterThanOrEqual(1)
+
+  // Opening a preview changes `previewing`/`previewPast` — none of which
+  // are inputs to the mini-graph (head, branches, versions). The row's
+  // interactive surface is the <button> RowShell renders INSIDE the
+  // testid'd wrapper div, not the wrapper itself — a click on the wrapper
+  // does not bubble down into it.
+  const activateButton = row.querySelector('button')
+  expect(activateButton).not.toBeNull()
+  await act(async () => {
+    fireEvent.click(activateButton as HTMLButtonElement)
+  })
+
+  expect(buildMiniGraphSpy).toHaveBeenCalledTimes(baseline)
+})

--- a/apps/web/src/components/VersionTimeline.tsx
+++ b/apps/web/src/components/VersionTimeline.tsx
@@ -1,6 +1,6 @@
 import type { OperatorInfo, VersionEntry } from '@kamiazya/whiteboard-mcp/api-contracts'
 import { History } from 'lucide-react'
-import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react'
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { CardContent } from '@/components/ui/card'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { useDaemonApi } from '@/contexts/DaemonApiContext'
@@ -400,17 +400,25 @@ export default function VersionTimeline({
   // unreachable — each row it drew was active by construction — and meant the
   // only way to see another variation's history was to switch onto it first.
   const visibleVersions = versions
-  const miniGraphRows = buildMiniGraph({
-    head,
-    branches: branchesState.branches,
-    versions: visibleVersions.map((v) => ({
-      id: v.id,
-      branchName: v.branchName ?? 'main',
-      createdAt: v.createdAt,
-      ...(v.restoredFrom === undefined ? {} : { restoredFrom: v.restoredFrom }),
-    })),
-  })
-  const miniGraphById = new Map(miniGraphRows.map((r) => [r.versionId, r]))
+  // Re-derived only off head/branches/versions — NOT off previewing,
+  // isRestoring, restoreError, stale, or loading, all of which change far
+  // more often and none of which buildMiniGraph (O(versions)) reads.
+  const { miniGraphById, versionsById } = useMemo(() => {
+    const rows = buildMiniGraph({
+      head,
+      branches: branchesState.branches,
+      versions: visibleVersions.map((v) => ({
+        id: v.id,
+        branchName: v.branchName ?? 'main',
+        createdAt: v.createdAt,
+        ...(v.restoredFrom === undefined ? {} : { restoredFrom: v.restoredFrom }),
+      })),
+    })
+    return {
+      miniGraphById: new Map(rows.map((r) => [r.versionId, r])),
+      versionsById: new Map(visibleVersions.map((v) => [v.id, v])),
+    }
+  }, [head, branchesState.branches, visibleVersions])
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-2 p-3">
@@ -463,9 +471,7 @@ export default function VersionTimeline({
               const row = miniGraphById.get(v.id)
               const author = versionAuthor(v.operator)
               const restoredSource =
-                row?.restoredFrom === undefined
-                  ? undefined
-                  : visibleVersions.find((other) => other.id === row.restoredFrom)
+                row?.restoredFrom === undefined ? undefined : versionsById.get(row.restoredFrom)
               const restoredFromTitle =
                 restoredSource === undefined ? null : versionTitle(restoredSource)
               return (

--- a/apps/web/src/components/latest-thumbnail-version.test.ts
+++ b/apps/web/src/components/latest-thumbnail-version.test.ts
@@ -1,0 +1,48 @@
+import type { VersionEntry } from '@kamiazya/whiteboard-mcp/api-contracts'
+import { describe, expect, it } from 'vitest'
+import { latestThumbnailVersion } from './MergeDialog.js'
+
+function version(overrides: Partial<VersionEntry> & Pick<VersionEntry, 'id'>): VersionEntry {
+  return {
+    path: 'canvas-a',
+    createdAt: '2026-01-01T00:00:00Z',
+    elementCount: 0,
+    auto: true,
+    hasThumbnail: true,
+    branchName: 'main',
+    ...overrides,
+  }
+}
+
+describe('latestThumbnailVersion', () => {
+  it('picks the latest hasThumbnail match on the branch, wherever it sits in the array', () => {
+    const versions = [
+      version({ id: 'mid', createdAt: '2026-01-02T00:00:00Z' }),
+      version({ id: 'oldest', createdAt: '2026-01-01T00:00:00Z' }),
+      version({ id: 'newest', createdAt: '2026-01-03T00:00:00Z' }),
+    ]
+    expect(latestThumbnailVersion(versions, 'main')?.id).toBe('newest')
+  })
+
+  it('picks the FIRST array entry on a createdAt tie, preserving stable-sort-desc[0] semantics', () => {
+    const versions = [
+      version({ id: 'first', createdAt: '2026-01-01T00:00:00Z' }),
+      version({ id: 'second', createdAt: '2026-01-01T00:00:00Z' }),
+    ]
+    expect(latestThumbnailVersion(versions, 'main')?.id).toBe('first')
+  })
+
+  it('excludes entries with hasThumbnail: false', () => {
+    const versions = [version({ id: 'no-thumb', hasThumbnail: false })]
+    expect(latestThumbnailVersion(versions, 'main')).toBeNull()
+  })
+
+  it('excludes entries on a different branch', () => {
+    const versions = [version({ id: 'other-branch', branchName: 'feature' })]
+    expect(latestThumbnailVersion(versions, 'main')).toBeNull()
+  })
+
+  it('returns null when no version matches', () => {
+    expect(latestThumbnailVersion([], 'main')).toBeNull()
+  })
+})

--- a/apps/web/src/components/markdown-editor/MinimapRail.render-memo.test.tsx
+++ b/apps/web/src/components/markdown-editor/MinimapRail.render-memo.test.tsx
@@ -1,0 +1,61 @@
+// MinimapRail rebuilt its geometry from railGeometry(blocks, {...}) on every
+// render, even though `blocks` — the expensive-to-derive input — was
+// unchanged; only `viewport` (updated per scroll tick) actually needs a
+// fresh render. A fresh geometry object every render also defeats
+// useCallback(seekTo, [geometry, onSeek]).
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { MinimapRail } from './MinimapRail.js'
+
+const railGeometrySpy = vi.fn()
+
+vi.mock('./rail-geometry.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./rail-geometry.js')>()
+  return {
+    ...actual,
+    railGeometry: (...args: Parameters<typeof actual.railGeometry>) => {
+      railGeometrySpy(...args)
+      return actual.railGeometry(...args)
+    },
+  }
+})
+
+const RAIL_HEIGHT = 200
+const blocks = [{ x: 0, y: 0, w: 400, h: 100 }]
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      disconnect() {}
+    },
+  )
+  vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(RAIL_HEIGHT)
+  railGeometrySpy.mockClear()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+it('does not recompute geometry on a re-render with the same blocks, only a new viewport object', () => {
+  const onSeek = vi.fn()
+  const { rerender } = render(
+    <MinimapRail blocks={blocks} viewport={{ top: 0, height: 100 }} onSeek={onSeek} />,
+  )
+  // Mount itself legitimately recomputes geometry once more when the
+  // ResizeObserver effect settles railHeight from 0 to its measured value —
+  // a real dependency change. That settles synchronously here (render()
+  // flushes effects via act), so the baseline is taken AFTER mount rather
+  // than assumed to be exactly one call.
+  const baseline = railGeometrySpy.mock.calls.length
+  expect(baseline).toBeGreaterThanOrEqual(1)
+
+  // Same blocks reference, a brand-new viewport object with the same
+  // values as an ordinary scroll-tick update would produce.
+  rerender(<MinimapRail blocks={blocks} viewport={{ top: 0, height: 100 }} onSeek={onSeek} />)
+  expect(railGeometrySpy).toHaveBeenCalledTimes(baseline)
+})

--- a/apps/web/src/components/markdown-editor/MinimapRail.tsx
+++ b/apps/web/src/components/markdown-editor/MinimapRail.tsx
@@ -13,7 +13,7 @@
  * second one here would silently answer for the preview.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { cn } from '../../lib/utils.js'
 import { RAIL_WIDTH_PX } from './preview-width.js'
 import {
@@ -47,7 +47,12 @@ export function MinimapRail({ blocks, viewport, onSeek, className }: MinimapRail
     return () => observer.disconnect()
   }, [])
 
-  const geometry = railGeometry(blocks, { railHeight, railWidth: RAIL_WIDTH_PX })
+  // `viewport` changes on every scroll tick and must not force this back to
+  // O(blocks) — only `blocks`/`railHeight` change the geometry itself.
+  const geometry = useMemo(
+    () => railGeometry(blocks, { railHeight, railWidth: RAIL_WIDTH_PX }),
+    [blocks, railHeight],
+  )
   const frame = viewportFrame(viewport, geometry)
 
   const seekTo = useCallback(

--- a/apps/web/src/components/spatial-editor/CanvasDisplaySettings.render-memo.test.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasDisplaySettings.render-memo.test.tsx
@@ -1,0 +1,58 @@
+// CanvasDisplaySettings re-derives its contribution `groups`
+// (resolveFacetContributions(...).map().filter()) in the component body on
+// every render, even though facetRegistry/widgets are stable props with
+// defaults — recomputing on an unrelated re-render is pure waste.
+import { createFacetRegistry } from '@kamiazya/whiteboard-facet-engine'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { bundledPlugins } from '@kamiazya/whiteboard-plugin-visual'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { CanvasDisplaySettings } from './CanvasDisplaySettings.js'
+import { CANVAS_SETTINGS_WIDGETS } from './facet-widgets/index.js'
+
+const resolveSpy = vi.fn()
+
+vi.mock('@kamiazya/whiteboard-facet-engine', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@kamiazya/whiteboard-facet-engine')>()
+  return {
+    ...actual,
+    resolveFacetContributions: (...args: Parameters<typeof actual.resolveFacetContributions>) => {
+      resolveSpy(...args)
+      return actual.resolveFacetContributions(...args)
+    },
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  resolveSpy.mockClear()
+})
+
+const canvas: SpatialCanvas = { nodes: [], edges: [] }
+const registry = createFacetRegistry(bundledPlugins)
+
+function Host() {
+  const [, setTick] = useState(0)
+  return (
+    <div>
+      <button type="button" data-testid="force-rerender" onClick={() => setTick((t) => t + 1)}>
+        rerender
+      </button>
+      <CanvasDisplaySettings
+        canvas={canvas}
+        onChange={() => {}}
+        facetRegistry={registry}
+        widgets={CANVAS_SETTINGS_WIDGETS}
+      />
+    </div>
+  )
+}
+
+it('does not recompute contribution groups on a re-render with unchanged facetRegistry/widgets', () => {
+  const { getByTestId } = render(<Host />)
+  expect(resolveSpy).toHaveBeenCalledTimes(1)
+
+  fireEvent.click(getByTestId('force-rerender'))
+  expect(resolveSpy).toHaveBeenCalledTimes(1)
+})

--- a/apps/web/src/components/spatial-editor/CanvasDisplaySettings.render-memo.test.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasDisplaySettings.render-memo.test.tsx
@@ -56,3 +56,34 @@ it('does not recompute contribution groups on a re-render with unchanged facetRe
   fireEvent.click(getByTestId('force-rerender'))
   expect(resolveSpy).toHaveBeenCalledTimes(1)
 })
+
+// The other direction, so a dependency-array regression (e.g. `[]`) cannot
+// pass: a CHANGED registry must recompute the groups.
+function SwappingHost() {
+  const [reg, setReg] = useState(() => createFacetRegistry(bundledPlugins))
+  return (
+    <div>
+      <button
+        type="button"
+        data-testid="swap-registry"
+        onClick={() => setReg(createFacetRegistry(bundledPlugins))}
+      >
+        swap
+      </button>
+      <CanvasDisplaySettings
+        canvas={canvas}
+        onChange={() => {}}
+        facetRegistry={reg}
+        widgets={CANVAS_SETTINGS_WIDGETS}
+      />
+    </div>
+  )
+}
+
+it('recomputes contribution groups when the facetRegistry changes', () => {
+  const { getByTestId } = render(<SwappingHost />)
+  expect(resolveSpy).toHaveBeenCalledTimes(1)
+
+  fireEvent.click(getByTestId('swap-registry'))
+  expect(resolveSpy).toHaveBeenCalledTimes(2)
+})

--- a/apps/web/src/components/spatial-editor/CanvasDisplaySettings.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasDisplaySettings.tsx
@@ -20,7 +20,7 @@ import { type FacetRegistry, resolveFacetContributions } from '@kamiazya/whitebo
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { bundledFacetRegistry } from '@kamiazya/whiteboard-plugin-visual'
 import { SlidersHorizontal } from 'lucide-react'
-import { Fragment, useEffect, useRef, useState } from 'react'
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover.js'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js'
@@ -57,15 +57,19 @@ export function CanvasDisplaySettings({
     onChange(running, command)
   }
 
-  const groups = resolveFacetContributions(facetRegistry, 'canvasSettings')
-    .map((group) => ({
-      group,
-      widgets: group.facets.flatMap((facet) => {
-        const widget = widgets[facet.key]
-        return widget === undefined ? [] : [{ key: facet.key, widget }]
-      }),
-    }))
-    .filter((entry) => entry.widgets.length > 0)
+  const groups = useMemo(
+    () =>
+      resolveFacetContributions(facetRegistry, 'canvasSettings')
+        .map((group) => ({
+          group,
+          widgets: group.facets.flatMap((facet) => {
+            const widget = widgets[facet.key]
+            return widget === undefined ? [] : [{ key: facet.key, widget }]
+          }),
+        }))
+        .filter((entry) => entry.widgets.length > 0),
+    [facetRegistry, widgets],
+  )
 
   const [activeNamespace, setActiveNamespace] = useState<string | null>(null)
   const active = groups.find((entry) => entry.group.namespace === activeNamespace) ?? groups[0]

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -148,7 +148,7 @@ import { LinkUrlDialog } from './LinkUrlDialog.js'
 import { MarkdownNodeEditor } from './MarkdownNodeEditor.js'
 import { MarqueeOverlay } from './MarqueeOverlay.js'
 import { MemberOutlinesOverlay } from './MemberOutlinesOverlay.js'
-import { MinimapOverlay, type MinimapNode } from './MinimapOverlay.js'
+import { type MinimapNode, MinimapOverlay } from './MinimapOverlay.js'
 import {
   createIdleNavigation,
   DOUBLE_PRESS_WINDOW_MS,

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -62,6 +62,7 @@ import type {
   BoundingBox,
   MeasureText,
   ResolvedReference,
+  SpatialPalette,
   SpatialPresetKey,
 } from '@kamiazya/whiteboard-canvas-render'
 import {
@@ -123,7 +124,14 @@ import { createEditorAppearance, editorTextFill } from './editor-appearance.js'
 import { FacetFormPanel } from './facet-widgets/FacetFormPanel.js'
 import { isFollowableUrl } from './followable-url.js'
 import { GhostOverlay } from './GhostOverlay.js'
-import { distanceToPolyline, findFreeSpot, hitTest, indexNodeBoxes, unionBox } from './geometry.js'
+import {
+  distanceToPolyline,
+  findFreeSpot,
+  hitTest,
+  indexNodeBoxes,
+  type NodeBox,
+  unionBox,
+} from './geometry.js'
 import { snapGesturePoint } from './gesture-snap.js'
 import { describeTarget, gestureTrace } from './gesture-trace.js'
 import { carriedByGesture } from './gesture-view.js'
@@ -140,7 +148,7 @@ import { LinkUrlDialog } from './LinkUrlDialog.js'
 import { MarkdownNodeEditor } from './MarkdownNodeEditor.js'
 import { MarqueeOverlay } from './MarqueeOverlay.js'
 import { MemberOutlinesOverlay } from './MemberOutlinesOverlay.js'
-import { MinimapOverlay } from './MinimapOverlay.js'
+import { MinimapOverlay, type MinimapNode } from './MinimapOverlay.js'
 import {
   createIdleNavigation,
   DOUBLE_PRESS_WINDOW_MS,
@@ -482,6 +490,33 @@ function trySetPointerCapture(root: HTMLElement, pointerId: number): void {
   } catch {
     // best-effort — see doc comment above
   }
+}
+
+/**
+ * Node boxes for the minimap overview, with each authored colour resolved to
+ * the accent the scene already uses for it. A preset key resolves through
+ * the given palette; a hex passes through; an unstyled node carries no
+ * colour and the overview falls back to its muted default.
+ *
+ * Looks up each box's node by id via a `Map` built once, rather than
+ * `nodes.find` per box (O(n) per lookup, O(n^2) over the whole canvas) —
+ * `find`-first and `Map`-last-wins cannot diverge for valid input, since
+ * node id uniqueness is a schema invariant (spatial.ts's `superRefine`
+ * rejects a duplicate node id before a canvas is ever constructed).
+ */
+export function buildMinimapNodes(
+  nodes: SpatialCanvas['nodes'],
+  boxes: readonly NodeBox[],
+  palette: SpatialPalette,
+): readonly MinimapNode[] {
+  const byId = new Map(nodes.map((node) => [node.id, node]))
+  const colorOf = (id: string): string | undefined => {
+    const color = byId.get(id)?.color
+    if (color === undefined) return undefined
+    if (color.startsWith('#')) return color
+    return palette.presets[color as SpatialPresetKey]?.stroke
+  }
+  return boxes.map((entry) => ({ ...entry.box, color: colorOf(entry.id) }))
 }
 
 export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>(
@@ -1960,13 +1995,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      */
     const minimapNodes = useMemo(() => {
       const palette = theme === 'dark' ? SPATIAL_DARK_PALETTE : SPATIAL_LIGHT_PALETTE
-      const colorOf = (id: string): string | undefined => {
-        const color = canvas.nodes.find((n) => n.id === id)?.color
-        if (color === undefined) return undefined
-        if (color.startsWith('#')) return color
-        return palette.presets[color as SpatialPresetKey]?.stroke
-      }
-      return boxes.map((entry) => ({ ...entry.box, color: colorOf(entry.id) }))
+      return buildMinimapNodes(canvas.nodes, boxes, palette)
     }, [boxes, canvas, theme])
 
     /**

--- a/apps/web/src/components/spatial-editor/build-minimap-nodes.test.ts
+++ b/apps/web/src/components/spatial-editor/build-minimap-nodes.test.ts
@@ -1,5 +1,5 @@
-import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { SPATIAL_LIGHT_PALETTE } from '@kamiazya/whiteboard-canvas-render'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { describe, expect, it } from 'vitest'
 import { indexNodeBoxes } from './geometry.js'
 import { buildMinimapNodes } from './SpatialEditor.js'

--- a/apps/web/src/components/spatial-editor/build-minimap-nodes.test.ts
+++ b/apps/web/src/components/spatial-editor/build-minimap-nodes.test.ts
@@ -1,0 +1,62 @@
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { SPATIAL_LIGHT_PALETTE } from '@kamiazya/whiteboard-canvas-render'
+import { describe, expect, it } from 'vitest'
+import { indexNodeBoxes } from './geometry.js'
+import { buildMinimapNodes } from './SpatialEditor.js'
+
+function nodes(entries: SpatialCanvas['nodes']): SpatialCanvas['nodes'] {
+  return entries
+}
+
+describe('buildMinimapNodes', () => {
+  it('passes an authored hex color through unchanged', () => {
+    const n = nodes([
+      { id: 'a', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hi', color: '#ff0000' },
+    ])
+    const boxes = indexNodeBoxes({ nodes: n, edges: [] })
+    expect(buildMinimapNodes(n, boxes, SPATIAL_LIGHT_PALETTE)).toEqual([
+      { x: 0, y: 0, width: 100, height: 50, color: '#ff0000' },
+    ])
+  })
+
+  it('resolves a preset key through the palette presets stroke', () => {
+    const n = nodes([
+      { id: 'a', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hi', color: '3' },
+    ])
+    const boxes = indexNodeBoxes({ nodes: n, edges: [] })
+    expect(buildMinimapNodes(n, boxes, SPATIAL_LIGHT_PALETTE)).toEqual([
+      { x: 0, y: 0, width: 100, height: 50, color: SPATIAL_LIGHT_PALETTE.presets['3'].stroke },
+    ])
+  })
+
+  it('leaves an unstyled node with no color', () => {
+    const n = nodes([{ id: 'a', type: 'text', x: 0, y: 0, width: 100, height: 50, text: 'hi' }])
+    const boxes = indexNodeBoxes({ nodes: n, edges: [] })
+    expect(buildMinimapNodes(n, boxes, SPATIAL_LIGHT_PALETTE)).toEqual([
+      { x: 0, y: 0, width: 100, height: 50, color: undefined },
+    ])
+  })
+
+  it('maps every box, in order, over a mixed set of nodes', () => {
+    const n = nodes([
+      { id: 'a', type: 'text', x: 0, y: 0, width: 10, height: 10, text: 'a', color: '#00ff00' },
+      { id: 'b', type: 'file', x: 20, y: 0, width: 10, height: 10, file: 'b.png' },
+      {
+        id: 'c',
+        type: 'text',
+        x: 40,
+        y: 0,
+        width: 10,
+        height: 10,
+        text: 'c',
+        color: '1',
+      },
+    ])
+    const boxes = indexNodeBoxes({ nodes: n, edges: [] })
+    expect(buildMinimapNodes(n, boxes, SPATIAL_LIGHT_PALETTE)).toEqual([
+      { x: 0, y: 0, width: 10, height: 10, color: '#00ff00' },
+      { x: 20, y: 0, width: 10, height: 10, color: undefined },
+      { x: 40, y: 0, width: 10, height: 10, color: SPATIAL_LIGHT_PALETTE.presets['1'].stroke },
+    ])
+  })
+})

--- a/apps/web/src/pages/SettingsPage.test.tsx
+++ b/apps/web/src/pages/SettingsPage.test.tsx
@@ -1,4 +1,5 @@
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { useState } from 'react'
 import { createMemoryRouter, MemoryRouter, RouterProvider } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { celebrate } from '@/lib/celebrate'
@@ -609,5 +610,186 @@ describe('SettingsPage — storage evidence wiring', () => {
     // The step itself still reports connected — only the figure is absent.
     expect(await within(mobile).findByText('connected')).toBeTruthy()
     expect(mobile.querySelector('[data-journey-detail="daemon"]')).toBeNull()
+  })
+})
+
+// ConnectionsSection/FontsSection build their daemon-aware fetch inline on
+// every render (`createDaemonFetch(daemon.baseUrl, ...)`), so a re-render
+// with an unchanged daemon still hands DaemonApiContext a brand-new function
+// identity. Every consumer effect keyed on that identity (PairedOriginsCard's
+// load/fingerprint effects, FontsCard's refresh effect) then re-fires and
+// re-issues its daemon request — observable here as extra fetch calls with no
+// daemon change to justify them.
+describe('SettingsPage — daemon fetch identity is stable across unrelated re-renders', () => {
+  const DAEMON_A = { baseUrl: 'http://127.0.0.1:9999', token: 'tok-a' }
+  const DAEMON_B = { baseUrl: 'http://127.0.0.1:8888', token: 'tok-b' }
+
+  function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  function countingFetch(counts: { grants: number; fonts: number }) {
+    return vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.includes('/api/pairing/grants')) {
+        counts.grants += 1
+        return jsonResponse({ grants: [] })
+      }
+      if (url.includes('/api/fonts')) {
+        counts.fonts += 1
+        return jsonResponse({ fonts: [] })
+      }
+      if (url.includes('/api/runtime/storage')) {
+        return jsonResponse({ totalBytes: 0, fileCount: 0, byCategory: {} })
+      }
+      return jsonResponse({}, 404)
+    })
+  }
+
+  // Both mobile and desktop layouts mount the active section's content at
+  // once (see the module doc comment on SettingsPage), so PairedOriginsCard/
+  // FontsCard legitimately mount TWICE and fetch twice on first paint —
+  // and SettingsPage's own unrelated effects (queryPersistentStorage, etc.)
+  // settle shortly after mount and cause one more organic re-render. A count
+  // that keeps changing settles into a real steady state; this polls until
+  // two checks 100ms apart agree, so a baseline is taken only once nothing
+  // is still in flight.
+  async function waitForStableCount(getValue: () => number): Promise<number> {
+    let previous: number | null = null
+    await waitFor(
+      () => {
+        const current = getValue()
+        if (previous === null || current !== previous) {
+          previous = current
+          throw new Error('count still changing')
+        }
+      },
+      { timeout: 3000, interval: 100 },
+    )
+    return previous as unknown as number
+  }
+
+  // Swaps the `daemon` prop on click, letting a test drive an unrelated
+  // re-render (same values, a new object) or a real daemon change (new
+  // values) from outside SettingsPage.
+  function DaemonSwapHarness({
+    path,
+    initial,
+    swapTo,
+  }: {
+    path: string
+    initial?: { baseUrl: string; token: string | null }
+    swapTo?: { baseUrl: string; token: string | null }
+  }) {
+    const [daemon, setDaemon] = useState(initial)
+    return (
+      <div>
+        <button type="button" data-testid="swap-daemon" onClick={() => setDaemon(swapTo)}>
+          swap
+        </button>
+        <MemoryRouter initialEntries={[path]}>
+          <SettingsPage daemon={daemon} />
+        </MemoryRouter>
+      </div>
+    )
+  }
+
+  it('does not re-issue Connections requests on a re-render with the same daemon values', async () => {
+    const counts = { grants: 0, fonts: 0 }
+    vi.stubGlobal('fetch', countingFetch(counts))
+
+    render(
+      <DaemonSwapHarness
+        path="/settings/connections"
+        initial={DAEMON_A}
+        // Same baseUrl/token VALUES, but a new object — proves the memo key
+        // is the primitive fields, not object identity.
+        swapTo={{ baseUrl: DAEMON_A.baseUrl, token: DAEMON_A.token }}
+      />,
+    )
+    const mobile = screen.getByTestId('settings-mobile')
+    await within(mobile).findByText('Paired web apps')
+    const baseline = await waitForStableCount(() => counts.grants)
+    expect(baseline).toBeGreaterThanOrEqual(1)
+
+    fireEvent.click(screen.getByTestId('swap-daemon'))
+    const afterSwap = await waitForStableCount(() => counts.grants)
+    expect(afterSwap).toBe(baseline)
+  })
+
+  it('does not re-issue Fonts requests on a re-render with the same daemon values', async () => {
+    const counts = { grants: 0, fonts: 0 }
+    vi.stubGlobal('fetch', countingFetch(counts))
+
+    render(
+      <DaemonSwapHarness
+        path="/settings/fonts"
+        initial={DAEMON_A}
+        swapTo={{ baseUrl: DAEMON_A.baseUrl, token: DAEMON_A.token }}
+      />,
+    )
+    const baseline = await waitForStableCount(() => counts.fonts)
+    expect(baseline).toBeGreaterThanOrEqual(1)
+
+    fireEvent.click(screen.getByTestId('swap-daemon'))
+    const afterSwap = await waitForStableCount(() => counts.fonts)
+    expect(afterSwap).toBe(baseline)
+  })
+
+  it('re-issues Connections requests when the daemon baseUrl actually changes', async () => {
+    const counts = { grants: 0, fonts: 0 }
+    vi.stubGlobal('fetch', countingFetch(counts))
+
+    render(<DaemonSwapHarness path="/settings/connections" initial={DAEMON_A} swapTo={DAEMON_B} />)
+    const mobile = screen.getByTestId('settings-mobile')
+    await within(mobile).findByText('Paired web apps')
+    const baseline = await waitForStableCount(() => counts.grants)
+
+    fireEvent.click(screen.getByTestId('swap-daemon'))
+    const afterSwap = await waitForStableCount(() => counts.grants)
+    expect(afterSwap).toBeGreaterThan(baseline)
+  })
+
+  it('re-issues Connections requests when the daemon token changes to undefined', async () => {
+    const counts = { grants: 0, fonts: 0 }
+    vi.stubGlobal('fetch', countingFetch(counts))
+
+    render(
+      <DaemonSwapHarness
+        path="/settings/connections"
+        initial={DAEMON_A}
+        swapTo={{ baseUrl: DAEMON_A.baseUrl, token: null }}
+      />,
+    )
+    const mobile = screen.getByTestId('settings-mobile')
+    await within(mobile).findByText('Paired web apps')
+    const baseline = await waitForStableCount(() => counts.grants)
+
+    fireEvent.click(screen.getByTestId('swap-daemon'))
+    const afterSwap = await waitForStableCount(() => counts.grants)
+    expect(afterSwap).toBeGreaterThan(baseline)
+  })
+
+  it('renders the disconnected Connections and Fonts branches without a daemon, without throwing', () => {
+    expect(() =>
+      render(
+        <MemoryRouter initialEntries={['/settings/connections']}>
+          <SettingsPage />
+        </MemoryRouter>,
+      ),
+    ).not.toThrow()
+    expect(within(screen.getByTestId('settings-mobile')).getByText(/not connected/i)).toBeTruthy()
+    cleanup()
+    expect(() =>
+      render(
+        <MemoryRouter initialEntries={['/settings/fonts']}>
+          <SettingsPage />
+        </MemoryRouter>,
+      ),
+    ).not.toThrow()
+    expect(within(screen.getByTestId('settings-mobile')).getByText(/not connected/i)).toBeTruthy()
   })
 })

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -13,7 +13,15 @@ import {
   Waves,
   Wrench,
 } from 'lucide-react'
-import { useCallback, useEffect, useId, useRef, useState, useSyncExternalStore } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { AppVersionRow } from '@/components/settings/AppVersionRow'
 import { GestureTraceRow } from '@/components/settings/GestureTraceRow'
@@ -210,6 +218,17 @@ function ConnectionsSection({
   daemon?: ConnectedDaemon
   onDisconnected?: () => void
 }) {
+  // Keyed on the primitive fields, not `daemon` itself, so a re-render that
+  // rebuilds the same `daemon` object (a new reference, same values) does not
+  // rebuild this function — which would hand DaemonApiContext a new identity
+  // and re-fire every consumer effect keyed on it (PairedOriginsCard's
+  // load/fingerprint effects, StorageReportCard's fetch). Above the early
+  // return so hook order stays unconditional across the connected/
+  // disconnected branches; null-safe inside since `daemon` may be absent.
+  const daemonFetch = useMemo(
+    () => (daemon ? createDaemonFetch(daemon.baseUrl, daemon.token ?? undefined) : undefined),
+    [daemon?.baseUrl, daemon?.token],
+  )
   if (!daemon) {
     return (
       <div className="space-y-6">
@@ -225,9 +244,8 @@ function ConnectionsSection({
       </div>
     )
   }
-  const daemonFetch = createDaemonFetch(daemon.baseUrl, daemon.token ?? undefined)
   return (
-    <DaemonApiContext.Provider value={daemonFetch}>
+    <DaemonApiContext.Provider value={daemonFetch ?? null}>
       <div className="space-y-6">
         <section aria-label="Paired web apps">
           <PairedOriginsCard />
@@ -274,6 +292,13 @@ function stripScheme(baseUrl: string): string {
  * and saying so beats an empty list.
  */
 function FontsSection({ daemon }: { daemon?: ConnectedDaemon }) {
+  // See ConnectionsSection's daemonFetch comment: hoisted above the early
+  // return, keyed on the primitive fields so an unrelated re-render does not
+  // hand FontsCard's fetch-keyed effect a new identity to re-fire on.
+  const daemonFetch = useMemo(
+    () => (daemon ? createDaemonFetch(daemon.baseUrl, daemon.token ?? undefined) : undefined),
+    [daemon?.baseUrl, daemon?.token],
+  )
   if (!daemon) {
     return (
       <section>
@@ -286,7 +311,7 @@ function FontsSection({ daemon }: { daemon?: ConnectedDaemon }) {
     )
   }
   return (
-    <DaemonApiContext.Provider value={createDaemonFetch(daemon.baseUrl, daemon.token ?? undefined)}>
+    <DaemonApiContext.Provider value={daemonFetch ?? null}>
       <section aria-label="Fonts">
         <FontsCard />
       </section>


### PR DESCRIPTION
Applies the seven verified violations found by auditing 147 React source files against the newly imported `react-best-practices` skill (#1286). All behavior-preserving; each fix carries a red-first regression test (call-count / identity / equality), TDD per AGENTS.md.

## Fixes
1. **SettingsPage** — `createDaemonFetch` memoized (null-safe, hoisted above the early return) in ConnectionsSection + FontsSection; the `DaemonApiContext` value identity is now stable, so unrelated re-renders no longer re-issue the daemon identity ping, `/api/pairing/grants`, `/api/runtime/storage`, and the font catalogue fetches. Red test measured the refetch (4→6 fetches across one unrelated re-render).
2. **SpatialEditor** — `buildMinimapNodes` extracted; minimap colours resolve by `Map` lookup instead of `nodes.find` per box (O(n²)→O(n) per canvas edit).
3. **CanvasDisplaySettings** — contribution `groups` memoized on `[facetRegistry, widgets]`; both directions tested (no-recompute + invalidation), invalidation case mutation-checked.
4. **MinimapRail** — `railGeometry` memoized on `[blocks, railHeight]`; no longer rebuilt per scroll tick, and `seekTo`'s identity stops churning.
5. **VersionTimeline** — mini-graph rows/lookup maps in one `useMemo`; unrelated state churn (preview/restore/stale/loading) no longer re-runs `buildMiniGraph`.
6. **VersionTimeline** — `restoredFrom` lookup via `versionsById.get` instead of `find` inside the render loop. Honesty note: not independently red-first — rides inside fix 5's memo as a guarded refactor, pinned by the pre-existing restored-from rendering test (per the PlanReview Codex lane's objection; recorded in the commit body).
7. **MergeDialog** — `latestThumbnailVersion` single-pass max (strictly-greater, preserving first-among-ties) replaces filter+sort+`[0]`.

## Gates
- Review workflow (multi-dimension + adversarial verify + QA): 0 CRITICAL/HIGH; the one confirmed MEDIUM (missing invalidation-direction coverage on fix 3) is fixed in a follow-up commit, mutation-checked.
- `pnpm --filter @kamiazya/whiteboard-web test` (CI-matching, jsdom + node): 3592 tests green under `TZ=UTC`.
- `web-browser` (real Chromium, full 189-file run): touched-component files all green. One unrelated load-dependent failure in `folding-browser-index.conformance.browser.test.tsx` (not in this diff's 12 files; 38/38 green re-run in isolation — the integrator-flow discriminator for the load-dependent family).
- Known pre-existing, unrelated: `format-relative.test.ts` fails without `TZ=UTC` on a UTC+9 machine (TZ-dependent assertion; file untouched by this diff).

Visual evidence: none — behavior-preserving perf/memoization refactor with no pixel or flow change; the regression guards are the call-count/identity tests listed above (each confirmed red before its fix, e.g. `expected 4 to be 1` fetches, `expected "vi.fn()" to be called 1 times, but got 2 times`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7iuGxJAXjr6rEXfS7YAC6