### PR TITLE
fix(web): a document already standing at the target path is not corruption

### DIFF
--- a/apps/web/src/lib/browser-backend.browser.test.tsx
+++ b/apps/web/src/lib/browser-backend.browser.test.tsx
@@ -14,6 +14,7 @@
 // approximates). IndexedDB-only suites with no such stake run in jsdom via
 // fake-indexeddb instead — see e.g. local-document-summary.test.tsx.
 import {
+  createWorkspaceDocumentAtPath,
   documentContainers,
   projectWorkspaceDocument,
   readSpatialCanvas,
@@ -183,6 +184,40 @@ describe('BrowserBackend', () => {
     expect(projected === null ? [] : readSpatialCanvas(projected).nodes.map((n) => n.id)).toEqual([
       'n-old',
     ])
+    backend.disconnect()
+  })
+
+  it('refuses to deliver when another document already owns the target path, without calling it corruption', async () => {
+    // The tree already has a DIFFERENT document standing where this one
+    // wants to be placed. `createWorkspaceDocumentAtPath` answers null for
+    // that, and the backend used to ignore the answer: it saved and delivered
+    // bytes holding no node for the target, and the session then reported
+    // `corrupt-snapshot` — the screen whose one action deletes the record.
+    // Nothing is corrupt. The bytes are intact and say exactly what is there.
+    const workspaceId = getBrowserWorkspaceId()
+    const docs = new BrowserWorkspaceDocs()
+    const seeded = await docs.create(workspaceId)
+    expect(
+      createWorkspaceDocumentAtPath(seeded, { path: 'design', documentId: ID_B, kind: 'spatial' }),
+    ).not.toBeNull()
+    await docs.save(workspaceId, seeded)
+
+    const handlers = makeHandlers()
+    const backend = new BrowserBackend(target(ID_A, 'design'))
+    backend.connect(handlers)
+    await vi.waitFor(
+      () => {
+        expect(handlers.onError).toHaveBeenCalledTimes(1)
+      },
+      { timeout: WAIT_TIMEOUT },
+    )
+
+    // Non-destructive: a reason the page answers with "try again", never
+    // with an offer to start fresh over the document that IS there.
+    expect(handlers.onError).toHaveBeenCalledWith('read-unavailable')
+    // And no snapshot — an editor over bytes that lack this document is how
+    // the next save shadows the one at that path.
+    expect(handlers.onSnapshot).not.toHaveBeenCalled()
     backend.disconnect()
   })
 

--- a/apps/web/src/lib/browser-backend.ts
+++ b/apps/web/src/lib/browser-backend.ts
@@ -346,22 +346,43 @@ export class BrowserBackend implements DocumentBackend {
       if (!this.isStale(handlers)) handlers.onError?.(legacy.kind)
       return false
     }
+    let placed: ReturnType<typeof createWorkspaceDocumentAtPath>
     if (legacy.kind === 'ok') {
       const source = new Loro()
       source.import(legacy.snapshot)
       for (const delta of legacy.deltas ?? []) source.import(delta)
-      adoptWorkspaceDocument(
+      placed = adoptWorkspaceDocument(
         workspaceDoc,
         { path, documentId, kind, ...(name === undefined ? {} : { name }) },
         source,
       )
     } else {
-      createWorkspaceDocumentAtPath(workspaceDoc, {
+      placed = createWorkspaceDocumentAtPath(workspaceDoc, {
         path,
         documentId,
         kind,
         ...(name === undefined ? {} : { name }),
       })
+    }
+    if (placed === null) {
+      // Neither helper placed the target: a DIFFERENT document already owns
+      // `path` (the id itself is absent, or this method was not reached).
+      // Delivering anyway hands the session bytes with no node for this
+      // document, which it reports as `corrupt-snapshot` — and the page
+      // answers that with an offer to delete the record. Nothing is corrupt;
+      // the tree has a document standing where this one wanted to.
+      //
+      // ponytail: `read-unavailable` is the nearest non-destructive reason —
+      // it keeps the editor closed and claims nothing about the bytes — but
+      // its copy implies a retry will help, and here it will not. The upgrade
+      // is a reason of its own once a collision has a product answer (open
+      // the document that IS there, or number this one around it).
+      getAppLogger('browser-backend').warn('another document owns the target path; not placing', {
+        documentId,
+        path,
+      })
+      if (!this.isStale(handlers)) handlers.onError?.('read-unavailable')
+      return false
     }
     await this.docs.save(getBrowserWorkspaceId(), workspaceDoc)
     return true


### PR DESCRIPTION
## Summary

One small fix, and the investigation of #36 that found it. The investigation is the larger half, and it corrects two things the issue's own record had wrong.

### The fix

`placeMissingDocument` called `adoptWorkspaceDocument` / `createWorkspaceDocumentAtPath` and **ignored their return**. Both answer `null` when a *different* document already owns the path (`workspace-tree.ts:465`, `:552`). The backend then saved and delivered workspace bytes holding no node for the target; the sync session reads that as `corrupt-snapshot` (`document-sync-session.ts:766`); the page answers with *"This canvas's data could not be read"* and **Start fresh**, whose one effect is to delete the record. Nothing was corrupt — the tree had a document standing where this one wanted to.

A `null` now stops delivery, logs id and path, and reports `read-unavailable`: the nearest reason that keeps the editor closed and claims nothing about the bytes (`BrowserDocumentPage.read-unavailable.test.tsx:58` already pins that it offers a retry and never the delete). Its copy implies a retry will help, which here it will not — recorded as a `ponytail:`; the upgrade is a reason of its own once a collision has a product answer.

**This is not the cause of #36's observation** (fresh database, no collision possible). It is a reachable producer of the same destructive screen that #1300 and #1308 did not touch — narrow in production (the page uses the tree-backed `sharedFoldingBrowserIndex()`, so index and tree agree by construction; the plain index plus concurrent creation across tabs is the door) and destructive when reached.

### What #36 actually was

The issue had exactly one observation: run 33881291929 / `test-browser (1)`, 2026-09-04 14:04, a **clean** run (97 files, 500 tests, one failure) on a tree equivalent to then-main — **before** #1289, #1300 and #1308. Across 14 days of failed main runs its signature appears zero times; locally it did not reproduce in five full `web-browser` runs and five isolated runs of the file.

Two corrections to the record:

1. **It was not a remount race.** The failing line (`:152`) is the settle check *after* `waitForTitle('untitled')` passed — the loaded-looking page switched to the corrupt screen within 400 ms. The remount is at `:155+` and was never reached.
2. **The earlier "refuted by probe, 0 hits" claims were vacuous**: those runs never reproduced the failure, so a silent probe said nothing.

The mechanism: `renderLoaded()` waits for `spatial-editor-container`, which is the **root** of `SpatialEditorPane`'s render and does not depend on `canvasLoaded` — so the gate passes as soon as the index-derived snapshot arrives, **before the backend delivers**. Rename → Escape → `waitForTitle` all run off that snapshot. Meanwhile the *first* `connect()` → `docs.create` was still in flight, and its transient rejection landed during the settle, where the pre-#1300 bare `catch` reported it as `corrupt-snapshot`. No second backend, no reconnect.

What the rejection was is not recoverable — the catch swallowed it unlogged, the run uploaded no trace artifact, and the raw job log carries no exception. Since #1300 the same catch discriminates and logs (`getAppLogger` is active under vitest's dev build and browser console is forwarded), so a recurrence will name itself in the job log.

Refuted with real evidence along the way: torn reads (every store operation is one transaction); module-load capture of the DB name (lazy default parameters, checked at all three module-scope stores); duplicate isolation tags (45, all unique); same-origin cross-iframe signals (none in the browser keeper); the workspace-id accessor throwing; a pending-dependency Loro update throwing (measured: `{success:{}, pending:{}}`); the legacy path (the page writes only the workspace record); index path duplication (`DocumentPathTakenError`); any reconnect trigger in the rename flow.

One real latent defect fell out and is filed rather than fixed here: `DocumentStoreWorkspaceDocs.open()` reads snapshot and deltas in **two** transactions, and a fold committed between them yields a silently stale document (Loro holds the orphaned deltas pending rather than throwing).

## Test plan

- [x] New `web-browser` test added
- [x] `pnpm --filter @kamiazya/whiteboard-web test` passes locally
- [ ] Manual verification completed (see below)
- [ ] E2E coverage added or extended where applicable

**Red first**: seeded the workspace record with another document at the target's path and connected — `onError` was never called and `onSnapshot` was. **Green** after the fix. **Mutation-checked**: turning the guard into a no-op makes the test red again (`1 failed`), restored `1 passed`.

`browser-backend.browser.test.tsx` **20/20**. Full `web-browser` project **194 files / 1055 passed** in 207 s. `apps/web` **346 files / 3647 passed** (jsdom) and **14 / 92** (node). `arch-lint` 120 passed. `tsc`, `lint`, `knip` clean.

Manual verification is unticked deliberately: the trigger is a workspace tree that disagrees with the index about who owns a path, which I can seed in a test but not stage in the running app without faking the same seam.

## Visual evidence

**Visual evidence: none — no user-visible change is intended.** The screen a collision reaches changes from *"could not be read" + Start fresh* to *"could not be opened just now" + Try again*, and that mapping is already pinned at the page layer; this PR only makes the backend report the reason that reaches it.

## Related

- #36 — stays **open and watched** per the earlier decision; its record is corrected as above. The destructive presentation is closed by #1300 + #1308; the flake itself (a slow first connect) has not recurred in 14 days.
- #40 (filed) — `open()`'s two-transaction read.
- Follow-up (not filed as code): `renderLoaded`'s gate is weaker than its name across 8 page test files; a delivered-marker would turn a slow first connect into a timeout at the right line.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu

---
_Generated by [Claude Code](https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu)_