### PR TITLE
refactor(web): the daemon keeper reaches its branches through the seam, and the seam has a contract

### DIFF
--- a/apps/web/src/lib/branches-backend.contract.test.ts
+++ b/apps/web/src/lib/branches-backend.contract.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment node
+/**
+ * The branches contract, run against every keeper the seam has.
+ *
+ * The daemon keeper's CLIENT runs against an in-memory stand-in for its
+ * routes. What that proves and what it does not, said plainly (the same
+ * caveat `versions-backend.contract.browser.test.tsx` carries): the daemon's
+ * real branch behaviour — tips recorded against the workspace record, the
+ * compaction pin, merge as tip adoption — is pinned where it lives, in
+ * `mcp-node`, against the real routes and the real store. What is untested
+ * anywhere else, and is exactly what this run adds, is that the client half
+ * translates faithfully: that `create` sends the colour and reads the row
+ * back out of the response, that `setHead` reports the head it left, that
+ * `loadDocument` turns a 404 into `null` rather than a throw.
+ *
+ * The browser keeper has no branches yet and runs the branchless half.
+ */
+import type { BranchMeta } from '@kamiazya/whiteboard-daemon-client/api-contracts/index'
+import { describe } from 'vitest'
+import {
+  type BranchesBackendHarness,
+  branchesBackendContract,
+  branchlessBackendContract,
+} from './branches-backend.contract.js'
+import { createBrowserBranchesBackend, createDaemonBranchesBackend } from './branches-backend.js'
+
+function daemonHarness(): BranchesBackendHarness {
+  const main: BranchMeta = {
+    name: 'main',
+    tipFrontiers: '',
+    color: '#888',
+    createdAt: '2026-01-01T00:00:00.000Z',
+  }
+  const branches: BranchMeta[] = [main]
+  let head = 'main'
+
+  const json = (body: unknown, status = 200): Response =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  const bodyOf = (init?: RequestInit): Record<string, unknown> =>
+    typeof init?.body === 'string' ? (JSON.parse(init.body) as Record<string, unknown>) : {}
+  const named = (segment: string): string => decodeURIComponent(segment)
+
+  const routes = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+    const method = init?.method ?? 'GET'
+
+    const stats = url.match(/\/branches\/([^/]+)\/stats$/)
+    if (stats) {
+      const name = named(stats[1] as string)
+      if (!branches.some((b) => b.name === name)) return json({ error: 'not_found' }, 404)
+      return json({ unmergedCommits: 0, isHead: head === name })
+    }
+
+    const merge = url.match(/\/branches\/([^/]+)\/merge$/)
+    if (merge && method === 'POST') {
+      const source = named(merge[1] as string)
+      const { into, dryRun } = bodyOf(init) as { into: string; dryRun?: boolean }
+      if (!branches.some((b) => b.name === source) || !branches.some((b) => b.name === into)) {
+        return json({ error: 'not_found' }, 404)
+      }
+      const counts = { elementCount: 0 }
+      return json({
+        badges: [],
+        preview: counts,
+        target: counts,
+        source: counts,
+        ...(dryRun === true ? {} : { committed: counts }),
+      })
+    }
+
+    const documentRoute = url.match(/\/branches\/([^/]+)\/document$/)
+    if (documentRoute) {
+      const name = named(documentRoute[1] as string)
+      if (!branches.some((b) => b.name === name)) return json({ error: 'not_found' }, 404)
+      return json({ kind: 'spatial', canvas: { nodes: [], edges: [] } })
+    }
+
+    if (url.endsWith('/head') && method === 'PUT') {
+      const { branch } = bodyOf(init) as { branch: string }
+      if (!branches.some((b) => b.name === branch)) return json({ error: 'not_found' }, 404)
+      const previousHead = head
+      head = branch
+      return json({ head, previousHead })
+    }
+
+    const one = url.match(/\/branches\/([^/]+)$/)
+    if (one) {
+      const name = named(one[1] as string)
+      const at = branches.findIndex((b) => b.name === name)
+      if (at === -1) return json({ error: 'not_found' }, 404)
+      if (method === 'DELETE') {
+        branches.splice(at, 1)
+        return json({ ok: true, unmergedCommits: 0 })
+      }
+      if (method === 'PATCH') {
+        const next = bodyOf(init) as { name: string }
+        const renamed = { ...(branches[at] as BranchMeta), name: next.name }
+        branches[at] = renamed
+        if (head === name) head = next.name
+        return json({ branch: renamed, renamedVersionCount: 0 })
+      }
+    }
+
+    if (url.endsWith('/branches')) {
+      if (method === 'POST') {
+        const args = bodyOf(init) as { name: string; color?: string }
+        const made: BranchMeta = {
+          name: args.name,
+          tipFrontiers: '',
+          baseBranch: head,
+          color: args.color ?? '#123',
+          createdAt: '2026-01-02T00:00:00.000Z',
+        }
+        branches.push(made)
+        return json({ branch: made })
+      }
+      return json({ branches, head })
+    }
+
+    return json({ error: `unrouted ${method} ${url}` }, 500)
+  }
+
+  return {
+    backend: createDaemonBranchesBackend(routes as typeof fetch),
+    workspaceId: 'w1',
+    path: 'notes/canvas-a',
+    cleanup: async () => {},
+  }
+}
+
+describe('branches contract', () => {
+  describe('daemon keeper (client over an in-memory stand-in for its routes)', () => {
+    branchesBackendContract(daemonHarness)
+  })
+
+  describe('browser keeper (no branches yet)', () => {
+    branchlessBackendContract(createBrowserBranchesBackend)
+  })
+})

