### PR TITLE
chore: delete the inert eslint-disable directives — ESLint is not in this repo

### DIFF
--- a/.claude/workflows/lib/args-parse.test.mjs
+++ b/.claude/workflows/lib/args-parse.test.mjs
@@ -35,7 +35,7 @@ function extractArgsParser(file) {
   const source = readFileSync(path.join(workflowDir, file), 'utf8')
   const match = source.match(/\nconst A = (\(\(\) => \{[\s\S]*?\n\}\)\(\))\n/)
   assert.ok(match, `could not locate the \`const A = (() => {...})()\` args parser in ${file}`)
-  // eslint-disable-next-line no-new-func -- evaluating our own source with `args` injected, not untrusted input
+  // Evaluating our own source with `args` injected, not untrusted input
   return new Function('args', `return ${match[1]}`)
 }
 

--- a/.claude/workflows/lib/claude-config-wiring.test.mjs
+++ b/.claude/workflows/lib/claude-config-wiring.test.mjs
@@ -37,7 +37,7 @@ function defaultWorkflowDimensions() {
   const source = readFileSync(reviewWorkflowPath, 'utf8')
   const match = source.match(/const RAW_DIMENSIONS = A\.dimensions \|\| (\[[^\]]*\])/)
   assert.ok(match, 'could not locate the default `RAW_DIMENSIONS` array in review.workflow.mjs')
-  // eslint-disable-next-line no-new-func -- evaluating a plain array literal from our own source
+  // Evaluating a plain array literal from our own source
   return new Function(`return (${match[1]})`)()
 }
 
