### PR TITLE
fix(devx): worktree-aware Codex MCP override via the stdio proxy, and working contributor setup docs

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,9 +1,12 @@
 # Repo Codex MCP override.
 #
-# Connects every Codex reload to the long-lived daemon launched by
-# `pnpm mcp:http:dev`, which serves http://127.0.0.1:3099/mcp. The HTTP
-# transport sidesteps the stdio + daemon-registry path that would otherwise
-# reuse stale daemons recorded in ~/.whiteboard/daemon.json.
+# Connects every Codex reload to THIS CHECKOUT's dev daemon through the
+# stdio proxy (mcp-http-stdio-proxy.mjs), which derives the checkout's own
+# port from its on-disk location — the main checkout and every linked
+# worktree each reach their own daemon, code, and data. The proxy also
+# survives daemon watch restarts and sidesteps the daemon-registry path
+# that would otherwise reuse stale daemons recorded in
+# ~/.whiteboard/daemon.json.
 #
 # A SessionStart hook below starts the dev daemon automatically. If hooks are
 # disabled or the project is not trusted yet, start it manually:
@@ -13,8 +16,8 @@
 #   system < user (~/.codex/config.toml) < cwd < tree (./.codex/config.toml)
 #   < repo (<git-root>/.codex/config.toml) < runtime
 # This file disables the plugin-provided published `whiteboard` stdio server
-# and adds `whiteboard_dev` for the local HTTP daemon. The separate name avoids
-# merging `url` into the plugin's stdio `command`/`args` entry.
+# and adds `whiteboard_dev` for the dev stdio proxy. The separate name keeps
+# Codex from merging the override into the plugin's published entry.
 #
 # Trust gating: the cwd / tree / repo layers stay disabled unless either
 #   [projects."<absolute_path>"]
@@ -42,9 +45,8 @@ timeout = 40
 statusMessage = "Starting whiteboard MCP dev daemon"
 
 # Codex currently merges this repo-local table with the plugin-provided
-# `.mcp.json` stdio entry when the server name is also `whiteboard`. That leaves
-# `command`/`args` in place and rejects `url` with "url is not supported for
-# stdio", so the hot-reload HTTP endpoint uses a dev-only server name.
+# `.mcp.json` stdio entry when the server name is also `whiteboard`, so the
+# hot-reload dev override uses a dev-only server name.
 [mcp_servers.whiteboard]
 enabled = false
 # Codex >= 0.144 validates every mcp_servers entry's transport even when
@@ -54,6 +56,9 @@ enabled = false
 command = "npx"
 args = ["-y", "@kamiazya/whiteboard-mcp@latest"]
 
+# args arrays are not shell-expanded, so the git-root resolution needs the
+# same `sh -c` wrapper the SessionStart hook above already uses. The proxy
+# sends the bearer token itself; no headers needed here.
 [mcp_servers.whiteboard_dev]
-url = "http://127.0.0.1:3099/mcp"
-http_headers = { Authorization = "Bearer whiteboard-dev" }
+command = "sh"
+args = ["-c", 'exec node "$(git rev-parse --show-toplevel)/packages/mcp-server/scripts/dev/mcp-http-stdio-proxy.mjs"']

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,12 @@ Thanks for considering a contribution. This repo is a pnpm monorepo for `@kamiaz
 ```bash
 git clone https://github.com/kamiazya/whiteboard.git
 cd whiteboard      # Node: match .node-version (currently 24) — use nvm / fnm / Volta
+                   # pnpm is pinned by package.json's packageManager (pnpm@11.12.0) — run `corepack enable` first,
+                   # or an older global pnpm silently rewrites the lockfile and fails CI's --frozen-lockfile
                    # ImageMagick (convert/identify) is also required — pnpm test:scripts and pnpm check:local call it;
                    # full prerequisites: docs/contributing/development.md
 pnpm install
