### PR TITLE
test(web): wait for the trash's own read before asserting its count

### DIFF
--- a/apps/web/src/pages/BrowserIndexPage.flow.browser.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.flow.browser.test.tsx
@@ -171,7 +171,10 @@ describe('browser list landing (browser — real IndexedDB)', () => {
     expect(screen.queryByText('What will you make first?')).toBeNull()
 
     // Restore one from the trash: the card returns to the list.
-    await userEvent.click(within(trash).getByText(/^Trash \(2\)/))
+    // The count is a SECOND async list, and the loop above only waited for the
+    // card list to shrink — so the section can still read `Trash (1)` here while
+    // the delete's own trash re-read is in flight.
+    await userEvent.click(await within(trash).findByText(/^Trash \(2\)/))
     await userEvent.click((await within(trash).findAllByRole('button', { name: 'Restore' }))[0]!)
     await waitFor(() => expect(screen.queryAllByTestId('card-title')).toHaveLength(1), {
       timeout: 15_000,


### PR DESCRIPTION
`BrowserIndexPage.flow.browser.test.tsx` failed on main (run 33952850675) with `Unable to find an element with the text: /^Trash \(2\)/` — its second occurrence in 14 days, which `flake-watch` promotes to a fix lane.

It reads as the restore affordance being gone. It was not. The CI error printed the section's own DOM: mounted, connected, reading `Trash (1)` with one row. The count was behind.

The delete loop waits for the **card** list to shrink. The trash is a second list with its own read, and nothing waited for that one, so a synchronous `getByText` could run between the second delete and the read that would have seen it. `findByText` retries over exactly that window.

## Two candidate causes refuted, not assumed

- **The held `trash` reference is not detached.** `setDocuments(null)` has one call site — the switch-scoped reset — so a delete never unmounts the section. Probed on a passing run: `connected=true`, held subtree text equal to the live one's.
- **`TrashSection` has no read-ordering bug.** `readSeq` already drops a stale read, and an instrumented run showed ~30 overlapping reads landing in order (`land 1@6597` … `land 2@7282`).

## What is not claimed

No local reproduction. Three attempts to induce it by delaying the trash read stayed green, because the effect re-fires often enough that a later read wins immediately. The evidence for the failing state is the DOM CI printed, not a synthetic repro — and there was therefore no mutation check to run. Said plainly so the next reader does not credit one.

## Verification

Five fresh-process runs of the file, then one inside the whole `web-browser` project (200 files, 1086 tests) — passes in both. That project run surfaced an unrelated pre-existing failure in `BrowserDocumentPage.markdown.browser.test.tsx` (`expected 'Write in Markdown…' to contain 'body first'` — lost keystrokes under load), filed to the backlog rather than folded in here.

Visual evidence: none — test-only change, no user-visible surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved browser-flow test reliability by waiting for the Trash item count to update before continuing.
  - Added coverage for asynchronous updates that may occur after items are removed from a list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->