### PR TITLE
feat(dev): proactive flake prevention — lint rules, bounded quarantine, PR-time stress runs

### DIFF
--- a/.claude/rules/integrator-flow.md
+++ b/.claude/rules/integrator-flow.md
@@ -65,6 +65,8 @@ imports. Start the run, then leave the working tree alone.
 
 ## CI flakes
 
+- Parking a flake is BOUNDED: `it.skip` + `// QUARANTINE(<date> <issue>): <why>` above it. `.claude/scripts/quarantine.test.mjs` fails past 8 parked or 14 days each. PR-touched test files are stressed 5x by CI's `stress-changed-tests`.
+
 - A known-flake failure gets one `gh run rerun <id> --failed`. The second occurrence of the same flake in CI promotes it to a root-cause fix lane (own worktree + dev-loop); do not keep re-running. The second occurrence is WATCHED: `flake-watch.mjs` (a quiet SessionStart hook) reports any test failing >=2 distinct main runs in 14 days, from the annotations vitest already emits.
 - **Read the property test's MESSAGE before hunting a counterexample.**
   `@fast-check/vitest` prints the seed in the test NAME, so a plain per-test

--- a/.claude/scripts/biome-plugin.test.mjs
+++ b/.claude/scripts/biome-plugin.test.mjs
@@ -1,0 +1,46 @@
+// Lint-the-linter: the GritQL plugin (tools/biome-plugins/test-flake-shapes.grit)
+// is config, and config regresses silently — a pattern edit that stops
+// matching leaves `pnpm lint` green over the exact shapes it was built to
+// catch. So a fixture pair pins both directions: the bad fixture must yield
+// BOTH diagnostics, the good one none. Fixtures live under .claude/scripts/
+// fixtures/, which biome.json's `!.claude/**` keeps out of the real lint run.
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+
+const REPO_ROOT = join(import.meta.dirname, '../..')
+const FIXTURES = join(import.meta.dirname, 'fixtures/biome-plugin')
+
+function lint(file) {
+  const dir = mkdtempSync(join(tmpdir(), 'biome-plugin-guard-'))
+  writeFileSync(
+    join(dir, 'biome.json'),
+    JSON.stringify({
+      plugins: [join(REPO_ROOT, 'tools/biome-plugins/test-flake-shapes.grit')],
+      formatter: { enabled: false },
+      linter: { rules: { correctness: { noUnusedVariables: 'off' } } },
+    }),
+  )
+  try {
+    execFileSync(join(REPO_ROOT, 'node_modules/.bin/biome'), ['lint', '--config-path', dir, file], {
+      encoding: 'utf8',
+    })
+    return ''
+  } catch (err) {
+    return `${err.stdout ?? ''}${err.stderr ?? ''}`
+  }
+}
+
+test('the bad fixture trips BOTH rules', () => {
+  const out = lint(join(FIXTURES, 'bad.test.tsx'))
+  assert.match(out, /Side effect inside waitFor/)
+  assert.match(out, /afterEach wipes document\.body/)
+})
+
+test('the good fixture trips neither rule', () => {
+  const out = lint(join(FIXTURES, 'good.test.tsx'))
+  assert.doesNotMatch(out, /Side effect inside waitFor|afterEach wipes/)
+})

--- a/.claude/scripts/fixtures/biome-plugin/bad.test.tsx
+++ b/.claude/scripts/fixtures/biome-plugin/bad.test.tsx
@@ -1,0 +1,12 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { afterEach } from 'vitest'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+export async function bad() {
+  await waitFor(() => {
+    fireEvent.click(screen.getByRole('button'))
+  })
+}

--- a/.claude/scripts/fixtures/biome-plugin/good.test.tsx
+++ b/.claude/scripts/fixtures/biome-plugin/good.test.tsx
@@ -1,0 +1,13 @@
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react'
+import { afterEach } from 'vitest'
+
+afterEach(() => {
+  cleanup()
+})
+
+export async function good() {
+  fireEvent.click(screen.getByRole('button'))
+  await waitFor(() => {
+    if (screen.queryByText('done') === null) throw new Error('not yet')
+  })
+}

