### PR TITLE
fix(daemon-client): the exports map lists each consumed subpath — and knip immediately found a dead barrel

### DIFF
--- a/.claude/rules/package-daemon-client.md
+++ b/.claude/rules/package-daemon-client.md
@@ -44,6 +44,16 @@ re-export shims and mcp-server's published client subpaths are retired
 only). tsup's `noExternal` MUST list this package or the published tarball
 carries a bare specifier for an unpublished workspace dep.
 
+## The exports map is explicit, and that is the dead-export gate
+
+`package.json` lists each consumed subpath individually — never a `"./*"`
+wildcard. The wildcard made every module a knip entry point, so the package
+was structurally blind to dead exports: browser-tracing.ts shipped an entire
+unused SDK half (and browser-shared-index.ts a dead barrel) under a green
+knip. With the explicit map, an unconsumed module fails `pnpm knip` as an
+unused file, and a NEW subpath is added here in the same diff that first
+imports it — the resolve error is loud if forgotten.
+
 ## Tests
 
 Vitest project `daemon-client-node`. Contract round-trips use the package's

--- a/apps/web/src/lib/daemon-backend-alias.test.ts
+++ b/apps/web/src/lib/daemon-backend-alias.test.ts
@@ -3,7 +3,7 @@ import { DaemonBackend } from '@kamiazya/whiteboard-daemon-client/daemon-backend
 import { describe, expect, it, vi } from 'vitest'
 
 // Regression lock for source-level resolution of the daemon-client package.
-// Its wildcard `exports` points every subpath at `src/*.ts`, so there is no
+// Its explicit `exports` map points every subpath at `src/*.ts`, so there is no
 // dist to go stale — and this test keeps it that way: if the package ever
 // switches its exports to a built dist, a stale build's DaemonBackend would
 // stop observing the injected fetch here before anything subtler breaks.

--- a/packages/daemon-client/package.json
+++ b/packages/daemon-client/package.json
@@ -6,10 +6,93 @@
   "description": "The daemon's browser-safe client half: the /api contracts the web app parses (Zod, single source of truth), the fetch/WS/SSE document backends, the api-client wrapper, and the shared backend contract test suites. Runs unchanged in the browser; no node:*, no server internals.",
   "type": "module",
   "exports": {
-    "./package.json": "./package.json",
-    "./*": {
-      "types": "./src/*.ts",
-      "import": "./src/*.ts"
+    "./api-client": {
+      "types": "./src/api-client.ts",
+      "import": "./src/api-client.ts"
+    },
+    "./api-contracts/branches": {
+      "types": "./src/api-contracts/branches.ts",
+      "import": "./src/api-contracts/branches.ts"
+    },
+    "./api-contracts/document": {
+      "types": "./src/api-contracts/document.ts",
+      "import": "./src/api-contracts/document.ts"
+    },
+    "./api-contracts/document-url": {
+      "types": "./src/api-contracts/document-url.ts",
+      "import": "./src/api-contracts/document-url.ts"
+    },
+    "./api-contracts/errors": {
+      "types": "./src/api-contracts/errors.ts",
+      "import": "./src/api-contracts/errors.ts"
+    },
+    "./api-contracts/fonts": {
+      "types": "./src/api-contracts/fonts.ts",
+      "import": "./src/api-contracts/fonts.ts"
+    },
+    "./api-contracts/index": {
+      "types": "./src/api-contracts/index.ts",
+      "import": "./src/api-contracts/index.ts"
+    },
+    "./api-contracts/pairing": {
+      "types": "./src/api-contracts/pairing.ts",
+      "import": "./src/api-contracts/pairing.ts"
+    },
+    "./api-contracts/pairing-link": {
+      "types": "./src/api-contracts/pairing-link.ts",
+      "import": "./src/api-contracts/pairing-link.ts"
+    },
+    "./api-contracts/roundtrip.test-helper": {
+      "types": "./src/api-contracts/roundtrip.test-helper.ts",
+      "import": "./src/api-contracts/roundtrip.test-helper.ts"
+    },
+    "./api-contracts/runtime": {
+      "types": "./src/api-contracts/runtime.ts",
+      "import": "./src/api-contracts/runtime.ts"
+    },
+    "./daemon-backend": {
+      "types": "./src/daemon-backend.ts",
+      "import": "./src/daemon-backend.ts"
+    },
+    "./document-backend-contract": {
+      "types": "./src/document-backend-contract.ts",
+      "import": "./src/document-backend-contract.ts"
+    },
+    "./select-document-transport": {
+      "types": "./src/select-document-transport.ts",
+      "import": "./src/select-document-transport.ts"
+    },
+    "./sse-backend": {
+      "types": "./src/sse-backend.ts",
+      "import": "./src/sse-backend.ts"
+    },
+    "./sse-stream-hub": {
+      "types": "./src/sse-stream-hub.ts",
+      "import": "./src/sse-stream-hub.ts"
+    },
+    "./sync-sse-contract": {
+      "types": "./src/sync-sse-contract.ts",
+      "import": "./src/sync-sse-contract.ts"
+    },
+    "./test-utils/document-backend-contract": {
+      "types": "./src/test-utils/document-backend-contract.ts",
+      "import": "./src/test-utils/document-backend-contract.ts"
+    },
+    "./test-utils/sse-stream-source-contract": {
+      "types": "./src/test-utils/sse-stream-source-contract.ts",
+      "import": "./src/test-utils/sse-stream-source-contract.ts"
+    },
+    "./token-store": {
+      "types": "./src/token-store.ts",
+      "import": "./src/token-store.ts"
+    },
+    "./ws-messages": {
+      "types": "./src/ws-messages.ts",
+      "import": "./src/ws-messages.ts"
+    },
+    "./ws-protocol": {
+      "types": "./src/ws-protocol.ts",
+      "import": "./src/ws-protocol.ts"
     }
   },
   "scripts": {

--- a/packages/daemon-client/src/browser-shared-index.ts
+++ b/packages/daemon-client/src/browser-shared-index.ts
@@ -1,2 +1,0 @@
-export type { ExportResponseMessage } from './ws-messages.js'
-export { exportResponseMessageSchema } from './ws-messages.js'


### PR DESCRIPTION
## What

audit-triage 2026-09-06 (MEDIUM): the wildcard `"./*"` exports map made every module a package entry point in knip's eyes, so daemon-client was structurally blind to dead exports — the gate that would have caught the browser-tracing SDK half (#1407) automatically.

A knip workspace entry **cannot** fix that: knip keeps deriving entries from the exports map, and the explicit list came back as 22 "redundant entry pattern" hints (tried first, reverted). The fix is the map itself: the 22 subpaths `apps/web`, `mcp-server` and the smoke scripts actually import, each pointing at `src/*.ts` (source-resolution unchanged — the stale-`dist` reasoning from #1383 carries over).

**The gate paid for itself on its first run**: `browser-shared-index.ts` — the old `./browser-shared` barrel, zero consumers since the published subpaths retired in #1370 — surfaced as an unused file and is deleted here. Adding a new subpath happens in the same diff that first imports it; forgetting is loud (the import fails to resolve).

## Verification

knip clean after the deletion (red on the barrel before it) · daemon-client 284/284 · mcp-server release + publish-contract 503 pass · `daemon-backend-alias` source-resolution pin 1/1 · `-r` typecheck · lint.

Visual evidence: none — packaging/gate change; knip's red→green on the dead barrel is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D
