### PR TITLE
fix(mcp-server): register the auto-version signal synchronously, not through a dangling import

### DIFF
--- a/packages/canvas-render/vitest.node.config.ts
+++ b/packages/canvas-render/vitest.node.config.ts
@@ -6,6 +6,21 @@ export default defineProject({
     environment: 'node',
     include: ['src/**/*.test.ts'],
     exclude: ['src/**/*.browser.test.ts'],
+    // Vitest's default is 5s, which this project never chose — and the
+    // live-drag parity property sits right at it. Measured: 1427/1642/1512ms
+    // with its file alone, 4654ms with all vitest projects running, so the
+    // margin is a few hundred milliseconds of noise and the same run is red
+    // or green by luck. It timed out twice that way, each time reading as a
+    // property failure because @fast-check/vitest prints the seed in the test
+    // NAME — sending the reader after a shrunk counterexample that does not
+    // exist.
+    //
+    // 20s is ~4x the loaded measurement, and the number this package's own
+    // stryker config already declares. It does NOT double as a cost guard:
+    // spatial-canvas.bench.ts is what notices this path getting slower, and a
+    // timeout that tried to do both would have to sit close enough to the
+    // real cost to keep flaking.
+    testTimeout: 20_000,
     // `vitest bench` only — `vitest run` never picks these up, since
     // `include` above matches *.test.ts and nothing else.
     benchmark: { include: ['src/**/*.bench.ts'] },

--- a/packages/mcp-server/src/server/routes/document.test.ts
+++ b/packages/mcp-server/src/server/routes/document.test.ts
@@ -16,6 +16,24 @@ const { clearCache } = await import('../store/doc-cache.js')
 
 // Dynamically import the Hono app.
 const { createDocumentRouter } = await import('./document.js')
+const { currentAutoVersionSignal, setAutoVersionTrigger } = await import(
+  './document/auto-version.js'
+)
+
+describe('auto-version signal registration', () => {
+  it('is registered by the time the router exists, with no import left in flight', () => {
+    // The registration used to ride on `void import('./ws.js').then(...)`,
+    // which nobody awaited. Two consequences, and this pins both: a WS
+    // message arriving before it landed signalled the no-op and took no
+    // checkpoint, and the promise outlived the test that built the router —
+    // measured at two still in flight when a file's last test ended, which is
+    // how a fully passing mcp-node run exits 1 on an EnvironmentTeardownError.
+    const sentinel = () => {}
+    setAutoVersionTrigger(sentinel)
+    createDocumentRouter()
+    expect(currentAutoVersionSignal()).not.toBe(sentinel)
+  })
+})
 
 // canvas.ts's own job is composing the canvas/*.ts sub-routers into one
 // router (see route-coverage.test.ts, which requires every route source

--- a/packages/mcp-server/src/server/routes/document.ts
+++ b/packages/mcp-server/src/server/routes/document.ts
@@ -3,7 +3,11 @@ import { Hono } from 'hono'
 import { getLogger } from '../log.js'
 import { installAutoCompact } from '../store/auto-compact.js'
 import { FileVersionStore, type VersionStore } from '../store/version-store.js'
-import { type AutoVersionTrigger, createAutoVersionTrigger } from './document/auto-version.js'
+import {
+  type AutoVersionTrigger,
+  createAutoVersionTrigger,
+  setAutoVersionTrigger,
+} from './document/auto-version.js'
 import { createDocumentSvgExportRouter } from './document/export-svg.js'
 import { createLiveDocRouter } from './document/live-doc.js'
 import { createMaintenanceRouter } from './document/maintenance.js'
@@ -71,11 +75,10 @@ export function createDocumentRouter(options: DocumentRouterOptions = {}) {
     },
   })
   options.onAutoVersionTrigger?.(triggerAutoVersion)
