### PR TITLE
test(dev): every test file must belong to a vitest project — close the three glob holes and guard the invariant

### DIFF
--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -69,7 +69,9 @@ export default defineConfig({
   },
   test: {
     name: 'web-browser',
-    include: ['src/**/*.browser.test.tsx'],
+    // BOTH extensions: a `.browser.test.ts` (no x) matched by neither this
+    // include nor web-jsdom (which excludes it) would silently never run.
+    include: ['src/**/*.browser.test.tsx', 'src/**/*.browser.test.ts'],
     // Browser mode's 15s default is a real ceiling here, not a safety net: a
     // test that mounts a page, drives Radix through a portal and waits on
     // IndexedDB spends most of its budget on machine time, and vitest runs

--- a/apps/web/vitest.node.config.ts
+++ b/apps/web/vitest.node.config.ts
@@ -11,16 +11,9 @@ export default defineConfig({
   test: {
     name: 'web-node',
     environment: 'node',
-    include: [
-      'vite-pwa-options.test.ts',
-      'vite-manual-chunks.test.ts',
-      'public-headers.test.ts',
-      'vite-dev-headers.test.ts',
-      'vite-plugin-strip-wasm-sourcemap.test.ts',
-      'index-html.test.ts',
-      'pwa-icons.test.ts',
-      'mcp-source-alias-coverage.test.ts',
-      'scripts/**/*.test.ts',
-    ],
+    // Root-level build/deploy guards by glob, not a hand list: a new root
+    // test file added without editing this line used to run NOWHERE while
+    // CI stayed green (src/** belongs to web-jsdom/web-browser).
+    include: ['*.test.ts', 'scripts/**/*.test.ts'],
   },
 })

--- a/packages/canvas-viewer/vitest.browser.config.ts
+++ b/packages/canvas-viewer/vitest.browser.config.ts
@@ -6,7 +6,7 @@ export default defineProject({
   plugins: [react()],
   test: {
     name: 'canvas-viewer-browser',
-    include: ['src/**/*.browser.test.tsx'],
+    include: ['src/**/*.browser.test.tsx', 'src/**/*.browser.test.ts'],
     browser: sharedBrowserTestConfig({ projectRoot: import.meta.dirname }),
   },
 })

--- a/packages/canvas-viewer/vitest.node.config.ts
+++ b/packages/canvas-viewer/vitest.node.config.ts
@@ -5,5 +5,8 @@ export default defineProject({
     name: 'canvas-viewer-node',
     environment: 'node',
     include: ['src/**/*.test.ts'],
+    // A browser test must not run in the node environment just because its
+    // extension matches — it belongs to canvas-viewer-browser.
+    exclude: ['src/**/*.browser.test.ts'],
   },
 })

--- a/packages/mcp-server/src/server/release/vitest-projects.test.ts
+++ b/packages/mcp-server/src/server/release/vitest-projects.test.ts
@@ -10,6 +10,7 @@
 // checkout — mutating the checkout to force those same paths red is done
 // separately, by hand, as this task's required mutation checks.
 
+import { readdirSync, readFileSync } from 'node:fs'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -350,5 +351,142 @@ describe('sharedBrowserTestConfig trace budget', () => {
   it('records them when the trace script asks for them', () => {
     process.env[VAR] = '1'
     expect(sharedBrowserTestConfig().trace.snapshots).toBe(true)
+  })
+})
+
+// ── Test-file coverage: every test file belongs to a project ──
+//
+// vitest only errors when a --project FILTER matches nothing; a test FILE
+// matched by no project's include (or swallowed by an exclude with no other
+// project picking it up) is silently never run, forever, while CI stays
+// green. Three real glob holes had that shape (a `.browser.test.ts` under
+// apps/web, the same under canvas-viewer landing in the NODE project, and
+// apps/web's hand-listed root files). This guard walks the real tree and
+// asserts the invariant that outlives them.
+describe('every test file belongs to a vitest project', () => {
+  interface ProjectGlobs {
+    configPath: string
+    dir: string
+    name: string | undefined
+    isBrowser: boolean
+    include: string[]
+    exclude: string[]
+  }
+  let projects: ProjectGlobs[]
+  let matches: (pattern: string, relPath: string) => boolean
+  beforeEach(async () => {
+    const mod = (await import(pathToFileURL(VITEST_PROJECTS_MODULE_PATH).href)) as {
+      readProjectTestGlobs: (repoRoot: string) => ProjectGlobs[]
+      testGlobMatches: (pattern: string, relPath: string) => boolean
+    }
+    projects = mod.readProjectTestGlobs(ROOT)
+    matches = mod.testGlobMatches
+  })
+
+  function matchedProjects(repoRelPath: string): ProjectGlobs[] {
+    return projects.filter((project) => {
+      if (!repoRelPath.startsWith(`${project.dir}/`)) return false
+      const rel = repoRelPath.slice(project.dir.length + 1)
+      return (
+        project.include.some((pattern) => matches(pattern, rel)) &&
+        !project.exclude.some((pattern) => matches(pattern, rel))
+      )
+    })
+  }
+
+  it('the matcher handles exactly the grammar the configs use', () => {
+    expect(matches('src/**/*.test.ts', 'src/a/b/c.test.ts')).toBe(true)
+    expect(matches('src/**/*.test.ts', 'src/c.test.ts')).toBe(true)
+    expect(matches('src/**/*.test.ts', 'src/c.test.tsx')).toBe(false)
+    expect(matches('*.test.ts', 'root.test.ts')).toBe(true)
+    expect(matches('*.test.ts', 'src/root.test.ts')).toBe(false)
+    expect(matches('scripts/**/*.test.ts', 'scripts/a/b.test.ts')).toBe(true)
+    expect(matches('src/**/*.browser.test.tsx', 'src/x.browser.test.tsx')).toBe(true)
+    expect(matches('src/**/*.browser.test.tsx', 'src/x.test.tsx')).toBe(false)
+  })
+
+  // The three holes, as virtual probes — each was real when this guard was
+  // written, and the probe form keeps them checkable without committing a
+  // file that exists only to be found.
+  it('a .browser.test.ts under apps/web/src runs in the web-browser project', () => {
+    const hit = matchedProjects('apps/web/src/probe.browser.test.ts')
+    expect(hit.map((p) => p.name)).toContain('web-browser')
+    expect(hit.every((p) => p.isBrowser)).toBe(true)
+  })
+
+  it('a .browser.test.ts under canvas-viewer/src runs only in browser projects', () => {
+    const hit = matchedProjects('packages/canvas-viewer/src/probe.browser.test.ts')
+    expect(hit.length).toBeGreaterThan(0)
+    expect(
+      hit.map((p) => p.name),
+      'a browser test file must never land in a node/jsdom project',
+    ).toEqual(hit.filter((p) => p.isBrowser).map((p) => p.name))
+  })
+
+  it('a new root-level apps/web test file runs in web-node without editing a hand list', () => {
+    expect(matchedProjects('apps/web/probe-added-later.test.ts').map((p) => p.name)).toContain(
+      'web-node',
+    )
+  })
+
+  // Families deliberately outside the root project list, each pinned to the
+  // config that runs it — an entry here whose config vanishes fails, so the
+  // allowlist cannot outlive its reason.
+  const OUT_OF_ROOT: Array<{ suffixPattern: RegExp; config: string; mustInclude: string }> = [
+    {
+      suffixPattern: /\.docs-snapshot\.test\.tsx$/,
+      config: 'apps/web/vitest.docs-snapshots.config.ts',
+      mustInclude: 'docs-snapshot',
+    },
+    {
+      suffixPattern: /\.distribution\.test\.ts$/,
+      config: 'packages/mcp-server/vitest.distribution.config.ts',
+      mustInclude: 'distribution',
+    },
+  ]
+
+  it('walking the real tree finds no test file that no project runs', () => {
+    const orphans: string[] = []
+    const wrongProject: string[] = []
+    const roots = [...new Set(projects.map((p) => p.dir))]
+    const skipDirs = new Set(['node_modules', 'dist', 'tmp', '.vitest-attachments', 'coverage'])
+    const walk = (dir: string): string[] =>
+      readdirSync(join(ROOT, dir), { withFileTypes: true }).flatMap((entry) => {
+        if (entry.isDirectory()) {
+          return skipDirs.has(entry.name) ? [] : walk(`${dir}/${entry.name}`)
+        }
+        return /\.test\.tsx?$/.test(entry.name) ? [`${dir}/${entry.name}`] : []
+      })
+    for (const root of roots) {
+      for (const file of walk(root)) {
+        const out = OUT_OF_ROOT.find((o) => o.suffixPattern.test(file))
+        if (out) {
+          const config = readFileSync(join(ROOT, out.config), 'utf8')
+          expect(config, `${out.config} must still run ${file}`).toContain(out.mustInclude)
+          continue
+        }
+        const hit = matchedProjects(file)
+        if (hit.length === 0) orphans.push(file)
+        if (/\.browser\.test\.tsx?$/.test(file) && hit.some((p) => !p.isBrowser)) {
+          wrongProject.push(file)
+        }
+      }
+    }
+    expect(
+      orphans,
+      'these test files are matched by NO vitest project and silently never run',
+    ).toEqual([])
+    expect(wrongProject, 'these browser test files are matched by a non-browser project').toEqual(
+      [],
+    )
+  })
+
+  it('the sweep itself sees a plausible number of files, so a broken walk cannot pass vacuously', () => {
+    const roots = [...new Set(projects.map((p) => p.dir))]
+    expect(roots.length).toBeGreaterThan(10)
+    // Spot-anchor: the busiest project dir must resolve many files through
+    // matchedProjects, or the include parsing has silently gone empty.
+    const anyMcp = matchedProjects('packages/mcp-server/src/server/app.test.ts')
+    expect(anyMcp.map((p) => p.name)).toContain('mcp-node')
   })
 })

--- a/tools/checks/src/vitest-projects.mjs
+++ b/tools/checks/src/vitest-projects.mjs
@@ -168,3 +168,63 @@ export function deriveSharedLayerProjectNames(repoRoot) {
 export function buildVitestArgv(names) {
   return ['exec', 'vitest', 'run', ...names.map((name) => `--project=${name}`)]
 }
+
+/**
+ * @typedef {{ configPath: string, dir: string, name: string | undefined, isBrowser: boolean, include: string[], exclude: string[] }} VitestProjectGlobs
+ */
+
+// Per-project include/exclude patterns, for the coverage guard that asserts
+// every test file in the tree belongs to at least one root project. The
+// arrays are read textually (this package stays dependency-free), keeping
+// only entries that look like test-path globs so an optimizeDeps.include or
+// setupFiles list in the same config cannot pollute the result.
+/**
+ * @param {string} repoRoot
+ * @returns {VitestProjectGlobs[]}
+ */
+export function readProjectTestGlobs(repoRoot) {
+  const rootVitestConfig = readFileSync(join(repoRoot, 'vitest.config.ts'), 'utf8')
+  const configPaths = [...rootVitestConfig.matchAll(/'([^']+\.config\.ts)'/g)].map(
+    (match) => match[1],
+  )
+  return configPaths.map((configPath) => {
+    const content = readFileSync(join(repoRoot, configPath), 'utf8')
+    const arrays = (key) =>
+      [...content.matchAll(new RegExp(`${key}:\\s*\\[([^\\]]*)\\]`, 'g'))]
+        // Strip line comments BEFORE scanning quotes: an apostrophe in a
+        // comment ("this project's own...") otherwise pairs with a real
+        // entry's opening quote and silently swallows it.
+        .map((match) => match[1].replace(/\/\/[^\n]*/g, ''))
+        .flatMap((body) => [...body.matchAll(/'([^']+)'/g)].map((entry) => entry[1]))
+        .filter((pattern) => pattern.includes('.test.') || pattern.includes('.bench.'))
+    return {
+      configPath,
+      dir: configPath.slice(0, configPath.lastIndexOf('/')),
+      name: content.match(/name:\s*'([^']+)'/)?.[1],
+      isBrowser:
+        /browser:\s*\{\s*\n?\s*enabled:\s*true/.test(content) ||
+        /browser:\s*sharedBrowserTestConfig\(/.test(content),
+      include: arrays('include'),
+      exclude: arrays('exclude'),
+    }
+  })
+}
+
+// The one glob grammar the configs above actually use: literal path
+// segments, `*` within a segment, and `**/` for zero or more directories.
+// Deliberately NOT a general glob engine — the coverage guard's own unit
+// tests pin each form, and an unsupported form fails visibly there rather
+// than silently matching nothing.
+/**
+ * @param {string} pattern
+ * @param {string} relPath path relative to the config's directory, '/'-separated
+ * @returns {boolean}
+ */
+export function testGlobMatches(pattern, relPath) {
+  const escapeRegExp = (s) => s.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+  const regex = pattern
+    .split('**/')
+    .map((part) => escapeRegExp(part).replace(/\*/g, '[^/]*'))
+    .join('(?:[^/]+/)*')
+  return new RegExp(`^${regex}$`).test(relPath)
+}


### PR DESCRIPTION
## What

Audit finding (MEDIUM, test-gaps): **a test file matched by no vitest project is silently never run, forever, while CI stays green** — vitest only errors when a `--project` *filter* matches nothing, never when a *file* belongs to no project. Three glob holes had exactly that shape (zero affected files today, so this closes them while they're still free):

1. **apps/web**: a `src/**/*.browser.test.ts` (no `x`) was excluded by `web-jsdom` and not included by `web-browser` (tsx-only include) → ran **nowhere**.
2. **canvas-viewer**: the same file shape ran in the **node** project (`src/**/*.test.ts` include, no exclude) → wrong environment.
3. **apps/web root**: `web-node` hand-listed eight filenames, so a ninth root build guard would run nowhere. Now `'*.test.ts'` by glob — verified the glob resolves exactly the previous list today: **14 files / 92 tests**, all green.

## The guard

`release/vitest-projects.test.ts` gains a sweep that walks the real tree and asserts: every `*.test.{ts,tsx}` under a project dir matches ≥1 root project; `.browser.test.*` files match **only** browser projects; the out-of-root families (`.docs-snapshot`, `.distribution`) stay pinned to the configs that run them (an allowlist entry whose config vanishes fails). The matcher covers exactly the one glob grammar the configs use, with its own unit fixtures. All three holes ride along as virtual probes — **red-first: each failed before its config edit**.

## Bonus catch

The first real-tree sweep flagged `packages/mcp-server/vitest-data-dir.test.ts` as an orphan — a **parser bug, not a real orphan**: an apostrophe in an include-array comment ("this project**'s** own…") paired with a real entry's opening quote and silently swallowed the entry from the parsed inventory. `readProjectTestGlobs` now strips line comments before scanning quotes; the file resolves to `mcp-node` again.

## Verification

Guard 19/19 (post-fix; 4 red pre-fix). `web-node` 14 files / 92 tests (set-identical to the hand list), canvas-viewer node+jsdom 20 files / 110 tests, release suite 520 passed / 5 skipped, typecheck + biome green. No `.browser.test.ts` files exist yet under either package — the include additions are pure future-proofing, changing today's run set by zero files.

Visual evidence: none — vitest config globs and a coverage guard; the evidence is the red-first probe results and the unchanged suite counts above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D
