### PR TITLE
refactor(web): the editor overlays leave SpatialEditor's return as named components

### DIFF
--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -58,18 +58,12 @@
  * diagram that needs a shape uses an image node.
  */
 
-import type { BoundingBox, MeasureText, ReferenceWire } from '@kamiazya/whiteboard-canvas-render'
+import type { MeasureText, ReferenceWire } from '@kamiazya/whiteboard-canvas-render'
 import {
   BODY_FONT_SIZE_PX,
   BODY_LINE_HEIGHT_PX,
-  COMMENT_BUBBLE_PADDING_PX,
-  COMMENT_BUBBLE_RADIUS_PX,
-  commentAnchor,
   outlineContentBox,
-  placeCommentBubble,
   referenceSeamsFromWire,
-  SPATIAL_DARK_PALETTE,
-  SPATIAL_LIGHT_PALETTE,
   SPATIAL_THEME_FONT_FAMILY,
   SPATIAL_THEME_GEOMETRY,
 } from '@kamiazya/whiteboard-canvas-render'
@@ -118,6 +112,7 @@ import { CanvasContextMenu } from './CanvasContextMenu.js'
 import { CommentDragLayer } from './CommentDragLayer.js'
 import { CommentThreadCard } from './CommentThreadCard.js'
 import { ConnectOverlay } from './ConnectOverlay.js'
+import { CommentComposeOverlay, commentComposeStyle } from './comment-compose-overlay.js'
 import { CREATION_LABELS } from './creation-labels.js'
 import { DocumentPickerDialog } from './DocumentPickerDialog.js'
 import { DragPreviewLayer } from './DragPreviewLayer.js'
@@ -151,7 +146,6 @@ import { SelectionOverlay } from './SelectionOverlay.js'
 import { SnapGuidesOverlay } from './SnapGuidesOverlay.js'
 import { reduceSelection } from './selection.js'
 import { isTextEntryEvent } from './shortcuts.js'
-import { TextNodeEditor } from './TextNodeEditor.js'
 import { type DraggableCreation, draggedCreation, ToolPalette } from './ToolPalette.js'
 import { useCanvasReplacement } from './use-canvas-replacement.js'
 import { useClipboardActions } from './use-clipboard-actions.js'
