### PR TITLE
feat(lint): turn three silent logging and coverage failures into loud ones

### DIFF
--- a/.claude/scripts/biome-plugin.test.mjs
+++ b/.claude/scripts/biome-plugin.test.mjs
@@ -1,4 +1,4 @@
-// Lint-the-linter: the GritQL plugin (tools/biome-plugins/test-flake-shapes.grit)
+// Lint-the-linter: the GritQL plugin (tools/biome-plugins/*.grit)
 // is config, and config regresses silently — a pattern edit that stops
 // matching leaves `pnpm lint` green over the exact shapes it was built to
 // catch. So a fixture pair pins both directions: the bad fixture must yield
@@ -14,12 +14,12 @@ import { test } from 'node:test'
 const REPO_ROOT = join(import.meta.dirname, '../..')
 const FIXTURES = join(import.meta.dirname, 'fixtures/biome-plugin')
 
-function lint(file) {
+function lint(file, plugin = 'tools/biome-plugins/test-flake-shapes.grit') {
   const dir = mkdtempSync(join(tmpdir(), 'biome-plugin-guard-'))
   writeFileSync(
     join(dir, 'biome.json'),
     JSON.stringify({
-      plugins: [join(REPO_ROOT, 'tools/biome-plugins/test-flake-shapes.grit')],
+      plugins: [join(REPO_ROOT, plugin)],
       formatter: { enabled: false },
       linter: { rules: { correctness: { noUnusedVariables: 'off' } } },
     }),
@@ -48,4 +48,23 @@ test('the good fixture trips none of the four rules', () => {
     out,
     /Side effect inside waitFor|afterEach wipes|Non-ASCII character in a userEvent|vi\.useFakeTimers\(\) with no vi\.useRealTimers\(\)/,
   )
+})
+
+// The logger rule lives in its own plugin because its scope is the opposite
+// of the flake shapes': production source under packages/mcp-server/src/
+// server/**, never a test file. The good fixture carries the three shapes
+// that must stay silent — fields-first, a bare message, and a real printf
+// call — because the printf carve-out is the one a tightening edit would
+// take out first.
+const LOGGER_PLUGIN = 'tools/biome-plugins/logger-argument-order.grit'
+
+test('the bad logger fixture trips the argument-order rule on every call', () => {
+  const out = lint(join(FIXTURES, 'bad-logger.ts'), LOGGER_PLUGIN)
+  const hits = out.match(/Message first, argument second/g) ?? []
+  assert.equal(hits.length, 2, `expected both wrong calls flagged, got ${hits.length}`)
+})
+
+test('the good logger fixture trips nothing', () => {
+  const out = lint(join(FIXTURES, 'good-logger.ts'), LOGGER_PLUGIN)
+  assert.doesNotMatch(out, /Message first, argument second/)
 })

--- a/.claude/scripts/fixtures/biome-plugin/bad-logger.ts
+++ b/.claude/scripts/fixtures/biome-plugin/bad-logger.ts
@@ -1,0 +1,11 @@
+// Fixture: the pino printf-overload mistake. The object is read as an
+// interpolation argument for a message with no placeholder, so it is
+// dropped and the record ships with no fields at all.
+declare const log: Record<string, (...args: unknown[]) => void>
+declare const workspaceId: string
+declare const err: unknown
+
+export function wrong(): void {
+  log.warning('skipped corrupt row', { workspaceId, err })
+  log.error('request failed', { workspaceId })
+}

--- a/.claude/scripts/fixtures/biome-plugin/good-logger.ts
+++ b/.claude/scripts/fixtures/biome-plugin/good-logger.ts
@@ -1,0 +1,12 @@
+// Fixture: the correct pino order, plus the two shapes the rule must NOT
+// flag — a bare message, and a real printf call whose placeholder makes the
+// second argument an interpolation argument on purpose.
+declare const log: Record<string, (...args: unknown[]) => void>
+declare const workspaceId: string
+declare const err: unknown
+
+export function right(): void {
+  log.warning({ workspaceId, err }, 'skipped corrupt row')
+  log.notice('no auth token provided; admission disabled')
+  log.info('resolved %s', workspaceId)
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,13 +154,15 @@ const log = getLogger('canvas-store')
 log.warning({ workspaceId, documentId, err }, 'skipped corrupt row')
 ```
 
-**Fields first, message second.** This is pino's signature, and getting it
-round the wrong way is silent: `log.warning('msg', { … })` matches the
-printf overload, where the object is an interpolation argument for a message
-with no placeholder, so it is dropped and the record ships with no fields at
-all. Nothing fails — not the types (`...args` is `any[]`), not a test that
-only checks the message. Measured on a real call site: `{"level":"warning",
-"scope":"…","msg":"…"}` with the `dataDir` and `err` simply gone.
+**Fields first, message second — pino, so `mcp-server/src/server/**` only.**
+`log.warning('msg', x)` hits the printf overload: no placeholder, nothing to
+interpolate, so `x` is DROPPED whatever it is — object, `Error`, string —
+and nothing fails, not the types (`...args` is `any[]`) nor a test checking
+only the message. `logger-argument-order.grit` makes it a lint error.
+
+**`server-core`'s seam and `apps/web`'s `app-logger` take the OPPOSITE
+order**, `(message, data)` — so the rule is scoped, and `log.error('x', err)`
+is right there, lossy here.
 
 Why this exists:
 
@@ -178,8 +180,8 @@ Why this exists:
 - Clients can call MCP `logging/setLevel` to adjust their per-session view; the
   SDK handles the request once the `logging: {}` capability is registered.
 
-Tests use `resetLoggerForTests({ level, sink })` to install a fake sink and
-assert against structured records instead of spying on `console`.
+Tests use `captureLogsForTests(level)` to buffer parsed records and assert
+against them rather than spying on `console`; `restore()` in `afterEach`.
 
 ### Redaction
 

--- a/biome.json
+++ b/biome.json
@@ -115,6 +115,10 @@
     {
       "path": "./tools/biome-plugins/test-flake-shapes.grit",
       "includes": ["**/*.test.ts", "**/*.test.tsx", "**/*.browser.test.ts", "**/*.browser.test.tsx"]
+    },
+    {
+      "path": "./tools/biome-plugins/logger-argument-order.grit",
+      "includes": ["packages/mcp-server/src/server/**/*.ts", "!**/*.test.ts"]
     }
   ]
 }

--- a/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
+++ b/packages/mcp-server/scripts/smoke/mcp-e2e-smoke.mjs
@@ -1046,6 +1046,7 @@ async function main() {
     versionId: saved.version.id,
   })
   if (
+    restored.mode !== 'in-place' ||
     restored.documentId !== documentId ||
     restored.restoredVersionId !== saved.version.id ||
     restored.label !== 'e2e'

--- a/packages/mcp-server/src/server/mcp/smoke-tool-list-parity.test.ts
+++ b/packages/mcp-server/src/server/mcp/smoke-tool-list-parity.test.ts
@@ -1,9 +1,22 @@
-// The smoke script keeps its own copy of the tool list (it is plain .mjs and
-// cannot import the TS module), and a comment asking the two to agree is not
-// a guard: adding a tool updated one list and left the other, which reads as
+// Guards over what the smoke script actually DOES, in two directions the
+// script cannot check about itself.
+//
+// The smoke keeps its own copy of the tool list (it is plain .mjs and cannot
+// import the TS module), and a comment asking the two to agree is not a
+// guard: adding a tool updated one list and left the other, which reads as
 // "tools/list does not match expected" long after the edit that caused it.
+//
+// The second direction is finer than the tool. Coverage here is recorded per
+// TOOL, and what the MCP SDK validates at runtime is per OUTPUT SHAPE — so a
+// tool whose output is partitioned by a discriminator can sit in
+// COVERED_TOOLS, truthfully, with some of its shapes never produced. That is
+// not hypothetical: `wb_version_restore` was COVERED with only one of its
+// three modes reached, and renaming a field on either of the other two left
+// `pnpm smoke:e2e` green.
+
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
+import { versionRestoreOutputSchema } from '@kamiazya/whiteboard-server-core'
 import { describe, expect, it } from 'vitest'
 import {
   ALL_REGISTERED_TOOLS,
@@ -59,5 +72,50 @@ describe('the smoke script really calls what COVERED_TOOLS claims', () => {
       calledSet.has(name),
       `${name} is classified UNIT_ONLY/DEFERRED but the smoke calls it — move it to COVERED_TOOLS`,
     ).toBe(false)
+  })
+})
+
+// `wb_version_restore` is the repo's ONLY tool whose output schema carries a
+// discriminator that partitions the output into distinct shapes — measured
+// across every registered tool, not assumed. `deleted`/`imported` are
+// constants and thread-edit's `status` is a data field, none of them naming
+// a second shape. So this is a rule about one surface rather than a table
+// over many, per `.claude/rules/coverage-ledger.md`: a scan generalized from
+// a single instance is how a convention gets made by accident.
+//
+// The modes are read from the SCHEMA, so adding a fourth fails here until
+// the smoke produces it. A hand-written list beside the enum would be the
+// same drift one level up.
+describe('the smoke script produces every restore output shape', () => {
+  const MODES = versionRestoreOutputSchema.shape.mode.options
+
+  // Comments are stripped first. This file's own history is the reason: the
+  // smoke's prose names all three modes while its assertions name fewer, so
+  // a raw scan would report full coverage from the comments alone — the
+  // "strip comments before matching" lesson `coverage-ledger.md` records.
+  const executable = smokeSource
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('//'))
+    .join('\n')
+  const asserted = new Set(
+    [...executable.matchAll(/\.mode !== '([a-z-]+)'/g)].map((match) => match[1]),
+  )
+
+  it('found a plausible number of mode assertions (scan sanity, not vacuous)', () => {
+    // Without this, a regex that matched nothing would make every assertion
+    // below read as "the smoke covers no mode", which is a different and
+    // far more alarming failure than the one that is real.
+    expect(asserted.size).toBeGreaterThan(0)
+  })
+
+  it.each(MODES)('asserts mode === %s', (mode) => {
+    expect(
+      asserted.has(mode),
+      `wb_version_restore can answer mode: '${mode}' and the smoke never asserts it — that shape's structuredContent is never validated at runtime`,
+    ).toBe(true)
+  })
+
+  it('asserts no mode the schema cannot answer', () => {
+    expect([...asserted].sort()).toEqual([...MODES].sort())
   })
 })

--- a/tools/biome-plugins/logger-argument-order.grit
+++ b/tools/biome-plugins/logger-argument-order.grit
@@ -1,0 +1,50 @@
+language js
+
+// Executable half of AGENTS.md's "Fields first, message second."
+// Guarded by .claude/scripts/biome-plugin.test.mjs (fixture pair).
+//
+// `log.warning('msg', x)` matches pino's PRINTF overload: with no
+// placeholder in the message there is nothing to interpolate, so `x` is
+// dropped and the record ships without it. Nothing fails — not the types
+// (`...args` is `any[]`), not a test that asserts on the message.
+//
+// Observed on this repo's own logger rather than taken from the prose. The
+// second argument is lost whatever it is, which is why this rule does not
+// bother to check its shape:
+//
+//   log.warning('A obj second', { a: 1 })      -> {"msg":"A obj second"}
+//   log.warning('B err second', new Error())   -> {"msg":"B err second"}
+//   log.warning('C string second', 'extra')    -> {"msg":"C string second"}
+//   log.warning('D with %s placeholder', 'interp')
+//                                              -> {"msg":"D with interp placeholder"}
+//   log.warning({ a: 1 }, 'E fields first')    -> {"a":1,"msg":"E fields first"}
+//
+// A message carrying `%` is a real printf call (row D) and is left alone.
+//
+// SCOPED in biome.json to packages/mcp-server/src/server/**, and it has to
+// be: this is the only pino logger in the repo. server-core's seam and
+// apps/web's app-logger both take (message, data) — the OPPOSITE order — so
+// a rule reaching them would flag correct code, and the wrong habit is
+// genuinely one package away.
+//
+// Two limits, stated rather than discovered later:
+//   - The receiver is not constrained. Keying on `log` would miss the one
+//     site called `httpLog` (46 use `log`, 1 does not), and a miss here is
+//     silent while a false positive is visible — measured 0 non-logger
+//     matches in the scoped directory.
+//   - A template-literal message is not matched; no node name for one
+//     compiles in this dialect. Measured 0 such log calls in scope, and
+//     AGENTS.md already discourages interpolating into the message.
+`$logger.$level($msg, $second)` where {
+  $level <: or {
+    `debug`, `info`, `notice`, `warning`,
+    `error`, `critical`, `alert`, `emergency`
+  },
+  $msg <: string() as $s,
+  not $s <: r".*%.*",
+  register_diagnostic(
+    span = $msg,
+    message = "Message first, argument second: pino reads this as printf, and with no placeholder in the message the second argument is DROPPED — the record ships without it, and nothing fails. Swap them: log.<level>({ … }, 'message').",
+    severity = "error"
+  )
+}


### PR DESCRIPTION
Three commits, one subject: a failure that ships green is worse than one that fails, and each of these did.

## 1. A restore mode the smoke never produced (`ba3de60c`)

Smoke coverage is recorded **per tool**; the MCP SDK validates **per output shape**. A tool whose output is partitioned by a discriminator can sit in `COVERED_TOOLS` — truthfully, the smoke calls it — with some shapes never produced and never runtime-validated.

The guard reads the modes from `versionRestoreOutputSchema` and requires the smoke to assert each one. **It found a real hole on its first run**: `in-place` was called and its `mode` never asserted, so a drift answering `mode: 'subtree'` for an in-place restore would have passed. #1294, which added the other two modes, missed it — that miss is the argument for a mechanical check over a careful reader.

Deliberately one rule, not a table. Measured across every registered tool, this is the only output discriminator that partitions shapes (`deleted`/`imported` are constants; thread-edit's `status` is a data field), and `coverage-ledger.md` says a uniform surface earns a note rather than a table.

## 2. pino's printf overload, now a lint error (`90384ea0`)

`log.warning('msg', x)` matches pino's printf overload: no placeholder, nothing to interpolate, so `x` is dropped. The types do not object (`...args` is `any[]`) and a test asserting on the message still passes.

**Measuring changed the design twice.** Observed on this repo's own logger:

| call | record shipped |
|---|---|
| `log.warning('A obj second', { a: 1 })` | `{"msg":"A obj second"}` |
| `log.warning('B err second', new Error())` | `{"msg":"B err second"}` |
| `log.warning('C string second', 'extra')` | `{"msg":"C string second"}` |
| `log.warning('D with %s placeholder', 'x')` | `{"msg":"D with x placeholder"}` |
| `log.warning({ a: 1 }, 'E fields first')` | `{"a":1,"msg":"E fields first"}` |

- I set out to match an **object literal** second — the shape the prose describes. Row B says the argument is lost *whatever it is*, so that rule would have missed `log.error('failed', err)`, which loses the error entirely. The rule got simpler and stronger.
- I set out to run it **repo-wide**. There are **three loggers and two argument orders**: `server-core`'s seam and `apps/web`'s `app-logger` are both `(message, data)`. Repo-wide it would have flagged a large amount of correct code, so it is scoped in `biome.json` to `packages/mcp-server/src/server/**`. Row D is carved out as a real printf call.

Measured before writing it: **0** occurrences of the wrong shape in that directory, **59** of the right one — preventive over a live surface, with no cleanup needed first. Repo-wide `pnpm lint` gains no new diagnostics.

Two limits are in the rule's own comment rather than left to be found later: the receiver is unconstrained (keying on `log` would miss the one site named `httpLog`, and a miss is silent where a false positive is visible), and a template-literal message is not matched (no node name for one compiles in this dialect; 0 such calls in scope).

## 3. The doc that told you to do it wrong (`bd1fda58`)

AGENTS.md stated "Fields first, message second" repo-wide, under a heading about server-side code generally. It is true for one of the three loggers. A reader applying it in `server-core` or `apps/web` would have got the opposite of what the doc promised. Also corrects the test helper — it is `captureLogsForTests(level)`; `resetLoggerForTests({ level, sink })` does not exist.

**Net shorter** (17017 → 16993 chars, same budget bucket) while carrying more. The pin was left where it is rather than raised: this file is read in every session, so a fact that earns its place should displace prose rather than be added on top.

## Mutation checks

Both guards, four directions each, every mutation applied and re-run:

| guard | mutations | result |
|---|---|---|
| smoke mode coverage | schema gains a mode / smoke asserts an unknown mode / an assertion is deleted / the probe matches nothing | all red |
| GritQL logger rule | pattern gutted / printf carve-out removed / good fixture gains a violation / bad fixture loses one | all red |

**One came back GREEN the first time and the guard was not at fault**: the `sed` pattern assumed a line break the source does not have, so nothing was mutated. Re-run with the anchor asserted present, it fails naming the mode. Recorded because a green mutation result is worth nothing until the mutation is shown to have landed — it reads exactly like a weak guard.

## Test plan

- [x] New or updated tests — the mode guard, the GritQL rule + its fixture pair, and the `in-place` assertion the first guard demanded. Both written **red first**.
- [x] `pnpm smoke:e2e` — `ALL OK`.
- [x] `node --test .claude/scripts/biome-plugin.test.mjs` — 4 passed.
- [x] `pnpm vitest run --project mcp-node dev-rules-budget smoke-tool-list-parity` — 31 passed.
- [x] `pnpm lint`, `pnpm -r typecheck`, `pnpm knip` clean.
- [x] Manual verification — the observation tables above, taken on the real logger and the real smoke.

## Visual evidence

Visual evidence: none — no user-visible change; this adds two guards, a lint rule and a doc correction, and touches no rendering, UI or product contract.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title — `feat(lint)`, the change with the broadest effect (it changes what lint rejects)
- [x] Docs updated — AGENTS.md's logging section, corrected in the same increment as the rule that enforces it
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema — the mode guard reads the schema rather than restating it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo