### PR TITLE
fix(web): a read that did not complete stops claiming the document is damaged

### DIFF
--- a/apps/web/src/lib/browser-backend.read-failure.test.ts
+++ b/apps/web/src/lib/browser-backend.read-failure.test.ts
@@ -1,0 +1,89 @@
+/**
+ * What the reader is TOLD when the workspace record does not come back.
+ *
+ * Two failures reach the same `catch`, and they are about different things:
+ *
+ * - the record is there and this build cannot make sense of it — a claim
+ *   about the DATA, and the one `corrupt-snapshot` exists to make;
+ * - the read did not complete at all — a blocked open (another tab holding
+ *   this app at an older version, which `openWhiteboardDb` rejects by name),
+ *   an aborted transaction, storage that went away. Nothing about the stored
+ *   document is known, and saying it "could not be read" accuses intact data.
+ *
+ * The second one is not hypothetical: the page turns `corrupt-snapshot` into
+ * a full-page "This canvas’s data could not be read." — the editor replaced
+ * by a banner and a Start fresh button — so a reader whose second tab is
+ * merely stale is shown their work as damaged. `document-read-failure.ts`
+ * states the rule this breaks: every sentence there is about the STORAGE,
+ * never about the document being missing.
+ *
+ * Worse than a wrong sentence: the page answers `corrupt-snapshot` with a
+ * `Start fresh` button, which DELETES the record. Someone whose only problem
+ * was a second tab is one click from losing the document.
+ *
+ * `read-unavailable` keeps the page-level treatment — the content did not
+ * arrive either way, and an editor over an empty canvas would be its own lie
+ * — and changes what is said and what is offered.
+ */
+import { StoredDocumentUnreadableError } from '@kamiazya/whiteboard-ports'
+import type { WorkspaceDocs } from '@kamiazya/whiteboard-workspace-index'
+import { describe, expect, it, vi } from 'vitest'
+import { BrowserBackend } from './browser-backend.js'
+import type { DocumentFileStore } from './document-file-store.js'
+import type { LoroStore } from './loro-store.js'
+
+const TARGET = {
+  documentId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+  path: 'notes/reviewed',
+  kind: 'spatial' as const,
+}
+
+/** A workspace store whose every read fails with the given error. */
+function docsFailingWith(error: unknown): WorkspaceDocs {
+  return {
+    open: () => Promise.reject(error),
+    create: () => Promise.reject(error),
+    save: () => Promise.reject(error),
+    readCursor: () => Promise.reject(error),
+    catchUp: () => Promise.reject(error),
+  } as unknown as WorkspaceDocs
+}
+
+function connectAgainst(error: unknown): { reasons: string[] } {
+  const reasons: string[] = []
+  const legacy = { load: async () => ({ kind: 'not-found' }) as const } as unknown as LoroStore
+  const files = {} as unknown as DocumentFileStore
+  const backend = new BrowserBackend(TARGET, docsFailingWith(error), files, legacy)
+  backend.connect({
+    onConnected: () => {},
+    onSnapshot: (_snapshot: Uint8Array) => {},
+    onError: (reason: string) => reasons.push(reason),
+  } as never)
+  return { reasons }
+}
+
+describe('what a failed workspace read is reported as', () => {
+  it('says the record is unreadable only when the store said so', async () => {
+    const { reasons } = connectAgainst(
+      new StoredDocumentUnreadableError('malformed', 'chunks do not match the manifest'),
+    )
+    await vi.waitFor(() => expect(reasons).toEqual(['corrupt-snapshot']))
+  })
+
+  it('reports a read that never completed as unavailable, not as damage', async () => {
+    // The exact rejection `openWhiteboardDb` produces when another tab holds
+    // an older version. Nothing is known about the stored document here.
+    const { reasons } = connectAgainst(
+      new Error('another tab has this app open at an older version; close it and reload'),
+    )
+    await vi.waitFor(() => expect(reasons).toEqual(['read-unavailable']))
+  })
+
+  it('treats an aborted IndexedDB transaction the same way', async () => {
+    // The shape a transaction abort arrives in. Grouped with the case above
+    // rather than listed as its own rule: what makes both storage failures is
+    // that neither says anything about the bytes.
+    const { reasons } = connectAgainst(new DOMException('transaction aborted', 'AbortError'))
+    await vi.waitFor(() => expect(reasons).toEqual(['read-unavailable']))
+  })
+})

