### PR TITLE
feat(web): Properties and Connections join the inspector slot as tabs

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -476,12 +476,15 @@ gutter marker beside its line), and the document-level rail both editors
 share (ADR-0026 decision 5; `useCommentsRail` holds its state,
 `CommentsRailAside` is its vessel — a column where there is width, a bottom
 sheet over the editor under 768px, since a 288px column beside a 412px phone
-screen left the editor a strip a finger could not write in). The rail and the
-history column share the page's ONE inspector slot (`lib/inspector.ts`):
-opening either closes the other, and each opener reads released, because two
-panels beside one editor — measured on a phone as the display popover, the
-comments sheet and the history sheet all open at once — is what the header
-retune set out to end. The rail carries
+screen left the editor a strip a finger could not write in). The rail is one
+of four panels sharing the page's ONE inspector slot (`lib/inspector.ts`,
+vessel `InspectorPanel`): a markdown document's properties, its comments, the
+documents linking to it (a daemon keeper only), its history. Opening any one
+closes the others and every opener reads released, because two panels beside
+one editor — measured on a phone as the display popover, the comments sheet
+and the history sheet all open at once — is what the header retune set out to
+end; the properties editor and the connections list used to overlay UNDER the
+header instead, a third shape for the same job. The rail carries
 the conversation's own verbs beside its reply box — Resolve/Reopen and Edit
 of the opening message — because a NOTE's thread has no card, and the rail
 is the only place it can be closed or corrected; both go through the threads

