### PR TITLE
test(web): declare apps/web's layer order and pin its upward edges

### DIFF
--- a/.claude/rules/app-web.md
+++ b/.claude/rules/app-web.md
@@ -1,0 +1,75 @@
+---
+paths:
+  - "apps/web/**"
+---
+
+# apps/web — the browser composition root
+
+## Layers, bottom to top
+
+`src/layer-order.test.ts` is the executable half of this section; the order
+it declares is:
+
+| layer | holds | may import |
+|---|---|---|
+| `lib/` (+ root `runtime-config.ts`) | browser-only mechanics: stores, adapters, workers, pure helpers. No React | packages, `lib/` |
+| `pwa/` | service-worker registration and its update scheduler | `lib/` |
+| `contexts/` | React context objects and their providers | `lib/`, `pwa/` |
+| `hooks/` | React state over lib | everything below |
+| `components/` | rendering | everything below |
+| `pages/` | route-level screens, each `React.lazy` | everything below |
+| root (`App.tsx`, `boot.ts`, `boot-splash.ts`, `main.tsx`) | composition | everything |
+
+An edge points DOWN that order or it is a filing mistake: the type or helper
+the lower module wanted was written under the screen that first needed it
+and never moved. `runtime-config.ts` sits at the root because the README
+and ADR-0002 name it there, and is filed with `lib/`, which is what it is.
+`test-utils/`, `test-config/`, `docs-snapshots/` and every `*.test.*` are
+exempt — a test that composes a whole page as its fixture is doing setup.
+
+**Type-only edges count.** tsc erases them, so the bundle never sees the
+inversion, but a `lib/` module that names `EditorCommand` from a component
+is a `lib/` module whose contract is defined above it. The guard tags them
+`(type)` so the burn-down can read which is a type move and which a helper
+move.
+
+## The debt, and its burn-down
+
+Measured when the guard landed: 21 upward edges, 15 of them `import type`,
+every one allowlisted in `UPWARD_EDGES` with the length pinned by equality
+and each entry checked to still be a real edge — an entry cannot outlive
+what it names. Shrink the list by moving the TARGET down, then delete the
+line and lower the ceiling; never add to it for new code.
+
+In the order that pays best:
+
+1. **Types into `lib/`** (15 edges, no runtime change): `ResolvedTheme` out
+   of `hooks/useThemeMode` (3 importers in `lib/`), `DocumentFileAdapter` /
+   `LoadedFileDocument` out of `hooks/use-document-file-seams` (2),
+   `EditorCommand` / `EditorLeafCommand` out of `spatial-editor/commands`
+   (2), `WorkspaceDocumentEntry` out of `workspace-files/document-entry`
+   (2), and one each of `RailBlock`, `LinkTarget`, `ConnectionState`,
+   `SpatialEditorHandle`, `EditorTool`, `BrowserPersistenceState`.
+2. **Pure helpers out of `components/`** (6 value edges): `minimap.ts`
+   (`favicon.ts` draws the favicon with it), `workspace-files/files-source`
+   (both files-source implementations live in `lib/` and import their own
+   contract from above), and the render glue `layout-worker.ts` runs off
+   the main thread — `scene-render`, `scene-render-core`, `render-preview`.
+   A worker importing from `components/` is the clearest sign those are
+   not components.
+
+## What the other guards already cover
+
+- `packages/mcp-server/src/server/release/web-app-boundary.test.ts` — what
+  this app may import from `@kamiazya/whiteboard-mcp` (browser-safe
+  subpaths only) and that no relative import reaches the daemon's `src/`.
+- `src/entry-graph-loro-free.test.ts` — `App.tsx`'s static closure never
+  reaches loro; the workspace machinery stays behind the lazy page boundary.
+- `src/component-reach.test.ts` — every component under `components/` and
+  `pages/` has a non-test importer.
+- `tools/arch-lint` — the package-level direction check; this app is a
+  composition root there, allowed `node:*`-free DOM and inversify-free
+  React, and never imported by a shared package.
+
+None of them sees an edge INSIDE `src/`, which is the gap `layer-order`
+closes.