@@ -334,61 +328,6 @@ export interface SpatialEditorProps {
    * navigating to an asset reference is a dead end.
    */
   readonly isImageFileRef?: (file: string) => boolean
-}
-
-/** The compose bubble sits where the saved comment's bubble will be drawn,
- * so committing reads as the draft settling rather than jumping. */
-const COMMENT_COMPOSE_WIDTH_PX = 216
-const COMMENT_COMPOSE_HEIGHT_PX = 64
-/**
- * Where the draft opens: placed by canvas-render's own bubble placer over
- * the same obstacles, so it opens in the quadrant the settled bubble will
- * take rather than over the node the comment is about.
- */
-function commentDraftBox(
-  anchor: Point,
-  obstacles: readonly BoundingBox[],
-): { x: number; y: number; width: number; height: number } {
-  const placed = placeCommentBubble(
-    anchor,
-    { w: COMMENT_COMPOSE_WIDTH_PX, h: COMMENT_COMPOSE_HEIGHT_PX },
-    obstacles,
-  )
-  return { x: placed.x, y: placed.y, width: placed.w, height: placed.h }
-}
-
-/**
- * The compose bubble wears the theme's comment chrome — the same palette
- * entry, padding and corner the renderer draws the settled bubble with —
- * so the draft and the saved comment read as one object rather than a
- * plain editor a card replaces on commit. The shadow mirrors the SVG
- * drop-shadow filter (dy 1, blur ~3px at 30% black) that lifts the
- * settled chrome off the canvas plane.
- */
-function commentComposeStyle(theme: ResolvedTheme): React.CSSProperties {
-  const { bubble } = (theme === 'dark' ? SPATIAL_DARK_PALETTE : SPATIAL_LIGHT_PALETTE).comment
-  return {
-    background: bubble.fill,
-    color: editorTextFill(theme),
-    border: `1px solid ${bubble.stroke}`,
-    borderRadius: COMMENT_BUBBLE_RADIUS_PX,
-    padding: COMMENT_BUBBLE_PADDING_PX,
-    // Focus is shown as a soft halo in the bubble's own stroke colour
-    // rather than the UA's dark outline ring, which read as a second,
-    // heavier border around the card. The bubble is only ever mounted
-    // focused, so the halo is always the focus indicator.
-    outline: 'none',
-    boxShadow: `0 0 0 2px ${bubble.stroke}55, 0 1px 3px rgba(0, 0, 0, 0.3)`,
-    fontFamily: SPATIAL_THEME_FONT_FAMILY,
-    fontSize: BODY_FONT_SIZE_PX,
-    lineHeight: `${BODY_LINE_HEIGHT_PX}px`,
-    // Size to the draft like the settled bubble sizes to its text: one
-    // line to start, growing as lines are added (`field-sizing`; browsers
-    // without it keep the one-line minimum and scroll).
-    height: 'auto',
-    minHeight: BODY_LINE_HEIGHT_PX + 2 * COMMENT_BUBBLE_PADDING_PX + 2,
-    ...({ fieldSizing: 'content' } as React.CSSProperties),
-  }
 }
 
 /** Screen-space px within which a press/right-click counts as hitting an
@@ -2582,94 +2521,16 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
               />
             )}
             {commentCompose !== null && (
-              <TextNodeEditor
-                exitHintScale={1 / viewport.zoom}
-                box={commentDraftBox(
-                  // An edge comment opens ON the routed path, where the layer
-                  // will pin it — one producer for the geometry.
-                  commentCompose.targetEdgeId === undefined
-                    ? commentCompose.point
-                    : commentAnchor(
-                        {
-                          id: '',
-                          text: ' ',
-                          x: commentCompose.point.x,
-                          y: commentCompose.point.y,
-                          targetEdgeId: commentCompose.targetEdgeId,
-                        },
-                        canvas,
-                        edgePathOf,
-                      ),
-                  commentPlacementObstacles(commentCompose.editing?.id),
-                )}
-                initialText={commentCompose.editing?.initialText ?? ''}
-                testId="comment-compose"
-                style={commentComposeStyle(theme)}
-                onCommit={(draft) => {
-                  const text = draft.trim()
-                  // A blank commit is a cancel: an empty comment says nothing
-                  // and would still ask the reader to resolve it. Editing an
-                  // existing comment to blank likewise keeps its stored text —
-                  // removal stays MCP-only in v1 (ADR-0025).
-                  if (commentCompose.editing !== undefined) {
-                    if (text.length > 0 && text !== commentCompose.editing.initialText) {
-                      applyResult({
-                        state: { kind: 'idle' },
-                        commands: [
-                          {
-                            kind: 'set-comment-text',
-                            id: commentCompose.editing.id,
-                            text,
-                          } as const,
-                        ],
-                      })
-                    }
-                  } else if (text.length > 0 && commentCompose.threadAnchor !== undefined) {
-                    // A passage of a node's text, or a node set: a THREAD,
-                    // since a flat comment cannot carry either anchor.
-                    const id = (createId ?? defaultCreateId)()
-                    const createdAt = new Date().toISOString()
-                    applyResult({
-                      state: { kind: 'idle' },
-                      commands: [
-                        {
-                          kind: 'create-thread',
-                          thread: {
-                            id,
-                            anchor: commentCompose.threadAnchor,
-                            status: 'open',
-                            createdAt,
-                            messages: [{ id: `${id}-m1`, body: text, createdAt }],
-                          },
-                        } as const,
-                      ],
-                    })
-                  } else if (text.length > 0) {
-                    const { point, targetNodeId, targetEdgeId } = commentCompose
-                    applyResult({
-                      state: { kind: 'idle' },
-                      commands: [
-                        {
-                          kind: 'create-comment',
-                          comment: {
-                            id: (createId ?? defaultCreateId)(),
-                            // Rounded for the same reason the pin drag rounds:
-                            // an integer by schema, and a fractional anchor
-                            // is dropped on read rather than rejected here.
-                            x: Math.round(point.x),
-                            y: Math.round(point.y),
-                            text,
-                            createdAt: new Date().toISOString(),
-                            ...(targetNodeId === undefined ? {} : { targetNodeId }),
-                            ...(targetEdgeId === undefined ? {} : { targetEdgeId }),
-                          },
-                        } as const,
-                      ],
-                    })
-                  }
-                  setCommentCompose(null)
-                }}
-                onCancel={() => setCommentCompose(null)}
+              <CommentComposeOverlay
+                compose={commentCompose}
+                canvas={canvas}
+                edgePathOf={edgePathOf}
+                obstacles={commentPlacementObstacles(commentCompose.editing?.id)}
+                createId={createId}
+                zoom={viewport.zoom}
+                theme={theme}
+                applyResult={applyResult}
+                onClose={() => setCommentCompose(null)}
               />
             )}
             {gestureState.kind === 'editing-text' &&

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -59,14 +59,7 @@
  */
 
 import type { MeasureText, ReferenceWire } from '@kamiazya/whiteboard-canvas-render'
