### PR TITLE
fix(web): a saved-bookmark badge no longer outlives its document — useVersionSaveFlow owns its scope reset

### DIFF
--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -312,7 +312,8 @@ export function BrowserDocumentPage({
     setConfirmDelete(false)
     setDuplicateError(null)
     setIsDuplicating(false)
-    clearSaveVersionOutcome()
+    // saveVersionOutcome clears itself: useVersionSaveFlow owns that reset,
+    // keyed on the same documentId this effect watches.
     setHistoryOpen(false)
     setBookmarkArmed(0)
     setPreview(null)
@@ -638,8 +639,7 @@ export function BrowserDocumentPage({
     saving: savingVersion,
     outcome: saveVersionOutcome,
     run: runVersionSave,
-    clearOutcome: clearSaveVersionOutcome,
-  } = useVersionSaveFlow(currentDocumentIdRef, async (label) => {
+  } = useVersionSaveFlow(currentDocumentIdRef, documentId, async (label) => {
     // Narrowed by the precondition in `saveVersionFromPanel` below, which
     // never calls `run` (so never reaches this body) while either is null.
     if (versionsBackend === null || documentPath === null) {

--- a/apps/web/src/pages/DaemonDocumentPage.surface-outlives-document.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.surface-outlives-document.test.tsx
@@ -22,7 +22,14 @@ import type {
   DocumentBackendHandlers,
 } from '@kamiazya/whiteboard-mcp/browser-contract'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
-import { act, cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from '@testing-library/react'
 import { LoroDoc } from 'loro-crdt'
 import type { ReactElement } from 'react'
 import { MemoryRouter } from 'react-router-dom'
@@ -89,13 +96,32 @@ describe('the body surface does not outlive its document (daemon)', () => {
     window.localStorage.clear()
     vi.stubGlobal(
       'fetch',
-      vi.fn(async (input: RequestInfo | URL) => {
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = typeof input === 'string' ? input : input.toString()
         if (url.includes('/names')) {
           return new Response(
             JSON.stringify({ documents: { 'doc-a': 'Doc A', 'doc-b': 'Doc B' }, pinned: [] }),
             { status: 200 },
           )
+        }
+        if (url.endsWith('/versions') && init?.method === 'POST') {
+          return new Response(
+            JSON.stringify({
+              version: {
+                id: 'v1',
+                path: 'doc-a',
+                createdAt: '2026-01-01T00:00:00Z',
+                elementCount: 0,
+                auto: false,
+                hasThumbnail: false,
+                branchName: 'main',
+              },
+            }),
+            { status: 200 },
+          )
+        }
+        if (url.endsWith('/versions')) {
+          return new Response(JSON.stringify({ versions: [] }), { status: 200 })
         }
         return new Response('{}', { status: 404 })
       }),
@@ -155,6 +181,47 @@ describe('the body surface does not outlive its document (daemon)', () => {
     expect(
       screen.queryByTestId('node-text-overlay'),
       'the body surface is still open after this page switched document under it — scoped to the props, which a controller-driven switch never moves',
+    ).toBeNull()
+  })
+
+  it('a saved-bookmark badge does not outlive its document', async () => {
+    await act(async () => {
+      render(
+        <DaemonDocumentPage
+          daemonBaseUrl={DAEMON_BASE_URL}
+          workspaceId="w1"
+          path="doc-a"
+          createBackend={() => new FakeBackend()}
+        />,
+      )
+    })
+    await waitFor(() => expect(openFileRef).not.toBeNull())
+
+    // ⌘S opens the history panel with the naming field armed; naming + Enter
+    // performs the save this badge reports.
+    await act(async () => {
+      fireEvent.keyDown(window, { key: 's', ctrlKey: true })
+    })
+    const field = await screen.findByLabelText('Name this point')
+    fireEvent.change(field, { target: { value: 'Milestone' } })
+    await act(async () => {
+      fireEvent.keyDown(field, { key: 'Enter' })
+    })
+    await waitFor(() => expect(screen.getByText('Bookmark saved')).toBeTruthy())
+
+    // The switch this page makes by itself; the history panel closes with it.
+    await act(async () => {
+      openFileRef?.('id-b')
+    })
+    await waitFor(() => expect(screen.queryByTestId('bookmark-action')).toBeNull())
+
+    // Reopen history on the ARRIVED document via the toolbar (not ⌘S, which
+    // would arm the naming field and hide the badge either way).
+    fireEvent.click(screen.getByRole('button', { name: 'History' }))
+    await screen.findByTestId('bookmark-action')
+    expect(
+      screen.queryByText('Bookmark saved'),
+      "a 'saved' badge earned on the departed document is still lit under the arrived one",
     ).toBeNull()
   })
 })

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -820,7 +820,7 @@ export function DaemonDocumentPage({
     saving: savingVersion,
     outcome: saveVersionOutcome,
     run: runVersionSave,
-  } = useVersionSaveFlow(currentDocumentPathRef, async (label) => {
+  } = useVersionSaveFlow(currentDocumentPathRef, controller.path, async (label) => {
     // Narrowed by the precondition in `saveVersion` below, which never
     // calls `run` (so never reaches this body) while canvas is null.
     if (canvas === null) {

--- a/apps/web/src/pages/use-version-save-flow.test.ts
+++ b/apps/web/src/pages/use-version-save-flow.test.ts
@@ -52,7 +52,7 @@ describe('useVersionSaveFlow', () => {
           resolveSave = resolve
         }),
     )
-    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, save))
+    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, 'doc-1', save))
 
     let runPromise!: Promise<void>
     act(() => {
@@ -79,7 +79,7 @@ describe('useVersionSaveFlow', () => {
     const scopeRef = scope('doc-a')
     const commit = vi.fn()
     const save = vi.fn((): Promise<() => void> => Promise.reject(new Error('boom')))
-    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, save))
+    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, 'doc-1', save))
 
     await act(async () => {
       await result.current.run('a bookmark').catch(() => undefined)
@@ -99,7 +99,7 @@ describe('useVersionSaveFlow', () => {
           resolveSave = resolve
         }),
     )
-    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, save))
+    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, 'doc-1', save))
 
     let firstRun!: Promise<void>
     act(() => {
@@ -121,7 +121,7 @@ describe('useVersionSaveFlow', () => {
   it('clears a prior outcome to null at the start of a new run', async () => {
     const scopeRef = scope('doc-a')
     const save = vi.fn((): Promise<() => void> => Promise.reject(new Error('boom')))
-    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, save))
+    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, 'doc-1', save))
 
     await act(async () => {
       await result.current.run('first').catch(() => undefined)
@@ -154,7 +154,7 @@ describe('useVersionSaveFlow', () => {
           resolveSave = resolve
         }),
     )
-    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, save))
+    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, 'doc-1', save))
 
     let runPromise!: Promise<void>
     act(() => {
@@ -183,7 +183,7 @@ describe('useVersionSaveFlow', () => {
           rejectSave = reject
         }),
     )
-    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, save))
+    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, 'doc-1', save))
 
     let runPromise!: Promise<void>
     act(() => {
@@ -200,19 +200,20 @@ describe('useVersionSaveFlow', () => {
     expect(result.current.saving).toBe(true)
   })
 
-  it('clearOutcome resets outcome to null', async () => {
+  it('a scope-key change clears the outcome — the hook owns its own reset', async () => {
     const scopeRef = scope('doc-a')
     const save = vi.fn((): Promise<() => void> => Promise.reject(new Error('boom')))
-    const { result } = renderHook(() => useVersionSaveFlow(scopeRef, save))
+    const { result, rerender } = renderHook(
+      ({ key }: { key: string }) => useVersionSaveFlow(scopeRef, key, save),
+      { initialProps: { key: 'doc-1' } },
+    )
 
     await act(async () => {
       await result.current.run('first').catch(() => undefined)
     })
     expect(result.current.outcome).toBe('failed')
 
-    act(() => {
-      result.current.clearOutcome()
-    })
+    rerender({ key: 'doc-2' })
     expect(result.current.outcome).toBe(null)
   })
 })

--- a/apps/web/src/pages/use-version-save-flow.ts
+++ b/apps/web/src/pages/use-version-save-flow.ts
@@ -20,18 +20,18 @@
  */
 
 import type { RefObject } from 'react'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import type { SaveVersionOutcome } from '../components/workspace-top-bar/BookmarkAction.js'
 
 export interface VersionSaveFlow {
   readonly saving: boolean
   readonly outcome: SaveVersionOutcome
   readonly run: (label: string) => Promise<void>
-  readonly clearOutcome: () => void
 }
 
 export function useVersionSaveFlow<Scope>(
   scopeRef: RefObject<Scope>,
+  scopeKey: unknown,
   save: (label: string) => Promise<() => void>,
 ): VersionSaveFlow {
   // Names kept as `savingVersion`/`saveVersionOutcome` (not the shorter
@@ -66,11 +66,14 @@ export function useVersionSaveFlow<Scope>(
     [savingVersion, save, scopeRef],
   )
 
-  // SCOPE RESET — the page's own scope-reset effect calls this; the marker
-  // lets scoped-screen-state.test.ts verify the setter from here.
-  const clearOutcome = useCallback(() => {
+  // SCOPE RESET — owned HERE, keyed on the page's document identity, not
+  // delegated to each page's hand-written reset effect. The daemon page
+  // shipped without the clear, and a 'saved' badge earned on one document
+  // stayed lit under the next — a hook that owns its own reset makes that
+  // omission impossible for the next page too.
+  useEffect(() => {
     setSaveVersionOutcome(null)
-  }, [])
+  }, [scopeKey])
 
-  return { saving: savingVersion, outcome: saveVersionOutcome, run, clearOutcome }
+  return { saving: savingVersion, outcome: saveVersionOutcome, run }
 }


### PR DESCRIPTION
## What

First increment of the page-unification backlog item (`issues/unify-document-pages-behind-backend-port`), which started with a duplication inventory across `BrowserDocumentPage` / `DaemonDocumentPage` (23 duplicated concerns catalogued; three silent divergences found). This lands the highest-value divergence as a fix:

**A 'saved' bookmark badge outlived its document on the daemon page.** The browser page's switch-reset effect called `clearOutcome()`; the daemon page never even destructured it. Save a version on document A, switch (file ref, chip, MCP-driven — any controller switch), reopen History on document B: the sr-only/live "Bookmark saved" state still reports document A's save. It survived because `scoped-screen-state.test.ts` scans only the browser page — the daemon page's own comment admits its reset is "by hand".

## Fix — structural, not another hand-written call

`useVersionSaveFlow` now takes the page's document-identity key (`documentId` / `controller.path`) and **owns the outcome reset itself**; `clearOutcome` is deleted from the hook's surface and from the browser page's reset effect. A future page consuming the hook cannot repeat the omission — the same rationale the hook's original extraction (#1319) recorded for the race guard.

## Verification

- Red-first: new `surface-outlives-document` case drives a real ⌘S save (naming field + Enter, stubbed POST /versions), switches via a file reference, reopens History on the arrived document, asserts the badge is dark — **red before the fix** (`expected <span role="status"…> to be null`).
- Mutation check: removing the hook's reset effect fails that case AND the hook's own new unit test (scope-key change clears outcome); restored green.
- Suites: pages jsdom 50 files / 443 passed; scoped-screen-state ledger, save-conformance, hook units all green; typecheck, biome, knip clean.

Next increments on the same ticket (serial, same files): the comments-rail bundle (~120 verbatim-duplicated lines), then the tab-identity block.

Visual evidence: none — the symptom is an sr-only live-region announcement plus a state badge; the discriminating evidence is the red-first assertion quoted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Saved-bookmark status now resets correctly when switching between documents.
  - Version-save results no longer carry over from one document to another, preventing stale status indicators from appearing on the active document.

- **Tests**
  - Added coverage for document switching and saved-bookmark status behavior.
  - Updated version-save flow tests to verify automatic reset when the document scope changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->