### PR TITLE
feat(web): one inspector slot beside the editor, so History and Comments are exclusive

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -476,7 +476,12 @@ gutter marker beside its line), and the document-level rail both editors
 share (ADR-0026 decision 5; `useCommentsRail` holds its state,
 `CommentsRailAside` is its vessel — a column where there is width, a bottom
 sheet over the editor under 768px, since a 288px column beside a 412px phone
-screen left the editor a strip a finger could not write in). The rail carries
+screen left the editor a strip a finger could not write in). The rail and the
+history column share the page's ONE inspector slot (`lib/inspector.ts`):
+opening either closes the other, and each opener reads released, because two
+panels beside one editor — measured on a phone as the display popover, the
+comments sheet and the history sheet all open at once — is what the header
+retune set out to end. The rail carries
 the conversation's own verbs beside its reply box — Resolve/Reopen and Edit
 of the opening message — because a NOTE's thread has no card, and the rail
 is the only place it can be closed or corrected; both go through the threads

--- a/apps/web/src/components/document-editor/DocumentPageShell.aside.test.tsx
+++ b/apps/web/src/components/document-editor/DocumentPageShell.aside.test.tsx
@@ -34,14 +34,28 @@ describe('DocumentPageShell places the history column', () => {
     expect(screen.getByTestId('hdr').parentElement).not.toBe(pane.parentElement)
   })
 
-  it('leaves the editor row untouched when no aside is passed, so every existing page is unchanged', () => {
-    const { container } = render(
+  it('keeps the editor mounted when an aside arrives, rather than re-parenting the row around it', () => {
+    // The row is wrapped whether or not there is an aside. Wrapping it only
+    // once one arrived moved the editor to a new parent, and React remounts
+    // what changes parent — the spatial editor lost its viewport and
+    // selection every time the history column or the comments rail opened.
+    const { rerender } = render(
       <DocumentPageShell srTitle="doc" header={<div />}>
         <div data-testid="editor" />
       </DocumentPageShell>,
     )
-    const main = container.querySelector('main')
-    // The editor is a DIRECT child of the grid, exactly as before.
-    expect(screen.getByTestId('editor').parentElement).toBe(main)
+    const editorBefore = screen.getByTestId('editor')
+    rerender(
+      <DocumentPageShell
+        srTitle="doc"
+        header={<div />}
+        aside={<aside data-testid="pane">history</aside>}
+      >
+        <div data-testid="editor" />
+      </DocumentPageShell>,
+    )
+    // The same DOM node, still attached: a remount would have replaced it.
+    expect(screen.getByTestId('editor')).toBe(editorBefore)
+    expect(editorBefore.isConnected).toBe(true)
   })
 })

--- a/apps/web/src/components/document-editor/DocumentPageShell.tsx
+++ b/apps/web/src/components/document-editor/DocumentPageShell.tsx
@@ -11,14 +11,17 @@ import { cn } from '../../lib/utils.js'
  * `<h1>` landmark by hand; owning them here means a layout or a11y drift
  * between the two modes cannot happen quietly.
  *
- * `aside` is the document's history. It rides in the editor row rather than
- * beside the whole page, so the top bar keeps the full width and the aside is
- * exactly as tall as the editor it belongs to. The row is only wrapped when
- * there IS an aside — without one the editor stays a direct grid child, which
- * is what every page had before this slot existed. The wrapper is
- * `relative` because the aside is a column only where there is width for one:
- * under 768px it is a bottom sheet, positioned against this row so it covers
- * the editor and not the top bar above it.
+ * `aside` is the document's inspector — its history column or its comments
+ * rail, whichever the page's one inspector slot holds. It rides in the editor
+ * row rather than beside the whole page, so the top bar keeps the full width
+ * and the aside is exactly as tall as the editor it belongs to. The row is
+ * wrapped whether or not there is an aside: wrapping it only when one arrived
+ * re-parented the editor, and React remounts what changes parent — so opening
+ * the history column threw away the editor's own state (its viewport, its
+ * selection) for a layout that had not changed. The wrapper is `relative`
+ * because the aside is a column only where there is width for one: under
+ * 768px it is a bottom sheet, positioned against this row so it covers the
+ * editor and not the top bar above it.
  *
  * `mainRef` and `mainClassName` exist for one caller and one reason that
  * travel together: the browser page fullscreens this element, and a
