### PR TITLE
refactor(web): decompose SpatialEditor into six state/effect hooks

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -68,7 +68,6 @@ import {
   BODY_LINE_HEIGHT_PX,
   COMMENT_BUBBLE_PADDING_PX,
   COMMENT_BUBBLE_RADIUS_PX,
-  commentAnchor,
   edgeLabelAnchor,
   outlineContentBox,
   placeCommentBubble,
@@ -78,29 +77,16 @@ import {
   SPATIAL_THEME_GEOMETRY,
 } from '@kamiazya/whiteboard-canvas-render'
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
-import type {
-  CanvasComment,
-  CommentThread,
-  SpatialCanvas,
-  SpatialNode,
-} from '@kamiazya/whiteboard-model'
+import type { CommentThread, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
 import { bundledFacetRegistry } from '@kamiazya/whiteboard-plugin-visual'
-import {
-  forwardRef,
-  type ReactNode,
-  useEffect,
-  useImperativeHandle,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import { forwardRef, type ReactNode, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { writeLastTool } from '@/lib/initial-tool'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
 import { parseClipboardText } from '../../lib/clipboard-fragment.js'
 import { hapticTick } from '../../lib/haptics.js'
 import { hasCoarsePointer } from '../../lib/platform.js'
 import type { BoxMove } from './align.js'
-import { CanvasContextMenu, type CommentComposeState } from './CanvasContextMenu.js'
+import { CanvasContextMenu } from './CanvasContextMenu.js'
 import { CommentDragLayer } from './CommentDragLayer.js'
 import { CommentThreadCard } from './CommentThreadCard.js'
 import { ConnectOverlay } from './ConnectOverlay.js'
@@ -163,6 +149,7 @@ import {
 } from './ToolPalette.js'
 import { useCanvasReplacement } from './use-canvas-replacement.js'
 import { useClipboardActions } from './use-clipboard-actions.js'
+import { useCommentState } from './use-comment-state.js'
 import { useDragLayers } from './use-drag-layers.js'
 import { useEditSessionState } from './use-edit-session-state.js'
 import { useEditorKeyboard } from './use-editor-keyboard.js'
@@ -714,107 +701,20 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     )
     const { keyed, edgePaths, commentChromeBoxes, selectionMembers, selectionBox, minimapNodes } =
       useSceneProjection({ scene, bounds, boxes, canvas, theme, selectedId, extraIds })
-    /**
-     * What a comment's bubble is placed around — the same obstacle set
-     * canvas-render's placer sees for it: every node that is not a group
-     * frame, plus the bubbles of the comments BEFORE it in document order
-     * (all of them for a comment about to be created, which goes last). The
-     * editor's draft and its drag preview both place through this, so a
-     * bubble opens, drags and settles in one spot.
-     */
-    const commentPlacementObstacles = (beforeCommentId?: string): BoundingBox[] => {
-      const out: BoundingBox[] = canvasRef.current.nodes
-        .filter((node) => node.type !== 'group')
-        .map((node) => ({ x: node.x, y: node.y, w: node.width, h: node.height }))
-      for (const entry of commentChromeBoxes) {
-        if (entry.part !== 'bubble') continue
-        if (entry.commentId === beforeCommentId) break
-        out.push(entry.bbox)
-      }
-      return out
-    }
-    const hitTestComment = (point: Point): string | undefined => {
-      for (let i = commentChromeBoxes.length - 1; i >= 0; i -= 1) {
-        const entry = commentChromeBoxes[i]
-        if (entry === undefined) continue
-        const { bbox } = entry
-        if (
-          point.x >= bbox.x &&
-          point.x <= bbox.x + bbox.w &&
-          point.y >= bbox.y &&
-          point.y <= bbox.y + bbox.h
-        ) {
-          return entry.commentId
-        }
-      }
-      return undefined
-    }
-    const commentById = (id: string): CanvasComment | undefined =>
-      canvasRef.current['x-whiteboard']?.comments?.find((entry) => entry.id === id)
-    /**
-     * Opens a conversation in place, or shuts the one already open. Pressing
-     * the comment whose card is up is how it closes without hunting for the
-     * ×, which is the gesture people try first.
-     */
-    const toggleCommentCard = (commentId: string): void => {
-      setOpenCommentId((current) => (current === commentId ? null : commentId))
-    }
-    /** Opens the compose bubble over an existing comment, pre-filled, to rewrite its text. */
-    const openCommentEditor = (comment: CanvasComment) => {
-      setCommentCompose({
-        point: commentAnchor(comment, canvasRef.current),
-        editing: { id: comment.id, initialText: comment.text },
-      })
-    }
-    const [commentCompose, setCommentCompose] = useState<CommentComposeState | null>(null)
-    /**
-     * The conversation opened in place on the canvas — at most one, because
-     * a card is a place to read and answer ONE thread, and a canvas of
-     * simultaneously open cards is the comments rail with worse layout.
-     */
-    const [openCommentId, setOpenCommentId] = useState<string | null>(null)
-    /**
-     * The comment a press landed on, read back at the release. A press that
-     * never travelled opens the card; one that travelled was a pin drag and
-     * the drag branch owns it.
-     */
-    const pressedCommentRef = useRef<string | null>(null)
-    /**
-     * A point-anchored comment's pin being dragged: the comment as it was
-     * at the press (its stored anchor), the press point, and the live
-     * pointer. Kept beside the gesture machine rather than in it — see
-     * CommentDragLayer for why — so the node machinery (snapping, carried
-     * sets, live edges) never has to learn what a comment is.
-     */
-    const [commentDrag, setCommentDrag] = useState<{
-      readonly comment: CanvasComment
-      readonly startPoint: Point
-      readonly live: Point | null
-      /** The obstacle set at the press, so the preview places like the committed chrome. */
-      readonly obstacles: readonly BoundingBox[]
-      /**
-       * Set on release: the anchor the move was committed at. The drag then
-       * SETTLES rather than ending — the preview stays up, and the committed
-       * copy stays out of the surface, until the committed scene carries the
-       * comment at this anchor (a worker round trip later on a large canvas).
-       * Ending at the release instead showed the old copy for a frame and
-       * animated it to the new anchor.
-       */
-      readonly dropped: Point | null
-    } | null>(null)
-    useEffect(() => {
-      if (commentDrag?.dropped == null) return
-      const { dropped } = commentDrag
-      const pin = commentChromeBoxes.find(
-        (entry) => entry.commentId === commentDrag.comment.id && entry.part === 'pin',
-      )
-      const arrived =
-        pin !== undefined &&
-        pin.bbox.x + pin.bbox.w / 2 === dropped.x &&
-        pin.bbox.y + pin.bbox.h / 2 === dropped.y
-      // Gone (removed underneath the drag) settles too: nothing to wait for.
-      if (arrived || commentById(commentDrag.comment.id) === undefined) setCommentDrag(null)
-    }, [commentDrag, commentChromeBoxes])
+    const {
+      commentPlacementObstacles,
+      hitTestComment,
+      commentById,
+      toggleCommentCard,
+      openCommentEditor,
+      commentCompose,
+      setCommentCompose,
+      openCommentId,
+      setOpenCommentId,
+      pressedCommentRef,
+      commentDrag,
+      setCommentDrag,
+    } = useCommentState({ canvasRef, commentChromeBoxes })
     // The committed surface without the comment in flight (see
     // keyedWithoutPrefix for why it leaves rather than hides).
     const draggedCommentId = commentDrag?.comment.id

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -79,7 +79,7 @@ import {
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
 import type { CommentThread, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
 import { bundledFacetRegistry } from '@kamiazya/whiteboard-plugin-visual'
-import { forwardRef, type ReactNode, useImperativeHandle, useMemo, useRef, useState } from 'react'
+import { forwardRef, type ReactNode, useImperativeHandle, useMemo, useRef } from 'react'
 import { writeLastTool } from '@/lib/initial-tool'
 import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
 import { parseClipboardText } from '../../lib/clipboard-fragment.js'
@@ -105,14 +105,7 @@ import { distanceToPolyline, findFreeSpot, hitTest, indexNodeBoxes } from './geo
 import { snapGesturePoint } from './gesture-snap.js'
 import { describeTarget, gestureTrace } from './gesture-trace.js'
 import { carriedByGesture } from './gesture-view.js'
-import type { GestureState } from './gestures.js'
-import {
-  createIdleState,
-  defaultCreateId,
-  NEW_NODE_HEIGHT,
-  NEW_NODE_WIDTH,
-  reduceGesture,
-} from './gestures.js'
+import { defaultCreateId, NEW_NODE_HEIGHT, NEW_NODE_WIDTH, reduceGesture } from './gestures.js'
 import { LinkEmbedLayer } from './LinkEmbedLayer.js'
 import { LinkUrlDialog } from './LinkUrlDialog.js'
 import { MarkdownNodeEditor } from './MarkdownNodeEditor.js'
@@ -124,7 +117,6 @@ import {
   DOUBLE_PRESS_WINDOW_MS,
   type NavigationEvent,
   type NavigationResult,
-  type NavigationState,
   type PointerKind,
   reduceNavigation,
 } from './navigation.js'
@@ -133,12 +125,7 @@ import { SelectionOverlay } from './SelectionOverlay.js'
 import { SnapGuidesOverlay } from './SnapGuidesOverlay.js'
 import { requiredTextNodeHeight } from './scene-render.js'
 import { keyedWithoutPrefix } from './scene-render-core.js'
-import {
-  EMPTY_SELECTION,
-  reduceSelection,
-  type SelectionEvent,
-  type SelectionState,
-} from './selection.js'
+import { reduceSelection } from './selection.js'
 import { isTextEntryEvent } from './shortcuts.js'
 import { TextNodeEditor } from './TextNodeEditor.js'
 import {
@@ -155,6 +142,7 @@ import { useEditSessionState } from './use-edit-session-state.js'
 import { useEditorKeyboard } from './use-editor-keyboard.js'
 import { MINIMAP_MIN_ROOT_WIDTH_PX, useEditorMeasurements } from './use-editor-measurements.js'
 import { EXPAND_MIN_H, EXPAND_MIN_W, useFileSeamScene } from './use-file-seam-scene.js'
+import { useInteractionState } from './use-interaction-state.js'
 import { useKeyboardAvoidance } from './use-keyboard-avoidance.js'
 import { useLockPolicy } from './use-lock-policy.js'
 import { useNativeCanvasListeners } from './use-native-canvas-listeners.js'
@@ -503,37 +491,29 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     const { shellRef, rootSize, inspectorIsSheet, viewportCenterScreen, containerSizeOf } =
       useEditorMeasurements(rootRef)
 
-    /**
-     * The multi-selection lives in ONE state object and every transition
-     * routes through the pure `reduceSelection` (selection.ts), so its
-     * invariants (primary never inside extras; extras only with a primary)
-     * hold by construction — never hand-write a primary/extras update pair.
-     * Functional updates make sequential events inside one handler compose
-     * instead of clobbering each other through stale closures.
-     */
-    const [selectionState, setSelectionState] = useState<SelectionState>(EMPTY_SELECTION)
+    const {
+      selectionState,
+      setSelectionState,
+      applySelection,
+      gestureState,
+      setGestureState,
+      gestureStateRef,
+      livePoint,
+      setLivePoint,
+      snapGuides,
+      setSnapGuides,
+      doublePressRef,
+      marquee,
+      setMarquee,
+      spaceDownRef,
+      lastPressRef,
+      activePointerIdRef,
+      navigationRef,
+      canvasRef,
+      longPressRef,
+      clearLongPress,
+    } = useInteractionState({ canvas })
     const selectedId = selectionState.primaryId
-    const applySelection = (event: SelectionEvent) =>
-      setSelectionState((prev) => reduceSelection(prev, event))
-    const [gestureState, setGestureState] = useState<GestureState>(createIdleState())
-    /**
-     * Live pointer position during an in-flight move/resize/connect, in canvas
-     * space. Component-local on purpose: the reducer still recomputes the real
-     * commit from startPoint at pointerup, so this drives ONLY the preview
-     * overlay below and never becomes a source of truth. Keeping it out of
-     * `canvas` is what stops a per-frame `renderCanvasToSvg` (measured at
-     * ~30ms on an 80-node canvas — far past a frame budget).
-     */
-    const [livePoint, setLivePoint] = useState<Point | null>(null)
-    /**
-     * Canvas-space lines justifying the current snap, cleared with the
-     * gesture. Same rationale as `livePoint`: a per-frame value that drives
-     * only an overlay, never the document.
-     */
-    const [snapGuides, setSnapGuides] = useState<{
-      readonly x: readonly number[]
-      readonly y: readonly number[]
-    } | null>(null)
     const {
       tool,
       setTool,
@@ -569,71 +549,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       viewportCenterScreen,
       containerSizeOf,
     })
-    /**
-     * Armed by a second same-target press inside the double-press window;
-     * RESOLVED at pointerup: zero movement opens the editor (node) or
-     * creates (empty), any movement means it was a drag all along. Firing
-     * at the release also sidesteps mousedown's default focus action, which
-     * used to blur the just-mounted textarea when we opened at the press.
-     */
-    const doublePressRef = useRef<{ key: string; point: Point } | null>(null)
-    /** In-flight marquee selection rect, in canvas space (Excalidraw
-     * semantics: plain drag on empty space selects; pan is Space+drag,
-     * middle-button drag, or wheel). */
-    const [marquee, setMarquee] = useState<{ start: Point; current: Point } | null>(null)
-    const spaceDownRef = useRef(false)
-    /**
-     * Last press for the SELECT tool's double press, keyed by what was under
-     * it — a node id, an edge id, or `'empty'`. Hand mode's own double press
-     * is not here: it has no target to key on, so the navigation machine
-     * holds it with the distance bound that keying cannot supply.
-     */
-    const lastPressRef = useRef<{ key: string; at: number; point: Point } | null>(null)
-    /**
-     * The pointerId this component currently holds capture for, or `null`.
-     * Tracked so unmount can best-effort release capture (see the teardown
-     * effect below) even though no window-level fallback listener exists to
-     * do it otherwise — mirrors `trySetPointerCapture`'s own
-     * best-effort/never-throw reasoning.
-     */
-    const activePointerIdRef = useRef<number | null>(null)
-    /**
-     * Everything navigation owns, as one value: which fingers are down, what
-     * is driving the viewport, what the last hand press was. See
-     * `navigation.ts` — the refs this replaced could not say when a gesture
-     * was over, and twice shipped a field that outlived one.
-     */
-    const navigationRef = useRef<NavigationState>(createIdleNavigation())
-
-    const canvasRef = useRef(canvas)
-    canvasRef.current = canvas
-
-    // Mirror for callbacks that outlive their render — the long-press timer
-    // fires ~500ms after the closure that armed it, by which time the press
-    // itself has usually advanced the gesture ('pressing'/'moving'); reducing
-    // a cancel against the ARM-time state would mis-apply it.
-    const gestureStateRef = useRef(gestureState)
-    gestureStateRef.current = gestureState
-
-    /**
-     * Touch long-press -> context menu. iOS Safari never synthesises a
-     * `contextmenu` event from a touch long-press (Android Chrome does), so
-     * without this the app's object menu is simply unreachable on an iPhone
-     * — the press reads as a drag start and the menu never opens. Armed on
-     * a single stationary touch, cancelled by movement past the slop, a
-     * second finger, or lift.
-     */
-    const longPressRef = useRef<{
-      timer: ReturnType<typeof setTimeout>
-      pointerId: number
-      screen: Point
-    } | null>(null)
-    const clearLongPress = () => {
-      if (longPressRef.current !== null) {
-        clearTimeout(longPressRef.current.timer)
-        longPressRef.current = null
-      }
-    }
     // The file-reference seam — the LOD gate, label/missing resolution and
     // the content cache — built once in useFileSeamScene and spread into
     // every scene-building call below (committed scene, drag ghost,

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -100,12 +100,7 @@ import { parseClipboardText } from '../../lib/clipboard-fragment.js'
 import { hapticTick } from '../../lib/haptics.js'
 import { hasCoarsePointer } from '../../lib/platform.js'
 import type { BoxMove } from './align.js'
-import {
-  CanvasContextMenu,
-  type CommentComposeState,
-  type DocumentPickerState,
-  type LinkDialogState,
-} from './CanvasContextMenu.js'
+import { CanvasContextMenu, type CommentComposeState } from './CanvasContextMenu.js'
 import { CommentDragLayer } from './CommentDragLayer.js'
 import { CommentThreadCard } from './CommentThreadCard.js'
 import { ConnectOverlay } from './ConnectOverlay.js'
@@ -169,6 +164,7 @@ import {
 import { useCanvasReplacement } from './use-canvas-replacement.js'
 import { useClipboardActions } from './use-clipboard-actions.js'
 import { useDragLayers } from './use-drag-layers.js'
+import { useEditSessionState } from './use-edit-session-state.js'
 import { useEditorKeyboard } from './use-editor-keyboard.js'
 import { MINIMAP_MIN_ROOT_WIDTH_PX, useEditorMeasurements } from './use-editor-measurements.js'
 import { EXPAND_MIN_H, EXPAND_MIN_W, useFileSeamScene } from './use-file-seam-scene.js'
@@ -686,12 +682,24 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       containerSizeOf,
       setViewport,
     })
-    /**
-     * Whether resolved comments are drawn (muted) — ADR-0025 decision 2:
-     * per-user VIEW state, never written to the shared document, so one
-     * person's toggle cannot change what another person sees.
-     */
-    const [showResolvedComments, setShowResolvedComments] = useState(false)
+    const {
+      showResolvedComments,
+      setShowResolvedComments,
+      selectedEdgeId,
+      setSelectedEdgeId,
+      pendingCut,
+      setPendingCut,
+      edgeLabelEditId,
+      setEdgeLabelEditId,
+      groupLabelEditId,
+      setGroupLabelEditId,
+      linkDialog,
+      setLinkDialog,
+      canvasPicker,
+      setDocumentPicker,
+      facetPanelOpen,
+      setFacetPanelOpen,
+    } = useEditSessionState({ canvas, selectedId })
     const { bounds, scene, anchors, sceneCurrent } = useWorkerScene(
       canvas,
       {
@@ -758,34 +766,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         editing: { id: comment.id, initialText: comment.text },
       })
     }
-    const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null)
-    /**
-     * A cut waiting for its paste — the front half of a move. Pure view
-     * state (never persisted or synced): the nodes stay in the document,
-     * dimmed by GhostOverlay, until a same-canvas paste MOVES them, or the
-     * hold is lifted (Escape, a newer copy/cut, or any edit that touches a
-     * held node). `snapshot` records each held node's full serialized value
-     * at cut time so ANY change — a drag, a text or color edit, a remote
-     * write, a delete — reads as "someone touched it" and cancels the hold;
-     * nothing is ever lost by a cancel, because nothing was deleted.
-     */
-    const [pendingCut, setPendingCut] = useState<{
-      readonly cutId: string
-      readonly snapshot: ReadonlyMap<string, string>
-    } | null>(null)
-    useEffect(() => {
-      // Anyone touching a held node — local drag, remote edit, delete —
-      // lifts the hold; the veil must never dim a node that changed under
-      // it. The move resolution clears the hold before it applies, so its
-      // own geometry change never races this.
-      if (pendingCut === null) return
-      const touched = [...pendingCut.snapshot].some(([id, frozen]) => {
-        const node = canvas.nodes.find((n) => n.id === id)
-        return node === undefined || JSON.stringify(node) !== frozen
-      })
-      if (touched) setPendingCut(null)
-    }, [canvas, pendingCut])
-    const [edgeLabelEditId, setEdgeLabelEditId] = useState<string | null>(null)
     const [commentCompose, setCommentCompose] = useState<CommentComposeState | null>(null)
     /**
      * The conversation opened in place on the canvas — at most one, because
@@ -843,27 +823,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         draggedCommentId === undefined ? keyed : keyedWithoutPrefix(keyed, `${draggedCommentId}/`),
       [keyed, draggedCommentId],
     )
-    // The URL dialog serves both palette-create and context-menu-edit; which
-    // one decides what its submit does.
-    const [groupLabelEditId, setGroupLabelEditId] = useState<string | null>(null)
-    const [linkDialog, setLinkDialog] = useState<LinkDialogState | null>(null)
-    const [canvasPicker, setDocumentPicker] = useState<DocumentPickerState | null>(null)
-    // The inspector is open or shut; WHICH node it edits follows the
-    // selection. Pinning it to the node the menu was opened on made it a
-    // dialog you had to close before you could look at anything else.
-    const [facetPanelOpen, setFacetPanelOpen] = useState(false)
-    // Deselecting CLOSES it, rather than leaving it standing with nothing to
-    // edit. It is the same act that dismisses the context menu, and on touch
-    // a press on blank canvas is how you put a surface away — one semantic
-    // instead of two, and no dismiss control for this panel to carry.
-    //
-    // Cleared during render rather than in an effect, the shape
-    // `DerivedFacetForm` uses for its draft: an effect would let the panel
-    // paint one frame with nothing in it. Clearing the FLAG (rather than
-    // rendering null and leaving it true) is what keeps a later re-open an
-    // ordinary open — the earlier version of this returned null and stranded
-    // the flag, which only a new selection could get out of.
-    if (facetPanelOpen && selectedId === null) setFacetPanelOpen(false)
     // Lock seams + coherence (predicates, selectable subset, and the two
     // effects that retire state a lock arrival invalidates) — see
     // use-lock-policy.ts.

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -62,8 +62,6 @@ import type {
   BoundingBox,
   MeasureText,
   ResolvedReference,
-  SpatialPalette,
-  SpatialPresetKey,
 } from '@kamiazya/whiteboard-canvas-render'
 import {
   BODY_FONT_SIZE_PX,
@@ -72,7 +70,6 @@ import {
   COMMENT_BUBBLE_RADIUS_PX,
   commentAnchor,
   edgeLabelAnchor,
-  flattenDrawnEdgePath,
   outlineContentBox,
   placeCommentBubble,
   SPATIAL_DARK_PALETTE,
@@ -124,14 +121,7 @@ import { createEditorAppearance, editorTextFill } from './editor-appearance.js'
 import { FacetFormPanel } from './facet-widgets/FacetFormPanel.js'
 import { isFollowableUrl } from './followable-url.js'
 import { GhostOverlay } from './GhostOverlay.js'
-import {
-  distanceToPolyline,
-  findFreeSpot,
-  hitTest,
-  indexNodeBoxes,
-  type NodeBox,
-  unionBox,
-} from './geometry.js'
+import { distanceToPolyline, findFreeSpot, hitTest, indexNodeBoxes } from './geometry.js'
 import { snapGesturePoint } from './gesture-snap.js'
 import { describeTarget, gestureTrace } from './gesture-trace.js'
 import { carriedByGesture } from './gesture-view.js'
@@ -148,7 +138,7 @@ import { LinkUrlDialog } from './LinkUrlDialog.js'
 import { MarkdownNodeEditor } from './MarkdownNodeEditor.js'
 import { MarqueeOverlay } from './MarqueeOverlay.js'
 import { MemberOutlinesOverlay } from './MemberOutlinesOverlay.js'
-import { type MinimapNode, MinimapOverlay } from './MinimapOverlay.js'
+import { MinimapOverlay } from './MinimapOverlay.js'
 import {
   createIdleNavigation,
   DOUBLE_PRESS_WINDOW_MS,
@@ -162,7 +152,7 @@ import { PendingCutChip } from './PendingCutChip.js'
 import { SelectionOverlay } from './SelectionOverlay.js'
 import { SnapGuidesOverlay } from './SnapGuidesOverlay.js'
 import { requiredTextNodeHeight } from './scene-render.js'
-import { keyedWithoutPrefix, renderedCanvasKeyed } from './scene-render-core.js'
+import { keyedWithoutPrefix } from './scene-render-core.js'
 import {
   EMPTY_SELECTION,
   reduceSelection,
@@ -188,6 +178,7 @@ import { useLockPolicy } from './use-lock-policy.js'
 import { useNativeCanvasListeners } from './use-native-canvas-listeners.js'
 import { useNodeBoxes } from './use-node-boxes.js'
 import { useNodeCreation } from './use-node-creation.js'
+import { useSceneProjection } from './use-scene-projection.js'
 import { useViewportControls } from './use-viewport-controls.js'
 import { useWorkerScene } from './use-worker-scene.js'
 import {
@@ -493,33 +484,6 @@ function trySetPointerCapture(root: HTMLElement, pointerId: number): void {
   }
 }
 
-/**
- * Node boxes for the minimap overview, with each authored colour resolved to
- * the accent the scene already uses for it. A preset key resolves through
- * the given palette; a hex passes through; an unstyled node carries no
- * colour and the overview falls back to its muted default.
- *
- * Looks up each box's node by id via a `Map` built once, rather than
- * `nodes.find` per box (O(n) per lookup, O(n^2) over the whole canvas) —
- * `find`-first and `Map`-last-wins cannot diverge for valid input, since
- * node id uniqueness is a schema invariant (spatial.ts's `superRefine`
- * rejects a duplicate node id before a canvas is ever constructed).
- */
-export function buildMinimapNodes(
-  nodes: SpatialCanvas['nodes'],
-  boxes: readonly NodeBox[],
-  palette: SpatialPalette,
-): readonly MinimapNode[] {
-  const byId = new Map(nodes.map((node) => [node.id, node]))
-  const colorOf = (id: string): string | undefined => {
-    const color = byId.get(id)?.color
-    if (color === undefined) return undefined
-    if (color.startsWith('#')) return color
-    return palette.presets[color as SpatialPresetKey]?.stroke
-  }
-  return boxes.map((entry) => ({ ...entry.box, color: colorOf(entry.id) }))
-}
-
 export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>(
   function SpatialEditor(
     {
@@ -750,51 +714,8 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       fileRefOptions,
       missingFileRefs,
     )
-    // The committed surface's keyed projection, derived from the scene the
-    // worker (or sync path) delivered — ~3ms of stringify against the
-    // 66-125ms layout, so the worker protocol stays plain-data. The patch
-    // container below consumes it; the plain `svg` string is no longer
-    // read here.
-    const keyed = useMemo(() => renderedCanvasKeyed({ scene, bounds }), [scene, bounds])
-    // Routed edge paths in canvas coordinates, for edge hit-testing and the
-    // selection highlight. Edges have no area, so selection is a
-    // distance-to-polyline test against a zoom-adjusted tolerance. The
-    // hit/highlight path is the DRAWN line — rounded corners flattened and
-    // line-jump hops arced over — via the same decomposition the SVG
-    // backend serializes, so a tap and the highlight land on the ink.
-    const edgePaths = useMemo(
-      () =>
-        scene.nodes.flatMap((node) =>
-          node.kind === 'edge'
-            ? [
-                {
-                  id: node.id,
-                  path: flattenDrawnEdgePath(node.path, node.jumps, node.rounded === true),
-                },
-              ]
-            : [],
-        ),
-      [scene],
-    )
-    // Comment chrome (pins and bubbles) from the committed scene, for
-    // hit-testing: the shapes carry `${commentId}/pin` / `/bubble` ids and
-    // the commentChrome marker (ADR-0025 decision 5), so the boxes a press
-    // is tested against are exactly the boxes the renderer painted — one
-    // producer for the geometry. Later entries draw on top, so hit-testing
-    // walks them in reverse.
-    const commentChromeBoxes = useMemo(
-      () =>
-        scene.nodes.flatMap((node) => {
-          if (node.kind !== 'shape' || node.commentChrome !== true || node.id === undefined)
-            return []
-          const cut = node.id.lastIndexOf('/')
-          if (cut <= 0) return []
-          const part = node.id.slice(cut + 1)
-          if (part !== 'pin' && part !== 'bubble') return []
-          return [{ commentId: node.id.slice(0, cut), part, bbox: node.bbox }]
-        }),
-      [scene],
-    )
+    const { keyed, edgePaths, commentChromeBoxes, selectionMembers, selectionBox, minimapNodes } =
+      useSceneProjection({ scene, bounds, boxes, canvas, theme, selectedId, extraIds })
     /**
      * What a comment's bubble is placed around — the same obstacle set
      * canvas-render's placer sees for it: every node that is not a group
@@ -1023,25 +944,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       [boxes],
     )
 
-    /**
-     * Every selected node with the box it currently occupies, primary first.
-     *
-     * The resize handles surround the UNION of these rather than the primary
-     * alone: handles drawn around a group have to act on the group, or a
-     * three-node selection offers one node's handles and resizes that node
-     * while the other two watch.
-     */
-    const selectionMembers = useMemo(() => {
-      if (selectedId === null) return []
-      return [selectedId, ...extraIds].flatMap((id) => {
-        const entry = boxes.find((candidate) => candidate.id === id)
-        return entry === undefined ? [] : [{ id, box: entry.box }]
-      })
-    }, [selectedId, extraIds, boxes])
-    const selectionBox = useMemo(
-      () => unionBox(selectionMembers.map((member) => member.box)),
-      [selectionMembers],
-    )
     const isMultiSelection = selectionMembers.length > 1
 
     /**
@@ -1980,17 +1882,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * CURRENT node boxes (read from `canvasRef.current`, not the possibly-
      * stale `canvas` prop) so two rapid clicks still see each other's result.
      */
-    /**
-     * Node boxes for the overview, with each authored colour resolved to the
-     * accent the scene already uses for it. A preset key resolves through the
-     * current mode's palette; a hex passes through; an unstyled node carries
-     * no colour and the overview falls back to its muted default.
-     */
-    const minimapNodes = useMemo(() => {
-      const palette = theme === 'dark' ? SPATIAL_DARK_PALETTE : SPATIAL_LIGHT_PALETTE
-      return buildMinimapNodes(canvas.nodes, boxes, palette)
-    }, [boxes, canvas, theme])
-
     /**
      * Pans so the union of all node boxes sits centered in the viewport,
      * keeping the current zoom (the hand-mode "where did my content go"

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -186,6 +186,7 @@ import { EXPAND_MIN_H, EXPAND_MIN_W, useFileSeamScene } from './use-file-seam-sc
 import { useKeyboardAvoidance } from './use-keyboard-avoidance.js'
 import { useLockPolicy } from './use-lock-policy.js'
 import { useNativeCanvasListeners } from './use-native-canvas-listeners.js'
+import { useNodeBoxes } from './use-node-boxes.js'
 import { useNodeCreation } from './use-node-creation.js'
 import { useViewportControls } from './use-viewport-controls.js'
 import { useWorkerScene } from './use-worker-scene.js'
@@ -610,15 +611,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * delete paths). Cleared whenever the primary selection clears.
      */
     const extraIds = selectionState.extraIds
-    const boxes = useMemo(() => indexNodeBoxes(canvas), [canvas])
-    const selectedBox = useMemo(
-      () => (selectedId === null ? undefined : boxes.find((b) => b.id === selectedId)?.box),
-      [boxes, selectedId],
-    )
-    const selectedNode = useMemo(
-      () => (selectedId === null ? undefined : canvas.nodes.find((n) => n.id === selectedId)),
-      [canvas, selectedId],
-    )
+    const { boxes, selectedBox, selectedNode } = useNodeBoxes({ canvas, selectedId })
     /** Narrowed pair so the overlay never has to assert a non-null `selectedId`. */
     const selection =
       selectedId !== null && selectedBox !== undefined

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -103,7 +103,6 @@ import type { BoxMove } from './align.js'
 import {
   CanvasContextMenu,
   type CommentComposeState,
-  type ContextMenuTarget,
   type DocumentPickerState,
   type LinkDialogState,
 } from './CanvasContextMenu.js'
@@ -179,6 +178,7 @@ import { useNativeCanvasListeners } from './use-native-canvas-listeners.js'
 import { useNodeBoxes } from './use-node-boxes.js'
 import { useNodeCreation } from './use-node-creation.js'
 import { useSceneProjection } from './use-scene-projection.js'
+import { useToolState } from './use-tool-state.js'
 import { useViewportControls } from './use-viewport-controls.js'
 import { useWorkerScene } from './use-worker-scene.js'
 import {
@@ -551,22 +551,16 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       readonly x: readonly number[]
       readonly y: readonly number[]
     } | null>(null)
-    // OOUI interaction mode (S6/S7): Hand (navigation) is the default —
-    // Select restores the pre-tool editing behavior byte-for-byte; Connect
-    // arms object-first click-A, click-B edge creation. Creation is
-    // deliberately NOT a mode — the palette's Note entry works in every mode.
-    const [tool, setTool] = useState<EditorTool>(defaultTool)
-    const toolChosenByUserRef = useRef(false)
-    const initialToolAppliedRef = useRef(false)
-    useEffect(() => {
-      if (initialTool === undefined) return
-      if (initialToolAppliedRef.current || toolChosenByUserRef.current) return
-      initialToolAppliedRef.current = true
-      setTool(initialTool)
-    }, [initialTool])
-    const [contextMenu, setContextMenu] = useState<ContextMenuTarget | null>(null)
-    // Screen point of the last committed long-press, while its pulse plays.
-    const [longPressPulse, setLongPressPulse] = useState<Point | null>(null)
+    const {
+      tool,
+      setTool,
+      toolChosenByUserRef,
+      contextMenu,
+      setContextMenu,
+      longPressPulse,
+      setLongPressPulse,
+      openContextMenuAtRef,
+    } = useToolState({ defaultTool, initialTool })
     /**
      * Additional selected node ids beyond the reducer's single primary
      * selection. Multi-select lives at the component layer on purpose: the
@@ -657,10 +651,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         longPressRef.current = null
       }
     }
-    // The timer must call the LATEST render's opener (fresh viewport/boxes/
-    // selection), not the one captured when the finger landed.
-    const openContextMenuAtRef = useRef<(screen: Point) => void>(() => {})
-
     // The file-reference seam — the LOD gate, label/missing resolution and
     // the content cache — built once in useFileSeamScene and spread into
     // every scene-building call below (committed scene, drag ghost,

--- a/apps/web/src/components/spatial-editor/build-minimap-nodes.test.ts
+++ b/apps/web/src/components/spatial-editor/build-minimap-nodes.test.ts
@@ -2,7 +2,7 @@ import { SPATIAL_LIGHT_PALETTE } from '@kamiazya/whiteboard-canvas-render'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { describe, expect, it } from 'vitest'
 import { indexNodeBoxes } from './geometry.js'
-import { buildMinimapNodes } from './SpatialEditor.js'
+import { buildMinimapNodes } from './minimap.js'
 
 function nodes(entries: SpatialCanvas['nodes']): SpatialCanvas['nodes'] {
   return entries

--- a/apps/web/src/components/spatial-editor/editor-state-surface.test.ts
+++ b/apps/web/src/components/spatial-editor/editor-state-surface.test.ts
@@ -38,6 +38,7 @@ import { assertScannedLedger } from '../../test-utils/coverage-ledger.js'
 const sources = import.meta.glob(
   [
     './SpatialEditor.tsx',
+    './use-comment-state.ts',
     './use-edit-session-state.ts',
     './use-editor-measurements.ts',
     './use-file-seam-scene.ts',

--- a/apps/web/src/components/spatial-editor/editor-state-surface.test.ts
+++ b/apps/web/src/components/spatial-editor/editor-state-surface.test.ts
@@ -42,6 +42,7 @@ const sources = import.meta.glob(
     './use-edit-session-state.ts',
     './use-editor-measurements.ts',
     './use-file-seam-scene.ts',
+    './use-interaction-state.ts',
     './use-tool-state.ts',
     './use-viewport-controls.ts',
   ],

--- a/apps/web/src/components/spatial-editor/editor-state-surface.test.ts
+++ b/apps/web/src/components/spatial-editor/editor-state-surface.test.ts
@@ -38,6 +38,7 @@ import { assertScannedLedger } from '../../test-utils/coverage-ledger.js'
 const sources = import.meta.glob(
   [
     './SpatialEditor.tsx',
+    './use-edit-session-state.ts',
     './use-editor-measurements.ts',
     './use-file-seam-scene.ts',
     './use-tool-state.ts',

--- a/apps/web/src/components/spatial-editor/editor-state-surface.test.ts
+++ b/apps/web/src/components/spatial-editor/editor-state-surface.test.ts
@@ -40,6 +40,7 @@ const sources = import.meta.glob(
     './SpatialEditor.tsx',
     './use-editor-measurements.ts',
     './use-file-seam-scene.ts',
+    './use-tool-state.ts',
     './use-viewport-controls.ts',
   ],
   { query: '?raw', import: 'default', eager: true },

--- a/apps/web/src/components/spatial-editor/minimap.ts
+++ b/apps/web/src/components/spatial-editor/minimap.ts
@@ -7,6 +7,10 @@
  * into minimap space.
  */
 
+import type { SpatialPalette, SpatialPresetKey } from '@kamiazya/whiteboard-canvas-render'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import type { NodeBox } from './geometry.js'
+
 export interface MinimapBox {
   readonly x: number
   readonly y: number
@@ -119,4 +123,31 @@ export function unprojectPoint(
   fit: MinimapFit,
 ): { x: number; y: number } {
   return { x: point.x / fit.scale + fit.originX, y: point.y / fit.scale + fit.originY }
+}
+
+/**
+ * Node boxes for the minimap overview, with each authored colour resolved to
+ * the accent the scene already uses for it. A preset key resolves through
+ * the given palette; a hex passes through; an unstyled node carries no
+ * colour and the overview falls back to its muted default.
+ *
+ * Looks up each box's node by id via a `Map` built once, rather than
+ * `nodes.find` per box (O(n) per lookup, O(n^2) over the whole canvas) —
+ * `find`-first and `Map`-last-wins cannot diverge for valid input, since
+ * node id uniqueness is a schema invariant (spatial.ts's `superRefine`
+ * rejects a duplicate node id before a canvas is ever constructed).
+ */
+export function buildMinimapNodes(
+  nodes: SpatialCanvas['nodes'],
+  boxes: readonly NodeBox[],
+  palette: SpatialPalette,
+): readonly (MinimapBox & { readonly color?: string })[] {
+  const byId = new Map(nodes.map((node) => [node.id, node]))
+  const colorOf = (id: string): string | undefined => {
+    const color = byId.get(id)?.color
+    if (color === undefined) return undefined
+    if (color.startsWith('#')) return color
+    return palette.presets[color as SpatialPresetKey]?.stroke
+  }
+  return boxes.map((entry) => ({ ...entry.box, color: colorOf(entry.id) }))
 }

--- a/apps/web/src/components/spatial-editor/use-comment-state.ts
+++ b/apps/web/src/components/spatial-editor/use-comment-state.ts
@@ -6,8 +6,8 @@
 // since `commentChromeBoxes` — the boxes the renderer actually painted — is
 // its whole hit-testing input.
 
-import { commentAnchor } from '@kamiazya/whiteboard-canvas-render'
 import type { BoundingBox } from '@kamiazya/whiteboard-canvas-render'
+import { commentAnchor } from '@kamiazya/whiteboard-canvas-render'
 import type { CanvasComment, SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { type MutableRefObject, useEffect, useRef, useState } from 'react'
 import type { CommentComposeState } from './CanvasContextMenu.js'

--- a/apps/web/src/components/spatial-editor/use-comment-state.ts
+++ b/apps/web/src/components/spatial-editor/use-comment-state.ts
@@ -1,0 +1,142 @@
+// The comment-conversation state, extracted from SpatialEditor: the compose
+// draft, which thread is open, the in-flight pin drag and its settle
+// effect, the press-vs-drag disambiguation ref, and the comment-geometry
+// helpers every one of those leans on (bubble placement, hit-testing, the
+// document's own comment lookup). Called right after use-scene-projection,
+// since `commentChromeBoxes` — the boxes the renderer actually painted — is
+// its whole hit-testing input.
+
+import { commentAnchor } from '@kamiazya/whiteboard-canvas-render'
+import type { BoundingBox } from '@kamiazya/whiteboard-canvas-render'
+import type { CanvasComment, SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { type MutableRefObject, useEffect, useRef, useState } from 'react'
+import type { CommentComposeState } from './CanvasContextMenu.js'
+import type { Point } from './viewport.js'
+
+export interface CommentStateInputs {
+  readonly canvasRef: MutableRefObject<SpatialCanvas>
+  readonly commentChromeBoxes: readonly {
+    readonly commentId: string
+    readonly part: string
+    readonly bbox: BoundingBox
+  }[]
+}
+
+export function useCommentState({ canvasRef, commentChromeBoxes }: CommentStateInputs) {
+  /**
+   * What a comment's bubble is placed around — the same obstacle set
+   * canvas-render's placer sees for it: every node that is not a group
+   * frame, plus the bubbles of the comments BEFORE it in document order
+   * (all of them for a comment about to be created, which goes last). The
+   * editor's draft and its drag preview both place through this, so a
+   * bubble opens, drags and settles in one spot.
+   */
+  const commentPlacementObstacles = (beforeCommentId?: string): BoundingBox[] => {
+    const out: BoundingBox[] = canvasRef.current.nodes
+      .filter((node) => node.type !== 'group')
+      .map((node) => ({ x: node.x, y: node.y, w: node.width, h: node.height }))
+    for (const entry of commentChromeBoxes) {
+      if (entry.part !== 'bubble') continue
+      if (entry.commentId === beforeCommentId) break
+      out.push(entry.bbox)
+    }
+    return out
+  }
+  const hitTestComment = (point: Point): string | undefined => {
+    for (let i = commentChromeBoxes.length - 1; i >= 0; i -= 1) {
+      const entry = commentChromeBoxes[i]
+      if (entry === undefined) continue
+      const { bbox } = entry
+      if (
+        point.x >= bbox.x &&
+        point.x <= bbox.x + bbox.w &&
+        point.y >= bbox.y &&
+        point.y <= bbox.y + bbox.h
+      ) {
+        return entry.commentId
+      }
+    }
+    return undefined
+  }
+  const commentById = (id: string): CanvasComment | undefined =>
+    canvasRef.current['x-whiteboard']?.comments?.find((entry) => entry.id === id)
+  /**
+   * Opens a conversation in place, or shuts the one already open. Pressing
+   * the comment whose card is up is how it closes without hunting for the
+   * ×, which is the gesture people try first.
+   */
+  const toggleCommentCard = (commentId: string): void => {
+    setOpenCommentId((current) => (current === commentId ? null : commentId))
+  }
+  /** Opens the compose bubble over an existing comment, pre-filled, to rewrite its text. */
+  const openCommentEditor = (comment: CanvasComment) => {
+    setCommentCompose({
+      point: commentAnchor(comment, canvasRef.current),
+      editing: { id: comment.id, initialText: comment.text },
+    })
+  }
+  const [commentCompose, setCommentCompose] = useState<CommentComposeState | null>(null)
+  /**
+   * The conversation opened in place on the canvas — at most one, because
+   * a card is a place to read and answer ONE thread, and a canvas of
+   * simultaneously open cards is the comments rail with worse layout.
+   */
+  const [openCommentId, setOpenCommentId] = useState<string | null>(null)
+  /**
+   * The comment a press landed on, read back at the release. A press that
+   * never travelled opens the card; one that travelled was a pin drag and
+   * the drag branch owns it.
+   */
+  const pressedCommentRef = useRef<string | null>(null)
+  /**
+   * A point-anchored comment's pin being dragged: the comment as it was
+   * at the press (its stored anchor), the press point, and the live
+   * pointer. Kept beside the gesture machine rather than in it — see
+   * CommentDragLayer for why — so the node machinery (snapping, carried
+   * sets, live edges) never has to learn what a comment is.
+   */
+  const [commentDrag, setCommentDrag] = useState<{
+    readonly comment: CanvasComment
+    readonly startPoint: Point
+    readonly live: Point | null
+    /** The obstacle set at the press, so the preview places like the committed chrome. */
+    readonly obstacles: readonly BoundingBox[]
+    /**
+     * Set on release: the anchor the move was committed at. The drag then
+     * SETTLES rather than ending — the preview stays up, and the committed
+     * copy stays out of the surface, until the committed scene carries the
+     * comment at this anchor (a worker round trip later on a large canvas).
+     * Ending at the release instead showed the old copy for a frame and
+     * animated it to the new anchor.
+     */
+    readonly dropped: Point | null
+  } | null>(null)
+  useEffect(() => {
+    if (commentDrag?.dropped == null) return
+    const { dropped } = commentDrag
+    const pin = commentChromeBoxes.find(
+      (entry) => entry.commentId === commentDrag.comment.id && entry.part === 'pin',
+    )
+    const arrived =
+      pin !== undefined &&
+      pin.bbox.x + pin.bbox.w / 2 === dropped.x &&
+      pin.bbox.y + pin.bbox.h / 2 === dropped.y
+    // Gone (removed underneath the drag) settles too: nothing to wait for.
+    if (arrived || commentById(commentDrag.comment.id) === undefined) setCommentDrag(null)
+  }, [commentDrag, commentChromeBoxes])
+
+  return {
+    commentPlacementObstacles,
+    hitTestComment,
+    commentById,
+    toggleCommentCard,
+    openCommentEditor,
+    commentCompose,
+    setCommentCompose,
+    openCommentId,
+    setOpenCommentId,
+    pressedCommentRef,
+    commentDrag,
+    setCommentDrag,
+  }
+}

--- a/apps/web/src/components/spatial-editor/use-edit-session-state.ts
+++ b/apps/web/src/components/spatial-editor/use-edit-session-state.ts
@@ -1,0 +1,93 @@
+// The editor's open-dialog and pending-edit state, extracted from
+// SpatialEditor: which id-pinned editor is open (edge label, group label,
+// link dialog, document picker, facet inspector), the pending-cut hold, the
+// selected edge, and the per-user "show resolved comments" toggle. None of
+// this reaches the scene — every value here is either read straight off the
+// canvas/selection or resolves its target in the render, which is why it is
+// called ahead of useWorkerScene.
+
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { useEffect, useState } from 'react'
+import type { DocumentPickerState, LinkDialogState } from './CanvasContextMenu.js'
+
+export interface EditSessionStateInputs {
+  readonly canvas: SpatialCanvas
+  readonly selectedId: string | null
+}
+
+export function useEditSessionState({ canvas, selectedId }: EditSessionStateInputs) {
+  /**
+   * Whether resolved comments are drawn (muted) — ADR-0025 decision 2:
+   * per-user VIEW state, never written to the shared document, so one
+   * person's toggle cannot change what another person sees.
+   */
+  const [showResolvedComments, setShowResolvedComments] = useState(false)
+  const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null)
+  /**
+   * A cut waiting for its paste — the front half of a move. Pure view
+   * state (never persisted or synced): the nodes stay in the document,
+   * dimmed by GhostOverlay, until a same-canvas paste MOVES them, or the
+   * hold is lifted (Escape, a newer copy/cut, or any edit that touches a
+   * held node). `snapshot` records each held node's full serialized value
+   * at cut time so ANY change — a drag, a text or color edit, a remote
+   * write, a delete — reads as "someone touched it" and cancels the hold;
+   * nothing is ever lost by a cancel, because nothing was deleted.
+   */
+  const [pendingCut, setPendingCut] = useState<{
+    readonly cutId: string
+    readonly snapshot: ReadonlyMap<string, string>
+  } | null>(null)
+  useEffect(() => {
+    // Anyone touching a held node — local drag, remote edit, delete —
+    // lifts the hold; the veil must never dim a node that changed under
+    // it. The move resolution clears the hold before it applies, so its
+    // own geometry change never races this.
+    if (pendingCut === null) return
+    const touched = [...pendingCut.snapshot].some(([id, frozen]) => {
+      const node = canvas.nodes.find((n) => n.id === id)
+      return node === undefined || JSON.stringify(node) !== frozen
+    })
+    if (touched) setPendingCut(null)
+  }, [canvas, pendingCut])
+  const [edgeLabelEditId, setEdgeLabelEditId] = useState<string | null>(null)
+  // The URL dialog serves both palette-create and context-menu-edit; which
+  // one decides what its submit does.
+  const [groupLabelEditId, setGroupLabelEditId] = useState<string | null>(null)
+  const [linkDialog, setLinkDialog] = useState<LinkDialogState | null>(null)
+  const [canvasPicker, setDocumentPicker] = useState<DocumentPickerState | null>(null)
+  // The inspector is open or shut; WHICH node it edits follows the
+  // selection. Pinning it to the node the menu was opened on made it a
+  // dialog you had to close before you could look at anything else.
+  const [facetPanelOpen, setFacetPanelOpen] = useState(false)
+  // Deselecting CLOSES it, rather than leaving it standing with nothing to
+  // edit. It is the same act that dismisses the context menu, and on touch
+  // a press on blank canvas is how you put a surface away — one semantic
+  // instead of two, and no dismiss control for this panel to carry.
+  //
+  // Cleared during render rather than in an effect, the shape
+  // `DerivedFacetForm` uses for its draft: an effect would let the panel
+  // paint one frame with nothing in it. Clearing the FLAG (rather than
+  // rendering null and leaving it true) is what keeps a later re-open an
+  // ordinary open — the earlier version of this returned null and stranded
+  // the flag, which only a new selection could get out of.
+  if (facetPanelOpen && selectedId === null) setFacetPanelOpen(false)
+
+  return {
+    showResolvedComments,
+    setShowResolvedComments,
+    selectedEdgeId,
+    setSelectedEdgeId,
+    pendingCut,
+    setPendingCut,
+    edgeLabelEditId,
+    setEdgeLabelEditId,
+    groupLabelEditId,
+    setGroupLabelEditId,
+    linkDialog,
+    setLinkDialog,
+    canvasPicker,
+    setDocumentPicker,
+    facetPanelOpen,
+    setFacetPanelOpen,
+  }
+}

--- a/apps/web/src/components/spatial-editor/use-interaction-state.ts
+++ b/apps/web/src/components/spatial-editor/use-interaction-state.ts
@@ -1,0 +1,144 @@
+// The gesture/selection interaction state, extracted from SpatialEditor:
+// the multi-selection, the gesture machine, the per-frame preview values
+// (livePoint, snapGuides, marquee), the mutable canvas mirror every
+// callback-that-outlives-its-render reads instead of a stale closure, and
+// the gesture-arming refs (double-press, last-press, space-down,
+// active-pointer, navigation, long-press). Called first, ahead of every
+// other cluster: `selectionState` is this component's earliest declaration.
+
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { useRef, useState } from 'react'
+import { createIdleState, type GestureState } from './gestures.js'
+import { createIdleNavigation, type NavigationState } from './navigation.js'
+import {
+  EMPTY_SELECTION,
+  reduceSelection,
+  type SelectionEvent,
+  type SelectionState,
+} from './selection.js'
+import type { Point } from './viewport.js'
+
+export interface InteractionStateInputs {
+  readonly canvas: SpatialCanvas
+}
+
+export function useInteractionState({ canvas }: InteractionStateInputs) {
+  /**
+   * The multi-selection lives in ONE state object and every transition
+   * routes through the pure `reduceSelection` (selection.ts), so its
+   * invariants (primary never inside extras; extras only with a primary)
+   * hold by construction — never hand-write a primary/extras update pair.
+   * Functional updates make sequential events inside one handler compose
+   * instead of clobbering each other through stale closures.
+   */
+  const [selectionState, setSelectionState] = useState<SelectionState>(EMPTY_SELECTION)
+  const applySelection = (event: SelectionEvent) =>
+    setSelectionState((prev) => reduceSelection(prev, event))
+  const [gestureState, setGestureState] = useState<GestureState>(createIdleState())
+  /**
+   * Live pointer position during an in-flight move/resize/connect, in canvas
+   * space. Component-local on purpose: the reducer still recomputes the real
+   * commit from startPoint at pointerup, so this drives ONLY the preview
+   * overlay below and never becomes a source of truth. Keeping it out of
+   * `canvas` is what stops a per-frame `renderCanvasToSvg` (measured at
+   * ~30ms on an 80-node canvas — far past a frame budget).
+   */
+  const [livePoint, setLivePoint] = useState<Point | null>(null)
+  /**
+   * Canvas-space lines justifying the current snap, cleared with the
+   * gesture. Same rationale as `livePoint`: a per-frame value that drives
+   * only an overlay, never the document.
+   */
+  const [snapGuides, setSnapGuides] = useState<{
+    readonly x: readonly number[]
+    readonly y: readonly number[]
+  } | null>(null)
+  /**
+   * Armed by a second same-target press inside the double-press window;
+   * RESOLVED at pointerup: zero movement opens the editor (node) or
+   * creates (empty), any movement means it was a drag all along. Firing
+   * at the release also sidesteps mousedown's default focus action, which
+   * used to blur the just-mounted textarea when we opened at the press.
+   */
+  const doublePressRef = useRef<{ key: string; point: Point } | null>(null)
+  /** In-flight marquee selection rect, in canvas space (Excalidraw
+   * semantics: plain drag on empty space selects; pan is Space+drag,
+   * middle-button drag, or wheel). */
+  const [marquee, setMarquee] = useState<{ start: Point; current: Point } | null>(null)
+  const spaceDownRef = useRef(false)
+  /**
+   * Last press for the SELECT tool's double press, keyed by what was under
+   * it — a node id, an edge id, or `'empty'`. Hand mode's own double press
+   * is not here: it has no target to key on, so the navigation machine
+   * holds it with the distance bound that keying cannot supply.
+   */
+  const lastPressRef = useRef<{ key: string; at: number; point: Point } | null>(null)
+  /**
+   * The pointerId this component currently holds capture for, or `null`.
+   * Tracked so unmount can best-effort release capture (see the teardown
+   * effect below) even though no window-level fallback listener exists to
+   * do it otherwise — mirrors `trySetPointerCapture`'s own
+   * best-effort/never-throw reasoning.
+   */
+  const activePointerIdRef = useRef<number | null>(null)
+  /**
+   * Everything navigation owns, as one value: which fingers are down, what
+   * is driving the viewport, what the last hand press was. See
+   * `navigation.ts` — the refs this replaced could not say when a gesture
+   * was over, and twice shipped a field that outlived one.
+   */
+  const navigationRef = useRef<NavigationState>(createIdleNavigation())
+
+  const canvasRef = useRef(canvas)
+  canvasRef.current = canvas
+
+  // Mirror for callbacks that outlive their render — the long-press timer
+  // fires ~500ms after the closure that armed it, by which time the press
+  // itself has usually advanced the gesture ('pressing'/'moving'); reducing
+  // a cancel against the ARM-time state would mis-apply it.
+  const gestureStateRef = useRef(gestureState)
+  gestureStateRef.current = gestureState
+
+  /**
+   * Touch long-press -> context menu. iOS Safari never synthesises a
+   * `contextmenu` event from a touch long-press (Android Chrome does), so
+   * without this the app's object menu is simply unreachable on an iPhone
+   * — the press reads as a drag start and the menu never opens. Armed on
+   * a single stationary touch, cancelled by movement past the slop, a
+   * second finger, or lift.
+   */
+  const longPressRef = useRef<{
+    timer: ReturnType<typeof setTimeout>
+    pointerId: number
+    screen: Point
+  } | null>(null)
+  const clearLongPress = () => {
+    if (longPressRef.current !== null) {
+      clearTimeout(longPressRef.current.timer)
+      longPressRef.current = null
+    }
+  }
+
+  return {
+    selectionState,
+    setSelectionState,
+    applySelection,
+    gestureState,
+    setGestureState,
+    gestureStateRef,
+    livePoint,
+    setLivePoint,
+    snapGuides,
+    setSnapGuides,
+    doublePressRef,
+    marquee,
+    setMarquee,
+    spaceDownRef,
+    lastPressRef,
+    activePointerIdRef,
+    navigationRef,
+    canvasRef,
+    longPressRef,
+    clearLongPress,
+  }
+}

--- a/apps/web/src/components/spatial-editor/use-node-boxes.ts
+++ b/apps/web/src/components/spatial-editor/use-node-boxes.ts
@@ -3,9 +3,9 @@
 // `canvas` prop — before layout runs — so useViewportControls (which frames
 // on `boxes`) never waits on the worker-laid-out scene.
 
-import { useMemo } from 'react'
 import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
-import { indexNodeBoxes, type Box, type NodeBox } from './geometry.js'
+import { useMemo } from 'react'
+import { type Box, indexNodeBoxes, type NodeBox } from './geometry.js'
 
 export interface NodeBoxesInputs {
   readonly canvas: SpatialCanvas

--- a/apps/web/src/components/spatial-editor/use-node-boxes.ts
+++ b/apps/web/src/components/spatial-editor/use-node-boxes.ts
@@ -1,0 +1,30 @@
+// The pre-scene node-geometry memos, extracted from SpatialEditor: every
+// node's box, and the selected node's box/value. Computed straight off the
+// `canvas` prop — before layout runs — so useViewportControls (which frames
+// on `boxes`) never waits on the worker-laid-out scene.
+
+import { useMemo } from 'react'
+import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
+import { indexNodeBoxes, type Box, type NodeBox } from './geometry.js'
+
+export interface NodeBoxesInputs {
+  readonly canvas: SpatialCanvas
+  readonly selectedId: string | null
+}
+
+export function useNodeBoxes({ canvas, selectedId }: NodeBoxesInputs): {
+  readonly boxes: readonly NodeBox[]
+  readonly selectedBox: Box | undefined
+  readonly selectedNode: SpatialNode | undefined
+} {
+  const boxes = useMemo(() => indexNodeBoxes(canvas), [canvas])
+  const selectedBox = useMemo(
+    () => (selectedId === null ? undefined : boxes.find((b) => b.id === selectedId)?.box),
+    [boxes, selectedId],
+  )
+  const selectedNode = useMemo(
+    () => (selectedId === null ? undefined : canvas.nodes.find((n) => n.id === selectedId)),
+    [canvas, selectedId],
+  )
+  return { boxes, selectedBox, selectedNode }
+}

--- a/apps/web/src/components/spatial-editor/use-scene-projection.ts
+++ b/apps/web/src/components/spatial-editor/use-scene-projection.ts
@@ -1,0 +1,115 @@
+// The post-scene derived memos, extracted from SpatialEditor: everything
+// projected off the COMMITTED scene once useWorkerScene has produced it —
+// the keyed patch surface, edge hit-test paths, comment chrome boxes, the
+// selection's own boxes, and the minimap overview. Called immediately after
+// useWorkerScene, since every input here is that hook's output (plus boxes,
+// canvas, theme, selectedId, extraIds, all already available by then).
+
+import type { BoundingBox, Scene } from '@kamiazya/whiteboard-canvas-render'
+import {
+  flattenDrawnEdgePath,
+  SPATIAL_DARK_PALETTE,
+  SPATIAL_LIGHT_PALETTE,
+} from '@kamiazya/whiteboard-canvas-render'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { useMemo } from 'react'
+import type { ResolvedTheme } from '../../hooks/useThemeMode.js'
+import { type NodeBox, unionBox } from './geometry.js'
+import { buildMinimapNodes } from './minimap.js'
+import { renderedCanvasKeyed } from './scene-render-core.js'
+
+export interface SceneProjectionInputs {
+  readonly scene: Scene
+  readonly bounds: BoundingBox
+  readonly boxes: readonly NodeBox[]
+  readonly canvas: SpatialCanvas
+  readonly theme: ResolvedTheme
+  readonly selectedId: string | null
+  readonly extraIds: ReadonlySet<string>
+}
+
+export function useSceneProjection({
+  scene,
+  bounds,
+  boxes,
+  canvas,
+  theme,
+  selectedId,
+  extraIds,
+}: SceneProjectionInputs) {
+  // The committed surface's keyed projection, derived from the scene the
+  // worker (or sync path) delivered — ~3ms of stringify against the
+  // 66-125ms layout, so the worker protocol stays plain-data. The patch
+  // container below consumes it; the plain `svg` string is no longer
+  // read here.
+  const keyed = useMemo(() => renderedCanvasKeyed({ scene, bounds }), [scene, bounds])
+  // Routed edge paths in canvas coordinates, for edge hit-testing and the
+  // selection highlight. Edges have no area, so selection is a
+  // distance-to-polyline test against a zoom-adjusted tolerance. The
+  // hit/highlight path is the DRAWN line — rounded corners flattened and
+  // line-jump hops arced over — via the same decomposition the SVG
+  // backend serializes, so a tap and the highlight land on the ink.
+  const edgePaths = useMemo(
+    () =>
+      scene.nodes.flatMap((node) =>
+        node.kind === 'edge'
+          ? [
+              {
+                id: node.id,
+                path: flattenDrawnEdgePath(node.path, node.jumps, node.rounded === true),
+              },
+            ]
+          : [],
+      ),
+    [scene],
+  )
+  // Comment chrome (pins and bubbles) from the committed scene, for
+  // hit-testing: the shapes carry `${commentId}/pin` / `/bubble` ids and
+  // the commentChrome marker (ADR-0025 decision 5), so the boxes a press
+  // is tested against are exactly the boxes the renderer painted — one
+  // producer for the geometry. Later entries draw on top, so hit-testing
+  // walks them in reverse.
+  const commentChromeBoxes = useMemo(
+    () =>
+      scene.nodes.flatMap((node) => {
+        if (node.kind !== 'shape' || node.commentChrome !== true || node.id === undefined) return []
+        const cut = node.id.lastIndexOf('/')
+        if (cut <= 0) return []
+        const part = node.id.slice(cut + 1)
+        if (part !== 'pin' && part !== 'bubble') return []
+        return [{ commentId: node.id.slice(0, cut), part, bbox: node.bbox }]
+      }),
+    [scene],
+  )
+  /**
+   * Every selected node with the box it currently occupies, primary first.
+   *
+   * The resize handles surround the UNION of these rather than the primary
+   * alone: handles drawn around a group have to act on the group, or a
+   * three-node selection offers one node's handles and resizes that node
+   * while the other two watch.
+   */
+  const selectionMembers = useMemo(() => {
+    if (selectedId === null) return []
+    return [selectedId, ...extraIds].flatMap((id) => {
+      const entry = boxes.find((candidate) => candidate.id === id)
+      return entry === undefined ? [] : [{ id, box: entry.box }]
+    })
+  }, [selectedId, extraIds, boxes])
+  const selectionBox = useMemo(
+    () => unionBox(selectionMembers.map((member) => member.box)),
+    [selectionMembers],
+  )
+  /**
+   * Node boxes for the overview, with each authored colour resolved to the
+   * accent the scene already uses for it. A preset key resolves through the
+   * current mode's palette; a hex passes through; an unstyled node carries
+   * no colour and the overview falls back to its muted default.
+   */
+  const minimapNodes = useMemo(() => {
+    const palette = theme === 'dark' ? SPATIAL_DARK_PALETTE : SPATIAL_LIGHT_PALETTE
+    return buildMinimapNodes(canvas.nodes, boxes, palette)
+  }, [boxes, canvas, theme])
+
+  return { keyed, edgePaths, commentChromeBoxes, selectionMembers, selectionBox, minimapNodes }
+}

--- a/apps/web/src/components/spatial-editor/use-tool-state.test.ts
+++ b/apps/web/src/components/spatial-editor/use-tool-state.test.ts
@@ -1,0 +1,44 @@
+// The one moved behavior the design's manual walk listed that no browser
+// test covered: the initial-tool-once effect. The other three walk items
+// (facet-panel clear, comment-drag settle, cut invalidation) already have
+// real-browser coverage; this pins the fourth at the hook seam the
+// decomposition created.
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import type { EditorTool } from './ToolPalette.js'
+import { useToolState } from './use-tool-state.js'
+
+type Props = { initialTool: EditorTool | undefined }
+
+function mount(initialTool: EditorTool | undefined) {
+  return renderHook(
+    (p: Props) => useToolState({ defaultTool: 'hand', initialTool: p.initialTool }),
+    {
+      initialProps: { initialTool } satisfies Props,
+    },
+  )
+}
+
+describe('useToolState initial-tool-once', () => {
+  it('stays on defaultTool when no initialTool is given', () => {
+    const { result } = mount(undefined)
+    expect(result.current.tool).toBe('hand')
+  })
+
+  it('applies initialTool once, and a later different initialTool does not re-apply', () => {
+    const { result, rerender } = mount('select')
+    expect(result.current.tool).toBe('select')
+    rerender({ initialTool: 'connect' })
+    expect(result.current.tool).toBe('select')
+  })
+
+  it("a user's explicit choice beats an initialTool that arrives afterwards", () => {
+    const { result, rerender } = mount(undefined)
+    act(() => {
+      result.current.toolChosenByUserRef.current = true
+      result.current.setTool('connect')
+    })
+    rerender({ initialTool: 'select' })
+    expect(result.current.tool).toBe('connect')
+  })
+})

--- a/apps/web/src/components/spatial-editor/use-tool-state.ts
+++ b/apps/web/src/components/spatial-editor/use-tool-state.ts
@@ -1,0 +1,47 @@
+// The tool/mode state, extracted from SpatialEditor: which OOUI mode is
+// armed, the initial-tool-once effect, the context menu, the long-press
+// pulse, and the ref the long-press timer calls through to open that menu
+// with the LATEST render's closure.
+
+import { useEffect, useRef, useState } from 'react'
+import type { ContextMenuTarget } from './CanvasContextMenu.js'
+import type { EditorTool } from './ToolPalette.js'
+import type { Point } from './viewport.js'
+
+export interface ToolStateInputs {
+  readonly defaultTool: EditorTool
+  readonly initialTool: EditorTool | undefined
+}
+
+export function useToolState({ defaultTool, initialTool }: ToolStateInputs) {
+  // OOUI interaction mode (S6/S7): Hand (navigation) is the default —
+  // Select restores the pre-tool editing behavior byte-for-byte; Connect
+  // arms object-first click-A, click-B edge creation. Creation is
+  // deliberately NOT a mode — the palette's Note entry works in every mode.
+  const [tool, setTool] = useState<EditorTool>(defaultTool)
+  const toolChosenByUserRef = useRef(false)
+  const initialToolAppliedRef = useRef(false)
+  useEffect(() => {
+    if (initialTool === undefined) return
+    if (initialToolAppliedRef.current || toolChosenByUserRef.current) return
+    initialToolAppliedRef.current = true
+    setTool(initialTool)
+  }, [initialTool])
+  const [contextMenu, setContextMenu] = useState<ContextMenuTarget | null>(null)
+  // Screen point of the last committed long-press, while its pulse plays.
+  const [longPressPulse, setLongPressPulse] = useState<Point | null>(null)
+  // The timer must call the LATEST render's opener (fresh viewport/boxes/
+  // selection), not the one captured when the finger landed.
+  const openContextMenuAtRef = useRef<(screen: Point) => void>(() => {})
+
+  return {
+    tool,
+    setTool,
+    toolChosenByUserRef,
+    contextMenu,
+    setContextMenu,
+    longPressPulse,
+    setLongPressPulse,
+    openContextMenuAtRef,
+  }
+}


### PR DESCRIPTION
Audit follow-up (`issues/spatial-editor-decomposition`, MEDIUM): SpatialEditor.tsx shrinks **3043 → 2691 lines** by extracting six clusters VERBATIM into `use-*.ts` hooks (one cluster per commit), per a PlanReview-approved design (plan-reviewer + Codex both pass): use-node-boxes, use-scene-projection (buildMinimapNodes moves to minimap.ts), use-tool-state, use-edit-session-state, use-comment-state, use-interaction-state. `surfaceKeyed` and `suppressedBodyNodeIds` deliberately stay (bridge memo / pipeline input adapter — reasons in the commit bodies); the ~900-line pointer-handler block is out of scope by design (follow-up shape: pass the cluster bundles, not 20 loose params).

## Behavior preservation evidence
- Moves verbatim: same useState forms, byte-identical dependency arrays, no new memoization; the render-time facetPanel clear stays a render-time clear.
- Exactly two mechanical test edits (build-minimap-nodes import line; editor-state-surface sources glob per that ledger's own contract — **mutation-checked**: dropping a hook from the glob fails the ledger naming the missing state).
- Review workflow (multi-dimension + adversarial verify + QA): **0 findings**. QA re-ran jsdom 556/556 and the real-browser directory suite twice (465/467 both runs) and **A/B'd the 2 failures against origin/main by swapping in the pre-refactor file: byte-identical failures** → pre-existing (`shaped-node-editing.browser.test.tsx`, already filed as `issues/shaped-node-editing-local-only-failure`).
- Manual-walk substitution: the design asked for a live walk of four moved behaviors; three are pinned by existing real-browser tests (inspector-follows-selection, comment-drag-follow/move/placement, clipboard + PendingCutChip) and the fourth (initial-tool-once) gains a renderHook test at the new seam in this PR, mutation-checked (user-choice guard removed → red).
- typecheck / lint / knip clean; `pnpm build` + daemon startup smoke green (QA).

Visual evidence: none — behavior-preserving refactor, zero intended pixel change; the evidence is the un-weakened 556-test jsdom + 467-test browser suites and the A/B above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7iuGxJAXjr6rEXfS7YAC6