### PR TITLE
fix(web): pin shaped-node-editing test's font and fixture width

### DIFF
--- a/apps/web/src/components/spatial-editor/shaped-node-editing.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/shaped-node-editing.browser.test.tsx
@@ -4,16 +4,34 @@
 // a non-rectangular node for the duration of the edit — so the scene now
 // keeps drawing the chrome and suppresses only the edited node's text
 // (canvas-render's `suppressedBodyNodeIds`), and the overlay is transparent.
+import { ensureViewerFontLoaded } from '@kamiazya/whiteboard-canvas-viewer'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
-import { afterEach, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
 import { nodeEditorContent } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
 
+// SpatialEditor never awaits font readiness itself (unlike CanvasViewer,
+// it has no subscribeViewerFontReady re-measure) — the app's real guarantee
+// is boot.ts awaiting this before the first render. Without it here, the
+// very first layout measures against whatever "Roboto" resolves to on this
+// machine (a real system Roboto, a metric-different substitute, or nothing)
+// instead of the vendored face every other measurement in the app agrees on.
+beforeAll(async () => {
+  await ensureViewerFontLoaded()
+})
+
+// The diamond's inscribed content box is only half the node's width (see
+// the contentBox comment below), so at the label font size (16px) the real
+// vendored Roboto face — the one every on-screen measurement in the app
+// agrees on, per beforeAll above — measures a 10-character word like
+// 'shapedbody' at ~86px against an 84px box: an unforced, environment-
+// dependent truncation that has nothing to do with the behavior under test.
+// 'shapefit' measures ~58px, leaving margin.
 const DIAMOND: SpatialCanvas = {
   nodes: [
     {
@@ -23,7 +41,7 @@ const DIAMOND: SpatialCanvas = {
       y: 100,
       width: 200,
       height: 100,
-      text: 'shapedbody',
+      text: 'shapefit',
       'x-whiteboard': { facets: { 'visual.shape/v0': { kind: 'diamond' } } },
     },
   ],
@@ -56,14 +74,14 @@ function svgText(container: HTMLElement): string {
 it('keeps the diamond silhouette on screen while its text is being edited', async () => {
   const { container } = render(<Host start={DIAMOND} />)
   expect(container.querySelector('svg polygon')).not.toBeNull()
-  expect(svgText(container)).toContain('shapedbody')
+  expect(svgText(container)).toContain('shapefit')
 
   await userEvent.dblClick(rootOf(container), { position: { x: 200, y: 150 } })
   await vi.waitFor(() => expect(nodeEditorContent(container)).not.toBeNull())
 
   // The silhouette still draws; only the committed text yields to the editor.
   expect(container.querySelector('svg polygon')).not.toBeNull()
-  await vi.waitFor(() => expect(svgText(container)).not.toContain('shapedbody'))
+  await vi.waitFor(() => expect(svgText(container)).not.toContain('shapefit'))
 })
 
 it("the editor sits in the diamond's inscribed content box, not the full bbox", async () => {
@@ -88,7 +106,7 @@ it('commit puts the committed text back into the scene', async () => {
   await vi.waitFor(() => expect(nodeEditorContent(container)).not.toBeNull())
   await userEvent.keyboard('{Control>}{Enter}{/Control}')
   await vi.waitFor(() => expect(nodeEditorContent(container)).toBeNull())
-  await vi.waitFor(() => expect(svgText(container)).toContain('shapedbody'))
+  await vi.waitFor(() => expect(svgText(container)).toContain('shapefit'))
 })
 
 it('a plain rect node shows no doubled committed text under the now-transparent editor', async () => {


### PR DESCRIPTION
Closes `issues/shaped-node-editing-browser-test-fails-on-main` (deterministic local failure, CI green — the inverse of a flake). Root-caused with discriminating observations before touching anything:

- The reported `'     shapedbod'` is a **test-helper artifact**: `svgText()` joins textContent across 5 empty icon-toolbar `<svg>`s + the diamond's — five empty strings joined by `' '` produce exactly the 5 leading spaces. The real SVG holds `>shapedbod<` under the app's own truncation fade: a **legitimate 1-character truncation**, not a measurement bug producing spaces.
- Width probe under the properly-loaded vendored Roboto: `'shapedbody'` measures **86–93px against an 84px** inscribed diamond content box, under every font tried. `document.fonts.check('16px Roboto')` was true BEFORE the vendored load — this machine has system Roboto (`fc-list`), so ambient resolution hands the same face; CI lacks it and passed **by coincidence**, not validation.
- Mutation checks both ways: font-wait alone → identical failure byte-for-byte (refutes a timing race); shorter fixture + wait → green; reverting only the fixture word reproduces the original 2 failures (the width margin is the load-bearing fix).

Fix (test-only): `beforeAll(ensureViewerFontLoaded())` mirroring `boot.ts`'s real production guarantee (SpatialEditor itself never re-measures on font readiness — the test had bypassed the boot chain), fixture `'shapedbody'` → `'shapefit'` (~58px, ~26px margin), and a comment stating the width invariant so a wider string is not reintroduced.

## Gates
Touched file green 3× in isolation; **entire web-browser project 193 files / 1052 tests green**; typecheck/biome clean.

Visual evidence: none — test-only change; the executable evidence is the quoted width probe (86px vs 84px box), the join-artifact SVG dump, and the two-way mutation checks above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7iuGxJAXjr6rEXfS7YAC6