### PR TITLE
fix(test): one definition for deleting a test database, and it waits

### DIFF
--- a/.claude/skills/steward/reference/failure-modes.md
+++ b/.claude/skills/steward/reference/failure-modes.md
@@ -2,7 +2,9 @@
 
 An index, not an explanation. Every entry's reasoning, measurement and fix
 lives in `.claude/rules/integrator-flow.md` (always loaded) — this file exists
-so a symptom string can be recognised before it is investigated.
+so a symptom string can be recognised before it is investigated. One entry
+points elsewhere, and says so in the row: a test-infrastructure defect with no
+PR attached belongs beside the technique, not in the CI-flakes section.
 
 Contents: browser suites · property tests · environment · order effects.
 
@@ -19,6 +21,7 @@ Contents: browser suites · property tests · environment · order effects.
 | an assertion reads an empty value that was definitely typed | The element was remounted and the held reference is detached. Query inside the assertion |
 | a test times out only under the full suite | An `await import()` of a heavy module inside a test body, or a `React.lazy` page racing a `findBy*` (testing-library's budget is 1000ms). Hoist the import |
 | an assertion on a global counter or a "most recent" handle | Another test's `SharedWorker` is still alive. Scope every assertion to a handle the test itself minted |
+| a page reports `This canvas's data could not be read.` as the lone failure | Not the page. A cleanup resolved while its `deleteDatabase` was still `blocked`, so this file started on the previous one's rows. Went through `rename` and twice through `delete-confirm` reading as a missing kebab menu. Fix and measurements: `testing-techniques/resources/isolation-and-state.md` |
 
 ## Property tests
 

--- a/.claude/skills/testing-techniques/resources/isolation-and-state.md
+++ b/.claude/skills/testing-techniques/resources/isolation-and-state.md
@@ -56,6 +56,35 @@ export rather than falling through to the real implementation. `vi.mock('./modul
   can run at once) and `globalSetup` empties it before every run — a database migrated by an
   older branch once died with unhandled `IncompatibleDatabaseError` while every test passed.
   `vitest-data-dir.test.ts` guards the isolation.
+- **A deletion that resolves on `blocked` has not deleted anything.** IndexedDB fires
+  `blocked` INSTEAD of `success`/`error` while another connection is open, so settling there
+  tells the next test a database was cleared when it was not — and the failure surfaces in
+  another FILE, as a page reporting `This canvas's data could not be read.`, naming neither
+  IndexedDB nor the cleanup that lied. It flaked `BrowserDocumentPage.rename` once and
+  `delete-confirm` twice before anyone looked at the cleanup. `clearWhiteboardDb`
+  (`apps/web/src/test-utils/browser-document.ts`) is the only definition and WAITS, so a
+  connection that never closes becomes a timeout naming the file that holds it;
+  `shared-idb-version-games.test.ts` fails on a hand-rolled 27th copy.
+
+  Two things it measured that generalise to any such sweep:
+
+  - **Probe for the ACT, not the name.** Grepping `function clearDb` found 20 of the 26
+    hand-rolled deletions; six were called `deleteDb` and were invisible. Five of those six
+    were already correct and said why in a comment — the knowledge was in the repo, and only
+    a single definition for it to live in was missing.
+  - **Eventual state could not tell the defect from correct behaviour.** The database is gone
+    a tick later either way (the blocker closes, the deletion completes), so
+    `expect(await databaseExists()).toBe(false)` passes against both. The guard had to assert
+    the ORDER the helper resolved in, closing the blocker from a `setTimeout` inside the
+    `blocked` handler so any promise resolution from that same event loses the race. Two
+    earlier versions of that test passed against the unfixed code, and the second one even
+    verified `blocked` had really fired.
+- **A point-free hook callback that gains a parameter binds the test context to it.**
+  `beforeEach(clearWhiteboardDb)` is fine while the function takes nothing; adding one
+  optional parameter made vitest's `TestContext` the database name. Measured: 18 tests across
+  7 files red, none of them mentioning a name. The fix is the API shape — the shared helper
+  takes no argument and `clearNamedDb(name)` carries the few suites that must pass one —
+  rather than 14 call sites remembering to wrap it.
 - **Per-worker names**: `VITEST_POOL_ID` / `VITEST_WORKER_ID` are 1-based. Nothing in the
   repo reads them (measured).
 - `vi.stubEnv` / `vi.stubGlobal` restore with `vi.unstubAllEnvs()` / `vi.unstubAllGlobals()`

--- a/apps/web/src/boot.test.ts
+++ b/apps/web/src/boot.test.ts
@@ -16,6 +16,7 @@ import {
 } from './lib/browser-workspace-id.js'
 import { IdbDocumentIndex } from './lib/idb-document-index.js'
 import { loadWorkspaceDocumentProjection } from './lib/workspace-content.js'
+import { clearNamedDb } from './test-utils/browser-document.js'
 
 const REAL_DB_NAME = 'whiteboard-boot-test'
 
@@ -25,14 +26,6 @@ const REAL_DB_NAME = 'whiteboard-boot-test'
 // without the address ever being read. The first draft used a 2017 ULID and
 // did exactly that.
 const ADDRESSED_ULID = '7ZZZZZZZZZZZZZZZZZZZZZZZZZ'
-
-async function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(REAL_DB_NAME)
-    req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-  })
-}
 
 function rootEl(): HTMLElement {
   const el = document.createElement('div')
@@ -58,11 +51,11 @@ async function openStubbornAtOldVersion(dbName: string): Promise<IDBDatabase> {
 describe('startBootSequence — resolver rejection does not block render', () => {
   beforeEach(async () => {
     resetBrowserWorkspaceIdForTests()
-    await clearDb()
+    await clearNamedDb(REAL_DB_NAME)
   })
   afterEach(async () => {
     resetBrowserWorkspaceIdForTests()
-    await clearDb()
+    await clearNamedDb(REAL_DB_NAME)
   })
 
   it('settles, renders, and records the cause without an unhandled rejection, then recovers on retry', async () => {
@@ -197,12 +190,12 @@ describe('startBootSequence — the address chooses which workspace boots', () =
   beforeEach(async () => {
     resetBrowserWorkspaceIdForTests()
     setWhiteboardDbNameForTests(REAL_DB_NAME)
-    await clearDb()
+    await clearNamedDb(REAL_DB_NAME)
   })
   afterEach(async () => {
     resetBrowserWorkspaceIdForTests()
     window.history.replaceState(null, '', '/')
-    await clearDb()
+    await clearNamedDb(REAL_DB_NAME)
   })
 
   it('boots the workspace the address names, through the DEFAULT resolver', async () => {

--- a/apps/web/src/lib/browser-backend.browser.test.tsx
+++ b/apps/web/src/lib/browser-backend.browser.test.tsx
@@ -36,6 +36,7 @@ import { BROWSER_DEFAULT_SEGMENT, openWhiteboardDb } from './browser-idb.js'
 /** A canonical id no fixture mints, so a save under it can only be the bug. */
 const ELSEWHERE_ULID = '7ZZZZZZZZZZZZZZZZZZZZZZZZZ'
 
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
 import { getBrowserWorkspaceId, setBrowserWorkspaceIdForTests } from './browser-workspace-id.js'
 
@@ -57,14 +58,6 @@ function target(documentId: string, path = 'design'): BrowserBackendTarget {
 // handler call (instead of wall-clock time) keeps the test both fast on a
 // healthy machine and stable under CI load.
 const WAIT_TIMEOUT = 10_000
-
-async function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(ISOLATED_DB)
-    req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-  })
-}
 
 function makeHandlers(overrides: Partial<DocumentBackendHandlers> = {}): DocumentBackendHandlers {
   return {
@@ -122,10 +115,10 @@ function editAsSession(snapshotBytes: Uint8Array, documentId: string, nodeId: st
 
 describe('BrowserBackend', () => {
   beforeEach(async () => {
-    await clearDb()
+    await clearWhiteboardDb()
   })
   afterEach(async () => {
-    await clearDb()
+    await clearWhiteboardDb()
   })
 
   it('connect() on an empty store delivers a workspace snapshot already holding the target document', async () => {

--- a/apps/web/src/lib/browser-document-counts.browser.test.tsx
+++ b/apps/web/src/lib/browser-document-counts.browser.test.tsx
@@ -6,6 +6,7 @@
 import { adoptWorkspaceDocument } from '@kamiazya/whiteboard-loro-adapter'
 import { Loro } from 'loro-crdt'
 import { afterEach, beforeEach, expect, it } from 'vitest'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { browserDocumentCounts } from './browser-document-counts.js'
 import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
@@ -20,19 +21,11 @@ const DB_NAME = claimIsolatedWhiteboardDb('browser-doc-counts')
 const ACTIVE = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
 const SECOND = '01BX5ZZKBKACTAV9WEVGEMMVRZ'
 
-function deleteDb(): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.deleteDatabase(DB_NAME)
-    req.onsuccess = () => resolve()
-    req.onerror = () => reject(req.error)
-  })
-}
-
 beforeEach(async () => {
-  await deleteDb()
+  await clearWhiteboardDb()
   // Through the seam rather than whatever the page resolved earlier. The
   // accessor is a module singleton shared by every test in this browser page,
-  // and `deleteDb` above pulls the row it resolved from under it — so leaving
+  // and `clearWhiteboardDb` above pulls the row it resolved from under it — so leaving
   // it ambient made this file assert against an id it did not choose, and a
   // re-resolution added a third workspace nothing had seeded.
   setBrowserWorkspaceIdForTests(ACTIVE)

--- a/apps/web/src/lib/browser-idb-migration.browser.test.tsx
+++ b/apps/web/src/lib/browser-idb-migration.browser.test.tsx
@@ -23,6 +23,7 @@ import { workspaceSegmentSchema } from '@kamiazya/whiteboard-model'
 import { chunkSnapshot, type SnapshotChunk } from '@kamiazya/whiteboard-ports'
 import { Loro } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { clearNamedDb } from '../test-utils/browser-document.js'
 import {
   BROWSER_DEFAULT_SEGMENT,
   DB_VERSION,
@@ -63,7 +64,7 @@ import { purgeLegacyReconnectCredentials } from './purge-legacy-reconnect-creden
  */
 const MIGRATION_DB = 'whiteboard-migration-test'
 
-// Every test in this file re-seeds MIGRATION_DB from scratch (see `clearDb`
+// Every test in this file re-seeds MIGRATION_DB from scratch (see `(() => clearNamedDb(MIGRATION_DB))`
 // below), so the id `getBrowserWorkspaceId()` would answer is different on
 // every run — a v13 fixture's rekey step mints a fresh ULID each time the
 // database is torn down and rebuilt. Resetting the accessor's cache before
@@ -124,14 +125,6 @@ async function loroStore(): Promise<LoroStore> {
  */
 function letFixtureStepAside(db: IDBDatabase): void {
   db.onversionchange = () => db.close()
-}
-
-async function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(MIGRATION_DB)
-    req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-  })
 }
 
 /** Seed a pre-v3 ("v2 shape") fixture DB via raw IDB, bypassing the app's opener/schema. */
@@ -488,8 +481,8 @@ async function legacyLocalKeys(): Promise<{
 const V13_DOCUMENT_ID = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
 
 describe("IndexedDB v13 -> v14 (re-keys the 'local' workspace)", () => {
-  beforeEach(clearDb)
-  afterEach(clearDb)
+  beforeEach(() => clearNamedDb(MIGRATION_DB))
+  afterEach(() => clearNamedDb(MIGRATION_DB))
 
   it('current DB_VERSION is 14 or higher', () => {
     expect(DB_VERSION).toBeGreaterThanOrEqual(14)
@@ -654,8 +647,8 @@ describe("IndexedDB v13 -> v14 (re-keys the 'local' workspace)", () => {
 })
 
 describe('IndexedDB v14 -> v15 (the browser workspace gets a segment)', () => {
-  beforeEach(clearDb)
-  afterEach(clearDb)
+  beforeEach(() => clearNamedDb(MIGRATION_DB))
+  afterEach(() => clearNamedDb(MIGRATION_DB))
 
   it('current DB_VERSION is 15 or higher', () => {
     expect(DB_VERSION).toBeGreaterThanOrEqual(15)
@@ -745,8 +738,8 @@ describe('IndexedDB v14 -> v15 (the browser workspace gets a segment)', () => {
 })
 
 describe('whiteboard IndexedDB v6 -> v7 upgrade (renames the container stores)', () => {
-  beforeEach(clearDb)
-  afterEach(clearDb)
+  beforeEach(() => clearNamedDb(MIGRATION_DB))
+  afterEach(() => clearNamedDb(MIGRATION_DB))
 
   it('current DB_VERSION is 7 or higher (guards against reverting the bump alone)', () => {
     expect(DB_VERSION).toBeGreaterThanOrEqual(7)
@@ -761,7 +754,7 @@ describe('whiteboard IndexedDB v6 -> v7 upgrade (renames the container stores)',
     const db = await openWhiteboardDb(MIGRATION_DB)
     // Read before asserting, and assert after: a failed expect() between the
     // open and the close would leak the connection, and every later test in
-    // this file would then meet a database clearDb cannot delete.
+    // this file would then meet a database (() => clearNamedDb(MIGRATION_DB)) cannot delete.
     const storeNames = [...db.objectStoreNames].sort()
     // The old names are DELETED, not merely abandoned. A store left in place
     // would keep a second copy of every document readable by anything that
@@ -840,10 +833,10 @@ describe('whiteboard IndexedDB v6 -> v7 upgrade (renames the container stores)',
 describe('IndexedDB v5 -> v6 (removes reconnectKeypairs)', () => {
   const LEGACY_RECONNECT_SECRET_KEY = 'whiteboard.reconnect-secret.v1'
 
-  beforeEach(clearDb)
+  beforeEach(() => clearNamedDb(MIGRATION_DB))
   afterEach(() => {
     localStorage.removeItem(LEGACY_RECONNECT_SECRET_KEY)
-    return clearDb()
+    return clearNamedDb(MIGRATION_DB)
   })
 
   it('current DB_VERSION is 6 or higher (guards against reverting the bump alone)', () => {
@@ -918,8 +911,8 @@ describe('IndexedDB v5 -> v6 (removes reconnectKeypairs)', () => {
 })
 
 describe('IndexedDB v4 -> v5', () => {
-  beforeEach(clearDb)
-  afterEach(clearDb)
+  beforeEach(() => clearNamedDb(MIGRATION_DB))
+  afterEach(() => clearNamedDb(MIGRATION_DB))
 
   it('current DB_VERSION is 5 or higher (guards against reverting the bump alone)', () => {
     expect(DB_VERSION).toBeGreaterThanOrEqual(5)
@@ -964,8 +957,8 @@ describe('IndexedDB v4 -> v5', () => {
 })
 
 describe('whiteboard IndexedDB v3 -> v4 upgrade', () => {
-  beforeEach(clearDb)
-  afterEach(clearDb)
+  beforeEach(() => clearNamedDb(MIGRATION_DB))
+  afterEach(() => clearNamedDb(MIGRATION_DB))
 
   it('current DB_VERSION is 4 or higher (guards against reverting the bump alone)', () => {
     expect(DB_VERSION).toBeGreaterThanOrEqual(4)
@@ -998,8 +991,8 @@ describe('whiteboard IndexedDB v3 -> v4 upgrade', () => {
 })
 
 describe('whiteboard IndexedDB v2 -> v3 upgrade', () => {
-  beforeEach(clearDb)
-  afterEach(clearDb)
+  beforeEach(() => clearNamedDb(MIGRATION_DB))
+  afterEach(() => clearNamedDb(MIGRATION_DB))
 
   it('current DB_VERSION is 3 or higher (guards against reverting the bump alone)', () => {
     expect(DB_VERSION).toBeGreaterThanOrEqual(3)
@@ -1165,8 +1158,8 @@ const POST_PATH_ID = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
 const PRE_PATH_ID = 'f81d4fae-7dec-11d0-a765-00a0c91e6bf6'
 
 describe('whiteboard IndexedDB v7 -> v8 upgrade (discards pre-path documents)', () => {
-  beforeEach(clearDb)
-  afterEach(clearDb)
+  beforeEach(() => clearNamedDb(MIGRATION_DB))
+  afterEach(() => clearNamedDb(MIGRATION_DB))
 
   it('current DB_VERSION is 8 or higher (guards against reverting the bump alone)', () => {
     expect(DB_VERSION).toBeGreaterThanOrEqual(8)
@@ -1251,8 +1244,8 @@ describe('whiteboard IndexedDB v7 -> v8 upgrade (discards pre-path documents)', 
 })
 
 describe('v6 -> v8 in one upgrade (the discard must see what the v7 copy produced)', () => {
-  beforeEach(clearDb)
-  afterEach(clearDb)
+  beforeEach(() => clearNamedDb(MIGRATION_DB))
+  afterEach(() => clearNamedDb(MIGRATION_DB))
 
   it('discards a pre-path row that arrives in `documents` via the v7 rename copy', async () => {
     // The two passes share ONE versionchange transaction: the rename copies
@@ -1270,8 +1263,8 @@ describe('v6 -> v8 in one upgrade (the discard must see what the v7 copy produce
 })
 
 describe('cross-tab upgrades', () => {
-  beforeEach(clearDb)
-  afterEach(clearDb)
+  beforeEach(() => clearNamedDb(MIGRATION_DB))
+  afterEach(() => clearNamedDb(MIGRATION_DB))
 
   it('an open connection closes itself so a newer version is not blocked behind it', async () => {
     // Stands in for the second tab: a connection this module handed out and
@@ -1363,14 +1356,14 @@ describe('cross-tab upgrades', () => {
       // created it, is what keeps the next test's seed from meeting a
       // database at a version it did not put there.
       await new Promise((r) => setTimeout(r, 300))
-      await clearDb()
+      await clearNamedDb(MIGRATION_DB)
     }
   })
 })
 
 describe('IndexedDB v9 -> v10 (backfills the index)', () => {
-  beforeEach(clearDb)
-  afterEach(clearDb)
+  beforeEach(() => clearNamedDb(MIGRATION_DB))
+  afterEach(() => clearNamedDb(MIGRATION_DB))
 
   it('carries every surviving document into the index', async () => {
     // v9 added the index stores EMPTY and said the bespoke `documents` store
@@ -1427,8 +1420,8 @@ describe('IndexedDB v9 -> v10 (backfills the index)', () => {
 })
 
 describe('IndexedDB v11 -> v12 (carries content to the port)', () => {
-  beforeEach(clearDb)
-  afterEach(clearDb)
+  beforeEach(() => clearNamedDb(MIGRATION_DB))
+  afterEach(() => clearNamedDb(MIGRATION_DB))
 
   it('carries a snapshot, its log and its timestamp across', async () => {
     // The whole point of the version: content moves to the `DocumentStore`

--- a/apps/web/src/lib/browser-version-store.browser.test.tsx
+++ b/apps/web/src/lib/browser-version-store.browser.test.tsx
@@ -5,21 +5,16 @@ import {
 } from '@kamiazya/whiteboard-loro-adapter'
 import { LoroDoc } from 'loro-crdt'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { BrowserVersionStore } from './browser-version-store.js'
 import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
 import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import { FoldingBrowserIndex } from './folding-browser-index.js'
 
-const ISOLATED_DB = claimIsolatedWhiteboardDb('browserversionstore')
-
-function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(ISOLATED_DB)
-    req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-  })
-}
+// The claim seeds the db-name seam every opener in this page resolves;
+// nothing here needs the name itself now that clearWhiteboardDb reads it.
+claimIsolatedWhiteboardDb('browserversionstore')
 
 function textDoc(text: string): LoroDoc {
   const doc = new LoroDoc()
@@ -55,7 +50,7 @@ async function seedDocument(path: string) {
 
 describe('BrowserVersionStore (real IndexedDB)', () => {
   beforeEach(async () => {
-    await clearDb()
+    await clearWhiteboardDb()
   })
 
   it('saves a frontier, lists newest first, and checks the past out through a fresh store', async () => {

--- a/apps/web/src/lib/browser-workspace-id.test.ts
+++ b/apps/web/src/lib/browser-workspace-id.test.ts
@@ -4,6 +4,7 @@
  */
 import 'fake-indexeddb/auto'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { clearNamedDb } from '../test-utils/browser-document.js'
 import { BROWSER_DEFAULT_SEGMENT, setWhiteboardDbNameForTests } from './browser-idb.js'
 import {
   browserWorkspaceHandleOrNull,
@@ -25,23 +26,15 @@ const DB_NAME = 'whiteboard-workspace-id-test'
 const EARLIER_ULID = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
 const LATER_ULID = '01BX5ZZKBKACTAV9WEVGEMMVRZ'
 
-async function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(DB_NAME)
-    req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-  })
-}
-
 describe('browser workspace id accessor', () => {
   beforeEach(async () => {
     resetBrowserWorkspaceIdForTests()
     setWhiteboardDbNameForTests(DB_NAME)
-    await clearDb()
+    await clearNamedDb(DB_NAME)
   })
   afterEach(async () => {
     resetBrowserWorkspaceIdForTests()
-    await clearDb()
+    await clearNamedDb(DB_NAME)
   })
 
   it('throws an actionable message before resolveBrowserWorkspaceId() has completed', () => {

--- a/apps/web/src/lib/create-browser-workspace.test.ts
+++ b/apps/web/src/lib/create-browser-workspace.test.ts
@@ -4,26 +4,19 @@
  */
 import 'fake-indexeddb/auto'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { clearNamedDb } from '../test-utils/browser-document.js'
 import { setWhiteboardDbNameForTests } from './browser-idb.js'
 import { createBrowserWorkspace } from './create-browser-workspace.js'
 import { IdbDocumentIndex } from './idb-document-index.js'
 
 const DB_NAME = 'whiteboard-create-workspace-test'
 
-async function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(DB_NAME)
-    req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-  })
-}
-
 describe('createBrowserWorkspace', () => {
   beforeEach(async () => {
     setWhiteboardDbNameForTests(DB_NAME)
-    await clearDb()
+    await clearNamedDb(DB_NAME)
   })
-  afterEach(clearDb)
+  afterEach(() => clearNamedDb(DB_NAME))
 
   it('mints a canonical id here, because the browser is its own keeper', async () => {
     // The daemon's create surface mints server-side (the MintBoundary). The

--- a/apps/web/src/lib/document-file-store.browser.test.tsx
+++ b/apps/web/src/lib/document-file-store.browser.test.tsx
@@ -4,35 +4,18 @@
  * Real browser context required for IndexedDB.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { BLOBS_STORE, openWhiteboardDb } from './browser-idb.js'
 import { DocumentFileStore, documentFileRecordSchema } from './document-file-store.js'
 
-const ISOLATED_DB = claimIsolatedWhiteboardDb('document-file-store')
-
-// Rejects on failure: silently keeping stale fixed-key records would let
-// these persistence tests pass without exercising the current write.
-// 'blocked' is NOT a failure — store operations close their connections in
-// tx.oncomplete, which can land after the op's promise resolves, so the
-// deletion is briefly blocked and then proceeds (onsuccess still fires).
-// Waiting keeps that benign race quiet; a genuinely stuck connection still
-// surfaces as a loud test timeout.
-async function clearDb(): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.deleteDatabase(ISOLATED_DB)
-    req.onsuccess = () => resolve()
-    req.onerror = () => reject(req.error ?? new Error('whiteboard database deletion failed'))
-    req.onblocked = () => {
-      console.warn(
-        'clearDb: whiteboard database deletion blocked — waiting for open connections to close',
-      )
-    }
-  })
-}
+// The claim seeds the db-name seam every opener in this page resolves;
+// nothing here needs the name itself now that clearWhiteboardDb reads it.
+claimIsolatedWhiteboardDb('document-file-store')
 
 describe('DocumentFileStore', () => {
-  beforeEach(clearDb)
-  afterEach(clearDb)
+  beforeEach(clearWhiteboardDb)
+  afterEach(clearWhiteboardDb)
 
   it('put then get round-trips a Blob with identical bytes and mimeType', async () => {
     const store = new DocumentFileStore()
@@ -81,8 +64,8 @@ describe('DocumentFileStore', () => {
 })
 
 describe('DocumentFileStore over the blob store', () => {
-  beforeEach(clearDb)
-  afterEach(clearDb)
+  beforeEach(clearWhiteboardDb)
+  afterEach(clearWhiteboardDb)
 
   async function blobCount(): Promise<number> {
     const db = await openWhiteboardDb()

--- a/apps/web/src/lib/fold-workspace.browser.test.tsx
+++ b/apps/web/src/lib/fold-workspace.browser.test.tsx
@@ -14,6 +14,7 @@ import {
 } from '@kamiazya/whiteboard-loro-adapter'
 import { Loro } from 'loro-crdt'
 import { beforeEach, expect, it } from 'vitest'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
 import { getBrowserWorkspaceId } from './browser-workspace-id.js'
@@ -23,15 +24,7 @@ import { LoroStore } from './loro-store.js'
 
 const DB_NAME = claimIsolatedWhiteboardDb('fold-workspace')
 
-function deleteDb(): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.deleteDatabase(DB_NAME)
-    req.onsuccess = () => resolve()
-    req.onerror = () => reject(req.error)
-  })
-}
-
-beforeEach(deleteDb)
+beforeEach(clearWhiteboardDb)
 
 async function seedDocument(path: string, text: string): Promise<string> {
   const index = new IdbDocumentIndex(DB_NAME)

--- a/apps/web/src/lib/folding-browser-index.browser.test.tsx
+++ b/apps/web/src/lib/folding-browser-index.browser.test.tsx
@@ -8,6 +8,7 @@
 import { readSpatialCanvas, writeSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
 import { Loro } from 'loro-crdt'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { seedSyncDocument } from '../test-utils/seed-sync-document.js'
 import { DOCUMENT_INDEX_STORE } from './browser-idb.js'
@@ -18,16 +19,9 @@ import { inTransaction, request } from './idb-tx.js'
 import { LoroStore } from './loro-store.js'
 import { loadDocumentContent, seedWorkspaceDocumentContent } from './workspace-content.js'
 
-const ISOLATED_DB = claimIsolatedWhiteboardDb('folding-browser-index')
-
-async function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(ISOLATED_DB)
-    req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-    req.onblocked = () => resolve()
-  })
-}
+// The claim seeds the db-name seam every opener in this page resolves;
+// nothing here needs the name itself now that clearWhiteboardDb reads it.
+claimIsolatedWhiteboardDb('folding-browser-index')
 
 /** Rewrites a stored index row to the pre-kind shape (no `kind` recorded). */
 async function stripKindInPlace(documentId: string): Promise<void> {
@@ -51,7 +45,7 @@ function canvasWith(text: string) {
 
 describe('FoldingBrowserIndex (tree-backed composition)', () => {
   beforeEach(async () => {
-    await clearDb()
+    await clearWhiteboardDb()
   })
 
   it('lists a legacy per-document record after its startup fold, content included', async () => {

--- a/apps/web/src/lib/idb-blob-store.browser.test.tsx
+++ b/apps/web/src/lib/idb-blob-store.browser.test.tsx
@@ -9,6 +9,7 @@
  */
 import { describeBlobStoreConformance } from '@kamiazya/whiteboard-ports/test-utils'
 import { describe } from 'vitest'
+import { clearNamedDb } from '../test-utils/browser-document.js'
 import { IdbBlobStore } from './idb-blob-store.js'
 
 // Its OWN database, not the app's — browser tests share an origin, so
@@ -16,24 +17,12 @@ import { IdbBlobStore } from './idb-blob-store.js'
 // other file is mid-fixture, and the failure would land there.
 const DB_NAME = 'whiteboard-blob-store-conformance'
 
-async function deleteDb(): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.deleteDatabase(DB_NAME)
-    // No `onblocked` resolve: `blocked` means the delete has NOT happened
-    // yet, so resolving there starts the next case against the previous
-    // one's rows. `IdbBlobStore` closes its connection in a `finally`, so
-    // nothing this suite opens outlives its own call.
-    req.onsuccess = () => resolve()
-    req.onerror = () => reject(req.error)
-  })
-}
-
 describe('IdbBlobStore', () => {
   describeBlobStoreConformance(async () => {
-    await deleteDb()
+    await clearNamedDb(DB_NAME)
     return {
       store: new IdbBlobStore(DB_NAME),
-      dispose: deleteDb,
+      dispose: () => clearNamedDb(DB_NAME),
     }
   })
 })

--- a/apps/web/src/lib/idb-document-index.browser.test.tsx
+++ b/apps/web/src/lib/idb-document-index.browser.test.tsx
@@ -15,6 +15,7 @@
 import { generateDocumentId } from '@kamiazya/whiteboard-model'
 import { describeDocumentIndexConformance } from '@kamiazya/whiteboard-ports/test-utils'
 import { describe, expect, it } from 'vitest'
+import { clearNamedDb } from '../test-utils/browser-document.js'
 import { DOCUMENT_INDEX_STORE } from './browser-idb.js'
 import { IdbDocumentIndex } from './idb-document-index.js'
 import { inTransaction, request } from './idb-tx.js'
@@ -26,24 +27,9 @@ import { inTransaction, request } from './idb-tx.js'
 // `browser-idb-migration.browser.test.tsx`.
 const DB_NAME = 'whiteboard-document-index-conformance'
 
-async function deleteDb(): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.deleteDatabase(DB_NAME)
-    // No `onblocked` resolve. `blocked` fires when a connection is still open,
-    // and the deletion happens only once it closes — so resolving there means
-    // starting the next case against rows the previous one left, which every
-    // conformance case assumes are gone. Waiting is safe here because
-    // `IdbDocumentIndex` closes its connection in a `finally`, so nothing this
-    // suite opens outlives its own call; if that ever stops being true, the
-    // hang names this file rather than corrupting the case after it.
-    req.onsuccess = () => resolve()
-    req.onerror = () => reject(req.error)
-  })
-}
-
 describe('IdbDocumentIndex row hydration', () => {
   it('a malformed stored row fails the read loudly instead of flowing into the UI as a DocumentEntry', async () => {
-    await deleteDb()
+    await clearNamedDb(DB_NAME)
     try {
       const index = new IdbDocumentIndex(DB_NAME)
       await index.createWorkspace({ workspaceId: 'ws' })
@@ -63,18 +49,18 @@ describe('IdbDocumentIndex row hydration', () => {
       // corrupt data wearing the contract's type. The schema names the field.
       await expect(index.listDocuments({ workspaceId: 'ws' })).rejects.toThrow(/path/)
     } finally {
-      await deleteDb()
+      await clearNamedDb(DB_NAME)
     }
   })
 })
 
 describe('IdbDocumentIndex', () => {
   describeDocumentIndexConformance(async () => {
-    await deleteDb()
+    await clearNamedDb(DB_NAME)
     const index = new IdbDocumentIndex(DB_NAME)
     return {
       index,
-      dispose: deleteDb,
+      dispose: () => clearNamedDb(DB_NAME),
       // This index IS its own registry — one IndexedDB store holding the row
       // `createWorkspace` writes — so the seam is that call.
       seedWorkspace: async (entry) => index.createWorkspace(entry),

--- a/apps/web/src/lib/idb-document-store.browser.test.tsx
+++ b/apps/web/src/lib/idb-document-store.browser.test.tsx
@@ -11,6 +11,7 @@ import type { DocRef } from '@kamiazya/whiteboard-ports'
 import { chunkSnapshot, docRefKey } from '@kamiazya/whiteboard-ports'
 import { describeDocumentStoreConformance } from '@kamiazya/whiteboard-ports/test-utils'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { clearNamedDb } from '../test-utils/browser-document.js'
 import { SYNC_DOCUMENTS_STORE, SYNC_SNAPSHOT_CHUNKS_STORE } from './browser-idb.js'
 import { IdbDocumentStore } from './idb-document-store.js'
 
@@ -19,25 +20,13 @@ import { IdbDocumentStore } from './idb-document-store.js'
 // is mid-fixture, and the failure would land there.
 const DB_NAME = 'whiteboard-document-store-conformance'
 
-async function deleteDb(): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.deleteDatabase(DB_NAME)
-    // No `onblocked` resolve: `blocked` means the delete has NOT happened yet,
-    // so resolving there starts the next case against the previous one's rows.
-    // `IdbDocumentStore` closes its connection in a `finally`, so nothing this
-    // suite opens outlives its own call.
-    req.onsuccess = () => resolve()
-    req.onerror = () => reject(req.error)
-  })
-}
-
 describe('IdbDocumentStore', () => {
   describeDocumentStoreConformance(async () => {
-    await deleteDb()
+    await clearNamedDb(DB_NAME)
     const store = new IdbDocumentStore(DB_NAME)
     return {
       store,
-      dispose: deleteDb,
+      dispose: () => clearNamedDb(DB_NAME),
       writeUnreadableRecord: (docRef) => store.writeUnreadableRecord(docRef),
     }
   })
@@ -114,8 +103,8 @@ describe('IdbDocumentStore layout', () => {
     })
   }
 
-  beforeEach(deleteDb)
-  afterEach(deleteDb)
+  beforeEach(() => clearNamedDb(DB_NAME))
+  afterEach(() => clearNamedDb(DB_NAME))
 
   it('keeps snapshot bytes out of the record the delta log lives in', async () => {
     const store = new IdbDocumentStore(DB_NAME)

--- a/apps/web/src/lib/local-document-summary.browser.test.tsx
+++ b/apps/web/src/lib/local-document-summary.browser.test.tsx
@@ -11,6 +11,7 @@
 import { generateDocumentId } from '@kamiazya/whiteboard-model'
 import { Loro } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { clearNamedDb } from '../test-utils/browser-document.js'
 import { getBrowserWorkspaceId, setBrowserWorkspaceIdForTests } from './browser-workspace-id.js'
 import { IdbDocumentIndex } from './idb-document-index.js'
 import {
@@ -21,14 +22,6 @@ import {
 import { LoroStore } from './loro-store.js'
 
 const DB_NAME = 'whiteboard-summary-test'
-
-async function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(DB_NAME)
-    req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-  })
-}
 
 async function seedWorkspace(): Promise<IdbDocumentIndex> {
   // This file's DB is claimed by literal name rather than through
@@ -48,8 +41,8 @@ async function writeContent(documentId: string): Promise<void> {
 }
 
 describe('local document summary', () => {
-  beforeEach(clearDb)
-  afterEach(clearDb)
+  beforeEach(() => clearNamedDb(DB_NAME))
+  afterEach(() => clearNamedDb(DB_NAME))
 
   it('carries the index entry plus the time its content was last written', async () => {
     const index = await seedWorkspace()

--- a/apps/web/src/lib/local-document-summary.test.tsx
+++ b/apps/web/src/lib/local-document-summary.test.tsx
@@ -15,6 +15,7 @@
 import 'fake-indexeddb/auto'
 import { Loro } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { clearNamedDb } from '../test-utils/browser-document.js'
 import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import { IdbDocumentIndex } from './idb-document-index.js'
 import {
@@ -25,14 +26,6 @@ import {
 import { LoroStore } from './loro-store.js'
 
 const DB_NAME = 'whiteboard-summary-test'
-
-async function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(DB_NAME)
-    req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-  })
-}
 
 async function seedWorkspace(): Promise<IdbDocumentIndex> {
   const index = new IdbDocumentIndex(DB_NAME)
@@ -47,8 +40,8 @@ async function writeContent(documentId: string): Promise<void> {
 }
 
 describe('local document summary', () => {
-  beforeEach(clearDb)
-  afterEach(clearDb)
+  beforeEach(() => clearNamedDb(DB_NAME))
+  afterEach(() => clearNamedDb(DB_NAME))
 
   it('carries the index entry plus the time its content was last written', async () => {
     const index = await seedWorkspace()

--- a/apps/web/src/lib/loro-store.browser.test.tsx
+++ b/apps/web/src/lib/loro-store.browser.test.tsx
@@ -10,21 +10,16 @@
 // fake-indexeddb instead — see e.g. local-document-summary.test.tsx.
 import { Loro } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { seedSyncDocument } from '../test-utils/seed-sync-document.js'
 import { IdbDocumentStore } from './idb-document-store.js'
 import { loroRecordEnvelopeSchema } from './loro-record-envelope.js'
 import { LoroStore } from './loro-store.js'
 
-const ISOLATED_DB = claimIsolatedWhiteboardDb('loro-store')
-
-async function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(ISOLATED_DB)
-    req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-  })
-}
+// The claim seeds the db-name seam every opener in this page resolves;
+// nothing here needs the name itself now that clearWhiteboardDb reads it.
+claimIsolatedWhiteboardDb('loro-store')
 
 function makeSnapshot(elements: unknown[]): Uint8Array {
   const doc = new Loro()
@@ -67,10 +62,10 @@ describe('loroRecordEnvelopeSchema', () => {
 
 describe('LoroStore (real IndexedDB)', () => {
   beforeEach(async () => {
-    await clearDb()
+    await clearWhiteboardDb()
   })
   afterEach(async () => {
-    await clearDb()
+    await clearWhiteboardDb()
   })
 
   it('load returns not-found for unknown documentId', async () => {

--- a/apps/web/src/lib/shared-idb-version-games.test.ts
+++ b/apps/web/src/lib/shared-idb-version-games.test.ts
@@ -33,6 +33,25 @@ const sources = import.meta.glob('../**/*.{test,browser.test}.{ts,tsx}', {
 /** `indexedDB.open(<anything>, <version>)` — a version-pinned open, however the name is spelled. */
 const VERSION_PINNED_OPEN = /indexedDB\.open\([^,)]+,\s*([^)]+)\)/g
 
+/** Any deletion at all, however the database is named. */
+const ANY_DELETE = /indexedDB\s*\.\s*deleteDatabase\(/
+
+/**
+ * The one place a test may delete a database, and the one reasoned exception.
+ *
+ * `clearWhiteboardDb` is the definition; everything else awaits it. The
+ * exception deletes a name NO LATER CASE REUSES, so a blocked deletion there
+ * cannot hand anyone stale rows — and it must stay best-effort, because it
+ * does not own when its collaborators close their connections and waiting
+ * could hang instead.
+ *
+ * Both sides are checked below, so an entry cannot outlive what it names.
+ */
+const MAY_DELETE = [
+  '../test-utils/browser-document.ts',
+  './folding-browser-index.conformance.browser.test.tsx',
+]
+
 /** The shared database's name as a standalone literal, not a prefix of another one. */
 const SHARED_NAME_LITERAL = /'whiteboard'/
 
@@ -58,6 +77,14 @@ function offendingFiles(entries: Record<string, string>): string[] {
 /** Touching the SHARED database by its literal name, in either destructive form. */
 const DELETES_SHARED = /deleteDatabase\(\s*['"]whiteboard['"]\s*\)/
 const OPENS_SHARED = /indexedDB\s*\.\s*open\(\s*['"]whiteboard['"]/
+
+function handRolledDeleters(entries: Record<string, string>): string[] {
+  return Object.entries(entries)
+    .filter(([path]) => !MAY_DELETE.includes(path))
+    .filter(([, source]) => ANY_DELETE.test(source))
+    .map(([path]) => path)
+    .sort()
+}
 
 function sharedDbTouchers(entries: Record<string, string>): string[] {
   return Object.entries(entries)
@@ -113,5 +140,37 @@ describe('the shared whiteboard database, by name', () => {
     expect(
       sharedDbTouchers({ 'x.browser.test.tsx': "extractTextFromPng(bytes, 'whiteboard')" }),
     ).toEqual([])
+  })
+})
+
+describe('deleting a database between cases', () => {
+  // 26 files hand-rolled this, and 20 of them got `blocked` wrong the same
+  // way: they resolved on it. `blocked` fires INSTEAD of success or error
+  // while another connection is open, so resolving there tells the next test
+  // a database was cleared when it was not — and the failure surfaces
+  // somewhere else entirely, as a page reporting it could not read its own
+  // data. It took two files showing that symptom before anyone looked here.
+  //
+  // The five that had it right said so in a comment each. The knowledge was
+  // in the repo the whole time; what was missing was one definition for it
+  // to live in.
+  it('goes through clearWhiteboardDb, which is the only definition', () => {
+    expect(handRolledDeleters(sources)).toEqual([])
+  })
+
+  it('exempts only files that exist, so an entry cannot outlive what it names', () => {
+    // The other half. A path that stops matching any file is an exemption
+    // nobody can trip over — and reads exactly like a rule being obeyed.
+    expect(MAY_DELETE.filter((path) => !(path in sources))).toEqual([
+      // The definition itself is not a test file, so the glob never sees it.
+      '../test-utils/browser-document.ts',
+    ])
+  })
+
+  it('is actually detected — an empty result means clean, not blind', () => {
+    expect(handRolledDeleters({ 'x.browser.test.tsx': 'indexedDB.deleteDatabase(NAME)' })).toEqual([
+      'x.browser.test.tsx',
+    ])
+    expect(handRolledDeleters({ 'x.browser.test.tsx': 'await clearNamedDb(NAME)' })).toEqual([])
   })
 })

--- a/apps/web/src/lib/versions-backend.contract.browser.test.tsx
+++ b/apps/web/src/lib/versions-backend.contract.browser.test.tsx
@@ -7,6 +7,7 @@ import {
 import type { VersionEntry } from '@kamiazya/whiteboard-mcp/api-contracts'
 import { LoroDoc } from 'loro-crdt'
 import { describe } from 'vitest'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { BrowserBackend } from './browser-backend.js'
 import { BrowserVersionStore } from './browser-version-store.js'
@@ -20,7 +21,9 @@ import {
 } from './versions-backend.contract.js'
 import { createDaemonVersionsBackend } from './versions-backend.js'
 
-const ISOLATED_DB = claimIsolatedWhiteboardDb('versionsbackendcontract')
+// The claim seeds the db-name seam every opener in this page resolves;
+// nothing here needs the name itself now that clearWhiteboardDb reads it.
+claimIsolatedWhiteboardDb('versionsbackendcontract')
 
 function textDoc(text: string): LoroDoc {
   const doc = new LoroDoc()
@@ -38,20 +41,12 @@ function textOf(doc: LoroDoc | null): string | undefined {
   return node?.type === 'text' ? node.text : undefined
 }
 
-function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(ISOLATED_DB)
-    req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-  })
-}
-
 /**
  * The browser keeper, end to end: a real IndexedDB record, the real store,
  * the real backend that reconciles a restore onto it.
  */
 async function browserHarness(): Promise<VersionsBackendHarness> {
-  await clearDb()
+  await clearWhiteboardDb()
   const workspaceId = getBrowserWorkspaceId()
   const index = new FoldingBrowserIndex()
   await index.createWorkspace({ workspaceId })
@@ -120,7 +115,7 @@ async function browserHarness(): Promise<VersionsBackendHarness> {
     },
     async cleanup() {
       backend.disconnect()
-      await clearDb()
+      await clearWhiteboardDb()
     },
   }
 }

--- a/apps/web/src/pages/BrowserDocumentPage.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.browser.test.tsx
@@ -13,9 +13,12 @@ import { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { BrowserDocumentPage } from './BrowserDocumentPage.js'
 // Real app styles so layout assertions measure the shipped geometry.
 import '../index.css'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 
-const ISOLATED_DB = claimIsolatedWhiteboardDb('browserdocumentpage')
+// The claim seeds the db-name seam every opener in this page resolves;
+// nothing here needs the name itself now that clearWhiteboardDb reads it.
+claimIsolatedWhiteboardDb('browserdocumentpage')
 
 // The page reads/writes the canvas id through the router, so it needs a router
 // in scope exactly as it has one in main.tsx.
@@ -29,17 +32,9 @@ function render(ui: ReactElement) {
   )
 }
 
-async function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(ISOLATED_DB)
-    req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-  })
-}
-
 describe('BrowserDocumentPage (browser — real IndexedDB)', () => {
   beforeEach(async () => {
-    await clearDb()
+    await clearWhiteboardDb()
   })
 
   afterEach(() => {

--- a/apps/web/src/pages/BrowserDocumentPage.delete-confirm.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.delete-confirm.browser.test.tsx
@@ -14,10 +14,13 @@ import { listLocalDocuments } from '../lib/local-document-summary.js'
 import { BrowserDocumentPage } from './BrowserDocumentPage.js'
 // Real app styles so a11y/focus assertions run against the shipped geometry.
 import '../index.css'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { seedIdbDocument } from '../test-utils/seed-idb-document.js'
 
-const ISOLATED_DB = claimIsolatedWhiteboardDb('browserdocumentpage-delete-confirm')
+// The claim seeds the db-name seam every opener in this page resolves;
+// nothing here needs the name itself now that clearWhiteboardDb reads it.
+claimIsolatedWhiteboardDb('browserdocumentpage-delete-confirm')
 
 // The page reads/writes the canvas id through the router, so it needs a router
 // in scope exactly as it has one in main.tsx.
@@ -29,14 +32,6 @@ function render(ui: ReactElement) {
       <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
     </div>,
   )
-}
-
-async function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(ISOLATED_DB)
-    req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-  })
 }
 
 async function renderLoaded(
@@ -63,7 +58,7 @@ async function openDeleteDialog(): Promise<HTMLElement> {
 
 describe('BrowserDocumentPage delete confirmation (browser — real IndexedDB)', () => {
   beforeEach(async () => {
-    await clearDb()
+    await clearWhiteboardDb()
   })
 
   afterEach(() => {

--- a/apps/web/src/pages/BrowserDocumentPage.export.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.export.browser.test.tsx
@@ -6,9 +6,12 @@ import { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { extractTextFromPng } from '../lib/png-embed.js'
 import { BrowserDocumentPage } from './BrowserDocumentPage.js'
 import '../index.css'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 
-const ISOLATED_DB = claimIsolatedWhiteboardDb('browserdocumentpage-export')
+// The claim seeds the db-name seam every opener in this page resolves;
+// nothing here needs the name itself now that clearWhiteboardDb reads it.
+claimIsolatedWhiteboardDb('browserdocumentpage-export')
 
 function render(ui: ReactElement) {
   return rtlRender(
@@ -18,14 +21,6 @@ function render(ui: ReactElement) {
       <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
     </div>,
   )
-}
-
-async function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(ISOLATED_DB)
-    req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-  })
 }
 
 // Captures every Blob handed to URL.createObjectURL so assertions can inspect
@@ -101,7 +96,7 @@ const EXPORT_TIMEOUT_MS = 15_000
 
 describe('BrowserDocumentPage export (browser — real SpatialEditor, no Excalidraw)', () => {
   beforeEach(async () => {
-    await clearDb()
+    await clearWhiteboardDb()
   })
 
   afterEach(() => {

--- a/apps/web/src/pages/BrowserDocumentPage.initial-tool.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.initial-tool.browser.test.tsx
@@ -6,9 +6,12 @@ import { userEvent } from 'vitest/browser'
 import { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { BrowserDocumentPage } from './BrowserDocumentPage.js'
 import '../index.css'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 
-const ISOLATED_DB = claimIsolatedWhiteboardDb('browserdocumentpage-initial-tool')
+// The claim seeds the db-name seam every opener in this page resolves;
+// nothing here needs the name itself now that clearWhiteboardDb reads it.
+claimIsolatedWhiteboardDb('browserdocumentpage-initial-tool')
 
 // Real browser + real IndexedDB: the canvas's node count comes from the Loro
 // document the backend actually loads, which is exactly the input the initial
@@ -19,14 +22,6 @@ function render(ui: ReactElement) {
       <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
     </div>,
   )
-}
-
-async function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(ISOLATED_DB)
-    req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-  })
 }
 
 async function mountLoaded(): Promise<void> {
@@ -44,7 +39,7 @@ beforeEach(async () => {
   // Only the key this suite is about: storages are origin-shared across
   // parallel test files, and clear() wipes the neighbours' state too.
   sessionStorage.removeItem('wb.lastTool')
-  await clearDb()
+  await clearWhiteboardDb()
 })
 
 afterEach(() => {

--- a/apps/web/src/pages/BrowserDocumentPage.rename.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.rename.browser.test.tsx
@@ -6,9 +6,12 @@ import { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { BrowserDocumentPage } from './BrowserDocumentPage.js'
 // Real app styles so layout assertions measure the shipped geometry.
 import '../index.css'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 
-const ISOLATED_DB = claimIsolatedWhiteboardDb('browserdocumentpage-rename')
+// The claim seeds the db-name seam every opener in this page resolves;
+// nothing here needs the name itself now that clearWhiteboardDb reads it.
+claimIsolatedWhiteboardDb('browserdocumentpage-rename')
 
 // The page reads/writes the canvas id through the router, so it needs a router
 // in scope exactly as it has one in main.tsx.
@@ -20,14 +23,6 @@ function render(ui: ReactElement) {
       <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
     </div>,
   )
-}
-
-async function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(ISOLATED_DB)
-    req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-  })
 }
 
 async function renderLoaded(): Promise<void> {
@@ -57,7 +52,7 @@ async function titleField(): Promise<HTMLElement> {
 
 describe('BrowserDocumentPage rename (real IndexedDB)', () => {
   beforeEach(async () => {
-    await clearDb()
+    await clearWhiteboardDb()
   })
 
   afterEach(() => {

--- a/apps/web/src/pages/BrowserDocumentPage.shell-connection.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.shell-connection.browser.test.tsx
@@ -7,17 +7,12 @@ import { resetShellStatusForTests } from '../lib/shell-status-store.js'
 import { BrowserDocumentPage } from './BrowserDocumentPage.js'
 // Real app styles so the chip is laid out the way it ships.
 import '../index.css'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 
-const ISOLATED_DB = claimIsolatedWhiteboardDb('browserdocumentpage-shell-connection')
-
-async function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(ISOLATED_DB)
-    req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-  })
-}
+// The claim seeds the db-name seam every opener in this page resolves;
+// nothing here needs the name itself now that clearWhiteboardDb reads it.
+claimIsolatedWhiteboardDb('browserdocumentpage-shell-connection')
 
 // The composition main.tsx ships: the shell above the routed page, both in one
 // router. Neither half proves this on its own — the page publishes a state it
@@ -40,7 +35,7 @@ function renderApp() {
 describe('shell mark over a real document kept in this browser', () => {
   beforeEach(async () => {
     resetShellStatusForTests()
-    await clearDb()
+    await clearWhiteboardDb()
   })
 
   afterEach(() => {

--- a/apps/web/src/pages/BrowserDocumentPage.versions.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.versions.browser.test.tsx
@@ -19,8 +19,11 @@ import { FoldingBrowserIndex } from '../lib/folding-browser-index.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { BrowserDocumentPage } from './BrowserDocumentPage.js'
 import '../index.css'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 
-const ISOLATED_DB = claimIsolatedWhiteboardDb('browserdocumentpageversions')
+// The claim seeds the db-name seam every opener in this page resolves;
+// nothing here needs the name itself now that clearWhiteboardDb reads it.
+claimIsolatedWhiteboardDb('browserdocumentpageversions')
 
 function render(ui: ReactElement) {
   return rtlRender(
@@ -28,14 +31,6 @@ function render(ui: ReactElement) {
       <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
     </div>,
   )
-}
-
-function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(ISOLATED_DB)
-    req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-  })
 }
 
 function textDoc(text: string): LoroDoc {
@@ -94,7 +89,7 @@ async function openPage() {
 // is the top bar, not the canvas dock — history belongs to the document.
 describe('BrowserDocumentPage version history (browser)', () => {
   beforeEach(async () => {
-    await clearDb()
+    await clearWhiteboardDb()
   })
 
   afterEach(() => {

--- a/apps/web/src/pages/use-browser-document-controller.multi-document.browser.test.tsx
+++ b/apps/web/src/pages/use-browser-document-controller.multi-document.browser.test.tsx
@@ -10,18 +10,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { IdbDefaultDocumentPointer } from '../lib/local-document-summary.js'
 import { LoroStore } from '../lib/loro-store.js'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { useBrowserDocumentController } from './use-browser-document-controller.js'
 
-const ISOLATED_DB = claimIsolatedWhiteboardDb('use-browser-document-controller-multi-document')
-
-async function clearDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(ISOLATED_DB)
-    req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-  })
-}
+// The claim seeds the db-name seam every opener in this page resolves;
+// nothing here needs the name itself now that clearWhiteboardDb reads it.
+claimIsolatedWhiteboardDb('use-browser-document-controller-multi-document')
 
 function snapshotWithElements(elements: unknown[]): Uint8Array {
   const doc = new Loro()
@@ -32,12 +27,12 @@ function snapshotWithElements(elements: unknown[]): Uint8Array {
 
 describe('multi-canvas foundation (real IndexedDB)', () => {
   beforeEach(async () => {
-    await clearDb()
+    await clearWhiteboardDb()
   })
 
   afterEach(async () => {
     cleanup()
-    await clearDb()
+    await clearWhiteboardDb()
   })
 
   it('createDocument twice persists both, and listDocuments returns both by their real id', async () => {

--- a/apps/web/src/test-utils/browser-document.ts
+++ b/apps/web/src/test-utils/browser-document.ts
@@ -19,16 +19,64 @@ import type { EditorCommand } from '../lib/spatial/commands.js'
 
 const DOCUMENT_STORE = SYNC_DOCUMENTS_STORE
 
-/** Deletes the app's IndexedDB database. */
+/**
+ * Deletes the app's IndexedDB database, and resolves only once it is GONE.
+ *
+ * The single definition on purpose: it is awaited in a `beforeEach` to mean
+ * "this file starts from nothing", and every caller depends on that sentence
+ * being true when the promise settles.
+ *
+ * **`blocked` is not a settlement.** `deleteDatabase` fires it — and neither
+ * `success` nor `error` — while another connection is still open, which in
+ * this suite is routine: a store closes its connection in `tx.oncomplete`,
+ * which can land after the operation's own promise has resolved. The
+ * deletion is briefly blocked and then proceeds, so waiting is what makes
+ * the common case correct.
+ *
+ * Resolving on `blocked` instead hands the next test a database it was told
+ * had been cleared. That is not a theoretical hazard: it is the shape behind
+ * a flake that hit `BrowserDocumentPage.rename` and then
+ * `BrowserDocumentPage.delete-confirm` with an identical symptom — the
+ * editor replaced by "This canvas's data could not be read." — a failure
+ * whose message names neither IndexedDB nor the file that broke the
+ * invariant. It only appears under the full parallel run, because that is
+ * when a neighbour's connection is still open often enough to matter.
+ *
+ * A connection that never closes therefore becomes a test TIMEOUT, which is
+ * loud and names the file holding it. That is the trade, and it is the right
+ * way round: a hang is a bug report, a silent wrong answer is not.
+ *
+ * Takes NO ARGUMENT, deliberately. Fourteen call sites pass it point-free to
+ * `beforeEach`, and a hook hands its callback the test context — so an
+ * optional first parameter silently binds that context as the database name
+ * and the deletion goes to a database nobody has. Measured while writing
+ * this: adding one optional parameter turned 18 tests across 7 files red,
+ * none of which said anything about a name. `clearNamedDb` below is the door
+ * for the few suites that need one, and it cannot be passed point-free by
+ * accident because it would delete `undefined`.
+ */
 export async function clearWhiteboardDb(): Promise<void> {
-  return new Promise((resolve) => {
-    const req = indexedDB.deleteDatabase(whiteboardDbName())
+  return deleteDatabaseAndWait(whiteboardDbName())
+}
+
+/**
+ * The same deletion, for a suite that names its own database — a migration
+ * fixture, boot's real-name case, a conformance suite deliberately off the
+ * claimed name.
+ *
+ * Separate from `clearWhiteboardDb` rather than an optional parameter on it,
+ * for the reason stated above; here the name is always written out at the
+ * call site, so there is nothing for a hook to fill in.
+ */
+export async function clearNamedDb(dbName: string): Promise<void> {
+  return deleteDatabaseAndWait(dbName)
+}
+
+function deleteDatabaseAndWait(dbName: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(dbName)
     req.onsuccess = () => resolve()
-    req.onerror = () => resolve()
-    // If a prior connection isn't fully closed, deleteDatabase fires onblocked
-    // (not onsuccess/onerror); settle anyway so the suite fails clearly instead
-    // of hanging until timeout.
-    req.onblocked = () => resolve()
+    req.onerror = () => reject(req.error ?? new Error('whiteboard database deletion failed'))
   })
 }
 

--- a/apps/web/src/test-utils/clear-whiteboard-db.browser.test.tsx
+++ b/apps/web/src/test-utils/clear-whiteboard-db.browser.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * What `clearWhiteboardDb` promises when it resolves.
+ *
+ * The contract is one sentence — once it resolves, the database is gone —
+ * and it is the whole reason the helper is awaited in a `beforeEach`. A
+ * version that settles while the deletion is still BLOCKED breaks it
+ * silently: the next test seeds a fixture into rows the previous one left
+ * behind, or reads a database that is being deleted underneath it, and the
+ * failure surfaces two files away as a page that could not read its own
+ * data.
+ *
+ * That is not hypothetical. It is the shape behind a flake that hit
+ * `BrowserDocumentPage.rename` and then `BrowserDocumentPage.delete-confirm`
+ * with an identical symptom: the editor replaced by "This canvas's data could
+ * not be read." — a failure whose message names neither IndexedDB nor the
+ * test that actually broke the invariant.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { whiteboardDbName } from '../lib/browser-idb.js'
+import { clearWhiteboardDb } from './browser-document.js'
+import { claimIsolatedWhiteboardDb } from './isolated-whiteboard-db.js'
+
+const ISOLATED_DB = claimIsolatedWhiteboardDb('clear-whiteboard-db')
+
+/** Opens the database and hands back the connection, still open. */
+async function openHeld(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(ISOLATED_DB)
+    req.onupgradeneeded = () => req.result.createObjectStore('held')
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+}
+
+async function databaseExists(): Promise<boolean> {
+  return (await indexedDB.databases()).some((one) => one.name === ISOLATED_DB)
+}
+
+/**
+ * Drives one blocked deletion and reports the ORDER of what happened.
+ *
+ * Eventual state cannot tell the two behaviours apart, which is the trap
+ * this replaced: a helper that resolves the moment `blocked` fires still
+ * leaves a database that is gone a tick later, because the blocking
+ * connection closes and the deletion completes on its own. Asking
+ * `databaseExists()` afterwards therefore answers `false` either way, and
+ * reads exactly like a guard.
+ *
+ * What differs is WHEN the helper resolves. So the blocker is closed from a
+ * `setTimeout` inside the `blocked` handler — a macrotask, which every
+ * promise resolution from that same event beats — and the sequence is the
+ * assertion.
+ *
+ * `addEventListener` rather than assigning `onblocked`, so the helper's own
+ * handler is left exactly as it is. Reporting `blocked` itself is what keeps
+ * the case honest: if the deletion was never blocked, the helper was never
+ * asked the question and the green means nothing.
+ */
+async function orderOfOneBlockedDeletion(held: IDBDatabase): Promise<string[]> {
+  const real = indexedDB.deleteDatabase.bind(indexedDB)
+  const order: string[] = []
+  indexedDB.deleteDatabase = (name: string) => {
+    const req = real(name)
+    req.addEventListener('blocked', () => {
+      order.push('blocked')
+      setTimeout(() => {
+        order.push('closed the blocker')
+        held.close()
+      }, 0)
+    })
+    return req
+  }
+  try {
+    await clearWhiteboardDb()
+    order.push('resolved')
+  } finally {
+    indexedDB.deleteDatabase = real
+  }
+  return order
+}
+
+afterEach(async () => {
+  await clearWhiteboardDb()
+})
+
+describe('clearWhiteboardDb', () => {
+  it('is about the database this file claimed, not the shared one', () => {
+    expect(whiteboardDbName()).toBe(ISOLATED_DB)
+  })
+
+  it('deletes a database nothing is holding open', async () => {
+    ;(await openHeld()).close()
+    expect(await databaseExists()).toBe(true)
+
+    await clearWhiteboardDb()
+
+    expect(await databaseExists()).toBe(false)
+  })
+
+  it('waits out a blocked deletion instead of resolving over it', async () => {
+    // The whole contract: when this resolves, the database is gone. A
+    // version that settles on `blocked` hands the next test a database it
+    // was told had been cleared — which is how a fixture ends up seeded on
+    // top of the previous file's rows, and how the failure surfaces two
+    // files away as a page that cannot read its own data.
+    const held = await openHeld()
+
+    expect(await orderOfOneBlockedDeletion(held)).toEqual([
+      'blocked',
+      'closed the blocker',
+      'resolved',
+    ])
+    expect(await databaseExists()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- A test cleanup that resolves on `blocked` has not deleted anything. IndexedDB fires `blocked` **instead of** `success` or `error` while another connection is open, so settling there tells the next test a database was cleared when it was not.
- The failure then surfaces in a **different file**, as a page reporting `This canvas's data could not be read.` — naming neither IndexedDB nor the cleanup that lied. That is why it took three appearances to look here: `BrowserDocumentPage.rename` once and `delete-confirm` twice, each as the lone failure in an otherwise green run, each reading as "the kebab menu is missing" (task #189).
- `clearWhiteboardDb` is now the only definition and **waits**, so a connection that never closes becomes a timeout naming the file that holds it rather than a wrong answer somewhere else. `shared-idb-version-games.test.ts` fails on a 27th hand-rolled copy.

Measured: **26 files hand-rolled the deletion, 20 of them resolved on `blocked`.** The other five were already correct *and each said why in a comment* — the knowledge was in the repo the whole time; what was missing was a single definition for it to live in. The one remaining exemption (a conformance suite that mints a fresh database name per case, so a blocked deletion cannot hand anyone stale rows, and which does not own when its collaborators close) is allowlisted with its reason, and its path is checked to still name a file.

## Two things this cost, kept because the shapes recur

- **Probe for the act, not the name.** Grepping `function clearDb` found 20 of the 26; six were called `deleteDb` and were invisible to it. Widening to `deleteDatabase(` is what found them — the same lesson the keeper-parity scan learned about the least conventional way of reaching a subject.
- **Eventual state cannot tell this defect from correct behaviour.** The database is gone a tick later either way — the blocker closes, the deletion completes — so `expect(await databaseExists()).toBe(false)` passes against both. Two versions of the guard did exactly that (the second even verified `blocked` had really fired) before the third asserted the **order** the helper resolved in, closing the blocker from a `setTimeout` inside the `blocked` handler so any promise resolution from that same event loses the race.

## The API shape is part of the fix

Giving `clearWhiteboardDb` an optional database name turned **18 tests across 7 files red, none of them mentioning a name**: fourteen call sites pass it point-free to `beforeEach`, and a hook hands its callback the test context. So the shared helper takes **no argument**, and `clearNamedDb(name)` carries the few suites that name their own database — a shape a hook cannot fill in. Fixing the 14 call sites instead would have left the trap armed for the fifteenth.

## Test plan

- [x] New or updated tests added — `clear-whiteboard-db.browser.test.tsx` (the contract, red first) and three cases in `shared-idb-version-games.test.ts` (the scan, mutation-checked in both directions: a reappearing hand-rolled deletion fails it, and an exemption naming no file fails it).
- [x] `pnpm test` passes locally — **`--project web-browser` 200 files / 1,085 tests**, which is the run this flake only ever appears in, including the two files it hit; `pnpm --filter @kamiazya/whiteboard-web test` (CI's `test-jsdom`) 353/3,694 + 14/92; `pnpm -r typecheck`, `pnpm knip`, `pnpm lint`, `pnpm lint:noconsole`, `pnpm intent:validate` clean.
- [x] Manual verification completed — the red test was driven against the unfixed helper and reported `['blocked', 'resolved']`, i.e. resolution before the blocker closed. Five fresh-process runs of the new guard, all green.
- [ ] E2E coverage — not applicable; this is test infrastructure.

The test count moved 1,082 → 1,085 on this base, which is exactly the three cases the new file adds (`it(` count unchanged everywhere else). An earlier run in this session read 1,079, but that was the pre-merge base — 17 PRs including the Vitest 5 upgrade have landed since, so those two numbers were never comparable.

## Visual evidence

Visual evidence: none — this changes test infrastructure only and moves no pixels. The evidence is the browser-suite run above plus the two mutation checks on the scan.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — one symptom→verdict row in `steward/reference/failure-modes.md` and the measurements in `testing-techniques/resources/isolation-and-state.md`. Deliberately **not** in `integrator-flow.md`: `dev-rules-budget` showed a full entry there would push the always-on context up two buckets, and a test-infrastructure defect with no PR attached belongs beside the technique. The index row says where it went.
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_