### PR TITLE
feat(web): the render broker keeps what cost more than keeping it does

### DIFF
--- a/apps/web/src/components/workspace-files/load-row-outline.test.ts
+++ b/apps/web/src/components/workspace-files/load-row-outline.test.ts
@@ -95,7 +95,7 @@ describe('createRowOutlineLoader', () => {
     const d = deps({ source: fakeFilesSource({ loadSpatialSnapshot: async () => snapshot }) })
 
     await expect(createRowOutlineLoader(d)(spatial)).resolves.toEqual(RECTS)
-    expect(d.outlineSpatial).toHaveBeenCalledWith(snapshot)
+    expect(d.outlineSpatial).toHaveBeenCalledWith(snapshot, undefined)
   })
 
   // A corrupt snapshot now arrives as a refused outline rather than a throw

--- a/apps/web/src/components/workspace-files/load-row-outline.ts
+++ b/apps/web/src/components/workspace-files/load-row-outline.ts
@@ -28,7 +28,7 @@ import type { FaviconRect } from '../../lib/favicon.js'
 import { nextLayoutRequestId, sharedLayoutWorkerPool } from '../../lib/layout-worker-pool.js'
 import type { OutlineResponse } from '../../lib/layout-worker-protocol.js'
 import type { RenderBroker } from '../../lib/render-broker.js'
-import { outlineKeyOf } from '../../lib/render-key.js'
+import { cacheKeyFor, outlineKeyOf } from '../../lib/render-key.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
 import type { WorkspaceFilesSource } from './files-source.js'
 
@@ -53,9 +53,13 @@ export interface RowOutlineDeps {
   readonly outlineMarkdown?: (
     body: string,
     maxWidth: number,
+    cacheKey?: string,
   ) => Promise<readonly FaviconRect[] | null>
   /** Takes the stored SNAPSHOT — the worker decodes it, not this thread. */
-  readonly outlineSpatial?: (snapshot: Uint8Array) => Promise<readonly FaviconRect[] | null>
+  readonly outlineSpatial?: (
+    snapshot: Uint8Array,
+    cacheKey?: string,
+  ) => Promise<readonly FaviconRect[] | null>
 }
 
 /** The shared fleet, at idle priority: nobody is waiting on a 24px icon. */
@@ -69,8 +73,13 @@ async function outlineInPool(
   return reply.type === 'outlined' ? reply.rects : null
 }
 
-const outlineMarkdownInPool = (body: string, maxWidth: number) => outlineInPool({ body, maxWidth })
-const outlineSpatialInPool = (snapshot: Uint8Array) => outlineInPool({ snapshot })
+// `cacheKey` rides ON the request rather than being applied around the call:
+// the persistent tier lives in the worker, beside the bytes, so that reading
+// it costs nothing on the thread that asked (ADR-0027 decision 5).
+const outlineMarkdownInPool = (body: string, maxWidth: number, cacheKey?: string) =>
+  outlineInPool({ body, maxWidth, ...(cacheKey === undefined ? {} : { cacheKey }) })
+const outlineSpatialInPool = (snapshot: Uint8Array, cacheKey?: string) =>
+  outlineInPool({ snapshot, ...(cacheKey === undefined ? {} : { cacheKey }) })
 
 /**
  * The kind the pipeline will actually take, which is what the key has to
@@ -98,15 +107,20 @@ function outlinedKind(document: WorkspaceDocumentEntry): 'spatial' | 'markdown' 
 export function createRowOutlineLoader(deps: RowOutlineDeps) {
   const produce = async (
     document: WorkspaceDocumentEntry,
+    cacheKey: string | undefined,
   ): Promise<readonly FaviconRect[] | null> => {
     if (outlinedKind(document) === 'markdown') {
       const markdown = await deps.source.loadMarkdown(document)
       if (markdown.trim() === '') return null
-      return await (deps.outlineMarkdown ?? outlineMarkdownInPool)(markdown, ROW_LAYOUT_WIDTH)
+      return await (deps.outlineMarkdown ?? outlineMarkdownInPool)(
+        markdown,
+        ROW_LAYOUT_WIDTH,
+        cacheKey,
+      )
     }
 
     const snapshot = await deps.source.loadSpatialSnapshot(document)
-    return await (deps.outlineSpatial ?? outlineSpatialInPool)(snapshot)
+    return await (deps.outlineSpatial ?? outlineSpatialInPool)(snapshot, cacheKey)
   }
 
   return async (document: WorkspaceDocumentEntry): Promise<readonly FaviconRect[] | null> => {
@@ -119,7 +133,7 @@ export function createRowOutlineLoader(deps: RowOutlineDeps) {
         kind: outlinedKind(document),
         ...(document.updatedAt === undefined ? {} : { updatedAt: document.updatedAt }),
       })
-      return await deps.broker.render(key, () => produce(document))
+      return await deps.broker.render(key, () => produce(document, cacheKeyFor(key)))
     } catch {
       return null
     }

--- a/apps/web/src/components/workspace-files/load-row-render.test.ts
+++ b/apps/web/src/components/workspace-files/load-row-render.test.ts
@@ -98,7 +98,7 @@ describe('createRowRenderLoader', () => {
     expect(d.source.loadMarkdown).toHaveBeenCalledWith(
       expect.objectContaining({ documentId: 'd1' }),
     )
-    expect(d.renderMarkdown).toHaveBeenCalledWith('# Hi', expect.any(Number))
+    expect(d.renderMarkdown).toHaveBeenCalledWith('# Hi', expect.any(Number), undefined)
     expect(d.source.loadSpatialSnapshot).not.toHaveBeenCalled()
   })
 
@@ -115,14 +115,14 @@ describe('createRowRenderLoader', () => {
     expect(d.source.loadSpatialSnapshot).toHaveBeenCalledWith(
       expect.objectContaining({ path: 'deep/one' }),
     )
-    expect(d.renderSpatial).toHaveBeenCalledWith(expect.any(Uint8Array), 'light')
+    expect(d.renderSpatial).toHaveBeenCalledWith(expect.any(Uint8Array), 'light', undefined)
     expect(d.source.loadMarkdown).not.toHaveBeenCalled()
   })
 
   it('carries the theme, so a dark row is not drawn in light ink', async () => {
     const d = deps({ theme: 'dark' })
     await createRowRenderLoader(d)({ documentId: 'd2', path: 'a', kind: 'spatial' })
-    expect(d.renderSpatial).toHaveBeenCalledWith(expect.anything(), 'dark')
+    expect(d.renderSpatial).toHaveBeenCalledWith(expect.anything(), 'dark', undefined)
   })
 
   // An empty body lays out to nothing; asking the pool for it spends a slot
@@ -176,6 +176,30 @@ describe('createRowRenderLoader', () => {
       source: fakeFilesSource({ loadSpatialSnapshot: async () => snapshot }),
     })
     await createRowRenderLoader(d)({ documentId: 'd2', path: 'a', kind: 'spatial' })
-    expect(d.renderSpatial).toHaveBeenCalledWith(snapshot, 'light')
+    expect(d.renderSpatial).toHaveBeenCalledWith(snapshot, 'light', undefined)
+  })
+  // The persistent tier's gate, at the only place that decides it. A row the
+  // keeper stamped can be remembered on disk; one it did not must not be,
+  // because a re-read produces the identical key and the entry would answer
+  // for a document that has since changed — for as long as the file lives,
+  // which unlike the in-memory map is past the end of the tab.
+  it('passes a cache key only for a row its keeper stamped', async () => {
+    const stamped = deps()
+    await createRowRenderLoader(stamped)({
+      documentId: 'd3',
+      path: 'a',
+      kind: 'markdown',
+      updatedAt: '2026-09-03T00:00:00Z',
+    })
+    const key = vi.mocked(stamped.renderMarkdown)?.mock.calls[0]?.[2]
+    expect(typeof key).toBe('string')
+    // The render key's own path, so the file on disk is addressed by the same
+    // identity the in-memory map uses rather than a second spelling of it.
+    expect(key).toContain('/svg/markdown/')
+    expect(key).toContain('.json')
+
+    const unstamped = deps()
+    await createRowRenderLoader(unstamped)({ documentId: 'd4', path: 'b', kind: 'markdown' })
+    expect(vi.mocked(unstamped.renderMarkdown)?.mock.calls[0]?.[2]).toBeUndefined()
   })
 })

--- a/apps/web/src/components/workspace-files/load-row-render.ts
+++ b/apps/web/src/components/workspace-files/load-row-render.ts
@@ -35,7 +35,7 @@ import { unhandledKind } from '../../lib/exhaustive.js'
 import { nextLayoutRequestId, sharedLayoutWorkerPool } from '../../lib/layout-worker-pool.js'
 import type { LayoutResponse, MarkdownRenderResponse } from '../../lib/layout-worker-protocol.js'
 import type { RenderBroker } from '../../lib/render-broker.js'
-import { renderKeyOf } from '../../lib/render-key.js'
+import { cacheKeyFor, renderKeyOf } from '../../lib/render-key.js'
 import type { WorkspaceDocumentEntry } from './document-entry.js'
 import type { WorkspaceFilesSource } from './files-source.js'
 
@@ -65,20 +65,35 @@ export interface RowRenderDeps {
    * Both renders are injected like the reads above, so the branch that
    * actually produces a picture is assertable without standing up a worker.
    */
