### PR TITLE
fix(ci): scope the mutation lane to a merge-base range, not a moving one

### DIFF
--- a/.claude/scripts/mutation-scope.test.mjs
+++ b/.claude/scripts/mutation-scope.test.mjs
@@ -3,8 +3,13 @@
 // Run with: pnpm test:scripts (also wired into the CI "check" job).
 
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
 import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
 import { scopeToDiff } from './mutation-scope.mjs'
+
+const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
 
 const PREFIX = 'packages/canvas-render/'
 const CURATED = ['src/svg/format.ts', 'src/tidy.ts']
@@ -33,5 +38,49 @@ test('a glob in the curated list throws instead of matching nothing', () => {
   assert.throws(
     () => scopeToDiff(['src/**/*.ts'], [`${PREFIX}src/tidy.ts`], PREFIX),
     /cannot intersect a glob/,
+  )
+})
+
+// --- the range the scope is computed over ---
+//
+// `scopeToDiff` is only as honest as the file list handed to it, and the
+// workflow computes that list with `git diff`. A TWO-dot range against
+// `pull_request.base.sha` is where the base branch stood when the PR opened,
+// not the merge base — so once the base moves ahead, everything that landed
+// on it in between reads as a file THIS diff changed.
+//
+// Measured on #1293, which touched `apps/web` and `docs/` only: the two-dot
+// range reported six curated `canvas-render` files and the three-dot range
+// reported none. The lane ran and attributed ten survivors in a file that PR
+// never opened to that PR. The lane's whole stated purpose is that its PR
+// signal is trustworthy, so the input needs a guard as much as the filter.
+//
+// The same trap is already recorded for dev-loop in `.claude/rules`: it
+// "reviews a merge-base range, not a moving two-dot range".
+
+/** The `git diff` whose output becomes `--changed-from`. */
+function scopeDiffLines() {
+  return readFileSync(path.join(REPO_ROOT, '.github/workflows/mutation.yml'), 'utf8')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('git diff') && line.includes('changed.txt'))
+}
+
+// A regex that quietly stops matching reads exactly like a passing guard, so
+// the count is asserted on its own before anything is concluded from it.
+test('the workflow still computes the scope from a git diff', () => {
+  assert.equal(
+    scopeDiffLines().length,
+    1,
+    'expected exactly one `git diff ... > /tmp/changed.txt` in mutation.yml — if it moved, this guard is now reading nothing',
+  )
+})
+
+test('that diff is a merge-base range, so a moving base cannot widen the scope', () => {
+  const [line] = scopeDiffLines()
+  assert.match(
+    line ?? '',
+    /"\$BASE"\.\.\."\$HEAD"/,
+    `expected a three-dot (merge-base) range, got: ${line}`,
   )
 })

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -65,7 +65,14 @@ jobs:
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          git diff --name-only "$BASE" "$HEAD" > /tmp/changed.txt
+          # THREE dots: the merge base, not the base branch's tip. `base.sha` is
+          # where the base branch stood when the PR opened, so a two-dot range
+          # grows every time the base moves ahead — and everything that landed
+          # on it in between reads as a file this PR changed. Measured on
+          # #1293, which touched apps/web and docs only: two-dot reported six
+          # curated files and three-dot reported none, and the lane attributed
+          # ten survivors to a PR that never opened that file.
+          git diff --name-only "$BASE"..."$HEAD" > /tmp/changed.txt
           scoped=$(node .claude/scripts/mutation-scope.mjs \
             --targets ./packages/canvas-render/stryker-targets.mjs \
             --prefix packages/canvas-render/ \


### PR DESCRIPTION
## Summary

- The mutation lane computed "the files this diff changed" with a **two-dot** `git diff "$BASE" "$HEAD"`, where `$BASE` is `pull_request.base.sha` — where the base branch stood when the PR opened, not the merge base. Once the base moves ahead, everything that landed on it in between reads as a file this PR changed.
- Found by reading a comment it addressed to the wrong PR: #1293 touches `apps/web` and `docs/` only, and the lane posted ten survivors in `canvas-render/src/layout/nodes/truncate.ts` under it.
- Three dots fixes it, plus a guard so the range cannot quietly go back.

## The measurement

On #1293's head, with five commits landed on main while it was open:

```
git diff --name-only origin/main HEAD      → 6 canvas-render files
git diff --name-only origin/main...HEAD    → 0
```

The lane's whole stated purpose is in its own comment: *"The curated list is what keeps the PR signal trustworthy."* A survivor reported on a PR should be a survivor in code that PR wrote. Ten of them were information about somebody else's change, addressed to the wrong author — and because the lane is report-only, nothing anywhere went red about it.

`fetch-depth: 0` is already set on the checkout, so the merge base is reachable.

## Why the guard is on the workflow rather than the script

`scopeToDiff` was tested and correct throughout. It is only ever as honest as the file list handed to it, and that list comes from the workflow — so the input needed a guard as much as the filter does.

It asserts the scan's **own hit count first**, in its own test, per `.claude/rules/coverage-ledger.md`: a pattern that quietly stops matching reads exactly like a guard that checked, and would have sent the next reader to the wrong file.

The same trap is already recorded for dev-loop in `.claude/rules/dev-flow.md` — it *"reviews a merge-base range, not a moving two-dot range"*. This is that defect in a second workflow.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — `.claude/scripts/mutation-scope.test.mjs`, run by `pnpm test:scripts` in CI's `check` job
- [x] `pnpm test` passes locally — `test:scripts` 256 passed; the one failure is the pre-existing `compose-figure.test.mjs`, which hard-fails instead of skipping when ImageMagick is absent (untouched here, noted below)
- [ ] Manual verification completed — a workflow's own diff range cannot be exercised locally; the measurement above is against real branch state, and the next PR that opens while main moves is the live check
- [ ] E2E coverage added or extended where applicable — not applicable

Mutation-checked both ways: restoring the two-dot range fails the range assertion, breaking the scan's filter fails the count assertion. Baseline and restore green.

## Visual evidence

Visual evidence: none — a CI workflow's diff range moves no pixels. The evidence is the two `git diff` counts above.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — not user-visible; the reasoning is in the workflow beside the line and in the test
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

## Noted, not fixed here

`.claude/scripts/compose-figure.test.mjs` **fails** rather than skips when ImageMagick is absent — it probes correctly and then throws, which stops `pnpm check:local` completing on any machine without it. That contradicts this repo's own rule (*"a test whose PREMISE this environment cannot establish skips, and says so — probed, never inferred"*). Left alone to keep this PR to one subject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh)_