### PR TITLE
feat(web): peek — look at a document on touch without opening it

### DIFF
--- a/apps/web/src/components/workspace-files/FolderContentsList.tsx
+++ b/apps/web/src/components/workspace-files/FolderContentsList.tsx
@@ -89,7 +89,10 @@ export function FolderContentsList({
   return (
     <ul
       {...longPress}
-      className={cn('grid grid-cols-[repeat(auto-fill,minmax(10rem,1fr))] gap-2 p-0.5', className)}
+      className={cn(
+        'grid grid-cols-[repeat(auto-fill,minmax(10rem,1fr))] gap-2 p-0.5 md:grid-cols-[repeat(auto-fill,minmax(13rem,1fr))]',
+        className,
+      )}
     >
       {folders.map((child) => (
         <li key={child.path}>

--- a/apps/web/src/components/workspace-files/PeekDialog.tsx
+++ b/apps/web/src/components/workspace-files/PeekDialog.tsx
@@ -1,0 +1,52 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { DocumentPreview } from './DocumentPreview.js'
+import type { WorkspaceDocumentEntry } from './document-entry.js'
+import type { DocumentRender } from './load-row-render.js'
+
+/**
+ * The peek: look at a document without committing to it.
+ *
+ * Exists only where a tap OPENS — there the preview pane does not render,
+ * so the card menu's Preview verb is the one way to see content before
+ * opening. Where the pane renders, selection already answers this and the
+ * verb is not offered.
+ *
+ * Deliberately just the existing DocumentPreview in a dialog, with only the
+ * Open handler wired: rename/duplicate/delete stay on the card menu that
+ * opened this, so the peek never grows a second set of object verbs.
+ */
+export function PeekDialog({
+  document,
+  loadRender,
+  onOpen,
+  onClose,
+}: {
+  /** The document being peeked at, or null when closed. */
+  readonly document: WorkspaceDocumentEntry | null
+  readonly loadRender: (document: WorkspaceDocumentEntry) => Promise<DocumentRender | null>
+  readonly onOpen: (document: WorkspaceDocumentEntry) => void
+  readonly onClose: () => void
+}) {
+  return (
+    <Dialog open={document !== null} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="flex max-h-[85vh] flex-col">
+        <DialogHeader>
+          <DialogTitle>
+            {document === null ? '' : (document.name ?? document.path.split('/').at(-1))}
+          </DialogTitle>
+        </DialogHeader>
+        {document !== null && (
+          <DocumentPreview
+            document={document}
+            loadRender={loadRender}
+            onOpen={(entry) => {
+              onClose()
+              onOpen(entry)
+            }}
+            className="min-h-0 flex-1"
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -3,6 +3,7 @@ import {
   Columns2,
   CopyPlus,
   ExternalLink,
+  Eye,
   List,
   Pencil,
   Pin,
@@ -27,6 +28,7 @@ import { createRowOutlineLoader } from './load-row-outline.js'
 import { createRowRenderLoader } from './load-row-render.js'
 import { NewDocumentMenu } from './NewDocumentMenu.js'
 import { newDocumentPathIn } from './new-document-path.js'
+import { PeekDialog } from './PeekDialog.js'
 import { RenameDocumentDialog } from './RenameDocumentDialog.js'
 import { SearchResults } from './SearchResults.js'
 import { searchDocuments, withNameMatches } from './search-documents.js'
@@ -191,6 +193,9 @@ export function WorkspaceFilesPanel({
     x: number
     y: number
   } | null>(null)
+  // The peek: a document being looked at without being opened. Only ever
+  // set where tapOpens (no preview pane); see PeekDialog.
+  const [peek, setPeek] = useState<WorkspaceDocumentEntry | null>(null)
   // The rename dialog's target, plus the in-flight/refusal state its form
   // shows. Null means closed.
   const [renaming, setRenaming] = useState<WorkspaceDocumentEntry | null>(null)
@@ -269,6 +274,7 @@ export function WorkspaceFilesPanel({
     // `setDocumentName` on the new workspace's store.
     setSelected(null)
     setCardMenu(null)
+    setPeek(null)
     setRenaming(null)
     setRenameError(null)
     setRenameBusy(false)
@@ -329,6 +335,9 @@ export function WorkspaceFilesPanel({
           const entry = entries.find((row) => row.path === current.entry.path)
           return entry === undefined ? null : { ...current, entry }
         })
+        setPeek((current) =>
+          current === null ? null : (entries.find((row) => row.path === current.path) ?? null),
+        )
       })
       .catch(() => undefined)
     return () => {
@@ -625,6 +634,15 @@ export function WorkspaceFilesPanel({
                   onSelect: () => onOpenDocument(cardMenu.entry.path),
                 },
               ]),
+          ...(tapOpens
+            ? [
+                {
+                  label: 'Preview',
+                  icon: <Eye />,
+                  onSelect: () => setPeek(cardMenu.entry),
+                },
+              ]
+            : []),
           ...(onDuplicateDocument === undefined
             ? []
             : [
@@ -945,6 +963,12 @@ export function WorkspaceFilesPanel({
           }}
         />
       )}
+      <PeekDialog
+        document={peek}
+        loadRender={loadRender}
+        onOpen={openEntry}
+        onClose={() => setPeek(null)}
+      />
       <RenameDocumentDialog
         document={renaming}
         workspace={workspace}

--- a/apps/web/src/components/workspace-files/peek.test.tsx
+++ b/apps/web/src/components/workspace-files/peek.test.tsx
@@ -98,3 +98,24 @@ describe('peek', () => {
     expect(within(menu).queryByRole('menuitem', { name: 'Preview' })).toBeNull()
   })
 })
+
+describe('peek follows the list', () => {
+  it('a document deleted behind the panel closes its peek instead of ghosting', async () => {
+    coarse = true
+    let rows: readonly (typeof entries)[number][] = entries
+    const source = fakeFilesSource({ listDocuments: () => Promise.resolve(rows) })
+    const { rerender } = render(
+      <WorkspaceFilesPanel source={source} onOpenDocument={vi.fn()} revision={0} />,
+    )
+
+    const menu = await openCardMenu()
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Preview' }))
+    await screen.findByRole('dialog', { name: /Meeting notes/ })
+
+    // The document vanishes elsewhere; `revision` is the panel's documented
+    // "changed behind this panel's back" signal.
+    rows = []
+    rerender(<WorkspaceFilesPanel source={source} onOpenDocument={vi.fn()} revision={1} />)
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: /Meeting notes/ })).toBeNull())
+  })
+})

--- a/apps/web/src/components/workspace-files/peek.test.tsx
+++ b/apps/web/src/components/workspace-files/peek.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
+import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
+
+// The peek (slice 3 of the 2026-09-05 picker redesign): with a tap opening
+// the document and no preview column, a touch user had no way to LOOK at a
+// document without committing to it. The object menu gains a Preview verb —
+// only where the pane is absent, because where it renders, selection
+// already answers the same question.
+
+afterEach(cleanup)
+
+const entries = [
+  { documentId: 'd1', path: 'meeting-notes', name: 'Meeting notes', kind: 'markdown' as const },
+]
+
+const realMatchMedia = window.matchMedia
+let coarse = false
+const stubMql = (matches: boolean, media: string) =>
+  ({
+    matches,
+    media,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }) as unknown as MediaQueryList
+beforeEach(() => {
+  coarse = false
+  window.matchMedia = (query: string) =>
+    query === '(pointer: coarse)'
+      ? stubMql(coarse, query)
+      : realMatchMedia
+        ? realMatchMedia.call(window, query)
+        : stubMql(false, query)
+})
+afterEach(() => {
+  window.matchMedia = realMatchMedia
+})
+
+function renderPanel(onOpenDocument = vi.fn()) {
+  const source = fakeFilesSource({ listDocuments: () => Promise.resolve(entries) })
+  render(<WorkspaceFilesPanel source={source} onOpenDocument={onOpenDocument} />)
+  return onOpenDocument
+}
+
+async function openCardMenu() {
+  await waitFor(() => {
+    expect(screen.getAllByTestId('card-title').length).toBeGreaterThan(0)
+  })
+  const card = screen.getAllByTestId('card-title')[0]?.closest('button') as HTMLElement
+  fireEvent.contextMenu(card, { clientX: 40, clientY: 40 })
+  return screen.findByRole('menu', { name: 'Document actions' })
+}
+
+describe('peek', () => {
+  it('coarse: the menu offers Preview, and it shows the document without opening it', async () => {
+    coarse = true
+    const onOpenDocument = renderPanel()
+
+    const menu = await openCardMenu()
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Preview' }))
+
+    const dialog = await screen.findByRole('dialog', { name: /Meeting notes/ })
+    expect(within(dialog).getByTestId('okf-preview')).toBeTruthy()
+    expect(onOpenDocument).not.toHaveBeenCalled()
+  })
+
+  it('coarse: Open from the peek opens the document and closes the peek', async () => {
+    coarse = true
+    const onOpenDocument = renderPanel()
+
+    const menu = await openCardMenu()
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Preview' }))
+    const dialog = await screen.findByRole('dialog', { name: /Meeting notes/ })
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Open' }))
+    expect(onOpenDocument).toHaveBeenCalledWith('meeting-notes')
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: /Meeting notes/ })).toBeNull())
+  })
+
+  it('coarse: Escape closes the peek without opening', async () => {
+    coarse = true
+    const onOpenDocument = renderPanel()
+
+    const menu = await openCardMenu()
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Preview' }))
+    const dialog = await screen.findByRole('dialog', { name: /Meeting notes/ })
+
+    fireEvent.keyDown(dialog, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: /Meeting notes/ })).toBeNull())
+    expect(onOpenDocument).not.toHaveBeenCalled()
+  })
+
+  it('fine pointer: no Preview verb — the pane beside the list already answers it', async () => {
+    renderPanel()
+    const menu = await openCardMenu()
+    expect(within(menu).queryByRole('menuitem', { name: 'Preview' })).toBeNull()
+  })
+})

