### PR TITLE
feat(render): the layout worker takes references as data, so a text node's `![[note]]` draws on both threads

### DIFF
--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -186,8 +186,11 @@ seam a root forgot never failed — the web preview drew a canvas behind
 `![[path]]` while `wb_scene_render` refused the document, all green.
 `tools/arch-lint`'s `reference-seams-check.test.ts` fails on a seam defined
 by hand outside that module (passing one along, `overlayReferences`, or
-handing the builder an alias table is fine). The gap that remains, so nobody
-rediscovers it: the editor's canvas text-node bodies take no markdown seams,
-because the layout worker cannot receive a function.
+handing the builder an alias table is fine). The bundle also has a DATA
+form, `ReferenceWire` / `referenceSeamsFromWire`, for the layout worker: a
+function cannot cross `postMessage`, so the graph and the tables it was
+built over cross instead, and both threads build the same seams from the
+same bytes. That closed the last gap — a text node's `![[note]]` drew a
+placeholder in the worker, and for parity on the main thread too.
 
 The LoroDoc<->model bridge originally scoped for `codec` is DEFERRED to `crdt` — a single-document codec has no need for CRDT merge semantics, and pulling `loro-crdt` into this package would violate its own "model + remark only" dependency rule.

--- a/.claude/rules/package-canvas-render.md
+++ b/.claude/rules/package-canvas-render.md
@@ -789,10 +789,9 @@ the table alone.
     Three things the six could not do. A caller has ONE document per
     reference, so six closures over the same lookup meant the same key was
     resolved four times per file node. A record is plain DATA, which a
-    function can never be — the layout worker refuses a canvas whose file
-    seams are wired precisely because a function cannot cross
-    `postMessage`, and `apps/web`'s `composeReferenceSeam` is now the ONE
-    producer both threads build their seam through. And a content kind added
+    function can never be — a function cannot cross `postMessage`, so the
+    layout worker receives the records (decision #14's wire) and both
+    threads build one seam from them. And a content kind added
     later is a field rather than a seventh callback threaded through every
     consumer, of which there are four.
     The price, stated because it is a real behaviour change: one resolver
@@ -952,7 +951,13 @@ the table alone.
     (labels, dangling marks) for the layout worker and the main thread
     alike. Both layouts accept the bundle as `references` and apply it under
     the individual seams (`withReferenceSeams`), which stay for a test
-    probing one alone. The reason is the drift class decision #11 already
+    probing one alone. `ReferenceWire` is the bundle as DATA — the graph
+    plus the alias, title and extras tables evaluated over what it names —
+    and `referenceSeamsFromWire` builds the bundle back on either side of a
+    `postMessage`; `apps/web`'s editor builds its own seams from the wire it
+    posts, so the worker and the main thread cannot disagree. Before it, a
+    text node's `![[note]]` was a placeholder on both, and `referenceTargets`
+    never named it: it scans text-node bodies now. The reason is the drift class decision #11 already
     names: every root wrote these by hand, each answered a different subset,
     and the total layout hid the difference. `tools/arch-lint`'s
     `reference-seams-check.test.ts` refuses a seam defined outside this

--- a/apps/web/src/components/document-editor/SpatialEditorPane.tsx
+++ b/apps/web/src/components/document-editor/SpatialEditorPane.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode, Ref } from 'react'
+import { referenceSeamsFromWire } from '@kamiazya/whiteboard-canvas-render'
+import { type ReactNode, type Ref, useMemo } from 'react'
 import type { DocumentFileSeams } from '../../hooks/use-document-file-seams.js'
 import { readLastTool, resolveInitialTool } from '../../lib/initial-tool.js'
 import type { SpatialEditorHandle } from '../../lib/spatial/editor-handle.js'
