### PR TITLE
feat(web): wire the annotation layer into DaemonDocumentPage (ADR-0026)

### DIFF
--- a/apps/web/src/pages/DaemonDocumentPage.comments-panel.browser.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.comments-panel.browser.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * The comments panel on the daemon page (ADR-0026 decision 5), real-browser
+ * geometry only — the interaction surface (rail contents, reply routing,
+ * orphaned marking, preview gating) is already pinned at the jsdom layer in
+ * DaemonDocumentPage.comments-panel.test.tsx. What THIS file adds is the one
+ * thing jsdom cannot check: the opener's real position relative to the
+ * editor surface, mirroring the case that caught BrowserDocumentPage's own
+ * overlay defect (see BrowserDocumentPage.comments-panel.browser.test.tsx).
+ *
+ * SpatialEditor is mocked — the subject is the document-level surface, not
+ * the canvas.
+ */
+import { writeCommentThread } from '@kamiazya/whiteboard-loro-adapter'
+import type {
+  DocumentBackend,
+  DocumentBackendHandlers,
+} from '@kamiazya/whiteboard-mcp/browser-contract'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import { LoroDoc } from 'loro-crdt'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import '../index.css'
+
+vi.mock('../components/spatial-editor/index.js', () => ({
+  SpatialEditor: (_props: { canvas: SpatialCanvas }) => (
+    <div data-testid="mock-spatial-editor" style={{ height: '100%', width: '100%' }} />
+  ),
+}))
+
+vi.mock('../lib/daemon-api-client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/daemon-api-client.js')>()
+  return {
+    ...actual,
+    listWorkspaces: vi.fn(async () => ({ workspaces: [{ workspaceId: 'w1' }] })),
+    listDocuments: vi.fn(async () => ({
+      documents: [{ path: 'board', id: 'id-board', updatedAt: '2026-01-01', kind: 'spatial' }],
+    })),
+    createDocument: vi.fn(),
+    getDocumentBacklinks: vi.fn(async () => ({ backlinks: [], unlinkedMentions: [] })),
+  }
+})
+
+vi.mock('../lib/replica-refresh.js', () => ({
+  scheduleReplicaRefresh: vi.fn(),
+  scheduleReplicaPush: vi.fn(),
+}))
+
+const { DaemonDocumentPage } = await import('./DaemonDocumentPage.js')
+
+function render(ui: ReactElement) {
+  return rtlRender(
+    <div style={{ height: '100vh' }}>
+      <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
+    </div>,
+  )
+}
+
+/** One open thread, seeded at document root — matches how an injected `createBackend` scopes a connection (see DaemonDocumentPage.comments-panel.test.tsx's own note on `contentDocumentId`). */
+function seededSnapshot(): Uint8Array {
+  const doc = new LoroDoc()
+  writeCommentThread(doc, {
+    id: 't-open',
+    anchor: { kind: 'spatial', x: 20, y: 30 },
+    status: 'open',
+    messages: [{ id: 'm1', body: 'still needs a decision' }],
+  })
+  return doc.export({ mode: 'snapshot' })
+}
+
+class FakeBackend implements DocumentBackend {
+  handlers: DocumentBackendHandlers | null = null
+  connect(handlers: DocumentBackendHandlers): void {
+    this.handlers = handlers
+    handlers.onConnected()
+    handlers.onSnapshot(seededSnapshot())
+  }
+  disconnect(): void {}
+  pushLocalUpdate(): void {}
+  getFile(): Promise<Blob | null> {
+    return Promise.resolve(null)
+  }
+  putFile(): Promise<void> {
+    return Promise.resolve()
+  }
+  sendClientReady(): void {}
+  sendExportResponse(): void {}
+}
+
+const DAEMON_BASE_URL = 'http://127.0.0.1:3099'
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+it('opens the rail from the document actions row, without the opener overlaying the editor surface', async () => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response('{}', { status: 404 })),
+  )
+
+  render(
+    <DaemonDocumentPage
+      daemonBaseUrl={DAEMON_BASE_URL}
+      workspaceId="w1"
+      path="board"
+      createBackend={() => new FakeBackend()}
+    />,
+  )
+
+  const surface = await screen.findByTestId('mock-spatial-editor', undefined, { timeout: 15_000 })
+  const opener = await screen.findByRole('button', { name: /comments/i })
+
+  // Geometric, not merely a class name: floated over the surface's top-right
+  // corner, this control sat on top of whatever chrome the mounted editor
+  // puts there — measured on the browser page, the markdown editor's own
+  // catalog trigger, which then could not be clicked at all.
+  const a = opener.getBoundingClientRect()
+  const b = surface.getBoundingClientRect()
+  const overlaps = a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom
+  expect({ overlaps, opener: a.toJSON(), surface: b.toJSON() }).toMatchObject({ overlaps: false })
+
+  await userEvent.click(opener)
+  await waitFor(() => expect(screen.getByText('still needs a decision')).toBeInTheDocument(), {
+    timeout: 15_000,
+  })
+})

