### PR TITLE
fix(web): Back after the first create no longer shows onboarding over a non-empty store

### DIFF
--- a/apps/web/src/pages/BrowserIndexPage.defaults.browser.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.defaults.browser.test.tsx
@@ -10,6 +10,7 @@
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
 import { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
@@ -20,6 +21,23 @@ claimIsolatedWhiteboardDb('browserindexpage-defaults')
 describe('list page, production wiring', () => {
   beforeEach(clearWhiteboardDb)
   afterEach(cleanup)
+
+  it('a create lands in this mount own list - Back can arrive before it ever unmounts', async () => {
+    // react-router wraps navigation in startTransition, so the editor's lazy
+    // chunk loads while THIS page is still mounted; a Back in that window
+    // returns to this same mount. Its list has to carry the document it just
+    // created, or onboarding sticks over a store that has one.
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <BrowserIndexPage index={new IdbDocumentIndex()} onOpenDocument={() => {}} />
+      </MemoryRouter>,
+    )
+    await screen.findByText('What will you make first?', undefined, { timeout: 10_000 })
+    await userEvent.click(screen.getByRole('button', { name: 'Create a canvas' }))
+    const cards = await screen.findAllByTestId('card-title', undefined, { timeout: 10_000 })
+    expect(cards).toHaveLength(1)
+    expect(screen.queryByText('What will you make first?')).toBeNull()
+  })
 
   it('reads the index once, not once per render', async () => {
     // A default evaluated in the parameter list is a NEW value every render.

--- a/apps/web/src/pages/BrowserIndexPage.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.test.tsx
@@ -214,6 +214,22 @@ describe('BrowserIndexPage', () => {
     expect(await store.getDefaultDocumentId()).toBe(created?.documentId)
   })
 
+  it('a create this page performed reaches its own list without an unmount', async () => {
+    // react-router wraps navigation in startTransition, so while the lazy
+    // editor chunk loads this page STAYS MOUNTED — and a Back landing in
+    // that window returns to this same mount. The list it renders must
+    // therefore include what it just created, or the onboarding empty state
+    // sticks over a store that has a document (the back-from-editor bug).
+    const store = new LocalStoreDouble()
+    renderPage(store)
+
+    fireEvent.click(await screen.findByRole('button', { name: /create a canvas/i }))
+
+    const titles = await screen.findAllByTestId('card-title')
+    expect(titles).toHaveLength(1)
+    expect(screen.queryByText('What will you make first?')).toBeNull()
+  })
+
   it('empty store also offers a markdown note, creating and opening one', async () => {
     const store = new LocalStoreDouble()
     const { onOpenDocument } = renderPage(store)

--- a/apps/web/src/pages/BrowserIndexPage.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.tsx
@@ -145,7 +145,12 @@ export function BrowserIndexPage({
     // accessor themselves — but it IS what this effect follows. Depending on
     // the value rather than calling it is the difference between a list that
     // re-reads on a switch and one that does not.
-  }, [index, clock, filesSource, activeWorkspace])
+    // `filesRevision` follows this page's own writes (create below, delete
+    // dialog): react-router wraps navigation in startTransition, so while a
+    // lazy page chunk loads this page stays mounted — and a Back in that
+    // window returns to THIS mount, whose list must already carry what it
+    // created or the onboarding empty state sticks over a non-empty store.
+  }, [index, clock, filesSource, activeWorkspace, filesRevision])
 
   // The index deletes by PATH, and the list already addresses rows that way,
   // so this carries the path rather than the id it used to need.
@@ -213,6 +218,10 @@ export function BrowserIndexPage({
         // Repointed so a later plain load resumes in the new document — the
         // same contract the editor's own create/switch flows keep.
         await pointer.set(created.documentId)
+        // This page's own list must see the create even if it never
+        // unmounts (Back before the editor chunk mounts) — see the load
+        // effect's dependency note.
+        setFilesRevision((n) => n + 1)
         onOpenDocument(created.path)
       } catch {
         setError(`Failed to create a ${kindNoun(kind)} in this browser.`)


### PR DESCRIPTION
## What

Fixes the ticketed bug "Back from the editor shows onboarding although a document exists": create your first document from onboarding, press Back, and the app claimed you had nothing — inviting a duplicate create.

## Root cause (measured, not assumed)

react-router v7 wraps navigation in `startTransition`, so while the editor's **lazy chunk** is loading, `BrowserIndexPage` **stays mounted** — the old tree is kept on screen instead of a Suspense fallback. A Back in that window returns to that same mount. Its load effect was keyed on `[index, clock, filesSource, activeWorkspace]`, none of which move on a Back, so `snapshots` kept the pre-create empty list and the onboarding empty state stuck over a store that had the document.

The window is invisible on a warm desktop (the existing flow browser test Backs *after* the editor mounts and passes) and wide on a phone — which is why the ticket found it under iPhone emulation. Reproduced against the real vite dev app with Playwright, immediate Back after the URL change:

```
before fix: back+200ms..+6000ms {"onboarding":1,"cards":0}   (stuck)
            control full reload {"onboarding":0,"cards":1}   (data was fine)
after  fix: back+200ms          {"onboarding":0,"cards":1}
```

The ticket's own repro steps at its own commit (slow Back) do NOT reproduce — the missing ingredient was Back-before-the-chunk-mounts, confirmed by isolating route, viewport, real editor, StrictMode, and real popstate one at a time.

## Fix

`handleCreate` bumps `filesRevision` — the signal the delete dialog already uses — and the load effect now depends on it, so this page's own list carries what it just created whether or not the page ever unmounts. Two lines plus the dependency; both halves individually mutation-checked (removing either fails the new test).

## Regression coverage

- `web-jsdom`: "a create this page performed reaches its own list without an unmount" (red before the fix, both mutants killed).
- `web-browser` (real IndexedDB, production defaults): same invariant in `BrowserIndexPage.defaults.browser.test.tsx`.

## Visual repro

Same flow through the real app (iPhone-13 emulation, immediate Back): before — onboarding sticks over a store holding the document; after — the list shows it.

Visual evidence: attached separately by the maintainer — `gh` 2.97 here has no `--attach`; the figure is `tmp/screenshots/backnav-figure.png` (compose-figure digests: before a7017b58, after a011a4fc), delivered via the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D