@@ -97,6 +98,12 @@ export function SpatialEditorPane({
   agentTouchedNodeIds,
   threads,
 }: SpatialEditorPaneProps) {
+  // The overlay's markdown editor reads the seams as functions; it builds
+  // them from the same wire the canvas posts to its worker.
+  const overlaySeams = useMemo(
+    () => referenceSeamsFromWire(fileSeams.references),
+    [fileSeams.references],
+  )
   return (
     <div data-testid="spatial-editor-container" className={className}>
       {children}
@@ -139,7 +146,7 @@ export function SpatialEditorPane({
           title={overlayTitle}
           initialText={nodeInEditor.editing.text}
           theme={theme}
-          references={fileSeams.references}
+          references={overlaySeams}
           linkTargets={linkTargets}
           onCommit={nodeInEditor.commit}
           onClose={nodeInEditor.close}

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -58,7 +58,7 @@
  * diagram that needs a shape uses an image node.
  */
 
-import type { BoundingBox, MeasureText, ReferenceSeams } from '@kamiazya/whiteboard-canvas-render'
+import type { BoundingBox, MeasureText, ReferenceWire } from '@kamiazya/whiteboard-canvas-render'
 import {
   BODY_FONT_SIZE_PX,
   BODY_LINE_HEIGHT_PX,
@@ -68,6 +68,7 @@ import {
   edgeLabelAnchor,
   outlineContentBox,
   placeCommentBubble,
+  referenceSeamsFromWire,
   SPATIAL_DARK_PALETTE,
   SPATIAL_LIGHT_PALETTE,
   SPATIAL_THEME_FONT_FAMILY,
@@ -312,16 +313,15 @@ export interface SpatialEditorProps {
    * synchronous: hosts pre-fetch and cache, and an unresolved reference
    * returns undefined and the card renders. Absent → embeds never expand.
    *
-   * Content only. The readable LABEL comes from `fileRefOptions` and the
-   * dangling state from `missingFileRef`, both of which this component
-   * layers on top — they are plain data, so they can cross to the layout
-   * worker while this cannot, and keeping them apart is what lets a canvas
-   * with labelled references still lay out off the main thread.
-   *
-   * A markdown body arrives parsed rather than raw so layout never runs a
-   * markdown parse per file node per frame.
+   * Content only, as DATA: the loaded reference graph with its alias,
+   * title and extras tables. The readable LABEL comes from `fileRefOptions`
+   * and the dangling state from `missingFileRef`, layered on top. This
+   * component builds the reference bundle from the wire for its own
+   * thread and posts the wire to the layout worker, which builds the same
+   * bundle from the same bytes — so what a text node embeds and what a file
+   * node shows cannot differ between the two.
    */
-  readonly references?: ReferenceSeams
+  readonly references?: ReferenceWire
   /**
    * Stores a picked/dropped/pasted image and returns the reference to put
    * in the created file node, or undefined on failure (nothing is
@@ -559,10 +559,14 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     // the content cache — built once in useFileSeamScene and spread into
     // every scene-building call below (committed scene, drag ghost,
     // drag-static backdrop, resize preview).
-    const { fileSeamOptions, missingFileRefs } = useFileSeamScene({
+    const seams = useMemo(
+      () => (references === undefined ? undefined : referenceSeamsFromWire(references)),
+      [references],
+    )
+    const { fileSeamOptions, missingFileRefs, expandedFileIds } = useFileSeamScene({
       canvas,
       zoom: viewport.zoom,
-      references,
+      references: seams,
       fileRefOptions,
       missingFileRef,
       resolvedMeasure,
@@ -615,8 +619,7 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
         threads,
       },
       fileSeamOptions,
-      fileRefOptions,
-      missingFileRefs,
+      { fileRefLabels: fileRefOptions, missingFileRefs, references, expandedFileIds },
     )
     const { keyed, edgePaths, commentChromeBoxes, selectionMembers, selectionBox, minimapNodes } =
       useSceneProjection({ scene, bounds, boxes, canvas, theme, selectedId, extraIds })

--- a/apps/web/src/components/spatial-editor/canvas-embed-lod.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/canvas-embed-lod.browser.test.tsx
@@ -1,4 +1,4 @@
-import { referenceSeams } from '@kamiazya/whiteboard-canvas-render'
+import { referenceWire } from '@kamiazya/whiteboard-canvas-render'
 // LOD auto-expansion for canvas embeds (embed spec v2): a file node whose
 // on-screen box is large enough renders the referenced canvas as an inline
 // miniature; smaller ones stay cards. The decision follows zoom — zooming
@@ -32,8 +32,8 @@ function makeHost(initial: SpatialCanvas) {
           onChange={(next) => setCanvas(next)}
           theme="light"
           fileRefOptions={[{ file: 'ref-1', label: 'Referenced canvas' }]}
-          references={referenceSeams(new Map(), {
-            extra: (ref) => (ref === 'ref-1' ? { canvas: referenced } : undefined),
+          references={referenceWire(new Map(), {
+            extras: new Map([['ref-1', { canvas: referenced }]]),
           })}
         />
       </div>

--- a/apps/web/src/components/spatial-editor/drag-ghost-embed.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/drag-ghost-embed.browser.test.tsx
@@ -1,4 +1,4 @@
-import { referenceSeams } from '@kamiazya/whiteboard-canvas-render'
+import { referenceWire } from '@kamiazya/whiteboard-canvas-render'
 // The drag ghost renders the carried node's REAL content — including an
 // expanded canvas embed. Omitting the embed resolvers from the ghost's
 // one-shot render made an inline miniature drag as a plain card and snap
@@ -52,9 +52,7 @@ it('drags an expanded embed with its miniature content in the ghost', async () =
         onChange={() => {}}
         theme="light"
         fileRefOptions={[{ file: 'child', label: 'child canvas' }]}
-        references={referenceSeams(new Map(), {
-          extra: (ref) => (ref === 'child' ? { canvas: inner } : undefined),
-        })}
+        references={referenceWire(new Map(), { extras: new Map([['child', { canvas: inner }]]) })}
       />
     </div>,
   )

--- a/apps/web/src/components/spatial-editor/file-node-markdown.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/file-node-markdown.browser.test.tsx
@@ -1,4 +1,4 @@
-import { referenceSeams } from '@kamiazya/whiteboard-canvas-render'
+import { referenceWire } from '@kamiazya/whiteboard-canvas-render'
 /**
  * The verified user flow, locked in: a file node pointing at a markdown
  * document in the same workspace renders that document's prose inside the
@@ -53,9 +53,7 @@ describe('a file node referencing a markdown document', () => {
       <SpatialEditor
         canvas={canvasWithDocumentNode()}
         onChange={() => {}}
-        references={referenceSeams(new Map(), {
-          extra: (ref) => (ref === 'notes' ? { markdown: BODY } : undefined),
-        })}
+        references={referenceWire(new Map(), { extras: new Map([['notes', { markdown: BODY }]]) })}
       />,
     )
 
@@ -69,7 +67,9 @@ describe('a file node referencing a markdown document', () => {
       <SpatialEditor
         canvas={canvasWithDocumentNode()}
         onChange={() => {}}
-        references={referenceSeams(new Map(), { extra: () => ({ markdown: BODY, facets: CARD }) })}
+        references={referenceWire(new Map(), {
+          extras: new Map([['notes', { markdown: BODY, facets: CARD }]]),
+        })}
       />,
     )
 
@@ -82,7 +82,7 @@ describe('a file node referencing a markdown document', () => {
       <SpatialEditor
         canvas={canvasWithDocumentNode()}
         onChange={() => {}}
-        references={referenceSeams(new Map(), { extra: () => ({ facets: CARD }) })}
+        references={referenceWire(new Map(), { extras: new Map([['notes', { facets: CARD }]]) })}
       />,
     )
 
@@ -97,7 +97,7 @@ describe('a file node referencing a markdown document', () => {
       <SpatialEditor
         canvas={canvasWithDocumentNode()}
         onChange={() => {}}
-        references={referenceSeams(new Map(), { extra: () => ({ markdown: long }) })}
+        references={referenceWire(new Map(), { extras: new Map([['notes', { markdown: long }]]) })}
       />,
     )
 

--- a/apps/web/src/components/spatial-editor/hand-pan-dead-zone.property.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/hand-pan-dead-zone.property.browser.test.tsx
@@ -1,4 +1,4 @@
-import { referenceSeams } from '@kamiazya/whiteboard-canvas-render'
+import { referenceWire } from '@kamiazya/whiteboard-canvas-render'
 /**
  * Hand tool: every press on the canvas surface pans, wherever it lands and
  * at whatever zoom.
@@ -97,8 +97,8 @@ function Host({ handle }: { handle: React.RefObject<SpatialEditorHandle | null> 
         onChange={(next) => setCanvas(next)}
         theme="light"
         fileRefOptions={[{ file: 'ref-1', label: 'Referenced canvas' }]}
-        references={referenceSeams(new Map(), {
-          extra: (ref) => (ref === 'ref-1' ? { canvas: referenced } : undefined),
+        references={referenceWire(new Map(), {
+          extras: new Map([['ref-1', { canvas: referenced }]]),
         })}
       />
     </div>

--- a/apps/web/src/components/spatial-editor/image-node.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/image-node.browser.test.tsx
@@ -1,4 +1,4 @@
-import { referenceSeams } from '@kamiazya/whiteboard-canvas-render'
+import { referenceWire } from '@kamiazya/whiteboard-canvas-render'
 // Media file nodes (embed spec J5b): images arrive via the host's storage
 // seam (picker input, drop, paste) and render as <image> elements filling
 // the node's padded box. The reference is opaque to the editor; the host
@@ -46,11 +46,15 @@ function makeHost(initial: SpatialCanvas) {
             latest.stored.push(file)
             return Promise.resolve(`asset:${latest.stored.length}`)
           }}
-          references={referenceSeams(new Map(), {
-            extra: (ref) =>
-              ref.startsWith('asset:')
-                ? { image: { href: PNG_HREF, alt: 'stored image' } }
-                : undefined,
+          references={referenceWire(new Map(), {
+            // The refs the store above mints, in order — data, so it crosses
+            // to the layout worker like a real page's object URLs do.
+            extras: new Map(
+              [1, 2, 3, 4].map((n) => [
+                `asset:${n}`,
+                { image: { href: PNG_HREF, alt: 'stored image' } },
+              ]),
+            ),
           })}
           isImageFileRef={(file) => file.startsWith('asset:')}
           onOpenFileRef={(file) => latest.opened.push(file)}

--- a/apps/web/src/components/spatial-editor/text-node-embed.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/text-node-embed.browser.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * The verified user flow, locked in: a text node whose body embeds a note
+ * draws that note's prose inside the node, the way the markdown preview
+ * draws it — through the reference bundle the editor builds from the wire
+ * it also posts to the layout worker.
+ *
+ * Both paths a committed scene can take are covered: a small canvas lays
+ * out synchronously, and a canvas past the offload threshold goes through
+ * the worker on its first change. The prose has to appear either way, and
+ * it did not before the wire existed — a function cannot cross
+ * `postMessage`, so the worker drew a placeholder, and for parity the main
+ * thread did too.
+ */
+import { referenceWire } from '@kamiazya/whiteboard-canvas-render'
+import type { SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { SpatialEditor } from './SpatialEditor.js'
+
+const NOTE = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+
+const embeddingNode: SpatialNode = {
+  id: 't',
+  type: 'text',
+  x: 40,
+  y: 40,
+  width: 320,
+  height: 220,
+  text: `Plan:\n\n![[${NOTE}]]`,
+}
+
+/** Enough bystanders to cross the worker's offload threshold (12 elements). */
+const bystanders = (count: number): SpatialNode[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `b${i}`,
+    type: 'text' as const,
+    x: 500,
+    y: 40 + i * 60,
+    width: 120,
+    height: 40,
+    text: `bystander ${i}`,
+  }))
+
+const references = referenceWire(
+  new Map([[NOTE, { documentId: NOTE, name: 'Note', body: 'PROSE FROM THE NOTE' }]]),
+)
+
+const svgText = (container: HTMLElement) =>
+  [...container.querySelectorAll('svg text')].map((node) => node.textContent ?? '').join(' ')
+
+afterEach(cleanup)
+
+describe('a text node embedding a note', () => {
+  it('draws the note prose inside the node on the synchronous path', async () => {
+    const canvas: SpatialCanvas = { nodes: [embeddingNode], edges: [] }
+    const { container } = render(
+      <SpatialEditor canvas={canvas} onChange={() => {}} references={references} />,
+    )
+    await waitFor(() => expect(svgText(container)).toContain('PROSE FROM THE NOTE'))
+  })
+
+  it('keeps drawing it after a change that lays the canvas out in the worker', async () => {
+    const canvas: SpatialCanvas = { nodes: [embeddingNode, ...bystanders(12)], edges: [] }
+    const { container, rerender } = render(
+      <SpatialEditor canvas={canvas} onChange={() => {}} references={references} />,
+    )
+    await waitFor(() => expect(svgText(container)).toContain('PROSE FROM THE NOTE'))
+    // A committed change past the threshold is what the worker lays out.
+    const changed: SpatialCanvas = {
+      ...canvas,
+      nodes: [...canvas.nodes, ...bystanders(13).slice(12)],
+    }
+    rerender(<SpatialEditor canvas={changed} onChange={() => {}} references={references} />)
+    await waitFor(() => expect(svgText(container)).toContain('bystander 12'))
+    expect(svgText(container)).toContain('PROSE FROM THE NOTE')
+  })
+})

--- a/apps/web/src/components/spatial-editor/use-file-seam-scene.ts
+++ b/apps/web/src/components/spatial-editor/use-file-seam-scene.ts
@@ -119,23 +119,30 @@ export function useFileSeamScene({
   // (LayoutRequest carries plain data only); the worker keeps its own.
   const contentCache = useMemo(
     () => createSpatialContentCache(),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- theme and
-    // measure invalidate cached layout; nothing else does.
-    [resolvedMeasure, theme],
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- theme, measure
+    // and the references a text node's body can embed invalidate cached
+    // layout; nothing else does.
+    [resolvedMeasure, theme, references],
   )
   const fileSeamOptions = useMemo(
     () => ({
+      references,
       resolveReference: overlayReferences({
         content: resolveReference,
         labels: fileRefLabelMap,
         missing: missingRefSet,
       }),
-      resolveReferenceContent: resolveReference,
       expandFileNode,
       contentCache,
     }),
-    [resolveReference, fileRefLabelMap, missingRefSet, expandFileNode, contentCache],
+    [references, resolveReference, fileRefLabelMap, missingRefSet, expandFileNode, contentCache],
+  )
+  // The gate's decision as data, for the worker: it reads the viewport,
+  // which the worker does not have.
+  const expandedFileIdList = useMemo(
+    () => (expandFileNode === undefined ? undefined : [...expandedFileIds].sort()),
+    [expandFileNode, expandedFileIds],
   )
 
-  return { fileSeamOptions, missingFileRefs }
+  return { fileSeamOptions, missingFileRefs, expandedFileIds: expandedFileIdList }
 }

--- a/apps/web/src/components/spatial-editor/use-worker-scene.ts
+++ b/apps/web/src/components/spatial-editor/use-worker-scene.ts
@@ -14,8 +14,8 @@
  * - Every later scene keeps the previous one on screen until its replacement
  *   arrives. The visible trade: a change appears one worker round-trip later
  *   instead of blocking the thread until it can appear instantly.
- * - Anything the worker cannot serve — a host-supplied function seam, a
- *   missing pre-parsed body, a worker that failed to start or threw — falls
+ * - Anything the worker cannot serve — a worker that failed to start or
+ *   threw, a realm without the vendored face — falls
  *   back to laying the same canvas out synchronously. A degraded worker costs
  *   responsiveness, never content.
  *
@@ -23,11 +23,10 @@
  * note), so an offloaded commit costs this thread nothing but the postMessage.
  */
 
-import type { MeasureText } from '@kamiazya/whiteboard-canvas-render'
+import type { MeasureText, ReferenceWire } from '@kamiazya/whiteboard-canvas-render'
 import type { CommentThread, SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import {
-  canLayoutInWorker,
   type FileRefLabel,
   FONT_DEGRADED,
   type LayoutRequest,
@@ -87,21 +86,25 @@ export function useWorkerScene(
     /** The document's conversations, for passage highlights (plain data, crosses to the worker). */
     readonly threads?: readonly CommentThread[]
   },
-  fileSeamOptions: Omit<RenderCanvasOptions, 'measure' | 'theme'> & {
-    /**
-     * The host's CONTENT resolver, uncomposed. `resolveReference` beside it
-     * already has the label/missing chrome folded in, which crosses to the
-     * worker as data — so only this one decides whether the canvas has to
-     * stay on the main thread.
-     */
-    readonly resolveReferenceContent?: unknown
+  fileSeamOptions: Omit<RenderCanvasOptions, 'measure' | 'theme'>,
+  /**
+   * The plain-data twins of the seams in `fileSeamOptions`: the label
+   * table, the refs the host resolved as dangling in THIS canvas, the
+   * reference graph with its tables, and the ids the LOD gate expanded.
+   * The composed seams serve the synchronous path; only this can cross to
+   * the worker, which rebuilds the same seams from it.
+   */
+  wire?: {
+    readonly fileRefLabels?: readonly FileRefLabel[]
+    readonly missingFileRefs?: readonly string[]
+    readonly references?: ReferenceWire
+    readonly expandedFileIds?: readonly string[]
   },
-  fileRefLabels: readonly FileRefLabel[] | undefined,
-  // The plain-data twin of the seam's `missing` field: the refs the host
-  // resolved as dangling in THIS canvas. The composed seam serves the
-  // synchronous path; only this list can cross to the worker.
-  missingFileRefs?: readonly string[],
 ): RenderedCanvas & { readonly sceneCurrent: boolean } {
+  const fileRefLabels = wire?.fileRefLabels
+  const missingFileRefs = wire?.missingFileRefs
+  const references = wire?.references
+  const expandedFileIds = wire?.expandedFileIds
   const options = useMemo(
     () => ({ ...base, ...fileSeamOptions }),
     [
@@ -113,7 +116,7 @@ export function useWorkerScene(
       fileSeamOptions,
     ],
   )
-  const offloadable = canLayoutInWorker(fileSeamOptions, canvas) && worthOffloading(canvas)
+  const offloadable = worthOffloading(canvas)
   // Synchronous layout of the CURRENT inputs, computed only when it is needed:
   // the first render, and any render the worker cannot serve.
   const renderNow = () => renderCanvasToSvg(canvas, options)
@@ -145,6 +148,8 @@ export function useWorkerScene(
       theme: options.theme,
       fileRefLabels,
       missingFileRefs,
+      references,
+      expandedFileIds,
       suppressedBodyNodeIds: options.suppressedBodyNodeIds,
       showResolved: options.showResolved,
       threads: options.threads,
@@ -154,6 +159,8 @@ export function useWorkerScene(
       options.theme,
       fileRefLabels,
       missingFileRefs,
+      references,
+      expandedFileIds,
       options.suppressedBodyNodeIds,
       options.showResolved,
       options.threads,
@@ -222,6 +229,8 @@ export function useWorkerScene(
       theme: inputs.theme,
       fileRefLabels: inputs.fileRefLabels,
       missingFileRefs: inputs.missingFileRefs,
+      references: inputs.references,
+      expandedFileIds: inputs.expandedFileIds,
       suppressedBodyNodeIds: inputs.suppressedBodyNodeIds,
       showResolved: inputs.showResolved,
       threads: inputs.threads,

--- a/apps/web/src/hooks/use-document-file-seams.markdown.test.tsx
+++ b/apps/web/src/hooks/use-document-file-seams.markdown.test.tsx
@@ -1,3 +1,4 @@
+import { type ReferenceWire, referenceSeamsFromWire } from '@kamiazya/whiteboard-canvas-render'
 /**
  * The editor's markdown-body seam: a file node pointing at a markdown
  * document in the same workspace renders that document's prose, instead of
@@ -12,6 +13,10 @@ import { renderHook, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import type { DocumentFileAdapter } from '../lib/document-file-contract.js'
 import { useDocumentFileSeams } from './use-document-file-seams.js'
+
+/** The bundle a surface builds from the wire the hook hands the editor. */
+const seamsOf = (result: { current: { references: ReferenceWire } }) =>
+  referenceSeamsFromWire(result.current.references)
 
 const BODY = '# Weekly notes\n\nShipped the markdown file node.'
 
@@ -50,10 +55,8 @@ describe("a resolved reference's markdown body", () => {
       makeAdapter({ loadDocument: vi.fn(async () => ({ body: BODY })) }),
     )
 
-    await waitFor(() =>
-      expect(result.current.references.resolveReference('notes')?.markdown).toBeDefined(),
-    )
-    const root = result.current.references.resolveReference('notes')?.markdown
+    await waitFor(() => expect(seamsOf(result).resolveReference('notes')?.markdown).toBeDefined())
+    const root = seamsOf(result).resolveReference('notes')?.markdown
     expect(root?.type).toBe('root')
     expect(root?.children[0]).toMatchObject({ type: 'heading', depth: 1 })
   })
@@ -69,10 +72,8 @@ describe("a resolved reference's markdown body", () => {
       }),
     )
 
-    await waitFor(() =>
-      expect(result.current.references.resolveReference('diagram')?.canvas).toBeUndefined(),
-    )
-    expect(result.current.references.resolveReference('diagram')?.markdown).toBeUndefined()
+    await waitFor(() => expect(seamsOf(result).resolveReference('diagram')?.canvas).toBeUndefined())
+    expect(seamsOf(result).resolveReference('diagram')?.markdown).toBeUndefined()
   })
 
   it('returns undefined for a whitespace-only body, keeping the lower-ranked card', async () => {
@@ -82,10 +83,8 @@ describe("a resolved reference's markdown body", () => {
       makeAdapter({ loadDocument: vi.fn(async () => ({ body: '   \n\n  ' })) }),
     )
 
-    await waitFor(() =>
-      expect(result.current.references.resolveReference('empty')?.facets).toBeUndefined(),
-    )
-    expect(result.current.references.resolveReference('empty')?.markdown).toBeUndefined()
+    await waitFor(() => expect(seamsOf(result).resolveReference('empty')?.facets).toBeUndefined())
+    expect(seamsOf(result).resolveReference('empty')?.markdown).toBeUndefined()
   })
 
   it('keeps the canvas seam quiet for a daemon-shaped markdown document', async () => {
@@ -117,15 +116,13 @@ describe("a resolved reference's markdown body", () => {
       }),
     )
 
-    await waitFor(() =>
-      expect(result.current.references.resolveReference('notes')?.markdown).toBeDefined(),
-    )
-    expect(result.current.references.resolveReference('notes')?.canvas).toBeUndefined()
+    await waitFor(() => expect(seamsOf(result).resolveReference('notes')?.markdown).toBeDefined())
+    expect(seamsOf(result).resolveReference('notes')?.canvas).toBeUndefined()
   })
 
   it('returns undefined for a reference that never loaded', () => {
     const { result } = mount(canvasWith('gone'), makeAdapter())
-    expect(result.current.references.resolveReference('gone')?.markdown).toBeUndefined()
+    expect(seamsOf(result).resolveReference('gone')?.markdown).toBeUndefined()
   })
 
   it('parses each body once, not once per resolver call', async () => {
@@ -135,14 +132,15 @@ describe("a resolved reference's markdown body", () => {
       makeAdapter({ loadDocument: vi.fn(async () => ({ body: BODY })) }),
     )
 
-    await waitFor(() =>
-      expect(result.current.references.resolveReference('notes')?.markdown).toBeDefined(),
-    )
+    await waitFor(() => expect(seamsOf(result).resolveReference('notes')?.markdown).toBeDefined())
     // Referential equality is the observable form of "parsed once": a
     // resolver that parsed per call would hand back a fresh tree each time,
     // and canvas-render calls this for every file node on every re-layout.
-    expect(result.current.references.resolveReference('notes')?.markdown).toBe(
-      result.current.references.resolveReference('notes')?.markdown,
+    // One bundle, two calls — each thread rebuilds its bundle from the wire
+    // once, and it is the bundle's cache that has to hold.
+    const seams = seamsOf(result)
+    expect(seams.resolveReference('notes')?.markdown).toBe(
+      seams.resolveReference('notes')?.markdown,
     )
   })
 
@@ -155,9 +153,7 @@ describe("a resolved reference's markdown body", () => {
       makeAdapter({ loadDocument: vi.fn(async () => ({ body: '\uD800' })) }),
     )
 
-    await waitFor(() =>
-      expect(result.current.references.resolveReference('bad')?.canvas).toBeUndefined(),
-    )
-    expect(() => result.current.references.resolveReference('bad')?.markdown).not.toThrow()
+    await waitFor(() => expect(seamsOf(result).resolveReference('bad')?.canvas).toBeUndefined())
+    expect(() => seamsOf(result).resolveReference('bad')?.markdown).not.toThrow()
   })
 })

--- a/apps/web/src/hooks/use-document-file-seams.test.tsx
+++ b/apps/web/src/hooks/use-document-file-seams.test.tsx
@@ -1,3 +1,4 @@
+import { type ReferenceWire, referenceSeamsFromWire } from '@kamiazya/whiteboard-canvas-render'
 /**
  * The backend-agnostic half of the editor's file seams. This logic used to
  * live inline in BrowserDocumentPage, which is why the daemon page shipped
@@ -10,6 +11,10 @@ import { renderHook, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { DocumentFileAdapter } from '../lib/document-file-contract.js'
 import { toFacetCard, useDocumentFileSeams } from './use-document-file-seams.js'
+
+/** The bundle a surface builds from the wire the hook hands the editor. */
+const seamsOf = (result: { current: { references: ReferenceWire } }) =>
+  referenceSeamsFromWire(result.current.references)
 
 const canvasWith = (...files: string[]): SpatialCanvas => ({
   nodes: files.map((file, i) => ({
@@ -53,11 +58,9 @@ describe('useDocumentFileSeams', () => {
 
     // The editor's seam is synchronous, so nothing is available on the first
     // render — the point of the pre-fetch.
-    expect(result.current.references.resolveReference('other')?.canvas).toBeUndefined()
-    await waitFor(() =>
-      expect(result.current.references.resolveReference('other')?.canvas).toBeDefined(),
-    )
-    expect(result.current.references.resolveReference('other')?.canvas).toEqual(embedded('other'))
+    expect(seamsOf(result).resolveReference('other')?.canvas).toBeUndefined()
+    await waitFor(() => expect(seamsOf(result).resolveReference('other')?.canvas).toBeDefined())
+    expect(seamsOf(result).resolveReference('other')?.canvas).toEqual(embedded('other'))
   })
 
   it('routes image refs to the image loader and canvas refs to the canvas loader', async () => {
@@ -70,10 +73,8 @@ describe('useDocumentFileSeams', () => {
       }),
     )
 
-    await waitFor(() =>
-      expect(result.current.references.resolveReference('asset:pic')?.image).toBeDefined(),
-    )
-    expect(result.current.references.resolveReference('asset:pic')?.image).toEqual({
+    await waitFor(() => expect(seamsOf(result).resolveReference('asset:pic')?.image).toBeDefined())
+    expect(seamsOf(result).resolveReference('asset:pic')?.image).toEqual({
       href: 'blob:asset:pic',
     })
     expect(adapter.loadDocument).toHaveBeenCalledWith('sibling')
@@ -89,9 +90,7 @@ describe('useDocumentFileSeams', () => {
         useDocumentFileSeams({ canvas, adapter, stampOf }),
       { initialProps: { stampOf: new Map([['other', 'v1']]) as ReadonlyMap<string, string> } },
     )
-    await waitFor(() =>
-      expect(result.current.references.resolveReference('other')?.canvas).toBeDefined(),
-    )
+    await waitFor(() => expect(seamsOf(result).resolveReference('other')?.canvas).toBeDefined())
     expect(adapter.loadDocument).toHaveBeenCalledTimes(1)
 
     // Same stamp, new map identity: a re-render must not re-fetch.
@@ -124,9 +123,7 @@ describe('useDocumentFileSeams', () => {
     const { result, unmount } = renderHook(() =>
       useDocumentFileSeams({ canvas: canvasWith('asset:pic'), adapter, stampOf: new Map() }),
     )
-    await waitFor(() =>
-      expect(result.current.references.resolveReference('asset:pic')?.image).toBeDefined(),
-    )
+    await waitFor(() => expect(seamsOf(result).resolveReference('asset:pic')?.image).toBeDefined())
 
     unmount()
 
@@ -156,6 +153,81 @@ describe('useDocumentFileSeams', () => {
 
     expect(result.current.isImageFileRef('asset:pic')).toBe(true)
     expect(result.current.isImageFileRef('sibling')).toBe(false)
+  })
+})
+
+describe('useDocumentFileSeams reaches what a text node embeds', () => {
+  const NOTE_ID = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+  const canvasEmbedding = (target: string): SpatialCanvas => ({
+    nodes: [
+      { id: 't', type: 'text', x: 0, y: 0, width: 300, height: 200, text: `see ![[${target}]]` },
+    ],
+    edges: [],
+  })
+
+  it('loads a note a text node embeds, so the composer can draw it', async () => {
+    // No file node at all: the only reference is inside a text node's body,
+    // which the layout lays out with the same seams a note gets.
+    const adapter = makeAdapter({
+      loadDocument: vi.fn(async () => ({ body: 'PROSE FROM THE NOTE', name: 'Note' })),
+    })
+    const { result } = renderHook(() =>
+      useDocumentFileSeams({ canvas: canvasEmbedding(NOTE_ID), adapter, stampOf: new Map() }),
+    )
+    await waitFor(() => {
+      expect(seamsOf(result).resolveEmbed(NOTE_ID)?.title).toBe('Note')
+    })
+    expect(adapter.loadDocument).toHaveBeenCalledWith(NOTE_ID)
+  })
+
+  it('resolves a path written in a body through the page table, and the record carries the id', async () => {
+    const adapter = makeAdapter({
+      loadDocument: vi.fn(async () => ({ body: 'PROSE FROM THE NOTE' })),
+    })
+    const { result } = renderHook(() =>
+      useDocumentFileSeams({
+        canvas: canvasEmbedding('notes/plan'),
+        adapter,
+        resolveAlias: (alias) => (alias === 'notes/plan' ? NOTE_ID : null),
+        resolveTitle: (id) => (id === NOTE_ID ? 'Plan' : undefined),
+        stampOf: new Map(),
+      }),
+    )
+    await waitFor(() => {
+      expect(seamsOf(result).resolveEmbed(NOTE_ID)?.title).toBe('Plan')
+    })
+    // The wire holds the same answers as data: the alias the page resolved
+    // and the title of the id it resolved to, beside the record.
+    const wire = result.current.references
+    expect(wire.aliases).toEqual([['notes/plan', NOTE_ID]])
+    expect(wire.titles).toEqual([[NOTE_ID, 'Plan']])
+    expect(wire.entries).toEqual([
+      ['notes/plan', { documentId: NOTE_ID, body: 'PROSE FROM THE NOTE' }],
+    ])
+    expect(structuredClone(wire)).toEqual(wire)
+  })
+
+  it('puts an image href and a facet card on the wire as extras', async () => {
+    const adapter = makeAdapter({
+      loadDocument: vi.fn(async () => ({
+        canvas: embedded('x'),
+        facets: { type: 'note' } as CoreFacets,
+      })),
+    })
+    const { result } = renderHook(() =>
+      useDocumentFileSeams({
+        canvas: canvasWith('asset:pic', 'doc-1'),
+        adapter,
+        stampOf: new Map(),
+      }),
+    )
+    await waitFor(() => {
+      expect(result.current.references.extras).toHaveLength(2)
+    })
+    expect(new Map(result.current.references.extras).get('asset:pic')).toEqual({
+      image: { href: 'blob:asset:pic' },
+    })
+    expect(new Map(result.current.references.extras).get('doc-1')?.facets).toBeDefined()
   })
 })
 
@@ -237,11 +309,9 @@ describe('useDocumentFileSeams facets', () => {
       useDocumentFileSeams({ canvas: canvasWith('other'), adapter, stampOf: new Map() }),
     )
 
-    expect(result.current.references.resolveReference('other')?.facets).toBeUndefined()
-    await waitFor(() =>
-      expect(result.current.references.resolveReference('other')?.facets).toBeDefined(),
-    )
-    expect(result.current.references.resolveReference('other')?.facets?.title).toBe('Spec')
+    expect(seamsOf(result).resolveReference('other')?.facets).toBeUndefined()
+    await waitFor(() => expect(seamsOf(result).resolveReference('other')?.facets).toBeDefined())
+    expect(seamsOf(result).resolveReference('other')?.facets?.title).toBe('Spec')
   })
 
   it('keeps a facet-only document cached even though it has no canvas', async () => {
@@ -252,10 +322,8 @@ describe('useDocumentFileSeams facets', () => {
       useDocumentFileSeams({ canvas: canvasWith('doc'), adapter, stampOf: new Map() }),
     )
 
-    await waitFor(() =>
-      expect(result.current.references.resolveReference('doc')?.facets).toBeDefined(),
-    )
-    expect(result.current.references.resolveReference('doc')?.canvas).toBeUndefined()
+    await waitFor(() => expect(seamsOf(result).resolveReference('doc')?.facets).toBeDefined())
+    expect(seamsOf(result).resolveReference('doc')?.canvas).toBeUndefined()
   })
 
   it('has no card for a document that loads without facets', async () => {
@@ -266,10 +334,8 @@ describe('useDocumentFileSeams facets', () => {
       useDocumentFileSeams({ canvas: canvasWith('other'), adapter, stampOf: new Map() }),
     )
 
-    await waitFor(() =>
-      expect(result.current.references.resolveReference('other')?.canvas).toBeDefined(),
-    )
-    expect(result.current.references.resolveReference('other')?.facets).toBeUndefined()
+    await waitFor(() => expect(seamsOf(result).resolveReference('other')?.canvas).toBeDefined())
+    expect(seamsOf(result).resolveReference('other')?.facets).toBeUndefined()
   })
 
   it('settles at one load for a reference that has no staleness stamp', async () => {
@@ -321,10 +387,8 @@ describe('useDocumentFileSeams empty documents', () => {
       useDocumentFileSeams({ canvas: canvasWith('note'), adapter, stampOf: new Map() }),
     )
 
-    await waitFor(() =>
-      expect(result.current.references.resolveReference('note')?.facets).toBeDefined(),
-    )
-    expect(result.current.references.resolveReference('note')?.canvas).toBeUndefined()
+    await waitFor(() => expect(seamsOf(result).resolveReference('note')?.facets).toBeDefined())
+    expect(seamsOf(result).resolveReference('note')?.canvas).toBeUndefined()
   })
 })
 

--- a/apps/web/src/hooks/use-document-file-seams.ts
+++ b/apps/web/src/hooks/use-document-file-seams.ts
@@ -18,11 +18,17 @@
 import {
   type FacetCardData,
   type LoadedReference,
-  type ReferenceSeams,
-  referenceSeams,
+  type ReferenceExtra,
+  type ReferenceWire,
+  referenceTargets,
+  referenceWire,
 } from '@kamiazya/whiteboard-canvas-render'
 import type { AliasResolver } from '@kamiazya/whiteboard-codec'
-import type { SpatialCanvas, StoredCoreFacets } from '@kamiazya/whiteboard-model'
+import {
+  documentIdSchema,
+  type SpatialCanvas,
+  type StoredCoreFacets,
+} from '@kamiazya/whiteboard-model'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { collectFileRefs } from '../lib/document-embed-content.js'
 import type { DocumentFileAdapter, LoadedFileDocument } from '../lib/document-file-contract.js'
@@ -43,12 +49,16 @@ export interface UseDocumentFileSeamsOptions {
 
 export interface DocumentFileSeams {
   /**
-   * Every reference seam over what this hook has loaded, built by
-   * canvas-render's `referenceSeams` — the layout ranks the fields, this
-   * hook only reaches the keeper and adds what a file reference carries
-   * beyond its document (an image asset, a facet card).
+   * Everything the canvas points at, as DATA: what this hook loaded, the
+   * page's alias and title tables evaluated over it, and what a file
+   * reference carries beyond its document (an image asset, a facet card).
+   * The editor builds the reference bundle from it on both threads — the
+   * layout worker cannot take a function — so the two renders cannot
+   * disagree; a surface beside the canvas builds its own with
+   * `referenceSeamsFromWire`. The shape is the editor's prop set, so a page
+   * hands the object over and spreads it once.
    */
-  references: ReferenceSeams
+  references: ReferenceWire
   onAddImage: (file: File) => Promise<string | undefined>
   isImageFileRef: (file: string) => boolean
 }
@@ -89,8 +99,39 @@ export function useDocumentFileSeams({
     [],
   )
 
+  // The shared record per reference: what this keeper loaded, minus the
+  // facets, which are a surface extra below. `null` keeps the terminal
+  // "nothing here" slot so the seams answer without the layout retrying.
+  // The id the page's table resolved a written path to rides on the record,
+  // so a body's `![[path]]` finds it by id.
+  const graph = useMemo(() => {
+    const entries = new Map<string, LoadedReference | null>()
+    for (const [ref, document] of embedContent) {
+      const documentId = documentIdSchema.safeParse(ref).success
+        ? ref
+        : (resolveAlias?.(ref) ?? undefined)
+      entries.set(
+        ref,
+        document === null
+          ? null
+          : {
+              ...(documentId !== undefined ? { documentId } : {}),
+              ...(document.name !== undefined ? { name: document.name } : {}),
+              ...(document.body !== undefined ? { body: document.body } : {}),
+              ...(document.canvas !== undefined ? { canvas: document.canvas } : {}),
+            },
+      )
+    }
+    return entries
+  }, [embedContent, resolveAlias])
+
   useEffect(() => {
-    const refs = collectFileRefs(canvas).filter((ref) => !adapterRef.current.isImageRef(ref))
+    // Everything the canvas points at — its file nodes AND what its text
+    // nodes embed or link, transitively through what has loaded — minus
+    // image assets, which are not documents.
+    const refs = referenceTargets({ canvases: [canvas], loaded: graph }).filter(
+      (ref) => !adapterRef.current.isImageRef(ref),
+    )
     if (refs.length === 0) return
     // Normalised on BOTH sides: the write below stores `?? ''`, so comparing
     // against a raw `undefined` left a reference with no stamp entry (a
@@ -121,7 +162,7 @@ export function useDocumentFileSeams({
     return () => {
       cancelled = true
     }
-  }, [canvas, embedContent, stampOf])
+  }, [canvas, embedContent, graph, stampOf])
 
   useEffect(() => {
     const refs = collectFileRefs(canvas).filter(
@@ -153,44 +194,29 @@ export function useDocumentFileSeams({
     }
   }, [canvas, imageUrls])
 
-  // The shared record per reference: what this keeper loaded, minus the
-  // facets, which are a surface extra below. `null` keeps the terminal
-  // "nothing here" slot so the seams answer without the layout retrying.
-  const graph = useMemo(() => {
-    const entries = new Map<string, LoadedReference | null>()
+  // What this surface adds beside the content, as data so it rides the
+  // wire as-is. An image reference is never loaded as a document, so its
+  // href stands alone, and the layout ranks an image above everything
+  // anyway; a document with readable facets carries its card.
+  const extras = useMemo(() => {
+    const out = new Map<string, ReferenceExtra>()
+    for (const [ref, href] of imageUrls) out.set(ref, { image: { href } })
     for (const [ref, document] of embedContent) {
-      entries.set(
-        ref,
-        document === null
-          ? null
-          : {
-              ...(document.name !== undefined ? { name: document.name } : {}),
-              ...(document.body !== undefined ? { body: document.body } : {}),
-              ...(document.canvas !== undefined ? { canvas: document.canvas } : {}),
-            },
-      )
+      if (document === null || out.has(ref)) continue
+      const facets = toFacetCard(ref, document.facets, document.name)
+      if (facets !== undefined) out.set(ref, { facets })
     }
-    return entries
-  }, [embedContent])
+    return out
+  }, [embedContent, imageUrls])
 
   const references = useMemo(
     () =>
-      referenceSeams(graph, {
+      referenceWire(graph, {
         ...(resolveAlias !== undefined ? { resolveAlias } : {}),
         ...(resolveTitle !== undefined ? { resolveTitle } : {}),
-        extra: (ref) => {
-          // Checked first and returned alone: an image reference is never
-          // loaded as a document, so there is nothing else to carry, and the
-          // layout ranks an image above everything anyway.
-          const href = imageUrls.get(ref)
-          if (href !== undefined) return { image: { href } }
-          const document = embedContent.get(ref)
-          if (document === undefined || document === null) return undefined
-          const facets = toFacetCard(ref, document.facets, document.name)
-          return facets === undefined ? undefined : { facets }
-        },
+        extras,
       }),
-    [graph, embedContent, imageUrls, resolveAlias, resolveTitle],
+    [graph, extras, resolveAlias, resolveTitle],
   )
   const onAddImage = useCallback((file: File) => adapterRef.current.storeImage(file), [])
   const isImageFileRef = useCallback((file: string) => adapterRef.current.isImageRef(file), [])

--- a/apps/web/src/lib/layout-worker-parity.browser.test.tsx
+++ b/apps/web/src/lib/layout-worker-parity.browser.test.tsx
@@ -13,6 +13,11 @@
  */
 
 import {
+  overlayReferences,
+  referenceSeamsFromWire,
+  referenceWire,
+} from '@kamiazya/whiteboard-canvas-render'
+import {
   createBrowserMeasureText,
   ensureViewerFontLoaded,
 } from '@kamiazya/whiteboard-canvas-viewer'
@@ -136,6 +141,48 @@ it('carries the file-label seam across the wire', async () => {
   if (fromWorker.type !== 'laid-out') return
   expect(fromWorker.svg).toContain('Readable name')
   expect(fromWorker.svg).toBe(onMain.svg)
+}, 60_000)
+
+it('draws what a text node embeds and what a file node shows from one wire on both threads', async () => {
+  expect(await ensureViewerFontLoaded()).toBe('loaded')
+  const NOTE = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+  const withEmbed: SpatialCanvas = {
+    nodes: [
+      // Its own paragraph: an embed resolves at block level, as in a note.
+      { id: 't', type: 'text', x: 0, y: 0, width: 300, height: 200, text: `See\n\n![[${NOTE}]]` },
+      { id: 'f', type: 'file', x: 400, y: 0, width: 300, height: 200, file: NOTE },
+    ],
+    edges: [],
+  } as SpatialCanvas
+  const wire = referenceWire(
+    new Map([[NOTE, { documentId: NOTE, name: 'Note', body: 'NOTEPROSE' }]]),
+  )
+  // The main thread builds its seams from the wire it posts — the same
+  // bytes the worker rebuilds from — so the two scenes are equal by
+  // construction. This asserts it anyway.
+  const seams = referenceSeamsFromWire(wire)
+  const onMain = renderCanvasToSvg(withEmbed, {
+    measure: createBrowserMeasureText(),
+    theme: 'light',
+    references: seams,
+    resolveReference: overlayReferences({ content: seams.resolveReference }),
+    expandFileNode: () => true,
+  })
+  const fromWorker = await layoutInWorker({
+    type: 'layout',
+    id: 4,
+    canvas: withEmbed,
+    theme: 'light',
+    references: wire,
+    expandedFileIds: ['f'],
+  })
+  expect(fromWorker.type).toBe('laid-out')
+  if (fromWorker.type !== 'laid-out') return
+  // Once for the text node's embed, once for the file node — one word, so
+  // a wrapped line cannot split what is counted.
+  expect(fromWorker.svg.split('NOTEPROSE')).toHaveLength(3)
+  expect(fromWorker.svg).toBe(onMain.svg)
+  expect(fromWorker.scene).toEqual(onMain.scene)
 }, 60_000)
 
 it('parses markdown itself — no pre-parsed bodies cross the wire', async () => {

--- a/apps/web/src/lib/layout-worker-protocol.test.ts
+++ b/apps/web/src/lib/layout-worker-protocol.test.ts
@@ -1,57 +1,54 @@
 // @vitest-environment node
+/**
+ * The wire's whole claim is that everything on it is structured-cloneable
+ * and that the seams rebuilt from it answer as the seams it was made from.
+ * A field that is a function would throw in `structuredClone` — which is
+ * exactly the failure a real `postMessage` would raise, and the one this
+ * file exists to catch before a worker does.
+ */
+import { referenceSeamsFromWire, referenceWire } from '@kamiazya/whiteboard-canvas-render'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { describe, expect, it } from 'vitest'
-import { canLayoutInWorker } from './layout-worker-protocol.js'
+import type { LayoutRequest } from './layout-worker-protocol.js'
 
-const textOnly: SpatialCanvas = {
-  nodes: [{ id: 'a', type: 'text', x: 0, y: 0, width: 100, height: 60, text: 'hi' }],
-  edges: [],
-}
-const withFile: SpatialCanvas = {
+const NOTE_ID = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+const canvas: SpatialCanvas = {
   nodes: [
-    { id: 'a', type: 'text', x: 0, y: 0, width: 100, height: 60, text: 'hi' },
+    { id: 'a', type: 'text', x: 0, y: 0, width: 100, height: 60, text: `see ![[${NOTE_ID}]]` },
     { id: 'f', type: 'file', x: 200, y: 0, width: 100, height: 60, file: 'doc-1' },
   ],
   edges: [],
 }
-/**
- * One entry per seam the predicate disqualifies on. Listed individually
- * rather than only as a combined object because a combined fixture cannot
- * fail for a seam the predicate FORGOT: with the other clause already
- * returning false, deleting either one leaves every assertion green. That is
- * how a seam was once added to the predicate with no test that could fail —
- * caught in review, pinned here.
- */
-const SEAMS: Record<string, unknown> = {
-  resolveReferenceContent: () => undefined,
-  expandFileNode: () => false,
-}
 
-const seams = SEAMS
+describe('LayoutRequest', () => {
+  it('carries the reference bundle as data that survives structuredClone and rebuilds the same seams', () => {
+    const wire = referenceWire(
+      new Map([
+        [NOTE_ID, { documentId: NOTE_ID, name: 'Note', body: '# From the note' }],
+        ['doc-1', { canvas: { nodes: [], edges: [] } }],
+      ]),
+      {
+        resolveTitle: (id) => (id === NOTE_ID ? 'Note' : undefined),
+        extras: new Map([['doc-1', { label: 'Doc one' }]]),
+      },
+    )
+    const request: LayoutRequest = {
+      type: 'layout',
+      id: 1,
+      canvas,
+      theme: 'light',
+      references: wire,
+      expandedFileIds: ['f'],
+      fileRefLabels: [{ file: 'doc-1', label: 'Doc one' }],
+      missingFileRefs: [],
+    }
+    const crossed = structuredClone(request)
+    expect(crossed).toEqual(request)
 
-describe('canLayoutInWorker', () => {
-  it('offloads a canvas with no file nodes even when the host supplies file seams', () => {
-    // The real pages ALWAYS supply the seams (useDocumentFileSeams returns them
-    // unconditionally), so a presence check disables the worker for every
-    // production canvas — including the plain text-and-edges ones the seams
-    // can never influence. Every seam is keyed on a file reference; a canvas
-    // without a file node cannot call one.
-    expect(canLayoutInWorker(seams, textOnly)).toBe(true)
-  })
-
-  it('stays synchronous when a file node could actually call a seam', () => {
-    // A function cannot cross a postMessage, so a canvas whose layout depends
-    // on one must fall back rather than silently render without it.
-    expect(canLayoutInWorker(seams, withFile)).toBe(false)
-  })
-
-  it.each(Object.keys(SEAMS))('stays synchronous for %s supplied alone', (key) => {
-    // In isolation, so each clause of the predicate is the ONLY reason the
-    // answer is false and deleting it turns exactly this case red.
-    expect(canLayoutInWorker({ [key]: SEAMS[key] }, withFile)).toBe(false)
-  })
-
-  it('offloads a canvas with file nodes when no seam is supplied', () => {
-    expect(canLayoutInWorker({}, withFile)).toBe(true)
+    const seams = referenceSeamsFromWire(crossed.references as typeof wire)
+    expect(seams.resolveEmbed(NOTE_ID)?.title).toBe('Note')
+    expect(seams.resolveTitle(NOTE_ID)).toBe('Note')
+    // An empty canvas is a card for a file node, with the surface's label.
+    expect(seams.resolveReference('doc-1')).toEqual({ label: 'Doc one' })
   })
 })

--- a/apps/web/src/lib/layout-worker-protocol.ts
+++ b/apps/web/src/lib/layout-worker-protocol.ts
@@ -2,13 +2,20 @@
  * The wire between the editor and the layout worker.
  *
  * Everything here is structured-cloneable BY CONSTRUCTION, which is the
- * constraint that shapes it: `renderCanvasToSvg` takes FUNCTION seams
- * (`resolveReference`, `expandFileNode`) and a function cannot cross a
- * `postMessage`. Only the parts whose input is plain data — the
- * file-reference label table and the dangling-ref list — are carried here
- * and rebuilt worker-side by `composeReferenceSeam`; a canvas whose host
- * resolves reference CONTENT falls back to main-thread layout rather than
- * silently rendering without it (see `canLayoutInWorker`).
+ * constraint that shapes it: a layout reads FUNCTION seams, and a function
+ * cannot cross a `postMessage`. So what crosses is what the seams are a
+ * function OF — the reference graph and its tables as `ReferenceWire`, the
+ * label table, the dangling-ref list, the ids the LOD gate expanded — and
+ * the worker rebuilds the same seams from the same bytes
+ * (`referenceSeamsFromWire`, `overlayReferences`). The main thread builds
+ * its canvas seams from that wire too, which is what makes the two renders
+ * agree by construction; `layout-worker-parity.browser.test.tsx` asserts it
+ * anyway.
+ *
+ * It used to be narrower — only labels and dangling marks crossed, and a
+ * canvas whose host resolved reference CONTENT fell back to main-thread
+ * layout — which left every text-node embed a placeholder in the worker
+ * and, for parity, on the main thread too.
  *
  * Markdown text crosses as part of the canvas and the WORKER parses it, so
  * parse and layout leave the main thread together. The old blocker was never
@@ -24,7 +31,12 @@
  * Dates that a JSON round trip would quietly drop.
  */
 
-import type { BoundingBox, EdgeAnchorPair, Scene } from '@kamiazya/whiteboard-canvas-render'
+import type {
+  BoundingBox,
+  EdgeAnchorPair,
+  ReferenceWire,
+  Scene,
+} from '@kamiazya/whiteboard-canvas-render'
 import type { CommentThread, SpatialCanvas } from '@kamiazya/whiteboard-model'
 import type { FaviconRect } from './favicon.js'
 import type { ResolvedTheme } from './theme.js'
@@ -69,6 +81,19 @@ export type LayoutRequest = LayoutSubject & {
   readonly id: number
   readonly theme: ResolvedTheme
   readonly fileRefLabels?: readonly FileRefLabel[]
+  /**
+   * What the canvas points at, as data: the loaded graph and the alias,
+   * title and extras tables evaluated over it. The worker rebuilds the
+   * reference bundle from this, so a text node's `![[note]]` and a file
+   * node's content draw here exactly as on the main thread.
+   */
+  readonly references?: ReferenceWire
+  /**
+   * File nodes the editor's LOD gate expanded THIS render — the gate reads
+   * the viewport, which the worker does not have, so its decision crosses as
+   * ids and the worker's `expandFileNode` is a lookup.
+   */
+  readonly expandedFileIds?: readonly string[]
   /** File refs the host resolved as dangling — the plain-data form of the
    * seam's `missing` field, precomputed against THIS canvas's file nodes
    * (a function cannot cross the wire; a small ref list can). */
@@ -258,32 +283,3 @@ export type LayoutResponse =
  * the caller must stop asking rather than retry.
  */
 export const FONT_DEGRADED = 'font-degraded'
-
-/**
- * Whether a canvas's render options can cross the wire at all.
- *
- * The CONTENT seam is supplied by a host page and cannot be serialized, so
- * a canvas that could call it has to be laid out on the main thread —
- * shipping a scene rendered WITHOUT a seam the caller wired would be a
- * silent content regression, worse than the jank this worker exists to
- * remove. Labels and dangling refs are exempt because they already cross as
- * data and the worker rebuilds them through `composeReferenceSeam`.
- */
-export function canLayoutInWorker(
-  options: {
-    readonly resolveReferenceContent?: unknown
-    readonly expandFileNode?: unknown
-  },
-  canvas: SpatialCanvas,
-): boolean {
-  // The seam only disqualifies a canvas that could actually CALL it: it is
-  // keyed on a file reference, so a canvas without a file node lays out
-  // identically with or without it. This is judged per canvas rather than
-  // per host because the real pages supply the seam UNCONDITIONALLY
-  // (useDocumentFileSeams returns it whether or not any file node exists) — a
-  // presence check reads as "this host has file support" and silently turns
-  // the worker off for every production canvas.
-  const hasFileNode = canvas.nodes.some((node) => node.type === 'file')
-  if (!hasFileNode) return true
-  return options.resolveReferenceContent === undefined && options.expandFileNode === undefined
-}

--- a/apps/web/src/lib/layout-worker.ts
+++ b/apps/web/src/lib/layout-worker.ts
@@ -1,4 +1,4 @@
-import { overlayReferences } from '@kamiazya/whiteboard-canvas-render'
+import { overlayReferences, referenceSeamsFromWire } from '@kamiazya/whiteboard-canvas-render'
 /**
  * Lays a spatial canvas out off the main thread.
  *
@@ -53,16 +53,18 @@ import type { ResolvedTheme } from './theme.js'
 
 const measure = createBrowserMeasureText()
 
-// One content cache per theme, for the worker's whole lifetime. Sound
-// because this worker REFUSES to lay out until its font face is loaded
-// (the FONT_DEGRADED gate below), so `measure` behaves identically for
-// every request it ever serves — theme is the only remaining cache axis.
-const contentCaches = new Map<ResolvedTheme, SpatialContentCache>()
-function contentCacheFor(theme: ResolvedTheme): SpatialContentCache {
+// One content cache per theme, kept while the reference wire is the one
+// it was filled under. Sound because this worker REFUSES to lay out until
+// its font face is loaded (the FONT_DEGRADED gate below), so `measure`
+// behaves identically for every request it ever serves — theme and what a
+// text node's body can embed are the only remaining cache axes, and the
+// second is compared by its bytes: a different wire is a different cache.
+const contentCaches = new Map<ResolvedTheme, { key: string; cache: SpatialContentCache }>()
+function contentCacheFor(theme: ResolvedTheme, wireKey: string): SpatialContentCache {
   const existing = contentCaches.get(theme)
-  if (existing !== undefined) return existing
+  if (existing !== undefined && existing.key === wireKey) return existing.cache
   const cache = createSpatialContentCache()
-  contentCaches.set(theme, cache)
+  contentCaches.set(theme, { key: wireKey, cache })
   return cache
 }
 
@@ -314,11 +316,21 @@ self.onmessage = async (
     // different document.
     const canvas = request.canvas ?? (await decodeSnapshot(request.snapshot))
     const startedAt = performance.now()
+    // The same bundle the main thread builds, from the same bytes.
+    const references =
+      request.references === undefined ? undefined : referenceSeamsFromWire(request.references)
+    const expanded = new Set(request.expandedFileIds ?? [])
     const { svg, bounds, scene, anchors } = renderCanvasToSvgWith(canvas, {
       measure,
       theme: request.theme,
-      resolveReference: overlayReferences({ labels, missing: missingRefs }),
-      contentCache: contentCacheFor(request.theme),
+      references,
+      resolveReference: overlayReferences({
+        content: references?.resolveReference,
+        labels,
+        missing: missingRefs,
+      }),
+      expandFileNode: references === undefined ? undefined : (node) => expanded.has(node.id),
+      contentCache: contentCacheFor(request.theme, JSON.stringify(request.references ?? null)),
       suppressedBodyNodeIds: request.suppressedBodyNodeIds,
       showResolved: request.showResolved,
       threads: request.threads,

--- a/apps/web/src/lib/spatial/scene-render-core.ts
+++ b/apps/web/src/lib/spatial/scene-render-core.ts
@@ -18,6 +18,7 @@ import type {
   EdgeAnchorPair,
   KeyedSvgRender,
   MeasureText,
+  ReferenceSeams,
   ResolvedReference,
   Scene,
   SpatialContentCache,
@@ -36,6 +37,8 @@ import { createEditorAppearance } from './editor-appearance.js'
 export interface RenderCanvasCoreOptions {
   readonly measure: MeasureText
   readonly theme?: ResolvedTheme
+  /** The reference bundle, for what text-node bodies embed and link. */
+  readonly references?: ReferenceSeams
   readonly resolveReference?: (ref: string) => ResolvedReference | undefined
   readonly expandFileNode?: (node: Extract<SpatialNode, { type: 'file' }>) => boolean
   /**
@@ -95,6 +98,7 @@ export function renderCanvasToSvgWith(
   const { scene, anchors } = layoutSpatialCanvasWithAnchors(canvas, {
     measure: options.measure,
     appearance: createEditorAppearance(options.theme ?? 'light'),
+    references: options.references,
     resolveReference: options.resolveReference,
     expandFileNode: options.expandFileNode,
     contentCache: options.contentCache,

--- a/apps/web/src/lib/spatial/scene-render.ts
+++ b/apps/web/src/lib/spatial/scene-render.ts
@@ -8,6 +8,7 @@
 import type {
   BoundingBox,
   MeasureText,
+  ReferenceSeams,
   ResolvedReference,
 } from '@kamiazya/whiteboard-canvas-render'
 import { naturalNodeContentSize, SPATIAL_THEME_GEOMETRY } from '@kamiazya/whiteboard-canvas-render'
@@ -23,6 +24,8 @@ export interface RenderCanvasOptions {
   /** Defaults to 'light' so existing call sites render the pre-existing chrome unchanged. */
   readonly theme?: ResolvedTheme
   /** Passed through to layout: what the host resolved for one reference. */
+  /** Passed through to layout: the reference bundle text-node bodies read. */
+  readonly references?: ReferenceSeams
   readonly resolveReference?: (ref: string) => ResolvedReference | undefined
   /** Passed through to layout: the LOD gate deciding card vs miniature. */
   readonly expandFileNode?: (node: Extract<SpatialNode, { type: 'file' }>) => boolean

--- a/packages/canvas-render/src/index.ts
+++ b/packages/canvas-render/src/index.ts
@@ -74,6 +74,12 @@ export {
   referenceSeams,
 } from './references/seams.js'
 export { referenceTargets } from './references/targets.js'
+export {
+  type ReferenceExtra,
+  type ReferenceWire,
+  referenceSeamsFromWire,
+  referenceWire,
+} from './references/wire.js'
 export { MIN_SCENE_EXTENT_PX, sceneBounds } from './scene-bounds.js'
 export type { SceneDigest } from './scene-digest.js'
 export { sceneDigest, sceneDigestSchema } from './scene-digest.js'

--- a/packages/canvas-render/src/layout/spatial-canvas.ts
+++ b/packages/canvas-render/src/layout/spatial-canvas.ts
@@ -25,7 +25,11 @@
 // a total function of a deterministic canvas, so the same canvas renders
 // the same SVG twice regardless.
 
-import { parseMarkdownBody } from '@kamiazya/whiteboard-codec'
+import {
+  type AliasResolver,
+  parseMarkdownBody,
+  resolveReferences,
+} from '@kamiazya/whiteboard-codec'
 import type {
   AnchorRect,
   CanvasComment,
@@ -235,6 +239,13 @@ export interface SpatialLayoutOptions {
    */
   readonly references?: ReferenceSeams
   /**
+   * What a text node's `[[target]]` resolves to, applied to its parsed body
+   * the way a note's caller applies it before layout. Filled from
+   * `references` when absent; an id names itself, and a target nobody
+   * resolves stays the literal text the author wrote.
+   */
+  readonly resolveAlias?: AliasResolver
+  /**
    * Tokeniser for fenced code. Defaults to this package's own lowlight-backed
    * implementation, for the same reason `parseBody` defaults to codec's
    * parser: every surface that lays a markdown body out wants it, and the one
@@ -284,8 +295,8 @@ export interface SpatialLayoutOptions {
    * ORIGIN-RELATIVE coordinates and placed by `placeInNode`, so a cached
    * value is position-independent by construction: keyed by the node's
    * text and box size only. Everything else that shapes content —
-   * `measure`, the appearance resolver, `geometry`, `parseBody`, the mdast
-   * seams — is deliberately NOT in the key: the CALLER owns the cache's
+   * `measure`, the appearance resolver, `geometry`, `parseBody`, the
+   * reference and mdast seams — is deliberately NOT in the key: the CALLER owns the cache's
    * lifetime and must discard it when any of those change (in practice:
    * one cache per document+theme, dropped on theme/font switches). Cached
    * values are shared between scenes and must be treated as immutable,
@@ -728,7 +739,7 @@ function composeTextNode(
   } else {
     try {
       const laid = layoutMdastBlocks(
-        options.parseBody(node.text),
+        resolveReferences(options.parseBody(node.text), options.resolveAlias),
         mdastOptionsFor(maxWidth, options),
       )
       body = fitTextBody(laid, node, options)
@@ -1381,8 +1392,12 @@ export function naturalNodeContentSize(
 function withSpatialReferenceSeams(options: SpatialLayoutOptions): SpatialLayoutOptions {
   const applied = withReferenceSeams(options)
   const seams = options.references
-  if (seams === undefined || options.resolveReference !== undefined) return applied
-  return { ...applied, resolveReference: seams.resolveReference }
+  if (seams === undefined) return applied
+  return {
+    ...applied,
+    resolveAlias: options.resolveAlias ?? seams.resolveAlias,
+    resolveReference: options.resolveReference ?? seams.resolveReference,
+  }
 }
 
 /** The embed path needs only the scene; the anchor map is per-top-level-canvas. */

--- a/packages/canvas-render/src/layout/text-node-embed.test.ts
+++ b/packages/canvas-render/src/layout/text-node-embed.test.ts
@@ -1,0 +1,78 @@
+/**
+ * A text node's body is markdown like a note's, so what it writes in the
+ * reference grammar resolves the same way: `![[id]]` draws the document,
+ * `[[id]]` is labelled by its title. Nothing did this before — the composer
+ * parsed the body and laid the literal brackets out — and the wire to the
+ * layout worker only made the omission visible on both threads at once.
+ */
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { describe, expect, it } from 'vitest'
+import { referenceSeams } from '../references/seams.js'
+import type { SceneNode } from '../scene-graph.js'
+import { createFakeMeasure } from '../test-utils/fake-measure.js'
+import { layoutSpatialCanvas } from './spatial-canvas.js'
+
+const NOTE = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+const APPEARANCE = { resolveNode: () => ({}), resolveEdge: () => ({}), resolveLabel: () => ({}) }
+
+function textOf(nodes: readonly SceneNode[]): string[] {
+  const out: string[] = []
+  const visit = (node: SceneNode) => {
+    const entry = node as {
+      kind: string
+      text?: string
+      runs?: readonly SceneNode[]
+      children?: readonly SceneNode[]
+    }
+    if (entry.kind === 'textRun' && entry.text !== undefined) out.push(entry.text)
+    for (const run of entry.runs ?? []) visit(run)
+    for (const child of entry.children ?? []) visit(child)
+  }
+  for (const node of nodes) visit(node)
+  return out
+}
+
+const canvas: SpatialCanvas = {
+  nodes: [
+    {
+      id: 't',
+      type: 'text',
+      x: 0,
+      y: 0,
+      width: 400,
+      height: 300,
+      text: `See [[${NOTE}]]\n\n![[${NOTE}]]`,
+    },
+  ],
+  edges: [],
+}
+
+describe('a text node body in the reference grammar', () => {
+  it('embeds the document and labels the link through the reference bundle', () => {
+    const scene = layoutSpatialCanvas(canvas, {
+      measure: createFakeMeasure(),
+      appearance: APPEARANCE,
+      references: referenceSeams(
+        new Map([[NOTE, { documentId: NOTE, name: 'Note', body: 'PROSE FROM THE NOTE' }]]),
+      ),
+    })
+    const text = textOf(scene.nodes).join(' ')
+    expect(text).toContain('PROSE FROM THE NOTE')
+    expect(text).toContain('Note')
+    expect(text).not.toContain('![[')
+  })
+
+  it('keeps a target nobody resolves as the literal text the author wrote', () => {
+    const literal: SpatialCanvas = {
+      nodes: [
+        { id: 't', type: 'text', x: 0, y: 0, width: 400, height: 100, text: 'See [[nowhere]]' },
+      ],
+      edges: [],
+    }
+    const scene = layoutSpatialCanvas(literal, {
+      measure: createFakeMeasure(),
+      appearance: APPEARANCE,
+    })
+    expect(textOf(scene.nodes).join(' ')).toContain('[[nowhere]]')
+  })
+})

--- a/packages/canvas-render/src/mutation-lane-coverage.test.ts
+++ b/packages/canvas-render/src/mutation-lane-coverage.test.ts
@@ -62,7 +62,7 @@ describe('the mutation lane covers what it says it covers', () => {
   it('names exactly the modules it mutates, out of exactly this many', () => {
     expect({ mutated: MUTATED.length, production: production.length }).toEqual({
       mutated: 10,
-      production: 55,
+      production: 56,
     })
   })
 

--- a/packages/canvas-render/src/references/references.test.ts
+++ b/packages/canvas-render/src/references/references.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { LoadedReference, ReferenceGraph } from './loaded-reference.js'
 import { overlayReferences, referenceSeams } from './seams.js'
 import { REFERENCE_BUDGET, referenceTargets } from './targets.js'
+import { referenceSeamsFromWire, referenceWire } from './wire.js'
 
 const NOTE_ID = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
 const BOARD_ID = '01BX5ZZKBKACTAV9WEVGEMMVRZ'
@@ -45,6 +46,23 @@ describe('referenceTargets', () => {
       loaded: graphOf({ 'boards/a': { documentId: BOARD_ID, canvas: nested } }),
     })
     expect(targets).toEqual(['boards/a', 'boards/b'])
+  })
+
+  it("names what a canvas's text nodes embed and link, as a seed and once loaded", () => {
+    // A text node's body is markdown like any note's, and the composer lays
+    // it out with the same seams — so what it points at has to load too.
+    const withText: SpatialCanvas = {
+      nodes: [
+        { id: 't', type: 'text', x: 0, y: 0, width: 10, height: 10, text: 'see ![[notes/a]]' },
+      ],
+      edges: [],
+    }
+    expect(referenceTargets({ canvases: [withText] })).toEqual(['notes/a'])
+    const targets = referenceTargets({
+      bodies: ['![[boards/b]]'],
+      loaded: graphOf({ 'boards/b': { documentId: BOARD_ID, canvas: withText } }),
+    })
+    expect(targets).toEqual(['boards/b', 'notes/a'])
   })
 
   it("stops at the layout's embed depth, so a link graph is never loaded whole", () => {
@@ -148,6 +166,42 @@ describe('referenceSeams', () => {
     const seams = referenceSeams(graphOf({ bad: { documentId: 'B', name: 'Bad', body: ' ' } }))
     expect(() => seams.resolveEmbed('B')).not.toThrow()
     expect(seams.resolveReference('bad')).toEqual({ label: 'Bad' })
+  })
+})
+
+describe('referenceWire', () => {
+  it('carries a graph, the tables the caller answers over it, and data extras, so the rebuilt seams answer as the originals', () => {
+    // The wire is what crosses postMessage: every field is plain data, and
+    // the alias/title tables hold exactly the answers the caller's functions
+    // gave for what this graph names — so a worker building seams from the
+    // wire answers what the main thread's bundle would have.
+    const graph = graphOf({
+      'notes/plan': { documentId: NOTE_ID, body: 'see [[boards/roadmap]]' },
+      'boards/roadmap': { canvas: board },
+      'notes/missing': null,
+    })
+    const wire = referenceWire(graph, {
+      resolveAlias: (alias) => (alias === 'boards/roadmap' ? BOARD_ID : null),
+      resolveTitle: (id) => (id === BOARD_ID ? 'Roadmap' : id === NOTE_ID ? 'Plan' : undefined),
+      extras: new Map([['boards/roadmap', { label: 'Board card' }]]),
+    })
+    expect(structuredClone(wire)).toEqual(wire)
+    expect(wire.aliases).toEqual([['boards/roadmap', BOARD_ID]])
+    expect(wire.titles).toEqual(
+      expect.arrayContaining([
+        [NOTE_ID, 'Plan'],
+        [BOARD_ID, 'Roadmap'],
+      ]),
+    )
+
+    const seams = referenceSeamsFromWire(wire)
+    expect(seams.resolveAlias('boards/roadmap')).toBe(BOARD_ID)
+    expect(seams.resolveAlias('notes/plan')).toBe(NOTE_ID)
+    expect(seams.resolveTitle(BOARD_ID)).toBe('Roadmap')
+    expect(seams.resolveTitle(NOTE_ID)).toBe('Plan')
+    expect(seams.resolveEmbed(NOTE_ID)?.title).toBe('Plan')
+    expect(seams.resolveReference('boards/roadmap')).toEqual({ label: 'Board card', canvas: board })
+    expect(seams.resolveReference('notes/missing')).toBeUndefined()
   })
 })
 

--- a/packages/canvas-render/src/references/seams.ts
+++ b/packages/canvas-render/src/references/seams.ts
@@ -102,7 +102,10 @@ export function referenceSeams(
   const resolveEmbed = (documentId: string): EmbeddedDocument | undefined => {
     const entry = byId.get(documentId)
     if (entry === undefined) return undefined
-    const title = entry.name !== undefined ? { title: entry.name } : {}
+    // The record's own name first; the caller's table (a page's list, the
+    // wire's title table) labels a keeper that loads content without names.
+    const name = entry.name ?? options.resolveTitle?.(documentId)
+    const title = name !== undefined ? { title: name } : {}
     if (entry.body !== undefined) {
       const root = rootOf(entry)
       return root === undefined ? undefined : { ...title, root }

--- a/packages/canvas-render/src/references/targets.ts
+++ b/packages/canvas-render/src/references/targets.ts
@@ -24,8 +24,9 @@ export const REFERENCE_BUDGET = 256
  *
  * The ONE definition of "what counts as a reference", so a keeper never
  * decides it alone: a body's `[[target]]` and `![[target]]` (the codec
- * scanner's grammar, the same one the reference index uses) and a canvas's
- * file nodes, minus image assets, which are not documents. Passing what is
+ * scanner's grammar, the same one the reference index uses), a canvas's
+ * file nodes, minus image assets, which are not documents, and whatever
+ * its text nodes' bodies write in that grammar. Passing what is
  * already `loaded` extends the walk one step through each loaded body and
  * canvas — so a prefetch loop calls this until it answers nothing new — but
  * only as far as `DEPTH_CAP`, and never past `REFERENCE_BUDGET` targets in
@@ -49,6 +50,9 @@ export function referenceTargets(seeds: {
   const addCanvas = (canvas: SpatialCanvas, depth: number) => {
     for (const node of canvas.nodes) {
       if (node.type === 'file' && !isImageRef(node.file)) add(node.file, depth)
+      // A text node's body is markdown the composer lays out with the same
+      // seams a note gets, so what it embeds and links has to load too.
+      else if (node.type === 'text') addBody(node.text, depth)
     }
   }
   const addEntry = (entry: LoadedReference, depth: number) => {

--- a/packages/canvas-render/src/references/wire.ts
+++ b/packages/canvas-render/src/references/wire.ts
@@ -1,0 +1,84 @@
+import type { AliasResolver } from '@kamiazya/whiteboard-codec'
+import type { ResolvedReference } from '../layout/spatial-canvas.js'
+import type { LoadedReference, ReferenceGraph } from './loaded-reference.js'
+import { type ReferenceSeams, referenceSeams } from './seams.js'
+
+/**
+ * What a surface adds beside a reference's loaded content — a label, an
+ * image href, a facet card, a dangling mark — as data, so it can travel.
+ * A test may hand content this way too; a keeper puts content in the
+ * record, where the seams derive it once.
+ */
+export type ReferenceExtra = Partial<ResolvedReference>
+
+/**
+ * The reference bundle as DATA, so it can cross a `postMessage`.
+ *
+ * A seam is a function and a function cannot be posted, which is why the
+ * layout worker used to draw every text-node embed as a placeholder while
+ * the main thread beside it could have drawn the note. The bundle is a pure
+ * function of what was loaded plus three finite tables, so the tables are
+ * what cross: the alias each written target resolved to, the title of each
+ * id the graph can name, and the extras a surface attached per reference.
+ * `referenceSeamsFromWire` rebuilds the bundle on either side of the wire
+ * from the same bytes, which is what makes the two renders agree by
+ * construction rather than by a parity test alone.
+ */
+export interface ReferenceWire {
+  readonly entries: readonly (readonly [string, LoadedReference | null])[]
+  /** Written target -> the id the caller's table resolved it to. */
+  readonly aliases: readonly (readonly [string, string])[]
+  /** Document id -> display name, for every id the graph or the aliases name. */
+  readonly titles: readonly (readonly [string, string])[]
+  readonly extras: readonly (readonly [string, ReferenceExtra])[]
+}
+
+export interface ReferenceWireOptions {
+  readonly resolveAlias?: AliasResolver
+  readonly resolveTitle?: (documentId: string) => string | undefined
+  readonly extras?: ReadonlyMap<string, ReferenceExtra>
+}
+
+/**
+ * Evaluates the caller's tables over what the graph names — every written
+ * target and every id a record or an alias answers with — so nothing a body
+ * in this graph can ask is left for a function that cannot travel.
+ */
+export function referenceWire(
+  graph: ReferenceGraph,
+  options: ReferenceWireOptions = {},
+): ReferenceWire {
+  const aliases: [string, string][] = []
+  const ids = new Set<string>()
+  for (const [key, entry] of graph) {
+    if (entry !== null) ids.add(entry.documentId ?? key)
+    const own = options.resolveAlias?.(key)
+    if (own !== undefined && own !== null) {
+      aliases.push([key, own])
+      ids.add(own)
+    }
+  }
+  const titles: [string, string][] = []
+  for (const id of ids) {
+    const title = options.resolveTitle?.(id)
+    if (title !== undefined) titles.push([id, title])
+  }
+  return {
+    entries: [...graph.entries()],
+    aliases,
+    titles,
+    extras: [...(options.extras ?? new Map<string, ReferenceExtra>()).entries()],
+  }
+}
+
+/** The bundle again, from the wire — the same on both sides of it. */
+export function referenceSeamsFromWire(wire: ReferenceWire): ReferenceSeams {
+  const aliases = new Map(wire.aliases)
+  const titles = new Map(wire.titles)
+  const extras = new Map(wire.extras)
+  return referenceSeams(new Map(wire.entries), {
+    resolveAlias: (alias) => aliases.get(alias) ?? null,
+    resolveTitle: (documentId) => titles.get(documentId),
+    extra: (ref) => extras.get(ref),
+  })
+}


### PR DESCRIPTION
## Summary

- **Closes the gap the reference layer documented**: the layout worker could not receive functions, so a canvas text node's `[[note]]` / `[[note]]` was never resolved on either thread. `canvas-render` now offers the seam bundle as **data** — `ReferenceWire` (loaded graph + alias/title/extras tables) built by `referenceWire` and rebuilt on either side by `referenceSeamsFromWire` — and `referenceTargets` scans text-node bodies so their targets are loaded at all.
- **Text-node bodies now go through reference resolution in the composer**: `SpatialLayoutOptions.resolveAlias` (filled from `references`) is applied via codec's `resolveReferences` before layout. A block-level `[[id]]` draws the document, `[[id]]` draws its title, an unresolvable target stays literal. This was a real gap on every surface, not only in the worker — a bundle alone could not have fixed it.
- **apps/web**: `useDocumentFileSeams` returns the wire (loading everything `referenceTargets` names, with image hrefs and facet cards as extras); `SpatialEditor` takes `references: ReferenceWire`, builds its own seams from it and posts the wire plus the LOD decision (`expandedFileIds`) to the worker, which rebuilds the same seams from the same bytes. `canLayoutInWorker` and the main-thread content fallback are deleted: every canvas offloads. Content caches on both threads are keyed on the wire.

Trade-off worth knowing: the node-text overlay's live preview resolves aliases/titles only for targets already on the wire (i.e. until the edit commits and the hook reloads). It never resolved them at all before, so this is strictly more.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
  - `canvas-render`: `references.test.ts` (text-node scan, wire round trip), `layout/text-node-embed.test.ts` (red before the composer change)
  - `apps/web`: hook cases for text-node targets / path via page table / extras on the wire; `layout-worker-protocol.test.ts` asserts a request with a wire survives `structuredClone`; `layout-worker-parity.browser.test.tsx` (text-node embed + file node, worker == main thread, byte-identical SVG); `text-node-embed.browser.test.tsx` (editor draws the note on the sync path and after a worker layout)
- [x] `pnpm test` passes locally (area suites: `canvas-render-node` 113 files, `apps/web` jsdom+node as CI runs it, all 104 spatial-editor / document-editor browser files, `arch-lint-node`, pinned `mcp-node` tests; `pnpm -r typecheck`, `pnpm lint`, `pnpm knip`; the two new browser files stressed 5x)
- [x] Manual verification completed — the browser tests above mount the real `SpatialEditor` against a mocked adapter and assert the rendered SVG, on both the synchronous and the worker path
- [ ] E2E coverage added or extended where applicable — not needed: no routing, websocket or persistence is involved

## Visual evidence

Visual evidence: none — the user-visible change is covered by `text-node-embed.browser.test.tsx`, which asserts the note's prose appears in the rendered SVG on both layout paths; the parity test asserts the worker and main-thread SVG are byte-identical, which is the property a figure could not show.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — `.claude/rules/architecture-map.md` and `package-canvas-render.md` now describe the wire instead of the gap
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8HzhgLpsT6XLvJNcz2fxD

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8HzhgLpsT6XLvJNcz2fxD)_