### PR TITLE
chore(mcp-server): bind maintenance responses to their contracts, drop the dead no-auth strategy, fix stale comments

### DIFF
--- a/packages/mcp-server/src/server/routes/document/maintenance.ts
+++ b/packages/mcp-server/src/server/routes/document/maintenance.ts
@@ -1,4 +1,8 @@
 import { Hono } from 'hono'
+import type {
+  OptimizeAllDocumentsResponse,
+  PruneSandwichedVersionsResponse,
+} from '../../../shared/api-contracts/document.js'
 import { evictDoc } from '../../store/doc-cache.js'
 import { compactDocument, listDocuments } from '../../store/document-store.js'
 import type { VersionStore } from '../../store/version-store.js'
@@ -56,7 +60,11 @@ export function createMaintenanceRouter(options: MaintenanceRouterOptions) {
         results.push({ path, deletedCount: r.deletedCount })
         totalDeleted += r.deletedCount
       }
-      return c.json({ results, totalDeleted })
+      // Bound to the contract the Storage tab hard-parses; `results` rides
+      // along deliberately unvalidated (see the schema's comment).
+      return c.json({ results, totalDeleted } satisfies PruneSandwichedVersionsResponse & {
+        results: unknown
+      })
     } catch (err) {
       const issue = handleCorruptStoredData(err)
       if (issue) return c.json(issue.body, issue.status)
@@ -97,7 +105,11 @@ export function createMaintenanceRouter(options: MaintenanceRouterOptions) {
         totalBeforeBytes += result.beforeBytes
         totalAfterBytes += result.afterBytes
       }
-      return c.json({ results, totalBeforeBytes, totalAfterBytes })
+      return c.json({
+        results,
+        totalBeforeBytes,
+        totalAfterBytes,
+      } satisfies OptimizeAllDocumentsResponse & { results: unknown })
     } catch (err) {
       const issue = handleCorruptStoredData(err)
       if (issue) return c.json(issue.body, issue.status)

--- a/packages/mcp-server/src/server/security/mcp-auth.ts
+++ b/packages/mcp-server/src/server/security/mcp-auth.ts
@@ -117,17 +117,6 @@ export function buildMcpProtectedResourceMetadata(
   }
 }
 
-function _createNoAuthMcpHttpAuthStrategy(
-  metadata?: McpProtectedResourceMetadataConfig,
-): McpHttpAuthStrategy {
-  return {
-    protectedResourceMetadata: metadata,
-    authorize() {
-      return { ok: true }
-    },
-  }
-}
-
 export function createLocalTokenMcpHttpAuthStrategy(options: {
   token?: string
   protectedResourceMetadata?: McpProtectedResourceMetadataConfig

--- a/packages/mcp-server/src/server/security/route-scope-registry.test.ts
+++ b/packages/mcp-server/src/server/security/route-scope-registry.test.ts
@@ -1,9 +1,10 @@
 // Registry-wide guard: every /api/* route actually mounted on the server-mode
 // app must resolve to a declared scope decision here (`scoped` or the
 // documented `public` carve-out) — never fall through silently. Mirrors
-// `mcp/tool-registry-descriptions.test.ts`'s "walk what's actually
-// registered, fail if the registry doesn't cover it" shape, applied to HTTP
-// routes instead of MCP tool schemas.
+// the MCP smoke's `tools/list` vs `ALL_REGISTERED_TOOLS`
+// (`mcp/mcp-smoke-coverage.ts`) "walk what's actually registered, fail if
+// the registry doesn't cover it" shape, applied to HTTP routes instead of
+// MCP tools.
 
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'

--- a/packages/mcp-server/src/server/security/route-scope-registry.ts
+++ b/packages/mcp-server/src/server/security/route-scope-registry.ts
@@ -14,7 +14,8 @@
 // `route-scope-registry.test.ts` walks every route actually mounted on the
 // server-mode Hono app (`app.routes`) and asserts each one resolves to a
 // non-null decision here — the same "registry vs what's actually registered"
-// guard shape as `mcp/tool-registry-descriptions.test.ts`.
+// guard shape as the MCP smoke's `tools/list` vs `ALL_REGISTERED_TOOLS`
+// (`mcp/mcp-smoke-coverage.ts`).
 
 import type { AuthScope } from './auth-strategy.js'
 

--- a/packages/mcp-server/src/server/security/ws-scope-registry.test.ts
+++ b/packages/mcp-server/src/server/security/ws-scope-registry.test.ts
@@ -8,8 +8,8 @@ import {
 } from './ws-scope-registry.js'
 
 // Discriminated-union options expose their literal `type` value as
-// `.shape.type.value` — the same introspection technique the codebase
-// already uses in tool-registry-descriptions.test.ts style guards.
+// `.shape.type.value`, so the guard enumerates message types from the
+// schema itself instead of a hand-kept list that could drift.
 function discriminatedUnionLiterals(schema: typeof clientTextMessageSchema): string[] {
   return schema.options.map((option) => option.shape.type.value)
 }


### PR DESCRIPTION
## What

Three small, disjoint findings from today's whole-codebase audit (`audit-triage`), all in `packages/mcp-server`:

1. **Bind the maintenance responses to their contracts.** `optimize-all` and `prune-sandwiched-versions` returned inline literals while `StorageReportCard.tsx` hard-parses them against `optimizeAllDocumentsResponseSchema` / `pruneSandwichedVersionsResponseSchema` — the one route pair in the file family without a producer-side binding. Now `satisfies` the inferred types (`results` deliberately rides along unvalidated, per the schema's own comment). Mutation-checked: renaming `totalDeleted` in the literal fails typecheck.
2. **Delete `_createNoAuthMcpHttpAuthStrategy`.** An always-ok `authorize()` with zero references, underscore-prefixed past both lint gates — a ready-made footgun one call site away from disabling MCP HTTP auth. A genuine no-auth mode is already `createLocalTokenMcpHttpAuthStrategy({})` with no token configured.
3. **Repoint three comments citing `mcp/tool-registry-descriptions.test.ts`,** deleted in #341. Two now name the surviving embodiment of the "walk what's actually registered" shape (the MCP smoke's `tools/list` vs `ALL_REGISTERED_TOOLS`); the third inlines its one-sentence rationale since no surviving file demonstrates the introspection technique.

## Verification

`mcp-node` security + maintenance suites: 30 files / 568 passed. Typecheck + biome + knip clean. Mutation check on the binding recorded above.

Visual evidence: none — server-side type bindings, a dead-code deletion, and comment corrections; nothing a pixel can show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D