@@ -143,7 +143,7 @@ test('every workflow script parses as a workflow function body', () => {
       // The runtime runs scripts as an ASYNC function body (top-level await is legal), so the
       // parse check must use the async function constructor, not `new Function`.
       const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor
-      // eslint-disable-next-line no-new-func -- parse check of our own scripts, never executed
+      // Parse check of our own scripts, never executed
       new AsyncFunction('args', 'agent', 'workflow', 'phase', 'log', 'parallel', 'pipeline', 'budget', source)
     } catch (err) {
       bad.push(`${file}: ${err.message}`)

--- a/.claude/workflows/lib/codex-lane-optional.test.mjs
+++ b/.claude/workflows/lib/codex-lane-optional.test.mjs
@@ -41,7 +41,7 @@ function extractOptionalLane(file) {
   const source = readFileSync(path.join(workflowDir, file), 'utf8')
   const match = source.match(/\nconst optionalLane = (\([\s\S]*?)\n/)
   assert.ok(match, `could not locate \`const optionalLane = ...\` in ${file}`)
-  // eslint-disable-next-line no-new-func -- evaluating a plain arrow function from our own source, not untrusted input
+  // Evaluating a plain arrow function from our own source, not untrusted input
   return { fn: new Function(`return (${match[1]})`)(), source }
 }
 

--- a/.claude/workflows/lib/dev-loop-design-schema-sync.test.mjs
+++ b/.claude/workflows/lib/dev-loop-design-schema-sync.test.mjs
@@ -24,7 +24,7 @@ const source = readFileSync(workflowPath, 'utf8')
 function extractInlineDesignSchema() {
   const match = source.match(/\nconst DESIGN_SCHEMA = (\{[\s\S]*?\n\})\n\nconst PLAN_VERDICT_SCHEMA/)
   assert.ok(match, 'could not locate the inline `const DESIGN_SCHEMA = {...}` literal in dev-loop.workflow.mjs')
-  // eslint-disable-next-line no-new-func -- evaluating a plain object literal extracted from our own source, not untrusted input
+  // Evaluating a plain object literal extracted from our own source, not untrusted input
   return new Function(`return (${match[1]})`)()
 }
 
@@ -36,14 +36,14 @@ function extractIsValidDesignShape() {
     match,
     'could not locate `nonBlankItem` + `function isValidDesignShape(d) {...}` in dev-loop.workflow.mjs',
   )
-  // eslint-disable-next-line no-new-func -- evaluating our own source (DESIGN_SCHEMA + a plain function declaration), not untrusted input
+  // Evaluating our own source (DESIGN_SCHEMA + a plain function declaration), not untrusted input
   return new Function('DESIGN_SCHEMA', `${match[0]}\nreturn isValidDesignShape`)(DESIGN_SCHEMA)
 }
 
 function extractShouldGenerateDesign() {
   const match = source.match(/\nfunction shouldGenerateDesign\(\{[\s\S]*?\n\}\n/)
   assert.ok(match, 'could not locate `function shouldGenerateDesign({...}) {...}` in dev-loop.workflow.mjs')
-  // eslint-disable-next-line no-new-func -- evaluating a plain function declaration extracted from our own source, not untrusted input
+  // Evaluating a plain function declaration extracted from our own source, not untrusted input
   return new Function(`${match[0]}\nreturn shouldGenerateDesign`)()
 }
 
@@ -53,7 +53,7 @@ function extractShouldBlockOnFailedPlanReview() {
     match,
     'could not locate `function shouldBlockOnFailedPlanReview({...}) {...}` in dev-loop.workflow.mjs',
   )
-  // eslint-disable-next-line no-new-func -- evaluating a plain function declaration extracted from our own source, not untrusted input
+  // Evaluating a plain function declaration extracted from our own source, not untrusted input
   return new Function(`${match[0]}\nreturn shouldBlockOnFailedPlanReview`)()
 }
 

--- a/.claude/workflows/lib/explain-design.test.mjs
+++ b/.claude/workflows/lib/explain-design.test.mjs
@@ -124,7 +124,7 @@ test('inline shouldHandBackForLiveVerification in dev-loop matches this module, 
   const source = readFileSync(path.join(__dirname, '..', 'dev-loop.workflow.mjs'), 'utf8')
   const match = source.match(/\nfunction shouldHandBackForLiveVerification\(\{[\s\S]*?\n\}\n/)
   assert.ok(match, 'could not locate the inline shouldHandBackForLiveVerification')
-  // eslint-disable-next-line no-new-func -- evaluating our own source
+  // Evaluating our own source
   const inline = new Function(`${match[0]}\nreturn shouldHandBackForLiveVerification`)()
   for (const input of [
     { manualVerification: 'drag a node', dogfood: false },

--- a/.claude/workflows/lib/fix-loop.test.mjs
+++ b/.claude/workflows/lib/fix-loop.test.mjs
@@ -62,7 +62,7 @@ test('inline triageReview in dev-loop.workflow.mjs matches this module', () => {
   const source = readFileSync(workflowPath, 'utf8')
   const match = source.match(/\nconst SEVERITY_RANK = [\s\S]*?\nfunction triageReview\(review, threshold\) \{[\s\S]*?\n\}\n/)
   assert.ok(match, 'could not locate the inline SEVERITY_RANK + triageReview in dev-loop.workflow.mjs')
-  // eslint-disable-next-line no-new-func -- evaluating our own source, not untrusted input
+  // Evaluating our own source, not untrusted input
   const inline = new Function(`${match[0]}\nreturn { SEVERITY_RANK, triageReview }`)()
   assert.deepEqual(inline.SEVERITY_RANK, SEVERITY_RANK)
   const review = {

--- a/apps/web/scripts/smoke-preview-origin.mjs
+++ b/apps/web/scripts/smoke-preview-origin.mjs
@@ -72,7 +72,6 @@ try {
   // would behave: the Workers/Pages platform injects __WHITEBOARD_RUNTIME_CONFIG__
   // with the deploy's public origin before serving the HTML.
   await page.addInitScript(() => {
-    // eslint-disable-next-line no-undef
     window.__WHITEBOARD_RUNTIME_CONFIG__ = { publicOrigin: 'https://abc123.whiteboard.pages.dev' }
   })
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -191,7 +191,6 @@ export function App({ providerState }: AppProps) {
     }).then(setGrantConnection)
     // Runs once per page load — the fragment only exists on a fresh
     // top-level navigation back from the consent page.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // Silent renewal: a later visit to a hosted origin that already holds a
@@ -229,7 +228,6 @@ export function App({ providerState }: AppProps) {
       }
     })
     // Cold-load decision over mount-time facts; the ref guards StrictMode.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // A #wb= fragment carrying both workspaceId+path skips straight to the
@@ -391,7 +389,6 @@ export function App({ providerState }: AppProps) {
     // location.pathname is read, not depended on: including it would refire
     // this effect on every navigation (including the one it just performed),
     // which is harmless but noisy. daemonView is the actual trigger.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [daemonView, navigate, isPairRoute, daemonKept])
 
   // Which daemon the SHELL is talking to, resolved once from the same three
@@ -610,7 +607,6 @@ export function App({ providerState }: AppProps) {
     setDaemonView((current) =>
       workspaceRoutePath(current) === workspaceRoutePath(parsed) ? current : parsed,
     )
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.pathname, isPairRoute])
 
   // Persists ONLY the reconnect target (baseUrl/workspaceId/path), never the
@@ -643,7 +639,6 @@ export function App({ providerState }: AppProps) {
     // daemonConnection is a stable module-scope singleton for the life of the
     // tab (see useDaemonConnection.ts) — this effect is meant to run once per
     // successful pairing, not on every unrelated re-render.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [daemonConnection.status])
 
   useEffect(() => {
@@ -652,7 +647,6 @@ export function App({ providerState }: AppProps) {
       ...current,
       storage: { ...current.storage, daemonBaseUrl: grantConnection.daemonBaseUrl },
     }))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [grantConnection?.status])
 
   // /settings renders on its own route ahead of (and independent from) the

--- a/apps/web/src/components/markdown-editor/SourcePane.tsx
+++ b/apps/web/src/components/markdown-editor/SourcePane.tsx
@@ -399,7 +399,6 @@ export function SourcePane({
     }
     // Intentionally created once per mount — external `value` changes are
     // reconciled below, not by recreating the view.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useEffect(() => {

--- a/apps/web/src/components/migration/DaemonDetectedBanner.tsx
+++ b/apps/web/src/components/migration/DaemonDetectedBanner.tsx
@@ -206,7 +206,6 @@ export function DaemonDetectedBanner({
     }
     // challengeFn is an injected seam with a stable default; re-challenging
     // is keyed on WHICH daemon was detected, not the callback identity.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [detectedCount, detectedBaseUrl])
 
   // 'http:'/'https:' -> 'http'/'https'; any other scheme (e.g. jsdom's
@@ -337,7 +336,6 @@ export function DaemonDetectedBanner({
       clearHintTimer()
     }
     // Auto-probe once on mount for the http: (loopback) path only.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [locationProtocol])
 
   function handleDismiss() {

--- a/apps/web/src/components/spatial-editor/drag-start-responsiveness.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/drag-start-responsiveness.browser.test.tsx
@@ -131,6 +131,6 @@ it('measures the main-thread block at drag start on a heavy canvas', async () =>
   const summarize = (gaps: number[]) =>
     `maxGapMs=${Math.max(...gaps).toFixed(1)} gapsOver50ms=${gaps.filter((g) => g > 50).length}`
   const report = `[drag-start-instrument] nodes=${NODES} edges=${EDGES} first: ${summarize(first)} second: ${summarize(second)}`
-  // eslint-disable-next-line no-console -- the instrument's output IS the point
+  // The instrument's output IS the point
   console.log(report)
 }, 30_000)

--- a/apps/web/src/components/spatial-editor/use-canvas-replacement.ts
+++ b/apps/web/src/components/spatial-editor/use-canvas-replacement.ts
@@ -107,6 +107,5 @@ export function useCanvasReplacement({
     // gestureState intentionally omitted: this effect only reacts to a new
     // canvas identity, not every gestureState transition (that would create
     // an infinite render loop feeding the reducer's own output back in).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [canvas, externalVersion])
 }

--- a/apps/web/src/components/spatial-editor/use-drag-layers.ts
+++ b/apps/web/src/components/spatial-editor/use-drag-layers.ts
@@ -145,7 +145,6 @@ export function useDragLayers({
       originY: gestureState.startY - rendered.bounds.y,
     }
     // isLocked closes over lockedNodeIds/lockEnabled, both listed.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     gestureState,
     canvas,
@@ -226,7 +225,6 @@ export function useDragLayers({
       committedAnchors: gestureCommitted.anchors,
     }
     // isLocked closes over lockedNodeIds/lockEnabled, both listed.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     gestureState,
     canvas,

--- a/apps/web/src/components/spatial-editor/use-file-seam-scene.ts
+++ b/apps/web/src/components/spatial-editor/use-file-seam-scene.ts
@@ -119,7 +119,7 @@ export function useFileSeamScene({
   // (LayoutRequest carries plain data only); the worker keeps its own.
   const contentCache = useMemo(
     () => createSpatialContentCache(),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- theme, measure
+    // Theme, measure
     // and the references a text node's body can embed invalidate cached
     // layout; nothing else does.
     [resolvedMeasure, theme, references],

--- a/apps/web/src/components/spatial-editor/use-lock-policy.ts
+++ b/apps/web/src/components/spatial-editor/use-lock-policy.ts
@@ -52,7 +52,6 @@ export function useLockPolicy({
   const selectableBoxes = useMemo(
     () => (lockEnabled ? boxes.filter((entry) => !isLocked(entry.id)) : boxes),
     // isLocked closes over lockedNodeIds/lockEnabled, both listed here.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [boxes, lockEnabled, lockedNodeIds],
   )
   /** Same seam rule as the node lock: no callback, no enforcement. */
@@ -76,7 +75,6 @@ export function useLockPolicy({
       setEdgeLabelEditId((current) => (current === selectedEdgeId ? null : current))
     }
     // isEdgeLocked closes over lockedEdgeIds/edgeLockEnabled, both listed.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [edgeLockEnabled, lockedEdgeIds, selectedEdgeId])
 
   useEffect(() => {
@@ -89,7 +87,6 @@ export function useLockPolicy({
     )
     if (lockedMembers.size > 0) applySelection({ type: 'drop-locked', lockedIds: lockedMembers })
     // isLocked closes over lockedNodeIds/lockEnabled, both listed here.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lockEnabled, lockedNodeIds, selectedId, extraIds, gestureState])
 
   return { lockEnabled, isLocked, selectableBoxes, edgeLockEnabled, isEdgeLocked }

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -391,7 +391,6 @@ export function BrowserDocumentPage({
     isFirstCanvasUrlSyncRef.current = false
     if (location.pathname === path) return
     navigate(path, { replace: isFirstSync })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [documentPath, navigate])
 
   // URL -> canvas id: browser Back/Forward (and any other history navigation)
@@ -458,7 +457,6 @@ export function BrowserDocumentPage({
     void switchDocument(requestedId).then((switched) => {
       if (!switched) repair()
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.pathname, documentId, documentPath, switchDocument])
 
   useEffect(() => {
@@ -498,7 +496,6 @@ export function BrowserDocumentPage({
       })
     },
     // Re-create backend only when documentId/kind changes; a null id means not-yet-loaded.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [documentId, documentKind],
   )
 

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -336,7 +336,6 @@ export function DaemonDocumentPage({
       ),
       contentDocumentId: workspaceSyncDocumentId,
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     controller.workspaceId,
     controller.path,

--- a/apps/web/src/pages/use-daemon-document-controller.ts
+++ b/apps/web/src/pages/use-daemon-document-controller.ts
@@ -102,7 +102,6 @@ export function useDaemonDocumentController(
     // Resolution is a one-shot mount effect; daemonFetch/options are stable
     // for the page's lifetime (App.tsx only mounts DaemonDocumentPage once per
     // pairing).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const switchDocument = useCallback((nextPath: string) => {

--- a/packages/canvas-viewer/src/CanvasViewer.tsx
+++ b/packages/canvas-viewer/src/CanvasViewer.tsx
@@ -137,8 +137,8 @@ export function CanvasViewer({
       padding: padding ?? 0,
       background,
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- fontReady is a
-    // pure re-measure trigger, not a value read inside the callback.
+    // fontReady is a pure re-measure trigger, not a value read inside the
+    // callback.
   }, [
     canvas,
     resolvedMeasure,

--- a/packages/canvas-viewer/src/font-embedding.ts
+++ b/packages/canvas-viewer/src/font-embedding.ts
@@ -1,4 +1,4 @@
-// eslint-disable-next-line import/no-unresolved -- Vite's `?url` asset suffix, resolved at build/dev-server time.
+// Vite's `?url` asset suffix, resolved at build/dev-server time.
 import robotoFontUrl from '../assets/fonts/Roboto/Roboto-Regular.ttf?url'
 import { VIEWER_FONT_FAMILY } from './font.js'
 

--- a/packages/canvas-viewer/src/font-loading.ts
+++ b/packages/canvas-viewer/src/font-loading.ts
@@ -5,7 +5,7 @@
 // Canvas 2D silently falls back to a system font, and the editor's on-screen
 // layout diverges from what a user exports (see font.ts's doc comment).
 
-// eslint-disable-next-line import/no-unresolved -- Vite's `?url` asset suffix, resolved at build/dev-server time.
+// Vite's `?url` asset suffix, resolved at build/dev-server time.
 import robotoFontUrl from '../assets/fonts/Roboto/Roboto-Regular.ttf?url'
 import { VIEWER_FONT_FAMILY } from './font.js'
 


### PR DESCRIPTION
## What

audit-triage 2026-09-06: **36** `eslint-disable-next-line` directives suppressed nothing — there is no ESLint in this repo, and the corresponding Biome rules are off — so each read as a reviewed exemption that never happened. The 21 bare markers (`react-hooks/exhaustive-deps`, one `no-undef`) are deleted outright; the 15 carrying real reasoning after `--` (the `no-new-func` "evaluating our own source" family, canvas-viewer's Vite `?url` notes, the no-console bench note, the deps-invalidation sentences) keep the prose and lose only the directive.

Deliberately not decided here: enabling Biome's `useExhaustiveDependencies` — a lint-policy change with its own review, recorded on the audit backlog ticket.

## Verification

Zero `eslint-disable` left repo-wide (grep across apps/.claude/packages/tools/docs) · web + canvas-viewer typecheck · `pnpm test:scripts` 285 pass · lint.

Visual evidence: none — comment-only sweep; the zero-count grep is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D