### PR TITLE
fix(search): cut snippets between grapheme clusters, not code points

### DIFF
--- a/packages/search/src/snippet.bench.ts
+++ b/packages/search/src/snippet.bench.ts
@@ -1,0 +1,51 @@
+// The cost of one search result's excerpts. `full-text.ts` calls
+// `snippetAround` up to three times per matching document, each on the whole
+// searchable text with the hit somewhere inside it, so the body here is
+// document-sized and the hits are interior — the shape the function meets in
+// production, not a short string with the needle at the front.
+//
+// Run with `pnpm vitest bench --project search-node --run`.
+//
+// **The pair is the measurement, not either row.** `ascii` cannot hold a
+// grapheme cluster at all, so it is the floor of what the function costs
+// with nothing to segment; `emoji` and `cjk` are the bodies where a
+// grapheme-aware cut has work to do. The DIFFERENCE is that work's price.
+// A single row drifts 2-3x with machine load; compare before/after on the
+// same machine, interleaved, in one sitting.
+import { bench, describe } from 'vitest'
+import { snippetAround } from './snippet.js'
+
+const NEEDLE = 'needle'
+const HITS = 3
+
+/** A body with the needle planted at three interior offsets, like a real match. */
+function bodyOf(filler: string, length: number): { text: string; indexes: number[] } {
+  const chunk = filler.repeat(Math.ceil(length / 3 / filler.length))
+  const text = `${chunk} ${NEEDLE} ${chunk} ${NEEDLE} ${chunk} ${NEEDLE} ${chunk}`
+  const indexes: number[] = []
+  let at = -1
+  while ((at = text.indexOf(NEEDLE, at + 1)) !== -1) indexes.push(at)
+  return { text, indexes: indexes.slice(0, HITS) }
+}
+
+const ASCII = bodyOf('lorem ipsum dolor sit amet consectetur ', 6000)
+const EMOJI = bodyOf('review 👨‍👩‍👧‍👦 shipped 🇯🇵 done 👍🏽 next 1️⃣ ', 6000)
+const CJK = bodyOf('設計レビューを終えて次の段階に進む。', 6000)
+
+function excerpts(body: { text: string; indexes: number[] }): number {
+  let total = 0
+  for (const index of body.indexes) total += snippetAround(body.text, index, NEEDLE.length).length
+  return total
+}
+
+describe('snippetAround, three excerpts of a document-sized body', () => {
+  bench('ascii body', () => {
+    excerpts(ASCII)
+  })
+  bench('emoji-bearing body', () => {
+    excerpts(EMOJI)
+  })
+  bench('cjk body', () => {
+    excerpts(CJK)
+  })
+})

--- a/packages/search/src/snippet.bench.ts
+++ b/packages/search/src/snippet.bench.ts
@@ -23,8 +23,9 @@ function bodyOf(filler: string, length: number): { text: string; indexes: number
   const chunk = filler.repeat(Math.ceil(length / 3 / filler.length))
   const text = `${chunk} ${NEEDLE} ${chunk} ${NEEDLE} ${chunk} ${NEEDLE} ${chunk}`
   const indexes: number[] = []
-  let at = -1
-  while ((at = text.indexOf(NEEDLE, at + 1)) !== -1) indexes.push(at)
+  for (let at = text.indexOf(NEEDLE); at !== -1; at = text.indexOf(NEEDLE, at + 1)) {
+    indexes.push(at)
+  }
   return { text, indexes: indexes.slice(0, HITS) }
 }
 

--- a/packages/search/src/snippet.test.ts
+++ b/packages/search/src/snippet.test.ts
@@ -93,3 +93,89 @@ describe('snippetAround', () => {
     expect(snippetAround('a  \n\t b', 0, 1)).toBe('a b')
   })
 })
