### PR TITLE
feat(web): the picker gets a selection mode, whose one verb is bulk delete

### DIFF
--- a/apps/web/src/components/document-list/DeleteDocumentDialog.tsx
+++ b/apps/web/src/components/document-list/DeleteDocumentDialog.tsx
@@ -13,8 +13,16 @@ import { DESTRUCTIVE_COPY, type DestructiveActionId } from '../../lib/destructiv
 import { kindNoun } from '../../lib/kind-noun.js'
 
 export interface DeleteDocumentDialogProps {
-  // The document pending deletion, or null when the dialog is closed.
-  pending: { displayName: string; kind?: DocumentKind } | null
+  /**
+   * The document pending deletion, or null when the dialog is closed.
+   *
+   * `count` makes the subject a NUMBER rather than a name, for a bulk
+   * delete. Its absence is the singular case, so no existing caller changes
+   * and there is one rule rather than two competing subjects. A count of one
+   * never arrives: the panel routes a single selection to the singular
+   * confirmation, which can say which document it means.
+   */
+  pending: { displayName: string; kind?: DocumentKind; count?: number } | null
   busy: boolean
   error: string | null
   /**
@@ -51,10 +59,18 @@ export function DeleteDocumentDialog({
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>
-            {pending ? `Delete "${pending.displayName}"?` : 'Delete canvas?'}
+            {pending === null
+              ? 'Delete canvas?'
+              : pending.count === undefined
+                ? `Delete "${pending.displayName}"?`
+                : `Delete ${pending.count} documents?`}
           </AlertDialogTitle>
           <AlertDialogDescription>
-            {DESTRUCTIVE_COPY[action](kindNoun(pending?.kind))}
+            {/* A bulk delete spans kinds, so the noun cannot come from one
+                document's kind the way the singular subject's does. */}
+            {DESTRUCTIVE_COPY[action](
+              pending?.count === undefined ? kindNoun(pending?.kind) : 'documents',
+            )}
             {error && <span className="mt-2 block text-destructive">{error}</span>}
           </AlertDialogDescription>
         </AlertDialogHeader>

--- a/apps/web/src/components/document-list/delete-many-dialog.test.tsx
+++ b/apps/web/src/components/document-list/delete-many-dialog.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { DESTRUCTIVE_COPY } from '../../lib/destructive-copy.js'
+import { DeleteDocumentDialog } from './DeleteDocumentDialog.js'
+
+// The bulk confirmation reuses the single one: same busy pinning, same error
+// slot, same buttons. Only the SUBJECT differs — a count instead of a name —
+// so a `count` on the pending object is the whole difference.
+
+afterEach(cleanup)
+
+const noop = () => {}
+
+describe('the delete confirmation with a count', () => {
+  it('names the count instead of a document, and drops the quotes with it', () => {
+    render(
+      <DeleteDocumentDialog
+        pending={{ displayName: '', count: 3 }}
+        busy={false}
+        error={null}
+        action="delete-documents-browser"
+        onCancel={noop}
+        onConfirm={noop}
+      />,
+    )
+
+    expect(screen.getByRole('heading').textContent).toBe('Delete 3 documents?')
+  })
+
+  it('promises the trash in the plural, from the declared copy', () => {
+    render(
+      <DeleteDocumentDialog
+        pending={{ displayName: '', count: 2 }}
+        busy={false}
+        error={null}
+        action="delete-documents-browser"
+        onCancel={noop}
+        onConfirm={noop}
+      />,
+    )
+
+    expect(
+      screen.getByText(DESTRUCTIVE_COPY['delete-documents-browser']('documents'), { exact: false }),
+    ).toBeTruthy()
+  })
+
+  it('still names the document when there is no count', () => {
+    render(
+      <DeleteDocumentDialog
+        pending={{ displayName: 'Roadmap', kind: 'spatial' }}
+        busy={false}
+        error={null}
+        action="delete-document-browser"
+        onCancel={noop}
+        onConfirm={noop}
+      />,
+    )
+
+    expect(screen.getByRole('heading').textContent).toBe('Delete "Roadmap"?')
+  })
+})

--- a/apps/web/src/components/workspace-files/FolderContentsList.tsx
+++ b/apps/web/src/components/workspace-files/FolderContentsList.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, FileText, Folder, LayoutGrid, Pin } from 'lucide-react'
+import { CheckCircle2, ChevronRight, Circle, FileText, Folder, LayoutGrid, Pin } from 'lucide-react'
 import { type ReactNode, useMemo } from 'react'
 import type { WorkspaceDocumentEntry } from '../../lib/document-entry.js'
 import { cn } from '../../lib/utils.js'
@@ -31,6 +31,14 @@ export interface FolderContentsListProps {
   onDocumentContextMenu?: (entry: WorkspaceDocumentEntry, x: number, y: number) => void
   /** The document the preview is showing, so the two panes agree. */
   selectedPath?: string
+  /**
+   * The paths a live selection holds, or absent when there is no selection.
+   *
+   * Absent and empty are different: absent means the list is in its ordinary
+   * mode and a card carries no `aria-pressed` at all, while empty would
+   * announce every card as an unpressed toggle.
+   */
+  selection?: ReadonlySet<string>
   /**
    * A card's picture. This component neither fetches nor renders, so a
    * caller with no daemon to read from still gets a working list — with the
@@ -66,6 +74,7 @@ export function FolderContentsList({
   onActivateDocument,
   onDocumentContextMenu,
   selectedPath,
+  selection,
   renderThumbnail,
   className,
 }: FolderContentsListProps) {
@@ -125,6 +134,7 @@ export function FolderContentsList({
             type="button"
             data-doc-path={entry.path}
             aria-current={entry.path === selectedPath ? 'true' : undefined}
+            aria-pressed={selection === undefined ? undefined : selection.has(entry.path)}
             onClick={() => onOpen({ kind: 'document', document: entry })}
             onDoubleClick={
               onActivateDocument === undefined ? undefined : () => onActivateDocument(entry)
@@ -149,9 +159,14 @@ export function FolderContentsList({
                     onDocumentContextMenu(entry, event.clientX, event.clientY)
                   }
             }
-            className="hover:bg-accent/40 aria-[current]:border-primary aria-[current]:ring-primary/40 flex w-full flex-col overflow-hidden rounded-md border text-left aria-[current]:ring-1"
+            // `group` + `aria-pressed:` so the SELECTED look is derived from
+            // the attribute a screen reader reads, rather than written a
+            // second time from `selection.has(...)`. toggle-state-surface
+            // enforces that, and caught this card doing exactly the doubled
+            // thing it forbids.
+            className="group hover:bg-accent/40 aria-[current]:border-primary aria-[current]:ring-primary/40 aria-pressed:border-primary aria-pressed:bg-accent/30 flex w-full flex-col overflow-hidden rounded-md border text-left aria-[current]:ring-1"
           >
-            <span className="bg-muted/40 flex aspect-video w-full items-center justify-center overflow-hidden">
+            <span className="bg-muted/40 relative flex aspect-video w-full items-center justify-center overflow-hidden">
               {renderThumbnail?.(entry) ?? (
                 <span
                   data-kind={entry.kind ?? 'markdown'}
@@ -159,6 +174,23 @@ export function FolderContentsList({
                 >
                   {entry.kind ?? 'markdown'}
                 </span>
+              )}
+              {/* Both drawn while a selection is live, and CSS picks between
+                  them from the button's own `aria-pressed` — so the picture
+                  cannot disagree with what is announced. Presence is gated on
+                  the MODE, which is a different question from the state.
+                  `aria-hidden` because the button already says it. */}
+              {selection !== undefined && (
+                <>
+                  <Circle
+                    aria-hidden="true"
+                    className="text-muted-foreground/70 absolute top-1 left-1 size-5 group-aria-pressed:hidden"
+                  />
+                  <CheckCircle2
+                    aria-hidden="true"
+                    className="fill-primary text-primary-foreground absolute top-1 left-1 hidden size-5 group-aria-pressed:block"
+                  />
+                </>
               )}
             </span>
             <span className="flex min-w-0 flex-col px-2 py-1.5">

