### PR TITLE
test(canvas-render): close the one truncate gap the cluster tests could not see, and settle the rest

### DIFF
--- a/packages/canvas-render/src/layout/nodes/truncate.test.ts
+++ b/packages/canvas-render/src/layout/nodes/truncate.test.ts
@@ -374,4 +374,16 @@ describe('fitToWidth: cuts between characters a reader sees as one', () => {
     // smaller version of the family, it is a different picture.
     expect(fit('👨‍👩‍👧‍👦x', 5).text).toBe('👨‍👩‍👧‍👦')
   })
+
+  it('keeps it whole when NOTHING in the text is below U+0300', () => {
+    // The same rule with the ASCII taken away, and that is the whole test.
+    // Every other cluster case in this file sits beside plain text — an `x`,
+    // a `Task … done` label — and one character below U+0300 is enough on
+    // its own to send the string down the segmenter path. So none of them
+    // can see whether the GATE agrees about which strings may hold a
+    // cluster; they pass with it inverted. A text made only of characters at
+    // or above U+0300 is the one shape that asks it, and the answer under an
+    // inverted gate is a lone `👨`.
+    expect(fit('👨‍👩‍👧‍👦', 5).text).toBe('👨‍👩‍👧‍👦')
+  })
 })

--- a/packages/canvas-render/src/layout/nodes/truncate.ts
+++ b/packages/canvas-render/src/layout/nodes/truncate.ts
@@ -1,6 +1,17 @@
 import type { FontDescriptor, MeasureText } from '../../measure.js'
 import { clampAdvance } from '../../measure.js'
 
