### PR TITLE
docs: tell self-hosting operators that server mode serves no browser UI

### DIFF
--- a/docs/how-to/self-host-with-docker.md
+++ b/docs/how-to/self-host-with-docker.md
@@ -7,6 +7,12 @@ Provider (OAuth/JWT resource-server validation with external IdP). It is a
 separate deployment path from the local daemon mode — do not mix local-daemon
 tokens with server JWT authentication.
 
+> **Server mode serves no browser UI.** The web app is not part of this
+> deployment: the container's root URL answers with a small placeholder
+> page, because the web app has no server-mode-aware sign-in yet. What this
+> deployment serves is the HTTP API under `/api/...` and the MCP endpoint at
+> `/mcp` — point API clients and MCP agents at those.
+
 ## Prerequisites
 
 - Docker 20.10+ with Compose v2

--- a/packages/mcp-server/src/server/docs-contract.test.ts
+++ b/packages/mcp-server/src/server/docs-contract.test.ts
@@ -243,6 +243,19 @@ describe('docs/ contract', () => {
     expect(devRow).toContain('stdio proxy')
   })
 
+  // The operator guide reads as complete (Dockerfile, compose, TLS, backup)
+  // but server mode serves only a static placeholder page — apps/web has no
+  // server-mode-aware auth flow yet (see SERVER_MODE_PLACEHOLDER_HTML's
+  // rationale in app-helpers.ts). An operator who follows Quick start and
+  // opens the root URL must learn that from the guide, not from a dead page.
+  it('tells self-hosting operators that server mode serves no browser UI', () => {
+    const guide = readFileSync(join(DOCS_ROOT, 'how-to/self-host-with-docker.md'), 'utf8')
+    expect(guide).toContain('no browser UI')
+    // The two surfaces this deployment actually serves.
+    expect(guide).toContain('/api')
+    expect(guide).toContain('/mcp')
+  })
+
   // A count spelled out in prose is the kind of claim nobody re-reads: it read
   // "seventeen" for at least two added projects, next to an enumeration that
   // still named a `workspace node` project the repo no longer has.


### PR DESCRIPTION
## What

Audit finding (MEDIUM, devx): `docs/how-to/self-host-with-docker.md` reads as a complete operator guide but never states that **server mode serves no browser UI** — the root URL answers with a static placeholder because apps/web has no server-mode-aware sign-in yet. The limitation lived only in a developer-facing code comment (`SERVER_MODE_PLACEHOLDER_HTML`'s rationale in `app-helpers.ts`), so an operator following Quick start got a dead UI with no signal why.

A callout near the top now says so and points at the two surfaces this deployment actually serves: `/api/...` and `/mcp`. Pinned red-first in `docs-contract.test.ts` (10/10 after; the new assertion failed against the unedited guide). The larger companion item — a server-mode-aware auth flow in apps/web — stays on the backlog by design.

Visual evidence: none — a documentation callout and its contract test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D
