### PR TITLE
feat(web): a tap opens a document, and long-press reaches its actions

### DIFF
--- a/apps/web/src/components/workspace-files/FolderContentsList.tsx
+++ b/apps/web/src/components/workspace-files/FolderContentsList.tsx
@@ -4,6 +4,7 @@ import { cn } from '../../lib/utils.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
 import { folderContents } from './folder-contents.js'
 import { formatRelative } from './format-relative.js'
+import { useLongPressMenu } from './use-long-press.js'
 
 /**
  * What a click in the contents pane means. A folder and a document are
@@ -20,7 +21,13 @@ export interface FolderContentsListProps {
   /** The folder being looked inside. `''` is the workspace root. */
   folder: string
   onOpen: (target: FolderContentsOpen) => void
-  /** Right-click on a document card — the object-action menu hook. */
+  /**
+   * The committed open — double-click, or Enter on a focused card. Space
+   * keeps the native button click (select-and-preview), so a keyboard user
+   * has both verbs where a mouse user has two gestures.
+   */
+  onActivateDocument?: (entry: WorkspaceDocumentEntry) => void
+  /** Right-click or touch long-press on a document card — the object-action menu hook. */
   onDocumentContextMenu?: (entry: WorkspaceDocumentEntry, x: number, y: number) => void
   /** The document the preview is showing, so the two panes agree. */
   selectedPath?: string