-pnpm exec playwright install --with-deps chromium   # required for the browser test projects (canvas-viewer-browser / web-browser)
+pnpm --filter @kamiazya/whiteboard-web exec playwright install --with-deps chromium   # required for the browser test projects (canvas-viewer-browser / web-browser / canvas-render-browser)
 pnpm test         # all 22 vitest projects (listed under Workflow below)
 pnpm typecheck
 pnpm smoke:e2e    # stdio MCP smoke (no API quota)
@@ -83,6 +85,7 @@ Hooks are a local safety net, **not** a replacement for CI (the authoritative ga
 
 ## Pull request checklist
 
+- `pnpm check:local` is green — the local mirror of CI's `check` job (needs ImageMagick)
 - `pnpm test` is green
 - `pnpm typecheck` is green
 - New behavior has at least one nearest-layer automated test

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -6,6 +6,7 @@ do not need anything here — user-facing docs live under the [documentation hom
 Contributor and maintainer guides:
 
 - **[development](development.md)** — local checkout and the HTTP MCP development loop.
+  Before opening a PR, `pnpm check:local` mirrors CI's `check` job locally (see CONTRIBUTING.md's checklist).
 - **[testing](testing.md)** — test strategy, layer selection, property/mutation testing, and quality gates.
 - **[mcp-debugging](mcp-debugging.md)** — debugging the MCP server during development.
 - **[releasing](releasing.md)** — release-please and npm/GHCR publishing.

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -4,7 +4,9 @@ Local-checkout setup, the HTTP MCP development loop, and how the repo's committe
 
 ## Prerequisites
 
-- Node.js **24** — the major `.node-version` pins and CI installs — and `pnpm`.
+- Node.js **24** — the major `.node-version` pins and CI installs — and `pnpm`,
+  pinned by `package.json`'s `packageManager` (pnpm@11.12.0): run `corepack enable`
+  before `pnpm install`, or an older global pnpm rewrites the lockfile.
   Not a recommendation: `local-node-version.test.ts` fails on any other major,
   because nine `web-jsdom` tests fail on 22 with a message about `Blob` that
   names neither Node nor the cause, so a run on the wrong major looks like nine
@@ -21,7 +23,7 @@ Local-checkout setup, the HTTP MCP development loop, and how the repo's committe
 git clone https://github.com/kamiazya/whiteboard.git
 cd whiteboard
 pnpm install
-pnpm exec playwright install --with-deps chromium
+pnpm --filter @kamiazya/whiteboard-web exec playwright install --with-deps chromium
 ```
 
 This installs Playwright's own Chromium, which is what a local browser-mode run uses. **CI does not**: every browser job in `.github/workflows/ci.yml` sets `WHITEBOARD_CHROME_PATH=/usr/bin/google-chrome-stable`, so CI drives the runner's system Chrome. Local and CI therefore execute browser tests in *different* browser builds — worth remembering when a browser test disagrees between them, since the browser itself is one of the variables. Set `WHITEBOARD_CHROME_PATH` locally to match CI when you are chasing exactly that kind of divergence.

--- a/packages/mcp-server/src/server/docs-contract.test.ts
+++ b/packages/mcp-server/src/server/docs-contract.test.ts
@@ -119,6 +119,68 @@ describe('docs/ contract', () => {
     }
   })
 
+  // The quick-start playwright command must work FROM REPO ROOT. The bare
+  // `pnpm exec playwright install` form fails there (playwright is a
+  // devDependency of apps/web and canvas-viewer only), which a clean-clone
+  // contributor hits at step 4 — and CI never notices, because it sets
+  // WHITEBOARD_CHROME_PATH and skips playwright install entirely.
+  it('gives contributors the filtered playwright install command, never the bare root form', () => {
+    const filtered =
+      'pnpm --filter @kamiazya/whiteboard-web exec playwright install --with-deps chromium'
+    const contributing = readFileSync(join(REPO_ROOT, 'CONTRIBUTING.md'), 'utf8')
+    const development = readFileSync(join(DOCS_ROOT, 'contributing/development.md'), 'utf8')
+    for (const [name, content] of [
+      ['CONTRIBUTING.md', contributing],
+      ['development.md', development],
+    ] as const) {
+      expect(content, `${name} must carry the filtered command`).toContain(filtered)
+      expect(
+        /^pnpm exec playwright install/m.test(content),
+        `${name} still carries the bare root-level form, which fails from repo root`,
+      ).toBe(false)
+    }
+    // The parenthetical names every real-browser project, derived from the
+    // configs so a new browser project cannot leave it stale again.
+    for (const projectName of readBrowserProjectNames(REPO_ROOT)) {
+      expect(contributing, `CONTRIBUTING.md's playwright line must name ${projectName}`).toContain(
+        projectName,
+      )
+    }
+  })
+
+  // The single pre-PR gate the repo actually maintains (derived from ci.yml
+  // by local-gate-command.test.ts) must be the one the human checklist names —
+  // its absence taught contributors five missing gates via a red CI job.
+  it('puts pnpm check:local in the PR checklist, cross-referenced from the docs index', () => {
+    const contributing = readFileSync(join(REPO_ROOT, 'CONTRIBUTING.md'), 'utf8')
+    const checklist = contributing.split('## Pull request checklist')[1]?.split('\n## ')[0] ?? ''
+    expect(checklist).toContain('pnpm check:local')
+    const docsIndex = readFileSync(join(DOCS_ROOT, 'contributing/README.md'), 'utf8')
+    expect(docsIndex).toContain('check:local')
+  })
+
+  // packageManager pins the exact pnpm; a contributor on an older global pnpm
+  // silently rewrites the lockfile on first install and fails CI's
+  // --frozen-lockfile. Deriving the version here means a future pnpm bump
+  // that forgets the docs fails this test instead of leaving a stale number.
+  it('states the pinned pnpm version and corepack enable in both prerequisite blocks', () => {
+    const pkg = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')) as {
+      packageManager?: string
+    }
+    const pinned = pkg.packageManager
+    expect(pinned).toMatch(/^pnpm@/)
+    for (const path of [
+      join(REPO_ROOT, 'CONTRIBUTING.md'),
+      join(DOCS_ROOT, 'contributing/development.md'),
+    ]) {
+      const content = readFileSync(path, 'utf8')
+      expect(content, `${path} must state the pinned ${pinned}`).toContain(pinned as string)
+      expect(content, `${path} must tell contributors to run corepack enable`).toContain(
+        'corepack enable',
+      )
+    }
+  })
+
   // The repo-local dev-override table names the exact config key a
   // contributor is told to edit. Both rows had drifted to a key that does not
   // exist: `.claude/settings.json` has no `mcpServers` field in its schema (a