--- a/apps/web/src/components/annotations/CommentsRailChrome.browser.test.tsx
+++ b/apps/web/src/components/annotations/CommentsRailChrome.browser.test.tsx
@@ -53,7 +53,8 @@ it('is a column beside the editor where there is width for one', async () => {
   mount()
   const rail = page.getByTestId('comments-rail').element()
   expect(getComputedStyle(rail).position).toBe('static')
-  expect(rail.getBoundingClientRect().width).toBe(288)
+  // One vessel for every inspector panel, so one width: the history column's.
+  expect(rail.getBoundingClientRect().width).toBe(300)
 })
 
 it('is a sheet over the editor on a phone, and can be closed from it', async () => {

--- a/apps/web/src/components/annotations/CommentsRailChrome.tsx
+++ b/apps/web/src/components/annotations/CommentsRailChrome.tsx
@@ -1,17 +1,17 @@
 /**
- * The comments rail's chrome — the toggle button and the `<aside>` that
- * hosts `CommentsPanel` — shared by the browser and daemon document pages
- * (previously duplicated verbatim). Both are pure projections of
- * `useCommentsRail`'s output plus one keeper answer: whether the surface
- * behind the rail is WRITABLE right now.
+ * The comments rail's chrome — the toggle button and the panel the
+ * inspector's vessel hosts `CommentsPanel` in — shared by the browser and
+ * daemon document pages (previously duplicated verbatim). Both are pure
+ * projections of `useCommentsRail`'s output plus one keeper answer: whether
+ * the surface behind the rail is WRITABLE right now.
  */
 
 import type { CommentThread } from '@kamiazya/whiteboard-model'
-import { ChevronUp, MessageSquare, X } from 'lucide-react'
-import { type JSX, useState } from 'react'
+import { MessageSquare } from 'lucide-react'
+import type { JSX } from 'react'
 import type { CommentsRail } from '../../hooks/use-comments-rail.js'
-import { cn } from '../../lib/utils.js'
-import { HEADER_BUTTON_CLASS, HEADER_WIDE_TOGGLE_CLASS } from '../ui/header-button.js'
+import { InspectorPanel } from '../document-editor/InspectorPanel.js'
+import { HEADER_WIDE_TOGGLE_CLASS } from '../ui/header-button.js'
 import { CommentsPanel } from './CommentsPanel.js'
 
 export function CommentsRailToggle({ rail }: { readonly rail: CommentsRail }): JSX.Element {
@@ -51,50 +51,10 @@ export function CommentsRailAside({
    */
   readonly writable: boolean
 }): JSX.Element | null {
-  // A column where there is width for one, a bottom sheet over the editor
-  // under 768px — the same two shapes the history panel takes, because a
-  // 288px column beside a 412px phone screen left the editor a strip a
-  // finger could not write in. The sheet peeks at 45% and expands to the
-  // full height from its grab handle.
-  const [expanded, setExpanded] = useState(false)
   if (!rail.open) return null
   return (
-    <aside
-      aria-label="Comments"
-      data-testid="comments-rail"
-      data-stage={expanded ? 'full' : 'peek'}
-      className={cn(
-        'absolute inset-x-0 bottom-0 z-20 flex min-h-0 flex-col border-t bg-background shadow-[0_-8px_24px_-12px_rgb(0_0_0/0.35)]',
-        expanded ? 'h-full' : 'h-[45%] rounded-t-2xl',
-        'md:static md:z-auto md:h-auto md:w-72 md:max-w-[calc(100vw-1.5rem)] md:shrink-0 md:rounded-none md:border-t-0 md:border-l md:shadow-none',
-      )}
-    >
-      <div className="flex shrink-0 items-center justify-between gap-2 px-2 pt-1.5 md:hidden">
-        <span className="text-xs font-medium text-muted-foreground">Comments</span>
-        <button
-          type="button"
-          data-testid="comments-stage-toggle"
-          aria-label={expanded ? 'Collapse comments' : 'Expand comments'}
-          aria-expanded={expanded}
-          onClick={() => setExpanded((v) => !v)}
-          // The sheet's grab handle: a wide, shallow target a thumb aims at
-          // the edge for, not an icon-sized one. One chevron, turned by the
-          // ARIA state rather than swapped for another glyph, so the
-          // announced state and the drawn one cannot disagree.
-          className="flex h-6 w-16 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground aria-expanded:[&>svg]:rotate-180"
-        >
-          <ChevronUp aria-hidden="true" className="size-4 transition-transform" />
-        </button>
-        <button
-          type="button"
-          aria-label="Close comments"
-          onClick={rail.toggle}
-          className={cn(HEADER_BUTTON_CLASS, 'ml-auto')}
-        >
-          <X aria-hidden="true" className="size-4" />
-        </button>
-      </div>
-      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+    <InspectorPanel kind="comments" onClose={rail.toggle}>
+      <div className="p-2">
         <CommentsPanel
           threads={threads}
           resolveAnchor={rail.resolveAnchor}
@@ -109,6 +69,6 @@ export function CommentsRailAside({
           onEditMessage={writable ? rail.editMessage : undefined}
         />
       </div>
-    </aside>
+    </InspectorPanel>
   )
 }

--- a/apps/web/src/components/connections/ConnectionsChip.test.tsx
+++ b/apps/web/src/components/connections/ConnectionsChip.test.tsx
@@ -1,6 +1,12 @@
 import { fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
 import { describe, expect, it, vi } from 'vitest'
-import { ConnectionsChip } from './ConnectionsChip.js'
+import {
+  type ConnectionsBacklink,
+  ConnectionsChip,
+  ConnectionsPanel,
+  type ConnectionsPanelProps,
+} from './ConnectionsChip.js'
 
 const TWO = [
   {
@@ -18,9 +24,43 @@ const TWO = [
   },
 ]
 
+/**
+ * The opener and the panel the way the document page composes them: the
+ * page holds the inspector slot, the chip asks for it, the panel shows in
+ * it. The chip alone opens nothing — that is the point of the split.
+ */
+function Connections({
+  backlinks,
+  ...panel
+}: Omit<ConnectionsPanelProps, 'backlinks'> & {
+  readonly backlinks: readonly ConnectionsBacklink[] | null
+}) {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <ConnectionsChip backlinks={backlinks} open={open} onToggle={() => setOpen((o) => !o)} />
+      {open && backlinks !== null && <ConnectionsPanel backlinks={backlinks} {...panel} />}
+    </>
+  )
+}
+
 describe('ConnectionsChip', () => {
+  it('is controlled by the page: aria-expanded follows `open`, a press only asks', () => {
+    const onToggle = vi.fn()
+    const { rerender } = render(
+      <ConnectionsChip backlinks={TWO} open={false} onToggle={onToggle} />,
+    )
+    const chip = screen.getByRole('button', { name: /connections/i })
+    expect(chip.getAttribute('aria-expanded')).toBe('false')
+    fireEvent.click(chip)
+    expect(onToggle).toHaveBeenCalledTimes(1)
+    expect(chip.getAttribute('aria-expanded')).toBe('false')
+    rerender(<ConnectionsChip backlinks={TWO} open={true} onToggle={onToggle} />)
+    expect(chip.getAttribute('aria-expanded')).toBe('true')
+  })
+
   it('shows the backlink count and opens the panel with sources and contexts', () => {
-    render(<ConnectionsChip backlinks={TWO} onOpen={() => {}} />)
+    render(<Connections backlinks={TWO} onOpen={() => {}} />)
     const chip = screen.getByRole('button', { name: /connections/i })
     expect(chip.textContent).toContain('2')
     expect(screen.queryByRole('region', { name: /connections/i })).toBeNull()
@@ -36,7 +76,7 @@ describe('ConnectionsChip', () => {
   it('shows unlinked mentions as their own section, and navigates on click', () => {
     const onOpen = vi.fn()
     render(
-      <ConnectionsChip
+      <Connections
         backlinks={TWO}
         mentions={[
           {
@@ -68,25 +108,20 @@ describe('ConnectionsChip', () => {
       contexts: ['…Release plan の前提が…'],
     }
     const { unmount } = render(
-      <ConnectionsChip
-        backlinks={TWO}
-        mentions={[mention]}
-        onOpen={() => {}}
-        onLinkify={onLinkify}
-      />,
+      <Connections backlinks={TWO} mentions={[mention]} onOpen={() => {}} onLinkify={onLinkify} />,
     )
     fireEvent.click(screen.getByRole('button', { name: /connections/i }))
     fireEvent.click(screen.getByRole('button', { name: /link it/i }))
     expect(onLinkify).toHaveBeenCalledWith(expect.objectContaining({ path: 'standup' }))
     unmount()
 
-    render(<ConnectionsChip backlinks={TWO} mentions={[mention]} onOpen={() => {}} />)
+    render(<Connections backlinks={TWO} mentions={[mention]} onOpen={() => {}} />)
     fireEvent.click(screen.getByRole('button', { name: /connections/i }))
     expect(screen.queryByRole('button', { name: /link it/i })).toBeNull()
   })
 
   it('hides the mentions section when there are none', () => {
-    render(<ConnectionsChip backlinks={TWO} mentions={[]} onOpen={() => {}} />)
+    render(<Connections backlinks={TWO} mentions={[]} onOpen={() => {}} />)
     fireEvent.click(screen.getByRole('button', { name: /connections/i }))
     expect(screen.getByRole('region', { name: /connections/i }).textContent).not.toContain(
       'Mentioned, not linked',
@@ -95,19 +130,19 @@ describe('ConnectionsChip', () => {
 
   it('navigates to the source document when its row is clicked', () => {
     const onOpen = vi.fn()
-    render(<ConnectionsChip backlinks={TWO} onOpen={onOpen} />)
+    render(<Connections backlinks={TWO} onOpen={onOpen} />)
     fireEvent.click(screen.getByRole('button', { name: /connections/i }))
     fireEvent.click(screen.getByRole('button', { name: /sprint notes/i }))
     expect(onOpen).toHaveBeenCalledWith(expect.objectContaining({ path: 'notes' }))
   })
 
   it('renders a zero count rather than hiding — the empty state is the invitation', () => {
-    render(<ConnectionsChip backlinks={[]} onOpen={() => {}} />)
+    render(<Connections backlinks={[]} onOpen={() => {}} />)
     expect(screen.getByRole('button', { name: /connections/i }).textContent).toContain('0')
   })
 
   it('stays quiet while backlinks are not loaded yet', () => {
-    render(<ConnectionsChip backlinks={null} onOpen={() => {}} />)
+    render(<Connections backlinks={null} onOpen={() => {}} />)
     expect(screen.getByRole('button', { name: /connections/i }).hasAttribute('disabled')).toBe(true)
   })
 })

--- a/apps/web/src/components/connections/ConnectionsChip.tsx
+++ b/apps/web/src/components/connections/ConnectionsChip.tsx
@@ -1,6 +1,5 @@
 import type { DocumentBacklinksResponse } from '@kamiazya/whiteboard-daemon-client/api-contracts/index'
 import { FileText, LayoutDashboard, Waypoints } from 'lucide-react'
-import { useId, useState } from 'react'
 import { HEADER_WIDE_TOGGLE_CLASS } from '../../components/ui/header-button.js'
 import { cn } from '../../lib/utils.js'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js'
@@ -10,6 +9,45 @@ export type ConnectionsBacklink = DocumentBacklinksResponse['backlinks'][number]
 export interface ConnectionsChipProps {
   /** `null` while the fetch is in flight or unavailable — the chip waits. */
   readonly backlinks: readonly ConnectionsBacklink[] | null
+  /** Whether the inspector slot is showing the connections panel. */
+  readonly open: boolean
+  readonly onToggle: () => void
+}
+
+/**
+ * The opener for the "linked from" half of the incentive loop: a link
+ * someone writes elsewhere permanently shows up HERE, on the document it
+ * points at. Renders beside DocumentProperties in the merged header row;
+ * what it opens is `ConnectionsPanel`, in the page's one inspector slot.
+ *
+ * A zero count still renders. The empty chip is the affordance that says
+ * links land somewhere, which is the reason to write one; hiding it until
+ * content exists would hide the loop exactly where it needs starting.
+ */
+export function ConnectionsChip({ backlinks, open, onToggle }: ConnectionsChipProps) {
+  const loaded = backlinks !== null
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={`Connections${loaded ? ` (${backlinks.length})` : ''}`}
+          aria-expanded={open}
+          disabled={!loaded}
+          onClick={onToggle}
+          className={cn(HEADER_WIDE_TOGGLE_CLASS, 'text-xs tabular-nums')}
+        >
+          <Waypoints aria-hidden="true" className="size-4" />
+          {loaded && backlinks.length}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>Connections — documents linking here</TooltipContent>
+    </Tooltip>
+  )
+}
+
+export interface ConnectionsPanelProps {
+  readonly backlinks: readonly ConnectionsBacklink[]
   /**
    * Sources naming this document in prose without a link — the panel's
    * seeding section. Absent hides it (a backend that answers no mentions).
@@ -25,84 +63,42 @@ export interface ConnectionsChipProps {
   readonly onLinkify?: (mention: ConnectionsBacklink) => void
 }
 
-/**
- * The "linked from" half of the incentive loop: a link someone writes
- * elsewhere permanently shows up HERE, on the document it points at. Renders
- * beside DocumentProperties in the merged header row, and — like its
- * Type/Tags disclosure — overlays below the header instead of growing it.
- *
- * A zero count still renders. The empty chip is the affordance that says
- * links land somewhere, which is the reason to write one; hiding it until
- * content exists would hide the loop exactly where it needs starting.
- */
-export function ConnectionsChip({ backlinks, mentions, onOpen, onLinkify }: ConnectionsChipProps) {
-  const [open, setOpen] = useState(false)
-  const panelId = useId()
-  const loaded = backlinks !== null
-
+/** The documents linking here, and the ones naming this document without a link. */
+export function ConnectionsPanel({
+  backlinks,
+  mentions,
+  onOpen,
+  onLinkify,
+}: ConnectionsPanelProps) {
   return (
-    <>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            aria-label={`Connections${loaded ? ` (${backlinks.length})` : ''}`}
-            aria-expanded={open}
-            aria-controls={panelId}
-            disabled={!loaded}
-            onClick={() => setOpen((current) => !current)}
-            className={cn(HEADER_WIDE_TOGGLE_CLASS, 'text-xs tabular-nums')}
-          >
-            <Waypoints aria-hidden="true" className="size-4" />
-            {loaded && backlinks.length}
-          </button>
-        </TooltipTrigger>
-        <TooltipContent>Connections — documents linking here</TooltipContent>
-      </Tooltip>
-      {open && loaded && (
-        <section
-          id={panelId}
-          aria-label="Connections"
-          className="border-border bg-background absolute left-0 right-0 top-full z-20 max-h-80 overflow-y-auto border-b px-3 py-2 shadow-md"
-        >
-          <p className="text-muted-foreground mb-1 text-[11px] font-semibold uppercase tracking-wide">
-            Linked from {backlinks.length}
-          </p>
-          {backlinks.length === 0 ? (
-            <p className="text-muted-foreground py-2 text-sm">
-              No links yet — a [[link]] written in any document lands here.
-            </p>
-          ) : (
-            <SourceList
-              entries={backlinks}
-              onPick={(entry) => {
-                setOpen(false)
-                onOpen(entry)
-              }}
-            />
-          )}
-          {(mentions?.length ?? 0) > 0 && (
-            <>
-              <p className="text-muted-foreground mb-1 mt-3 text-[11px] font-semibold uppercase tracking-wide">
-                Mentioned, not linked {mentions?.length}
-              </p>
-              <SourceList
-                entries={mentions ?? []}
-                onPick={(entry) => {
-                  setOpen(false)
-                  onOpen(entry)
-                }}
-                action={
-                  onLinkify === undefined
-                    ? undefined
-                    : { label: 'Link it', onPick: (entry) => onLinkify(entry) }
-                }
-              />
-            </>
-          )}
-        </section>
+    <section aria-label="Connections" className="px-3 py-2">
+      <p className="text-muted-foreground mb-1 text-[11px] font-semibold uppercase tracking-wide">
+        Linked from {backlinks.length}
+      </p>
+      {backlinks.length === 0 ? (
+        <p className="text-muted-foreground py-2 text-sm">
+          No links yet — a [[link]] written in any document lands here.
+        </p>
+      ) : (
+        <SourceList entries={backlinks} onPick={onOpen} />
       )}
-    </>
+      {(mentions?.length ?? 0) > 0 && (
+        <>
+          <p className="text-muted-foreground mb-1 mt-3 text-[11px] font-semibold uppercase tracking-wide">
+            Mentioned, not linked {mentions?.length}
+          </p>
+          <SourceList
+            entries={mentions ?? []}
+            onPick={onOpen}
+            action={
+              onLinkify === undefined
+                ? undefined
+                : { label: 'Link it', onPick: (entry) => onLinkify(entry) }
+            }
+          />
+        </>
+      )}
+    </section>
   )
 }
 

--- a/apps/web/src/components/document-editor/InspectorPanel.tsx
+++ b/apps/web/src/components/document-editor/InspectorPanel.tsx
@@ -1,0 +1,83 @@
+/**
+ * The vessel every inspector panel stands in — the one `aside` of
+ * `DocumentPageShell`, showing whichever panel the page's inspector slot
+ * holds (`lib/inspector.ts`).
+ *
+ * A COLUMN of the editor row where there is width for one, a bottom sheet
+ * over the editor under 768px. The history panel arrived at that shape
+ * first: a 300px column beside a 375px phone editor is two unusable halves,
+ * so under 768px the same panel is a sheet anchored to the bottom edge, out
+ * of flow, with two stages. The PEEK stage is the load-bearing one —
+ * looking at a past version draws it in place of the editor, and on a phone
+ * that is only worth anything if the sheet leaves the document above it
+ * visible while you choose. The FULL stage is for reading a long list, where
+ * the document behind it has nothing to say. The comments rail then copied
+ * the shape verbatim; this is the copy folded back into one place, so a
+ * third and fourth panel could not drift from it.
+ *
+ * Position-agnostic within that: the shell's `aside` slot owns where the
+ * panel sits, and the sheet positions against the row the shell wraps.
+ */
+
+import { ChevronUp, X } from 'lucide-react'
+import type { ReactNode, Ref } from 'react'
+import { useState } from 'react'
+import { INSPECTOR_CHROME, type InspectorKind } from '../../lib/inspector.js'
+import { cn } from '../../lib/utils.js'
+import { HEADER_BUTTON_CLASS } from '../ui/header-button.js'
+
+export function InspectorPanel({
+  kind,
+  onClose,
+  panelRef,
+  children,
+}: {
+  readonly kind: InspectorKind
+  /** Releases the slot — the sheet's own way out, since its opener is up in the header. */
+  readonly onClose: () => void
+  readonly panelRef?: Ref<HTMLDivElement>
+  readonly children: ReactNode
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const { label, testId } = INSPECTOR_CHROME[kind]
+  const lower = label.toLowerCase()
+  return (
+    <div
+      ref={panelRef}
+      data-testid={testId}
+      data-stage={expanded ? 'full' : 'peek'}
+      className={cn(
+        'absolute inset-x-0 bottom-0 z-20 flex min-h-0 flex-col border-t bg-background shadow-[0_-8px_24px_-12px_rgb(0_0_0/0.35)]',
+        expanded ? 'h-full' : 'h-[45%] rounded-t-2xl',
+        'md:static md:z-auto md:h-auto md:w-[300px] md:max-w-[calc(100vw-1.5rem)] md:shrink-0 md:rounded-none md:border-t-0 md:border-l md:shadow-none',
+      )}
+    >
+      <div className="flex shrink-0 items-center justify-between gap-2 px-2 pt-1.5 md:hidden">
+        <span className="text-xs font-medium text-muted-foreground">{label}</span>
+        <button
+          type="button"
+          data-testid={`${kind}-stage-toggle`}
+          aria-label={expanded ? `Collapse ${lower}` : `Expand ${lower}`}
+          aria-expanded={expanded}
+          onClick={() => setExpanded((v) => !v)}
+          // The sheet's grab handle: a wide, shallow target a thumb aims at
+          // the edge for, not an icon-sized one. One chevron, turned by the
+          // ARIA state rather than swapped for another glyph, so the
+          // announced state and the drawn one cannot disagree.
+          className="flex h-6 w-16 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground aria-expanded:[&>svg]:rotate-180"
+        >
+          <ChevronUp aria-hidden="true" className="size-4 transition-transform" />
+        </button>
+        <button
+          type="button"
+          aria-label={`Close ${lower}`}
+          onClick={onClose}
+          className={cn(HEADER_BUTTON_CLASS, 'ml-auto')}
+        >
+          <X aria-hidden="true" className="size-4" />
+        </button>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">{children}</div>
+    </div>
+  )
+}

--- a/apps/web/src/components/document-properties/DocumentProperties.test.tsx
+++ b/apps/web/src/components/document-properties/DocumentProperties.test.tsx
@@ -1,5 +1,6 @@
 /**
- * The canvas row: the document's name, plus the OKF core-facet editor.
+ * The canvas row (the document's name and the Properties opener) and the OKF
+ * core-facet editor the opener asks the page's inspector slot for.
  * `writeCoreFacets` REPLACES the whole bucket rather than merging, so every
  * facet edit here has to hand back a complete `StoredCoreFacets` — including
  * `facetsRaw`, the bucket holding root-level frontmatter keys this app does
@@ -13,7 +14,7 @@
 import type { StoredCoreFacets } from '@kamiazya/whiteboard-model'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { DocumentProperties } from './DocumentProperties.js'
+import { DocumentFacetsEditor, DocumentProperties } from './DocumentProperties.js'
 
 // An `<input list=...>` maps to role combobox, not textbox — the datalist
 // is what makes `type` offer completions while staying free text.
@@ -38,43 +39,42 @@ function titleProps(overrides: { title?: string; onTitleChange?: (next: string) 
 
 describe('DocumentProperties', () => {
   it('shows the workspace name as the title, without needing the panel opened', () => {
-    render(
-      <DocumentProperties
-        {...titleProps({ title: 'Release plan' })}
-        facets={meta()}
-        onFacetsChange={vi.fn()}
-      />,
-    )
+    render(<DocumentProperties {...titleProps({ title: 'Release plan' })} facets={meta()} />)
     expect(textboxValue(/title/i)).toBe('Release plan')
   })
 
   it("labels the software keyboard's Enter as Done on the title field", () => {
     // The one keyboard extension point the web has: Enter finishes the edit
     // here, so the key says so instead of showing a return arrow.
-    render(<DocumentProperties {...titleProps()} facets={meta()} onFacetsChange={vi.fn()} />)
+    render(<DocumentProperties {...titleProps()} facets={meta()} />)
     expect(screen.getByRole('textbox', { name: /title/i }).getAttribute('enterkeyhint')).toBe(
       'done',
     )
   })
 
-  it('keeps type and tags behind the disclosure until it is opened', async () => {
-    render(<DocumentProperties {...titleProps()} facets={meta()} onFacetsChange={vi.fn()} />)
+  it('offers only the opener: the facet editor lives in the inspector slot, not under the row', () => {
+    const onToggleProperties = vi.fn()
+    render(
+      <DocumentProperties
+        {...titleProps()}
+        facets={meta()}
+        onToggleProperties={onToggleProperties}
+      />,
+    )
     expect(screen.queryByRole('combobox', { name: /type/i })).toBeNull()
 
+    // A press asks the page for the slot; nothing opens here, because the
+    // row does not own the slot and a second editor under the header is the
+    // overlay the retune retired.
     fireEvent.click(screen.getByRole('button', { name: /properties/i }))
-    expect(typeBox().value).toBe('markdown')
+    expect(onToggleProperties).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('combobox', { name: /type/i })).toBeNull()
   })
 
   it('reports an edited title through onTitleChange, and never as a facet', () => {
     const onChange = vi.fn()
     const onTitleChange = vi.fn()
-    render(
-      <DocumentProperties
-        {...titleProps({ title: 'old', onTitleChange })}
-        facets={meta()}
-        onFacetsChange={onChange}
-      />,
-    )
+    render(<DocumentProperties {...titleProps({ title: 'old', onTitleChange })} facets={meta()} />)
 
     fireEvent.change(screen.getByRole('textbox', { name: /title/i }), {
       target: { value: 'new' },
@@ -87,13 +87,7 @@ describe('DocumentProperties', () => {
 
   it('reports a cleared title as the empty string, which the workspace reads as unnamed', () => {
     const onTitleChange = vi.fn()
-    render(
-      <DocumentProperties
-        {...titleProps({ title: 'old', onTitleChange })}
-        facets={meta()}
-        onFacetsChange={vi.fn()}
-      />,
-    )
+    render(<DocumentProperties {...titleProps({ title: 'old', onTitleChange })} facets={meta()} />)
 
     fireEvent.change(screen.getByRole('textbox', { name: /title/i }), { target: { value: '  ' } })
     expect(onTitleChange).toHaveBeenCalledWith('  ')
@@ -102,8 +96,7 @@ describe('DocumentProperties', () => {
   it('preserves facetsRaw across an edit to another field', () => {
     const onChange = vi.fn()
     const withRaw = meta({ facetsRaw: { author: 'kamiazya' } })
-    render(<DocumentProperties {...titleProps()} facets={withRaw} onFacetsChange={onChange} />)
-    fireEvent.click(screen.getByRole('button', { name: /properties/i }))
+    render(<DocumentFacetsEditor facets={withRaw} onChange={onChange} />)
 
     const tagInput = screen.getByRole('textbox', { name: /add tag/i })
     fireEvent.change(tagInput, { target: { value: 'ops' } })
@@ -117,39 +110,21 @@ describe('DocumentProperties', () => {
 
   it('adds a tag on Enter and removes it again', () => {
     const onChange = vi.fn()
-    const { rerender } = render(
-      <DocumentProperties {...titleProps()} facets={meta()} onFacetsChange={onChange} />,
-    )
-    fireEvent.click(screen.getByRole('button', { name: /properties/i }))
+    const { rerender } = render(<DocumentFacetsEditor facets={meta()} onChange={onChange} />)
 
     const tagInput = screen.getByRole('textbox', { name: /add tag/i })
     fireEvent.change(tagInput, { target: { value: 'ops' } })
     fireEvent.keyDown(tagInput, { key: 'Enter' })
     expect(onChange).toHaveBeenLastCalledWith({ type: 'markdown', tags: ['ops'] })
 
-    // No second Properties click: rerender keeps the same instance, so the
-    // panel is still open — clicking again would close it.
-    rerender(
-      <DocumentProperties
-        {...titleProps()}
-        facets={meta({ tags: ['ops'] })}
-        onFacetsChange={onChange}
-      />,
-    )
+    rerender(<DocumentFacetsEditor facets={meta({ tags: ['ops'] })} onChange={onChange} />)
     fireEvent.click(screen.getByRole('button', { name: /remove tag ops/i }))
     expect(onChange).toHaveBeenLastCalledWith({ type: 'markdown' })
   })
 
   it('does not commit a tag on the Enter that confirms an IME composition', () => {
     const onChange = vi.fn()
-    render(
-      <DocumentProperties
-        {...titleProps()}
-        facets={meta({ tags: [] })}
-        onFacetsChange={onChange}
-      />,
-    )
-    fireEvent.click(screen.getByRole('button', { name: /properties/i }))
+    render(<DocumentFacetsEditor facets={meta({ tags: [] })} onChange={onChange} />)
     const box = screen.getByRole('textbox', { name: /add tag/i })
     fireEvent.change(box, { target: { value: '\u4f01\u753b' } })
     fireEvent.keyDown(box, { key: 'Enter', isComposing: true })
@@ -158,14 +133,7 @@ describe('DocumentProperties', () => {
 
   it('ignores a duplicate or blank tag instead of storing it', () => {
     const onChange = vi.fn()
-    render(
-      <DocumentProperties
-        {...titleProps()}
-        facets={meta({ tags: ['ops'] })}
-        onFacetsChange={onChange}
-      />,
-    )
-    fireEvent.click(screen.getByRole('button', { name: /properties/i }))
+    render(<DocumentFacetsEditor facets={meta({ tags: ['ops'] })} onChange={onChange} />)
 
     const tagInput = screen.getByRole('textbox', { name: /add tag/i })
     for (const value of ['ops', '   ']) {
@@ -180,13 +148,11 @@ describe('DocumentProperties', () => {
   it('edits the OKF description, and clears it to absent rather than to an empty string', () => {
     const onChange = vi.fn()
     render(
-      <DocumentProperties
-        {...titleProps()}
+      <DocumentFacetsEditor
         facets={meta({ description: 'One row per order.' })}
-        onFacetsChange={onChange}
+        onChange={onChange}
       />,
     )
-    fireEvent.click(screen.getByRole('button', { name: /properties/i }))
 
     const box = screen.getByRole('textbox', { name: /summary/i })
     expect((box as HTMLInputElement).value).toBe('One row per order.')
@@ -205,8 +171,7 @@ describe('DocumentProperties', () => {
 
   it('edits the OKF resource, which §6.2 lets be a URL or a path', () => {
     const onChange = vi.fn()
-    render(<DocumentProperties {...titleProps()} facets={meta()} onFacetsChange={onChange} />)
-    fireEvent.click(screen.getByRole('button', { name: /properties/i }))
+    render(<DocumentFacetsEditor facets={meta()} onChange={onChange} />)
 
     const box = screen.getByRole('textbox', { name: /describes/i })
     fireEvent.change(box, { target: { value: '../computations/revenue.md' } })
@@ -219,13 +184,11 @@ describe('DocumentProperties', () => {
   it('preserves description and resource across an edit to another field', () => {
     const onChange = vi.fn()
     render(
-      <DocumentProperties
-        {...titleProps()}
+      <DocumentFacetsEditor
         facets={meta({ description: 'A summary.', resource: 'https://example.com' })}
-        onFacetsChange={onChange}
+        onChange={onChange}
       />,
     )
-    fireEvent.click(screen.getByRole('button', { name: /properties/i }))
 
     const tagInput = screen.getByRole('textbox', { name: /add tag/i })
     fireEvent.change(tagInput, { target: { value: 'ops' } })
@@ -240,8 +203,7 @@ describe('DocumentProperties', () => {
 
   it('refuses to emit an empty type, the one field the schema requires', () => {
     const onChange = vi.fn()
-    render(<DocumentProperties {...titleProps()} facets={meta()} onFacetsChange={onChange} />)
-    fireEvent.click(screen.getByRole('button', { name: /properties/i }))
+    render(<DocumentFacetsEditor facets={meta()} onChange={onChange} />)
 
     fireEvent.change(typeBox(), { target: { value: '' } })
     expect(onChange).not.toHaveBeenCalled()
@@ -263,7 +225,6 @@ describe('DocumentProperties title typing (controlled-input round trip)', () => 
         title={current === 'untitled' ? '' : current}
         onTitleChange={onTitleChange}
         facets={{ type: 'markdown' }}
-        onFacetsChange={vi.fn()}
       />
     )
     const { rerender } = render(view())
@@ -292,11 +253,7 @@ describe('DocumentProperties title typing (controlled-input round trip)', () => 
       current = next
     })
     const view = () => (
-      <DocumentProperties
-        {...titleProps({ title: current, onTitleChange })}
-        facets={meta()}
-        onFacetsChange={vi.fn()}
-      />
+      <DocumentProperties {...titleProps({ title: current, onTitleChange })} facets={meta()} />
     )
     render(view())
 
@@ -321,7 +278,6 @@ describe('DocumentProperties title typing (controlled-input round trip)', () => 
         <DocumentProperties
           {...titleProps({ title: 'Release plan', onTitleChange: vi.fn() })}
           facets={meta()}
-          onFacetsChange={vi.fn()}
         />
       </div>,
     )
@@ -342,7 +298,6 @@ describe('DocumentProperties title typing (controlled-input round trip)', () => 
       <DocumentProperties
         {...titleProps({ title: 'Draft', onTitleChange: onChange })}
         facets={meta()}
-        onFacetsChange={vi.fn()}
       />,
     )
     const box = screen.getByRole('textbox', { name: /title/i }) as HTMLInputElement
@@ -360,13 +315,7 @@ describe('DocumentProperties title typing (controlled-input round trip)', () => 
   // the middle of typing a word. Both spellings of "an IME is active" must
   // hold the field open (see lib/ime-keydown.ts).
   it('stays focused on the Enter that confirms an IME composition', () => {
-    render(
-      <DocumentProperties
-        {...titleProps({ title: 'Draft' })}
-        facets={meta()}
-        onFacetsChange={vi.fn()}
-      />,
-    )
+    render(<DocumentProperties {...titleProps({ title: 'Draft' })} facets={meta()} />)
     const box = screen.getByRole('textbox', { name: /title/i }) as HTMLInputElement
     box.focus()
     fireEvent.keyDown(box, { key: 'Enter', isComposing: true })
@@ -382,7 +331,6 @@ describe('DocumentProperties title typing (controlled-input round trip)', () => 
       <DocumentProperties
         {...titleProps({ title: 'Release plan', onTitleChange })}
         facets={meta()}
-        onFacetsChange={vi.fn()}
       />,
     )
     const box = screen.getByRole('textbox', { name: /title/i })
@@ -396,23 +344,24 @@ describe('DocumentProperties title typing (controlled-input round trip)', () => 
 })
 
 describe('DocumentProperties as the canvas row', () => {
-  it('the Properties toggle is an icon button with a real accessible name and controls link', () => {
-    render(
-      <DocumentProperties
-        {...titleProps()}
-        facets={{ type: 'markdown' }}
-        onFacetsChange={vi.fn()}
-      />,
+  it('the Properties toggle is an icon button with a real accessible name, and reads the slot it is given', () => {
+    const { rerender } = render(
+      <DocumentProperties {...titleProps()} facets={{ type: 'markdown' }} propertiesOpen={false} />,
     )
     const toggle = screen.getByRole('button', { name: 'Properties' })
     // Icon-only: the word moved into aria-label + tooltip, off the surface.
     expect(toggle.textContent).not.toContain('Properties')
     expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    // Controlled: the page's inspector slot decides, so a press alone
+    // changes nothing here, and the prop is what the state follows.
     fireEvent.click(toggle)
-    expect(toggle.getAttribute('aria-expanded')).toBe('true')
-    const disclosureId = toggle.getAttribute('aria-controls')
-    expect(disclosureId).toBeTruthy()
-    expect(document.getElementById(disclosureId as string)).toBeTruthy()
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    rerender(
+      <DocumentProperties {...titleProps()} facets={{ type: 'markdown' }} propertiesOpen={true} />,
+    )
+    expect(screen.getByRole('button', { name: 'Properties' }).getAttribute('aria-expanded')).toBe(
+      'true',
+    )
   })
 
   it('renders the settings slot beside the toggle and the actions cluster at the right edge', () => {
@@ -420,7 +369,6 @@ describe('DocumentProperties as the canvas row', () => {
       <DocumentProperties
         {...titleProps()}
         facets={{ type: 'markdown' }}
-        onFacetsChange={vi.fn()}
         settings={<button type="button" aria-label="Display settings" />}
         actions={<span data-testid="row-actions">ops</span>}
       />,
@@ -431,25 +379,14 @@ describe('DocumentProperties as the canvas row', () => {
 })
 
 describe('DocumentProperties inline variant (merged header row)', () => {
-  it('renders as a row segment without its own chrome, and the disclosure overlays', () => {
+  it('renders as a row segment without its own chrome', () => {
     const { container } = render(
-      <DocumentProperties
-        inline
-        {...titleProps()}
-        facets={{ type: 'canvas' }}
-        onFacetsChange={() => {}}
-      />,
+      <DocumentProperties inline {...titleProps()} facets={{ type: 'canvas' }} />,
     )
     const wrapper = container.firstElementChild as HTMLElement
     // No own border/背景 chrome — the merged header row provides it.
     expect(wrapper.className).not.toContain('border-b')
     expect(wrapper.className).toContain('flex-1')
-
-    fireEvent.click(screen.getByRole('button', { name: 'Properties' }))
-    const disclosure = container.querySelector('[id$="-disclosure"]') as HTMLElement
-    expect(disclosure).toBeTruthy()
-    // Overlay below the header instead of growing the row.
-    expect(disclosure.className).toContain('absolute')
   })
 })
 
@@ -473,7 +410,7 @@ describe('a spatial document has no facets to edit', () => {
   })
 
   it('a markdown document keeps the disclosure', () => {
-    render(<DocumentProperties {...titleProps()} facets={meta()} onFacetsChange={vi.fn()} />)
+    render(<DocumentProperties {...titleProps()} facets={meta()} />)
 
     expect(screen.queryByRole('button', { name: /properties/i })).not.toBeNull()
   })

--- a/apps/web/src/components/document-properties/DocumentProperties.tsx
+++ b/apps/web/src/components/document-properties/DocumentProperties.tsx
@@ -9,9 +9,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js'
 export interface DocumentPropertiesProps {
   /**
    * Renders as a segment of the merged header row instead of a standalone
-   * chrome strip: no own border/background, and the Type/Tags disclosure
-   * overlays below the header rather than growing the row (which would
-   * push the canvas down mid-edit).
+   * chrome strip: no own border/background.
    */
   inline?: boolean
   /**
@@ -30,14 +28,17 @@ export interface DocumentPropertiesProps {
    * The document's OKF frontmatter, or absent when the document has none to
    * hold: a facet belongs to OKF and a JSON Canvas document has nowhere to
    * put one (ADR-0009 decision 3), so a spatial canvas omits both this and
-   * `onFacetsChange` and gets no disclosure. Absent rather than a
+   * `onFacetsChange` and gets no Properties opener. Absent rather than a
    * `showFacets={false}` flag beside a value, because the flag hid the
-   * disclosure while the document went on storing what it would have shown.
+   * opener while the document went on storing what it would have shown.
+   *
+   * The row only OPENS the editor: `DocumentFacetsEditor` lives in the
+   * page's inspector slot beside the document, which the row does not own.
    */
   readonly facets?: StoredCoreFacets
-  readonly onFacetsChange?: (next: StoredCoreFacets) => void
-  /** Offered as datalist completions for `type`; the field stays free text. */
-  readonly typeSuggestions?: readonly string[]
+  /** Whether the inspector slot is showing the facets editor. */
+  readonly propertiesOpen?: boolean
+  readonly onToggleProperties?: () => void
   /**
    * Save-state indicator, rendered LEFT of the title — the canvas's "am I
    * safe" signal reads before its name, like a title-bar dirty dot.
@@ -67,34 +68,19 @@ const DEFAULT_TYPE_SUGGESTIONS = ['markdown', 'note', 'issue', 'spec', 'meeting'
 
 /**
  * The canvas row: the document's name, plus — for a document that HAS OKF
- * frontmatter — an editor for its core facets behind a disclosure.
- *
- * The labels are the product's words, not the format's: OKF's `description`
- * is shown as "Summary" and `resource` as "Describes", because those read to
- * someone who has never heard of OKF. What is STORED is the spec's spelling;
- * only the label is translated.
- *
- * `resource` is NOT labelled "Source". OKF has a separate `sources` field for
- * provenance (§5.1) meaning something else entirely — the materials a concept
- * derives FROM, rather than the asset it describes — and the two would be
- * indistinguishable in a properties panel.
- *
- * Neither field carries an `aria-label`. One would override the visible label
- * as the accessible name, so a voice-control user saying what they can see
- * would match nothing (WCAG 2.5.3). The `<label htmlFor>` is the name.
+ * frontmatter — the opener for its core-facet editor.
  */
 export function DocumentProperties({
   inline = false,
   title,
   onTitleChange,
   facets,
-  onFacetsChange,
-  typeSuggestions = DEFAULT_TYPE_SUGGESTIONS,
+  propertiesOpen = false,
+  onToggleProperties,
   status,
   settings,
   actions,
 }: DocumentPropertiesProps) {
-  const [open, setOpen] = useState(false)
   // Null means "not being edited" — the box then shows the canonical name.
   // While it is a string the box shows that instead, because the name comes
   // back NORMALISED (trimmed, and blank replaced by the unnamed sentinel) and
@@ -179,10 +165,9 @@ export function DocumentProperties({
             <TooltipTrigger asChild>
               <button
                 type="button"
-                onClick={() => setOpen((current) => !current)}
+                onClick={onToggleProperties}
                 aria-label="Properties"
-                aria-expanded={open}
-                aria-controls={`${suggestionsId}-disclosure`}
+                aria-expanded={propertiesOpen}
                 className={HEADER_TOGGLE_CLASS}
               >
                 <Info aria-hidden="true" className="size-4" />
@@ -196,25 +181,29 @@ export function DocumentProperties({
           <div className="ml-auto flex shrink-0 items-center gap-1.5">{actions}</div>
         )}
       </div>
-
-      {facets !== undefined && open && (
-        <FacetDisclosure
-          id={`${suggestionsId}-disclosure`}
-          suggestionsId={suggestionsId}
-          inline={inline}
-          facets={facets}
-          onChange={onFacetsChange}
-          typeSuggestions={typeSuggestions}
-        />
-      )}
     </div>
   )
 }
 
 /**
- * The core-facet editor — OKF's `type`, `description`, `resource` and `tags`.
- * Its own component so the handlers below close over a `facets` that is
- * present by construction rather than re-proving it.
+ * The core-facet editor — OKF's `type`, `description`, `resource` and `tags`
+ * — shown in the page's inspector slot when the row's Properties opener is
+ * pressed. Its own component so the handlers below close over a `facets`
+ * that is present by construction rather than re-proving it.
+ *
+ * The labels are the product's words, not the format's: OKF's `description`
+ * is shown as "Summary" and `resource` as "Describes", because those read to
+ * someone who has never heard of OKF. What is STORED is the spec's spelling;
+ * only the label is translated.
+ *
+ * `resource` is NOT labelled "Source". OKF has a separate `sources` field for
+ * provenance (§5.1) meaning something else entirely — the materials a concept
+ * derives FROM, rather than the asset it describes — and the two would be
+ * indistinguishable in a properties panel.
+ *
+ * Neither field carries an `aria-label`. One would override the visible label
+ * as the accessible name, so a voice-control user saying what they can see
+ * would match nothing (WCAG 2.5.3). The `<label htmlFor>` is the name.
  *
  * Every handler emits a WHOLE `StoredCoreFacets`, never a patch, because
  * `writeCoreFacets` replaces the stored bucket outright and deletes any field
@@ -227,21 +216,17 @@ export function DocumentProperties({
  * are not editable here yet, so the control would have nothing to choose
  * between.
  */
-function FacetDisclosure({
-  id,
-  suggestionsId,
-  inline,
+export function DocumentFacetsEditor({
   facets,
   onChange,
-  typeSuggestions,
+  typeSuggestions = DEFAULT_TYPE_SUGGESTIONS,
 }: {
-  readonly id: string
-  readonly suggestionsId: string
-  readonly inline: boolean
   readonly facets: StoredCoreFacets
   readonly onChange?: (next: StoredCoreFacets) => void
-  readonly typeSuggestions: readonly string[]
+  /** Offered as datalist completions for `type`; the field stays free text. */
+  readonly typeSuggestions?: readonly string[]
 }) {
+  const suggestionsId = useId()
   const [draftTag, setDraftTag] = useState('')
   const tags = facets.tags ?? []
 
@@ -272,14 +257,7 @@ function FacetDisclosure({
   }
 
   return (
-    <div
-      id={id}
-      className={
-        inline
-          ? 'border-border bg-background absolute left-0 right-0 top-full z-20 flex flex-col gap-2 border-b px-3 py-2 shadow-md'
-          : 'flex flex-col gap-2 pb-1'
-      }
-    >
+    <div data-testid="document-facets-editor" className="flex flex-col gap-2 px-3 py-2">
       <div className="flex min-w-0 flex-1 items-center gap-2">
         <label
           className="text-muted-foreground w-16 shrink-0 text-xs"

--- a/apps/web/src/components/workspace-top-bar/VersionPanel.narrow.browser.test.tsx
+++ b/apps/web/src/components/workspace-top-bar/VersionPanel.narrow.browser.test.tsx
@@ -64,7 +64,7 @@ function renderRow() {
     <div style={{ height: '600px', width: '100%', display: 'flex' }}>
       <div className="relative flex min-h-0 min-w-0 flex-1">
         <div className="flex min-h-0 min-w-0 flex-1 flex-col" data-testid="editor-stand-in" />
-        <VersionPanel workspaceId="sess_1" path="canvas-a" />
+        <VersionPanel workspaceId="sess_1" path="canvas-a" onClose={() => {}} />
       </div>
     </div>,
   )

--- a/apps/web/src/components/workspace-top-bar/VersionPanel.tsx
+++ b/apps/web/src/components/workspace-top-bar/VersionPanel.tsx
@@ -1,10 +1,9 @@
-import { ChevronDown, ChevronUp } from 'lucide-react'
-import { type ReactNode, type Ref, useState } from 'react'
+import type { ReactNode, Ref } from 'react'
 import VersionTimeline, {
   type VersionPreviewSession,
   type VersionTimelineCapabilities,
 } from '../../components/VersionTimeline.js'
-import { cn } from '../../lib/utils.js'
+import { InspectorPanel } from '../document-editor/InspectorPanel.js'
 
 interface VersionPanelProps {
   panelRef?: Ref<HTMLDivElement>
@@ -15,29 +14,17 @@ interface VersionPanelProps {
   refreshSignal?: number
   onPreview?: (session: VersionPreviewSession | null) => void
   headerActions?: ReactNode
+  onClose: () => void
 }
 
 /**
- * The document's history: a COLUMN of the editor row where there is width
- * for one, a bottom sheet where there is not.
+ * The document's history in the inspector's vessel (`InspectorPanel`).
  *
  * It was a 340x480 popover hanging off the spatial editor's dock, which cost
  * it two things: a markdown document has no dock to hang it from, and a past
  * state cannot be previewed inside a box that size. As a column it is as tall
  * as the editor beside it and belongs to the document rather than to one
  * editor — which is what lets both kinds reach the same history.
- *
- * Under 768px a 300px column and the editor are two unusable halves, so the
- * same panel becomes a sheet anchored to the bottom edge, out of flow, with
- * two stages. The PEEK stage is the load-bearing one: looking at a past
- * version draws it in place of the editor, and on a phone that is only worth
- * anything if the sheet leaves the document above it visible while you choose.
- * The FULL stage is for reading a long history, where the document behind it
- * has nothing to say.
- *
- * Position-agnostic within that: the shell's `aside` slot owns where the
- * column sits and provides the positioned ancestor the sheet needs, this
- * component owns the surface.
  */
 export function VersionPanel({
   panelRef,
@@ -48,49 +35,23 @@ export function VersionPanel({
   refreshSignal,
   onPreview,
   headerActions,
+  onClose,
 }: VersionPanelProps) {
-  const [expanded, setExpanded] = useState(false)
-
   return (
-    <div
-      ref={panelRef}
-      data-testid="history-panel"
-      data-stage={expanded ? 'full' : 'peek'}
-      className={cn(
-        'absolute inset-x-0 bottom-0 z-20 flex min-h-0 flex-col border-t bg-background shadow-[0_-8px_24px_-12px_rgb(0_0_0/0.35)]',
-        expanded ? 'h-full' : 'h-[45%] rounded-t-2xl',
-        'md:static md:z-auto md:h-auto md:w-[300px] md:max-w-[calc(100vw-1.5rem)] md:shrink-0 md:rounded-none md:border-t-0 md:border-l md:shadow-none',
-      )}
+    <InspectorPanel
+      kind="history"
+      onClose={onClose}
+      {...(panelRef === undefined ? {} : { panelRef })}
     >
-      <div className="flex shrink-0 justify-center pt-1.5 md:hidden">
-        <button
-          type="button"
-          data-testid="history-stage-toggle"
-          aria-label={expanded ? 'Collapse history' : 'Expand history'}
-          aria-expanded={expanded}
-          onClick={() => setExpanded((v) => !v)}
-          // A wide, shallow target rather than an icon-sized one: it is the
-          // sheet's grab handle, and a thumb aims at the edge, not at a glyph.
-          className="flex h-6 w-16 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground"
-        >
-          {expanded ? (
-            <ChevronDown aria-hidden="true" className="size-4" />
-          ) : (
-            <ChevronUp aria-hidden="true" className="size-4" />
-          )}
-        </button>
-      </div>
-      <div className="flex min-h-0 flex-1 flex-col">
-        <VersionTimeline
-          workspaceId={workspaceId}
-          path={path}
-          capabilities={capabilities}
-          onRestored={onRestored}
-          refreshSignal={refreshSignal}
-          onPreview={onPreview}
-          headerActions={headerActions}
-        />
-      </div>
-    </div>
+      <VersionTimeline
+        workspaceId={workspaceId}
+        path={path}
+        capabilities={capabilities}
+        onRestored={onRestored}
+        refreshSignal={refreshSignal}
+        onPreview={onPreview}
+        headerActions={headerActions}
+      />
+    </InspectorPanel>
   )
 }

--- a/apps/web/src/header-button-surface.test.ts
+++ b/apps/web/src/header-button-surface.test.ts
@@ -43,8 +43,9 @@ const HEADER_SURFACES: Record<string, number> = {
   './components/workspace-top-bar/DocumentMenu.tsx': 1,
   './components/document-properties/DocumentProperties.tsx': 1,
   './components/spatial-editor/CanvasDisplaySettings.tsx': 1,
-  './components/annotations/CommentsRailChrome.tsx': 2,
+  './components/annotations/CommentsRailChrome.tsx': 1,
   './components/connections/ConnectionsChip.tsx': 1,
+  './components/document-editor/InspectorPanel.tsx': 1,
 }
 
 const HEADER_CLASS = /\bHEADER_(?:WIDE_)?(?:BUTTON|TOGGLE)_CLASS\b/g

--- a/apps/web/src/lib/inspector.ts
+++ b/apps/web/src/lib/inspector.ts
@@ -7,6 +7,23 @@
  * the header retune — a display popover, the comments sheet and the history
  * sheet all open together, each unaware of the others. A union is the
  * declared surface (`.claude/rules/coverage-ledger.md`): the next panel
- * that belongs beside the editor is a member here, not a fourth boolean.
+ * that belongs beside the editor is a member here, not a fifth boolean.
+ *
+ * Every member is the same kind of thing — information ABOUT the open
+ * document, read or written beside it: its frontmatter (`properties`, a
+ * markdown document only), its conversations, the documents that link to it
+ * (`connections`, a daemon keeper only), its history.
  */
-export type InspectorKind = 'history' | 'comments'
+export type InspectorKind = 'properties' | 'comments' | 'connections' | 'history'
+
+/**
+ * What the vessel calls each panel. The test id spellings are the ones the
+ * panels carried before they shared a vessel, kept so every browser flow
+ * that finds them by name keeps finding them.
+ */
+export const INSPECTOR_CHROME = {
+  properties: { label: 'Properties', testId: 'properties-panel' },
+  comments: { label: 'Comments', testId: 'comments-rail' },
+  connections: { label: 'Connections', testId: 'connections-panel' },
+  history: { label: 'History', testId: 'history-panel' },
+} as const satisfies Record<InspectorKind, { label: string; testId: string }>

--- a/apps/web/src/pages/DaemonDocumentPage.comments-panel.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.comments-panel.test.tsx
@@ -333,6 +333,77 @@ describe('DaemonDocumentPage comments panel', () => {
     )
   })
 
+  it('Connections takes the same slot: opening it closes the rail, and its list is a column, not a band', async () => {
+    mockGetDocumentBacklinks.mockResolvedValue({
+      backlinks: [
+        {
+          documentId: 'id-source',
+          path: 'source',
+          name: 'Source board',
+          kind: 'spatial',
+          contexts: ['embedded on this canvas'],
+        },
+      ],
+      unlinkedMentions: [],
+    })
+    await renderSpatial()
+    fireEvent.click(await screen.findByRole('button', { name: /^comments/i }))
+    await screen.findByTestId('comments-panel')
+
+    fireEvent.click(await screen.findByRole('button', { name: /connections \(1\)/i }))
+    const panel = await screen.findByTestId('connections-panel')
+    expect(within(panel).getByText('Source board')).toBeTruthy()
+    expect(screen.queryByTestId('comments-panel')).toBeNull()
+    expect(screen.getByRole('button', { name: /^comments/i }).getAttribute('aria-pressed')).toBe(
+      'false',
+    )
+    // A column in the editor row — the shell's inspector slot — rather than
+    // a strip overlaid under the header.
+    expect(panel.closest('main')).not.toBeNull()
+    expect(panel.className).not.toContain('top-full')
+  })
+
+  it('Properties takes the slot on a markdown document: opening it closes History', async () => {
+    mockListDocuments.mockResolvedValue({
+      documents: [{ path: 'note', id: 'id-note', updatedAt: '2026-01-01', kind: 'markdown' }],
+    })
+    const fakeVersionsBackend: VersionsBackend = {
+      list: async () => [],
+      loadPast: async () => ({ kind: 'markdown', body: '' }),
+      save: async () => {
+        throw new Error('not exercised by this test')
+      },
+      restore: async () => {},
+      putThumbnail: async () => {},
+      loadThumbnail: async () => null,
+    }
+    await act(async () => {
+      render(
+        <VersionsBackendContext.Provider value={fakeVersionsBackend}>
+          <DaemonDocumentPage
+            daemonBaseUrl={DAEMON_BASE_URL}
+            workspaceId="w1"
+            path="note"
+            createBackend={() => new FakeBackend(markdownSnapshotWithThread)}
+          />
+        </VersionsBackendContext.Provider>,
+        { container: document.body },
+      )
+    })
+    fireEvent.click(await screen.findByRole('button', { name: /history/i }))
+    await screen.findByTestId('history-panel')
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Properties' }))
+    const panel = await screen.findByTestId('properties-panel')
+    expect(within(panel).getByRole('combobox', { name: /type/i })).toBeTruthy()
+    expect(screen.queryByTestId('history-panel')).toBeNull()
+    expect(screen.getByRole('button', { name: /history/i }).getAttribute('aria-expanded')).toBe(
+      'false',
+    )
+    // And no second copy of the editor overlaid under the header.
+    expect(screen.getAllByRole('combobox', { name: /type/i })).toHaveLength(1)
+  })
+
   it('opens the rail under a variation preview, but withholds the reply box', async () => {
     // A VERSION preview cannot host the rail any more: it is entered from the
     // History column, which holds the one inspector slot, and the preview

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -13,7 +13,6 @@ import { useSearchParams } from 'react-router-dom'
 import { AgentPresenceChip } from '../components/AgentPresenceChip.js'
 import { CapabilityTeaser } from '../components/capability-teaser/CapabilityTeaser.js'
 import type { ConnectionsBacklink } from '../components/connections/ConnectionsChip.js'
-import { ConnectionsChip } from '../components/connections/ConnectionsChip.js'
 import { DocumentPageSkeleton } from '../components/DocumentPageSkeleton.js'
 import { LoadDegradedView } from '../components/document-editor/LoadDegradedView.js'
 import { HeaderBranchBanner } from '../components/HeaderBranchBanner.js'
@@ -820,29 +819,31 @@ export function DaemonDocumentPage({
       agentTouchedNodeIds: agentActivity.touchedNodeIds,
       children: <AgentPresenceChip summary={agentActivity.summary} />,
     },
+    ...(canvas
+      ? {
+          connections: {
+            backlinks: connections === null ? null : connections.backlinks,
+            ...(connections === null ? {} : { mentions: connections.unlinkedMentions }),
+            onOpen: (entry) => controller.switchDocument(entry.path),
+            onLinkify: (mention) => {
+              if (controller.workspaceId === null || currentDocumentId === undefined) return
+              void linkifyDocumentMentions(
+                daemonFetch,
+                daemonBaseUrl,
+                controller.workspaceId,
+                mention.documentId,
+                currentDocumentId,
+              )
+                .then(() => setConnectionsRefresh((n) => n + 1))
+                .catch(() => {
+                  // The panel simply keeps showing the mention; the
+                  // next open retries.
+                })
+            },
+          },
+        }
+      : {}),
     slots: {
-      afterTitle: canvas && (
-        <ConnectionsChip
-          backlinks={connections === null ? null : connections.backlinks}
-          mentions={connections?.unlinkedMentions}
-          onOpen={(entry) => controller.switchDocument(entry.path)}
-          onLinkify={(mention) => {
-            if (controller.workspaceId === null || currentDocumentId === undefined) return
-            void linkifyDocumentMentions(
-              daemonFetch,
-              daemonBaseUrl,
-              controller.workspaceId,
-              mention.documentId,
-              currentDocumentId,
-            )
-              .then(() => setConnectionsRefresh((n) => n + 1))
-              .catch(() => {
-                // The panel simply keeps showing the mention; the
-                // next open retries.
-              })
-          }}
-        />
-      ),
       headerExtras: (
         <>
           {capabilities.branches && canvas && variationPreview !== null && (

--- a/apps/web/src/pages/DocumentPage.tsx
+++ b/apps/web/src/pages/DocumentPage.tsx
@@ -3,12 +3,17 @@ import {
   CommentsRailAside,
   CommentsRailToggle,
 } from '../components/annotations/CommentsRailChrome.js'
+import { ConnectionsChip, ConnectionsPanel } from '../components/connections/ConnectionsChip.js'
 import { DocumentPreview } from '../components/DocumentPreview.js'
 import { DocumentEditorSurface } from '../components/document-editor/DocumentEditorSurface.js'
 import { DocumentPageShell } from '../components/document-editor/DocumentPageShell.js'
+import { InspectorPanel } from '../components/document-editor/InspectorPanel.js'
 import { SpatialEditorPane } from '../components/document-editor/SpatialEditorPane.js'
 import { useNodeInEditor } from '../components/document-editor/use-node-in-editor.js'
-import { DocumentProperties } from '../components/document-properties/DocumentProperties.js'
+import {
+  DocumentFacetsEditor,
+  DocumentProperties,
+} from '../components/document-properties/DocumentProperties.js'
 import { CanvasDisplaySettings } from '../components/spatial-editor/CanvasDisplaySettings.js'
 import type { VersionPreviewSession } from '../components/VersionTimeline'
 import { BookmarkAction } from '../components/workspace-top-bar/BookmarkAction.js'
@@ -53,7 +58,7 @@ const log = getAppLogger('document-page')
  * The document page, whoever keeps the document (ADR-0004 decision 1).
  *
  * Renders the shell, the merged header row, the editor surface and the
- * inspector beside it (the history column or the comments rail) from a
+ * inspector beside it (properties, comments, connections or history) from a
  * `DocumentPageModel`, and owns the page state that names no keeper: which
  * inspector is open, which past state is being looked at, the
  * save-a-version flow, the seams the editor reads.
@@ -70,12 +75,13 @@ export function DocumentPage({ model }: { model: DocumentPageModel }) {
   const [settingsStore] = useState(() => createUserSettingsStore())
   const { resolvedTheme } = useThemeMode()
 
-  // The one inspector slot beside the editor: the document's history or its
-  // conversations, never both — two panels beside one editor is what the
-  // header retune set out to end. Which panel is open is how the reader
-  // looks rather than what at, so it survives a document switch: everything
-  // a panel SAYS is document-scoped and reset below or by the hook that owns
-  // it, and both panels refetch on the path.
+  // The one inspector slot beside the editor: the document's properties,
+  // its conversations, the documents linking to it, or its history — never
+  // two at once, which is what the header retune set out to end. Which
+  // panel is open is how the reader looks rather than what at, so it
+  // survives a document switch: everything a panel SAYS is document-scoped
+  // and reset below or by the hook that owns it, and every panel reads the
+  // document on screen.
   const [inspector, setInspector] = useState<InspectorKind | null>(null)
   const toggleInspector = (kind: InspectorKind) =>
     setInspector((open) => (open === kind ? null : kind))
@@ -244,6 +250,7 @@ export function DocumentPage({ model }: { model: DocumentPageModel }) {
             onRestored={sync.clearLocalUndo}
             onPreview={setPreview}
             refreshSignal={versions.refreshSignal}
+            onClose={() => setInspector(null)}
             headerActions={
               <BookmarkAction
                 saving={savingVersion}
@@ -268,6 +275,35 @@ export function DocumentPage({ model }: { model: DocumentPageModel }) {
             threads={threads.annotations}
             writable={preview === null && model.readOnlyPast === null}
           />
+        ) : inspector === 'connections' &&
+          model.connections !== undefined &&
+          model.connections.backlinks !== null ? (
+          <InspectorPanel kind="connections" onClose={() => setInspector(null)}>
+            <ConnectionsPanel
+              backlinks={model.connections.backlinks}
+              {...(model.connections.mentions === undefined
+                ? {}
+                : { mentions: model.connections.mentions })}
+              // Following a row leaves for the source document, which is
+              // the panel's job done — so the slot is released with it.
+              onOpen={(entry) => {
+                setInspector(null)
+                model.connections?.onOpen(entry)
+              }}
+              {...(model.connections.onLinkify === undefined
+                ? {}
+                : { onLinkify: model.connections.onLinkify })}
+            />
+          </InspectorPanel>
+        ) : inspector === 'properties' && model.properties.facets !== undefined ? (
+          <InspectorPanel kind="properties" onClose={() => setInspector(null)}>
+            <DocumentFacetsEditor
+              facets={model.properties.facets}
+              {...(model.properties.onFacetsChange === undefined
+                ? {}
+                : { onChange: model.properties.onFacetsChange })}
+            />
+          </InspectorPanel>
         ) : undefined
       }
       header={
@@ -302,9 +338,8 @@ export function DocumentPage({ model }: { model: DocumentPageModel }) {
                         {...(model.properties.facets === undefined
                           ? {}
                           : { facets: model.properties.facets })}
-                        {...(model.properties.onFacetsChange === undefined
-                          ? {}
-                          : { onFacetsChange: model.properties.onFacetsChange })}
+                        propertiesOpen={inspector === 'properties'}
+                        onToggleProperties={() => toggleInspector('properties')}
                         // Canvas-level display settings, gated on kind the
                         // same way the facet disclosure is: a markdown
                         // document has no canvas to configure.
@@ -321,7 +356,13 @@ export function DocumentPage({ model }: { model: DocumentPageModel }) {
                         actions={rowActions}
                       />
                     ) : null}
-                    {model.slots.afterTitle}
+                    {model.connections !== undefined && (
+                      <ConnectionsChip
+                        backlinks={model.connections.backlinks}
+                        open={inspector === 'connections'}
+                        onToggle={() => toggleInspector('connections')}
+                      />
+                    )}
                   </>
                 )}
                 workspaceId={topBar.workspaceId}

--- a/apps/web/src/pages/document-page-model.ts
+++ b/apps/web/src/pages/document-page-model.ts
@@ -3,9 +3,9 @@
  *
  * ADR-0004 decided one page with capability-gated chrome and a controller
  * selected per keeper. What the two pages had in common — the shell, the
- * history column, the comments rail, the file and reference seams, the
- * editor surface, the document actions row — is rendered once, in
- * `DocumentPage`. What differs is not the chrome but its SUPPLY: where the
+ * inspector beside the editor (properties, comments, connections, history),
+ * the file and reference seams, the editor surface, the document actions
+ * row — is rendered once, in `DocumentPage`. What differs is not the chrome but its SUPPLY: where the
  * document's facts come from, how a write travels, which store keeps the
  * versions. This model is that supply, so a keeper answers it and the page
  * never asks which keeper it is talking to.
@@ -15,6 +15,7 @@
  */
 import type { DocumentKind, SpatialCanvas, StoredCoreFacets } from '@kamiazya/whiteboard-model'
 import type { ComponentProps, ReactNode, Ref, RefObject } from 'react'
+import type { ConnectionsPanelProps } from '../components/connections/ConnectionsChip.js'
 import type { MarkdownDocumentSession } from '../components/document-editor/DocumentEditorSurface.js'
 import type { SpatialEditorPaneProps } from '../components/document-editor/SpatialEditorPane.js'
 import type { VersionPanel } from '../components/workspace-top-bar/VersionPanel.js'
@@ -69,6 +70,14 @@ export interface DocumentPageModel {
     readonly onFacetsChange?: (next: StoredCoreFacets) => void
     /** Hidden persistence facts for tests; the row shows no save state. */
     readonly status?: ReactNode
+  }
+  /**
+   * The documents linking here, for the inspector's Connections panel and
+   * its opener. Absent for a keeper that answers no backlinks (the browser);
+   * `backlinks: null` while the daemon's answer is in flight.
+   */
+  readonly connections?: Omit<ConnectionsPanelProps, 'backlinks'> & {
+    readonly backlinks: ConnectionsPanelProps['backlinks'] | null
   }
   readonly threads: {
     readonly annotations: UseDocumentSyncResult['annotations']
@@ -126,8 +135,6 @@ export interface DocumentPageModel {
   readonly readOnlyPast: PastDocument | null
   readonly spatial: Pick<SpatialEditorPaneProps, 'editorRef' | 'agentTouchedNodeIds' | 'children'>
   readonly slots: {
-    /** After the title row, inside the top bar's title slot. */
-    readonly afterTitle?: ReactNode
     /** Alerts in the document actions row, before the ⋯ menu. */
     readonly rowAlerts?: ReactNode
     /** Items inside the document ⋯ menu, after Export. */

--- a/apps/web/src/pages/file-seam-conformance.test.ts
+++ b/apps/web/src/pages/file-seam-conformance.test.ts
@@ -103,10 +103,6 @@ const MODE_SPECIFIC_CHROME = {
     page: './DaemonDocumentPage.tsx',
     why: 'no agents connect in browser mode',
   },
-  ConnectionsChip: {
-    page: './DaemonDocumentPage.tsx',
-    why: 'backlinks come from the daemon index',
-  },
   CapabilityTeaser: { page: './DaemonDocumentPage.tsx', why: 'it teases daemon capabilities' },
 } satisfies Record<string, { page: (typeof KEEPER_PAGES)[number]; why: string }>
 
@@ -248,6 +244,18 @@ describe('the spatial-editor-container hook means one thing', () => {
  */
 const SHARED_DOCUMENT_CHROME = ['CommentsRailAside'] as const
 
+/**
+ * The inspector beside the editor (`lib/inspector.ts`): one vessel and the
+ * panels the shared page puts in it. Rendered by the SHARED page even where
+ * only one keeper can fill it — the Connections opener and panel are fed by
+ * the daemon's backlinks through `model.connections`, and a keeper that
+ * answers none gets no opener. That is the gating the model does with DATA
+ * rather than with a keeper page rendering its own copy: `ConnectionsChip`
+ * used to be daemon-page chrome in `MODE_SPECIFIC_CHROME`, overlaid under the
+ * header as its own band, and moved here when the inspector slot took it.
+ */
+const SHARED_INSPECTOR_CHROME = ['InspectorPanel', 'ConnectionsChip', 'ConnectionsPanel'] as const
+
 describe('document page canvas chrome', () => {
   it.each(SHARED_CANVAS_CHROME)('the shared page renders %s', async (chrome) => {
     expect(
@@ -319,6 +327,29 @@ describe('document page document-level chrome', () => {
     expect(loader, 'no source loader for CommentsRailChrome').toBeDefined()
     const source = (await loader?.()) as string
     expect(renders(source, 'CommentsPanel')).toBe(true)
+  })
+})
+
+describe('document page inspector chrome', () => {
+  it.each(SHARED_INSPECTOR_CHROME)('the shared page renders %s', async (chrome) => {
+    expect(
+      renders(await read(SHARED_PAGE), chrome),
+      `${chrome} is placed by the PAGE in its one inspector slot; a page that ` +
+        'omits it leaves a keeper with the opener and no panel, or the panel ' +
+        'overlaid somewhere else.',
+    ).toBe(true)
+  })
+
+  it.each(SHARED_INSPECTOR_CHROME)('no keeper page renders %s of its own', async (chrome) => {
+    const renderedBy: string[] = []
+    for (const page of KEEPER_PAGES) {
+      if (renders(await read(page), chrome)) renderedBy.push(page)
+    }
+    expect(
+      renderedBy,
+      `${chrome} rendered by a keeper page is a second inspector growing back ` +
+        'beside the shared one — two slots, which is what the retune ended.',
+    ).toEqual([])
   })
 })
 

--- a/apps/web/src/scoped-screen-state.test.ts
+++ b/apps/web/src/scoped-screen-state.test.ts
@@ -365,15 +365,15 @@ const DOCUMENT_PAGE_HOOK_STATE: Record<string, ScopeCoverage> = {
 
 const DOCUMENT_PAGE_STATE: Record<string, ScopeCoverage> = {
   ...DOCUMENT_PAGE_HOOK_STATE,
-  // Which panel the one inspector slot shows — the history column or the
-  // comments rail. How the reader looks rather than what at: everything a
-  // panel SAYS is document-scoped and cleared on its own (`preview` and
-  // `bookmarkArmed` below, `selectedThreadId` and `composeAnchor` above),
-  // and both panels refetch on the path, so a column left open across a
-  // switch shows the arrived document — as the rail always did, and as the
-  // threads themselves are republished per document.
+  // Which panel the one inspector slot shows — properties, comments,
+  // connections or history. How the reader looks rather than what at:
+  // everything a panel SAYS is document-scoped and cleared on its own
+  // (`preview` and `bookmarkArmed` below, `selectedThreadId` and
+  // `composeAnchor` above, the facets and backlinks the keeper republishes
+  // per document), so a panel left open across a switch shows the arrived
+  // document — as the rail always did.
   inspector:
-    'no subject: which inspector panel is open, not what is in it — what each panel shows is cleared by its own entries, and the panels refetch on the path',
+    'no subject: which inspector panel is open, not what is in it — what each panel shows is cleared by its own entries or republished per document by the keeper',
   // The past state being looked at. Restoring one the person opened on the
   // DEPARTED document would apply that version id to the arrived one.
   preview: 'cleared on switch',


### PR DESCRIPTION
## What

P3 of the header retune (decided 2026-09-05 in the "Header Retune" artifact; P2 was #1398). The one inspector slot beside the editor now holds **four** panels — a markdown document's properties, its comments, the documents linking to it (daemon keeper only), its history — and every opener in the header is a controlled toggle on that slot. Opening any one closes the rest, and its opener reads released.

Before, two of those four had a third shape of their own: the ⓘ Properties editor **overlaid under the header** on top of the note, and the Connections list overlaid under the header as a **full-width band**. Both lived in component-local `open` state, so they could stack on top of the History column and the Comments rail.

## What moved

- **`InspectorPanel`** is the one vessel: the column-at-768px / two-stage bottom-sheet shape `VersionPanel` arrived at first and `CommentsRailAside` had copied verbatim, folded into one component (label, stage toggle, close). Both now render through it. The two panels' widths were 300px and 288px; there is one width now.
- **`DocumentProperties`** no longer owns an `open` state and no longer overlays the facet editor. It takes `propertiesOpen` / `onToggleProperties`; the editor is exported as `DocumentFacetsEditor` for the page to put in the slot.
- **`ConnectionsChip`** splits into a controlled opener and `ConnectionsPanel`. The daemon page supplies backlinks through a new `model.connections` seam instead of rendering the chip into `slots.afterTitle` (slot deleted), so the shared `DocumentPage` renders the opener and the panel and the keeper only feeds them. The parity ledger's new `SHARED_INSPECTOR_CHROME` group pins that shape: the shared page renders all three, no keeper page renders any.
- **`lib/inspector.ts`** declares the four kinds plus each panel's label and test id (the test ids are the pre-existing spellings, so every browser flow that finds `history-panel` / `comments-rail` keeps finding them).

Following a Connections row still releases the slot (the panel's job is done once you have left for the source), so the daemon page's document-switch flows are unchanged.

## Tests

- `DaemonDocumentPage.comments-panel.test.tsx` (jsdom), red first: Connections displaces Comments and its list arrives as a column in `<main>` rather than a `top-full` band; Properties on a markdown document displaces History with exactly one copy of the editor on screen.
- `DocumentProperties.test.tsx`: the row offers only the opener (a press reports through `onToggleProperties`, nothing opens under the row); `aria-expanded` follows the prop; the field-editing cases drive `DocumentFacetsEditor` directly.
- `ConnectionsChip.test.tsx`: the controlled contract, and every panel case through a small page-shaped harness (chip + panel over one `open`).
- `file-seam-conformance.test.ts`: `ConnectionsChip` leaves `MODE_SPECIFIC_CHROME` for `SHARED_INSPECTOR_CHROME`.
- `CommentsRailChrome.browser` / `VersionPanel.narrow.browser`: the vessel's column and sheet geometry, unchanged except the rail's width.

## Real-app verification (local vite, Playwright)

A fresh markdown note in the browser keeper, desktop 1280×800 and iPhone 13 emulation:

| step | properties panel | comments rail | ⓘ `aria-expanded` | 💬 `aria-pressed` |
|---|---|---|---|---|
| Properties | 1 (desktop: x=980, w=300, full height; iPhone: full width, bottom sheet) | 0 | true | false |
| then Comments | 0 | 1 | false | true |
| then Properties | 1 | 0 | true | false |

Typing into the panel's Summary field reached the document on both devices. Connections needs a daemon and is verified by the jsdom page test above.

## Visual repro

Same device (iPhone 13), same action (ⓘ on a note), main vs this branch, composed with `compose-figure.mjs`: on main the facet editor overlays under the header on top of the note; on this branch it is the inspector's bottom sheet, labelled and closable. `gh` is unavailable in this environment, so the figure was handed to the author directly rather than attached here.

## Gates

web-jsdom for `pages/`, `workspace-top-bar/`, `annotations/`, `document-editor/`, `document-properties/`, `connections/`, `hooks/` and the five surface ledgers: 923 passed · web-browser for the touched surfaces: 8 files green · five fresh-process runs of each changed file (jsdom 43/43 ×5, browser 24/24 ×5) · `pnpm --filter @kamiazya/whiteboard-web typecheck` · `pnpm biome check` · `pnpm knip` clean · `pnpm check:local` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_