### PR TITLE
fix(web): the WebMCP toggle claims exactly what the tool returns

### DIFF
--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -183,8 +183,9 @@ function GeneralSection({
               WebMCP
             </p>
             <p id={webMcpDescId} className="text-xs text-muted-foreground">
-              Lets in-page scripts in supporting browsers read a canvas summary (identifier,
-              selection count, viewport). Never exposes secrets, tokens, or full scene content.
+              Lets in-page scripts in supporting browsers read which keeper is active and which
+              document is open (workspace and path, or document id). Never exposes content,
+              selection, viewport, secrets, or tokens.
             </p>
           </div>
           <button

--- a/apps/web/src/pages/webmcp-settings-copy.test.ts
+++ b/apps/web/src/pages/webmcp-settings-copy.test.ts
@@ -1,0 +1,41 @@
+/**
+ * The WebMCP toggle's description is the user's sole privacy statement
+ * about what an in-page agent can read, so it must claim exactly what the
+ * one registered tool returns — getAppContextResultSchema is
+ * {provider: {mode}, canvas: identity | null}, nothing else. The first
+ * version promised a "selection count" and "viewport" the tool never
+ * returned: overstating the exposed surface in the very copy someone reads
+ * to decide whether to flip the switch.
+ */
+import { describe, expect, it } from 'vitest'
+import { getAppContextResultSchema } from '../lib/commands/types.js'
+
+const sources = import.meta.glob('./SettingsPage.tsx', { query: '?raw', import: 'default' })
+
+async function settingsSource(): Promise<string> {
+  const loader = sources['./SettingsPage.tsx']
+  expect(loader, 'SettingsPage source loader').toBeDefined()
+  return (await loader?.()) as string
+}
+
+describe('WebMCP settings copy matches the tool contract', () => {
+  it('claims no field the schema does not carry', async () => {
+    const source = await settingsSource()
+    const descStart = source.indexOf('webMcpDescId}')
+    expect(descStart).toBeGreaterThan(-1)
+    const description = source.slice(descStart, source.indexOf('</p>', descStart))
+    // The two claims the copy used to overstate. Naming them as NON-exposed
+    // ("Never exposes ... selection, viewport") is fine and expected; what
+    // must not come back is an affirmative claim, which always read as
+    // "read a ... (..., selection count, viewport)".
+    expect(description).not.toMatch(/read[^.]*selection/i)
+    expect(description).not.toMatch(/read[^.]*viewport/i)
+  })
+
+  it('the schema still carries only provider mode and canvas identity — the copy is written to THIS shape', () => {
+    // If the tool ever starts returning more (selection, viewport), this
+    // fails first and the copy is re-reviewed together with the schema.
+    const keys = Object.keys(getAppContextResultSchema.shape)
+    expect(keys.sort()).toEqual(['canvas', 'provider'])
+  })
+})


### PR DESCRIPTION
## What

audit-triage 2026-09-06: the WebMCP toggle's description — the user's sole privacy statement about what an in-page agent can read — promised a "selection count" and "viewport" that `whiteboard_get_app_context` never returns (`getAppContextResultSchema` is `{provider: {mode}, canvas: identity | null}`). The copy now names the real surface (active keeper + open document identity) and lists selection/viewport among the never-exposed.

Pinned two ways (`webmcp-settings-copy.test.ts`): the description may not affirmatively claim selection/viewport, and the schema's key set is asserted so a future widening re-reviews the copy with it.

## Verification

New pin + SettingsPage suite 47/47 · typecheck · lint.

Visual evidence: none — settings copy text; the pin test is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D