### PR TITLE
docs(web): the header's four roles, and that a control's role follows its subject

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -139,6 +139,44 @@ write), a filled cap on a broken stroke is the daemon's "not keeping"
   such facts, so the mark is the shell's; the document's own title, actions
   and history are the page's. The dividing question is not importance, it is
   whether the answer survives navigation.
+- **Every control in the two chrome rows serves one of four roles, and its
+  ROLE follows from its subject.** The roles are:
+
+  | role | asks | where it lives |
+  |---|---|---|
+  | **identity** | where am I? | the mark (workspace), the document's title, the way back |
+  | **inspect** | what am I looking at, beside the document? | ONE slot, exclusive: properties, comments, connections, history |
+  | **act** | what do I do to this document? | ONE `⋯`, in ADR-0006's band order |
+  | **view** | how much of the screen, and how is it drawn? | fullscreen in the SHELL row (subject: the app), `Display…` inside the `⋯` (subject: this canvas) |
+
+  Two things follow, and both were violations before this rule existed:
+
+  - **Inspect is one slot, not N toggles.** Properties, comments,
+    connections and history each owned their own open state, and nothing
+    said they were alternatives. Captured on a phone before the retune: the
+    display popover, the comments rail and the history sheet all up at
+    once, over an editor with room for one. `lib/inspector.ts` declares the
+    union and `InspectorPanel` is the single vessel — a fifth panel joins
+    them rather than opening beside them.
+  - **A view control's ROW follows its subject, not its convenience.**
+    Fullscreen asks how much screen the app gets, which does not change
+    when a document opens, so it is the shell's. Display settings ask how
+    THIS canvas is drawn, so they are the document's — and being one
+    plugin's worth of edge routing, they earn a menu row rather than an
+    icon in a row the title wants.
+
+  What this rule refuses is the control with no answer: an affordance added
+  to whichever row its implementing file already rendered. That is how the
+  rows came to hold five button spellings, a second `⋯` a header above the
+  first, and a fullscreen toggle whose subject was a `<main>` element.
+  `header-button-surface.test.ts` is the mechanical half — one class set,
+  and the count per file pinned by equality from both sides, so a new
+  control cannot arrive without changing a number there. Which role it
+  serves stays a reader's judgement: the controls are written per-file and
+  are not declared anywhere one scan could enumerate, and until they are (a
+  registry every header control registers with is the upgrade path) a
+  per-item table here would be the hand-kept list this file exists to
+  replace.
 - **The mark IS the switcher, and the row does not name the workspace.** The
   strip is `[mark] ALPHA <spacer> gear` and nothing else. The mark states
   which workspace you are in through its ACCESSIBLE name


### PR DESCRIPTION
## Summary

P6, and the last increment of the header retune (P1 #1393, P2 #1398, P3 #1401, P4 #1410, P5 #1417). Five increments moved controls without writing down the rule they were moving them **by**, and the rule is what stops the rows drifting back.

- **The four roles** — `identity` / `inspect` / `act` / `view` — as a table in DESIGN.md's `## Rules`, beside the shell's own dividing question ("does the answer survive navigation?").
- **A control's role follows its SUBJECT**, not its convenience. That is the assignment rule; the table is what it assigns to.
- Two consequences get their own paragraph, because each was a real violation rather than a hypothetical:
  - **Inspect is one slot, not N toggles.** Captured on a phone before the retune: the display popover, the comments rail and the history sheet all up at once, over an editor with room for one.
  - **A view control's ROW follows its subject.** Fullscreen asks how much screen the app gets — unchanged when a document opens — so it is the shell's. Display settings ask how *this canvas* is drawn, so they are the document's, and being one plugin's worth of edge routing they earn a menu row rather than an icon in a row the title wants.

## Why this is prose, and says so

A per-item table classifying each control by role would be the hand-kept list a ledger exists to replace. `.claude/rules/coverage-ledger.md`'s own criterion rules it out: the controls are written per-file and declared nowhere a scan could enumerate, so there is no surface to tally and nothing modelling them underneath.

The mechanical half already exists and the rule points at it: `header-button-surface.test.ts` pins one class set with the count per file by equality **from both sides**, so a new header control cannot arrive without changing a number there — which is exactly where a reader gets sent to this rule. The upgrade path (a registry every header control registers with) is named in the rule rather than built on speculation.

## Test plan

- [ ] New or updated tests — none; this adds no behaviour
- [x] `pnpm check:local` exit 0 (`biome`, `secretlint`, `test:scripts`, `knip`, `intent:validate`, `audit:prod`, `typecheck`)
- [x] `vocabulary-check` green over the edited doc (it scans `apps/web/DESIGN.md`, so a retired word here would fail)
- [ ] E2E coverage — not applicable

The three `biome` warnings in the run are pre-existing: the same three appear with this change stashed, and biome does not process markdown at all.

## Visual evidence

Visual evidence: none — documentation only, no rendered surface changes. The pixels this rule describes were shipped and shown in P1–P5.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — this IS the docs increment; the shell-owns-fullscreen half landed with P4
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_