### PR TITLE
test(web): the scoped-state ledger reaches the daemon document page

### DIFF
--- a/apps/web/src/pages/DaemonDocumentPage.surface-outlives-document.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.surface-outlives-document.test.tsx
@@ -36,8 +36,8 @@ import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as daemonApiClient from '../lib/daemon-api-client.js'
 
-function render(ui: ReactElement) {
-  return rtlRender(<MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>, {
+function render(ui: ReactElement, search = '') {
+  return rtlRender(<MemoryRouter initialEntries={[`/${search}`]}>{ui}</MemoryRouter>, {
     container: document.body,
   })
 }
@@ -223,5 +223,42 @@ describe('the body surface does not outlive its document (daemon)', () => {
       screen.queryByText('Bookmark saved'),
       "a 'saved' badge earned on the departed document is still lit under the arrived one",
     ).toBeNull()
+  })
+
+  it('a variation notice about the document being left does not follow the switch', async () => {
+    // `?v` is not stripped by a switch — `switchDocument` sets the path and
+    // nothing else — and no branch of the variation effect clears the
+    // NOTICE. So `Variation «nope» was not found`, which is a statement
+    // about doc-a, was still on screen over doc-b.
+    //
+    // A message naming a document the reader has left is the same class as
+    // the dialog above, one surface over: it reads as being about what is in
+    // front of them.
+    await act(async () => {
+      render(
+        <DaemonDocumentPage
+          daemonBaseUrl={DAEMON_BASE_URL}
+          workspaceId="w1"
+          path="doc-a"
+          createBackend={() => new FakeBackend()}
+        />,
+        '?v=nope',
+      )
+    })
+    await waitFor(() => expect(openFileRef).not.toBeNull())
+    await waitFor(
+      () => expect(screen.queryByTestId('variation-preview-notice')).not.toBeNull(),
+      // Without the notice on screen the switch below proves nothing, so
+      // this wait is the case's premise rather than part of its assertion.
+      { timeout: 3000 },
+    )
+
+    await act(async () => {
+      openFileRef?.('id-b')
+    })
+
+    await waitFor(() => expect(screen.queryByTestId('variation-preview-notice')).toBeNull(), {
+      timeout: 2000,
+    })
   })
 })

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -539,6 +539,20 @@ export function DaemonDocumentPage({
     setHistoryOpen(false)
     setBookmarkArmed(0)
     setPreview(null)
+    // The variation view and its message are about the DEPARTED document.
+    // `?v` is not stripped by a switch — `switchDocument` sets the path and
+    // nothing else — so the effect below re-resolves the same name against
+    // the ARRIVED document, and until it answers the previous document's
+    // preview is on screen under the new one's name. The notice is worse: no
+    // branch of that effect clears it, so `Variation «x» was not found`
+    // about one document outlives it onto the next.
+    setVariationPreview(null)
+    setVariationNotice(null)
+    // Backlinks OF this document. The fetch below nulls them itself, but only
+    // once it knows the arrived document's id — which comes from a list that
+    // may still be refreshing, so the departed document's connections would
+    // be listed under the arrived one until it does.
+    setConnections(null)
   }, [controller.path])
 
   const canvasValueRef = useRef(canvasValue)

--- a/apps/web/src/scoped-screen-state.test.ts
+++ b/apps/web/src/scoped-screen-state.test.ts
@@ -50,6 +50,7 @@ const sources = import.meta.glob(
     './components/VersionTimeline.tsx',
     './pages/use-markdown-document.ts',
     './pages/BrowserDocumentPage.tsx',
+    './pages/DaemonDocumentPage.tsx',
     './pages/use-version-save-flow.ts',
     './hooks/use-comments-rail.ts',
   ],
@@ -84,6 +85,7 @@ const BRANCH_CHIP = './components/HeaderBranchChip.tsx'
 const VERSION_TIMELINE = './components/VersionTimeline.tsx'
 const MARKDOWN_DOCUMENT = './pages/use-markdown-document.ts'
 const BROWSER_DOCUMENT_PAGE = './pages/BrowserDocumentPage.tsx'
