### PR TITLE
feat(web): a non-default variation is addressable as a read-only ?v= preview (ADR-0022)

### DIFF
--- a/apps/web/src/components/HeaderBranchChip.browser.test.tsx
+++ b/apps/web/src/components/HeaderBranchChip.browser.test.tsx
@@ -66,6 +66,32 @@ describe('HeaderBranchChip (real Radix dropdown/dialog)', () => {
     expect(stateHolder.current.setHead).toHaveBeenCalledWith('feature-x')
   })
 
+  it('the preview control on a non-HEAD row previews without switching (ADR-0022)', async () => {
+    const onPreviewVariation = vi.fn()
+    render(<HeaderBranchChip workspaceId="s1" path="c1" onPreviewVariation={onPreviewVariation} />)
+    await userEvent.click(screen.getByTestId('header-branch-chip'))
+
+    const previewButton = await screen.findByTestId('branch-preview-feature-x')
+    await userEvent.click(previewButton)
+
+    expect(onPreviewVariation).toHaveBeenCalledWith('feature-x')
+    // Looking is not switching: the shared act must not ride along.
+    expect(stateHolder.current.setHead).not.toHaveBeenCalled()
+  })
+
+  it('offers no preview control for the HEAD row, and none at all without the callback', async () => {
+    render(<HeaderBranchChip workspaceId="s1" path="c1" onPreviewVariation={vi.fn()} />)
+    await userEvent.click(screen.getByTestId('header-branch-chip'))
+    await screen.findByText('feature-x')
+    expect(screen.queryByTestId('branch-preview-main')).toBeNull()
+    cleanup()
+
+    render(<HeaderBranchChip workspaceId="s1" path="c1" />)
+    await userEvent.click(screen.getByTestId('header-branch-chip'))
+    await screen.findByText('feature-x')
+    expect(screen.queryByTestId('branch-preview-feature-x')).toBeNull()
+  })
+
   it('kebab -> rename -> Enter calls renameBranch with the old and new names', async () => {
     // Rename is disabled while head === 'main', so switch HEAD first.
     stateHolder.current.state = { head: 'feature-x', branches }

--- a/apps/web/src/components/HeaderBranchChip.tsx
+++ b/apps/web/src/components/HeaderBranchChip.tsx
@@ -1,6 +1,7 @@
 import type { BranchMeta } from '@kamiazya/whiteboard-mcp/api-contracts'
 import {
   ChevronDown,
+  Eye,
   GitBranch,
   GitMerge,
   MoreHorizontal,
@@ -78,6 +79,10 @@ export interface HeaderBranchChipProps {
   // callers must pass `capabilities.merge` explicitly to hide the merge
   // entry point when the provider does not support it.
   mergeEnabled?: boolean
+  // Look at a variation WITHOUT switching (ADR-0022's addressable preview).
+  // The host page owns the address, so this only reports the chosen name;
+  // omitted (a host with no preview surface) hides the control.
+  onPreviewVariation?: (name: string) => void
 }
 
 interface PendingMerge {
@@ -103,6 +108,7 @@ export function HeaderBranchChip({
   disabled,
   refreshSignal,
   mergeEnabled = true,
+  onPreviewVariation,
 }: HeaderBranchChipProps): JSX.Element {
   const fetchFn = useDaemonApi()
   const {
@@ -406,6 +412,23 @@ export function HeaderBranchChip({
               <span className="truncate" title={b.name}>
                 {displayBranchName(b.name)}
               </span>
+              {onPreviewVariation && (
+                <button
+                  type="button"
+                  aria-label={`Preview variation ${displayBranchName(b.name)}`}
+                  data-testid={`branch-preview-${b.name}`}
+                  className="ml-auto shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+                  // Looking must not become switching: stop the row's own
+                  // select (setHead) from firing under this button.
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    event.preventDefault()
+                    onPreviewVariation(b.name)
+                  }}
+                >
+                  <Eye className="size-3.5" aria-hidden />
+                </button>
+              )}
             </DropdownMenuItem>
           ))}
           <DropdownMenuSeparator />

--- a/apps/web/src/components/HeaderVariationBanner.tsx
+++ b/apps/web/src/components/HeaderVariationBanner.tsx
@@ -1,0 +1,94 @@
+import { Eye, GitMerge, X } from 'lucide-react'
+import { type JSX, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import type { BranchMeta, MergeResult } from '@/hooks/useBranches'
+import { displayBranchName } from '@/lib/utils'
+import { MergeDialog } from './MergeDialog'
+
+// The banner over a `?v=<name>` variation preview (ADR-0022's addressability
+// increment). The preview itself is read-only by construction
+// (DocumentPreview); this banner carries the two ways FORWARD from looking:
+// switching HEAD — kept an explicit control because it is a shared act that
+// moves every peer — and combining the variation into the current HEAD.
+export interface HeaderVariationBannerProps {
+  workspaceId: string
+  path: string
+  /** The previewed variation. Never the default: `?v=main` strips upstream. */
+  name: string
+  head: string
+  branches: readonly BranchMeta[]
+  onSwitch: () => void
+  onExit: () => void
+  runMerge: (source: string, args: { into: string; dryRun?: boolean }) => Promise<MergeResult>
+}
+
+export function HeaderVariationBanner({
+  workspaceId,
+  path,
+  name,
+  head,
+  branches,
+  onSwitch,
+  onExit,
+  runMerge,
+}: HeaderVariationBannerProps): JSX.Element {
+  const [mergeOpen, setMergeOpen] = useState(false)
+  const sourceBranch = branches.find((b) => b.name === name) ?? null
+  const targetBranch = branches.find((b) => b.name === head) ?? null
+
+  return (
+    <>
+      <div
+        role="status"
+        data-testid="variation-preview-banner"
+        className="flex items-center gap-3 border-b border-sky-400/40 bg-sky-50 px-3 py-1.5 text-xs text-sky-900"
+      >
+        <Eye className="size-3.5 shrink-0 text-sky-600" aria-hidden />
+        <span className="min-w-0 flex-1 truncate">
+          Viewing variation «<strong>{displayBranchName(name)}</strong>» — read-only. The document
+          stays on «{displayBranchName(head)}».
+        </span>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-7 gap-1 border-sky-400/60 bg-sky-100/70 text-xs text-sky-900 hover:bg-sky-200"
+          data-testid="variation-preview-switch"
+          title="Switches the document for everyone working on it"
+          onClick={onSwitch}
+        >
+          Switch to this variation
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-7 gap-1 border-sky-400/60 bg-sky-100/70 text-xs text-sky-900 hover:bg-sky-200"
+          data-testid="variation-preview-merge"
+          onClick={() => setMergeOpen(true)}
+        >
+          <GitMerge className="size-3.5" />
+          Combine into «{displayBranchName(head)}»
+        </Button>
+        <button
+          type="button"
+          aria-label="Back to the current document"
+          data-testid="variation-preview-exit"
+          className="shrink-0 rounded-md p-1 text-sky-700 hover:bg-sky-200"
+          onClick={onExit}
+        >
+          <X className="size-3.5" aria-hidden />
+        </button>
+      </div>
+      <MergeDialog
+        open={mergeOpen}
+        source={sourceBranch}
+        target={targetBranch}
+        onClose={() => setMergeOpen(false)}
+        runMerge={runMerge}
+        workspaceId={workspaceId}
+        path={path}
+      />
+    </>
+  )
+}

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -63,6 +63,9 @@ interface Props {
   // (merge). Undefined means "all capabilities on", matching every existing
   // caller's behavior.
   capabilities?: WorkspaceTopBarCapabilities
+  // Passed through to HeaderBranchChip: preview a variation without
+  // switching. The page owns the address, so it owns the handler.
+  onPreviewVariation?: (name: string) => void
   /**
    * Opens and closes the document's history. The PAGE owns both the state and
    * the panel: history is a column of the editor row, not a popover hanging
@@ -130,6 +133,7 @@ export default function WorkspaceTopBar({
   onNavigateBack,
   dataMode = 'daemon',
   capabilities,
+  onPreviewVariation,
   onToggleHistory,
   historyOpen = false,
   preview,
@@ -234,6 +238,7 @@ export default function WorkspaceTopBar({
               path={path}
               refreshSignal={branchRefreshSignal}
               mergeEnabled={mergeEnabled}
+              onPreviewVariation={onPreviewVariation}
             />
           </>
         )}

--- a/apps/web/src/hooks/useBranches.test.ts
+++ b/apps/web/src/hooks/useBranches.test.ts
@@ -113,6 +113,38 @@ describe('branchesApi', () => {
     expect(firstCall?.[0]).toBe('/api/workspaces/sess_1/documents/canvas-a/branches')
   })
 
+  it('loadDocument() GETs the branch document URL and parses the past shape', async () => {
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () =>
+        new Response(JSON.stringify({ kind: 'markdown', body: '# at the tip' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const api = branchesApi('sess_1', 'canvas-a')
+    const past = await api.loadDocument('idea/2')
+    expect(past).toEqual({ kind: 'markdown', body: '# at the tip' })
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      '/api/workspaces/sess_1/documents/canvas-a/branches/idea%2F2/document',
+    )
+  })
+
+  it('loadDocument() answers null on 404 (branch gone) and rejects on other errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{"error":"branch_not_found"}', { status: 404 })),
+    )
+    expect(await branchesApi('sess_1', 'canvas-a').loadDocument('gone')).toBeNull()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{}', { status: 500 })),
+    )
+    await expect(branchesApi('sess_1', 'canvas-a').loadDocument('sick')).rejects.toMatchObject({
+      status: 500,
+    })
+  })
+
   it('create() POSTs JSON body', async () => {
     const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
       async () =>

--- a/apps/web/src/hooks/useBranches.ts
+++ b/apps/web/src/hooks/useBranches.ts
@@ -16,6 +16,8 @@ import {
   renameBranchResponseSchema,
   type SetHeadResponse,
   setHeadResponseSchema,
+  type VersionDocumentResponse,
+  versionDocumentResponseSchema,
 } from '@kamiazya/whiteboard-mcp/api-contracts'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ZodError } from 'zod'
@@ -41,6 +43,7 @@ export function buildBranchUrls(
   deleteBranch: (name: string) => string
   stats: (name: string) => string
   merge: (source: string) => string
+  branchDocument: (name: string) => string
 } {
   const safePath = encodeURIComponent(path)
   const base = `/api/workspaces/${workspaceId}/documents/${safePath}`
@@ -50,6 +53,7 @@ export function buildBranchUrls(
     deleteBranch: (name) => `${base}/branches/${encodeURIComponent(name)}`,
     stats: (name) => `${base}/branches/${encodeURIComponent(name)}/stats`,
     merge: (source) => `${base}/branches/${encodeURIComponent(source)}/merge`,
+    branchDocument: (name) => `${base}/branches/${encodeURIComponent(name)}/document`,
   }
 }
 
@@ -168,6 +172,15 @@ export function branchesApi(workspaceId: string, path: string, fetchFn: typeof f
         }),
       )
       return safeParse(setHeadResponseSchema, await res.json())
+    },
+    // One variation's content at its tip, read-only — what ?v=<name> draws.
+    // null when the branch (or its tip) is gone: the caller shows "variation
+    // not found" and falls back to the live document.
+    async loadDocument(name: string): Promise<VersionDocumentResponse | null> {
+      const res = await fetchFn(urls.branchDocument(name))
+      if (res.status === 404) return null
+      await requireOk(res)
+      return safeParse(versionDocumentResponseSchema, await res.json())
     },
     async merge(source: string, args: { into: string; dryRun?: boolean }): Promise<MergeResult> {
       const res = await requireOk(

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -1205,11 +1205,12 @@ export function DaemonDocumentPage({
                 <CommentsPanel
                   threads={annotations}
                   resolveAnchor={resolveAnchor}
-                  // Not while a past version is on screen: the editor is
-                  // replaced by DocumentPreview but this rail is not, and a
-                  // reply is a write to the LIVE document — sent from a
-                  // surface showing something else entirely.
-                  onReply={preview === null ? handleReply : undefined}
+                  // Not while a past version OR a variation preview is on
+                  // screen: the editor is replaced by DocumentPreview but
+                  // this rail is not, and a reply is a write to the LIVE
+                  // document — sent from a surface showing something else
+                  // entirely.
+                  onReply={preview === null && variationPreview === null ? handleReply : undefined}
                 />
               </aside>
             ) : null}

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -1016,8 +1016,13 @@ export function DaemonDocumentPage({
               />
             )}
             {variationNotice !== null && (
+              // role="alert", not "status": every notice here reports a
+              // failure (unknown name, unreadable tip, failed switch), and
+              // an alert injected with its content is the supported pattern
+              // — a conditionally-mounted status region is not
+              // (polite-live-region.test.ts).
               <div
-                role="status"
+                role="alert"
                 data-testid="variation-preview-notice"
                 className="flex items-center gap-3 border-b bg-muted px-3 py-1.5 text-xs text-muted-foreground"
               >

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -6,6 +6,7 @@ import { selectDocumentTransport } from '@kamiazya/whiteboard-mcp/select-documen
 import { SseBackend } from '@kamiazya/whiteboard-mcp/sse-backend'
 import { type DocumentKind, isImageRef } from '@kamiazya/whiteboard-model'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { AgentPresenceChip } from '../components/AgentPresenceChip.js'
 import { CapabilityTeaser } from '../components/capability-teaser/CapabilityTeaser.js'
 import type { ConnectionsBacklink } from '../components/connections/ConnectionsChip.js'
@@ -19,6 +20,7 @@ import { SpatialEditorPane } from '../components/document-editor/SpatialEditorPa
 import { useNodeInEditor } from '../components/document-editor/use-node-in-editor.js'
 import { DocumentProperties } from '../components/document-properties/DocumentProperties.js'
 import { HeaderBranchBanner } from '../components/HeaderBranchBanner.js'
+import { HeaderVariationBanner } from '../components/HeaderVariationBanner.js'
 import { MergeToast } from '../components/MergeToast.js'
 import { CanvasDisplaySettings } from '../components/spatial-editor/CanvasDisplaySettings.js'
 import type { SpatialEditorHandle } from '../components/spatial-editor/index.js'
@@ -45,6 +47,7 @@ import {
   type MarkdownEmbedLoader,
   useMarkdownEmbedContent,
 } from '../hooks/use-markdown-embed-content.js'
+import { type BranchMeta, branchesApi } from '../hooks/useBranches.js'
 import { useDirtyState } from '../hooks/useDirtyState.js'
 import { useDocumentOutline } from '../hooks/useDocumentOutline.js'
 import { dispatchIdentityEvent, useDocumentSync } from '../hooks/useDocumentSync.js'
@@ -73,6 +76,7 @@ import { setShellConnection } from '../lib/shell-status-store.js'
 import { createSharedSseStreamSource } from '../lib/sse-shared-stream-source.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
 import { attachVersionThumbnail } from '../lib/version-thumbnail.js'
+import type { PastDocument } from '../lib/versions-backend.js'
 import { applyViewportRequest } from '../lib/viewport-request.js'
 import { useBrowserToolRegistry } from '../lib/webmcp/use-browser-tool-registry.js'
 import { deriveDaemonPageState } from './daemon-page-state.js'
@@ -175,6 +179,102 @@ export function DaemonDocumentPage({
   // tool call) so HeaderBranchChip refetches; the chip's own switch/create/
   // rename/delete actions already refetch internally and don't need this.
   const [branchRefreshSignal, setBranchRefreshSignal] = useState(0)
+  // ── ?v=<name>: a non-default variation, addressable (ADR-0022) ──
+  // The address names a READ-ONLY view of that variation's tip; HEAD does
+  // not move. Decision 1 holds on both edges: `?v=main` and a `?v` naming
+  // the current HEAD strip back to the plain address, so the default
+  // variation is never decorated.
+  const [searchParams, setSearchParams] = useSearchParams()
+  const variationParam = searchParams.get('v')
+  const [variationPreview, setVariationPreview] = useState<{
+    name: string
+    head: string
+    branches: readonly BranchMeta[]
+    past: PastDocument
+  } | null>(null)
+  const [variationNotice, setVariationNotice] = useState<string | null>(null)
+  const clearVariationParam = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        next.delete('v')
+        return next
+      },
+      { replace: true },
+    )
+  }, [setSearchParams])
+
+  useEffect(() => {
+    if (!canvas || variationParam === null || !capabilities.branches) {
+      setVariationPreview(null)
+      return
+    }
+    const { workspaceId: wsId, path: docPath } = canvas
+    let cancelled = false
+    const api = branchesApi(wsId, docPath, daemonFetch)
+    void (async () => {
+      try {
+        const state = await api.list()
+        if (cancelled) return
+        if (variationParam === 'main' || variationParam === state.head) {
+          clearVariationParam()
+          return
+        }
+        if (!state.branches.some((b) => b.name === variationParam)) {
+          setVariationNotice(`Variation «${variationParam}» was not found`)
+          clearVariationParam()
+          return
+        }
+        const past = await api.loadDocument(variationParam)
+        if (cancelled) return
+        if (past === null) {
+          setVariationNotice(`Variation «${variationParam}» could not be read`)
+          clearVariationParam()
+          return
+        }
+        setVariationNotice(null)
+        setVariationPreview({
+          name: variationParam,
+          head: state.head,
+          branches: state.branches,
+          past,
+        })
+      } catch {
+        if (!cancelled) {
+          setVariationNotice('Variation preview failed to load')
+          clearVariationParam()
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+    // branchRefreshSignal: an external HEAD change can make the previewed
+    // name the HEAD, which must strip the param rather than keep a stale
+    // "read-only" claim over what is now the live document.
+  }, [
+    canvas?.workspaceId,
+    canvas?.path,
+    variationParam,
+    capabilities.branches,
+    daemonFetch,
+    clearVariationParam,
+    branchRefreshSignal,
+  ])
+
+  const switchToVariation = useCallback(() => {
+    if (!canvas || variationPreview === null) return
+    const { workspaceId: wsId, path: docPath } = canvas
+    void (async () => {
+      try {
+        await branchesApi(wsId, docPath, daemonFetch).setHead(variationPreview.name)
+        setBranchRefreshSignal((n) => n + 1)
+        clearVariationParam()
+      } catch {
+        setVariationNotice('Switching to this variation failed')
+      }
+    })()
+  }, [canvas, variationPreview, daemonFetch, clearVariationParam])
   // The document's history column. Cleared on a document switch: this page
   // does not remount, and a panel left open across a switch would be listing
   // the departed document's versions under the arrived document's name.
@@ -797,11 +897,49 @@ export function DaemonDocumentPage({
                 historyOpen={historyOpen}
                 {...(preview === null ? {} : { preview })}
                 branchRefreshSignal={branchRefreshSignal}
+                onPreviewVariation={(name) => {
+                  setSearchParams((prev) => {
+                    const next = new URLSearchParams(prev)
+                    next.set('v', name)
+                    return next
+                  })
+                }}
                 onNavigateBack={onNavigateBack}
                 // Version thumbnails come from the same PNG export path the
                 // user can trigger by hand. Without this the save flow skips
                 // the upload entirely and latest-thumbnail stays 204 forever.
               />
+            )}
+            {capabilities.branches && canvas && variationPreview !== null && (
+              <HeaderVariationBanner
+                workspaceId={canvas.workspaceId}
+                path={canvas.path}
+                name={variationPreview.name}
+                head={variationPreview.head}
+                branches={variationPreview.branches}
+                onSwitch={switchToVariation}
+                onExit={clearVariationParam}
+                runMerge={(src, args) =>
+                  branchesApi(canvas.workspaceId, canvas.path, daemonFetch).merge(src, args)
+                }
+              />
+            )}
+            {variationNotice !== null && (
+              <div
+                role="status"
+                data-testid="variation-preview-notice"
+                className="flex items-center gap-3 border-b bg-muted px-3 py-1.5 text-xs text-muted-foreground"
+              >
+                <span className="min-w-0 flex-1 truncate">{variationNotice}</span>
+                <button
+                  type="button"
+                  aria-label="Dismiss"
+                  className="shrink-0 rounded-md p-1 hover:bg-accent"
+                  onClick={() => setVariationNotice(null)}
+                >
+                  ×
+                </button>
+              </div>
             )}
             {capabilities.branches && canvas && (
               <HeaderBranchBanner workspaceId={canvas.workspaceId} path={canvas.path} />
@@ -898,6 +1036,8 @@ export function DaemonDocumentPage({
           </div>
         ) : preview ? (
           <DocumentPreview past={preview.past} theme={resolvedTheme} />
+        ) : variationPreview ? (
+          <DocumentPreview past={variationPreview.past} theme={resolvedTheme} />
         ) : (
           <DocumentEditorSurface
             kind={documentKind}

--- a/apps/web/src/pages/DaemonDocumentPage.variation-preview.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.variation-preview.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * ADR-0022's later increment: a non-default variation is ADDRESSABLE via
+ * `?v=<name>` — a read-only preview of that variation's tip, without moving
+ * HEAD (switching stays a shared act behind an explicit control). Decision 1
+ * holds: the default variation is never decorated, so `?v=main` and a `?v=`
+ * naming the current HEAD both strip back to the plain address.
+ */
+
+import {
+  writeCoreFacets,
+  writeDocumentKind,
+  writeMarkdownBody,
+} from '@kamiazya/whiteboard-loro-adapter'
+import type {
+  DocumentBackend,
+  DocumentBackendHandlers,
+} from '@kamiazya/whiteboard-mcp/browser-contract'
+import {
+  act,
+  cleanup,
+  fireEvent,
+  type RenderOptions,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { LoroDoc } from 'loro-crdt'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as daemonApiClient from '../lib/daemon-api-client.js'
+
+function render(ui: ReactElement, options?: RenderOptions & { search?: string }) {
+  const { search = '', ...rest } = options ?? {}
+  return rtlRender(<MemoryRouter initialEntries={[`/${search}`]}>{ui}</MemoryRouter>, rest)
+}
+
+vi.mock('../lib/daemon-api-client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/daemon-api-client.js')>()
+  return {
+    ...actual,
+    listWorkspaces: vi.fn(),
+    listDocuments: vi.fn(),
+    createDocument: vi.fn(),
+  }
+})
+
+const { DaemonDocumentPage } = await import('./DaemonDocumentPage.js')
+
+const mockListWorkspaces = vi.mocked(daemonApiClient.listWorkspaces)
+const mockListDocuments = vi.mocked(daemonApiClient.listDocuments)
+
+function markdownSnapshot(): Uint8Array {
+  const doc = new LoroDoc()
+  writeMarkdownBody(doc, '# Live body on HEAD')
+  writeCoreFacets(doc, { type: 'markdown' })
+  writeDocumentKind(doc, 'markdown')
+  return doc.export({ mode: 'snapshot' })
+}
+
+class FakeBackend implements DocumentBackend {
+  handlers: DocumentBackendHandlers | null = null
+  connect(handlers: DocumentBackendHandlers): void {
+    this.handlers = handlers
+    handlers.onConnected()
+    handlers.onSnapshot(markdownSnapshot())
+  }
+  disconnect(): void {}
+  pushLocalUpdate(): void {}
+  getFile(): Promise<Blob | null> {
+    return Promise.resolve(null)
+  }
+  putFile(): Promise<void> {
+    return Promise.resolve()
+  }
+  sendClientReady(): void {}
+  sendExportResponse(): void {}
+}
+
+const DAEMON_BASE_URL = 'http://127.0.0.1:3099'
+
+const BRANCHES_STATE = {
+  head: 'main',
+  branches: [
+    { name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '2026-01-01T00:00:00Z' },
+    { name: 'idea', tipFrontiers: 'dGlw', color: '#e8590c', createdAt: '2026-01-02T00:00:00Z' },
+  ],
+}
+
+/** Records every request; answers branches, the branch document, and names. */
+function stubDaemon(overrides?: { headState?: typeof BRANCHES_STATE }) {
+  const requests: Array<{ url: string; method: string }> = []
+  const state = overrides?.headState ?? BRANCHES_STATE
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const method = init?.method ?? 'GET'
+      requests.push({ url, method })
+      if (url.includes('/names')) {
+        return new Response(JSON.stringify({ documents: { note: 'Note' }, pinned: [] }), {
+          status: 200,
+        })
+      }
+      if (url.endsWith('/branches/idea/document')) {
+        return new Response(JSON.stringify({ kind: 'markdown', body: '# From the idea tip' }), {
+          status: 200,
+        })
+      }
+      if (url.endsWith('/branches')) {
+        return new Response(JSON.stringify(state), { status: 200 })
+      }
+      if (url.endsWith('/head') && method === 'PUT') {
+        return new Response(JSON.stringify({ head: 'idea', previousHead: 'main' }), {
+          status: 200,
+        })
+      }
+      return new Response('{}', { status: 404 })
+    }),
+  )
+  return requests
+}
+
+function mountPage(search: string) {
+  return render(
+    <DaemonDocumentPage
+      daemonBaseUrl={DAEMON_BASE_URL}
+      workspaceId="w1"
+      path="note"
+      createBackend={() => new FakeBackend()}
+    />,
+    { container: document.body, search },
+  )
+}
+
+describe('DaemonDocumentPage ?v= variation preview', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    mockListWorkspaces.mockResolvedValue({ workspaces: [{ workspaceId: 'w1' }] })
+    mockListDocuments.mockResolvedValue({
+      documents: [{ path: 'note', id: 'id-note', updatedAt: '2026-01-01', kind: 'markdown' }],
+    })
+  })
+  afterEach(() => {
+    cleanup()
+    window.localStorage.clear()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('shows the variation tip read-only with a banner, and never mounts the editor', async () => {
+    stubDaemon()
+    await act(async () => {
+      mountPage('?v=idea')
+    })
+    await waitFor(() => expect(screen.getByTestId('variation-preview-banner')).toBeTruthy())
+    // The preview draws the BRANCH tip, not the live HEAD body.
+    await waitFor(() => expect(document.body.textContent).toContain('From the idea tip'))
+    expect(screen.queryByTestId('markdown-source-wrap')).toBeNull()
+    expect(document.body.textContent).not.toContain('Live body on HEAD')
+  })
+
+  it('switch control PUTs head — the shared act stays explicit — and leaves the preview', async () => {
+    const requests = stubDaemon()
+    await act(async () => {
+      mountPage('?v=idea')
+    })
+    await waitFor(() => expect(screen.getByTestId('variation-preview-switch')).toBeTruthy())
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('variation-preview-switch'))
+    })
+    await waitFor(() =>
+      expect(requests.some((r) => r.method === 'PUT' && r.url.endsWith('/head'))).toBe(true),
+    )
+    await waitFor(() => expect(screen.queryByTestId('variation-preview-banner')).toBeNull())
+  })
+
+  it('offers the combine lead-in from the banner', async () => {
+    stubDaemon()
+    await act(async () => {
+      mountPage('?v=idea')
+    })
+    await waitFor(() => expect(screen.getByTestId('variation-preview-merge')).toBeTruthy())
+  })
+
+  it('strips ?v naming the current HEAD (the plain address already means it)', async () => {
+    stubDaemon()
+    await act(async () => {
+      mountPage('?v=main')
+    })
+    await waitFor(() => expect(screen.getByTestId('markdown-source-wrap')).toBeTruthy())
+    expect(screen.queryByTestId('variation-preview-banner')).toBeNull()
+  })
+
+  it('strips ?v naming a non-default HEAD too (the plain address means whatever HEAD is)', async () => {
+    stubDaemon({ headState: { ...BRANCHES_STATE, head: 'idea' } })
+    await act(async () => {
+      mountPage('?v=idea')
+    })
+    await waitFor(() => expect(screen.getByTestId('markdown-source-wrap')).toBeTruthy())
+    expect(screen.queryByTestId('variation-preview-banner')).toBeNull()
+  })
+
+  it('strips ?v=main even while HEAD is elsewhere — the default is never decorated (decision 1)', async () => {
+    const requests = stubDaemon({ headState: { ...BRANCHES_STATE, head: 'idea' } })
+    await act(async () => {
+      mountPage('?v=main')
+    })
+    await waitFor(() => expect(screen.getByTestId('markdown-source-wrap')).toBeTruthy())
+    expect(screen.queryByTestId('variation-preview-banner')).toBeNull()
+    // Stripped by decision 1, not by a failed read: the default's content
+    // was never requested, and no "could not be read" notice appears.
+    expect(requests.some((r) => r.url.includes('/branches/main/document'))).toBe(false)
+    expect(screen.queryByTestId('variation-preview-notice')).toBeNull()
+  })
+
+  it('falls back to the live document with a notice for an unknown variation', async () => {
+    stubDaemon()
+    await act(async () => {
+      mountPage('?v=nope')
+    })
+    await waitFor(() => expect(screen.getByTestId('markdown-source-wrap')).toBeTruthy())
+    await waitFor(() =>
+      expect(screen.getByTestId('variation-preview-notice').textContent).toMatch(/not found/i),
+    )
+    expect(screen.queryByTestId('variation-preview-banner')).toBeNull()
+  })
+})

