### PR TITLE
docs(web): the worker pool's cap is a measurement now, not a starting point

### DIFF
--- a/apps/web/src/lib/layout-worker-pool.ts
+++ b/apps/web/src/lib/layout-worker-pool.ts
@@ -81,8 +81,10 @@ export interface LayoutWorkerPool {
  *   size 6  warm 127-165ms   cold 2.0-2.3s
  *
  * Three things the numbers say. A list is RENDER-bound, so fill time tracks
- * the slots it may use — and `background` gets `size - 1` of them, which is
- * why sizes 1 and 2 are the same speed (one slot each). Past the core count
+ * the slots it may use — and `background` gets `deferrableSlotCap(size)` of
+ * them: `size - 1`, except that a fleet of one keeps its single slot rather
+ * than none. That exception is why sizes 1 and 2 are the same speed — one
+ * slot each, by two different rules. Past the core count
  * the curve is flat inside its own noise, so on a four-core machine nothing
  * above 4 is measurable HERE; whether an eight-core machine would use a
  * fifth worker is unmeasured, and this cap is what leaves that question

--- a/apps/web/src/lib/layout-worker-pool.ts
+++ b/apps/web/src/lib/layout-worker-pool.ts
@@ -66,13 +66,30 @@ export interface LayoutWorkerPool {
 /**
  * How many workers a thumbnail fleet gets.
  *
- * One core is left for the main thread, and the fleet is capped well below
- * the core count: past a handful, the queue is no longer what a list is
- * waiting on — fetching each document's bytes is — and every extra worker is
- * another module graph and another font registration paid at startup.
+ * One core is left for the main thread, and the fleet is capped at four.
+ * The cap once rested on a claim that fetching a document's bytes, not the
+ * render queue, is what a list waits on; that claim is false (a fetch is a
+ * near-constant 4-6ms against a render of 9-29ms that grows with the
+ * document), so the cap was re-measured on what a list actually does. Forty
+ * rows — twenty 20-section markdown bodies and twenty 40-node canvases — at
+ * `background` priority, two runs, real browser, four cores:
  *
- * The cap is a starting point, not a measurement. What would move it is the
- * real fill time of a real list, which needs the list to exist first.
+ *   size 1  warm 284-304ms   cold 2.4-2.9s
+ *   size 2  warm 253-263ms   cold 1.3-1.8s
+ *   size 3  warm 160-167ms   cold 1.2-2.1s
+ *   size 4  warm 137-141ms   cold 1.9-2.0s
+ *   size 6  warm 127-165ms   cold 2.0-2.3s
+ *
+ * Three things the numbers say. A list is RENDER-bound, so fill time tracks
+ * the slots it may use — and `background` gets `size - 1` of them, which is
+ * why sizes 1 and 2 are the same speed (one slot each). Past the core count
+ * the curve is flat inside its own noise, so on a four-core machine nothing
+ * above 4 is measurable HERE; whether an eight-core machine would use a
+ * fifth worker is unmeasured, and this cap is what leaves that question
+ * open rather than answering it. And the cold pass is 1-3s whatever the
+ * size — that is worker startup (module graph, WASM, font registration) paid
+ * once per list, not a cap effect, so a smaller fleet does not buy a faster
+ * first list.
  *
  * `navigator.hardwareConcurrency` is absent on some browsers; 2 is the
  * conservative answer there, not a guess at the machine.


### PR DESCRIPTION
## Summary

- `defaultPoolSize`'s comment said its cap of four was "a starting point, not a measurement", and rested on a claim ADR-0027 had already refuted (that a list waits on fetching bytes rather than on the render queue).
- The cap is now backed by a measurement of what a list actually does, and the comment says what that measurement can and **cannot** settle.
- No code changes. The cap stays 4 — the numbers support it on this machine and cannot speak above it.

## The measurement

Forty rows — twenty 20-section markdown bodies and twenty 40-node canvases — at `background` priority, fresh pool of real `Worker`s per size, one cold fill then two warm fills (best of two), real browser, **4 cores**, two runs:

| size | `background` slots | warm | cold |
|---|---|---|---|
| 1 | 1 | 284–304 ms | 2.4–2.9 s |
| 2 | 1 | 253–263 ms | 1.3–1.8 s |
| 3 | 2 | 160–167 ms | 1.2–2.1 s |
| 4 | 3 | **137–141 ms** | 1.9–2.0 s |
| 6 | 5 | 127–165 ms | 2.0–2.3 s |

Three things it says, each of which the old comment either got wrong or could not say:

1. **A list is render-bound.** Fill time tracks the slots the `background` band may use — which is `size − 1`, since one is reserved for interactive work. That is why sizes 1 and 2 are the same speed: both give a list exactly one slot. The old premise (fetch dominates) would have predicted a flat curve everywhere.
2. **Past the core count the curve is flat inside its own noise** (4 vs 6 reversed between runs). So on a four-core machine nothing above 4 is measurable *here* — and the comment now says that an eight-core machine is unmeasured, rather than implying the cap was chosen with one in mind.
3. **The cold pass is 1–3s at every size.** That is worker startup — module graph, WASM, font registration — paid once per list, not a cap effect. A smaller fleet does not buy a faster first list.

## Test plan

- [ ] New or updated tests — none; a comment changed. The measurement was taken with a throwaway `web-browser` bench (deleted), not pinned: a pool-size timing assertion would flake on exactly the load it is measuring.
- [x] `pnpm exec biome check` — clean
- [ ] Manual verification — not applicable
- [ ] E2E — not applicable

## Visual evidence

Visual evidence: none — a source comment; nothing rendered changes.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — ADR-0027's "worth revisiting" bullet is updated on #1322's branch, which already edits that file, to avoid a conflict
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the rationale for the worker-pool size cap.
  * Added performance measurements for different worker-pool sizes on a four-core machine.
  * Documented that cold-start timing reflects worker startup and that behavior on systems with more than four cores remains unmeasured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->