### PR TITLE
test(web): fail on a vi.mock that names a module which does not exist

### DIFF
--- a/.claude/rules/app-web.md
+++ b/.claude/rules/app-web.md
@@ -65,11 +65,23 @@ same shapes will recur, and each was cheaper than it looked:
    `lib/`. A worker importing from `components/` was the clearest sign
    those were never components.
 
-Two traps a mechanical move does not see, each found by a test going red:
-a `vi.mock('./x.js', …)` specifier is a string, not an import, and keeps
-pointing at the old path (the spy then counts zero calls); and
-`purity-guard.test.ts` scans its files by explicit relative path on
-purpose, so a moved file falls out of it loudly rather than silently.
+Three things a mechanical move does not see, and what catches each now:
+
+- A `vi.mock('./x.js', …)` specifier is a string, not an import, so it keeps
+  pointing at the old path and mocks nothing — the test runs against the
+  real module and stays green. Found once by a spy that happened to count
+  its calls; measured afterwards, two more had been dead since the
+  component they mocked was deleted. `mock-specifiers.test.ts` resolves
+  every relative and `@/` mock specifier the way the layer guard resolves
+  imports and fails on one that names no module. Not a GritQL rule: a
+  Biome plugin sees one file's syntax and cannot know whether a path
+  exists.
+- `purity-guard.test.ts` (apps/web) and `file-size-budget.test.ts`
+  (mcp-server) hold files by explicit path on purpose and check the path
+  still exists, so a move fails them loudly — the second in CI, because the
+  local area run for an `apps/web` move had not included `mcp-node`. It
+  does now: a move runs `--project mcp-node file-size-budget` alongside the
+  web guards.
 
 ## What the other guards already cover
 

--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -8,7 +8,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 vi.mock('./HeaderBranchChip', () => ({
   HeaderBranchChip: () => <div data-testid="header-branch-chip" />,
 }))
-vi.mock('./HeaderVersionDot', () => ({ HeaderVersionDot: () => null }))
 vi.mock('./VersionTimeline', () => ({ default: () => null }))
 vi.mock('@/hooks/useDirtyState', () => ({ useDirtyState: () => ({ isDirty: false }) }))
 vi.mock('@kamiazya/whiteboard-mcp/api-client', () => ({ apiFetch: vi.fn() }))

--- a/apps/web/src/components/workspace-top-bar/history-entry.test.tsx
+++ b/apps/web/src/components/workspace-top-bar/history-entry.test.tsx
@@ -17,7 +17,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 vi.mock('../HeaderBranchChip', () => ({
   HeaderBranchChip: () => <div data-testid="header-branch-chip" />,
 }))
-vi.mock('../HeaderVersionDot', () => ({ HeaderVersionDot: () => null }))
 vi.mock('@/hooks/useDirtyState', () => ({ useDirtyState: () => ({ isDirty: false }) }))
 vi.mock('@kamiazya/whiteboard-mcp/api-client', () => ({ apiFetch: vi.fn() }))
 