--- a/.claude/workflows/lib/claude-config-wiring.test.mjs
+++ b/.claude/workflows/lib/claude-config-wiring.test.mjs
@@ -105,11 +105,12 @@ test('the Simplify phase runs a repo-owned agent, not a foreign plugin agent', (
 // into every session regardless of what was being touched. This is that prose made executable.
 // A rule for something under `tools/` is named `tool-<name>.md` and scoped there, for the same
 // reason and by the same check: `package-arch-lint.md` scoped to `tools/arch-lint/**` failed this
-// guard, and the name was the thing that was wrong — arch-lint is not a package.
-test('every package-/tool-<name>.md rule is path-scoped to its own directory', () => {
+// guard, and the name was the thing that was wrong — arch-lint is not a package. `apps/` gets
+// the same treatment as `app-<name>.md`, so a composition root's rule is scoped the same way.
+test('every package-/tool-/app-<name>.md rule is path-scoped to its own directory', () => {
   const rulesDir = path.join(repoRoot, '.claude', 'rules')
   const unscoped = []
-  const prefixes = { 'package-': 'packages', 'tool-': 'tools' }
+  const prefixes = { 'package-': 'packages', 'tool-': 'tools', 'app-': 'apps' }
   for (const file of readdirSync(rulesDir).filter((f) => f.endsWith('.md'))) {
     const prefix = Object.keys(prefixes).find((p) => file.startsWith(p))
     if (prefix === undefined) continue

--- a/apps/web/src/layer-order.test.ts
+++ b/apps/web/src/layer-order.test.ts
@@ -1,0 +1,193 @@
+/**
+ * `apps/web/src` has layers, and until this test it had them only by
+ * convention: `lib/` (browser-only mechanics, no React), `contexts/` and
+ * `hooks/` (React state over lib), `components/`, `pages/`, and the
+ * composition at the root (`App.tsx`, `boot.ts`, `main.tsx`). Every edge
+ * should point DOWN that order — a page may use a hook, a hook may use lib;
+ * lib importing a component means the type or helper lib wanted was filed
+ * under the screen that first needed it and never moved.
+ *
+ * Measured before writing this: 21 upward edges, 15 of them `import type`.
+ * They are allowlisted below rather than fixed here, because each is a
+ * relocation with its own importers to carry, and the point of the guard is
+ * that the count only ever goes down. The list is guarded from both sides —
+ * an entry that stops being a real edge fails, and the length is pinned by
+ * equality — the way `adapter-mechanic-check.ts` holds ADR-0018's debt.
+ *
+ * Type-only edges COUNT. tsc erases them, so the bundle never sees the
+ * inversion, but layering is about what a module has to know: a lib module
+ * that names `EditorCommand` from a component is a lib module whose contract
+ * is defined above it. They are tagged so the burn-down can read which are
+ * a type move and which are a helper move.
+ *
+ * Sources are read via `?raw` glob, not `node:fs` — apps/web is browser-only
+ * (the same reason `entry-graph-loro-free.test.ts` reads them that way).
+ */
+
+import { describe, expect, it } from 'vitest'
+
+const RAW_SOURCES = import.meta.glob('./**/*.{ts,tsx}', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+/** Bottom to top. A module may import from its own layer or any layer before it. */
+const LAYERS = ['lib', 'pwa', 'contexts', 'hooks', 'components', 'pages', 'app'] as const
+type Layer = (typeof LAYERS)[number]
+
+/**
+ * Root-level modules are the composition — except `runtime-config.ts`, a
+ * zod config leaf that README and ADR-0002 name at the root, so it stays
+ * there and is filed with lib, which is what it is.
+ */
+const ROOT_MODULES: Record<string, Layer> = {
+  './runtime-config.ts': 'lib',
+  './App.tsx': 'app',
+  './boot.ts': 'app',
+  './boot-splash.ts': 'app',
+  './main.tsx': 'app',
+  './_type-probe.ts': 'app',
+}
+
+/** Test support and doc snapshots: setup for tests, not part of the app's graph. */
+const EXEMPT_DIRS = ['./test-utils/', './test-config/', './docs-snapshots/']
+
+const isTest = (key: string): boolean => key.includes('.test.')
+
+function layerOf(key: string): Layer | undefined {
+  if (isTest(key) || EXEMPT_DIRS.some((d) => key.startsWith(d))) return undefined
+  const root = ROOT_MODULES[key]
+  if (root !== undefined) return root
+  return LAYERS.find((layer) => key.startsWith(`./${layer}/`))
+}
+
+/** Static import/export-from specifiers, each tagged with whether tsc erases it. */
+function staticImports(source: string): { specifier: string; typeOnly: boolean }[] {
+  const edges: { specifier: string; typeOnly: boolean }[] = []
+  for (const match of source.matchAll(
+    /(?:^|\n)\s*(import|export)\s+(type\s+)?([^'"]*?)from\s+['"]([^'"]+)['"]/g,
+  )) {
+    edges.push({ specifier: match[4] as string, typeOnly: match[2] !== undefined })
+  }
+  for (const match of source.matchAll(/(?:^|\n)\s*import\s+['"]([^'"]+)['"]/g)) {
+    edges.push({ specifier: match[1] as string, typeOnly: false })
+  }
+  return edges
+}
+
+/** Resolves a specifier from a glob key to another glob key, or null for externals and assets. */
+function resolveLocal(fromKey: string, specifier: string): string | null {
+  let path: string
+  if (specifier.startsWith('@/')) {
+    path = `./${specifier.slice(2)}`
+  } else if (specifier.startsWith('.')) {
+    const dir = fromKey.split('/').slice(0, -1)
+    for (const segment of specifier.split('/')) {
+      if (segment === '.') continue
+      if (segment === '..') dir.pop()
+      else dir.push(segment)
+    }
+    path = dir.join('/')
+  } else {
+    return null
+  }
+  const stems = [path, path.replace(/\.js$/, '')]
+  const candidates = stems.flatMap((stem) => [
+    stem,
+    `${stem}.ts`,
+    `${stem}.tsx`,
+    `${stem}/index.ts`,
+    `${stem}/index.tsx`,
+  ])
+  return candidates.find((candidate) => candidate in RAW_SOURCES) ?? null
+}
+
+/** `./lib/x.ts -> ./hooks/y.ts (type)`, in the strings the allowlist is written in. */
+function upwardEdges(): string[] {
+  const rank = (layer: Layer): number => LAYERS.indexOf(layer)
+  const edges: string[] = []
+  for (const [key, source] of Object.entries(RAW_SOURCES)) {
+    const from = layerOf(key)
+    if (from === undefined) continue
+    for (const { specifier, typeOnly } of staticImports(source)) {
+      const target = resolveLocal(key, specifier)
+      if (target === null) continue
+      const to = layerOf(target)
+      if (to === undefined || rank(to) <= rank(from)) continue
+      edges.push(`${key.slice(2)} -> ${target.slice(2)}${typeOnly ? ' (type)' : ''}`)
+    }
+  }
+  return edges.sort()
+}
+
+/**
+ * Every upward edge that exists today, each a relocation still to do. Shrink
+ * it by moving the target down (a type into `lib/`, a pure helper out of
+ * `components/`), then delete the line and lower the ceiling. Never add to
+ * it for new code — file the module where its importers can reach it.
+ */
+const UPWARD_EDGES: readonly string[] = [
+  'components/SaveStatusChip.tsx -> pages/use-browser-document-controller.ts (type)',
+  'hooks/useDocumentSync.ts -> components/spatial-editor/commands.ts (type)',
+  'hooks/useDocumentSync.ts -> components/spatial-editor/scene-render.ts',
+  'hooks/useMarkdownOutline.ts -> components/markdown-editor/rail-geometry.ts (type)',
+  'lib/daemon-file-adapter.ts -> hooks/use-document-file-seams.ts (type)',
+  'lib/daemon-files-source.ts -> components/workspace-files/document-entry.ts (type)',
+  'lib/daemon-files-source.ts -> components/workspace-files/files-source.ts',
+  'lib/daemon-link-entries.ts -> components/markdown-editor/link-target.ts (type)',
+  'lib/document-embed-content.ts -> hooks/use-document-file-seams.ts (type)',
+  'lib/document-sync-session.ts -> components/spatial-editor/commands.ts (type)',
+  'lib/favicon.ts -> components/spatial-editor/minimap.ts',
+  'lib/initial-tool.ts -> components/spatial-editor/ToolPalette.tsx (type)',
+  'lib/layout-worker-protocol.ts -> hooks/useThemeMode.ts (type)',
+  'lib/layout-worker.ts -> components/markdown-editor/render-preview.ts',
+  'lib/layout-worker.ts -> components/spatial-editor/scene-render-core.ts',
+  'lib/layout-worker.ts -> hooks/useThemeMode.ts (type)',
+  'lib/local-files-source.ts -> components/workspace-files/document-entry.ts (type)',
+  'lib/local-files-source.ts -> components/workspace-files/files-source.ts',
+  'lib/render-key.ts -> hooks/useThemeMode.ts (type)',
+  'lib/shell-status-store.ts -> components/connection/ConnectionStatus.tsx (type)',
+  'lib/viewport-request.ts -> components/spatial-editor/index.ts (type)',
+]
+
+const UPWARD_EDGES_CEILING = 21
+
+describe('apps/web layer order', () => {
+  const actual = upwardEdges()
+
+  it('scans every layer', () => {
+    // A guard over a glob that matched nothing passes for the wrong reason.
+    expect(Object.keys(RAW_SOURCES).length).toBeGreaterThan(100)
+    for (const layer of LAYERS) {
+      const inLayer = Object.keys(RAW_SOURCES).filter((key) => layerOf(key) === layer)
+      expect(inLayer.length, `no production modules filed under ${layer}`).toBeGreaterThan(0)
+    }
+    for (const key of Object.keys(RAW_SOURCES)) {
+      if (isTest(key) || EXEMPT_DIRS.some((d) => key.startsWith(d))) continue
+      expect(
+        layerOf(key),
+        `${key} belongs to no layer — file it, or name it in ROOT_MODULES`,
+      ).toBeDefined()
+    }
+  })
+
+  it('has no upward edge outside the allowlist', () => {
+    const unexpected = actual.filter((edge) => !UPWARD_EDGES.includes(edge))
+    expect(
+      unexpected,
+      'a module imports from a layer above it — move what it needs down rather than adding to the allowlist',
+    ).toEqual([])
+  })
+
+  it('every allowlist entry is still a real edge', () => {
+    const stale = UPWARD_EDGES.filter((edge) => !actual.includes(edge))
+    expect(stale, 'an entry that outlives its edge is how an allowlist stops being read').toEqual(
+      [],
+    )
+  })
+
+  it('holds the allowlist at its declared ceiling', () => {
+    expect(UPWARD_EDGES.length).toBe(UPWARD_EDGES_CEILING)
+  })
+})


### PR DESCRIPTION
## Summary

- `apps/web/src` had layers only by convention, and no guard could see an edge inside `src/`: `web-app-boundary.test.ts` polices what the app imports from the daemon package, `entry-graph-loro-free` the first-paint closure, `component-reach` that a component has an importer, arch-lint the package level. `apps/web/src/layer-order.test.ts` declares the order **lib (+ root `runtime-config.ts`) < pwa < contexts < hooks < components < pages < root** and fails on any import pointing the other way.
- Measured on landing: **21 upward edges, 15 of them `import type`**. They are allowlisted with the length pinned by equality and each entry checked to still be a real edge (the `adapter-mechanic-check.ts` shape for ADR-0018's debt), so the count only goes down. Type-only edges count and are tagged `(type)`: tsc erases them, but a `lib/` module naming `EditorCommand` from a component is a `lib/` module whose contract is defined above it.
- `.claude/rules/app-web.md` (path-scoped to `apps/web/**`) carries the order, why `runtime-config.ts` stays at the root, what the other guards already cover, and the burn-down in the order that pays best: the 15 types into `lib/` first (no runtime change), then the six pure helpers out of `components/` — three of them render glue that `lib/layout-worker.ts` already runs off the main thread, which is the clearest sign they are not components.
- `claude-config-wiring.test.mjs` now maps `app-<name>.md` → `apps/<name>/**` the way it maps `package-`/`tool-`; that is why the rule is not `package-web.md` (it failed that guard, correctly — apps/web is not a package). A one-sentence pointer in `architecture-map.md` was written and withdrawn: it crossed the always-on rules budget (89,186 > 89,000 chars), and a bucket is not worth a cross-reference the path-scoped rule already makes.

No production module moves in this PR; it records the debt so the next new edge fails and the burn-down can be its own increments.

## Test plan

- [x] `apps/web/src/layer-order.test.ts` (`web-jsdom`): scan floor (>100 sources, every layer populated, every non-exempt module filed), no upward edge outside the allowlist, every entry still a real edge, allowlist at its ceiling — 4 passed on the new base
- [x] Mutation-checked, each confirmed landed: delete an allowlist entry → ceiling + outside-allowlist red; fabricate an entry → stale-entry red; add `import type { EditorTool } from '@/components/…'` to `lib/utils.ts` → outside-allowlist red; scope `app-web.md` to `packages/web/**` → config-wiring guard red
- [x] `pnpm test:scripts` 276 passed; `pnpm --filter @kamiazya/whiteboard-web test` run locally: new guard green, `web-node` 92/92; the 4 `web-jsdom` failures (`VersionTimeline`, `MergeDialog`, `daemon-file-adapter` — all Blob/objectURL) reproduce in isolation and are the documented Node 22-vs-24 shape (`.node-version` is 24, this container runs 22; `local-node-version.test.ts` names it), so CI's Node 24 run is the authority there
- [x] `pnpm lint`, `pnpm knip`, `pnpm typecheck`, `dev-rules-budget.test.ts` clean
- [ ] E2E: n/a — a static guard over source text
- Manual verification: none — running the guard red first over the real tree is the observation, and its 21 edges match the grep that motivated the change

## Visual evidence

Visual evidence: none — a test and a rule file; nothing rendered changes.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs: `.claude/rules/app-web.md` is the doc for this; no user-facing behaviour changes
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_