--- a/apps/web/src/lib/branches-backend.contract.ts
+++ b/apps/web/src/lib/branches-backend.contract.ts
@@ -1,0 +1,184 @@
+import { expect, it } from 'vitest'
+import type { BranchesBackend } from './branches-backend.js'
+import { BranchesUnsupportedError } from './branches-backend.js'
+
+/**
+ * The behavioural contract a `BranchesBackend` with branches must satisfy,
+ * written once and run against each keeper that has them.
+ *
+ * Today that is the daemon alone, so this file pins what a caller of the seam
+ * is entitled to rely on before a second keeper exists — the shape the
+ * browser keeper will have to answer when it grows branches, rather than the
+ * shape it happens to grow. Same reasoning as `versions-backend.contract.ts`:
+ * a behaviour one keeper gets wrong is only caught if somebody thought to
+ * write that case in that keeper's file, and a feature the other keeper never
+ * gets is an absent test rather than a failing one. This contract is the
+ * first half; `keeper-parity.test.ts` is the ledger for the second.
+ *
+ * Cases are keeper-independent — no assertion about which route is called or
+ * which row is written. `main` is the one name every keeper has to know: it
+ * is the default variation (ADR-0022), the one with no name to put in an
+ * address, and the head a document has before anybody makes a branch.
+ */
+export interface BranchesBackendHarness {
+  backend: BranchesBackend
+  workspaceId: string
+  path: string
+  cleanup(): Promise<void>
+}
+
+export function branchesBackendContract(
+  create: () => BranchesBackendHarness | Promise<BranchesBackendHarness>,
+): void {
+  it('declares that it has branches', async () => {
+    const h = await create()
+    try {
+      expect(h.backend.hasBranches).toBe(true)
+    } finally {
+      await h.cleanup()
+    }
+  })
+
+  it('answers main as the resting head before any branch is made', async () => {
+    const h = await create()
+    try {
+      const state = await h.backend.list(h.workspaceId, h.path)
+      expect(state.head).toBe('main')
+      expect(state.branches.map((b) => b.name)).toContain('main')
+    } finally {
+      await h.cleanup()
+    }
+  })
+
+  it('lists a created branch with the colour it was given, and leaves HEAD where it was', async () => {
+    const h = await create()
+    try {
+      const made = await h.backend.create(h.workspaceId, h.path, { name: 'idea', color: '#abc' })
+      expect(made.name).toBe('idea')
+
+      const state = await h.backend.list(h.workspaceId, h.path)
+      // The row `create` answered is the row `list` shows.
+      expect(state.branches.find((b) => b.name === 'idea')?.color).toBe('#abc')
+      // Making a variation is not switching to it.
+      expect(state.head).toBe('main')
+    } finally {
+      await h.cleanup()
+    }
+  })
+
+  it('switches HEAD, naming the head it left, and the list agrees', async () => {
+    const h = await create()
+    try {
+      await h.backend.create(h.workspaceId, h.path, { name: 'idea' })
+      const switched = await h.backend.setHead(h.workspaceId, h.path, 'idea')
+      expect(switched).toEqual({ head: 'idea', previousHead: 'main' })
+      expect((await h.backend.list(h.workspaceId, h.path)).head).toBe('idea')
+    } finally {
+      await h.cleanup()
+    }
+  })
+
+  it('renames a branch in place: the old name is gone and the new one is listed', async () => {
+    const h = await create()
+    try {
+      await h.backend.create(h.workspaceId, h.path, { name: 'idea' })
+      const renamed = await h.backend.rename(h.workspaceId, h.path, 'idea', 'plan')
+      expect(renamed.branch.name).toBe('plan')
+
+      const names = (await h.backend.list(h.workspaceId, h.path)).branches.map((b) => b.name)
+      expect(names).toContain('plan')
+      expect(names).not.toContain('idea')
+    } finally {
+      await h.cleanup()
+    }
+  })
+
+  it('says which branch is HEAD in its stats', async () => {
+    const h = await create()
+    try {
+      await h.backend.create(h.workspaceId, h.path, { name: 'idea' })
+      await h.backend.setHead(h.workspaceId, h.path, 'idea')
+      expect((await h.backend.getStats(h.workspaceId, h.path, 'idea')).isHead).toBe(true)
+      expect((await h.backend.getStats(h.workspaceId, h.path, 'main')).isHead).toBe(false)
+    } finally {
+      await h.cleanup()
+    }
+  })
+
+  it('a dry-run merge answers a preview and changes nothing', async () => {
+    const h = await create()
+    try {
+      await h.backend.create(h.workspaceId, h.path, { name: 'idea' })
+      const before = await h.backend.list(h.workspaceId, h.path)
+
+      const preview = await h.backend.merge(h.workspaceId, h.path, 'idea', {
+        into: 'main',
+        dryRun: true,
+      })
+      // Badges are advisory (a CRDT merge never fails), so the answer is a
+      // list, possibly empty, never an absence.
+      expect(Array.isArray(preview.badges)).toBe(true)
+      expect(preview.committed).toBeUndefined()
+
+      expect(await h.backend.list(h.workspaceId, h.path)).toEqual(before)
+    } finally {
+      await h.cleanup()
+    }
+  })
+
+  it('answers null for a variation that is not there, rather than throwing', async () => {
+    const h = await create()
+    try {
+      expect(await h.backend.loadDocument(h.workspaceId, h.path, 'nowhere')).toBeNull()
+    } finally {
+      await h.cleanup()
+    }
+  })
+
+  it('takes a removed branch off the list', async () => {
+    const h = await create()
+    try {
+      await h.backend.create(h.workspaceId, h.path, { name: 'idea' })
+      const removed = await h.backend.remove(h.workspaceId, h.path, 'idea')
+      expect(removed.ok).toBe(true)
+      expect(
+        (await h.backend.list(h.workspaceId, h.path)).branches.map((b) => b.name),
+      ).not.toContain('idea')
+    } finally {
+      await h.cleanup()
+    }
+  })
+}
+
+/**
+ * The contract for a keeper that has NO branches yet: the resting state, and
+ * refusals that are local and typed. This is what the browser keeper answers
+ * today; when it grows branches it moves to `branchesBackendContract` above
+ * and this describe goes with it.
+ */
+export function branchlessBackendContract(create: () => BranchesBackend): void {
+  it('declares that it has no branches, and answers the resting state', async () => {
+    const backend = create()
+    expect(backend.hasBranches).toBe(false)
+    expect(await backend.list('w', 'p')).toEqual({ branches: [], head: 'main' })
+    expect(await backend.loadDocument('w', 'p', 'main')).toBeNull()
+  })
+
+  it('refuses every mutator with the typed error, never a request that failed', async () => {
+    const backend = create()
+    const refusals = await Promise.allSettled([
+      backend.create('w', 'p', { name: 'idea' }),
+      backend.remove('w', 'p', 'idea'),
+      backend.rename('w', 'p', 'idea', 'plan'),
+      backend.setHead('w', 'p', 'idea'),
+      backend.getStats('w', 'p', 'idea'),
+      backend.merge('w', 'p', 'idea', { into: 'main' }),
+    ])
+    for (const outcome of refusals) {
+      expect(outcome.status).toBe('rejected')
+      if (outcome.status === 'rejected') {
+        expect(outcome.reason).toBeInstanceOf(BranchesUnsupportedError)
+      }
+    }
+  })
+}

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -20,6 +20,7 @@ import { HeaderVariationBanner } from '../components/HeaderVariationBanner.js'
 import { MergeToast } from '../components/MergeToast.js'
 import { Button } from '../components/ui/button.js'
 import { DAEMON_HISTORY_CAPABILITIES } from '../components/VersionTimeline'