--- a/.claude/scripts/lib/quarantine.mjs
+++ b/.claude/scripts/lib/quarantine.mjs
@@ -9,8 +9,8 @@
 import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
-export const QUARANTINE_CAP = 8
-export const QUARANTINE_MAX_AGE_DAYS = 14
+const QUARANTINE_CAP = 8
+const QUARANTINE_MAX_AGE_DAYS = 14
 
 const MARKER = /^\s*\/\/\s*QUARANTINE\(([^)]*)\):\s*(.*)$/
 

--- a/.claude/scripts/lib/quarantine.mjs
+++ b/.claude/scripts/lib/quarantine.mjs
@@ -52,7 +52,7 @@ export function judgeQuarantine(markers, nowMs) {
   return { ok: problems.length === 0, problems }
 }
 
-const SCAN_ROOTS = ['apps/web/src', 'packages', 'tools']
+const SCAN_ROOTS = ['apps/web', 'packages', 'tools']
 const TEST_FILE = /\.test\.(ts|tsx|mts|mjs)$/
 
 export function scanRepoQuarantine(repoRoot = join(import.meta.dirname, '../../..')) {

--- a/.claude/scripts/lib/quarantine.mjs
+++ b/.claude/scripts/lib/quarantine.mjs
@@ -1,0 +1,74 @@
+// Quarantine ledger over test files: parse `QUARANTINE(...)` markers and
+// judge them against Fowler's bounded-quarantine rule (cap + age), so a
+// parked flaky test cannot silently become a permanent skip.
+// Marker grammar, one line, directly above the skipped test:
+//   // QUARANTINE(<YYYY-MM-DD> <issue-ref>): <reason>
+// <issue-ref> names the whiteboard issue (e.g. wb:issues/foo) per the
+// ticketing skill; the DATE is when parking started, and the budget is
+// judged from it — not from git history, which a refactor rewrites.
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export const QUARANTINE_CAP = 8
+export const QUARANTINE_MAX_AGE_DAYS = 14
+
+const MARKER = /^\s*\/\/\s*QUARANTINE\(([^)]*)\):\s*(.*)$/
+
+export function parseQuarantineMarkers(source, file) {
+  const markers = []
+  const lines = source.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const m = MARKER.exec(lines[i])
+    if (!m) continue
+    const head = m[1].trim()
+    const space = head.indexOf(' ')
+    const date = space === -1 ? head : head.slice(0, space)
+    const issue = space === -1 ? '' : head.slice(space + 1).trim()
+    markers.push({ file, line: i + 1, date, issue, reason: m[2].trim() })
+  }
+  return markers
+}
+
+export function judgeQuarantine(markers, nowMs) {
+  const problems = []
+  for (const q of markers) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(q.date) || !Number.isFinite(Date.parse(q.date))) {
+      problems.push(`${q.file}:${q.line} QUARANTINE has no parseable YYYY-MM-DD date`)
+      continue
+    }
+    if (q.issue === '') {
+      problems.push(`${q.file}:${q.line} QUARANTINE names no issue — park it with a ticket or fix it`)
+    }
+    const ageDays = (nowMs - Date.parse(q.date)) / 86_400_000
+    if (ageDays > QUARANTINE_MAX_AGE_DAYS) {
+      problems.push(
+        `${q.file}:${q.line} quarantined ${Math.floor(ageDays)}d — past the ${QUARANTINE_MAX_AGE_DAYS}d budget: fix it, or decide to delete it`,
+      )
+    }
+  }
+  if (markers.length > QUARANTINE_CAP) {
+    problems.push(`${markers.length} quarantined tests exceed the cap of ${QUARANTINE_CAP}`)
+  }
+  return { ok: problems.length === 0, problems }
+}
+
+const SCAN_ROOTS = ['apps/web/src', 'packages', 'tools']
+const TEST_FILE = /\.test\.(ts|tsx|mts|mjs)$/
+
+export function scanRepoQuarantine(repoRoot = join(import.meta.dirname, '../../..')) {
+  const markers = []
+  let scannedFiles = 0
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name.startsWith('.')) continue
+      const path = join(dir, entry.name)
+      if (entry.isDirectory()) walk(path)
+      else if (TEST_FILE.test(entry.name)) {
+        scannedFiles++
+        markers.push(...parseQuarantineMarkers(readFileSync(path, 'utf8'), path))
+      }
+    }
+  }
+  for (const root of SCAN_ROOTS) walk(join(repoRoot, root))
+  return { markers, scannedFiles }
+}