@@ -43,6 +50,7 @@ export function FolderContentsList({
   documents,
   folder,
   onOpen,
+  onActivateDocument,
   onDocumentContextMenu,
   selectedPath,
   renderThumbnail,
@@ -52,6 +60,14 @@ export function FolderContentsList({
     () => folderContents(documents, folder),
     [documents, folder],
   )
+  const longPress = useLongPressMenu(
+    onDocumentContextMenu === undefined
+      ? undefined
+      : (path, x, y) => {
+          const entry = here.find((row) => row.path === path)
+          if (entry !== undefined) onDocumentContextMenu(entry, x, y)
+        },
+  )
 
   if (folders.length === 0 && here.length === 0) {
     return <p className={cn('text-muted-foreground text-sm', className)}>This folder is empty.</p>
@@ -59,6 +75,7 @@ export function FolderContentsList({
 
   return (
     <ul
+      {...longPress}
       className={cn('grid grid-cols-[repeat(auto-fill,minmax(9rem,1fr))] gap-2 p-0.5', className)}
     >
       {folders.map((child) => (
@@ -90,8 +107,24 @@ export function FolderContentsList({
         <li key={entry.documentId}>
           <button
             type="button"
+            data-doc-path={entry.path}
             aria-current={entry.path === selectedPath ? 'true' : undefined}
             onClick={() => onOpen({ kind: 'document', document: entry })}
+            onDoubleClick={
+              onActivateDocument === undefined ? undefined : () => onActivateDocument(entry)
+            }
+            onKeyDown={
+              onActivateDocument === undefined
+                ? undefined
+                : (event) => {
+                    if (event.key === 'Enter') {
+                      // Without this the keydown ALSO fires the native
+                      // button click, selecting after the open.
+                      event.preventDefault()
+                      onActivateDocument(entry)
+                    }
+                  }
+            }
             onContextMenu={
               onDocumentContextMenu === undefined
                 ? undefined

--- a/apps/web/src/components/workspace-files/SearchResults.tsx
+++ b/apps/web/src/components/workspace-files/SearchResults.tsx
@@ -18,6 +18,7 @@ import { type ReactNode, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '../../lib/utils.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
+import { useLongPressMenu } from './use-long-press.js'
 
 /**
  * A row: the document, and the excerpts that say why it is here. Empty
@@ -49,7 +50,12 @@ export interface SearchResultsProps {
   searchedContents?: boolean
   selectedPath?: string
   onSelect: (document: WorkspaceDocumentEntry) => void
-  /** Right-click on a result row — the object-action menu hook. */
+  /**
+   * The committed open — double-click, or Enter on a focused row. Space
+   * keeps the native button click (select-and-preview).
+   */
+  onActivate?: (document: WorkspaceDocumentEntry) => void
+  /** Right-click or touch long-press on a result row — the object-action menu hook. */
   onDocumentContextMenu?: (entry: WorkspaceDocumentEntry, x: number, y: number) => void
   renderThumbnail?: (document: WorkspaceDocumentEntry) => ReactNode
   className?: string
@@ -86,10 +92,19 @@ export function SearchResults({
   searchedContents = true,
   selectedPath,
   onSelect,
+  onActivate,
   onDocumentContextMenu,
   renderThumbnail,
   className,
 }: SearchResultsProps) {
+  const longPress = useLongPressMenu(
+    onDocumentContextMenu === undefined
+      ? undefined
+      : (path, x, y) => {
+          const row = results.find(({ document: entry }) => entry.path === path)
+          if (row !== undefined) onDocumentContextMenu(row.document, x, y)
+        },
+  )
   // List first: the row form carries the path inline beside the title, which
   // is the stronger answer to "where is this" — the grid trades that density
   // for a bigger picture, the way Finder's icon view does.
@@ -161,13 +176,27 @@ export function SearchResults({
         </div>
       </div>
       {layout === 'list' ? (
-        <ul data-testid="search-results-list" className="space-y-1 p-0.5">
+        <ul {...longPress} data-testid="search-results-list" className="space-y-1 p-0.5">
           {results.map(({ document: entry, contexts, lexicalRank }) => (
             <li key={entry.documentId}>
               <button
                 type="button"
+                data-doc-path={entry.path}
                 aria-current={entry.path === selectedPath ? 'true' : undefined}
                 onClick={() => onSelect(entry)}
+                onDoubleClick={onActivate === undefined ? undefined : () => onActivate(entry)}
+                onKeyDown={
+                  onActivate === undefined
+                    ? undefined
+                    : (event) => {
+                        if (event.key === 'Enter') {
+                          // Without this the keydown ALSO fires the native
+                          // button click, selecting after the open.
+                          event.preventDefault()
+                          onActivate(entry)
+                        }
+                      }
+                }
                 onContextMenu={
                   onDocumentContextMenu === undefined
                     ? undefined
@@ -220,6 +249,7 @@ export function SearchResults({
         </ul>
       ) : (
         <ul
+          {...longPress}
           data-testid="search-results-grid"
           className="grid grid-cols-2 gap-2 p-0.5 md:grid-cols-3"
         >
@@ -227,8 +257,22 @@ export function SearchResults({
             <li key={entry.documentId}>
               <button
                 type="button"
+                data-doc-path={entry.path}
                 aria-current={entry.path === selectedPath ? 'true' : undefined}
                 onClick={() => onSelect(entry)}
+                onDoubleClick={onActivate === undefined ? undefined : () => onActivate(entry)}
+                onKeyDown={
+                  onActivate === undefined
+                    ? undefined
+                    : (event) => {
+                        if (event.key === 'Enter') {
+                          // Without this the keydown ALSO fires the native
+                          // button click, selecting after the open.
+                          event.preventDefault()
+                          onActivate(entry)
+                        }
+                      }
+                }
                 onContextMenu={
                   onDocumentContextMenu === undefined
                     ? undefined

--- a/apps/web/src/components/workspace-files/WorkspaceFileTree.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFileTree.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, ChevronRight, FileText, Folder, LayoutGrid } from 'lucide-
 import { type ReactNode, useMemo, useState } from 'react'
 import { cn } from '../../lib/utils.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
+import { useLongPressMenu } from './use-long-press.js'
 
 export interface WorkspaceFileTreeProps {
   documents: readonly WorkspaceDocumentEntry[]
@@ -11,6 +12,13 @@ export interface WorkspaceFileTreeProps {
    * keeps the native button click (select-and-preview).
    */
   onActivate?: (document: WorkspaceDocumentEntry) => void
+  /**
+   * Right-click or touch long-press on a document row — the object-action
+   * menu hook. Without it the one-column view has NO route to
+   * rename/delete/pin on touch: the preview pane that used to carry those
+   * verbs does not render when a tap opens.
+   */
+  onDocumentContextMenu?: (entry: WorkspaceDocumentEntry, x: number, y: number) => void
   /** The document the preview is showing, so the two agree. */
   selectedPath?: string
   /**
@@ -71,12 +79,14 @@ function TreeItem({
   node,
   onOpen,
   onActivate,
+  onDocumentContextMenu,
   renderIcon,
   selectedPath,
 }: {
   node: TreeNode
   onOpen: (document: WorkspaceDocumentEntry) => void
   onActivate?: (document: WorkspaceDocumentEntry) => void
+  onDocumentContextMenu?: (entry: WorkspaceDocumentEntry, x: number, y: number) => void
   renderIcon?: (document: WorkspaceDocumentEntry) => ReactNode
   selectedPath?: string
 }) {
@@ -115,8 +125,18 @@ function TreeItem({
         {node.canvas ? (
           <button
             type="button"
+            data-doc-path={node.canvas.path}
             aria-current={node.canvas.path === selectedPath ? 'true' : undefined}
             onClick={() => node.canvas && onOpen(node.canvas)}
+            onContextMenu={
+              onDocumentContextMenu === undefined
+                ? undefined
+                : (event) => {
+                    event.preventDefault()
+                    if (node.canvas)
+                      onDocumentContextMenu(node.canvas, event.clientX, event.clientY)
+                  }
+            }
             onDoubleClick={
               onActivate === undefined ? undefined : () => node.canvas && onActivate(node.canvas)
             }
@@ -169,6 +189,7 @@ function TreeItem({
               node={child}
               onOpen={onOpen}
               onActivate={onActivate}
+              onDocumentContextMenu={onDocumentContextMenu}
               renderIcon={renderIcon}
               selectedPath={selectedPath}
             />
@@ -195,11 +216,20 @@ export function WorkspaceFileTree({
   documents,
   onOpen,
   onActivate,
+  onDocumentContextMenu,
   renderIcon,
   selectedPath,
   className,
 }: WorkspaceFileTreeProps) {
   const tree = useMemo(() => buildTree(documents), [documents])
+  const longPress = useLongPressMenu(
+    onDocumentContextMenu === undefined
+      ? undefined
+      : (path, x, y) => {
+          const entry = documents.find((row) => row.path === path)
+          if (entry !== undefined) onDocumentContextMenu(entry, x, y)
+        },
+  )
 
   if (tree.length === 0) {
     return (
@@ -210,13 +240,19 @@ export function WorkspaceFileTree({
   }
 
   return (
-    <div role="tree" aria-label="Workspace documents" className={cn('space-y-0.5', className)}>
+    <div
+      role="tree"
+      aria-label="Workspace documents"
+      {...longPress}
+      className={cn('space-y-0.5', className)}
+    >
       {tree.map((node) => (
         <TreeItem
           key={node.path}
           node={node}
           onOpen={onOpen}
           onActivate={onActivate}
+          onDocumentContextMenu={onDocumentContextMenu}
           renderIcon={renderIcon}
           selectedPath={selectedPath}
         />

--- a/apps/web/src/components/workspace-files/WorkspaceFileTree.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFileTree.tsx
@@ -6,6 +6,11 @@ import type { WorkspaceDocumentEntry } from './document-entry.js'
 export interface WorkspaceFileTreeProps {
   documents: readonly WorkspaceDocumentEntry[]
   onOpen: (document: WorkspaceDocumentEntry) => void
+  /**
+   * The committed open — double-click, or Enter on a focused row. Space
+   * keeps the native button click (select-and-preview).
+   */
+  onActivate?: (document: WorkspaceDocumentEntry) => void
   /** The document the preview is showing, so the two agree. */
   selectedPath?: string
   /**
@@ -65,11 +70,13 @@ function buildTree(documents: readonly WorkspaceDocumentEntry[]): TreeNode[] {
 function TreeItem({
   node,
   onOpen,
+  onActivate,
   renderIcon,
   selectedPath,
 }: {
   node: TreeNode
   onOpen: (document: WorkspaceDocumentEntry) => void
+  onActivate?: (document: WorkspaceDocumentEntry) => void
   renderIcon?: (document: WorkspaceDocumentEntry) => ReactNode
   selectedPath?: string
 }) {
@@ -110,6 +117,21 @@ function TreeItem({
             type="button"
             aria-current={node.canvas.path === selectedPath ? 'true' : undefined}
             onClick={() => node.canvas && onOpen(node.canvas)}
+            onDoubleClick={
+              onActivate === undefined ? undefined : () => node.canvas && onActivate(node.canvas)
+            }
+            onKeyDown={
+              onActivate === undefined
+                ? undefined
+                : (event) => {
+                    if (event.key === 'Enter' && node.canvas) {
+                      // Without this the keydown ALSO fires the native
+                      // button click, selecting after the open.
+                      event.preventDefault()
+                      onActivate(node.canvas)
+                    }
+                  }
+            }
             className="hover:bg-accent hover:text-accent-foreground aria-[current]:bg-accent aria-[current]:text-accent-foreground flex min-w-0 items-center gap-1.5 rounded px-1.5 py-0.5 text-left text-sm"
           >
             {/* A caller-supplied miniature when there is one; otherwise the
@@ -146,6 +168,7 @@ function TreeItem({
               key={child.path}
               node={child}
               onOpen={onOpen}
+              onActivate={onActivate}
               renderIcon={renderIcon}
               selectedPath={selectedPath}
             />
@@ -171,6 +194,7 @@ function TreeItem({
 export function WorkspaceFileTree({
   documents,
   onOpen,
+  onActivate,
   renderIcon,
   selectedPath,
   className,
@@ -192,6 +216,7 @@ export function WorkspaceFileTree({
           key={node.path}
           node={node}
           onOpen={onOpen}
+          onActivate={onActivate}
           renderIcon={renderIcon}
           selectedPath={selectedPath}
         />

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -1,8 +1,9 @@
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
-import { Columns2, List, Search } from 'lucide-react'
+import { Columns2, CopyPlus, ExternalLink, List, Pencil, Pin, PinOff, Search, Trash2 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useThemeMode } from '../../hooks/useThemeMode.js'
+import { hasCoarsePointer } from '../../lib/platform.js'
 import { createInTabRenderBroker } from '../../lib/render-broker.js'
 import { ContextMenu } from '../spatial-editor/ContextMenu.js'
 import { DocumentMinimap } from './DocumentMinimap.js'
@@ -226,6 +227,23 @@ export function WorkspaceFilesPanel({
   const onOpenDocumentRef = useRef(onOpenDocument)
   onOpenDocumentRef.current = onOpenDocument
   const lastReadListRef = useRef(readList)
+
+  /**
+   * Tap-to-open (2026-09-05 redesign). On a coarse pointer a tap on a
+   * document card OPENS it, matching the gallery convention every canvas
+   * product shares (Figma, Miro, Freeform: tap = open, long-press = the
+   * object menu) — the select-then-Open round trip was two taps everywhere
+   * and left the Open button below the fold on a phone. On a fine pointer a
+   * click still selects into the preview; double-click and Enter open.
+   *
+   * Gated on the host actually offering an open: a read-only host keeps the
+   * selection behavior AND the preview column, because looking is all there
+   * is to do.
+   */
+  const tapOpens = hasCoarsePointer() && onOpenDocument !== undefined
+  const openEntry = useCallback((entry: WorkspaceDocumentEntry) => {
+    onOpenDocumentRef.current?.(entry.path)
+  }, [])
 
   // SCOPE RESET — see scoped-screen-state.test.ts
   useEffect(() => {
@@ -590,20 +608,34 @@ export function WorkspaceFilesPanel({
       : [
           ...(onOpenDocument === undefined
             ? []
-            : [{ label: 'Open', onSelect: () => onOpenDocument(cardMenu.entry.path) }]),
+            : [
+                {
+                  label: 'Open',
+                  icon: <ExternalLink />,
+                  onSelect: () => onOpenDocument(cardMenu.entry.path),
+                },
+              ]),
           ...(onDuplicateDocument === undefined
             ? []
-            : [{ label: 'Duplicate', onSelect: () => onDuplicateDocument(cardMenu.entry.path) }]),
+            : [
+                {
+                  label: 'Duplicate',
+                  icon: <CopyPlus />,
+                  onSelect: () => onDuplicateDocument(cardMenu.entry.path),
+                },
+              ]),
           ...(source.setPinned === undefined
             ? []
             : [
                 {
                   label: cardMenu.entry.pinOrder === undefined ? 'Pin' : 'Unpin',
+                  icon: cardMenu.entry.pinOrder === undefined ? <Pin /> : <PinOff />,
                   onSelect: () => void togglePinned(cardMenu.entry),
                 },
               ]),
           {
             label: 'Rename…',
+            icon: <Pencil />,
             onSelect: () => {
               setSelected(cardMenu.entry)
               setRenameError(null)
@@ -615,6 +647,7 @@ export function WorkspaceFilesPanel({
             : [
                 {
                   label: 'Delete',
+                  icon: <Trash2 />,
                   danger: true,
                   onSelect: () =>
                     onRequestDelete(
@@ -760,6 +793,7 @@ export function WorkspaceFilesPanel({
                   : ''}
               </p>
               <SearchResults
+                {...(onOpenDocument === undefined ? {} : { onActivate: openEntry })}
                 // A `#tag` query is a FILTER over what is loaded (#975's
                 // contract), not a content search — it never leaves the
                 // client. Everything else asks the source.
@@ -786,7 +820,7 @@ export function WorkspaceFilesPanel({
                 query={query}
                 searchedContents={activeTag === null && hits !== null}
                 selectedPath={selected?.path}
-                onSelect={setSelected}
+                onSelect={tapOpens ? openEntry : setSelected}
                 onDocumentContextMenu={openCardMenu}
                 renderThumbnail={(entry) => (
                   <DocumentThumbnail
@@ -803,7 +837,8 @@ export function WorkspaceFilesPanel({
           <div className="min-w-0 flex-1 overflow-y-auto md:border-r md:pr-3">
             <WorkspaceFileTree
               documents={documents}
-              onOpen={setSelected}
+              onOpen={tapOpens ? openEntry : setSelected}
+              {...(onOpenDocument === undefined ? {} : { onActivate: openEntry })}
               selectedPath={selected?.path}
               renderIcon={(entry) => (
                 <DocumentMinimap
@@ -835,8 +870,11 @@ export function WorkspaceFilesPanel({
                   onOpen={(target) =>
                     target.kind === 'folder'
                       ? selectFolder(target.path)
-                      : setSelected(target.document)
+                      : tapOpens
+                        ? openEntry(target.document)
+                        : setSelected(target.document)
                   }
+                  {...(onOpenDocument === undefined ? {} : { onActivateDocument: openEntry })}
                   onDocumentContextMenu={openCardMenu}
                   renderThumbnail={(entry) => (
                     <DocumentThumbnail
@@ -851,6 +889,11 @@ export function WorkspaceFilesPanel({
             </div>
           </>
         )}
+        {/* When a tap opens, selection can no longer fill this pane, so it
+            would sit permanently on its empty state — below the grid on a
+            phone, where it held the only Open button (the 2-tap bug). The
+            long-press menu is the object surface on touch. */}
+        {!tapOpens && (
         <div className="w-full shrink-0 overflow-y-auto md:w-72">
           <DocumentPreview
             document={selected}
@@ -876,6 +919,7 @@ export function WorkspaceFilesPanel({
             className="h-full"
           />
         </div>
+        )}
       </div>
       {source.listTrash !== undefined && source.restoreFromTrash !== undefined && (
         <TrashSection
@@ -911,6 +955,7 @@ export function WorkspaceFilesPanel({
           label="Document actions"
           items={cardMenuItems}
           onClose={() => setCardMenu(null)}
+          variant={hasCoarsePointer() ? 'sheet' : 'list'}
         />
       )}
     </section>

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -1,5 +1,15 @@
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
-import { Columns2, CopyPlus, ExternalLink, List, Pencil, Pin, PinOff, Search, Trash2 } from 'lucide-react'
+import {
+  Columns2,
+  CopyPlus,
+  ExternalLink,
+  List,
+  Pencil,
+  Pin,
+  PinOff,
+  Search,
+  Trash2,
+} from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useThemeMode } from '../../hooks/useThemeMode.js'
@@ -894,31 +904,31 @@ export function WorkspaceFilesPanel({
             phone, where it held the only Open button (the 2-tap bug). The
             long-press menu is the object surface on touch. */}
         {!tapOpens && (
-        <div className="w-full shrink-0 overflow-y-auto md:w-72">
-          <DocumentPreview
-            document={selected}
-            loadRender={loadRender}
-            {...(onOpenDocument === undefined
-              ? {}
-              : { onOpen: (entry: WorkspaceDocumentEntry) => onOpenDocument(entry.path) })}
-            onRename={(entry: WorkspaceDocumentEntry) => {
-              setRenameError(null)
-              setRenaming(entry)
-            }}
-            {...(onDuplicateDocument === undefined
-              ? {}
-              : {
-                  onDuplicate: (entry: WorkspaceDocumentEntry) => onDuplicateDocument(entry.path),
-                })}
-            {...(onRequestDelete === undefined
-              ? {}
-              : {
-                  onDelete: (entry: WorkspaceDocumentEntry) =>
-                    onRequestDelete(entry.path, entry.name ?? entry.path, entry.kind),
-                })}
-            className="h-full"
-          />
-        </div>
+          <div className="w-full shrink-0 overflow-y-auto md:w-72">
+            <DocumentPreview
+              document={selected}
+              loadRender={loadRender}
+              {...(onOpenDocument === undefined
+                ? {}
+                : { onOpen: (entry: WorkspaceDocumentEntry) => onOpenDocument(entry.path) })}
+              onRename={(entry: WorkspaceDocumentEntry) => {
+                setRenameError(null)
+                setRenaming(entry)
+              }}
+              {...(onDuplicateDocument === undefined
+                ? {}
+                : {
+                    onDuplicate: (entry: WorkspaceDocumentEntry) => onDuplicateDocument(entry.path),
+                  })}
+              {...(onRequestDelete === undefined
+                ? {}
+                : {
+                    onDelete: (entry: WorkspaceDocumentEntry) =>
+                      onRequestDelete(entry.path, entry.name ?? entry.path, entry.kind),
+                  })}
+              className="h-full"
+            />
+          </div>
         )}
       </div>
       {source.listTrash !== undefined && source.restoreFromTrash !== undefined && (

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -849,6 +849,7 @@ export function WorkspaceFilesPanel({
               documents={documents}
               onOpen={tapOpens ? openEntry : setSelected}
               {...(onOpenDocument === undefined ? {} : { onActivate: openEntry })}
+              onDocumentContextMenu={openCardMenu}
               selectedPath={selected?.path}
               renderIcon={(entry) => (
                 <DocumentMinimap

--- a/apps/web/src/components/workspace-files/open-wayfinding.browser.test.tsx
+++ b/apps/web/src/components/workspace-files/open-wayfinding.browser.test.tsx
@@ -1,0 +1,109 @@
+// The open wayfinding contract, in a REAL browser — jsdom's synthetic
+// events cannot prove the parts that live in native event ORDER: a real
+// double-click dispatches click, click, dblclick (so the open must arrive
+// exactly once, after two harmless selects), and a real Enter on a focused
+// <button> fires the native click that our keydown preventDefault has to
+// swallow (without it, Enter would open AND select).
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
+import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
+
+afterEach(cleanup)
+
+const entries = [
+  { documentId: 'd1', path: 'meeting-notes', name: 'Meeting notes', kind: 'markdown' as const },
+]
+
+const realMatchMedia = window.matchMedia
+let coarse = false
+beforeEach(() => {
+  coarse = false
+  window.matchMedia = (query: string) =>
+    query === '(pointer: coarse)'
+      ? ({
+          matches: coarse,
+          media: query,
+          addEventListener: () => {},
+          removeEventListener: () => {},
+        } as unknown as MediaQueryList)
+      : realMatchMedia.call(window, query)
+})
+afterEach(() => {
+  window.matchMedia = realMatchMedia
+})
+
+function renderPanel(onOpenDocument: (path: string) => void) {
+  const source = fakeFilesSource({ listDocuments: async () => entries })
+  render(<WorkspaceFilesPanel source={source} onOpenDocument={onOpenDocument} />)
+}
+
+async function card() {
+  const title = (await screen.findAllByTestId('card-title'))[0] as HTMLElement
+  return title.closest('button') as HTMLElement
+}
+
+describe('open wayfinding', () => {
+  it('double-click opens once', async () => {
+    const onOpenDocument = vi.fn()
+    renderPanel(onOpenDocument)
+    await userEvent.dblClick(await card())
+    expect(onOpenDocument).toHaveBeenCalledTimes(1)
+    expect(onOpenDocument).toHaveBeenCalledWith('meeting-notes')
+  })
+
+  it('Enter opens once, without a stray select', async () => {
+    const onOpenDocument = vi.fn()
+    renderPanel(onOpenDocument)
+    const button = await card()
+    button.focus()
+    await userEvent.keyboard('{Enter}')
+    expect(onOpenDocument).toHaveBeenCalledTimes(1)
+    // The native Enter->click was swallowed: nothing selected, so the
+    // preview pane still shows its empty state.
+    expect(screen.getByText('Select a document to preview its content.')).toBeTruthy()
+  })
+
+  it('coarse: tap opens, no preview pane', async () => {
+    coarse = true
+    const onOpenDocument = vi.fn()
+    renderPanel(onOpenDocument)
+    const button = await card()
+    expect(screen.queryByText('Select a document to preview its content.')).toBeNull()
+    await userEvent.click(button)
+    expect(onOpenDocument).toHaveBeenCalledWith('meeting-notes')
+  })
+
+  it('coarse: touch long-press opens the sheet, not the document', async () => {
+    coarse = true
+    const onOpenDocument = vi.fn()
+    renderPanel(onOpenDocument)
+    const button = await card()
+
+    // A real held touch: pointerdown with pointerType touch, no release
+    // until the menu shows. userEvent has no long-press, so dispatch the
+    // native events the browser would.
+    const rect = button.getBoundingClientRect()
+    button.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        pointerType: 'touch',
+        pointerId: 7,
+        clientX: rect.x + 10,
+        clientY: rect.y + 10,
+        bubbles: true,
+      }),
+    )
+    const menu = await screen.findByRole('menu', { name: 'Document actions' })
+    expect(within(menu).getByRole('menuitem', { name: 'Rename…' })).toBeTruthy()
+
+    button.dispatchEvent(
+      new PointerEvent('pointerup', { pointerType: 'touch', pointerId: 7, bubbles: true }),
+    )
+    button.dispatchEvent(new MouseEvent('click', { detail: 1, bubbles: true, cancelable: true }))
+    expect(onOpenDocument).not.toHaveBeenCalled()
+    // The sheet closes on Escape and the release did not leak an open.
+    await userEvent.keyboard('{Escape}')
+    await waitFor(() => expect(screen.queryByRole('menu', { name: 'Document actions' })).toBeNull())
+  })
+})

--- a/apps/web/src/components/workspace-files/open-wayfinding.test.tsx
+++ b/apps/web/src/components/workspace-files/open-wayfinding.test.tsx
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
+import type { WorkspaceDocumentEntry } from './document-entry.js'
+import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
+
+// The open wayfinding contract (2026-09-05 redesign decision):
+// - coarse pointer (touch): a tap on a document card OPENS it — no
+//   select-then-Open round trip — and the preview column does not render.
+//   Long-press is the object-action path (the sheet menu), finally giving
+//   Pin a touch route.
+// - fine pointer (desktop): click still selects into the preview pane;
+//   double-click opens; Enter opens (one activation for keyboard users);
+//   Space keeps the native button click, i.e. select-and-preview.
+
+afterEach(cleanup)
+
+const entries = [
+  { documentId: 'd1', path: 'meeting-notes', name: 'Meeting notes', kind: 'markdown' as const },
+  { documentId: 'd2', path: 'plans/roadmap', name: 'Roadmap', kind: 'spatial' as const },
+]
+
+const realMatchMedia = window.matchMedia
+let coarse = false
+const stubMql = (matches: boolean, media: string) =>
+  ({
+    matches,
+    media,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }) as unknown as MediaQueryList
+beforeEach(() => {
+  coarse = false
+  window.matchMedia = (query: string) =>
+    query === '(pointer: coarse)'
+      ? stubMql(coarse, query)
+      : realMatchMedia
+        ? realMatchMedia.call(window, query)
+        : stubMql(false, query)
+})
+afterEach(() => {
+  window.matchMedia = realMatchMedia
+})
+
+function renderPanel(
+  overrides: {
+    onOpenDocument?: (path: string) => void
+    setPinned?: (entry: { readonly path: string }, pinned: boolean) => Promise<void>
+    rows?: readonly WorkspaceDocumentEntry[]
+  } = {},
+) {
+  const { setPinned, rows, ...panelProps } = overrides
+  const source = fakeFilesSource({
+    listDocuments: () => Promise.resolve(rows ?? entries),
+    ...(setPinned === undefined ? {} : { setPinned }),
+  })
+  render(<WorkspaceFilesPanel source={source} {...panelProps} />)
+  return source
+}
+
+async function cardButton(title: string) {
+  await waitFor(() => {
+    expect(screen.getAllByTestId('card-title').some((el) => el.textContent === title)).toBe(true)
+  })
+  const el = screen.getAllByTestId('card-title').find((n) => n.textContent === title)
+  return el?.closest('button') as HTMLElement
+}
+
+describe('coarse pointer: tap opens', () => {
+  it('a tap on a document card opens it and the preview column is gone', async () => {
+    coarse = true
+    const onOpenDocument = vi.fn()
+    renderPanel({ onOpenDocument })
+
+    const card = await cardButton('Meeting notes')
+    // The preview column must not render at all on touch: it stacked below
+    // the grid and held the only Open button, which is the 2-tap bug.
+    expect(screen.queryByText('Select a document to preview its content.')).toBeNull()
+
+    fireEvent.click(card, { detail: 1 })
+    expect(onOpenDocument).toHaveBeenCalledWith('meeting-notes')
+  })
+
+  it('with no open handler the tap still selects and the preview stays', async () => {
+    // A read-only host (no onOpenDocument) has nothing to open into;
+    // looking must keep working, so the preview column survives.
+    coarse = true
+    renderPanel()
+
+    const card = await cardButton('Meeting notes')
+    expect(screen.getByText('Select a document to preview its content.')).toBeTruthy()
+    fireEvent.click(card, { detail: 1 })
+    expect(await screen.findByTestId('okf-preview')).toBeTruthy()
+  })
+
+  it('a long-press on a card opens the sheet menu and does not open the document', async () => {
+    coarse = true
+    const onOpenDocument = vi.fn()
+    const setPinned = vi.fn(async () => {})
+    renderPanel({ onOpenDocument, setPinned })
+
+    const card = await cardButton('Meeting notes')
+    fireEvent.pointerDown(card, { pointerType: 'touch', clientX: 40, clientY: 40, pointerId: 7 })
+    const menu = await screen.findByRole('menu', { name: 'Document actions' })
+    // Pin's first touch-reachable path: it used to live only behind
+    // right-click, which a finger cannot perform.
+    expect(within(menu).getByRole('menuitem', { name: 'Pin' })).toBeTruthy()
+
+    // The release of the long-press must not read as a tap-to-open.
+    fireEvent.pointerUp(card, { pointerType: 'touch', pointerId: 7 })
+    fireEvent.click(card, { detail: 1 })
+    expect(onOpenDocument).not.toHaveBeenCalled()
+  })
+
+  it('a short tap does not open the menu', async () => {
+    coarse = true
+    const onOpenDocument = vi.fn()
+    renderPanel({ onOpenDocument })
+
+    const card = await cardButton('Meeting notes')
+    fireEvent.pointerDown(card, { pointerType: 'touch', clientX: 40, clientY: 40, pointerId: 7 })
+    fireEvent.pointerUp(card, { pointerType: 'touch', pointerId: 7 })
+    fireEvent.click(card, { detail: 1 })
+    expect(screen.queryByRole('menu', { name: 'Document actions' })).toBeNull()
+    expect(onOpenDocument).toHaveBeenCalledWith('meeting-notes')
+  })
+
+  it('a tap on a search result opens it', async () => {
+    coarse = true
+    const onOpenDocument = vi.fn()
+    renderPanel({ onOpenDocument })
+    await cardButton('Meeting notes')
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search documents' }), {
+      target: { value: 'Roadmap' },
+    })
+    const results = await screen.findByTestId('search-results')
+    await waitFor(() => {
+      expect(within(results).getAllByTestId('result-title').length).toBeGreaterThan(0)
+    })
+    const hit = within(results)
+      .getAllByTestId('result-title')
+      .find((el) => el.textContent?.includes('Roadmap'))
+    fireEvent.click(hit?.closest('button') as HTMLElement, { detail: 1 })
+    expect(onOpenDocument).toHaveBeenCalledWith('plans/roadmap')
+  })
+})
+
+describe('fine pointer: click previews, double-click and Enter open', () => {
+  it('click selects into the preview and does not open', async () => {
+    const onOpenDocument = vi.fn()
+    renderPanel({ onOpenDocument })
+
+    const card = await cardButton('Meeting notes')
+    fireEvent.click(card, { detail: 1 })
+    expect(onOpenDocument).not.toHaveBeenCalled()
+    expect(await screen.findByTestId('okf-preview')).toBeTruthy()
+  })
+
+  it('double-click opens', async () => {
+    const onOpenDocument = vi.fn()
+    renderPanel({ onOpenDocument })
+
+    const card = await cardButton('Meeting notes')
+    fireEvent.doubleClick(card)
+    expect(onOpenDocument).toHaveBeenCalledWith('meeting-notes')
+  })
+
+  it('Enter on a focused card opens in one activation', async () => {
+    const onOpenDocument = vi.fn()
+    renderPanel({ onOpenDocument })
+
+    const card = await cardButton('Meeting notes')
+    card.focus()
+    fireEvent.keyDown(card, { key: 'Enter' })
+    expect(onOpenDocument).toHaveBeenCalledWith('meeting-notes')
+  })
+
+  it('Enter opens from the one-column tree too', async () => {
+    localStorage.setItem('whiteboard.document-browser.columns.v1', 'one')
+    try {
+      const onOpenDocument = vi.fn()
+      renderPanel({ onOpenDocument })
+
+      const row = await screen.findByRole('treeitem', { name: /Meeting notes/ })
+      const button = within(row).getByRole('button', { name: /Meeting notes/ })
+      fireEvent.keyDown(button, { key: 'Enter' })
+      expect(onOpenDocument).toHaveBeenCalledWith('meeting-notes')
+    } finally {
+      localStorage.removeItem('whiteboard.document-browser.columns.v1')
+    }
+  })
+})

--- a/apps/web/src/components/workspace-files/open-wayfinding.test.tsx
+++ b/apps/web/src/components/workspace-files/open-wayfinding.test.tsx
@@ -192,3 +192,127 @@ describe('fine pointer: click previews, double-click and Enter open', () => {
     }
   })
 })
+
+describe('one-column tree: object actions stay reachable', () => {
+  // The HIGH regression this locks: with a tap opening the document, the
+  // preview pane (the old route to rename/delete) does not render — so the
+  // tree itself must reach the object menu, on touch AND by right-click.
+  it('coarse: long-press on a tree row opens the action menu', async () => {
+    localStorage.setItem('whiteboard.document-browser.columns.v1', 'one')
+    try {
+      coarse = true
+      const onOpenDocument = vi.fn()
+      renderPanel({ onOpenDocument })
+
+      const row = await screen.findByRole('treeitem', { name: /Meeting notes/ })
+      const button = within(row).getByRole('button', { name: /Meeting notes/ })
+      fireEvent.pointerDown(button, {
+        pointerType: 'touch',
+        clientX: 30,
+        clientY: 30,
+        pointerId: 3,
+      })
+      const menu = await screen.findByRole('menu', { name: 'Document actions' })
+      expect(within(menu).getByRole('menuitem', { name: 'Rename…' })).toBeTruthy()
+
+      fireEvent.pointerUp(button, { pointerType: 'touch', pointerId: 3 })
+      fireEvent.click(button, { detail: 1 })
+      expect(onOpenDocument).not.toHaveBeenCalled()
+    } finally {
+      localStorage.removeItem('whiteboard.document-browser.columns.v1')
+    }
+  })
+
+  it('right-click on a tree row opens the action menu', async () => {
+    localStorage.setItem('whiteboard.document-browser.columns.v1', 'one')
+    try {
+      renderPanel({ onOpenDocument: vi.fn() })
+      const row = await screen.findByRole('treeitem', { name: /Meeting notes/ })
+      const button = within(row).getByRole('button', { name: /Meeting notes/ })
+      fireEvent.contextMenu(button, { clientX: 30, clientY: 30 })
+      expect(await screen.findByRole('menu', { name: 'Document actions' })).toBeTruthy()
+    } finally {
+      localStorage.removeItem('whiteboard.document-browser.columns.v1')
+    }
+  })
+
+  it('double-click on a tree row opens', async () => {
+    localStorage.setItem('whiteboard.document-browser.columns.v1', 'one')
+    try {
+      const onOpenDocument = vi.fn()
+      renderPanel({ onOpenDocument })
+      const row = await screen.findByRole('treeitem', { name: /Meeting notes/ })
+      fireEvent.doubleClick(within(row).getByRole('button', { name: /Meeting notes/ }))
+      expect(onOpenDocument).toHaveBeenCalledWith('meeting-notes')
+    } finally {
+      localStorage.removeItem('whiteboard.document-browser.columns.v1')
+    }
+  })
+})
+
+describe('search results: activation and long-press', () => {
+  async function searchHit(query: string) {
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search documents' }), {
+      target: { value: query },
+    })
+    const results = await screen.findByTestId('search-results')
+    await waitFor(() => {
+      expect(within(results).getAllByTestId('result-title').length).toBeGreaterThan(0)
+    })
+    const hit = within(results)
+      .getAllByTestId('result-title')
+      .find((el) => el.textContent?.includes(query))
+    return hit?.closest('button') as HTMLElement
+  }
+
+  it('double-click on a result opens', async () => {
+    const onOpenDocument = vi.fn()
+    renderPanel({ onOpenDocument })
+    await cardButton('Meeting notes')
+    fireEvent.doubleClick(await searchHit('Roadmap'))
+    expect(onOpenDocument).toHaveBeenCalledWith('plans/roadmap')
+  })
+
+  it('Enter on a result opens without a stray select', async () => {
+    const onOpenDocument = vi.fn()
+    renderPanel({ onOpenDocument })
+    await cardButton('Meeting notes')
+    const row = await searchHit('Roadmap')
+    row.focus()
+    fireEvent.keyDown(row, { key: 'Enter' })
+    expect(onOpenDocument).toHaveBeenCalledWith('plans/roadmap')
+  })
+
+  it('coarse: long-press on a result opens the menu, not the document', async () => {
+    coarse = true
+    const onOpenDocument = vi.fn()
+    renderPanel({ onOpenDocument })
+    await cardButton('Meeting notes')
+    const row = await searchHit('Roadmap')
+    fireEvent.pointerDown(row, { pointerType: 'touch', clientX: 30, clientY: 30, pointerId: 5 })
+    expect(await screen.findByRole('menu', { name: 'Document actions' })).toBeTruthy()
+    fireEvent.pointerUp(row, { pointerType: 'touch', pointerId: 5 })
+    fireEvent.click(row, { detail: 1 })
+    expect(onOpenDocument).not.toHaveBeenCalled()
+  })
+})
+
+describe('long-press guards', () => {
+  it('a drifting hold is a scroll, not a menu', async () => {
+    coarse = true
+    renderPanel({ onOpenDocument: vi.fn() })
+    const card = await cardButton('Meeting notes')
+    fireEvent.pointerDown(card, { pointerType: 'touch', clientX: 40, clientY: 40, pointerId: 7 })
+    fireEvent.pointerMove(card, { pointerType: 'touch', clientX: 40, clientY: 80, pointerId: 7 })
+    await new Promise((resolve) => setTimeout(resolve, 650))
+    expect(screen.queryByRole('menu', { name: 'Document actions' })).toBeNull()
+  })
+
+  it('a held mouse button is not a long-press', async () => {
+    renderPanel({ onOpenDocument: vi.fn() })
+    const card = await cardButton('Meeting notes')
+    fireEvent.pointerDown(card, { pointerType: 'mouse', clientX: 40, clientY: 40, pointerId: 1 })
+    await new Promise((resolve) => setTimeout(resolve, 650))
+    expect(screen.queryByRole('menu', { name: 'Document actions' })).toBeNull()
+  })
+})

--- a/apps/web/src/components/workspace-files/use-long-press.ts
+++ b/apps/web/src/components/workspace-files/use-long-press.ts
@@ -1,0 +1,91 @@
+import { type MouseEvent as ReactMouseEvent, type PointerEvent, useMemo, useRef } from 'react'
+
+/** Matches the platform's own long-press feel (iOS/Android context menus). */
+export const LONG_PRESS_MS = 500
+/** A hold that drifts this far is a scroll, not a press. */
+const MOVE_SLOP_PX = 8
+
+/**
+ * Container-level long-press → object menu, for lists of document cards.
+ *
+ * One hook per LIST, not per card: the cards are rendered inline in a map,
+ * where a per-card hook cannot live, and a timer held in per-render state
+ * would be lost to any re-render that happens mid-hold. The card is found
+ * from the event target's closest `[data-doc-path]`, which each list
+ * already has reason to stamp.
+ *
+ * Touch only (`pointerType === 'touch'`): a mouse held down is a drag or a
+ * hesitation, and right-click already reaches the same menu. Android fires
+ * a native `contextmenu` at roughly the same hold, which opens the same
+ * menu through the card's existing handler — both paths land on the same
+ * state, so racing is harmless.
+ *
+ * `onClickCapture` is the suppression: releasing a long-press still
+ * dispatches a click, and with tap-to-open wired that click would OPEN the
+ * document under the menu that just asked what to do with it.
+ */
+export function useLongPressMenu(
+  onLongPress: ((path: string, x: number, y: number) => void) | undefined,
+): {
+  onPointerDown?: (event: PointerEvent) => void
+  onPointerMove?: (event: PointerEvent) => void
+  onPointerUp?: () => void
+  onPointerCancel?: () => void
+  onClickCapture?: (event: ReactMouseEvent) => void
+} {
+  const pending = useRef<{
+    timer: ReturnType<typeof setTimeout>
+    pointerId: number
+    x: number
+    y: number
+  } | null>(null)
+  const fired = useRef(false)
+
+  return useMemo(() => {
+    if (onLongPress === undefined) return {}
+    const clear = () => {
+      if (pending.current !== null) {
+        clearTimeout(pending.current.timer)
+        pending.current = null
+      }
+    }
+    return {
+      onPointerDown: (event: PointerEvent) => {
+        // Reset here, not only in onClickCapture: after a native
+        // contextmenu (Android) no click follows, and a stale flag would
+        // swallow the NEXT genuine tap.
+        fired.current = false
+        if (event.pointerType !== 'touch') return
+        const path = (event.target as Element)
+          .closest?.('[data-doc-path]')
+          ?.getAttribute('data-doc-path')
+        if (path == null) return
+        clear()
+        const { clientX, clientY, pointerId } = event
+        pending.current = {
+          pointerId,
+          x: clientX,
+          y: clientY,
+          timer: setTimeout(() => {
+            pending.current = null
+            fired.current = true
+            onLongPress(path, clientX, clientY)
+          }, LONG_PRESS_MS),
+        }
+      },
+      onPointerMove: (event: PointerEvent) => {
+        const held = pending.current
+        if (held === null || event.pointerId !== held.pointerId) return
+        if (Math.hypot(event.clientX - held.x, event.clientY - held.y) > MOVE_SLOP_PX) clear()
+      },
+      onPointerUp: clear,
+      onPointerCancel: clear,
+      onClickCapture: (event: ReactMouseEvent) => {
+        if (!fired.current) return
+        fired.current = false
+        event.preventDefault()
+        event.stopPropagation()
+      },
+    }
+  }, [onLongPress])
+}

--- a/apps/web/src/components/workspace-files/use-long-press.ts
+++ b/apps/web/src/components/workspace-files/use-long-press.ts
@@ -1,4 +1,4 @@
-import { type MouseEvent as ReactMouseEvent, type PointerEvent, useMemo, useRef } from 'react'
+import { type PointerEvent, type MouseEvent as ReactMouseEvent, useMemo, useRef } from 'react'
 
 /** Matches the platform's own long-press feel (iOS/Android context menus). */
 export const LONG_PRESS_MS = 500

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -21,9 +21,12 @@ you can put it on a canvas later) and it opens ready to work in.
 
 ![Onboarding chooser](../assets/onboarding-chooser.png)
 
-Once you have documents, the page lands on your document browser: a folder
-tree with a preview pane. Click a card to preview it, **Open** to edit it,
-and use the toolbar to search everything or move a document to a new path.
+Once you have documents, the page lands on your document browser. On a
+touch screen, tap a card to open the document, and press and hold for its
+actions (open, pin, rename, delete). With a mouse, a click previews a card
+in the pane beside the list, and a double-click — or Enter on a focused
+card — opens it. Use the toolbar to search everything or move a document to
+a new path.
 
 **New** in that toolbar opens the same two choices — **Canvas** or **Markdown
 note** — and creates one in whichever folder you are standing in. A kind


### PR DESCRIPTION
## Summary

Slice 1 of the document-browser wayfinding redesign (UX analysis + prior-art review, decided 2026-09-05). The select→preview→Open round trip required **2 taps everywhere** to open a document, and on a phone the only Open button sat below the fold, inside a preview pane stacked under the grid. Every surveyed canvas product (Figma, Miro, Freeform, Excalidraw+) and both platform HIGs converge on the same convention: tap opens, long-press/right-click reaches actions.

- **Coarse pointer (touch): a tap on a card/row/result opens the document.** The preview column does not render there — it could never be filled once a tap opens. Long-press opens the object-action **sheet** (`ContextMenu`'s existing `'sheet'` vessel, 48px targets), which is also **Pin's first touch-reachable path** — it lived only behind right-click, which a finger cannot perform.
- **Fine pointer (desktop): unchanged select-into-preview on click**, plus **double-click opens** and **Enter opens** (keyboard went from two separately-located activations to one; Space keeps the native click, so a keyboard user can still preview — the Explorer/Drive split).
- A read-only host (no `onOpenDocument`) keeps selection + preview: looking is all there is to do.
- Card menu items gained icons (the sheet vessel renders icon-only buttons; the list vessel already had the slot).

Mechanism notes: the long-press is one container-level hook per list (`useLongPressMenu` — a per-card hook cannot live inside a `map`, and a timer in render state dies to any mid-hold re-render); its `onClickCapture` swallows the click a released long-press still dispatches, which with tap-to-open would have opened the document under its own menu.

Next slices (agreed direction, separate PRs): non-verbal card language (kind badges instead of the `markdown · 2d ago` string, visible pin state, larger thumbnails), then the structural pass (grid growth, peek).

## Visual repro

![before: tap selects and Open is a small text button below the fold / after: tap opens; long-press raises the action sheet with Open, Pin, Rename, Delete](tmp/screenshots/picker-figure.png)

Composed by `compose-figure.mjs` (digests `619df044` / `25560afc`); this machine's `gh` is 2.97 (no `--attach`), so the PNG is delivered to the session owner (`tmp/screenshots/picker-figure.png`) for attachment from there, as PR #1092 did. What the figure cannot show: the double-click/Enter desktop path (interaction, not pixels) — that is pinned by the real-browser tests below.

## Test plan

- [x] Red-first jsdom suite `open-wayfinding.test.tsx` (9 cases): coarse tap opens + no preview column, read-only host keeps preview, long-press opens the sheet with Pin and suppresses the release-click, short tap opens without a menu, search-result tap opens, fine click still previews, double-click opens, Enter opens (grid + one-column tree).
- [x] Real-browser lock `open-wayfinding.browser.test.tsx` (4 cases): native event ORDER is what jsdom cannot prove — a real dblclick dispatches click,click,dblclick (open fires exactly once), a real Enter fires the native click the keydown's preventDefault must swallow, and a real held touch pointer raises the sheet without leaking an open on release.
- [x] `pnpm vitest run --project web-browser`: 1046 passed; the 2 failures are `shaped-node-editing.browser.test.tsx`, which fails identically on a clean `main` checkout (pre-existing, unrelated — filed as an issue).
- [x] `web-jsdom` for `src/components/workspace-files` + `src/pages`: 632 passed / 1 pre-existing load-shaped flake (`BrowserDocumentPage.create-delete-node`, passes in isolation).
- [x] `pnpm --filter @kamiazya/whiteboard-web typecheck`, biome clean.
- [x] Manual verification completed against the real preview deployment (`https://picker-tap-open.kamiazya-whiteboard.pages.dev`), driven by local Playwright — real Chromium, real service worker, iPhone-13 emulation for touch (`pointer: coarse` verified true) and a fine-pointer context for desktop. All 11 checks passed: touch tap opens / no preview column / long-press raises the bottom sheet (Open · Rename · Delete; Pin absent because the browser keeper has no `setPinned` — correct) and its release does not open; desktop click previews without navigating, double-click opens, Enter opens, right-click menu intact. Driver: `tmp/scripts/verify-picker-preview.mjs`.
- [x] Review gate (`review.workflow.mjs`, 15 agents) ran over the diff: its HIGH finding — the one-column tree on touch lost every route to the object verbs once the preview pane stopped rendering — is fixed in `7722992` (tree gets the same long-press + right-click wiring; mutation-checked), and its coverage findings are locked by 8 added tests (search-result dblclick/Enter/long-press, tree dblclick, drift-cancels-long-press, mouse-hold-is-not-long-press).
- Found during verification, filed as an issue (pre-existing on main, reproduced at 85e5c511 locally): SPA **Back** from the editor to the index shows stale onboarding although the created document exists; a direct load lists it correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLiRSAKQA8rRW7j6XBJhAE

