### PR TITLE
test(mcp-server): the production index passes the DocumentIndex conformance suite

### DIFF
--- a/packages/mcp-server/src/server/store/document-store.conformance.test.ts
+++ b/packages/mcp-server/src/server/store/document-store.conformance.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The daemon's PRODUCTION index — CacheCoherentDocumentIndex over the
+ * DB-backed registry and FsBlobStore, exactly as store-local.module.ts
+ * binds it — run through the DocumentIndex port's conformance suite.
+ *
+ * Every other implementation already passed this bar (the in-memory double,
+ * the browser store, the bare LoroWorkspaceDocumentIndex); the one that
+ * persists and serves production traffic was the one never checked. The
+ * suite lives beside the port (ports/test-utils) precisely so this file is
+ * one wiring, not a second copy of 38 cases.
+ */
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describeDocumentIndexConformance } from '@kamiazya/whiteboard-ports/test-utils'
+import { describe, vi } from 'vitest'
+
+let tempDir: string
+vi.mock('../config.js', () => ({
+  get DATA_DIR() {
+    return tempDir
+  },
+  getDataDir: () => tempDir,
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+  REPO_ROOT: '/tmp',
+}))
+
+const { CacheCoherentDocumentIndex, cacheBackedWorkspaceDocs, workspaceRegistry } = await import(
+  './document-store.js'
+)
+const { FsBlobStore } = await import('./fs/fs-blob-store.js')
+const { clearCache } = await import('./doc-cache.js')
+const { createIsolatedDb } = await import('./db/test-helpers.js')
+
+describe('CacheCoherentDocumentIndex (the daemon production index)', () => {
+  describeDocumentIndexConformance(async () => {
+    // Self-contained per call: the suite invokes this factory once per test,
+    // so setup/teardown live here rather than in beforeEach hooks it cannot
+    // see. The module-level doc cache is cleared for the same reason —
+    // production has one process-wide cache, and a stale entry from the
+    // previous case is exactly the class this wrapper exists to manage.
+    tempDir = await mkdtemp(join(tmpdir(), 'prod-index-conformance-'))
+    const handle = await createIsolatedDb({ dataDir: tempDir })
+    clearCache()
+    const index = new CacheCoherentDocumentIndex(
+      cacheBackedWorkspaceDocs(),
+      new FsBlobStore(tempDir),
+      workspaceRegistry(),
+    )
+    return {
+      index,
+      dispose: async () => {
+        await handle.dispose()
+        await rm(tempDir, { recursive: true, force: true })
+      },
+      // The registry the index resolves against is the workspaces TABLE, and
+      // only the composition root writes rows — so the seed writes one
+      // directly, updating identity if createWorkspace already inserted the
+      // id (its own insert is doNothing on conflict and MAY ignore segment,
+      // which is the very reason the port makes this seam mandatory).
+      seedWorkspace: async (entry) => {
+        const now = Date.now()
+        await handle.db
+          .insertInto('workspaces')
+          .values({
+            id: entry.workspaceId,
+            segment: entry.segment ?? null,
+            displayName: entry.displayName ?? null,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .onConflict((oc) =>
+            oc.column('id').doUpdateSet({
+              segment: entry.segment ?? null,
+              displayName: entry.displayName ?? null,
+              updatedAt: now,
+            }),
+          )
+          .execute()
+      },
+    }
+  })
+})


### PR DESCRIPTION
## What

audit-triage 2026-09-06 (HIGH, adversarially verified): `CacheCoherentDocumentIndex` over the DB-backed registry and `FsBlobStore` — the exact binding `store-local.module.ts` gives the daemon — was the **only** `DocumentIndex` implementation never run through the port's 38-case contract suite; the in-memory double, the browser store, and the bare tree index all were.

One wiring closes it (`document-store.conformance.test.ts`): the factory is self-contained per test (temp data dir + isolated db + doc-cache clear — production has one process-wide cache, and stale entries are exactly the class the wrapper manages), and `seedWorkspace` writes the workspaces **table** row directly, updating identity when `createWorkspace` already inserted the id — its own insert is doNothing-on-conflict and MAY ignore `segment`, which is why the port makes the seam mandatory rather than optional.

**Result: 38/38 on first run** — no latent defect found; the value is that the production binding is now held to the same bar as every double, permanently.

## Verification

38/38 · seam mutation-checked: a no-op `seedWorkspace` fails 7 cases (so the suite demonstrably reaches the registry through it) · lint.

Visual evidence: none — test-only addition; the mutation check is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D
