### PR TITLE
fix(web): use-keyboard-avoidance tests run in jsdom again — main was red

### DIFF
--- a/apps/web/src/components/spatial-editor/use-keyboard-avoidance.test.ts
+++ b/apps/web/src/components/spatial-editor/use-keyboard-avoidance.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment node
 // The occlusion arithmetic behind keyboard avoidance: client rects are
 // layout-viewport coordinates and the visual viewport's offsetTop + height
 // is its bottom edge in the same space, so the covered strip is whatever of


### PR DESCRIPTION
## What

#1360 stamped `// @vitest-environment node` onto `use-keyboard-avoidance.test.ts`, whose `keyboardAvoidanceSubject` cases build real elements (`document.createElement` + `appendChild`) — so **main's `test-jsdom` is red** since it merged (`ReferenceError: document is not defined`, 3 tests, reproduced on a clean checkout of main; the latest main CI run is `failure`, #1360's own was `cancelled`). Surfaced on #1383's post-merge run, which inherited it.

The header comes off; nothing else changes. The other three files #1360 stamped (`editor-focus-discipline`, `keeper-parity`, `persistent-storage`) are genuinely DOM-free — their only matches for DOM words are comments, strings, and a regex — verified before scoping the fix to this one file.

## Verification

Red on main confirmed locally (3 failed), 6/6 after removing the header.

Visual evidence: none — env-header fix for a red main; the before/after test run is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D
