### PR TITLE
feat(annotations): the hand tool's right-click and touch long-press open the annotation verbs, and nothing else

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -528,7 +528,19 @@ does too. A press on comment chrome opens it under EITHER tool — the hand
 tool takes every plain press as a pan, but a comment is chrome, not content,
 and the release decides: a press that never travelled past the slop opens
 the card, one that travelled was the pan (hand) or the pin drag (select) it
-became on its first move. The press arms nothing visible until then, on
+became on its first move. The same line runs through the hand tool's MENU:
+a right-click, or a stationary touch long-press, opens the context menu
+there too, carrying the annotation layer's verb for what is under the press
+and nothing else — "Comment here" on a spot, "Comment on this" on a node or
+an edge, a comment's own lifecycle on its bubble — and the press selects
+nothing on the way (`context-menu-items/annotation-verbs.tsx` is the one
+definition those rows and the Select menus share). The hand tool used to
+open no menu at all, because an EDIT affordance surfacing mid-pan was the
+harm on a phone; a comment verb is not one, and a reader panning around a
+canvas has as much reason to talk about it as one selecting on it. The
+long-press timer is armed under the hand tool for the same reason, and it
+strands no pan: a finger that travels clears it before it fires, and one
+that does not has not panned. The press arms nothing visible until then, on
 purpose: arming the pin drag at the press took the committed copy out of the
 surface under a touch pointer implicitly captured on it, and its release
 then died on a detached node — every later tap replayed the stale press.

--- a/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasContextMenu.tsx
@@ -18,6 +18,7 @@ import { verbCatalogItems } from '../markdown-editor/verb-catalog.js'
 import type { BoxMove } from './align.js'
 import { alignableBoxesOf } from './align.js'
 import { ContextMenu, type ContextMenuItem } from './ContextMenu.js'
+import { annotationVerbItems } from './context-menu-items/annotation-verbs.js'
 import { canvasMenuItems } from './context-menu-items/canvas-menu-items.js'
 import { commentMenuItems } from './context-menu-items/comment-menu-items.js'
 import { edgeMenuItems } from './context-menu-items/edge-menu-items.js'