--- a/docs/contributing/adr/0022-variation-addressing.md
+++ b/docs/contributing/adr/0022-variation-addressing.md
@@ -1,6 +1,6 @@
 # ADR-0022: A variation is not in the address, and the default one has no name to put there
 
-**Status:** Accepted — records the current shape and fixes the grammar for a later increment
+**Status:** Accepted — decision 2 revisited on 2026-09-05 (see the dated note); decision 1 unchanged
 
 ## Context
 
@@ -50,6 +50,20 @@ Decision 1 is the durable one: whatever addresses a variation later — a URL
 segment, a query parameter, something else — the default is never decorated.
 Decision 2 is a scope decision for now and may be revisited; decision 1
 constrains what revisiting it may look like.
+
+> **Note (2026-09-05): decision 2 revisited — a non-default variation is now
+> addressable, as a READ-ONLY view.** `?v=<name>` on a daemon document's
+> address opens that variation's tip through the same read-only projection
+> version previews use (`GET .../branches/:name/document`), without moving
+> HEAD. Sharing and bookmarking a variation work; switching stays a shared
+> act behind an explicit control on the preview banner, which also carries
+> the combine lead-in. Decision 1 held exactly as written: the default is
+> never decorated — `?v=main` strips back to the plain address (even while
+> HEAD is elsewhere), and so does a `?v` naming the current HEAD, so there
+> is still exactly one address for the page a plain URL means. The rejected
+> per-reader EDITING variation stays rejected; a per-reader read-only VIEW
+> is what shipped, and it is a different thing — nothing anyone draws lands
+> in it.
 
 ## Consequences
 