+/**
+ * `granularity` is stated rather than defaulted. Dropping the whole options
+ * object is equivalent — 'grapheme' IS the default — but naming it is what
+ * makes the unit this file cuts at readable at its declaration.
+ *
+ * The mutation lane reports emptying the STRING as a survivor. It is not one:
+ * `new Intl.Segmenter(undefined, { granularity: '' })` throws `RangeError` at
+ * module load, and applying it takes 34 test files down with it. The report is
+ * an artifact of that mutant being judged by zero tests — every file that
+ * would have caught it failed to import instead of failing an assertion.
+ */
 const GRAPHEMES = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
 
 /**
@@ -24,6 +35,22 @@ const GRAPHEMES = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
  * ever be made MORE eager — which is also why most edits to this function
  * cannot be caught by a test, and why the mutation lane reports them as
  * survivors.
+ *
+ * That is an invariant rather than an excuse, and it was measured: over the
+ * domain the cheap path actually serves — every character below U+0300, no
+ * CR — code-point iteration and grapheme segmentation agree on every one of
+ * 714,056 strings (all singles, all pairs, a stratified triple sample). So
+ * any edit that only makes this function ANSWER TRUE MORE OFTEN is
+ * output-equivalent by construction: it buys the segmenter, which is the
+ * right answer everywhere, at the price of walking text that did not need
+ * it. Only a bench can see those, which is why they are recorded as
+ * equivalent rather than chased.
+ *
+ * The edit that is NOT free is one that answers `false` for a string holding
+ * a cluster. Inverting the threshold does exactly that for a text made only
+ * of characters at or above U+0300, and every cluster test in this file
+ * except one sits beside ASCII, which alone sends the string down the
+ * segmenter path and hides it.
  *
  * Deliberately coarse: it sends Japanese, Chinese and Korean down the
  * segmenter path even though most of their text carries no clusters. A
@@ -106,6 +133,9 @@ export function fitToWidth(
   if (!Number.isFinite(maxWidth) || maxWidth <= 0) return { text }
   if (clampAdvance(measure(text, font).advanceWidth) <= maxWidth) return { text }
   let fitted = ''
+  // Read only when `fitted` is still empty, which can only happen if the loop
+  // broke on its FIRST iteration — so the guard below and an unconditional
+  // assignment cannot differ, and the mutation lane is right to survive it.
   let firstUnit = ''
   for (const unit of cutUnits(text)) {
     if (firstUnit === '') firstUnit = unit

--- a/packages/canvas-render/stryker-targets.mjs
+++ b/packages/canvas-render/stryker-targets.mjs
@@ -79,6 +79,29 @@ export const MUTATED = [
  * anyway.
  */
 export const KNOWN_EQUIVALENT = {
+  // Every one of these makes `mayCluster` answer TRUE more often, which buys
+  // the segmenter path — the correct one everywhere — at the price of walking
+  // text that did not need it. The invariant is on `mayCluster`, backed by a
+  // sweep of the domain the cheap path serves; only a bench can see them.
+  // `firstUnit` is a separate algebraic case, stated at its declaration, and
+  // naming `granularity` is equivalent to leaving it to the default.
+  //
+  // NOT recorded here, deliberately: `StringLiteral: 'grapheme' -> ""`, which
+  // the lane also reports on this file. That one is KILLED — it throws
+  // `RangeError` at module load and 34 test files fail to import — and it
+  // survives the report only because it was judged by zero tests. An entry
+  // would make this ledger claim no test can kill it, which is false; the
+  // measurement is on `GRAPHEMES` instead.
+  'src/layout/nodes/truncate.ts': {
+    'BlockStatement: { yield* text return } -> {}': 1,
+    'BooleanLiteral: false -> true': 1,
+    'ConditionalExpression: !mayCluster(text) -> false': 1,
+    'ConditionalExpression: code >= 0x0300 || code === 0x000d -> true': 1,
+    "ConditionalExpression: firstUnit === '' -> true": 1,
+    'EqualityOperator: code === 0x000d -> code !== 0x000d': 1,
+    'EqualityOperator: i < text.length -> i <= text.length': 1,
+    "ObjectLiteral: { granularity: 'grapheme' } -> {}": 1,
+  },
   // A placed bubble sits a whole offset to one side of its anchor on each
   // axis, so the anchor is never on a centre line and `<=` cannot differ from
   // `<`; a zero-extent overlap contributes nothing to the sum whether the


### PR DESCRIPTION
## Summary

The mutation lane reported ten survivors on `truncate.ts`. Each was verified by applying that exact edit and running the suite — the check this repo already asks for, because a survivor is a hypothesis. They turn out to be **three different things**, and only one is debt.

### One is a real gap, and the TESTS are the reason

Inverting the gate (`code >= 0x0300` → `code < 0x0300`) sends a text made only of characters at or above U+0300 down the cheap path, where the never-empty rule returns a lone 👨 — the exact output this module's own comment forbids (*"not a smaller version of the family, it is a different picture"*).

Every cluster case in the file sits beside ASCII — `'👨‍👩‍👧‍👦x'`, a `` `Task … done` `` label — and **one character below U+0300 is enough on its own to send the string down the segmenter path**. So none of them can see whether the gate agrees about which strings may hold a cluster; they all pass with it inverted. One case with the ASCII taken away is the whole fix.

### Six are equivalent, by measurement rather than argument

They all make `mayCluster` answer `true` more often, which buys the segmenter — the right answer everywhere — at the price of walking text that did not need it. That is only equivalent if the two walks agree over the domain the cheap path actually serves, so I swept it instead of asserting it: every character below U+0300, no CR, all singles and all pairs plus a stratified triple sample — **714,056 strings, zero disagreements**. The control confirms the sweep can see a difference when one exists (`"á"`, `"a\r\n"` and a ZWJ pair all differ).

Two more are algebraic: `firstUnit` is read only when the loop broke on its first iteration, where the guard and an unconditional assignment assign the same thing; and naming `granularity` is equivalent to leaving it to the default.

### One is a FALSE survivor, and is deliberately not recorded as equivalent

`'grapheme' -> ""` throws `RangeError` at module load and takes **34 test files** down with it. It survives the report only because it was judged by zero tests — every file that would have caught it failed to *import* rather than failing an assertion. Recording it in `KNOWN_EQUIVALENT` would make that ledger claim no test can kill it, which is false, so the measurement goes next to `GRAPHEMES` instead and the mutant keeps being reported.

Worth noting its output shape, which is the same trap as the ninth and tenth flake families: `Test Files 34 failed | 74 passed (108)` alongside `Tests 753 passed (753)`. Every test that ran passed.

## Test plan

- [x] New or updated `canvas-render-node` test added
- [x] `pnpm test` passes locally for the touched area
- [ ] Manual verification completed
- [ ] E2E coverage added or extended where applicable

`canvas-render-node`: **108 files, 1101 passed**. `typecheck`, `lint`, `knip` clean.

**Mutation-checked, both directions.** The new case: green on the real code (`35 passed`), red on the inverted gate (`1 failed | 34 passed`). The two survivors I had not previously hand-checked (`code === 0x000d -> code !== 0x000d`, `firstUnit === '' -> true`) were each applied against the full suite and left all 1101 green, confirming equivalence rather than assuming it.

**The ledger guard was mutation-checked too**, per the coverage-ledger rule that a guard which cannot fail reads exactly like a guard that checked: corrupting one new key's original expression fails `names an expression that is still in the file it names`.

Manual verification is unticked deliberately: production behaviour is unchanged — the diff to `truncate.ts` is comments only, verified by filtering the diff.

## Visual evidence

**Visual evidence: none — no production behaviour changes.** This is one test case, three source comments and a mutation-ledger entry; the `truncate.ts` diff contains no non-comment lines.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_