+import { BranchesBackendContext } from '../contexts/BranchesBackendContext.js'
 import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
 import { useVersionsBackend } from '../contexts/VersionsBackendContext.js'
 import { useAgentActivity } from '../hooks/use-agent-activity.js'
@@ -28,7 +29,7 @@ import { useDocumentFavicon } from '../hooks/use-document-favicon.js'
 import type { ReferenceLoader } from '../hooks/use-reference-seams.js'
 import { dispatchIdentityEvent, useDocumentSync } from '../hooks/useDocumentSync.js'
 import { getAppLogger } from '../lib/app-logger.js'
-import { type BranchMeta, branchesApi } from '../lib/branches-backend.js'
+import { type BranchMeta, createDaemonBranchesBackend } from '../lib/branches-backend.js'
 import {
   createDaemonFetch,
   getDocumentBacklinks,
@@ -102,6 +103,11 @@ function useDaemonDocument(
   // Stable across the page's lifetime: daemonBaseUrl/token come from a fixed
   // pairing payload, so this never needs to change once mounted.
   const daemonFetch = useMemo(() => createDaemonFetch(daemonBaseUrl, token), [daemonBaseUrl, token])
+  // This keeper's branches, over the same authorized fetch: the one supplier
+  // for the `?v=` preview below and for every consumer under the provider
+  // (chip, banner, dialog), so a hosted page paired to a loopback daemon
+  // cannot have half of them fall back to its own origin.
+  const branches = useMemo(() => createDaemonBranchesBackend(daemonFetch), [daemonFetch])
 
   // The WebSocket URL is derived from this locationHref (see
   // buildWhiteboardWsUrl), so it must be the daemon's own origin — a hosted
@@ -194,10 +200,9 @@ function useDaemonDocument(
     }
     const { workspaceId: wsId, path: docPath } = canvas
     let cancelled = false
-    const api = branchesApi(wsId, docPath, daemonFetch)
     void (async () => {
       try {
-        const state = await api.list()
+        const state = await branches.list(wsId, docPath)
         if (cancelled) return
         if (variationParam === 'main' || variationParam === state.head) {
           clearVariationParam()
@@ -208,7 +213,7 @@ function useDaemonDocument(
           clearVariationParam()
           return
         }
-        const past = await api.loadDocument(variationParam)
+        const past = await branches.loadDocument(wsId, docPath, variationParam)
         if (cancelled) return
         if (past === null) {
           setVariationNotice(`Variation «${variationParam}» could not be read`)
@@ -240,7 +245,7 @@ function useDaemonDocument(
     canvas?.path,
     variationParam,
     capabilities.branches,
-    daemonFetch,
+    branches,
     clearVariationParam,
     branchRefreshSignal,
   ])
@@ -250,14 +255,14 @@ function useDaemonDocument(
     const { workspaceId: wsId, path: docPath } = canvas
     void (async () => {
       try {
-        await branchesApi(wsId, docPath, daemonFetch).setHead(variationPreview.name)
+        await branches.setHead(wsId, docPath, variationPreview.name)
         setBranchRefreshSignal((n) => n + 1)
         clearVariationParam()
       } catch {
         setVariationNotice('Switching to this variation failed')
       }
     })()
-  }, [canvas, variationPreview, daemonFetch, clearVariationParam])
+  }, [canvas, variationPreview, branches, clearVariationParam])
 
   // Every listed document is tree-served and syncs at workspace-document
   // granularity; the id is what binds this session's content inside the
@@ -859,9 +864,7 @@ function useDaemonDocument(
               branches={variationPreview.branches}
               onSwitch={switchToVariation}
               onExit={clearVariationParam}
-              runMerge={(src, args) =>
-                branchesApi(canvas.workspaceId, canvas.path, daemonFetch).merge(src, args)
-              }
+              runMerge={(src, args) => branches.merge(canvas.workspaceId, canvas.path, src, args)}
             />
           )}
           {variationNotice !== null && (
@@ -921,7 +924,9 @@ function useDaemonDocument(
     kind: 'render',
     model,
     wrap: (page: ReactNode) => (
-      <DaemonApiContext.Provider value={daemonFetch}>{page}</DaemonApiContext.Provider>
+      <DaemonApiContext.Provider value={daemonFetch}>
+        <BranchesBackendContext.Provider value={branches}>{page}</BranchesBackendContext.Provider>
+      </DaemonApiContext.Provider>
     ),
   }
 }

--- a/packages/mcp-server/src/server/file-size-budget.test.ts
+++ b/packages/mcp-server/src/server/file-size-budget.test.ts
@@ -102,12 +102,14 @@ const FILE_SIZE_GRANDFATHER: Record<string, number> = {
   'apps/web/src/components/workspace-files/WorkspaceFilesPanel.tsx': 1196,
   'packages/loro-adapter/src/workspace-tree.ts': 1032,
   'packages/canvas-render/src/svg/backend.ts': 991,
-  // Raised from 921: the page became a KEEPER — its wiring now answers the
+  // Raised from 921 when the page became a KEEPER — its wiring answers the
   // `DocumentKeeper` contract (the hook signature, the two terminal answers,
   // the provider `wrap`, the bound component) instead of rendering the page
-  // itself. Paid once per keeper, and the same conversion took the browser
-  // page below from 981 to 926, so the pair is 38 lines smaller than before.
-  'apps/web/src/pages/DaemonDocumentPage.tsx': 938,
+  // itself — and from 938 when its branches moved behind the seam: one
+  // supplier built here, mounted for every consumer under it, in place of
+  // four call sites building their own. Both are paid once; the keeper
+  // conversion also took the browser page below from 981 to 926.
+  'apps/web/src/pages/DaemonDocumentPage.tsx': 942,
   'apps/web/src/lib/document-sync-session.ts': 1366,
   'packages/mcp-server/src/server/store/document-store.ts': 1131,
   'apps/web/src/pages/BrowserDocumentPage.tsx': 926,


### PR DESCRIPTION
## Summary

The first slice of giving the browser keeper the same variations and combine the daemon has. Nothing user-visible changes here: it closes the seam the browser implementation will be written against, and puts a behavioural contract behind it.

- `DaemonDocumentPage` built its own `branchesApi(workspaceId, path, fetch)` at **four** call sites — the `?v=` preview's list and load, the switch-to-variation `setHead`, and the merge the header banner runs. Each one was a supplier of its own, and a page whose consumers under the provider (chip, banner, dialog) resolved a DIFFERENT one is exactly how half a hosted page ends up talking to its own origin while the other half talks to the loopback daemon. There is now one `createDaemonBranchesBackend(daemonFetch)` built in the keeper and mounted through `BranchesBackendContext` for everything below it.
- `lib/branches-backend.contract.ts` is that seam's behavioural suite, run here against the daemon implementation over an in-memory stand-in for its routes: a resting head of `main`, create with its colour, `setHead` answering both the new head and the previous one, rename, the stats a head reports, a dry-run that changes nothing, `loadDocument` answering null off-head, and remove. `branchlessBackendContract` is the other half — what a keeper that HAS no branches must answer instead of falling through to a daemon that is not there.

The contract is what the browser backend will be held to in the next slice; today it documents the daemon's behaviour and pins it.

## Test plan

- [x] `branches-backend.contract` against the daemon implementation: 11 cases green, and five fresh-process runs of the file plus one inside its whole project (rule 12).
- [x] Mutation-checked: dropping the previous head from `setHead`'s answer turns the contract red.
- [x] `pnpm exec vitest run --project web-jsdom src/lib/branches-backend.contract.test.ts src/pages …` — 57 files / 645 tests green.
- [x] `pnpm exec vitest run --project web-browser apps/web/src/pages` — 24 files / 92 tests green.
- [x] `mcp-node file-size-budget` — green, with the daemon page's ceiling raised 938 → 942 on the record: one supplier built in the keeper in place of four call sites building their own.
- [x] `pnpm --filter @kamiazya/whiteboard-web typecheck`, `pnpm lint`, `pnpm knip` — clean. (`pnpm lint`'s three warnings are `packages/mcp-server/src/server/docker-contract.test.ts` from #1395, outside this diff.)
- [ ] Manual verification — no user-visible change: the same four operations, reaching the same routes through one supplier instead of four.
- [ ] E2E — not applicable.

## Visual evidence

Visual evidence: none — no pixel moves. The change is which object the page's four branch operations are called on.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — none does
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh)_