### PR TITLE
fix(web): the changed dot is a hue, not ink

### DIFF
--- a/apps/web/src/components/workspace-files/FolderContentsList.tsx
+++ b/apps/web/src/components/workspace-files/FolderContentsList.tsx
@@ -198,7 +198,17 @@ export function FolderContentsList({
                   role="img"
                   aria-label="Changed since you last opened it"
                   data-testid="card-changed-dot"
-                  className="bg-primary absolute top-1 right-1 size-2.5 rounded-full"
+                  // A HUE, not `--primary`. This theme's primary is
+                  // `oklch(0.205 0 0)` — chroma zero — so the dot shipped
+                  // black in light mode and white in dark, reading as
+                  // punctuation rather than as a status. Blue is the unread
+                  // convention; a raw palette colour rather than a token
+                  // because the conflict badge below does the same, and
+                  // `--manipulation` is spoken for (it means selection and
+                  // handles on the canvas, not "something happened here").
+                  // The ring keeps it legible over a thumbnail of any
+                  // colour, which is what a real document renders as.
+                  className="absolute top-1 right-1 size-2.5 rounded-full bg-sky-500 ring-2 ring-background dark:bg-sky-400"
                 />
               )}
               {selection !== undefined && (

--- a/apps/web/src/components/workspace-files/changed-dot.browser.test.tsx
+++ b/apps/web/src/components/workspace-files/changed-dot.browser.test.tsx
@@ -5,6 +5,10 @@
 import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { userEvent } from 'vitest/browser'
+// The real stylesheet, so computed colours are the app's and not the
+// browser defaults — the same import manipulation-tokens.browser.test.tsx
+// needs for the same reason.
+import '../../index.css'
 import type { WorkspaceDocumentEntry } from '../../lib/document-entry.js'
 import { STORAGE_KEY } from '../../lib/seen-documents.js'
 import { fakeFilesSource } from '../../test-utils/fake-files-source.js'
@@ -22,6 +26,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup()
   localStorage.removeItem(STORAGE_KEY)
+  document.documentElement.classList.remove('dark')
 })
 
 function renderPanel() {
@@ -48,6 +53,24 @@ async function openCard(name: string) {
 async function settle(name: string) {
   const grid = await screen.findByTestId('folder-contents')
   await within(grid).findByText(name)
+}
+
+/**
+ * Whether a computed colour carries any hue at all.
+ *
+ * Both forms are handled because the browser echoes whichever the stylesheet
+ * used: a `var(--primary)` background computes back as `oklch(0.205 0 0)`,
+ * where the SECOND number is chroma. Reading that string with a bare `\d+`
+ * match — as the first version of this guard did — parses `0.205 0 0` into
+ * `[0, 205, 0]` and calls a pure grey chromatic, which is a guard that
+ * passes for a reason unrelated to what it claims.
+ */
+function isChromatic(colour: string): boolean {
+  const oklch = colour.match(/^oklch\(\s*[\d.]+\s+([\d.]+)/)
+  if (oklch !== null) return Number(oklch[1]) > 0
+  const rgb = (colour.match(/\d+/g) ?? []).slice(0, 3).map(Number)
+  if (rgb.length < 3) throw new Error(`unrecognised colour: ${colour}`)
+  return Math.max(...rgb) !== Math.min(...rgb)
 }
 
 const dotFor = (name: string) => {
@@ -88,6 +111,29 @@ describe('changed since you last opened it', () => {
     // And only that one: the untouched neighbour was never opened, so it has
     // no baseline and must stay silent rather than read as changed.
     expect(dotFor('Tokens')).toBeNull()
+  })
+
+  it('is drawn in a hue rather than in ink, and answers to the theme', async () => {
+    // `bg-primary` shipped first and this theme's `--primary` is
+    // `oklch(0.205 0 0)` — chroma ZERO — so the dot came out black in light
+    // mode and white in dark, reading as punctuation rather than as a
+    // status. The invariant is not a particular blue: it is that the dot is
+    // not grey, and that the dark variant is a DIFFERENT colour rather than
+    // a `dark:` class nobody checked.
+    renderPanel()
+    await openCard('Roadmap')
+    cleanup()
+    rows = rows.map((row) => (row.path === 'roadmap' ? { ...row, contentDigest: 'v2' } : row))
+
+    renderPanel()
+    await waitFor(() => expect(dotFor('Roadmap')).not.toBeNull())
+    const light = getComputedStyle(dotFor('Roadmap') as HTMLElement).backgroundColor
+    expect(isChromatic(light)).toBe(true)
+
+    document.documentElement.classList.add('dark')
+    const dark = getComputedStyle(dotFor('Roadmap') as HTMLElement).backgroundColor
+    expect(isChromatic(dark)).toBe(true)
+    expect(dark).not.toBe(light)
   })
 
   it('clears once the person opens it again', async () => {


### PR DESCRIPTION
Reported from the merged figure: **the dot was black.**

It used `bg-primary`, and this theme's primary is `oklch(0.205 0 0)` — **chroma zero** — so it drew near-black in light mode and near-white in dark. A status marker made of the same ink as the text reads as punctuation, which is the opposite of what a dot is for.

## Visual repro

![before — bg-primary is chroma 0, so the marker was ink; after — a hue, with a ring so it survives any thumbnail](tmp/screenshots/dot-colour-figure.png)

> Not uploaded: `gh` here is 2.97.0 and `--attach` landed in 2.99.0. Panels `1b43bda9` / `8aa5a2b6`.

## Why this blue, this way

Blue is the unread convention the dot borrows its whole legibility from. A **raw palette colour rather than a token**, because the conflict badge two elements away already does exactly that — and because `--manipulation` is spoken for: it means *selection and handles on the canvas*, not "something happened here". Borrowing it would put a second meaning on a word this repo defines carefully.

The `ring-2 ring-background` keeps it legible over a thumbnail of any colour, which is what a real document renders as — the figure's placeholder icon is the easy case.

## The guard, and how its first version was wrong

Worth recording, because it passed against the unfixed code.

The first version read the computed background with a bare `\d+` match and compared max to min. But a `var(--primary)` background computes back as the **string** `oklch(0.205 0 0)` — so the match returned `[0, 205, 0]`, and the guard called a pure grey chromatic. Probing the actual value is what caught it; reasoning would not have.

It now reads oklch's *second* number, which is chroma, and falls back to the rgb comparison for that form. It asserts the **invariant** rather than the colour — not grey, and the dark variant genuinely different — so a later palette change is free and only a return to ink fails.

The dark half is asserted because **two screenshots of `sky-500` and `sky-400` looked identical to me** at dot size. Measuring is what established the `dark:` variant applies at all, rather than my eye.

## Verification

Mutation-checked: back to `bg-primary` → 1 red. `web-jsdom` over `workspace-files` + `toggle-state-surface` 269/269; the changed-dot browser file 5/5. Typecheck and lint clean.
