### PR TITLE
fix(loro-adapter): two replicas opening one thread container no longer lose a side

### DIFF
--- a/.claude/rules/dev-flow.md
+++ b/.claude/rules/dev-flow.md
@@ -116,7 +116,7 @@ Native **Task list** = live board (in-flight / blocked / done; main session owns
 
 ## Skills (load for detail)
 
-`ticketing`, `workflow-authoring`, `zod-schema-discipline`, `test-layer-selection`, `testing-techniques`, `measured-change`, `diagnosis-evidence`, `visual-evidence`, `docs-sync`, `whiteboard-mcp-smoke`, `review-gate`, `audit-triage`, `ci-triage`, `dependabot-review`, `stacking-pull-requests`, `steward`, `react-best-practices`.
+`ticketing`, `workflow-authoring`, `zod-schema-discipline`, `test-layer-selection`, `testing-techniques`, `measured-change`, `diagnosis-evidence`, `visual-evidence`, `docs-sync`, `whiteboard-mcp-smoke`, `loro-crdt-usage`, `review-gate`, `audit-triage`, `ci-triage`, `dependabot-review`, `stacking-pull-requests`, `steward`, `react-best-practices`.
 
 `steward` is the one with a load-bearing PATH: the harness reads `.claude/skills/steward/SKILL.md` on a PR event and lets it override the generic drive-to-green rules on conventions and on how proactive to be. Its `reference/failure-modes.md` is an INDEX into `integrator-flow.md`'s CI-flakes section — symptom to verdict — so the reasoning and the measurements stay there, in one place, and keep covering a flake that has no PR attached.
 

--- a/.claude/rules/package-loro-adapter.md
+++ b/.claude/rules/package-loro-adapter.md
@@ -74,7 +74,10 @@ implementations live in the composition roots.
 - A tree-node host opens containers through `mergeable-containers.ts`, never
   `setContainer`. The latter REPLACES what is at the key: measured, a second
   `setContainer` on an occupied key leaves `{}`, so writing a document twice
-  would wipe it. A document's own content containers stay REGULAR children
+  would wipe it. The one place `setContainer` is right is `copyNodeData`,
+  whose target is a node `createNode()` just minted — replacing on an empty
+  node replaces nothing, and it is what copies a container by KIND without a
+  hardcoded list of keys. A document's own content containers stay REGULAR children
   deliberately — pre-attached at creation, so no replica opens one first, and
   mergeable would cost 18.6% of the delta log to close a hazard that is
   already closed (`mergeable-containers.test.ts` carries the numbers).

--- a/.claude/rules/package-loro-adapter.md
+++ b/.claude/rules/package-loro-adapter.md
@@ -71,9 +71,13 @@ implementations live in the composition roots.
   a root of the document, or a key on a tree node's meta — so the bridge is
   written once and hosted twice. `LoroDoc` satisfies the interface
   structurally, which is why the move cost no call site a change.
-- A tree-node host uses `getOrCreateContainer`, never `setContainer`. The
-  latter REPLACES what is at the key: measured, a second `setContainer` on
-  an occupied key leaves `{}`, so writing a document twice would wipe it.
+- A tree-node host opens containers through `mergeable-containers.ts`, never
+  `setContainer`. The latter REPLACES what is at the key: measured, a second
+  `setContainer` on an occupied key leaves `{}`, so writing a document twice
+  would wipe it. A document's own content containers stay REGULAR children
+  deliberately — pre-attached at creation, so no replica opens one first, and
+  mergeable would cost 18.6% of the delta log to close a hazard that is
+  already closed (`mergeable-containers.test.ts` carries the numbers).
 - LoroDoc spatial layout: `doc.getMap('nodes')` keyed by nodeId,
   `doc.getMap('edges')` keyed by edgeId. Each value is a plain object
   (not a nested LoroMap container) — this preserves node-level CRDT
@@ -110,11 +114,24 @@ implementations live in the composition roots.
   The price, measured on loro-crdt 1.13.6: when two replicas create a
   container under the same key with **no common ancestor for that key**, the
   merge keeps one of them and every entry the other side put in it is gone —
-  no conflict, no marker. So only the CREATION path may open a thread
-  container (its id is minted, and cannot collide); a reply or a status change
-  to a thread this replica has not received writes nothing rather than opening
-  a rival. `setContainer` is banned here for the reason it is banned on tree
-  nodes, and `getOrCreateContainer` alone is not enough.
+  no conflict, no marker.
+
+  A thread's key does NOT protect against that, and the claim here that it
+  did ("its id is minted, and cannot collide") was wrong: the key is the
+  CALLER's comment id, which `writeCommentInto` passes straight through and
+  `deleteCommentInto` looks the thread up by. Two keepers migrating the same
+  legacy comment, or each applying one `comment.add`, reach the same key
+  having never seen the other's. `openMergeableMap`
+  (`mergeable-containers.ts`) is what closes it — a deterministic child id,
+  so the two were editing one container all along — and
+  `comment-threads.convergence.test.ts` is the measurement. Which containers
+  are mergeable and what the choice costs in oplog bytes is the
+  `loro-crdt-usage` skill.
+
+  Creation is still the only path allowed to OPEN a thread container, now for
+  intent rather than convergence: a reply to a thread this replica does not
+  hold would otherwise materialise an anchorless, statusless thread around it.
+  `setContainer` is banned here for the reason it is banned on tree nodes.
 - A third map, `doc.getMap('canvas')`, holds the canvas ENVELOPE —
   properties of the canvas rather than of anything on it (today
   `x-whiteboard`, the rendering preferences). Separate because the merge

--- a/.claude/skills/loro-crdt-usage/SKILL.md
+++ b/.claude/skills/loro-crdt-usage/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: loro-crdt-usage
+description: How this repo uses loro-crdt correctly — mergeable child containers vs the deprecated getOrCreateContainer, what a container choice costs in oplog bytes, rich-text marks, and how to measure a Loro claim against the installed version instead of trusting a doc page. Use when adding or changing anything that opens a container, stores a collection, exports/imports a document, or when a CRDT merge is losing data.
+---
+
+# Using loro-crdt in this repo
+
+Loro is where this project's data actually lives, and its failure mode is
+the worst kind: **a wrong container choice loses data with no conflict, no
+error, and both replicas agreeing on the truncated result.** Nothing goes
+red. The loss is found, if ever, by a person noticing their reply is gone.
+
+So the rule here is the repo's rule everywhere else, sharpened: **a claim
+about Loro is worth what its measurement is worth.** The version is pinned
+in `pnpm-workspace.yaml` (`loro-crdt: "1.13.6"`), the API has changed
+under this repo more than once, and `loro.dev` is not reachable from this
+environment anyway. What IS reachable and authoritative is shipped inside
+the package — see "Where the answers actually are" below.
+
+## The rule: a lazily-created child container must be mergeable
+
+`map.getOrCreateContainer(key, new LoroMap())` mints a **regular op-id**
+child. Two replicas that each open the same key having never seen the
+other's end up with two containers, and the map's conflict resolution keeps
+one and hides the other.
+
+Measured on 1.13.6 — two peers, no common ancestor for the key, each
+writing one entry:
+
+| opened with | both replicas read |
+|---|---|
+| `getOrCreateContainer` | `{"fromB": "reply B"}` |
+| `ensureMergeableMap` | `{"fromA": "reply A", "fromB": "reply B"}` |
+
+Same for `ensureMergeableText` (`"ab"` vs `"b"`) and
+`ensureMergeableMovableList` (`["A","B"]` vs `["B"]`).
+
+loro-crdt says so itself. 1.13.0's changelog: *"`getOrCreateContainer` is
+deprecated for lazy map-child creation; migrate those call sites to
+`ensureMergeable*`."* A mergeable child lives at a deterministic
+`ContainerID` derived from `(parent, key, kind)`, so the two peers were
+editing one container all along.
+
+**Use `openMergeableMap` / `openMergeableText` /
+`openMergeableMovableList` from
+`packages/loro-adapter/src/mergeable-containers.ts`**, never the raw
+method. Four things the helper exists for, each measured:
+
+1. **`ensureMergeable*` THROWS on a key that already holds a non-mergeable
+   value** — `Cannot create a mergeable Map at key "k": the key already
+   holds a non-mergeable value`. That is every document written before the
+   helper landed, so a bare swap breaks stored data. The helper takes the
+   mergeable branch only for an ABSENT key and leaves an occupied one
+   exactly as it was, which is what makes this safe with no migration.
+2. **They live on `LoroMap` alone.** Not on `LoroList`, `LoroMovableList`
+   or `LoroTree` — which is the shape of the problem, not an omission: a
+   list position is already a unique op, so only a map KEY needs two peers
+   to agree on which child it names.
+3. **A mixed pair still loses one side.** One replica opening the key the
+   old way while another opens it mergeable converges on the mergeable one.
+   The fix removes the hazard for containers created from here on; it
+   cannot repair a fork that already happened.
+4. `getOrCreateContainer` reading a container `ensureMergeable*` created is
+   fine, so a reader on an older code path is not broken by the switch.
+
+## What it costs, and where this repo therefore does NOT use it
+
+A mergeable child's id is deterministic rather than an op id, and every
+write into one encodes that. Measured against
+`workspace-record-growth.test.ts` with the whole package switched over:
+
+| scoreboard | regular | mergeable | delta |
+|---|---|---|---|
+| one document, no edits | 919 B | 1069 B | +16.3% |
+| 10 documents x 100 edits (delta log) | 178560 B | 211860 B | +18.6% |
+
+**Attributed, not assumed**: reverting `workspace-tree.ts` alone put every
+number back, so the entire cost is the per-document CONTENT containers and
+the thread plane's share of it is zero.
+
+Which settles where it goes. A document's content containers are
+pre-attached by whoever creates the document (`attachContentContainers`
+over `CONTENT_CONTAINER_KEYS`), so they ride the op log and no second
+replica ever opens one first — the hazard is already closed there, and
+18.6% of the delta log is paid by the compaction subsystem forever. A
+thread's key is **the caller's comment id** and nothing pre-attaches it, so
+there the hazard is real and the cost is nil.
+
+`mergeable-containers.test.ts` keeps that a decision rather than a habit:
+every remaining regular call is registered with a reason and a pinned
+count, so a new lazily-created container fails the suite until someone
+answers which kind it is.
+
+## Where the answers actually are
+
+`loro.dev` and `deepwiki.com` are blocked by this environment's egress
+proxy. Do not build a claim on a search-result summary of them. The
+reachable, version-exact sources are all inside the installed package:
+
+```bash
+D=$(dirname $(node -e "console.log(require.resolve('loro-crdt/package.json'))"))
+sed -n '/getOrCreateContainer/,+20p' "$D"/nodejs/loro_wasm.d.ts   # the deprecation, in full
+grep -i -B4 -A10 mergeable "$D"/CHANGELOG.md                       # when and why it changed
+```
+
+The typings carry the semantics no summary does — that activation writes a
+binary marker into the parent map slot, that a different `ensureMergeable*`
+kind at a live key is a deliberate kind change, that deleting the key hides
+the child but preserves its state and re-ensuring resurfaces it.
+
+## Measuring a Loro claim
+
+Put the probe where `loro-crdt` resolves. Node resolves bare specifiers
+from the SCRIPT's directory, so a script in `tmp/scripts/` fails with
+`ERR_MODULE_NOT_FOUND` however you invoke it; write it under
+`packages/loro-adapter/` and delete it after, or better, write it as the
+test it is about to become.
+
+**Calibrate the instrument first.** `doc.version().toJSON()` answers `{}`
+in 1.13.6, so a probe built on it reports "no ops emitted" for a write that
+definitely emitted one — which reads as a finding. `doc.frontiers()` is the
+one that moves:
+
+```js
+const fr = (d) => JSON.stringify(d.frontiers())
+const before = fr(doc); doc.getMap('m').set('a', 1); doc.commit()
+console.log('a write moves the frontier:', before !== fr(doc))  // must be true
+```
+
+That calibration caught a wrong conclusion here: opening a container LOOKED
+free, and it is an op on both a root map and a tree node's data map. The
+`attachContentContainers` rationale in `loro-bridge.ts` stands because of
+it.
+
+The standing shape for a convergence question — used by
+`comment-threads.convergence.test.ts` — is two peers with **a common
+ancestor that does not contain the key**, each writing something the other
+cannot produce, then importing both ways. Assert on the merged content of
+both replicas; "they converged" alone passes when both converged on the
+loss.
+
+## What this repo already does right
+
+Do not rediscover these; they are wired and tested.
+
+- **Batching.** `withSpatialBatch` owns the commit boundary for a user
+  action. A write helper called under it must not commit — an extra commit
+  splits one action into two undo steps. That is why `comment-threads.ts`
+  has both `writeCommentThread` (commits) and `writeThreadInto` (does not).
+- **Export modes.** `mode: 'update'` with a `VersionVector` for the
+  incremental path, `'snapshot'` for stored state, `'shallow-snapshot'`
+  with a frontier for compaction (`document-store.ts`). The delta log is
+  what the scoreboard above prices.
+- **Rich-text marks.** `configureTextStyle` REPLACES the config rather than
+  adding to it, so the complete set is configured at once —
+  `markThreadPassages` derives it from every thread it can see, so no call
+  site can forget. A mark belongs to the CHARACTERS: it follows edits and
+  vanishes with its passage, which is why `writeMarkdownBody` splices
+  minimally instead of rewriting the body.
+- **Undo/redo needs 1.13.6.** 1.13.6 fixes *"undo/redo restoring mergeable
+  map children as regular non-mergeable containers"*. This repo runs an
+  `UndoManager`, so the mergeable path and that floor travel together.

--- a/.claude/skills/loro-crdt-usage/SKILL.md
+++ b/.claude/skills/loro-crdt-usage/SKILL.md
@@ -151,7 +151,7 @@ Do not rediscover these; they are wired and tested.
   incremental path, `'snapshot'` for stored state, `'shallow-snapshot'`
   with a frontier for compaction (`document-store.ts`). The delta log is
   what the scoreboard above prices.
-- **Rich-text marks.** `configureTextStyle` REPLACES the config rather than
+- **Rich-text marks.** `configTextStyle` REPLACES the config rather than
   adding to it, so the complete set is configured at once —
   `markThreadPassages` derives it from every thread it can see, so no call
   site can forget. A mark belongs to the CHARACTERS: it follows edits and

--- a/packages/loro-adapter/src/comment-threads.convergence.test.ts
+++ b/packages/loro-adapter/src/comment-threads.convergence.test.ts
@@ -1,0 +1,64 @@
+/**
+ * What happens when two replicas open the SAME thread container first.
+ *
+ * A thread's key is not minted by the writer — it is the caller's comment id
+ * (`writeCommentInto` passes it straight through, and `deleteCommentInto`
+ * looks the thread up by it). So two keepers can genuinely reach
+ * `writeThreadInto` with the same key having never seen each other's: the
+ * daemon and this browser's replica each running
+ * `migrateCanvasCommentsToThreads` over the same legacy comment, or each
+ * applying a `comment.add` for one id.
+ *
+ * Under `getOrCreateContainer` that is silent loss. Measured on loro-crdt
+ * 1.13.6: two peers writing distinct entries into a container they each
+ * created at one key converge on ONE of the two containers, and the other
+ * side's entries are gone — no conflict, no error, and both replicas agree
+ * on the truncated result, which is what makes it unfindable afterwards.
+ */
+
+import type { CommentThread } from '@kamiazya/whiteboard-model'
+import { LoroDoc } from 'loro-crdt'
+import { describe, expect, it } from 'vitest'
+import { readCommentThreads, writeCommentThread } from './comment-threads.js'
+
+const ANCHOR = { kind: 'spatial', nodeId: 'n1', x: 10, y: 20 } as const
+
+function threadFrom(messageId: string, body: string): CommentThread {
+  return { id: 'shared-id', anchor: ANCHOR, status: 'open', messages: [{ id: messageId, body }] }
+}
+
+/** Two replicas that have never seen the key, each writing the same thread. */
+function replicasThatBothOpenTheThread(): { a: LoroDoc; b: LoroDoc } {
+  const a = new LoroDoc()
+  a.setPeerId(1)
+  const b = new LoroDoc()
+  b.setPeerId(2)
+  // A common ancestor that does NOT contain the thread, so neither side is
+  // merely writing into a container the other already made.
+  a.getMap('nodes').set('n1', { id: 'n1' })
+  a.commit()
+  b.import(a.export({ mode: 'snapshot' }))
+
+  writeCommentThread(a, threadFrom('m-a', 'from the daemon'))
+  writeCommentThread(b, threadFrom('m-b', 'from the browser'))
+
+  a.import(b.export({ mode: 'update' }))
+  b.import(a.export({ mode: 'update' }))
+  return { a, b }
+}
+
+describe('two replicas opening one thread container', () => {
+  it('keeps both sides messages instead of hiding one behind the other', () => {
+    const { a } = replicasThatBothOpenTheThread()
+
+    const bodies = readCommentThreads(a).flatMap((t) => t.messages.map((m) => m.body))
+
+    expect(bodies.sort()).toEqual(['from the browser', 'from the daemon'])
+  })
+
+  it('converges: both replicas read the same thing', () => {
+    const { a, b } = replicasThatBothOpenTheThread()
+
+    expect(readCommentThreads(a)).toEqual(readCommentThreads(b))
+  })
+})

--- a/packages/loro-adapter/src/comment-threads.ts
+++ b/packages/loro-adapter/src/comment-threads.ts
@@ -11,6 +11,7 @@ import {
 } from '@kamiazya/whiteboard-model'
 import { LoroMap } from 'loro-crdt'
 import { COMMENTS_KEY, type DocumentContainers, THREADS_KEY } from './containers.js'
+import { openMergeableMap } from './mergeable-containers.js'
 
 /** The nested map of messages inside one thread's container. */
 const MESSAGES_KEY = 'messages'
@@ -52,13 +53,16 @@ function assertFiniteAnchor(thread: CommentThread): void {
 /**
  * Creates or replaces one thread's own fields and writes its messages.
  *
- * `getOrCreateContainer` and not `setContainer`: the latter REPLACES the
- * container, discarding whatever a peer put in it. Creating one is still the
- * only path allowed to open a thread container at all — measured on
- * loro-crdt 1.13.6, two replicas that create a container under the same key
- * with no common ancestor merge to ONE of them and the other side's entries
- * are gone. Creation mints its own id and cannot collide; every other write
- * below therefore refuses to open a container it did not find.
+ * `openMergeableMap` and not `setContainer`: the latter REPLACES the
+ * container, discarding whatever a peer put in it.
+ *
+ * Creating one is still the only path allowed to open a thread container at
+ * all, even though `openMergeableMap` now makes two replicas opening one key
+ * converge rather than hide one another. The reason is no longer convergence
+ * but INTENT: a reply to a thread this replica does not hold is a reply to
+ * something that was never created here, and materialising an anchorless,
+ * statusless thread around it would turn a lost import into a half-formed
+ * conversation. `writeThreadMessage` returns without writing instead.
  */
 export function writeCommentThread(doc: DocumentContainers, thread: CommentThread): void {
   writeThreadInto(doc, thread)
@@ -73,11 +77,11 @@ export function writeCommentThread(doc: DocumentContainers, thread: CommentThrea
  */
 export function writeThreadInto(doc: DocumentContainers, thread: CommentThread): void {
   assertFiniteAnchor(thread)
-  const container = doc.getMap(THREADS_KEY).getOrCreateContainer(thread.id, new LoroMap())
+  const container = openMergeableMap(doc.getMap(THREADS_KEY), thread.id)
   container.set(ANCHOR_FIELD, thread.anchor)
   container.set(STATUS_FIELD, thread.status)
   if (thread.createdAt !== undefined) container.set(CREATED_AT_FIELD, thread.createdAt)
-  const messages = container.getOrCreateContainer(MESSAGES_KEY, new LoroMap())
+  const messages = openMergeableMap(container, MESSAGES_KEY)
   for (const message of thread.messages) messages.set(message.id, messageToFields(message))
 }
 
@@ -96,9 +100,7 @@ export function writeThreadMessage(
 ): void {
   const container = threadContainer(doc, threadId)
   if (container === undefined) return
-  container
-    .getOrCreateContainer(MESSAGES_KEY, new LoroMap())
-    .set(message.id, messageToFields(message))
+  openMergeableMap(container, MESSAGES_KEY).set(message.id, messageToFields(message))
   doc.commit()
 }
 

--- a/packages/loro-adapter/src/loro-bridge.ts
+++ b/packages/loro-adapter/src/loro-bridge.ts
@@ -871,7 +871,8 @@ export function readDocumentKind(doc: DocumentContainers): DocumentKind | undefi
  * an OP — a workspace tree node's meta map, unlike a doc's roots, which are
  * implicit. Such a host must pre-attach these when the document node is
  * created: otherwise the first READ of a missing container attaches it via
- * `getOrCreateContainer`, and that stray local op clears the UndoManager's
+ * `openMergeableMap`/`openMergeableText`, and that stray local op clears the
+ * UndoManager's
  * redo stack. Measured: create → undo → read → redo left the document empty,
  * while the same sequence without the read redid fine.
  *

--- a/packages/loro-adapter/src/mergeable-containers.test.ts
+++ b/packages/loro-adapter/src/mergeable-containers.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Which lazily-created containers are mergeable, and which deliberately are
+ * not.
+ *
+ * `openMergeable*` fixes a real class of silent loss (see
+ * `comment-threads.convergence.test.ts`), and it is not free: a mergeable
+ * child's id is deterministic rather than an op id, and every write into one
+ * encodes that. Measured with the whole package on it, against
+ * `workspace-record-growth.test.ts`'s scoreboard:
+ *
+ * | scoreboard number      | regular | mergeable | delta  |
+ * |------------------------|---------|-----------|--------|
+ * | one document, no edits | 919 B   | 1069 B    | +16.3% |
+ * | 10 docs x 100 edits    | 178560 B| 211860 B  | +18.6% |
+ *
+ * Attributed rather than assumed: reverting `workspace-tree.ts` alone put
+ * every number back, so the whole cost is the per-document CONTENT
+ * containers and the thread plane's share of it is zero.
+ *
+ * That is why the swap is not blanket. A document's content containers are
+ * pre-attached by whoever creates the document (`attachContentContainers`
+ * over `CONTENT_CONTAINER_KEYS`), so they travel in the op log and a second
+ * replica never opens one first — the hazard is already closed there, and
+ * paying 18.6% of the delta log to close it twice would be paid by the
+ * compaction subsystem forever. A thread's key is the caller's comment id
+ * and nothing pre-attaches it, so there the hazard is real and the cost is
+ * nil.
+ *
+ * The scan below is what keeps that a decision. A container opened the
+ * regular way is fine where it is reasoned about; a NEW one, written by
+ * habit next to the existing ones, would reopen the loss in silence.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { LoroDoc, LoroMap } from 'loro-crdt'
+import { describe, expect, it } from 'vitest'
+import {
+  openMergeableMap,
+  openMergeableMovableList,
+  openMergeableText,
+} from './mergeable-containers.js'
+
+/**
+ * Files allowed to open a REGULAR child container, with why and how many.
+ *
+ * The count is pinned by equality on purpose: a ninth call in
+ * `workspace-tree.ts` is a new lazily-created container, which is exactly
+ * the decision this file exists to force someone to take.
+ */
+const REGULAR_CONTAINER_SITES: Record<string, { calls: number; reason: string }> = {
+  'mergeable-containers.ts': {
+    calls: 3,
+    reason:
+      'the helper itself: an occupied key keeps the behaviour it had, because ensureMergeable* throws on one',
+  },
+  'workspace-tree.ts': {
+    calls: 9,
+    reason:
+      "a document's content containers, pre-attached at creation from CONTENT_CONTAINER_KEYS so no replica opens one first; mergeable costs 18.6% of the delta log here for a hazard that is already closed",
+  },
+}
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) return sourceFiles(full)
+    return entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts') ? [full] : []
+  })
+}
+
+/** Calls only — the word appears in prose in several files that make none. */
+function countCalls(source: string): number {
+  return (source.match(/\.getOrCreateContainer\(/g) ?? []).length
+}
+
+const CALLS_BY_FILE = new Map(
+  sourceFiles(new URL('.', import.meta.url).pathname)
+    .map(
+      (path) =>
+        [path.slice(path.lastIndexOf('/') + 1), countCalls(readFileSync(path, 'utf8'))] as const,
+    )
+    .filter(([, calls]) => calls > 0),
+)
+
+describe('regular container sites', () => {
+  it('scanned a plausible number of files', () => {
+    // A regex that stops matching would otherwise report itself as "every
+    // entry is stale", which sends the reader to the wrong file entirely.
+    expect(sourceFiles(new URL('.', import.meta.url).pathname).length).toBeGreaterThan(10)
+    expect(CALLS_BY_FILE.size).toBeGreaterThan(0)
+  })
+
+  it('opens a regular container only where a reason is recorded', () => {
+    expect([...CALLS_BY_FILE.keys()].sort()).toEqual(Object.keys(REGULAR_CONTAINER_SITES).sort())
+  })
+
+  it('records no more calls than the file makes, and no fewer', () => {
+    const declared = Object.fromEntries(
+      Object.entries(REGULAR_CONTAINER_SITES).map(([file, { calls }]) => [file, calls]),
+    )
+    expect(Object.fromEntries(CALLS_BY_FILE)).toEqual(declared)
+  })
+})
+
+describe('openMergeable*', () => {
+  it('adopts a container an earlier regular write already left at the key', () => {
+    // The whole reason for the helper: `ensureMergeable*` throws on a key
+    // holding a non-mergeable value, and every document stored before this
+    // change has exactly that.
+    const doc = new LoroDoc()
+    doc.getMap('m').getOrCreateContainer('k', new LoroMap()).set('written-before', 1)
+    doc.commit()
+
+    openMergeableMap(doc.getMap('m'), 'k').set('written-after', 2)
+    doc.commit()
+
+    expect(doc.toJSON().m.k).toEqual({ 'written-before': 1, 'written-after': 2 })
+  })
+
+  /**
+   * Two peers with a common ancestor that does NOT hold the key, each
+   * writing something the other cannot produce. Asserting on the merged
+   * CONTENT of both, because "they converged" alone passes when both
+   * converged on the loss.
+   */
+  function twoReplicas(): [LoroDoc, LoroDoc] {
+    const a = new LoroDoc()
+    a.setPeerId(1)
+    const b = new LoroDoc()
+    b.setPeerId(2)
+    a.getMap('m').set('seed', 1)
+    a.commit()
+    b.import(a.export({ mode: 'snapshot' }))
+    return [a, b]
+  }
+
+  function exchange(a: LoroDoc, b: LoroDoc): void {
+    a.commit()
+    b.commit()
+    a.import(b.export({ mode: 'update' }))
+    b.import(a.export({ mode: 'update' }))
+  }
+
+  it('merges a map two replicas created at once', () => {
+    const [a, b] = twoReplicas()
+    openMergeableMap(a.getMap('m'), 'k').set('a', 'a')
+    openMergeableMap(b.getMap('m'), 'k').set('b', 'b')
+
+    exchange(a, b)
+
+    expect(a.toJSON().m.k).toEqual({ a: 'a', b: 'b' })
+    expect(b.toJSON().m.k).toEqual({ a: 'a', b: 'b' })
+  })
+
+  it('merges a text two replicas created at once', () => {
+    const [a, b] = twoReplicas()
+    openMergeableText(a.getMap('m'), 'k').insert(0, 'a')
+    openMergeableText(b.getMap('m'), 'k').insert(0, 'b')
+
+    exchange(a, b)
+
+    // Both characters survive; which order the two concurrent inserts take
+    // is Loro's to decide, so only the SET is asserted.
+    expect([...String(a.toJSON().m.k)].sort()).toEqual(['a', 'b'])
+    expect(a.toJSON().m.k).toEqual(b.toJSON().m.k)
+  })
+
+  it('merges a movable list two replicas created at once', () => {
+    const [a, b] = twoReplicas()
+    openMergeableMovableList(a.getMap('m'), 'k').push('a')
+    openMergeableMovableList(b.getMap('m'), 'k').push('b')
+
+    exchange(a, b)
+
+    expect([...(a.toJSON().m.k as string[])].sort()).toEqual(['a', 'b'])
+    expect(a.toJSON().m.k).toEqual(b.toJSON().m.k)
+  })
+})

--- a/packages/loro-adapter/src/mergeable-containers.ts
+++ b/packages/loro-adapter/src/mergeable-containers.ts
@@ -1,0 +1,50 @@
+import { LoroMap, LoroMovableList, LoroText } from 'loro-crdt'
+
+/**
+ * The one way this package opens a lazily-created child container on a map.
+ *
+ * `getOrCreateContainer` mints a REGULAR op-id child, so two replicas that
+ * each open the same key having never seen the other's converge on ONE of
+ * the two containers and hide the other. Not a conflict and not an error:
+ * both sides agree on the truncated result, which is what makes the loss
+ * unfindable afterwards. loro-crdt deprecated it for this use in 1.13.0 and
+ * `ensureMergeable*` replaces it — a deterministic child id derived from
+ * `(parent, key, kind)`, so the two peers were editing one container all
+ * along.
+ *
+ * Measured on 1.13.6, two replicas each writing one entry at one key:
+ * `getOrCreateContainer` reads back `{fromB}` on both sides,
+ * `ensureMergeableMap` reads back `{fromA, fromB}`.
+ *
+ * Why a helper rather than the method: **`ensureMergeable*` throws on a key
+ * that already holds a non-mergeable value** — the container every document
+ * written before this change already has, and any scalar left at the key by
+ * corrupt data. So the mergeable branch is taken only for an ABSENT key, and
+ * an occupied one keeps the exact behaviour it had. That makes this safe to
+ * apply to stored documents without a migration: an old container is adopted
+ * and written through, and only a container created from here on is
+ * mergeable.
+ *
+ * `ensureMergeable*` lives on `LoroMap` alone, which is the whole shape of
+ * the problem — a list position is already a unique op, so only a map KEY
+ * needs two peers to agree on which child it names.
+ */
+export function openMergeableMap(map: LoroMap, key: string): LoroMap {
+  return map.get(key) === undefined
+    ? map.ensureMergeableMap(key)
+    : map.getOrCreateContainer(key, new LoroMap())
+}
+
+/** `openMergeableMap` for a text child. See it for why this shape. */
+export function openMergeableText(map: LoroMap, key: string): LoroText {
+  return map.get(key) === undefined
+    ? map.ensureMergeableText(key)
+    : map.getOrCreateContainer(key, new LoroText())
+}
+
+/** `openMergeableMap` for a movable-list child. See it for why this shape. */
+export function openMergeableMovableList(map: LoroMap, key: string): LoroMovableList {
+  return map.get(key) === undefined
+    ? map.ensureMergeableMovableList(key)
+    : map.getOrCreateContainer(key, new LoroMovableList())
+}

--- a/packages/loro-adapter/src/workspace-tree.test.ts
+++ b/packages/loro-adapter/src/workspace-tree.test.ts
@@ -555,6 +555,29 @@ describe('row-relocated meta (dual-plane collapse S4a)', () => {
     expect(readPinnedDocumentIds(doc)).toEqual([ULID_A])
   })
 
+  it('keeps both pins when two replicas pin first on a workspace nobody had pinned', () => {
+    // The list is opened lazily by the first pin — nothing pre-attaches it —
+    // so this is a first creation at one key on both sides. Opened the
+    // regular way the merge keeps one list and the other pin is gone, with
+    // both replicas agreeing on the truncated result.
+    const a = new LoroDoc()
+    a.setPeerId(1)
+    createWorkspaceDocumentAtPath(a, { path: 'a', documentId: ULID_A, kind: 'spatial' })
+    createWorkspaceDocumentAtPath(a, { path: 'b', documentId: ULID_B, kind: 'spatial' })
+    a.commit()
+    const b = new LoroDoc()
+    b.setPeerId(2)
+    b.import(a.export({ mode: 'snapshot' }))
+
+    setWorkspacePinned(a, ULID_A, true)
+    setWorkspacePinned(b, ULID_B, true)
+    a.import(b.export({ mode: 'update' }))
+    b.import(a.export({ mode: 'update' }))
+
+    expect([...readPinnedDocumentIds(a)].sort()).toEqual([ULID_A, ULID_B].sort())
+    expect(readPinnedDocumentIds(a)).toEqual(readPinnedDocumentIds(b))
+  })
+
   it('lastCompactedAt is workspace-level meta', () => {
     const doc = new LoroDoc()
     expect(readWorkspaceMeta(doc).lastCompactedAt).toBeUndefined()

--- a/packages/loro-adapter/src/workspace-tree.ts
+++ b/packages/loro-adapter/src/workspace-tree.ts
@@ -29,6 +29,7 @@ import { z } from 'zod'
 import type { DocumentContainers } from './containers.js'
 import { contentDigestOf } from './content-digest.js'
 import { CONTENT_CONTAINER_KEYS } from './loro-bridge.js'
+import { openMergeableMovableList } from './mergeable-containers.js'
 
 /** The one root container a workspace document has. */
 export const WORKSPACE_TREE_KEY = 'tree'
@@ -271,7 +272,7 @@ export function readPinnedDocumentIds(doc: LoroDoc): string[] {
 export function setWorkspacePinned(doc: LoroDoc, documentId: string, pinned: boolean): void {
   documentIdSchema.parse(documentId)
   const map = workspaceMetaMap(doc)
-  const list = map.getOrCreateContainer(PINNED_KEY, new LoroMovableList())
+  const list = openMergeableMovableList(map, PINNED_KEY)
   const index = list.toArray().indexOf(documentId)
   if (pinned) {
     // Idempotent: re-pinning keeps the position it already has.


### PR DESCRIPTION
## What

Two containers in this package are opened **lazily**, by whoever writes to them first, and both were opened the way loro-crdt deprecated in 1.13.0. When two replicas open one first, the merge keeps one container and the other side's writes are gone.

- **A comment thread.** Its key is not minted by the writer — it is the caller's comment id, which `writeCommentInto` passes straight through and `deleteCommentInto` looks the thread up by. The daemon and a browser replica each migrating the same legacy comment, or each applying one `comment.add`, reach `writeThreadInto` with the same key having never seen the other's.
- **The pinned-document list.** Nothing pre-attaches it, so two replicas pinning first on a workspace nobody had pinned is the same shape.

## The measurement

Two peers, a common ancestor that does not hold the key, each writing one entry — loro-crdt 1.13.6:

| opened with | both replicas read back |
|---|---|
| `getOrCreateContainer` | `{"fromB": "reply B"}` |
| `ensureMergeableMap` | `{"fromA": "reply A", "fromB": "reply B"}` |

No conflict, no error, and **both replicas agree on the truncated result** — which is what makes it unfindable afterwards. `comment-threads.convergence.test.ts` is that measurement as a permanent test; its second case (`both replicas read the same thing`) passes either way, which is exactly the point. `workspace-tree.test.ts` carries the pinning case, where the same defect reads back one pin instead of two.

loro-crdt says so itself. 1.13.0's CHANGELOG: *"`getOrCreateContainer` is deprecated for lazy map-child creation; migrate those call sites to `ensureMergeable*`."*

## Why a helper, not the bare method

`ensureMergeable*` **throws** on a key already holding a non-mergeable value — `Cannot create a mergeable Map at key "k": the key already holds a non-mergeable value` — which is every document written before this change. `mergeable-containers.ts` takes the mergeable branch only for an **absent** key and leaves an occupied one exactly as it was, so this is safe on stored data with no migration.

## Why it is deliberately not blanket

Switching the whole package moved `workspace-record-growth`'s scoreboard:

| scoreboard | regular | mergeable | delta |
|---|---|---|---|
| one document, no edits | 919 B | 1069 B | +16.3% |
| 10 documents × 100 edits (delta log) | 178560 B | 211860 B | +18.6% |

**Attributed, not assumed**: reverting `workspace-tree.ts` alone put every number back, so the whole cost is the per-document CONTENT containers — which `attachContentContainers` pre-attaches at creation, so no replica opens one first. Paying 18.6% of the delta log forever to close a hazard that is already closed is a bad trade. The two containers that did move are per-thread and per-workspace rather than per-edit, and cost zero on the scoreboard — measured separately, with the pinned list applied alone.

`mergeable-containers.test.ts` registers each remaining regular call with a reason and a pinned count, so a new lazily-created container fails the suite until someone decides which kind it is.

## Also

- `.claude/rules/package-loro-adapter.md` claimed a thread container's id *"is minted, and cannot collide"*. That was wrong, and is what let this stand — corrected with the measurement behind it.
- New `loro-crdt-usage` skill: the version-exact facts, what a container choice costs, where the authoritative answers live (loro.dev is unreachable from this environment; the typings and CHANGELOG ship inside the package), and how to calibrate a probe.

## Mutation checks

| mutation | result |
|---|---|
| thread container back to `getOrCreateContainer` | `1 failed \| 1 passed` |
| pinned list back to `getOrCreateContainer` | `1 failed \| 28 passed` — reads `['01BX5ZZ…']`, one pin lost |
| helper drops its compatibility branch | `2 failed \| 5 passed` |
| a tenth regular call appears in `workspace-tree.ts` | `1 failed \| 6 passed` |
| a regular call in an unregistered file | `2 failed \| 5 passed` |
| baseline | `7 passed` / `2 passed` / `29 passed` |

## Gates

`loro-adapter-node` 231 · `mcp-node`+`loro-adapter-node` 4221 · `arch-lint-node` 131 · `apps/web` (CI's `test-jsdom` command) 3703 + 88 · `pnpm -r typecheck` · `pnpm lint` · `pnpm lint:noconsole` · `pnpm knip` — all clean.

Visual evidence: none — a CRDT merge defect has no pixels. The evidence is the convergence tests' before/after values above, which a reviewer can re-run.

## A wrong conclusion this nearly shipped

The first probe reported that opening a container emits **no ops**, which would have made `attachContentContainers`'s whole rationale obsolete. It was the instrument: `doc.version().toJSON()` answers `{}` in 1.13.6. `doc.frontiers()` is the one that moves, and calibrated against a known write, opening a container **is** an op on both a root map and a tree node. That trap is in the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2