### PR TITLE
feat(web): the document's ⋯ carries display, export and bookmark

### DIFF
--- a/apps/web/src/components/document-properties/DocumentProperties.test.tsx
+++ b/apps/web/src/components/document-properties/DocumentProperties.test.tsx
@@ -364,17 +364,24 @@ describe('DocumentProperties as the canvas row', () => {
     )
   })
 
-  it('renders the settings slot beside the toggle and the actions cluster at the right edge', () => {
+  it('renders the actions cluster at the right edge', () => {
     render(
       <DocumentProperties
         {...titleProps()}
         facets={{ type: 'markdown' }}
-        settings={<button type="button" aria-label="Display settings" />}
         actions={<span data-testid="row-actions">ops</span>}
       />,
     )
-    expect(screen.getByRole('button', { name: 'Display settings' })).toBeTruthy()
     expect(screen.getByTestId('row-actions')).toBeTruthy()
+  })
+
+  // Display settings had a slot of their own here, beside the properties
+  // toggle. They are the only VIEW control the row ever carried; they live
+  // in the ⋯ menu's leading band now, so the row has no way to take one.
+  it('has no slot for a display control', () => {
+    render(<DocumentProperties {...titleProps()} facets={{ type: 'canvas' }} />)
+
+    expect(screen.queryByRole('button', { name: 'Display settings' })).toBeNull()
   })
 })
 