@@ -153,21 +215,32 @@ describe('docs/ contract', () => {
     // The mechanism that does work, documented earlier in the same file.
     expect(content).toContain('claude mcp add --scope local')
 
-    // Every `[mcp_servers.X]` the doc presents as the Codex dev override must
-    // be an entry that carries a `url` (the hot-reload HTTP endpoint) rather
-    // than the disabled published `command`/`args` mirror.
-    const codexUrlEntries = [
-      ...codexConfig.matchAll(/\[mcp_servers\.([\w-]+)\]\n(?:(?!\[)[\s\S])*?^url = /gm),
-    ].map((match) => match[1])
-    expect(codexUrlEntries.length).toBeGreaterThan(0)
-    for (const line of content.split('\n')) {
-      const named = line.match(/\[mcp_servers\.([\w-]+)\]/)
-      if (!named || !/dev override/i.test(line)) continue
-      expect(
-        codexUrlEntries,
-        `development.md calls [mcp_servers.${named[1]}] the Codex dev override, but .codex/config.toml gives no url to that entry`,
-      ).toContain(named[1])
-    }
+    // The Codex dev override goes through the stdio proxy, which derives the
+    // per-worktree port from its own on-disk location — a hardcoded URL here
+    // silently pointed every linked worktree's Codex session at the MAIN
+    // checkout's daemon, code, and data. The whole file is held to it: no
+    // port literal and no loopback-URL literal may survive anywhere,
+    // including the header prose, so the comments cannot drift back to
+    // describing the retired HTTP-URL transport.
+    const devEntry = codexConfig.split('[mcp_servers.whiteboard_dev]')[1] ?? ''
+    expect(devEntry, 'whiteboard_dev must exist').not.toBe('')
+    expect(devEntry).toContain('mcp-http-stdio-proxy.mjs')
+    expect(/^url\s*=/m.test(devEntry), 'whiteboard_dev must not carry a url key').toBe(false)
+    expect(codexConfig, 'no hardcoded port may survive anywhere in the file').not.toContain('3099')
+    expect(codexConfig).not.toContain('http://127.0.0.1')
+    // The published mirror stays disabled — the separate _dev name is what
+    // keeps Codex from merging the override into the stdio entry.
+    const publishedEntry = codexConfig
+      .split('[mcp_servers.whiteboard]')[1]
+      ?.split('[mcp_servers.')[0]
+    expect(publishedEntry).toContain('enabled = false')
+    // development.md's table row for the dev override must use the transport
+    // word that is now true: the stdio proxy.
+    const devRow = content
+      .split('\n')
+      .find((line) => line.startsWith('|') && line.includes('whiteboard_dev'))
+    expect(devRow, 'development.md must table the whiteboard_dev override').toBeTruthy()
+    expect(devRow).toContain('stdio proxy')
   })
 
   // A count spelled out in prose is the kind of claim nobody re-reads: it read


### PR DESCRIPTION
## What

Four contributor-facing audit findings (two HIGH), one increment:

1. **Codex worktree bug (HIGH).** The tracked `.codex/config.toml` hardcoded `url=http://127.0.0.1:3099/mcp`, so every linked worktree's Codex session silently talked to the **main checkout's** daemon, code, and `.dev-data` — the exact cross-worktree attach the per-worktree-port design exists to prevent. `whiteboard_dev` now launches `mcp-http-stdio-proxy.mjs` (via the same `sh -c` + `git rev-parse --show-toplevel` pattern the file's SessionStart hook already uses), which derives the checkout's own port from its on-disk location. `http_headers` is dropped — the proxy sends the bearer itself.
2. **Broken playwright install command (HIGH).** `pnpm exec playwright install --with-deps chromium` fails at repo root (playwright is a devDependency of apps/web and canvas-viewer only) — a clean-clone contributor hits it at quick-start step 4, and CI never notices because it sets `WHITEBOARD_CHROME_PATH`. Both docs now carry the `--filter @kamiazya/whiteboard-web` form `release.yml` already uses, and the parenthetical names all three browser projects.
3. **`pnpm check:local` joins the PR checklist** (the documented local mirror of CI's `check` job; needs ImageMagick), cross-referenced from `docs/contributing/README.md`.
4. **Prerequisites state the pinned pnpm + `corepack enable`** — an older global pnpm silently rewrites the lockfile and fails CI's `--frozen-lockfile`.

## Guards (all red-first in `docs-contract.test.ts`)

- Filtered playwright command present in both docs, bare root form banned; browser-project list derived from `readBrowserProjectNames` so it cannot go stale.
- The reworked dev-override test holds the **whole** `.codex/config.toml` to the new transport: `whiteboard_dev` names the proxy and carries no `url` key; no `3099` or `http://127.0.0.1` literal survives anywhere (header prose included — it used to say "serves http://127.0.0.1:3099/mcp"); the published mirror stays `enabled = false`; development.md's table row must say "stdio proxy", which is now true rather than aspirational.
- check:local checklist + README reference; pnpm version derived from `package.json`'s `packageManager` so a future bump that forgets the docs fails the test.

## Verification

Ran the exact configured command from a linked worktree and piped a JSON-RPC `initialize`: full response received, and the proxy's own log line reads `proxying stdio <-> http://127.0.0.1:3735/mcp` — the worktree's derived port, not 3099. `docs-contract.test.ts` 9/9 (4 were red before the edits); typecheck + biome clean. Design + plan review by a dev-loop lane; implemented from the approved design.

Visual evidence: none — docs, a client config, and contract tests; the executable evidence is the worktree-port proxy log quoted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D
