### PR TITLE
feat(lint): catch the two ways a test file quietly stops running

### DIFF
--- a/.claude/scripts/biome-plugin.test.mjs
+++ b/.claude/scripts/biome-plugin.test.mjs
@@ -34,19 +34,20 @@ function lint(file, plugin = 'tools/biome-plugins/test-flake-shapes.grit') {
   }
 }
 
-test('the bad fixture trips ALL FOUR rules', () => {
+test('the bad fixture trips ALL FIVE rules', () => {
   const out = lint(join(FIXTURES, 'bad.test.tsx'))
   assert.match(out, /Side effect inside waitFor/)
   assert.match(out, /afterEach wipes document\.body/)
   assert.match(out, /Non-ASCII character in a userEvent/)
   assert.match(out, /vi\.useFakeTimers\(\) with no vi\.useRealTimers\(\)/)
+  assert.match(out, /A focused test drops every other test/)
 })
 
 test('the good fixture trips none of the four rules', () => {
   const out = lint(join(FIXTURES, 'good.test.tsx'))
   assert.doesNotMatch(
     out,
-    /Side effect inside waitFor|afterEach wipes|Non-ASCII character in a userEvent|vi\.useFakeTimers\(\) with no vi\.useRealTimers\(\)/,
+    /Side effect inside waitFor|afterEach wipes|Non-ASCII character in a userEvent|vi\.useFakeTimers\(\) with no vi\.useRealTimers\(\)|A focused test drops every other test/,
   )
 })
 

--- a/.claude/scripts/fixtures/biome-plugin/bad.test.tsx
+++ b/.claude/scripts/fixtures/biome-plugin/bad.test.tsx
@@ -19,3 +19,8 @@ export async function badKeystrokes() {
 export function badTimers() {
   vi.useFakeTimers()
 }
+
+// biome-ignore lint/suspicious/noExportsInTest: fixture, never executed
+export const badFocus = () => {
+  it.only('focused, so the rest of this file never runs', () => {})
+}

--- a/.claude/scripts/fixtures/biome-plugin/good.test.tsx
+++ b/.claude/scripts/fixtures/biome-plugin/good.test.tsx
@@ -21,3 +21,9 @@ export async function goodKeystrokes() {
 export function goodTimers() {
   vi.useFakeTimers()
 }
+
+import { it } from "vitest"
+
+export const goodFocus = () => {
+  it('plain, so every sibling still runs', () => {})
+}

--- a/.claude/scripts/lib/quarantine.mjs
+++ b/.claude/scripts/lib/quarantine.mjs
@@ -1,6 +1,8 @@
 // Quarantine ledger over test files: parse `QUARANTINE(...)` markers and
 // judge them against Fowler's bounded-quarantine rule (cap + age), so a
-// parked flaky test cannot silently become a permanent skip.
+// parked flaky test cannot silently become a permanent skip — and find the
+// skips that carry no marker at all, which the cap and the age limit cannot
+// see because both judge what declared itself.
 // Marker grammar, one line, directly above the skipped test:
 //   // QUARANTINE(<YYYY-MM-DD> <issue-ref>): <reason>
 // <issue-ref> names the whiteboard issue (e.g. wb:issues/foo) per the
@@ -13,6 +15,11 @@ const QUARANTINE_CAP = 8
 const QUARANTINE_MAX_AGE_DAYS = 14
 
 const MARKER = /^\s*\/\/\s*QUARANTINE\(([^)]*)\):\s*(.*)$/
+
+// `\b` after `skip` is what keeps `skipIf` out: a test whose PREMISE this
+// environment cannot establish should skip and say so (AGENTS.md asks for it
+// probed rather than inferred), and that is not a park.
+const SKIP = /\b(?:it|test|describe)\.skip\b/
 
 export function parseQuarantineMarkers(source, file) {
   const markers = []
@@ -27,6 +34,25 @@ export function parseQuarantineMarkers(source, file) {
     markers.push({ file, line: i + 1, date, issue, reason: m[2].trim() })
   }
   return markers
+}
+
+/**
+ * Skips with no marker above them.
+ *
+ * The cap and the age limit judge what DECLARED itself, so before this an
+ * undeclared skip was outside the whole mechanism — never counted, never
+ * aged out. The cheapest way to park a test permanently was to leave the
+ * marker off, which is the graveyard the cap exists to prevent.
+ */
+export function findUndeclaredSkips(source, file) {
+  const lines = source.split('\n')
+  const found = []
+  for (let i = 0; i < lines.length; i++) {
+    if (!SKIP.test(lines[i])) continue
+    if (i > 0 && MARKER.test(lines[i - 1])) continue
+    found.push({ file, line: i + 1, text: lines[i].trim() })
+  }
+  return found
 }
 
 export function judgeQuarantine(markers, nowMs) {
@@ -57,6 +83,7 @@ const TEST_FILE = /\.test\.(ts|tsx|mts|mjs)$/
 
 export function scanRepoQuarantine(repoRoot = join(import.meta.dirname, '../../..')) {
   const markers = []
+  const undeclaredSkips = []
   let scannedFiles = 0
   const walk = (dir) => {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -65,10 +92,12 @@ export function scanRepoQuarantine(repoRoot = join(import.meta.dirname, '../../.
       if (entry.isDirectory()) walk(path)
       else if (TEST_FILE.test(entry.name)) {
         scannedFiles++
-        markers.push(...parseQuarantineMarkers(readFileSync(path, 'utf8'), path))
+        const source = readFileSync(path, 'utf8')
+        markers.push(...parseQuarantineMarkers(source, path))
+        undeclaredSkips.push(...findUndeclaredSkips(source, path))
       }
     }
   }
   for (const root of SCAN_ROOTS) walk(join(repoRoot, root))
-  return { markers, scannedFiles }
+  return { markers, undeclaredSkips, scannedFiles }
 }

--- a/.claude/scripts/quarantine.test.mjs
+++ b/.claude/scripts/quarantine.test.mjs
@@ -5,7 +5,12 @@
 // CI's check job via `pnpm test:scripts`.
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { judgeQuarantine, parseQuarantineMarkers, scanRepoQuarantine } from './lib/quarantine.mjs'
+import {
+  findUndeclaredSkips,
+  judgeQuarantine,
+  parseQuarantineMarkers,
+  scanRepoQuarantine,
+} from './lib/quarantine.mjs'
 
 const NOW = Date.parse('2026-09-05T00:00:00Z')
 
@@ -74,4 +79,38 @@ test('live repo scan: reaches the real test surface, and the budget holds', () =
   assert.ok(scannedFiles > 300, `scanned only ${scannedFiles} test files — the glob missed the surface`)
   const verdict = judgeQuarantine(markers, Date.now())
   assert.equal(verdict.ok, true, verdict.problems.join('\n'))
+})
+
+// The budget above counts what DECLARED itself. A skip with no marker was
+// invisible to all of it — not capped, never aged out — so the cheapest way
+// to park a test forever was to skip the marker too, which is exactly the
+// graveyard the cap exists to prevent.
+test('an undeclared skip is found, and a declared one is not', () => {
+  const src = [
+    "// QUARANTINE(2026-09-01 wb:issues/x): parked on purpose",
+    "it.skip('declared', () => {})",
+    "test.skip('undeclared', () => {})",
+    "describe.skip('also undeclared', () => {})",
+  ].join('\n')
+  const found = findUndeclaredSkips(src, 'a.test.ts')
+  assert.deepEqual(
+    found.map((s) => s.line),
+    [3, 4],
+  )
+})
+
+test('skipIf is a probed premise, not a park, and is left alone', () => {
+  // A test whose premise this environment cannot establish SHOULD skip and
+  // say so — AGENTS.md asks for exactly that, probed rather than inferred.
+  const src = "it.skipIf(!CAN_DENY_FILE_READ)('needs a deniable path', () => {})\n"
+  assert.deepEqual(findUndeclaredSkips(src, 'b.test.ts'), [])
+})
+
+test('live repo scan: no undeclared skip is parked outside the budget', () => {
+  const { undeclaredSkips } = scanRepoQuarantine()
+  assert.deepEqual(
+    undeclaredSkips.map((s) => `${s.file}:${s.line}`),
+    [],
+    'a skipped test with no QUARANTINE marker is invisible to the cap and never ages out',
+  )
 })

--- a/tools/biome-plugins/test-flake-shapes.grit
+++ b/tools/biome-plugins/test-flake-shapes.grit
@@ -1,6 +1,8 @@
 language js
 
-// Executable half of four flake shapes from .claude/rules/integrator-flow.md.
+// Executable half of four flake shapes from .claude/rules/integrator-flow.md,
+// plus one shape that is not a flake but fails the same way: the run reports
+// green while covering less than it appears to.
 // Guarded by .claude/scripts/biome-plugin.test.mjs (fixture pair per rule).
 any {
   // A retried waitFor callback re-fires any action inside it, so the action
@@ -50,6 +52,23 @@ any {
     register_diagnostic(
       span = $program,
       message = "vi.useFakeTimers() with no vi.useRealTimers() anywhere in this file: a leaked fake-timer state runs into whatever the suite executes next. Restore it (typically in afterEach), or say why a shared teardown already does.",
+      severity = "error"
+    )
+  },
+  // A focused test silently drops every OTHER test in its file. vitest
+  // reports the survivors as skipped and exits 0, so CI is green over a file
+  // that ran one case — the same "a smaller total reads like good news"
+  // hazard AGENTS.md records for a mis-filtered `--project` run, in-file.
+  //
+  // Biome's own noFocusedTests is not enabled here (verified by linting a
+  // fixture carrying `it.only` and getting no diagnostic), and nothing else
+  // in the repo looks for it. Measured 0 occurrences when this was added, so
+  // it costs nothing to keep out.
+  `$runner.only($_, $_)` where {
+    $runner <: or { `it`, `test`, `describe` },
+    register_diagnostic(
+      span = $runner,
+      message = "A focused test drops every other test in this file and still exits 0 — CI goes green having run one case. Remove `.only` before committing.",
       severity = "error"
     )
   }


### PR DESCRIPTION
## Summary

Two shapes that let a suite report green over less than it covers — the failure this repo keeps rediscovering, now in its in-file form.

- **`.only`** → GritQL, added to the existing test-file plugin.
- **An undeclared `.skip`** → the quarantine scanner. The split is forced, not chosen; see below.

## What I looked at before adding anything

The catalogue in `integrator-flow.md` has ~10 flake shapes and the plugin carried four. I checked each remaining one for an existing rung before proposing anything, and most were already covered:

| shape | already guarded? |
|---|---|
| in-body `await import()` with no `vi.mock` | ✅ `tools/arch-lint/test-lazy-import-check` (with a `lazy-import: <reason>` escape) |
| `lazy()` racing `findBy*` | ✅ `App.lazy-coverage.test.ts` |
| non-ASCII `userEvent` | ✅ GritQL **and** `browser-test-keyboard-ascii.test.ts` |
| element ref across a remount | deliberately not scan-guarded (~90% false positives, standing decision) |
| global counter / "most recent" handle | no clean structural tell |
| menu still dismissing | flow-sensitive, not expressible |

So nothing from the catalogue was both uncovered and structural. Both additions here come from elsewhere.

## 1. `.only` — one case runs, CI is green

`it.only` drops every other test in its file and exits 0. That is the same hazard AGENTS.md records for a mis-filtered `--project` run — *"a smaller total reads like good news"* — except in-file, where no count comparison catches it.

**Not a duplicate of a built-in**: Biome ships `noFocusedTests`, so I checked rather than assumed — linted a fixture carrying `it.only` under this repo's real config and got **no diagnostic**. It is not enabled here, and no repo guard looks for `.only` either (0 references). Measured **0** occurrences, so it costs nothing to keep out.

## 2. An undeclared skip — outside the budget entirely

The quarantine budget (cap 8, 14-day age) judges `QUARANTINE(...)` **markers**. `lib/quarantine.mjs` contained **zero** references to `.skip`.

So a skip with no marker was outside the whole mechanism — never counted against the cap, never aged out. **The cheapest way to park a test permanently was to leave the marker off**, which is precisely the graveyard the cap exists to prevent, reachable by doing *less* work. Measured **0** undeclared skips today, so this lands with nothing to clean up.

`skipIf` is deliberately left alone: a test whose premise this environment cannot establish *should* skip and say so, probed rather than inferred. `\b` after `skip` is what keeps it out, and a test pins that.

### Why this one is not GritQL

The marker sits on the line **above** the skip, and no GritQL form for "not preceded by a comment" compiles in this dialect — `after comment()` fails to compile. A rule there would flag the legitimately parked test alongside the undeclared one. The scanner already walks the repo, can read the line above, and is where the policy lives.

## Mutation checks

Each applied and re-run, both directions per guard:

| guard | mutation | result |
|---|---|---|
| GritQL `.only` | runner alternation gutted | red |
| | `.only` removed from the bad fixture | red |
| | `.only` added to the good fixture | red |
| scanner | marker check dropped (a declared park reads as undeclared) | red |
| | `skipIf` boundary lost (`\b` removed) | red |
| | **a real undeclared skip placed in the repo** | red |

That last one is the one worth naming: it fails the **live repo scan**, not a fixture — evidence the guard works outside its own test data.

## Test plan

- [x] `node --test .claude/scripts/biome-plugin.test.mjs` — 4 passed (bad fixture now trips all five rules).
- [x] `node --test .claude/scripts/quarantine.test.mjs` — 10 passed, including 3 new; written **red first** (the file failed to import before `findUndeclaredSkips` existed).
- [x] `pnpm lint` — 2262 files, no new diagnostics.
- [x] `pnpm test:scripts` — 276 passed, 1 failed: `compose-figure.test.mjs`, which needs ImageMagick. **Pre-existing and not this diff** — verified by stashing the whole change and re-running, where it fails identically (0 pass / 1 fail).
- [x] Manual verification — the empirical Biome probe and the live-scan mutation above.

## Visual evidence

Visual evidence: none — no user-visible change; this adds a lint rule and a scanner check over test files, and touches no rendering, UI or product contract.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — n/a: no prose rule added. Both reasons live in the rule's own message and the scanner's docblock; `dev-flow.md`'s ladder puts `executable` above `prose-rule`, and always-on budget is not spent on a rule nobody has to read.
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_