### PR TITLE
test(web): cover the two untested defect-fixing primitives — pending index writes and touch long-press

### DIFF
--- a/apps/web/src/components/workspace-files/use-long-press.browser.test.tsx
+++ b/apps/web/src/components/workspace-files/use-long-press.browser.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * The touch long-press → object menu contract, in a real browser: jsdom
+ * cannot express the pointer/click ordering this hook exists to manage,
+ * and its failure mode is a real wrong-navigation bug — the trailing click
+ * a released long-press still dispatches would OPEN the document the menu
+ * just asked about.
+ */
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { LONG_PRESS_MS, useLongPressMenu } from './use-long-press.js'
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+function Host({
+  onLongPress,
+  onOpen,
+}: {
+  onLongPress: (path: string, x: number, y: number) => void
+  onOpen: () => void
+}) {
+  const longPress = useLongPressMenu(onLongPress)
+  return (
+    <div data-testid="list" {...longPress}>
+      <button type="button" data-doc-path="plan/doc" onClick={onOpen}>
+        card
+      </button>
+    </div>
+  )
+}
+
+function mount() {
+  const onLongPress = vi.fn()
+  const onOpen = vi.fn()
+  const { getByText } = render(<Host onLongPress={onLongPress} onOpen={onOpen} />)
+  return { onLongPress, onOpen, card: getByText('card') }
+}
+
+const touch = { pointerId: 7, pointerType: 'touch', clientX: 40, clientY: 60 }
+
+it('a touch held past the threshold opens the menu for the card, and the trailing click does not open the document', () => {
+  vi.useFakeTimers()
+  const { onLongPress, onOpen, card } = mount()
+
+  fireEvent.pointerDown(card, touch)
+  vi.advanceTimersByTime(LONG_PRESS_MS)
+  expect(onLongPress).toHaveBeenCalledWith('plan/doc', 40, 60)
+
+  // Releasing a long-press still dispatches a click; suppressed, or it
+  // would open the document under the menu that just asked what to do.
+  fireEvent.pointerUp(card, touch)
+  fireEvent.click(card)
+  expect(onOpen).not.toHaveBeenCalled()
+
+  // The NEXT genuine tap opens normally — suppression is one-shot.
+  fireEvent.pointerDown(card, touch)
+  fireEvent.pointerUp(card, touch)
+  fireEvent.click(card)
+  expect(onOpen).toHaveBeenCalledTimes(1)
+})
+
+it('a hold that drifts past the slop is a scroll: no menu, and the click opens normally', () => {
+  vi.useFakeTimers()
+  const { onLongPress, onOpen, card } = mount()
+
+  fireEvent.pointerDown(card, touch)
+  fireEvent.pointerMove(card, { ...touch, clientX: 40 + 9, clientY: 60 })
+  vi.advanceTimersByTime(LONG_PRESS_MS)
+  expect(onLongPress).not.toHaveBeenCalled()
+
+  fireEvent.pointerUp(card, touch)
+  fireEvent.click(card)
+  expect(onOpen).toHaveBeenCalledTimes(1)
+})
+
+it('a mouse held down is not a long-press — right-click already reaches the menu', () => {
+  vi.useFakeTimers()
+  const { onLongPress, card } = mount()
+
+  fireEvent.pointerDown(card, { ...touch, pointerType: 'mouse' })
+  vi.advanceTimersByTime(LONG_PRESS_MS * 2)
+  expect(onLongPress).not.toHaveBeenCalled()
+})
+
+it('a release before the threshold cancels the hold', () => {
+  vi.useFakeTimers()
+  const { onLongPress, card } = mount()
+
+  fireEvent.pointerDown(card, touch)
+  vi.advanceTimersByTime(LONG_PRESS_MS - 1)
+  fireEvent.pointerUp(card, touch)
+  vi.advanceTimersByTime(LONG_PRESS_MS)
+  expect(onLongPress).not.toHaveBeenCalled()
+})

--- a/apps/web/src/lib/pending-index-writes.test.ts
+++ b/apps/web/src/lib/pending-index-writes.test.ts
@@ -1,0 +1,79 @@
+/**
+ * The one place a documented, measured data-loss regression is prevented:
+ * a title typed and left immediately came back a character short, because
+ * a QUEUED (not yet issued) write holds no IndexedDB transaction for
+ * creation-order to protect a read against. These tests hold the module to
+ * the three properties its doc comment claims, with hand-held deferreds —
+ * no IndexedDB involved, the contract is purely about promise ordering.
+ */
+import { describe, expect, it } from 'vitest'
+import { indexWritesSettled, trackIndexWrite } from './pending-index-writes.js'
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('pending index writes', () => {
+  it('a read started after a tracked write settles only after that write does', async () => {
+    const write = deferred()
+    trackIndexWrite(write.promise)
+
+    let settled = false
+    const read = indexWritesSettled().then(() => {
+      settled = true
+    })
+    // Give the read every chance to resolve early — the assertion is that
+    // it CANNOT while the write is open, not that it merely has not yet.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(settled).toBe(false)
+
+    write.resolve()
+    await read
+    expect(settled).toBe(true)
+  })
+
+  it('a rejected write still clears, and the rejection does not escape the tracker', async () => {
+    const write = deferred()
+    // Attach the caller's own handler the way a real save loop does, so the
+    // tracked promise's rejection is observed exactly once.
+    const observed = trackIndexWrite(write.promise).catch((err) => err)
+    write.reject(new Error('quota'))
+    expect(await observed).toBeInstanceOf(Error)
+    // The failed write must not wedge every future read open.
+    await expect(indexWritesSettled()).resolves.toBeUndefined()
+  })
+
+  it('a write registered WHILE settling is also waited for — the gap the loop exists to close', async () => {
+    const first = deferred()
+    const second = deferred()
+    trackIndexWrite(first.promise)
+
+    let settled = false
+    const read = indexWritesSettled().then(() => {
+      settled = true
+    })
+
+    // The save loop's shape: finishing the first write queues the next one
+    // before anything else runs.
+    void first.promise.then(() => {
+      trackIndexWrite(second.promise)
+    })
+    first.resolve()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(settled).toBe(false)
+
+    second.resolve()
+    await read
+    expect(settled).toBe(true)
+  })
+
+  it('an empty set resolves without waiting on anything', async () => {
+    await expect(indexWritesSettled()).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
## What

audit-triage 2026-09-06, two test-gap items in one increment:

- **`pending-index-writes.test.ts`** (jsdom, hand-held deferreds — the contract is promise ordering, no IndexedDB needed): a read started after a tracked write settles only after it; a rejected write clears without wedging future reads; a write registered *while settling* is also waited for — the gap the module's loop exists to close, and the module is the only place a measured data-loss bug (a typed title came back a character short) is prevented. **Mutation-checked**: collapsing the settle loop to a single await fails the mid-settle case.

- **`use-long-press.browser.test.tsx`** (real browser — jsdom cannot express the pointer/click ordering): a touch held past `LONG_PRESS_MS` opens the menu for the card's `data-doc-path` and the trailing click is suppressed one-shot (the wrong-navigation bug the hook exists for); >8px drift is a scroll; a mouse never long-presses; an early release cancels. **Mutation-checked**: removing the click suppression fails the trailing-click case.

## Verification

4/4 + 4/4, both mutations red→restored green · typecheck · lint.

Visual evidence: none — test-only additions; the two mutation checks are the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV1euXVHjCdB6MuPgWc3D