--- a/apps/web/src/components/document-properties/DocumentProperties.tsx
+++ b/apps/web/src/components/document-properties/DocumentProperties.tsx
@@ -45,12 +45,6 @@ export interface DocumentPropertiesProps {
    */
   readonly status?: ReactNode
   /**
-   * Canvas display settings control, rendered beside the properties toggle.
-   * Spatial documents pass the settings popover; markdown documents omit it —
-   * edge routing has no meaning for a document with no spatial scene.
-   */
-  readonly settings?: ReactNode
-  /**
    * Right-edge cluster: canvas STATE and whole-document operations (save
    * chip, duplicate, delete). Supplied by the page — this component owns
    * the canvas row's layout, not the operations themselves.
@@ -78,7 +72,6 @@ export function DocumentProperties({
   propertiesOpen = false,
   onToggleProperties,
   status,
-  settings,
   actions,
 }: DocumentPropertiesProps) {
   // Null means "not being edited" — the box then shows the canonical name.
@@ -176,7 +169,6 @@ export function DocumentProperties({
             <TooltipContent>Properties</TooltipContent>
           </Tooltip>
         )}
-        {settings}
         {actions !== undefined && (
           <div className="ml-auto flex shrink-0 items-center gap-1.5">{actions}</div>
         )}

--- a/apps/web/src/components/spatial-editor/CanvasDisplaySettings.tsx
+++ b/apps/web/src/components/spatial-editor/CanvasDisplaySettings.tsx
@@ -1,8 +1,12 @@
 /**
- * Canvas-wide display settings as a gear popover for the canvas header row.
- * Standalone from SpatialEditor so the PAGE places it with the other
- * canvas-level chrome; it speaks the same (canvas, onChange) command
- * contract the editor does.
+ * Canvas-wide display settings as a PANEL. The document's ⋯ menu hangs it in
+ * a popover off its own trigger, from the leading `Display…` row; this
+ * module owns what is in the panel and nothing about how it is opened.
+ *
+ * It used to carry its own gear in the header row — the row's only VIEW
+ * control, one icon for one plugin's edge routing, against width the title
+ * wanted. Standalone from SpatialEditor so the PAGE places it; it speaks the
+ * same (canvas, onChange) command contract the editor does.
  *
  * This surface OWNS the `canvasSettings` contribution point and knows no
  * facet domain (facet-wiring-guard.test.ts): panels come from the registry,
@@ -12,21 +16,18 @@
  * display name may be reworded or localized and must not move the order).
  *
  * Picks apply immediately and keep the popover open — these are property
- * pickers, and closing per pick would force a reopen for every adjustment.
- * Radix owns dismissal (outside click, Escape) and returns focus to the
- * gear, so a keyboard user never falls to <body>.
+ * pickers, and closing per pick would force a reopen for every adjustment,
+ * which is also why the ⋯ row opens a popover rather than a submenu. Radix
+ * owns dismissal (outside click, Escape) and returns focus to the kebab the
+ * popover is anchored on, so a keyboard user never falls to <body>.
  */
 import { type FacetRegistry, resolveFacetContributions } from '@kamiazya/whiteboard-facet-engine'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { bundledFacetRegistry } from '@kamiazya/whiteboard-plugin-visual'
-import { SlidersHorizontal } from 'lucide-react'
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import type { EditorCommand } from '../../lib/spatial/commands.js'
 import { applyCommand } from '../../lib/spatial/commands.js'
 import { cn } from '../../lib/utils.js'
-import { HEADER_TOGGLE_CLASS } from '../ui/header-button.js'
-import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover.js'
-import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js'
 import { CANVAS_SETTINGS_WIDGETS, type CanvasSettingsWidget } from './facet-widgets/index.js'
 
 export interface CanvasDisplaySettingsProps {
@@ -76,48 +77,31 @@ export function CanvasDisplaySettings({
   const active = groups.find((entry) => entry.group.namespace === activeNamespace) ?? groups[0]
 
   return (
-    <Popover>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <PopoverTrigger asChild>
+    <>
+      {groups.length >= 2 && (
+        <div role="tablist" className="mb-2 flex items-center gap-1 border-b border-border">
+          {groups.map(({ group }) => (
             <button
+              key={group.namespace}
               type="button"
-              data-testid="canvas-settings-button"
-              aria-label="Display settings"
-              className={HEADER_TOGGLE_CLASS}
+              role="tab"
+              aria-selected={group.namespace === active?.group.namespace}
+              onClick={() => setActiveNamespace(group.namespace)}
+              className={cn(
+                'rounded-t px-2 py-1 text-xs',
+                group.namespace === active?.group.namespace
+                  ? 'bg-accent font-medium text-foreground'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
             >
-              <SlidersHorizontal aria-hidden="true" className="size-4" />
+              {group.displayName}
             </button>
-          </PopoverTrigger>
-        </TooltipTrigger>
-        <TooltipContent>Display settings</TooltipContent>
-      </Tooltip>
-      <PopoverContent data-testid="canvas-settings-menu" className="w-auto min-w-52 p-2">
-        {groups.length >= 2 && (
-          <div role="tablist" className="mb-2 flex items-center gap-1 border-b border-border">
-            {groups.map(({ group }) => (
-              <button
-                key={group.namespace}
-                type="button"
-                role="tab"
-                aria-selected={group.namespace === active?.group.namespace}
-                onClick={() => setActiveNamespace(group.namespace)}
-                className={cn(
-                  'rounded-t px-2 py-1 text-xs',
-                  group.namespace === active?.group.namespace
-                    ? 'bg-accent font-medium text-foreground'
-                    : 'text-muted-foreground hover:text-foreground',
-                )}
-              >
-                {group.displayName}
-              </button>
-            ))}
-          </div>
-        )}
-        {active?.widgets.map(({ key, widget }) => (
-          <Fragment key={key}>{widget({ canvas, run })}</Fragment>
-        ))}
-      </PopoverContent>
-    </Popover>
+          ))}
+        </div>
+      )}
+      {active?.widgets.map(({ key, widget }) => (
+        <Fragment key={key}>{widget({ canvas, run })}</Fragment>
+      ))}
+    </>
   )
 }

--- a/apps/web/src/components/spatial-editor/canvas-settings.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/canvas-settings.browser.test.tsx
@@ -9,6 +9,7 @@ import { bundledPlugins, type VisualEdgesFacet } from '@kamiazya/whiteboard-plug
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
 import { z } from 'zod'
 import { DocumentMenu } from '../workspace-top-bar/DocumentMenu.js'
 import { CanvasDisplaySettings } from './CanvasDisplaySettings.js'
@@ -49,12 +50,19 @@ const option = (label: string) =>
     | undefined
 
 /**
- * Open the panel the way a person does: the kebab, then its leading row.
- * Radix's DropdownMenuTrigger opens on pointerDown and its Item selects on
- * pointerUp, so a plain click on either would be a no-op.
+ * Open the panel the way a person does: REAL clicks on the kebab and its
+ * leading row, through the browser's own event and focus sequence.
+ *
+ * Synthetic `fireEvent.pointerDown`/`pointerUp` drive Radix's menu fine and
+ * are what this file used to do — but they skip the focus movement, which
+ * is where the defect lived: the closing menu returned focus to the trigger
+ * and the popover, having just opened, read that as an outside interaction
+ * and dismissed itself. Measured in a real browser: popover present at
+ * 50ms and 150ms, gone by 400ms, while every synthetic-event test stayed
+ * green.
  */
 async function openPanel(container: HTMLElement) {
-  fireEvent.pointerDown(kebab(container), { button: 0, ctrlKey: false })
+  await userEvent.click(kebab(container))
   const row = await vi.waitFor(() => {
     const found = [...document.querySelectorAll('[role="menuitem"]')].find(
       (item) => item.textContent?.trim() === 'Display…',
@@ -62,8 +70,20 @@ async function openPanel(container: HTMLElement) {
     expect(found).toBeDefined()
     return found as HTMLElement
   })
-  fireEvent.pointerUp(row)
-  await vi.waitFor(() => expect(menu()).toBeTruthy())
+  await userEvent.click(row)
+  // Wait for where focus COMES TO REST, not merely for the panel to appear.
+  // A `waitFor(panel exists)` is satisfied by the transient open and reads
+  // exactly like a pass; the two builds differ in the end state — focus in
+  // the panel, or back on the kebab with the panel gone with it.
+  await vi.waitFor(() => {
+    expect(document.querySelector('[role="menu"]'), 'the menu is still closing').toBeNull()
+    const panel = menu()
+    expect(panel, 'the panel closed again as the menu finished closing').toBeTruthy()
+    expect(
+      panel?.contains(document.activeElement),
+      'focus went somewhere other than the panel',
+    ).toBe(true)
+  })
 }
 
 it('the Display row opens the popover with both option rows', async () => {

--- a/apps/web/src/components/spatial-editor/canvas-settings.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/canvas-settings.browser.test.tsx
@@ -1,7 +1,8 @@
-// The canvas display-settings popover, standalone: the gear opens it, a
-// pick applies the canvas-wide command immediately and keeps it open for
-// the next tweak, consecutive picks chain under a deferred parent, and
-// dismissal returns focus to the gear.
+// The canvas display-settings panel in the vessel that actually opens it:
+// the document's ⋯, whose leading `Display…` row hangs the popover off the
+// kebab. A pick applies the canvas-wide command immediately and keeps the
+// popover open for the next tweak, consecutive picks chain under a deferred
+// parent, and dismissal returns focus to the kebab.
 import { createFacetRegistry, defineFacet, definePlugin } from '@kamiazya/whiteboard-facet-engine'
 import type { SpatialCanvas } from '@kamiazya/whiteboard-model'
 import { bundledPlugins, type VisualEdgesFacet } from '@kamiazya/whiteboard-plugin-visual'
@@ -9,6 +10,7 @@ import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { z } from 'zod'
+import { DocumentMenu } from '../workspace-top-bar/DocumentMenu.js'
 import { CanvasDisplaySettings } from './CanvasDisplaySettings.js'
 import { CANVAS_SETTINGS_WIDGETS } from './facet-widgets/index.js'
 
@@ -30,26 +32,46 @@ function makeHost() {
   function Host() {
     const [canvas, setCanvas] = useState(initial)
     latest.canvas = canvas
-    return <CanvasDisplaySettings canvas={canvas} onChange={(next) => setCanvas(next)} />
+    return (
+      <DocumentMenu
+        display={<CanvasDisplaySettings canvas={canvas} onChange={(next) => setCanvas(next)} />}
+      />
+    )
   }
   return { Host, latest }
 }
 
-const gear = (c: HTMLElement) =>
-  c.querySelector('[data-testid="canvas-settings-button"]') as HTMLElement
+const kebab = (c: HTMLElement) => c.querySelector('[aria-label="More actions"]') as HTMLElement
 const menu = () => document.querySelector('[data-testid="canvas-settings-menu"]')
 const option = (label: string) =>
   [...(menu()?.querySelectorAll('button') ?? [])].find((b) => b.textContent?.trim() === label) as
     | HTMLButtonElement
     | undefined
 
-it('the gear opens the popover with both option rows', async () => {
+/**
+ * Open the panel the way a person does: the kebab, then its leading row.
+ * Radix's DropdownMenuTrigger opens on pointerDown and its Item selects on
+ * pointerUp, so a plain click on either would be a no-op.
+ */
+async function openPanel(container: HTMLElement) {
+  fireEvent.pointerDown(kebab(container), { button: 0, ctrlKey: false })
+  const row = await vi.waitFor(() => {
+    const found = [...document.querySelectorAll('[role="menuitem"]')].find(
+      (item) => item.textContent?.trim() === 'Display…',
+    )
+    expect(found).toBeDefined()
+    return found as HTMLElement
+  })
+  fireEvent.pointerUp(row)
+  await vi.waitFor(() => expect(menu()).toBeTruthy())
+}
+
+it('the Display row opens the popover with both option rows', async () => {
   const { Host } = makeHost()
   const { container } = render(<Host />)
 
   expect(menu()).toBeNull()
-  fireEvent.click(gear(container))
-  await vi.waitFor(() => expect(menu()).toBeTruthy())
+  await openPanel(container)
   expect(menu()?.textContent).toContain('Edge routing')
   expect(menu()?.textContent).toContain('Line jumps')
 })
@@ -58,7 +80,7 @@ it('a pick applies canvas-wide and keeps the popover open; current values are ma
   const { Host, latest } = makeHost()
   const { container } = render(<Host />)
 
-  fireEvent.click(gear(container))
+  await openPanel(container)
   await vi.waitFor(() => expect(option('Curved')).toBeDefined())
   fireEvent.click(option('Curved') as HTMLElement)
 
@@ -80,19 +102,23 @@ it('consecutive picks both survive a deferred parent', async () => {
     const [canvas, setCanvas] = useState(initial)
     latest.canvas = canvas
     return (
-      <CanvasDisplaySettings
-        canvas={canvas}
-        onChange={(next) => {
-          setTimeout(() => {
-            latest.canvas = next
-            setCanvas(next)
-          }, 30)
-        }}
+      <DocumentMenu
+        display={
+          <CanvasDisplaySettings
+            canvas={canvas}
+            onChange={(next) => {
+              setTimeout(() => {
+                latest.canvas = next
+                setCanvas(next)
+              }, 30)
+            }}
+          />
+        }
       />
     )
   }
   const { container } = render(<DeferredHost />)
-  fireEvent.click(gear(container))
+  await openPanel(container)
   await vi.waitFor(() => expect(option('Orthogonal')).toBeDefined())
   fireEvent.click(option('Orthogonal') as HTMLElement)
   fireEvent.click(option('On') as HTMLElement)
@@ -105,18 +131,18 @@ it('consecutive picks both survive a deferred parent', async () => {
   })
 })
 
-it('Escape closes and hands focus back to the gear', async () => {
+it('Escape closes and hands focus back to the kebab', async () => {
   const { Host } = makeHost()
   const { container } = render(<Host />)
 
-  const trigger = gear(container)
-  fireEvent.click(trigger)
-  await vi.waitFor(() => expect(menu()).toBeTruthy())
+  const trigger = kebab(container)
+  await openPanel(container)
 
   fireEvent.keyDown(menu() as HTMLElement, { key: 'Escape' })
   await vi.waitFor(() => expect(menu()).toBeNull())
-  // Radix hands focus back to the trigger, so a keyboard user keeps their
-  // place instead of falling to <body>.
+  // The row that opened this unmounted with the menu, so the popover is
+  // anchored on the kebab and hands focus back there — a keyboard user keeps
+  // their place instead of falling to <body>.
   await vi.waitFor(() => expect(document.activeElement).toBe(trigger))
 })
 
@@ -138,20 +164,23 @@ it('a second contributing namespace introduces displayName tabs; one namespace s
   function Host() {
     const [canvas, setCanvas] = useState(initial)
     return (
-      <CanvasDisplaySettings
-        canvas={canvas}
-        onChange={(next) => setCanvas(next)}
-        facetRegistry={registry}
-        widgets={{
-          ...CANVAS_SETTINGS_WIDGETS,
-          'planning.board/v0': () => <div>Board options</div>,
-        }}
+      <DocumentMenu
+        display={
+          <CanvasDisplaySettings
+            canvas={canvas}
+            onChange={(next) => setCanvas(next)}
+            facetRegistry={registry}
+            widgets={{
+              ...CANVAS_SETTINGS_WIDGETS,
+              'planning.board/v0': () => <div>Board options</div>,
+            }}
+          />
+        }
       />
     )
   }
   const { container } = render(<Host />)
-  fireEvent.click(gear(container))
-  await vi.waitFor(() => expect(menu()).toBeTruthy())
+  await openPanel(container)
 
   const tabs = [...(menu()?.querySelectorAll('[role="tab"]') ?? [])]
   expect(tabs.map((t) => t.textContent)).toEqual(['Planning', 'Visual style'])
@@ -165,7 +194,6 @@ it('a second contributing namespace introduces displayName tabs; one namespace s
   // The bundled registry alone (one namespace) shows no tablist.
   const { Host: BareHost } = makeHost()
   const { container: bare } = render(<BareHost />)
-  fireEvent.click(gear(bare))
-  await vi.waitFor(() => expect(menu()).toBeTruthy())
+  await openPanel(bare)
   expect(menu()?.querySelector('[role="tab"]')).toBeNull()
 })

--- a/apps/web/src/components/spatial-editor/edge-routing-menu.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/edge-routing-menu.browser.test.tsx
@@ -11,6 +11,7 @@ import type { VisualEdgesFacet } from '@kamiazya/whiteboard-plugin-visual'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
+import { DocumentMenu } from '../workspace-top-bar/DocumentMenu.js'
 import { CanvasDisplaySettings } from './CanvasDisplaySettings.js'
 import { SpatialEditor } from './SpatialEditor.js'
 
@@ -34,7 +35,9 @@ function makeHost() {
     latest.canvas = canvas
     return (
       <div style={{ width: 900, height: 700 }}>
-        <CanvasDisplaySettings canvas={canvas} onChange={(next) => setCanvas(next)} />
+        <DocumentMenu
+          display={<CanvasDisplaySettings canvas={canvas} onChange={(next) => setCanvas(next)} />}
+        />
         <SpatialEditor
           defaultTool="select"
           canvas={canvas}
@@ -47,9 +50,21 @@ function makeHost() {
   return { Host, latest }
 }
 
-function openSettings(container: HTMLElement) {
-  const gear = container.querySelector('[data-testid="canvas-settings-button"]') as HTMLElement
-  fireEvent.click(gear)
+// Radix's DropdownMenuTrigger opens on pointerDown and its Item selects on
+// pointerUp, so neither step is a plain click.
+async function openSettings(container: HTMLElement) {
+  fireEvent.pointerDown(container.querySelector('[aria-label="More actions"]') as HTMLElement, {
+    button: 0,
+    ctrlKey: false,
+  })
+  const row = await vi.waitFor(() => {
+    const found = [...document.querySelectorAll('[role="menuitem"]')].find(
+      (item) => item.textContent?.trim() === 'Display…',
+    )
+    expect(found).toBeDefined()
+    return found as HTMLElement
+  })
+  fireEvent.pointerUp(row)
 }
 
 // The popover renders in a portal, so options are queried from the document.
@@ -61,7 +76,7 @@ const optionButton = (_container: HTMLElement, label: string) =>
 it('offers the routing style from the settings popover, not the creation menu', async () => {
   const { Host } = makeHost()
   const { container } = render(<Host />)
-  openSettings(container)
+  await openSettings(container)
 
   await vi.waitFor(() => {
     expect(document.querySelector('[data-testid="canvas-settings-menu"]')).not.toBeNull()
@@ -82,7 +97,7 @@ it('offers the routing style from the settings popover, not the creation menu', 
 it('records the choice on the canvas and bends the edge', async () => {
   const { Host, latest } = makeHost()
   const { container } = render(<Host />)
-  openSettings(container)
+  await openSettings(container)
 
   await vi.waitFor(() => expect(optionButton(container, 'Orthogonal')).toBeDefined())
   optionButton(container, 'Orthogonal')?.click()
@@ -103,7 +118,7 @@ it('drops the setting again when the style returns to straight', async () => {
   const { Host, latest } = makeHost()
   const { container } = render(<Host />)
 
-  openSettings(container)
+  await openSettings(container)
   await vi.waitFor(() => expect(optionButton(container, 'Orthogonal')).toBeDefined())
   optionButton(container, 'Orthogonal')?.click()
   await vi.waitFor(() => expect(edgesFacetOf(latest.canvas)?.routing).toBe('orthogonal'))
@@ -123,7 +138,7 @@ it('drops the setting again when the style returns to straight', async () => {
 it('draws a curve when the canvas asks for one', async () => {
   const { Host, latest } = makeHost()
   const { container } = render(<Host />)
-  openSettings(container)
+  await openSettings(container)
 
   await vi.waitFor(() => expect(optionButton(container, 'Curved')).toBeDefined())
   optionButton(container, 'Curved')?.click()
@@ -159,7 +174,9 @@ it('toggles line jumps from the canvas menu and draws the hop arc', async () => 
     latest.canvas = canvas
     return (
       <div style={{ width: 900, height: 700 }}>
-        <CanvasDisplaySettings canvas={canvas} onChange={(next) => setCanvas(next)} />
+        <DocumentMenu
+          display={<CanvasDisplaySettings canvas={canvas} onChange={(next) => setCanvas(next)} />}
+        />
         <SpatialEditor
           defaultTool="select"
           canvas={canvas}
@@ -170,7 +187,7 @@ it('toggles line jumps from the canvas menu and draws the hop arc', async () => 
     )
   }
   const { container } = render(<CrossHost />)
-  openSettings(container)
+  await openSettings(container)
 
   await vi.waitFor(() => expect(optionButton(container, 'On')).toBeDefined())
   optionButton(container, 'On')?.click()
@@ -210,13 +227,13 @@ it('consecutive style + jumps picks both survive a deferred parent', async () =>
     }
     return (
       <div style={{ width: 900, height: 700 }}>
-        <CanvasDisplaySettings canvas={canvas} onChange={deferSet} />
+        <DocumentMenu display={<CanvasDisplaySettings canvas={canvas} onChange={deferSet} />} />
         <SpatialEditor defaultTool="select" canvas={canvas} onChange={deferSet} theme="light" />
       </div>
     )
   }
   const { container } = render(<DeferredHost />)
-  openSettings(container)
+  await openSettings(container)
 
   await vi.waitFor(() => expect(optionButton(container, 'Orthogonal')).toBeDefined())
   optionButton(container, 'Orthogonal')?.click()

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -1,5 +1,5 @@
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
-import { Check } from 'lucide-react'
+import { Check, ChevronRight } from 'lucide-react'
 import type * as React from 'react'
 import { cn } from '../../lib/utils.js'
 
@@ -107,6 +107,48 @@ function DropdownMenuLabel({
   )
 }
 
+function DropdownMenuSub({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger>) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRight className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.SubContent
+        data-slot="dropdown-menu-sub-content"
+        className={cn(
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md',
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
 function DropdownMenuSeparator({
   className,
   ...props
@@ -128,5 +170,8 @@ export {
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 }

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -11,6 +11,15 @@ function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimiti
   return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
 }
 
+/**
+ * Where the popover hangs when its opener is not its trigger. The display
+ * panel is opened from a menu row, and the row unmounts with the menu — so
+ * the anchor is the kebab that owns both.
+ */
+function PopoverAnchor({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
 function PopoverContent({
   className,
   align = 'end',
@@ -39,4 +48,4 @@ function PopoverContent({
   )
 }
 
-export { Popover, PopoverContent, PopoverTrigger }
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger }

--- a/apps/web/src/components/workspace-top-bar/DocumentMenu.test.tsx
+++ b/apps/web/src/components/workspace-top-bar/DocumentMenu.test.tsx
@@ -8,13 +8,22 @@ import { DocumentMenu } from './DocumentMenu'
 
 function renderMenu(props?: {
   onExport?: (format: 'png' | 'svg') => void
+  onBookmark?: () => void
+  display?: React.ReactNode
   children?: React.ReactNode
 }) {
   // Radix portals render into document.body, a DOM sibling of the default
   // container — rooting React at body is what lets portal events reach it.
-  return render(<DocumentMenu onExport={props?.onExport}>{props?.children}</DocumentMenu>, {
-    container: document.body,
-  })
+  return render(
+    <DocumentMenu
+      onExport={props?.onExport}
+      {...(props?.onBookmark === undefined ? {} : { onBookmark: props.onBookmark })}
+      {...(props?.display === undefined ? {} : { display: props.display })}
+    >
+      {props?.children}
+    </DocumentMenu>,
+    { container: document.body },
+  )
 }
 
 // Radix DropdownMenuTrigger opens on pointerDown; DropdownMenuItem selects on pointerUp.
@@ -23,16 +32,36 @@ async function openMenu() {
   return screen.findByRole('menu')
 }
 
+// A submenu opens on pointerMove over its trigger (Radix's hover intent) —
+// keyboard would work too, but the whole menu is driven by pointer here.
+async function openExportSubmenu() {
+  const trigger = screen.getByRole('menuitem', { name: 'Export…' })
+  fireEvent.pointerMove(trigger, { pointerType: 'mouse' })
+  return waitFor(() => expect(screen.getByRole('menuitem', { name: 'Export as PNG' })).toBeTruthy())
+}
+
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
 })
 
 describe('DocumentMenu — export entries', () => {
-  it('renders no export entries when onExport is omitted', async () => {
+  it('renders no export entry when onExport is omitted', async () => {
     renderMenu()
     await openMenu()
 
+    expect(screen.queryByText('Export…')).toBeNull()
+    expect(screen.queryByText('Export as PNG')).toBeNull()
+  })
+
+  // ONE row for exporting, with the formats behind it. Two sibling rows made
+  // the menu's length a function of how many formats exist, and a format is
+  // not a different act — it is the same act, parameterised.
+  it('offers one Export row, and keeps the formats behind it until it is opened', async () => {
+    renderMenu({ onExport: vi.fn() })
+    await openMenu()
+
+    expect(screen.getByRole('menuitem', { name: 'Export…' })).toBeTruthy()
     expect(screen.queryByText('Export as PNG')).toBeNull()
     expect(screen.queryByText('Export as SVG')).toBeNull()
   })
@@ -43,8 +72,9 @@ describe('DocumentMenu — export entries', () => {
     const onExport = vi.fn()
     renderMenu({ onExport })
     await openMenu()
+    await openExportSubmenu()
 
-    fireEvent.pointerUp(await screen.findByText(`Export as ${format.toUpperCase()}`))
+    fireEvent.pointerUp(screen.getByText(`Export as ${format.toUpperCase()}`))
     await waitFor(() => expect(onExport).toHaveBeenCalledWith(format))
   })
 
@@ -53,10 +83,79 @@ describe('DocumentMenu — export entries', () => {
   it('offers PNG and SVG only', async () => {
     renderMenu({ onExport: vi.fn() })
     await openMenu()
+    await openExportSubmenu()
 
     expect(screen.getByText('Export as PNG')).toBeTruthy()
     expect(screen.getByText('Export as SVG')).toBeTruthy()
     expect(screen.queryByText(/Export as (JSON|Excalidraw|PDF)/i)).toBeNull()
+  })
+})
+
+/**
+ * Display settings used to be a gear of their own in the row, beside the
+ * properties toggle. It is the only VIEW control the document row carried,
+ * and one icon for one plugin's edge routing is a poor trade against the
+ * width the title wants — so it moves into the menu, in the leading band
+ * ADR-0006 reserves for properties.
+ */
+describe('DocumentMenu — display settings', () => {
+  it('has no Display row when the document has no canvas to configure', async () => {
+    renderMenu({ onExport: vi.fn() })
+    await openMenu()
+
+    expect(screen.queryByText('Display…')).toBeNull()
+  })
+
+  it('puts Display… in the leading band, ahead of the verbs', async () => {
+    renderMenu({ onExport: vi.fn(), display: <div>edge routing</div> })
+    await openMenu()
+
+    const labels = screen.getAllByRole('menuitem').map((item) => item.textContent?.trim())
+    expect(labels[0]).toBe('Display…')
+  })
+
+  // The panel is a POPOVER, not a submenu: its widgets are segmented
+  // controls a person adjusts several times in a row, and a menu closes on
+  // the first select. It hangs off the kebab because the row that opened it
+  // unmounted with the menu.
+  it('opens the panel from that row', async () => {
+    renderMenu({ onExport: vi.fn(), display: <div>edge routing</div> })
+    await openMenu()
+
+    expect(screen.queryByText('edge routing')).toBeNull()
+    fireEvent.pointerUp(screen.getByRole('menuitem', { name: 'Display…' }))
+    await waitFor(() => expect(screen.getByText('edge routing')).toBeTruthy())
+  })
+
+  it('renders no display control of its own in the row', () => {
+    renderMenu({ onExport: vi.fn(), display: <div>edge routing</div> })
+
+    expect(screen.queryByRole('button', { name: 'Display settings' })).toBeNull()
+  })
+})
+
+/**
+ * Bookmarking a point was reachable only while the History column was open,
+ * which is backwards: you decide a point is worth naming while you are
+ * working, not while you are reading the list. The row asks for one; the
+ * naming still happens beside the list, which is where an unnamed row would
+ * be indistinguishable from the checkpoint above it.
+ */
+describe('DocumentMenu — bookmark', () => {
+  it('has no Bookmark row when the keeper writes no history', async () => {
+    renderMenu({ onExport: vi.fn() })
+    await openMenu()
+
+    expect(screen.queryByText(/bookmark/i)).toBeNull()
+  })
+
+  it('asks for a bookmark', async () => {
+    const onBookmark = vi.fn()
+    renderMenu({ onExport: vi.fn(), onBookmark })
+    await openMenu()
+
+    fireEvent.pointerUp(screen.getByRole('menuitem', { name: 'Bookmark this point…' }))
+    await waitFor(() => expect(onBookmark).toHaveBeenCalledTimes(1))
   })
 })
 
@@ -69,7 +168,7 @@ describe('DocumentMenu — page-contributed entries', () => {
     await openMenu()
 
     const labels = screen.getAllByRole('menuitem').map((item) => item.textContent?.trim())
-    expect(labels).toEqual(['Export as PNG', 'Export as SVG', 'Delete'])
+    expect(labels).toEqual(['Export…', 'Delete'])
   })
 })
 

--- a/apps/web/src/components/workspace-top-bar/DocumentMenu.tsx
+++ b/apps/web/src/components/workspace-top-bar/DocumentMenu.tsx
@@ -1,22 +1,39 @@
-import { Download, EllipsisVertical } from 'lucide-react'
-import type { ReactNode, RefObject } from 'react'
+import { BookmarkPlus, Download, EllipsisVertical, SlidersHorizontal } from 'lucide-react'
+import { type ReactNode, type RefObject, useState } from 'react'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '../../components/ui/dropdown-menu.js'
 import { HEADER_BUTTON_CLASS } from '../../components/ui/header-button.js'
+import { Popover, PopoverAnchor, PopoverContent } from '../../components/ui/popover.js'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../components/ui/tooltip.js'
 import type { SceneExportFormat } from '../../hooks/useDocumentSync.js'
 
 interface DocumentMenuProps {
   /**
    * Already-wrapped export handler (the page owns the download and its error
-   * state through `useSceneExport`). Omitted hides the export entries rather
-   * than wiring controls to a capability the page has not set up.
+   * state through `useSceneExport`). Omitted hides the export entry rather
+   * than wiring a control to a capability the page has not set up.
    */
   readonly onExport?: (format: SceneExportFormat) => void
+  /**
+   * The canvas display panel, shown in a popover hung off this menu's own
+   * trigger. Omitted hides the row — a markdown document has no canvas to
+   * configure.
+   */
+  readonly display?: ReactNode
+  /**
+   * Asks for a bookmark: the page opens its History column with the naming
+   * field ready. Omitted hides the row — a keeper with no history has no
+   * list of points to name one in.
+   */
+  readonly onBookmark?: () => void
   /**
    * Lets a page's own dialog return focus to this trigger on close — the
    * menu item that opened it unmounted with the menu, so the default
@@ -41,6 +58,10 @@ interface DocumentMenuProps {
  * opened a different menu depending on the backend. ADR-0006 puts per-object
  * actions on the object, and the open document is one object.
  *
+ * Its bands follow ADR-0006's order: the properties band first (Display…),
+ * then the verbs, then whatever the page contributes, ending in its
+ * destructive entry.
+ *
  * Rename is deliberately absent: naming happens in place on the title field
  * (ADR-0006 point 3), and changing a document's PATH as well as its name is
  * the document browser's Rename dialog, where the tree the move affects is
@@ -53,39 +74,74 @@ interface DocumentMenuProps {
  * already handed out. Sharing returns when it is designed against the keeper
  * that has to honour it.
  */
-export function DocumentMenu({ onExport, triggerRef, children }: DocumentMenuProps) {
+export function DocumentMenu({
+  onExport,
+  display,
+  onBookmark,
+  triggerRef,
+  children,
+}: DocumentMenuProps) {
+  // The display panel is a popover rather than a submenu because its widgets
+  // are segmented controls a person adjusts several times in a row, and a
+  // menu closes on the first select. Opened from a row that unmounts with
+  // the menu, so it hangs off the trigger below instead.
+  const [displayOpen, setDisplayOpen] = useState(false)
   return (
-    <DropdownMenu>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <DropdownMenuTrigger asChild>
-            <button
-              ref={triggerRef}
-              type="button"
-              aria-label="More actions"
-              className={HEADER_BUTTON_CLASS}
-            >
-              <EllipsisVertical aria-hidden="true" className="size-4" />
-            </button>
-          </DropdownMenuTrigger>
-        </TooltipTrigger>
-        <TooltipContent>More actions</TooltipContent>
-      </Tooltip>
-      <DropdownMenuContent align="end">
-        {onExport && (
-          <>
-            <DropdownMenuItem onSelect={() => onExport('png')} className="gap-2">
-              <Download aria-hidden="true" className="size-3.5" />
-              Export as PNG
+    <Popover open={displayOpen} onOpenChange={setDisplayOpen}>
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverAnchor asChild>
+              <DropdownMenuTrigger asChild>
+                <button
+                  ref={triggerRef}
+                  type="button"
+                  aria-label="More actions"
+                  className={HEADER_BUTTON_CLASS}
+                >
+                  <EllipsisVertical aria-hidden="true" className="size-4" />
+                </button>
+              </DropdownMenuTrigger>
+            </PopoverAnchor>
+          </TooltipTrigger>
+          <TooltipContent>More actions</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="end">
+          {display !== undefined && (
+            <>
+              <DropdownMenuItem onSelect={() => setDisplayOpen(true)} className="gap-2">
+                <SlidersHorizontal aria-hidden="true" className="size-3.5" />
+                Display…
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+            </>
+          )}
+          {onExport && (
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger className="gap-2">
+                <Download aria-hidden="true" className="size-3.5" />
+                Export…
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                <DropdownMenuItem onSelect={() => onExport('png')}>Export as PNG</DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => onExport('svg')}>Export as SVG</DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          )}
+          {onBookmark && (
+            <DropdownMenuItem onSelect={onBookmark} className="gap-2">
+              <BookmarkPlus aria-hidden="true" className="size-3.5" />
+              Bookmark this point…
             </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => onExport('svg')} className="gap-2">
-              <Download aria-hidden="true" className="size-3.5" />
-              Export as SVG
-            </DropdownMenuItem>
-          </>
-        )}
-        {children}
-      </DropdownMenuContent>
-    </DropdownMenu>
+          )}
+          {children}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {display !== undefined && (
+        <PopoverContent data-testid="canvas-settings-menu" className="w-auto min-w-52 p-2">
+          {display}
+        </PopoverContent>
+      )}
+    </Popover>
   )
 }

--- a/apps/web/src/components/workspace-top-bar/DocumentMenu.tsx
+++ b/apps/web/src/components/workspace-top-bar/DocumentMenu.tsx
@@ -1,5 +1,5 @@
 import { BookmarkPlus, Download, EllipsisVertical, SlidersHorizontal } from 'lucide-react'
-import { type ReactNode, type RefObject, useState } from 'react'
+import { type ReactNode, type RefObject, useRef, useState } from 'react'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -85,7 +85,24 @@ export function DocumentMenu({
   // are segmented controls a person adjusts several times in a row, and a
   // menu closes on the first select. Opened from a row that unmounts with
   // the menu, so it hangs off the trigger below instead.
+  //
+  // It opens on the menu's CLOSE, not in the row's own handler, and the
+  // difference is the whole thing working: a menu returns focus to its
+  // trigger when it finishes closing, and a popover that opened in the
+  // meantime reads that as an interaction outside itself and dismisses.
+  // Measured in a real browser — popover present at 50ms and 150ms, gone by
+  // 400ms, focus back on the kebab. Synthetic pointer events skip the focus
+  // move, so every test stayed green over it.
   const [displayOpen, setDisplayOpen] = useState(false)
+  const openDisplayOnClose = useRef(false)
+  // The panel has an ANCHOR rather than a trigger, and Radix returns focus
+  // to a trigger — so without this a keyboard user who dismisses the panel
+  // falls to <body>. The kebab is what opened it, so the kebab takes it back.
+  const kebabRef = useRef<HTMLButtonElement | null>(null)
+  const setKebab = (node: HTMLButtonElement | null) => {
+    kebabRef.current = node
+    if (triggerRef !== undefined) triggerRef.current = node
+  }
   return (
     <Popover open={displayOpen} onOpenChange={setDisplayOpen}>
       <DropdownMenu>
@@ -94,7 +111,7 @@ export function DocumentMenu({
             <PopoverAnchor asChild>
               <DropdownMenuTrigger asChild>
                 <button
-                  ref={triggerRef}
+                  ref={setKebab}
                   type="button"
                   aria-label="More actions"
                   className={HEADER_BUTTON_CLASS}
@@ -106,10 +123,25 @@ export function DocumentMenu({
           </TooltipTrigger>
           <TooltipContent>More actions</TooltipContent>
         </Tooltip>
-        <DropdownMenuContent align="end">
+        <DropdownMenuContent
+          align="end"
+          onCloseAutoFocus={(event) => {
+            if (!openDisplayOnClose.current) return
+            openDisplayOnClose.current = false
+            // The panel takes focus itself; letting it go to the trigger
+            // first is exactly what dismissed the panel.
+            event.preventDefault()
+            setDisplayOpen(true)
+          }}
+        >
           {display !== undefined && (
             <>
-              <DropdownMenuItem onSelect={() => setDisplayOpen(true)} className="gap-2">
+              <DropdownMenuItem
+                onSelect={() => {
+                  openDisplayOnClose.current = true
+                }}
+                className="gap-2"
+              >
                 <SlidersHorizontal aria-hidden="true" className="size-3.5" />
                 Display…
               </DropdownMenuItem>
@@ -138,7 +170,14 @@ export function DocumentMenu({
         </DropdownMenuContent>
       </DropdownMenu>
       {display !== undefined && (
-        <PopoverContent data-testid="canvas-settings-menu" className="w-auto min-w-52 p-2">
+        <PopoverContent
+          data-testid="canvas-settings-menu"
+          className="w-auto min-w-52 p-2"
+          onCloseAutoFocus={(event) => {
+            event.preventDefault()
+            kebabRef.current?.focus()
+          }}
+        >
           {display}
         </PopoverContent>
       )}

--- a/apps/web/src/header-button-surface.test.ts
+++ b/apps/web/src/header-button-surface.test.ts
@@ -41,7 +41,6 @@ const HEADER_SURFACES: Record<string, number> = {
   './components/WorkspaceTopBar.tsx': 2,
   './components/workspace-top-bar/DocumentMenu.tsx': 1,
   './components/document-properties/DocumentProperties.tsx': 1,
-  './components/spatial-editor/CanvasDisplaySettings.tsx': 1,
   './components/annotations/CommentsRailChrome.tsx': 1,
   './components/connections/ConnectionsChip.tsx': 1,
   './components/document-editor/InspectorPanel.tsx': 1,

--- a/apps/web/src/pages/BrowserDocumentPage.export.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.export.browser.test.tsx
@@ -71,6 +71,10 @@ async function openExportMenuItem(label: string): Promise<HTMLElement> {
     const kebab = allKebabs[allKebabs.length - 1]!
     fireEvent.pointerDown(kebab, { button: 0, ctrlKey: false })
     try {
+      // The formats sit behind one `Export…` row now; Radix opens a submenu
+      // on pointerMove over its trigger (hover intent).
+      const triggers = await waitFor(() => screen.getAllByText('Export…'), { timeout: 1500 })
+      fireEvent.pointerMove(triggers[triggers.length - 1]!, { pointerType: 'mouse' })
       const allItems = await waitFor(() => screen.getAllByText(label), { timeout: 1500 })
       item = allItems[allItems.length - 1]!
     } catch {
@@ -156,6 +160,9 @@ describe('BrowserDocumentPage export (browser — real SpatialEditor, no Excalid
       button: 0,
       ctrlKey: false,
     })
+    // Open the formats submenu: what this asserts is about the formats
+    // OFFERED, so it has to look where they are.
+    fireEvent.pointerMove(await screen.findByText('Export…'), { pointerType: 'mouse' })
     await waitFor(() => expect(screen.getByText('Export as PNG')).toBeInTheDocument())
 
     expect(screen.queryByText(/excalidraw/i)).toBeNull()

--- a/apps/web/src/pages/BrowserDocumentPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.markdown.browser.test.tsx
@@ -127,6 +127,22 @@ async function expectTitleValue(expected: string): Promise<void> {
   )
 }
 
+/**
+ * The document's ⋯. Radix opens it on pointerDown, so `userEvent.click`
+ * (which sends the whole down-up pair) both opens and immediately dismisses.
+ */
+async function openDocumentMenu(): Promise<void> {
+  const trigger = await screen.findByRole('button', { name: 'More actions' })
+  trigger.dispatchEvent(
+    new PointerEvent('pointerdown', { bubbles: true, cancelable: true, button: 0 }),
+  )
+}
+
+const displayRow = () =>
+  [...document.querySelectorAll('[role="menuitem"]')].find(
+    (item) => item.textContent?.trim() === 'Display…',
+  )
+
 describe('BrowserDocumentPage markdown 導線 (real IndexedDB)', () => {
   beforeEach(async () => {
     await clearWhiteboardDb()
@@ -237,14 +253,16 @@ describe('BrowserDocumentPage markdown 導線 (real IndexedDB)', () => {
     )
   })
 
-  it('a markdown canvas has no display-settings gear — edge routing is spatial-only', async () => {
+  it('a markdown canvas has no Display row — edge routing is spatial-only', async () => {
     const spatialStore = new IdbDocumentIndex()
     const spatial = render(<BrowserDocumentPage store={spatialStore} />)
 
-    // A spatial canvas is where the gear is offered.
+    // A spatial canvas is where the row is offered. It lives in the
+    // document's ⋯ now, so reaching it means opening that.
     await screen.findByTestId('mock-spatial-editor')
+    await openDocumentMenu()
     await waitFor(() => {
-      expect(document.querySelector('[data-testid="canvas-settings-button"]')).not.toBeNull()
+      expect(displayRow()).toBeDefined()
     })
     spatial.unmount()
 
@@ -256,8 +274,12 @@ describe('BrowserDocumentPage markdown 導線 (real IndexedDB)', () => {
     })
 
     // Edge routing has no meaning for a document with no spatial scene —
-    // the gear must not carry over; the rest of the canvas row does.
-    expect(document.querySelector('[data-testid="canvas-settings-button"]')).toBeNull()
+    // the row must not carry over; the rest of the canvas row does.
+    await openDocumentMenu()
+    await waitFor(() => {
+      expect(document.querySelector('[role="menu"]')).not.toBeNull()
+    })
+    expect(displayRow()).toBeUndefined()
     // The rest of the row does carry over: the hidden persistence fact rides
     // the same slot the spatial row uses.
     expect(document.querySelector('[data-testid="persistence-state"]')).toBeTruthy()

--- a/apps/web/src/pages/BrowserDocumentPage.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.test.tsx
@@ -436,8 +436,10 @@ describe('BrowserDocumentPage', () => {
     // No link handout: a document kept in this browser is reachable from no
     // other browser, so a link is a promise this keeper cannot honour.
     expect(screen.queryByText(/copy link/i)).toBeNull()
-    expect(await documentOpsItem(/export as png/i)).toBeTruthy()
-    expect(await documentOpsItem(/export as svg/i)).toBeTruthy()
+    // ONE export row; the formats sit behind it (DocumentMenu's submenu),
+    // so what this page owns is that the row is HERE and nowhere else.
+    expect(await documentOpsItem(/^export…$/i)).toBeTruthy()
+    expect(screen.queryByText(/export as png/i)).toBeNull()
     expect(await documentOpsItem(/duplicate/i)).toBeTruthy()
     expect(await documentOpsItem(/^delete$/i)).toBeTruthy()
   })
@@ -485,8 +487,9 @@ describe('BrowserDocumentPage', () => {
     const fact = screen.getByTestId('persistence-state')
     expect(fact.hidden).toBe(true)
     expect(fact.getAttribute('data-save-state')).toBe('saved')
-    // A spatial canvas offers its display settings from the same row.
-    expect(screen.getByRole('button', { name: 'Display settings' })).toBeTruthy()
+    // A spatial canvas offers its display settings from the row's ⋯, not
+    // from a gear of its own — see DocumentMenu's leading band.
+    expect(screen.queryByRole('button', { name: 'Display settings' })).toBeNull()
     // The whole cluster lives inside the canvas row (DocumentProperties) —
     // the dot LEFT of the title, the rare operations behind one kebab at
     // the right edge — not in a second header strip of its own.

--- a/apps/web/src/pages/DaemonDocumentPage.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.test.tsx
@@ -225,13 +225,14 @@ describe('DaemonDocumentPage', () => {
     expect(createdBackends[0]?.connectCount).toBe(1)
   })
 
-  it('offers the canvas display settings gear, so plugin canvasSettings are reachable here too', async () => {
+  it('offers the canvas display settings row, so plugin canvasSettings are reachable here too', async () => {
     // The source scan in file-seam-conformance.test.ts asserts the PROP is
     // written; this asserts the surface actually appears, which is what a
     // reader of the scan cannot tell. `CanvasDisplaySettings` owns the
     // `canvasSettings` contribution point — `visual.edges/v0` is contributed
     // there today — and only the browser page placed it, so those settings
-    // were unreachable in daemon mode with nothing failing.
+    // were unreachable in daemon mode with nothing failing. Both pages now
+    // reach them through the shared page's ⋯.
     await act(async () => {
       render(
         <DaemonDocumentPage daemonBaseUrl={DAEMON_BASE_URL} createBackend={makeCreateBackend()} />,
@@ -240,7 +241,10 @@ describe('DaemonDocumentPage', () => {
     })
 
     await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
-    expect(screen.getByTestId('canvas-settings-button')).toBeTruthy()
+    // Reached through the document's ⋯ now, not a gear of its own — the
+    // leading `Display…` row. Radix opens the menu on pointerDown.
+    fireEvent.pointerDown(screen.getByLabelText('More actions'), { button: 0, ctrlKey: false })
+    expect(await screen.findByRole('menuitem', { name: 'Display…' })).toBeTruthy()
   })
 
   it('shows the Connections chip with the backlink count and switches to a source on click', async () => {

--- a/apps/web/src/pages/DocumentPage.tsx
+++ b/apps/web/src/pages/DocumentPage.tsx
@@ -87,17 +87,24 @@ export function DocumentPage({ model }: { model: DocumentPageModel }) {
   const toggleInspector = (kind: InspectorKind) =>
     setInspector((open) => (open === kind ? null : kind))
   const setCommentsOpen = useCallback((open: boolean) => setInspector(open ? 'comments' : null), [])
-  // Bumped by ⌘/Ctrl+S to open the column with its naming field ready. The
-  // chord asks for a bookmark now; it does not take one.
+  // Bumped by whoever asks for a bookmark (see requestBookmark below), which
+  // opens the column with its naming field ready. Nothing here takes one.
   const [bookmarkArmed, setBookmarkArmed] = useState(0)
   // The past state the person is LOOKING at, drawn in place of the editor.
   // Read-only by construction — see DocumentPreview — so "look, then decide"
   // cannot turn into an edit against a state that is not the document's.
   const [preview, setPreview] = useState<VersionPreviewSession | null>(null)
-  useBookmarkShortcut(versions.enabled, () => {
+  // Asking for a bookmark opens the History column with its naming field
+  // ready — the naming is the whole value, and a row named nothing is
+  // indistinguishable from the automatic checkpoint above it, so it happens
+  // beside the list rather than in the chrome. Two routes reach it: the
+  // ⌘/Ctrl+S chord, which no longer saves anything by itself, and the
+  // document's ⋯ menu, which is what a finger has.
+  const requestBookmark = useCallback(() => {
     setInspector('history')
     setBookmarkArmed((n) => n + 1)
-  })
+  }, [])
+  useBookmarkShortcut(versions.enabled, requestBookmark)
 
   // SCOPE RESET — see scoped-screen-state.test.ts. Everything above but the
   // inspector slot names a document, and none of it may outlive the document
@@ -223,6 +230,15 @@ export function DocumentPage({ model }: { model: DocumentPageModel }) {
       )}
       <DocumentMenu
         onExport={(format) => void handleExport(format)}
+        // Canvas-level display settings, gated on kind the same way the
+        // facet disclosure is: a markdown document has no canvas to
+        // configure. They live in the menu's leading band rather than as a
+        // gear of their own — the row's only VIEW control, against width
+        // the title wanted.
+        {...(documentKind === 'spatial'
+          ? { display: <CanvasDisplaySettings canvas={sync.canvas} onChange={sync.onChange} /> }
+          : {})}
+        {...(versions.enabled ? { onBookmark: requestBookmark } : {})}
         {...(model.slots.menuTriggerRef === undefined
           ? {}
           : { triggerRef: model.slots.menuTriggerRef })}
@@ -342,14 +358,6 @@ export function DocumentPage({ model }: { model: DocumentPageModel }) {
                           : { facets: model.properties.facets })}
                         propertiesOpen={inspector === 'properties'}
                         onToggleProperties={() => toggleInspector('properties')}
-                        // Canvas-level display settings, gated on kind the
-                        // same way the facet disclosure is: a markdown
-                        // document has no canvas to configure.
-                        settings={
-                          documentKind === 'spatial' ? (
-                            <CanvasDisplaySettings canvas={sync.canvas} onChange={sync.onChange} />
-                          ) : undefined
-                        }
                         // No save state in the row: the shell mark answers
                         // for the keeper, and only when there is a condition.
                         {...(model.properties.status === undefined

--- a/apps/web/src/pages/file-seam-conformance.test.ts
+++ b/apps/web/src/pages/file-seam-conformance.test.ts
@@ -66,7 +66,8 @@ async function read(page: string): Promise<string> {
  *
  * Measured when this was added: `resolveFacetContributions(bundledFacetRegistry,
  * 'canvasSettings')` answers one group — `visual` contributing
- * `visual.edges/v0` — and only BrowserDocumentPage rendered the gear. A grep
+ * `visual.edges/v0` — and only BrowserDocumentPage rendered it (a gear of its
+ * own then; the document's ⋯ opens it now, from the shared page). A grep
  * for the string `canvasSettings` in plugin-visual finds nothing, because the
  * contribution is declared through the facet definition rather than spelled
  * at a call site; resolving the registry is what shows it is real.


### PR DESCRIPTION
## Summary

P5 of the header retune (P1 #1393, P2 #1398, P3 #1401, P4 #1410). The kebab's contents follow ADR-0006's band order now, and two affordances that lived elsewhere move into it.

- **`Display…` leads the menu.** `CanvasDisplaySettings` had a gear of its own in the document row — the row's only VIEW control, one icon for one plugin's edge routing, against width the title wanted. It is a panel now; the ⋯ hangs it in a popover anchored on its own trigger, because the row that opens it unmounts with the menu. A popover rather than a submenu: the widgets are segmented controls a person adjusts several times in a row, and a menu closes on the first select. `DocumentProperties` loses its `settings` slot, so the row has no way to take a display control back.
- **`Export…` is one row**, with PNG and SVG behind it. Two sibling rows made the menu's length a function of how many formats exist, and a format is not a different act — it is the same act, parameterised.
- **`Bookmark this point…` is new here.** It was reachable only while the History column was open, which is backwards: you decide a point is worth naming while you are working. The row calls the same `requestBookmark` the ⌘/Ctrl+S chord does, so the naming still happens beside the list of points.

`ui/dropdown-menu` gains Sub/SubTrigger/SubContent and `ui/popover` gains Anchor for the two shapes above.

## The defect the tests could not see

Found by driving the running app, not by a test: selecting `Display…` opened the panel and then lost it.

| after clicking `Display…` | popover in DOM | menus | focus |
|---|---|---|---|
| 50ms | 1 | 1 | (popover) |
| 150ms | 1 | 0 | More actions |
| 400ms+ | **0** | 0 | More actions |

A menu returns focus to its trigger when it finishes closing, and the popover — having just taken focus — reads that as an interaction outside itself and dismisses. So the panel opens on the menu's **close** (`onCloseAutoFocus`, with the focus return prevented because the panel takes focus itself). A second, related one: the panel has an anchor and no trigger, so Radix had nothing to hand focus back to on dismissal either, and a keyboard user fell to `<body>`. The kebab takes it.

Every test stayed green over both, for the same reason: `fireEvent.pointerDown`/`pointerUp` drive Radix's menu correctly but skip the focus movement, which is the whole mechanism. `canvas-settings.browser.test.tsx` uses real clicks now and waits for where focus **comes to rest** rather than for the panel to appear — a `waitFor(panel exists)` is satisfied by the transient open and reads exactly like a pass. Mutation-checked: reverting either half fails it (5/5 red on the first, 1/5 on the second).

## Test plan

- [x] New or updated `web-browser` tests added
- [x] `pnpm test` passes locally (see Gates)
- [x] Manual verification completed (below)
- [ ] E2E coverage added or extended where applicable — the flow is component-plus-menu, which browser mode covers

**Red first**, in `DocumentMenu.test.tsx` (jsdom): one Export row with the formats hidden until it opens, `Display…` leading the band, the panel opening from that row, `onBookmark`. 8 failing before the change. The band order is mutation-checked — moving `Display…` after `Export…` fails that one case and nothing else.

**A third thing the targeted run missed and the project run caught**: `BrowserDocumentPage.export.browser.test.tsx` still clicked `Export as PNG`/`SVG` straight out of the kebab. `pnpm vitest run --project web-browser` (whole project) is what found it; the changed-files run was green. Fixed in its own commit.

**Manual verification** — local vite, Playwright, desktop 1280×800 and iPhone 13, identical on both:

| | result |
|---|---|
| `Display settings` gear in the row | 0 |
| menu contents | `Display…`, `Export…`, `Bookmark this point…`, `Copy as JSON Canvas`, `Duplicate`, `Delete` |
| `Display…` → panel + `Edge routing` | present |
| `Export…` → submenu | `Export as PNG`, `Export as SVG` |
| `Bookmark this point…` | opens the History column with the naming field focused |

## Visual evidence

Same device (iPhone 13), same canvas, main vs this branch, ⋯ open, composed with `compose-figure.mjs` (digests `4545faee` / `f663660a`). Before: a sliders gear beside the title and two Export rows. After: no gear, `Display…` in its own leading band, one `Export…` with a submenu chevron, `Bookmark this point…` added. `gh` is unavailable in this environment, so the figure was handed to the author directly rather than attached here.

## Gates

`pnpm check:local` exit 0 · web-jsdom for the touched files 114/114 across 5 fresh-process runs · `web-browser` whole project **1133/1133** · 5 fresh-process runs each of `canvas-settings` / `edge-routing` / `DocumentMenu.browser` (12/12) and `BrowserDocumentPage.export` (3/3) · `pnpm knip` clean.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [ ] Docs updated — the header's four-role rule and this band order are P6's increment, which is what DESIGN.md is waiting for
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_