+const DAEMON_DOCUMENT_PAGE = './pages/DaemonDocumentPage.tsx'
 // The save-a-version guard extracted to its own hook: part of the same
 // SCREEN by the same rule the panel's search/columns hooks are — its state
 // moved there, not away.
@@ -323,7 +325,34 @@ const MARKDOWN_DOCUMENT_STATE: Record<string, ScopeCoverage> = {
 // The page itself, not a panel inside it. It keeps its own document
 // switching rather than remounting — `App.tsx` says so at the mount site —
 // so everything it holds about a document has to be dropped by hand.
+/**
+ * What the two document pages share, because they mount the same two hooks.
+ *
+ * Spread into both ledgers rather than written twice: these are one
+ * judgement about one piece of code, and two copies of it drift — the whole
+ * failure this file exists to stop, one level up. A hook gaining state now
+ * fails BOTH screens with the same message.
+ */
+const DOCUMENT_PAGE_HOOK_STATE: Record<string, ScopeCoverage> = {
+  savingVersion: 'no subject: an in-flight flag for this screen\u2019s own submit',
+  saveVersionOutcome: 'cleared on switch',
+  // Unlike `open`, this one names a THREAD, and a thread id belongs to the
+  // document that holds it: left standing across a switch it would scroll
+  // the arrived body to a passage the departed document quoted, or expand a
+  // conversation that is not on this document at all. Cleared by
+  // useCommentsRail's own scope reset.
+  selectedThreadId: 'cleared on switch',
+  // A passage inside the DEPARTED document's body. Left standing it would
+  // hand the arrived document an anchor quoting text it does not contain —
+  // and a submitted one would open a conversation on the wrong document
+  // about a sentence nobody there wrote. Cleared by useCommentsRail.
+  composeAnchor: 'cleared on switch',
+  open: 'no subject: whether the rail is open, not what is in it — the threads themselves are republished per document (on the session\u2019s annotation channel for a spatial document, off the markdown hook\u2019s own host for a note), so a switch changes the LIST while leaving the reader where they chose to be',
+  writeRef: 'no subject: mirrors the keeper-specific write door, reassigned every render',
+}
+
 const BROWSER_DOCUMENT_PAGE_STATE: Record<string, ScopeCoverage> = {
+  ...DOCUMENT_PAGE_HOOK_STATE,
   historyOpen: 'cleared on switch',
   // The past state being looked at. Restoring one the person opened on the
   // DEPARTED document would apply that version id to the arrived one.
@@ -331,8 +360,6 @@ const BROWSER_DOCUMENT_PAGE_STATE: Record<string, ScopeCoverage> = {
   // Cleared with the panel: a field left armed across a switch would name
   // the arrived document from the departed one's keystroke.
   bookmarkArmed: 'cleared on switch',
-  savingVersion: 'no subject: an in-flight flag for this screen’s own submit',
-  saveVersionOutcome: 'cleared on switch',
   versionRefreshSignal:
     'no subject: a counter that nudges the History panel to refetch; the list it refreshes is the panel’s own, and the panel remounts per document',
   // The one that bit: a bare boolean over `triggerCleanup()`, which acts on
@@ -344,19 +371,6 @@ const BROWSER_DOCUMENT_PAGE_STATE: Record<string, ScopeCoverage> = {
 
   isFullscreen:
     'no subject: how you are looking at the page rather than what at — and the browser owns the real state, so a reset here would disagree with the `document.fullscreenElement` the label follows',
-  // Unlike `open`, this one names a THREAD, and a thread id belongs
-  // to the document that holds it: left standing across a switch it would
-  // scroll the arrived body to a passage the departed document quoted, or
-  // expand a conversation that is not on this document at all. Cleared by
-  // useCommentsRail's own scope reset.
-  selectedThreadId: 'cleared on switch',
-  // A passage inside the DEPARTED document's body. Left standing it would
-  // hand the arrived document an anchor quoting text it does not contain —
-  // and a submitted one would open a conversation on the wrong document
-  // about a sentence nobody there wrote. Cleared by useCommentsRail.
-  composeAnchor: 'cleared on switch',
-  open: 'no subject: whether the rail is open, not what is in it — the threads themselves are republished per document (on the session\u2019s annotation channel for a spatial document, off the markdown hook\u2019s own host for a note), so a switch changes the LIST while leaving the reader where they chose to be',
-  writeRef: 'no subject: mirrors the keeper-specific write door, reassigned every render',
   documents:
     'no subject: the WORKSPACE’s list, which a document switch does not change; its own refresh effect keys on the document identity that belongs in it',
   canvasOpsButtonRef: 'no subject: the kebab’s DOM node',
@@ -375,6 +389,52 @@ const BROWSER_DOCUMENT_PAGE_STATE: Record<string, ScopeCoverage> = {
   lastKnownCanvasIdRef:
     'no subject: holds the previously loaded id ON PURPOSE, to tell an external navigation from this page’s own pending push — clearing it is exactly what breaks that',
   shortcutHandledRef: 'no subject: a once-per-page-load flag for the ?new=canvas launcher param',
+}
+
+const DAEMON_DOCUMENT_PAGE_STATE: Record<string, ScopeCoverage> = {
+  ...DOCUMENT_PAGE_HOOK_STATE,
+
+  historyOpen: 'cleared on switch',
+  // The past state being looked at, exactly as on the browser page:
+  // restoring one the person opened on the DEPARTED document would apply
+  // that version id to the arrived one.
+  preview: 'cleared on switch',
+  bookmarkArmed: 'cleared on switch',
+  // A read-only view of ONE document's variation tip (ADR-0022). `?v` is
+  // not stripped by a switch — `switchDocument` sets the path and nothing
+  // else — so the effect that owns this re-resolves the same NAME against
+  // the arrived document. Until it answers, the departed document's preview
+  // is on screen under the new one's name.
+  variationPreview: 'cleared on switch',
+  // Worse than the preview, which is why it is called out separately: no
+  // branch of that effect clears the notice, so `Variation «x» was not
+  // found` about one document outlived it onto the next until this reset.
+  variationNotice: 'cleared on switch',
+  // Backlinks OF this document. Its own fetch nulls them, but only once it
+  // knows the arrived document's id — which comes from a list that may
+  // still be refreshing.
+  connections: 'cleared on switch',
+
+  authError:
+    'no subject: whether the DAEMON refused this pairing, which spans every document it serves — a switch does not re-authorise anything, and the session effect below reads it to say `sync-off`',
+  creating: 'no subject: an in-flight flag for this screen’s own create submit',
+  branchRefreshSignal:
+    'no subject: a counter that nudges HeaderBranchChip to refetch on an externally observed HEAD change; the chip is keyed on the document itself and refetches on a switch without this',
+  versionRefreshSignal:
+    'no subject: a counter that nudges the History panel to refetch; the list it refreshes is the panel’s own, and the panel remounts per document',
+  connectionsRefresh:
+    'no subject: a counter that re-runs the backlinks fetch; that fetch is keyed on the document id and nulls the value first, so the counter decides WHEN to refetch, never WHAT is shown',
+
+  createBackendRef:
+    'no subject: mirrors the `createBackend` prop, reassigned every render — it exists so a parent’s inline arrow cannot make the session’s lifetime depend on the parent’s render',
+  spatialEditorRef:
+    'no subject: the mounted editor’s imperative handle, and the editor is keyed per document — React swaps the handle on a switch without anything here clearing it',
+  canvasesRef:
+    'no subject: mirrors the WORKSPACE’s document list, reassigned every render — a document switch does not change which documents exist',
+  currentDocumentPathRef:
+    'no subject: mirrors the scope itself, written during render — it is what a handler outliving a switch asks to find out what arrived rather than trusting its own closure',
+  canvasValueRef:
+    'no subject: mirrors the current canvas value, reassigned every render — it is how a write sends the CURRENT canvas rather than the one its closure captured',
 }
 
 const CASES = [
@@ -402,6 +462,12 @@ const CASES = [
     files: [BROWSER_DOCUMENT_PAGE, VERSION_SAVE_FLOW_HOOK, COMMENTS_RAIL_HOOK],
     ledger: BROWSER_DOCUMENT_PAGE_STATE,
     label: 'BrowserDocumentPage',
+    scanRefs: true,
+  },
+  {
+    files: [DAEMON_DOCUMENT_PAGE, VERSION_SAVE_FLOW_HOOK, COMMENTS_RAIL_HOOK],
+    ledger: DAEMON_DOCUMENT_PAGE_STATE,
+    label: 'DaemonDocumentPage',
     scanRefs: true,
   },
 ] as const


### PR DESCRIPTION
## Summary

- `scoped-screen-state.test.ts` covered `BrowserDocumentPage` and not `DaemonDocumentPage`. **A ledger over one of two sibling screens is worse than none over either**: it makes the uncovered one look guarded. The gap was measured rather than supposed — when the comment compose anchor landed (#1341), the browser page's entry failed and named the defect, while the daemon page took the same state with nothing watching, and its reset got written by hand because someone happened to remember (task #191).
- All 22 of the daemon page's slots are now classified, and the six the two pages share — they mount the same two hooks — are spread from one `DOCUMENT_PAGE_HOOK_STATE` rather than written twice. Two copies of one judgement drift, which is the failure this file exists to stop, one level up.

## Classifying it found a real defect

**`?v` is not stripped by a document switch.** `switchDocument` sets the path and nothing else, so the variation effect re-resolves the same *name* against the arrived document — and no branch of it clears the notice. `Variation «nope» was not found`, a statement about the document you left, stayed on screen over the one you arrived at.

`variationPreview` and `connections` had the narrower version of the same shape: each is re-derived by its own effect, but only once that effect knows the arrived document, and until then the departed document's value is what is rendered.

All three now clear in the scope-reset effect — which is also what makes their `cleared on switch` entries **true rather than argued**. I considered bending the ledger's vocabulary to describe "re-derived by its own scope-keyed effect" instead; putting the setters where the claim can be checked is the honest version and it fixes the notice as a side effect.

## Test plan

- [x] New or updated tests added — a red-first regression in `DaemonDocumentPage.surface-outlives-document.test.tsx`, the file that already owns "state outliving a document" on this page, driven through the real `onOpenFileRef` seam rather than a test hook.
- [x] `pnpm test` passes locally — `pnpm --filter @kamiazya/whiteboard-web test` (CI's `test-jsdom`) **353 files / 3,708 + 14 / 92**; `pnpm -r typecheck`, `pnpm knip`, `pnpm lint`, `pnpm lint:noconsole`, `dev-rules-budget` + `file-size-budget` all clean.
- [x] Manual verification completed — the regression was run against the unfixed page and reported `expected <div role="alert" …> to be null`, i.e. the notice still on screen after the switch. Five fresh-process runs of the file, all green.
- [ ] E2E coverage — not applicable; the switch this exercises is in-SPA and the page's own seam reaches it.

Mutation-checked in four directions: a new `useState` on the page fails it; an entry marked `no subject:` that the reset clears fails it; a `cleared on switch` entry whose setter leaves the block fails it; and removing a **shared-hook** entry now fails **both** screens — which is the check that the extraction did not weaken the browser case.

The fourth is worth recording because the experiment was wrong before the guard was. Removing `setVariationNotice(null)` first came back green: my `sed` had deleted the *first* occurrence in the file — inside the variation effect, not the scope-reset block. Aimed at the right line it fails as it should. **A mutation that comes back green reads as a hole in the guard; here it was a hole in the experiment.**

Test count: `scoped-screen-state` goes 30 → 35, exactly one new case × the file's five `it.each` tests, plus the one regression above. My diff touches three files and adds `it(` nowhere else.

## Visual evidence

**Visual evidence: none — the visible change is one stale alert no longer appearing, and the regression names it more precisely than a screenshot could.** The red/green pair is the evidence: against the unfixed page the assertion reports `expected <div role="alert" …> to be null` (the notice still rendered over the arrived document); with the fix the node is gone. A two-panel figure would show the same alert present and absent, and would say less about *which* document it belonged to — which is the whole defect.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — no user-facing surface or contract changed; the reasoning lives in the ledger entries and the page's scope-reset comment, where the next reader of that code will be
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_