### PR TITLE
test(scripts): compose-figure probes for ImageMagick and skips locally, fails on CI

### DIFF
--- a/.claude/scripts/compose-figure.test.mjs
+++ b/.claude/scripts/compose-figure.test.mjs
@@ -18,17 +18,35 @@ import assert from 'node:assert/strict'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const scriptPath = resolve(__dirname, 'compose-figure.mjs')
 
-// Not skipped when ImageMagick is absent, on purpose: these cover a guard
-// whose whole point is that a check which quietly does not run is worse than
-// no check. CI installs it; a developer without it gets told what to install.
-try {
-  execFileSync('convert', ['-version'], { stdio: 'ignore' })
-} catch {
+// The premise is PROBED, never inferred: the same binary compose-figure.mjs
+// shells out to, asked directly.
+const IMAGEMAGICK_ABSENT = (() => {
+  try {
+    execFileSync('convert', ['-version'], { stdio: 'ignore' })
+    return false
+  } catch {
+    return true
+  }
+})()
+
+// Guarded from both sides, the way every probed skip in this repo is. On CI
+// the premise MUST hold — ci.yml installs ImageMagick for exactly this file —
+// so absence there is the install step regressing, and a skip would let a
+// guard stop running while every summary line stayed green. Locally a
+// developer without it is told what to install and `pnpm check:local` still
+// completes; before this, one absent binary failed the whole local gate.
+if (IMAGEMAGICK_ABSENT && process.env.CI) {
   console.error(
-    'compose-figure.test.mjs needs ImageMagick (`convert`, `identify`) — the same tool ' +
-      'compose-figure.mjs shells out to. Install it (apt: imagemagick, brew: imagemagick) and re-run.',
+    'compose-figure.test.mjs needs ImageMagick (`convert`, `identify`) on CI — the same tool ' +
+      'compose-figure.mjs shells out to. ci.yml installs it; that step has regressed.',
   )
   process.exit(1)
+}
+
+const needsImageMagick = {
+  skip: IMAGEMAGICK_ABSENT
+    ? 'ImageMagick (`convert`) is absent — install it (apt: imagemagick, brew: imagemagick) to run these; CI does'
+    : false,
 }
 
 const scratchDirs = []
@@ -59,7 +77,7 @@ function run(args) {
   }
 }
 
-test('refuses two panels that are byte-identical', () => {
+test('refuses two panels that are byte-identical', needsImageMagick, () => {
   const dir = scratch()
   const before = join(dir, 'before.png')
   const after = join(dir, 'after.png')
@@ -72,7 +90,7 @@ test('refuses two panels that are byte-identical', () => {
   assert.equal(existsSync(out), false, 'must not leave a figure that shows one picture twice')
 })
 
-test('composes a figure when the panels differ, and reports both digests', () => {
+test('composes a figure when the panels differ, and reports both digests', needsImageMagick, () => {
   const dir = scratch()
   const before = join(dir, 'before.png')
   const after = join(dir, 'after.png')
@@ -88,7 +106,7 @@ test('composes a figure when the panels differ, and reports both digests', () =>
   assert.equal(new Set(digests).size >= 2, true, `expected two distinct digests, got ${stdout}`)
 })
 
-test('refuses two panels that differ only in metadata', () => {
+test('refuses two panels that differ only in metadata', needsImageMagick, () => {
   // A byte compare says these differ; they are the same picture. Whatever
   // wrote them stamped something incidental, and the refusal has to survive
   // that or it protects nothing.
@@ -105,7 +123,7 @@ test('refuses two panels that differ only in metadata', () => {
   assert.match(stderr, /same picture/i)
 })
 
-test('gives a wider panel a label band of its own width', () => {
+test('gives a wider panel a label band of its own width', needsImageMagick, () => {
   // A change can legitimately resize what it renders, so mismatched panels
   // are not an error — but a label band built at the OTHER panel's width
   // crops the text, silently, in the half of the figure that is the point.
@@ -143,7 +161,7 @@ test('gives a wider panel a label band of its own width', () => {
   assert.equal(mean < white, true, `expected label text past x=60, got mean ${mean} vs white ${white}`)
 })
 
-test('refuses a missing input rather than composing half a figure', () => {
+test('refuses a missing input rather than composing half a figure', needsImageMagick, () => {
   const dir = scratch()
   const before = join(dir, 'before.png')
   png(before, 'white')
@@ -159,7 +177,7 @@ test('refuses a missing input rather than composing half a figure', () => {
   assert.match(stderr, /nope\.png/)
 })
 
-test('carries the labels it was given into the figure', () => {
+test('carries the labels it was given into the figure', needsImageMagick, () => {
   const dir = scratch()
   const before = join(dir, 'before.png')
   const after = join(dir, 'after.png')


### PR DESCRIPTION
## Summary

- `compose-figure.test.mjs` hard-failed wherever ImageMagick was absent — deliberately, so a guard could not quietly stop running. The cost was that **one absent binary failed the whole of `pnpm check:local`** on any machine without it.
- It now uses the shape this repo already has for exactly that tension (`CAN_DENY_FILE_READ`, `test-layer-selection`): the premise is **probed**, and the skip is **guarded from both sides** — a loud, reasoned skip locally, still a hard failure on CI.
- `pnpm check:local` completes on a machine without ImageMagick; CI loses nothing.

## The two sides

| where | ImageMagick absent | why |
|---|---|---|
| local | six cases **skip**, each carrying *"install it (apt/brew) to run these; CI does"* | the developer is told what to install and the rest of the local gate runs |
| CI (`process.env.CI`) | **exit 1** with the install message, as before | `ci.yml` installs ImageMagick for this file, so absence there is that step regressing — a skip would let a guard stop running while every summary line stayed green |

node:test has no `skipIf`; its equivalent is the `{ skip: reason | false }` option, which the six cases share as `needsImageMagick`.

## Measured on a machine without ImageMagick

| command | before | after |
|---|---|---|
| `node --test .claude/scripts/compose-figure.test.mjs` | exit 1 | exit 0 — `tests 6, pass 0, skipped 6` |
| same, `CI=1` | exit 1 | exit 1, install message |
| `pnpm test:scripts` | exit 1 | exit 0 — `tests 282, pass 276, fail 0, skipped 6` |

`pass 0 / skipped 6` is the property that matters: a skipped test must not read as a passing one, and node:test prints each with its reason.

## Test plan

- [x] New or updated tests — the guard's own behaviour is the change; both sides are exercised above
- [x] `pnpm test:scripts` — 282 tests, 276 pass, 6 skipped, exit 0
- [ ] Manual verification — not applicable
- [ ] E2E — not applicable

The `.claude/` tree is excluded from biome and from the quarantine scan (dot-directories are skipped, and its regex matches only `it|test|describe.skip`), so nothing else needed adjusting — checked rather than assumed.

## Visual evidence

Visual evidence: none — a test file's skip policy; nothing rendered changes.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — n/a; the `visual-evidence` skill already says the script needs ImageMagick
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh)_