### PR TITLE
feat(web): a card says when its content moved since this device opened it

### DIFF
--- a/apps/web/src/components/workspace-files/FolderContentsList.tsx
+++ b/apps/web/src/components/workspace-files/FolderContentsList.tsx
@@ -40,6 +40,13 @@ export interface FolderContentsListProps {
    */
   selection?: ReadonlySet<string>
   /**
+   * The documentIds whose content has changed since this device last opened
+   * them. Absent means the caller has no baseline to compare against, which
+   * is not the same as "nothing changed" — a fresh device shows no dots
+   * rather than dots on everything.
+   */
+  changed?: ReadonlySet<string>
+  /**
    * A card's picture. This component neither fetches nor renders, so a
    * caller with no daemon to read from still gets a working list — with the
    * kind label the list already carries.
@@ -75,6 +82,7 @@ export function FolderContentsList({
   onDocumentContextMenu,
   selectedPath,
   selection,
+  changed,
   renderThumbnail,
   className,
 }: FolderContentsListProps) {
@@ -180,6 +188,19 @@ export function FolderContentsList({
                   cannot disagree with what is announced. Presence is gated on
                   the MODE, which is a different question from the state.
                   `aria-hidden` because the button already says it. */}
+              {changed?.has(entry.documentId) && (
+                /* Binary, and in the corner opposite the selection check so
+                   the two never collide. `role="img"` with a name rather
+                   than a bare colour: a dot nobody can see or hear is not a
+                   signal, and this one contributes to the card's own
+                   accessible name the way the kind badge already does. */
+                <span
+                  role="img"
+                  aria-label="Changed since you last opened it"
+                  data-testid="card-changed-dot"
+                  className="bg-primary absolute top-1 right-1 size-2.5 rounded-full"
+                />
+              )}
               {selection !== undefined && (
                 <>
                   <Circle

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -18,9 +18,7 @@ import { useThemeMode } from '../../hooks/useThemeMode.js'
 import type { WorkspaceDocumentEntry } from '../../lib/document-entry.js'
 import { type WorkspaceFilesSource, WorkspaceMissingError } from '../../lib/files-source.js'
 import { hasCoarsePointer } from '../../lib/platform.js'
-import { readRecentIds, recordRecentDocument } from '../../lib/recent-documents.js'
 import { createInTabRenderBroker } from '../../lib/render-broker.js'
-import { readSeenDigest, recordSeenDocument } from '../../lib/seen-documents.js'
 import { ContextMenu } from '../spatial-editor/ContextMenu.js'
 import { DocumentMinimap } from './DocumentMinimap.js'
 import { DocumentPreview } from './DocumentPreview.js'
@@ -40,6 +38,7 @@ import { searchDocuments, withNameMatches } from './search-documents.js'
 import { TrashSection } from './TrashSection.js'
 import { useBrowserColumns } from './use-browser-columns.js'
 import { useDebouncedDocumentSearch } from './use-debounced-document-search.js'
+import { useDeviceMemory } from './use-device-memory.js'
 import { WorkspaceFileTree } from './WorkspaceFileTree.js'
 import { WorkspaceFolderTree } from './WorkspaceFolderTree.js'
 
@@ -144,32 +143,7 @@ export function WorkspaceFilesPanel({
   // a failure. 'error' is a genuine fetch/schema failure and keeps the alert.
   const [listStatus, setListStatus] = useState<'ok' | 'not-found' | 'error'>('ok')
   const [selected, setSelected] = useState<WorkspaceDocumentEntry | null>(null)
-  /**
-   * What this device opened most recently in THIS workspace, newest first.
-   *
-   * Held as ids and resolved against `documents` at render, so a deleted or
-   * renamed document leaves the lane on its own.
-   */
-  const [recentIds, setRecentIds] = useState<readonly string[]>([])
-  /**
-   * The live selection's paths, or null when there is no selection.
-   *
-   * null rather than an empty set, because the two mean different things to
-   * the grid: null is the ordinary mode where a card is not a toggle at all,
-   * and a set is the mode where every card carries `aria-pressed`. Emptying
-   * the set is therefore how the mode ENDS, not a state it rests in.
-   *
-   * Not folded into `selected`: that one names the document the preview is
-   * showing, which is a different question with a different answer, and a
-   * preview that followed a multi-selection would have to pick one.
-   */
   const [selection, setSelection] = useState<ReadonlySet<string> | null>(null)
-  /**
-   * Bumped when this panel records a baseline, so the derived `changed` set
-   * below recomputes. Storage is not reactive and this is the only writer in
-   * the tab, so a counter is the whole subscription.
-   */
-  const [seenRevision, setSeenRevision] = useState(0)
   /**
    * How many cards the last successful listing drew, kept so a RE-READ can
    * hold the layout it is about to replace.
@@ -186,6 +160,12 @@ export function WorkspaceFilesPanel({
   // unless the address named a folder, which is the whole point of naming it.
   const [folder, setFolder] = useState(initialFolder ?? '')
   const { columns, chooseColumns } = useBrowserColumns()
+  const {
+    recentIds,
+    changed,
+    remember: rememberOpen,
+    reset: resetDeviceMemory,
+  } = useDeviceMemory(workspace, documents)
   /**
    * A write that LANDED, whose list refresh or open failed after the fact.
    * Separate from the refusal states because the two need opposite things:
@@ -315,28 +295,9 @@ export function WorkspaceFilesPanel({
    */
   const tapOpens = hasCoarsePointer() && onOpenDocument !== undefined
   const openEntry = useCallback((entry: WorkspaceDocumentEntry) => {
-    const scope = workspaceRef.current
-    if (scope !== undefined) {
-      recordRecentDocument(scope, entry.documentId)
-      setRecentIds(readRecentIds(scope))
-      // The baseline for the changed dot: what this device is about to SEE.
-      // Only when the keeper derived one — a row with no digest has nothing
-      // to compare later, and a missing baseline must read as "no dot", not
-      // as "changed".
-      if (entry.contentDigest !== undefined) {
-        recordSeenDocument(scope, entry.documentId, entry.contentDigest)
-        setSeenRevision((revision) => revision + 1)
-      }
-    }
+    rememberOpen(entry)
     onOpenDocumentRef.current?.(entry.path)
   }, [])
-
-  // Keyed on the handle rather than folded into the SCOPE RESET below,
-  // because the handle is the scope this is filed under and it can arrive
-  // after the source (a page still resolving its address passes undefined).
-  useEffect(() => {
-    setRecentIds(workspace === undefined ? [] : readRecentIds(workspace))
-  }, [workspace])
 
   const toggleSelected = useCallback((entry: WorkspaceDocumentEntry) => {
     setSelection((current) => {
@@ -390,31 +351,6 @@ export function WorkspaceFilesPanel({
     onRequestDeleteMany?.(paths)
   }
 
-  /**
-   * The documents whose content differs from what this device last opened.
-   *
-   * Compared on `contentDigest`, never `updatedAt`: `document-entry.ts`
-   * records the measurement that a merge does not consult the stamp, so a
-   * signal built on it can call a document unchanged in the one case this
-   * dot exists for — something rewriting it while the person was elsewhere.
-   *
-   * A document with no recorded baseline is absent from the set, so an
-   * unopened document is silent rather than announced as changed.
-   */
-  const changed = useMemo(() => {
-    if (documents === null || workspace === undefined) return undefined
-    const marked = new Set<string>()
-    for (const entry of documents) {
-      if (entry.contentDigest === undefined) continue
-      const seen = readSeenDigest(workspace, entry.documentId)
-      if (seen !== undefined && seen !== entry.contentDigest) marked.add(entry.documentId)
-    }
-    return marked
-    // `seenRevision` is not read by the body — it is the signal that this
-    // panel wrote a baseline, which is the only way the answer changes
-    // without `documents` changing too.
-  }, [documents, workspace, seenRevision])
-
   // SCOPE RESET — see scoped-screen-state.test.ts
   useEffect(() => {
     let cancelled = false
@@ -434,15 +370,8 @@ export function WorkspaceFilesPanel({
     // bulk delete carried across a switch would address the departed
     // workspace's names into the store now on screen.
     setSelection(null)
-    // The departed workspace's lane names its documents, so it is emptied
-    // here like everything else — and refilled in the same effect, from the
-    // ref rather than a dependency. Both halves together, because splitting
-    // them across two effects made the ORDER load-bearing and it was wrong:
-    // the handle-keyed effect below loaded first and this one blanked it, so
-    // the lane never survived a remount. Each effect now ends on the same
-    // value whichever runs last.
-    setRecentIds([])
-    if (workspaceRef.current !== undefined) setRecentIds(readRecentIds(workspaceRef.current))
+    // The departed workspace's memory names its documents.
+    resetDeviceMemory()
     setRenaming(null)
     setRenameError(null)
     setRenameBusy(false)

--- a/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
+++ b/apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx
@@ -20,6 +20,7 @@ import { type WorkspaceFilesSource, WorkspaceMissingError } from '../../lib/file
 import { hasCoarsePointer } from '../../lib/platform.js'
 import { readRecentIds, recordRecentDocument } from '../../lib/recent-documents.js'
 import { createInTabRenderBroker } from '../../lib/render-broker.js'
+import { readSeenDigest, recordSeenDocument } from '../../lib/seen-documents.js'
 import { ContextMenu } from '../spatial-editor/ContextMenu.js'
 import { DocumentMinimap } from './DocumentMinimap.js'
 import { DocumentPreview } from './DocumentPreview.js'
@@ -163,6 +164,12 @@ export function WorkspaceFilesPanel({
    * preview that followed a multi-selection would have to pick one.
    */
   const [selection, setSelection] = useState<ReadonlySet<string> | null>(null)
+  /**
+   * Bumped when this panel records a baseline, so the derived `changed` set
+   * below recomputes. Storage is not reactive and this is the only writer in
+   * the tab, so a counter is the whole subscription.
+   */
+  const [seenRevision, setSeenRevision] = useState(0)
   /**
    * How many cards the last successful listing drew, kept so a RE-READ can
    * hold the layout it is about to replace.
@@ -312,6 +319,14 @@ export function WorkspaceFilesPanel({
     if (scope !== undefined) {
       recordRecentDocument(scope, entry.documentId)
       setRecentIds(readRecentIds(scope))
+      // The baseline for the changed dot: what this device is about to SEE.
+      // Only when the keeper derived one — a row with no digest has nothing
+      // to compare later, and a missing baseline must read as "no dot", not
+      // as "changed".
+      if (entry.contentDigest !== undefined) {
+        recordSeenDocument(scope, entry.documentId, entry.contentDigest)
+        setSeenRevision((revision) => revision + 1)
+      }
     }
     onOpenDocumentRef.current?.(entry.path)
   }, [])
@@ -374,6 +389,31 @@ export function WorkspaceFilesPanel({
     }
     onRequestDeleteMany?.(paths)
   }
+
+  /**
+   * The documents whose content differs from what this device last opened.
+   *
+   * Compared on `contentDigest`, never `updatedAt`: `document-entry.ts`
+   * records the measurement that a merge does not consult the stamp, so a
+   * signal built on it can call a document unchanged in the one case this
+   * dot exists for — something rewriting it while the person was elsewhere.
+   *
+   * A document with no recorded baseline is absent from the set, so an
+   * unopened document is silent rather than announced as changed.
+   */
+  const changed = useMemo(() => {
+    if (documents === null || workspace === undefined) return undefined
+    const marked = new Set<string>()
+    for (const entry of documents) {
+      if (entry.contentDigest === undefined) continue
+      const seen = readSeenDigest(workspace, entry.documentId)
+      if (seen !== undefined && seen !== entry.contentDigest) marked.add(entry.documentId)
+    }
+    return marked
+    // `seenRevision` is not read by the body — it is the signal that this
+    // panel wrote a baseline, which is the only way the answer changes
+    // without `documents` changing too.
+  }, [documents, workspace, seenRevision])
 
   // SCOPE RESET — see scoped-screen-state.test.ts
   useEffect(() => {
@@ -1092,6 +1132,7 @@ export function WorkspaceFilesPanel({
                           : setSelected(target.document)
                   }
                   {...(selection === null ? { selection: undefined } : { selection })}
+                  {...(changed === undefined ? {} : { changed })}
                   {...(onOpenDocument === undefined || selection !== null
                     ? {}
                     : { onActivateDocument: openEntry })}

--- a/apps/web/src/components/workspace-files/changed-dot.browser.test.tsx
+++ b/apps/web/src/components/workspace-files/changed-dot.browser.test.tsx
@@ -1,0 +1,105 @@
+// The dot end to end in a REAL browser: a real open writes a real baseline
+// to real localStorage, and the next mount compares a real listing against
+// it. jsdom covers the rendering; what only this proves is that the two
+// halves meet through storage the panel actually writes to.
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import type { WorkspaceDocumentEntry } from '../../lib/document-entry.js'
+import { STORAGE_KEY } from '../../lib/seen-documents.js'
+import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
+import { WorkspaceFilesPanel } from './WorkspaceFilesPanel.js'
+
+let rows: WorkspaceDocumentEntry[] = []
+
+beforeEach(() => {
+  localStorage.removeItem(STORAGE_KEY)
+  rows = [
+    { documentId: 'd1', path: 'roadmap', name: 'Roadmap', kind: 'markdown', contentDigest: 'v1' },
+    { documentId: 'd2', path: 'tokens', name: 'Tokens', kind: 'markdown', contentDigest: 'v1' },
+  ]
+})
+afterEach(() => {
+  cleanup()
+  localStorage.removeItem(STORAGE_KEY)
+})
+
+function renderPanel() {
+  render(
+    <WorkspaceFilesPanel
+      source={fakeFilesSource({ listDocuments: async () => rows })}
+      workspace="space"
+      onOpenDocument={() => {}}
+    />,
+  )
+}
+
+async function openCard(name: string) {
+  const grid = await screen.findByTestId('folder-contents')
+  const title = await within(grid).findByText(name)
+  const card = title.closest('button')
+  if (card === null) throw new Error(`no card for ${name}`)
+  await userEvent.dblClick(card)
+}
+
+// Scoped to the GRID: once a document has been opened the recently-opened
+// lane carries the same name, so an unscoped query is ambiguous exactly when
+// the test has done its setup.
+async function settle(name: string) {
+  const grid = await screen.findByTestId('folder-contents')
+  await within(grid).findByText(name)
+}
+
+const dotFor = (name: string) => {
+  const title = screen.getAllByTestId('card-title').find((each) => each.textContent === name)
+  const card = (title as HTMLElement).closest('button') as HTMLElement
+  return within(card).queryByRole('img', { name: /changed since/i })
+}
+
+describe('changed since you last opened it', () => {
+  it('says nothing about a document this device has never opened', async () => {
+    renderPanel()
+    await settle('Roadmap')
+
+    expect(dotFor('Roadmap')).toBeNull()
+  })
+
+  it('stays silent when the content has not moved since the open', async () => {
+    renderPanel()
+    await openCard('Roadmap')
+    cleanup()
+
+    renderPanel()
+    await settle('Roadmap')
+    expect(dotFor('Roadmap')).toBeNull()
+  })
+
+  it('marks the document whose content moved while the person was elsewhere', async () => {
+    renderPanel()
+    await openCard('Roadmap')
+    cleanup()
+
+    // What an agent writing to the document looks like from here: the same
+    // row comes back under a different content identity.
+    rows = rows.map((row) => (row.path === 'roadmap' ? { ...row, contentDigest: 'v2' } : row))
+    renderPanel()
+
+    await waitFor(() => expect(dotFor('Roadmap')).not.toBeNull())
+    // And only that one: the untouched neighbour was never opened, so it has
+    // no baseline and must stay silent rather than read as changed.
+    expect(dotFor('Tokens')).toBeNull()
+  })
+
+  it('clears once the person opens it again', async () => {
+    renderPanel()
+    await openCard('Roadmap')
+    cleanup()
+    rows = rows.map((row) => (row.path === 'roadmap' ? { ...row, contentDigest: 'v2' } : row))
+
+    renderPanel()
+    await waitFor(() => expect(dotFor('Roadmap')).not.toBeNull())
+    await openCard('Roadmap')
+
+    await waitFor(() => expect(dotFor('Roadmap')).toBeNull())
+  })
+})

--- a/apps/web/src/components/workspace-files/changed-dot.test.tsx
+++ b/apps/web/src/components/workspace-files/changed-dot.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { WorkspaceDocumentEntry } from '../../lib/document-entry.js'
+import { FolderContentsList } from './FolderContentsList.js'
+
+// The dot answers "did this change while I was not looking", which is a
+// different question from the age text beside it and does not replace it.
+// Binary on purpose: an unread badge needs no legend, where a freshness
+// gradient would have to teach its own mapping.
+
+afterEach(cleanup)
+
+const entry = (over: Partial<WorkspaceDocumentEntry>): WorkspaceDocumentEntry => ({
+  documentId: 'd1',
+  path: 'roadmap',
+  name: 'Roadmap',
+  kind: 'markdown',
+  updatedAt: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+  contentDigest: 'digest-now',
+  ...over,
+})
+
+const documents = [
+  entry({ documentId: 'd1', path: 'roadmap', name: 'Roadmap' }),
+  entry({ documentId: 'd2', path: 'tokens', name: 'Tokens' }),
+]
+
+const cardFor = (name: string) => {
+  const title = screen.getAllByTestId('card-title').find((each) => each.textContent === name)
+  return (title as HTMLElement).closest('button') as HTMLElement
+}
+
+const dotIn = (name: string) => within(cardFor(name)).queryByRole('img', { name: /changed since/i })
+
+describe('the changed dot', () => {
+  it('marks a document the set names, and only that one', () => {
+    render(
+      <FolderContentsList
+        documents={documents}
+        folder=""
+        onOpen={() => {}}
+        changed={new Set(['d2'])}
+      />,
+    )
+
+    expect(dotIn('Tokens')).toBeTruthy()
+    expect(dotIn('Roadmap')).toBeNull()
+  })
+
+  it('marks nothing when the set is empty, which is what a fresh device shows', () => {
+    render(
+      <FolderContentsList documents={documents} folder="" onOpen={() => {}} changed={new Set()} />,
+    )
+
+    expect(dotIn('Roadmap')).toBeNull()
+    expect(dotIn('Tokens')).toBeNull()
+  })
+
+  it('marks nothing at all when the caller passes no set', () => {
+    render(<FolderContentsList documents={documents} folder="" onOpen={() => {}} />)
+
+    expect(dotIn('Roadmap')).toBeNull()
+  })
+
+  it('carries a text alternative, so nothing is said by colour alone', () => {
+    render(
+      <FolderContentsList
+        documents={documents}
+        folder=""
+        onOpen={() => {}}
+        changed={new Set(['d1'])}
+      />,
+    )
+
+    expect(dotIn('Roadmap')?.getAttribute('aria-label')).toMatch(
+      /changed since you last opened it/i,
+    )
+  })
+
+  it('leaves the age text in place beside it — the two answer different questions', () => {
+    render(
+      <FolderContentsList
+        documents={documents}
+        folder=""
+        onOpen={() => {}}
+        changed={new Set(['d1'])}
+      />,
+    )
+
+    expect(within(cardFor('Roadmap')).getByText('2d ago')).toBeTruthy()
+  })
+})

--- a/apps/web/src/components/workspace-files/use-device-memory.ts
+++ b/apps/web/src/components/workspace-files/use-device-memory.ts
@@ -1,0 +1,101 @@
+import { useCallback, useMemo, useRef, useState } from 'react'
+import type { WorkspaceDocumentEntry } from '../../lib/document-entry.js'
+import { readRecentIds, recordRecentDocument } from '../../lib/recent-documents.js'
+import { readSeenDigest, recordSeenDocument } from '../../lib/seen-documents.js'
+
+/**
+ * What THIS DEVICE remembers about a workspace, and what the picker draws
+ * from it: the recently-opened lane, and the dot on a card whose content
+ * moved since the last time this device opened it.
+ *
+ * One hook rather than two because both are written at the same instant — an
+ * open — and read by the same render. They are STORED apart
+ * (`recent-documents.ts` is an ordered list capped at a handful,
+ * `seen-documents.ts` a per-document map), which is a difference that
+ * matters and is not this hook's to flatten: a digest riding on the lane
+ * would lose its dot the moment the document fell off the end of it.
+ *
+ * Both are per-device and unsynced by decision (owner, 2026-09-05): what
+ * this device opened is a fact about this device, so a phone and a desktop
+ * disagreeing is correct rather than a gap — and it keeps both out of the
+ * document model entirely.
+ */
+export interface DeviceMemory {
+  /** Most recent first, for the lane. Empty until a workspace handle exists. */
+  recentIds: readonly string[]
+  /**
+   * The documents whose content differs from what this device last opened.
+   *
+   * `undefined` while there is nothing to compare against — no listing yet,
+   * or no workspace handle — which the grid renders as no dots at all rather
+   * than as "nothing changed".
+   */
+  changed: ReadonlySet<string> | undefined
+  /** Record an open. Stable identity: the panel hands it to four children. */
+  remember: (entry: WorkspaceDocumentEntry) => void
+  /** SCOPE RESET — see scoped-screen-state.test.ts */
+  reset: () => void
+}
+
+export function useDeviceMemory(
+  workspace: string | undefined,
+  documents: readonly WorkspaceDocumentEntry[] | null,
+): DeviceMemory {
+  const [recentIds, setRecentIds] = useState<readonly string[]>([])
+  /**
+   * Bumped when this hook records a baseline, so `changed` recomputes.
+   * Storage is not reactive and this is the only writer in the tab, so a
+   * counter is the whole subscription.
+   */
+  const [seenRevision, setSeenRevision] = useState(0)
+  // Read at CALL time, so `remember` and `reset` keep a stable identity.
+  const workspaceRef = useRef(workspace)
+  workspaceRef.current = workspace
+
+  const remember = useCallback((entry: WorkspaceDocumentEntry) => {
+    const scope = workspaceRef.current
+    if (scope === undefined) return
+    recordRecentDocument(scope, entry.documentId)
+    setRecentIds(readRecentIds(scope))
+    // Only when the keeper derived a digest: a row without one has nothing
+    // to compare later, and a missing baseline must read as "no dot" rather
+    // than as "changed".
+    if (entry.contentDigest !== undefined) {
+      recordSeenDocument(scope, entry.documentId, entry.contentDigest)
+      setSeenRevision((revision) => revision + 1)
+    }
+  }, [])
+
+  /**
+   * Compared on `contentDigest`, never `updatedAt`: `document-entry.ts`
+   * records the measurement that a merge does not consult the stamp, so a
+   * signal built on it can call a document unchanged in the one case this
+   * dot exists for — something rewriting it while the person was elsewhere.
+   */
+  const changed = useMemo(() => {
+    if (documents === null || workspace === undefined) return undefined
+    const marked = new Set<string>()
+    for (const entry of documents) {
+      if (entry.contentDigest === undefined) continue
+      const seen = readSeenDigest(workspace, entry.documentId)
+      if (seen !== undefined && seen !== entry.contentDigest) marked.add(entry.documentId)
+    }
+    return marked
+    // `seenRevision` is not read by the body — it is the signal that this
+    // hook wrote a baseline, which is the only way the answer changes
+    // without `documents` changing too.
+  }, [documents, workspace, seenRevision])
+
+  const reset = useCallback(() => {
+    // SCOPE RESET — see scoped-screen-state.test.ts
+    // Emptied and refilled together, from the CURRENT handle. Two effects
+    // doing one half each made the ORDER load-bearing, and it was wrong: the
+    // load ran first and the reset blanked it, so the lane never survived a
+    // remount.
+    setRecentIds([])
+    const scope = workspaceRef.current
+    if (scope !== undefined) setRecentIds(readRecentIds(scope))
+  }, [])
+
+  return { recentIds, changed, remember, reset }
+}

--- a/apps/web/src/lib/seen-documents.property.test.ts
+++ b/apps/web/src/lib/seen-documents.property.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment node
+import { describe, expect } from 'vitest'
+import { fc, fcTest, withDefaults } from '../test-utils/fast-check.js'
+import { recordSeen, SEEN_CAP } from './seen-documents.js'
+
+// The pure half only — no storage, so this runs in node. The localStorage
+// contract is `seen-documents.test.ts`.
+const PROPERTY_PARAMS = withDefaults({ numRuns: 200 })
+
+// A dense small alphabet: ids drawn from `fc.string()` would collide almost
+// never, so re-recording — the branch that decides whether the cap counts a
+// document twice — would not be reached.
+const idArb = fc.constantFrom('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j')
+const digestArb = fc.constantFrom('d1', 'd2', 'd3')
+const writesArb = fc.array(fc.tuple(idArb, digestArb))
+
+const replay = (writes: readonly (readonly [string, string])[]) =>
+  writes.reduce<Record<string, string>>((acc, [id, digest]) => recordSeen(acc, id, digest), {})
+
+describe('recordSeen (fast-check)', () => {
+  fcTest.prop([writesArb], PROPERTY_PARAMS)('never exceeds the cap', (writes) => {
+    expect(Object.keys(replay(writes)).length).toBeLessThanOrEqual(SEEN_CAP)
+  })
+
+  fcTest.prop([writesArb, idArb, digestArb], PROPERTY_PARAMS)(
+    'always retains the most recently recorded document',
+    (writes, id, digest) => {
+      expect(recordSeen(replay(writes), id, digest)[id]).toBe(digest)
+    },
+  )
+
+  fcTest.prop([writesArb, idArb, digestArb], PROPERTY_PARAMS)(
+    'is idempotent: the same document and digest twice leaves the same record',
+    (writes, id, digest) => {
+      const once = recordSeen(replay(writes), id, digest)
+      expect(recordSeen(once, id, digest)).toEqual(once)
+    },
+  )
+
+  fcTest.prop([writesArb], PROPERTY_PARAMS)(
+    'answers, for every id it kept, the digest of that id LAST write',
+    (writes) => {
+      const record = replay(writes)
+      const lastWrite = new Map<string, string>(writes.map(([id, digest]) => [id, digest]))
+      for (const [id, digest] of Object.entries(record)) {
+        expect(digest).toBe(lastWrite.get(id))
+      }
+    },
+  )
+
+  fcTest.prop([writesArb], PROPERTY_PARAMS)('never invents a document nobody wrote', (writes) => {
+    const written = new Set<string>(writes.map(([id]) => id))
+    for (const id of Object.keys(replay(writes))) expect(written.has(id)).toBe(true)
+  })
+})

--- a/apps/web/src/lib/seen-documents.test.ts
+++ b/apps/web/src/lib/seen-documents.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { readSeenDigest, recordSeenDocument, SEEN_CAP, STORAGE_KEY } from './seen-documents.js'
+
+afterEach(() => {
+  localStorage.clear()
+  vi.restoreAllMocks()
+})
+
+describe('seen documents (per-device, localStorage)', () => {
+  it('reads back the digest a document was recorded with', () => {
+    recordSeenDocument('space', 'doc-1', 'digest-a')
+
+    expect(readSeenDigest('space', 'doc-1')).toBe('digest-a')
+  })
+
+  it('answers undefined for a document never recorded, which is what makes an unseen card silent', () => {
+    expect(readSeenDigest('space', 'never-opened')).toBeUndefined()
+  })
+
+  it('keeps the newest digest when a document is recorded again', () => {
+    recordSeenDocument('space', 'doc-1', 'digest-a')
+    recordSeenDocument('space', 'doc-1', 'digest-b')
+
+    expect(readSeenDigest('space', 'doc-1')).toBe('digest-b')
+  })
+
+  it('keeps each workspace independent', () => {
+    recordSeenDocument('alpha', 'shared-id', 'digest-a')
+    recordSeenDocument('beta', 'shared-id', 'digest-b')
+
+    expect(readSeenDigest('alpha', 'shared-id')).toBe('digest-a')
+    expect(readSeenDigest('beta', 'shared-id')).toBe('digest-b')
+  })
+
+  it('caps the record rather than growing without bound', () => {
+    for (let i = 0; i < SEEN_CAP + 5; i++) recordSeenDocument('space', `doc-${i}`, `digest-${i}`)
+
+    expect(readSeenDigest('space', `doc-${SEEN_CAP + 4}`)).toBe(`digest-${SEEN_CAP + 4}`)
+    expect(readSeenDigest('space', 'doc-0')).toBeUndefined()
+  })
+
+  it('answers undefined rather than throwing when the payload is not what we wrote', () => {
+    localStorage.setItem(STORAGE_KEY, '{"space":"not-a-record"}')
+
+    expect(readSeenDigest('space', 'doc-1')).toBeUndefined()
+  })
+
+  it('answers undefined rather than throwing when the payload is not JSON', () => {
+    localStorage.setItem(STORAGE_KEY, 'not json at all')
+
+    expect(readSeenDigest('space', 'doc-1')).toBeUndefined()
+  })
+
+  it('degrades to empty when localStorage itself throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError')
+    })
+
+    expect(readSeenDigest('space', 'doc-1')).toBeUndefined()
+  })
+
+  it('swallows a write localStorage refuses', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError')
+    })
+
+    expect(() => recordSeenDocument('space', 'doc-1', 'digest-a')).not.toThrow()
+  })
+
+  // The same class that crashed the recency lane: a plain object answers some
+  // handles with an INHERITED member, and `constructor` is reachable because
+  // it passes the workspace segment charset and `deriveWorkspaceSegment`
+  // lowercases a display name. Covered on BOTH axes here — the workspace
+  // handle and the document id — since either indexes an object.
+  for (const poisoned of ['constructor', '__proto__', 'toString', 'valueOf', 'hasOwnProperty']) {
+    it(`never throws or answers a non-string for the workspace handle ${poisoned}`, () => {
+      expect(readSeenDigest(poisoned, 'doc-1')).toBeUndefined()
+      expect(() => recordSeenDocument(poisoned, 'doc-1', 'digest-a')).not.toThrow()
+      const back = readSeenDigest(poisoned, 'doc-1')
+      expect(back === undefined || typeof back === 'string').toBe(true)
+    })
+
+    it(`never throws or answers a non-string for the document id ${poisoned}`, () => {
+      expect(readSeenDigest('space', poisoned)).toBeUndefined()
+      expect(() => recordSeenDocument('space', poisoned, 'digest-a')).not.toThrow()
+      const back = readSeenDigest('space', poisoned)
+      expect(back === undefined || typeof back === 'string').toBe(true)
+    })
+  }
+})

--- a/apps/web/src/lib/seen-documents.ts
+++ b/apps/web/src/lib/seen-documents.ts
@@ -1,0 +1,107 @@
+/**
+ * What content this device last SAW of a document, per workspace.
+ *
+ * The card's dot answers "did this change while I was not looking", and the
+ * baseline for that is the content the person actually opened.
+ *
+ * Keyed on `contentDigest`, never `updatedAt`. `document-entry.ts` records
+ * what a measurement found: `updatedAt` is a register one replica wrote and
+ * a merge does not consult it, so a replica's content became a state nobody
+ * had written while its stamp stayed put. A freshness signal built on the
+ * stamp can therefore call a document unchanged in the exact case that
+ * matters here — an agent rewriting it behind the person's back.
+ *
+ * Deliberately NOT stored with the recency lane (`recent-documents.ts`),
+ * though both are written at the same moment. That one is an ordered list
+ * capped at a handful, and a digest riding on it would make the dot vanish
+ * for the 9th-oldest document for no reason a person could see.
+ */
+
+import { z } from 'zod'
+
+// Namespaced + version-suffixed, like `recent-documents.ts` and
+// `user-settings-store.ts`. Disposable in the same way: losing it costs one
+// round of dots, so a breaking change here may bump the key with no
+// migration.
+export const STORAGE_KEY = 'whiteboard:seen-documents:v1'
+
+/**
+ * How many documents per workspace keep a baseline.
+ *
+ * Far above the recency lane's handful, because this record is not a list
+ * anyone reads — it is the memory behind a per-card signal, and a document
+ * dropping out of it silently loses its dot. Bounded all the same: a
+ * workspace is not guaranteed to be small, and localStorage is shared.
+ */
+export const SEEN_CAP = 500
+
+const storedSchema = z.record(z.string(), z.record(z.string(), z.string()).catch({}))
+
+/**
+ * The pure step: `id` recorded at `digest`, evicting the oldest once past
+ * the cap.
+ *
+ * Insertion order is the eviction order, which JS object key order gives for
+ * string keys that are not array indices. Document ids are ULIDs, so that
+ * holds — and a numeric-looking id would only evict in a different order,
+ * never lose the invariant the properties assert.
+ */
+export function recordSeen(
+  existing: Record<string, string>,
+  id: string,
+  digest: string,
+): Record<string, string> {
+  const next = { ...existing, [id]: digest }
+  const keys = Object.keys(next)
+  if (keys.length <= SEEN_CAP) return next
+  for (const stale of keys.slice(0, keys.length - SEEN_CAP)) delete next[stale]
+  return next
+}
+
+// The guard around ACCESS, not only around the parse: a browser told to block
+// storage raises on the property itself. Contract: neither of these throws,
+// and the grid degrades to no dots.
+function readAll(): Record<string, Record<string, string>> {
+  let raw: string | null
+  try {
+    raw = localStorage.getItem(STORAGE_KEY)
+  } catch {
+    return {}
+  }
+  if (raw === null) return {}
+  try {
+    const parsed = storedSchema.safeParse(JSON.parse(raw))
+    return parsed.success ? parsed.data : {}
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * One key's value, by OWN key only, on both axes.
+ *
+ * A workspace handle and a document id both index a plain object, and a
+ * plain object answers `constructor` (and every other `Object.prototype`
+ * member) with an inherited value — truthy, so `??` never fires. That
+ * crashed the recency lane's picker with storage empty, and `constructor` is
+ * reachable: it passes the workspace segment charset, and
+ * `deriveWorkspaceSegment` lowercases a display name.
+ */
+function own<T>(record: Record<string, T>, key: string): T | undefined {
+  return Object.hasOwn(record, key) ? record[key] : undefined
+}
+
+export function readSeenDigest(workspace: string, documentId: string): string | undefined {
+  const scope = own(readAll(), workspace)
+  return scope === undefined ? undefined : own(scope, documentId)
+}
+
+export function recordSeenDocument(workspace: string, documentId: string, digest: string): void {
+  const all = readAll()
+  const next = { ...all, [workspace]: recordSeen(own(all, workspace) ?? {}, documentId, digest) }
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+  } catch {
+    // An unwritable storage degrades to no dots, never to a failed open.
+  }
+}

--- a/apps/web/src/scoped-screen-state.test.ts
+++ b/apps/web/src/scoped-screen-state.test.ts
@@ -108,6 +108,12 @@ const PANEL_STATE: Record<string, ScopeCoverage> = {
   // workspace on screen. Its own effect, since the handle can arrive after
   // the source.
   recentIds: 'cleared on switch',
+  // A COUNTER, not a subject: it names no document and no path, and its
+  // only job is to tell the derived `changed` memo that this panel wrote a
+  // baseline. Surviving a switch is harmless — the memo also keys on
+  // `documents` and `workspace`, both of which change with the scope.
+  seenRevision:
+    'no subject: a bump counter for the changed-dot memo, naming nothing that belongs to a workspace',
   // Paths, and paths collide across workspaces — `untitled` is the first
   // document in most. A selection carried across a switch would address the
   // departed workspace's names into the store now on screen, in a BULK

--- a/apps/web/src/scoped-screen-state.test.ts
+++ b/apps/web/src/scoped-screen-state.test.ts
@@ -45,6 +45,7 @@ const sources = import.meta.glob(
     './components/workspace-files/WorkspaceFilesPanel.tsx',
     './components/workspace-files/use-browser-columns.ts',
     './components/workspace-files/use-debounced-document-search.ts',
+    './components/workspace-files/use-device-memory.ts',
     './pages/DaemonIndexPage.tsx',
     './components/HeaderBranchChip.tsx',
     './components/VersionTimeline.tsx',
@@ -81,6 +82,10 @@ const PANEL = './components/workspace-files/WorkspaceFilesPanel.tsx'
 // there, not away, so the scan surface is the concatenation of all three.
 const PANEL_COLUMNS_HOOK = './components/workspace-files/use-browser-columns.ts'
 const PANEL_SEARCH_HOOK = './components/workspace-files/use-debounced-document-search.ts'
+// What this device remembers about the workspace — the recently-opened
+// lane and the changed-dot baselines. Extracted from the panel when its
+// file-size budget said so; same SCREEN by the same rule as the two above.
+const PANEL_DEVICE_MEMORY_HOOK = './components/workspace-files/use-device-memory.ts'
 const DAEMON_INDEX = './pages/DaemonIndexPage.tsx'
 const BRANCH_CHIP = './components/HeaderBranchChip.tsx'
 const VERSION_TIMELINE = './components/VersionTimeline.tsx'
@@ -465,7 +470,7 @@ const DAEMON_DOCUMENT_PAGE_STATE: Record<string, ScopeCoverage> = {
 
 const CASES = [
   {
-    files: [PANEL, PANEL_COLUMNS_HOOK, PANEL_SEARCH_HOOK],
+    files: [PANEL, PANEL_COLUMNS_HOOK, PANEL_SEARCH_HOOK, PANEL_DEVICE_MEMORY_HOOK],
     ledger: PANEL_STATE,
     label: 'WorkspaceFilesPanel',
     scanRefs: true,


### PR DESCRIPTION
The last deferred item from the 2026-09-05 picker redesign — and **the shape it ships in is not the one that was deferred.**

## Why the deferred idea was rejected rather than postponed

The original was a freshness *ring*: age as a gradient. Three reasons from the initiative's own record:

- The non-verbal wins in slices 1–3 all rode **existing conventions** (tap to open, long-press, right-click, the file/grid kind icons). "How old" has no such mapping — a ring thickness or an opacity has to be learned, so it **adds a legend rather than removing words**, which is the opposite of what this initiative was for.
- It would have been built on `updatedAt`, which `document-entry.ts` records a measurement against: *a register one replica wrote that a merge does not consult*, observed leaving the stamp put while the content became a state nobody had written. A freshness signal on that field can call a document unchanged in the exact case worth showing.
- The recently-opened lane (#1392) already answers the question recency is *for* — "where was I" — by position, which is genuinely non-verbal.

## What ships instead

**Binary: did this change while I was not looking.** An unread dot needs no legend, and in this product the question is actionable rather than decorative — MCP agents write to documents behind the person's back, and until now nothing on the card said which one had moved.

Keyed on `contentDigest`, which both keepers already supply and which the same comment names as the reliable identity.

## Visual repro

![before — an agent rewrote one of these and nothing says which; after — the one that moved since you opened it](tmp/screenshots/changed-dot-figure.png)

> Not uploaded: `gh` here is 2.97.0 and `--attach` landed in 2.99.0. Panels `c540f156` / `091e860c`; `compose-figure.mjs` refuses identical ones.

**The figure is the argument.** Both panels read `2d ago` on every card — the age text cannot tell you anything — and only the dot distinguishes the document an agent rewrote.

## Design notes worth a reviewer's eye

- **Stored separately from the recency lane**, though both are written at the same moment. The lane is an ordered list capped at a handful; a digest riding on it would make the dot vanish for the 9th-oldest document for no reason a person could see.
- **Absence is a first-class answer in two places**, both tested: a document this device never opened has no baseline and stays *silent* rather than reading as changed, and a row the keeper gave no digest carries no dot rather than one that means nothing.
- **The age text stays** (owner decision): the dot says "changed while you were away", the text says "how old", and neither answers the other.
- **The dot carries a text alternative**, so nothing is conveyed by colour alone.

## One claim deliberately weakened

`Object.hasOwn` is here from the start after the lane shipped without it — but the failure it prevents is **milder than the lane's, and the commit says so rather than repeating that story**. `recordSeen` uses a spread, not `.filter`, so nothing crashes. Measured, exactly one case breaks without it: `readSeenDigest(ws, '__proto__')` after a record returns `Object.prototype` instead of a string, because zod's `z.record` rebuilds by assignment and cannot persist that key.

## Verification

Mutation-checked, each **asserted to have applied** before its run:

| mutation | result |
|---|---|
| cap eviction removed | 1 red |
| own-key guard removed | 1 red |
| newest write no longer wins | 4 red |
| the digest comparison always says changed | 4 red |
| no baseline recorded on open | 2 red |
| the dot never renders | 2 red |

`web-jsdom` **3870/3870** and `web-browser` **1136/1136** across 211 files. Typecheck, lint and knip clean.
