### PR TITLE
refactor(web): both pages build their version-save body from one helper

### DIFF
--- a/apps/web/src/lib/version-save-body.test.ts
+++ b/apps/web/src/lib/version-save-body.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest'
+import { buildVersionSaveBody } from './version-save-body.js'
+
+function harness(overrides?: { putThumbnail?: () => Promise<void> }) {
+  const calls: string[] = []
+  const blob = new Blob(['png'])
+  // Deferred created up front, NOT inside putThumbnail: release() must work
+  // whether or not the keeper call has started yet.
+  let releaseThumbnail = () => {}
+  const gate = new Promise<void>((r) => {
+    releaseThumbnail = r
+  })
+  const backend = {
+    putThumbnail: vi.fn(async (...args: unknown[]) => {
+      calls.push('putThumbnail')
+      await gate
+      if (overrides?.putThumbnail) await overrides.putThumbnail()
+      return args as never
+    }),
+  }
+  const deps = {
+    capture: vi.fn(() => {
+      calls.push('capture')
+      return Promise.resolve<Blob | null>(blob)
+    }),
+    save: vi.fn(async (label: string) => {
+      calls.push(`save:${label}`)
+      return { workspaceId: 'ws1', path: 'doc/a', versionId: 'v9' }
+    }),
+    backend,
+    announceRefresh: vi.fn(() => {
+      calls.push('announceRefresh')
+    }),
+    announceOnce: vi.fn(() => {
+      calls.push('announceOnce')
+    }),
+    onThumbnailFailed: vi.fn(() => {
+      calls.push('onThumbnailFailed')
+    }),
+  }
+  return { deps, calls, blob, release: () => releaseThumbnail() }
+}
+
+describe('buildVersionSaveBody', () => {
+  it('starts the capture BEFORE the save, so the picture binds to the state the save marks', async () => {
+    const { deps, calls } = harness()
+    await buildVersionSaveBody(deps)('point')
+    expect(calls.indexOf('capture')).toBeLessThan(calls.indexOf('save:point'))
+  })
+
+  it('the announce closure fires both beats synchronously and rides the thumbnail along unawaited', async () => {
+    const { deps, calls } = harness()
+    const announce = await buildVersionSaveBody(deps)('point')
+    expect(calls).not.toContain('announceRefresh')
+    announce()
+    // Both beats landed although the keeper call has not even STARTED
+    // (attachVersionThumbnail awaits the capture first) — the row must not
+    // wait for its picture.
+    expect(deps.announceRefresh).toHaveBeenCalledTimes(1)
+    expect(deps.announceOnce).toHaveBeenCalledTimes(1)
+    expect(deps.backend.putThumbnail).not.toHaveBeenCalled()
+    await vi.waitFor(() => {
+      expect(deps.backend.putThumbnail).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('hands the keeper the pre-save picture at the saved coordinates', async () => {
+    const { deps, blob, release } = harness()
+    const announce = await buildVersionSaveBody(deps)('point')
+    announce()
+    release()
+    await vi.waitFor(() => {
+      expect(deps.backend.putThumbnail).toHaveBeenCalledWith('ws1', 'doc/a', 'v9', blob)
+    })
+  })
+
+  it('announces a second time once the picture lands, so the refreshed row stops claiming it has none', async () => {
+    const { deps, release } = harness()
+    const announce = await buildVersionSaveBody(deps)('point')
+    announce()
+    release()
+    await vi.waitFor(() => {
+      expect(deps.announceRefresh).toHaveBeenCalledTimes(2)
+    })
+    // The one-shot beat stays one-shot.
+    expect(deps.announceOnce).toHaveBeenCalledTimes(1)
+  })
+
+  it('a failed thumbnail reports and does NOT re-announce', async () => {
+    const { deps, release } = harness({
+      putThumbnail: () => Promise.reject(new Error('keeper refused')),
+    })
+    const announce = await buildVersionSaveBody(deps)('point')
+    announce()
+    release()
+    await vi.waitFor(() => {
+      expect(deps.onThumbnailFailed).toHaveBeenCalledTimes(1)
+    })
+    expect(deps.announceRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('a rejected save propagates and nothing announces', async () => {
+    const { deps } = harness()
+    deps.save.mockRejectedValueOnce(new Error('offline'))
+    await expect(buildVersionSaveBody(deps)('point')).rejects.toThrow('offline')
+    expect(deps.announceRefresh).not.toHaveBeenCalled()
+    expect(deps.backend.putThumbnail).not.toHaveBeenCalled()
+  })
+
+  it('announceOnce is optional', async () => {
+    const { deps } = harness()
+    const { announceOnce: _omitted, ...rest } = deps
+    const announce = await buildVersionSaveBody(rest)('point')
+    announce()
+    expect(deps.announceRefresh).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/lib/version-save-body.ts
+++ b/apps/web/src/lib/version-save-body.ts
@@ -1,0 +1,54 @@
+import { attachVersionThumbnail } from './version-thumbnail.js'
+import type { VersionsBackend } from './versions-backend.js'
+
+/**
+ * The save body both document pages hand to `useVersionSaveFlow`, built from
+ * the four moves that only differ per keeper. The shape it pins:
+ *
+ * - The picture is captured BEFORE the save — started synchronously, so it
+ *   binds to the state the save is about to mark. Awaiting the save first
+ *   meant an edit made during it was drawn onto the older point: a picture
+ *   of content that version does not contain.
+ * - The announce closure runs only after `useVersionSaveFlow`'s guard has
+ *   confirmed the saved document is still on screen. Its beats are
+ *   synchronous; the thumbnail rides along unawaited, because the bookmark
+ *   has landed and its picture arriving late must not hold up the row.
+ * - Once the picture lands, `announceRefresh` fires a SECOND time: the row
+ *   landed before its picture did, so the list the first beat refreshed
+ *   holds a row that says it has none. A failed attach reports through
+ *   `onThumbnailFailed` and deliberately does not re-announce.
+ */
+export function buildVersionSaveBody(deps: {
+  /** Starts the pre-save capture; the promise rides to the keeper later. */
+  capture: () => Promise<Blob | null>
+  /** Performs the save and answers where the new version lives. */
+  save: (label: string) => Promise<{ workspaceId: string; path: string; versionId: string }>
+  backend: Pick<VersionsBackend, 'putThumbnail'>
+  /** The beat that refreshes this page's version list; fired after the save and again after the picture lands. */
+  announceRefresh: () => void
+  /** A beat fired exactly once after the save (e.g. the daemon page's identity event). */
+  announceOnce?: () => void
+  onThumbnailFailed: () => void
+}): (label: string) => Promise<() => void> {
+  return async (label) => {
+    const picture = deps.capture()
+    const saved = await deps.save(label)
+    return () => {
+      deps.announceRefresh()
+      deps.announceOnce?.()
+      void attachVersionThumbnail({
+        backend: deps.backend,
+        workspaceId: saved.workspaceId,
+        path: saved.path,
+        versionId: saved.versionId,
+        getBlob: () => picture,
+      }).then((outcome) => {
+        if (outcome === 'failed') {
+          deps.onThumbnailFailed()
+          return
+        }
+        deps.announceRefresh()
+      })
+    }
+  }
+}

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -84,7 +84,7 @@ import { BROWSER_CAPABILITIES, type WhiteboardCapabilities } from '../lib/provid
 import { setShellConnection } from '../lib/shell-status-store.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
 import { cn } from '../lib/utils.js'
-import { attachVersionThumbnail } from '../lib/version-thumbnail.js'
+import { buildVersionSaveBody } from '../lib/version-save-body.js'
 import { useBrowserToolRegistry } from '../lib/webmcp/use-browser-tool-registry.js'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
 import { derivePageState, refineForContentReadFailure } from './browser-page-state.js'
@@ -644,57 +644,36 @@ export function BrowserDocumentPage({
     if (versionsBackend === null || documentPath === null) {
       throw new Error('saveVersionFromPanel: no versions backend or document path')
     }
-    // Captured BEFORE the save, not after. Both arms read the live document
-    // at call time, so starting the capture here binds the picture to the
-    // state the save is about to mark. Awaiting the save first meant an edit
-    // made during it was drawn onto the older point — a picture of content
-    // that version does not contain.
-    const picture = captureBookmarkPicture(documentKind, {
-      exportScene,
-      body: markdownDoc.body,
-    })
-    let saved: Awaited<ReturnType<typeof versionsBackend.save>>
-    try {
-      saved = await versionsBackend.save(getBrowserWorkspaceId(), documentPath, { label })
-    } catch (err) {
-      log.warn('save version from the History panel failed', err)
-      throw err
-    }
-    // The rest is the post-save announce work — thumbnail attach, the
-    // event that clears the dot and refreshes the History panel — run only
-    // once the guard has confirmed this save's document is still on screen.
-    return () => {
-      // The picture rides with the bookmark, as it does on the daemon page —
-      // one path through the seam, so a browser-kept row is not the one that
-      // silently has no picture. Not awaited: the bookmark has landed, and
-      // its picture arriving late or not at all must not hold up the row.
-      void attachVersionThumbnail({
-        backend: versionsBackend,
-        workspaceId: getBrowserWorkspaceId(),
-        path: documentPath,
-        versionId: saved.id,
-        getBlob: () => picture,
-      }).then((outcome) => {
-        if (outcome === 'failed') {
-          log.warn('bookmark thumbnail failed')
-          return
+    // The shared body pins the beats: capture BEFORE the save, announce,
+    // thumbnail riding along unawaited, re-announce once the picture lands
+    // (see buildVersionSaveBody).
+    return buildVersionSaveBody({
+      capture: () =>
+        captureBookmarkPicture(documentKind, {
+          exportScene,
+          body: markdownDoc.body,
+        }),
+      save: async (saveLabel) => {
+        try {
+          const saved = await versionsBackend.save(getBrowserWorkspaceId(), documentPath, {
+            label: saveLabel,
+          })
+          return { workspaceId: getBrowserWorkspaceId(), path: documentPath, versionId: saved.id }
+        } catch (err) {
+          log.warn('save version from the History panel failed', err)
+          throw err
         }
-        // Announce a SECOND time. The row landed before its picture did, so
-        // the list this save already refreshed holds a row that says it has
-        // none — and without this the picture appears only when something
-        // else happens to refetch, which for a person means reloading.
+      },
+      backend: versionsBackend,
+      // The top bar addresses this document as `local`/path (its
+      // `dataMode="local"` placeholder), so the dot listens under that id.
+      announceRefresh: () =>
         dispatchIdentityEvent(DOCUMENT_SYNC_VERSION_SAVED_EVENT, {
           workspaceId: 'local',
           path: documentPath,
-        })
-      })
-      // The top bar addresses this document as `local`/path (its
-      // `dataMode="local"` placeholder), so the dot listens under that id.
-      dispatchIdentityEvent(DOCUMENT_SYNC_VERSION_SAVED_EVENT, {
-        workspaceId: 'local',
-        path: documentPath,
-      })
-    }
+        }),
+      onThumbnailFailed: () => log.warn('bookmark thumbnail failed'),
+    })(label)
   })
   const saveVersionFromPanel = async (label: string): Promise<void> => {
     if (versionsBackend === null || documentPath === null) return

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -78,7 +78,7 @@ import { setShellConnection } from '../lib/shell-status-store.js'
 import type { SpatialEditorHandle } from '../lib/spatial/editor-handle.js'
 import { createSharedSseStreamSource } from '../lib/sse-shared-stream-source.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
-import { attachVersionThumbnail } from '../lib/version-thumbnail.js'
+import { buildVersionSaveBody } from '../lib/version-save-body.js'
 import type { PastDocument } from '../lib/versions-backend.js'
 import { applyViewportRequest } from '../lib/viewport-request.js'
 import { useBrowserToolRegistry } from '../lib/webmcp/use-browser-tool-registry.js'
@@ -727,59 +727,45 @@ export function DaemonDocumentPage({
     if (canvas === null) {
       throw new Error('saveVersion: no canvas')
     }
-    // Captured BEFORE the POST, not after. `exportScene` reads the live scene
-    // synchronously at call time, so starting it here binds the picture to the
-    // state this save is about to mark. Awaiting the response first meant an
-    // edit made during it was drawn onto the older point — a picture of
-    // content that version does not contain.
-    const picture = getThumbnailBlob()
-    const res = await daemonFetch(
-      `${daemonBaseUrl}${documentsApiUrl(canvas.workspaceId, canvas.path, 'versions')}`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ label }),
-      },
-    )
-    if (!res.ok) throw new Error(`save failed: ${res.status}`)
-    const parsed = saveVersionResponseSchema.safeParse(await res.json().catch(() => null))
-    if (!parsed.success) {
-      log.error('POST /versions response did not match saveVersionResponseSchema:', parsed.error)
-      throw new Error('save response did not match schema')
-    }
-    // The rest is the post-save announce work — refresh signals, thumbnail
-    // attach, the identity event — run only once the guard has confirmed
-    // this save's document is still the one on screen.
-    return () => {
-      setVersionRefreshSignal((n) => n + 1)
-      // The thumbnail rides with the bookmark, as it did when the top bar
-      // owned the save. It moved here with the save itself: the bar no
-      // longer takes versions, so it no longer needs the scene exporter.
-      // Not awaited — the bookmark has landed, and its picture arriving late
-      // or not at all must not hold up the row.
-      void attachVersionThumbnail({
-        backend: versionsBackend,
-        workspaceId: canvas.workspaceId,
-        path: canvas.path,
-        versionId: parsed.data.version.id,
-        getBlob: () => picture,
-      }).then((outcome) => {
-        if (outcome === 'failed') {
-          log.error('bookmark thumbnail upload failed')
-          return
+    // The shared body pins the beats: capture BEFORE the save, announce,
+    // thumbnail riding along unawaited, re-announce once the picture lands
+    // (see buildVersionSaveBody).
+    return buildVersionSaveBody({
+      capture: getThumbnailBlob,
+      save: async (saveLabel) => {
+        const res = await daemonFetch(
+          `${daemonBaseUrl}${documentsApiUrl(canvas.workspaceId, canvas.path, 'versions')}`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ label: saveLabel }),
+          },
+        )
+        if (!res.ok) throw new Error(`save failed: ${res.status}`)
+        const parsed = saveVersionResponseSchema.safeParse(await res.json().catch(() => null))
+        if (!parsed.success) {
+          log.error(
+            'POST /versions response did not match saveVersionResponseSchema:',
+            parsed.error,
+          )
+          throw new Error('save response did not match schema')
         }
-        // Refresh a SECOND time, for the reason the browser page does: the
-        // row landed before its picture did, so the list refreshed above
-        // holds a row that says it has none.
-        setVersionRefreshSignal((n) => n + 1)
-      })
+        return {
+          workspaceId: canvas.workspaceId,
+          path: canvas.path,
+          versionId: parsed.data.version.id,
+        }
+      },
+      backend: versionsBackend,
+      announceRefresh: () => setVersionRefreshSignal((n) => n + 1),
       // The server's manual POST /versions route does not broadcast
       // version_created over the websocket (that only fires for auto-saves
       // and other peers' saves), so this button must dispatch the same
       // identity-scoped event useDocumentSync fires on a broadcast — otherwise
       // nothing listening for the save (the version list, the tab) learns it happened.
-      dispatchIdentityEvent('whiteboard:wb_version_saved', canvas ?? undefined)
-    }
+      announceOnce: () => dispatchIdentityEvent('whiteboard:wb_version_saved', canvas ?? undefined),
+      onThumbnailFailed: () => log.error('bookmark thumbnail upload failed'),
+    })(label)
   })
   const saveVersion = async (label: string): Promise<void> => {
     if (canvas === null) return

--- a/apps/web/src/pages/save-conformance.test.ts
+++ b/apps/web/src/pages/save-conformance.test.ts
@@ -34,52 +34,18 @@ async function read(page: string): Promise<string> {
 }
 
 describe('a saved point carries a picture, whoever keeps it', () => {
-  it.each(PAGES)('%s attaches one after its save', async (page) => {
+  it.each(PAGES)('%s routes its save through the shared body', async (page) => {
+    // buildVersionSaveBody is where the beats live now — attach through the
+    // seam, capture started BEFORE the save (mutation-checked in
+    // lib/version-save-body.test.ts), the unawaited thumbnail ride-along,
+    // the re-announce once the picture lands. A page that hand-rolls its
+    // save again loses every one of those silently, which is exactly the
+    // per-page blindness this file exists for.
     const source = await read(page)
     expect(
-      source.includes('attachVersionThumbnail('),
-      `${page} saves a version and never attaches a picture to it — its keeper's rows would be the ones that silently have none`,
+      source.includes('buildVersionSaveBody('),
+      `${page} saves a version without the shared body — its keeper's rows would be the ones that silently lose the pinned save beats`,
     ).toBe(true)
-  })
-
-  it.each(PAGES)('%s captures the picture before the save, not inside the attach', async (page) => {
-    // The bytes handed to the attach must be something captured EARLIER.
-    // `exportScene` reads the live scene at call time, so a `getBlob` that
-    // calls it runs after the save has resolved — and draws an edit made
-    // during the save onto the older point, a picture of content that
-    // version does not contain.
-    const source = await read(page)
-    const getBlob = /getBlob:\s*([^,\n]*)/.exec(source)?.[1] ?? ''
-    expect(getBlob, `${page} has no getBlob argument to check`).not.toBe('')
-    expect(
-      /exportScene|getThumbnailBlob|captureBookmarkPicture/.test(getBlob),
-      `${page} renders the picture inside getBlob, so it is taken after the save resolves — capture it before the save and hand the promise over`,
-    ).toBe(false)
-  })
-
-  it.each(PAGES)('%s starts the capture before it asks for the save', async (page) => {
-    // The check above is satisfied by a page that renders AFTER its save
-    // resolves and only then assigns the variable — the very ordering the
-    // change was about. So compare where each happens: the capture has to
-    // come first in the source, which for two straight-line functions is
-    // the order they run in.
-    const source = await read(page)
-    const at = (label: string, pattern: RegExp): number => {
-      const found = [...source.matchAll(pattern)]
-      // Exactly one, or "the first occurrence" would be a different
-      // statement from the one that matters and the order would say nothing.
-      expect(found.length, `${page}: expected one ${label}, found ${found.length}`).toBe(1)
-      return found[0]?.index ?? -1
-    }
-    const capture = at(
-      'picture capture',
-      /const picture = (?:captureBookmarkPicture\(|getThumbnailBlob\(\))/g,
-    )
-    const save = at('version save', /versionsBackend\.save\(|documentsApiUrl\([^)]*'versions'\)/g)
-    expect(
-      capture,
-      `${page} asks for the picture at ${capture} and saves at ${save} — capture it first, or the picture can hold an edit made during the save`,
-    ).toBeLessThan(save)
   })
 
   it.each(


### PR DESCRIPTION
## What

Unify increment #9 (ticket `unify-document-pages-behind-backend-port`): the save bodies both document pages hand to `useVersionSaveFlow` were the same four beats written twice — capture **before** the save (the picture must bind to the state the save marks), announce, thumbnail riding along unawaited, re-announce once the picture lands, failed attach reports and does not re-announce.

`buildVersionSaveBody` (new, `apps/web/src/lib/version-save-body.ts`) pins that shape once; each page supplies only its keeper-specific moves: the capture, the save call (seam vs daemon POST + schema parse), its refresh beat (identity event vs signal bump), and the daemon page's one-shot `whiteboard:wb_version_saved` dispatch.

`save-conformance.test.ts`'s source-scan ordering checks retire in favor of the builder's unit test — capture-before-save is mutation-checked (swapped order → red). What conformance still pins per page: the save routes through the builder at all, and the document-kind capture check.

## Verification

Red-first unit suite `version-save-body.test.ts` 7/7 (announce beats fire before the keeper call starts; failed attach → report, no re-announce; rejected save → nothing announces) · `use-version-save-flow` 7/7 · `save-conformance` 4/4 · DaemonDocumentPage jsdom 44/44 · `BrowserDocumentPage.versions.browser` 2/2 (real browser) · web typecheck · lint · knip clean.

Visual evidence: none — behavior-preserving refactor; the real-browser versions-flow test and the mutation-checked ordering invariant are the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D