### PR TITLE
fix(web): a workspace switch stops jolting the layout

### DIFF
--- a/apps/web/src/components/workspace-files/DocumentThumbnail.tsx
+++ b/apps/web/src/components/workspace-files/DocumentThumbnail.tsx
@@ -72,7 +72,11 @@ export function DocumentThumbnail({ document, loadRender, className }: DocumentT
         // no layout, so a selector aimed one level too high still passes every
         // test and draws a 2000px canvas inside a 24px row in a real browser.
         <span
-          className="size-full [&>svg]:size-full"
+          // The render lands well after the card (measured on a switch: 430ms
+          // later), so it arrives as a pop over a placeholder icon. A fade
+          // makes it read as the picture developing; the global
+          // prefers-reduced-motion floor collapses it.
+          className="size-full animate-in fade-in-0 duration-(--motion-duration-normal) ease-(--motion-ease-out) [&>svg]:size-full"
           // biome-ignore lint/security/noDangerouslySetInnerHtml: same-origin render output from canvas-render, as the markdown preview pane does
           dangerouslySetInnerHTML={{ __html: fitSvgToBox(drawn.svg) }}
         />

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -128,6 +128,18 @@ export function WorkspaceFilesPanel({
   // a failure. 'error' is a genuine fetch/schema failure and keeps the alert.
   const [listStatus, setListStatus] = useState<'ok' | 'not-found' | 'error'>('ok')
   const [selected, setSelected] = useState<WorkspaceDocumentEntry | null>(null)
+  /**
+   * How many cards the last successful listing drew, kept so a RE-READ can
+   * hold the layout it is about to replace.
+   *
+   * A workspace switch nulls `documents`, and the panel used to answer that
+   * with one line of text — measured on a real switch, the panel's box went
+   * 552px -> 0 -> 552 for 47ms, which is the jolt everything below it
+   * inherits. The skeleton below reserves the same room instead, and
+   * `.skeleton-appear`'s 300ms delay means a fast re-read never shows it at
+   * all: quiet background, unchanged geometry.
+   */
+  const lastCardCount = useRef(0)
   // '' is the workspace root, which is where a freshly loaded tree starts —
   // unless the address named a folder, which is the whole point of naming it.
   const [folder, setFolder] = useState(initialFolder ?? '')
@@ -301,7 +313,9 @@ export function WorkspaceFilesPanel({
     }
     readList()
       .then((entries) => {
-        if (!cancelled) setDocuments(entries)
+        if (cancelled) return
+        lastCardCount.current = entries.length
+        setDocuments(entries)
       })
       .catch((err) => {
         if (cancelled) return
@@ -602,10 +616,6 @@ export function WorkspaceFilesPanel({
   if (listStatus === 'not-found') {
     return <p className="text-muted-foreground text-sm">This workspace has no document tree yet.</p>
   }
-  if (documents === null) {
-    return <p className="text-muted-foreground text-sm">Loading files…</p>
-  }
-
   // Plain function, deliberately not a hook: this sits below the early
   // returns, where a hook would change the count between renders.
   // ContextMenu's x/y contract is ROOT-local (its absolute box resolves
@@ -802,7 +812,29 @@ export function WorkspaceFilesPanel({
         </fieldset>
       )}
       <div className="flex min-h-0 flex-1 flex-col gap-4 md:flex-row">
-        {query.trim() !== '' ? (
+        {documents === null ? (
+          // A re-read (a workspace switch, most of all) keeps the toolbar
+          // above and the room below: measured on a real switch, replacing
+          // the whole section with one line of text moved the card area up
+          // 38px and back within 54ms, which is the jolt everything inherits.
+          // `.skeleton-appear` holds it invisible for 300ms, so a fast
+          // re-read shows quiet background rather than a flash of
+          // placeholders.
+          <div
+            role="status"
+            aria-label="Loading documents"
+            className="skeleton-appear grid min-w-0 flex-1 grid-cols-[repeat(auto-fill,minmax(10rem,1fr))] content-start gap-2 p-0.5 md:grid-cols-[repeat(auto-fill,minmax(13rem,1fr))]"
+          >
+            {Array.from({ length: Math.max(lastCardCount.current, 1) }, (_, i) => (
+              <div key={i} className="overflow-hidden rounded-md border">
+                <div className="bg-muted/40 aspect-video w-full animate-pulse" />
+                <div className="px-2 py-1.5">
+                  <div className="bg-muted h-4 w-2/3 animate-pulse rounded" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : query.trim() !== '' ? (
           // Results come from everywhere, so neither the folder tree nor the
           // folder's own contents describes them. One flat list, in both
           // column modes — a search that behaved differently per mode would
@@ -950,19 +982,24 @@ export function WorkspaceFilesPanel({
           </div>
         )}
       </div>
-      {source.listTrash !== undefined && source.restoreFromTrash !== undefined && (
-        <TrashSection
-          listTrash={source.listTrash.bind(source)}
-          restoreFromTrash={source.restoreFromTrash.bind(source)}
-          revision={revision}
-          onRestored={() => {
-            // A restore that landed but whose refresh failed leaves the list
-            // stale, not the restore undone — same rule as every other write
-            // here, so the trash section never invents its own error shape.
-            void readList().then(setDocuments, () => undefined)
-          }}
-        />
-      )}
+      {/* Not while the list is loading: the trash is about content, there is
+          nothing to restore INTO yet, and rendering it early costs its own
+          read on every re-read — which is what a workspace switch is. */}
+      {documents !== null &&
+        source.listTrash !== undefined &&
+        source.restoreFromTrash !== undefined && (
+          <TrashSection
+            listTrash={source.listTrash.bind(source)}
+            restoreFromTrash={source.restoreFromTrash.bind(source)}
+            revision={revision}
+            onRestored={() => {
+              // A restore that landed but whose refresh failed leaves the list
+              // stale, not the restore undone — same rule as every other write
+              // here, so the trash section never invents its own error shape.
+              void readList().then(setDocuments, () => undefined)
+            }}
+          />
+        )}
       <PeekDialog
         document={peek}
         loadRender={loadRender}

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -982,9 +982,11 @@ export function WorkspaceFilesPanel({
           </div>
         )}
       </div>
-      {/* Not while the list is loading: the trash is about content, there is
-          nothing to restore INTO yet, and rendering it early costs its own
-          read on every re-read — which is what a workspace switch is. */}
+      {/* Not while the list is loading. The trash is a SECOND list of the
+          departed workspace's documents and reads on its own, so left
+          mounted it keeps showing that workspace's rows under the new
+          address until its own read answers — measured with a trash read
+          that never answers, which is the window this closes. */}
       {documents !== null &&
         source.listTrash !== undefined &&
         source.restoreFromTrash !== undefined && (

--- a/apps/web/src/components/workspace-files/switch-holds-layout.test.tsx
+++ b/apps/web/src/components/workspace-files/switch-holds-layout.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
+import type { WorkspaceDocumentEntry } from './document-entry.js'
+import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
+
+// What a re-read must not do is throw the layout away and put it back.
+// Measured on a real workspace switch before this: the panel's box went
+// 552px -> 0 -> 552 and the card area jumped up 38px and back, inside 54ms.
+// jsdom has no layout, so the assertion is on the STRUCTURE that produced
+// it — the toolbar stays mounted, and the card area is a grid of the same
+// shape rather than a line of text.
+
+afterEach(cleanup)
+
+const entries: WorkspaceDocumentEntry[] = [
+  { documentId: 'd1', path: 'one', name: 'One', kind: 'markdown' },
+  { documentId: 'd2', path: 'two', name: 'Two', kind: 'spatial' },
+]
+
+describe('a re-read holds the panel’s layout', () => {
+  it('keeps the toolbar and reserves the grid while the new list loads', async () => {
+    // A SWITCH is a new source identity — that is the panel's own signal, and
+    // the only path that clears the list (a `revision` bump deliberately
+    // keeps the cards up while it re-reads the same workspace).
+    const settled = fakeFilesSource({ listDocuments: () => Promise.resolve(entries) })
+    let release: ((rows: readonly WorkspaceDocumentEntry[]) => void) | undefined
+    const switching = fakeFilesSource({
+      listDocuments: () =>
+        new Promise((resolve) => {
+          release = resolve
+        }),
+    })
+
+    const { rerender } = render(<WorkspaceFilesPanel source={settled} />)
+    await waitFor(() => expect(screen.getAllByTestId('card-title')).toHaveLength(2))
+
+    rerender(<WorkspaceFilesPanel source={switching} />)
+
+    const loading = await screen.findByRole('status', { name: 'Loading documents' })
+    // The toolbar is what sits ABOVE the cards; losing it is what moved them.
+    expect(screen.getByRole('searchbox', { name: 'Search documents' })).toBeTruthy()
+    // Room for what is coming, in the same grid the cards use, and as many
+    // placeholders as the list it is replacing.
+    expect(loading.className).toContain('grid')
+    expect(loading.children).toHaveLength(2)
+    // Nothing from the departed workspace is still on screen.
+    expect(screen.queryAllByTestId('card-title')).toHaveLength(0)
+
+    release?.([entries[0] as WorkspaceDocumentEntry])
+    await waitFor(() => expect(screen.getAllByTestId('card-title')).toHaveLength(1))
+  })
+})

--- a/apps/web/src/components/workspace-files/switch-holds-layout.test.tsx
+++ b/apps/web/src/components/workspace-files/switch-holds-layout.test.tsx
@@ -25,6 +25,14 @@ describe('a re-read holds the panel’s layout', () => {
     // the only path that clears the list (a `revision` bump deliberately
     // keeps the cards up while it re-reads the same workspace).
     const settled = fakeFilesSource({ listDocuments: () => Promise.resolve(entries) })
+    // The trash is the panel's OTHER list of the departed workspace's
+    // documents, and it reads on its own — so a switch has to take it away
+    // with the cards rather than leave it holding rows from the workspace
+    // that was left.
+    settled.listTrash = async () => [
+      { documentId: 'gone-1', path: 'left-behind/plan', deletedAt: 1_700_000 },
+    ]
+    settled.restoreFromTrash = async () => {}
     let release: ((rows: readonly WorkspaceDocumentEntry[]) => void) | undefined
     const switching = fakeFilesSource({
       listDocuments: () =>
@@ -32,9 +40,19 @@ describe('a re-read holds the panel’s layout', () => {
           release = resolve
         }),
     })
+    // Hanging on purpose: the window worth pinning is the one where the NEW
+    // workspace's trash has not answered yet. Resolved fast, the section
+    // re-reads within a microtask and nothing about the departed rows is
+    // observable at all.
+    switching.listTrash = () => new Promise(() => {})
+    switching.restoreFromTrash = async () => {}
 
     const { rerender } = render(<WorkspaceFilesPanel source={settled} />)
     await waitFor(() => expect(screen.getAllByTestId('card-title')).toHaveLength(2))
+    // The precondition, asserted rather than assumed: the trash section is
+    // ON SCREEN for the settled workspace, so its absence below means the
+    // switch took it away rather than that it was never there.
+    await screen.findByText(/^Trash/)
 
     rerender(<WorkspaceFilesPanel source={switching} />)
 
@@ -45,8 +63,11 @@ describe('a re-read holds the panel’s layout', () => {
     // placeholders as the list it is replacing.
     expect(loading.className).toContain('grid')
     expect(loading.children).toHaveLength(2)
-    // Nothing from the departed workspace is still on screen.
+    // Nothing from the departed workspace is still on screen — its trash
+    // included, which is a second list of its documents, reads on its own,
+    // and here has not answered for the new workspace yet.
     expect(screen.queryAllByTestId('card-title')).toHaveLength(0)
+    expect(screen.queryByText(/^Trash/)).toBeNull()
 
     release?.([entries[0] as WorkspaceDocumentEntry])
     await waitFor(() => expect(screen.getAllByTestId('card-title')).toHaveLength(1))

--- a/apps/web/src/components/workspace-files/switch-holds-layout.test.tsx
+++ b/apps/web/src/components/workspace-files/switch-holds-layout.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
+import type { WorkspaceDocumentEntry } from '../../lib/document-entry.js'
 import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
-import type { WorkspaceDocumentEntry } from './document-entry.js'
 import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
 
 // What a re-read must not do is throw the layout away and put it back.

--- a/apps/web/src/motion-feedback.browser.test.tsx
+++ b/apps/web/src/motion-feedback.browser.test.tsx
@@ -6,10 +6,14 @@
  * - The connection chip transitions its colors on the token duration.
  * - Entering sync-off pulses a finite attention echo on the chip dot —
  *   finite, so the chip guides attention once instead of pinging forever.
+ * - A document thumbnail's render fades in when it finally lands, measured
+ *   on a real switch at 430ms after its own card, so it develops instead of
+ *   popping.
  */
 import { cleanup, render } from '@testing-library/react'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import { ConnectionStatus } from './components/connection/ConnectionStatus.js'
+import { DocumentThumbnail } from './components/workspace-files/DocumentThumbnail.js'
 import './index.css'
 import { UpdateToast } from './pwa/UpdateToast.js'
 
@@ -29,6 +33,28 @@ describe('feedback micro-motion', () => {
     render(<UpdateToast onReload={vi.fn()} onDismiss={vi.fn()} />)
     const toast = document.querySelector('[role="status"]') as HTMLElement
     const cs = getComputedStyle(toast)
+    expect(cs.animationName).not.toBe('none')
+    expect(cs.animationDuration).toBe('0.22s')
+  })
+
+  it('a thumbnail fades its render in on the token duration', async () => {
+    // The class has to resolve to a REAL animation, not merely be present:
+    // a mistyped motion token renders a className nobody notices.
+    render(
+      <DocumentThumbnail
+        document={{ documentId: 'd1', path: 'note', kind: 'markdown' }}
+        loadRender={async () => ({
+          svg: '<svg viewBox="0 0 10 10"></svg>',
+          bounds: { x: 0, y: 0, w: 10, h: 10 },
+        })}
+      />,
+    )
+    const drawn = await vi.waitFor(() => {
+      const el = document.querySelector('[data-testid="document-thumbnail"] > span')
+      if (el === null) throw new Error('render not drawn yet')
+      return el as HTMLElement
+    })
+    const cs = getComputedStyle(drawn)
     expect(cs.animationName).not.toBe('none')
     expect(cs.animationDuration).toBe('0.22s')
   })

--- a/apps/web/src/pages/DaemonIndexPage.files-tab.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.files-tab.test.tsx
@@ -88,10 +88,11 @@ describe('DaemonIndexPage tree view', () => {
       <DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} token="secret" onOpenDocument={() => {}} />,
     )
 
-    await waitFor(() => {
-      expect(screen.getByTestId('workspace-files-panel')).not.toBeNull()
-    })
-    const tree = screen.getByRole('tree')
+    // The tree itself, not the panel around it: the panel now renders while
+    // its list is still loading (it holds the layout instead of collapsing
+    // to a line of text), so its presence no longer means the documents
+    // arrived.
+    const tree = await screen.findByRole('tree')
     // A nested path renders as a branch, not a flat 'notes/design' row.
     expect(within(tree).queryByText('notes/design')).toBeNull()
     expect(within(tree).getByText('notes')).not.toBeNull()

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -498,7 +498,7 @@ describe('DaemonIndexPage', () => {
     // The selection does not move — ws-a is still the right answer — so the
     // report is the ONLY signal, and it has to fire anyway.
     await waitFor(() => expect(onWorkspaceResolved).toHaveBeenCalledWith('ws-a'))
-    expect(screen.getByText('alpha')).toBeTruthy()
+    expect(await screen.findByText('alpha')).toBeTruthy()
   })
 
   it('finds a workspace created since its list was read, instead of falling back off it', async () => {
@@ -642,7 +642,7 @@ describe('DaemonIndexPage', () => {
     )
 
     await waitFor(() => expect(onWorkspaceResolved).toHaveBeenCalledWith('marketing'))
-    expect(screen.getByText('alpha')).toBeTruthy()
+    expect(await screen.findByText('alpha')).toBeTruthy()
     expect(screen.queryByText('beta')).toBeNull()
   })
 

--- a/apps/web/src/scoped-screen-state.test.ts
+++ b/apps/web/src/scoped-screen-state.test.ts
@@ -119,6 +119,8 @@ const PANEL_STATE: Record<string, ScopeCoverage> = {
     'no subject: a refused create, carrying a kind and the store’s words — no path of its own',
   creating: 'no subject: an in-flight flag for this screen’s own submit',
   query: 'no subject: what was typed; the results it produces are `hits`, which IS cleared',
+  lastCardCount:
+    'no subject: how MANY cards the last listing drew, never which — and it has to outlive the switch on purpose, because sizing the placeholder grid to the outgoing list is what holds the layout still while the incoming one loads',
 }
 
 const DAEMON_INDEX_STATE: Record<string, ScopeCoverage> = {


### PR DESCRIPTION
## Summary

Follow-up to #1351: the switch works, but it felt janky. **Measured before deciding anything** — frame by frame on a real switch between two non-empty workspaces — because "add an animation" would have been a lid on the wrong thing:

```
 t=0     head="second-space"  cards=2  panelH=552  gridTop=134
 t=464   head="default"       cards=2  panelH=552  gridTop=134
 t=467   loading              cards=0  panelH=0    gridTop=96    ← 552 → 0
 t=514   head="default"       cards=1  panelH=552  gridTop=134   ← and back
 t=944   the thumbnail draws, 430ms after its own card
```

The jolt is **layout, not motion**: the panel answered a re-read with a single line of text, so its box collapsed and the card area jumped 38px up and back inside ~50ms. Everything below inherited it.

**What changed**

- The loading state now reserves the same grid geometry, and renders **inside** the section so the toolbar above never leaves either. The first attempt kept the early return and still moved the grid 38px — the instrument caught that, not a reviewer.
- `.skeleton-appear` (already in `index.css`, 300ms delay) is what stops this trading a jump for a flash: at the measured ~50ms the placeholders never become visible at all, and only a genuinely slow load fades them in.
- The thumbnail's late arrival gets the repo's existing `animate-in fade-in-0`, so it develops instead of popping. Both collapse under the global `prefers-reduced-motion` floor, and the docs-snapshot suite runs with `reducedMotion: 'reduce'` — regenerated PNGs are unaffected.

**After, same steps:** `panelH=552` and `gridTop=134` for every frame of the switch. No layout movement at all.

## Visual repro

Visual evidence: none — the change is the ABSENCE of movement, which two still frames cannot show (before and after look identical at rest; the difference is the 50ms in between). The evidence is the frame-by-frame table above, taken with the same probe before and after.

## Notes on scope

- `TrashSection` is gated on a settled list. Not new scope: the panel now renders during a load, so without the gate it would fire an extra `listTrash` read per switch — the gate preserves exactly what the early return did.
- Three daemon-page tests were reading the panel's `data-testid` as a proxy for "documents loaded" and then asserting **synchronously**. The panel now exists while its list loads, so they await the thing they actually mean (the tree, the listed document). Same assertions, properly awaited — verified they fail for that reason and not another by running them against `origin/main`'s panel first (75/75 green there).

## Test plan

- [x] `switch-holds-layout.test.tsx` (new, jsdom): on a SOURCE change (the switch signal), the toolbar stays mounted, the card area is a grid of the same shape with as many placeholders as the list it replaces, and nothing from the departed listing is on screen. **Mutation-checked** (pin the placeholder count to 1 → fails).
- [x] `web-jsdom` over `src/components/workspace-files` + `src/pages`: 687 passed; the 1 failure is `BrowserDocumentPage.create-delete-node`, which passes in isolation (2/2) — the known load-dependent family, untouched here.
- [x] `web-browser` over the panel + the switch regression: 13 passed / 7 files.
- [x] Manual verification: the probe above, run before and after on the same dev server and the same steps.
- [x] typecheck + biome clean; merged current `origin/main` in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLiRSAKQA8rRW7j6XBJhAE
