### PR TITLE
fix(web): retire two silent browser/daemon divergences — legacy path refs resolve, version-refresh is identity-scoped

### DIFF
--- a/apps/web/src/hooks/use-identity-event.test.tsx
+++ b/apps/web/src/hooks/use-identity-event.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react'
+import { act } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { DOCUMENT_SYNC_VERSION_SAVED_EVENT } from '../lib/document-sync-types.js'
+import { useIdentityEvent } from './use-identity-event.js'
+
+function announce(workspaceId: string, path: string): void {
+  window.dispatchEvent(
+    new CustomEvent(DOCUMENT_SYNC_VERSION_SAVED_EVENT, { detail: { workspaceId, path } }),
+  )
+}
+
+describe('useIdentityEvent', () => {
+  it('delivers only announcements addressed to this document', () => {
+    const handler = vi.fn()
+    renderHook(() => useIdentityEvent(DOCUMENT_SYNC_VERSION_SAVED_EVENT, 'local', 'here', handler))
+
+    act(() => announce('local', 'some-other-doc'))
+    expect(handler, "another document's announcement must not be delivered").not.toHaveBeenCalled()
+    act(() => announce('daemon-ws', 'here'))
+    expect(
+      handler,
+      'a matching path in another workspace is another document',
+    ).not.toHaveBeenCalled()
+    act(() => window.dispatchEvent(new CustomEvent(DOCUMENT_SYNC_VERSION_SAVED_EVENT)))
+    expect(handler, 'a detail-less event addresses nobody').not.toHaveBeenCalled()
+
+    act(() => announce('local', 'here'))
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('subscribes to nothing while the page has no document', () => {
+    const handler = vi.fn()
+    renderHook(() => useIdentityEvent(DOCUMENT_SYNC_VERSION_SAVED_EVENT, 'local', null, handler))
+    act(() => announce('local', 'here'))
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('follows a document switch: the old identity stops delivering, the new one starts', () => {
+    const handler = vi.fn()
+    const { rerender } = renderHook(
+      ({ path }: { path: string }) =>
+        useIdentityEvent(DOCUMENT_SYNC_VERSION_SAVED_EVENT, 'local', path, handler),
+      { initialProps: { path: 'here' } },
+    )
+    rerender({ path: 'there' })
+    act(() => announce('local', 'here'))
+    expect(handler, 'the departed document must stop delivering').not.toHaveBeenCalled()
+    act(() => announce('local', 'there'))
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/hooks/use-identity-event.ts
+++ b/apps/web/src/hooks/use-identity-event.ts
@@ -1,0 +1,37 @@
+/**
+ * Subscribes to one of the document-sync window events, delivering only the
+ * announcements addressed to THIS document.
+ *
+ * The events carry `{ workspaceId, path }` (see `dispatchIdentityEvent`),
+ * and every consumer must check it: an unchecked listener refreshes on any
+ * document's announcement — the browser page's version-refresh listener
+ * had exactly that shape while the daemon page checked identity, the kind
+ * of silent divergence the page unification exists to retire.
+ */
+
+import { useEffect, useRef } from 'react'
+import type { DirtyEventDetail } from '../lib/document-sync-types.js'
+
+export function useIdentityEvent(
+  eventName: string,
+  workspaceId: string,
+  /** null while the page has no document yet; nothing is subscribed then. */
+  path: string | null,
+  handler: () => void,
+): void {
+  // The handler customises WHAT happens, not WHICH announcement this is —
+  // a ref keeps an inline callback from resubscribing every render.
+  const handlerRef = useRef(handler)
+  handlerRef.current = handler
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || path === null) return
+    const onEvent = (event: Event) => {
+      const detail = (event as CustomEvent<DirtyEventDetail>).detail
+      if (!detail || detail.workspaceId !== workspaceId || detail.path !== path) return
+      handlerRef.current()
+    }
+    window.addEventListener(eventName, onEvent)
+    return () => window.removeEventListener(eventName, onEvent)
+  }, [eventName, workspaceId, path])
+}

--- a/apps/web/src/pages/BrowserDocumentPage.file-refs.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.file-refs.test.tsx
@@ -144,6 +144,21 @@ describe('BrowserDocumentPage file references', () => {
     })
   })
 
+  it('marks refs matching neither a live id nor a live path as missing, sparing image refs', async () => {
+    // Same rule as the daemon page, deliberately: a legacy PATH ref (a
+    // document imported from elsewhere, or written before id refs existed)
+    // names a live document and must not render as a dangling
+    // "Missing reference" in browser mode alone.
+    const store = await seededStore()
+    await mountPage(store)
+    const missing = capturedEditorProps?.missingFileRef
+    expect(missing).toBeDefined()
+    expect(missing?.(TARGET_ID)).toBe(false)
+    expect(missing?.('archive/target')).toBe(false)
+    expect(missing?.('deleted-canvas-id')).toBe(true)
+    expect(missing?.('asset:0f5bffa1-9d0f-4d2f-a2c4-0f0d4a1a2b3c')).toBe(false)
+  })
+
   it('leaves the address bar alone for a reference the list does not carry', async () => {
     const router = await mountPage(await seededStore())
     const before = router.state.location.key

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -47,6 +47,7 @@ import { VersionsBackendContext } from '../contexts/VersionsBackendContext.js'
 import { useCommentsRail } from '../hooks/use-comments-rail.js'
 import { useDocumentFavicon } from '../hooks/use-document-favicon.js'
 import { useDocumentFileSeams } from '../hooks/use-document-file-seams.js'
+import { useIdentityEvent } from '../hooks/use-identity-event.js'
 import { useMarkdownEmbedContent } from '../hooks/use-markdown-embed-content.js'
 import { useDocumentSync } from '../hooks/useDocumentSync.js'
 import { useThemeMode } from '../hooks/useThemeMode.js'
@@ -69,6 +70,10 @@ import { DESTRUCTIVE_COPY } from '../lib/destructive-copy.js'
 import { BROWSER_FILE_ADAPTER } from '../lib/document-embed-content.js'
 import type { DocumentOutlineSource } from '../lib/document-outline.js'
 import { isDocumentReadFailure } from '../lib/document-read-failure.js'
+import {
+  DOCUMENT_SYNC_VERSION_SAVED_EVENT,
+  dispatchIdentityEvent,
+} from '../lib/document-sync-types.js'
 import { browserFaviconStatus } from '../lib/favicon.js'
 import { sharedFoldingBrowserIndex } from '../lib/folding-browser-index.js'
 import { kindNoun } from '../lib/kind-noun.js'
@@ -276,14 +281,15 @@ export function BrowserDocumentPage({
   // clobber a newer refresh triggered by a fast switch.
   const [documents, setDocuments] = useState<DocumentSnapshot[]>([])
   const listGenerationRef = useRef(0)
-  // A ref that matches no live canvas id points at a deleted canvas: the
-  // editor renders a quiet "Missing reference" and hides the follow
-  // affordances instead of navigating to a dead route. Image refs live in
-  // the file store, not this list; undefined while the list has not loaded
-  // keeps everything ordinary.
+  // A ref that matches NEITHER a live id nor a live path points at a
+  // deleted canvas: the editor renders a quiet "Missing reference" and hides
+  // the follow affordances instead of navigating to a dead route. Paths are
+  // known too — a legacy path ref names a live document, same rule as the
+  // daemon page. Image refs live in the file store, not this list; undefined
+  // while the list has not loaded keeps everything ordinary.
   const missingFileRef = useMemo(() => {
     if (documents.length === 0) return undefined
-    const known = new Set(documents.map((entry) => entry.documentId))
+    const known = new Set(documents.flatMap((entry) => [entry.documentId, entry.path]))
     return (ref: string) => !isImageRef(ref) && !known.has(ref)
   }, [documents])
   // Fullscreen target for WorkspaceTopBar's onToggleFullscreen; the whole page
@@ -625,11 +631,12 @@ export function BrowserDocumentPage({
     setBookmarkArmed((n) => n + 1)
   })
 
-  useEffect(() => {
-    const onSaved = () => setVersionRefreshSignal((n) => n + 1)
-    window.addEventListener('whiteboard:wb_version_saved', onSaved)
-    return () => window.removeEventListener('whiteboard:wb_version_saved', onSaved)
-  }, [])
+  // Scoped to THIS document's identity — an unchecked listener refreshed on
+  // any document's announcement, where the daemon page has always routed
+  // the same signal through identity-checked dispatch.
+  useIdentityEvent(DOCUMENT_SYNC_VERSION_SAVED_EVENT, 'local', documentPath, () =>
+    setVersionRefreshSignal((n) => n + 1),
+  )
   // A save the History panel itself offers. The top bar's dot and ⌘/Ctrl+S
   // are the other two routes; on a phone the shortcut is nothing and the
   // dot is small, so the panel a finger opens has to carry one too — the
@@ -684,19 +691,17 @@ export function BrowserDocumentPage({
         // the list this save already refreshed holds a row that says it has
         // none — and without this the picture appears only when something
         // else happens to refetch, which for a person means reloading.
-        window.dispatchEvent(
-          new CustomEvent('whiteboard:wb_version_saved', {
-            detail: { workspaceId: 'local', path: documentPath },
-          }),
-        )
+        dispatchIdentityEvent(DOCUMENT_SYNC_VERSION_SAVED_EVENT, {
+          workspaceId: 'local',
+          path: documentPath,
+        })
       })
       // The top bar addresses this document as `local`/path (its
       // `dataMode="local"` placeholder), so the dot listens under that id.
-      window.dispatchEvent(
-        new CustomEvent('whiteboard:wb_version_saved', {
-          detail: { workspaceId: 'local', path: documentPath },
-        }),
-      )
+      dispatchIdentityEvent(DOCUMENT_SYNC_VERSION_SAVED_EVENT, {
+        workspaceId: 'local',
+        path: documentPath,
+      })
     }
   })
   const saveVersionFromPanel = async (label: string): Promise<void> => {


### PR DESCRIPTION
## What

Fourth increment on `issues/unify-document-pages-behind-backend-port`: the inventory's remaining two **silent browser/daemon divergences**, both browser-page-only defects.

1. **Legacy path refs read as "Missing reference" in browser mode alone.** `missingFileRef`'s known set carried only document ids; the daemon page has always known ids AND paths (a legacy path ref — imported from elsewhere, or written before id refs existed — names a live document). The browser set now carries paths too. Red-first, mirroring the daemon page's own test case (`missing?.('archive/target')` was `true` before the fix).
2. **The History panel refreshed on ANY document's version-saved announcement.** The browser listener read no event detail, where the daemon routes the same signal through identity-checked dispatch. The identity check now lives in a small shared hook, `useIdentityEvent` (the same filter shape `useDirtyState` keeps inline), unit-tested for the discriminating cases: wrong path, wrong workspace, detail-less event, null path (no subscription), and a document switch moving the subscription. The page also stops hand-building the same `CustomEvent` twice — `dispatchIdentityEvent` + the pinned `DOCUMENT_SYNC_VERSION_SAVED_EVENT` constant, like every other producer.

## Verification

- Fix 1 red-first (the new browser case failed against the unfixed set); fix 2's check is unit-covered at the hook layer — a page-level injection wasn't honest (the page mounts its own VersionsBackend provider over any test one).
- Pages jsdom green except `create-delete-node`, which is a **pre-existing full-suite flake: control-verified failing on CLEAN MAIN under the same run**, passing 3/3 in isolation on this branch — ticketed separately with the measurements. `versions.browser` 2/2, typecheck/biome/knip clean.

Visual evidence: none — a set-membership fix and an event-scoping fix; the discriminating evidence is the red-first case and the hook's mismatch tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D
