### PR TITLE
feat(web): the offline replica takes spatial edits too — ADR-0023 decision 3 complete

### DIFF
--- a/apps/web/src/pages/ReplicaReadPage.browser.test.tsx
+++ b/apps/web/src/pages/ReplicaReadPage.browser.test.tsx
@@ -9,6 +9,7 @@ import {
   createWorkspaceDocumentAtPath,
   documentContainers,
   readMarkdownBody,
+  readSpatialCanvas,
   writeMarkdownBody,
   writeSpatialCanvas,
 } from '@kamiazya/whiteboard-loro-adapter'
@@ -16,6 +17,10 @@ import { cleanup, render, screen } from '@testing-library/react'
 import { LoroDoc } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import {
+  fillNodeEditor,
+  nodeEditorContent,
+} from '../components/spatial-editor/node-editor-test-utils.js'
 import { BrowserWorkspaceDocs } from '../lib/browser-workspace-docs.js'
 import { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { clearWhiteboardDb } from '../test-utils/browser-document.js'
@@ -66,11 +71,71 @@ describe('ReplicaReadPage', () => {
     expect(await screen.findAllByText(/Hello from the cache/)).toHaveLength(2)
   })
 
-  it('renders a spatial document through the read-only viewer', async () => {
+  it('a spatial edit persists as a visible diff — the unknown record survives', async () => {
+    // Decision 3's spatial half. The unknown-version record is the sharp
+    // edge: a whole-canvas resync would delete it, and on a replica that
+    // deletion SHIPS — so the page must persist through the visible-diff
+    // reconcile, and the planted record must survive an edit session.
     await seedReplica()
-    render(<ReplicaReadPage workspaceId={DAEMON_WS} syncedAt={SYNCED} />)
+    {
+      const docs = new BrowserWorkspaceDocs()
+      const record = await docs.open(DAEMON_WS)
+      // Into the DOCUMENT's own containers — the workspace record scopes
+      // each document's nodes map under its subtree, and a root-level map
+      // of the same name is a different (unread) container.
+      documentContainers(record!, DOC_SP)
+        .getMap('nodes')
+        .set('from-the-future', { type: 'hologram', shimmer: true })
+      record!.commit()
+      await docs.save(DAEMON_WS, record!)
+    }
+    const { unmount } = render(
+      // A real pane height: the page fills its parent, and RTL's default
+      // container has none — a zero-height editor is not the surface under
+      // test.
+      <div style={{ width: 900, height: 600 }}>
+        <ReplicaReadPage workspaceId={DAEMON_WS} syncedAt={SYNCED} />
+      </div>,
+    )
     await userEvent.click(await screen.findByText('sketch'))
+    const editor = await screen.findByTestId('spatial-editor')
     expect(await screen.findByText(/cached node/)).toBeTruthy()
+
+    // Double-click empty space: creates a text node and opens its editor.
+    // Coordinates from the editor's own box — the pane's size depends on
+    // the test viewport, and a point outside it would pan, not create.
+    const box = editor.getBoundingClientRect()
+    const cx = box.left + box.width * 0.7
+    const cy = box.top + box.height * 0.7
+    for (const type of ['pointerdown', 'pointerup', 'pointerdown', 'pointerup']) {
+      editor.dispatchEvent(
+        new PointerEvent(type, {
+          bubbles: true,
+          clientX: cx,
+          clientY: cy,
+          pointerId: 7,
+          button: 0,
+        }),
+      )
+      await new Promise((r) => setTimeout(r, 30))
+    }
+    await screen.findByTestId('text-node-editor')
+    fillNodeEditor(document, 'offline sketch note')
+    ;(nodeEditorContent(document) as HTMLElement).blur()
+    unmount()
+
+    await vi.waitFor(async () => {
+      const record = await new BrowserWorkspaceDocs().open(DAEMON_WS)
+      const canvas = readSpatialCanvas(documentContainers(record!, DOC_SP))
+      expect(canvas.nodes.map((n) => (n.type === 'text' ? n.text : ''))).toContain(
+        'offline sketch note',
+      )
+      // The record today's schema cannot read is still there, untouched.
+      expect(documentContainers(record!, DOC_SP).getMap('nodes').get('from-the-future')).toEqual({
+        type: 'hologram',
+        shimmer: true,
+      })
+    })
   })
 
   it('a missing replica renders as missing, and is NOT minted by the visit', async () => {

--- a/apps/web/src/pages/ReplicaReadPage.tsx
+++ b/apps/web/src/pages/ReplicaReadPage.tsx
@@ -15,17 +15,20 @@
  * viewer, which must stay out of the entry closure
  * (entry-graph-loro-free.test.ts).
  */
-import { CanvasViewer } from '@kamiazya/whiteboard-canvas-viewer'
+
 import {
   documentContainers,
   readMarkdownBody,
   readSpatialCanvas,
   readWorkspaceDocuments,
+  reconcileSpatialCanvas,
   writeMarkdownBody,
 } from '@kamiazya/whiteboard-loro-adapter'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import type { LoroDoc } from 'loro-crdt'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { MarkdownEditor } from '../components/markdown-editor/MarkdownEditor.js'
+import { SpatialEditor } from '../components/spatial-editor/SpatialEditor.js'
 import type { WorkspaceDocumentEntry } from '../components/workspace-files/document-entry.js'
 import { WorkspaceFileTree } from '../components/workspace-files/WorkspaceFileTree.js'
 import { BrowserWorkspaceDocs } from '../lib/browser-workspace-docs.js'
@@ -147,7 +150,30 @@ export function ReplicaReadPage({ workspaceId, displayName, syncedAt }: ReplicaR
   // Selection decides the draft; the record is the source on every switch.
   useEffect(() => {
     setDraft(content?.kind === 'markdown' ? content.body : null)
+    spatialPrev.current = content?.kind === 'spatial' ? content.canvas : null
+    setSpatialDraft(content?.kind === 'spatial' ? content.canvas : null)
   }, [content])
+
+  // The spatial draft mirrors the markdown one; `spatialPrev` is what the
+  // visible-diff reconcile compares against, advanced on every commit.
+  const [spatialDraft, setSpatialDraft] = useState<SpatialCanvas | null>(null)
+  const spatialPrev = useRef<SpatialCanvas | null>(null)
+  const onSpatialChange = useCallback(
+    (next: SpatialCanvas) => {
+      if (state.kind !== 'ready' || selected === undefined || selected.kind !== 'spatial') return
+      setSpatialDraft(next)
+      const prev = spatialPrev.current
+      if (prev !== null) {
+        // A visible diff, never a whole-canvas resync: a resync's silent
+        // deletion of an unknown-version record would become an op that
+        // SHIPS, erasing a newer client's node on the keeper.
+        reconcileSpatialCanvas(documentContainers(state.record, selected.documentId), prev, next)
+      }
+      spatialPrev.current = next
+      scheduleSave(state.record)
+    },
+    [state, selected, scheduleSave],
+  )
 
   const onDraftChange = useCallback(
     (next: string) => {
@@ -168,8 +194,7 @@ export function ReplicaReadPage({ workspaceId, displayName, syncedAt }: ReplicaR
         <span className="font-medium">{displayName ?? workspaceId}</span>
         {' — the daemon that keeps this workspace is unreachable. '}
         This is the copy cached in this browser (synced {new Date(syncedAt).toLocaleString()}).
-        Markdown edits save here and ship to the daemon when it returns; spatial documents open
-        read-only.
+        Edits save here and ship to the daemon when it returns.
       </div>
       {state.kind === 'loading' && <p className="p-4 text-sm text-muted-foreground">Loading…</p>}
       {state.kind === 'missing' && (
@@ -186,7 +211,18 @@ export function ReplicaReadPage({ workspaceId, displayName, syncedAt }: ReplicaR
               {...(selectedPath === null ? {} : { selectedPath })}
             />
           </div>
-          <div className="min-w-0 flex-1 overflow-auto p-4">
+          <div
+            className={
+              // The spatial editor measures itself: inside a padded
+              // overflow-auto box its h-full slightly overflows, a scrollbar
+              // appears, the box shrinks, the scrollbar leaves — a
+              // ResizeObserver oscillation React reports as "maximum update
+              // depth exceeded". Text content keeps the scrolling pane.
+              content?.kind === 'spatial'
+                ? 'min-w-0 flex-1 overflow-hidden'
+                : 'min-w-0 flex-1 overflow-auto p-4'
+            }
+          >
             {content === null && (
               <p className="text-sm text-muted-foreground">Select a document to read.</p>
             )}
@@ -198,10 +234,16 @@ export function ReplicaReadPage({ workspaceId, displayName, syncedAt }: ReplicaR
                 onChange={onDraftChange}
               />
             )}
-            {content?.kind === 'spatial' && (
-              <CanvasViewer
-                canvas={content.canvas}
-                label={selected === undefined ? undefined : (selected.name ?? selected.path)}
+            {content?.kind === 'spatial' && spatialDraft !== null && (
+              <SpatialEditor
+                key={selected?.documentId}
+                canvas={spatialDraft}
+                onChange={onSpatialChange}
+                // Editing-forward: the palette still offers the hand tool,
+                // but an offline visit that came here to fix something
+                // should not need a tool switch first.
+                defaultTool="select"
+                className="h-full"
               />
             )}
           </div>

--- a/docs/contributing/adr/0023-replica-model.md
+++ b/docs/contributing/adr/0023-replica-model.md
@@ -1,6 +1,6 @@
 # ADR-0023: A workspace has one keeper; every other copy is a replica
 
-**Status:** Accepted — decisions 1–5 are implemented; the dated notes under each decision say what landed when. Remaining later work: offline SPATIAL edits (decision 3's markdown half shipped; the canvas editor mount is the only missing piece — the convergence argument is identical)
+**Status:** Accepted — decisions 1–5 are implemented in full; the dated notes under each decision say what landed when
 
 ## Context
 
@@ -134,10 +134,21 @@ boundary, not a different design.
 > recorded frontier ships one full snapshot, ending the snapshot era).
 > `scheduleReplicaPush` runs on every daemon resolve, BEFORE the pull; a
 > clean replica costs one loro-free IndexedDB frontier read and no
-> network, so cleanliness is the dedupe. Spatial documents stay read-only;
-> control-plane actions stay absent. No "unsent edits" badge on purpose:
-> the push is automatic on the first resolve after the daemon returns, so
-> the state it would name resolves itself in seconds.
+> network, so cleanliness is the dedupe. Control-plane actions stay
+> absent. No "unsent edits" badge on purpose: the push is automatic on the
+> first resolve after the daemon returns, so the state it would name
+> resolves itself in seconds.
+>
+> **Spatial edits, 2026-09-05 — decision 3 complete.** The offline page
+> mounts the real spatial editor over the replica record; persistence goes
+> through `reconcileSpatialCanvas` (loro-adapter), a VISIBLE-diff applier —
+> writes what changed, deletes only ids the caller could see, and never
+> touches a record the current schema cannot read. That property is the
+> sharp edge on a replica: a whole-canvas resync's silent deletion of an
+> unknown-version record would become an op that SHIPS, erasing a newer
+> client's node on the keeper. Pinned by planting such a record and editing
+> around it; mutation-checked — degrading the page's persist to
+> `writeSpatialCanvas` turns exactly that test red.
 
 ### 4. Transparent mode is rejected as specified, and its goal is met here
 

--- a/packages/loro-adapter/src/index.ts
+++ b/packages/loro-adapter/src/index.ts
@@ -23,6 +23,7 @@ export {
   readNodeLocks,
   readSpatialCanvas,
   readTrustFacets,
+  reconcileSpatialCanvas,
   type SpatialBatchWriter,
   setEdgeLock,
   setNodeLock,

--- a/packages/loro-adapter/src/loro-bridge.test.ts
+++ b/packages/loro-adapter/src/loro-bridge.test.ts
@@ -17,6 +17,7 @@ import {
   readFacets,
   readNodeLocks,
   readSpatialCanvas,
+  reconcileSpatialCanvas,
   setEdgeLock,
   setNodeLock,
   withSpatialBatch,
@@ -1176,5 +1177,62 @@ describe('canvas comments bridge', () => {
       expect(readSpatialCanvas(doc).nodes).toEqual([])
       expect(undoManager.canUndo()).toBe(false)
     })
+  })
+})
+
+describe('reconcileSpatialCanvas', () => {
+  const A: SpatialNode = { id: 'a', type: 'text', text: 'alpha', x: 0, y: 0, width: 10, height: 10 }
+  const B: SpatialNode = { id: 'b', type: 'text', text: 'beta', x: 5, y: 5, width: 10, height: 10 }
+
+  test('writes only what changed, deletes only what the caller could SEE, never the rest', () => {
+    const doc = makeDoc()
+    writeSpatialCanvas(doc, { nodes: [A, B], edges: [] })
+    // A record from "another version": a shape today's schema rejects. A
+    // whole-canvas resync would delete it — and on a replica that deletion
+    // would SHIP, erasing a newer client's node on the daemon.
+    doc.getMap('nodes').set('from-the-future', { type: 'hologram', shimmer: true })
+
+    const prev = readSpatialCanvas(doc)
+    reconcileSpatialCanvas(doc, prev, { nodes: [{ ...A, text: 'alpha edited' }], edges: [] })
+
+    const after = readSpatialCanvas(doc)
+    expect(after.nodes.find((n) => n.id === 'a')).toMatchObject({ text: 'alpha edited' })
+    expect(after.nodes.find((n) => n.id === 'b')).toBeUndefined()
+    expect(doc.getMap('nodes').get('from-the-future')).toEqual({ type: 'hologram', shimmer: true })
+  })
+
+  test('reconciles edges and comments by the same visible-diff rule', () => {
+    const doc = makeDoc()
+    writeSpatialCanvas(doc, {
+      nodes: [A, B],
+      edges: [{ id: 'e1', fromNode: 'a', toNode: 'b' }],
+      'x-whiteboard': { comments: [{ id: 'c1', x: 1, y: 1, text: 'keep' }] },
+    })
+    const prev = readSpatialCanvas(doc)
+    reconcileSpatialCanvas(doc, prev, {
+      nodes: [A, B],
+      edges: [{ id: 'e2', fromNode: 'b', toNode: 'a' }],
+      'x-whiteboard': {
+        comments: [
+          { id: 'c1', x: 1, y: 1, text: 'keep' },
+          { id: 'c2', x: 2, y: 2, text: 'new' },
+        ],
+      },
+    })
+
+    const after = readSpatialCanvas(doc)
+    expect(after.edges.map((e) => e.id)).toEqual(['e2'])
+    expect((after['x-whiteboard']?.comments ?? []).map((c) => c.id).sort()).toEqual(['c1', 'c2'])
+  })
+
+  test('an unchanged canvas writes nothing at all', () => {
+    const doc = makeDoc()
+    writeSpatialCanvas(doc, { nodes: [A], edges: [] })
+    doc.commit()
+    const before = doc.oplogVersion().encode()
+    const prev = readSpatialCanvas(doc)
+    reconcileSpatialCanvas(doc, prev, prev)
+    doc.commit()
+    expect(Array.from(doc.oplogVersion().encode())).toEqual(Array.from(before))
   })
 })

--- a/packages/loro-adapter/src/loro-bridge.ts
+++ b/packages/loro-adapter/src/loro-bridge.ts
@@ -321,6 +321,77 @@ export function deleteSpatialEdge(doc: DocumentContainers, edgeId: string): void
   if (deleteEdgeInto(doc, edgeId)) doc.commit()
 }
 
+/**
+ * Applies `next` to the stored canvas as a VISIBLE-diff against `prev`:
+ * writes only entries that changed, deletes only ids the caller could SEE
+ * in `prev` — and therefore never touches a record the current schema
+ * cannot read. That is the property `writeSpatialCanvas`'s whole-truth
+ * resync deliberately does not have, and it is load-bearing for a REPLICA:
+ * a resync's silent deletion of an unknown-version record would become an
+ * op that SHIPS, erasing a newer client's node on the keeper.
+ *
+ * `prev` must be the canvas the edit started from (what `readSpatialCanvas`
+ * answered), not an older snapshot — a stale `prev` under-reports deletions
+ * and over-reports changes, both of which stay safe but write more ops than
+ * needed. Node/edge/comment writes share one commit; the envelope (the
+ * non-comment `x-whiteboard` fields) is a single LWW value and is only
+ * touched when it visibly changed.
+ */
+export function reconcileSpatialCanvas(
+  doc: DocumentContainers,
+  prev: SpatialCanvas,
+  next: SpatialCanvas,
+): void {
+  const same = (a: unknown, b: unknown): boolean =>
+    a === b || JSON.stringify(a) === JSON.stringify(b)
+
+  withSpatialBatch(doc, (writer) => {
+    const prevNodes = new Map(prev.nodes.map((node) => [node.id, node]))
+    const nextNodeIds = new Set(next.nodes.map((node) => node.id))
+    for (const node of next.nodes) {
+      const before = prevNodes.get(node.id)
+      if (before === undefined || !same(before, node)) writer.writeNode(node)
+    }
+    for (const id of prevNodes.keys()) if (!nextNodeIds.has(id)) writer.deleteNode(id)
+
+    const prevEdges = new Map(prev.edges.map((edge) => [edge.id, edge]))
+    const nextEdgeIds = new Set(next.edges.map((edge) => edge.id))
+    for (const edge of next.edges) {
+      const before = prevEdges.get(edge.id)
+      if (before === undefined || !same(before, edge)) writer.writeEdge(edge)
+    }
+    for (const id of prevEdges.keys()) if (!nextEdgeIds.has(id)) writer.deleteEdge(id)
+
+    const prevComments = new Map(
+      (prev[EXTENSION_FIELD]?.comments ?? []).map((comment) => [comment.id, comment]),
+    )
+    const nextComments = next[EXTENSION_FIELD]?.comments ?? []
+    const nextCommentIds = new Set(nextComments.map((comment) => comment.id))
+    for (const comment of nextComments) {
+      const before = prevComments.get(comment.id)
+      if (before === undefined || !same(before, comment)) writer.writeComment(comment)
+    }
+    for (const id of prevComments.keys()) {
+      if (!nextCommentIds.has(id)) writer.deleteComment(id)
+    }
+  })
+
+  const envelopeOf = (canvas: SpatialCanvas): Record<string, unknown> => {
+    const { comments: _comments, ...envelope } = canvas[EXTENSION_FIELD] ?? {}
+    return envelope
+  }
+  const nextEnvelope = envelopeOf(next)
+  if (!same(envelopeOf(prev), nextEnvelope)) {
+    const canvasMap = doc.getMap(CANVAS_KEY)
+    if (Object.values(nextEnvelope).every((value) => value === undefined)) {
+      canvasMap.delete(EXTENSION_FIELD)
+    } else {
+      canvasMap.set(EXTENSION_FIELD, nextEnvelope)
+    }
+    doc.commit()
+  }
+}
+
 /** Uncommitted spatial writes scoped to one `withSpatialBatch` call. */
 export interface SpatialBatchWriter {
   writeNode(node: SpatialNode): void


### PR DESCRIPTION
## What this completes

**ADR-0023 decision 3 in full**: the offline replica now takes spatial edits alongside markdown — the real `SpatialEditor` mounted over the replica record, edits appended as ordinary CRDT ops and shipped by the existing `replica-push` on the daemon's return. The ADR status line drops its last "remaining" item.

## Visual repro

Visual evidence: none — the figure WAS produced and verified (the same seeded replica sketch through the real `ReplicaReadPage`; before: the read-only `CanvasViewer` under a banner saying spatial opens read-only; after: the real spatial editor with its tool palette under the new banner; composed by `compose-figure.mjs`, panel digests before 9c864909 / after 0cdabb78, at `tmp/screenshots/spatial-edits-figure.png`) — this machine's `gh` (2.97) predates `--attach`; the figure was handed to the repo owner directly for attachment.

## The design point a reviewer should press on

**Persistence is a new loro-adapter primitive, `reconcileSpatialCanvas(doc, prev, next)` — a VISIBLE-diff applier — and deliberately not the editor's usual commit pipeline.** `document-sync-session`'s `commitToDoc` falls back to a whole-canvas `writeSpatialCanvas` resync, whose whole-truth semantics silently delete any record the current schema cannot read. Acceptable on a live session; on a replica that deletion becomes an op that **ships**, erasing a newer client's node on the keeper. The reconcile writes what changed and deletes only ids the caller could see in `prev`, so an unknown-version record is structurally unreachable.

Pinned at both layers:
- loro-adapter: planted `{type:'hologram'}` record survives a reconcile that edits and deletes around it; an unchanged canvas writes **zero ops** (byte-compared oplog).
- page: a real edit session (dblclick-create → type → blur → unmount-flush) persists the typed node and leaves the planted record intact, and files no index row.

Mutations red: reconcile degraded to whole-canvas resync, deletion loop dropped, and the page's persist degraded the same way. One **equivalent mutant** recorded honestly: dropping the unchanged-skip guard stays green because Loro's same-value map set already emits no op — the guard is a performance nicety.

## Also in here

- A test-harness finding worth the comment it now carries: mounting this page in RTL's default (height-less) container oscillates the editor's viewport measurement into a "maximum update depth" flood — ~5k console errors and a hung run. Real mounts always sit in a rooted `h-full` chain; the page test provides an explicit height and says why. Diagnosed by instrumenting `onChange` (fired once; the flood was internal) and confirmed by the sized-container control.
- Banner copy: "Edits save here and ship to the daemon when it returns" (both kinds).

## Verification

- loro-adapter-node 182/182 (3 new reconcile tests) · web-browser ReplicaReadPage 5/5 · `pnpm test:browser` full: only the 2 known local-only `shaped-node-editing` fails (CI green on main) · `-r typecheck` 0 · knip clean · lint clean. Per the 2026-09-05 policy, full non-browser suites are CI's job.
