### PR TITLE
fix(web): idempotent trailing-marker strip in titleFromMarkdownBody

### DIFF
--- a/apps/web/src/lib/title-from-body.test.ts
+++ b/apps/web/src/lib/title-from-body.test.ts
@@ -15,6 +15,14 @@ describe('titleFromMarkdownBody', () => {
     expect(titleFromMarkdownBody('# Weekly review ###')).toBe('Weekly review')
   })
 
+  it('strips EVERY trailing marker run, so the answer re-reads as itself (CI seed 1650547601)', () => {
+    // `# ! # # ` — CommonMark would call only the last `#` the closing run and
+    // answer `! #`, but that answer re-reads as `!`: not a stable name.
+    expect(titleFromMarkdownBody('# ! # # \nbody')).toBe('!')
+    expect(titleFromMarkdownBody('# foo # bar #\nbody')).toBe('foo # bar')
+    expect(titleFromMarkdownBody('# C#\nbody')).toBe('C#')
+  })
+
   it('refuses a heading marker with no space — `#tag` is body text', () => {
     expect(titleFromMarkdownBody('#tag\n')).toBeUndefined()
   })

--- a/apps/web/src/lib/title-from-body.ts
+++ b/apps/web/src/lib/title-from-body.ts
@@ -14,10 +14,19 @@
 
 /**
  * `# ` + text, with the space required — `#tag` is body text, matching
- * `set-heading-level.ts`'s heading rule. A closed ATX heading (`# Title #`)
- * drops its trailing run so the name does not keep a stray marker.
+ * `set-heading-level.ts`'s heading rule.
  */
-const ATX_H1 = /^#[ \t]+(.+?)(?:[ \t]+#+)?[ \t]*$/
+const ATX_H1 = /^#[ \t]+(.+)$/
+
+/**
+ * A closed ATX heading (`# Title #`) drops its trailing marker run so the
+ * name does not keep a stray marker. EVERY trailing run goes, not just the
+ * last one as CommonMark reads it: `# ! # # ` would otherwise answer `! #`,
+ * a name that re-reads as `!` — deriving a title must be idempotent, and a
+ * marker-only tail is never a name someone meant. `C#` keeps its `#` (no
+ * whitespace before it, so it is part of the word, not a marker).
+ */
+const TRAILING_MARKER_RUNS = /(?:[ \t]+#+)+[ \t]*$/
 
 /**
  * Long enough for any title someone means as one, short enough that a name
@@ -34,7 +43,7 @@ export function titleFromMarkdownBody(body: string): string | undefined {
     // document has not told us what it is called.
     const matched = ATX_H1.exec(line)
     if (matched === null) return undefined
-    const title = (matched[1] ?? '').replace(/\s+/g, ' ').trim()
+    const title = (matched[1] ?? '').replace(TRAILING_MARKER_RUNS, '').replace(/\s+/g, ' ').trim()
     if (title === '' || title.length > MAX_TITLE_LENGTH) return undefined
     return title
   }


### PR DESCRIPTION
## What

`titleFromMarkdownBody`'s closed-ATX-heading strip removed only the last trailing `#` run, so a heading like `# ! # # ` answered `! #` — a title that re-reads as `!`. The `web-jsdom` round-trip property caught it on unrelated PR #1362 (seed 1650547601, shrunk counterexample `"! # # "`). Genuine defect, not a flake — reproduced deterministically without the seed.

## Fix

Strip **every** trailing whitespace+marker run (`/(?:[ \t]+#+)+[ \t]*$/`), a deliberate, documented divergence from CommonMark's last-run-only reading: this is a naming heuristic, and a stable (idempotent) name outranks parser fidelity. `C#` keeps its `#` — no whitespace before it, so it is part of the word.

## Verification

- Red-first: the new example test failed (`'! #' !== '!'`) before the fix, 11/11 after.
- Round-trip property re-run with the CI seed 1650547601: green.

Visual evidence: none — a pure string-derivation fix with no rendered surface; the regression test above is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D