### PR TITLE
fix(web): the card list follows a browser workspace switch

### DIFF
--- a/apps/web/src/pages/BrowserIndexPage.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.tsx
@@ -87,16 +87,6 @@ export function BrowserIndexPage({
   // and a handler-side `if (creating) return` reads a stale closure in
   // exactly the same-tick case it would have to catch.
   const [creating, setCreating] = useState(false)
-  // The panel reads through the SAME stores this page was given — never a
-  // second instance that merely happens to open the same database.
-  const filesSource = useMemo(
-    () => createLocalFilesSource({ index, loro, clock }),
-    [index, loro, clock],
-  )
-  // Deletions happen in this page's dialog, behind the panel's back — the
-  // panel re-reads whenever this identity changes, exactly as on the daemon
-  // page.
-  const [filesRevision, setFilesRevision] = useState(0)
   // The workspace this page is listing. Subscribed, not read: ADR-0019's
   // switch is an in-SPA route change, so this page stays mounted across one,
   // and the load effect below keyed on the index and the clock — neither of
@@ -107,7 +97,29 @@ export function BrowserIndexPage({
     subscribeBrowserWorkspaceIdentity,
     browserWorkspaceIdentitySnapshot,
   )
-
+  // The panel reads through the SAME stores this page was given — never a
+  // second instance that merely happens to open the same database.
+  //
+  // Keyed on the ACTIVE WORKSPACE as well, because the panel detects a switch
+  // by this identity changing — the same contract the daemon page's source
+  // memo keeps with `selectedWorkspace`. Without it the panel never learned a
+  // switch had happened: its cards, selection, open folder and search results
+  // all still belonged to the workspace the person had left, while the page's
+  // own heading and onboarding decision had already followed. Worse than
+  // stale: paths collide across workspaces (`untitled` most of all) and the
+  // card menu's Delete carries a PATH, which this page then resolves against
+  // whichever workspace is active NOW.
+  const filesSource = useMemo(
+    () => createLocalFilesSource({ index, loro, clock }),
+    // `activeWorkspace` is not read by the factory — the source reads the
+    // accessor at call time. It is here as the switch SIGNAL the panel keys
+    // on, which is the whole point of the memo.
+    [index, loro, clock, activeWorkspace],
+  )
+  // Deletions happen in this page's dialog, behind the panel's back — the
+  // panel re-reads whenever this identity changes, exactly as on the daemon
+  // page.
+  const [filesRevision, setFilesRevision] = useState(0)
   // What this page calls itself. The identity the accessor publishes carries
   // no display name (it is the ADDRESSING half), so the row has to be read —
   // in the same effect, which already re-runs on a switch.

--- a/apps/web/src/pages/BrowserIndexPage.workspace-switch-list.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.workspace-switch-list.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  getBrowserWorkspaceId,
+  setBrowserWorkspaceIdForTests,
+} from '../lib/browser-workspace-id.js'
+import { LocalStoreDouble } from '../test-utils/local-index.js'
+import { BrowserIndexPage } from './BrowserIndexPage.js'
+
+// A workspace switch is an in-SPA route change (ADR-0019), so this page stays
+// mounted across one — and the CARDS come from WorkspaceFilesPanel, not from
+// this page's own `snapshots` (which only decides onboarding-vs-panel). The
+// panel detects a switch by its SOURCE IDENTITY changing, which is what the
+// daemon page's `filesSource` memo is keyed on. The browser page's was keyed
+// on [index, loro, clock] — none of which move when the workspace does — so
+// the panel kept listing the workspace the person had just left, under an
+// address naming the one they went to.
+//
+// The page-level test in BrowserIndexPage.test.tsx counts `listDocuments`
+// CALLS, which this page's own effect satisfies on its own; only an assertion
+// on the rendered cards can see this.
+
+afterEach(cleanup)
+
+const OTHER_WORKSPACE = '01BX5ZZKBKACTAV9WEVGEMMVRZ'
+
+function renderPage(store: LocalStoreDouble) {
+  const onOpenDocument = vi.fn()
+  render(
+    <MemoryRouter initialEntries={['/']}>
+      <BrowserIndexPage
+        index={store.index}
+        loro={store.loro}
+        pointer={store.pointer}
+        clock={store.clock}
+        onOpenDocument={onOpenDocument}
+      />
+    </MemoryRouter>,
+    { container: document.body },
+  )
+  return onOpenDocument
+}
+
+const titles = () => screen.getAllByTestId('card-title').map((el) => el.textContent)
+
+describe('the card list follows a workspace switch', () => {
+  it('lists the workspace it switched TO, and nothing from the one it left', async () => {
+    const settled = getBrowserWorkspaceId()
+    const store = new LocalStoreDouble()
+    await store.save({
+      documentId: '0CFJNRVY147ADGKPSWZ258BEHM',
+      workspaceId: settled,
+      path: 'left-behind',
+      name: 'Left behind',
+      updatedAt: '2026-09-01T00:00:00Z',
+      kind: 'spatial',
+    })
+    await store.index.createWorkspace({ workspaceId: OTHER_WORKSPACE })
+    store.index.seed({
+      workspaceId: OTHER_WORKSPACE,
+      documentId: '0Z258BEHMQTX0369CFJNRVY147',
+      path: 'arrived-at',
+      name: 'Arrived at',
+      kind: 'markdown',
+    })
+
+    try {
+      renderPage(store)
+      await waitFor(() => expect(titles()).toContain('Left behind'))
+
+      await act(async () => {
+        setBrowserWorkspaceIdForTests(OTHER_WORKSPACE, 'second')
+      })
+
+      await waitFor(() => expect(titles()).toContain('Arrived at'))
+      expect(titles()).not.toContain('Left behind')
+    } finally {
+      setBrowserWorkspaceIdForTests(settled)
+    }
+  })
+
+  it('search results stop naming the workspace that was left', async () => {
+    // The panel resets RESULTS on a switch and deliberately keeps the typed
+    // query (it re-runs against the new workspace). What must not survive is
+    // a row naming a document that is not here — paths and names collide
+    // across workspaces, and the row is clickable.
+    const settled = getBrowserWorkspaceId()
+    const store = new LocalStoreDouble()
+    await store.save({
+      documentId: '0CFJNRVY147ADGKPSWZ258BEHM',
+      workspaceId: settled,
+      path: 'left-behind',
+      name: 'Left behind',
+      updatedAt: '2026-09-01T00:00:00Z',
+      kind: 'spatial',
+    })
+    await store.index.createWorkspace({ workspaceId: OTHER_WORKSPACE })
+    store.index.seed({
+      workspaceId: OTHER_WORKSPACE,
+      documentId: '0Z258BEHMQTX0369CFJNRVY147',
+      path: 'arrived-at',
+      name: 'Arrived at',
+      kind: 'markdown',
+    })
+
+    try {
+      renderPage(store)
+      await waitFor(() => expect(titles()).toContain('Left behind'))
+      fireEvent.change(await screen.findByRole('searchbox', { name: 'Search documents' }), {
+        target: { value: 'e' },
+      })
+      const results = await screen.findByTestId('search-results')
+      await waitFor(() => expect(results.textContent).toContain('Left behind'))
+
+      await act(async () => {
+        setBrowserWorkspaceIdForTests(OTHER_WORKSPACE, 'second')
+      })
+
+      await waitFor(() => {
+        expect(document.body.textContent).not.toContain('Left behind')
+      })
+    } finally {
+      setBrowserWorkspaceIdForTests(settled)
+    }
+  })
+})

--- a/apps/web/src/pages/BrowserIndexPage.workspace-switch.browser.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.workspace-switch.browser.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * The card list follows a workspace switch — in a real browser, over real
+ * IndexedDB and the real switch path.
+ *
+ * jsdom can drive the identity accessor directly; only this layer runs the
+ * actual `switchBrowserWorkspace` against a real registry with two real
+ * workspaces. Both hold a document called `untitled` — the collision this
+ * bug rides on — so the workspaces are told apart by COUNT, which is what a
+ * hand-run of this same flow needed too (measured: with one document each,
+ * the stale list and the correct one are the same two words).
+ */
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import '../index.css'
+import { getBrowserWorkspaceId, switchBrowserWorkspace } from '../lib/browser-workspace-id.js'
+import { IdbDocumentIndex } from '../lib/idb-document-index.js'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { LocalStoreDouble } from '../test-utils/local-index.js'
+import { BrowserIndexPage } from './BrowserIndexPage.js'
+
+claimIsolatedWhiteboardDb('browserindexpage-workspace-switch')
+
+const OTHER = '01BX5ZZKBKACTAV9WEVGEMMVRZ'
+
+beforeEach(async () => {
+  await clearWhiteboardDb()
+})
+afterEach(cleanup)
+
+const titles = () => screen.getAllByTestId('card-title').map((el) => el.textContent)
+
+it('lists the workspace switched to, told apart by count', async () => {
+  const settled = getBrowserWorkspaceId()
+  const store = new LocalStoreDouble()
+  await store.save({
+    documentId: '0CFJNRVY147ADGKPSWZ258BEHM',
+    workspaceId: settled,
+    path: 'untitled',
+    name: 'untitled',
+    updatedAt: '2026-09-01T00:00:00Z',
+    kind: 'spatial',
+  })
+  await store.index.createWorkspace({ workspaceId: OTHER, segment: 'second' })
+  // The REAL registry too: `switchBrowserWorkspace` resolves a handle against
+  // IndexedDB, not against the injected index — without these it answers null
+  // and no switch happens, which reads exactly like a list that did not
+  // follow (measured: the first version of this test failed that way).
+  await new IdbDocumentIndex().createWorkspace({ workspaceId: settled, segment: 'default' })
+  await new IdbDocumentIndex().createWorkspace({ workspaceId: OTHER, segment: 'second' })
+  for (const [documentId, path] of [
+    ['0Z258BEHMQTX0369CFJNRVY147', 'untitled'],
+    ['069CFJNRVY147ADGKPSWZ258BE', 'untitled-2'],
+  ] as const) {
+    store.index.seed({ workspaceId: OTHER, documentId, path, kind: 'markdown' })
+  }
+
+  render(
+    <MemoryRouter initialEntries={['/']}>
+      <BrowserIndexPage
+        index={store.index}
+        loro={store.loro}
+        pointer={store.pointer}
+        clock={store.clock}
+        onOpenDocument={vi.fn()}
+      />
+    </MemoryRouter>,
+    { container: document.body },
+  )
+
+  await waitFor(() => expect(titles()).toHaveLength(1))
+  // Asserted, not assumed: a switch that did not happen leaves the list
+  // unchanged, which is indistinguishable from the bug under test.
+  expect(await switchBrowserWorkspace('second')).not.toBeNull()
+  await waitFor(() => expect(titles()).toHaveLength(2))
+  expect(await switchBrowserWorkspace('default')).not.toBeNull()
+  await waitFor(() => expect(titles()).toHaveLength(1))
+})


### PR DESCRIPTION
## Summary

Reported from a phone: the workspace switcher showed the destination checked while the cards behind it still belonged to the workspace just left.

**Root cause.** `WorkspaceFilesPanel` detects a switch by its **source identity** changing — the daemon page's memo says exactly that and is keyed on `selectedWorkspace`. The browser page's `filesSource` was keyed on `[index, loro, clock]`, none of which move when the workspace does, so the panel never learned a switch had happened. Its whole documented SCOPE RESET — the list, the selection, the open folder, the search results, the rename dialog's captured entry — was unreachable from this page. Meanwhile the page's *own* heading and onboarding decision already followed the switch, which is what made the screen self-contradictory in the report.

Worse than stale: paths collide across workspaces (`untitled` most of all) and the card menu's Delete carries a **path**, which this page then resolves against whichever workspace is active *now*.

The fix is the one line that gives the panel the signal it is built to watch, keyed on the identity this page already subscribes to.

## Visual repro

![before: switched to the 1-document workspace, still listing the other workspace's 2 documents / after: the list follows the switch](tmp/screenshots/ws-figure.png)

Both panels are the SAME destination (`default`, heading identical); only the cards differ. Composed by `compose-figure.mjs` (digests `5c765807` / `91025937`).

## Measurements

Real app, dev server, iPhone-13 emulation, same steps for both runs. Two **non-empty** workspaces, told apart by **count** (A: 1 document, B: 2) because both hold an `untitled` — with one document each, the stale list and the correct one are literally the same word:

```
before   B -> A: ["untitled","untitled-2"]     (A holds one document)
after    B -> A: ["untitled"]   ;  back to B: ["untitled","untitled-2"]
```

Two negative results worth keeping, both of which made an earlier attempt report success:

- **A switch to an EMPTY workspace cannot show this bug at all** — the page swaps to onboarding and the panel unmounts, so the stale list is hidden by a different mechanism. My first reproduction did that and passed.
- **The existing page-level switch test asserts only that `listDocuments` was CALLED again**, which this page's own effect satisfies while the rendered cards stay wrong. Only an assertion on the cards can see this.

## Test plan

- [x] Red-first jsdom `BrowserIndexPage.workspace-switch-list.test.tsx` (2): the list names the workspace switched TO and nothing from the one left; search results stop naming the departed workspace. **Mutation-checked** (drop the dependency → both fail).
- [x] Real-browser `BrowserIndexPage.workspace-switch.browser.test.tsx`: two workspaces in the REAL registry, switched through `switchBrowserWorkspace`, told apart by count. It **asserts the switch returned an identity** — the first version did not, and silently pinned nothing because the handle resolved against IndexedDB where the injected double's workspace did not exist. Mutation-checked.
- [x] Manual verification in the real app, before and after, quoted above.
- [x] `web-jsdom` over `src/pages` + `src/components/workspace-files`: 684 passed; the 1 failure is `BrowserDocumentPage.markdown-orphan` (from today's #1313), which passes in isolation — the known load-dependent family, untouched by this diff. typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLiRSAKQA8rRW7j6XBJhAE