--- a/packages/mcp-server/src/server/app.ts
+++ b/packages/mcp-server/src/server/app.ts
@@ -2,7 +2,12 @@ import { randomUUID } from 'node:crypto'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { serveStatic } from '@hono/node-server/serve-static'
-import { reconcileDocContent } from '@kamiazya/whiteboard-loro-adapter'
+import {
+  readDocumentKind,
+  readMarkdownBody,
+  readSpatialCanvas,
+  reconcileDocContent,
+} from '@kamiazya/whiteboard-loro-adapter'
 import { createServer as createDocumentServer } from '@kamiazya/whiteboard-server-core'
 import {
   createMcpHandler,
@@ -12,6 +17,7 @@ import {
 import { Hono } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
 import { encodeFrontiers, type LoroDoc } from 'loro-crdt'
+import type { VersionDocumentResponse } from '../shared/api-contracts/document.js'
 import type { RuntimeStatusResponse } from '../shared/api-contracts/runtime.js'
 import { errorMessage } from '../shared/error-message.js'
 import {
@@ -564,6 +570,42 @@ export function createApp(options: AppOptions) {
           await saveDocument(sid, path, doc, { overwrite: true })
           // The workspace record's funnel broadcasts the persisted bytes;
           // no per-document fan-out remains.
+        },
+        // One variation's content, read-only, at its tip — the projection
+        // GET /branches/:name/document serves. An empty tip names an
+        // uninitialized branch, whose content is the live document. Any
+        // failure to check the tip out answers null (a 404 upstream): this
+        // is a read, and an unreadable tip should refuse the preview, not
+        // report the store corrupt.
+        loadDocumentAtTip: async (sid, path, tipFrontiersBase64) => {
+          const project = (d: LoroDoc): VersionDocumentResponse =>
+            readDocumentKind(d) === 'markdown'
+              ? { kind: 'markdown', body: readMarkdownBody(d) }
+              : { kind: 'spatial', canvas: readSpatialCanvas(d) }
+          try {
+            if (tipFrontiersBase64 === '') {
+              return project(await getDoc(sid, path))
+            }
+            const targetFrontiers = decodeBranchTipOrThrow(
+              sid,
+              path,
+              'document-read',
+              tipFrontiersBase64,
+            )
+            const past = await projectDocumentAtWorkspaceFrontiers(sid, path, targetFrontiers)
+            if (past !== null) return project(past)
+            // Legacy per-document lineage: the tip names the live doc's own oplog.
+            const doc = await getDoc(sid, path)
+            const clone = checkoutCloneOrThrow(
+              doc,
+              targetFrontiers,
+              `${sid}/branches/${path}.json#document-read.tipFrontiers`,
+              'tipFrontiers could not be checked out against the live document',
+            )
+            return project(clone)
+          } catch {
+            return null
+          }
         },
         // Notify all peers when the HEAD switch is complete.
         notifyHeadChanged: (sid, path, head) => sendHeadChanged(sid, path, head),

--- a/packages/mcp-server/src/server/routes/branches.test.ts
+++ b/packages/mcp-server/src/server/routes/branches.test.ts
@@ -55,6 +55,11 @@ function makeApp(
     performMerge?: PerformMergeFn
     renameInVersions?: RenameInVersionsFn
     countVersionsOnBranch?: (sid: string, path: string, branch: string) => Promise<number>
+    loadDocumentAtTip?: (
+      sid: string,
+      path: string,
+      tip: string,
+    ) => Promise<import('../../shared/api-contracts/document.js').VersionDocumentResponse | null>
   } = {},
 ) {
   const app = new Hono()
@@ -1025,5 +1030,84 @@ describe('POST /api/workspaces/:sid/documents/:path/branches/:source/merge', () 
       body: JSON.stringify({ into: 'main' }),
     })
     expect(res.status).toBe(501)
+  })
+})
+
+describe('GET /api/workspaces/:sid/documents/:path/branches/:name/document', () => {
+  // The read that makes a variation ADDRESSABLE (ADR-0022's later increment):
+  // content at the branch tip, projected read-only, without moving HEAD.
+  const seed = async (app: Hono, name: string) => {
+    const res = await app.request('/api/workspaces/s1/documents/canvas-a/branches', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    })
+    expect(res.status).toBe(201)
+  }
+
+  it('projects the branch tip through the injected loadDocumentAtTip', async () => {
+    const calls: string[][] = []
+    const app = makeApp({
+      // A tip only exists once something recorded one; fromVersionId is the
+      // route-level way to mint a branch with a concrete tip.
+      resolveFromVersionFrontiers: async () => 'dGlwLWZyb250aWVycw==',
+      loadDocumentAtTip: async (sid, path, tip) => {
+        calls.push([sid, path, tip])
+        return { kind: 'markdown', body: '# at the tip' }
+      },
+    })
+    const created = await app.request('/api/workspaces/s1/documents/canvas-a/branches', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'idea', fromVersionId: 'v_0123456789abcdef' }),
+    })
+    expect(created.status).toBe(201)
+    const res = await app.request('/api/workspaces/s1/documents/canvas-a/branches/idea/document')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ kind: 'markdown', body: '# at the tip' })
+    expect(calls).toEqual([['s1', 'canvas-a', 'dGlwLWZyb250aWVycw==']])
+  })
+
+  it('passes an empty tip for an uninitialized branch (its content is the live document)', async () => {
+    const calls: string[] = []
+    const app = makeApp({
+      loadDocumentAtTip: async (_sid, _path, tip) => {
+        calls.push(tip)
+        return { kind: 'spatial', canvas: { nodes: [], edges: [] } }
+      },
+    })
+    await seed(app, 'fresh')
+    const res = await app.request('/api/workspaces/s1/documents/canvas-a/branches/fresh/document')
+    expect(res.status).toBe(200)
+    expect(calls).toEqual([''])
+  })
+
+  it('returns 404 for a branch that does not exist', async () => {
+    const app = makeApp({ loadDocumentAtTip: async () => ({ kind: 'markdown', body: '' }) })
+    const res = await app.request('/api/workspaces/s1/documents/canvas-a/branches/nope/document')
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 404 when the seam cannot check the tip out', async () => {
+    const app = makeApp({
+      loadDocumentAtTip: async () => null,
+    })
+    await seed(app, 'gone')
+    const res = await app.request('/api/workspaces/s1/documents/canvas-a/branches/gone/document')
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 501 when the deployment has no loadDocumentAtTip', async () => {
+    const app = makeApp()
+    await seed(app, 'idea')
+    const res = await app.request('/api/workspaces/s1/documents/canvas-a/branches/idea/document')
+    expect(res.status).toBe(501)
+  })
+
+  it('returns structured 400 for an invalid branch name', async () => {
+    const app = makeApp({ loadDocumentAtTip: async () => null })
+    const res = await app.request('/api/workspaces/s1/documents/canvas-a/branches/%20/document')
+    expect(res.status).toBe(400)
+    expect(apiErrorBodySchema.safeParse(await res.json()).success).toBe(true)
   })
 })

