### PR TITLE
ci: required checks report on merge_group, so a queue cannot stall on them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: ci
 
 on:
   pull_request:
+  # For the merge queue: its speculative merge commits fire `merge_group`,
+  # and a required check that never reports on that event stalls the whole
+  # queue until timeout. Harmless while no queue is configured — the event
+  # simply never fires.
+  merge_group:
   push:
     branches: [main]
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,6 +12,12 @@ name: pr-title
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+  # Required checks must also report on the merge queue's speculative
+  # commits or the queue stalls. A merge_group event carries no PR title to
+  # validate — and needs none: a PR only enters the queue after this check
+  # passed on the PR itself, `edited` included. The job below passes
+  # through on this event.
+  merge_group:
 
 permissions:
   contents: read
@@ -28,6 +34,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate PR title
+        if: github.event_name == 'pull_request'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: node tools/check-pr-title.mjs "$PR_TITLE"
+
+      - name: Pass through for a merge group
+        if: github.event_name == 'merge_group'
+        run: echo "title already validated on the pull request that entered the queue"


### PR DESCRIPTION
Groundwork for enabling the merge queue: its speculative merge commits fire `merge_group`, and **a required check that never reports on that event stalls the whole queue until timeout** — the classic first-day failure of turning a queue on.

Every required check lives in two workflows (list read from branch protection, not remembered):

| workflow | required checks | change |
|---|---|---|
| `ci.yml` | verify, check, test-unit (1)(2), test-jsdom, test-browser (1)(2), widget-smoke | `merge_group:` trigger added; the concurrency group keys on `github.ref` and merge-group refs are unique, so cancel-in-progress cannot cancel a neighbour |
| `pr-title.yml` | pr-title | trigger + a pass-through step — a `merge_group` event carries no PR title to validate, and needs none: a PR only enters the queue after this check passed on the PR itself, `edited` included |

**Harmless while no queue is configured** — the event simply never fires; nothing changes for today's PRs (this PR's own run is the proof).

Release guards: 514 passed. Enabling the queue itself (merge method squash, required checks as above) is a repository setting and stays a human step.

Visual evidence: none — workflow triggers; the evidence is this PR's own unchanged check run and the 514 passing release guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cmbb1zNhiZitB7tn9LQ5f3