--- a/apps/web/src/scoped-screen-state.test.ts
+++ b/apps/web/src/scoped-screen-state.test.ts
@@ -87,6 +87,7 @@ const PANEL_STATE: Record<string, ScopeCoverage> = {
   documents: 'cleared on switch',
   selected: 'cleared on switch',
   cardMenu: 'cleared on switch',
+  peek: 'cleared on switch',
   renaming: 'cleared on switch',
   renameError: 'cleared on switch',
   renameBusy: 'cleared on switch',


### PR DESCRIPTION
## Summary

Slice 3, closing the picker redesign initiative (owner decisions 2026-09-05). Slice 1 (#1304) made a tap open; that removed the preview column on touch — leaving a touch user **no way to look at a document without committing to it**. This adds the peek:

- The object menu (long-press sheet / right-click) gains a **Preview** verb — offered only where a tap opens, because where the preview pane renders, selection already answers the same question and the verb would be a second spelling of it.
- Preview opens the existing `DocumentPreview` in a dialog with **only Open wired**: rename/duplicate/delete stay on the menu that opened it, so the peek never grows a second set of object verbs. Escape/backdrop dismisses; Open closes the peek and opens the document.
- Peek state resets on a workspace switch (same SCOPE RESET contract as the card menu) and re-resolves on `revision`, so a document deleted behind the panel's back closes its peek instead of ghosting.
- The card grid's column floor grows to 13rem at `md+`, finishing slice 2's thumbnail growth where the screen has room.

Recently-opened lane and non-verbal recency encoding stay deliberately deferred (recorded in the initiative issue): the first needs a data-model decision, the second user testing before a ring/dot is trusted as self-explanatory.

## Visual repro

![the long-press sheet with the new Preview (eye) verb / the peek: rendered content, metadata, one Open button](tmp/screenshots/peek-figure.png)

Composed by `compose-figure.mjs` (digests `9f55ad53` / `20eda2f9`); gh 2.97 has no `--attach`, so the PNG goes to the session owner for attachment as before. What the figure cannot show: Escape/backdrop dismissal and the workspace-switch reset — those are pinned by the jsdom tests below.

## Test plan

- [x] Red-first `peek.test.tsx` (4 cases): coarse menu offers Preview and it shows the document without opening; Open from the peek opens and closes it; Escape closes without opening; fine pointer gets no Preview verb.
- [x] Touched-area suites: `web-jsdom` `workspace-files` + `pages` — 653 passed (the 1 failure is `BrowserDocumentPage.markdown-orphan` from today's #1313, passes in isolation — the known load-dependent family, my diff cannot reach it); typecheck + biome clean.
- [x] Manual verification completed against the real preview deployment (`https://picker-peek.kamiazya-whiteboard.pages.dev`), Playwright driver extended with peek checks — 16/16 passed: all slice-1/2 flows unregressed; the sheet lists `["Open","Preview","Rename…","Delete"]`; Preview shows the peek WITHOUT navigating; Open from the peek navigates; the desktop right-click menu correctly lists no Preview (`Open,Rename…,Delete`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLiRSAKQA8rRW7j6XBJhAE

