### PR TITLE
fix(web): the exit-fullscreen control takes the corner where the width allows

### DIFF
--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -229,12 +229,23 @@ export function AppShell({ daemon, onWorkInBrowser, workspaces }: AppShellProps)
     // band that genuinely IS the full width. Left, since the canvas keeps its
     // overview at bottom-right.
     //
-    // Lifted 70px because the bottom edge is where the editing surfaces keep a
-    // strip: the canvas dock's own 0.75rem offset, its 46px, and the gap
-    // again. That dock is content-sized and centred, so its left edge walks
-    // toward the corner as the viewport narrows — x=33 at 360px CSS, against
-    // this control's 12..48. One offset also clears the markdown formatting
-    // bar (44px), so no page has to say anything about it.
+    // The corner is the default, and the lift is the exception, because the
+    // bottom edge is also where the editing surfaces keep a strip. The canvas
+    // dock is centred, so its left edge walks toward the corner only as the
+    // viewport narrows: below 407px it reaches this control, and above it the
+    // dock is nowhere near — where a control floating a strip's height up,
+    // with empty space beneath it, reads as unanchored rather than as placed.
+    //
+    // 407 is arithmetic, not taste. The dock is centred at 295px, so its left
+    // edge is (vw - 295) / 2; this control spans 12..44; 8px of clearance
+    // wants vw >= 295 + 112. `declares a corner breakpoint that still clears
+    // the dock` reads the number back out of this class and re-measures it
+    // against the real dock, so widening the dock fails there rather than on
+    // someone's phone.
+    //
+    // 70px is that strip: the dock's own 0.75rem offset, its 46px, and the gap
+    // again. It clears the markdown formatting bar (44px) too, so no page has
+    // to say anything about either.
     return (
       <button
         ref={exitFullscreenRef}
@@ -244,7 +255,7 @@ export function AppShell({ daemon, onWorkInBrowser, workspaces }: AppShellProps)
         onClick={fullscreen.toggle}
         className={cn(
           HEADER_BUTTON_CLASS,
-          'fixed bottom-[calc(70px+env(safe-area-inset-bottom))] left-[calc(0.75rem+env(safe-area-inset-left))] z-50 border bg-background/80 shadow-sm backdrop-blur',
+          'fixed bottom-[calc(0.75rem+env(safe-area-inset-bottom))] max-[407px]:bottom-[calc(70px+env(safe-area-inset-bottom))] left-[calc(0.75rem+env(safe-area-inset-left))] z-50 border bg-background/80 shadow-sm backdrop-blur',
         )}
       >
         <Minimize2 aria-hidden="true" className="size-4" />

--- a/apps/web/src/pages/BrowserDocumentPage.fullscreen.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.fullscreen.browser.test.tsx
@@ -148,3 +148,65 @@ it('does not collide with the canvas dock at a phone width', async () => {
   const overlaps = a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom
   expect(overlaps, `exit ${JSON.stringify(a)} vs dock ${JSON.stringify(b)}`).toBe(false)
 })
+
+/** Puts the shell into fullscreen without the real API, which would pin the
+ *  viewport to the screen — and the viewport width is the variable here. */
+async function enterStubbedFullscreen(): Promise<HTMLElement> {
+  Object.defineProperty(document, 'fullscreenElement', {
+    configurable: true,
+    get: () => document.documentElement,
+  })
+  await act(async () => {
+    document.dispatchEvent(new Event('fullscreenchange'))
+  })
+  return await screen.findByRole('button', { name: 'Exit fullscreen' })
+}
+
+function rectsOverlap(a: DOMRect, b: DOMRect): boolean {
+  return a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom
+}
+
+/** The breakpoint as the control itself declares it, so this guard follows a
+ *  change to the declaration instead of pinning a second copy of the number. */
+function declaredCornerBreakpoint(control: HTMLElement): number {
+  const match = /max-\[(\d+)px\]/.exec(control.className)
+  expect(match, `no max-[Npx] variant in: ${control.className}`).not.toBeNull()
+  return Number((match as RegExpExecArray)[1])
+}
+
+// Lifting the control clear of the dock is only needed while the dock is near
+// the corner. On a wide screen it is nowhere near, and a control floating 70px
+// up with empty space beneath it reads as unanchored — reported from a landscape
+// device. So the lift is a narrow-width variant, and the corner is the default.
+it('takes the corner where the width allows', async () => {
+  await page.viewport(1280, 800)
+  await renderLoaded()
+  const exit = await enterStubbedFullscreen()
+
+  const control = exit.getBoundingClientRect()
+  // Within a gutter of the bottom-left corner, not a strip's height above it.
+  expect(window.innerHeight - control.bottom).toBeLessThan(24)
+  expect(control.left).toBeLessThan(24)
+})
+
+// The number in that variant is not free: below it the centred dock reaches the
+// corner. Measured at the breakpoint the control ITSELF declares, so changing
+// the declaration moves this guard with it — and widening the dock without
+// moving the breakpoint fails here rather than on someone's phone.
+it('declares a corner breakpoint that still clears the dock', async () => {
+  await page.viewport(1280, 800)
+  await renderLoaded()
+  const exit = await enterStubbedFullscreen()
+  const breakpoint = declaredCornerBreakpoint(exit)
+
+  await page.viewport(breakpoint, 780)
+  await act(async () => {})
+
+  const dock = document.querySelector('[data-testid="tool-palette"]')
+  expect(dock, 'the canvas dock must be on screen for this to mean anything').not.toBeNull()
+  const a = exit.getBoundingClientRect()
+  const b = (dock as HTMLElement).getBoundingClientRect()
+  // Still in corner mode at exactly the breakpoint — and still clear of the dock.
+  expect(window.innerHeight - a.bottom).toBeLessThan(24)
+  expect(rectsOverlap(a, b), `exit ${JSON.stringify(a)} vs dock ${JSON.stringify(b)}`).toBe(false)
+})


### PR DESCRIPTION
Follow-up to #1404, which moved the exit-fullscreen control to the bottom edge (the only one a camera cannot reach) and lifted it 70px so it would clear the canvas dock.

**The lift was unconditional, and it should not have been.** On a wide screen the dock is nowhere near the corner, so the control floats a strip's height up with empty space beneath it — unanchored rather than placed. Reported from a landscape device:

The corner becomes the default; the lift becomes a narrow-width variant.

```
bottom-[calc(0.75rem+env(safe-area-inset-bottom))]              # the corner
max-[407px]:bottom-[calc(70px+env(safe-area-inset-bottom))]     # clear of the dock
```

## 407 is arithmetic, not taste

The dock is centred at 295px, so its left edge is `(vw - 295) / 2`. This control spans `12..44`. Eight pixels of clearance wants `vw >= 295 + 112`.

| viewport | dock left | control | mode |
|---|---|---|---|
| 360 | 33 | 12..44 | lifted |
| **407** | **56** | 12..44 | corner, 12px clear |
| 1280 | 493 | 12..44 | corner |

## The number is not left on trust

`declares a corner breakpoint that still clears the dock` **reads the breakpoint back out of the control's own class list** and re-measures at that width against the real dock:

```ts
const breakpoint = declaredCornerBreakpoint(exit)   // parses max-[Npx] from className
await page.viewport(breakpoint, 780)
expect(rectsOverlap(controlRect, dockRect)).toBe(false)
```

So the guard follows a change to the declaration instead of pinning a second copy of the number — and widening the dock without moving the breakpoint fails here rather than on someone's phone.

Mutation-checked:

| mutation | result |
|---|---|
| drop the `max-[407px]` variant | both new tests fail (`no max-[Npx] variant in: …`, and the 360px overlap returns) |
| set the breakpoint to `360` | the guard fails: `exit {left:12,right:44} vs dock {left:32.5,…}: expected true to be false` |

The second is the one that matters — it proves the guard re-measures rather than echoing the number back.

## A correction to the filed issue

The issue said the threshold was not a constant because the dock is content-sized and varies by document capability. **That was wrong.** Every button in the dock's row is unconditional and `paletteLeading` is always supplied (`HistoryCluster`, two fixed buttons), so 295px is a constant in production. The conditional entries I had read are in the add **menu**, not the row.

The guard still earns its keep — as an assertion rather than an assumption — but the slice is smaller than the issue described, and there is no "widest configuration" to enumerate.

## Verification

```
vitest --project web-browser --project canvas-viewer-browser --project canvas-render-browser
  --exclude '**/BrowserDocumentPage.markdown.browser.test.tsx'   219 files, 1149 passed
pnpm --filter @kamiazya/whiteboard-web typecheck                 clean
```

The excluded file holds a Loro panic (`Index out of bound. The given pos is 1, but the length is 0` at `crates/loro-internal/src/handler.rs:2054`) whose unhandled rejection closes the vitest browser connection and can abort the run with no test-level failure to point at. Reproduced on clean `origin/main`; filed separately, unrelated to this branch.

## Visual evidence: none — the change is a viewport-width variant, and both states are already asserted numerically

Two panels would differ only by a 58px vertical offset of one 32px button, which the table above states exactly and the tests measure at three widths. `env(safe-area-inset-*)` still resolves to `0px` on every renderer here, so the safe-area half of the declaration cannot be pictured at all.
