### PR TITLE
feat(web): the picker keeps a lane of what this device opened recently

### DIFF
--- a/apps/web/src/components/workspace-files/RecentLane.tsx
+++ b/apps/web/src/components/workspace-files/RecentLane.tsx
@@ -1,0 +1,78 @@
+import { FileText, LayoutGrid } from 'lucide-react'
+import type { ReactNode } from 'react'
+import type { WorkspaceDocumentEntry } from '../../lib/document-entry.js'
+
+export interface RecentLaneProps {
+  /** The listing as loaded. Recorded ids are resolved against it. */
+  documents: readonly WorkspaceDocumentEntry[]
+  /** Most recent first, from `recent-documents.ts`. */
+  recentIds: readonly string[]
+  onOpen: (entry: WorkspaceDocumentEntry) => void
+  renderThumbnail?: (entry: WorkspaceDocumentEntry) => ReactNode
+}
+
+/**
+ * The documents this device opened most recently, as a strip above the grid.
+ *
+ * An ADDITION beside the grid rather than a reordering of it: the grid is
+ * sorted by path, and where a card sits is what a person remembers about it.
+ * Putting the newest first would move every card every time anything was
+ * opened, which is the spatial memory the sort exists to give (NN/g).
+ *
+ * Resolved against the listing already in hand, so a deleted or renamed
+ * document falls out on its own — the lane needs no reconciliation pass, and
+ * a stale id costs nothing but its own absence.
+ */
+export function RecentLane({ documents, recentIds, onOpen, renderThumbnail }: RecentLaneProps) {
+  const entries = recentIds
+    .map((id) => documents.find((each) => each.documentId === id))
+    .filter((each): each is WorkspaceDocumentEntry => each !== undefined)
+
+  // Nothing recorded, or nothing recorded that still exists: the lane is
+  // absent rather than empty. An empty strip is a row of chrome explaining
+  // that there is nothing to show, which is the wordiness this redesign is
+  // removing everywhere else.
+  if (entries.length === 0) return null
+
+  return (
+    <section aria-label="Recently opened" data-testid="recent-lane" className="px-2 pb-2">
+      {/* One word, and it earns its place: without it the strip reads as two
+          unexplained tiles above the grid — pinned, maybe, or a selection.
+          Every surveyed product labels this lane (Finder and iOS Files
+          "Recents", Figma "Recently viewed"); what this redesign is cutting is
+          instructional prose, not the noun that says what a thing is. */}
+      <h2 className="text-muted-foreground pb-1 text-[11px] font-medium">Recent</h2>
+      {/* Its own scroller: a phone fits two tiles, and the page body must
+          never scroll sideways to reach the third. */}
+      <div className="flex gap-2 overflow-x-auto">
+        {entries.map((entry) => {
+          const KindIcon = entry.kind === 'spatial' ? LayoutGrid : FileText
+          return (
+            <button
+              key={entry.documentId}
+              type="button"
+              onClick={() => onOpen(entry)}
+              className="hover:bg-accent/40 flex w-28 shrink-0 flex-col overflow-hidden rounded-md border text-left md:w-32"
+            >
+              <span className="bg-muted/40 flex aspect-video w-full items-center justify-center overflow-hidden">
+                {renderThumbnail?.(entry) ?? (
+                  <KindIcon
+                    role="img"
+                    aria-label={entry.kind ?? 'markdown'}
+                    className="text-muted-foreground size-4"
+                  />
+                )}
+              </span>
+              {/* The display name, with the path's last segment as the label
+                for a document nobody named — never a name invented from the
+                path, which is the same rule the cards below follow. */}
+              <span className="truncate px-2 py-1 text-xs">
+                {entry.name ?? entry.path.split('/').at(-1)}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -17,6 +17,7 @@ import { useThemeMode } from '../../hooks/useThemeMode.js'
 import type { WorkspaceDocumentEntry } from '../../lib/document-entry.js'
 import { type WorkspaceFilesSource, WorkspaceMissingError } from '../../lib/files-source.js'
 import { hasCoarsePointer } from '../../lib/platform.js'
+import { readRecentIds, recordRecentDocument } from '../../lib/recent-documents.js'
 import { createInTabRenderBroker } from '../../lib/render-broker.js'
 import { ContextMenu } from '../spatial-editor/ContextMenu.js'
 import { DocumentMinimap } from './DocumentMinimap.js'
@@ -29,6 +30,7 @@ import { createRowRenderLoader } from './load-row-render.js'
 import { NewDocumentMenu } from './NewDocumentMenu.js'
 import { newDocumentPathIn } from './new-document-path.js'
 import { PeekDialog } from './PeekDialog.js'
+import { RecentLane } from './RecentLane.js'
 import { RenameDocumentDialog } from './RenameDocumentDialog.js'
 import { SearchResults } from './SearchResults.js'
 import { searchDocuments, withNameMatches } from './search-documents.js'
@@ -128,6 +130,13 @@ export function WorkspaceFilesPanel({
   // a failure. 'error' is a genuine fetch/schema failure and keeps the alert.
   const [listStatus, setListStatus] = useState<'ok' | 'not-found' | 'error'>('ok')
   const [selected, setSelected] = useState<WorkspaceDocumentEntry | null>(null)
+  /**
+   * What this device opened most recently in THIS workspace, newest first.
+   *
+   * Held as ids and resolved against `documents` at render, so a deleted or
+   * renamed document leaves the lane on its own.
+   */
+  const [recentIds, setRecentIds] = useState<readonly string[]>([])
   /**
    * How many cards the last successful listing drew, kept so a RE-READ can
    * hold the layout it is about to replace.
@@ -253,6 +262,10 @@ export function WorkspaceFilesPanel({
   // list so an inline arrow from the page above cannot re-create it.
   const onOpenDocumentRef = useRef(onOpenDocument)
   onOpenDocumentRef.current = onOpenDocument
+  // Read through a ref for the same reason `onOpenDocument` is: `openEntry`
+  // is handed to four children and its identity has to stay stable.
+  const workspaceRef = useRef(workspace)
+  workspaceRef.current = workspace
   const lastReadListRef = useRef(readList)
 
   /**
@@ -269,8 +282,20 @@ export function WorkspaceFilesPanel({
    */
   const tapOpens = hasCoarsePointer() && onOpenDocument !== undefined
   const openEntry = useCallback((entry: WorkspaceDocumentEntry) => {
+    const scope = workspaceRef.current
+    if (scope !== undefined) {
+      recordRecentDocument(scope, entry.documentId)
+      setRecentIds(readRecentIds(scope))
+    }
     onOpenDocumentRef.current?.(entry.path)
   }, [])
+
+  // Keyed on the handle rather than folded into the SCOPE RESET below,
+  // because the handle is the scope this is filed under and it can arrive
+  // after the source (a page still resolving its address passes undefined).
+  useEffect(() => {
+    setRecentIds(workspace === undefined ? [] : readRecentIds(workspace))
+  }, [workspace])
 
   // SCOPE RESET — see scoped-screen-state.test.ts
   useEffect(() => {
@@ -287,6 +312,15 @@ export function WorkspaceFilesPanel({
     setSelected(null)
     setCardMenu(null)
     setPeek(null)
+    // The departed workspace's lane names its documents, so it is emptied
+    // here like everything else — and refilled in the same effect, from the
+    // ref rather than a dependency. Both halves together, because splitting
+    // them across two effects made the ORDER load-bearing and it was wrong:
+    // the handle-keyed effect below loaded first and this one blanked it, so
+    // the lane never survived a remount. Each effect now ends on the same
+    // value whichever runs last.
+    setRecentIds([])
+    if (workspaceRef.current !== undefined) setRecentIds(readRecentIds(workspaceRef.current))
     setRenaming(null)
     setRenameError(null)
     setRenameBusy(false)
@@ -810,6 +844,26 @@ export function WorkspaceFilesPanel({
             </button>
           ))}
         </fieldset>
+      )}
+      {/* Above the columns, and only in the browse view: a search has its
+          own answer to "which one did you mean", and a lane beside it
+          would compete with the results the person asked for. Absent on a
+          host that cannot open a document, since every tile would be
+          inert. */}
+      {documents !== null && query.trim() === '' && onOpenDocument !== undefined && (
+        <RecentLane
+          documents={documents}
+          recentIds={recentIds}
+          onOpen={openEntry}
+          renderThumbnail={(entry) => (
+            <DocumentThumbnail
+              key={entry.documentId}
+              document={entry}
+              loadRender={loadRender}
+              className="size-full"
+            />
+          )}
+        />
       )}
       <div className="flex min-h-0 flex-1 flex-col gap-4 md:flex-row">
         {documents === null ? (

--- a/apps/web/src/components/workspace-files/recent-lane.browser.test.tsx
+++ b/apps/web/src/components/workspace-files/recent-lane.browser.test.tsx
@@ -1,0 +1,112 @@
+// The recently-opened lane end to end in a REAL browser: a real click on a
+// real card, a real localStorage write, and the lane on the next mount. jsdom
+// covers the lane's own rendering; what only a browser proves is that the two
+// halves meet through storage the panel actually writes to.
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { STORAGE_KEY } from '../../lib/recent-documents.js'
+import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
+import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
+
+const entries = [
+  { documentId: 'd1', path: 'meeting-notes', name: 'Meeting notes', kind: 'markdown' as const },
+  { documentId: 'd2', path: 'roadmap', name: 'Roadmap', kind: 'spatial' as const },
+]
+
+beforeEach(() => localStorage.removeItem(STORAGE_KEY))
+afterEach(() => {
+  cleanup()
+  localStorage.removeItem(STORAGE_KEY)
+})
+
+// No default parameter: a default fires on an EXPLICIT undefined too, so
+// `renderPanel(undefined)` would have rendered the 'space' workspace and the
+// no-handle case would have tested nothing.
+function renderPanel(workspace: string | undefined) {
+  const source = fakeFilesSource({ listDocuments: async () => entries })
+  render(<WorkspaceFilesPanel source={source} workspace={workspace} onOpenDocument={() => {}} />)
+}
+
+async function openCard(name: string) {
+  // Scoped to the grid: once the lane exists it holds the same names, so an
+  // unscoped query is ambiguous exactly when the feature is working.
+  const grid = await screen.findByTestId('folder-contents')
+  const title = await within(grid).findByText(name)
+  const card = title.closest('button')
+  if (card === null) throw new Error(`no card for ${name}`)
+  // A fine pointer selects on click and opens on double-click, which is the
+  // desktop half of the wayfinding contract slice 1 established.
+  await userEvent.dblClick(card)
+}
+
+const lane = () => screen.queryByTestId('recent-lane')
+
+describe('recently opened lane', () => {
+  it('is absent until something has been opened', async () => {
+    renderPanel('space')
+    await screen.findByText('Meeting notes')
+
+    expect(lane()).toBeNull()
+  })
+
+  it('carries what was opened to the next mount, newest first', async () => {
+    renderPanel('space')
+    await openCard('Meeting notes')
+    await openCard('Roadmap')
+    cleanup()
+
+    renderPanel('space')
+    const strip = await screen.findByTestId('recent-lane')
+    await waitFor(() =>
+      expect(
+        within(strip)
+          .getAllByRole('button')
+          .map((each) => each.textContent),
+      ).toEqual(['Roadmap', 'Meeting notes']),
+    )
+  })
+
+  it('keeps one entry per document however often it is reopened', async () => {
+    renderPanel('space')
+    await openCard('Roadmap')
+    await openCard('Meeting notes')
+    await openCard('Roadmap')
+    cleanup()
+
+    renderPanel('space')
+    const strip = await screen.findByTestId('recent-lane')
+    await waitFor(() => expect(within(strip).getAllByRole('button')).toHaveLength(2))
+    expect(within(strip).getAllByRole('button')[0]?.textContent).toBe('Roadmap')
+  })
+
+  it('steps aside while a search is showing its own answer', async () => {
+    renderPanel('space')
+    await openCard('Roadmap')
+    await screen.findByTestId('recent-lane')
+
+    await userEvent.fill(screen.getByLabelText('Search documents'), 'meeting')
+
+    await waitFor(() => expect(lane()).toBeNull())
+  })
+
+  it('does not carry one workspace lane into another', async () => {
+    renderPanel('alpha')
+    await openCard('Roadmap')
+    cleanup()
+
+    renderPanel('beta')
+    await screen.findByText('Meeting notes')
+    expect(lane()).toBeNull()
+  })
+
+  it('stays absent for a host that passes no workspace handle', async () => {
+    renderPanel(undefined)
+    await openCard('Roadmap')
+    cleanup()
+
+    renderPanel(undefined)
+    await screen.findByText('Meeting notes')
+    expect(lane()).toBeNull()
+  })
+})

--- a/apps/web/src/components/workspace-files/recent-lane.test.tsx
+++ b/apps/web/src/components/workspace-files/recent-lane.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { WorkspaceDocumentEntry } from '../../lib/document-entry.js'
+import { RecentLane } from './RecentLane.js'
+
+// The lane is an ADDITION beside the grid, never a reordering of it: the grid
+// is sorted by path, and a person's memory of where a card sat is worth more
+// than putting the newest first (NN/g). So the lane's own order is recency
+// and the grid below it does not move.
+
+afterEach(cleanup)
+
+const entry = (over: Partial<WorkspaceDocumentEntry>): WorkspaceDocumentEntry => ({
+  documentId: 'd1',
+  path: 'design/login',
+  name: 'Login',
+  kind: 'markdown',
+  ...over,
+})
+
+const documents = [
+  entry({ documentId: 'd1', path: 'design/login', name: 'Login' }),
+  entry({ documentId: 'd2', path: 'design/board', name: 'Board', kind: 'spatial' }),
+  entry({ documentId: 'd3', path: 'notes/scratch', name: 'Scratch' }),
+]
+
+describe('RecentLane', () => {
+  it('lists the recorded documents in recency order, not the listing order', () => {
+    render(<RecentLane documents={documents} recentIds={['d3', 'd1']} onOpen={() => {}} />)
+
+    const lane = screen.getByRole('region', { name: /recent/i })
+    expect(
+      within(lane)
+        .getAllByRole('button')
+        .map((each) => each.textContent),
+    ).toEqual(['Scratch', 'Login'])
+  })
+
+  it('renders nothing at all when nothing has been recorded', () => {
+    render(<RecentLane documents={documents} recentIds={[]} onOpen={() => {}} />)
+
+    expect(screen.queryByRole('region', { name: /recent/i })).toBeNull()
+  })
+
+  it('drops a recorded id the listing no longer holds, rather than showing a dead tile', () => {
+    // A deleted document — the lane resolves against the listing already in
+    // hand, so it needs no reconciliation pass of its own.
+    render(<RecentLane documents={documents} recentIds={['gone', 'd2']} onOpen={() => {}} />)
+
+    const lane = screen.getByRole('region', { name: /recent/i })
+    expect(within(lane).getAllByRole('button')).toHaveLength(1)
+    expect(within(lane).getByRole('button').textContent).toBe('Board')
+  })
+
+  it('renders nothing when every recorded id has gone', () => {
+    render(<RecentLane documents={documents} recentIds={['gone', 'also-gone']} onOpen={() => {}} />)
+
+    expect(screen.queryByRole('region', { name: /recent/i })).toBeNull()
+  })
+
+  it('opens the entry it was given, not one looked up by path', () => {
+    const onOpen = vi.fn()
+    render(<RecentLane documents={documents} recentIds={['d2']} onOpen={onOpen} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Board/ }))
+
+    expect(onOpen).toHaveBeenCalledWith(documents[1])
+  })
+
+  it('shows the path tail when a document was never named', () => {
+    render(
+      <RecentLane
+        documents={[entry({ documentId: 'd9', path: 'notes/untitled-2', name: undefined })]}
+        recentIds={['d9']}
+        onOpen={() => {}}
+      />,
+    )
+
+    expect(screen.getByRole('button').textContent).toBe('untitled-2')
+  })
+
+  it('draws each tile through the thumbnail renderer it is given', () => {
+    render(
+      <RecentLane
+        documents={documents}
+        recentIds={['d1', 'd2']}
+        onOpen={() => {}}
+        renderThumbnail={(each) => <span data-testid={`thumb-${each.documentId}`} />}
+      />,
+    )
+
+    expect(screen.getByTestId('thumb-d1')).toBeTruthy()
+    expect(screen.getByTestId('thumb-d2')).toBeTruthy()
+  })
+})

--- a/apps/web/src/lib/recent-documents.property.test.ts
+++ b/apps/web/src/lib/recent-documents.property.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+import { describe, expect } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { RECENT_CAP, recordRecentId } from './recent-documents.js'
+
+// The pure half only — no storage, so this runs in node. The localStorage
+// contract is `recent-documents.test.ts`.
+const PROPERTY_PARAMS = withDefaults({ numRuns: 200 })
+
+// Ids are opaque to the module, so a dense small alphabet is what actually
+// exercises dedupe and the cap; `fc.string()` would draw distinct ids almost
+// every time and the interesting branch would never run.
+const idArb = fc.constantFrom('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k')
+const idsArb = fc.array(idArb)
+
+describe('recordRecentId (fast-check)', () => {
+  fcTest.prop([idsArb, idArb], PROPERTY_PARAMS)(
+    'puts the recorded id at the head',
+    (existing, id) => {
+      expect(recordRecentId(existing, id)[0]).toBe(id)
+    },
+  )
+
+  fcTest.prop([idsArb, idArb], PROPERTY_PARAMS)(
+    'is idempotent: recording the same id twice leaves the same list',
+    (existing, id) => {
+      const once = recordRecentId(existing, id)
+      expect(recordRecentId(once, id)).toEqual(once)
+    },
+  )
+
+  fcTest.prop([idsArb, idArb], PROPERTY_PARAMS)('never exceeds the cap', (existing, id) => {
+    expect(recordRecentId(existing, id).length).toBeLessThanOrEqual(RECENT_CAP)
+  })
+
+  fcTest.prop([idsArb, idArb], PROPERTY_PARAMS)('holds no id twice', (existing, id) => {
+    const next = recordRecentId(existing, id)
+    expect(new Set(next).size).toBe(next.length)
+  })
+
+  fcTest.prop([idsArb, idArb], PROPERTY_PARAMS)(
+    'keeps the order of what it did not touch',
+    (existing, id) => {
+      // Everything that survives, minus the id just recorded, must appear in
+      // its original relative order — the list is a recency ranking, so a
+      // record may only move ONE entry.
+      const next = recordRecentId(existing, id).filter((each) => each !== id)
+      const before = existing.filter((each, i) => existing.indexOf(each) === i && each !== id)
+      expect(next).toEqual(before.slice(0, next.length))
+    },
+  )
+
+  fcTest.prop([fc.array(idArb, { minLength: 1 })], PROPERTY_PARAMS)(
+    'recording every id in turn leaves the last one first',
+    (ids) => {
+      const result = ids.reduce<readonly string[]>((acc, id) => recordRecentId(acc, id), [])
+      expect(result[0]).toBe(ids[ids.length - 1])
+    },
+  )
+})

--- a/apps/web/src/lib/recent-documents.test.ts
+++ b/apps/web/src/lib/recent-documents.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RECENT_CAP, readRecentIds, recordRecentDocument, STORAGE_KEY } from './recent-documents.js'
+
+afterEach(() => {
+  localStorage.clear()
+  vi.restoreAllMocks()
+})
+
+describe('recent documents (per-device, localStorage)', () => {
+  it('reads back what was recorded, most recent first', () => {
+    recordRecentDocument('space', 'one')
+    recordRecentDocument('space', 'two')
+
+    expect(readRecentIds('space')).toEqual(['two', 'one'])
+  })
+
+  it('keeps each workspace handle independent', () => {
+    recordRecentDocument('alpha', 'a-doc')
+    recordRecentDocument('beta', 'b-doc')
+
+    expect(readRecentIds('alpha')).toEqual(['a-doc'])
+    expect(readRecentIds('beta')).toEqual(['b-doc'])
+  })
+
+  it('caps the stored list rather than growing without bound', () => {
+    for (let i = 0; i < RECENT_CAP + 5; i++) recordRecentDocument('space', `doc-${i}`)
+
+    expect(readRecentIds('space')).toHaveLength(RECENT_CAP)
+    // The oldest fell off, the newest is at the head.
+    expect(readRecentIds('space')[0]).toBe(`doc-${RECENT_CAP + 4}`)
+    expect(readRecentIds('space')).not.toContain('doc-0')
+  })
+
+  it('answers empty for a workspace that has recorded nothing', () => {
+    expect(readRecentIds('never-visited')).toEqual([])
+  })
+
+  it('answers empty rather than throwing when the stored payload is not what we wrote', () => {
+    // Another tab, an older build, or a person with devtools open. The
+    // contract is that the picker still renders.
+    localStorage.setItem(STORAGE_KEY, '{"space":"not-a-list"}')
+
+    expect(readRecentIds('space')).toEqual([])
+  })
+
+  it('answers empty rather than throwing when the stored payload is not JSON', () => {
+    localStorage.setItem(STORAGE_KEY, 'not json at all')
+
+    expect(readRecentIds('space')).toEqual([])
+  })
+
+  it('degrades to empty when localStorage itself throws', () => {
+    // A browser configured to block storage raises SecurityError on ACCESS,
+    // not on parse — so a try/catch around JSON.parse alone would not hold.
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError')
+    })
+
+    expect(readRecentIds('space')).toEqual([])
+  })
+
+  it('swallows a write that localStorage refuses', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError')
+    })
+
+    expect(() => recordRecentDocument('space', 'one')).not.toThrow()
+  })
+
+  it('leaves another workspace intact when one is recorded', () => {
+    recordRecentDocument('alpha', 'a-doc')
+    recordRecentDocument('beta', 'b-doc')
+    recordRecentDocument('alpha', 'a-doc-2')
+
+    expect(readRecentIds('beta')).toEqual(['b-doc'])
+  })
+})

--- a/apps/web/src/lib/recent-documents.test.ts
+++ b/apps/web/src/lib/recent-documents.test.ts
@@ -67,6 +67,45 @@ describe('recent documents (per-device, localStorage)', () => {
     expect(() => recordRecentDocument('space', 'one')).not.toThrow()
   })
 
+  // A workspace handle is text the user chose: `deriveWorkspaceSegment`
+  // lowercases a display name, and `constructor` passes the segment charset,
+  // so a workspace named "Constructor" mints exactly that handle. A plain
+  // object answers it with an INHERITED value that is truthy, so `?? []`
+  // never fires and the lane is handed a Function to map over — measured, it
+  // threw on `.map` and took the whole panel down, with storage EMPTY and so
+  // no way for the person to clear it.
+  //
+  // The whole prototype class is covered rather than the one reachable
+  // member, since what the segment charset allows is not this module's to
+  // know and a widened charset must not reopen this.
+  const PROTOTYPE_HANDLES = ['constructor', '__proto__', 'toString', 'valueOf', 'hasOwnProperty']
+
+  for (const handle of PROTOTYPE_HANDLES) {
+    it(`answers empty for the unrecorded prototype-named handle ${handle}`, () => {
+      expect(readRecentIds(handle)).toEqual([])
+    })
+
+    it(`never throws or answers a non-array for the handle ${handle}`, () => {
+      expect(() => recordRecentDocument(handle, 'doc-1')).not.toThrow()
+      expect(Array.isArray(readRecentIds(handle))).toBe(true)
+    })
+  }
+
+  // `__proto__` is deliberately absent: zod's `z.record` rebuilds the parsed
+  // object by ASSIGNMENT, and assigning `__proto__` sets the prototype rather
+  // than defining an own property, so the entry does not survive a round
+  // trip. It degrades to an empty lane, which is the guarantee above, and it
+  // is unreachable anyway — the segment charset has no underscore. Chasing
+  // persistence for it would mean a null-prototype store for a handle nobody
+  // can mint.
+  for (const handle of PROTOTYPE_HANDLES.filter((each) => each !== '__proto__')) {
+    it(`reads back what was recorded under the handle ${handle}`, () => {
+      recordRecentDocument(handle, 'doc-1')
+
+      expect(readRecentIds(handle)).toEqual(['doc-1'])
+    })
+  }
+
   it('leaves another workspace intact when one is recorded', () => {
     recordRecentDocument('alpha', 'a-doc')
     recordRecentDocument('beta', 'b-doc')

--- a/apps/web/src/lib/recent-documents.ts
+++ b/apps/web/src/lib/recent-documents.ts
@@ -64,13 +64,31 @@ function readAll(): Record<string, readonly string[]> {
   }
 }
 
+/**
+ * One workspace's list, by OWN key only.
+ *
+ * A handle is text the user chose — `deriveWorkspaceSegment` lowercases a
+ * display name, and `constructor` passes the segment charset — so a plain
+ * object answers some handles with an INHERITED member. That value is
+ * truthy, so `?? []` never fires: the lane was handed `Object.prototype`'s
+ * constructor and threw on `.map`, crashing the whole panel for anyone whose
+ * workspace was named that, with storage empty and no way to clear it.
+ *
+ * Nothing is ever WRITTEN to the prototype — a computed key in an object
+ * literal defines an own property rather than invoking the `__proto__`
+ * setter — so this is a read-side confusion, not pollution.
+ */
+function scopeOf(all: Record<string, readonly string[]>, workspace: string): readonly string[] {
+  return Object.hasOwn(all, workspace) ? (all[workspace] ?? []) : []
+}
+
 export function readRecentIds(workspace: string): readonly string[] {
-  return readAll()[workspace] ?? []
+  return scopeOf(readAll(), workspace)
 }
 
 export function recordRecentDocument(workspace: string, documentId: string): void {
   const all = readAll()
-  const next = { ...all, [workspace]: recordRecentId(all[workspace] ?? [], documentId) }
+  const next = { ...all, [workspace]: recordRecentId(scopeOf(all, workspace), documentId) }
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
   } catch {

--- a/apps/web/src/lib/recent-documents.ts
+++ b/apps/web/src/lib/recent-documents.ts
@@ -1,0 +1,79 @@
+/**
+ * What this device opened recently, per workspace.
+ *
+ * Deliberately NOT synced. "Recently opened" is a record of what happened on
+ * THIS device, so a phone and a desktop holding different answers is the
+ * correct behaviour rather than a gap — and keeping it out of the document
+ * model means no schema change and identical behaviour whether the workspace
+ * is kept by the browser or by the daemon (owner decision, 2026-09-05).
+ *
+ * Ids, not paths: a rename must not drop a document out of the lane, and a
+ * path freed by a rename can be taken by a different document.
+ */
+
+import { z } from 'zod'
+
+// Namespaced + version-suffixed, like `user-settings-store.ts`. This payload
+// is disposable — losing it costs a lane, not a setting — so a breaking change
+// here may bump the key without a migration, which is the one way it differs.
+export const STORAGE_KEY = 'whiteboard:recent-documents:v1'
+
+/**
+ * How many the lane remembers.
+ *
+ * A lane is a shortcut, not a history: past a handful it becomes a second
+ * list to search, which is the cost the grid already pays and the reason the
+ * lane exists.
+ */
+export const RECENT_CAP = 8
+
+// Per workspace handle, most recent first. A workspace whose entry fails to
+// parse degrades to empty ON ITS OWN rather than discarding every other
+// workspace's lane with it — the whole-payload discard is the trap
+// `user-settings-store.ts` records paying for.
+const storedSchema = z.record(z.string(), z.array(z.string()).catch([]))
+
+/**
+ * The pure ranking step: `id` to the head, no duplicates, never past the cap.
+ *
+ * Separated from storage so the invariants can be stated as properties
+ * (`recent-documents.property.test.ts`) without a DOM.
+ */
+export function recordRecentId(existing: readonly string[], id: string): readonly string[] {
+  const rest = existing.filter((each, i) => each !== id && existing.indexOf(each) === i)
+  return [id, ...rest].slice(0, RECENT_CAP)
+}
+
+// localStorage access itself throws when a browser blocks storage
+// (SecurityError, privacy settings or an embedded context), so the guard has
+// to sit around the ACCESS and not only around the parse. Contract: neither
+// of these ever throws, and the picker renders with an empty lane instead.
+function readAll(): Record<string, readonly string[]> {
+  let raw: string | null
+  try {
+    raw = localStorage.getItem(STORAGE_KEY)
+  } catch {
+    return {}
+  }
+  if (raw === null) return {}
+  try {
+    const parsed = storedSchema.safeParse(JSON.parse(raw))
+    return parsed.success ? parsed.data : {}
+  } catch {
+    return {}
+  }
+}
+
+export function readRecentIds(workspace: string): readonly string[] {
+  return readAll()[workspace] ?? []
+}
+
+export function recordRecentDocument(workspace: string, documentId: string): void {
+  const all = readAll()
+  const next = { ...all, [workspace]: recordRecentId(all[workspace] ?? [], documentId) }
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+  } catch {
+    // An unwritable storage degrades to not remembering, never to a failed open.
+  }
+}

--- a/apps/web/src/pages/BrowserIndexPage.recent-lane.browser.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.recent-lane.browser.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * The lane on the REAL page, over real IndexedDB and the page's own handle.
+ *
+ * The panel's own suite proves the lane renders and that opening records;
+ * what only this layer proves is that `BrowserIndexPage` passes a workspace
+ * handle at all. Without one the panel records nothing and the lane is
+ * permanently absent — a wiring gap every component-level test passes
+ * through, because they supply the handle themselves.
+ */
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import '../index.css'
+import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
+import { IdbDocumentIndex } from '../lib/idb-document-index.js'
+import { STORAGE_KEY } from '../lib/recent-documents.js'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { LocalStoreDouble } from '../test-utils/local-index.js'
+import { BrowserIndexPage } from './BrowserIndexPage.js'
+
+claimIsolatedWhiteboardDb('browserindexpage-recent-lane')
+
+beforeEach(async () => {
+  await clearWhiteboardDb()
+  localStorage.removeItem(STORAGE_KEY)
+})
+afterEach(() => {
+  cleanup()
+  localStorage.removeItem(STORAGE_KEY)
+})
+
+it('records an open under the page own handle, and shows it on return', async () => {
+  const settled = getBrowserWorkspaceId()
+  const store = new LocalStoreDouble()
+  await store.save({
+    documentId: '0CFJNRVY147ADGKPSWZ258BEHM',
+    workspaceId: settled,
+    path: 'roadmap',
+    name: 'roadmap',
+    updatedAt: '2026-09-01T00:00:00Z',
+    kind: 'spatial',
+  })
+  await new IdbDocumentIndex().createWorkspace({ workspaceId: settled, segment: 'default' })
+
+  const page = (
+    <MemoryRouter initialEntries={['/']}>
+      <BrowserIndexPage
+        index={store.index}
+        loro={store.loro}
+        pointer={store.pointer}
+        clock={store.clock}
+        onOpenDocument={vi.fn()}
+      />
+    </MemoryRouter>
+  )
+  render(page, { container: document.body })
+  const card = (await screen.findByTestId('card-title')).closest('button')
+  if (card === null) throw new Error('no card')
+  await userEvent.dblClick(card)
+
+  // The record is what the page's handle produced. Asserted before the
+  // remount, so a lane that never appears is told apart from an open that
+  // was never recorded.
+  await waitFor(() => expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull())
+
+  // cleanup() rather than unmount(): rendering into `document.body` twice
+  // reuses testing-library's cached root, and React refuses to update an
+  // unmounted one. cleanup clears that registration too.
+  cleanup()
+  render(page, { container: document.body })
+
+  const lane = await screen.findByTestId('recent-lane')
+  await waitFor(() => expect(lane.textContent).toContain('roadmap'))
+})

--- a/apps/web/src/scoped-screen-state.test.ts
+++ b/apps/web/src/scoped-screen-state.test.ts
@@ -98,6 +98,11 @@ const PANEL_STATE: Record<string, ScopeCoverage> = {
   selected: 'cleared on switch',
   cardMenu: 'cleared on switch',
   peek: 'cleared on switch',
+  // Reloaded from storage on every `workspace` change rather than emptied,
+  // which is the same guarantee: what is on screen always belongs to the
+  // workspace on screen. Its own effect, since the handle can arrive after
+  // the source.
+  recentIds: 'cleared on switch',
   renaming: 'cleared on switch',
   renameError: 'cleared on switch',
   renameBusy: 'cleared on switch',
@@ -114,6 +119,7 @@ const PANEL_STATE: Record<string, ScopeCoverage> = {
   rootRef: 'no subject: the panel’s own DOM node',
   onFolderChangeRef: 'no subject: mirrors the callback prop, reassigned every render',
   onOpenDocumentRef: 'no subject: mirrors the callback prop, reassigned every render',
+  workspaceRef: 'no subject: mirrors the workspace prop, reassigned every render',
   moveDocumentRef: 'no subject: mirrors the current handler, reassigned every render',
   lastReadListRef:
     'no subject: holds the PREVIOUS source’s identity so the reset block can tell a real switch from a StrictMode replay — clearing it would make every replay read as a switch, which is the trap the effect’s own note describes',


### PR DESCRIPTION
The last deferred item from the 2026-09-05 picker redesign, unblocked by the owner's decision on the question that was holding it: **recency is kept per device and not synced.**

"Recently opened" is a record of what happened on *this* device, so a phone and a desktop holding different answers is correct rather than a gap — and keeping it out of the document model means no schema change and identical behaviour whether the workspace is kept by the browser or by the daemon.

## Visual repro

![before — reopening means scanning a path-sorted grid; after — the last two opened, one tap, at a fixed position](tmp/screenshots/recent-lane-figure.png)

Look at the **grid below the lane**: `design` and `notes` are in the same positions on both panels. That is the design claim — an addition beside the grid, never a reordering of it (NN/g: reordering destroys the spatial memory the path sort exists to give).

> The image is **not uploaded**: `gh` on this machine is 2.97.0 and `--attach` landed in 2.99.0, so the reference above resolves only in a local checkout. The panel digests below are what tells you the two panels are genuinely different renders, and `compose-figure.mjs` refuses identical ones.

What the figure cannot show: the tiles carry the kind icon rather than a document thumbnail, because the fixture's source produces no render. In the app each tile draws through the same `DocumentThumbnail` the cards below it use. Panels `90dff68a` / `06738804`.

## Design

- **Ids, not paths.** A rename must not drop a document out of the lane, and a path freed by a rename can be taken by a different document.
- **Resolved against the listing already in hand**, so a deleted document leaves the lane on its own — no reconciliation pass, no extra read.
- **One word of chrome.** The strip first shipped with only an `aria-label`; looking at the rendered figure is what caught it, since two unexplained tiles above the grid read as pinned documents or as a selection. Every surveyed product labels this lane (Finder and iOS Files "Recents", Figma "Recently viewed") — what this redesign cuts is instructional prose, not the noun that says what a thing is.
- **Absent, not empty**, when nothing is recorded; absent during a search, which has its own answer to "which one did you mean"; absent on a host that cannot open a document, since every tile would be inert.

## Two things the tests were built to catch, both of which fired

- Splitting "clear" and "load" across two effects made the **effect order load-bearing, and it was wrong** — the handle-keyed load ran first and the scope reset blanked it, so the lane never survived a remount. The browser test failed exactly there. Both halves now live in the scope-reset effect and each ends on the same value, so whichever runs last is right.
- The scoped-state ledger **refused a reset that writes a computed value**; it wants a real empty. That is the stricter and better rule, and following it is what made the fix above order-proof rather than order-dependent.

A test bug worth recording: `renderPanel(workspace = 'space')` used a **default parameter, which fires on an explicit `undefined` too** — so the "host passes no handle" case was silently exercising the `'space'` workspace. It surfaced only because the lane wrongly appeared.

## Verification

Mutation-checked, each mutation **asserted to have applied** before its run — the discipline exists because two mutations earlier in this session silently matched nothing and came back green:

| mutation | result |
|---|---|
| cap removed | 1 property red |
| dedupe removed | 2 properties red |
| append instead of prepend | 2 properties red |
| recording call removed | 2 browser tests red |
| empty-lane early return removed | 2 jsdom tests red |
| recency order → listing order | 1 jsdom test red |
| search gate removed | 1 browser test red |

`web-jsdom` and `web-browser` over `components/workspace-files` and `pages` (735 + 106 tests), plus typecheck, lint and knip. One unrelated failure in `BrowserDocumentPage.markdown-orphan.test.tsx` — the known full-suite flake already filed as `create-delete-node-full-suite-flake`; it passes in isolation and this diff does not touch `pages/` at all.