--- a/.claude/scripts/quarantine.test.mjs
+++ b/.claude/scripts/quarantine.test.mjs
@@ -33,6 +33,17 @@ test('a marker missing the issue reference is itself a violation', () => {
   assert.match(verdict.problems.join('\n'), /issue/)
 })
 
+test('a marker with no parseable date fails, and is not silently age-exempt', () => {
+  for (const date of ['not-a-date', '2026-13-40']) {
+    const verdict = judgeQuarantine(
+      [{ file: 'c.test.ts', line: 1, date, issue: 'wb:x', reason: 'r' }],
+      NOW,
+    )
+    assert.equal(verdict.ok, false, `date ${date} must not pass`)
+    assert.match(verdict.problems.join('\n'), /parseable/)
+  }
+})
+
 test('within cap and age: ok', () => {
   const markers = [{ file: 'a', line: 1, date: '2026-09-01', issue: 'wb:x', reason: 'r' }]
   assert.equal(judgeQuarantine(markers, NOW).ok, true)

--- a/.claude/scripts/quarantine.test.mjs
+++ b/.claude/scripts/quarantine.test.mjs
@@ -1,0 +1,66 @@
+// Quarantine budget: a flaky test may be parked (`it.skip` + a QUARANTINE
+// marker naming a whiteboard issue) but the parking lot is BOUNDED — Fowler's
+// cap — so quarantine cannot become the graveyard it always decays into
+// unbounded. Cap and age both fail this suite, which runs in check:local and
+// CI's check job via `pnpm test:scripts`.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { judgeQuarantine, parseQuarantineMarkers, scanRepoQuarantine } from './lib/quarantine.mjs'
+
+const NOW = Date.parse('2026-09-05T00:00:00Z')
+
+test('parses a QUARANTINE marker with date, issue and reason', () => {
+  const src = `
+// QUARANTINE(2026-09-01 wb:issues/version-timeline-flake): focus contention, root-cause pending
+it.skip('flaky case', () => {})
+`
+  assert.deepEqual(parseQuarantineMarkers(src, 'a.test.ts'), [
+    {
+      file: 'a.test.ts',
+      line: 2,
+      date: '2026-09-01',
+      issue: 'wb:issues/version-timeline-flake',
+      reason: 'focus contention, root-cause pending',
+    },
+  ])
+})
+
+test('a marker missing the issue reference is itself a violation', () => {
+  const src = "// QUARANTINE(2026-09-01): no ticket\nit.skip('x', () => {})\n"
+  const markers = parseQuarantineMarkers(src, 'b.test.ts')
+  const verdict = judgeQuarantine(markers, NOW)
+  assert.equal(verdict.ok, false)
+  assert.match(verdict.problems.join('\n'), /issue/)
+})
+
+test('within cap and age: ok', () => {
+  const markers = [{ file: 'a', line: 1, date: '2026-09-01', issue: 'wb:x', reason: 'r' }]
+  assert.equal(judgeQuarantine(markers, NOW).ok, true)
+})
+
+test('a marker older than 14 days fails with its file named', () => {
+  const markers = [{ file: 'old.test.ts', line: 3, date: '2026-08-01', issue: 'wb:x', reason: 'r' }]
+  const verdict = judgeQuarantine(markers, NOW)
+  assert.equal(verdict.ok, false)
+  assert.match(verdict.problems.join('\n'), /old\.test\.ts/)
+  assert.match(verdict.problems.join('\n'), /14/)
+})
+
+test('more than 8 quarantined tests fails on the cap', () => {
+  const markers = Array.from({ length: 9 }, (_, i) => ({
+    file: `f${i}`, line: 1, date: '2026-09-04', issue: 'wb:x', reason: 'r',
+  }))
+  const verdict = judgeQuarantine(markers, NOW)
+  assert.equal(verdict.ok, false)
+  assert.match(verdict.problems.join('\n'), /cap/i)
+})
+
+test('live repo scan: reaches the real test surface, and the budget holds', () => {
+  const { markers, scannedFiles } = scanRepoQuarantine()
+  // The subject-is-present floor: a glob that stops matching reports itself
+  // as "0 quarantined" — which is what a broken scan looks like. The file
+  // count proves the scan reached the surface it governs.
+  assert.ok(scannedFiles > 300, `scanned only ${scannedFiles} test files — the glob missed the surface`)
+  const verdict = judgeQuarantine(markers, Date.now())
+  assert.equal(verdict.ok, true, verdict.problems.join('\n'))
+})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,9 +187,16 @@ jobs:
 
       - name: Collect changed test files
         id: changed
+        # base_ref reaches the shell through env, never ${{ }} interpolation —
+        # a ref name may legally contain shell metacharacters.
+        # `.claude/**` is excluded: its test-NAMED files (biome-plugin lint
+        # fixtures) belong to no vitest project, and vitest exits 1 on a file
+        # list that matches no project.
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch origin "${{ github.base_ref }}" --depth=1
-          files=$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD -- '*.test.ts' '*.test.tsx' '*.browser.test.ts' '*.browser.test.tsx' | while read -r f; do [ -f "$f" ] && echo "$f"; done | tr '\n' ' ')
+          git fetch origin "$BASE_REF" --depth=1
+          files=$(git diff --name-only "origin/$BASE_REF"...HEAD -- '*.test.ts' '*.test.tsx' '*.browser.test.ts' '*.browser.test.tsx' ':(exclude).claude/**' | while read -r f; do [ -f "$f" ] && echo "$f"; done | tr '\n' ' ')
           echo "files=$files" >> "$GITHUB_OUTPUT"
           echo "changed test files: $files"
 
@@ -202,7 +209,7 @@ jobs:
         run: |
           for i in 1 2 3 4 5; do
             echo "=== stress run $i/5 ==="
-            pnpm exec vitest run ${{ steps.changed.outputs.files }}
+            pnpm exec vitest run --passWithNoTests ${{ steps.changed.outputs.files }}
           done
 
   sbom-npm:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,47 @@ jobs:
         timeout-minutes: 12
         run: pnpm test:browser --shard=${{ matrix.shard }}/2
 
+  # Detection-at-introduction (industry pattern: run new/changed tests many
+  # times BEFORE they can flake on main): every test file this PR touches is
+  # re-run 5x in fresh processes. A test that cannot survive five quiet runs
+  # has no business gating anyone; catching it here costs one job, catching
+  # it on main costs a root-cause lane (integrator-flow.md, CI flakes).
+  stress-changed-tests:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      WHITEBOARD_CHROME_PATH: /usr/bin/google-chrome-stable
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Collect changed test files
+        id: changed
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          files=$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD -- '*.test.ts' '*.test.tsx' '*.browser.test.ts' '*.browser.test.tsx' | while read -r f; do [ -f "$f" ] && echo "$f"; done | tr '\n' ' ')
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+          echo "changed test files: $files"
+
+      - name: Stress changed test files (5 runs, fresh process each)
+        if: steps.changed.outputs.files != ''
+        # Fresh vitest process per iteration on purpose: module state, test
+        # order and process env all reset, which is closer to the conditions
+        # a flake needs than one long in-process repeat (and config-level
+        # test.repeats is ignored by vitest 4.1 anyway — measured).
+        run: |
+          for i in 1 2 3 4 5; do
+            echo "=== stress run $i/5 ==="
+            pnpm exec vitest run ${{ steps.changed.outputs.files }}
+          done
+
   sbom-npm:
     # Standing regression job: generate:sbom:npm only ran in release.yml before
     # this job existed, so an upstream cyclonedx-npm regression was invisible