+
+/**
+ * The cut falls between GRAPHEMES, not code points.
+ *
+ * Code-point snapping (above) stops a lone surrogate; it does not stop a
+ * flag, a ZWJ family or a combining mark being cut in half. The flag case is
+ * the one with teeth: a cut inside a run of regional indicators leaves an
+ * odd half at the edge, and the segmenter on the OUTPUT then pairs every
+ * following flag one half off — the excerpt shows flags the document does
+ * not hold. That is an excerpt that lies, not one that looks rough.
+ */
+describe('snippetAround cuts between characters a reader sees as one', () => {
+  const GRAPHEMES = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+  const split = (value: string): string[] => [...GRAPHEMES.segment(value)].map((g) => g.segment)
+  const boundaries = (value: string): Set<number> => {
+    const at = new Set<number>()
+    for (const g of GRAPHEMES.segment(value)) at.add(g.index)
+    at.add(value.length)
+    return at
+  }
+
+  const CLASSES = ['👨‍👩‍👧‍👦', '🇯🇵', '👍🏽', '1️⃣', 'e\u0301', 'ｶﾞ'] as const
+  /** Longer than the radius in code units for every class, so the cut stays in the run. */
+  const RUN = CONTEXT_RADIUS
+
+  /**
+   * Runs whose start boundary landed STRICTLY INSIDE a cluster. Counted, and
+   * floored, for the same reason as `enteredDefectZone`: the assertion below
+   * is vacuous over a sweep that only ever cuts on a boundary.
+   */
+  let cutInsideACluster = 0
+
+  afterAll(() => {
+    expect(
+      cutInsideACluster,
+      'the sweep never cut inside a cluster — the grapheme property proved nothing',
+    ).toBeGreaterThan(20)
+  })
+
+  fcTest.prop([fc.integer({ min: 0, max: 11 }), fc.constantFrom(...CLASSES)], withDefaults())(
+    'every grapheme of the excerpt is a grapheme of the source',
+    (k, cluster) => {
+      // `k` filler units BETWEEN the run and the needle walk the cut through
+      // every interior offset of the cluster; the run's own start is fixed.
+      const body = `${cluster.repeat(RUN)}${'y'.repeat(k)}${NEEDLE}${cluster.repeat(RUN)}`
+      const index = body.indexOf(NEEDLE)
+      if (!boundaries(body).has(index - CONTEXT_RADIUS)) cutInsideACluster += 1
+
+      const out = snippetAround(body, index, NEEDLE.length)
+      const source = new Set(split(body))
+      const foreign = split(out).filter((g) => g !== '…' && g !== ' ' && !source.has(g))
+      expect(foreign).toEqual([])
+    },
+  )
+
+  it('honours a Prepend: the character after one is never the first thing shown', () => {
+    // Every code point in the first two planes, each put right before the
+    // start cut with an ASCII letter ON the cut — the one shape the cheap
+    // boundary test would wave through. The runtime's segmenter is the
+    // oracle, so a Unicode update that moves the Prepend set fails here
+    // rather than in someone's Arabic search results.
+    const tail = `${'b'.repeat(CONTEXT_RADIUS - 1)}${NEEDLE}`
+    const misses: string[] = []
+    let prepends = 0
+    for (let cp = 0; cp < 0x20000; cp += 1) {
+      if (cp >= 0xd800 && cp <= 0xdfff) continue
+      const head = String.fromCodePoint(cp)
+      const body = `${head}a${tail}`
+      const joined = split(`${head}a`).length === 1
+      if (joined) prepends += 1
+      const out = snippetAround(body, body.indexOf(NEEDLE), NEEDLE.length)
+      const expected = joined ? `…${tail}` : `…a${tail}`
+      if (out !== expected) misses.push(`U+${cp.toString(16)}: ${JSON.stringify(out)}`)
+    }
+    expect(misses).toEqual([])
+    expect(prepends, 'no Prepend found — the sweep tested nothing').toBeGreaterThan(20)
+  })
+
+  it('never shows a flag the document does not hold', () => {
+    // k=2 puts the cut between the two regional indicators of one flag.
+    const body = `${'🇯🇵'.repeat(RUN)}yy${NEEDLE}${'🇯🇵'.repeat(RUN)}`
+    const out = snippetAround(body, body.indexOf(NEEDLE), NEEDLE.length)
+    const first = split(out).find((g) => g !== '…')
+    expect(first).toBe('🇯🇵')
+  })
+})