--- a/apps/web/src/components/workspace-files/SelectionBar.tsx
+++ b/apps/web/src/components/workspace-files/SelectionBar.tsx
@@ -1,0 +1,48 @@
+import { Trash2, X } from 'lucide-react'
+
+export interface SelectionBarProps {
+  count: number
+  onDelete: () => void
+  onCancel: () => void
+}
+
+/**
+ * What a live selection offers: the count, and its one verb.
+ *
+ * The count is the only text here that a person has to read, and it is the
+ * one thing an icon cannot say. Everything else is the card menu's existing
+ * icon vocabulary.
+ *
+ * One verb by decision (owner, 2026-09-05), not by omission: the trash
+ * already provides the undo, so a selection mode can be judged on bulk
+ * delete alone rather than on a family of bulk actions nobody has asked for.
+ */
+export function SelectionBar({ count, onDelete, onCancel }: SelectionBarProps) {
+  return (
+    <div
+      data-testid="selection-bar"
+      // A live region: the count changes under the person's finger, and on a
+      // phone the bar can sit below the card they are tapping.
+      role="status"
+      className="bg-accent/60 flex items-center gap-2 rounded-md px-2 py-1.5"
+    >
+      <span className="flex-1 text-sm font-medium">{count} selected</span>
+      <button
+        type="button"
+        onClick={onDelete}
+        className="text-destructive hover:bg-destructive/10 flex items-center gap-1 rounded border px-2 py-0.5 text-xs"
+      >
+        <Trash2 className="size-3.5" aria-hidden="true" />
+        Delete
+      </button>
+      <button
+        type="button"
+        onClick={onCancel}
+        className="text-muted-foreground hover:text-foreground flex items-center gap-1 rounded border px-2 py-0.5 text-xs"
+      >
+        <X className="size-3.5" aria-hidden="true" />
+        Cancel
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -1,5 +1,6 @@
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import {
+  CheckCircle2,
   Columns2,
   CopyPlus,
   ExternalLink,
@@ -33,6 +34,7 @@ import { PeekDialog } from './PeekDialog.js'
 import { RecentLane } from './RecentLane.js'
 import { RenameDocumentDialog } from './RenameDocumentDialog.js'
 import { SearchResults } from './SearchResults.js'
+import { SelectionBar } from './SelectionBar.js'
 import { searchDocuments, withNameMatches } from './search-documents.js'
 import { TrashSection } from './TrashSection.js'
 import { useBrowserColumns } from './use-browser-columns.js'
@@ -81,6 +83,16 @@ export interface WorkspaceFilesPanelProps {
   onDuplicateDocument?: (path: string) => void
   onRequestDelete?: (path: string, displayName: string, kind?: DocumentKind) => void
   /**
+   * Delete every one of these paths, behind ONE confirmation.
+   *
+   * Page-owned for the same reason the single delete is: the confirmation
+   * dialog and the store call already live there, and a second copy of
+   * either would be a second set of rules for the same destructive act. Its
+   * absence is what withholds selection mode — a mode whose only verb
+   * cannot fire is a mode with nothing in it.
+   */
+  onRequestDeleteMany?: (paths: readonly string[]) => void
+  /**
    * Any value that changes when the workspace's documents may have changed
    * behind this panel's back.
    *
@@ -122,6 +134,7 @@ export function WorkspaceFilesPanel({
   onFolderChange,
   onDuplicateDocument,
   onRequestDelete,
+  onRequestDeleteMany,
   revision,
 }: WorkspaceFilesPanelProps) {
   const { resolvedTheme } = useThemeMode()
@@ -137,6 +150,19 @@ export function WorkspaceFilesPanel({
    * renamed document leaves the lane on its own.
    */
   const [recentIds, setRecentIds] = useState<readonly string[]>([])
+  /**
+   * The live selection's paths, or null when there is no selection.
+   *
+   * null rather than an empty set, because the two mean different things to
+   * the grid: null is the ordinary mode where a card is not a toggle at all,
+   * and a set is the mode where every card carries `aria-pressed`. Emptying
+   * the set is therefore how the mode ENDS, not a state it rests in.
+   *
+   * Not folded into `selected`: that one names the document the preview is
+   * showing, which is a different question with a different answer, and a
+   * preview that followed a multi-selection would have to pick one.
+   */
+  const [selection, setSelection] = useState<ReadonlySet<string> | null>(null)
   /**
    * How many cards the last successful listing drew, kept so a RE-READ can
    * hold the layout it is about to replace.
@@ -297,6 +323,58 @@ export function WorkspaceFilesPanel({
     setRecentIds(workspace === undefined ? [] : readRecentIds(workspace))
   }, [workspace])
 
+  const toggleSelected = useCallback((entry: WorkspaceDocumentEntry) => {
+    setSelection((current) => {
+      const next = new Set(current ?? [])
+      if (next.has(entry.path)) next.delete(entry.path)
+      else next.add(entry.path)
+      // Emptying it ENDS the mode rather than leaving an empty toggle grid
+      // with a bar offering to delete nothing.
+      return next.size === 0 ? null : next
+    })
+  }, [])
+
+  // A selected path that has left the listing leaves the selection with it.
+  // Pruned rather than merely filtered at the point of use: filtering would
+  // keep the stale path in state, so a document restored from the trash
+  // mid-selection would come back already selected — a document the person
+  // never chose in this session, in a bulk delete.
+  useEffect(() => {
+    if (documents === null) return
+    setSelection((current) => {
+      if (current === null) return current
+      const live = [...current].filter((path) => documents.some((each) => each.path === path))
+      // Same identity when nothing was pruned, or this sets state on every
+      // listing and re-renders forever.
+      if (live.length === current.size) return current
+      return live.length === 0 ? null : new Set(live)
+    })
+  }, [documents])
+
+  const deleteSelected = () => {
+    if (selection === null || documents === null) return
+    // In the order SHOWN, not in insertion order: the confirmation names a
+    // count and the page deletes a list, and a reader comparing the two
+    // should not have to reconcile two orders.
+    const paths = documents.filter((each) => selection.has(each.path)).map((each) => each.path)
+    if (paths.length === 0) return
+    // The selection is NOT cleared here. The page confirms first, and a
+    // cancelled confirmation must return the person to what they had chosen.
+    // What clears it is the re-read after a delete that landed: the pruning
+    // effect above drops every path that left the listing, so a PARTIAL
+    // failure leaves exactly the documents that survived still selected,
+    // with no outcome plumbed back through a prop.
+    const only = paths.length === 1 ? documents.find((each) => each.path === paths[0]) : undefined
+    // A single selection borrows the singular confirmation, which NAMES the
+    // document. A plural dialog reading "Delete 1 document?" would be a
+    // second confirmation that has to agree in number for no gain.
+    if (only !== undefined && onRequestDelete !== undefined) {
+      onRequestDelete(only.path, only.name ?? only.path, only.kind)
+      return
+    }
+    onRequestDeleteMany?.(paths)
+  }
+
   // SCOPE RESET — see scoped-screen-state.test.ts
   useEffect(() => {
     let cancelled = false
@@ -312,6 +390,10 @@ export function WorkspaceFilesPanel({
     setSelected(null)
     setCardMenu(null)
     setPeek(null)
+    // A selection names paths, and paths collide across workspaces — a
+    // bulk delete carried across a switch would address the departed
+    // workspace's names into the store now on screen.
+    setSelection(null)
     // The departed workspace's lane names its documents, so it is emptied
     // here like everything else — and refilled in the same effect, from the
     // ref rather than a dependency. Both halves together, because splitting
@@ -705,6 +787,15 @@ export function WorkspaceFilesPanel({
                   onSelect: () => void togglePinned(cardMenu.entry),
                 },
               ]),
+          ...(onRequestDeleteMany === undefined
+            ? []
+            : [
+                {
+                  label: 'Select',
+                  icon: <CheckCircle2 />,
+                  onSelect: () => setSelection(new Set([cardMenu.entry.path])),
+                },
+              ]),
           {
             label: 'Rename…',
             icon: <Pencil />,
@@ -844,6 +935,15 @@ export function WorkspaceFilesPanel({
             </button>
           ))}
         </fieldset>
+      )}
+      {selection !== null && (
+        <div className="px-2 pb-2">
+          <SelectionBar
+            count={selection.size}
+            onDelete={deleteSelected}
+            onCancel={() => setSelection(null)}
+          />
+        </div>
       )}
       {/* Above the columns, and only in the browse view: a search has its
           own answer to "which one did you mean", and a lane beside it
@@ -985,11 +1085,16 @@ export function WorkspaceFilesPanel({
                   onOpen={(target) =>
                     target.kind === 'folder'
                       ? selectFolder(target.path)
-                      : tapOpens
-                        ? openEntry(target.document)
-                        : setSelected(target.document)
+                      : selection !== null
+                        ? toggleSelected(target.document)
+                        : tapOpens
+                          ? openEntry(target.document)
+                          : setSelected(target.document)
                   }
-                  {...(onOpenDocument === undefined ? {} : { onActivateDocument: openEntry })}
+                  {...(selection === null ? { selection: undefined } : { selection })}
+                  {...(onOpenDocument === undefined || selection !== null
+                    ? {}
+                    : { onActivateDocument: openEntry })}
                   onDocumentContextMenu={openCardMenu}
                   renderThumbnail={(entry) => (
                     <DocumentThumbnail

--- a/apps/web/src/components/workspace-files/selection-mode.test.tsx
+++ b/apps/web/src/components/workspace-files/selection-mode.test.tsx
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
+import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
+
+// Selection mode, whose one verb is bulk delete (owner decision 2026-09-05:
+// "bulk delete only" — the trash already provides the undo, so the mode can
+// be judged on a single verb rather than a family of them).
+//
+// Entered from the card menu, which is the object surface both pointers
+// already reach: right-click on a desktop, long-press on a touch screen.
+// That is also where Finder and iOS Files put it.
+
+afterEach(cleanup)
+
+const entries = [
+  { documentId: 'd1', path: 'meeting-notes', name: 'Meeting notes', kind: 'markdown' as const },
+  { documentId: 'd2', path: 'roadmap', name: 'Roadmap', kind: 'spatial' as const },
+  { documentId: 'd3', path: 'tokens', name: 'Tokens', kind: 'markdown' as const },
+]
+
+const realMatchMedia = window.matchMedia
+beforeEach(() => {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }) as unknown as MediaQueryList
+})
+afterEach(() => {
+  window.matchMedia = realMatchMedia
+})
+
+function renderPanel(
+  overrides: {
+    onOpenDocument?: (path: string) => void
+    onRequestDeleteMany?: (paths: readonly string[]) => void
+    onRequestDelete?: (path: string, displayName: string) => void
+  } = {},
+) {
+  render(
+    <WorkspaceFilesPanel
+      source={fakeFilesSource({ listDocuments: () => Promise.resolve(entries) })}
+      {...overrides}
+    />,
+  )
+}
+
+async function cardButton(name: string) {
+  const title = (await screen.findAllByTestId('card-title')).find(
+    (each) => each.textContent === name,
+  )
+  if (title === undefined) throw new Error(`no card titled ${name}`)
+  return title.closest('button') as HTMLElement
+}
+
+async function enterSelection(name: string) {
+  const card = await cardButton(name)
+  fireEvent.contextMenu(card, { clientX: 30, clientY: 30 })
+  const menu = await screen.findByRole('menu', { name: 'Document actions' })
+  fireEvent.click(within(menu).getByRole('menuitem', { name: 'Select' }))
+  await waitFor(() => expect(screen.queryByRole('menu')).toBeNull())
+  return card
+}
+
+const bar = () => screen.queryByTestId('selection-bar')
+
+describe('selection mode', () => {
+  it('offers Select only where a bulk delete can actually happen', async () => {
+    renderPanel({})
+
+    fireEvent.contextMenu(await cardButton('Roadmap'), { clientX: 5, clientY: 5 })
+    const menu = await screen.findByRole('menu', { name: 'Document actions' })
+
+    expect(within(menu).queryByRole('menuitem', { name: 'Select' })).toBeNull()
+  })
+
+  it('starts with the card the menu was opened on already selected', async () => {
+    renderPanel({ onRequestDeleteMany: vi.fn() })
+
+    const card = await enterSelection('Roadmap')
+
+    expect(card.getAttribute('aria-pressed')).toBe('true')
+    expect(bar()?.textContent).toContain('1 selected')
+  })
+
+  it('toggles a card on click instead of opening it', async () => {
+    const onOpenDocument = vi.fn()
+    renderPanel({ onOpenDocument, onRequestDeleteMany: vi.fn() })
+    await enterSelection('Roadmap')
+
+    const other = await cardButton('Tokens')
+    fireEvent.click(other, { detail: 1 })
+
+    expect(other.getAttribute('aria-pressed')).toBe('true')
+    expect(onOpenDocument).not.toHaveBeenCalled()
+    await waitFor(() => expect(bar()?.textContent).toContain('2 selected'))
+  })
+
+  it('does not open on a double-click while a selection is live', async () => {
+    const onOpenDocument = vi.fn()
+    renderPanel({ onOpenDocument, onRequestDeleteMany: vi.fn() })
+    await enterSelection('Roadmap')
+
+    // A SECOND card, so the mode is unambiguously still live: clicking the
+    // only selected card deselects it and ends the mode, after which a
+    // double-click opens correctly and the test would assert nothing. It
+    // was written that way first, and failed for exactly that reason.
+    const other = await cardButton('Tokens')
+    fireEvent.click(other, { detail: 1 })
+    await waitFor(() => expect(bar()?.textContent).toContain('2 selected'))
+    fireEvent.doubleClick(other)
+
+    expect(onOpenDocument).not.toHaveBeenCalled()
+  })
+
+  it('leaves selection mode when the last card is deselected', async () => {
+    renderPanel({ onRequestDeleteMany: vi.fn() })
+    const card = await enterSelection('Roadmap')
+
+    fireEvent.click(card, { detail: 1 })
+
+    await waitFor(() => expect(bar()).toBeNull())
+    expect(card.getAttribute('aria-pressed')).toBeNull()
+  })
+
+  it('Cancel clears the selection without deleting anything', async () => {
+    const onRequestDeleteMany = vi.fn()
+    renderPanel({ onRequestDeleteMany })
+    await enterSelection('Roadmap')
+
+    fireEvent.click(within(bar() as HTMLElement).getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => expect(bar()).toBeNull())
+    expect(onRequestDeleteMany).not.toHaveBeenCalled()
+  })
+
+  it('raises one request carrying every selected path, in the order shown', async () => {
+    const onRequestDeleteMany = vi.fn()
+    renderPanel({ onRequestDeleteMany })
+    await enterSelection('Tokens')
+    fireEvent.click(await cardButton('Meeting notes'), { detail: 1 })
+
+    fireEvent.click(within(bar() as HTMLElement).getByRole('button', { name: 'Delete' }))
+
+    expect(onRequestDeleteMany).toHaveBeenCalledTimes(1)
+    expect(onRequestDeleteMany).toHaveBeenCalledWith(['meeting-notes', 'tokens'])
+  })
+
+  it('routes a single selection through the singular delete, which names the document', async () => {
+    // Not a plural dialog reading "Delete 1 document?": the singular path is
+    // already built and says which one, so the mode borrows it rather than
+    // growing a second confirmation that agrees in number.
+    const onRequestDelete = vi.fn()
+    const onRequestDeleteMany = vi.fn()
+    renderPanel({ onRequestDelete, onRequestDeleteMany })
+    await enterSelection('Roadmap')
+
+    fireEvent.click(within(bar() as HTMLElement).getByRole('button', { name: 'Delete' }))
+
+    expect(onRequestDeleteMany).not.toHaveBeenCalled()
+    expect(onRequestDelete).toHaveBeenCalledWith('roadmap', 'Roadmap', 'spatial')
+  })
+
+  it('keeps the selection while the confirmation is up, so a cancel returns to it', async () => {
+    const onRequestDeleteMany = vi.fn()
+    renderPanel({ onRequestDeleteMany })
+    await enterSelection('Tokens')
+    fireEvent.click(await cardButton('Meeting notes'), { detail: 1 })
+
+    fireEvent.click(within(bar() as HTMLElement).getByRole('button', { name: 'Delete' }))
+
+    // The page owns the dialog; from here the request has been raised and
+    // nothing has been deleted yet.
+    expect(bar()?.textContent).toContain('2 selected')
+  })
+
+  it('drops a selected path that has left the listing', async () => {
+    // A concurrent delete, seen from here: the same panel re-reads and the
+    // path it had selected is simply not in the answer.
+    let rows = entries
+    const source = fakeFilesSource({ listDocuments: () => Promise.resolve(rows) })
+    const view = render(
+      <WorkspaceFilesPanel source={source} onRequestDeleteMany={vi.fn()} revision={1} />,
+    )
+    await enterSelection('Roadmap')
+    fireEvent.click(await cardButton('Tokens'), { detail: 1 })
+    await waitFor(() => expect(bar()?.textContent).toContain('2 selected'))
+
+    rows = entries.filter((each) => each.path !== 'tokens')
+    view.rerender(
+      <WorkspaceFilesPanel source={source} onRequestDeleteMany={vi.fn()} revision={2} />,
+    )
+
+    await waitFor(() => expect(screen.queryAllByTestId('card-title')).toHaveLength(2))
+    await waitFor(() => expect(bar()?.textContent).toContain('1 selected'))
+  })
+})

--- a/apps/web/src/lib/destructive-copy.ts
+++ b/apps/web/src/lib/destructive-copy.ts
@@ -30,7 +30,11 @@
  */
 
 /** A destructive confirmation this app shows. */
-export type DestructiveActionId = 'delete-document-browser' | 'delete-document-daemon'
+export type DestructiveActionId =
+  | 'delete-document-browser'
+  | 'delete-document-daemon'
+  | 'delete-documents-browser'
+  | 'delete-documents-daemon'
 
 /**
  * Built from the noun for the thing being destroyed, so a note reads "The
@@ -55,6 +59,17 @@ export const DESTRUCTIVE_COPY = {
   // half worth warning about, rather than a blanket "no undo" that is false.
   'delete-document-daemon': (noun) =>
     `The ${noun} moves to the Trash, where you can restore it. Its versions and branches are deleted, and restoring does not bring them back.`,
+
+  // The bulk pair. Separate entries rather than one number-aware sentence,
+  // because English agreement ("moves"/"move", "it"/"them") would put a
+  // branch inside the one place this module exists to keep branch-free — and
+  // a selection of ONE never reaches here anyway: the panel routes it to the
+  // singular confirmation above, which can name the document.
+  'delete-documents-browser': (noun) =>
+    `The selected ${noun} move to the Trash, where you can restore them.`,
+
+  'delete-documents-daemon': (noun) =>
+    `The selected ${noun} move to the Trash, where you can restore them. Their versions and branches are deleted, and restoring does not bring them back.`,
 } satisfies Record<DestructiveActionId, DestructiveDescription>
 
 /**

--- a/apps/web/src/pages/BrowserIndexPage.bulk-delete.browser.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.bulk-delete.browser.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Bulk delete on the REAL page, over real IndexedDB.
+ *
+ * The panel's own suite proves the selection raises one request with the
+ * right paths; what only this layer proves is that the page LOOPS it — every
+ * selected path really reaching the store — behind one confirmation that
+ * names the count rather than a document.
+ */
+
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import '../index.css'
+import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
+import { IdbDocumentIndex } from '../lib/idb-document-index.js'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { LocalStoreDouble } from '../test-utils/local-index.js'
+import { BrowserIndexPage } from './BrowserIndexPage.js'
+
+claimIsolatedWhiteboardDb('browserindexpage-bulk-delete')
+
+beforeEach(async () => {
+  await clearWhiteboardDb()
+})
+afterEach(cleanup)
+
+const titles = () => screen.getAllByTestId('card-title').map((each) => each.textContent)
+
+async function seedThree() {
+  const workspaceId = getBrowserWorkspaceId()
+  const store = new LocalStoreDouble()
+  for (const [documentId, path] of [
+    ['0CFJNRVY147ADGKPSWZ258BEHM', 'alpha'],
+    ['0Z258BEHMQTX0369CFJNRVY147', 'beta'],
+    ['069CFJNRVY147ADGKPSWZ258BE', 'gamma'],
+  ] as const) {
+    await store.save({
+      documentId,
+      workspaceId,
+      path,
+      name: path,
+      updatedAt: '2026-09-01T00:00:00Z',
+      kind: 'markdown',
+    })
+  }
+  await new IdbDocumentIndex().createWorkspace({ workspaceId, segment: 'default' })
+  return store
+}
+
+async function cardFor(name: string) {
+  const title = (await screen.findAllByTestId('card-title')).find(
+    (each) => each.textContent === name,
+  )
+  if (title === undefined) throw new Error(`no card titled ${name}`)
+  const card = title.closest('button')
+  if (card === null) throw new Error(`no button around ${name}`)
+  return card
+}
+
+it('deletes every selected document behind one confirmation naming the count', async () => {
+  const store = await seedThree()
+  render(
+    <MemoryRouter initialEntries={['/']}>
+      <BrowserIndexPage
+        index={store.index}
+        loro={store.loro}
+        pointer={store.pointer}
+        clock={store.clock}
+        onOpenDocument={vi.fn()}
+      />
+    </MemoryRouter>,
+    { container: document.body },
+  )
+  await waitFor(() => expect(titles()).toHaveLength(3))
+
+  // Enter selection from the card menu — the object surface both pointers
+  // reach — then add a second card by a plain click.
+  await userEvent.click(await cardFor('alpha'), { button: 'right' })
+  const menu = await screen.findByRole('menu', { name: 'Document actions' })
+  await userEvent.click(within(menu).getByRole('menuitem', { name: 'Select' }))
+  await waitFor(() => expect(screen.queryByRole('menu')).toBeNull())
+  await userEvent.click(await cardFor('beta'))
+
+  const bar = await screen.findByTestId('selection-bar')
+  await waitFor(() => expect(bar.textContent).toContain('2 selected'))
+  await userEvent.click(within(bar).getByRole('button', { name: 'Delete' }))
+
+  const dialog = await screen.findByRole('alertdialog')
+  expect(within(dialog).getByRole('heading').textContent).toBe('Delete 2 documents?')
+  await userEvent.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+  await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull(), { timeout: 15_000 })
+  await waitFor(() => expect(titles()).toEqual(['gamma']), { timeout: 15_000 })
+
+  // NOT asserted here: that the trash holds both. The store double this page
+  // is given implements no trash at all (`InMemoryDocumentIndex` has no
+  // `listTrash`), so the section never renders — nothing to do with the
+  // delete. Recovery is the SINGLE delete's existing contract, covered end to
+  // end over the real index by `BrowserIndexPage.flow.browser.test.tsx`, and
+  // a bulk delete routes every path through that same `index.deleteDocument`.
+})

--- a/apps/web/src/pages/BrowserIndexPage.test.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.test.tsx
@@ -520,6 +520,59 @@ describe('BrowserIndexPage', () => {
     expect(screen.getAllByTestId('card-title')).toHaveLength(1)
   })
 
+  it('a partial bulk failure names the count and narrows the retry to what failed', async () => {
+    const store = await seededStore([
+      {
+        documentId: '0CFJNRVY147ADGKPSWZ258BEHM',
+        workspaceId: 'local',
+        path: 'alpha',
+        name: 'Alpha',
+        updatedAt: '2026-08-01T00:00:00Z',
+        kind: 'spatial',
+      },
+      {
+        documentId: '0Z258BEHMQTX0369CFJNRVY147',
+        workspaceId: 'local',
+        path: 'beta',
+        name: 'Beta',
+        updatedAt: '2026-08-01T00:00:00Z',
+        kind: 'markdown',
+      },
+    ])
+    const attempted: string[] = []
+    const real = store.index.deleteDocument.bind(store.index)
+    let betaFails = true
+    store.index.deleteDocument = (args: { workspaceId: string; path: string }) => {
+      attempted.push(args.path)
+      if (args.path === 'beta' && betaFails) return Promise.reject(new Error('quota exceeded'))
+      return real(args)
+    }
+    renderPage(store)
+
+    const card = (await screen.findByText('Alpha')).closest('button') as HTMLElement
+    fireEvent.contextMenu(card, { clientX: 10, clientY: 10 })
+    const menu = await screen.findByRole('menu', { name: 'Document actions' })
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Select' }))
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull())
+    fireEvent.click((await screen.findByText('Beta')).closest('button') as HTMLElement)
+    fireEvent.click(
+      within(await screen.findByTestId('selection-bar')).getByRole('button', { name: 'Delete' }),
+    )
+    const dialog = await screen.findByRole('alertdialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+    expect(await within(dialog).findByText('1 of 2 could not be deleted.')).toBeTruthy()
+    // The lone survivor gets its NAME back rather than staying "2 documents",
+    // which would be the count of the attempt and not of what is now offered.
+    await waitFor(() => expect(within(dialog).getByText('Delete "Beta"?')).toBeTruthy())
+
+    betaFails = false
+    attempted.length = 0
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+    expect(attempted).toEqual(['beta'])
+  })
+
   it('shows each name over its own real path, which is never derived from that name', async () => {
     // Neither name carries ASCII, so a name-derived path would collapse both
     // to `untitled` / `untitled-2` — indistinguishable in the very column the

--- a/apps/web/src/pages/BrowserIndexPage.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.tsx
@@ -185,7 +185,10 @@ export function BrowserIndexPage({
   // The index deletes by PATH, and the list already addresses rows that way,
   // so this carries the path rather than the id it used to need.
   const [pendingDelete, setPendingDelete] = useState<{
-    path: string
+    // A LIST, so one confirmation and one handler serve both the single
+    // delete and the selection's bulk delete. A single delete is a list of
+    // one, and keeps naming its document.
+    paths: readonly string[]
     displayName: string
     kind?: DocumentKind
   } | null>(null)
@@ -204,13 +207,23 @@ export function BrowserIndexPage({
       // would hand the user an error screen the next time they open the
       // editor.
       const pointed = await pointer.get()
-      const target = await index.resolveDocument({
-        workspaceId: getBrowserWorkspaceId(),
-        path: pendingDelete.path,
-      })
-      await index.deleteDocument({ workspaceId: getBrowserWorkspaceId(), path: pendingDelete.path })
-      if (pointed !== null && target !== null && pointed === target.documentId) {
-        await pointer.clear()
+      // Sequential, and each failure recorded rather than thrown: one path
+      // that cannot be deleted must not abandon the rest, and the person has
+      // to be told how many did not go.
+      const failed: string[] = []
+      for (const path of pendingDelete.paths) {
+        try {
+          const target = await index.resolveDocument({
+            workspaceId: getBrowserWorkspaceId(),
+            path,
+          })
+          await index.deleteDocument({ workspaceId: getBrowserWorkspaceId(), path })
+          if (pointed !== null && target !== null && pointed === target.documentId) {
+            await pointer.clear()
+          }
+        } catch {
+          failed.push(path)
+        }
       }
       setSnapshots(await listLocalDocuments(index, clock))
       // The delete just moved a document INTO the trash — re-count so the
@@ -220,6 +233,18 @@ export function BrowserIndexPage({
       // The tree view holds its own copy of the list; this identity change is
       // its signal to re-read, same contract as the daemon page's `revision`.
       setFilesRevision((revision) => revision + 1)
+      if (failed.length > 0) {
+        // Held open on the count, because the list behind it has already
+        // changed: the ones that went are gone, and closing silently would
+        // read as "all deleted". The panel's own pruning leaves exactly the
+        // failures selected, so trying again is one press away.
+        setDeleteError(
+          failed.length === pendingDelete.paths.length
+            ? 'Failed to delete the document from this browser.'
+            : `${failed.length} of ${pendingDelete.paths.length} could not be deleted.`,
+        )
+        return
+      }
       setPendingDelete(null)
     } catch {
       setDeleteError('Failed to delete the document from this browser.')
@@ -307,7 +332,10 @@ export function BrowserIndexPage({
           onFolderChange={setRoutedFolder}
           onOpenDocument={onOpenDocument}
           onRequestDelete={(path, displayName, kind) =>
-            setPendingDelete({ path, displayName, kind })
+            setPendingDelete({ paths: [path], displayName, kind })
+          }
+          onRequestDeleteMany={(paths) =>
+            setPendingDelete({ paths, displayName: `${paths.length} documents` })
           }
           revision={filesRevision}
         />
@@ -326,10 +354,22 @@ export function BrowserIndexPage({
         </button>
       )}
       <DeleteDocumentDialog
-        pending={pendingDelete}
+        pending={
+          pendingDelete === null
+            ? null
+            : {
+                displayName: pendingDelete.displayName,
+                ...(pendingDelete.kind === undefined ? {} : { kind: pendingDelete.kind }),
+                ...(pendingDelete.paths.length > 1 ? { count: pendingDelete.paths.length } : {}),
+              }
+        }
         busy={deleting}
         error={deleteError}
-        action="delete-document-browser"
+        action={
+          pendingDelete !== null && pendingDelete.paths.length > 1
+            ? 'delete-documents-browser'
+            : 'delete-document-browser'
+        }
         onCancel={() => {
           setPendingDelete(null)
           setDeleteError(null)

--- a/apps/web/src/pages/BrowserIndexPage.tsx
+++ b/apps/web/src/pages/BrowserIndexPage.tsx
@@ -234,14 +234,29 @@ export function BrowserIndexPage({
       // its signal to re-read, same contract as the daemon page's `revision`.
       setFilesRevision((revision) => revision + 1)
       if (failed.length > 0) {
+        const attempted = pendingDelete.paths.length
         // Held open on the count, because the list behind it has already
-        // changed: the ones that went are gone, and closing silently would
-        // read as "all deleted". The panel's own pruning leaves exactly the
-        // failures selected, so trying again is one press away.
+        // changed (refreshed above): the ones that went are gone, and closing
+        // silently would read as "all deleted". The panel's own pruning
+        // leaves exactly the failures selected.
+        //
+        // Narrowed to what failed, so pressing Delete again retries exactly
+        // those. This browser index no-ops a delete for an absent row, so a
+        // re-send would be harmless here — but the daemon page answers 404
+        // and its retry genuinely diverged, and one operation should not
+        // converge differently per keeper.
+        const only = failed.length === 1 ? snapshots?.find((s) => s.path === failed[0]) : undefined
+        setPendingDelete({
+          paths: failed,
+          // A lone survivor gets its NAME back: `Delete "2 documents"?` would
+          // be the count of the attempt, not of what it now offers to do.
+          displayName: only?.name ?? (failed[0] as string),
+          ...(only?.kind === undefined ? {} : { kind: only.kind }),
+        })
         setDeleteError(
-          failed.length === pendingDelete.paths.length
+          failed.length === attempted
             ? 'Failed to delete the document from this browser.'
-            : `${failed.length} of ${pendingDelete.paths.length} could not be deleted.`,
+            : `${failed.length} of ${attempted} could not be deleted.`,
         )
         return
       }

--- a/apps/web/src/pages/DaemonIndexPage.test.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.test.tsx
@@ -1951,4 +1951,159 @@ describe('the workspace names the page', () => {
 
     expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('marketing-team')
   })
+
+  // Bulk delete on THIS keeper. The browser page has its own end-to-end test
+  // for the same capability; without one here, a regression in the daemon's
+  // loop — a wrong path, a dialog that never closes, a list that never
+  // refreshes — would pass every test in the repo.
+  async function enterSelectionOn(name: string) {
+    const card = (await screen.findByText(name)).closest('button') as HTMLElement
+    fireEvent.contextMenu(card, { clientX: 20, clientY: 20 })
+    const menu = await screen.findByRole('menu', { name: 'Document actions' })
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Select' }))
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull())
+  }
+
+  async function addToSelection(name: string) {
+    fireEvent.click((await screen.findByText(name)).closest('button') as HTMLElement)
+  }
+
+  it('a bulk delete sends one DELETE per selected path and refreshes the list', async () => {
+    const deleted: string[] = []
+    let rows = [
+      { path: 'alpha', updatedAt: new Date().toISOString() },
+      { path: 'beta', updatedAt: new Date().toISOString() },
+      { path: 'gamma', updatedAt: new Date().toISOString() },
+    ]
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      documentsByWorkspace: {
+        get 'ws-a'() {
+          return rows
+        },
+      },
+      onDeleteCanvas: (_ws, path) => {
+        deleted.push(path)
+        rows = rows.filter((r) => r.path !== path)
+        return undefined
+      },
+    })
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenDocument={vi.fn()} />, {
+      container: document.body,
+    })
+    await screen.findByText('alpha')
+
+    await enterSelectionOn('alpha')
+    await addToSelection('beta')
+    const bar = await screen.findByTestId('selection-bar')
+    await waitFor(() => expect(bar.textContent).toContain('2 selected'))
+    fireEvent.click(within(bar).getByRole('button', { name: 'Delete' }))
+
+    const dialog = await screen.findByRole('alertdialog')
+    expect(within(dialog).getByText('Delete 2 documents?')).toBeTruthy()
+    expect(
+      within(dialog).getByText(DESTRUCTIVE_COPY['delete-documents-daemon']('documents')),
+    ).toBeTruthy()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+    expect(deleted.sort()).toEqual(['alpha', 'beta'])
+    await waitFor(() => expect(screen.queryByText('alpha')).toBeNull())
+    expect(screen.getByText('gamma')).toBeTruthy()
+  })
+
+  it('a partial bulk failure reports the count, refreshes, and retries only what failed', async () => {
+    const attempts: string[] = []
+    let rows = [
+      { path: 'alpha', updatedAt: new Date().toISOString() },
+      { path: 'beta', updatedAt: new Date().toISOString() },
+    ]
+    let betaFails = true
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      documentsByWorkspace: {
+        get 'ws-a'() {
+          return rows
+        },
+      },
+      onDeleteCanvas: (_ws, path) => {
+        attempts.push(path)
+        if (path === 'beta' && betaFails) return jsonResponse({ title: 'nope' }, 500)
+        rows = rows.filter((r) => r.path !== path)
+        return undefined
+      },
+    })
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenDocument={vi.fn()} />, {
+      container: document.body,
+    })
+    await screen.findByText('alpha')
+
+    await enterSelectionOn('alpha')
+    await addToSelection('beta')
+    fireEvent.click(
+      within(await screen.findByTestId('selection-bar')).getByRole('button', { name: 'Delete' }),
+    )
+    fireEvent.click(
+      within(await screen.findByRole('alertdialog')).getByRole('button', { name: 'Delete' }),
+    )
+
+    const dialog = await screen.findByRole('alertdialog')
+    await waitFor(() =>
+      expect(within(dialog).getByText('1 of 2 could not be deleted.')).toBeTruthy(),
+    )
+    // The list behind the dialog must already say so — the one that went is
+    // gone. The comment on this branch used to claim this without doing it.
+    await waitFor(() => expect(screen.queryByText('alpha')).toBeNull())
+
+    // Retry: only the failure is attempted again, so the operation converges
+    // instead of re-issuing DELETE for a path the daemon has already removed.
+    betaFails = false
+    attempts.length = 0
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+    expect(attempts).toEqual(['beta'])
+  })
+
+  it('reports a 404 inside a bulk as a failure, the same as a single delete does', async () => {
+    // NOT treated as "already gone". A single delete that 404s shows the
+    // daemon's message (its own test above), and a bulk delete making the
+    // opposite choice would be the same operation meaning two things. Retry
+    // converges through NARROWING instead: only what failed is sent again,
+    // so a path the first attempt deleted is never re-sent.
+    let rows = [
+      { path: 'alpha', updatedAt: new Date().toISOString() },
+      { path: 'beta', updatedAt: new Date().toISOString() },
+    ]
+    installFetchMock({
+      workspaces: [{ workspaceId: 'ws-a' }],
+      documentsByWorkspace: {
+        get 'ws-a'() {
+          return rows
+        },
+      },
+      onDeleteCanvas: (_ws, path) => {
+        if (path === 'beta') return jsonResponse({ title: 'not found' }, 404)
+        rows = rows.filter((r) => r.path !== path)
+        return undefined
+      },
+    })
+    render(<DaemonIndexPage daemonBaseUrl={DAEMON_BASE_URL} onOpenDocument={vi.fn()} />, {
+      container: document.body,
+    })
+    await screen.findByText('alpha')
+
+    await enterSelectionOn('alpha')
+    await addToSelection('beta')
+    fireEvent.click(
+      within(await screen.findByTestId('selection-bar')).getByRole('button', { name: 'Delete' }),
+    )
+    fireEvent.click(
+      within(await screen.findByRole('alertdialog')).getByRole('button', { name: 'Delete' }),
+    )
+
+    const dialog = await screen.findByRole('alertdialog')
+    await waitFor(() =>
+      expect(within(dialog).getByText('1 of 2 could not be deleted.')).toBeTruthy(),
+    )
+  })
 })

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -550,15 +550,31 @@ export function DaemonIndexPage({
         }
       }
       if (failed.length > 0) {
-        // Not closed: the list behind the dialog has already changed, and
-        // closing silently would read as "all deleted". The panel's own
-        // pruning leaves exactly the failures selected.
+        const attempted = pendingDelete.paths.length
+        // Refreshed HERE rather than only in closeDeleteDialog, which this
+        // branch does not reach: the ones that went are gone, and a list
+        // still showing them behind the dialog contradicts the count above
+        // it. The panel's pruning then drops them from the selection too.
+        const isStale = () => selectedWorkspaceRef.current !== workspaceAtStart
+        void loadWorkspace(workspaceAtStart, isStale)
+        // Narrowed to what actually failed, so pressing Delete again retries
+        // exactly those. Left un-narrowed, a retry re-sent DELETE for every
+        // path the first attempt had already removed.
+        const only = failed.length === 1 ? rows.find((row) => row.path === failed[0]) : undefined
+        setPendingDelete({
+          paths: failed,
+          // A lone survivor gets its NAME back: a dialog reading
+          // `Delete "2 documents"?` would be the count of the attempt, not of
+          // what it is now offering to do.
+          displayName: only?.displayName ?? only?.path ?? `${failed.length} documents`,
+          ...(only?.kind === undefined ? {} : { kind: only.kind }),
+        })
         setDeleteError(
-          failed.length === pendingDelete.paths.length
+          failed.length === attempted
             ? lastError instanceof Error
               ? lastError.message
               : 'Failed to delete document.'
-            : `${failed.length} of ${pendingDelete.paths.length} could not be deleted.`,
+            : `${failed.length} of ${attempted} could not be deleted.`,
         )
         return
       }

--- a/apps/web/src/pages/DaemonIndexPage.tsx
+++ b/apps/web/src/pages/DaemonIndexPage.tsx
@@ -506,7 +506,10 @@ export function DaemonIndexPage({
   )
 
   const [pendingDelete, setPendingDelete] = useState<{
-    path: string
+    // A LIST, so one confirmation and one handler serve both the single
+    // delete and the selection's bulk delete. A single delete is a list of
+    // one, and keeps naming its document.
+    paths: readonly string[]
     displayName: string
     kind?: DocumentKind
   } | null>(null)
@@ -533,7 +536,32 @@ export function DaemonIndexPage({
     setDeleting(true)
     setDeleteError(null)
     try {
-      await deleteDocument(daemonFetch, daemonBaseUrl, workspaceAtStart, pendingDelete.path)
+      // Sequential, and each failure recorded rather than thrown: one path
+      // the daemon refuses must not abandon the rest, and the person has to
+      // be told how many did not go.
+      const failed: string[] = []
+      let lastError: unknown = null
+      for (const path of pendingDelete.paths) {
+        try {
+          await deleteDocument(daemonFetch, daemonBaseUrl, workspaceAtStart, path)
+        } catch (err) {
+          failed.push(path)
+          lastError = err
+        }
+      }
+      if (failed.length > 0) {
+        // Not closed: the list behind the dialog has already changed, and
+        // closing silently would read as "all deleted". The panel's own
+        // pruning leaves exactly the failures selected.
+        setDeleteError(
+          failed.length === pendingDelete.paths.length
+            ? lastError instanceof Error
+              ? lastError.message
+              : 'Failed to delete document.'
+            : `${failed.length} of ${pendingDelete.paths.length} could not be deleted.`,
+        )
+        return
+      }
       closeDeleteDialog()
     } catch (err) {
       // daemon-api-client errors are already sanitized (problem-details
@@ -683,7 +711,10 @@ export function DaemonIndexPage({
               onOpenDocument={(path) => onOpenDocument(selectedWorkspace, path)}
               onDuplicateDocument={(path) => void handleDuplicate(path)}
               onRequestDelete={(path, displayName, kind) =>
-                setPendingDelete({ path, displayName, kind })
+                setPendingDelete({ paths: [path], displayName, kind })
+              }
+              onRequestDeleteMany={(paths) =>
+                setPendingDelete({ paths, displayName: `${paths.length} documents` })
               }
               // A new array on every successful read, which is exactly the
               // signal the panel needs: the page reloads this list after a
@@ -696,10 +727,22 @@ export function DaemonIndexPage({
           <p className="text-sm text-muted-foreground">No workspace selected.</p>
         )}
         <DeleteDocumentDialog
-          pending={pendingDelete}
+          pending={
+            pendingDelete === null
+              ? null
+              : {
+                  displayName: pendingDelete.displayName,
+                  ...(pendingDelete.kind === undefined ? {} : { kind: pendingDelete.kind }),
+                  ...(pendingDelete.paths.length > 1 ? { count: pendingDelete.paths.length } : {}),
+                }
+          }
           busy={deleting}
           error={deleteError}
-          action="delete-document-daemon"
+          action={
+            pendingDelete !== null && pendingDelete.paths.length > 1
+              ? 'delete-documents-daemon'
+              : 'delete-document-daemon'
+          }
           onCancel={closeDeleteDialog}
           onConfirm={() => void handleConfirmDelete()}
         />

--- a/apps/web/src/scoped-screen-state.test.ts
+++ b/apps/web/src/scoped-screen-state.test.ts
@@ -108,6 +108,11 @@ const PANEL_STATE: Record<string, ScopeCoverage> = {
   // workspace on screen. Its own effect, since the handle can arrive after
   // the source.
   recentIds: 'cleared on switch',
+  // Paths, and paths collide across workspaces — `untitled` is the first
+  // document in most. A selection carried across a switch would address the
+  // departed workspace's names into the store now on screen, in a BULK
+  // delete, which is the worst place for that class of mistake.
+  selection: 'cleared on switch',
   renaming: 'cleared on switch',
   renameError: 'cleared on switch',
   renameBusy: 'cleared on switch',


### PR DESCRIPTION
The last deferred item from the 2026-09-05 picker redesign. Its blocker was that bulk actions did not exist; the owner scoped them to **bulk delete only** — the narrowest useful surface, since the trash already provides the undo, so the mode can be judged on one verb rather than a family.

Entered from the card menu, the object surface both pointers already reach: right-click on a desktop, long-press on a touch screen. Finder and iOS Files put it there too, and it costs no new affordance on the card.

## Visual repro

![before — deleting five means five menu-Delete-confirm cycles; after — five toggles and one confirmation](tmp/screenshots/selection-figure.png)

> Not uploaded: `gh` here is 2.97.0 and `--attach` landed in 2.99.0, so the reference resolves only in a local checkout. Panels `27beb260` / `80e7e8de`; `compose-figure.mjs` refuses identical ones.

In the after panel: the bar with the count and its two verbs, an **empty circle** on the unselected "Reading list" (so the affordance says "this is a toggle" before anything is chosen), and the filled check plus derived border on the two selected.

## Two decisions worth reviewing

**A single selection borrows the singular confirmation**, which can name the document. Not a shortcut — it removes number agreement from the copy entirely, so the two new plural sentences in `destructive-copy.ts` are plural-only and branch-free, which is the property that module exists to have.

**The selection is not cleared when Delete is pressed.** The page confirms first, and a cancelled confirmation must return the person to what they chose. What clears it is the re-read after a delete that landed: the pruning effect drops every path that left the listing, so a **partial failure leaves exactly the survivors still selected**, with no outcome plumbed back through a prop. Both pages loop sequentially and report `N of M could not be deleted` rather than closing on a half-done job.

## Three things a test caught, all of them mine

- **The first double-click test asserted nothing.** Its own first click deselected the only selected card, ending the mode, so the double-click that followed opened correctly. It now uses a second card and says why in the test.
- **The pruning property was declared in the design and not implemented.** The test written for it failed — which is what a property is for.
- **`toggle-state-surface` rejected the card outright.** It announced `aria-pressed` while drawing the check from a separate `selection.has()` expression — the doubled shape that guard forbids. The look is now derived from the attribute through `group-aria-pressed:`, so the picture cannot disagree with what is announced.

And one **user-facing regression** the existing suite caught: reworking the delete handler into a loop changed the single-failure sentence from "Failed to delete the document from this browser." to a shorter one. Restored.

## Scope ceiling, stated rather than left silent

Selection is offered in the folder-contents **grid only** — not in search results, not in the one-column tree. The grid is the browse surface where tidying happens; the other two multiply the interaction surface without changing whether the feature works.

## Verification

Mutation-checked, each mutation **asserted to have applied** before its run:

| mutation | result |
|---|---|
| click no longer routes to toggle | 6 red |
| pruning removed | 1 red |
| single selection no longer borrows the singular delete | 1 red |
| `aria-pressed` always absent | 2 red |
| dialog ignores the count | 1 red |

`web-jsdom` **3813/3814** and `web-browser` **1131/1132** before the merge of current main; after it, the touched area re-ran **759/759**. Each single failure was the known `BrowserDocumentPage` full-suite flake already filed as `create-delete-node-full-suite-flake` — both pass in isolation, and this diff touches no document page. Typecheck, lint and knip clean.