--- a/apps/web/src/mock-specifiers.test.ts
+++ b/apps/web/src/mock-specifiers.test.ts
@@ -1,0 +1,91 @@
+/**
+ * `vi.mock('./x.js', factory)` names a module by a STRING, and nothing
+ * checks the string. A mock for a path nothing imports is registered and
+ * never consulted, so a module that moves or is deleted leaves its mocks
+ * behind as silent no-ops — the test keeps passing, now against the real
+ * module (or against nothing).
+ *
+ * Measured before writing this: two mocks of `HeaderVersionDot`, a
+ * component deleted months earlier, still in place and green — and a third
+ * found only because the test happened to count the spy's calls
+ * (`MinimapRail.render-memo`, when `rail-geometry` moved to `lib/`). The
+ * import rewrite that carries a move cannot see these; a resolver can.
+ *
+ * Every relative or `@/` specifier handed to `vi.mock` / `vi.doMock` /
+ * `vi.unmock` / `vi.importActual` / `vi.importMock` must resolve to a
+ * module the glob captured. Bare package specifiers are out of scope — a
+ * package's existence is the lockfile's job.
+ *
+ * Sources are read via `?raw` glob, not `node:fs` — apps/web is browser-only
+ * (the same reason `layer-order.test.ts` reads them that way).
+ */
+
+import { describe, expect, it } from 'vitest'
+
+const RAW_SOURCES = import.meta.glob('./**/*.{ts,tsx}', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+const isTest = (key: string): boolean => key.includes('.test.')
+
+/** `vi.mock('spec', …)` and friends, string form only — `vi.mock(import('x'))` is unused here. */
+function mockSpecifiers(source: string): string[] {
+  return [
+    ...source.matchAll(
+      /\bvi\.(?:mock|doMock|unmock|importActual|importMock)\(\s*['"]([^'"]+)['"]/g,
+    ),
+  ].map((m) => m[1] as string)
+}
+
+/** Resolves a specifier from a glob key to another glob key, or null for a bare package specifier. */
+function resolveLocal(fromKey: string, specifier: string): { local: boolean; key: string | null } {
+  let path: string
+  if (specifier.startsWith('@/')) {
+    path = `./${specifier.slice(2)}`
+  } else if (specifier.startsWith('.')) {
+    const dir = fromKey.split('/').slice(0, -1)
+    for (const segment of specifier.split('/')) {
+      if (segment === '.') continue
+      if (segment === '..') dir.pop()
+      else dir.push(segment)
+    }
+    path = dir.join('/')
+  } else {
+    return { local: false, key: null }
+  }
+  const stems = [path, path.replace(/\.js$/, '')]
+  const candidates = stems.flatMap((stem) => [
+    stem,
+    `${stem}.ts`,
+    `${stem}.tsx`,
+    `${stem}/index.ts`,
+    `${stem}/index.tsx`,
+  ])
+  return { local: true, key: candidates.find((candidate) => candidate in RAW_SOURCES) ?? null }
+}
+
+describe('vi.mock specifiers name modules that exist', () => {
+  const mocks = Object.entries(RAW_SOURCES)
+    .filter(([key]) => isTest(key))
+    .flatMap(([key, source]) => mockSpecifiers(source).map((specifier) => ({ key, specifier })))
+
+  it('scans a real population of mocks', () => {
+    // A resolver over a glob that matched nothing passes for the wrong reason.
+    expect(
+      mocks.filter(({ specifier }) => resolveLocal('./x.ts', specifier).local).length,
+    ).toBeGreaterThan(50)
+  })
+
+  it('resolves every local specifier to a module', () => {
+    const dangling = mocks
+      .map(({ key, specifier }) => ({ key, specifier, target: resolveLocal(key, specifier) }))
+      .filter((m) => m.target.local && m.target.key === null)
+      .map((m) => `${m.key.slice(2)} mocks ${m.specifier}`)
+    expect(
+      dangling,
+      'a vi.mock names a module that does not exist — it mocks nothing, so the test runs against the real module; delete it or re-point it',
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

- `vi.mock('./x.js', factory)` names a module by a **string**, and nothing checked the string: a mock for a path nothing imports is registered and never consulted, so when the module moves or is deleted the mock stays behind as a silent no-op and the test keeps passing — against the real module, or against nothing. The layering burn-down hit this once (#1335: `rail-geometry` moved, the one test that mocked it went red only because it happened to count the spy's calls).
- Measured afterwards across the repo's 285 mock specifiers (244 relative): **two more were already dead in `main`** — `WorkspaceTopBar.test.tsx` and `history-entry.test.tsx` mocking `HeaderVersionDot`, a component #1245 deleted. Both tests have been green since, mocking nothing. Those two lines go.
- `apps/web/src/mock-specifiers.test.ts` resolves every relative and `@/` specifier handed to `vi.mock` / `vi.doMock` / `vi.unmock` / `vi.importActual` / `vi.importMock` with the same resolver `layer-order.test.ts` uses for imports, and fails naming any that resolves to no module. Bare package specifiers are out of scope (the lockfile's job). Population floor: >50 local mocks scanned, so a broken glob cannot pass vacuously.
- This is deliberately not a GritQL rule: a Biome plugin sees one file's syntax and cannot know whether a path exists. `.claude/rules/app-web.md` records it beside the other two path-holding guards a move trips (`purity-guard.test.ts`, mcp-server's `file-size-budget.test.ts`), and that an `apps/web` move now runs `mcp-node file-size-budget` locally rather than learning about it from CI.

## Test plan

- [x] Red first on the real tree: the guard named exactly the two `HeaderVersionDot` mocks; green after deleting them, with `WorkspaceTopBar.test.tsx` (still 19 passed) and `history-entry.test.tsx` unchanged in outcome
- [x] Mutation-checked: `vi.mock('./does-not-exist.js', () => ({}))` appended to a test → red, naming `components/WorkspaceTopBar.test.tsx mocks ./does-not-exist.js`; restored → 2/2
- [x] `layer-order.test.ts` 4/4, `pnpm --filter @kamiazya/whiteboard-web typecheck`, Biome, `claude-config-wiring` guard clean on the pushed head
- [ ] E2E: n/a — a source-scanning guard
- Manual verification: none — the red run over the real tree is the observation, and the two dead mocks it found are the evidence the guard was worth writing

## Visual evidence

Visual evidence: none — a test file and two deleted test lines; nothing rendered changes.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs: `.claude/rules/app-web.md` updated; no user-facing behaviour changes
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAhbSNwp1kBKr74gCR2voo)_