### PR TITLE
refactor(web): extract the tab-identity favicon wiring into useDocumentFavicon

### DIFF
--- a/apps/web/src/hooks/use-document-favicon.test.tsx
+++ b/apps/web/src/hooks/use-document-favicon.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+
+/**
+ * The shared tab-identity wiring, covered ONCE for both pages — the browser
+ * page previously had no favicon coverage at all (the daemon page's suite
+ * was the only watcher, and only of its own keeper values).
+ */
+
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { UserSettingsStore } from '../lib/user-settings-store.js'
+
+const { useFaviconMock, useDocumentOutlineMock } = vi.hoisted(() => ({
+  useFaviconMock: vi.fn(),
+  useDocumentOutlineMock: vi.fn(() => ['outline-rects']),
+}))
+vi.mock('./useFavicon.js', () => ({ useFavicon: useFaviconMock }))
+vi.mock('./useDocumentOutline.js', () => ({ useDocumentOutline: useDocumentOutlineMock }))
+
+import { useDocumentFavicon } from './use-document-favicon.js'
+
+function settingsWith(faviconStyle?: 'minimap' | 'dot'): UserSettingsStore {
+  return {
+    load: () => ({ appearance: faviconStyle ? { faviconStyle } : {} }),
+  } as unknown as UserSettingsStore
+}
+
+describe('useDocumentFavicon', () => {
+  beforeEach(() => {
+    useFaviconMock.mockClear()
+    useDocumentOutlineMock.mockClear()
+  })
+
+  it('wires the settings style, the keeper status, and the outline into useFavicon', () => {
+    renderHook(() =>
+      useDocumentFavicon({
+        settingsStore: settingsWith('dot'),
+        documentId: 'doc-1',
+        kind: 'spatial',
+        revision: 'r1',
+        readSource: () => null,
+        status: 'syncing',
+      }),
+    )
+    expect(useFaviconMock).toHaveBeenCalledWith({
+      style: 'dot',
+      status: 'syncing',
+      rects: ['outline-rects'],
+    })
+    expect(useDocumentOutlineMock).toHaveBeenCalledWith(
+      expect.objectContaining({ documentId: 'doc-1', kind: 'spatial', revision: 'r1' }),
+    )
+  })
+
+  it('defaults the style to minimap when settings carry none', () => {
+    renderHook(() =>
+      useDocumentFavicon({
+        settingsStore: settingsWith(),
+        documentId: null,
+        kind: 'markdown',
+        revision: null,
+        readSource: () => null,
+        status: 'saved',
+      }),
+    )
+    expect(useFaviconMock).toHaveBeenCalledWith(expect.objectContaining({ style: 'minimap' }))
+  })
+
+  it('keeps one broker across re-renders — the outline cache must not be reminted', () => {
+    const props = {
+      settingsStore: settingsWith(),
+      documentId: 'doc-1',
+      kind: 'spatial' as const,
+      revision: 'r1' as unknown,
+      readSource: () => null,
+      status: 'saved' as const,
+    }
+    const { rerender } = renderHook((p: typeof props) => useDocumentFavicon(p), {
+      initialProps: props,
+    })
+    rerender({ ...props, revision: 'r2' })
+    const brokers = useDocumentOutlineMock.mock.calls.map(
+      (call) => (call as unknown as [{ broker: unknown }])[0].broker,
+    )
+    expect(brokers.length).toBeGreaterThan(1)
+    expect(new Set(brokers).size).toBe(1)
+  })
+})

--- a/apps/web/src/hooks/use-document-favicon.ts
+++ b/apps/web/src/hooks/use-document-favicon.ts
@@ -1,0 +1,62 @@
+/**
+ * The tab-identity favicon wiring, shared by the browser and daemon
+ * document pages (previously duplicated statement-for-statement — the third
+ * page-unification extraction after `useVersionSaveFlow` and
+ * `useCommentsRail`). What stays keeper-specific arrives as VALUES: the
+ * status (`browserFaviconStatus` / `daemonFaviconStatus`), the document
+ * identity, the revision trigger, and the outline reader.
+ */
+
+import type { DocumentKind } from '@kamiazya/whiteboard-model'
+import { useMemo } from 'react'
+import type { DocumentOutlineSource } from '../lib/document-outline.js'
+import type { FaviconStatus, FaviconStyle } from '../lib/favicon.js'
+import { createInTabRenderBroker } from '../lib/render-broker.js'
+import type { UserSettingsStore } from '../lib/user-settings-store.js'
+import { useDocumentOutline } from './useDocumentOutline.js'
+import { useFavicon } from './useFavicon.js'
+
+export function useDocumentFavicon({
+  settingsStore,
+  documentId,
+  kind,
+  revision,
+  readSource,
+  status,
+}: {
+  settingsStore: UserSettingsStore
+  documentId: string | null
+  kind: DocumentKind
+  /**
+   * Whatever the page re-renders with when this document changes — its
+   * canvas value or its body. Identity-only trigger; see useDocumentOutline.
+   */
+  revision: unknown
+  readSource: (kind: DocumentKind) => DocumentOutlineSource | null
+  status: FaviconStatus
+}): void {
+  // Read once per render, effectively once at mount: the routed /settings
+  // page is the only place the style toggles, and navigating there and back
+  // remounts the page — no in-mount reactivity needed.
+  const faviconStyle: FaviconStyle = settingsStore.load().appearance?.faviconStyle ?? 'minimap'
+
+  // One broker per page mount, for the tab icon's outline. It is the same
+  // seam the list surfaces ask through (ADR-0027); what it buys HERE is that
+  // a re-render, a sync-status change or a remount does not recompute a
+  // shape the document already has — the version key is what makes that safe.
+  const outlineBroker = useMemo(() => createInTabRenderBroker(), [])
+
+  const documentOutline = useDocumentOutline({
+    documentId,
+    kind,
+    revision,
+    readSource,
+    broker: outlineBroker,
+  })
+
+  useFavicon({
+    style: faviconStyle,
+    status,
+    rects: documentOutline,
+  })
+}

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -45,11 +45,10 @@ import { VersionPanel } from '../components/workspace-top-bar/VersionPanel.js'
 import { BranchesBackendContext } from '../contexts/BranchesBackendContext.js'
 import { VersionsBackendContext } from '../contexts/VersionsBackendContext.js'
 import { useCommentsRail } from '../hooks/use-comments-rail.js'
+import { useDocumentFavicon } from '../hooks/use-document-favicon.js'
 import { useDocumentFileSeams } from '../hooks/use-document-file-seams.js'
 import { useMarkdownEmbedContent } from '../hooks/use-markdown-embed-content.js'
-import { useDocumentOutline } from '../hooks/useDocumentOutline.js'
 import { useDocumentSync } from '../hooks/useDocumentSync.js'
-import { useFavicon } from '../hooks/useFavicon.js'
 import { useThemeMode } from '../hooks/useThemeMode.js'
 import { getAppLogger } from '../lib/app-logger.js'
 import {
@@ -70,14 +69,13 @@ import { DESTRUCTIVE_COPY } from '../lib/destructive-copy.js'
 import { BROWSER_FILE_ADAPTER } from '../lib/document-embed-content.js'
 import type { DocumentOutlineSource } from '../lib/document-outline.js'
 import { isDocumentReadFailure } from '../lib/document-read-failure.js'
-import { browserFaviconStatus, type FaviconStyle } from '../lib/favicon.js'
+import { browserFaviconStatus } from '../lib/favicon.js'
 import { sharedFoldingBrowserIndex } from '../lib/folding-browser-index.js'
 import { kindNoun } from '../lib/kind-noun.js'
 import type { ContentClock, DefaultDocumentPointer } from '../lib/local-document-summary.js'
 import { composeOutlineSource } from '../lib/outline-source.js'
 import { ensurePersistentStorage } from '../lib/persistent-storage.js'
 import { BROWSER_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
-import { createInTabRenderBroker } from '../lib/render-broker.js'
 import { setShellConnection } from '../lib/shell-status-store.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
 import { cn } from '../lib/utils.js'
@@ -815,11 +813,6 @@ export function BrowserDocumentPage({
 
   // Tab favicon: persistence state as the status dot (degraded reads as
   // offline — data is at risk either way), scene content as the minimap.
-  // Read once at mount for the same remount-re-reads reason as webMcpEnabled
-  // above — the style picker now lives on the routed /settings page.
-  const faviconStyle: FaviconStyle = settingsStore.load().appearance?.faviconStyle ?? 'minimap'
-  // One shape for whichever kind this document is — the favicon draws
-  // it today, and a tree row's icon draws the same one.
   // Which owner holds THIS document — see `composeOutlineSource`, which is
   // where the two of them and the reason are written down.
   const readDocumentOutlineSource = useCallback(
@@ -827,25 +820,13 @@ export function BrowserDocumentPage({
       composeOutlineSource(kind, readOutlineSource, markdownDoc),
     [readOutlineSource, markdownDoc],
   )
-
-  // One broker per page mount, for the tab icon's outline. It is the same
-  // seam the list surfaces ask through (ADR-0027); what it buys HERE is that
-  // a re-render, a sync-status change or a remount does not recompute a
-  // shape the document already has — the version key is what makes that safe.
-  const outlineBroker = useMemo(() => createInTabRenderBroker(), [])
-
-  const documentOutline = useDocumentOutline({
+  useDocumentFavicon({
+    settingsStore,
     documentId,
     kind: documentKind,
     revision: documentKind === 'markdown' ? markdownDoc.body : canvas,
     readSource: readDocumentOutlineSource,
-    broker: outlineBroker,
-  })
-
-  useFavicon({
-    style: faviconStyle,
     status: browserFaviconStatus(persistence.kind),
-    rects: documentOutline,
   })
 
   // The option list refreshes asynchronously (see the effect above) while the

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -43,15 +43,14 @@ import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
 import { useVersionsBackend } from '../contexts/VersionsBackendContext.js'
 import { useAgentActivity } from '../hooks/use-agent-activity.js'
 import { useCommentsRail } from '../hooks/use-comments-rail.js'
+import { useDocumentFavicon } from '../hooks/use-document-favicon.js'
 import { useDocumentFileSeams } from '../hooks/use-document-file-seams.js'
 import {
   type MarkdownEmbedLoader,
   useMarkdownEmbedContent,
 } from '../hooks/use-markdown-embed-content.js'
 import { useDirtyState } from '../hooks/useDirtyState.js'
-import { useDocumentOutline } from '../hooks/useDocumentOutline.js'
 import { dispatchIdentityEvent, useDocumentSync } from '../hooks/useDocumentSync.js'
-import { useFavicon } from '../hooks/useFavicon.js'
 import { useThemeMode } from '../hooks/useThemeMode.js'
 import { getAppLogger } from '../lib/app-logger.js'
 import { captureBookmarkPicture } from '../lib/bookmark-picture.js'
@@ -70,9 +69,8 @@ import {
 } from '../lib/daemon-link-entries.js'
 import { deriveNewDocumentPath } from '../lib/derive-new-document-path.js'
 import { devTransportOverride } from '../lib/dev-transport-override.js'
-import { daemonFaviconStatus, type FaviconStyle } from '../lib/favicon.js'
+import { daemonFaviconStatus } from '../lib/favicon.js'
 import { DAEMON_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provider.js'
-import { createInTabRenderBroker } from '../lib/render-broker.js'
 import { scheduleReplicaPush, scheduleReplicaRefresh } from '../lib/replica-refresh.js'
 import { setShellConnection } from '../lib/shell-status-store.js'
 import type { SpatialEditorHandle } from '../lib/spatial/editor-handle.js'
@@ -650,31 +648,15 @@ export function DaemonDocumentPage({
     webMcpEnabled,
   )
 
-  // Tab favicon: sync state as the status dot, scene content as the minimap
-  // (style user-selectable on the routed /settings page; same remount-
-  // re-reads reasoning as webMcpEnabled above).
-  const faviconStyle: FaviconStyle = settingsStore.load().appearance?.faviconStyle ?? 'minimap'
+  // Tab favicon: sync state as the status dot, scene content as the minimap.
   const { isDirty } = useDirtyState(canvas?.workspaceId ?? '', canvas?.path ?? '')
-  // One shape for whichever kind this document is — the favicon draws
-  // it today, and a tree row's icon draws the same one.
-  // One broker per page mount, for the tab icon's outline. It is the same
-  // seam the list surfaces ask through (ADR-0027); what it buys HERE is that
-  // a re-render, a sync-status change or a remount does not recompute a
-  // shape the document already has — the version key is what makes that safe.
-  const outlineBroker = useMemo(() => createInTabRenderBroker(), [])
-
-  const documentOutline = useDocumentOutline({
+  useDocumentFavicon({
+    settingsStore,
     documentId: backendState?.contentDocumentId ?? null,
     kind: documentKind,
     revision: documentKind === 'markdown' ? markdownBody : canvasValue,
     readSource: readOutlineSource,
-    broker: outlineBroker,
-  })
-
-  useFavicon({
-    style: faviconStyle,
     status: daemonFaviconStatus({ authError, syncStatus, isDirty }),
-    rects: documentOutline,
   })
 
   // The connection is app-level, so the App-mounted shell draws it and this


### PR DESCRIPTION
## What

Third page-unification extraction (`issues/unify-document-pages-behind-backend-port`), after #1354 (`useVersionSaveFlow` scope reset) and #1355 (`useCommentsRail`): the **tab-identity favicon wiring** — settings style read, outline render broker, `useDocumentOutline`, `useFavicon` — was duplicated statement-for-statement across `BrowserDocumentPage` and `DaemonDocumentPage`, differing only in **values** (keeper status `browserFaviconStatus`/`daemonFaviconStatus`, document identity, revision trigger, outline reader). Now one hook, `useDocumentFavicon`, in the `hooks/` layer.

## The coverage gained

The inventory flagged that **the browser page had no favicon coverage at all** (only the daemon page's suite watched its own keeper values). The hook's unit tests now cover the shared wiring once for both pages:

- settings style read + the `minimap` default,
- keeper status passthrough — **mutation-checked** (hardcoding `'saved'` in the hook fails the test),
- broker identity stability across re-renders, which is what keeps the outline cache warm instead of reminting it per render.

## Verification (behavior-preserving)

Pages jsdom + layer-order + scoped-screen-state ledger: **481/481**; typecheck, biome, knip clean. No existing test modified.

Deliberately not extracted from the same inventory group: the theme line (1 line/page) and the webMCP registry block (2 shared lines around per-keeper provider descriptors) — extraction overhead exceeds the duplication.

Visual evidence: none — behavior-preserving extraction of identical wiring; the evidence is the unmodified suites plus the new mutation-checked hook tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D
