### PR TITLE
test(web): the trash-count wait gets the budget every other wait in its file already has

### DIFF
--- a/apps/web/src/pages/BrowserIndexPage.flow.browser.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.flow.browser.test.tsx
@@ -173,9 +173,18 @@ describe('browser list landing (browser — real IndexedDB)', () => {
     // Restore one from the trash: the card returns to the list.
     // The count is a SECOND async list, and the loop above only waited for the
     // card list to shrink — so the section can still read `Trash (1)` here while
-    // the delete's own trash re-read is in flight.
-    await userEvent.click(await within(trash).findByText(/^Trash \(2\)/))
-    await userEvent.click((await within(trash).findAllByRole('button', { name: 'Restore' }))[0]!)
+    // the delete's own trash re-read is in flight. These two were the last
+    // waits in this file left on testing-library's 1000ms default, and the
+    // count was the step that failed on CI (run 33952850675: `Unable to find
+    // ... /^Trash \(2\)/` — the same class as the typing wait above, fixed the
+    // same way): the assertion is unchanged, only the budget matches the
+    // fifteen-second waits around it.
+    await userEvent.click(
+      await within(trash).findByText(/^Trash \(2\)/, undefined, { timeout: 15_000 }),
+    )
+    await userEvent.click(
+      (await within(trash).findAllByRole('button', { name: 'Restore' }, { timeout: 15_000 }))[0]!,
+    )
     await waitFor(() => expect(screen.queryAllByTestId('card-title')).toHaveLength(1), {
       timeout: 15_000,
     })


### PR DESCRIPTION
## What

Second CI occurrence for `BrowserIndexPage.flow.browser.test.tsx` (runs 33170355608 / 33952850675) — promoted to a root-cause fix per integrator-flow. The two runs failed at **different steps** of the same long flow test:

- 08-28: the typing wait — already fixed in-file by raising it to the 15s budget the neighbouring waits use.
- 09-05: the **last wait left on testing-library's 1000ms default** — the `Trash (2)` count, whose own comment already documented the race (the delete loop only waits for the card list to shrink, so the section can still read `Trash (1)` while the delete's trash re-read is in flight).

Same class, same in-file remedy: assertions unchanged, budgets matched to the fifteen-second waits around them. The `Restore` lookup beside it comes along — it reads the same async list.

## Verification

Real-browser isolated run 1/1 (isolation proves reachability, not the load behavior — the change is a pure budget raise on unchanged assertions, so it cannot regress the loaded run) · web typecheck · lint.

Visual evidence: none — test-budget change; the two CI runs' failure messages quoted in the diff comment are the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D
