### PR TITLE
test(web): VersionTimeline lane queries use the component's own testid

### DIFF
--- a/apps/web/src/components/VersionTimeline.test.tsx
+++ b/apps/web/src/components/VersionTimeline.test.tsx
@@ -317,7 +317,7 @@ describe('VersionTimeline', () => {
     expect(screen.getByText(/4 els/)).toBeTruthy()
 
     await waitFor(() => {
-      expect(document.querySelectorAll('svg[viewBox="0 0 24 36"]').length).toBe(3)
+      expect(document.querySelectorAll('[data-testid="version-lane"]').length).toBe(3)
     })
 
     // Branch tabs are gone, so no tab role should exist.
@@ -333,9 +333,9 @@ describe('VersionTimeline', () => {
     render(<VersionTimeline workspaceId="sess_1" path="canvas-a" onPreview={preview.onPreview} />)
 
     await waitFor(() => {
-      expect(document.querySelectorAll('svg[viewBox="0 0 24 36"]').length).toBe(3)
+      expect(document.querySelectorAll('[data-testid="version-lane"]').length).toBe(3)
     })
-    const dots = [...document.querySelectorAll('svg[viewBox="0 0 24 36"] circle')]
+    const dots = [...document.querySelectorAll('[data-testid="version-lane"] circle')]
     expect(dots.length).toBe(3)
 
     const rings = dots.filter((c) => c.getAttribute('fill') === 'none')
@@ -404,7 +404,7 @@ describe('VersionTimeline', () => {
       expect(screen.getByText(/Alice/)).toBeTruthy()
     })
 
-    const circles = document.querySelectorAll('svg[viewBox="0 0 24 36"] circle')
+    const circles = document.querySelectorAll('[data-testid="version-lane"] circle')
     expect(circles).toHaveLength(3)
     // Each lane keeps its own BranchMeta.color, on the stroke whichever shape
     // the dot takes — that is what makes a ring readable as the same lane.
@@ -840,7 +840,7 @@ describe('VersionTimeline HEAD polling', () => {
     // every lane is shown either way — but which of them is the active one.
     // The `feature` row becomes solid and the two `main` rows become rings.
     await waitFor(() => {
-      const dots = [...document.querySelectorAll('svg[viewBox="0 0 24 36"] circle')]
+      const dots = [...document.querySelectorAll('[data-testid="version-lane"] circle')]
       const solid = dots.filter((c) => c.getAttribute('fill') !== 'none')
       expect(solid).toHaveLength(1)
       expect(solid[0]?.getAttribute('stroke')).toBe('#9333ea')


### PR DESCRIPTION
## What

jsdom 30 stops matching camelCase SVG attribute selectors: `querySelectorAll('svg[viewBox="0 0 24 36"]')` answers 0 on a DOM where jsdom 29 answers 1, while `getAttribute('viewBox')` still returns the value — verified in isolation by the dependabot-triage adversarial lane, and Dependabot's jsdom PR (#1058) is red on exactly these five `VersionTimeline.test.tsx` assertions while real Chromium matches fine.

The lane SVG already carries `data-testid="version-lane"` (`VersionTimeline.tsx:493`), so the five queries switch to it — stable under both jsdom majors. This unblocks #1058 (jsdom 29→30) as a plain rebase-and-merge.

## Verification

`VersionTimeline.test.tsx` 36/36 under the current jsdom 29 · lint.

Visual evidence: none — test-selector change; the green run on both jsdom majors (this PR now, #1058 after rebase) is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated timeline visual tests to use stable lane identifiers when locating version lanes.
  * Preserved existing checks for lane counts, markers, colors, stroke widths, and polling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->