### PR TITLE
fix(server): server mode mounts the /api/v1 surface — the self-hosted daemon stops 404ing on half its API

### DIFF
--- a/packages/mcp-server/src/server/release/server-mode-route-parity.test.ts
+++ b/packages/mcp-server/src/server/release/server-mode-route-parity.test.ts
@@ -1,0 +1,111 @@
+// Server mode must serve the same /api surface as the local daemon, minus
+// the routes that are local-only BY DESIGN — not minus whatever its
+// composition root happened to forget to wire.
+//
+// The gap this closes was live and invisible to every existing guard:
+// web-api-paths-mounted.test.ts builds its server-mode app WITH serverDeps
+// (the intended shape), while server-mode-http.ts — the real composition
+// root — passed none, so a self-hosted deployment 404'd on /api/v1/search,
+// /document-tags, /backlinks, /linkify-mentions, /okf and the v1 document
+// CRUD while /api/workspaces/* worked, and self-host-with-docker.md's
+// promise of "the HTTP API under /api/..." was false. A guard that supplies
+// the wiring itself cannot see a root that does not, which is why the first
+// test below reads the ROOT'S OWN SOURCE for the option.
+
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterAll, describe, expect, it } from 'vitest'
+import { createContainer, resolveServerDeps } from '../../di/container.js'
+import { createApp } from '../app.js'
+import { createDaemonIdentity } from '../security/daemon-identity.js'
+import { createPairingGrantStore } from '../security/pairing-grant-store.js'
+import { createPairingCodeStore, createPairingTokenStore } from '../security/pairing-session.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const tempDirs: string[] = []
+afterAll(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('server mode mounts the same /api surface as the local daemon', () => {
+  it("server-mode-http.ts passes serverDeps to createApp — the root's own wiring, not a test's", () => {
+    // Source-level on purpose: the functional check below configures both
+    // apps itself, so it can only prove the SHAPE works — a composition
+    // root that stops passing the option would leave it green. This line is
+    // what failed before the fix.
+    const source = readFileSync(join(__dirname, '../server-mode-http.ts'), 'utf-8')
+    expect(
+      /\bserverDeps\b/.test(source),
+      'server-mode-http.ts builds no ServerDeps, so createApp mounts no /api/v1 surface — the self-hosted daemon 404s on half its documented API',
+    ).toBe(true)
+  })
+
+  it('the two modes register identical /api/* route sets, minus the declared local-only routes', () => {
+    const serverMode = createApp({
+      authMode: 'server-mode',
+      publicBaseUrl: 'https://example.com',
+      allowedOrigins: ['https://example.com'],
+      authStrategy: () => ({ ok: false as const, status: 401 as const, error: 'denied' }),
+      touch: () => {},
+      getStatus: () => ({}) as never,
+      shutdown: () => Promise.resolve(),
+      serverDeps: resolveServerDeps(createContainer()),
+    })
+
+    const pairingDir = mkdtempSync(join(tmpdir(), 'route-parity-'))
+    tempDirs.push(pairingDir)
+    const localDaemon = createApp({
+      authMode: 'local-daemon',
+      token: 'test-token',
+      publicBaseUrl: 'http://127.0.0.1:3099',
+      allowedOrigins: ['http://127.0.0.1:3099'],
+      touch: () => {},
+      getStatus: () => ({}) as never,
+      shutdown: () => Promise.resolve(),
+      identity: createDaemonIdentity({ dataDir: pairingDir }),
+      pairing: {
+        grants: createPairingGrantStore(pairingDir),
+        codes: createPairingCodeStore(),
+        tokens: createPairingTokenStore(),
+      },
+      serverDeps: resolveServerDeps(createContainer()),
+    })
+
+    const apiRoutes = (app: ReturnType<typeof createApp>): Set<string> =>
+      new Set(
+        app.routes
+          .filter((route) => route.path.startsWith('/api/'))
+          .map((route) => `${route.method} ${route.path}`),
+      )
+
+    const server = apiRoutes(serverMode)
+    const local = apiRoutes(localDaemon)
+
+    // Local-only BY DESIGN, each with the reason recorded where it is
+    // enforced: pairing-grant consent assumes the daemon's own served UI
+    // and loopback reachability (app.ts's pairing mount comment), and the
+    // ws-ticket mint pairs with the WS upgrade endpoint that only the local
+    // daemon's HTTP server hosts (server mode installs no upgrade handler —
+    // whether any client uses the ticket flow at all is a separate open
+    // question, issues/adr-0005-ws-ticket-fate).
+    const LOCAL_ONLY_PREFIXES = ['/api/pairing', '/api/ws-ticket']
+
+    const missingFromServerMode = [...local].filter(
+      (route) =>
+        !server.has(route) &&
+        !LOCAL_ONLY_PREFIXES.some((prefix) => route.split(' ')[1]?.startsWith(prefix)),
+    )
+    const extraInServerMode = [...server].filter((route) => !local.has(route))
+
+    // Not vacuous: both sets must actually carry the surfaces this test is
+    // about, or a broken option shape would compare two empty sets.
+    expect([...server].some((route) => route.includes('/api/v1/'))).toBe(true)
+    expect([...local].some((route) => route.includes('/api/workspaces'))).toBe(true)
+
+    expect(missingFromServerMode).toEqual([])
+    expect(extraInServerMode).toEqual([])
+  })
+})

--- a/packages/mcp-server/src/server/server-mode-http.test.ts
+++ b/packages/mcp-server/src/server/server-mode-http.test.ts
@@ -23,6 +23,17 @@ const { mockServe, getLastServer } = vi.hoisted(() => {
 
 vi.mock('@hono/node-server', () => ({ serve: mockServe }))
 vi.mock('./app.js', () => ({ createApp: vi.fn(() => ({ fetch: vi.fn() })) }))
+// The root now builds real ServerDeps before createApp (the /api/v1 mount
+// fix); this unit harness is about listen/close mechanics, so the store
+// layer is stubbed — unmocked, ensureWorkspaceId/getDb would open the
+// contributor's real data dir and time the test out.
+vi.mock('./current-workspace.js', () => ({ ensureWorkspaceId: vi.fn(async () => 'ws') }))
+vi.mock('./store/db/index.js', () => ({ getDb: vi.fn(async () => ({})) }))
+vi.mock('../di/container.js', () => ({
+  createContainer: vi.fn(() => ({})),
+  resolveServerDeps: vi.fn(() => ({})),
+}))
+vi.mock('../di/store-local.module.js', () => ({ createStoreLocalModule: vi.fn(() => ({})) }))
 
 import { createApp } from './app.js'
 import { startServerModeHttp } from './server-mode-http.js'
@@ -37,6 +48,21 @@ function makeOptions() {
   }
 }
 
+/**
+ * The mock server, once startServerModeHttp has actually reached serve().
+ * The root now awaits its ServerDeps construction first, so lastServer is
+ * null for a few microtasks after the call — reading it synchronously (the
+ * old pattern) hands the test a null and the 'listening' emit goes nowhere.
+ */
+async function serverOnceServing() {
+  await vi.waitFor(() => {
+    expect(mockServe).toHaveBeenCalled()
+  })
+  const server = getLastServer()
+  expect(server).not.toBeNull()
+  return server!
+}
+
 describe('startServerModeHttp', () => {
   afterEach(() => {
     vi.clearAllMocks()
@@ -45,7 +71,7 @@ describe('startServerModeHttp', () => {
   it('resolves with port, host, startedAt, resolvedDataDir, and close on successful startup', async () => {
     const options = makeOptions()
     const startPromise = startServerModeHttp(options)
-    const server = getLastServer()!
+    const server = await serverOnceServing()
     setImmediate(() => server.emit('listening'))
 
     const result = await startPromise
@@ -60,7 +86,7 @@ describe('startServerModeHttp', () => {
   it('close() calls server.close() exactly once and resolves', async () => {
     const options = makeOptions()
     const startPromise = startServerModeHttp(options)
-    const server = getLastServer()!
+    const server = await serverOnceServing()
     setImmediate(() => server.emit('listening'))
     const { close } = await startPromise
 
@@ -72,7 +98,7 @@ describe('startServerModeHttp', () => {
   it('close() is idempotent — subsequent calls do nothing', async () => {
     const options = makeOptions()
     const startPromise = startServerModeHttp(options)
-    const server = getLastServer()!
+    const server = await serverOnceServing()
     setImmediate(() => server.emit('listening'))
     const { close } = await startPromise
 
@@ -86,7 +112,7 @@ describe('startServerModeHttp', () => {
   it('wires getStatus() to report the always-available server-placeholder UI', async () => {
     const options = makeOptions()
     const startPromise = startServerModeHttp(options)
-    const server = getLastServer()!
+    const server = await serverOnceServing()
     setImmediate(() => server.emit('listening'))
     await startPromise
 
@@ -124,7 +150,7 @@ describe('startServerModeHttp', () => {
       ...makeOptions(),
       fileGcSweeperFactory: () => sweeper,
     })
-    const server = getLastServer()!
+    const server = await serverOnceServing()
     setImmediate(() => server.emit('listening'))
     const { close } = await startPromise
 
@@ -140,7 +166,7 @@ describe('startServerModeHttp', () => {
   it('rejects when the server emits an error before listening', async () => {
     const options = makeOptions()
     const startPromise = startServerModeHttp(options)
-    const server = getLastServer()!
+    const server = await serverOnceServing()
     const portError = Object.assign(new Error('EADDRINUSE'), { code: 'EADDRINUSE' })
     setImmediate(() => server.emit('error', portError))
 

--- a/packages/mcp-server/src/server/server-mode-http.ts
+++ b/packages/mcp-server/src/server/server-mode-http.ts
@@ -8,14 +8,18 @@
 import { randomUUID } from 'node:crypto'
 import { accessSync, constants as fsConstants } from 'node:fs'
 import { serve } from '@hono/node-server'
+import { createContainer, resolveServerDeps } from '../di/container.js'
+import { createStoreLocalModule } from '../di/store-local.module.js'
 import { PACKAGE_VERSION } from '../shared/package-version.js'
 import { createApp } from './app.js'
 import { startBackgroundWork } from './background-work.js'
 import { LOOP_COSTS } from './background-work-costs.js'
 import { getDataDir } from './config.js'
+import { ensureWorkspaceId } from './current-workspace.js'
 import type { AutoVersionTrigger } from './routes/document.js'
 import type { AsyncAuthStrategy } from './security/oauth-resource-strategy.js'
 import { createBackupLease, createBackupScheduler } from './store/backup-scheduler.js'
+import { getDb } from './store/db/index.js'
 import { createFileGcSweeper } from './store/file-gc-sweeper.js'
 import { parseBackupDir, parseBackupKeep, parseBackupSchedule } from './store/storage-env.js'
 
@@ -90,11 +94,27 @@ export async function startServerModeHttp(
     await autoVersionTrigger?.flush()
   }
 
+  // The same explicit production wiring the local daemon builds
+  // (http-server.ts), minus its WS-only clientNotifier — server mode
+  // installs no upgrade handler, so there is no live-socket audience to
+  // notify. Without this, createApp mounted no /api/v1 surface at all and
+  // a self-hosted deployment 404'd on search/backlinks/tags/okf and the v1
+  // document CRUD while /api/workspaces/* worked
+  // (server-mode-route-parity.test.ts pins both the option and the route
+  // set now). ensureWorkspaceId first, as the sibling root does: a fresh
+  // data dir must not answer an empty workspace list.
+  const dataDir = getDataDir()
+  await ensureWorkspaceId(dataDir)
+  const serverDeps = resolveServerDeps(
+    createContainer(createStoreLocalModule({ db: await getDb(dataDir), blobDir: dataDir })),
+  )
+
   // Filled synchronously by createApp below, and read only by the
   // auto-checkpoint declaration's stop() — which runs long after.
   let autoVersionTrigger: AutoVersionTrigger | undefined
   const app = createApp({
     authMode: 'server-mode',
+    serverDeps,
     onAutoVersionTrigger: (trigger) => {
       autoVersionTrigger = trigger
     },


### PR DESCRIPTION
## What

audit-triage 2026-09-06 (HIGH, adversarially verified): `server-mode-http.ts` passed no `serverDeps` to `createApp`, so the `/api/v1` router (search, document-tags, backlinks, linkify-mentions, okf, v1 document CRUD) **never mounted in server mode** while `/api/workspaces/*` worked — `self-host-with-docker.md`'s "the HTTP API under /api/…" was false for exactly the deployment it describes.

The root now builds the same explicit production wiring the local daemon does (`ensureWorkspaceId` + `getDb` + container), minus the WS-only `clientNotifier` (server mode installs no upgrade handler — no live-socket audience).

**Why no existing guard saw it**: `web-api-paths-mounted.test.ts` builds its server-mode app *with* `serverDeps` — the intended shape — so it proves the shape works, never that the root uses it. The new `server-mode-route-parity.test.ts` pins both halves:
- the root's own source carries the option (**red before this fix** — TDD'd);
- the two modes register identical `/api/*` route sets minus the declared local-only routes (`/api/pairing` — consent assumes the daemon's served UI + loopback; `/api/ws-ticket` — pairs with the WS upgrade only the local daemon hosts; the ticket flow's overall fate is a separate audit issue).

`server-mode-http.test.ts`'s harness stubs the store layer (unmocked, the new deps construction opened the contributor's **real** data dir and timed the suite out) and awaits `serve()` being reached instead of reading the mock synchronously.

## Verification

route-parity 2/2 (source pin red→green) · server-mode-http 6/6 · app/app.server-mode/app.api-v1 + whole release dir 622 pass · typecheck · lint.

Manual runtime check skipped with reason: booting real server mode needs an OAuth strategy + JWKS; the functional half of the parity test registers the identical Hono route table, which is the property the 404s violated.

Visual evidence: none — HTTP surface fix; the red→green source pin and route-set equality are the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D
