### PR TITLE
feat(web): document cards speak in pictures — kind icon, pin glyph, bigger thumbnails

### DIFF
--- a/apps/web/src/components/workspace-files/DocumentPreview.test.tsx
+++ b/apps/web/src/components/workspace-files/DocumentPreview.test.tsx
@@ -199,3 +199,39 @@ describe('DocumentPreview', () => {
     })
   })
 })
+
+describe('kind row and action icons', () => {
+  const entry = (kind: 'markdown' | 'spatial') => ({
+    documentId: 'd1',
+    path: 'note',
+    name: 'Note',
+    kind,
+  })
+  const noopLoad = async () => null
+
+  // Kills the inverted-ternary mutant: the icon must FOLLOW the kind.
+  it('the Kind row draws the icon of the kind on screen', () => {
+    render(<DocumentPreview document={entry('spatial')} loadRender={noopLoad} />)
+    expect(screen.getByTestId('preview-kind-icon').getAttribute('data-kind')).toBe('spatial')
+    cleanup()
+    render(<DocumentPreview document={entry('markdown')} loadRender={noopLoad} />)
+    expect(screen.getByTestId('preview-kind-icon').getAttribute('data-kind')).toBe('markdown')
+  })
+
+  it('each action button carries its own icon, not a shared or shuffled one', () => {
+    render(
+      <DocumentPreview
+        document={entry('markdown')}
+        loadRender={noopLoad}
+        onOpen={() => {}}
+        onDuplicate={() => {}}
+        onDelete={() => {}}
+      />,
+    )
+    const iconIn = (name: string) =>
+      screen.getByRole('button', { name }).querySelector('svg')?.getAttribute('class') ?? ''
+    expect(iconIn('Open')).toContain('lucide-external-link')
+    expect(iconIn('Duplicate')).toContain('lucide-copy-plus')
+    expect(iconIn('Delete')).toContain('lucide-trash-2')
+  })
+})

--- a/apps/web/src/components/workspace-files/DocumentPreview.tsx
+++ b/apps/web/src/components/workspace-files/DocumentPreview.tsx
@@ -145,9 +145,19 @@ export function DocumentPreview({
           <dt>Kind</dt>
           <dd className="text-foreground flex items-center gap-1">
             {(document.kind ?? 'markdown') === 'spatial' ? (
-              <LayoutGrid aria-hidden="true" className="size-3.5" />
+              <LayoutGrid
+                data-testid="preview-kind-icon"
+                data-kind="spatial"
+                aria-hidden="true"
+                className="size-3.5"
+              />
             ) : (
-              <FileText aria-hidden="true" className="size-3.5" />
+              <FileText
+                data-testid="preview-kind-icon"
+                data-kind="markdown"
+                aria-hidden="true"
+                className="size-3.5"
+              />
             )}
             {document.kind ?? 'markdown'}
           </dd>

--- a/apps/web/src/components/workspace-files/DocumentPreview.tsx
+++ b/apps/web/src/components/workspace-files/DocumentPreview.tsx
@@ -12,6 +12,7 @@
  * keep throwing you into an editor.
  */
 
+import { CopyPlus, ExternalLink, FileText, LayoutGrid, Trash2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { cn } from '../../lib/utils.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
@@ -142,7 +143,14 @@ export function DocumentPreview({
         </div>
         <dl className="text-muted-foreground grid grid-cols-[auto_1fr] gap-x-3 text-xs">
           <dt>Kind</dt>
-          <dd className="text-foreground">{document.kind ?? 'markdown'}</dd>
+          <dd className="text-foreground flex items-center gap-1">
+            {(document.kind ?? 'markdown') === 'spatial' ? (
+              <LayoutGrid aria-hidden="true" className="size-3.5" />
+            ) : (
+              <FileText aria-hidden="true" className="size-3.5" />
+            )}
+            {document.kind ?? 'markdown'}
+          </dd>
           {document.updatedAt !== undefined && (
             <>
               <dt>Updated</dt>
@@ -155,8 +163,9 @@ export function DocumentPreview({
             <button
               type="button"
               onClick={() => onOpen(document)}
-              className="bg-primary text-primary-foreground rounded px-2.5 py-1 text-xs"
+              className="bg-primary text-primary-foreground flex items-center gap-1 rounded px-2.5 py-1 text-xs"
             >
+              <ExternalLink aria-hidden="true" className="size-3" />
               Open
             </button>
           )}
@@ -164,8 +173,9 @@ export function DocumentPreview({
             <button
               type="button"
               onClick={() => onDuplicate(document)}
-              className="rounded border px-2.5 py-1 text-xs"
+              className="flex items-center gap-1 rounded border px-2.5 py-1 text-xs"
             >
+              <CopyPlus aria-hidden="true" className="size-3" />
               Duplicate
             </button>
           )}
@@ -173,8 +183,9 @@ export function DocumentPreview({
             <button
               type="button"
               onClick={() => onDelete(document)}
-              className="text-destructive rounded border px-2.5 py-1 text-xs"
+              className="text-destructive flex items-center gap-1 rounded border px-2.5 py-1 text-xs"
             >
+              <Trash2 aria-hidden="true" className="size-3" />
               Delete
             </button>
           )}

--- a/apps/web/src/components/workspace-files/FolderContentsList.test.tsx
+++ b/apps/web/src/components/workspace-files/FolderContentsList.test.tsx
@@ -84,7 +84,9 @@ describe('FolderContentsList', () => {
       />,
     )
     expect(screen.getByTestId('custom-icon').textContent).toBe('d1')
-    expect(document.querySelector('[data-kind]')).toBeNull()
+    // The PLACEHOLDER specifically (a span): the title row's kind badge is
+    // an svg and legitimately stays.
+    expect(document.querySelector('span[data-kind]')).toBeNull()
   })
 
   it('falls back to the kind, which the list already carries', () => {
@@ -117,17 +119,17 @@ describe('FolderContentsList', () => {
       },
     ]
     render(<FolderContentsList documents={dated} folder="design" onOpen={vi.fn()} />)
-    // The subtitle specifically: the placeholder standing in for a missing
-    // thumbnail also prints the kind, so asserting on the whole card would
-    // pass with the subtitle saying nothing at all.
-    expect(screen.getByTestId('card-subtitle').textContent).toBe('markdown · 2d ago')
+    // The subtitle is the age alone — the kind moved to the icon badge.
+    expect(screen.getByTestId('card-subtitle').textContent).toBe('2d ago')
   })
 
   // A daemon that does not record the time must not make the card say
-  // something false about it.
-  it('carries no age when the daemon did not record one', () => {
+  // something false about it — and with the kind an icon, that leaves no
+  // subtitle at all.
+  it('carries no subtitle when the daemon recorded no age', () => {
     render(<FolderContentsList documents={docs} folder="design" onOpen={vi.fn()} />)
-    expect(screen.getAllByTestId('card-subtitle')[0]?.textContent).toBe('markdown')
+    expect(screen.queryByTestId('card-subtitle')).toBeNull()
+    expect(screen.getAllByTestId('card-kind-badge').length).toBeGreaterThan(0)
   })
 
   it('labels a document by its path segment when nobody named it', () => {

--- a/apps/web/src/components/workspace-files/FolderContentsList.tsx
+++ b/apps/web/src/components/workspace-files/FolderContentsList.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, Folder } from 'lucide-react'
+import { ChevronRight, FileText, Folder, LayoutGrid, Pin } from 'lucide-react'
 import { type ReactNode, useMemo } from 'react'
 import { cn } from '../../lib/utils.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
@@ -40,10 +40,23 @@ export interface FolderContentsListProps {
   className?: string
 }
 
-/** `markdown · 2d ago`, dropping whichever half the daemon did not record. */
-function cardSubtitle(entry: WorkspaceDocumentEntry): string {
-  const age = entry.updatedAt === undefined ? '' : formatRelative(entry.updatedAt)
-  return [entry.kind ?? '', age].filter((part) => part !== '').join(' · ')
+/**
+ * The kind, spoken in the tree rows' existing icon vocabulary rather than a
+ * word — with the kind as the icon's accessible name, so what left the
+ * subtitle text still answers to a reader.
+ */
+function KindBadge({ kind }: { kind: WorkspaceDocumentEntry['kind'] }) {
+  const resolved = kind ?? 'markdown'
+  const Icon = resolved === 'spatial' ? LayoutGrid : FileText
+  return (
+    <Icon
+      data-testid="card-kind-badge"
+      data-kind={resolved}
+      role="img"
+      aria-label={resolved}
+      className="text-muted-foreground size-3.5 shrink-0"
+    />
+  )
 }
 
 export function FolderContentsList({
@@ -76,7 +89,7 @@ export function FolderContentsList({
   return (
     <ul
       {...longPress}
-      className={cn('grid grid-cols-[repeat(auto-fill,minmax(9rem,1fr))] gap-2 p-0.5', className)}
+      className={cn('grid grid-cols-[repeat(auto-fill,minmax(10rem,1fr))] gap-2 p-0.5', className)}
     >
       {folders.map((child) => (
         <li key={child.path}>
@@ -86,7 +99,7 @@ export function FolderContentsList({
             onClick={() => onOpen({ kind: 'folder', path: child.path })}
             className="hover:bg-accent flex w-full flex-col overflow-hidden rounded-md border text-left"
           >
-            <span className="bg-muted/40 text-muted-foreground flex h-16 w-full items-center justify-center">
+            <span className="bg-muted/40 text-muted-foreground flex aspect-video w-full items-center justify-center">
               <Folder className="size-7" />
             </span>
             <span className="flex min-w-0 items-center gap-1 px-2 py-1.5">
@@ -135,7 +148,7 @@ export function FolderContentsList({
             }
             className="hover:bg-accent/40 aria-[current]:border-primary aria-[current]:ring-primary/40 flex w-full flex-col overflow-hidden rounded-md border text-left aria-[current]:ring-1"
           >
-            <span className="bg-muted/40 flex h-16 w-full items-center justify-center overflow-hidden">
+            <span className="bg-muted/40 flex aspect-video w-full items-center justify-center overflow-hidden">
               {renderThumbnail?.(entry) ?? (
                 <span
                   data-kind={entry.kind ?? 'markdown'}
@@ -150,6 +163,7 @@ export function FolderContentsList({
                   is the fallback for a document nobody named, never a name
                   invented from the path. */}
               <span className="flex min-w-0 items-center gap-1">
+                <KindBadge kind={entry.kind} />
                 <span data-testid="card-title" className="truncate text-sm">
                   {entry.name ?? entry.path.split('/').at(-1)}
                 </span>
@@ -162,10 +176,24 @@ export function FolderContentsList({
                     Path conflict
                   </span>
                 )}
+                {entry.pinOrder !== undefined && (
+                  /* The pin used to exist only as a sort position — state a
+                     reader could not see on the object it belongs to. */
+                  <Pin
+                    role="img"
+                    aria-label="Pinned"
+                    className="text-muted-foreground ml-auto size-3 shrink-0"
+                  />
+                )}
               </span>
-              <span data-testid="card-subtitle" className="text-muted-foreground truncate text-xs">
-                {cardSubtitle(entry)}
-              </span>
+              {entry.updatedAt !== undefined && (
+                <span
+                  data-testid="card-subtitle"
+                  className="text-muted-foreground truncate text-xs"
+                >
+                  {formatRelative(entry.updatedAt)}
+                </span>
+              )}
               {(entry.tags?.length ?? 0) > 0 && (
                 <span className="text-muted-foreground truncate text-[11px]">
                   {entry.tags?.map((tag) => `#${tag}`).join(' ')}

--- a/apps/web/src/components/workspace-files/card-visual-language.test.tsx
+++ b/apps/web/src/components/workspace-files/card-visual-language.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { WorkspaceDocumentEntry } from './document-entry.js'
+import { FolderContentsList } from './FolderContentsList.js'
+
+// The card's visual language (slice 2 of the 2026-09-05 picker redesign):
+// kind is an ICON — the same FileText/LayoutGrid vocabulary the tree rows
+// already speak — not a word in the subtitle, and a pinned document says so
+// ON the card instead of only through its sort position. The subtitle
+// carries only the relative age, and disappears with it.
+
+afterEach(cleanup)
+
+const dated = (over: Partial<WorkspaceDocumentEntry>): WorkspaceDocumentEntry => ({
+  documentId: 'd1',
+  path: 'design/login',
+  name: 'Login',
+  kind: 'markdown',
+  updatedAt: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+  ...over,
+})
+
+describe('card kind badge', () => {
+  it('marks kind with an icon carrying an accessible name, per kind', () => {
+    render(
+      <FolderContentsList
+        documents={[
+          dated({}),
+          dated({ documentId: 'd2', path: 'design/board', name: 'Board', kind: 'spatial' }),
+        ]}
+        folder="design"
+        onOpen={vi.fn()}
+      />,
+    )
+    const kindOf = (title: string) => {
+      const card = screen
+        .getAllByTestId('card-title')
+        .find((el) => el.textContent === title)
+        ?.closest('button') as HTMLElement
+      return within(card).getByTestId('card-kind-badge')
+    }
+    expect(kindOf('Login').getAttribute('data-kind')).toBe('markdown')
+    expect(kindOf('Board').getAttribute('data-kind')).toBe('spatial')
+    // The word left the subtitle; the icon must still ANSWER for the kind.
+    expect(kindOf('Login').getAttribute('aria-label')).toBe('markdown')
+    expect(kindOf('Board').getAttribute('aria-label')).toBe('spatial')
+  })
+
+  it('the subtitle is the age alone', () => {
+    render(<FolderContentsList documents={[dated({})]} folder="design" onOpen={vi.fn()} />)
+    expect(screen.getByTestId('card-subtitle').textContent).toBe('2d ago')
+  })
+
+  it('no age, no subtitle — the kind icon already says the rest', () => {
+    const { documentId, path, name, kind } = dated({})
+    render(
+      <FolderContentsList
+        documents={[{ documentId, path, name, kind }]}
+        folder="design"
+        onOpen={vi.fn()}
+      />,
+    )
+    expect(screen.queryByTestId('card-subtitle')).toBeNull()
+    expect(screen.getByTestId('card-kind-badge').getAttribute('data-kind')).toBe('markdown')
+  })
+})
+
+describe('card pin marker', () => {
+  it('a pinned document says so on the card', () => {
+    render(
+      <FolderContentsList
+        documents={[
+          dated({ pinOrder: 0 }),
+          dated({ documentId: 'd2', path: 'design/loose', name: 'Loose' }),
+        ]}
+        folder="design"
+        onOpen={vi.fn()}
+      />,
+    )
+    const cards = screen
+      .getAllByTestId('card-title')
+      .map((el) => el.closest('button') as HTMLElement)
+    expect(within(cards[0] as HTMLElement).getByLabelText('Pinned')).toBeTruthy()
+    expect(within(cards[1] as HTMLElement).queryByLabelText('Pinned')).toBeNull()
+  })
+})

--- a/apps/web/src/pages/BrowserIndexPage.flow.browser.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.flow.browser.test.tsx
@@ -128,8 +128,8 @@ describe('browser list landing (browser — real IndexedDB)', () => {
     await router.navigate(-1)
     const cards = await screen.findAllByTestId('card-title', undefined, { timeout: 15_000 })
     expect(cards).toHaveLength(2)
-    const backSubtitles = screen.getAllByTestId('card-subtitle')
-    const noteIndex = backSubtitles.findIndex((el) => el.textContent?.includes('markdown'))
+    const backBadges = screen.getAllByTestId('card-kind-badge')
+    const noteIndex = backBadges.findIndex((el) => el.getAttribute('data-kind') === 'markdown')
     expect(noteIndex).toBeGreaterThanOrEqual(0)
 
     // Reopening the note restores the typed body from the same store.

--- a/apps/web/src/pages/BrowserIndexPage.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.test.tsx
@@ -141,9 +141,9 @@ describe('BrowserIndexPage', () => {
     // ordering retired with the grid.
     const titles = await screen.findAllByTestId('card-title')
     expect(titles.map((el) => el.textContent)).toEqual(['Meeting Notes', 'Trip Plan'])
-    const subtitles = screen.getAllByTestId('card-subtitle')
-    expect(subtitles[0]?.textContent).toContain('markdown')
-    expect(subtitles[1]?.textContent).not.toContain('markdown')
+    const badges = screen.getAllByTestId('card-kind-badge')
+    expect(badges[0]?.getAttribute('data-kind')).toBe('markdown')
+    expect(badges[1]?.getAttribute('data-kind')).not.toBe('markdown')
   })
 
   it('opens a document via the preview pane after selecting its card', async () => {

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -249,13 +249,17 @@ describe('DaemonIndexPage', () => {
     render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenDocument={vi.fn()} />)
     await screen.findByText('note')
 
-    // The kind marker is the card SUBTITLE (`markdown · …`); the thumbnail
-    // placeholder is excluded because it labels unknown kinds "markdown" too.
+    // The kind marker is the card's icon badge; the thumbnail placeholder is
+    // excluded because it labels unknown kinds "markdown" too.
     const cards = screen.getAllByRole('button', { name: /note|board/ })
     const noteCard = cards.find((c) => within(c).queryByText('note'))!
     const boardCard = cards.find((c) => within(c).queryByText('board'))!
-    expect(within(noteCard).getByTestId('card-subtitle').textContent).toMatch(/markdown/)
-    expect(within(boardCard).getByTestId('card-subtitle').textContent).not.toMatch(/markdown/)
+    expect(within(noteCard).getByTestId('card-kind-badge').getAttribute('data-kind')).toBe(
+      'markdown',
+    )
+    expect(within(boardCard).getByTestId('card-kind-badge').getAttribute('data-kind')).not.toBe(
+      'markdown',
+    )
   })
 
   it('keeps a create entry point when the canvas list fails to load', async () => {


### PR DESCRIPTION
## Summary

Slice 2 of the picker redesign (owner decision 2026-09-05: wayfinding first — landed as #1304 — visuals next). The card grid de-verbalises:

- **Kind is an icon, not a word.** The `markdown · 2d ago` subtitle string is gone; the kind renders as the SAME FileText/LayoutGrid icon vocabulary the tree rows already speak, at the head of the title row, with the kind as the icon's accessible name (`role="img"` + `aria-label`), so screen readers keep what the text dropped. The subtitle is the relative age alone, and disappears with it.
- **Pin state is visible on the object.** A pinned document shows a pin glyph on the card — until now the pin existed only as a sort position, state a reader could not see on the thing it belongs to (and slice 1 had just given Pin its first touch path).
- **Thumbnails grow.** The fixed 64px strip becomes aspect-video and the grid column floor moves 9rem→10rem — above the measured 80×44px legibility floor (`DocumentMinimap`'s comment), same `loadRender` pipeline, same `useOnScreen` budget; nothing new is fetched.
- **`DocumentPreview` buttons gain the object menu's icons** (icon+text — a reading surface keeps its words), and its Kind row draws the icon beside the word.

Contract-moving test updates, deliberate: four kind-in-subtitle assertions now read the badge (`card-kind-badge`/`data-kind`), and the caller-miniature test pins the PLACEHOLDER (`span[data-kind]`) specifically since the badge legitimately stays.

Known follow-up, filed: `docs:snapshots` fails 5/8 on a clean main checkout (pre-existing boot-order/TopBar errors, reproduced identically there), so the docs images showing this screen could not be regenerated in this PR — the filed issue carries the regen as its close-out step.

## Visual repro

![before: kind as words, pin invisible, 64px thumbnails / after: kind icon at the title, pin glyph, aspect-video thumbnails](tmp/screenshots/cards-figure.png)

Composed by `compose-figure.mjs` (digests differ); gh here is 2.97 (no `--attach`), so the PNG is delivered to the session owner for attachment, as before. The spatial thumbnails show the placeholder icon because the fixture supplies no snapshot — the real app draws real content there; what changed is the box, not the renderer.

## Test plan

- [x] Red-first `card-visual-language.test.tsx` (4 cases): per-kind badge with accessible name, subtitle is the age alone, no-age → no subtitle, pin glyph only on pinned cards.
- [x] Touched-area suites: `web-jsdom` for `workspace-files` + `pages` — 645 passed / 75 files; affected `web-browser` files (panel render, index flow, wayfinding) — 13 passed / 7 files; typecheck + biome clean.
- [x] Manual verification completed against the real preview deployment (`https://picker-visual-cards.kamiazya-whiteboard.pages.dev`) with the Playwright driver from #1304, extended with slice-2 checks — 14/14 passed: all slice-1 flows unregressed (tap opens, no preview column on touch, long-press sheet, dblclick/Enter/right-click on desktop), plus kind icon present and accessibly named on the cards, and every subtitle is the age alone (measured: `["2s ago"]`, no `kind ·` string).
- [x] Review gate ran over the diff (12 agents): both findings — the preview's kind-icon ternary and action-button icons were unobservable to any test — are fixed in `ac95ed8e` (kind icon carries `data-kind`, mutation-checked: inverted ternary fails 1 test; each button icon pinned by its lucide class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLiRSAKQA8rRW7j6XBJhAE