--- a/apps/web/src/lib/browser-backend.ts
+++ b/apps/web/src/lib/browser-backend.ts
@@ -10,6 +10,7 @@ import type {
   DocumentBackendHandlers,
 } from '@kamiazya/whiteboard-mcp/browser-contract'
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
+import { isStoredDocumentUnreadableError } from '@kamiazya/whiteboard-ports'
 import type { WorkspaceDocs } from '@kamiazya/whiteboard-workspace-index'
 import { Loro, type LoroDoc } from 'loro-crdt'
 import { getAppLogger } from './app-logger.js'
@@ -269,10 +270,32 @@ export class BrowserBackend implements DocumentBackend {
     let workspaceDoc: LoroDoc
     try {
       workspaceDoc = await this.docs.create(getBrowserWorkspaceId())
-    } catch {
-      // The workspace record would not read back. Every document is in it,
-      // so this is the browser twin of a corrupt per-document snapshot.
-      if (!this.isStale(handlers)) handlers.onError?.('corrupt-snapshot')
+    } catch (err) {
+      // WHICH failure this was decides what the reader is told, and the two
+      // sentences are about different things.
+      //
+      // A typed unreadable error is a claim about the RECORD: every document
+      // is in the workspace document, so this is the browser twin of a
+      // corrupt per-document snapshot, and `corrupt-snapshot` is what the
+      // page turns into a full-page "This canvas’s data could not be read."
+      //
+      // Anything else is a read that never completed — a blocked open
+      // (another tab holding this app at an older version, which
+      // `openWhiteboardDb` rejects by name), an aborted transaction, storage
+      // that went away. Nothing about the stored bytes is known, and calling
+      // that damage accuses data that is sitting intact on disk — the one
+      // thing `document-read-failure.ts` says these sentences must never do,
+      // and worse, the page answers `corrupt-snapshot` with a Start fresh
+      // button that DELETES the record. `read-unavailable` keeps the page
+      // level treatment, since the content did not arrive either way and an
+      // editor over an empty canvas would be its own lie, and changes what
+      // is said and what is offered.
+      if (!this.isStale(handlers)) {
+        handlers.onError?.(
+          isStoredDocumentUnreadableError(err) ? 'corrupt-snapshot' : 'read-unavailable',
+        )
+      }
+      getAppLogger('browser-backend').warn('opening the workspace record failed', err)
       return
     }
     if (this.isStale(handlers)) return

--- a/apps/web/src/lib/document-read-failure.ts
+++ b/apps/web/src/lib/document-read-failure.ts
@@ -12,12 +12,25 @@
  * being empty or missing: the bytes are there, and telling their owner
  * otherwise is the one thing this must not do.
  */
-export type DocumentReadFailure = 'unsupported-version' | 'corrupt-snapshot' | 'corrupt-delta'
+export type DocumentReadFailure =
+  | 'unsupported-version'
+  | 'corrupt-snapshot'
+  | 'corrupt-delta'
+  | 'read-unavailable'
 
 const MESSAGES: Record<DocumentReadFailure, string> = {
   'unsupported-version': 'This canvas was saved by a newer version of the app. Update to open it.',
   'corrupt-snapshot': 'This canvas’s data could not be read.',
   'corrupt-delta': 'This canvas’s edit history could not be read.',
+  // The fourth is the one that is NOT about the bytes: storage did not answer,
+  // so nothing at all is known about them. It belongs here rather than under
+  // `storage-failure` because the consequence is the same as the others' —
+  // the content never arrived, so there is no document to edit and the editor
+  // must not be presented over an empty canvas. What it must NOT share is the
+  // recovery: `Start fresh` deletes the record, and offering that over data
+  // whose only problem was a blocked read is how someone loses work by
+  // opening a document twice.
+  'read-unavailable': 'This canvas could not be opened just now. Its data has not been changed.',
 }
 
 export function documentReadFailureMessage(kind: DocumentReadFailure): string {

--- a/apps/web/src/pages/BrowserDocumentPage.read-unavailable.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.read-unavailable.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * The recovery a failed open offers, which is the half of this that can
+ * destroy something.
+ *
+ * `Start fresh` DELETES the record. It is the right last resort for a
+ * document this build genuinely cannot read — there is nothing to lose that
+ * is not already lost — and it is the worst button in the app to put in front
+ * of someone whose read was merely blocked, because their work is intact and
+ * one click removes it. Until `read-unavailable` existed, every failure to
+ * open the workspace record took that branch, so a second tab at an older
+ * version was enough to be offered the delete.
+ */
+import type { DocumentBackendHandlers } from '@kamiazya/whiteboard-mcp/browser-contract'
+import { cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, expect, it, vi } from 'vitest'
+import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
+import { LocalStoreDouble } from '../test-utils/local-index.js'
+
+vi.mock('../components/spatial-editor/index.js', () => ({
+  SpatialEditor: () => <div data-testid="mock-spatial-editor" />,
+}))
+
+// A backend whose load never completes, reporting the reason this file is
+// about. Nothing is said about the stored bytes.
+vi.mock('../lib/browser-backend.js', async () => {
+  const { FakeBrowserBackend } = await import('../test-utils/fake-browser-backend.js')
+  class UnavailableBackend extends FakeBrowserBackend {
+    // Named from the published contract rather than derived off the base
+    // class: inside a `vi.mock` factory the base is a dynamic import, so a
+    // `Parameters<…>` lookup over it resolves to `unknown`.
+    connect(handlers: DocumentBackendHandlers): void {
+      handlers.onConnected()
+      handlers.onError?.('read-unavailable')
+    }
+  }
+  return { BrowserBackend: UnavailableBackend }
+})
+
+const { BrowserDocumentPage } = await import('./BrowserDocumentPage.js')
+
+function render(ui: ReactElement) {
+  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>)
+}
+
+const snap: DocumentSnapshot = {
+  documentId: '0W16BGNTZ49EKRX27CHPV05AFM',
+  workspaceId: 'local',
+  path: 'notes/reviewed',
+  name: 'Reviewed',
+  updatedAt: '2026-09-04T00:00:00.000Z',
+  kind: 'spatial' as const,
+}
+
+afterEach(cleanup)
+
+it('offers a retry and never the delete when the read simply did not complete', async () => {
+  const store = new LocalStoreDouble()
+  await store.setDefaultDocumentId(snap.documentId)
+  await store.save(snap)
+
+  render(
+    <BrowserDocumentPage
+      store={store.index}
+      pointer={store.pointer}
+      clock={store.clock}
+      loro={store.loro}
+    />,
+  )
+
+  await waitFor(() => expect(screen.getByRole('button', { name: /try again/i })).toBeTruthy())
+  // The load-bearing half. A retry beside a delete would still be a delete
+  // one slip away.
+  expect(screen.queryByRole('button', { name: /start fresh/i })).toBeNull()
+  // And it says what happened without claiming the data is damaged.
+  expect(screen.getByRole('alert').textContent).toMatch(/has not been changed/i)
+})

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -839,13 +839,30 @@ export function BrowserDocumentPage({
   if (renderState.kind === 'load-degraded') {
     return (
       <LoadDegradedView message={renderState.message}>
-        <button
-          type="button"
-          onClick={() => void startFresh()}
-          className="rounded-md border bg-background px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-accent"
-        >
-          Start fresh
-        </button>
+        {/* WHICH recovery is offered follows what the failure knows, and
+            getting it wrong is destructive rather than merely unhelpful:
+            `Start fresh` deletes the record, which is the right last resort
+            for a document this build cannot read, and the worst possible
+            button for one whose read was simply blocked — the data is
+            intact and one click removes it. So the retry is what an
+            unavailable read gets, and it is the only affordance there. */}
+        {backendError === 'read-unavailable' ? (
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="rounded-md border bg-background px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-accent"
+          >
+            Try again
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => void startFresh()}
+            className="rounded-md border bg-background px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-accent"
+          >
+            Start fresh
+          </button>
+        )}
       </LoadDegradedView>
     )
   }

--- a/packages/mcp-server/src/shared/document-backend-contract.ts
+++ b/packages/mcp-server/src/shared/document-backend-contract.ts
@@ -105,11 +105,26 @@ export interface DocumentBackendHandlers {
    * 'corrupt-snapshot': the persisted snapshot bytes are not valid Loro bytes.
    * 'corrupt-delta': one of the persisted delta bytes is not valid Loro bytes.
    * 'unsupported-version': the envelope version number is not supported.
-   * 'storage-failure': IDB open, transaction, or write failed; or corrupt record
-   *   detected during a pushLocalUpdate (delta would be lost).
+   * 'read-unavailable': the LOAD did not complete, so nothing is known about
+   *   the stored bytes — a blocked IDB open (another tab at an older
+   *   version), an aborted transaction, storage that went away. Distinct from
+   *   the three above because those are claims about the record and this one
+   *   is not: a caller that conflates them tells someone their work is
+   *   damaged over data that is intact, and may offer a delete as the
+   *   recovery. Distinct from 'storage-failure' because the content never
+   *   arrived, so there is nothing to edit — a caller must not present an
+   *   editor over an empty document.
+   * 'storage-failure': a WRITE did not land — IDB open, transaction, or write
+   *   failed; or a corrupt record detected during a pushLocalUpdate (delta
+   *   would be lost). The document on screen is still the document.
    */
   onError?: (
-    reason: 'corrupt-snapshot' | 'corrupt-delta' | 'unsupported-version' | 'storage-failure',
+    reason:
+      | 'corrupt-snapshot'
+      | 'corrupt-delta'
+      | 'unsupported-version'
+      | 'read-unavailable'
+      | 'storage-failure',
   ) => void
 }
 

--- a/packages/workspace-index/src/document-store-workspace-docs.ts
+++ b/packages/workspace-index/src/document-store-workspace-docs.ts
@@ -12,7 +12,12 @@
  * constructor argument and nothing else.
  */
 import type { DocRef, DocumentStore } from '@kamiazya/whiteboard-ports'
-import { chunkSnapshot, reassembleSnapshot, shouldCompact } from '@kamiazya/whiteboard-ports'
+import {
+  chunkSnapshot,
+  reassembleSnapshot,
+  StoredDocumentUnreadableError,
+  shouldCompact,
+} from '@kamiazya/whiteboard-ports'
 import { LoroDoc, VersionVector } from 'loro-crdt'
 import type { CaughtUp, WorkspaceDocCursor, WorkspaceDocs } from './workspace-docs.js'
 
@@ -20,6 +25,33 @@ const MAX_CHUNK_BYTES = 1_000_000
 
 function refOf(workspaceId: string): DocRef {
   return { kind: 'workspace-tree', workspaceId }
+}
+
+/**
+ * Import bytes that came OUT of the record, and say so when the CRDT refuses
+ * them.
+ *
+ * `open` can fail two ways and a caller has to tell them apart before it can
+ * say anything true to a person: the store did not answer (a transaction
+ * aborted, a connection blocked behind another tab), or the bytes it DID
+ * answer are not a document. Only this layer knows both halves at once —
+ * that these bytes are the record, and that loro-crdt rejected them — so the
+ * typing belongs here rather than at any call site.
+ *
+ * Untyped, the second arrived as whatever loro threw ("Decode error: (Invalid
+ * import data)") and was indistinguishable from the first, which is how
+ * `apps/web` came to classify every failed read as damage and show a healthy
+ * document behind "This canvas’s data could not be read."
+ */
+function importStored(doc: LoroDoc, bytes: Uint8Array, workspaceId: string): void {
+  try {
+    doc.import(bytes)
+  } catch (cause) {
+    throw new StoredDocumentUnreadableError(
+      'malformed',
+      `stored workspace document ${workspaceId} could not be imported: ${String(cause)}`,
+    )
+  }
 }
 
 export class DocumentStoreWorkspaceDocs implements WorkspaceDocs {
@@ -30,9 +62,9 @@ export class DocumentStoreWorkspaceDocs implements WorkspaceDocs {
     const stored = await this.store.loadSnapshot({ docRef })
     if (stored === null) return null
     const doc = new LoroDoc()
-    doc.import(reassembleSnapshot(stored.manifest, stored.chunks))
+    importStored(doc, reassembleSnapshot(stored.manifest, stored.chunks), workspaceId)
     const { updates } = await this.store.loadDeltas({ docRef, afterSeq: null })
-    for (const update of updates) doc.import(update)
+    for (const update of updates) importStored(doc, update, workspaceId)
     return doc
   }
 

--- a/packages/workspace-index/src/document-store-workspace-docs.unreadable.test.ts
+++ b/packages/workspace-index/src/document-store-workspace-docs.unreadable.test.ts
@@ -1,0 +1,103 @@
+/**
+ * What `open` raises when the record is there and cannot be made sense of.
+ *
+ * The distinction this pins is not cosmetic. `open` has two ways to fail —
+ * the store could not be read (a transaction aborted, a connection blocked),
+ * and the bytes the store DID return are not a document — and a caller has to
+ * tell them apart to say anything true to a person: one is "storage is having
+ * a moment", the other is "this record is damaged". Until the CRDT's refusal
+ * was typed, the second arrived as whatever loro-crdt threw, indistinguishable
+ * from the first, so `apps/web`'s backend classified every failure as damage
+ * and showed a healthy document as unreadable.
+ *
+ * Typed HERE rather than at the call site because this is the only layer that
+ * knows both facts at once: that the bytes came out of the record, and that
+ * the CRDT refused them.
+ */
+import type {
+  AppendDeltasInput,
+  AppendDeltasResult,
+  DeleteDocInput,
+  DocumentStore,
+  LoadDeltasInput,
+  LoadDeltasResult,
+  LoadSnapshotInput,
+  LoadSnapshotResult,
+  ReadFrontierInput,
+  ReadFrontierResult,
+  ReadSnapshotManifestInput,
+  ReadSnapshotManifestResult,
+  SaveCompactedSnapshotInput,
+  SaveCompactedSnapshotResult,
+  SaveSnapshotInput,
+} from '@kamiazya/whiteboard-ports'
+import { isStoredDocumentUnreadableError } from '@kamiazya/whiteboard-ports'
+import { LoroDoc } from 'loro-crdt'
+import { expect, it } from 'vitest'
+import { DocumentStoreWorkspaceDocs } from './document-store-workspace-docs.js'
+
+/**
+ * A store that answers a manifest and chunks which AGREE with each other —
+ * so nothing before the import can refuse them — over bytes that are not a
+ * loro snapshot. That is the shape a half-written or bit-rotted record has,
+ * and the only thing left to notice it is the CRDT.
+ */
+function storeHolding(bytes: Uint8Array<ArrayBuffer>): DocumentStore {
+  const chunks: SaveSnapshotInput['chunks'] = [{ index: 0, of: 1, bytes }]
+  return {
+    async loadSnapshot(_input: LoadSnapshotInput): Promise<LoadSnapshotResult> {
+      return {
+        manifest: { chunkCount: 1, totalBytes: bytes.byteLength, maxChunkBytes: bytes.byteLength },
+        chunks,
+        frontier: new Uint8Array(),
+      }
+    },
+    async loadDeltas(_input: LoadDeltasInput): Promise<LoadDeltasResult> {
+      return { updates: [], lastSeq: null, generation: 1, frontier: new Uint8Array() }
+    },
+    async readSnapshotManifest(_i: ReadSnapshotManifestInput): Promise<ReadSnapshotManifestResult> {
+      return null
+    },
+    async readFrontier(_input: ReadFrontierInput): Promise<ReadFrontierResult> {
+      return null
+    },
+    async saveSnapshot(_input: SaveSnapshotInput): Promise<void> {},
+    async saveCompactedSnapshot(
+      _input: SaveCompactedSnapshotInput,
+    ): Promise<SaveCompactedSnapshotResult> {
+      return { ok: true, generation: 1 }
+    },
+    async appendDeltas(_input: AppendDeltasInput): Promise<AppendDeltasResult> {
+      return { frontier: new Uint8Array() }
+    },
+    async deleteDoc(_input: DeleteDocInput): Promise<void> {},
+  } as unknown as DocumentStore
+}
+
+it('raises a typed unreadable error when the stored snapshot is not a document', async () => {
+  const docs = new DocumentStoreWorkspaceDocs(storeHolding(new Uint8Array([1, 2, 3, 4, 5])))
+
+  await expect(docs.open('ws')).rejects.toSatisfy(isStoredDocumentUnreadableError)
+})
+
+it('raises the same when a stored DELTA is not importable', async () => {
+  // A snapshot that reads and a log entry that does not: the record is still
+  // the thing at fault, and the second import is as much part of reading it
+  // as the first.
+  const sound = new LoroDoc()
+  sound.getMap('meta').set('title', 'readable')
+  sound.commit()
+  const store = storeHolding(new Uint8Array(sound.export({ mode: 'snapshot' })))
+  store.loadDeltas = async () => ({
+    updates: [new Uint8Array([9, 9, 9])],
+    lastSeq: 1,
+    generation: 1,
+    frontier: new Uint8Array(),
+  })
+
+  await expect(docs_open(store)).rejects.toSatisfy(isStoredDocumentUnreadableError)
+})
+
+function docs_open(store: DocumentStore): Promise<unknown> {
+  return new DocumentStoreWorkspaceDocs(store).open('ws')
+}


### PR DESCRIPTION
## Summary

Chasing a CI failure whose DOM was the full-page **"This canvas’s data could not be read."** led to a `catch` with no discrimination in it:

```ts
try { workspaceDoc = await this.docs.create(getBrowserWorkspaceId()) }
catch { handlers.onError?.('corrupt-snapshot'); return }
```

Every way that read can fail becomes a claim about the **data**. One of those ways is `openWhiteboardDb`'s own `req.onblocked`, which rejects by name with *"another tab has this app open at an older version; close it and reload"* — so a reader whose only problem is a second tab is told their work is unreadable. And the page answers `corrupt-snapshot` with a **Start fresh** button, which **deletes the record**: the misreport does not stop at a wrong sentence, it puts the destroying action in front of intact data.

`document-read-failure.ts` already states the rule this breaks — every sentence there is about the STORAGE, never about the document being missing.

Three changes, one per layer, each with its own test:

- **`DocumentStoreWorkspaceDocs.open`** wraps its two `doc.import` calls in `StoredDocumentUnreadableError`. This is the only layer that knows both halves at once — that the bytes came out of the record, and that the CRDT refused them — so it is where a caller's discrimination has to come from. Untyped, that arrived as `Decode error: (Invalid import data)`, indistinguishable from a transaction that aborted.
- **The backend contract** gains `read-unavailable`: the load did not complete, so nothing is known about the stored bytes. Distinct from the three corrupt-record reasons because those are claims about the record; distinct from `storage-failure` because the content never arrived, so a caller must not present an editor over an empty document.
- **The page** keeps the page-level treatment for it — an editor over a document that did not load would be its own lie, and the save path would then be writing from a view that never read the record — and changes what is said and what is offered: *"This canvas could not be opened just now. Its data has not been changed."* with **Try again**, and no Start fresh anywhere near it.

**Not claimed**: that this is what failed in CI. The `BrowserDocumentPage.rename` browser test that surfaced it did not reproduce in three full-project local runs (189/189 twice; the third had only the known #187 flake and four import failures), and nothing observed which exception was thrown there. What **is** demonstrated, at the class itself, is that a blocked open and an aborted transaction were both reported as damage.

## Test plan

- [x] New or updated tests added
  - `packages/workspace-index/src/document-store-workspace-docs.unreadable.test.ts` (`workspace-index-node`): a stored snapshot that is not a document, and a stored delta that is not importable, both raise a typed unreadable error. **Red first** — the second reported the raw `Decode error: (Invalid import data)`.
  - `apps/web/src/lib/browser-backend.read-failure.test.ts` (`web-jsdom`): a typed unreadable error is still `corrupt-snapshot`; a blocked open and a `DOMException('AbortError')` are `read-unavailable`. **Red first** on both transient cases, which reported `corrupt-snapshot`.
  - `apps/web/src/pages/BrowserDocumentPage.read-unavailable.test.tsx` (`web-jsdom`): the page offers **Try again**, offers **no** Start fresh, and says the data has not been changed.
- [x] `pnpm test` passes locally — `pnpm --filter @kamiazya/whiteboard-web test`: **3487 passed / 327 files**. `web-browser` + `mcp-node` + `workspace-index-node` together: 5325 passed / 570 files, with one failure in `file-gc-loop-availability` — the known load-sensitive threshold already tracked as its own task, in server code this diff does not touch, and reached here only by running three projects at once.
- [x] `pnpm check:local` exits 0 (lint, secretlint, test:scripts, knip, intent:validate, audit:prod, typecheck across all 16 projects).
- [x] Manual verification — not through the running app: reaching this state by hand means opening a second tab at an older schema version, which is a build-swap rather than an interaction. The page-level test drives the real page and reads the real DOM instead, and the two panels below come from it.
- [ ] E2E coverage — not applicable.

**Mutation-checked**: with the page's branch forced to the old arm, the page test finds **Start fresh** where **Try again** should be, and fails naming it.

## Visual evidence

Two states of the same failure, both from the page-level test's real DOM:

**before** — `This canvas’s data could not be read.` over a `Start fresh` button. The data is intact; the button deletes it.
**after** — `This canvas could not be opened just now. Its data has not been changed.` over `Try again`, with no destructive affordance present.

No composed PNG attached: this environment has no `gh` CLI and the GitHub MCP tools expose no image-upload endpoint. Both strings and both button names are asserted in `BrowserDocumentPage.read-unavailable.test.tsx`, which is the durable form of the same evidence.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — the contract change is documented at its declaration (`document-backend-contract.ts` now says what each reason means and what a caller must not do with it); no `docs/` page describes this failure surface.
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document-opening error handling by distinguishing corrupted data from temporary storage or availability failures.
  * Added a **Try again** option when a document cannot be opened temporarily, preventing accidental replacement of unchanged data.
  * Added clearer messaging confirming that document data remains unchanged when retrying is appropriate.
  * Improved detection and reporting of unreadable stored snapshots and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->