### PR TITLE
refactor(web): extract the duplicated version-save race guard into useVersionSaveFlow

### DIFF
--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -34,10 +34,7 @@ import {
   BROWSER_HISTORY_CAPABILITIES,
   type VersionPreviewSession,
 } from '../components/VersionTimeline'
-import {
-  BookmarkAction,
-  type SaveVersionOutcome,
-} from '../components/workspace-top-bar/BookmarkAction.js'
+import { BookmarkAction } from '../components/workspace-top-bar/BookmarkAction.js'
 import { DocumentMenu } from '../components/workspace-top-bar/DocumentMenu.js'
 import { sanitizeExportFilenameBase } from '../components/workspace-top-bar/export-filename.js'
 import { useBookmarkShortcut } from '../components/workspace-top-bar/useBookmarkShortcut.js'
@@ -89,6 +86,7 @@ import {
   useBrowserDocumentController,
 } from './use-browser-document-controller.js'
 import { useMarkdownDocument } from './use-markdown-document.js'
+import { useVersionSaveFlow } from './use-version-save-flow.js'
 
 // WorkspaceTopBar statically imports Radix, lucide, HeaderSaveDot,
 // VersionTimeline, HeaderBranchChip, and the Zod-validated
@@ -311,7 +309,7 @@ export function BrowserDocumentPage({
     setConfirmDelete(false)
     setDuplicateError(null)
     setIsDuplicating(false)
-    setSaveVersionOutcome(null)
+    clearSaveVersionOutcome()
     setHistoryOpen(false)
     setBookmarkArmed(0)
     setPreview(null)
@@ -624,28 +622,34 @@ export function BrowserDocumentPage({
   // dot is small, so the panel a finger opens has to carry one too — the
   // daemon page's panel does. Announced on the window like every other
   // save, which is what clears the dot and refreshes the list.
-  const [savingVersion, setSavingVersion] = useState(false)
-  const [saveVersionOutcome, setSaveVersionOutcome] = useState<SaveVersionOutcome>(null)
-  const saveVersionFromPanel = async (label: string): Promise<void> => {
-    if (versionsBackend === null || documentPath === null || savingVersion) return
-    // The document this run is about, fixed before the first await. The page
-    // switches documents without remounting, so a save that started on A can
-    // settle after B is on screen — and the scope-reset effect has already
-    // cleared the outcome by then, so the message would appear under B as if
-    // B had been saved. Same residual `handleDuplicate` guards against.
-    const startedOn = currentDocumentIdRef.current
-    setSavingVersion(true)
-    setSaveVersionOutcome(null)
+  const {
+    saving: savingVersion,
+    outcome: saveVersionOutcome,
+    run: runVersionSave,
+    clearOutcome: clearSaveVersionOutcome,
+  } = useVersionSaveFlow(currentDocumentIdRef, async (label) => {
+    // Narrowed by the precondition in `saveVersionFromPanel` below, which
+    // never calls `run` (so never reaches this body) while either is null.
+    if (versionsBackend === null || documentPath === null) {
+      throw new Error('saveVersionFromPanel: no versions backend or document path')
+    }
+    // Captured BEFORE the save, not after. `exportScene` reads the live
+    // scene synchronously at call time, so starting it here binds the
+    // picture to the state the save is about to mark. Awaiting the save
+    // first meant an edit made during it was drawn onto the older point —
+    // a picture of content that version does not contain.
+    const picture = exportScene('png')
+    let saved: Awaited<ReturnType<typeof versionsBackend.save>>
     try {
-      // Captured BEFORE the save, not after. `exportScene` reads the live
-      // scene synchronously at call time, so starting it here binds the
-      // picture to the state the save is about to mark. Awaiting the save
-      // first meant an edit made during it was drawn onto the older point —
-      // a picture of content that version does not contain.
-      const picture = exportScene('png')
-      const saved = await versionsBackend.save(getBrowserWorkspaceId(), documentPath, { label })
-      if (currentDocumentIdRef.current !== startedOn) return
-      setSaveVersionOutcome('saved')
+      saved = await versionsBackend.save(getBrowserWorkspaceId(), documentPath, { label })
+    } catch (err) {
+      log.warn('save version from the History panel failed', err)
+      throw err
+    }
+    // The rest is the post-save announce work — thumbnail attach, the
+    // event that clears the dot and refreshes the History panel — run only
+    // once the guard has confirmed this save's document is still on screen.
+    return () => {
       // The picture rides with the bookmark, as it does on the daemon page —
       // one path through the seam, so a browser-kept row is not the one that
       // silently has no picture. Not awaited: the bookmark has landed, and
@@ -678,13 +682,11 @@ export function BrowserDocumentPage({
           detail: { workspaceId: 'local', path: documentPath },
         }),
       )
-    } catch (err) {
-      log.warn('save version from the History panel failed', err)
-      if (currentDocumentIdRef.current !== startedOn) return
-      setSaveVersionOutcome('failed')
-    } finally {
-      if (currentDocumentIdRef.current === startedOn) setSavingVersion(false)
     }
+  })
+  const saveVersionFromPanel = async (label: string): Promise<void> => {
+    if (versionsBackend === null || documentPath === null) return
+    await runVersionSave(label)
   }
 
   // The second phase of the page state. `pageState` above is derived from what

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -32,10 +32,7 @@ import {
   type VersionPreviewSession,
 } from '../components/VersionTimeline'
 import WorkspaceTopBar from '../components/WorkspaceTopBar.js'
-import {
-  BookmarkAction,
-  type SaveVersionOutcome,
-} from '../components/workspace-top-bar/BookmarkAction.js'
+import { BookmarkAction } from '../components/workspace-top-bar/BookmarkAction.js'
 import { DocumentMenu } from '../components/workspace-top-bar/DocumentMenu.js'
 import { sanitizeExportFilenameBase } from '../components/workspace-top-bar/export-filename.js'
 import { useBookmarkShortcut } from '../components/workspace-top-bar/useBookmarkShortcut.js'
@@ -82,6 +79,7 @@ import { applyViewportRequest } from '../lib/viewport-request.js'
 import { useBrowserToolRegistry } from '../lib/webmcp/use-browser-tool-registry.js'
 import { deriveDaemonPageState } from './daemon-page-state.js'
 import { useDaemonDocumentController } from './use-daemon-document-controller.js'
+import { useVersionSaveFlow } from './use-version-save-flow.js'
 
 const log = getAppLogger('daemon-document-page')
 
@@ -206,9 +204,6 @@ export function DaemonDocumentPage({
     setHistoryOpen(true)
     setBookmarkArmed((n) => n + 1)
   })
-
-  const [savingVersion, setSavingVersion] = useState(false)
-  const [saveVersionOutcome, setSaveVersionOutcome] = useState<SaveVersionOutcome>(null)
 
   // Every listed document is tree-served and syncs at workspace-document
   // granularity; the id is what binds this session's content inside the
@@ -668,37 +663,40 @@ export function DaemonDocumentPage({
     }
   }
 
-  const saveVersion = async (label: string): Promise<void> => {
-    if (canvas === null || savingVersion) return
-    // The document this run is about, fixed before the first await — a save
-    // that started on A must not report itself under B. The scope-reset has
-    // already cleared the outcome by then, so the message would read as B's.
-    const startedOn = canvas.path
-    setSavingVersion(true)
-    setSaveVersionOutcome(null)
+  const {
+    saving: savingVersion,
+    outcome: saveVersionOutcome,
+    run: runVersionSave,
+  } = useVersionSaveFlow(currentDocumentPathRef, async (label) => {
+    // Narrowed by the precondition in `saveVersion` below, which never
+    // calls `run` (so never reaches this body) while canvas is null.
+    if (canvas === null) {
+      throw new Error('saveVersion: no canvas')
+    }
     // Captured BEFORE the POST, not after. `exportScene` reads the live scene
     // synchronously at call time, so starting it here binds the picture to the
     // state this save is about to mark. Awaiting the response first meant an
     // edit made during it was drawn onto the older point — a picture of
     // content that version does not contain.
     const picture = getThumbnailBlob()
-    try {
-      const res = await daemonFetch(
-        `${daemonBaseUrl}${documentsApiUrl(canvas.workspaceId, canvas.path, 'versions')}`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ label }),
-        },
-      )
-      if (!res.ok) throw new Error(`save failed: ${res.status}`)
-      const parsed = saveVersionResponseSchema.safeParse(await res.json().catch(() => null))
-      if (!parsed.success) {
-        log.error('POST /versions response did not match saveVersionResponseSchema:', parsed.error)
-        throw new Error('save response did not match schema')
-      }
-      if (currentDocumentPathRef.current !== startedOn) return
-      setSaveVersionOutcome('saved')
+    const res = await daemonFetch(
+      `${daemonBaseUrl}${documentsApiUrl(canvas.workspaceId, canvas.path, 'versions')}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label }),
+      },
+    )
+    if (!res.ok) throw new Error(`save failed: ${res.status}`)
+    const parsed = saveVersionResponseSchema.safeParse(await res.json().catch(() => null))
+    if (!parsed.success) {
+      log.error('POST /versions response did not match saveVersionResponseSchema:', parsed.error)
+      throw new Error('save response did not match schema')
+    }
+    // The rest is the post-save announce work — refresh signals, thumbnail
+    // attach, the identity event — run only once the guard has confirmed
+    // this save's document is still the one on screen.
+    return () => {
       setVersionRefreshSignal((n) => n + 1)
       // The thumbnail rides with the bookmark, as it did when the top bar
       // owned the save. It moved here with the save itself: the bar no
@@ -727,12 +725,11 @@ export function DaemonDocumentPage({
       // identity-scoped event useDocumentSync fires on a broadcast — otherwise
       // HeaderSaveDot never learns this save happened and stays dirty.
       dispatchIdentityEvent('whiteboard:wb_version_saved', canvas ?? undefined)
-    } catch {
-      if (currentDocumentPathRef.current !== startedOn) return
-      setSaveVersionOutcome('failed')
-    } finally {
-      if (currentDocumentPathRef.current === startedOn) setSavingVersion(false)
     }
+  })
+  const saveVersion = async (label: string): Promise<void> => {
+    if (canvas === null) return
+    await runVersionSave(label)
   }
 
   // The page-level render state, derived once (see daemon-page-state.ts for

--- a/apps/web/src/pages/use-version-save-flow.test.ts
+++ b/apps/web/src/pages/use-version-save-flow.test.ts
@@ -1,0 +1,218 @@
+/**
+ * The race-guard seam both document pages duplicated: `run` no-ops while
+ * saving, captures the scope before the save's own await, and bails on
+ * outcome/commit/finally alike once the scope has moved on. Written before
+ * the extraction (the use-tool-state.test.ts pattern) so it is red against
+ * the pages' own inline logic having no shared hook to call.
+ */
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useVersionSaveFlow } from './use-version-save-flow.js'
+
+/**
+ * React defers a `setState` call's effect on rendered output until after
+ * the current synchronous stretch of work — automatic batching means
+ * `result.current` still reads the PRE-update value at the exact moment a
+ * same-tick statement runs `setOutcome('saved')` and calls `commit()` right
+ * after it, in either order. So the only way to pin which one the hook
+ * actually calls FIRST is to watch the call to the setter itself, not its
+ * rendered effect — this wraps `useState` to record the moment
+ * `setOutcome('saved')` is invoked, in the same shared array `commit`
+ * pushes into.
+ */
+const { order } = vi.hoisted(() => ({ order: [] as string[] }))
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>()
+  return {
+    ...actual,
+    useState: <S>(initial: S | (() => S)) => {
+      const [value, setValue] = actual.useState(initial)
+      const trackedSetValue = (next: S | ((prev: S) => S)): void => {
+        if (next === ('saved' as unknown as S)) order.push('setOutcome(saved)')
+        setValue(next)
+      }
+      return [value, trackedSetValue] as const
+    },
+  }
+})
+
+/** A scope ref the test can mutate directly, the way a page's own ref does. */
+function scope(initial: string): { current: string } {
+  return { current: initial }
+}
+
+describe('useVersionSaveFlow', () => {
+  it('applies the saved outcome before the commit thunk runs, and runs it once', async () => {
+    order.length = 0
+    const scopeRef = scope('doc-a')
+    let resolveSave!: (commit: () => void) => void
+    const save = vi.fn(
+      () =>
+        new Promise<() => void>((resolve) => {
+          resolveSave = resolve
+        }),
+    )
+    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, save))
+
+    let runPromise!: Promise<void>
+    act(() => {
+      runPromise = result.current.run('a bookmark')
+    })
+    expect(result.current.saving).toBe(true)
+
+    const commit = vi.fn(() => {
+      order.push('commit')
+    })
+    await act(async () => {
+      resolveSave(commit)
+      await runPromise
+    })
+
+    expect(save).toHaveBeenCalledWith('a bookmark')
+    expect(commit).toHaveBeenCalledTimes(1)
+    expect(order).toEqual(['setOutcome(saved)', 'commit'])
+    expect(result.current.outcome).toBe('saved')
+    expect(result.current.saving).toBe(false)
+  })
+
+  it('sets outcome failed and does not commit when save rejects', async () => {
+    const scopeRef = scope('doc-a')
+    const commit = vi.fn()
+    const save = vi.fn((): Promise<() => void> => Promise.reject(new Error('boom')))
+    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, save))
+
+    await act(async () => {
+      await result.current.run('a bookmark').catch(() => undefined)
+    })
+
+    expect(commit).not.toHaveBeenCalled()
+    expect(result.current.outcome).toBe('failed')
+    expect(result.current.saving).toBe(false)
+  })
+
+  it('is a no-op re-entry while a save is already in flight', async () => {
+    const scopeRef = scope('doc-a')
+    let resolveSave!: (commit: () => void) => void
+    const save = vi.fn(
+      () =>
+        new Promise<() => void>((resolve) => {
+          resolveSave = resolve
+        }),
+    )
+    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, save))
+
+    let firstRun!: Promise<void>
+    act(() => {
+      firstRun = result.current.run('first')
+    })
+    await act(async () => {
+      await result.current.run('second')
+    })
+
+    expect(save).toHaveBeenCalledTimes(1)
+    expect(save).toHaveBeenCalledWith('first')
+
+    await act(async () => {
+      resolveSave(vi.fn())
+      await firstRun
+    })
+  })
+
+  it('clears a prior outcome to null at the start of a new run', async () => {
+    const scopeRef = scope('doc-a')
+    const save = vi.fn((): Promise<() => void> => Promise.reject(new Error('boom')))
+    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, save))
+
+    await act(async () => {
+      await result.current.run('first').catch(() => undefined)
+    })
+    expect(result.current.outcome).toBe('failed')
+
+    let resolveSecondSave!: (commit: () => void) => void
+    save.mockImplementationOnce(
+      () =>
+        new Promise<() => void>((resolve) => {
+          resolveSecondSave = resolve
+        }),
+    )
+    act(() => {
+      void result.current.run('second')
+    })
+    expect(result.current.outcome).toBe(null)
+
+    await act(async () => {
+      resolveSecondSave(vi.fn())
+    })
+  })
+
+  it('bails on success when the scope switched during the save: outcome stays null, commit is skipped, saving stays true', async () => {
+    const scopeRef = scope('doc-a')
+    let resolveSave!: (commit: () => void) => void
+    const save = vi.fn(
+      () =>
+        new Promise<() => void>((resolve) => {
+          resolveSave = resolve
+        }),
+    )
+    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, save))
+
+    let runPromise!: Promise<void>
+    act(() => {
+      runPromise = result.current.run('a bookmark')
+    })
+
+    const commit = vi.fn()
+    await act(async () => {
+      scopeRef.current = 'doc-b'
+      resolveSave(commit)
+      await runPromise
+    })
+
+    expect(commit).not.toHaveBeenCalled()
+    expect(result.current.outcome).toBe(null)
+    // Verbatim current finally semantics: a bail skips the clear too.
+    expect(result.current.saving).toBe(true)
+  })
+
+  it('bails on failure when the scope switched during the save: outcome stays null, saving stays true', async () => {
+    const scopeRef = scope('doc-a')
+    let rejectSave!: (err: unknown) => void
+    const save = vi.fn(
+      () =>
+        new Promise<() => void>((_resolve, reject) => {
+          rejectSave = reject
+        }),
+    )
+    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, save))
+
+    let runPromise!: Promise<void>
+    act(() => {
+      runPromise = result.current.run('a bookmark')
+    })
+
+    await act(async () => {
+      scopeRef.current = 'doc-b'
+      rejectSave(new Error('boom'))
+      await runPromise
+    })
+
+    expect(result.current.outcome).toBe(null)
+    expect(result.current.saving).toBe(true)
+  })
+
+  it('clearOutcome resets outcome to null', async () => {
+    const scopeRef = scope('doc-a')
+    const save = vi.fn((): Promise<() => void> => Promise.reject(new Error('boom')))
+    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, save))
+
+    await act(async () => {
+      await result.current.run('first').catch(() => undefined)
+    })
+    expect(result.current.outcome).toBe('failed')
+
+    act(() => {
+      result.current.clearOutcome()
+    })
+    expect(result.current.outcome).toBe(null)
+  })
+})

--- a/apps/web/src/pages/use-version-save-flow.ts
+++ b/apps/web/src/pages/use-version-save-flow.ts
@@ -1,0 +1,76 @@
+/**
+ * The save-a-version race guard, shared by the browser and daemon document
+ * pages (previously duplicated between them, guard-for-guard).
+ *
+ * A document page keeps its own document switching rather than remounting
+ * (App.tsx says so at the mount site), so a save that started on one
+ * document can settle after another is already on screen. `scopeRef` names
+ * whatever the page's document identity currently is —
+ * `currentDocumentIdRef` on the browser page, `currentDocumentPathRef` on
+ * the daemon page — read fresh on every settle rather than captured once,
+ * because the page's own effect keeps it current across the switch this
+ * guard is defending against.
+ *
+ * `save` performs the actual write and resolves to a COMMIT THUNK: the
+ * post-save announce work (thumbnail attach, event dispatch) that must run
+ * only while the save's own document is still the one on screen. Returning
+ * it instead of running it inline is what keeps the outcome applied before
+ * that work runs, and skipped along with it after a switch — flattening the
+ * contract into a plain `Promise<void>` loses both.
+ */
+
+import type { RefObject } from 'react'
+import { useCallback, useState } from 'react'
+import type { SaveVersionOutcome } from '../components/workspace-top-bar/BookmarkAction.js'
+
+export interface VersionSaveFlow {
+  readonly saving: boolean
+  readonly outcome: SaveVersionOutcome
+  readonly run: (label: string) => Promise<void>
+  readonly clearOutcome: () => void
+}
+
+export function useVersionSaveFlow<Scope>(
+  scopeRef: RefObject<Scope>,
+  save: (label: string) => Promise<() => void>,
+): VersionSaveFlow {
+  // Names kept as `savingVersion`/`saveVersionOutcome` (not the shorter
+  // `saving`/`outcome`) because scoped-screen-state.test.ts's source scan
+  // keys its BrowserDocumentPage ledger on these identifiers — renaming
+  // them here would silently stop the scan from finding the state it moved.
+  const [savingVersion, setSavingVersion] = useState(false)
+  const [saveVersionOutcome, setSaveVersionOutcome] = useState<SaveVersionOutcome>(null)
+
+  const run = useCallback(
+    async (label: string): Promise<void> => {
+      if (savingVersion) return
+      // The document this run is about, fixed before the first await. A
+      // switch mid-save must not report itself under the arrived document.
+      const startedOn = scopeRef.current
+      setSavingVersion(true)
+      setSaveVersionOutcome(null)
+      try {
+        const commit = await save(label)
+        if (scopeRef.current !== startedOn) return
+        setSaveVersionOutcome('saved')
+        commit()
+      } catch {
+        if (scopeRef.current !== startedOn) return
+        setSaveVersionOutcome('failed')
+      } finally {
+        // Verbatim: after a genuine switch mid-save, `saving` stays true —
+        // this bail is intentional, not an oversight to "fix" in passing.
+        if (scopeRef.current === startedOn) setSavingVersion(false)
+      }
+    },
+    [savingVersion, save, scopeRef],
+  )
+
+  // SCOPE RESET — the page's own scope-reset effect calls this; the marker
+  // lets scoped-screen-state.test.ts verify the setter from here.
+  const clearOutcome = useCallback(() => {
+    setSaveVersionOutcome(null)
+  }, [])
+
+  return { saving: savingVersion, outcome: saveVersionOutcome, run, clearOutcome }
+}

--- a/apps/web/src/scoped-screen-state.test.ts
+++ b/apps/web/src/scoped-screen-state.test.ts
@@ -50,6 +50,7 @@ const sources = import.meta.glob(
     './components/VersionTimeline.tsx',
     './pages/use-markdown-document.ts',
     './pages/BrowserDocumentPage.tsx',
+    './pages/use-version-save-flow.ts',
   ],
   { query: '?raw', import: 'default', eager: true },
 ) as Record<string, string>
@@ -82,6 +83,10 @@ const BRANCH_CHIP = './components/HeaderBranchChip.tsx'
 const VERSION_TIMELINE = './components/VersionTimeline.tsx'
 const MARKDOWN_DOCUMENT = './pages/use-markdown-document.ts'
 const BROWSER_DOCUMENT_PAGE = './pages/BrowserDocumentPage.tsx'
+// The save-a-version guard extracted to its own hook: part of the same
+// SCREEN by the same rule the panel's search/columns hooks are — its state
+// moved there, not away.
+const VERSION_SAVE_FLOW_HOOK = './pages/use-version-save-flow.ts'
 
 const PANEL_STATE: Record<string, ScopeCoverage> = {
   documents: 'cleared on switch',
@@ -373,7 +378,7 @@ const CASES = [
     scanRefs: true,
   },
   {
-    files: [BROWSER_DOCUMENT_PAGE],
+    files: [BROWSER_DOCUMENT_PAGE, VERSION_SAVE_FLOW_HOOK],
     ledger: BROWSER_DOCUMENT_PAGE_STATE,
     label: 'BrowserDocumentPage',
     scanRefs: true,


### PR DESCRIPTION
Audit follow-up (`issues/version-save-flow-duplicated`, MEDIUM — the last of the four): BrowserDocumentPage and DaemonDocumentPage each held the identical `savingVersion`/`saveVersionOutcome` state pair guarding the same captured-before-await, bail-if-document-switched race, cross-referencing each other by hand-written comments. A race-guard fix in one was never guaranteed to reach the other.

## What lands
- `use-version-save-flow.ts` (pages/, per the sibling shared-page-hook pattern): the guard moved VERBATIM in logic — capture scope before any await, bail on switch (incl. `saving` staying true after a switch-mid-save, the current finally semantics), outcome `'saved'` set BEFORE the commit thunk runs, `clearOutcome` carrying the `// SCOPE RESET` marker so `scoped-screen-state.test.ts`'s marker-block scan keeps seeing the reset (its files array gains the hook, both ledger entries kept accurate).
- Both pages consume it with their backend-specific save bodies; **zero duplicated guard/state lines remain** (grep in the PR's implementation report: every hit is the hook call site or a BookmarkAction prop pass-through).
- Seven hook-seam tests, written red-first (`Failed to resolve import` before the hook existed), **two mutation checks quoted from real runs**: startedOn comparison deleted → both bail cases red; commit reordered before setOutcome → the ordering case red (`expected [ 'commit', 'setOutcome(saved)' ] to deeply equal [ 'setOutcome(saved)', 'commit' ]`). Methodology note: React 18 batching makes the rendered outcome unobservable at thunk time — the test records the setter CALL order via a react useState interception, after flushSync/nested-act/microtask reads were each tried and failed to discriminate.
- One flagged improvement (in the commit body, not hidden): a synchronous `getThumbnailBlob()` throw on the daemon page now resolves to `'failed'` with `saving` cleared, where the old code stranded `savingVersion: true` forever; no existing test pinned the stranding.

## Gates
Targeted jsdom 112 + 41 (post-main-merge re-verification incl. #1318's new files), browser versions suite 2/2, file-size-budget 4/4 (both pages stay grandfathered), typecheck/lint/knip clean; origin/main merged twice during the work (clean both times). No existing test weakened.

Visual evidence: none — behavior-preserving extraction with zero UI change; the evidence is the un-weakened page suites plus the mutation-checked hook-seam tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7iuGxJAXjr6rEXfS7YAC6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version-saving behavior when switching documents during a save, preventing stale results from being applied.
  * Standardized save-state handling across browser and daemon document pages.
  * Improved resetting of save outcomes when changing document context.

* **Tests**
  * Added comprehensive coverage for successful saves, failures, repeated save attempts, outcome resets, and document changes during saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->