@@ -35,6 +36,12 @@ export interface ContextMenuTarget {
   readonly point: Point
   /** The ⋯ control opens the same catalog in the icon-grid or sheet vessel. */
   readonly variant?: 'list' | 'grid' | 'sheet'
+  /**
+   * The hand tool's menu: the annotation layer's verb for what is under the
+   * press and nothing else. Panning keeps content out of reach; a
+   * conversation about it is not content (`annotation-verbs.tsx`).
+   */
+  readonly verbs?: 'annotation'
   /**
    * A right-click INSIDE a node's text editor: the menu is the editing
    * catalog for that text (the note editor's own), not the canvas's. The
@@ -247,74 +254,83 @@ export function CanvasContextMenu({
         })
       : comment !== undefined
         ? commentMenuItems({ comment, canvasRef, edgePathOf, setCommentCompose, applyResult })
-        : node === undefined && edge !== undefined
-          ? edgeMenuItems({
+        : contextMenu.verbs === 'annotation'
+          ? annotationVerbItems({
+              node,
               edge,
               point: contextMenu.point,
               setCommentCompose,
-              theme,
-              isEdgeLocked,
-              edgeLockEnabled,
-              applyResult,
-              setEdgeLabelEditId,
-              setSelectedEdgeId,
-              onToggleEdgeLock,
+              showResolvedComments,
+              setShowResolvedComments,
             })
-          : node === undefined
-            ? canvasMenuItems({
+          : node === undefined && edge !== undefined
+            ? edgeMenuItems({
+                edge,
                 point: contextMenu.point,
-                canvas,
-                canvasRef,
-                isLocked,
-                fileRefOptions,
-                onAddImage,
-                pendingImagePointRef,
-                imageInputRef,
-                pasteClipboard,
-                createNodeAt,
-                setLinkDialog,
-                createGroupAtViewportCenter,
-                setDocumentPicker,
-                applyBoxMoves,
                 setCommentCompose,
-                showResolvedComments,
-                setShowResolvedComments,
-              })
-            : nodeMenuItems({
-                node,
-                canvas,
-                canvasRef,
                 theme,
-                gestureState,
-                isLocked,
-                lockEnabled,
                 isEdgeLocked,
-                extraIds,
-                selectedId,
-                isImageFileRef,
-                missingFileRef,
-                fileRefOptions,
-                facetRegistry,
-                selectedAlignableBoxes,
-                pendingBackgroundGroupIdRef,
-                imageInputRef,
+                edgeLockEnabled,
                 applyResult,
-                applyBoxMoves,
-                copySelection,
-                cutSelection,
-                duplicateSelection,
-                reorderSelection,
-                groupSelection,
-                openLinkNode,
-                onOpenFileRef,
-                onAddImage,
-                onToggleNodeLock,
-                setGroupLabelEditId,
-                setLinkDialog,
-                setDocumentPicker,
-                setFacetPanelOpen,
-                setCommentCompose,
+                setEdgeLabelEditId,
+                setSelectedEdgeId,
+                onToggleEdgeLock,
               })
+            : node === undefined
+              ? canvasMenuItems({
+                  point: contextMenu.point,
+                  canvas,
+                  canvasRef,
+                  isLocked,
+                  fileRefOptions,
+                  onAddImage,
+                  pendingImagePointRef,
+                  imageInputRef,
+                  pasteClipboard,
+                  createNodeAt,
+                  setLinkDialog,
+                  createGroupAtViewportCenter,
+                  setDocumentPicker,
+                  applyBoxMoves,
+                  setCommentCompose,
+                  showResolvedComments,
+                  setShowResolvedComments,
+                })
+              : nodeMenuItems({
+                  node,
+                  canvas,
+                  canvasRef,
+                  theme,
+                  gestureState,
+                  isLocked,
+                  lockEnabled,
+                  isEdgeLocked,
+                  extraIds,
+                  selectedId,
+                  isImageFileRef,
+                  missingFileRef,
+                  fileRefOptions,
+                  facetRegistry,
+                  selectedAlignableBoxes,
+                  pendingBackgroundGroupIdRef,
+                  imageInputRef,
+                  applyResult,
+                  applyBoxMoves,
+                  copySelection,
+                  cutSelection,
+                  duplicateSelection,
+                  reorderSelection,
+                  groupSelection,
+                  openLinkNode,
+                  onOpenFileRef,
+                  onAddImage,
+                  onToggleNodeLock,
+                  setGroupLabelEditId,
+                  setLinkDialog,
+                  setDocumentPicker,
+                  setFacetPanelOpen,
+                  setCommentCompose,
+                })
 
   return (
     <ContextMenu

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -810,10 +810,12 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
      * the press started (a node move's 'pressing' state, marquee arming):
      * the press has become a menu invocation, not a drag.
      *
-     * The navigation machine decides WHETHER to arm — hand mode never does,
-     * because the press below it starts a pan and this teardown would strand
-     * it mid-drag — and the timer itself stays here, where the menu, the
-     * haptic and the pulse live.
+     * The navigation machine decides WHETHER to arm (a second finger never
+     * does), and the timer itself stays here, where the menu, the haptic
+     * and the pulse live. Under the hand tool the press below started a
+     * pan; a finger still enough for the timer to fire never advanced it,
+     * so the teardown strands nothing — a finger that moves clears the
+     * timer before it can fire (see handlePointerMove).
      */
     const armLongPress = (pointerId: number, screen: Point) => {
       clearLongPress()
@@ -834,6 +836,9 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           gestureTrace.recordReset('long-press-menu', Math.round(performance.now()))
           lastPressRef.current = null
           doublePressRef.current = null
+          // The press is spent on the menu: the release that follows must
+          // not ALSO open the card of the comment it landed on.
+          pressedCommentRef.current = null
           // The native long-press this replaces gave a system haptic; keep
           // that cue so the menu opening under a still-down finger reads as
           // deliberate, not glitchy.
@@ -1164,11 +1169,6 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     }
 
     const openContextMenuAt = (screenPoint: Point) => {
-      // Hand mode is navigation-ONLY: surfacing the edit menu on a touch
-      // long-press there made phone panning fall into editing mid-gesture
-      // (user report 2026-08-08). Switching to Select is the explicit gate
-      // into editing affordances.
-      if (tool === 'hand') return
       const point = screenToCanvas(screenPoint, viewport)
       // A comment under the pointer gets ITS menu — and leaves the node or
       // edge selection alone, since the menu is about the comment.
@@ -1188,6 +1188,31 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
       // to stay right-clickable or Unlock would be unreachable. Only the
       // selection side effect below is skipped for it.
       const hitId = hitTest(boxes, point)
+      // Hand mode keeps CONTENT out of reach — a press pans, nothing
+      // selects, nothing edits — but a conversation about what is on screen
+      // is not content, and a reader panning has as much reason to open one
+      // as a reader selecting. So the menu opens with the annotation verb
+      // for what is under the press and nothing else, and the press selects
+      // nothing along the way: an editing affordance surfacing mid-pan was
+      // the harm (user report 2026-08-08), and a comment verb is not one.
+      if (tool === 'hand') {
+        const hitEdge =
+          hitId === undefined
+            ? edgePaths.find(
+                (edge) =>
+                  distanceToPolyline(point, edge.path) <= EDGE_HIT_TOLERANCE_PX / viewport.zoom,
+              )
+            : undefined
+        setContextMenu({
+          x: screenPoint.x,
+          y: screenPoint.y,
+          nodeId: hitId,
+          edgeId: hitEdge?.id,
+          point,
+          verbs: 'annotation',
+        })
+        return
+      }
       // Node and edge selection stay mutually exclusive here too (see the
       // pointerdown path): Delete acts on a selected edge FIRST, so leaving
       // the other object type selected makes Delete remove the wrong thing.

--- a/apps/web/src/components/spatial-editor/context-menu-items/annotation-verbs.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu-items/annotation-verbs.tsx
@@ -1,0 +1,117 @@
+/**
+ * The annotation layer's rows, defined once and worn by three menus.
+ *
+ * Under Select each object's menu carries its own comment verb among its
+ * edit verbs — a node's beside Lock, an edge's beside Edit label, empty
+ * space's after the creation set. Under the hand tool the SAME rows are the
+ * whole menu: panning keeps content out of reach (a press pans, nothing
+ * selects, nothing edits) while a conversation about what is on screen
+ * stays one right-click or long-press away, exactly as it is under Select.
+ * One definition per row is what keeps the two readings equal — a verb
+ * added to one menu and not the other is the drift the surface-parity
+ * matrix exists to catch, one level up.
+ */
+import type { CanvasEdge, SpatialNode } from '@kamiazya/whiteboard-model'
+import { Eye, EyeOff, MessageSquare, MessageSquarePlus } from 'lucide-react'
+import type { Point } from '../../../lib/spatial/viewport.js'
+import type { CanvasCommands } from '../CanvasContextMenu.js'
+import type { ContextMenuItem } from '../ContextMenu.js'
+
+type SetCommentCompose = CanvasCommands['setCommentCompose']
+
+/**
+ * Anchored at the node's top-right corner, the same convention the MCP
+ * `comment` op uses, so a comment reads the same whoever made it. A comment
+ * is ABOUT the node and never touches it, which is why it is the one verb a
+ * LOCKED node keeps beside Unlock — and the one the hand tool keeps at all.
+ */
+export function commentOnNodeItem(
+  node: SpatialNode,
+  setCommentCompose: SetCommentCompose,
+): ContextMenuItem {
+  return {
+    label: 'Comment on this',
+    icon: <MessageSquarePlus />,
+    onSelect: () =>
+      setCommentCompose({
+        point: { x: node.x + node.width, y: node.y },
+        targetNodeId: node.id,
+      }),
+  }
+}
+
+/**
+ * The point pressed is what the comment stores, and the layer pins it on
+ * the edge's routed path from there (canvas-render's `commentAnchor`), so
+ * it rides a reroute.
+ */
+export function commentOnEdgeItem(
+  edge: CanvasEdge,
+  point: Point,
+  setCommentCompose: SetCommentCompose,
+): ContextMenuItem {
+  return {
+    label: 'Comment on this',
+    icon: <MessageSquare />,
+    onSelect: () =>
+      setCommentCompose({
+        point: { x: Math.round(point.x), y: Math.round(point.y) },
+        targetEdgeId: edge.id,
+      }),
+  }
+}
+
+/** A comment about a spot: anchored at the pressed point, about no object. */
+export function commentHereItem(
+  point: Point,
+  setCommentCompose: SetCommentCompose,
+): ContextMenuItem {
+  return {
+    label: 'Comment here',
+    icon: <MessageSquarePlus />,
+    onSelect: () => setCommentCompose({ point }),
+  }
+}
+
+/**
+ * Resolved comments stay in the document; this is the one way to see them
+ * again (and reopen one). View state, per user (ADR-0025 decision 2).
+ */
+export function resolvedCommentsItem(
+  showResolvedComments: boolean,
+  setShowResolvedComments: CanvasCommands['setShowResolvedComments'],
+): ContextMenuItem {
+  return {
+    label: showResolvedComments ? 'Hide resolved comments' : 'Show resolved comments',
+    icon: showResolvedComments ? <EyeOff /> : <Eye />,
+    onSelect: () => setShowResolvedComments(!showResolvedComments),
+  }
+}
+
+export interface AnnotationVerbItemsInput {
+  /** The node under the press, if any: its verb is the menu. */
+  readonly node: SpatialNode | undefined
+  /** The edge under the press when no node is: its verb is the menu. */
+  readonly edge: CanvasEdge | undefined
+  readonly point: Point
+  readonly setCommentCompose: SetCommentCompose
+  readonly showResolvedComments: boolean
+  readonly setShowResolvedComments: CanvasCommands['setShowResolvedComments']
+}
+
+/** The hand tool's whole menu: the annotation verb for what is under the press. */
+export function annotationVerbItems({
+  node,
+  edge,
+  point,
+  setCommentCompose,
+  showResolvedComments,
+  setShowResolvedComments,
+}: AnnotationVerbItemsInput): ContextMenuItem[] {
+  if (node !== undefined) return [commentOnNodeItem(node, setCommentCompose)]
+  if (edge !== undefined) return [commentOnEdgeItem(edge, point, setCommentCompose)]
+  return [
+    commentHereItem(point, setCommentCompose),
+    resolvedCommentsItem(showResolvedComments, setShowResolvedComments),
+  ]
+}

--- a/apps/web/src/components/spatial-editor/context-menu-items/canvas-menu-items.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu-items/canvas-menu-items.tsx
@@ -6,13 +6,10 @@ import { tidyNodes } from '@kamiazya/whiteboard-canvas-render'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import {
   ClipboardPaste,
-  Eye,
-  EyeOff,
   FileBox,
   Frame,
   Image as ImageIcon,
   Link,
-  MessageSquarePlus,
   Sparkles,
   StickyNote,
 } from 'lucide-react'
@@ -23,6 +20,7 @@ import type { Point } from '../../../lib/spatial/viewport.js'
 import type { CanvasCommands } from '../CanvasContextMenu.js'
 import type { ContextMenuItem } from '../ContextMenu.js'
 import { CREATION_LABELS } from '../creation-labels.js'
+import { commentHereItem, resolvedCommentsItem } from './annotation-verbs.js'
 
 export interface CanvasMenuItemsInput {
   readonly point: Point
@@ -125,17 +123,7 @@ export function canvasMenuItems({
   // Its own band: a comment is not content, so it sits apart from the
   // creation set rather than reading as a sixth node kind.
   emptyItems.push({ kind: 'separator' })
-  emptyItems.push({
-    label: 'Comment here',
-    icon: <MessageSquarePlus />,
-    onSelect: () => setCommentCompose({ point }),
-  })
-  // Resolved comments stay in the document; this is the one way to see
-  // them again (and reopen one). View state, per user.
-  emptyItems.push({
-    label: showResolvedComments ? 'Hide resolved comments' : 'Show resolved comments',
-    icon: showResolvedComments ? <EyeOff /> : <Eye />,
-    onSelect: () => setShowResolvedComments(!showResolvedComments),
-  })
+  emptyItems.push(commentHereItem(point, setCommentCompose))
+  emptyItems.push(resolvedCommentsItem(showResolvedComments, setShowResolvedComments))
   return emptyItems
 }

--- a/apps/web/src/components/spatial-editor/context-menu-items/edge-menu-items.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu-items/edge-menu-items.tsx
@@ -6,7 +6,6 @@ import type { CanvasEdge } from '@kamiazya/whiteboard-model'
 import {
   Lock as LockIcon,
   LockOpen,
-  MessageSquare,
   PanelBottom,
   PanelLeft,
   PanelRight,
@@ -20,6 +19,7 @@ import type { Point } from '../../../lib/spatial/viewport.js'
 import type { ResolvedTheme } from '../../../lib/theme.js'
 import type { CanvasCommands } from '../CanvasContextMenu.js'
 import type { ContextMenuItem } from '../ContextMenu.js'
+import { commentOnEdgeItem } from './annotation-verbs.js'
 import { colorRow } from './color-row.js'
 
 export interface EdgeMenuItemsInput {
@@ -133,19 +133,7 @@ export function edgeMenuItems({
       icon: <Tag />,
       onSelect: () => setEdgeLabelEditId(edge.id),
     },
-    {
-      // The annotation layer's entry on an edge, beside the node's "Comment
-      // on this": the point pressed is what the comment stores, and the
-      // layer pins it on the edge's routed path from there (canvas-render's
-      // `commentAnchor`), so it rides a reroute.
-      label: 'Comment on this',
-      icon: <MessageSquare />,
-      onSelect: () =>
-        setCommentCompose({
-          point: { x: Math.round(point.x), y: Math.round(point.y) },
-          targetEdgeId: edge.id,
-        }),
-    },
+    commentOnEdgeItem(edge, point, setCommentCompose),
     ...(edgeLockEnabled
       ? [
           {

--- a/apps/web/src/components/spatial-editor/context-menu-items/node-menu-items.tsx
+++ b/apps/web/src/components/spatial-editor/context-menu-items/node-menu-items.tsx
@@ -45,6 +45,7 @@ import type { CanvasCommands } from '../CanvasContextMenu.js'
 import type { ContextMenuItem } from '../ContextMenu.js'
 import { nodePropertyItems } from '../facet-widgets/index.js'
 import { type GestureState, reduceGesture } from '../gestures.js'
+import { commentOnNodeItem } from './annotation-verbs.js'
 import { colorRow } from './color-row.js'
 
 export interface NodeMenuItemsInput {
@@ -124,19 +125,7 @@ export function nodeMenuItems({
   // 3. the destructive entry, alone at the bottom.
   const properties: ContextMenuItem[] = []
   const verbs: ContextMenuItem[] = []
-  // Anchored at the node's top-right corner, the same convention the MCP
-  // `comment` op uses, so a comment reads the same whoever made it. A
-  // comment is ABOUT the node and never touches it, which is why it is
-  // the one verb a LOCKED node keeps beside Unlock.
-  const commentOnThis: ContextMenuItem = {
-    label: 'Comment on this',
-    icon: <MessageSquarePlus />,
-    onSelect: () =>
-      setCommentCompose({
-        point: { x: node.x + node.width, y: node.y },
-        targetNodeId: node.id,
-      }),
-  }
+  const commentOnThis = commentOnNodeItem(node, setCommentCompose)
   if (node.type === 'group') {
     verbs.push({
       label: 'Edit label',

--- a/apps/web/src/components/spatial-editor/hand-comment.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/hand-comment.browser.test.tsx
@@ -7,7 +7,7 @@ import type { CanvasComment, CommentThread, SpatialCanvas } from '@kamiazya/whit
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
-import { page } from 'vitest/browser'
+import { page, userEvent } from 'vitest/browser'
 import type { EditorCommand } from '../../lib/spatial/commands.js'
 import { rootOf } from '../../test-utils/spatial-editor-root.js'
 import { SpatialEditor } from './SpatialEditor.js'
@@ -130,4 +130,93 @@ it('a press on the canvas shuts the card and stays shut, even though it also pan
   // The stale re-open this guards against happened AT the release, which
   // fireEvent flushed before returning: shut now is shut for good.
   expect(container.querySelector('[data-testid="comment-card"]')).toBeNull()
+})
+
+const menuLabels = (container: HTMLElement) =>
+  [...container.querySelectorAll('[role="menuitem"]')].map((item) => item.textContent?.trim())
+
+function touch(el: HTMLElement, type: string, x: number, y: number, pointerId = 7) {
+  const r = el.getBoundingClientRect()
+  el.dispatchEvent(
+    new PointerEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      clientX: r.left + x,
+      clientY: r.top + y,
+      pointerId,
+      pointerType: 'touch',
+      isPrimary: true,
+      button: type === 'pointerdown' ? 0 : -1,
+      buttons: type === 'pointerup' ? 0 : 1,
+    }),
+  )
+}
+
+// Panning is not a reason to be unable to talk about what is on the canvas.
+// The hand tool keeps CONTENT out of reach — a press pans, nothing selects,
+// nothing edits — while the annotation layer stays reachable the way it is
+// under Select: a right-click, or a stationary touch long-press, opens the
+// menu with the comment verbs alone.
+it('a right-click under the hand tool offers the annotation verbs alone, and selects nothing', async () => {
+  const { Host } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  await ready(container)
+  const r = root.getBoundingClientRect()
+
+  fireEvent.contextMenu(root, { clientX: r.left + 60, clientY: r.top + 560 })
+  expect(menuLabels(container)).toEqual(['Comment here', 'Show resolved comments'])
+  await userEvent.keyboard('{Escape}')
+  await vi.waitFor(() => expect(container.querySelector('[data-testid="context-menu"]')).toBeNull())
+
+  // Over the node: its comment verb, and none of its edit verbs — and the
+  // node is not selected by the press, since hand mode never selects.
+  fireEvent.contextMenu(root, { clientX: r.left + 200, clientY: r.top + 150 })
+  expect(menuLabels(container)).toEqual(['Comment on this'])
+  expect(container.querySelector('[data-testid="selection-overlay"]')).toBeNull()
+})
+
+it('Comment here from the hand-tool menu composes and commits a point-anchored comment', async () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  await ready(container)
+  const r = root.getBoundingClientRect()
+
+  fireEvent.contextMenu(root, { clientX: r.left + 60, clientY: r.top + 560 })
+  await userEvent.click(page.getByRole('menuitem', { name: 'Comment here' }))
+  await expect.element(page.getByTestId('comment-compose')).toBeInTheDocument()
+  await userEvent.keyboard('seen while panning')
+  await userEvent.keyboard('{Control>}{Enter}{/Control}')
+  await vi.waitFor(() =>
+    expect(latest.commands.map((entry) => entry.kind)).toContain('create-comment'),
+  )
+  expect(latest.commands[0]).toMatchObject({
+    kind: 'create-comment',
+    comment: { x: 60, y: 560, text: 'seen while panning' },
+  })
+})
+
+it('a stationary touch long-press under the hand tool opens the comment verbs, and lifting opens no card', async () => {
+  const { Host, latest } = makeHost()
+  const { container } = render(<Host />)
+  const root = rootOf(container)
+  await ready(container)
+  const before = transformOf(container)
+
+  // On the bubble: the comment's own menu (its lifecycle), and the release
+  // that follows the menu must not ALSO open the card — the press was
+  // spent on the menu.
+  touch(root, 'pointerdown', BUBBLE.x, BUBBLE.y)
+  await new Promise((resolve) => setTimeout(resolve, 650))
+  await vi.waitFor(() => expect(menuLabels(container)).toEqual(['Edit comment', 'Resolve']))
+  touch(root, 'pointerup', BUBBLE.x, BUBBLE.y)
+  // Closing the menu is the condition waited on: a card the release had
+  // opened would have rendered by the time the menu is gone, and a plain
+  // dispatch outside act() commits its render a tick later than the event.
+  await userEvent.keyboard('{Escape}')
+  await vi.waitFor(() => expect(container.querySelector('[data-testid="context-menu"]')).toBeNull())
+  expect(container.querySelector('[data-testid="comment-card"]')).toBeNull()
+  expect(transformOf(container)).toBe(before)
+  expect(latest.commands).toEqual([])
 })

--- a/apps/web/src/components/spatial-editor/hand-comment.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/hand-comment.browser.test.tsx
@@ -208,8 +208,10 @@ it('a stationary touch long-press under the hand tool opens the comment verbs, a
   // that follows the menu must not ALSO open the card — the press was
   // spent on the menu.
   touch(root, 'pointerdown', BUBBLE.x, BUBBLE.y)
-  await new Promise((resolve) => setTimeout(resolve, 650))
-  await vi.waitFor(() => expect(menuLabels(container)).toEqual(['Edit comment', 'Resolve']))
+  // Waited on as a condition: the menu is what the delay produces.
+  await vi.waitFor(() => expect(menuLabels(container)).toEqual(['Edit comment', 'Resolve']), {
+    timeout: 2000,
+  })
   touch(root, 'pointerup', BUBBLE.x, BUBBLE.y)
   // Closing the menu is the condition waited on: a card the release had
   // opened would have rendered by the time the menu is gone, and a plain

--- a/apps/web/src/components/spatial-editor/hand-tool.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/hand-tool.browser.test.tsx
@@ -111,19 +111,25 @@ it('in hand mode a plain drag pans the viewport — over empty space AND over a 
   expect(container.querySelector('[data-testid="selection-overlay"]')).toBeNull()
 })
 
-it('hand mode suppresses the long-press context menu — navigation only', () => {
+it('hand mode: a right-click opens the annotation verbs, never the edit catalog', () => {
   const { Host } = makeHost()
   const { container } = render(<Host />)
   const root = container.querySelector('[data-testid="spatial-editor"]') as HTMLElement
   const r = root.getBoundingClientRect()
+  const labels = () =>
+    [...container.querySelectorAll('[role="menuitem"]')].map(
+      (item) => item.textContent?.trim() ?? '',
+    )
   // Android synthesises a contextmenu from a touch long-press; in hand
-  // mode that must not surface editing affordances.
+  // mode that reaches the annotation layer and nothing else — every row
+  // is a comment verb, so no editing affordance surfaces mid-pan.
   fireEvent.contextMenu(root, { clientX: r.left + 150, clientY: r.top + 130 })
-  expect(container.querySelector('[data-testid="context-menu"]')).toBeNull()
+  expect(labels().length).toBeGreaterThan(0)
+  for (const label of labels()) expect(label).toMatch(/^Comment |resolved comments$/)
 
   fireEvent.click(container.querySelector('[data-testid="select-tool-button"]') as HTMLElement)
   fireEvent.contextMenu(root, { clientX: r.left + 150, clientY: r.top + 130 })
-  expect(container.querySelector('[data-testid="context-menu"]')).not.toBeNull()
+  expect(labels().some((label) => !/^Comment |resolved comments$/.test(label))).toBe(true)
 })
 
 it('the dock does NOT swap by mode: the host history cluster stays in hand mode too', () => {

--- a/apps/web/src/components/spatial-editor/navigation.test.ts
+++ b/apps/web/src/components/spatial-editor/navigation.test.ts
@@ -297,9 +297,13 @@ describe('long press arming', () => {
     })
   })
 
-  it('is never armed in hand mode, where its teardown would strand a live pan', () => {
+  it('is armed under the hand tool too: its menu is the annotation layer, which panning does not put out of reach', () => {
     const { effects } = run([down(1, { x: 10, y: 20 })])
-    expect(effects.filter((effect) => effect.kind === 'arm-long-press')).toEqual([])
+    expect(effects).toContainEqual({
+      kind: 'arm-long-press',
+      pointerId: 1,
+      screen: { x: 10, y: 20 },
+    })
   })
 })
 

--- a/apps/web/src/components/spatial-editor/navigation.ts
+++ b/apps/web/src/components/spatial-editor/navigation.ts
@@ -361,11 +361,12 @@ function reducePointerDown(
       }
     }
 
-    // Hand mode is navigation-only, so there is no menu for the timer to
-    // open — and arming it anyway is actively harmful: the press below
-    // starts a pan, and the timer's teardown would clear it mid-drag,
-    // stranding the pan under a finger that is still moving.
-    if (next.touches.size === 1 && !context.handMode) {
+    // Armed under the hand tool too: its menu is the annotation layer's
+    // verbs, which a reader panning around a canvas has as much reason to
+    // reach as one selecting on it. The pan the press starts below is not
+    // stranded by the timer's teardown, because a finger that travels
+    // clears the timer first and a finger that does not has not panned.
+    if (next.touches.size === 1) {
       effects.push({ kind: 'clear-long-press' })
       effects.push({ kind: 'arm-long-press', pointerId: event.pointerId, screen: event.point })
     }

--- a/apps/web/src/components/spatial-editor/touch-long-press-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/touch-long-press-menu.browser.test.tsx
@@ -111,15 +111,23 @@ it('hand mode: a stationary long-press opens the comment verbs, and a finger tha
   // Held still past the delay over the node: the annotation verb for it,
   // none of its edit verbs, and the node untouched by the press.
   touch(root, 'pointerdown', 200, 130)
-  await new Promise((resolve) => setTimeout(resolve, 650))
-  await vi.waitFor(() => {
-    expect(container.querySelector('[data-testid="context-menu"]')).not.toBeNull()
-  })
+  // Waited on as a condition: the menu is what the delay produces.
+  await vi.waitFor(
+    () => {
+      expect(container.querySelector('[data-testid="context-menu"]')).not.toBeNull()
+    },
+    { timeout: 2000 },
+  )
   expect(container.textContent).toContain('Comment on this')
   expect(container.textContent).not.toContain('Delete')
   touch(root, 'pointerup', 200, 130)
   expect(latest.canvas.nodes[0]).toMatchObject({ x: 100, y: 100 })
   // Closing it: a pointerdown anywhere outside is the menu's own dismissal.
+  // The menu takes focus in the same effect that subscribes to that press,
+  // so focus is the condition that the press will be heard.
+  await vi.waitFor(() =>
+    expect(document.activeElement?.closest('[data-testid="context-menu"]')).not.toBeNull(),
+  )
   touch(root, 'pointerdown', 700, 500, 8)
   touch(root, 'pointerup', 700, 500, 8)
   await vi.waitFor(() => {

--- a/apps/web/src/components/spatial-editor/touch-long-press-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/touch-long-press-menu.browser.test.tsx
@@ -102,20 +102,40 @@ it('cancels touchstart on the canvas so iOS cannot claim the press, but not on o
   expect(onOverlay.defaultPrevented).toBe(false)
 })
 
-it('hand mode stays navigation-only, and a slow pan keeps panning', async () => {
-  const { container } = mount(withNode, 'hand')
+it('hand mode: a stationary long-press opens the comment verbs, and a finger that moves first keeps panning', async () => {
+  const { container, latest } = mount(withNode, 'hand')
   const root = rootOf(container)
   const transform = () =>
     (container.querySelector('[data-testid="viewport-transform"]') as HTMLElement).style.transform
 
+  // Held still past the delay over the node: the annotation verb for it,
+  // none of its edit verbs, and the node untouched by the press.
   touch(root, 'pointerdown', 200, 130)
-  // Held past the long-press delay WITHOUT moving — the shape of a slow
-  // one-finger pan. No menu, and the pan must survive: an armed timer
-  // would have cleared isPanningRef here and stranded the drag.
+  await new Promise((resolve) => setTimeout(resolve, 650))
+  await vi.waitFor(() => {
+    expect(container.querySelector('[data-testid="context-menu"]')).not.toBeNull()
+  })
+  expect(container.textContent).toContain('Comment on this')
+  expect(container.textContent).not.toContain('Delete')
+  touch(root, 'pointerup', 200, 130)
+  expect(latest.canvas.nodes[0]).toMatchObject({ x: 100, y: 100 })
+  // Closing it: a pointerdown anywhere outside is the menu's own dismissal.
+  touch(root, 'pointerdown', 700, 500, 8)
+  touch(root, 'pointerup', 700, 500, 8)
+  await vi.waitFor(() => {
+    expect(container.querySelector('[data-testid="context-menu"]')).toBeNull()
+  })
+
+  // A pan that starts moving before the delay is a pan: the timer is
+  // cleared by the travel and the drag keeps going past the delay.
+  const before = transform()
+  touch(root, 'pointerdown', 400, 400, 9)
+  touch(root, 'pointermove', 440, 440, 9)
+  await vi.waitFor(() => expect(transform()).not.toBe(before))
   await new Promise((resolve) => setTimeout(resolve, 650))
   expect(container.querySelector('[data-testid="context-menu"]')).toBeNull()
-  const before = transform()
-  touch(root, 'pointermove', 260, 190)
-  await vi.waitFor(() => expect(transform()).not.toBe(before))
-  touch(root, 'pointerup', 260, 190)
+  const mid = transform()
+  touch(root, 'pointermove', 480, 480, 9)
+  await vi.waitFor(() => expect(transform()).not.toBe(mid))
+  touch(root, 'pointerup', 480, 480, 9)
 })


### PR DESCRIPTION
## Summary

- **Panning no longer puts a conversation out of reach.** The hand tool opened no context menu at all, because an EDIT affordance surfacing mid-pan was the harm on a phone. A comment verb is not one: a right-click, or a stationary touch long-press, now opens the menu under the hand tool carrying the annotation layer's verb for what is under the press — "Comment here" on a spot, "Comment on this" on a node or an edge, a comment's own lifecycle (Edit / Resolve / Reopen) on its bubble — and the press selects nothing on the way, since hand mode never selects.
- **One definition per row.** `context-menu-items/annotation-verbs.tsx` holds the comment rows; the node, edge and canvas menus wear them as before and the hand tool's menu is those rows alone (`ContextMenuTarget.verbs: 'annotation'`), so the two readings cannot drift apart.
- **The long-press timer is armed under the hand tool too, and strands no pan**: a finger that travels past the slop clears it before it fires, and one that does not has not panned. Its firing now also spends the comment press it landed on, in both tools — the release after a long-press on a bubble used to open the card under the menu it had just opened (mutation-checked: without that line the new test fails with the card present).

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — `hand-comment.browser.test.tsx` (right-click verbs on empty space and over a node with no selection; Comment here composing and committing; touch long-press on a bubble opening its menu and the release opening no card), `touch-long-press-menu.browser.test.tsx` (hand-mode hold opens the verbs, a moving finger keeps panning past the delay), `hand-tool.browser.test.tsx` (every row under the hand tool is a comment verb; Select still gets the catalog), `navigation.test.ts` (armed under the hand tool)
- [x] `pnpm test` passes locally — spatial-editor `web-browser` (100 files, 489 tests) and `web-jsdom` (46 files) plus the state and toggle scans; CI runs the full set
- [x] Manual verification completed — driven in the running app (`vite` dev server) through Playwright with CDP touch input: the hand tool's right-click on empty space (Comment here / Show resolved comments) and over a node (Comment on this, no selection overlay), a stationary touch hold opening the same menu, Comment here composing and committing onto the canvas, and a touch pan that moves before the delay still panning with no menu
- [ ] E2E coverage added or extended where applicable — not needed: no route, transport or MCP op changes; the flow is component-level and pinned in browser mode

## Visual evidence

Visual evidence: none — this session has no way to upload an image to GitHub (no `gh`, and the GitHub MCP surface carries no asset upload). The visible change is the menu's contents by tool, pinned by label in `hand-comment.browser.test.tsx` and `hand-tool.browser.test.tsx`; the Cloudflare preview comment on this PR shows it live (hand tool, right-click).

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — `apps/web/DESIGN.md` comment-surfaces section
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPGrBEknX78whd38tHXnLH

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPGrBEknX78whd38tHXnLH)_