@@ -40,7 +43,7 @@ export function DocumentPageShell({
   header: ReactNode
   /** The editor row, and any banner rows the page stacks above it. */
   children: ReactNode
-  /** The document's history, beside the editor row (a sheet over it when narrow). */
+  /** The document's inspector, beside the editor row (a sheet over it when narrow). */
   aside?: ReactNode
   mainRef?: Ref<HTMLElement>
   mainClassName?: string
@@ -54,14 +57,10 @@ export function DocumentPageShell({
         <h1 className="sr-only">{srTitle}</h1>
         {header}
       </div>
-      {aside === undefined ? (
-        children
-      ) : (
-        <div className="relative flex min-h-0 min-w-0">
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col">{children}</div>
-          {aside}
-        </div>
-      )}
+      <div className="relative flex min-h-0 min-w-0">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">{children}</div>
+        {aside}
+      </div>
     </main>
   )
 }

--- a/apps/web/src/components/workspace-top-bar/BookmarkAction.test.tsx
+++ b/apps/web/src/components/workspace-top-bar/BookmarkAction.test.tsx
@@ -87,4 +87,19 @@ describe('BookmarkAction', () => {
     )
     expect(screen.getByRole('textbox')).toBeTruthy()
   })
+
+  it('closes the field when the page takes the arm back, rather than reading the reset as a press', () => {
+    // The page zeroes `armed` on a document switch. Only an INCREASE is a
+    // press: a field armed on the departed document and left open would
+    // name the arrived one from that keystroke, so the reset closes it.
+    const { rerender } = renderAction({ armed: 1 })
+    expect(screen.getByRole('textbox', { name: 'Name this point' })).toBeTruthy()
+    rerender(
+      <TooltipProvider>
+        <BookmarkAction saving={false} outcome={null} armed={0} onSave={() => {}} />
+      </TooltipProvider>,
+    )
+    expect(screen.queryByRole('textbox', { name: 'Name this point' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Bookmark this point' })).toBeTruthy()
+  })
 })

--- a/apps/web/src/components/workspace-top-bar/BookmarkAction.tsx
+++ b/apps/web/src/components/workspace-top-bar/BookmarkAction.tsx
@@ -53,10 +53,16 @@ export function BookmarkAction({
   // very press that brought the panel up.
   const lastArmRef = useRef(0)
 
+  // Only an INCREASE is a press. The page zeroes the counter on a document
+  // switch, and a field armed on the departed document would otherwise
+  // re-open — or stay open — to name the arrived one from that keystroke;
+  // the reset closes it and drops the draft instead.
   useEffect(() => {
     if (armed === lastArmRef.current) return
+    const pressed = armed > lastArmRef.current
     lastArmRef.current = armed
-    setNaming(true)
+    setNaming(pressed)
+    if (!pressed) setDraft('')
   }, [armed])
 
   useEffect(() => {

--- a/apps/web/src/hooks/use-comments-rail.ts
+++ b/apps/web/src/hooks/use-comments-rail.ts
@@ -36,7 +36,7 @@ export interface CommentsRailWrite {
 }
 
 export interface CommentsRail {
-  /** Whether the rail is open. Per-user view state, written nowhere. */
+  /** Whether the rail is open — the page's inspector slot showing it. */
   readonly open: boolean
   readonly toggle: () => void
   /** The conversation the reader is on, shared by rail and body projection. */
@@ -66,11 +66,19 @@ export function useCommentsRail(args: {
    * thread id and a compose anchor both belong to the DOCUMENT (left
    * standing across a switch they would scroll the arrived body to a
    * passage the departed document quoted, or open a conversation about a
-   * sentence nobody there wrote). `open` is deliberately NOT reset — what a
-   * switch changes is the list, not whether the reader wanted to be looking
-   * at one.
+   * sentence nobody there wrote). Whether the rail is OPEN is the page's
+   * inspector slot and is not reset either — what a switch changes is the
+   * list, not whether the reader wanted to be looking at one.
    */
   scopeKey: unknown
+  /**
+   * Whether the rail is open, and how to change that. Owned by the PAGE
+   * rather than here because the rail shares one inspector slot with the
+   * history column: opening either closes the other, and a slot that lives
+   * in two hooks cannot be exclusive. Per-user view state, written nowhere.
+   */
+  open: boolean
+  onOpenChange: (open: boolean) => void
   threads: readonly CommentThread[]
   documentKind: DocumentKind | null
   /** The markdown body, for judging text anchors; null off a markdown doc. */
@@ -86,8 +94,8 @@ export function useCommentsRail(args: {
   canvas: SpatialCanvas | null
   write: CommentsRailWrite
 }): CommentsRail {
-  const { scopeKey, threads, documentKind, markdownBody, canvas, threadMarks } = args
-  const [open, setOpen] = useState(false)
+  const { scopeKey, open, onOpenChange, threads, documentKind, markdownBody, canvas, threadMarks } =
+    args
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null)
   const [composeAnchor, setComposeAnchor] = useState<AnnotationAnchor | null>(null)
 
@@ -102,21 +110,27 @@ export function useCommentsRail(args: {
     setComposeAnchor(null)
   }, [scopeKey])
 
-  const toggle = useCallback(() => setOpen((wasOpen) => !wasOpen), [])
+  const toggle = useCallback(() => onOpenChange(!open), [open, onOpenChange])
   const selectThread = useCallback((threadId: string | null) => {
     setSelectedThreadId(threadId)
   }, [])
-  const revealThread = useCallback((threadId: string) => {
-    setOpen(true)
-    setSelectedThreadId(threadId)
-  }, [])
-  const composeThread = useCallback((anchor: AnnotationAnchor) => {
-    setOpen(true)
-    // Nothing else expanded: the reader asked for a new conversation, and an
-    // already-open one beside the draft box is two reply fields on screen.
-    setSelectedThreadId(null)
-    setComposeAnchor(anchor)
-  }, [])
+  const revealThread = useCallback(
+    (threadId: string) => {
+      onOpenChange(true)
+      setSelectedThreadId(threadId)
+    },
+    [onOpenChange],
+  )
+  const composeThread = useCallback(
+    (anchor: AnnotationAnchor) => {
+      onOpenChange(true)
+      // Nothing else expanded: the reader asked for a new conversation, and an
+      // already-open one beside the draft box is two reply fields on screen.
+      setSelectedThreadId(null)
+      setComposeAnchor(anchor)
+    },
+    [onOpenChange],
+  )
   const cancelCompose = useCallback(() => setComposeAnchor(null), [])
 
   const openThreadCount = useMemo(

--- a/apps/web/src/lib/inspector.ts
+++ b/apps/web/src/lib/inspector.ts
@@ -1,0 +1,12 @@
+/**
+ * What the document page's one inspector slot can show.
+ *
+ * One slot rather than a boolean per panel because that is how the header
+ * reads: each opener is an `aria-pressed` / `aria-expanded` toggle, and two
+ * pressed at once beside one editor was the phone screenshot that started
+ * the header retune — a display popover, the comments sheet and the history
+ * sheet all open together, each unaware of the others. A union is the
+ * declared surface (`.claude/rules/coverage-ledger.md`): the next panel
+ * that belongs beside the editor is a member here, not a fourth boolean.
+ */
+export type InspectorKind = 'history' | 'comments'

--- a/apps/web/src/pages/BrowserDocumentPage.versions.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.versions.browser.test.tsx
@@ -170,20 +170,26 @@ describe('BrowserDocumentPage version history (browser)', () => {
     expect(await storedText(documentId)).toBe('second')
     await openPage()
 
-    await userEvent.click(screen.getByRole('button', { name: 'History' }))
-    const reopened = await screen.findByTestId('history-panel')
-    await waitFor(() => expect(within(reopened).getAllByTestId('version-row')).toHaveLength(2))
-    // Newest first; the OLDER row is the one holding 'first'.
-    // The annotation rail, opened while the LIVE document is on screen —
-    // its opener rides the editor's chrome, which the preview replaces, so
-    // this is also the only order a reader can reach the state below in.
-    await userEvent.click(screen.getByRole('button', { name: /comments/i }))
+    // The annotation rail first, while the LIVE document is on screen.
     // Scoped to the rail: the canvas draws this same text in its own bubble,
     // so an unscoped query matches two elements and reads the wrong one.
+    await userEvent.click(screen.getByRole('button', { name: /comments/i }))
     const rail = await screen.findByTestId('comments-panel')
     await userEvent.click(within(rail).getByText('still needs a decision'))
     expect(within(rail).getByRole('textbox', { name: /reply/i })).toBeTruthy()
 
+    // History takes the one inspector slot from it: the rail leaves as the
+    // column arrives, and its opener reads released. Two panels beside one
+    // editor was the phone screenshot the header retune started from.
+    await userEvent.click(screen.getByRole('button', { name: 'History' }))
+    const reopened = await screen.findByTestId('history-panel')
+    expect(screen.queryByTestId('comments-panel')).toBeNull()
+    expect(screen.getByRole('button', { name: /comments/i })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    )
+    await waitFor(() => expect(within(reopened).getAllByTestId('version-row')).toHaveLength(2))
+    // Newest first; the OLDER row is the one holding 'first'.
     const row = within(reopened).getAllByTestId('version-row')[1]
     const restoreTarget = row?.querySelector('button')
     if (!restoreTarget) throw new Error('the version row is not restorable')
@@ -200,14 +206,11 @@ describe('BrowserDocumentPage version history (browser)', () => {
     // Read-only: the editor is not on screen while a past state is.
     expect(screen.queryByTestId('spatial-editor-container')).toBeNull()
 
-    // …and read-only includes the annotation rail, which the preview does NOT
-    // replace: it is still open, still listing the conversation, and its reply
-    // box is gone. A reply is a write to the LIVE document, and offered here it
-    // would be sent by a reader with every reason to think they are answering
-    // what they can see.
-    const railInPreview = screen.getByTestId('comments-panel')
-    expect(within(railInPreview).getByText('still needs a decision')).toBeTruthy()
-    expect(within(railInPreview).queryByRole('textbox', { name: /reply/i })).toBeNull()
+    // The rail cannot be reached from here: the column that offered the
+    // preview holds the inspector slot, and the preview bar hides the rail's
+    // opener. (Its read-only stance under a preview is pinned on the daemon
+    // page's variation preview, where the opener stays.)
+    expect(screen.queryByTestId('comments-panel')).toBeNull()
 
     // The controls sit on the DOCUMENT's chrome, not inside the history.
     // What changed is the document, and on a narrow screen the panel is a

--- a/apps/web/src/pages/DaemonDocumentPage.comments-panel.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.comments-panel.test.tsx
@@ -285,20 +285,9 @@ describe('DaemonDocumentPage comments panel', () => {
     await waitFor(() => expect(panel().getByText('no, we changed it')).toBeTruthy())
   })
 
-  it('keeps the rail visible under a version preview, but withholds the reply box', async () => {
+  it('shares one slot with History: opening either closes the other', async () => {
     const fakeVersionsBackend: VersionsBackend = {
-      list: async () => [
-        {
-          id: 'v1',
-          path: 'board',
-          createdAt: '2026-01-01T00:00:00.000Z',
-          elementCount: 0,
-          label: 'a point',
-          auto: false,
-          hasThumbnail: false,
-          branchName: 'main',
-        },
-      ],
+      list: async () => [],
       loadPast: async () => ({ kind: 'spatial', canvas: { nodes: [], edges: [] } }),
       save: async () => {
         throw new Error('not exercised by this test')
@@ -307,7 +296,6 @@ describe('DaemonDocumentPage comments panel', () => {
       putThumbnail: async () => {},
       loadThumbnail: async () => null,
     }
-
     await act(async () => {
       render(
         <VersionsBackendContext.Provider value={fakeVersionsBackend}>
@@ -322,21 +310,85 @@ describe('DaemonDocumentPage comments panel', () => {
       )
     })
 
+    // Comments, then History: the rail leaves as the column arrives. Two
+    // panels beside one editor was the phone screenshot this exists for —
+    // a display popover, the rail and the history sheet all open at once.
     fireEvent.click(await screen.findByRole('button', { name: /comments/i }))
-    fireEvent.click(panel().getByText('still needs a decision'))
-    await waitFor(() => panel().getByRole('textbox', { name: /reply/i }))
-
+    await screen.findByTestId('comments-panel')
     fireEvent.click(await screen.findByRole('button', { name: /history/i }))
-    const row = (await screen.findAllByTestId('version-row'))[0]
-    const activate = row?.querySelector('button')
-    expect(activate, 'no interactive control on the version row').not.toBeNull()
-    fireEvent.click(activate as HTMLButtonElement)
+    await screen.findByTestId('history-panel')
+    expect(screen.queryByTestId('comments-panel')).toBeNull()
+    // The opener says so too: a toggle has to LOOK toggled off once its
+    // panel has been displaced.
+    expect(screen.getByRole('button', { name: /comments/i }).getAttribute('aria-pressed')).toBe(
+      'false',
+    )
 
-    // A reply is a write to the LIVE document, and the editor surface is
-    // replaced by DocumentPreview during a preview — the rail must not offer
-    // a control that would write against a state that is not the document's.
-    await waitFor(() => expect(panel().queryByRole('textbox', { name: /reply/i })).toBeNull())
-    expect(panel().getByText('still needs a decision')).toBeTruthy()
+    // And back: History gives way to Comments.
+    fireEvent.click(screen.getByRole('button', { name: /comments/i }))
+    await screen.findByTestId('comments-panel')
+    expect(screen.queryByTestId('history-panel')).toBeNull()
+    expect(screen.getByRole('button', { name: /history/i }).getAttribute('aria-expanded')).toBe(
+      'false',
+    )
+  })
+
+  it('opens the rail under a variation preview, but withholds the reply box', async () => {
+    // A VERSION preview cannot host the rail any more: it is entered from the
+    // History column, which holds the one inspector slot, and the preview
+    // bar hides the rail's opener. A VARIATION preview (`?v=`) keeps the
+    // ordinary top bar, so the rail can be opened over it — and a reply is
+    // still a write to the LIVE document, sent from a surface showing
+    // something else entirely.
+    mockListDocuments.mockResolvedValue({
+      documents: [{ path: 'note', id: 'id-note', updatedAt: '2026-01-01', kind: 'markdown' }],
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString()
+        if (url.includes('/names')) {
+          return new Response(JSON.stringify({ documents: {}, pinned: [] }), { status: 200 })
+        }
+        if (url.endsWith('/branches/idea/document')) {
+          return new Response(JSON.stringify({ kind: 'markdown', body: '# From the idea tip' }), {
+            status: 200,
+          })
+        }
+        if (url.endsWith('/branches')) {
+          return new Response(
+            JSON.stringify({
+              head: 'main',
+              branches: [
+                { name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '2026-01-01' },
+                { name: 'idea', tipFrontiers: 'dGlw', color: '#e8590c', createdAt: '2026-01-02' },
+              ],
+            }),
+            { status: 200 },
+          )
+        }
+        return new Response('{}', { status: 404 })
+      }),
+    )
+    await act(async () => {
+      rtlRender(
+        <MemoryRouter initialEntries={['/?v=idea']}>
+          <DaemonDocumentPage
+            daemonBaseUrl={DAEMON_BASE_URL}
+            workspaceId="w1"
+            path="note"
+            createBackend={() => new FakeBackend(markdownSnapshotWithThread)}
+          />
+        </MemoryRouter>,
+        { container: document.body },
+      )
+    })
+    await screen.findByTestId('document-preview')
+
+    fireEvent.click(await screen.findByRole('button', { name: /comments/i }))
+    await waitFor(() => expect(panel().getByText('is this still true?')).toBeTruthy())
+    fireEvent.click(panel().getByText('is this still true?'))
+    expect(panel().queryByRole('textbox', { name: /reply/i })).toBeNull()
   })
 })
 

--- a/apps/web/src/pages/DaemonDocumentPage.surface-outlives-document.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.surface-outlives-document.test.tsx
@@ -209,19 +209,24 @@ describe('the body surface does not outlive its document (daemon)', () => {
     })
     await waitFor(() => expect(screen.getByText('Bookmark saved')).toBeTruthy())
 
-    // The switch this page makes by itself; the history panel closes with it.
+    // The switch this page makes by itself. The history column stays open —
+    // which panel the inspector slot shows is how the reader looks, not what
+    // at — so the badge has to clear on its own rather than with a panel.
     await act(async () => {
       openFileRef?.('id-b')
     })
-    await waitFor(() => expect(screen.queryByTestId('bookmark-action')).toBeNull())
-
-    // Reopen history on the ARRIVED document via the toolbar (not ⌘S, which
-    // would arm the naming field and hide the badge either way).
-    fireEvent.click(screen.getByRole('button', { name: 'History' }))
+    await waitFor(() =>
+      expect(
+        screen.queryByText('Bookmark saved'),
+        "a 'saved' badge earned on the departed document is still lit under the arrived one",
+      ).toBeNull(),
+    )
+    // Still there once the arrived document lands (the column steps out
+    // while the canvas is null between the two, and back in with it).
     await screen.findByTestId('bookmark-action')
     expect(
-      screen.queryByText('Bookmark saved'),
-      "a 'saved' badge earned on the departed document is still lit under the arrived one",
+      screen.queryByLabelText('Name this point'),
+      'the naming field armed on the departed document is open under the arrived one',
     ).toBeNull()
   })
 

--- a/apps/web/src/pages/DocumentPage.tsx
+++ b/apps/web/src/pages/DocumentPage.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useRef, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react'
 import {
   CommentsRailAside,
   CommentsRailToggle,
@@ -24,6 +24,7 @@ import { useThemeMode } from '../hooks/useThemeMode.js'
 import { getAppLogger } from '../lib/app-logger.js'
 import { captureBookmarkPicture } from '../lib/bookmark-picture.js'
 import { useWhiteboardCommands } from '../lib/commands/index.js'
+import type { InspectorKind } from '../lib/inspector.js'
 import { fileRefOptions } from '../lib/link-entries.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
 import { cn } from '../lib/utils.js'
@@ -51,10 +52,11 @@ const log = getAppLogger('document-page')
 /**
  * The document page, whoever keeps the document (ADR-0004 decision 1).
  *
- * Renders the shell, the history column, the merged header row, the editor
- * surface and the comments rail from a `DocumentPageModel`, and owns the
- * page state that names no keeper: which column is open, which past state
- * is being looked at, the save-a-version flow, the seams the editor reads.
+ * Renders the shell, the merged header row, the editor surface and the
+ * inspector beside it (the history column or the comments rail) from a
+ * `DocumentPageModel`, and owns the page state that names no keeper: which
+ * inspector is open, which past state is being looked at, the
+ * save-a-version flow, the seams the editor reads.
  * A keeper page builds the model — controller, sync backend, body, versions
  * — and renders this; nothing in here asks which keeper it is.
  */
@@ -68,10 +70,16 @@ export function DocumentPage({ model }: { model: DocumentPageModel }) {
   const [settingsStore] = useState(() => createUserSettingsStore())
   const { resolvedTheme } = useThemeMode()
 
-  // The document's history column. The page switches documents without
-  // remounting, so an open column is cleared by hand with the rest of the
-  // document-scoped state below.
-  const [historyOpen, setHistoryOpen] = useState(false)
+  // The one inspector slot beside the editor: the document's history or its
+  // conversations, never both — two panels beside one editor is what the
+  // header retune set out to end. Which panel is open is how the reader
+  // looks rather than what at, so it survives a document switch: everything
+  // a panel SAYS is document-scoped and reset below or by the hook that owns
+  // it, and both panels refetch on the path.
+  const [inspector, setInspector] = useState<InspectorKind | null>(null)
+  const toggleInspector = (kind: InspectorKind) =>
+    setInspector((open) => (open === kind ? null : kind))
+  const setCommentsOpen = useCallback((open: boolean) => setInspector(open ? 'comments' : null), [])
   // Bumped by ⌘/Ctrl+S to open the column with its naming field ready. The
   // chord asks for a bookmark now; it does not take one.
   const [bookmarkArmed, setBookmarkArmed] = useState(0)
@@ -80,16 +88,15 @@ export function DocumentPage({ model }: { model: DocumentPageModel }) {
   // cannot turn into an edit against a state that is not the document's.
   const [preview, setPreview] = useState<VersionPreviewSession | null>(null)
   useBookmarkShortcut(versions.enabled, () => {
-    setHistoryOpen(true)
+    setInspector('history')
     setBookmarkArmed((n) => n + 1)
   })
 
-  // SCOPE RESET — see scoped-screen-state.test.ts. Everything above names a
-  // document, and none of it may outlive the document it is about. The
-  // save outcome and the comments rail clear themselves, keyed on the same
-  // scope.
+  // SCOPE RESET — see scoped-screen-state.test.ts. Everything above but the
+  // inspector slot names a document, and none of it may outlive the document
+  // it is about. The save outcome and the comments rail's selection clear
+  // themselves, keyed on the same scope.
   useEffect(() => {
-    setHistoryOpen(false)
     setBookmarkArmed(0)
     setPreview(null)
   }, [model.scopeKey])
@@ -143,6 +150,8 @@ export function DocumentPage({ model }: { model: DocumentPageModel }) {
   // document holds the threads, and only the keeper knows which that is.
   const commentsRail = useCommentsRail({
     scopeKey: model.scopeKey,
+    open: inspector === 'comments',
+    onOpenChange: setCommentsOpen,
     threads: threads.annotations,
     documentKind,
     markdownBody,
@@ -227,7 +236,7 @@ export function DocumentPage({ model }: { model: DocumentPageModel }) {
         ? {}
         : { mainClassName: model.shell.mainClassName })}
       aside={
-        historyOpen && versions.enabled ? (
+        inspector === 'history' && versions.enabled ? (
           <VersionPanel
             workspaceId={versions.workspaceId}
             path={versions.path}
@@ -243,6 +252,21 @@ export function DocumentPage({ model }: { model: DocumentPageModel }) {
                 onSave={(label) => void saveVersionFromPanel(label)}
               />
             }
+          />
+        ) : inspector === 'comments' ? (
+          /* The annotation layer's document-level surface (ADR-0026
+             decision 5) sits BESIDE the editor rather than inside it,
+             because one panel serves both document kinds and a markdown
+             document has no canvas chrome to host one. Its opener lives in
+             the document actions row, in flow.
+
+             Not writable while a past state is on screen: the editor is
+             replaced by DocumentPreview but this rail is not, and its
+             writes go to the LIVE document. */
+          <CommentsRailAside
+            rail={commentsRail}
+            threads={threads.annotations}
+            writable={preview === null && model.readOnlyPast === null}
           />
         ) : undefined
       }
@@ -322,10 +346,8 @@ export function DocumentPage({ model }: { model: DocumentPageModel }) {
                 // Whatever the document holds: a keeper writes a history for
                 // every kind, and gating this on the editor is what left a
                 // markdown document's checkpoints unreachable.
-                onToggleHistory={
-                  versions.enabled ? () => setHistoryOpen((open) => !open) : undefined
-                }
-                historyOpen={historyOpen}
+                onToggleHistory={versions.enabled ? () => toggleInspector('history') : undefined}
+                historyOpen={inspector === 'history'}
                 {...(preview === null ? {} : { preview })}
               />
             </Suspense>
@@ -336,100 +358,85 @@ export function DocumentPage({ model }: { model: DocumentPageModel }) {
     >
       {model.slots.overlay}
       {model.slots.replaceEditor ?? (
-        /* The annotation layer's document-level surface (ADR-0026
-           decision 5) sits BESIDE the editor rather than inside it,
-           because one panel serves both document kinds and a markdown
-           document has no canvas chrome to host one. Its opener lives in
-           the document actions row above, in flow. */
-        <div className="flex h-full min-h-0">
-          <div className="relative min-w-0 flex-1">
-            {preview ? (
-              <DocumentPreview past={preview.past} theme={resolvedTheme} />
-            ) : model.readOnlyPast ? (
-              <DocumentPreview past={model.readOnlyPast} theme={resolvedTheme} />
-            ) : (
-              <DocumentEditorSurface
-                kind={documentKind}
-                documentKey={documentKey}
-                markdown={
-                  model.markdown.hydrating
-                    ? { body: null, setBody: model.markdown.setBody }
-                    : {
-                        body: model.markdown.body,
-                        setBody: model.markdown.setBody,
-                        ...(model.markdown.sourceExtensions === undefined
-                          ? {}
-                          : { sourceExtensions: model.markdown.sourceExtensions }),
-                        ...(model.markdown.autoFocus === undefined
-                          ? {}
-                          : { autoFocus: model.markdown.autoFocus }),
-                        theme: resolvedTheme,
-                        meta: model.markdown.meta,
-                        ...(model.markdown.title === undefined
-                          ? {}
-                          : { title: model.markdown.title }),
-                        references,
-                        linkTargets: files.pickerTargets,
-                        onOpenDocument: model.openDocument,
-                        threads: threads.annotations,
-                        threadMarks: threads.threadMarks,
-                        selectedThreadId: commentsRail.selectedThreadId,
-                        onSelectThread: commentsRail.revealThread,
-                        onComposeThread: commentsRail.composeThread,
-                      }
-                }
-                spatial={() => (
-                  <SpatialEditorPane
-                    className="relative h-full min-h-0"
-                    editorKey={documentKey}
-                    canvasLoaded={sync.loaded}
-                    {...(model.spatial.editorRef === undefined
-                      ? {}
-                      : { editorRef: model.spatial.editorRef })}
-                    {...(model.spatial.agentTouchedNodeIds === undefined
-                      ? {}
-                      : { agentTouchedNodeIds: model.spatial.agentTouchedNodeIds })}
-                    canvas={sync.canvas}
-                    onChange={sync.onChange}
-                    externalVersion={sync.externalVersion}
-                    theme={resolvedTheme}
-                    // File-node reference = the target's immutable id; the
-                    // same rows the link picker offers (open document
-                    // excluded), so the two pickers cannot label one
-                    // document two ways.
-                    fileRefOptions={fileRefOptions(files.pickerTargets)}
-                    onOpenDocument={model.openDocument}
-                    missingFileRef={files.missingFileRef}
-                    fileSeams={fileSeams}
-                    lockedNodeIds={sync.lockedNodeIds}
-                    lockedEdgeIds={sync.lockedEdgeIds}
-                    onToggleNodeLock={sync.setNodeLock}
-                    onToggleEdgeLock={sync.setEdgeLock}
-                    nodeInEditor={nodeInEditor}
-                    history={{
-                      onUndo: () => void sync.undo(),
-                      onRedo: () => void sync.redo(),
-                      canUndo: sync.canUndo(),
-                      canRedo: sync.canRedo(),
-                    }}
-                    overlayTitle={model.overlayTitle}
-                    linkTargets={files.pickerTargets}
-                    threads={threads.annotations}
-                  >
-                    {model.spatial.children}
-                  </SpatialEditorPane>
-                )}
-              />
-            )}
-          </div>
-          {/* Not while a past state is on screen: the editor is replaced by
-              DocumentPreview but this rail is not, and its writes go to the
-              LIVE document. */}
-          <CommentsRailAside
-            rail={commentsRail}
-            threads={threads.annotations}
-            writable={preview === null && model.readOnlyPast === null}
-          />
+        <div className="relative h-full min-h-0 min-w-0">
+          {preview ? (
+            <DocumentPreview past={preview.past} theme={resolvedTheme} />
+          ) : model.readOnlyPast ? (
+            <DocumentPreview past={model.readOnlyPast} theme={resolvedTheme} />
+          ) : (
+            <DocumentEditorSurface
+              kind={documentKind}
+              documentKey={documentKey}
+              markdown={
+                model.markdown.hydrating
+                  ? { body: null, setBody: model.markdown.setBody }
+                  : {
+                      body: model.markdown.body,
+                      setBody: model.markdown.setBody,
+                      ...(model.markdown.sourceExtensions === undefined
+                        ? {}
+                        : { sourceExtensions: model.markdown.sourceExtensions }),
+                      ...(model.markdown.autoFocus === undefined
+                        ? {}
+                        : { autoFocus: model.markdown.autoFocus }),
+                      theme: resolvedTheme,
+                      meta: model.markdown.meta,
+                      ...(model.markdown.title === undefined
+                        ? {}
+                        : { title: model.markdown.title }),
+                      references,
+                      linkTargets: files.pickerTargets,
+                      onOpenDocument: model.openDocument,
+                      threads: threads.annotations,
+                      threadMarks: threads.threadMarks,
+                      selectedThreadId: commentsRail.selectedThreadId,
+                      onSelectThread: commentsRail.revealThread,
+                      onComposeThread: commentsRail.composeThread,
+                    }
+              }
+              spatial={() => (
+                <SpatialEditorPane
+                  className="relative h-full min-h-0"
+                  editorKey={documentKey}
+                  canvasLoaded={sync.loaded}
+                  {...(model.spatial.editorRef === undefined
+                    ? {}
+                    : { editorRef: model.spatial.editorRef })}
+                  {...(model.spatial.agentTouchedNodeIds === undefined
+                    ? {}
+                    : { agentTouchedNodeIds: model.spatial.agentTouchedNodeIds })}
+                  canvas={sync.canvas}
+                  onChange={sync.onChange}
+                  externalVersion={sync.externalVersion}
+                  theme={resolvedTheme}
+                  // File-node reference = the target's immutable id; the
+                  // same rows the link picker offers (open document
+                  // excluded), so the two pickers cannot label one
+                  // document two ways.
+                  fileRefOptions={fileRefOptions(files.pickerTargets)}
+                  onOpenDocument={model.openDocument}
+                  missingFileRef={files.missingFileRef}
+                  fileSeams={fileSeams}
+                  lockedNodeIds={sync.lockedNodeIds}
+                  lockedEdgeIds={sync.lockedEdgeIds}
+                  onToggleNodeLock={sync.setNodeLock}
+                  onToggleEdgeLock={sync.setEdgeLock}
+                  nodeInEditor={nodeInEditor}
+                  history={{
+                    onUndo: () => void sync.undo(),
+                    onRedo: () => void sync.redo(),
+                    canUndo: sync.canUndo(),
+                    canRedo: sync.canRedo(),
+                  }}
+                  overlayTitle={model.overlayTitle}
+                  linkTargets={files.pickerTargets}
+                  threads={threads.annotations}
+                >
+                  {model.spatial.children}
+                </SpatialEditorPane>
+              )}
+            />
+          )}
         </div>
       )}
       {model.slots.footer}

--- a/apps/web/src/scoped-screen-state.test.ts
+++ b/apps/web/src/scoped-screen-state.test.ts
@@ -358,7 +358,6 @@ const DOCUMENT_PAGE_HOOK_STATE: Record<string, ScopeCoverage> = {
   // and a submitted one would open a conversation on the wrong document
   // about a sentence nobody there wrote. Cleared by useCommentsRail.
   composeAnchor: 'cleared on switch',
-  open: 'no subject: whether the rail is open, not what is in it — the threads themselves are republished per document (on the session\u2019s annotation channel for a spatial document, off the markdown hook\u2019s own host for a note), so a switch changes the LIST while leaving the reader where they chose to be',
   writeRef: 'no subject: mirrors the keeper-specific write door, reassigned every render',
   threadsRef:
     'no subject: mirrors the threads the rail already holds, reassigned every render — an edit reads it to rebuild the message it rewrites, and the list it mirrors is republished per document',
@@ -366,7 +365,15 @@ const DOCUMENT_PAGE_HOOK_STATE: Record<string, ScopeCoverage> = {
 
 const DOCUMENT_PAGE_STATE: Record<string, ScopeCoverage> = {
   ...DOCUMENT_PAGE_HOOK_STATE,
-  historyOpen: 'cleared on switch',
+  // Which panel the one inspector slot shows — the history column or the
+  // comments rail. How the reader looks rather than what at: everything a
+  // panel SAYS is document-scoped and cleared on its own (`preview` and
+  // `bookmarkArmed` below, `selectedThreadId` and `composeAnchor` above),
+  // and both panels refetch on the path, so a column left open across a
+  // switch shows the arrived document — as the rail always did, and as the
+  // threads themselves are republished per document.
+  inspector:
+    'no subject: which inspector panel is open, not what is in it — what each panel shows is cleared by its own entries, and the panels refetch on the path',
   // The past state being looked at. Restoring one the person opened on the
   // DEPARTED document would apply that version id to the arrived one.
   preview: 'cleared on switch',


### PR DESCRIPTION
## What

P2 of the header retune (decided 2026-09-05 in the "Header Retune" artifact): **the panels beside the editor share one inspector slot.** History and Comments are exclusive — opening either closes the other, and its opener reads released (`aria-expanded` / `aria-pressed` both false).

Before, the document page held two independent booleans (`historyOpen` in the page, `open` inside `useCommentsRail`), so both panels could be open at once. On a phone that was the screenshot this work started from: the display popover, the comments sheet and the history sheet all open over one editor, each unaware of the others.

`DocumentPage` now holds one `inspector: InspectorKind | null`; `lib/inspector.ts` declares the union so the next panel (P3: Connections, Properties) is a member rather than a fourth boolean. `useCommentsRail` takes `open` / `onOpenChange` from the page instead of owning the flag, so the History toggle, ⌘/Ctrl+S and the rail's reveal/compose paths all write the same slot. Both panels render through `DocumentPageShell`'s `aside`.

Which panel is open is view state and now survives a document switch on both pages (both panels refetch on the path; everything a panel *says* is still reset per document — `preview`, `bookmarkArmed`, `selectedThreadId`, `composeAnchor`). The `scoped-screen-state` ledger carries the entry.

## Two defects the old unmount-on-switch had been hiding

Keeping the column mounted across a switch made these visible; both have a red-first test.

- **`BookmarkAction` read a reset as a press.** The page zeroes `armed` on a switch, and the effect treated any change as arming — so the naming field re-opened on the arrived document, ready to name it from the departed one's keystroke. Only an increase is a press now; a reset closes the field and drops the draft (`BookmarkAction.test.tsx`).
- **`DocumentPageShell` remounted the editor whenever a panel opened.** The editor row was wrapped only when an aside was present, so an aside's arrival re-parented the editor and React remounted it — the spatial editor lost its viewport and selection every time History opened. The wrapper is unconditional now; `DocumentPageShell.aside.test.tsx` pins the editor DOM node surviving an aside's arrival. Mutation-checked: with the conditional wrapper back, `1 failed | 1 passed`.

## Tests

- `DaemonDocumentPage.comments-panel.test.tsx` (jsdom): "shares one slot with History" — red before the change (`expected <section data-testid="comments-panel"> to be null`), green after; both directions.
- `BrowserDocumentPage.versions.browser.test.tsx`: the flow opens Comments first, then asserts History displaces it and the opener reads released.
- The "rail under a version preview withholds the reply box" case moved to the `?v=` **variation** preview — a version preview is entered from the History column, which now holds the slot, and its preview bar hides the rail's opener, so that state is unreachable; the variation preview keeps the ordinary top bar and is where `writable=false` still applies.
- `DaemonDocumentPage.surface-outlives-document.test.tsx`: the column survives the switch; the saved badge and the naming field do not.

## Real-app verification (local vite, Playwright)

Desktop 1280×800 and iPhone 13 emulation, browser keeper, a fresh canvas:

| step | history panel | comments rail | History `aria-expanded` | Comments `aria-pressed` |
|---|---|---|---|---|
| Comments | 0 | 1 | false | true |
| then History | 1 | 0 | true | false |
| then Comments | 0 | 1 | false | true |
| close Comments | 0 | 0 | false | false |
| Comments, then ⌘/Ctrl+S | 1 | 0 | true | false |

Identical on both devices.

## Visual repro

Same device, same order (Comments, then History), main vs this branch, composed with `compose-figure.mjs` (digests `46b37103` / `9fadb2d8`). On main both openers are pressed and both sheets are open with the history sheet on top; on this branch History holds the slot and Comments is released. `gh` is unavailable in this environment, so the figure was handed to the author directly rather than attached here.

## Gates

web-jsdom for `pages/`, `workspace-top-bar/`, `annotations/`, `document-editor/`, `hooks/`: 682 passed after the shell test was rewritten · web-browser for the touched surfaces: 8 files / 49 passed · five fresh-process runs of each changed file (jsdom 16/16 ×5, browser 15/15 ×5) · `pnpm --filter @kamiazya/whiteboard-web typecheck` · `pnpm biome check` · `pnpm knip` clean · `pnpm check:local` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_