### PR TITLE
fix(workspace-index): read a record's snapshot and log as one consistent read

### DIFF
--- a/packages/workspace-index/src/document-store-workspace-docs.test.ts
+++ b/packages/workspace-index/src/document-store-workspace-docs.test.ts
@@ -64,6 +64,15 @@ class FakeDocumentStore implements DocumentStore {
    */
   refusals = 0
 
+  /**
+   * Runs at the TOP of `loadDeltas` — the read-side twin of `beforeCompact`.
+   * `open()` reads the snapshot and the log in two calls, and this is the one
+   * place a rival fold can be made to land between them. Without it the
+   * straddle is unreachable from a test, and a reader that quietly answers a
+   * stale document is a reader nobody knows is stale.
+   */
+  beforeLoadDeltas: (() => Promise<void>) | undefined
+
   async loadSnapshot({ docRef }: LoadSnapshotInput): Promise<LoadSnapshotResult> {
     const stored = this.docs.get(docRefKey(docRef))
     if (stored === undefined || stored.manifest === null) return null
@@ -127,7 +136,8 @@ class FakeDocumentStore implements DocumentStore {
     return { frontier: stored.frontier }
   }
 
-  loadDeltas(input: LoadDeltasInput): Promise<LoadDeltasResult> {
+  async loadDeltas(input: LoadDeltasInput): Promise<LoadDeltasResult> {
+    if (this.beforeLoadDeltas !== undefined) await this.beforeLoadDeltas()
     return this.loadDeltasReal(input)
   }
 
@@ -289,6 +299,54 @@ it('keeps its ops when another writer wins the race to fold the log', async () =
   expect((reopened?.getMap('meta').get('bulk') as string | undefined)?.length).toBe(80 * 1024)
 })
 
+it('open() does not answer a stale document when a fold lands between its two reads', async () => {
+  const store = new FakeDocumentStore()
+  const docs = new DocumentStoreWorkspaceDocs(store)
+  const doc = new LoroDoc()
+  doc.getMap('meta').set('title', 'first')
+  doc.commit()
+  await docs.save('ws-a', doc)
+  // A small edit: appended to the log, never folded. It is ON DISK before
+  // open() below begins, which is what makes losing it a stale read rather
+  // than a race the reader could not have won.
+  doc.getMap('meta').set('e1', 'kept')
+  doc.commit()
+  await docs.save('ws-a', doc)
+  expect(store.docs.get('workspace-tree:ws-a')?.deltas).toHaveLength(1)
+
+  // A rival whose edit is big enough to FOLD, armed to land exactly between
+  // open()'s snapshot read and its log read. The fold absorbs e1 into the
+  // new snapshot and empties the log — so a reader holding the OLD snapshot
+  // and the NEW (empty) log has e1 nowhere. Loro does not throw on that: the
+  // ops the log used to carry simply never arrive.
+  const rival = new LoroDoc()
+  rival.import(store.docs.get('workspace-tree:ws-a')!.chunks[0]!.bytes)
+  for (const update of store.docs.get('workspace-tree:ws-a')!.deltas) rival.import(update)
+  rival.getMap('meta').set('bulk', 'y'.repeat(80 * 1024))
+  rival.commit()
+  let folds = 0
+  store.beforeLoadDeltas = async () => {
+    store.beforeLoadDeltas = undefined
+    await new DocumentStoreWorkspaceDocs(store).save('ws-a', rival)
+    folds += 1
+  }
+
+  const opened = await docs.open('ws-a')
+
+  // The trigger fired, and the fold was a real one: generation moved and the
+  // log is empty. Asserted so this cannot pass by the straddle never happening.
+  expect(folds).toBe(1)
+  expect(store.refusals).toBe(0)
+  expect(store.docs.get('workspace-tree:ws-a')?.generation).toBe(2)
+  expect(store.docs.get('workspace-tree:ws-a')?.deltas).toHaveLength(0)
+
+  expect(opened?.getMap('meta').get('title')).toBe('first')
+  // The edit that was on disk before the read began.
+  expect(opened?.getMap('meta').get('e1')).toBe('kept')
+  // And the fold's own edit, since the reader re-read past the generation move.
+  expect((opened?.getMap('meta').get('bulk') as string | undefined)?.length).toBe(80 * 1024)
+})
+
 /**
  * The shrunk counterexample from the multi-instance convergence property
  * (`mcp-server/src/server/store/multi-instance-convergence.test.ts`), pinned.
@@ -439,6 +497,65 @@ it('after a reload it still carries the deltas appended since the fold', async (
   await reader.catchUp('ws-a', held, cursor)
   expect(held.getMap('meta').get('after-fold')).toBe('1')
   expect((held.getMap('meta').get('folded') as string | undefined)?.length).toBe(80 * 1024)
+})
+
+it('catchUp does not answer a stale document when a fold lands inside its reload', async () => {
+  // The reload branch re-reads the snapshot and then the log, which is the
+  // same two-call window open() has — and its own comment already names the
+  // hazard ("a fold landing in between would leave the log half-applied")
+  // while covering only the fold that landed BEFORE the snapshot read.
+  const store = new FakeDocumentStore()
+  const writer = new DocumentStoreWorkspaceDocs(store)
+  const seed = new LoroDoc()
+  seed.getMap('meta').set('seed', '1')
+  seed.commit()
+  await writer.save('ws-a', seed)
+
+  const reader = new DocumentStoreWorkspaceDocs(store)
+  const held = (await reader.open('ws-a')) as LoroDoc
+  const cursor = await reader.readCursor('ws-a')
+
+  // A fold moves the generation, so catchUp below takes the reload branch...
+  const other = (await writer.open('ws-a')) as LoroDoc
+  other.getMap('meta').set('bulk', 'x'.repeat(80 * 1024))
+  other.commit()
+  await writer.save('ws-a', other)
+  // ...and a small edit sits in the post-fold log, ON DISK before catchUp
+  // begins. Losing it is a stale read, not a race the reader could not win.
+  other.getMap('meta').set('e1', 'kept')
+  other.commit()
+  await writer.save('ws-a', other)
+  expect(store.docs.get('workspace-tree:ws-a')?.generation).toBe(2)
+  expect(store.docs.get('workspace-tree:ws-a')?.deltas).toHaveLength(1)
+
+  // Armed for the reload branch's log read — the SECOND loadDeltas of this
+  // catchUp (the first is the tail read that notices the generation moved).
+  // The rival folds e1 into a new snapshot and empties the log.
+  const rival = (await writer.open('ws-a')) as LoroDoc
+  rival.getMap('meta').set('bulk2', 'y'.repeat(80 * 1024))
+  rival.commit()
+  let reads = 0
+  let folds = 0
+  store.beforeLoadDeltas = async () => {
+    reads += 1
+    if (reads !== 2) return
+    store.beforeLoadDeltas = undefined
+    await writer.save('ws-a', rival)
+    folds += 1
+  }
+
+  await reader.catchUp('ws-a', held, cursor)
+
+  expect(folds).toBe(1)
+  expect(store.refusals).toBe(0)
+  expect(store.docs.get('workspace-tree:ws-a')?.generation).toBe(3)
+  expect(store.docs.get('workspace-tree:ws-a')?.deltas).toHaveLength(0)
+
+  expect(held.getMap('meta').get('seed')).toBe('1')
+  expect((held.getMap('meta').get('bulk') as string | undefined)?.length).toBe(80 * 1024)
+  // The edit that was on disk before the reload began.
+  expect(held.getMap('meta').get('e1')).toBe('kept')
+  expect((held.getMap('meta').get('bulk2') as string | undefined)?.length).toBe(80 * 1024)
 })
 
 it('keeps a caught-up instance able to write, with both sides surviving the save', async () => {

--- a/packages/workspace-index/src/document-store-workspace-docs.ts
+++ b/packages/workspace-index/src/document-store-workspace-docs.ts
@@ -11,7 +11,12 @@
  * port methods — a second copy against libSQL would have differed in the
  * constructor argument and nothing else.
  */
-import type { DocRef, DocumentStore } from '@kamiazya/whiteboard-ports'
+import type {
+  DeltaSeq,
+  DocRef,
+  DocumentStore,
+  SnapshotGeneration,
+} from '@kamiazya/whiteboard-ports'
 import {
   chunkSnapshot,
   reassembleSnapshot,
@@ -22,6 +27,8 @@ import { LoroDoc, VersionVector } from 'loro-crdt'
 import type { CaughtUp, WorkspaceDocCursor, WorkspaceDocs } from './workspace-docs.js'
 
 const MAX_CHUNK_BYTES = 1_000_000
+/** How many times `readRecord` will re-read past a fold that landed mid-read. */
+const READ_ATTEMPTS = 3
 
 function refOf(workspaceId: string): DocRef {
   return { kind: 'workspace-tree', workspaceId }
@@ -58,14 +65,55 @@ export class DocumentStoreWorkspaceDocs implements WorkspaceDocs {
   constructor(private readonly store: DocumentStore) {}
 
   async open(workspaceId: string): Promise<LoroDoc | null> {
-    const docRef = refOf(workspaceId)
-    const stored = await this.store.loadSnapshot({ docRef })
-    if (stored === null) return null
+    const record = await this.readRecord(refOf(workspaceId))
+    if (record === null) return null
     const doc = new LoroDoc()
-    importStored(doc, reassembleSnapshot(stored.manifest, stored.chunks), workspaceId)
-    const { updates } = await this.store.loadDeltas({ docRef, afterSeq: null })
-    for (const update of updates) importStored(doc, update, workspaceId)
+    importStored(doc, record.snapshot, workspaceId)
+    for (const update of record.updates) importStored(doc, update, workspaceId)
     return doc
+  }
+
+  /**
+   * The record as ONE consistent read: a snapshot and the log that belongs
+   * to it, or `null` when there is no snapshot.
+   *
+   * The store answers the two in separate calls, and a fold committed between
+   * them hands back the OLD snapshot with the NEW log — entries that depend on
+   * ops only the new snapshot holds. Loro does not refuse those; it parks them
+   * pending, and the document opens without whatever the fold absorbed.
+   * Measured against the store double: an edit on disk before the read began,
+   * absent from what the read returned, and nothing red anywhere.
+   *
+   * The manifest's generation is read FIRST and compared with the one the log
+   * reports, so the snapshot read sits inside a span whose two ends agree —
+   * and generations only increase, so agreeing ends mean no fold landed
+   * between them. A mismatch retries the whole read.
+   *
+   * ponytail: bounded at three attempts, after which the last read is answered
+   * as-is. A fold happens once per COMPACT_DELTA_BYTES written, so one inside
+   * the span is rare and two are not a case a fourth read would settle.
+   */
+  private async readRecord(docRef: ReturnType<typeof refOf>): Promise<{
+    snapshot: Uint8Array
+    updates: Uint8Array[]
+    generation: SnapshotGeneration | null
+    lastSeq: DeltaSeq | null
+  } | null> {
+    for (let attempt = 1; ; attempt += 1) {
+      const header = await this.store.readSnapshotManifest({ docRef })
+      if (header === null) return null
+      const stored = await this.store.loadSnapshot({ docRef })
+      if (stored === null) return null
+      const tail = await this.store.loadDeltas({ docRef, afterSeq: null })
+      if (tail.generation === header.generation || attempt === READ_ATTEMPTS) {
+        return {
+          snapshot: reassembleSnapshot(stored.manifest, stored.chunks),
+          updates: tail.updates,
+          generation: tail.generation,
+          lastSeq: tail.lastSeq,
+        }
+      }
+    }
   }
 
   async create(workspaceId: string): Promise<LoroDoc> {
@@ -231,21 +279,21 @@ export class DocumentStoreWorkspaceDocs implements WorkspaceDocs {
     // snapshot AND could mistake reused seqs for ones already seen, so the
     // snapshot is re-read. Importing it is a MERGE, which is why `doc`'s own
     // unsaved edits survive.
-    const base = await this.store.loadSnapshot({ docRef })
-    const carried: Uint8Array[] = []
-    if (base !== null) {
-      const snapshot = reassembleSnapshot(base.manifest, base.chunks)
-      doc.import(snapshot)
-      carried.push(snapshot)
+    // One consistent read of snapshot and log, rather than one call each: the
+    // fold this branch exists to follow can land AGAIN between those two
+    // calls, and this branch used to cover only the one that landed before
+    // it. `readRecord` is what closes that.
+    const record = await this.readRecord(docRef)
+    if (record === null) {
+      // The record is gone (deleted while catching up): nothing to carry, and
+      // the cursor says what a log with no snapshot reports.
+      return { cursor: { generation: null, afterSeq: null }, updates: [] }
     }
-    // Re-read rather than reusing `tail`: the snapshot above was read after
-    // it, so a fold landing in between would leave the log half-applied.
-    const settled = await this.store.loadDeltas({ docRef, afterSeq: null })
-    for (const update of settled.updates) doc.import(update)
-    carried.push(...settled.updates)
+    doc.import(record.snapshot)
+    for (const update of record.updates) doc.import(update)
     return {
-      cursor: { generation: settled.generation, afterSeq: settled.lastSeq },
-      updates: carried,
+      cursor: { generation: record.generation, afterSeq: record.lastSeq },
+      updates: [record.snapshot, ...record.updates],
     }
   }
 }

--- a/packages/workspace-index/src/document-store-workspace-docs.unreadable.test.ts
+++ b/packages/workspace-index/src/document-store-workspace-docs.unreadable.test.ts
@@ -44,19 +44,21 @@ import { DocumentStoreWorkspaceDocs } from './document-store-workspace-docs.js'
  */
 function storeHolding(bytes: Uint8Array<ArrayBuffer>): DocumentStore {
   const chunks: SaveSnapshotInput['chunks'] = [{ index: 0, of: 1, bytes }]
+  const manifest = { chunkCount: 1, totalBytes: bytes.byteLength, maxChunkBytes: bytes.byteLength }
   return {
     async loadSnapshot(_input: LoadSnapshotInput): Promise<LoadSnapshotResult> {
-      return {
-        manifest: { chunkCount: 1, totalBytes: bytes.byteLength, maxChunkBytes: bytes.byteLength },
-        chunks,
-        frontier: new Uint8Array(),
-      }
+      return { manifest, chunks, frontier: new Uint8Array() }
     },
     async loadDeltas(_input: LoadDeltasInput): Promise<LoadDeltasResult> {
       return { updates: [], lastSeq: null, generation: 1, frontier: new Uint8Array() }
     },
+    // The same manifest the snapshot read answers, at the generation the log
+    // reports: `open()` reads this FIRST, as its fence against a fold landing
+    // between its two reads, and a store that holds a snapshot never answers
+    // its manifest with null. Doing so here made open() return null before
+    // the bytes it exists to refuse were ever imported.
     async readSnapshotManifest(_i: ReadSnapshotManifestInput): Promise<ReadSnapshotManifestResult> {
-      return null
+      return { manifest, generation: 1 }
     },
     async readFrontier(_input: ReadFrontierInput): Promise<ReadFrontierResult> {
       return null


### PR DESCRIPTION
## Summary

`DocumentStoreWorkspaceDocs.open()` read the snapshot in one store call and the log in another. A fold committed between them — another instance folding the log into a fresh snapshot — hands back the **old snapshot with the new, emptied log**, so every op the fold absorbed arrives nowhere. Loro does not refuse that: a delta whose base is missing is parked pending (`{success:{}, pending:{}}`, measured against this repo's `loro-crdt`) and the document opens without it. **Nothing is red anywhere**: no exception, no `corrupt-*`, a document that is simply missing edits that were on disk before the read began.

Found while investigating #36 (where it was *not* the cause — the rename test never writes enough to fold) and filed as #40; this PR closes it.

### Two sites, one read

`catchUp`'s reload branch — the one that runs *because* a fold moved the generation — re-read the snapshot and then the log with the same two calls. Its own comment named the hazard (*"a fold landing in between would leave the log half-applied"*) while covering only the fold that landed **before** the snapshot read.

Both now go through one `readRecord`: the manifest's generation is read first, then the snapshot, then the log, and the log's generation must match the manifest's. Generations only increase, so agreeing ends mean no fold landed inside the span. A mismatch retries the whole read.

Why manifest-first: `snapshotManifestSchema` carries no generation (`chunkCount`, `totalBytes`, `maxChunkBytes` only), so a two-read version has nothing to compare. `loadDeltas` already reports the generation at read time — it was designed for a tailing reader's cursor — and `readSnapshotManifest` answers it without the bytes, so the fence costs one small extra read and **no port change**: the six `DocumentStore` implementations and their conformance suite are untouched.

Bounded at three attempts, after which the last read is answered as-is — recorded as a `ponytail:`. A fold happens once per `COMPACT_DELTA_BYTES` written, so one inside the span is rare and two are not a case a fourth read would settle.

The daemon's own manifest → deltas read at `document-store.ts:955` runs under `withWorkspaceWriteLock` and is not affected; the eleven daemon-side callers of `open()` are.

### The double that had to change

`document-store-workspace-docs.unreadable.test.ts` (#1300) used a store double whose `readSnapshotManifest` answered `null` while `loadSnapshot` held a record — a shape no real store produces (IDB and libsql derive both from one row). With the manifest read first, `open()` returned `null` before the bytes those tests exist to refuse were ever imported. The double now answers the same manifest at the generation its log already reported, with a comment saying why. The two tests' intent is unchanged and they pass.

## Test plan

- [x] New `workspace-index-node` tests added (two, one per site)
- [x] `pnpm --filter @kamiazya/whiteboard-workspace-index test` passes locally
- [ ] Manual verification completed (see below)
- [ ] E2E coverage added or extended where applicable

**Red first, at both sites**, through a new read-side seam on the store double (`beforeLoadDeltas`, the twin of `beforeCompact`). Each test asserts the trigger fired (one fold, zero refusals, generation advanced, log emptied) and then that an edit **on disk before the read began** is present. Before the fix both failed with `expected undefined to be 'kept'`.

**Mutation-checked**: disabling the generation compare (`tail.generation === header.generation` → `true`) turns **exactly those two** red — `2 failed | 15 passed` — and restoring gives `17 passed`.

| suite | result |
|---|---|
| `workspace-index-node` | 5 files / **65 passed** |
| `mcp-node` store directory (incl. multi-instance convergence property) | 68 files / **641 passed** |
| `web-browser` (full project, run alone) | 197 files / **1070 passed**, 232 s |
| `apps/web` jsdom + node (CI's command) | 347 / **3654** and 14 / **92 passed** |
| `arch-lint` | **120 passed** |
| `pnpm -r typecheck`, `lint`, `knip` | clean |

Manual verification is unticked: the trigger is a fold committed by another instance between two reads of one open, which I can seed against the double but not stage in a running app without faking the same seam.

## Visual evidence

**Visual evidence: none — no pixel changes.** This is a read-consistency fix below every UI; what a user would have seen is a document quietly missing edits, which a screenshot could not show as anything but a document.

## Related

- #40 — closes.
- #36 — the investigation that surfaced this; not its cause.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated if this changes user-visible behavior or a published contract
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016op9NR7gZeygmEoJ6UJzAu