--- a/apps/web/src/pages/DaemonDocumentPage.comments-panel.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.comments-panel.test.tsx
@@ -1,0 +1,366 @@
+/**
+ * DaemonDocumentPage's annotation layer (ADR-0026), jsdom mirror of
+ * BrowserDocumentPage.comments-panel.browser.test.tsx's core interactions.
+ *
+ * What this asserts that the panel's own component test cannot is the
+ * WIRING: a thread stored in the document's threads plane reaches the panel
+ * through this page's sync session, and a reply typed into the rail travels
+ * back through that same session rather than a second write door. Real
+ * geometry (the opener's position relative to the editor surface) is a
+ * `web-browser` concern — see DaemonDocumentPage.comments-panel.browser.test.tsx.
+ */
+import {
+  readCommentThreads,
+  writeCommentThread,
+  writeCoreFacets,
+  writeDocumentKind,
+  writeMarkdownBody,
+  writeSpatialCanvas,
+} from '@kamiazya/whiteboard-loro-adapter'
+import type {
+  DocumentBackend,
+  DocumentBackendHandlers,
+} from '@kamiazya/whiteboard-mcp/browser-contract'
+import {
+  act,
+  cleanup,
+  fireEvent,
+  type RenderOptions,
+  render as rtlRender,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
+import { LoroDoc } from 'loro-crdt'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { VersionsBackendContext } from '../contexts/VersionsBackendContext.js'
+import * as daemonApiClient from '../lib/daemon-api-client.js'
+import type { VersionsBackend } from '../lib/versions-backend.js'
+
+function render(ui: ReactElement, options?: RenderOptions) {
+  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>, options)
+}
+
+vi.mock('../lib/daemon-api-client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/daemon-api-client.js')>()
+  return {
+    ...actual,
+    listWorkspaces: vi.fn(),
+    listDocuments: vi.fn(),
+    createDocument: vi.fn(),
+    getDocumentBacklinks: vi.fn(),
+  }
+})
+
+vi.mock('../lib/replica-refresh.js', () => ({
+  scheduleReplicaRefresh: vi.fn(),
+  scheduleReplicaPush: vi.fn(),
+}))
+
+const { DaemonDocumentPage } = await import('./DaemonDocumentPage.js')
+
+const mockListWorkspaces = vi.mocked(daemonApiClient.listWorkspaces)
+const mockListDocuments = vi.mocked(daemonApiClient.listDocuments)
+const mockGetDocumentBacklinks = vi.mocked(daemonApiClient.getDocumentBacklinks)
+
+const DAEMON_BASE_URL = 'http://127.0.0.1:3099'
+
+/**
+ * Serves `/names` (the workspace's display-name surface) and `/branches`
+ * (`useBranches`, always enabled on the daemon page's `DAEMON_HISTORY_
+ * CAPABILITIES`) so the History panel used by the preview test below has
+ * something real to render; everything else answers 404 rather than hang.
+ */
+function stubDaemonFetch(): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.includes('/names')) {
+        return new Response(JSON.stringify({ documents: {}, pinned: [] }), { status: 200 })
+      }
+      if (url.includes('/branches')) {
+        return new Response(
+          JSON.stringify({
+            branches: [
+              {
+                name: 'main',
+                tipFrontiers: '',
+                color: '#3b82f6',
+                createdAt: '2026-01-01T00:00:00.000Z',
+              },
+            ],
+            head: 'main',
+          }),
+          { status: 200 },
+        )
+      }
+      return new Response('{}', { status: 404 })
+    }),
+  )
+}
+
+/**
+ * Threads seeded straight onto the document root — the shape an INJECTED
+ * backend produces here, since `createBackend` sends `contentDocumentId:
+ * undefined` (see DaemonDocumentPage.tsx's `backendState` memo), unlike a
+ * real per-document connection scoped through `documentContainers`.
+ */
+function seededSpatialSnapshot(): Uint8Array {
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, { nodes: [], edges: [] })
+  writeCommentThread(doc, {
+    id: 't-open',
+    anchor: { kind: 'spatial', x: 20, y: 30 },
+    status: 'open',
+    messages: [{ id: 'm1', body: 'still needs a decision' }],
+  })
+  writeCommentThread(doc, {
+    id: 't-done',
+    anchor: { kind: 'spatial', x: 40, y: 50 },
+    status: 'resolved',
+    messages: [{ id: 'm2', body: 'settled last week' }],
+  })
+  // Anchored to a node the (empty) canvas does not contain — orphaned, not
+  // merely unplaced (ADR-0026 decision 4).
+  writeCommentThread(doc, {
+    id: 't-orphan',
+    anchor: { kind: 'spatial', nodeId: 'n-deleted', x: 60, y: 70 },
+    status: 'open',
+    messages: [{ id: 'm3', body: 'about a node that was deleted' }],
+  })
+  return doc.export({ mode: 'snapshot' })
+}
+
+function markdownSnapshotWithThread(): Uint8Array {
+  const doc = new LoroDoc()
+  writeMarkdownBody(doc, 'is this still true?')
+  writeCoreFacets(doc, { type: 'markdown' })
+  writeDocumentKind(doc, 'markdown')
+  writeCommentThread(doc, {
+    id: 't-note',
+    anchor: { kind: 'text', quote: { exact: 'is this still true?' }, start: 0, end: 20 },
+    status: 'open',
+    messages: [{ id: 'm-note', body: 'is this still true?' }],
+  })
+  return doc.export({ mode: 'snapshot' })
+}
+
+class FakeBackend implements DocumentBackend {
+  handlers: DocumentBackendHandlers | null = null
+  readonly pushLocalUpdateCalls: Uint8Array[] = []
+  constructor(private readonly snapshot: () => Uint8Array) {}
+  connect(handlers: DocumentBackendHandlers): void {
+    this.handlers = handlers
+    handlers.onConnected()
+    handlers.onSnapshot(this.snapshot())
+  }
+  disconnect(): void {}
+  pushLocalUpdate(bytes: Uint8Array): void {
+    this.pushLocalUpdateCalls.push(bytes)
+  }
+  getFile(): Promise<Blob | null> {
+    return Promise.resolve(null)
+  }
+  putFile(): Promise<void> {
+    return Promise.resolve()
+  }
+  sendClientReady(): void {}
+  sendExportResponse(): void {}
+}
+
+async function renderSpatial(backend: FakeBackend = new FakeBackend(seededSpatialSnapshot)) {
+  await act(async () => {
+    render(
+      <DaemonDocumentPage
+        daemonBaseUrl={DAEMON_BASE_URL}
+        workspaceId="w1"
+        path="board"
+        createBackend={() => backend}
+      />,
+      { container: document.body },
+    )
+  })
+  return backend
+}
+
+/**
+ * The rail, scoped. The real SpatialEditor (unmocked, unlike the browser
+ * test's mock) draws its own SVG bubble for every thread it is handed, so an
+ * unscoped `getByText` on a thread's body matches twice — once in the rail,
+ * once on the canvas. Only the rail is this file's subject.
+ */
+function panel() {
+  return within(screen.getByTestId('comments-panel'))
+}
+
+describe('DaemonDocumentPage comments panel', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    stubDaemonFetch()
+    mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
+    mockListDocuments.mockResolvedValue({
+      documents: [{ path: 'board', id: 'id-board', updatedAt: '2026-01-01', kind: 'spatial' }],
+    })
+    mockGetDocumentBacklinks.mockResolvedValue({ backlinks: [], unlinkedMentions: [] })
+  })
+
+  afterEach(() => {
+    cleanup()
+    window.localStorage.clear()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('opens a rail listing this document conversations, open ones first and by default', async () => {
+    await renderSpatial()
+    // Closed by default: the panel answers a question the reader asks,
+    // rather than taking a rail's width from everyone who never asks it.
+    expect(screen.queryByTestId('comments-panel')).toBeNull()
+
+    fireEvent.click(await screen.findByRole('button', { name: /comments/i }))
+    await waitFor(() => expect(panel().getByText('still needs a decision')).toBeTruthy())
+    // Resolved is one filter away, not on screen by default.
+    expect(panel().queryByText('settled last week')).toBeNull()
+  })
+
+  it('counts the open conversations on the opener and reflects the rail in aria-pressed', async () => {
+    await renderSpatial()
+    // One of three threads is resolved; a badge counting all of them would
+    // report work that is done as work outstanding.
+    const opener = await screen.findByRole('button', { name: /comments, 2 open/i })
+    expect(opener.getAttribute('aria-pressed')).toBe('false')
+
+    fireEvent.click(opener)
+    await screen.findByTestId('comments-panel')
+    expect(opener.getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('marks a thread whose node is gone, but not one anchored to bare coordinates', async () => {
+    await renderSpatial()
+    fireEvent.click(await screen.findByRole('button', { name: /comments/i }))
+
+    await waitFor(() => expect(screen.getByTestId('thread-orphaned-t-orphan')).toBeTruthy())
+    expect(screen.queryByTestId('thread-orphaned-t-open')).toBeNull()
+  })
+
+  it('replies from the rail through the sync session, with a fresh message id', async () => {
+    // Captured once: a SECOND call to seededSpatialSnapshot() below would
+    // build its threads container from an independent LoroDoc with no
+    // common ancestor with the session's own, and Loro merges two such
+    // creations under the same key to ONE of them — silently discarding the
+    // reply this test exists to observe (see comment-threads.ts's own note
+    // on writeCommentThread).
+    const seed = seededSpatialSnapshot()
+    const backend = await renderSpatial(new FakeBackend(() => seed))
+    fireEvent.click(await screen.findByRole('button', { name: /comments/i }))
+    fireEvent.click(panel().getByText('still needs a decision'))
+
+    fireEvent.change(panel().getByRole('textbox', { name: /reply/i }), {
+      target: { value: 'decided: ship it' },
+    })
+    fireEvent.click(panel().getByRole('button', { name: /^reply$/i }))
+
+    await waitFor(() => expect(panel().getByText('decided: ship it')).toBeTruthy())
+
+    // The write travelled the session's own path — replaying every update
+    // the FakeBackend recorded onto a copy of the seed reproduces the same
+    // reply, under an id distinct from every seeded message.
+    const replay = new LoroDoc()
+    replay.import(seed)
+    for (const bytes of backend.pushLocalUpdateCalls) replay.import(bytes)
+    const thread = readCommentThreads(replay).find((t) => t.id === 't-open')
+    const reply = thread?.messages.find((m) => m.body === 'decided: ship it')
+    expect(reply?.id).toBeDefined()
+    expect(new Set(thread?.messages.map((m) => m.id)).size).toBe(thread?.messages.length)
+  })
+
+  it("lists a markdown document's conversations from the same session, and replies through it", async () => {
+    mockListDocuments.mockResolvedValue({
+      documents: [{ path: 'note', id: 'id-note', updatedAt: '2026-01-01', kind: 'markdown' }],
+    })
+    await act(async () => {
+      render(
+        <DaemonDocumentPage
+          daemonBaseUrl={DAEMON_BASE_URL}
+          workspaceId="w1"
+          path="note"
+          createBackend={() => new FakeBackend(markdownSnapshotWithThread)}
+        />,
+        { container: document.body },
+      )
+    })
+
+    // Daemon markdown has no `markdownDoc`-style fallback — every document
+    // kind reads its conversations off the ONE sync session (unlike
+    // BrowserDocumentPage, whose markdown documents get no backend at all).
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /comments, 1 open/i })).toBeTruthy(),
+    )
+    fireEvent.click(screen.getByRole('button', { name: /comments/i }))
+    await waitFor(() => expect(panel().getByText('is this still true?')).toBeTruthy())
+
+    fireEvent.click(panel().getByText('is this still true?'))
+    fireEvent.change(panel().getByRole('textbox', { name: /reply/i }), {
+      target: { value: 'no, we changed it' },
+    })
+    fireEvent.click(panel().getByRole('button', { name: /^reply$/i }))
+    await waitFor(() => expect(panel().getByText('no, we changed it')).toBeTruthy())
+  })
+
+  it('keeps the rail visible under a version preview, but withholds the reply box', async () => {
+    const fakeVersionsBackend: VersionsBackend = {
+      list: async () => [
+        {
+          id: 'v1',
+          path: 'board',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          elementCount: 0,
+          label: 'a point',
+          auto: false,
+          hasThumbnail: false,
+          branchName: 'main',
+        },
+      ],
+      loadPast: async () => ({ kind: 'spatial', canvas: { nodes: [], edges: [] } }),
+      save: async () => {
+        throw new Error('not exercised by this test')
+      },
+      restore: async () => {},
+      putThumbnail: async () => {},
+      loadThumbnail: async () => null,
+    }
+
+    await act(async () => {
+      render(
+        <VersionsBackendContext.Provider value={fakeVersionsBackend}>
+          <DaemonDocumentPage
+            daemonBaseUrl={DAEMON_BASE_URL}
+            workspaceId="w1"
+            path="board"
+            createBackend={() => new FakeBackend(seededSpatialSnapshot)}
+          />
+        </VersionsBackendContext.Provider>,
+        { container: document.body },
+      )
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: /comments/i }))
+    fireEvent.click(panel().getByText('still needs a decision'))
+    await waitFor(() => panel().getByRole('textbox', { name: /reply/i }))
+
+    fireEvent.click(await screen.findByRole('button', { name: /history/i }))
+    const row = (await screen.findAllByTestId('version-row'))[0]
+    const activate = row?.querySelector('button')
+    expect(activate, 'no interactive control on the version row').not.toBeNull()
+    fireEvent.click(activate as HTMLButtonElement)
+
+    // A reply is a write to the LIVE document, and the editor surface is
+    // replaced by DocumentPreview during a preview — the rail must not offer
+    // a control that would write against a state that is not the document's.
+    await waitFor(() => expect(panel().queryByRole('textbox', { name: /reply/i })).toBeNull())
+    expect(panel().getByText('still needs a decision')).toBeTruthy()
+  })
+})

--- a/apps/web/src/pages/DaemonDocumentPage.comments-panel.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.comments-panel.test.tsx
@@ -364,3 +364,25 @@ describe('DaemonDocumentPage comments panel', () => {
     expect(panel().getByText('still needs a decision')).toBeTruthy()
   })
 })
+
+/** Every thread resolved: the zero-open branch of the opener's label. */
+function allResolvedSnapshot(): Uint8Array {
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, { nodes: [], edges: [] })
+  writeCommentThread(doc, {
+    id: 't-settled',
+    anchor: { kind: 'spatial', x: 20, y: 30 },
+    status: 'resolved',
+    messages: [{ id: 'm-settled', body: 'settled last week' }],
+  })
+  return doc.export({ mode: 'snapshot' })
+}
+
+describe('DaemonDocumentPage comments opener with zero open threads', () => {
+  it("reads plain 'Comments' and carries no count badge", async () => {
+    await renderSpatial(new FakeBackend(allResolvedSnapshot))
+    const opener = await screen.findByRole('button', { name: 'Comments' })
+    // The badge is the only digit the opener ever renders; zero open = none.
+    expect(opener.textContent ?? '').not.toMatch(/\d/)
+  })
+})

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -4,9 +4,12 @@ import type { DocumentBackend } from '@kamiazya/whiteboard-mcp/browser-contract'
 import { DaemonBackend } from '@kamiazya/whiteboard-mcp/daemon-backend'
 import { selectDocumentTransport } from '@kamiazya/whiteboard-mcp/select-document-transport'
 import { SseBackend } from '@kamiazya/whiteboard-mcp/sse-backend'
+import type { CommentThread } from '@kamiazya/whiteboard-model'
 import { type DocumentKind, isImageRef } from '@kamiazya/whiteboard-model'
+import { MessageSquare } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { AgentPresenceChip } from '../components/AgentPresenceChip.js'
+import { CommentsPanel } from '../components/annotations/CommentsPanel.js'
 import { CapabilityTeaser } from '../components/capability-teaser/CapabilityTeaser.js'
 import type { ConnectionsBacklink } from '../components/connections/ConnectionsChip.js'
 import { ConnectionsChip } from '../components/connections/ConnectionsChip.js'
@@ -23,6 +26,7 @@ import { MergeToast } from '../components/MergeToast.js'
 import { CanvasDisplaySettings } from '../components/spatial-editor/CanvasDisplaySettings.js'
 import type { SpatialEditorHandle } from '../components/spatial-editor/index.js'
 import { Button } from '../components/ui/button.js'
+import { TOGGLE_STATE_CLASS } from '../components/ui/dock-button.js'
 import {
   DAEMON_HISTORY_CAPABILITIES,
   type VersionPreviewSession,
@@ -189,6 +193,11 @@ export function DaemonDocumentPage({
   // MCP tool saves, and other peers) so an open VersionTimeline updates
   // without waiting for its 15s poll.
   const [versionRefreshSignal, setVersionRefreshSignal] = useState(0)
+  /**
+   * Whether the comments rail is open. Per-user view state, held here and
+   * written nowhere — mirrors BrowserDocumentPage's own `commentsOpen`.
+   */
+  const [commentsOpen, setCommentsOpen] = useState(false)
   // ⌘/Ctrl+S asks for a bookmark: open the history and arm its naming field.
   useBookmarkShortcut(canvas !== null, () => {
     setHistoryOpen(true)
@@ -311,6 +320,7 @@ export function DaemonDocumentPage({
 
   const {
     canvas: canvasValue,
+    annotations,
     loaded: canvasLoaded,
     onChange,
     externalVersion,
@@ -412,6 +422,25 @@ export function DaemonDocumentPage({
   const documentKind: DocumentKind =
     controller.documents.find((entry) => entry.path === controller.path)?.kind ?? 'spatial'
 
+  const openThreadCount = annotations.filter((thread) => thread.status === 'open').length
+  /**
+   * Whether a thread's anchor still finds its place (ADR-0026 decision 4:
+   * deleting the subject of a conversation must not delete the conversation).
+   *
+   * Spatial-only, mirroring BrowserDocumentPage's own memo: a markdown
+   * document has no canvas to judge a node-anchored thread against, and only
+   * an anchor that NAMES a node is judged at all.
+   */
+  const resolveAnchor = useMemo(() => {
+    if (documentKind !== 'spatial') return undefined
+    const nodeIds = new Set(canvasValue.nodes.map((node) => node.id))
+    return (thread: CommentThread): 'placed' | 'orphaned' => {
+      const { anchor } = thread
+      if (anchor.kind !== 'spatial' || anchor.nodeId === undefined) return 'placed'
+      return nodeIds.has(anchor.nodeId) ? 'placed' : 'orphaned'
+    }
+  }, [documentKind, canvasValue])
+
   // A markdown document's body lives in the doc's `body` text container —
   // the one place it is stored, and the shape `wb_document_set` writes. The
   // read comes from the sync session (which republishes it on hydration,
@@ -447,6 +476,28 @@ export function DaemonDocumentPage({
     [onChange],
   )
   const markdownBody = documentKind === 'markdown' && canvasLoaded ? syncedMarkdownBody : null
+
+  /**
+   * Appends the reader's reply to a conversation.
+   *
+   * Unlike BrowserDocumentPage — where a markdown document gets no backend at
+   * all and so has no session to send a command through — every daemon
+   * document, spatial or markdown, has a live sync session (the workspace
+   * document holds them all). So one route, `onChange`'s `reply-to-thread`
+   * command, serves both kinds here: one undo step, riding the same
+   * annotation channel every other edit does.
+   */
+  const handleReply = useCallback(
+    (threadId: string, body: string) => {
+      const message = {
+        id: crypto.randomUUID(),
+        body,
+        createdAt: new Date().toISOString(),
+      }
+      onChange(canvasValueRef.current, { kind: 'reply-to-thread', threadId, message })
+    },
+    [onChange],
+  )
 
   // `[[path]]` aliases resolve against the same list the user can see;
   // display names are retired from resolution and label the link at render
@@ -755,6 +806,27 @@ export function DaemonDocumentPage({
                       }
                       actions={
                         <>
+                          {/* The annotation layer's opener (ADR-0026 decision 5),
+                          in the document's own actions row rather than floated
+                          over the editor — see BrowserDocumentPage's own
+                          commentsToggle for the overlap defect this avoids. */}
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            aria-label={
+                              openThreadCount === 0
+                                ? 'Comments'
+                                : `Comments, ${openThreadCount} open`
+                            }
+                            aria-pressed={commentsOpen}
+                            onClick={() => setCommentsOpen((open) => !open)}
+                            className={TOGGLE_STATE_CLASS}
+                          >
+                            <MessageSquare aria-hidden="true" className="size-4" />
+                            {openThreadCount > 0 ? (
+                              <span className="ml-1 text-xs">{openThreadCount}</span>
+                            ) : null}
+                          </Button>
                           {exportError && (
                             <span className="text-destructive truncate text-xs" role="alert">
                               {exportError}
@@ -896,69 +968,94 @@ export function DaemonDocumentPage({
               Create a canvas
             </Button>
           </div>
-        ) : preview ? (
-          <DocumentPreview past={preview.past} theme={resolvedTheme} />
         ) : (
-          <DocumentEditorSurface
-            kind={documentKind}
-            documentKey={canvas ? `${canvas.workspaceId}/${canvas.path}` : 'no-canvas'}
-            markdown={{
-              body: markdownBody,
-              setBody: setMarkdownBody,
-              theme: resolvedTheme,
-              meta: coreFacets ?? { type: documentKind },
-              resolveAlias,
-              resolveTitle,
-              linkTargets,
-              onOpenDocument: (id) => controller.switchDocument(resolveRefPath(id) ?? id),
-              resolveEmbed,
-            }}
-            spatial={() => (
-              <SpatialEditorPane
-                className="relative h-full min-h-0"
-                editorKey={canvas ? `${canvas.workspaceId}/${canvas.path}` : 'no-canvas'}
-                canvasLoaded={canvasLoaded}
-                editorRef={spatialEditorRef}
-                agentTouchedNodeIds={agentActivity.touchedNodeIds}
-                canvas={canvasValue}
-                onChange={onChange}
-                externalVersion={externalVersion}
-                theme={resolvedTheme}
-                // File-node reference = the target's immutable id (rename-
-                // safe); the label shows its current path and the current
-                // canvas is excluded. Legacy documents still carry path refs,
-                // which resolveRefPath misses and switchDocument takes as-is.
-                fileRefOptions={controller.documents
-                  .filter((entry) => entry.path !== canvas?.path)
-                  .map((entry) => ({
-                    file: entry.id,
-                    label: entry.path,
-                    kind: entry.kind,
-                  }))}
-                onOpenDocument={(id) => controller.switchDocument(resolveRefPath(id) ?? id)}
-                missingFileRef={missingFileRef}
-                fileSeams={fileSeams}
-                lockedNodeIds={lockedNodeIds}
-                lockedEdgeIds={lockedEdgeIds}
-                onToggleNodeLock={setNodeLock}
-                onToggleEdgeLock={setEdgeLock}
-                nodeInEditor={nodeInEditor}
-                history={{
-                  onUndo: () => void undo(),
-                  onRedo: () => void redo(),
-                  canUndo: canUndo(),
-                  canRedo: canRedo(),
-                }}
-                overlayTitle={canvas?.path ?? 'Untitled'}
-                resolveAlias={resolveAlias}
-                resolveEmbed={resolveEmbed}
-                resolveTitle={resolveTitle}
-                linkTargets={linkTargets}
-              >
-                <AgentPresenceChip summary={agentActivity.summary} />
-              </SpatialEditorPane>
-            )}
-          />
+          // The annotation layer's document-level surface (ADR-0026 decision
+          // 5) sits BESIDE the editor rather than inside it, mirroring
+          // BrowserDocumentPage: one panel serves both document kinds, and a
+          // markdown document has no canvas chrome to host one. Its opener
+          // lives in the document actions row above, in flow.
+          <div className="flex h-full min-h-0">
+            <div className="relative min-w-0 flex-1">
+              {preview ? (
+                <DocumentPreview past={preview.past} theme={resolvedTheme} />
+              ) : (
+                <DocumentEditorSurface
+                  kind={documentKind}
+                  documentKey={canvas ? `${canvas.workspaceId}/${canvas.path}` : 'no-canvas'}
+                  markdown={{
+                    body: markdownBody,
+                    setBody: setMarkdownBody,
+                    theme: resolvedTheme,
+                    meta: coreFacets ?? { type: documentKind },
+                    resolveAlias,
+                    resolveTitle,
+                    linkTargets,
+                    onOpenDocument: (id) => controller.switchDocument(resolveRefPath(id) ?? id),
+                    resolveEmbed,
+                  }}
+                  spatial={() => (
+                    <SpatialEditorPane
+                      className="relative h-full min-h-0"
+                      editorKey={canvas ? `${canvas.workspaceId}/${canvas.path}` : 'no-canvas'}
+                      canvasLoaded={canvasLoaded}
+                      editorRef={spatialEditorRef}
+                      agentTouchedNodeIds={agentActivity.touchedNodeIds}
+                      canvas={canvasValue}
+                      onChange={onChange}
+                      externalVersion={externalVersion}
+                      theme={resolvedTheme}
+                      // File-node reference = the target's immutable id (rename-
+                      // safe); the label shows its current path and the current
+                      // canvas is excluded. Legacy documents still carry path refs,
+                      // which resolveRefPath misses and switchDocument takes as-is.
+                      fileRefOptions={controller.documents
+                        .filter((entry) => entry.path !== canvas?.path)
+                        .map((entry) => ({
+                          file: entry.id,
+                          label: entry.path,
+                          kind: entry.kind,
+                        }))}
+                      onOpenDocument={(id) => controller.switchDocument(resolveRefPath(id) ?? id)}
+                      missingFileRef={missingFileRef}
+                      fileSeams={fileSeams}
+                      lockedNodeIds={lockedNodeIds}
+                      lockedEdgeIds={lockedEdgeIds}
+                      onToggleNodeLock={setNodeLock}
+                      onToggleEdgeLock={setEdgeLock}
+                      nodeInEditor={nodeInEditor}
+                      history={{
+                        onUndo: () => void undo(),
+                        onRedo: () => void redo(),
+                        canUndo: canUndo(),
+                        canRedo: canRedo(),
+                      }}
+                      overlayTitle={canvas?.path ?? 'Untitled'}
+                      resolveAlias={resolveAlias}
+                      resolveEmbed={resolveEmbed}
+                      resolveTitle={resolveTitle}
+                      linkTargets={linkTargets}
+                      threads={annotations}
+                    >
+                      <AgentPresenceChip summary={agentActivity.summary} />
+                    </SpatialEditorPane>
+                  )}
+                />
+              )}
+            </div>
+            {commentsOpen ? (
+              <aside className="w-72 shrink-0 overflow-y-auto border-l bg-background p-2">
+                <CommentsPanel
+                  threads={annotations}
+                  resolveAnchor={resolveAnchor}
+                  // Not while a past version is on screen: the editor is
+                  // replaced by DocumentPreview but this rail is not, and a
+                  // reply is a write to the LIVE document — sent from a
+                  // surface showing something else entirely.
+                  onReply={preview === null ? handleReply : undefined}
+                />
+              </aside>
+            ) : null}
+          </div>
         )}
         {capabilities.merge && canvas && (
           <MergeToast

--- a/apps/web/src/pages/file-seam-conformance.test.ts
+++ b/apps/web/src/pages/file-seam-conformance.test.ts
@@ -225,6 +225,18 @@ describe('the spatial-editor-container hook means one thing', () => {
   })
 })
 
+/**
+ * Chrome that belongs to the DOCUMENT, not to the canvas — ADR-0026
+ * decision 5. `CommentsPanel` serves a markdown document exactly as it
+ * serves a spatial one (a note has no canvas to hang a per-node toggle on),
+ * so it deliberately does NOT join `SHARED_CANVAS_CHROME`: that group's own
+ * docblock is about chrome the PAGE positions around the editor, and this
+ * one is chrome that answers a question about the document as a whole.
+ * Kept as its own group so a reader does not have to infer the distinction
+ * from where an entry happens to sit.
+ */
+const SHARED_DOCUMENT_CHROME = ['CommentsPanel'] as const
+
 describe('document page canvas chrome', () => {
   it.each(SHARED_CANVAS_CHROME)('both pages render %s', async (chrome) => {
     const missing: string[] = []
@@ -270,6 +282,53 @@ describe('document page canvas chrome', () => {
     for (const page of PAGES) {
       expect((await read(page)).length, `${page} is empty`).toBeGreaterThan(10_000)
     }
+  })
+})
+
+describe('document page document-level chrome', () => {
+  it.each(SHARED_DOCUMENT_CHROME)('both pages render %s', async (chrome) => {
+    const missing: string[] = []
+    for (const page of PAGES) {
+      const source = await read(page)
+      if (!renders(source, chrome)) missing.push(page)
+    }
+
+    expect(
+      missing,
+      `${chrome} is document-level chrome (ADR-0026 decision 5): a page that ` +
+        'omits it leaves that document kind with no way to reach its ' +
+        'conversations at all.',
+    ).toEqual([])
+  })
+})
+
+/**
+ * `threads=` must reach the spatial pane on BOTH pages, and specifically
+ * inside their own spatial slot — the same reaches-subject discipline the
+ * "spatial editor pane is built once" scan above applies to the pane itself.
+ *
+ * `threads=` also appears once more per page, on `<CommentsPanel`, which sits
+ * OUTSIDE the spatial slot by design (it is document-level chrome, not
+ * canvas-level — see `SHARED_DOCUMENT_CHROME` above). So this checks that
+ * SOME occurrence lands inside the slot, not that every occurrence does; an
+ * entry for a `threads=` that stopped reaching the pane at all fails the same
+ * as the pane never having been found in the "built once" scan above.
+ */
+describe('document page threads reach the spatial pane', () => {
+  it.each(PAGES)('%s passes threads= inside its spatial slot', async (page) => {
+    const source = await read(page)
+    const [start, end] = spatialSlotRange(source)
+    expect(start, `${page} has no spatial slot`).toBeGreaterThan(-1)
+
+    const offsets: number[] = []
+    for (let i = source.indexOf('threads='); i !== -1; i = source.indexOf('threads=', i + 1)) {
+      offsets.push(i)
+    }
+    expect(offsets.length, `${page} never passes threads= to anything`).toBeGreaterThan(0)
+    expect(
+      offsets.some((at) => at >= start && at <= end),
+      `${page} never passes threads= inside its spatial slot`,
+    ).toBe(true)
   })
 })
 


### PR DESCRIPTION
Audit follow-up (`issues/daemon-page-annotations-unwired`, **HIGH wiring-gap**): a thread created against a daemon-hosted document synced into the CRDT but had no UI in daemon mode to see, open, reply to, or resolve — DaemonDocumentPage had zero occurrences of thread/comment/annotation while BrowserDocumentPage shipped the full surface. The audit also named the mechanism: keeper-parity tracked the page at FILE granularity, which passes silently over a feature-level gap.

## What lands
- DaemonDocumentPage mirrors BrowserDocumentPage: `annotations` destructured from useDocumentSync, `threads=` into SpatialEditorPane, CommentsPanel aside + toggle with the browser page's exact a11y contract (aria-label 'Comments' / 'Comments, N open', aria-pressed, count badge), one `handleReply` routing both document kinds through the session's `reply-to-thread` command (daemon markdown has a live session — deliberate divergence from browser markdown's fallback, commented), `resolveAnchor` spatial-only (orphaned marker per ADR-0026 decision 4), and `onReply` withheld while a version preview is on screen.
- **Feature-granularity parity guard**: `file-seam-conformance.test.ts` gains `SHARED_DOCUMENT_CHROME` (document-level per ADR-0026 decision 5 — deliberately NOT in the canvas-only list) + a threads-in-spatial-slot scan, reaches-subject both directions. **RED-first** against the unwired page (`expected ['./DaemonDocumentPage.tsx'] to deeply equal []`), **mutation-checked** (unwiring → `never passes threads= to anything`).
- New jsdom mirror (7 its incl. the review-found zero-open-label branch) + one real-browser geometry test (opener in the actions row, rail lists a seeded thread).
- Worked trap recorded in-test: seeding the same LoroDoc content twice creates independent peers whose same-key creations silently merge to one side — the seed bytes are captured once and reused for backend and replay.

## Gates
- Review workflow: 1 LOW confirmed (zero-open-thread label branch untested) — fixed in the last commit; QA verified the empty-reply guard and preview-withholding live in real Chromium, and ran build + daemon startup smoke green.
- Targeted jsdom 30/30 + pages directory 420/420; browser test 1/1; typecheck / lint / knip clean.

Visual evidence: none — the surface is the SAME CommentsPanel/opener components BrowserDocumentPage already ships, now mounted on the daemon page; the structural parity guard and mirrored interaction tests are the evidence, and a screenshot would show the already-shipped browser-page UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7iuGxJAXjr6rEXfS7YAC6