--- a/packages/search/src/snippet.ts
+++ b/packages/search/src/snippet.ts
@@ -112,8 +112,8 @@ function windowStart(value: string, at: number): number | null {
 
 /** The cluster the window around `at` puts `at` inside, in document offsets. */
 function clusterAround(value: string, at: number, from: number): { start: number; end: number } {
-  const window = value.slice(from, Math.min(value.length, at + LOCAL_UNITS))
-  const found = GRAPHEMES.segment(window).containing(at - from)
+  const span = value.slice(from, Math.min(value.length, at + LOCAL_UNITS))
+  const found = GRAPHEMES.segment(span).containing(at - from)
   const start = from + (found?.index ?? 0)
   return { start, end: start + (found?.segment.length ?? 0) }
 }

--- a/packages/search/src/snippet.ts
+++ b/packages/search/src/snippet.ts
@@ -13,21 +13,126 @@ export const CONTEXT_RADIUS = 60
  * from both surfaces.
  */
 export function snippetAround(value: string, index: number, length: number): string {
-  // Snapped to whole characters before slicing. `slice` indexes UTF-16 code
-  // UNITS, and everything outside the BMP — emoji, the rarer CJK ideographs —
-  // is two of them, so a radius landing between the halves used to emit a lone
-  // surrogate: a broken glyph at the edge of the excerpt, in every search
-  // result and backlink context for that document.
-  //
-  // Inward, so an excerpt can never grow past the radius it was asked for and
-  // the rule reads the same at both ends. This buys WHOLE CHARACTERS and not
-  // whole graphemes: a combining mark or a flag sequence can still be split,
-  // which needs `Intl.Segmenter` and is a larger question than the one
-  // measured here.
-  const start = snapForward(value, Math.max(0, index - CONTEXT_RADIUS))
-  const end = snapBack(value, Math.min(value.length, index + length + CONTEXT_RADIUS))
-  const text = value.slice(start, end).replace(/\s+/g, ' ').trim()
+  // Both edges snap INWARD to a grapheme boundary, so an excerpt can never
+  // grow past the radius it was asked for and the rule reads the same at
+  // both ends. Code points were not enough: `slice` indexes UTF-16 code
+  // units, and a radius landing inside a flag, a ZWJ family or a combining
+  // pair emitted a fragment at the edge of every search result and backlink
+  // context — and inside a run of flags, an excerpt whose first flag was not
+  // one the document contains.
+  const start = clusterStartAtOrAfter(value, Math.max(0, index - CONTEXT_RADIUS))
+  const end = clusterEndAtOrBefore(value, Math.min(value.length, index + length + CONTEXT_RADIUS))
+  const text = start < end ? value.slice(start, end).replace(/\s+/g, ' ').trim() : ''
   return `${start > 0 ? '…' : ''}${text}${end < value.length ? '…' : ''}`
+}
+
+/**
+ * How far a cut looks around itself before asking the segmenter.
+ *
+ * Asking is the cost: every `Intl.Segmenter#segment` call clones an ICU
+ * break iterator, ~5µs whatever the text, so the point of everything below
+ * is to not ask. Nothing below U+0300 joins the character before it — bar
+ * LF after CR, and anything after a Prepend character (UAX #29 GB9b) — so
+ * a unit like that AT the cut is a boundary already, which is every cut in
+ * Latin text. A cut on anything else asks, but over a window rather than
+ * the document: UAX #29's boundary rules are LOCAL — each reads a few code
+ * points — except regional-indicator pairing, which counts from the START
+ * of the run. So a window that begins `LOCAL_UNITS` back, or at the nearest
+ * boundary unit if one is closer, segments the same as the document does
+ * from there on, and only a run of flags pushes its start further back, up
+ * to `LOOKBACK_UNITS`. Priced on `snippet.bench.ts`: a CJK cut — no
+ * boundary unit within reach, so both edges ask — costs the one clone and
+ * nothing that grows with the document.
+ *
+ * ponytail: 64 units is the longest cluster a window is sure to hold whole;
+ * a cluster longer than that (sixty-odd combining marks on one base) can
+ * still be cut inside. 1024 units is 256 consecutive flags; past it the
+ * edge falls back to code-point snapping, exact for everything but a flag
+ * straddling the cut inside such a run. The upgrade for either is a
+ * backward walk over the class alone.
+ */
+const LOOKBACK_UNITS = 1024
+const LOCAL_UNITS = 64
+
+const GRAPHEMES = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+
+/**
+ * Code points that glue themselves to the character AFTER them (UAX #29
+ * GB9b, Grapheme_Cluster_Break=Prepend — Arabic number signs, Indic
+ * prefixes). Enumerated rather than derived, so `snippet.test.ts` asks the
+ * runtime's own segmenter for the list and fails when a Unicode update
+ * moves it.
+ */
+const PREPEND = new Set([
+  0x0600, 0x0601, 0x0602, 0x0603, 0x0604, 0x0605, 0x06dd, 0x070f, 0x0890, 0x0891, 0x08e2, 0x0d4e,
+  0x110bd, 0x110cd, 0x111c2, 0x111c3, 0x113d1, 0x1193f, 0x11941, 0x11a84, 0x11a85, 0x11a86, 0x11a87,
+  0x11a88, 0x11a89, 0x11d46, 0x11f02,
+])
+
+/** Whether the code point ending at `at - 1` is a Prepend. */
+function precededByPrepend(value: string, at: number): boolean {
+  const unit = value.charCodeAt(at - 1)
+  if (unit < 0x0600) return false
+  if (unit < 0xdc00 || unit > 0xdfff) return PREPEND.has(unit)
+  const high = value.charCodeAt(at - 2)
+  return (
+    high >= 0xd800 &&
+    high <= 0xdbff &&
+    PREPEND.has((high - 0xd800) * 0x400 + (unit - 0xdc00) + 0x10000)
+  )
+}
+
+/** A cut no cluster can straddle, decided from two units — the cheap test. */
+function isBoundaryUnit(value: string, at: number): boolean {
+  if (at === 0 || at === value.length) return true
+  const unit = value.charCodeAt(at)
+  return unit < 0x0300 && unit !== 0x000a && !precededByPrepend(value, at)
+}
+
+/** Whether the unit at `at` is the low half of a regional indicator. */
+function endsRegionalIndicator(value: string, at: number): boolean {
+  const low = value.charCodeAt(at)
+  return low >= 0xdde6 && low <= 0xddff && value.charCodeAt(at - 1) === 0xd83c
+}
+
+/**
+ * Where a window around `at` can start and still segment as the document
+ * does, or null when a run of flags outlasts the lookback.
+ */
+function windowStart(value: string, at: number): number | null {
+  const floor = Math.max(0, at - LOOKBACK_UNITS)
+  let sawRegionalIndicator = false
+  for (let p = at; p >= floor; p -= 1) {
+    if (isBoundaryUnit(value, p)) return p
+    if (endsRegionalIndicator(value, p)) sawRegionalIndicator = true
+    else if (!sawRegionalIndicator && at - p >= LOCAL_UNITS) return p
+  }
+  return null
+}
+
+/** The cluster the window around `at` puts `at` inside, in document offsets. */
+function clusterAround(value: string, at: number, from: number): { start: number; end: number } {
+  const window = value.slice(from, Math.min(value.length, at + LOCAL_UNITS))
+  const found = GRAPHEMES.segment(window).containing(at - from)
+  const start = from + (found?.index ?? 0)
+  return { start, end: start + (found?.segment.length ?? 0) }
+}
+
+/** The first grapheme boundary at or after `from`, inward. */
+function clusterStartAtOrAfter(value: string, from: number): number {
+  if (isBoundaryUnit(value, from)) return from
+  const anchor = windowStart(value, from)
+  if (anchor === null) return snapForward(value, from)
+  const cluster = clusterAround(value, from, anchor)
+  return cluster.start === from ? from : cluster.end
+}
+
+/** The last grapheme boundary at or before `to`, inward. */
+function clusterEndAtOrBefore(value: string, to: number): number {
+  if (isBoundaryUnit(value, to)) return to
+  const anchor = windowStart(value, to)
+  if (anchor === null) return snapBack(value, to)
+  return clusterAround(value, to, anchor).start
 }
 
 /** Past the low half of a pair, when the cut landed between the two. */

--- a/packages/search/vitest.node.config.ts
+++ b/packages/search/vitest.node.config.ts
@@ -5,5 +5,9 @@ export default defineProject({
     name: 'search-node',
     environment: 'node',
     include: ['src/**/*.test.ts'],
+    // `vitest bench --project search-node` only — `vitest run` never picks
+    // these up. snippet.bench.ts is what notices the excerpt path getting
+    // slower, and the pair of rows in it is the measurement, not either row.
+    benchmark: { include: ['src/**/*.bench.ts'] },
   },
 })