-import {
-  BODY_FONT_SIZE_PX,
-  BODY_LINE_HEIGHT_PX,
-  outlineContentBox,
-  referenceSeamsFromWire,
-  SPATIAL_THEME_FONT_FAMILY,
-  SPATIAL_THEME_GEOMETRY,
-} from '@kamiazya/whiteboard-canvas-render'
+import { referenceSeamsFromWire } from '@kamiazya/whiteboard-canvas-render'
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
 import type { CommentThread, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
 import { bundledFacetRegistry } from '@kamiazya/whiteboard-plugin-visual'
@@ -86,7 +79,7 @@ import type { FileRefOption } from '../../lib/link-entries.js'
 import { hasCoarsePointer } from '../../lib/platform.js'
 import type { EditorCommand } from '../../lib/spatial/commands.js'
 import { applyCommand } from '../../lib/spatial/commands.js'
-import { createEditorAppearance, editorTextFill } from '../../lib/spatial/editor-appearance.js'
+import { editorTextFill } from '../../lib/spatial/editor-appearance.js'
 import type { SpatialEditorHandle } from '../../lib/spatial/editor-handle.js'
 import {
   distanceToPolyline,
@@ -129,10 +122,10 @@ import { defaultCreateId, NEW_NODE_HEIGHT, NEW_NODE_WIDTH, reduceGesture } from 
 import { LinkEmbedLayer } from './LinkEmbedLayer.js'
 import { LinkUrlDialog } from './LinkUrlDialog.js'
 import { EdgeLabelEditorOverlay, GroupLabelEditorOverlay } from './label-editor-overlays.js'
-import { MarkdownNodeEditor } from './MarkdownNodeEditor.js'
 import { MarqueeOverlay } from './MarqueeOverlay.js'
 import { MemberOutlinesOverlay } from './MemberOutlinesOverlay.js'
 import { MinimapOverlay } from './MinimapOverlay.js'
+import { MarkdownBodyEditorOverlay } from './markdown-body-editor-overlay.js'
 import {
   createIdleNavigation,
   DOUBLE_PRESS_WINDOW_MS,
@@ -2536,40 +2529,12 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
             {gestureState.kind === 'editing-text' &&
               selectedNode?.type === 'text' &&
               selection !== undefined && (
-                <MarkdownNodeEditor
-                  // The scene keeps drawing this node's chrome (its body is
-                  // suppressed while this editor is open), so the editor is
-                  // TRANSPARENT and sits in the same box the committed text
-                  // uses: the silhouette's inscribed content box. A shaped
-                  // node therefore keeps its silhouette for the whole edit,
-                  // and the text does not jump on entering edit mode.
-                  box={(() => {
-                    const chrome = scene.nodes.find(
-                      (entry) => entry.kind === 'shape' && entry.id === selectedNode.id,
-                    )
-                    const shapeId =
-                      chrome !== undefined && chrome.kind === 'shape' ? chrome.shape : undefined
-                    const bbox = {
-                      x: selection.box.x,
-                      y: selection.box.y,
-                      w: selection.box.width,
-                      h: selection.box.height,
-                    }
-                    const inner = outlineContentBox(shapeId, bbox)
-                    return { x: inner.x, y: inner.y, width: inner.w, height: inner.h }
-                  })()}
-                  initialText={selectedNode.text}
-                  // The conversations about passages of this node's text,
-                  // highlighted over the draft; and the comment verb's seam,
-                  // which attaches the caret's scope to this node and opens
-                  // the compose bubble at the node's corner, where a node
-                  // comment opens. The editor commits on the blur the bubble
-                  // causes, so the passage the anchor quotes is the text
-                  // that gets committed.
-                  threads={threads?.filter(
-                    (thread) =>
-                      thread.anchor.kind === 'text' && thread.anchor.nodeId === selectedNode.id,
-                  )}
+                <MarkdownBodyEditorOverlay
+                  node={selectedNode}
+                  selectionBox={selection.box}
+                  sceneNodes={scene.nodes}
+                  sceneCurrent={sceneCurrent}
+                  threads={threads}
                   onRequestComment={(anchor) => {
                     setCommentCompose({
                       point: { x: selectedNode.x + selectedNode.width, y: selectedNode.y },
@@ -2578,55 +2543,11 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                     })
                     return true
                   }}
-                  exitHintTop={selection.box.y + selection.box.height + 6}
-                  exitHintScale={1 / viewport.zoom}
-                  centerContent={scene.nodes.some(
-                    (entry) =>
-                      entry.kind === 'shape' &&
-                      entry.id === selectedNode.id &&
-                      entry.shape !== undefined,
-                  )}
-                  style={{
-                    // Transparent once the scene below has stopped drawing
-                    // this node's text. An offloaded canvas lags one worker
-                    // round trip behind the suppression change, so for that
-                    // gap the overlay keeps the old opaque cover — otherwise
-                    // the committed text shows doubled under the draft.
-                    background: sceneCurrent
-                      ? 'transparent'
-                      : (() => {
-                          const fill =
-                            createEditorAppearance(theme).resolveNode(selectedNode).appearance?.fill
-                          return fill !== undefined && fill !== 'none'
-                            ? fill
-                            : theme === 'dark'
-                              ? 'oklch(0.145 0 0)'
-                              : '#ffffff'
-                        })(),
-                    color: editorTextFill(theme),
-                    fontFamily: SPATIAL_THEME_FONT_FAMILY,
-                    fontSize: BODY_FONT_SIZE_PX,
-                    // The overlay must advance by the SAME line box the
-                    // committed render uses, or the text moves under the
-                    // cursor on entering edit mode. Shared constant, not a
-                    // second copy of the number — these were equal until the
-                    // markdown theme took body line height to 1.5.
-                    lineHeight: `${BODY_LINE_HEIGHT_PX}px`,
-                    padding: SPATIAL_THEME_GEOMETRY.paddingPx,
-                  }}
-                  onCommit={(text) => {
-                    applyResult(
-                      reduceGesture(gestureState, canvas, { type: 'commit-text-edit', text }),
-                    )
-                  }}
-                  onCancel={() => {
-                    applyResult(reduceGesture(gestureState, canvas, { type: 'cancel-text-edit' }))
-                  }}
-                  onChange={(text) => {
-                    applyResult(
-                      reduceGesture(gestureState, canvas, { type: 'update-text-edit', text }),
-                    )
-                  }}
+                  zoom={viewport.zoom}
+                  theme={theme}
+                  canvas={canvas}
+                  gestureState={gestureState}
+                  applyResult={applyResult}
                 />
               )}
           </div>

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -65,7 +65,6 @@ import {
   COMMENT_BUBBLE_PADDING_PX,
   COMMENT_BUBBLE_RADIUS_PX,
   commentAnchor,
-  edgeLabelAnchor,
   outlineContentBox,
   placeCommentBubble,
   referenceSeamsFromWire,
@@ -134,6 +133,7 @@ import { carriedByGesture } from './gesture-view.js'
 import { defaultCreateId, NEW_NODE_HEIGHT, NEW_NODE_WIDTH, reduceGesture } from './gestures.js'
 import { LinkEmbedLayer } from './LinkEmbedLayer.js'
 import { LinkUrlDialog } from './LinkUrlDialog.js'
+import { EdgeLabelEditorOverlay, GroupLabelEditorOverlay } from './label-editor-overlays.js'
 import { MarkdownNodeEditor } from './MarkdownNodeEditor.js'
 import { MarqueeOverlay } from './MarqueeOverlay.js'
 import { MemberOutlinesOverlay } from './MemberOutlinesOverlay.js'
@@ -336,8 +336,6 @@ export interface SpatialEditorProps {
   readonly isImageFileRef?: (file: string) => boolean
 }
 
-const EDGE_LABEL_EDITOR_WIDTH_PX = 160
-const EDGE_LABEL_EDITOR_HEIGHT_PX = 28
 /** The compose bubble sits where the saved comment's bubble will be drawn,
  * so committing reads as the draft settling rather than jumping. */
 const COMMENT_COMPOSE_WIDTH_PX = 216
@@ -393,20 +391,6 @@ function commentComposeStyle(theme: ResolvedTheme): React.CSSProperties {
   }
 }
 
-/**
- * Opaque surface + label typography for the edge/group label editors. The
- * CSS reset makes form controls transparent, so without an explicit
- * background the object being edited (an edge line, the frame border)
- * shows through the draft.
- */
-function labelEditorStyle(theme: ResolvedTheme) {
-  return {
-    background: theme === 'dark' ? 'oklch(0.145 0 0)' : '#ffffff',
-    color: editorTextFill(theme),
-    fontFamily: SPATIAL_THEME_FONT_FAMILY,
-    fontSize: SPATIAL_THEME_GEOMETRY.labelFontSizePx,
-  }
-}
 /** Screen-space px within which a press/right-click counts as hitting an
  * edge line; divided by the zoom for the canvas-space comparison. */
 const EDGE_HIT_TOLERANCE_PX = 6
@@ -2576,66 +2560,27 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
                 applyResult={applyResult}
               />
             )}
-            {edgeLabelEditId !== null &&
-              (() => {
-                const edge = canvas.edges.find((entry) => entry.id === edgeLabelEditId)
-                const path = edgePaths.find((entry) => entry.id === edgeLabelEditId)?.path
-                if (edge === undefined || path === undefined) return null
-                // edgePaths is already the DRAWN (flattened) line, so the
-                // shared anchor needs no second rounding pass here.
-                const mid = edgeLabelAnchor(path)
-                if (mid === undefined) return null
-                return (
-                  <TextNodeEditor
-                    exitHintScale={1 / viewport.zoom}
-                    box={{
-                      x: mid.x - EDGE_LABEL_EDITOR_WIDTH_PX / 2,
-                      y: mid.y - EDGE_LABEL_EDITOR_HEIGHT_PX / 2,
-                      width: EDGE_LABEL_EDITOR_WIDTH_PX,
-                      height: EDGE_LABEL_EDITOR_HEIGHT_PX,
-                    }}
-                    initialText={edge.label ?? ''}
-                    testId="edge-label-editor"
-                    style={labelEditorStyle(theme)}
-                    onCommit={(label) => {
-                      applyResult({
-                        state: { kind: 'idle' },
-                        commands: [
-                          { kind: 'set-edge-label', id: edge.id, label: label.trim() } as const,
-                        ],
-                      })
-                      setEdgeLabelEditId(null)
-                    }}
-                    onCancel={() => setEdgeLabelEditId(null)}
-                  />
-                )
-              })()}
-            {groupLabelEditId !== null &&
-              (() => {
-                const group = canvas.nodes.find((entry) => entry.id === groupLabelEditId)
-                if (group === undefined || group.type !== 'group') return null
-                return (
-                  <TextNodeEditor
-                    exitHintScale={1 / viewport.zoom}
-                    // The label renders OUTSIDE, above the frame (container
-                    // convention) — the editor sits on that band.
-                    box={{ x: group.x, y: group.y - 44, width: group.width, height: 40 }}
-                    initialText={group.label ?? ''}
-                    testId="group-label-editor"
-                    style={labelEditorStyle(theme)}
-                    onCommit={(label) => {
-                      applyResult({
-                        state: { kind: 'idle' },
-                        commands: [
-                          { kind: 'set-group-label', id: group.id, label: label.trim() } as const,
-                        ],
-                      })
-                      setGroupLabelEditId(null)
-                    }}
-                    onCancel={() => setGroupLabelEditId(null)}
-                  />
-                )
-              })()}
+            {edgeLabelEditId !== null && (
+              <EdgeLabelEditorOverlay
+                editId={edgeLabelEditId}
+                canvas={canvas}
+                edgePaths={edgePaths}
+                zoom={viewport.zoom}
+                theme={theme}
+                applyResult={applyResult}
+                onClose={() => setEdgeLabelEditId(null)}
+              />
+            )}
+            {groupLabelEditId !== null && (
+              <GroupLabelEditorOverlay
+                editId={groupLabelEditId}
+                canvas={canvas}
+                zoom={viewport.zoom}
+                theme={theme}
+                applyResult={applyResult}
+                onClose={() => setGroupLabelEditId(null)}
+              />
+            )}
             {commentCompose !== null && (
               <TextNodeEditor
                 exitHintScale={1 / viewport.zoom}

--- a/apps/web/src/components/spatial-editor/comment-compose-overlay.tsx
+++ b/apps/web/src/components/spatial-editor/comment-compose-overlay.tsx
@@ -1,0 +1,187 @@
+import {
+  BODY_FONT_SIZE_PX,
+  BODY_LINE_HEIGHT_PX,
+  type BoundingBox,
+  COMMENT_BUBBLE_PADDING_PX,
+  COMMENT_BUBBLE_RADIUS_PX,
+  commentAnchor,
+  placeCommentBubble,
+  SPATIAL_DARK_PALETTE,
+  SPATIAL_LIGHT_PALETTE,
+  SPATIAL_THEME_FONT_FAMILY,
+} from '@kamiazya/whiteboard-canvas-render'
+import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { editorTextFill } from '../../lib/spatial/editor-appearance.js'
+import type { Point } from '../../lib/spatial/viewport.js'
+import type { ResolvedTheme } from '../../lib/theme.js'
+import type { CommentComposeState } from './CanvasContextMenu.js'
+import { defaultCreateId, type reduceGesture } from './gestures.js'
+import { TextNodeEditor } from './TextNodeEditor.js'
+
+/** The compose bubble sits where the saved comment's bubble will be drawn,
+ * so committing reads as the draft settling rather than jumping. */
+const COMMENT_COMPOSE_WIDTH_PX = 216
+const COMMENT_COMPOSE_HEIGHT_PX = 64
+
+/**
+ * Where the draft opens: placed by canvas-render's own bubble placer over
+ * the same obstacles, so it opens in the quadrant the settled bubble will
+ * take rather than over the node the comment is about.
+ */
+function commentDraftBox(
+  anchor: Point,
+  obstacles: readonly BoundingBox[],
+): { x: number; y: number; width: number; height: number } {
+  const placed = placeCommentBubble(
+    anchor,
+    { w: COMMENT_COMPOSE_WIDTH_PX, h: COMMENT_COMPOSE_HEIGHT_PX },
+    obstacles,
+  )
+  return { x: placed.x, y: placed.y, width: placed.w, height: placed.h }
+}
+
+/**
+ * The compose bubble wears the theme's comment chrome — the same palette
+ * entry, padding and corner the renderer draws the settled bubble with —
+ * so the draft and the saved comment read as one object rather than a
+ * plain editor a card replaces on commit. CommentThreadCard wears the
+ * same chrome, which is why this is exported rather than file-private. The shadow mirrors the SVG
+ * drop-shadow filter (dy 1, blur ~3px at 30% black) that lifts the
+ * settled chrome off the canvas plane.
+ */
+export function commentComposeStyle(theme: ResolvedTheme): React.CSSProperties {
+  const { bubble } = (theme === 'dark' ? SPATIAL_DARK_PALETTE : SPATIAL_LIGHT_PALETTE).comment
+  return {
+    background: bubble.fill,
+    color: editorTextFill(theme),
+    border: `1px solid ${bubble.stroke}`,
+    borderRadius: COMMENT_BUBBLE_RADIUS_PX,
+    padding: COMMENT_BUBBLE_PADDING_PX,
+    // Focus is shown as a soft halo in the bubble's own stroke colour
+    // rather than the UA's dark outline ring, which read as a second,
+    // heavier border around the card. The bubble is only ever mounted
+    // focused, so the halo is always the focus indicator.
+    outline: 'none',
+    boxShadow: `0 0 0 2px ${bubble.stroke}55, 0 1px 3px rgba(0, 0, 0, 0.3)`,
+    fontFamily: SPATIAL_THEME_FONT_FAMILY,
+    fontSize: BODY_FONT_SIZE_PX,
+    lineHeight: `${BODY_LINE_HEIGHT_PX}px`,
+    // Size to the draft like the settled bubble sizes to its text: one
+    // line to start, growing as lines are added (`field-sizing`; browsers
+    // without it keep the one-line minimum and scroll).
+    height: 'auto',
+    minHeight: BODY_LINE_HEIGHT_PX + 2 * COMMENT_BUBBLE_PADDING_PX + 2,
+    ...({ fieldSizing: 'content' } as React.CSSProperties),
+  }
+}
+
+/**
+ * The comment draft bubble: rewriting an existing comment's text, opening a
+ * THREAD when a passage/node-set anchor is attached (a flat comment cannot
+ * carry either), or creating a flat comment at a point. A blank commit is a
+ * cancel — an empty comment says nothing and would still ask the reader to
+ * resolve it; editing an existing comment to blank likewise keeps its
+ * stored text (removal stays MCP-only in v1, ADR-0025).
+ */
+export function CommentComposeOverlay({
+  compose,
+  canvas,
+  edgePathOf,
+  obstacles,
+  createId,
+  zoom,
+  theme,
+  applyResult,
+  onClose,
+}: {
+  readonly compose: CommentComposeState
+  readonly canvas: SpatialCanvas
+  readonly edgePathOf: (edgeId: string) => readonly Point[] | undefined
+  /** Precomputed by the caller so its obstacle closure stays where the boxes live. */
+  readonly obstacles: readonly BoundingBox[]
+  readonly createId?: () => string
+  readonly zoom: number
+  readonly theme: ResolvedTheme
+  readonly applyResult: (result: ReturnType<typeof reduceGesture>) => void
+  readonly onClose: () => void
+}) {
+  return (
+    <TextNodeEditor
+      exitHintScale={1 / zoom}
+      box={commentDraftBox(
+        // An edge comment opens ON the routed path, where the layer
+        // will pin it — one producer for the geometry.
+        compose.targetEdgeId === undefined
+          ? compose.point
+          : commentAnchor(
+              {
+                id: '',
+                text: ' ',
+                x: compose.point.x,
+                y: compose.point.y,
+                targetEdgeId: compose.targetEdgeId,
+              },
+              canvas,
+              edgePathOf,
+            ),
+        obstacles,
+      )}
+      initialText={compose.editing?.initialText ?? ''}
+      testId="comment-compose"
+      style={commentComposeStyle(theme)}
+      onCommit={(draft) => {
+        const text = draft.trim()
+        if (compose.editing !== undefined) {
+          if (text.length > 0 && text !== compose.editing.initialText) {
+            applyResult({
+              state: { kind: 'idle' },
+              commands: [{ kind: 'set-comment-text', id: compose.editing.id, text } as const],
+            })
+          }
+        } else if (text.length > 0 && compose.threadAnchor !== undefined) {
+          const id = (createId ?? defaultCreateId)()
+          const createdAt = new Date().toISOString()
+          applyResult({
+            state: { kind: 'idle' },
+            commands: [
+              {
+                kind: 'create-thread',
+                thread: {
+                  id,
+                  anchor: compose.threadAnchor,
+                  status: 'open',
+                  createdAt,
+                  messages: [{ id: `${id}-m1`, body: text, createdAt }],
+                },
+              } as const,
+            ],
+          })
+        } else if (text.length > 0) {
+          const { point, targetNodeId, targetEdgeId } = compose
+          applyResult({
+            state: { kind: 'idle' },
+            commands: [
+              {
+                kind: 'create-comment',
+                comment: {
+                  id: (createId ?? defaultCreateId)(),
+                  // Rounded for the same reason the pin drag rounds:
+                  // an integer by schema, and a fractional anchor
+                  // is dropped on read rather than rejected here.
+                  x: Math.round(point.x),
+                  y: Math.round(point.y),
+                  text,
+                  createdAt: new Date().toISOString(),
+                  ...(targetNodeId === undefined ? {} : { targetNodeId }),
+                  ...(targetEdgeId === undefined ? {} : { targetEdgeId }),
+                },
+              } as const,
+            ],
+          })
+        }
+        onClose()
+      }}
+      onCancel={onClose}
+    />
+  )
+}

--- a/apps/web/src/components/spatial-editor/label-editor-overlays.tsx
+++ b/apps/web/src/components/spatial-editor/label-editor-overlays.tsx
@@ -1,0 +1,118 @@
+import {
+  edgeLabelAnchor,
+  SPATIAL_THEME_FONT_FAMILY,
+  SPATIAL_THEME_GEOMETRY,
+} from '@kamiazya/whiteboard-canvas-render'
+import type { CanvasEdge, SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { editorTextFill } from '../../lib/spatial/editor-appearance.js'
+import type { Point } from '../../lib/spatial/viewport.js'
+import type { ResolvedTheme } from '../../lib/theme.js'
+import type { reduceGesture } from './gestures.js'
+import { TextNodeEditor } from './TextNodeEditor.js'
+
+const EDGE_LABEL_EDITOR_WIDTH_PX = 160
+const EDGE_LABEL_EDITOR_HEIGHT_PX = 28
+
+/**
+ * Opaque surface + label typography for the edge/group label editors. The
+ * CSS reset makes form controls transparent, so without an explicit
+ * background the object being edited (an edge line, the frame border)
+ * shows through the draft.
+ */
+function labelEditorStyle(theme: ResolvedTheme) {
+  return {
+    background: theme === 'dark' ? 'oklch(0.145 0 0)' : '#ffffff',
+    color: editorTextFill(theme),
+    fontFamily: SPATIAL_THEME_FONT_FAMILY,
+    fontSize: SPATIAL_THEME_GEOMETRY.labelFontSizePx,
+  }
+}
+
+type ApplyResult = (result: ReturnType<typeof reduceGesture>) => void
+
+/** The in-place editor for an edge's label, opened over the drawn line's
+ * midpoint — `edgePaths` is already the DRAWN (flattened) line, so the
+ * shared anchor needs no second rounding pass here. */
+export function EdgeLabelEditorOverlay({
+  editId,
+  canvas,
+  edgePaths,
+  zoom,
+  theme,
+  applyResult,
+  onClose,
+}: {
+  readonly editId: string
+  readonly canvas: SpatialCanvas
+  readonly edgePaths: readonly { readonly id: string; readonly path: readonly Point[] }[]
+  readonly zoom: number
+  readonly theme: ResolvedTheme
+  readonly applyResult: ApplyResult
+  readonly onClose: () => void
+}) {
+  const edge: CanvasEdge | undefined = canvas.edges.find((entry) => entry.id === editId)
+  const path = edgePaths.find((entry) => entry.id === editId)?.path
+  if (edge === undefined || path === undefined) return null
+  const mid = edgeLabelAnchor(path)
+  if (mid === undefined) return null
+  return (
+    <TextNodeEditor
+      exitHintScale={1 / zoom}
+      box={{
+        x: mid.x - EDGE_LABEL_EDITOR_WIDTH_PX / 2,
+        y: mid.y - EDGE_LABEL_EDITOR_HEIGHT_PX / 2,
+        width: EDGE_LABEL_EDITOR_WIDTH_PX,
+        height: EDGE_LABEL_EDITOR_HEIGHT_PX,
+      }}
+      initialText={edge.label ?? ''}
+      testId="edge-label-editor"
+      style={labelEditorStyle(theme)}
+      onCommit={(label) => {
+        applyResult({
+          state: { kind: 'idle' },
+          commands: [{ kind: 'set-edge-label', id: edge.id, label: label.trim() } as const],
+        })
+        onClose()
+      }}
+      onCancel={onClose}
+    />
+  )
+}
+
+/** The in-place editor for a group's label. The label renders OUTSIDE,
+ * above the frame (container convention) — the editor sits on that band. */
+export function GroupLabelEditorOverlay({
+  editId,
+  canvas,
+  zoom,
+  theme,
+  applyResult,
+  onClose,
+}: {
+  readonly editId: string
+  readonly canvas: SpatialCanvas
+  readonly zoom: number
+  readonly theme: ResolvedTheme
+  readonly applyResult: ApplyResult
+  readonly onClose: () => void
+}) {
+  const group = canvas.nodes.find((entry) => entry.id === editId)
+  if (group === undefined || group.type !== 'group') return null
+  return (
+    <TextNodeEditor
+      exitHintScale={1 / zoom}
+      box={{ x: group.x, y: group.y - 44, width: group.width, height: 40 }}
+      initialText={group.label ?? ''}
+      testId="group-label-editor"
+      style={labelEditorStyle(theme)}
+      onCommit={(label) => {
+        applyResult({
+          state: { kind: 'idle' },
+          commands: [{ kind: 'set-group-label', id: group.id, label: label.trim() } as const],
+        })
+        onClose()
+      }}
+      onCancel={onClose}
+    />
+  )
+}

--- a/apps/web/src/components/spatial-editor/markdown-body-editor-overlay.tsx
+++ b/apps/web/src/components/spatial-editor/markdown-body-editor-overlay.tsx
@@ -1,0 +1,118 @@
+import {
+  BODY_FONT_SIZE_PX,
+  BODY_LINE_HEIGHT_PX,
+  outlineContentBox,
+  type SceneNode,
+  SPATIAL_THEME_FONT_FAMILY,
+  SPATIAL_THEME_GEOMETRY,
+} from '@kamiazya/whiteboard-canvas-render'
+import type { CommentThread, SpatialCanvas, SpatialNode } from '@kamiazya/whiteboard-model'
+import { createEditorAppearance, editorTextFill } from '../../lib/spatial/editor-appearance.js'
+import type { TextAnchor } from '../../lib/text-anchor.js'
+import type { ResolvedTheme } from '../../lib/theme.js'
+import { type GestureState, reduceGesture } from './gestures.js'
+import { MarkdownNodeEditor } from './MarkdownNodeEditor.js'
+
+/**
+ * The in-place editor for a text node's markdown body. The scene keeps
+ * drawing the node's chrome (its body is suppressed while this editor is
+ * open), so the editor is TRANSPARENT and sits in the same box the
+ * committed text uses: the silhouette's inscribed content box. A shaped
+ * node therefore keeps its silhouette for the whole edit, and the text
+ * does not jump on entering edit mode.
+ */
+export function MarkdownBodyEditorOverlay({
+  node,
+  selectionBox,
+  sceneNodes,
+  sceneCurrent,
+  threads,
+  onRequestComment,
+  zoom,
+  theme,
+  canvas,
+  gestureState,
+  applyResult,
+}: {
+  /** The text node being edited (the caller has already narrowed the type). */
+  readonly node: SpatialNode & { readonly type: 'text'; readonly text: string }
+  readonly selectionBox: { x: number; y: number; width: number; height: number }
+  readonly sceneNodes: readonly SceneNode[]
+  readonly sceneCurrent: boolean
+  readonly threads: readonly CommentThread[] | undefined
+  readonly onRequestComment: (anchor: TextAnchor) => boolean
+  readonly zoom: number
+  readonly theme: ResolvedTheme
+  readonly canvas: SpatialCanvas
+  readonly gestureState: GestureState
+  readonly applyResult: (result: ReturnType<typeof reduceGesture>) => void
+}) {
+  return (
+    <MarkdownNodeEditor
+      box={(() => {
+        const chrome = sceneNodes.find((entry) => entry.kind === 'shape' && entry.id === node.id)
+        const shapeId = chrome !== undefined && chrome.kind === 'shape' ? chrome.shape : undefined
+        const bbox = {
+          x: selectionBox.x,
+          y: selectionBox.y,
+          w: selectionBox.width,
+          h: selectionBox.height,
+        }
+        const inner = outlineContentBox(shapeId, bbox)
+        return { x: inner.x, y: inner.y, width: inner.w, height: inner.h }
+      })()}
+      initialText={node.text}
+      // The conversations about passages of this node's text, highlighted
+      // over the draft; and the comment verb's seam, which attaches the
+      // caret's scope to this node and opens the compose bubble at the
+      // node's corner, where a node comment opens. The editor commits on
+      // the blur the bubble causes, so the passage the anchor quotes is
+      // the text that gets committed.
+      threads={threads?.filter(
+        (thread) => thread.anchor.kind === 'text' && thread.anchor.nodeId === node.id,
+      )}
+      onRequestComment={onRequestComment}
+      exitHintTop={selectionBox.y + selectionBox.height + 6}
+      exitHintScale={1 / zoom}
+      centerContent={sceneNodes.some(
+        (entry) => entry.kind === 'shape' && entry.id === node.id && entry.shape !== undefined,
+      )}
+      style={{
+        // Transparent once the scene below has stopped drawing this
+        // node's text. An offloaded canvas lags one worker round trip
+        // behind the suppression change, so for that gap the overlay
+        // keeps the old opaque cover — otherwise the committed text
+        // shows doubled under the draft.
+        background: sceneCurrent
+          ? 'transparent'
+          : (() => {
+              const fill = createEditorAppearance(theme).resolveNode(node).appearance?.fill
+              return fill !== undefined && fill !== 'none'
+                ? fill
+                : theme === 'dark'
+                  ? 'oklch(0.145 0 0)'
+                  : '#ffffff'
+            })(),
+        color: editorTextFill(theme),
+        fontFamily: SPATIAL_THEME_FONT_FAMILY,
+        fontSize: BODY_FONT_SIZE_PX,
+        // The overlay must advance by the SAME line box the committed
+        // render uses, or the text moves under the cursor on entering
+        // edit mode. Shared constant, not a second copy of the number —
+        // these were equal until the markdown theme took body line
+        // height to 1.5.
+        lineHeight: `${BODY_LINE_HEIGHT_PX}px`,
+        padding: SPATIAL_THEME_GEOMETRY.paddingPx,
+      }}
+      onCommit={(text) => {
+        applyResult(reduceGesture(gestureState, canvas, { type: 'commit-text-edit', text }))
+      }}
+      onCancel={() => {
+        applyResult(reduceGesture(gestureState, canvas, { type: 'cancel-text-edit' }))
+      }}
+      onChange={(text) => {
+        applyResult(reduceGesture(gestureState, canvas, { type: 'update-text-edit', text }))
+      }}
+    />
+  )
+}


### PR DESCRIPTION
## What

Ticket `spatial-editor-jsx-overlays` (follow-up of #1310's hook decomposition): the four in-place editors leave the ~1000-line JSX return as named sub-components, each taking its subject's state plus the shared `applyResult`/`theme`/`zoom` seam — SpatialEditor.tsx 2865 → 2592 lines, and each editor now has a boundary a reader can open by name.

- `label-editor-overlays.tsx` — `EdgeLabelEditorOverlay` (drawn-path midpoint anchor) + `GroupLabelEditorOverlay` (the outside-above label band), with `labelEditorStyle` and the editor dimensions.
- `comment-compose-overlay.tsx` — `CommentComposeOverlay`: the draft bubble's placement through canvas-render's own placer, its chrome (`commentComposeStyle` stays exported — `CommentThreadCard` wears the same chrome), and the commit's three arms (rewrite / thread when a passage or node-set anchor rides along / flat comment; blank commit = cancel per ADR-0025). The obstacle closure stays with the boxes in SpatialEditor; its value is a prop.
- `markdown-body-editor-overlay.tsx` — `MarkdownBodyEditorOverlay`: inscribed content-box geometry, passage-thread filtering, the suppression-lag-aware transparent background, the three `reduceGesture` commits. SpatialEditor keeps the mount condition and the comment-verb seam.

**Deliberately left in place**: the comment thread cards region (the annotations initiative is actively landing there — extracting under it buys a conflict, not a boundary), and the overlays that are already components (`MinimapOverlay`, `SelectionOverlay`, `ToolPalette`, the context-menu cluster) whose inline part is prop wiring a wrapper could only pass through (#1378's lesson).

## Verification

Per step: edge-label-edit + group-node 14/14 · comment create/edit/reply/placement 19/19 · text-edit-experience + markdown-node-editor + shaped-node-editing + double-press 17/17. Final: whole spatial-editor browser dir **491/491**, web typecheck, lint, knip clean.

Visual evidence: none — behavior-preserving JSX extraction; the full real-browser editor suite above is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D
