### PR TITLE
test(web): one rootOf for the spatial-editor browser suites

### DIFF
--- a/apps/web/src/components/spatial-editor/auto-grow-height.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/auto-grow-height.browser.test.tsx
@@ -9,6 +9,7 @@ import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { fillNodeEditor, nodeEditorContent } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
@@ -41,10 +42,6 @@ function makeHost(initial: SpatialCanvas) {
     )
   }
   return { Host, latest }
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 async function editNodeText(container: HTMLElement, text: string) {

--- a/apps/web/src/components/spatial-editor/canvas-embed-lod.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/canvas-embed-lod.browser.test.tsx
@@ -7,6 +7,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -36,10 +37,6 @@ function makeHost(initial: SpatialCanvas) {
     )
   }
   return Host
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 function embeddedTextExists(container: HTMLElement): boolean {

--- a/apps/web/src/components/spatial-editor/canvas-ref-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/canvas-ref-node.browser.test.tsx
@@ -7,6 +7,7 @@ import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -43,10 +44,6 @@ function makeHost(initial: SpatialCanvas, onOpen?: (file: string, subpath?: stri
     )
   }
   return { Host, latest }
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 function rightClick(el: HTMLElement, x: number, y: number) {

--- a/apps/web/src/components/spatial-editor/comment-compose-look.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/comment-compose-look.browser.test.tsx
@@ -8,6 +8,7 @@ import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -29,10 +30,6 @@ function Host({ theme }: { theme: 'light' | 'dark' }) {
       <SpatialEditor defaultTool="select" canvas={canvas} onChange={setCanvas} theme={theme} />
     </div>
   )
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 async function composeStyle(): Promise<CSSStyleDeclaration> {

--- a/apps/web/src/components/spatial-editor/comment-create.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/comment-create.browser.test.tsx
@@ -11,6 +11,7 @@ import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 import type { EditorCommand } from '../../lib/spatial/commands.js'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -46,10 +47,6 @@ function makeHost(options: { lockedIds?: readonly string[] } = {}) {
     )
   }
   return { Host, latest }
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 function rightClick(el: HTMLElement, x: number, y: number) {

--- a/apps/web/src/components/spatial-editor/comment-drag-follow.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/comment-drag-follow.browser.test.tsx
@@ -8,6 +8,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -37,10 +38,6 @@ function Host() {
       <SpatialEditor defaultTool="select" canvas={canvas} onChange={setCanvas} theme="light" />
     </div>
   )
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 function textOf(container: HTMLElement, testId: string): string {

--- a/apps/web/src/components/spatial-editor/comment-edit.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/comment-edit.browser.test.tsx
@@ -13,6 +13,7 @@ import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 import type { EditorCommand } from '../../lib/spatial/commands.js'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -60,10 +61,6 @@ function makeHost() {
     )
   }
   return { Host, latest }
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 function textEdits(commands: readonly EditorCommand[]) {

--- a/apps/web/src/components/spatial-editor/comment-integer-anchor.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/comment-integer-anchor.browser.test.tsx
@@ -12,6 +12,7 @@ import { afterEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 import type { EditorCommand } from '../../lib/spatial/commands.js'
 import type { SpatialEditorHandle } from '../../lib/spatial/editor-handle.js'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -56,10 +57,6 @@ function makeHost() {
     )
   }
   return { Host, latest }
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 /** Zoom 1.3 puts every screen pixel at a fractional canvas coordinate. */

--- a/apps/web/src/components/spatial-editor/comment-move.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/comment-move.browser.test.tsx
@@ -8,6 +8,7 @@ import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import type { EditorCommand } from '../../lib/spatial/commands.js'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -56,10 +57,6 @@ function makeHost(initial: SpatialCanvas = start) {
     )
   }
   return { Host, latest }
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 function commentOf(canvas: SpatialCanvas, id: string): CanvasComment | undefined {

--- a/apps/web/src/components/spatial-editor/comment-placement.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/comment-placement.browser.test.tsx
@@ -9,6 +9,7 @@ import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -38,10 +39,6 @@ function Host({ canvas: initial }: { canvas: SpatialCanvas }) {
       <SpatialEditor defaultTool="select" canvas={canvas} onChange={setCanvas} theme="light" />
     </div>
   )
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 async function waitForContent(container: HTMLElement, text: string) {

--- a/apps/web/src/components/spatial-editor/comment-reply.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/comment-reply.browser.test.tsx
@@ -9,6 +9,7 @@ import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 import type { EditorCommand } from '../../lib/spatial/commands.js'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -83,10 +84,6 @@ function makeHost(threads: readonly CommentThread[] = [THREAD]) {
     )
   }
   return { Host, latest }
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 function of(commands: readonly EditorCommand[], kind: EditorCommand['kind']) {

--- a/apps/web/src/components/spatial-editor/comment-resolve.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/comment-resolve.browser.test.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
 import type { EditorCommand } from '../../lib/spatial/commands.js'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -58,10 +59,6 @@ function makeHost(initial: SpatialCanvas = start) {
     )
   }
   return { Host, latest }
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 function pinOf(container: HTMLElement, id: string): SVGGElement | null {

--- a/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu.browser.test.tsx
@@ -9,6 +9,7 @@ import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { CREATION_LABELS } from './creation-labels.js'
 import { nodeEditorContent } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
@@ -35,10 +36,6 @@ function Host({ onCommand }: { onCommand?: (kind: string) => void }) {
       />
     </div>
   )
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 function rightClick(el: HTMLElement, x: number, y: number) {

--- a/apps/web/src/components/spatial-editor/dialog-target-vanishes.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/dialog-target-vanishes.browser.test.tsx
@@ -17,6 +17,7 @@ import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -67,10 +68,6 @@ function makeHost() {
     )
   }
   return { Host, latest }
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 function rightClick(root: HTMLElement, x: number, y: number) {

--- a/apps/web/src/components/spatial-editor/double-press-text-edit.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/double-press-text-edit.browser.test.tsx
@@ -11,6 +11,7 @@ import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { fillNodeEditor, nodeEditorContent, nodeEditorText } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
@@ -36,10 +37,6 @@ function Host({ onCommand }: { onCommand?: (kind: string) => void }) {
       />
     </div>
   )
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 it('a real double-click on a text node opens its editor with the existing text', async () => {

--- a/apps/web/src/components/spatial-editor/edge-curved-hit.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-curved-hit.browser.test.tsx
@@ -5,6 +5,7 @@
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { afterEach, expect, it, vi } from 'vitest'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -19,10 +20,6 @@ const canvas: SpatialCanvas = {
   ],
   edges: [{ id: 'e1', fromNode: 'a', toNode: 'b' }],
   'x-whiteboard': { edgeRouting: { style: 'curved' } },
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 it('selects a curved edge by clicking the drawn curve, and highlights along it', async () => {

--- a/apps/web/src/components/spatial-editor/edge-label-edit.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-label-edit.browser.test.tsx
@@ -8,6 +8,7 @@ import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -46,10 +47,6 @@ function makeHost(start: SpatialCanvas) {
     )
   }
   return { Host, latest }
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 /** Element-relative position ON the edge polyline (see edge-select-delete). */

--- a/apps/web/src/components/spatial-editor/edge-select-delete.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-select-delete.browser.test.tsx
@@ -6,6 +6,7 @@ import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -41,10 +42,6 @@ function makeHost() {
     )
   }
   return { Host, latest }
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 /**

--- a/apps/web/src/components/spatial-editor/edge-selection-coherence.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-selection-coherence.browser.test.tsx
@@ -15,6 +15,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -42,10 +43,6 @@ function Host() {
       />
     </div>
   )
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 /**

--- a/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edit-handle.browser.test.tsx
@@ -8,6 +8,7 @@ import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { nodeEditorText } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
@@ -30,10 +31,6 @@ function Host() {
       />
     </div>
   )
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 it('selecting a node shows one More-actions control; it opens the object menu HERE', async () => {

--- a/apps/web/src/components/spatial-editor/group-background-hex.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/group-background-hex.browser.test.tsx
@@ -5,6 +5,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -35,10 +36,6 @@ function makeHost(onAddImage?: (file: File) => Promise<string | undefined>) {
     )
   }
   return { Host, latest }
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 function rightClick(el: HTMLElement, x: number, y: number) {

--- a/apps/web/src/components/spatial-editor/group-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/group-node.browser.test.tsx
@@ -8,6 +8,7 @@ import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -44,10 +45,6 @@ function makeHost(initial: SpatialCanvas) {
     )
   }
   return { Host, latest }
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 function rightClick(el: HTMLElement, x: number, y: number) {

--- a/apps/web/src/components/spatial-editor/image-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/image-node.browser.test.tsx
@@ -7,6 +7,7 @@ import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -56,10 +57,6 @@ function makeHost(initial: SpatialCanvas) {
     )
   }
   return { Host, latest }
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 function pngFile(): File {

--- a/apps/web/src/components/spatial-editor/keyboard-avoidance.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/keyboard-avoidance.browser.test.tsx
@@ -11,6 +11,7 @@ import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
 import { PAN_MARGIN_PX } from '../../lib/spatial/viewport.js'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { DESKTOP_BAR_HEIGHT_PX, TOUCH_BAR_HEIGHT_PX } from '../markdown-editor/verb-bar-layout.js'
 import { nodeEditorContent } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
@@ -53,10 +54,6 @@ function Host({ start, height = 600 }: { start: SpatialCanvas; height?: number }
       />
     </div>
   )
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 function transformOf(container: HTMLElement): string {

--- a/apps/web/src/components/spatial-editor/link-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/link-node.browser.test.tsx
@@ -8,6 +8,7 @@ import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -49,10 +50,6 @@ function makeHost(initial: SpatialCanvas) {
     )
   }
   return { Host, latest }
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 // The dialog sits centered in the editor, which the vitest browser iframe's

--- a/apps/web/src/components/spatial-editor/lost-pointer-capture.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/lost-pointer-capture.browser.test.tsx
@@ -17,6 +17,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { nodeEditorContent } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
@@ -42,10 +43,6 @@ function Host({ onCommand }: { onCommand?: (kind: string) => void }) {
       />
     </div>
   )
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 /**

--- a/apps/web/src/components/spatial-editor/marquee.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/marquee.browser.test.tsx
@@ -6,6 +6,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { nodeEditorContent } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
@@ -35,10 +36,6 @@ function Host() {
       />
     </div>
   )
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 function ev(el: HTMLElement, type: string, x: number, y: number, extra: PointerEventInit = {}) {

--- a/apps/web/src/components/spatial-editor/multi-select.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/multi-select.browser.test.tsx
@@ -5,6 +5,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -33,10 +34,6 @@ function Host() {
       />
     </div>
   )
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 function press(el: HTMLElement, x: number, y: number, opts: { shift?: boolean; id?: number } = {}) {

--- a/apps/web/src/components/spatial-editor/object-first-connect.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/object-first-connect.browser.test.tsx
@@ -13,6 +13,7 @@ import { SpatialEditor } from './SpatialEditor.js'
 // sibling shifts it into the scene — where it becomes unclickable. This file
 // asserts on real click targets, so it needs real styles.
 import '../../index.css'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 
 afterEach(cleanup)
 
@@ -44,10 +45,6 @@ function makeHost() {
     )
   }
   return { Host, latest }
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 function connectToolButton(container: HTMLElement): HTMLButtonElement {

--- a/apps/web/src/components/spatial-editor/selection-survives-external-delete.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/selection-survives-external-delete.browser.test.tsx
@@ -12,6 +12,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -47,10 +48,6 @@ function Host() {
       />
     </div>
   )
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 function press(el: HTMLElement, x: number, y: number, shift = false) {

--- a/apps/web/src/components/spatial-editor/shaped-node-editing.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/shaped-node-editing.browser.test.tsx
@@ -10,6 +10,7 @@ import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, beforeAll, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { nodeEditorContent } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
@@ -60,10 +61,6 @@ function Host({ start }: { start: SpatialCanvas }) {
       />
     </div>
   )
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 /** The committed scene's text content — the SVG's, never the editor's. */

--- a/apps/web/src/components/spatial-editor/text-edit-experience.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/text-edit-experience.browser.test.tsx
@@ -9,6 +9,7 @@ import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { nodeEditor, nodeEditorContent, nodeEditorText } from './node-editor-test-utils.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
@@ -31,10 +32,6 @@ function Host({ theme = 'light' as const }: { theme?: 'light' | 'dark' }) {
       />
     </div>
   )
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 async function openEditor(container: HTMLElement): Promise<HTMLElement> {

--- a/apps/web/src/components/spatial-editor/touch-long-press-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/touch-long-press-menu.browser.test.tsx
@@ -8,6 +8,7 @@ import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
+import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
 afterEach(cleanup)
@@ -29,10 +30,6 @@ function mount(canvas: SpatialCanvas, tool: 'select' | 'hand' = 'select') {
     )
   }
   return { latest, ...render(<Host />) }
-}
-
-function rootOf(container: HTMLElement): HTMLElement {
-  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
 }
 
 function touch(el: HTMLElement, type: string, x: number, y: number, pointerId = 7) {

--- a/apps/web/src/test-utils/spatial-editor-root.ts
+++ b/apps/web/src/test-utils/spatial-editor-root.ts
@@ -1,0 +1,9 @@
+/**
+ * The editor surface inside a rendered test container. One definition for
+ * the 33 browser test files that all queried the same testid with the same
+ * cast — measured identical before extracting (the makeHost builders around
+ * it deliberately stay per-file: 34 distinct fixtures, not copies).
+ */
+export function rootOf(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
+}


### PR DESCRIPTION
## What

Ticket `spatial-editor-test-harness-dedup`, closed **by measurement rather than by the sweep it proposed**:

- **`rootOf`: extracted.** 33 byte-identical copies (hashed after whitespace normalization) → one test-util (`test-utils/spatial-editor-root.ts`); every file converted mechanically.
- **`makeHost`: deliberately NOT extracted.** 34 distinct variants across 38 files — each builds its test's own fixture (initial canvas, host dimensions, which callbacks `latest` records). They are per-test fixtures sharing a shape, not copies of one thing drifting apart; a parameterized `makeSpatialHost` would be a config DSL harder to read than the 25-line explicit versions. The audit's "drift between copies is how a fixture bug hides" premise does not hold for them — recorded on the ticket.

## Verification

Whole spatial-editor browser suite after conversion: **467/467 across 96 files** (real browser). Web typecheck · lint · knip clean.

Visual evidence: none — test-only mechanical extraction; the suite total above is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D