-  // Register the same trigger with ws.ts so the WS path shares the auto-version logic.
-  // Use dynamic import to avoid the ws.ts <- canvas.ts cycle evaluating in the wrong order.
-  void import('./ws.js').then(({ setAutoVersionTrigger }) => {
-    setAutoVersionTrigger?.(triggerAutoVersion)
-  })
+  // Register the same trigger for the WS path, synchronously. The holder is
+  // auto-version.ts rather than ws.ts precisely so this needs no import of a
+  // module that imports back — see its comment for the promise this replaced.
+  setAutoVersionTrigger(triggerAutoVersion)
 
   // Auto-compact debounce: every successful saveDocument reschedules a per-
   // canvas compaction. The 30s default lets active editing sessions burst

--- a/packages/mcp-server/src/server/routes/document/auto-version.ts
+++ b/packages/mcp-server/src/server/routes/document/auto-version.ts
@@ -61,6 +61,44 @@ export interface AutoVersionTrigger {
   stop(): void
 }
 
+/**
+ * The "this document changed" signal, held where BOTH halves can import it
+ * statically.
+ *
+ * `document.ts` registers it and `ws.ts` calls it, and those two cannot import
+ * each other — the di wiring's chain closes a value cycle back through
+ * canvas-client-notifier. document.ts bridged that with
+ * `void import('./ws.js').then(...)`, a promise nobody awaited: measured, TWO
+ * were still in flight when a router-building test file's last test ended, so
+ * whether that module graph finished before vitest tore the environment down
+ * was a coin flip. Losing it read as
+ * `EnvironmentTeardownError: Cannot load .../timing-safe.ts` — an unhandled
+ * rejection that exits the run 1 while every test reports passed, which is the
+ * most misleading shape a red run has.
+ *
+ * A third module both halves can see costs nothing and leaves nothing in
+ * flight. It also closes a real if narrow window: registration is now
+ * synchronous, where before a WS message arriving between the router's
+ * construction and the import's landing signalled the no-op below and took no
+ * checkpoint at all.
+ *
+ * Looser than `AutoVersionTrigger` deliberately — a caller needs the call
+ * signature and nothing else, and ws.ts's own tests register a bare function
+ * carrying neither `flush` nor `stop`.
+ */
+export type AutoVersionSignal = (workspaceId: string, path: string, doc: LoroDoc) => void
+
+let registeredSignal: AutoVersionSignal = () => {}
+
+export function setAutoVersionTrigger(fn: AutoVersionSignal): void {
+  registeredSignal = fn
+}
+
+/** The registered signal, or the no-op that stands in before one arrives. */
+export function currentAutoVersionSignal(): AutoVersionSignal {
+  return registeredSignal
+}
+
 interface Pending {
   timer: ReturnType<typeof setTimeout>
   doc: LoroDoc

--- a/packages/mcp-server/src/server/routes/ws.ts
+++ b/packages/mcp-server/src/server/routes/ws.ts
@@ -1,7 +1,6 @@
 import type { IncomingMessage } from 'node:http'
 import { applyWorkspaceDocumentUpdate, type ServerDeps } from '@kamiazya/whiteboard-server-core'
 import { SpanKind } from '@opentelemetry/api'
-import type { LoroDoc } from 'loro-crdt'
 import type { RawData, WebSocket } from 'ws'
 import type { VersionEntry } from '../../shared/api-contracts/document.js'
 import type { AgentActivityMessage, ServerTextMessage } from '../../shared/ws-messages.js'
@@ -121,14 +120,14 @@ setSyncSseHooks({
   resolveViewportRequest: (requestId) => resolveViewportFn?.(requestId),
 })
 
-// Injected from document.ts. Called after every WS binary message to SIGNAL
-// that the document changed; the checkpoint itself lands once the document
-// goes quiet, and the trigger broadcasts it from there.
-type AutoVersionTrigger = (workspaceId: string, path: string, doc: LoroDoc) => void
-var autoVersionTrigger: AutoVersionTrigger = () => {}
-export function setAutoVersionTrigger(fn: AutoVersionTrigger): void {
-  autoVersionTrigger = fn
-}
+// Registered from document.ts and called after every WS binary message to
+// SIGNAL that the document changed; the checkpoint itself lands once the
+// document goes quiet, and the trigger broadcasts it from there. The holder
+// lives in auto-version.ts so neither side needs an import of the other — see
+// its comment for the dangling promise that arrangement replaced.
+export { setAutoVersionTrigger } from './document/auto-version.js'
+
+import { currentAutoVersionSignal } from './document/auto-version.js'
 
 // Test-only completion signal for the WS persistence path. Firing strictly
 // after `saveDocument` resolves lets a real-socket test await a deterministic
@@ -483,7 +482,7 @@ export async function handleWsUpgrade(
       resolvedDeps.liveDocuments
         .get(workspaceId, path)
         .then((doc) => {
-          autoVersionTrigger(workspaceId, path, doc)
+          currentAutoVersionSignal()(workspaceId, path, doc)
         })
         .catch((err: unknown) => {
           getLogger('ws').error({ err: err as Error }, 'auto-version trigger failed')


### PR DESCRIPTION
Two flakes, each of which turns a **fully passing** suite red. They are in one PR because this session develops on a single designated branch and the first had not merged yet; they are independent and can be read as two commits.

## 1. `fix(mcp-server)` — mcp-node exits 1 while every test passes

The symptom is the most misleading a red run has: the summary says green and only the exit code disagrees, on an unhandled `EnvironmentTeardownError: Cannot load .../timing-safe.ts ... after the environment was torn down`, blamed on whichever test file happened to be named.

The cause is `createDocumentRouter`'s `void import('./ws.js').then(setAutoVersionTrigger)` — fired per router, awaited by nobody. **Measured** with a probe in `afterAll`: `pending=2` — two of those imports were still in flight when a router-building test file's last test ended, so whether that graph (`ws.js → auth-strategy → bearer-token → timing-safe`) finished before vitest tore the environment down was a coin flip. `pending=0` would have refuted it.

That measurement also explains why the earlier investigation stalled on *"every import in the chain is static, so hoisting fixes nothing"* — true, and beside the point: **the dynamic edge is the ROOT of the chain, not a link inside it.**

The holder moves to `auto-version.ts`, which both halves already import statically and which reaches neither, so the cycle the dynamic import existed to avoid never arises and nothing is left in flight. `ws.ts` re-exports the setter, so its tests are untouched.

It also closes a real if narrow window in production: registration is now synchronous, where a WS message arriving between the router's construction and the import's landing used to signal the no-op and take **no checkpoint at all**.

The remaining `import('./ws.js')` in `onSaved` stays — it fires on a save rather than per router, and carries a `.catch`, so it logs instead of becoming an unhandled rejection.

## 2. `test(canvas-render)` — a property sitting on its budget's edge

The live-drag parity property was failing full runs about half the time, and every failure read as a *property* failure: `@fast-check/vitest` prints the seed in the test NAME, so `... (with seed=-507398624)` sends the reader after a shrunk counterexample that does not exist.

Measured: **1427 / 1642 / 1512ms** with its file alone, **4654ms** with every vitest project running — a 3× load factor against a **5000ms** budget, leaving 346ms. The same run is red or green by luck, which is why an isolated re-run always passed and proved nothing.

5s was never chosen: it is vitest's default, and `canvas-render-node` was the one project declaring no timeout while `mcp-node` takes 10s, `web-browser` 60s, and *this package's own stryker config* already 20s. So the fix is the budget the measurement asks for — not a smaller `numRuns` (which buys it by covering less) and not a pinned seed, both ruled out for this shape by `integrator-flow.md`. The timeout deliberately does **not** double as a cost guard; `spatial-canvas.bench.ts` is what notices this path getting slower, and a timeout sized close enough to catch a regression is one that keeps flaking.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [x] `pnpm test` passes locally
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable

Red-first on (1): the registry and `ws.ts`'s wiring landed first with `document.ts` still holding the dynamic import, the new test went red on `expect(currentAutoVersionSignal()).not.toBe(sentinel)`, and removing the dangling import turned it green. The dangling-promise path is now gone structurally rather than made less likely.

`mcp-node`: **376 files, 4235 passed | 9 skipped, exit 0**, no unhandled errors. `canvas-render-node`: 1100 passed. The measuring run for (2) was a full `pnpm test`: 11570 passed, everything green. `pnpm -r typecheck`, `pnpm lint`, `pnpm knip` clean.

**Visual evidence: none — a teardown-ordering fix and a test-runner budget have no user-visible surface.**

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu