### PR TITLE
feat(annotations): a note can say which of its conversations lost their place

### DIFF
--- a/apps/web/src/lib/text-anchor.property.test.ts
+++ b/apps/web/src/lib/text-anchor.property.test.ts
@@ -1,0 +1,152 @@
+/**
+ * The invariant that makes re-anchoring worth doing at all: a resolved anchor
+ * points at ITS OWN quote, or says it has lost its place. Never at other
+ * words.
+ *
+ * A property rather than examples because the interesting inputs are edits,
+ * and the space of "where the edit landed relative to the passage" is exactly
+ * what a hand-written case set gets thin at — before it, inside it, after it,
+ * spanning its edge, and duplicating it.
+ *
+ * The generator builds a body out of NAMED pieces and then edits it, so every
+ * case knows where the passage is without the test having to search for it —
+ * which would be building the oracle out of the code under test.
+ */
+import { describe, expect, it } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { resolveTextAnchor, type TextAnchor } from './text-anchor.js'
+
+/** Ordinary prose, and never the passage's own text — see `passage`. */
+const filler = fc.stringMatching(/^[a-d ]{0,40}$/)
+/**
+ * The quoted passage. Drawn from a disjoint alphabet so a generated body
+ * cannot contain it by accident: an accidental second occurrence would make
+ * "the quote appears once" false and the case would be testing something
+ * other than what it says.
+ */
+const passage = fc.stringMatching(/^[x-z]{1,12}$/)
+
+interface Built {
+  readonly body: string
+  readonly anchor: TextAnchor
+  readonly quote: string
+}
+
+/** A body with the passage in it, and the anchor that was stored for it. */
+const built: fc.Arbitrary<Built> = fc
+  .tuple(filler, passage, filler)
+  .map(([before, quote, after]) => {
+    const body = `${before}${quote}${after}`
+    const start = before.length
+    return {
+      body,
+      quote,
+      anchor: {
+        kind: 'text' as const,
+        quote: {
+          exact: quote,
+          ...(before === '' ? {} : { prefix: before.slice(-8) }),
+          ...(after === '' ? {} : { suffix: after.slice(0, 8) }),
+        },
+        start,
+        end: start + quote.length,
+      },
+    }
+  })
+
+describe('resolveTextAnchor', () => {
+  fcTest.prop([built], withDefaults())(
+    'finds the passage in the body it was stored against',
+    (b) => {
+      const resolved = resolveTextAnchor(b.body, b.anchor)
+
+      expect(resolved.kind).toBe('placed')
+      if (resolved.kind !== 'placed') return
+      expect(b.body.slice(resolved.start, resolved.end)).toBe(b.quote)
+    },
+  )
+
+  fcTest.prop([built, filler], withDefaults())(
+    'follows the passage when text is inserted above it',
+    (b, inserted) => {
+      // The case offsets alone cannot survive, and the reason the quote is
+      // stored at all: everything below an edit moves by its length.
+      const edited = inserted + b.body
+      const resolved = resolveTextAnchor(edited, b.anchor)
+
+      expect(resolved.kind).toBe('placed')
+      if (resolved.kind !== 'placed') return
+      // The claim is about the TEXT, not the arithmetic: asserting
+      // `start + inserted.length` would just re-implement the shift and pass
+      // against a resolver that had shifted the wrong passage.
+      expect(edited.slice(resolved.start, resolved.end)).toBe(b.quote)
+    },
+  )
+
+  fcTest.prop([built], withDefaults())('says a passage that was deleted is orphaned', (b) => {
+    // The alphabets are disjoint, so removing the passage removes every
+    // occurrence of it — this is a real deletion, not a move.
+    const edited = b.body.replace(b.quote, '')
+
+    expect(resolveTextAnchor(edited, b.anchor)).toEqual({ kind: 'orphaned' })
+  })
+
+  fcTest.prop([built, filler], withDefaults())(
+    're-resolving from the offsets it just answered is a no-op',
+    (b, inserted) => {
+      // What the caller does with the answer: write it back and read again.
+      // Without this the resolver could be right once and drift on every
+      // subsequent read, which is the shape a reader would experience as a
+      // comment slowly walking down the document.
+      const edited = inserted + b.body
+      const first = resolveTextAnchor(edited, b.anchor)
+      if (first.kind !== 'placed') return
+
+      const again = resolveTextAnchor(edited, {
+        ...b.anchor,
+        start: first.start,
+        end: first.end,
+      })
+      expect(again).toEqual(first)
+    },
+  )
+})
+
+describe('choosing between several copies of the same passage', () => {
+  it('keeps the one the offsets point at, rather than the first', () => {
+    // Two identical sentences: the offsets are the ONLY thing that says which
+    // one the thread was about, and a search that ignored them would move
+    // every such comment to the top of the document.
+    const body = 'note it. note it. note it.'
+    const anchor: TextAnchor = {
+      kind: 'text',
+      quote: { exact: 'note it.' },
+      start: 18,
+      end: 26,
+    }
+
+    expect(resolveTextAnchor(body, anchor)).toEqual({ kind: 'placed', start: 18, end: 26 })
+  })
+
+  it('uses the remembered surroundings when the offsets no longer land on it', () => {
+    // The offsets have gone stale (text was inserted above), so the fast path
+    // misses and three candidates remain. `suffix` is what distinguishes them.
+    const body = 'PREAMBLE. ship it. later ship it. finally ship it.'
+    const anchor: TextAnchor = {
+      kind: 'text',
+      quote: { exact: 'ship it.', prefix: 'finally ', suffix: '' },
+      start: 0,
+      end: 8,
+    }
+
+    // Derived, not hand-counted: the claim is WHICH occurrence, and a typed
+    // offset only adds a second thing to get wrong. The first version of this
+    // line said 41 and the resolver was right.
+    const expected = body.lastIndexOf('ship it.')
+    expect(resolveTextAnchor(body, anchor)).toEqual({
+      kind: 'placed',
+      start: expected,
+      end: expected + 'ship it.'.length,
+    })
+  })
+})

--- a/apps/web/src/lib/text-anchor.ts
+++ b/apps/web/src/lib/text-anchor.ts
@@ -1,0 +1,142 @@
+/**
+ * Finding a text anchor's passage in a body that has since been edited.
+ *
+ * A stored anchor carries both a POSITION (`start`/`end`) and a QUOTE
+ * (`exact`, with optional `prefix`/`suffix`). The position is what makes the
+ * common case free — nothing moved, so the offsets still hold — and the quote
+ * is what survives everything else, which is why `annotation.ts` marks
+ * `exact` required and the neighbours optional. This module is the reader
+ * that uses both.
+ *
+ * Offsets alone cannot work. A body is a CRDT that anyone can edit from
+ * anywhere: a character typed in the first paragraph moves every anchor below
+ * it, and a thread whose offsets are not re-derived would silently point at
+ * different words. Pointing at the wrong words is worse than saying "this one
+ * has lost its place" — a reader can act on the second and cannot even detect
+ * the first.
+ *
+ * The resolution order follows W3C Web Annotation's TextQuoteSelector, which
+ * is what the schema was modelled on:
+ *
+ * 1. the stored offsets, if the text there is still the quote;
+ * 2. the only occurrence of the quote elsewhere;
+ * 3. among several occurrences, the one whose surroundings match `prefix` and
+ *    `suffix` best, and — where that still ties — the one nearest to where
+ *    the anchor last was;
+ * 4. nothing: the passage is gone, and the thread is orphaned (ADR-0026
+ *    decision 4 — deleting the subject must not delete the conversation).
+ */
+
+import type { AnnotationAnchor } from '@kamiazya/whiteboard-model'
+
+/** A text anchor, narrowed out of the anchor union. */
+export type TextAnchor = Extract<AnnotationAnchor, { kind: 'text' }>
+
+export type ResolvedTextAnchor =
+  | { readonly kind: 'placed'; readonly start: number; readonly end: number }
+  | { readonly kind: 'orphaned' }
+
+const ORPHANED: ResolvedTextAnchor = { kind: 'orphaned' }
+
+/** Every index where `needle` starts in `haystack`, including overlaps. */
+function occurrences(haystack: string, needle: string): number[] {
+  const found: number[] = []
+  // `indexOf` from the previous hit PLUS ONE, not plus the needle's length:
+  // overlapping occurrences are real candidates ("aa" in "aaa" starts twice),
+  // and skipping them would make the count wrong in exactly the case where
+  // disambiguation matters.
+  for (let at = haystack.indexOf(needle); at !== -1; at = haystack.indexOf(needle, at + 1)) {
+    found.push(at)
+  }
+  return found
+}
+
+/** How many characters of `context` the body actually has on that side. */
+function matchedBefore(body: string, at: number, prefix: string): number {
+  const before = body.slice(Math.max(0, at - prefix.length), at)
+  let shared = 0
+  while (
+    shared < before.length &&
+    before[before.length - 1 - shared] === prefix[prefix.length - 1 - shared]
+  ) {
+    shared += 1
+  }
+  return shared
+}
+
+function matchedAfter(body: string, at: number, suffix: string): number {
+  const after = body.slice(at, at + suffix.length)
+  let shared = 0
+  while (shared < after.length && after[shared] === suffix[shared]) shared += 1
+  return shared
+}
+
+export function resolveTextAnchor(body: string, anchor: TextAnchor): ResolvedTextAnchor {
+  const { exact, prefix = '', suffix = '' } = anchor.quote
+  // The stored offsets first. This is a COST shortcut, not a rule about which
+  // answer is right: on consistent data the search below reproduces it (the
+  // stored site is at distance 0 from itself, so it wins the tiebreak), and
+  // removing this branch leaves every test in this module green. That is the
+  // branch being a shortcut, not a hole in the tests.
+  //
+  // It is kept because the cost is not small and grows with the document.
+  // Measured, unique quotes and 2000 resolutions, this branch versus search
+  // only: 8KB body 0.5ms vs 12.3ms (24x), 48KB 0.4ms vs 61.0ms (170x), 200KB
+  // 0.1ms vs 228.1ms (2016x). The search scans the whole body once per
+  // anchor; this compares `exact.length` characters and stops.
+  if (body.slice(anchor.start, anchor.end) === exact) {
+    return { kind: 'placed', start: anchor.start, end: anchor.end }
+  }
+
+  const candidates = occurrences(body, exact)
+  if (candidates.length === 0) return ORPHANED
+  const at = candidates[0] as number
+  if (candidates.length === 1) return { kind: 'placed', start: at, end: at + exact.length }
+
+  // Score by how much of the remembered surroundings each candidate still
+  // has, and break the remaining ties by distance from where the anchor last
+  // was. Distance is the tiebreak rather than the score because it is the
+  // weaker evidence: an edit above the passage moves every offset, so a
+  // candidate can be far from `start` and still be the right one.
+  let best = at
+  let bestScore = -1
+  let bestDistance = Number.POSITIVE_INFINITY
+  for (const candidate of candidates) {
+    const score =
+      matchedBefore(body, candidate, prefix) + matchedAfter(body, candidate + exact.length, suffix)
+    const distance = Math.abs(candidate - anchor.start)
+    if (score > bestScore || (score === bestScore && distance < bestDistance)) {
+      best = candidate
+      bestScore = score
+      bestDistance = distance
+    }
+  }
+  return { kind: 'placed', start: best, end: best + exact.length }
+}
+
+/**
+ * Whether each of a document's threads still finds its place, for the rail's
+ * `resolveAnchor`.
+ *
+ * One function so the two keeper pages cannot answer this differently — the
+ * gap that let the rail exist on one page and not the other was exactly this
+ * shape, a decision made twice.
+ *
+ * `body` null means the document's text has not loaded yet, which is NOT the
+ * same as a passage being gone: answering `orphaned` there would mark every
+ * thread as lost for the moment before the body arrives, and a reader would
+ * see the badges appear and then vanish.
+ */
+export function markdownAnchorResolver(
+  body: string | null,
+): ((thread: { readonly anchor: AnnotationAnchor }) => 'placed' | 'orphaned') | undefined {
+  if (body === null) return undefined
+  return (thread) => {
+    // A spatial anchor on a markdown document has nothing here to be judged
+    // against — it is not lost, it is about a surface this document does not
+    // have. Saying `placed` is the honest answer for "not something I can
+    // tell you about".
+    if (thread.anchor.kind !== 'text') return 'placed'
+    return resolveTextAnchor(body, thread.anchor).kind === 'placed' ? 'placed' : 'orphaned'
+  }
+}

--- a/apps/web/src/pages/BrowserDocumentPage.markdown-orphan.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.markdown-orphan.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * A markdown document saying which of its conversations have lost their
+ * passage (ADR-0026 decision 4).
+ *
+ * Until the anchor reader existed, the page passed `resolveAnchor` as
+ * `undefined` for a note — which the panel correctly reads as "this host
+ * cannot tell", and which was true. The consequence was not a wrong badge but
+ * an ABSENT one: a thread whose sentence had been deleted looked exactly like
+ * one whose sentence was still there, in a surface whose whole job is to tell
+ * you what is still open.
+ *
+ * Two threads on one document, so the assertion is a DIFFERENCE rather than a
+ * presence: with a resolver that answered the same thing for everything, both
+ * would be marked or neither would, and either way this file would pass on a
+ * claim it had not made.
+ */
+import { writeCommentThread, writeMarkdownBody } from '@kamiazya/whiteboard-loro-adapter'
+import { cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import { LoroDoc } from 'loro-crdt'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, expect, it, vi } from 'vitest'
+import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
+import { LocalStoreDouble } from '../test-utils/local-index.js'
+
+vi.mock('../components/spatial-editor/index.js', () => ({
+  SpatialEditor: () => <div data-testid="mock-spatial-editor" />,
+}))
+
+const { BrowserDocumentPage } = await import('./BrowserDocumentPage.js')
+
+function render(ui: ReactElement) {
+  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>)
+}
+
+const note: DocumentSnapshot = {
+  documentId: '0W16BGNTZ49EKRX27CHPV05AFN',
+  workspaceId: 'local',
+  path: 'notes/plan',
+  name: 'Plan',
+  updatedAt: '2026-09-04T00:00:00.000Z',
+  kind: 'markdown' as const,
+}
+
+const BODY = 'Ship the annotation layer in three steps.'
+
+/** One thread whose quote is in the body, and one whose quote is not. */
+function noteWithBothKinds(): Uint8Array {
+  const doc = new LoroDoc()
+  writeMarkdownBody(doc, BODY)
+  const at = BODY.indexOf('three steps')
+  writeCommentThread(doc, {
+    id: 't-here',
+    anchor: {
+      kind: 'text',
+      quote: { exact: 'three steps' },
+      start: at,
+      end: at + 'three steps'.length,
+    },
+    status: 'open',
+    messages: [{ id: 'm1', body: 'is three still right?' }],
+  })
+  writeCommentThread(doc, {
+    id: 't-gone',
+    // A passage that was in the body when the thread was written and is not
+    // any more — the ordinary result of someone editing the paragraph.
+    anchor: { kind: 'text', quote: { exact: 'by Friday' }, start: 0, end: 9 },
+    status: 'open',
+    messages: [{ id: 'm2', body: 'still by Friday?' }],
+  })
+  return doc.export({ mode: 'snapshot' })
+}
+
+afterEach(cleanup)
+
+it('marks the conversation whose passage is gone, and only that one', async () => {
+  const store = new LocalStoreDouble()
+  await store.setDefaultDocumentId(note.documentId)
+  await store.save(note)
+  await store.loro.save(note.documentId, noteWithBothKinds())
+
+  render(
+    <BrowserDocumentPage
+      store={store.index}
+      pointer={store.pointer}
+      clock={store.clock}
+      loro={store.loro}
+    />,
+  )
+
+  await waitFor(() => expect(screen.getByRole('button', { name: /comments/i })).toBeTruthy())
+  screen.getByRole('button', { name: /comments/i }).click()
+
+  await waitFor(() => expect(screen.getByTestId('thread-orphaned-t-gone')).toBeTruthy())
+  // The difference is the claim: a resolver that marked everything would pass
+  // the line above and fail this one.
+  expect(screen.queryByTestId('thread-orphaned-t-here')).toBeNull()
+})

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -76,6 +76,7 @@ import { ensurePersistentStorage } from '../lib/persistent-storage.js'
 import { BROWSER_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
 import { createInTabRenderBroker } from '../lib/render-broker.js'
 import { setShellConnection } from '../lib/shell-status-store.js'
+import { markdownAnchorResolver } from '../lib/text-anchor.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
 import { cn } from '../lib/utils.js'
 import { attachVersionThumbnail } from '../lib/version-thumbnail.js'
@@ -723,6 +724,13 @@ export function BrowserDocumentPage({
    * matched against the body, which is the markdown projection's job.
    */
   const resolveAnchor = useMemo(() => {
+    // A markdown document CAN tell now: a text anchor's passage is either
+    // still findable in the body or it is gone (see text-anchor.ts). Until
+    // that reader existed this branch answered `undefined` for every note,
+    // which the panel correctly read as "this host cannot tell" — true then,
+    // and a thread whose sentence had been deleted looked exactly like one
+    // whose sentence was still there.
+    if (documentKind === 'markdown') return markdownAnchorResolver(markdownDoc.body)
     if (documentKind !== 'spatial') return undefined
     const nodeIds = new Set(canvas.nodes.map((node) => node.id))
     return (thread: CommentThread): 'placed' | 'orphaned' => {
@@ -730,7 +738,7 @@ export function BrowserDocumentPage({
       if (anchor.kind !== 'spatial' || anchor.nodeId === undefined) return 'placed'
       return nodeIds.has(anchor.nodeId) ? 'placed' : 'orphaned'
     }
-  }, [documentKind, canvas])
+  }, [documentKind, canvas, markdownDoc.body])
 
   /**
    * Appends the reader's reply to a conversation.

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -75,6 +75,7 @@ import { createInTabRenderBroker } from '../lib/render-broker.js'
 import { scheduleReplicaPush, scheduleReplicaRefresh } from '../lib/replica-refresh.js'
 import { setShellConnection } from '../lib/shell-status-store.js'
 import { createSharedSseStreamSource } from '../lib/sse-shared-stream-source.js'
+import { markdownAnchorResolver } from '../lib/text-anchor.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
 import { attachVersionThumbnail } from '../lib/version-thumbnail.js'
 import { applyViewportRequest } from '../lib/viewport-request.js'
@@ -450,26 +451,6 @@ export function DaemonDocumentPage({
     setPreview(null)
   }, [controller.path])
 
-  const openThreadCount = annotations.filter((thread) => thread.status === 'open').length
-  /**
-   * Whether a thread's anchor still finds its place (ADR-0026 decision 4:
-   * deleting the subject of a conversation must not delete the conversation).
-   *
-   * Spatial documents only, and only an anchor that NAMES a node — the same
-   * rule the browser page keeps, for the same reason: a markdown document has
-   * no canvas to judge against and would call every node-anchored thread
-   * orphaned, which is the opposite of not knowing.
-   */
-  const resolveAnchor = useMemo(() => {
-    if (documentKind !== 'spatial') return undefined
-    const nodeIds = new Set(canvasValue.nodes.map((node) => node.id))
-    return (thread: CommentThread): 'placed' | 'orphaned' => {
-      const { anchor } = thread
-      if (anchor.kind !== 'spatial' || anchor.nodeId === undefined) return 'placed'
-      return nodeIds.has(anchor.nodeId) ? 'placed' : 'orphaned'
-    }
-  }, [documentKind, canvasValue])
-
   const canvasValueRef = useRef(canvasValue)
   canvasValueRef.current = canvasValue
   /**
@@ -506,6 +487,29 @@ export function DaemonDocumentPage({
     [onChange],
   )
   const markdownBody = documentKind === 'markdown' && canvasLoaded ? syncedMarkdownBody : null
+
+  const openThreadCount = annotations.filter((thread) => thread.status === 'open').length
+  /**
+   * Whether a thread's anchor still finds its place (ADR-0026 decision 4:
+   * deleting the subject of a conversation must not delete the conversation).
+   *
+   * Spatial documents only, and only an anchor that NAMES a node — the same
+   * rule the browser page keeps, for the same reason: a markdown document has
+   * no canvas to judge against and would call every node-anchored thread
+   * orphaned, which is the opposite of not knowing.
+   */
+  const resolveAnchor = useMemo(() => {
+    // Same reader as the browser page, deliberately: whether a passage is
+    // still there is a fact about the document, not about who keeps it.
+    if (documentKind === 'markdown') return markdownAnchorResolver(markdownBody)
+    if (documentKind !== 'spatial') return undefined
+    const nodeIds = new Set(canvasValue.nodes.map((node) => node.id))
+    return (thread: CommentThread): 'placed' | 'orphaned' => {
+      const { anchor } = thread
+      if (anchor.kind !== 'spatial' || anchor.nodeId === undefined) return 'placed'
+      return nodeIds.has(anchor.nodeId) ? 'placed' : 'orphaned'
+    }
+  }, [documentKind, canvasValue, markdownBody])
 
   // `[[path]]` aliases resolve against the same list the user can see;
   // display names are retired from resolution and label the link at render


### PR DESCRIPTION
## Summary

- ADR-0026 decision 4 asks that deleting the subject of a conversation must not delete the conversation — which means a surface has to be able to **say** the subject is gone. The canvas could; a markdown document could not. The rail's `resolveAnchor` was `undefined` for a note, which the panel correctly reads as *"this host cannot tell"*, and which was true: nothing had ever resolved a text anchor against a body.
- The consequence was not a wrong badge but an **absent** one. A thread whose sentence had been deleted looked exactly like one whose sentence was still there, in the surface whose whole job is to say what is still open.
- `text-anchor.ts` is that reader, and it is why the schema stores a quote at all: offsets alone cannot work when the body is a CRDT anyone can edit from anywhere — a character typed in the first paragraph moves every anchor below it, and an anchor that is not re-derived points at *different words*. Pointing at the wrong words is worse than saying "this one has lost its place": a reader can act on the second and cannot even detect the first.
- Resolution follows W3C Web Annotation's `TextQuoteSelector`, which the schema was modelled on: the stored offsets if the text there is still the quote → the only occurrence elsewhere → among several, the one whose surroundings match `prefix`/`suffix` best, ties broken by distance from where the anchor last was → otherwise orphaned.
- **Both keeper pages get the same reader, in the same increment.** Whether a passage is still there is a fact about the document, not about who keeps it, and shipping it on one page would re-open the parity gap #1309 just closed.

**Not in this PR**: the in-place projection itself — a highlight on the passage and a gutter marker in the editor. This is the reader that needs, landed with a consumer rather than on its own.

### The fast path is a cost shortcut, and its mutation survives on purpose

Removing the stored-offset branch leaves **every test in the module green**, because on consistent data the search reproduces its answer (the stored site is at distance 0 from itself, so it wins the tiebreak). That is the branch being a shortcut, not a hole in the tests — and the comment at the branch says so.

It is kept on a measurement, not on a hunch. Unique quotes (the realistic shape), 2000 resolutions, branch vs search-only:

| body | with fast path | search only | |
|---|---|---|---|
| 8 KB | 0.5 ms | 12.3 ms | 24× |
| 48 KB | 0.4 ms | 61.0 ms | 170× |
| 200 KB | 0.1 ms | 228.1 ms | 2016× |

The search scans the whole body once per anchor; the branch compares `exact.length` characters and stops. The ratio grows with the document, which is the shape that becomes a problem later rather than now.

## Test plan

- [x] New tests added
  - `text-anchor.property.test.ts` (`web-jsdom`): four properties over generated bodies — a stored anchor resolves to its own quote; it follows the passage when text is inserted above it; a deleted passage is orphaned; re-resolving from the offsets it just answered is a no-op. Plus two examples for choosing between identical copies. Generators use **disjoint alphabets** for filler and passage, so a body cannot contain the quote by accident — an accidental second occurrence would quietly make "occurs once" false and the case would be testing something else.
  - `BrowserDocumentPage.markdown-orphan.test.tsx`: two threads on one note, one findable and one not. The assertion is a **difference**, so a resolver that answered the same thing for everything would fail it.
- [x] `pnpm test` passes locally — `pnpm --filter @kamiazya/whiteboard-web test`: **3573 passed / 338 files**.
- [x] `pnpm check:local` exits 0.
- [ ] Manual verification in a running app — not done: reaching this state means editing away a sentence an existing thread quotes, and there is no creation gesture on a note yet (that is the same follow-up as the projection), so the thread has to be seeded. The page-level test seeds it and drives the real page.
- [ ] E2E — not applicable.

**Mutation-checked**, all three restored green afterwards:

| mutation | result |
|---|---|
| ignore the search, always trust the stored offsets | 2 tests fail |
| never orphan | 1 test fails |
| drop the stored-offset fast path | **0 tests fail** — recorded above as intended |
| page: `resolveAnchor` back to `undefined` for markdown | the wiring test fails, naming the missing badge |

One number in an example was hand-counted and wrong (41 where the resolver said 42, and the resolver was right). It is now derived from the string, because the claim is *which* occurrence and a typed offset only adds a second thing to get wrong.

`web-browser` is not part of this plan: it has not completed in this container for several attempts (vite iframe / dynamic-import aborts at ~108 of 190 files, different files each time, with disk and memory ample). CI's `test-browser` is the authority for it.

## Visual evidence

Visual evidence: none — the change adds one badge to a rail whose appearance #1285's figure already shows, and what is new is *which* rows carry it, which a picture of one state cannot convey. The two-thread difference assertion is the evidence instead.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract — no published contract moves; no `docs/` page describes anchor resolution.
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema — `TextAnchor` is `Extract<AnnotationAnchor, { kind: 'text' }>`, narrowed off the model's own union.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_