--- a/apps/web/src/boot-splash.test.ts
+++ b/apps/web/src/boot-splash.test.ts
@@ -46,6 +46,7 @@ describe('dismissBootSplash', () => {
     vi.useFakeTimers()
     document.body.innerHTML = '<div id="root"><div class="wb-boot"></div></div>'
   })
+  // biome-ignore lint/plugin: boot splash DOM predates React; nothing mounts a root here
   afterEach(() => {
     vi.useRealTimers()
     document.body.innerHTML = ''

--- a/apps/web/src/lib/haptics.test.ts
+++ b/apps/web/src/lib/haptics.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { hapticTick } from './haptics.js'
 
+// biome-ignore lint/plugin: no React root in this file; the wipe clears plain fixture DOM
 afterEach(() => {
   vi.unstubAllGlobals()
   document.body.innerHTML = ''

--- a/apps/web/src/pwa/mount-update-toast.test.tsx
+++ b/apps/web/src/pwa/mount-update-toast.test.tsx
@@ -7,6 +7,7 @@ describe('mountUpdateToast', () => {
     vi.resetModules()
   })
 
+  // biome-ignore lint/plugin: mount-update-toast reuses one module-level root across mounts by design (see impl comment); resetModules in beforeEach retires it with the DOM
   afterEach(() => {
     document.body.innerHTML = ''
   })

--- a/biome.json
+++ b/biome.json
@@ -75,7 +75,9 @@
         "gemini-extension.json",
         "server.json"
       ],
-      "formatter": { "enabled": false }
+      "formatter": {
+        "enabled": false
+      }
     },
     {
       "includes": [
@@ -107,6 +109,12 @@
           }
         }
       }
+    }
+  ],
+  "plugins": [
+    {
+      "path": "./tools/biome-plugins/test-flake-shapes.grit",
+      "includes": ["**/*.test.ts", "**/*.test.tsx", "**/*.browser.test.ts", "**/*.browser.test.tsx"]
     }
   ]
 }

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -9,7 +9,11 @@
         // (PreToolUse/PostToolUse commands), which knip does not parse.
         ".claude/scripts/hooks/*.mjs"
       ],
