### PR TITLE
feat(annotations): a daemon-kept document's conversations reach a rail too

### DIFF
--- a/apps/web/src/pages/DaemonDocumentPage.comments.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.comments.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * The annotation layer, in daemon mode (ADR-0026 decision 5).
+ *
+ * The gap this closes is a KEEPER PARITY one, and it is the shape
+ * `keeper-parity.test.ts` exists to catch: the rail was built on the browser
+ * page and never mounted here, so a conversation on a daemon-kept document
+ * was writable by an MCP peer — which is where most of them come from — and
+ * reachable by nothing in the app. Decision 5 asks that a conversation be
+ * reachable from any document; it did not say "from any document the browser
+ * happens to keep".
+ *
+ * Nothing in this page's own suite would have noticed. The threads arrive on
+ * `useDocumentSync`'s annotation channel exactly as they do in the browser,
+ * so there is no failing call to find — only an absent one.
+ *
+ * jsdom, following this file's siblings: what is under test is the WIRING (do
+ * the threads reach a mounted panel), and the panel's own interaction
+ * behaviour has its own real-browser suite in
+ * `components/annotations/CommentsPanel.browser.test.tsx`.
+ */
+
+import { writeCommentThread, writeDocumentKind } from '@kamiazya/whiteboard-loro-adapter'
+import type {
+  DocumentBackend,
+  DocumentBackendHandlers,
+} from '@kamiazya/whiteboard-mcp/browser-contract'
+import { act, cleanup, render as rtlRender, screen, waitFor, within } from '@testing-library/react'
+import { LoroDoc } from 'loro-crdt'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as daemonApiClient from '../lib/daemon-api-client.js'
+
+function render(ui: ReactElement) {
+  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>, {
+    container: document.body,
+  })
+}
+
+vi.mock('../lib/daemon-api-client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/daemon-api-client.js')>()
+  return { ...actual, listWorkspaces: vi.fn(), listDocuments: vi.fn(), createDocument: vi.fn() }
+})
+
+const { DaemonDocumentPage } = await import('./DaemonDocumentPage.js')
+
+const mockListWorkspaces = vi.mocked(daemonApiClient.listWorkspaces)
+const mockListDocuments = vi.mocked(daemonApiClient.listDocuments)
+
+/** A daemon-held spatial document carrying two conversations, one resolved. */
+function snapshotWithThreads(): Uint8Array {
+  const doc = new LoroDoc()
+  writeDocumentKind(doc, 'spatial')
+  writeCommentThread(doc, {
+    id: 't-open',
+    anchor: { kind: 'spatial', x: 20, y: 30 },
+    status: 'open',
+    messages: [{ id: 'm1', body: 'still needs a decision' }],
+  })
+  writeCommentThread(doc, {
+    id: 't-done',
+    anchor: { kind: 'spatial', x: 40, y: 50 },
+    status: 'resolved',
+    messages: [{ id: 'm2', body: 'settled last week' }],
+  })
+  return doc.export({ mode: 'snapshot' })
+}
+
+class FakeBackend implements DocumentBackend {
+  connect(handlers: DocumentBackendHandlers): void {
+    handlers.onConnected()
+    handlers.onSnapshot(snapshotWithThreads())
+  }
+  disconnect(): void {}
+  pushLocalUpdate(): void {}
+  getFile(): Promise<Blob | null> {
+    return Promise.resolve(null)
+  }
+  putFile(): Promise<void> {
+    return Promise.resolve()
+  }
+  sendClientReady(): void {}
+  sendExportResponse(): void {}
+}
+
+const DAEMON_BASE_URL = 'http://127.0.0.1:3099'
+
+async function mountPage(): Promise<void> {
+  await act(async () => {
+    render(
+      <DaemonDocumentPage
+        daemonBaseUrl={DAEMON_BASE_URL}
+        workspaceId="w1"
+        path="board"
+        createBackend={() => new FakeBackend()}
+      />,
+    )
+  })
+}
+
+describe('DaemonDocumentPage comments rail', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString()
+        if (url.includes('/names')) {
+          return new Response(JSON.stringify({ documents: { board: 'Board' }, pinned: [] }), {
+            status: 200,
+          })
+        }
+        return new Response('{}', { status: 404 })
+      }),
+    )
+    mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
+    mockListDocuments.mockResolvedValue({
+      documents: [{ path: 'board', id: 'id-board', updatedAt: '2026-01-01', kind: 'spatial' }],
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    window.localStorage.clear()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('counts the open conversations on an opener, as the browser page does', async () => {
+    await mountPage()
+
+    // One of the two is resolved; counting both would report finished work as
+    // outstanding. The count is also what makes the rail worth not opening —
+    // the answer to "is there anything here" without taking the width.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /comments, 1 open/i })).toBeTruthy(),
+    )
+  })
+
+  it('opens a rail listing this document conversations', async () => {
+    await mountPage()
+
+    const opener = await waitFor(() => screen.getByRole('button', { name: /comments/i }))
+    // Closed by default, the same decision the browser page took: the panel
+    // answers a question the reader asks.
+    expect(screen.queryByTestId('comments-panel')).toBeNull()
+
+    await act(async () => {
+      opener.click()
+    })
+
+    // Scoped to the rail: the spatial editor draws the same conversation as a
+    // bubble on the canvas, so an unscoped query matches twice and would pass
+    // just as well with no rail mounted at all.
+    const rail = await waitFor(() => screen.getByTestId('comments-panel'))
+    await waitFor(() => expect(within(rail).getByText('still needs a decision')).toBeTruthy())
+    // Resolved is one filter away, not on screen by default.
+    expect(within(rail).queryByText('settled last week')).toBeNull()
+  })
+})

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -4,9 +4,12 @@ import type { DocumentBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
 import { DaemonBackend } from '@kamiazya/whiteboard-mcp/daemon-backend'
 import { selectDocumentTransport } from '@kamiazya/whiteboard-mcp/select-document-transport'
 import { SseBackend } from '@kamiazya/whiteboard-mcp/sse-backend'
+import type { CommentThread } from '@kamiazya/whiteboard-model'
 import { type DocumentKind, isImageRef } from '@kamiazya/whiteboard-model'
+import { MessageSquare } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { AgentPresenceChip } from '../components/AgentPresenceChip.js'
+import { CommentsPanel } from '../components/annotations/CommentsPanel.js'
 import { CapabilityTeaser } from '../components/capability-teaser/CapabilityTeaser.js'
 import type { ConnectionsBacklink } from '../components/connections/ConnectionsChip.js'
 import { ConnectionsChip } from '../components/connections/ConnectionsChip.js'
@@ -23,6 +26,7 @@ import { MergeToast } from '../components/MergeToast.js'
 import { CanvasDisplaySettings } from '../components/spatial-editor/CanvasDisplaySettings.js'
 import type { SpatialEditorHandle } from '../components/spatial-editor/index.js'
 import { Button } from '../components/ui/button.js'
+import { TOGGLE_STATE_CLASS } from '../components/ui/dock-button.js'
 import {
   DAEMON_HISTORY_CAPABILITIES,
   type VersionPreviewSession,
@@ -172,6 +176,13 @@ export function DaemonDocumentPage({
   // does not remount, and a panel left open across a switch would be listing
   // the departed document's versions under the arrived document's name.
   const [historyOpen, setHistoryOpen] = useState(false)
+  /**
+   * Whether the comments rail is open. Per-user view state, written nowhere,
+   * and NOT cleared on a document switch: what a switch changes is the list,
+   * not whether the reader wanted to be looking at one. Same decision the
+   * browser page took.
+   */
+  const [commentsOpen, setCommentsOpen] = useState(false)
   // Bumped by ⌘/Ctrl+S to open the panel with its naming field ready.
   const [bookmarkArmed, setBookmarkArmed] = useState(0)
   // The past state the person is LOOKING at, drawn in place of the editor.
@@ -322,6 +333,7 @@ export function DaemonDocumentPage({
     setEdgeLock,
     syncStatus,
     readOutlineSource,
+    annotations,
   } = useDocumentSync(backend, {
     ...(backendState?.contentDocumentId === undefined
       ? {}
@@ -431,8 +443,55 @@ export function DaemonDocumentPage({
     setPreview(null)
   }, [controller.path])
 
+  const openThreadCount = annotations.filter((thread) => thread.status === 'open').length
+  /**
+   * Whether a thread's anchor still finds its place (ADR-0026 decision 4:
+   * deleting the subject of a conversation must not delete the conversation).
+   *
+   * Spatial documents only, and only an anchor that NAMES a node — the same
+   * rule the browser page keeps, for the same reason: a markdown document has
+   * no canvas to judge against and would call every node-anchored thread
+   * orphaned, which is the opposite of not knowing.
+   */
+  const resolveAnchor = useMemo(() => {
+    if (documentKind !== 'spatial') return undefined
+    const nodeIds = new Set(canvasValue.nodes.map((node) => node.id))
+    return (thread: CommentThread): 'placed' | 'orphaned' => {
+      const { anchor } = thread
+      if (anchor.kind !== 'spatial' || anchor.nodeId === undefined) return 'placed'
+      return nodeIds.has(anchor.nodeId) ? 'placed' : 'orphaned'
+    }
+  }, [documentKind, canvasValue])
+
   const canvasValueRef = useRef(canvasValue)
   canvasValueRef.current = canvasValue
+  /**
+   * Appends the reader's reply to a conversation.
+   *
+   * Through `onChange` like every other edit here, so it is one undo step and
+   * rides the annotation channel back — the alternative, a direct write to
+   * the doc, would put a second door onto the same plane with different
+   * history behaviour. The canvas argument is the CURRENT one unchanged: a
+   * reply touches no node and no edge, which is why the command has its own
+   * write path at all.
+   */
+  const handleReply = useCallback(
+    (threadId: string, body: string) => {
+      onChange(canvasValueRef.current, {
+        kind: 'reply-to-thread',
+        threadId,
+        message: {
+          id: crypto.randomUUID(),
+          body,
+          // No author: this app has no accounts, so there is no name to write
+          // that would not be invented. A message an MCP peer wrote carries
+          // the one its caller supplied, and the panel shows whichever it has.
+          createdAt: new Date().toISOString(),
+        },
+      })
+    },
+    [onChange],
+  )
   const setMarkdownBody = useCallback(
     (next: string) => {
       onChange(canvasValueRef.current, { kind: 'set-body', text: next })
@@ -748,6 +807,34 @@ export function DaemonDocumentPage({
                       }
                       actions={
                         <>
+                          {/* The opener belongs in the document's own actions
+                              row, not floated over the editor: measured on the
+                              browser page, a control in the surface's
+                              top-right corner sat on top of the markdown
+                              editor's catalog trigger and intercepted every
+                              click meant for it. Both editor kinds put chrome
+                              in their corners, and the annotation layer is a
+                              document-level concern. */}
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            aria-label={
+                              openThreadCount === 0
+                                ? 'Comments'
+                                : `Comments, ${openThreadCount} open`
+                            }
+                            aria-pressed={commentsOpen}
+                            onClick={() => setCommentsOpen((open) => !open)}
+                            // A toggle has to LOOK toggled: without this the
+                            // rail's open state was announced to a screen
+                            // reader and invisible to everyone else.
+                            className={TOGGLE_STATE_CLASS}
+                          >
+                            <MessageSquare aria-hidden="true" className="size-4" />
+                            {openThreadCount > 0 ? (
+                              <span className="ml-1 text-xs">{openThreadCount}</span>
+                            ) : null}
+                          </Button>
                           {exportError && (
                             <span className="text-destructive truncate text-xs" role="alert">
                               {exportError}
@@ -889,69 +976,93 @@ export function DaemonDocumentPage({
               Create a canvas
             </Button>
           </div>
-        ) : preview ? (
-          <DocumentPreview past={preview.past} theme={resolvedTheme} />
         ) : (
-          <DocumentEditorSurface
-            kind={documentKind}
-            documentKey={canvas ? `${canvas.workspaceId}/${canvas.path}` : 'no-canvas'}
-            markdown={{
-              body: markdownBody,
-              setBody: setMarkdownBody,
-              theme: resolvedTheme,
-              meta: coreFacets ?? { type: documentKind },
-              resolveAlias,
-              resolveTitle,
-              linkTargets,
-              onOpenDocument: (id) => controller.switchDocument(resolveRefPath(id) ?? id),
-              resolveEmbed,
-            }}
-            spatial={() => (
-              <SpatialEditorPane
-                className="relative h-full min-h-0"
-                editorKey={canvas ? `${canvas.workspaceId}/${canvas.path}` : 'no-canvas'}
-                canvasLoaded={canvasLoaded}
-                editorRef={spatialEditorRef}
-                agentTouchedNodeIds={agentActivity.touchedNodeIds}
-                canvas={canvasValue}
-                onChange={onChange}
-                externalVersion={externalVersion}
-                theme={resolvedTheme}
-                // File-node reference = the target's immutable id (rename-
-                // safe); the label shows its current path and the current
-                // canvas is excluded. Legacy documents still carry path refs,
-                // which resolveRefPath misses and switchDocument takes as-is.
-                fileRefOptions={controller.documents
-                  .filter((entry) => entry.path !== canvas?.path)
-                  .map((entry) => ({
-                    file: entry.id,
-                    label: entry.path,
-                    kind: entry.kind,
-                  }))}
-                onOpenDocument={(id) => controller.switchDocument(resolveRefPath(id) ?? id)}
-                missingFileRef={missingFileRef}
-                fileSeams={fileSeams}
-                lockedNodeIds={lockedNodeIds}
-                lockedEdgeIds={lockedEdgeIds}
-                onToggleNodeLock={setNodeLock}
-                onToggleEdgeLock={setEdgeLock}
-                nodeInEditor={nodeInEditor}
-                history={{
-                  onUndo: () => void undo(),
-                  onRedo: () => void redo(),
-                  canUndo: canUndo(),
-                  canRedo: canRedo(),
-                }}
-                overlayTitle={canvas?.path ?? 'Untitled'}
-                resolveAlias={resolveAlias}
-                resolveEmbed={resolveEmbed}
-                resolveTitle={resolveTitle}
-                linkTargets={linkTargets}
-              >
-                <AgentPresenceChip summary={agentActivity.summary} />
-              </SpatialEditorPane>
-            )}
-          />
+          /* The annotation layer's document-level surface (ADR-0026
+             decision 5) sits BESIDE the editor rather than inside it,
+             because one panel serves both document kinds and a markdown
+             document has no canvas chrome to host one. Its opener lives in
+             the document actions row above, in flow. */
+          <div className="flex h-full min-h-0">
+            <div className="relative min-w-0 flex-1">
+              {preview ? (
+                <DocumentPreview past={preview.past} theme={resolvedTheme} />
+              ) : (
+                <DocumentEditorSurface
+                  kind={documentKind}
+                  documentKey={canvas ? `${canvas.workspaceId}/${canvas.path}` : 'no-canvas'}
+                  markdown={{
+                    body: markdownBody,
+                    setBody: setMarkdownBody,
+                    theme: resolvedTheme,
+                    meta: coreFacets ?? { type: documentKind },
+                    resolveAlias,
+                    resolveTitle,
+                    linkTargets,
+                    onOpenDocument: (id) => controller.switchDocument(resolveRefPath(id) ?? id),
+                    resolveEmbed,
+                  }}
+                  spatial={() => (
+                    <SpatialEditorPane
+                      className="relative h-full min-h-0"
+                      editorKey={canvas ? `${canvas.workspaceId}/${canvas.path}` : 'no-canvas'}
+                      canvasLoaded={canvasLoaded}
+                      editorRef={spatialEditorRef}
+                      agentTouchedNodeIds={agentActivity.touchedNodeIds}
+                      canvas={canvasValue}
+                      onChange={onChange}
+                      externalVersion={externalVersion}
+                      theme={resolvedTheme}
+                      // File-node reference = the target's immutable id (rename-
+                      // safe); the label shows its current path and the current
+                      // canvas is excluded. Legacy documents still carry path refs,
+                      // which resolveRefPath misses and switchDocument takes as-is.
+                      fileRefOptions={controller.documents
+                        .filter((entry) => entry.path !== canvas?.path)
+                        .map((entry) => ({
+                          file: entry.id,
+                          label: entry.path,
+                          kind: entry.kind,
+                        }))}
+                      onOpenDocument={(id) => controller.switchDocument(resolveRefPath(id) ?? id)}
+                      missingFileRef={missingFileRef}
+                      fileSeams={fileSeams}
+                      lockedNodeIds={lockedNodeIds}
+                      lockedEdgeIds={lockedEdgeIds}
+                      onToggleNodeLock={setNodeLock}
+                      onToggleEdgeLock={setEdgeLock}
+                      nodeInEditor={nodeInEditor}
+                      history={{
+                        onUndo: () => void undo(),
+                        onRedo: () => void redo(),
+                        canUndo: canUndo(),
+                        canRedo: canRedo(),
+                      }}
+                      overlayTitle={canvas?.path ?? 'Untitled'}
+                      resolveAlias={resolveAlias}
+                      resolveEmbed={resolveEmbed}
+                      resolveTitle={resolveTitle}
+                      linkTargets={linkTargets}
+                    >
+                      <AgentPresenceChip summary={agentActivity.summary} />
+                    </SpatialEditorPane>
+                  )}
+                />
+              )}
+            </div>
+            {commentsOpen ? (
+              <aside className="w-72 shrink-0 overflow-y-auto border-l bg-background p-2">
+                <CommentsPanel
+                  threads={annotations}
+                  resolveAnchor={resolveAnchor}
+                  // Not while a past version is on screen: the editor is
+                  // replaced by DocumentPreview but this rail is not, and a
+                  // reply is a write to the LIVE document — sent from a
+                  // surface showing something else entirely.
+                  onReply={preview === null ? handleReply : undefined}
+                />
+              </aside>
+            ) : null}
+          </div>
         )}
         {capabilities.merge && canvas && (
           <MergeToast


### PR DESCRIPTION
## Summary

- The comments rail was built on the browser page and **never mounted on the daemon one**, so a conversation on a daemon-kept document was writable by an MCP peer — which is where most of them come from — and reachable by nothing in the app. ADR-0026 decision 5 asks that a conversation be reachable from *any* document; it did not say "from any document the browser happens to keep".
- This is exactly the shape `keeper-parity.test.ts` exists to name: a feature built in one keeper and never written in the other is an **absent test, not a failing one**, and every suite stays green over it. Nothing in the daemon page's own suite would have noticed — the threads arrive on `useDocumentSync`'s annotation channel here exactly as they do in the browser, so there was no wrong call to find, only a missing one. The core of the change is a destructure the page never did.
- Mirrors the browser page rather than inventing a second arrangement: the opener sits in the document actions row (floated over the surface, it sat on top of the markdown editor's own corner chrome and swallowed its clicks — measured on the browser page), the rail is an `<aside>` beside the editor because one panel serves both document kinds, `resolveAnchor` judges only spatial anchors that NAME a node, and a reply goes through `onChange` so it is one undo step on the same channel.
- Replying is refused while a past version is on screen, for the reason the browser page states: the editor is replaced by `DocumentPreview` and the rail is not, so a reply would be a write to the LIVE document sent from a surface showing something else.

## Test plan

- [x] New tests added — `DaemonDocumentPage.comments.test.tsx`: the opener counts only OPEN conversations (one of the two seeded is resolved, and counting both would report finished work as outstanding), and opening the rail lists them. **Red first**: no opener existed at all. jsdom, following this file's siblings — what is under test is the wiring, and the panel's own interaction behaviour has its own real-browser suite.
  - The listing assertions are scoped with `within(rail)`: the spatial editor draws the same conversation as a canvas bubble, so an unscoped query matches twice and would pass just as well with no rail mounted.
- [x] `pnpm test` passes locally — `pnpm --filter @kamiazya/whiteboard-web test`: **3541 passed / 335 files**. Ledgers (keeper-parity, scoped-screen-state, component-reach, editor-state-surface): 180 passed.
- [x] `pnpm check:local` exits 0.
- [ ] Manual verification in a running app — **not done, and this is the gap in this PR**: it needs a real daemon, and this environment cannot reach one (the whiteboard MCP daemon has been `ConnectionRefused` throughout). The page-level test drives the real `DaemonDocumentPage` against a fake backend instead.
- [ ] E2E coverage — not applicable.

**`web-browser` could not complete in this container.** Two consecutive full runs aborted on vite iframe / dynamic-import failures after ~108 of 190 files (`Failed to fetch dynamically imported module`, `Cannot connect to the iframe`), with disk at 37% and 13.8 GB of memory free — infrastructure, not this diff, and different files each time. Its verdict on this change is CI's `test-browser`.

**Mutation-checked**: with the rail's mount forced off, the opening case fails and the counting case still passes — which is the pair the two cases are for.

## Visual evidence

Visual evidence: none — no figure was produced, because rendering the daemon page's rail truthfully needs a running daemon this environment cannot reach, and a screenshot of the same `CommentsPanel` the browser page already ships would show what #1285's figure already showed rather than what this PR changes. The two page-level cases assert the opener's label, its count, and the rail's contents instead.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — no published contract moves, and no `docs/` page describes the rail as browser-only.
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comment threads to daemon documents, available alongside spatial and Markdown editors.
  - Added a comments panel showing open conversations and excluding resolved threads.
  - Added an action to open or close the comments panel, including the number of open conversations.
  - Added support for replying to comments directly from the document.
  - Comment replies are unavailable while viewing an earlier document version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->