--- a/packages/mcp-server/src/server/routes/branches.ts
+++ b/packages/mcp-server/src/server/routes/branches.ts
@@ -12,6 +12,7 @@ import {
   type SetHeadResponse,
   setHeadRequestSchema,
 } from '../../shared/api-contracts/branches.js'
+import type { VersionDocumentResponse } from '../../shared/api-contracts/document.js'
 import type { ApiErrorBody } from '../../shared/api-contracts/errors.js'
 import type { PerformMergeHookResult } from '../store/branch-merge.js'
 import {
@@ -71,6 +72,15 @@ export interface CreateBranchesRouterOptions {
   // Count function used by DELETE /branches/:name to return actual unmergedCommits.
   // If omitted, the route falls back to 0.
   countVersionsOnBranch?: (workspaceId: string, path: string, branchName: string) => Promise<number>
+  // Project the document's content at a branch tip, read-only, for
+  // GET /branches/:name/document. An empty tipFrontiersBase64 names an
+  // uninitialized branch, whose content is the live document. null means the
+  // tip could not be checked out. Deployments without this hook return 501.
+  loadDocumentAtTip?: (
+    workspaceId: string,
+    path: string,
+    tipFrontiersBase64: string,
+  ) => Promise<VersionDocumentResponse | null>
 }
 
 // Helper that turns ValidationError into a structured 400 response.
@@ -113,6 +123,7 @@ export function createBranchesRouter(options: CreateBranchesRouterOptions = {}) 
   const notifyHeadChanged = options.notifyHeadChanged
   const performMerge = options.performMerge
   const renameInVersions = options.renameInVersions
+  const loadDocumentAtTip = options.loadDocumentAtTip
   const countVersionsOnBranch = options.countVersionsOnBranch
   const branchConflict = (message: string) => ({ error: 'branch_conflict', message })
   const branchNotFound = (message: string) => ({ error: 'branch_not_found', message })
@@ -392,6 +403,41 @@ export function createBranchesRouter(options: CreateBranchesRouterOptions = {}) 
   // ── GET /api/workspaces/:sid/documents/:path/branches/:name/stats ──
   // Pre-check endpoint for the delete confirmation dialog.
   // Returns actual unmergedCommits plus isHead.
+  // ── GET /api/workspaces/:sid/documents/:path/branches/:name/document ──
+  // One variation's CONTENT, read-only, without moving HEAD — the read that
+  // makes a non-default variation addressable (ADR-0022). Same response
+  // shape as GET /versions/:id/document: a viewer needs something to draw.
+  onDocumentsRoute(app, 'get', ['branches', ':name', 'document'], async (c, sid, path, params) => {
+    const name = params.name as string
+    const bn = validateBranchNameOrRespond(name)
+    if (bn) return c.json(bn.body, bn.status)
+    if (!loadDocumentAtTip) {
+      return c.json(
+        {
+          error: 'unsupported_branch_document',
+          message: 'branch document reads are not supported in this deployment',
+        },
+        501,
+      )
+    }
+    try {
+      const state = await loadDocumentBranches(sid, path)
+      const branch = state.branches.find((b) => b.name === name)
+      if (!branch) {
+        return c.json(branchNotFound(`Branch "${name}" not found on ${sid}/${path}`), 404)
+      }
+      const past = await loadDocumentAtTip(sid, path, branch.tipFrontiers)
+      if (past === null) {
+        return c.json(branchNotFound(`Branch "${name}" tip could not be read`), 404)
+      }
+      return c.json(past)
+    } catch (err) {
+      const corrupt = handleCorruption(err)
+      if (corrupt) return c.json(corrupt.body, corrupt.status)
+      throw err
+    }
+  })
+
   onDocumentsRoute(app, 'get', ['branches', ':name', 'stats'], async (c, sid, path, params) => {
     const name = params.name as string
     const bn = validateBranchNameOrRespond(name)


### PR DESCRIPTION
## What

ADR-0022's "later increment": a **non-default variation is now addressable** — `?v=<name>` on a daemon document's address opens a **read-only preview** of that variation's tip, without moving HEAD. Owner decision (2026-09-05): 読み込み専用プレビュー + マージへの導線, query-param grammar.

Decision 1 holds exactly as written — **the default is never decorated**:
- `?v=main` strips back to the plain address, even while HEAD is elsewhere (mutation-checked: the strip is by decision 1, not by a failed read — the test asserts `branches/main/document` was never requested).
- `?v=<current HEAD>` strips too: the plain address already means it, so there is still exactly one address for that page.

## How

- **daemon** — `GET .../branches/:name/document` projects the branch tip through the same read-only shape version previews use (`VersionDocumentResponse`, one Zod contract for both). Empty tip (uninitialized branch) = the live document; an unreadable tip answers 404, not 500 — a read should refuse the preview, not report the store corrupt. Wired in `app.ts` as the `loadDocumentAtTip` seam over `projectDocumentAtWorkspaceFrontiers`, with the legacy per-document-lineage fallback `checkoutTo` already has.
- **web** — `DaemonDocumentPage` reads `?v=`, draws the tip in `DocumentPreview` (read-only by construction) under a banner carrying the two ways forward: **Switch to this variation** (kept an explicit control — it is a shared act that moves every peer) and **Combine into «HEAD»** (existing `MergeDialog`). Unknown names fall back to the live document with a dismissible notice. Comment replies are gated while the preview is on screen, matching the version-preview rule.
- **chip** — each non-HEAD row gains an eye control that previews without switching (`stopPropagation`; a browser test asserts `setHead` was NOT called). Browser-kept documents are untouched: `BROWSER_CAPABILITIES.branches` is false.
- ADR-0022 carries a dated note recording the revisit; the rejected per-reader *editing* variation stays rejected — what shipped is a per-reader read-only *view*.

## Verification

- Red-first at every layer; both decision-1 strip clauses mutation-checked (each clause's removal fails exactly one test).
- **Real daemon E2E**: seeded a document, saved a version, edited on, branched from the version — `GET .../branches/idea2/document` answered `# version one` while the live document held `# version two (live)`; unknown branch → 404.
- Suites: `mcp-node` routes 511/511, page jsdom 13 files / 77 passed, `useBranches` 36/36, chip browser 22/22. Full `pnpm test:browser`: 1073/1075 — the 2 failures are the known local-only `shaped-node-editing` divergence (fails on clean main locally, CI green; untouched by this diff).
- Docs: variations have no user-doc page yet, so there is no home for a `?v=` paragraph; the contract record is ADR-0022's dated note.

## Visual repro

Before: the plain address reaches only the live HEAD. After: `?v=idea` shows the variation read-only with the switch/combine lead-ins (banner ringed).

Visual evidence: attached separately by the maintainer — `gh` 2.97 here has no `--attach`; the figure is `tmp/screenshots/variation-addressing-figure.png` (compose-figure digests: before 72255a35, after ae57ba9b), delivered via the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D