### PR DESCRIPTION
## Summary

- `snippetAround` (search results + backlink context) sliced its context radius in UTF-16 code units and only re-joined a surrogate pair, so a radius landing inside a flag, a ZWJ family, a keycap or a combining pair showed a fragment at the excerpt edge — and inside a run of flags, a flag the document does not contain (regional indicators re-pair from wherever the cut lands). Both edges now snap **inward** to a UAX #29 grapheme boundary.
- The cost is gated, not paid everywhere: a unit below U+0300 at the cut is a boundary on its own, so Latin text never touches `Intl.Segmenter`; anything else asks over a 64-unit window from the nearest boundary unit (one segmenter clone per edge, nothing that grows with the document), and only a run of regional indicators pushes the window start back — pairing is the one UAX #29 rule that is not local.
- Measuring the cheap gate found a hole in it: a **Prepend** character (GB9b — U+0600 ARABIC NUMBER SIGN and its kin) glues itself to whatever *follows* it, so the unit after one is not a boundary whatever its value. The gate now checks the predecessor, and a test sweeps every code point in the first two planes against the runtime's own segmenter, so a Unicode update that moves the Prepend set fails here. (Checked whether canvas-render's `truncate.ts` shares the hole: it does not — its gate is whole-string, so any unit ≥ U+0300 sends the label down the segmenter path.)