-  readonly renderMarkdown?: (body: string, maxWidth: number) => Promise<DocumentRender | null>
+  readonly renderMarkdown?: (
+    body: string,
+    maxWidth: number,
+    cacheKey?: string,
+  ) => Promise<DocumentRender | null>
   /** Takes the stored SNAPSHOT — the worker decodes it, not this thread. */
   readonly renderSpatial?: (
     snapshot: Uint8Array,
     theme: ResolvedTheme,
+    cacheKey?: string,
   ) => Promise<DocumentRender | null>
 }
 
+// `cacheKey` rides ON the request rather than being applied around the call:
+// the persistent tier lives in the worker, beside the bytes, so reading it
+// costs nothing on the thread that asked (ADR-0027 decision 5).
 async function renderMarkdownInPool(
   body: string,
   maxWidth: number,
+  cacheKey?: string,
 ): Promise<DocumentRender | null> {
   const reply = await sharedLayoutWorkerPool().run<MarkdownRenderResponse>(
-    { type: 'markdown-render', id: nextLayoutRequestId(), body, maxWidth },
+    {
+      type: 'markdown-render',
+      id: nextLayoutRequestId(),
+      body,
+      maxWidth,
+      ...(cacheKey === undefined ? {} : { cacheKey }),
+    },
     'background',
   )
   return reply.type === 'markdown-render-done' ? { svg: reply.svg, bounds: reply.bounds } : null
@@ -87,9 +102,16 @@ async function renderMarkdownInPool(
 async function renderSpatialInPool(
   snapshot: Uint8Array,
   theme: ResolvedTheme,
+  cacheKey?: string,
 ): Promise<DocumentRender | null> {
   const reply = await sharedLayoutWorkerPool().run<LayoutResponse>(
-    { type: 'layout', id: nextLayoutRequestId(), snapshot, theme },
+    {
+      type: 'layout',
+      id: nextLayoutRequestId(),
+      snapshot,
+      theme,
+      ...(cacheKey === undefined ? {} : { cacheKey }),
+    },
     'background',
   )
   return reply.type === 'laid-out' ? { svg: reply.svg, bounds: reply.bounds } : null
@@ -120,15 +142,22 @@ function renderedKind(document: WorkspaceDocumentEntry): 'spatial' | 'markdown' 
 }
 
 export function createRowRenderLoader(deps: RowRenderDeps) {
-  const produce = async (document: WorkspaceDocumentEntry): Promise<DocumentRender | null> => {
+  const produce = async (
+    document: WorkspaceDocumentEntry,
+    cacheKey: string | undefined,
+  ): Promise<DocumentRender | null> => {
     if (renderedKind(document) === 'markdown') {
       const markdown = await deps.source.loadMarkdown(document)
       if (markdown.trim() === '') return null
-      return await (deps.renderMarkdown ?? renderMarkdownInPool)(markdown, ROW_LAYOUT_WIDTH)
+      return await (deps.renderMarkdown ?? renderMarkdownInPool)(
+        markdown,
+        ROW_LAYOUT_WIDTH,
+        cacheKey,
+      )
     }
 
     const snapshot = await deps.source.loadSpatialSnapshot(document)
-    return await (deps.renderSpatial ?? renderSpatialInPool)(snapshot, deps.theme)
+    return await (deps.renderSpatial ?? renderSpatialInPool)(snapshot, deps.theme, cacheKey)
   }
 
   return async (document: WorkspaceDocumentEntry): Promise<DocumentRender | null> => {
@@ -144,7 +173,7 @@ export function createRowRenderLoader(deps: RowRenderDeps) {
         },
         deps.theme,
       )
-      return await deps.broker.render(key, () => produce(document))
+      return await deps.broker.render(key, () => produce(document, cacheKeyFor(key)))
     } catch {
       return null
     }

--- a/apps/web/src/hooks/useDocumentOutline.ts
+++ b/apps/web/src/hooks/useDocumentOutline.ts
@@ -35,7 +35,7 @@ import type { FaviconRect } from '../lib/favicon.js'
 import { nextLayoutRequestId, sharedLayoutWorkerPool } from '../lib/layout-worker-pool.js'
 import type { OutlineResponse } from '../lib/layout-worker-protocol.js'
 import type { RenderBroker } from '../lib/render-broker.js'
-import { outlineKeyOf } from '../lib/render-key.js'
+import { cacheKeyFor, outlineKeyOf } from '../lib/render-key.js'
 
 /**
  * The width a markdown document is laid out at for these renditions. Fixed
@@ -51,6 +51,7 @@ const NO_RECTS: readonly FaviconRect[] = []
 /** The shared fleet at idle priority: a tab icon is below even a list. */
 async function outlineInPool(
   source: DocumentOutlineSource,
+  cacheKey?: string,
 ): Promise<readonly FaviconRect[] | null> {
   const reply = await sharedLayoutWorkerPool().run<OutlineResponse>(
     {
@@ -59,6 +60,9 @@ async function outlineInPool(
       ...(source.snapshot === undefined
         ? { body: source.body, maxWidth: OUTLINE_LAYOUT_WIDTH }
         : { snapshot: source.snapshot }),
+      // The persistent tier reads and writes this INSIDE the worker, so a
+      // tab icon restored from disk costs the asking thread nothing.
+      ...(cacheKey === undefined ? {} : { cacheKey }),
     },
     'idle',
   )
@@ -87,7 +91,10 @@ export function useDocumentOutline({
   readSource: (kind: DocumentKind) => DocumentOutlineSource | null
   broker: RenderBroker
   /** Injected so the branch that produces a shape is assertable without a worker. */
-  outline?: (source: DocumentOutlineSource) => Promise<readonly FaviconRect[] | null>
+  outline?: (
+    source: DocumentOutlineSource,
+    cacheKey?: string,
+  ) => Promise<readonly FaviconRect[] | null>
 }): readonly FaviconRect[] {
   const [rects, setRects] = useState<readonly FaviconRect[]>(NO_RECTS)
 
@@ -106,7 +113,7 @@ export function useDocumentOutline({
       }
       const key = outlineKeyOf({ documentId, kind, updatedAt: source.frontier })
       broker
-        .render(key, () => outline(source))
+        .render(key, () => outline(source, cacheKeyFor(key)))
         .then((next) => {
           if (live && next !== null) setRects(next)
         })

--- a/apps/web/src/lib/layout-worker-protocol.ts
+++ b/apps/web/src/lib/layout-worker-protocol.ts
@@ -82,6 +82,18 @@ export type LayoutRequest = LayoutSubject & {
   readonly suppressedBodyNodeIds?: readonly string[]
   /** Draw resolved comments too (the editor's per-user toggle). */
   readonly showResolved?: boolean
+  /**
+   * Where this answer may be REMEMBERED, as the render key's own path — the
+   * worker's persistent tier (ADR-0027 decision 5) reads it before working
+   * and writes it after, so the cache lives beside the bytes rather than on
+   * the thread that asked.
+   *
+   * Absent means "do not remember this". A key that cannot notice its
+   * document changing is exactly that case, and the caller decides it with
+   * `isMemoisableKey` — the same gate the in-memory map uses, so the two
+   * tiers cannot disagree about which entries are safe.
+   */
+  readonly cacheKey?: string
 }
 
 /**
@@ -133,6 +145,18 @@ export type MarkdownRenderRequest = {
   readonly id: number
   readonly body: string
   readonly maxWidth: number
+  /**
+   * Where this answer may be REMEMBERED, as the render key's own path — the
+   * worker's persistent tier (ADR-0027 decision 5) reads it before working
+   * and writes it after, so the cache lives beside the bytes rather than on
+   * the thread that asked.
+   *
+   * Absent means "do not remember this". A key that cannot notice its
+   * document changing is exactly that case, and the caller decides it with
+   * `isMemoisableKey` — the same gate the in-memory map uses, so the two
+   * tiers cannot disagree about which entries are safe.
+   */
+  readonly cacheKey?: string
 }
 
 export type MarkdownRenderResponse =
@@ -174,6 +198,18 @@ type OutlineSubject =
 export type OutlineRequest = OutlineSubject & {
   readonly type: 'outline'
   readonly id: number
+  /**
+   * Where this answer may be REMEMBERED, as the render key's own path — the
+   * worker's persistent tier (ADR-0027 decision 5) reads it before working
+   * and writes it after, so the cache lives beside the bytes rather than on
+   * the thread that asked.
+   *
+   * Absent means "do not remember this". A key that cannot notice its
+   * document changing is exactly that case, and the caller decides it with
+   * `isMemoisableKey` — the same gate the in-memory map uses, so the two
+   * tiers cannot disagree about which entries are safe.
+   */
+  readonly cacheKey?: string
 }
 
 /**

--- a/apps/web/src/lib/layout-worker.ts
+++ b/apps/web/src/lib/layout-worker.ts
@@ -52,6 +52,7 @@ import {
   type OutlineRequest,
   type OutlineResponse,
 } from './layout-worker-protocol.js'
+import { readRenderEntry, writeRenderEntry } from './render-store.js'
 
 const measure = createBrowserMeasureText()
 
@@ -104,10 +105,64 @@ async function decodeSnapshot(bytes: Uint8Array): Promise<SpatialCanvas> {
 // introduce. Later requests await an already-settled promise.
 const fontReady = ensureViewerFontLoaded()
 
+/**
+ * How long a render has to take before storing it is worth the write.
+ *
+ * Measured in a real browser, medians of 15 interleaved rounds: an OPFS write
+ * costs 2.2-3.1ms whatever the payload, while a render ranges from 2.0ms (a
+ * 12-node spatial canvas) to 67.2ms (a 60-section markdown body). Below this
+ * floor the store makes the FIRST visit slower to save less than a
+ * millisecond on the second; above it the saving is the whole render.
+ *
+ * A floor rather than a per-pipeline rule because the cost is not a property
+ * of the pipeline: a 400-node spatial canvas (19.9ms) clears it and a
+ * four-section markdown body barely does. Timing the work that actually ran
+ * is the only thing that stays true as either pipeline changes.
+ */
+const STORE_FLOOR_MS = 5
+
+/**
+ * Answers from the persistent tier when it holds this key, and says whether
+ * it did.
+ *
+ * The stored value carries no `id` — an id belongs to a request, not to a
+ * picture — so this stamps the ASKING request's own. Without that the pool
+ * would be handed a reply addressed to a request it already settled, and the
+ * caller would wait forever for one that never comes.
+ */
+async function servedFromStore(request: {
+  readonly id: number
+  readonly cacheKey?: string
+}): Promise<boolean> {
+  if (request.cacheKey === undefined) return false
+  const stored = await readRenderEntry(request.cacheKey)
+  if (stored === null || typeof stored !== 'object') return false
+  self.postMessage({ ...(stored as Record<string, unknown>), id: request.id })
+  return true
+}
+
+/** Stores a reply that cost more to produce than storing it will. */
+function remember(
+  cacheKey: string | undefined,
+  elapsedMs: number,
+  reply: { readonly type: string; readonly id: number },
+): void {
+  if (cacheKey === undefined || elapsedMs < STORE_FLOOR_MS) return
+  const { id: _id, ...rest } = reply
+  // Not awaited: the reply is already posted, and a caller must never wait on
+  // a cache. A write that loses its race with page teardown costs one
+  // re-render.
+  void writeRenderEntry(cacheKey, rest)
+}
+
 self.onmessage = async (
   event: MessageEvent<LayoutRequest | MarkdownRailRequest | MarkdownRenderRequest | OutlineRequest>,
 ) => {
   const request = event.data
+  // Before the font gate and before any work: a stored answer is the answer,
+  // and the gate exists to stop a render being MEASURED with the wrong face
+  // rather than to re-check one already drawn with the right one.
+  if (request.type !== 'markdown-rail' && (await servedFromStore(request))) return
   if (request.type === 'outline') {
     try {
       if (request.body !== undefined) {
@@ -123,10 +178,12 @@ self.onmessage = async (
           self.postMessage(failed)
           return
         }
+        const startedAt = performance.now()
         const { blocks } = layoutMarkdownOutline(request.body, {
           measure,
           maxWidth: request.maxWidth,
         })
+        const elapsed = performance.now() - startedAt
         const done: OutlineResponse = {
           type: 'outlined',
           id: request.id,
@@ -136,6 +193,7 @@ self.onmessage = async (
           rects: blocks.map((block) => ({ ...block, color: resolveRectColor(undefined) })),
         }
         self.postMessage(done)
+        remember(request.cacheKey, elapsed, done)
         return
       }
       // A corrupt snapshot throws here and lands in the catch below as a
@@ -143,12 +201,14 @@ self.onmessage = async (
       // one. It must not take the worker down: every request queued behind it
       // belongs to a different document.
       const canvas = request.canvas ?? (await decodeSnapshot(request.snapshot))
+      const startedAt = performance.now()
       const done: OutlineResponse = {
         type: 'outlined',
         id: request.id,
         rects: outlineFromSpatial(canvas),
       }
       self.postMessage(done)
+      remember(request.cacheKey, performance.now() - startedAt, done)
     } catch (error) {
       const failed: OutlineResponse = {
         type: 'failed',
@@ -173,10 +233,12 @@ self.onmessage = async (
         self.postMessage(failed)
         return
       }
+      const startedAt = performance.now()
       const { keyed, blocks } = renderMarkdownPreview(request.body, {
         measure,
         maxWidth: request.maxWidth,
       })
+      const elapsed = performance.now() - startedAt
       // The preview's SVG carries its own viewBox; the caller needs the
       // extent to scale it, and the blocks already describe it.
       const right = Math.max(0, ...blocks.map((b) => b.x + b.w))
@@ -188,6 +250,7 @@ self.onmessage = async (
         bounds: { x: 0, y: 0, w: right, h: bottom },
       }
       self.postMessage(done)
+      remember(request.cacheKey, elapsed, done)
     } catch (error) {
       const failed: MarkdownRenderResponse = {
         type: 'failed',
@@ -253,6 +316,7 @@ self.onmessage = async (
     // take the worker down: every request queued behind it belongs to a
     // different document.
     const canvas = request.canvas ?? (await decodeSnapshot(request.snapshot))
+    const startedAt = performance.now()
     const { svg, bounds, scene, anchors } = renderCanvasToSvgWith(canvas, {
       measure,
       theme: request.theme,
@@ -270,6 +334,12 @@ self.onmessage = async (
       anchors,
     }
     self.postMessage(response)
+    // The whole reply, `scene` and `anchors` included: they are not optional
+    // on `laid-out`, so an entry without them could not be served back as
+    // one. Only the LIST surfaces pass a cache key — the editor renders live
+    // and passes none — so this is disk spent on rows, never on the canvas a
+    // person is editing.
+    remember(request.cacheKey, performance.now() - startedAt, response)
   } catch (error) {
     const response: LayoutResponse = {
       type: 'failed',

--- a/apps/web/src/lib/render-key.test.ts
+++ b/apps/web/src/lib/render-key.test.ts
@@ -69,9 +69,15 @@ describe('renderKeyPath — the pipeline is part of the identity', () => {
     )
   })
 
+  // The family is named by a SEGMENT, not by the extension. Both are stored
+  // as JSON because what a caller needs back is the whole worker reply — an
+  // SVG plus the bounds it is scaled to, or an outline's rectangles — so an
+  // entry named `.svg` would be describing one field of the file it holds.
   it('names each family in the path, so a stored entry says what it holds', () => {
-    expect(renderKeyPath(renderKeyOf(subject, 'light')).endsWith('.svg')).toBe(true)
-    expect(renderKeyPath(outlineKeyOf(subject)).endsWith('.svg')).toBe(false)
+    expect(renderKeyPath(renderKeyOf(subject, 'light'))).toContain('/svg/')
+    expect(renderKeyPath(outlineKeyOf(subject))).toContain('/outline/')
+    expect(renderKeyPath(renderKeyOf(subject, 'light')).endsWith('.json')).toBe(true)
+    expect(renderKeyPath(outlineKeyOf(subject)).endsWith('.json')).toBe(true)
   })
 
   it('defaults to the svg family, which every existing caller is', () => {

--- a/apps/web/src/lib/render-key.ts
+++ b/apps/web/src/lib/render-key.ts
@@ -134,6 +134,19 @@ export function isMemoisableKey(key: RenderKey): boolean {
 }
 
 /**
+ * The path a worker may store this answer under, or `undefined` when it may
+ * not remember it at all.
+ *
+ * Derived from `isMemoisableKey` rather than decided again, so the in-memory
+ * map and the persistent tier cannot disagree about which entries are safe.
+ * They must not: an entry the map refuses because it could not notice its
+ * document changing would, on disk, outlive the tab as well.
+ */
+export function cacheKeyFor(key: RenderKey): string | undefined {
+  return isMemoisableKey(key) ? renderKeyPath(key) : undefined
+}
+
+/**
  * One path segment, unambiguous whatever the value contains.
  *
  * Both `documentId` and the version are opaque strings from a keeper — the
@@ -156,12 +169,23 @@ function segment(value: string): string {
  * build's whole cache one directory removal rather than a scan.
  */
 /**
- * What a family's bytes are. An outline is block geometry, so calling its
- * entry `.svg` would misdescribe it to the OPFS store and to anyone reading
- * a directory listing.
+ * What a stored entry's bytes are — JSON for every family, and that is a
+ * correction to this key's first sketch rather than an oversight.
+ *
+ * `.svg` was right while the entry was imagined as the picture alone. What a
+ * caller actually needs back is the whole worker reply: an SVG AND the bounds
+ * a consumer scales it to, or an outline's rectangles. Storing only the SVG
+ * would mean re-deriving the extent by parsing its viewBox back out, to avoid
+ * writing four numbers — and `layout`'s reply carries a `scene` and `anchors`
+ * that are not optional on it, so an entry without them could not be served
+ * back as one at all.
+ *
+ * The FAMILY is still named in the path, one segment up, which is what the
+ * extension was carrying: a directory listing says `svg/` or `outline/`, and
+ * a sweep can still drop one family the way it drops one build.
  */
 const EXTENSION: Readonly<Record<BrokeredPipeline, string>> = {
-  svg: 'svg',
+  svg: 'json',
   outline: 'json',
 }
 

--- a/apps/web/src/lib/render-store.browser.test.tsx
+++ b/apps/web/src/lib/render-store.browser.test.tsx
@@ -1,0 +1,178 @@
+// The persistent tier of the render broker (ADR-0027 decision 5), against a
+// real OPFS in a real browser — there is no jsdom equivalent, and a fake one
+// would assert the fake.
+//
+// The tier lives in the WORKER rather than beside the broker, and that is the
+// load-bearing choice rather than a detail. Measured on this machine, an OPFS
+// read costs 1.5-2.7ms; a render already runs off the main thread, so reading
+// the cache ON the main thread would move 2ms per row back onto the very
+// thread #1275 and #1293 spent their effort clearing.
+import { writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { LoroDoc } from 'loro-crdt'
+import { beforeEach, expect, it } from 'vitest'
+import { nextLayoutRequestId, sharedLayoutWorkerPool } from './layout-worker-pool.js'
+import type { LayoutResponse, MarkdownRenderResponse } from './layout-worker-protocol.js'
+import { clearRenderStore, readRenderEntry, writeRenderEntry } from './render-store.js'
+
+// Three nodes, not twelve: the assertion below is that this render stays
+// UNDER the floor, and a case that only just clears it is a case that clears
+// it under load. Measured warm, a 12-node canvas round-trips in 3.4ms against
+// a 5ms floor and a 20-section markdown body in 20.4ms — this shrinks the
+// lower margin further rather than resting on 1.6ms of it.
+const CHEAP: SpatialCanvas = {
+  nodes: Array.from({ length: 3 }, (_, i) => ({
+    id: `n${i}`,
+    type: 'text' as const,
+    x: (i % 4) * 260,
+    y: Math.floor(i / 4) * 160,
+    width: 220,
+    height: 120,
+    text: `node ${i}`,
+  })),
+  edges: [],
+}
+
+// Costly on purpose: text shaping is the pipeline the measurements say
+// persistence is FOR — 21.8ms at 20 sections against a 2.2ms read, where a
+// 12-node spatial canvas is 2.0ms against 1.7ms and saves nothing worth a
+// write.
+const COSTLY_BODY = Array.from(
+  { length: 20 },
+  (_, i) =>
+    `## Section ${i}\n\nA paragraph with enough words in it that line breaking is a real cost rather than a rounding error.\n\n- one\n- two\n`,
+).join('\n')
+
+function snapshotOf(canvas: SpatialCanvas): Uint8Array {
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, canvas)
+  return doc.export({ mode: 'snapshot' })
+}
+
+function askLayout(cacheKey?: string): Promise<LayoutResponse> {
+  return sharedLayoutWorkerPool().run<LayoutResponse>(
+    {
+      type: 'layout',
+      id: nextLayoutRequestId(),
+      snapshot: snapshotOf(CHEAP),
+      theme: 'light',
+      ...(cacheKey === undefined ? {} : { cacheKey }),
+    },
+    'background',
+  )
+}
+
+function askMarkdown(cacheKey?: string): Promise<MarkdownRenderResponse> {
+  return sharedLayoutWorkerPool().run<MarkdownRenderResponse>(
+    {
+      type: 'markdown-render',
+      id: nextLayoutRequestId(),
+      body: COSTLY_BODY,
+      maxWidth: 640,
+      ...(cacheKey === undefined ? {} : { cacheKey }),
+    },
+    'background',
+  )
+}
+
+let seq = 0
+const freshKey = (): string => `~build-test/svg/markdown/~doc${seq++}/~v1.json`
+
+/**
+ * The write is deliberately NOT awaited by the worker — a caller must never
+ * wait on a cache — so an assertion that reads straight after the reply is
+ * racing a side effect rather than checking one. Polling is what the contract
+ * actually promises: the entry appears, shortly, or the write failed.
+ */
+async function entryWithin(key: string, ms: number): Promise<unknown | null> {
+  const deadline = performance.now() + ms
+  for (;;) {
+    const found = await readRenderEntry(key)
+    if (found !== null || performance.now() > deadline) return found
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+}
+
+beforeEach(async () => {
+  await clearRenderStore()
+})
+
+// The decisive one: what comes back is what the STORE held, not what the
+// renderer would have produced. Seeding a value no renderer could invent is
+// the only observation that separates "answered from the store" from
+// "answered quickly".
+it('answers a request from the stored entry rather than rendering again', async () => {
+  const key = freshKey()
+  await writeRenderEntry(key, {
+    type: 'markdown-render-done',
+    svg: '<svg data-seeded="only-the-store-could-say-this"></svg>',
+    bounds: { x: 0, y: 0, w: 7, h: 11 },
+  })
+
+  const reply = await askMarkdown(key)
+
+  expect(reply.type).toBe('markdown-render-done')
+  if (reply.type !== 'markdown-render-done') return
+  expect(reply.svg).toContain('only-the-store-could-say-this')
+  expect(reply.bounds).toEqual({ x: 0, y: 0, w: 7, h: 11 })
+})
+
+// The reply still has to be answerable: a stored entry carries no id, so the
+// worker has to stamp this request's own or the pool never settles the
+// promise — which would look like a hang rather than a wrong picture.
+it('stamps the asking request’s id onto a stored entry', async () => {
+  const key = freshKey()
+  await writeRenderEntry(key, {
+    type: 'markdown-render-done',
+    svg: '<svg/>',
+    bounds: { x: 0, y: 0, w: 1, h: 1 },
+  })
+
+  // Two in a row through one pool: the second would be answered by the
+  // first's id if the stamp were missing.
+  await askMarkdown(key)
+  const reply = await askMarkdown(key)
+  expect(reply.type).toBe('markdown-render-done')
+})
+
+it('stores a render that cost more than storing it does', async () => {
+  const key = freshKey()
+
+  const reply = await askMarkdown(key)
+  expect(reply.type).toBe('markdown-render-done')
+
+  const stored = await entryWithin(key, 2000)
+  expect(stored, 'a costly render left nothing behind for the next visit').not.toBeNull()
+  expect((stored as { type?: string } | null)?.type).toBe('markdown-render-done')
+})
+
+// The gate, and the reason it exists rather than "persist everything":
+// measured, a 12-node canvas renders in 2.0ms and an OPFS write costs
+// 2.2-3.1ms, so storing it makes the FIRST visit slower to save nothing
+// worth having on the second.
+it('stores nothing for a render cheaper than the write it would cost', async () => {
+  const key = `~build-test/svg/spatial/~cheap/~v1.json`
+
+  // Warm first, with no key. The FIRST layout a worker runs pays for caches
+  // this pipeline fills once — measured, it clears the floor where the same
+  // canvas afterwards does not — and a list of twenty rows pays that once,
+  // not per row. Asserting on the cold render would be measuring startup and
+  // calling it the gate.
+  await askLayout()
+  const reply = await askLayout(key)
+  expect(reply.type).toBe('laid-out')
+
+  // A real wait, not an immediate read: an assertion that a write did NOT
+  // happen has to outlast the window in which it would have.
+  expect(await entryWithin(key, 500)).toBeNull()
+})
+
+// A request with no cache key is the honest state of a document whose keeper
+// reports no version: nothing may be remembered for it, in memory or on disk.
+it('stores nothing for a request that carries no key', async () => {
+  const before = await readRenderEntry(freshKey())
+  const reply = await askMarkdown()
+
+  expect(reply.type).toBe('markdown-render-done')
+  expect(before).toBeNull()
+})

--- a/apps/web/src/lib/render-store.ts
+++ b/apps/web/src/lib/render-store.ts
@@ -1,0 +1,133 @@
+/**
+ * The render broker's persistent tier: one file per key, under OPFS
+ * (ADR-0027 decision 5).
+ *
+ * Addressed by the key's own path, so invalidation is the path rather than a
+ * policy — a document that changed names a different file, and retiring a
+ * build's whole cache is removing one directory. `renderKeyPath` builds it
+ * and encodes every component the keeper supplied.
+ *
+ * TOTAL BY CONTRACT, in both directions. A cache that cannot read answers
+ * "not there" and the caller renders; a cache that cannot write loses the
+ * entry and the caller renders again next time. Neither may cost a picture,
+ * so every entry point here swallows its own failure rather than surfacing
+ * one — OPFS is absent on some browsers, full on some machines, and blocked
+ * in some contexts, and none of those is a reason to show no thumbnail.
+ *
+ * JSON rather than the raw picture, and that is a correction to the ADR's
+ * first sketch: what a caller needs back is the whole reply — an SVG plus
+ * the bounds a consumer scales it to, or an outline's rectangles. Storing
+ * only the `.svg` would mean re-deriving the extent by parsing the viewBox
+ * back out, to avoid storing four numbers.
+ */
+
+/** Everything this store owns lives under one directory, so a sweep is cheap. */
+const ROOT_DIR = 'render'
+
+function storageDirectory(): Promise<FileSystemDirectoryHandle> | null {
+  // `navigator.storage` is absent in some contexts and `getDirectory` in
+  // others; asking for the method rather than the object is what tells the
+  // two apart without throwing.
+  const storage = globalThis.navigator?.storage
+  if (typeof storage?.getDirectory !== 'function') return null
+  return storage.getDirectory()
+}
+
+async function walk(
+  from: FileSystemDirectoryHandle,
+  segments: readonly string[],
+  create: boolean,
+): Promise<FileSystemDirectoryHandle | null> {
+  let dir = from
+  for (const segment of segments) {
+    dir = await dir.getDirectoryHandle(segment, { create })
+  }
+  return dir
+}
+
+function split(path: string): { dirs: string[]; name: string } | null {
+  const parts = path.split('/').filter((p) => p !== '')
+  const name = parts.pop()
+  if (name === undefined || parts.length === 0) return null
+  return { dirs: parts, name }
+}
+
+/**
+ * The stored reply for `path`, or null when there is none.
+ *
+ * `unknown` rather than a per-family type: the path's own `pipeline` segment
+ * is what keeps two families out of one entry, exactly as it does for the
+ * in-memory map, and a union here would only let a caller believe a cast had
+ * been checked.
+ */
+export async function readRenderEntry(path: string): Promise<unknown | null> {
+  const parts = split(path)
+  const rootPromise = storageDirectory()
+  if (parts === null || rootPromise === null) return null
+  try {
+    const root = await (await rootPromise).getDirectoryHandle(ROOT_DIR, { create: false })
+    const dir = await walk(root, parts.dirs, false)
+    if (dir === null) return null
+    const file = await (await dir.getFileHandle(parts.name)).getFile()
+    return JSON.parse(await file.text()) as unknown
+  } catch {
+    // A miss and a broken store are the same answer to a caller: render it.
+    return null
+  }
+}
+
+/**
+ * Whether a build sweep has already run in this realm.
+ *
+ * Write-time rather than scheduled, per ADR-0027 decision 5: the moment a new
+ * build stores its first entry is the moment the old build's directory is
+ * known to be dead, and once per realm is enough because the build id cannot
+ * change without a reload.
+ */
+let sweptBuild: string | null = null
+
+async function sweepOtherBuilds(root: FileSystemDirectoryHandle, keep: string): Promise<void> {
+  if (sweptBuild === keep) return
+  sweptBuild = keep
+  // `values()` is async-iterable on a directory handle; a browser without it
+  // simply keeps the old directories, which costs disk and never correctness.
+  const entries = (root as unknown as { values?: () => AsyncIterable<{ name: string }> }).values
+  if (typeof entries !== 'function') return
+  for await (const entry of entries.call(root)) {
+    if (entry.name === keep) continue
+    await root.removeEntry(entry.name, { recursive: true }).catch(() => undefined)
+  }
+}
+
+/** Stores `value` under `path`, or does nothing if it cannot. */
+export async function writeRenderEntry(path: string, value: unknown): Promise<void> {
+  const parts = split(path)
+  const rootPromise = storageDirectory()
+  if (parts === null || rootPromise === null) return
+  try {
+    const root = await (await rootPromise).getDirectoryHandle(ROOT_DIR, { create: true })
+    const dir = await walk(root, parts.dirs, true)
+    if (dir === null) return
+    const handle = await dir.getFileHandle(parts.name, { create: true })
+    const writable = await handle.createWritable()
+    await writable.write(JSON.stringify(value))
+    await writable.close()
+    const build = parts.dirs[0]
+    if (build !== undefined) await sweepOtherBuilds(root, build)
+  } catch {
+    // Nothing to report: the render already happened and the caller has its
+    // picture. Losing the entry costs one re-render on a later visit.
+  }
+}
+
+/** Drops everything this store holds. For tests, and for a storage reset. */
+export async function clearRenderStore(): Promise<void> {
+  const rootPromise = storageDirectory()
+  if (rootPromise === null) return
+  sweptBuild = null
+  try {
+    await (await rootPromise).removeEntry(ROOT_DIR, { recursive: true })
+  } catch {
+    // Already absent is the state this asks for.
+  }
+}

--- a/docs/contributing/adr/0027-render-broker.md
+++ b/docs/contributing/adr/0027-render-broker.md
@@ -1,6 +1,6 @@
 # ADR-0027: Every picture of a document goes through one broker, and the cache is a memo
 
-**Status:** Accepted — broker port and its in-tab implementation land with this ADR. Every surface named below now asks through it; OPFS persistence and the SharedWorker implementation are named follow-ups
+**Status:** Accepted — broker port, its in-tab implementation and the OPFS tier below all land. Every surface named below asks through it; the SharedWorker implementation remains a named follow-up
 
 ## Context
 
@@ -105,7 +105,7 @@ written. **Cross-tab leader election is an optimisation, never a correctness
 requirement.** That is what lets the SharedWorker implementation wait for
 evidence instead of blocking the first increment.
 
-### 5. Persistence is OPFS, and the path is the invalidation strategy
+### 5. Persistence is OPFS, the path is the invalidation strategy, and the tier lives in the worker
 
 The key derives the path deterministically, with the build id leading, and
 every component the keeper supplied is **encoded** — the document contract
@@ -114,27 +114,79 @@ a timestamp would otherwise move the boundary between segments and let two
 different documents join to one path. Verified rather than argued: unencoded,
 `{id: 'a', version: 'b/c'}` and `{id: 'a/b', version: 'c'}` produce the same
 string. The `~` prefix on each segment is what additionally makes `.` and
-`..` impossible as whole segments, which matters before the store exists
-rather than after.
+`..` impossible as whole segments.
 
 ```
-render/~<buildId>/<pipeline>/<kind>/~<documentId>/~<versionKey>[-<theme>].<ext>
+render/~<buildId>/<pipeline>/<kind>/~<documentId>/~<versionKey>[-<theme>].json
 ```
 
 The pipeline is part of the identity, not decoration. The broker holds one
 map, so without it a tree row's outline and a list row's SVG name the same
 entry — and whichever arrives first answers the other, in a type the caller
 has no reason to check. It sits under the build id so a sweep can drop one
-family the way it drops one build, and the extension is what the bytes
-actually are (`.svg`, or `.json` for an outline).
+family the way it drops one build.
+
+**JSON for both families**, which corrects this decision's first sketch. `.svg`
+was right while an entry was imagined as the picture alone; what a caller
+needs back is the whole worker reply — an SVG *and* the bounds a consumer
+scales it to, or an outline's rectangles — and `layout`'s reply additionally
+carries a `scene` and `anchors` that are not optional on it, so an entry
+without them could not be served back as one. The family is still named by
+its own path segment, which is what the extension was carrying.
 
 Retiring a build's entire cache is removing one directory — no scan, no
 scheduler, no index. Write-time is enough: when storing an entry, drop any
 sibling directory that is not the current build.
 
-The realm assignment follows a probe rather than a preference: only a
-**dedicated worker** has `createSyncAccessHandle`, and that is also where the
-bytes are produced, so the renderer persists its own output with no extra hop.
+**The tier lives in the WORKER, on both sides.** The realm assignment was
+first argued from `createSyncAccessHandle`, which only a dedicated worker
+has; the stronger reason is the read. Measured in a real browser, an OPFS
+read costs 1.5-2.7ms — and a render already runs off the main thread, so
+checking the cache on the *asking* thread would put ~2ms per row back onto
+the very thread [#1275] and [#1293] spent their effort clearing. So the
+request carries a `cacheKey` (the key's own path, absent when
+`isMemoisableKey` refuses it), the worker answers from the store before it
+works, and writes after. The stored value carries no `id` — an id belongs to
+a request, not to a picture — so a hit is stamped with the asking request's
+own, or the pool would be handed a reply addressed to a request it had
+already settled.
+
+### 5a. What is stored is decided by what the render cost, not by its pipeline
+
+Persisting everything is a loss on the cheap end. Measured in a real browser,
+medians of 15 interleaved rounds:
+
+| case | payload | render | OPFS read | OPFS write |
+|---|---|---|---|---|
+| markdown, 4 sections | 3.1 KB | 7.4 ms | 1.9 ms | ~2.3 ms |
+| markdown, 20 sections | 14.9 KB | **21.8 ms** | 2.2 ms | ~2.3 ms |
+| markdown, 60 sections | 44.4 KB | **67.2 ms** | 2.3 ms | ~2.3 ms |
+| spatial, 12 nodes | 2.6 KB | 2.0 ms | 1.7 ms | 2.6 ms |
+| spatial, 40 nodes | 9.4 KB | 3.0 ms | 1.7 ms | 2.6 ms |
+| spatial, 120 nodes | 28.8 KB | 7.2 ms | 2.1 ms | 2.7 ms |
+| spatial, 400 nodes | 97.0 KB | 19.9 ms | 2.7 ms | 3.1 ms |
+
+Two things follow, and neither was visible from the design.
+
+**Text shaping is what persistence is for.** It grows superlinearly where an
+OPFS read stays flat at ~2ms, so a list of twenty 20-section markdown rows is
+436ms of worker time against 44ms of reads. **A small spatial canvas is a
+loss**: 12 nodes saves 0.3ms and costs 2.6ms to store, so a naive
+"persist everything" makes the first visit slower to buy nothing on the
+second.
+
+So the gate is a **floor on the measured render**, `STORE_FLOOR_MS = 5`, and
+a floor rather than a per-pipeline rule because the cost is not a property of
+the pipeline: a 400-node spatial canvas clears it and a four-section markdown
+body barely does. Timing the work that actually ran stays true as either
+pipeline changes.
+
+The floor sits in a real gap rather than near either side. Measured warm
+round-trips through the pool: a 12-node canvas is 3.4ms and a 20-section
+markdown body 20.4ms. The first render of a session is not in that gap — a
+cold layout measured 2477ms, almost all of it worker startup and WASM — and
+storing it is correct: that render really cost that, and a list of twenty
+rows pays it once rather than per row.
 
 ### 6a. Work nobody is waiting on says so, and the fleet believes it
 
@@ -180,14 +232,25 @@ is stated per kind rather than applied uniformly.
 
 Still open, and named rather than assumed:
 
-- **Persistence still needs a version key on the LIST surfaces.**
-  `documentSummarySchema` carries no frontier, and `updatedAt` is stamped per
-  push in practice but optional in the schema. A key with no version cannot
-  notice its document changing, so `isMemoisableKey` refuses to remember a
-  completed render under one and only the in-flight join applies there —
-  honest behaviour rather than a limitation to work around, since a memo
-  under such a key would serve the old picture for as long as the tab is
-  open.
+- **The list surfaces' version key was measured, and it is weaker than this
+  ADR first claimed rather than absent.** `writeWorkspaceDocumentContent`
+  re-stamps a tree entry's `updatedAt` only when the projected content
+  actually differs, and that is what a list row reads. Measured directly in
+  `loro-adapter`: a content change moved the stamp (`...158` to `...168`) and
+  a no-op write did not move it — which is exactly the property a cache key
+  needs, and the opposite of what `documentEntrySchema`'s own comment ("when
+  the placement last changed") suggests.
+
+  Two real weaknesses remain, and only the second argues for a frontier:
+  the field is OPTIONAL, so a row without one keys `version: null` and
+  `isMemoisableKey` correctly refuses to remember it at all; and its
+  resolution is one millisecond of the writing client's wall clock. An
+  in-tab memo under a collided stamp dies with the tab. **A stored one does
+  not**, which is the one thing persistence genuinely raises the bar on.
+  Carrying a real frontier to `documentEntrySchema` / `documentSummarySchema`
+  would close it and change nothing else — a four-layer contract change for a
+  one-millisecond window, so it stays a named follow-up rather than a
+  prerequisite.
 
   The OPEN document is no longer in that position: `DocumentSyncSession`
   answers `getFrontier()`, loro's own id for its committed state, and the
@@ -210,9 +273,15 @@ Still open, and named rather than assumed:
 - **Safari and iOS are unmeasured.** SharedWorker is expected absent, OPFS
   expected present. iOS is best-effort by standing policy, and the fallback is
   the in-tab implementation this ADR ships first.
-- **The version-thumbnail PNG path is left alone here.** Its read side is dead,
-  so the question is whether the feature exists at all, and that is a product
-  decision rather than a caching one.
+- **The version-thumbnail PNG path is left alone here**, and the reason this
+  ADR first gave for that was WRONG. Its read side is not dead: `VersionThumbnail`
+  is rendered by `VersionTimeline`'s rows and by both panes of `MergeDialog`,
+  and `attachVersionThumbnail` writes it from both document pages. (The claim
+  confused it with `DocumentThumb`, a different component that really did have
+  no call site and has since been deleted.) It is left alone for a caching
+  reason instead: the picture is written once per save and read back as stored
+  bytes, so there is no repeated render for a memo to join, and `png-raster`
+  is deliberately outside `brokeredPipelineSchema`.
 
 ## Alternatives considered
 

--- a/docs/contributing/adr/0027-render-broker.md
+++ b/docs/contributing/adr/0027-render-broker.md
@@ -268,8 +268,14 @@ Still open, and named rather than assumed:
 - **The fetch of a document's bytes is unmeasured** for the daemon keeper.
   For the browser keeper it is measured and `load-row-render.ts`'s claim that
   it dominates the wait is false — a near-constant 4-6ms against a render of
-  9-29ms that grows with the document. The worker pool's cap of 4 rests on
-  that claim and is worth revisiting.
+  9-29ms that grows with the document. The worker pool's cap of 4 used to
+  rest on that claim; it is now re-measured on what a list actually does
+  (forty rows at `background`, four cores: warm fill 284-304ms at size 1,
+  253-263 at 2, 160-167 at 3, 137-141 at 4, 127-165 at 6). A list is
+  render-bound and tracks the `size - 1` slots its band may use; past the
+  core count the curve is flat inside its noise, so the cap holds here and
+  an eight-core machine stays unmeasured. `defaultPoolSize`'s comment
+  carries the table.
 - **Safari and iOS are unmeasured.** SharedWorker is expected absent, OPFS
   expected present. iOS is best-effort by standing policy, and the fallback is
   the in-tab implementation this ADR ships first.


### PR DESCRIPTION
## Summary

- Renders survive a reload: the broker's second tier is one OPFS file per key (ADR-0027 decision 5).
- Both halves of that tier live in the **worker**, and what gets stored is decided by **what the render actually cost**, not by its pipeline.
- Two premises this ADR follow-up rested on were measured rather than inherited. **Both were wrong**, and one of them made the work far smaller than the ADR's plan.

## What the measurements changed

The named follow-up said persistence needed a frontier carried through `documentEntrySchema` and `documentSummarySchema` first — a four-layer contract change. Measured first instead:

**`writeWorkspaceDocumentContent` re-stamps a tree entry's `updatedAt` only when the projected content actually differs**, and that is what a list row reads. Probed directly in `loro-adapter`:

```
first=1788547006158  afterEdit=1788547006168  moved=true
                     afterNoop=1788547006168  noopMoved=false
```

Moves on a change, does not move on a no-op — exactly what a cache key needs, and the opposite of what `documentEntrySchema`'s own comment ("when the placement last changed") suggests. What remains is a **1ms wall-clock resolution**: an in-tab memo under a collided stamp dies with the tab, a stored one does not. That is the one thing persistence genuinely raises the bar on, and a four-layer change for a one-millisecond window stays a follow-up rather than a prerequisite.

## Where the tier lives, and why it is not beside the broker

Measured in a real browser, an OPFS read costs **1.5–2.7ms**. A render already runs off the main thread, so checking the cache on the *asking* thread would put ~2ms per row back onto the very thread #1275 and #1293 spent their effort clearing.

So the request carries a `cacheKey`, the worker answers from the store before it works and writes after. A stored value carries no `id` — an id belongs to a request, not a picture — so a hit is stamped with the asking request's own; without that the pool is handed a reply addressed to a request it already settled, and the caller waits forever.

## The gate: persist what cost more than persisting it

Medians of 15 interleaved rounds, real browser:

| case | payload | render | OPFS read | OPFS write |
|---|---|---|---|---|
| markdown, 4 sections | 3.1 KB | 7.4 ms | 1.9 ms | ~2.3 ms |
| markdown, 20 sections | 14.9 KB | **21.8 ms** | 2.2 ms | ~2.3 ms |
| markdown, 60 sections | 44.4 KB | **67.2 ms** | 2.3 ms | ~2.3 ms |
| spatial, 12 nodes | 2.6 KB | 2.0 ms | 1.7 ms | 2.6 ms |
| spatial, 40 nodes | 9.4 KB | 3.0 ms | 1.7 ms | 2.6 ms |
| spatial, 120 nodes | 28.8 KB | 7.2 ms | 2.1 ms | 2.7 ms |
| spatial, 400 nodes | 97.0 KB | 19.9 ms | 2.7 ms | 3.1 ms |

Two things follow that the design could not show:

- **Text shaping is what persistence is for.** It grows superlinearly where the read stays flat at ~2ms — twenty 20-section markdown rows is **436ms of worker time against 44ms of reads**.
- **A small spatial canvas is a loss.** 12 nodes saves 0.3ms and costs 2.6ms to store, so "persist everything" makes the *first* visit slower to buy nothing on the second.

So the gate is a floor on the **measured render** (`STORE_FLOOR_MS = 5`), not a per-pipeline rule: cost is not a property of the pipeline, and a 400-node canvas clears the floor where a four-section body barely does. Warm round-trips through the pool are **3.4ms** and **20.4ms**, so the floor sits in a real gap rather than beside either side. A cold first render (2477ms, almost all worker startup and WASM) is stored, and that is correct — the list pays it once rather than per row.

## Two smaller decisions

**A stored entry is JSON for both families**, correcting the key's first sketch. `.svg` was right while an entry was the picture alone; a caller needs the whole reply — the SVG *and* the bounds it is scaled to — and `layout`'s reply carries a `scene` and `anchors` that are not optional on it. The family is still named by its own path segment, which is what the extension carried.

**`cacheKeyFor` derives from `isMemoisableKey`** rather than deciding again. A key the in-memory map refuses because it cannot notice its document changing would, on disk, outlive the tab as well — the two tiers must not be able to disagree about that.

## Test plan

- [x] New or updated tests — `render-store.browser.test.tsx` (5 cases, real OPFS + real worker), plus the gate assertion in `load-row-render.test.ts` and the extension change in `render-key.test.ts`
- [x] Nearest-layer suites pass locally
- [x] Manual verification — the measurements above ARE the verification; each is a real browser driving the real worker
- [ ] E2E coverage — nothing here depends on real routing, persistence or the daemon

Run:

- `web-jsdom` over all of `apps/web/src/lib` — **1228 passed (91 files)**
- `web-browser` (`render-store.browser`, `layout-worker-outline.browser`) — **10 passed**
- `pnpm --filter @kamiazya/whiteboard-web typecheck`, `pnpm knip`, `pnpm exec biome check` — clean

**Mutation-checked three ways, baseline green after each:**

| mutation | what failed |
|---|---|
| `STORE_FLOOR_MS = 0` | *stores nothing for a render cheaper than the write it would cost* |
| `STORE_FLOOR_MS = 10000` | *stores a render that cost more than storing it does* |
| the store read disabled | *answers a request from the stored entry rather than rendering again* |

The decisive case seeds an entry no renderer could invent (`only-the-store-could-say-this`) and asserts it comes back — the only observation that separates "answered from the store" from "answered quickly".

Two test-design notes, both from a green run that was not yet evidence:

- the worker deliberately does **not** await its write, so an assertion reading straight after the reply races a side effect. Both store assertions poll — including the negative one, which has to outlast the window in which a write would have happened.
- the "cheap render" case is **3 nodes, not 12**, and warms the pipeline first. A 12-node canvas is 3.4ms against a 5ms floor; asserting on 1.6ms of margin is asserting on load. The first render of a session clears the floor on its own (2477ms) and asserting on it would be measuring startup and calling it the gate.

## Visual evidence

Visual evidence: none — nothing about the drawn picture changes. A cached render is byte-identical to the one it replaces (`renderSceneToSvg` is pinned byte-for-byte against a committed golden in both the node and browser projects, which is the property that makes this a memo rather than a coordination problem). The measurements above are the evidence for what did change.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — ADR-0027's status, decision 5 rewritten, new decision 5a for the cost gate, and two of its open questions replaced with what measuring them found
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

## An ADR claim corrected on the way past

ADR-0027 said the version-thumbnail surface's "read side is dead, so the question is whether the feature exists at all". It is not dead — `VersionThumbnail` is rendered by `VersionTimeline`'s rows and both panes of `MergeDialog`, and both document pages write it. The ADR had confused it with `DocumentThumb`, a different component that really did have no call site and has since been deleted. It is still left out of the broker, for a caching reason instead: written once per save, read back as stored bytes, no repeated render for a memo to join.

This is the same claim #1307 corrects in `render-surfaces.ts`; that PR is independent of this one and touches no file here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh)_