-      "project": [".claude/workflows/**/*.mjs", ".claude/scripts/**/*.mjs", "tools/**/*.mjs"]
+      "project": [".claude/workflows/**/*.mjs", ".claude/scripts/**/*.mjs", "tools/**/*.mjs"],
+      // Biome-plugin lint fixtures: raw files the guard test feeds to
+      // `biome lint`, never executed or imported — their imports mimic a
+      // real test file for the reader, not for module resolution.
+      "ignore": [".claude/scripts/fixtures/**"]
     },
     "tools/checks": {
       "entry": [

--- a/packages/canvas-render/src/svg/pixel-golden.browser.test.ts
+++ b/packages/canvas-render/src/svg/pixel-golden.browser.test.ts
@@ -44,6 +44,7 @@ function mountScene(scene: Scene, testId: string): void {
   document.body.append(svg)
 }
 
+// biome-ignore lint/plugin: SVG markup appended raw, no React root to unmount
 afterEach(() => {
   document.body.innerHTML = ''
 })

--- a/packages/canvas-viewer/src/widget/comment-control.test.tsx
+++ b/packages/canvas-viewer/src/widget/comment-control.test.tsx
@@ -27,6 +27,7 @@ function submitForm(control: { element: HTMLFormElement }): void {
 }
 
 describe('createCommentControl', () => {
+  // biome-ignore lint/plugin: createCommentControl is plain DOM, no React root
   afterEach(() => {
     document.body.innerHTML = ''
   })

--- a/tools/biome-plugins/test-flake-shapes.grit
+++ b/tools/biome-plugins/test-flake-shapes.grit
@@ -1,0 +1,29 @@
+language js
+
+// Executable half of two flake shapes from .claude/rules/integrator-flow.md.
+// Guarded by .claude/scripts/biome-plugin.test.mjs (fixture pair per rule).
+any {
+  // A retried waitFor callback re-fires any action inside it, so the action
+  // double-fires under load and the failure blames the assertion.
+  `waitFor($cb)` where {
+    $cb <: contains or { `fireEvent.$m($a)`, `userEvent.$m($a)`, `render($a)` },
+    register_diagnostic(
+      span = $cb,
+      message = "Side effect inside waitFor: fire the event / render OUTSIDE the callback, assert inside. A retried callback re-fires the action (double-fired-action flake).",
+      severity = "error"
+    )
+  },
+  // The ninth flake shape: an afterEach wiping document.body leaves React
+  // roots mounted on detached nodes; the NEXT test's reconciler throws
+  // removeChild errors while every test in the file reports PASSED.
+  // A wipe behind a named helper (afterEach(resetDom)) is past this rule's
+  // floor — reader judgement in review covers that arrangement.
+  `afterEach($cb)` where {
+    $cb <: contains `document.body.innerHTML = $_`,
+    register_diagnostic(
+      span = $cb,
+      message = "afterEach wipes document.body with innerHTML: React roots stay mounted on detached nodes and the NEXT test fails with removeChild errors. Unmount through testing-library cleanup() (or the mount API's own unmount).",
+      severity = "error"
+    )
+  }
+}


### PR DESCRIPTION
Three proactive mechanisms so flakes are caught before they reach main, researched against industry practice (Google detection-at-introduction, Fowler's bounded quarantine, GitLab's ticket-required quarantine) and this repo's own flake catalogue (`integrator-flow.md`, CI flakes).

## 1. GritQL lint rules for two catalogued flake shapes (`tools/biome-plugins/test-flake-shapes.grit`)
- **Side effect inside `waitFor`**: a retried callback re-fires the action (double-fired-action flake). Suite is already clean — the rule is purely preventive.
- **`afterEach` wiping `document.body` via innerHTML** (the ninth shape): React roots stay mounted on detached nodes; the next test fails with removeChild errors while this file reports all-passed. Five existing wipes are deliberate non-React fixtures, each suppressed at the site with its reason.
- Scoped to `*.test.*` via the plugin's `includes`; guarded by a fixture pair in `.claude/scripts/biome-plugin.test.mjs` (**mutation-checked**: renaming the `waitFor` pattern fails the guard; restored, it greens).
- This answers "BiomeのGritQLは使えないか" — yes: nested-callback matching (`contains or {…}`), assignment patterns, `any {}` multi-rule files and `biome-ignore lint/plugin:` suppression all verified working on Biome 2.5.3.

## 2. Bounded quarantine (`.claude/scripts/quarantine.test.mjs`, runs in `test:scripts` = check:local + CI check job)
`// QUARANTINE(<date> <issue>): <why>` above an `it.skip` parks a flaky test. The budget fails past **8 parked** or **14 days** each, or on a marker with no issue ref — Fowler's cap, executable, using the existing whiteboard ticketing. The live scan asserts it reached >300 test files, so a glob that stops matching reports itself rather than reporting zero flakes.

## 3. PR-time stress runs (`stress-changed-tests` job in ci.yml)
Every test file a PR touches is re-run **5× in fresh vitest processes** before merge (detection-at-introduction). Fresh processes on purpose: config-level `test.repeats` is ignored by vitest 4.1 (measured with a fails-on-second-execution probe), and a fresh process resets module state, order and env — the conditions a flake needs. Skips when no test file changed.

## Gates
- `pnpm exec biome check .` clean (1 pre-existing info untouched); `pnpm test:scripts` 270/270 (incl. 8 new tests); dev-rules budget + contract, local-gate-command, ci-verify-coverage, ci-policy all green; ci.yml parses.
- Always-on prose addition fits the pinned budget (integrator-flow.md stays in bucket 14, total in 88).

Not adopted, deliberately: blanket `retry` (contradicts the promote-to-root-cause policy and ecosystem consensus), flaky-test SaaS (scale mismatch), and the ESLint layer (GritQL covers the target rules without a second linter).

Visual evidence: none — dev tooling and CI config only; the executable evidence is the mutation-checked fixture pair and the probe measurements quoted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7iuGxJAXjr6rEXfS7YAC6