Instrument landed first (`snippet.bench.ts`, `pnpm vitest bench --project search-node --run`), and the bench judged the shapes (hz, higher is better; 3 hits per op):

| body | before | shape 1 (segment from document start) | shape 2 (full-document `containing`) | **after** (windowed `containing`) |
|---|---|---|---|---|
| ascii | 141,604 | 4,346 | 92k* | **157,134** |
| emoji-bearing | 141,954 | — | 18k* | **46,772** |
| cjk | 421,416 | — | 11k*, and O(document) | **31,085** |

\* scratch harness, relative only. A CJK cut pays the ICU clone at both edges (~5µs each) and nothing more; ascii is unchanged.

Two follow-up commits fix what CI's `check` and `test-unit` jobs caught on the first push and the local area run had not: a local named `window` that arch-lint's name-based DOM-global scan flags, and a `while ((at = indexOf(…)))` in the bench that Biome's `noAssignInExpressions` rejects. Both are on me — `pnpm check:local` plus the shared-layer suite is the pre-push bar for a `packages/search` change, and it is what ran before the third push.

## Test plan

- [x] `packages/search/src/snippet.test.ts`: fast-check property over six cluster classes walking the cut through every interior offset (with a tally floor so the sweep provably cut inside clusters), a flag-identity example, and the exhaustive Prepend sweep (`search-node`, 25 passed)
- [x] Mutation-checked, each mutation confirmed landed before the run: drop the grapheme snap → property + flag-identity red; drop regional-indicator tracking → flag-identity red; drop the Prepend check → sweep red at U+0600…
- [x] `--project server-core-node references` (consumer) 24 passed; `--project arch-lint-node repo-coverage` 44 passed; `pnpm lint` clean; `pnpm knip` clean; typecheck (search, server-core) clean
- [x] Manual verification: real `snippetAround` on a 60-flag body with the radius landing between two regional indicators — before: `…🇵🇯🇵🇯🇵🇯…` (a flag the document never held), after: `…🇯🇵🇯🇵🇯🇵…`
- [ ] E2E: n/a — pure function in `packages/search`, exercised by the search and references suites

## Visual evidence

Visual evidence: none — the change is to a plain-text excerpt, not to anything rendered; the before/after strings above are the evidence.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs: no user-facing contract changes (excerpt shape unchanged, only where it cuts)
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo