### PR TITLE
fix(web): the thumbnail's render cross-fades in instead of cutting

### DIFF
--- a/apps/web/src/components/workspace-files/DocumentThumbnail.tsx
+++ b/apps/web/src/components/workspace-files/DocumentThumbnail.tsx
@@ -49,37 +49,52 @@ export function DocumentThumbnail({ document, loadRender, className }: DocumentT
     }
   }, [onScreen, document, loadRender])
 
+  const KindIcon = document.kind === 'spatial' ? LayoutGrid : FileText
+
   return (
     <span
       ref={ref}
       data-testid="document-thumbnail"
       aria-hidden="true"
-      className={cn('inline-flex shrink-0 items-center justify-center overflow-hidden', className)}
+      className={cn(
+        'relative inline-flex shrink-0 items-center justify-center overflow-hidden',
+        className,
+      )}
     >
       {drawn === null ? (
-        document.kind === 'spatial' ? (
-          <LayoutGrid data-kind="spatial" className="text-muted-foreground size-full" />
-        ) : (
-          <FileText
-            data-kind={document.kind ?? 'markdown'}
-            className="text-muted-foreground size-full"
-          />
-        )
-      ) : (
-        // The SVG is produced by this app's own renderer from the document's
-        // own content, never by a remote party.
-        // The rule lives on the span that actually PARENTS the svg. jsdom has
-        // no layout, so a selector aimed one level too high still passes every
-        // test and draws a 2000px canvas inside a 24px row in a real browser.
-        <span
-          // The render lands well after the card (measured on a switch: 430ms
-          // later), so it arrives as a pop over a placeholder icon. A fade
-          // makes it read as the picture developing; the global
-          // prefers-reduced-motion floor collapses it.
-          className="size-full animate-in fade-in-0 duration-(--motion-duration-normal) ease-(--motion-ease-out) [&>svg]:size-full"
-          // biome-ignore lint/security/noDangerouslySetInnerHtml: same-origin render output from canvas-render, as the markdown preview pane does
-          dangerouslySetInnerHTML={{ __html: fitSvgToBox(drawn.svg) }}
+        // Sole content, and the only place `data-kind` appears: its ABSENCE
+        // is how a test knows the render landed, so the copy that stays
+        // behind during the cross-fade below must not carry it.
+        <KindIcon
+          data-kind={document.kind ?? 'markdown'}
+          className="text-muted-foreground size-full"
         />
+      ) : (
+        <>
+          {/* The icon LEAVES rather than vanishing. Measured on the real app
+              before this: it unmounted in the same frame the render mounted
+              at opacity 0 (1913ms icon=1.00 -> 1929ms icon gone, render=0.00),
+              so the box was empty for a frame and the picture arrived over
+              nothing. */}
+          <KindIcon className="text-muted-foreground animate-out fade-out-0 fill-mode-forwards absolute inset-0 size-full duration-(--motion-duration-normal) ease-linear" />
+          {/* The SVG is produced by this app's own renderer from the
+              document's own content, never by a remote party.
+              The rule lives on the span that actually PARENTS the svg. jsdom
+              has no layout, so a selector aimed one level too high still
+              passes every test and draws a 2000px canvas inside a 24px row in
+              a real browser.
+
+              Linear, not the shared ease-out: that curve is built for
+              movement and front-loads opacity — measured, it reached 0.80 in
+              51ms of its nominal 220ms, which is what read as a pop. A
+              dissolve wants the two halves to trade evenly, and they now do:
+              their opacities sum to 1.00 across the whole 220ms. */}
+          <span
+            className="animate-in fade-in-0 relative size-full duration-(--motion-duration-normal) ease-linear [&>svg]:size-full"
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: same-origin render output from canvas-render, as the markdown preview pane does
+            dangerouslySetInnerHTML={{ __html: fitSvgToBox(drawn.svg) }}
+          />
+        </>
       )}
     </span>
   )

--- a/apps/web/src/components/workspace-files/DocumentThumbnail.tsx
+++ b/apps/web/src/components/workspace-files/DocumentThumbnail.tsx
@@ -71,18 +71,20 @@ export function DocumentThumbnail({ document, loadRender, className }: DocumentT
         />
       ) : (
         <>
-          {/* The icon LEAVES rather than vanishing. Measured on the real app
-              before this: it unmounted in the same frame the render mounted
-              at opacity 0 (1913ms icon=1.00 -> 1929ms icon gone, render=0.00),
-              so the box was empty for a frame and the picture arrived over
-              nothing. */}
-          <KindIcon className="text-muted-foreground animate-out fade-out-0 fill-mode-forwards absolute inset-0 size-full duration-(--motion-duration-normal) ease-linear" />
-          {/* The SVG is produced by this app's own renderer from the
-              document's own content, never by a remote party.
-              The rule lives on the span that actually PARENTS the svg. jsdom
-              has no layout, so a selector aimed one level too high still
-              passes every test and draws a 2000px canvas inside a 24px row in
-              a real browser.
+          {/* The render comes FIRST in document order, and rides above the
+              icon on z-10 rather than by being later in the tree. Both halves
+              are svgs now, and this box is reached for with
+              `querySelector('svg')` in more than one place — the same hazard
+              DocumentMinimap and MinimapOverlay each carry a note about. Put
+              the leaving icon first and that selector starts answering with
+              a 24x24 kind glyph instead of the document's own render.
+
+              The SVG is produced by this app's own renderer from the
+              document's own content, never by a remote party. The size rule
+              lives on the span that actually PARENTS the svg: jsdom has no
+              layout, so a selector aimed one level too high still passes
+              every test and draws a 2000px canvas inside a 24px row in a
+              real browser.
 
               Linear, not the shared ease-out: that curve is built for
               movement and front-loads opacity — measured, it reached 0.80 in
@@ -90,10 +92,17 @@ export function DocumentThumbnail({ document, loadRender, className }: DocumentT
               dissolve wants the two halves to trade evenly, and they now do:
               their opacities sum to 1.00 across the whole 220ms. */}
           <span
-            className="animate-in fade-in-0 relative size-full duration-(--motion-duration-normal) ease-linear [&>svg]:size-full"
+            className="animate-in fade-in-0 relative z-10 size-full duration-(--motion-duration-normal) ease-linear [&>svg]:size-full"
             // biome-ignore lint/security/noDangerouslySetInnerHtml: same-origin render output from canvas-render, as the markdown preview pane does
             dangerouslySetInnerHTML={{ __html: fitSvgToBox(drawn.svg) }}
           />
+          {/* The icon LEAVES rather than vanishing. Measured on the real app
+              before this: it unmounted in the same frame the render mounted
+              at opacity 0 (1913ms icon=1.00 -> 1929ms icon gone, render=0.00),
+              so the box was empty for a frame and the picture arrived over
+              nothing. No `data-kind` here: its absence is how a test knows a
+              render landed. */}
+          <KindIcon className="text-muted-foreground animate-out fade-out-0 fill-mode-forwards absolute inset-0 size-full duration-(--motion-duration-normal) ease-linear" />
         </>
       )}
     </span>

--- a/apps/web/src/motion-feedback.browser.test.tsx
+++ b/apps/web/src/motion-feedback.browser.test.tsx
@@ -37,6 +37,41 @@ describe('feedback micro-motion', () => {
     expect(cs.animationDuration).toBe('0.22s')
   })
 
+  it('a thumbnail CROSS-fades: the icon leaves as the render arrives', async () => {
+    // Measured on the real app before this existed: the icon unmounted in
+    // the same frame the render mounted at opacity 0, so the box was empty
+    // for a frame — 1913ms icon=1.00, 1929ms icon gone / render=0.00. Both
+    // halves must be on screen together, and the icon must be LEAVING.
+    render(
+      <DocumentThumbnail
+        document={{ documentId: 'd2', path: 'note-2', kind: 'markdown' }}
+        loadRender={async () => ({
+          svg: '<svg viewBox="0 0 10 10"></svg>',
+          bounds: { x: 0, y: 0, w: 10, h: 10 },
+        })}
+      />,
+    )
+    const box = await vi.waitFor(() => {
+      const el = document.querySelector('[data-testid="document-thumbnail"]')
+      if (el?.querySelector(':scope > span') == null) throw new Error('render not drawn yet')
+      return el as HTMLElement
+    })
+    const icon = box.querySelector(':scope > svg') as SVGElement | null
+    expect(icon).not.toBeNull()
+    // The signal a render landed is the ABSENCE of data-kind; the leaving
+    // copy must not restore it.
+    expect(icon?.getAttribute('data-kind')).toBeNull()
+    const leaving = getComputedStyle(icon as unknown as Element)
+    expect(leaving.animationName).not.toBe('none')
+    expect(leaving.animationDuration).toBe('0.22s')
+    // Linear on both halves: the shared ease-out is built for movement and
+    // front-loads opacity — measured at 0.80 in 51ms of its 220ms, which is
+    // what read as a pop. A dissolve wants the two to trade evenly.
+    expect(leaving.animationTimingFunction).toBe('linear')
+    const arriving = getComputedStyle(box.querySelector(':scope > span') as Element)
+    expect(arriving.animationTimingFunction).toBe('linear')
+  })
+
   it('a thumbnail fades its render in on the token duration', async () => {
     // The class has to resolve to a REAL animation, not merely be present:
     // a mistyped motion token renders a className nobody notices.


### PR DESCRIPTION
## Summary

Reported as the thumbnails still feeling too crisp after #1356 added their fade. Measured per animation frame on the real app before changing anything, and the fade I shipped was doing **two** things wrong:

```
1913ms  icon 1.00, no render
1929ms  icon GONE, render 0.00      ← the box is empty for a frame
1947ms  0.40 | 1963ms 0.65 | 1980ms 0.80   ← 80% in 51ms of a nominal 220ms
2143ms  1.00
```

1. **It was a cut, not a fade.** The icon lived in the `drawn === null` branch, so it unmounted in the same frame the render mounted at zero: solid icon → empty box → picture.
2. **The easing front-loaded it.** The shared `--motion-ease-out` (`cubic-bezier(.16,1,.3,1)`) is built for movement; on opacity it delivers most of the change in the first ~50ms, so 220ms reads as roughly 60.

**Now it is a cross-dissolve**: the icon *leaves* (`animate-out`, `fill-mode-forwards`, absolutely positioned) while the render arrives, both linear on the same token. Measured after — no empty frame, and the two opacities trade evenly:

```
1972ms  icon 1.00 / render 0.00
2056ms       0.62 /        0.38
2110ms       0.32 /        0.68
2179ms       0.00 /        1.00
```

## Visual repro

![before: at 110ms the icon is already gone and the render has snapped to full / after: at 110ms the icon and the render trade at 50/50](tmp/screenshots/thumb-figure.png)

Both panels are the same moment of the same transition, captured by pausing the animations at `currentTime = 110ms` (half the token). Composed by `compose-figure.mjs` (digests `5e81b0f0` / `89dd10b0`).

## The second commit, and why it exists

Both halves of a dissolve are `<svg>`, and this box is reached for with `querySelector('svg')` in more than one place — the hazard `DocumentMinimap` and `MinimapOverlay` each already carry a note about. With the leaving icon first in the tree, that selector answered with a 24×24 kind glyph instead of the document's render, and two `DocumentThumbnail` tests said so (`expected '0 0 24 24' to be '0 0 400 300'`). The render now comes **first** in document order and rides above on `z-10` rather than by being later in the tree; both tests pass unchanged.

## Test plan

- [x] `motion-feedback.browser.test.tsx` gains the cross-fade contract, in the file this repo already uses for entrance motion — by **computed style** in a real browser, not class presence: both halves present, the leaving copy carrying no `data-kind` (its absence is how `panel-one-render` knows a render landed), both timing functions `linear`, both on the 0.22s token.
- [x] **Mutation-checked in three directions, each verified to have actually applied** (a mutation that silently matches nothing reads exactly like a test that does not catch it — that happened twice in #1356): drop the leaving icon → fails; restore the ease-out on the render → fails; put `data-kind` back on the leaving copy → fails.
- [x] Manual verification: the frame-by-frame tables above, taken with the same probe before and after; an empty document draws nothing at all, so the fixture types a body first — without that the swap under test never happens.
- [x] `web-jsdom` over `src/components/workspace-files` + `src/pages`: 689 passed / 83 files. `web-browser` over the panel + both motion contracts: 19 passed / 7 files. typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLiRSAKQA8rRW7j6XBJhAE
