### PR TITLE
feat(mcp-server): the daemon keeps a branch on the workspace record, not in a row

### DIFF
--- a/packages/history/src/branches/record-store.ts
+++ b/packages/history/src/branches/record-store.ts
@@ -22,6 +22,7 @@
 import {
   openWorkspaceDocumentPlane,
   readWorkspaceDocumentPlane,
+  readWorkspaceDocuments,
   resolveWorkspaceDocumentById,
   updateWorkspaceDocumentMeta,
 } from '@kamiazya/whiteboard-loro-adapter'
@@ -72,6 +73,56 @@ export function readBranchesFromRecord(
   const branches = plane === null ? [] : branchesOf(plane)
   if (branches.length === 0) return { branches: [defaultMain(now)], head: 'main' }
   return { branches, head: resolveHead(branches, entry?.currentBranch) }
+}
+
+/** One branch's tip, with the document it belongs to. */
+export interface WorkspaceBranchTip {
+  readonly documentId: string
+  readonly name: string
+  readonly tipFrontiers: string
+}
+
+/**
+ * Every branch tip the whole workspace holds, across every document.
+ *
+ * Compaction needs this and nothing else: a cut that drops history a branch
+ * tip still needs makes that variation uncheckoutable, so the earliest point
+ * anybody can compact to is bounded by the OLDEST tip anywhere in the
+ * workspace. It is a workspace-wide question, which is the one thing a
+ * per-document read cannot answer, so it lives here beside what it reads
+ * rather than as a walk each keeper writes for itself.
+ *
+ * Empty tips are included; a caller that treats "no tip yet" as pinning
+ * nothing says so at its own use, where the reason belongs.
+ */
+export function readWorkspaceBranchTips(doc: LoroDoc): WorkspaceBranchTip[] {
+  const out: WorkspaceBranchTip[] = []
+  for (const entry of readWorkspaceDocuments(doc)) {
+    const plane = readWorkspaceDocumentPlane(doc, entry.documentId, BRANCHES_PLANE_KEY)
+    if (plane === null) continue
+    for (const branch of branchesOf(plane)) {
+      out.push({
+        documentId: entry.documentId,
+        name: branch.name,
+        tipFrontiers: branch.tipFrontiers,
+      })
+    }
+  }
+  return out
+}
+
+/**
+ * Whether this document's branches are on the record YET.
+ *
+ * `readBranchesFromRecord` invents `main` for a document that has none, which
+ * is right for a reader and useless to a keeper migrating off another store:
+ * it cannot tell an empty plane from a plane holding only `main`. This
+ * answers that one question, so a keeper's fallback to its old rows is a
+ * decision about where the data IS rather than a guess from a default.
+ */
+export function hasBranchesOnRecord(doc: LoroDoc, documentId: string): boolean {
+  const plane = readWorkspaceDocumentPlane(doc, documentId, BRANCHES_PLANE_KEY)
+  return plane !== null && branchesOf(plane).length > 0
 }
 
 /**

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -13,7 +13,10 @@ export {
 } from './branches/ops.js'
 export {
   BRANCHES_PLANE_KEY,
+  hasBranchesOnRecord,
   readBranchesFromRecord,
+  readWorkspaceBranchTips,
+  type WorkspaceBranchTip,
   writeBranchesToRecord,
 } from './branches/record-store.js'
 export {

--- a/packages/mcp-server/src/server/file-size-budget.test.ts
+++ b/packages/mcp-server/src/server/file-size-budget.test.ts
@@ -128,7 +128,13 @@ const FILE_SIZE_GRANDFATHER: Record<string, number> = {
   // conversion also took the browser page below from 981 to 926.
   'apps/web/src/pages/DaemonDocumentPage.tsx': 942,
   'apps/web/src/lib/document-sync-session.ts': 1366,
-  'packages/mcp-server/src/server/store/document-store.ts': 1131,
+  // Raised from 1131 because compaction's retained-history cut now reads
+  // branch tips from BOTH planes for the length of the migration: the record,
+  // where a document goes the first time its branches are written, and the
+  // rows a document that has not been written since still has. A union rather
+  // than a merge — a document is never in both — and the comment saying so is
+  // most of the 14 lines.
+  'packages/mcp-server/src/server/store/document-store.ts': 1145,
   'apps/web/src/pages/BrowserDocumentPage.tsx': 926,
   'packages/canvas-render/src/layout/nodes/mdast-blocks.ts': 1674,
   'packages/canvas-render/src/layout/spatial-canvas.ts': 1840,

--- a/packages/mcp-server/src/server/store/branch-merge.test.ts
+++ b/packages/mcp-server/src/server/store/branch-merge.test.ts
@@ -512,13 +512,26 @@ describe('performBranchMerge', () => {
     )
     await saveDocumentBranches(SID, PATH, state)
     await branchesStore.setHead(SID, PATH, 'feature')
-    // The failure injection point moved with the fan-out: the cleanup
-    // reconcile now fails at the workspace record's save instead of at a
-    // broadcast dep that no longer exists. Every save fails (not just once):
-    // the head switch's own fail-soft branch-HEAD mirror also saves the
-    // record now, and a single-shot rejection would be consumed there,
-    // letting the reconcile under test succeed.
-    vi.spyOn(DocumentStoreWorkspaceDocs.prototype, 'save').mockRejectedValue(new Error('save boom'))
+    // The failure injection point moves again, because branches moved onto
+    // the record: the head switch is now itself a record SAVE, so rejecting
+    // every save would fail the switch this case needs to have SUCCEEDED and
+    // would test nothing. So the rejection is armed at the one moment
+    // between the two — `sendHeadChanged`, which the cleanup calls after the
+    // switch has persisted and before the reconcile. (HEAD is `feature` here
+    // and the target is `main`, so the commit path's own `sendHeadChanged`
+    // does not run; this is the only call.)
+    const realSave = DocumentStoreWorkspaceDocs.prototype.save
+    let failSaves = false
+    vi.spyOn(DocumentStoreWorkspaceDocs.prototype, 'save').mockImplementation(async function (
+      this: InstanceType<typeof DocumentStoreWorkspaceDocs>,
+      ...args: Parameters<typeof realSave>
+    ) {
+      if (failSaves) throw new Error('save boom')
+      return realSave.apply(this, args)
+    })
+    deps.sendHeadChanged.mockImplementation(() => {
+      failSaves = true
+    })
     const cap = captureLogsForTests('warning')
 
     try {

--- a/packages/mcp-server/src/server/store/branches-store.record.test.ts
+++ b/packages/mcp-server/src/server/store/branches-store.record.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Where the daemon KEEPS a branch.
+ *
+ * Until now: a `branches` row. That row is the whole reason the browser
+ * keeper has no variations — it has no SQLite, and a row is not something a
+ * replica can carry. A branch is a name and a frontier of the workspace
+ * RECORD, and the record already reaches every replica, so the record is
+ * where it belongs.
+ *
+ * Moving it is not only about the browser. A workspace promoted from a
+ * browser to the daemon (ADR-0023) arrives as a record; branches kept
+ * anywhere else would be invisible on the other side of that move, and a
+ * variation that silently does not survive a promotion is exactly the kind of
+ * loss nothing goes red for.
+ *
+ * The migration is per document and read-through: a document whose branches
+ * are still rows reads them, and the first write moves it to the plane and
+ * drops its rows. Nothing folds at boot, so there is no partial fold to
+ * recover from and no marker to keep in step.
+ */
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Declare this first because vi.mock is hoisted.
+let tempDir: string
+
+vi.mock('../config.js', () => ({
+  get DATA_DIR() {
+    return tempDir
+  },
+  getDataDir: () => tempDir,
+  WHITEBOARD_ROOT: '/tmp/whiteboard',
+  REPO_ROOT: '/tmp',
+}))
+
+const { loadDocumentBranches, createBranch, updateBranchTip } = await import('./branches-store.js')
+const { createIsolatedDb } = await import('./db/test-helpers.js')
+const { _resetWorkspaceLocksForTests } = await import('./workspace-lock.js')
+const { saveDocument, openWorkspaceDocIfStored } = await import('./document-store.js')
+const { getDb } = await import('./db/index.js')
+const { resolveWorkspaceDocument } = await import('@kamiazya/whiteboard-loro-adapter')
+const { readWorkspaceBranchTips } = await import('@kamiazya/whiteboard-history')
+const { LoroDoc } = await import('loro-crdt')
+
+const WORKSPACE = 'sess-record'
+const PATH = 'canvas-x'
+
+let handle: Awaited<ReturnType<typeof createIsolatedDb>>
+
+async function branchRowNames(): Promise<string[]> {
+  const db = await getDb(tempDir)
+  const rows = await db.selectFrom('branches').select(['name']).orderBy('name', 'asc').execute()
+  return rows.map((r) => r.name)
+}
+
+/** The documentId the record answers for the seeded path. */
+async function documentId(): Promise<string> {
+  const record = await openWorkspaceDocIfStored(WORKSPACE)
+  if (record === null) throw new Error('no workspace record')
+  const entry = resolveWorkspaceDocument(record, PATH)
+  if (entry === null) throw new Error(`no document at ${PATH}`)
+  return entry.documentId
+}
+
+/** Seeds a branch the way the pre-plane daemon did: as a row, and nothing else. */
+async function seedBranchRow(name: string, tipFrontiers: string): Promise<void> {
+  const db = await getDb(tempDir)
+  await db
+    .insertInto('branches')
+    .values({
+      documentId: await documentId(),
+      workspaceId: WORKSPACE,
+      name,
+      tipFrontiers,
+      color: '#e03131',
+      sourceBranchName: null,
+      sourceVersionId: null,
+      createdAt: Date.parse('2026-01-02T03:04:05.000Z'),
+    })
+    .execute()
+}
+
+describe('branches on the workspace record', () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'whiteboard-branches-record-'))
+    handle = await createIsolatedDb({ dataDir: tempDir })
+    await saveDocument(WORKSPACE, PATH, new LoroDoc(), { kind: 'spatial' })
+  })
+
+  afterEach(async () => {
+    await handle.dispose()
+    await rm(tempDir, { recursive: true, force: true })
+    _resetWorkspaceLocksForTests()
+  })
+
+  it('answers a created branch from the record, with no row behind it', async () => {
+    await createBranch(WORKSPACE, PATH, { name: 'draft' })
+
+    // The discriminator: the rows are gone, so the read below cannot be
+    // coming from them. Asserting only that the branch reads back would pass
+    // against the row-backed store unchanged.
+    expect(await branchRowNames()).toEqual([])
+    const state = await loadDocumentBranches(WORKSPACE, PATH)
+    expect(state.branches.map((b) => b.name).sort()).toEqual(['draft', 'main'])
+  })
+
+  it('still reads a branch that exists only as a row, so no stored variation is lost', async () => {
+    await seedBranchRow('legacy', 'AQID')
+
+    const state = await loadDocumentBranches(WORKSPACE, PATH)
+
+    expect(state.branches.map((b) => b.name)).toEqual(['legacy'])
+    expect(state.branches[0]?.tipFrontiers).toBe('AQID')
+  })
+
+  it('moves a row-backed document onto the record the first time it is written', async () => {
+    await seedBranchRow('legacy', 'AQID')
+
+    await updateBranchTip(WORKSPACE, PATH, 'legacy', 'BAUG')
+
+    expect(await branchRowNames()).toEqual([])
+    const state = await loadDocumentBranches(WORKSPACE, PATH)
+    expect(state.branches.map((b) => b.name)).toEqual(['legacy'])
+    expect(state.branches[0]?.tipFrontiers).toBe('BAUG')
+  })
+
+  it('answers every tip in the workspace from the record alone, across documents', async () => {
+    // What the retired `branches.workspaceId` column bought: a
+    // workspace-scoped read with no join. Compaction needs it — a cut that
+    // drops history a tip still needs makes that variation uncheckoutable —
+    // and it is the one question a per-document read cannot answer. On the
+    // record the column is not needed at all: the tree IS the scope.
+    await saveDocument(WORKSPACE, 'canvas-y', new LoroDoc(), { kind: 'spatial' })
+    await createBranch(WORKSPACE, PATH, { name: 'draft', initialTipFrontiers: 'AQID' })
+    await createBranch(WORKSPACE, 'canvas-y', { name: 'other', initialTipFrontiers: 'BAUG' })
+
+    const record = await openWorkspaceDocIfStored(WORKSPACE)
+    if (record === null) throw new Error('no workspace record')
+    const tips = readWorkspaceBranchTips(record)
+
+    expect(tips.map((t) => `${t.name}=${t.tipFrontiers}`).sort()).toEqual([
+      'draft=AQID',
+      'main=',
+      'main=',
+      'other=BAUG',
+    ])
+  })
+
+  it('keeps another document’s rows when one document moves', async () => {
+    await saveDocument(WORKSPACE, 'canvas-y', new LoroDoc(), { kind: 'spatial' })
+    const db = await getDb(tempDir)
+    const other = resolveWorkspaceDocument(
+      (await openWorkspaceDocIfStored(WORKSPACE)) as InstanceType<typeof LoroDoc>,
+      'canvas-y',
+    )
+    await db
+      .insertInto('branches')
+      .values({
+        documentId: other?.documentId ?? '',
+        workspaceId: WORKSPACE,
+        name: 'other-doc',
+        tipFrontiers: '',
+        color: '#e03131',
+        sourceBranchName: null,
+        sourceVersionId: null,
+        createdAt: Date.now(),
+      })
+      .execute()
+
+    await createBranch(WORKSPACE, PATH, { name: 'draft' })
+
+    // Per document, not per workspace: a write to one document must not
+    // retire another's rows before anything has read them onto its plane.
+    expect(await branchRowNames()).toEqual(['other-doc'])
+  })
+})

--- a/packages/mcp-server/src/server/store/branches-store.test.ts
+++ b/packages/mcp-server/src/server/store/branches-store.test.ts
@@ -96,42 +96,6 @@ describe('branches-store', () => {
       ).rejects.toThrow(/no document/i)
     })
 
-    // Branches are keyed on workspaceId directly (dual-plane collapse S3),
-    // so workspace-scoped reads need no join through the documents table.
-    it('records the workspaceId on every branch row', async () => {
-      await saveDocumentBranches('sess-a', 'canvas-x', {
-        head: 'main',
-        branches: [
-          {
-            name: 'main',
-            color: DEFAULT_MAIN_COLOR,
-            tipFrontiers: '',
-            createdAt: '2026-04-23T00:00:00.000Z',
-          },
-          {
-            name: 'feature',
-            color: '#9333ea',
-            tipFrontiers: '',
-            createdAt: '2026-04-23T00:00:00.000Z',
-          },
-        ],
-      })
-      const { getDb } = await import('./db/index.js')
-      const db = await getDb(tempDir)
-      const rows = await db
-        .selectFrom('branches')
-        .select(['name', 'workspaceId'])
-        .orderBy('name')
-        .execute()
-      expect(rows).toEqual([
-        { name: 'feature', workspaceId: 'sess-a' },
-        { name: 'main', workspaceId: 'sess-a' },
-      ])
-    })
-
-    // The branch HEAD is shared CRDT state (dual-plane collapse S4b): the
-    // documents.currentBranch write keeps serving today's reads, and the
-    // workspace record's node meta is what every replica converges on.
     it('mirrors the branch HEAD into the workspace record node meta', async () => {
       const { openWorkspaceDocIfStored } = await import('./document-store.js')
       const { resolveWorkspaceDocument } = await import('@kamiazya/whiteboard-loro-adapter')

--- a/packages/mcp-server/src/server/store/branches-store.ts
+++ b/packages/mcp-server/src/server/store/branches-store.ts
@@ -6,18 +6,16 @@ import {
   DEFAULT_MAIN_COLOR,
   defaultMain,
   deleteBranch as deleteBranchOp,
+  hasBranchesOnRecord,
+  readBranchesFromRecord,
   renameBranch as renameBranchOp,
   resolveHead,
   setHead as setHeadOp,
   updateBranchTip as updateBranchTipOp,
+  writeBranchesToRecord,
 } from '@kamiazya/whiteboard-history'
-import {
-  resolveWorkspaceDocument,
-  resolveWorkspaceDocumentById,
-  updateWorkspaceDocumentMeta,
-} from '@kamiazya/whiteboard-loro-adapter'
+import { resolveWorkspaceDocument } from '@kamiazya/whiteboard-loro-adapter'
 import { getDataDir } from '../config.js'
-import { getLogger } from '../log.js'
 import { validateBranchName, validateDocumentPath, validateWorkspaceId } from '../validators.js'
 import { getDb } from './db/index.js'
 import { prepareDataDir } from './db/prepare.js'
@@ -25,15 +23,27 @@ import { DocumentNotFoundError } from './document-not-found-error.js'
 import { openWorkspaceDocIfStored, saveWorkspaceDoc } from './document-store.js'
 import { withWorkspaceWriteLock } from './workspace-lock.js'
 
-// Canvas-scoped branch state. Backed by:
-//   branches table         -> one row per branch keyed on (documentId, name)
-//   documents.currentBranch -> HEAD pointer per canvas row
+// Canvas-scoped branch state, kept on the WORKSPACE RECORD: the branch plane
+// of the document's tree node, with HEAD as that node's `currentBranch`.
+//
+// It used to be a `branches` row per branch. A row is not something a replica
+// can carry, which is why the browser keeper had no variations at all, and it
+// does not survive a browser-to-daemon promotion (ADR-0023) either — a
+// variation lost in a move is exactly the kind of loss nothing goes red for.
+// A branch is a name and a frontier OF THE RECORD, so the record is where it
+// belongs, and both keepers read it the same way.
+//
+// The migration is per document and READ-THROUGH: a document whose branches
+// are still rows reads them, and the first write moves it onto the plane and
+// drops its rows. Nothing folds at boot, so there is no partial fold to
+// recover from and no marker to keep in step — a document either has a plane
+// or has rows, never a half of each.
 //
 // What a branch IS, and every rule about changing one (no duplicate names,
 // `main` immovable, HEAD undeletable, a rename follows HEAD and every
 // `baseBranch` that named it) is `@kamiazya/whiteboard-history`'s: this
 // module is the daemon's read-modify-write around those pure steps — the
-// per-workspace lock, the rows, the HEAD mirror into the record.
+// per-workspace lock, and the record save.
 //
 // All accessors take (workspaceId, path) so the public API stays stable
 // across the path → documentId migration. Internally the path is resolved to
@@ -62,17 +72,33 @@ export async function loadDocumentBranches(
 ): Promise<DocumentBranches> {
   validateWorkspaceId(workspaceId)
   validateDocumentPath(path)
-  const db = await dbReady()
-  // The document and its HEAD resolve from the workspace record (S7); the
-  // branch ROWS stay in sqlite, keyed by the id the tree answers.
-  const target = await resolveDocumentForBranches(workspaceId, path)
-  if (target === null) {
-    return { branches: [defaultMain()], head: 'main' }
+  const workspaceDoc = await openWorkspaceDocIfStored(workspaceId)
+  if (workspaceDoc === null) return { branches: [defaultMain()], head: 'main' }
+  const entry = resolveWorkspaceDocument(workspaceDoc, path)
+  if (entry === null) return { branches: [defaultMain()], head: 'main' }
+  if (hasBranchesOnRecord(workspaceDoc, entry.documentId)) {
+    return readBranchesFromRecord(workspaceDoc, entry.documentId)
   }
+  return branchesFromRows(entry.documentId, entry.currentBranch)
+}
+
+/**
+ * The pre-plane reading: this document's `branches` rows.
+ *
+ * Kept because a document acquires a plane only when something WRITES its
+ * branches, and a workspace can sit for a long time with variations nobody
+ * has touched. Deleting these rows without reading them first is how a stored
+ * variation disappears with nothing red.
+ */
+async function branchesFromRows(
+  documentId: string,
+  currentBranch: string | undefined,
+): Promise<DocumentBranches> {
+  const db = await dbReady()
   const branchRows = await db
     .selectFrom('branches')
     .select(['name', 'tipFrontiers', 'sourceBranchName', 'sourceVersionId', 'color', 'createdAt'])
-    .where('documentId', '=', target.documentId)
+    .where('documentId', '=', documentId)
     .orderBy('createdAt', 'asc')
     .orderBy('name', 'asc')
     .execute()
@@ -87,22 +113,7 @@ export async function loadDocumentBranches(
     ...(r.sourceBranchName !== null ? { baseBranch: r.sourceBranchName } : {}),
     ...(r.sourceVersionId !== null ? { baseVersionId: r.sourceVersionId } : {}),
   }))
-  return { branches, head: resolveHead(branches, target.currentBranch) }
-}
-
-/** The documentId + HEAD for a path, answered from the workspace tree; null when the tree does not serve it. */
-async function resolveDocumentForBranches(
-  workspaceId: string,
-  path: string,
-): Promise<{ documentId: string; currentBranch?: string } | null> {
-  const workspaceDoc = await openWorkspaceDocIfStored(workspaceId)
-  if (workspaceDoc === null) return null
-  const entry = resolveWorkspaceDocument(workspaceDoc, path)
-  if (entry === null) return null
-  return {
-    documentId: entry.documentId,
-    ...(entry.currentBranch === undefined ? {} : { currentBranch: entry.currentBranch }),
-  }
+  return { branches, head: resolveHead(branches, currentBranch) }
 }
 
 // The actual write, assuming the workspace write lock is already held by
@@ -118,51 +129,23 @@ async function saveDocumentBranchesLocked(
     validateBranchName(branch.name)
   }
   validateBranchName(state.head)
-  const db = await dbReady()
-  const target = await resolveDocumentForBranches(workspaceId, path)
-  if (target === null) throw new DocumentNotFoundError(workspaceId, path)
-  const documentId = target.documentId
-  await db.transaction().execute(async (trx) => {
-    await trx.deleteFrom('branches').where('documentId', '=', documentId).execute()
-    if (state.branches.length > 0) {
-      await trx
-        .insertInto('branches')
-        .values(
-          state.branches.map((b) => ({
-            documentId,
-            workspaceId,
-            name: b.name,
-            tipFrontiers: b.tipFrontiers,
-            color: b.color ?? null,
-            sourceBranchName: b.baseBranch ?? null,
-            sourceVersionId: b.baseVersionId ?? null,
-            createdAt: parseIsoOrNow(b.createdAt),
-          })),
-        )
-        .execute()
-    }
-  })
-  // Mirror the HEAD into the workspace record's node meta (dual-plane
-  // collapse S4b): shared CRDT state every replica converges on, while the
-  // row column keeps serving today's reads. Guarded by a read so a tip-only
-  // save does not append a same-value op per save. Fail-soft while the row
-  // is what reads serve: a mirror hiccup must not fail a branch write that
-  // already durably committed.
-  try {
-    const workspaceDoc = await openWorkspaceDocIfStored(workspaceId)
-    if (workspaceDoc !== null) {
-      const entry = resolveWorkspaceDocumentById(workspaceDoc, documentId)
-      if (entry !== null && (entry.currentBranch ?? 'main') !== state.head) {
-        updateWorkspaceDocumentMeta(workspaceDoc, documentId, { currentBranch: state.head })
-        await saveWorkspaceDoc(workspaceId, workspaceDoc)
-      }
-    }
-  } catch (err) {
-    getLogger('branches-store').warning(
-      { workspaceId, path, err },
-      'failed to mirror branch HEAD into the workspace record',
-    )
+  const workspaceDoc = await openWorkspaceDocIfStored(workspaceId)
+  if (workspaceDoc === null) throw new DocumentNotFoundError(workspaceId, path)
+  const entry = resolveWorkspaceDocument(workspaceDoc, path)
+  if (entry === null) throw new DocumentNotFoundError(workspaceId, path)
+  if (!writeBranchesToRecord(workspaceDoc, entry.documentId, state)) {
+    throw new DocumentNotFoundError(workspaceId, path)
   }
+  await saveWorkspaceDoc(workspaceId, workspaceDoc)
+  // The rows this document's branches used to be, retired only now — after
+  // the record write has durably landed. In this order a failure leaves the
+  // rows as the reading, which is the state the load path already handles;
+  // the other order would leave the document with neither.
+  //
+  // Per DOCUMENT, never per workspace: another document's rows are still the
+  // only copy of its branches until something writes them.
+  const db = await dbReady()
+  await db.deleteFrom('branches').where('documentId', '=', entry.documentId).execute()
 }
 
 // Every branch mutation (createBranch, deleteBranch, updateBranchTip,
@@ -237,11 +220,6 @@ export async function withDocumentBranchesLock<T>(
     const state = await loadDocumentBranches(workspaceId, path)
     return fn(state, (next) => saveDocumentBranchesLocked(workspaceId, path, next))
   })
-}
-
-function parseIsoOrNow(iso: string): number {
-  const t = Date.parse(iso)
-  return Number.isFinite(t) ? t : Date.now()
 }
 
 function scopeOf(workspaceId: string, path: string): BranchScope {

--- a/packages/mcp-server/src/server/store/document-store.lifecycle.test.ts
+++ b/packages/mcp-server/src/server/store/document-store.lifecycle.test.ts
@@ -248,7 +248,7 @@ describe('renameDocumentPath', () => {
     await rm(tempDir, { recursive: true, force: true })
   })
 
-  it('moves only the path: branches/versions rows and the Libsql snapshot stay byte-identical and keyed to the same documentId', async () => {
+  it('moves only the path: branches, version rows and the Libsql snapshot stay byte-identical and keyed to the same documentId', async () => {
     const { getDb } = await import('./db/index.js')
     const { createBranch, loadDocumentBranches } = await import('./branches-store.js')
 
@@ -281,13 +281,6 @@ describe('renameDocumentPath', () => {
     const after = { id: afterId }
     expect(after.id).toBe(documentId)
 
-    const branchesAfter = await db
-      .selectFrom('branches')
-      .selectAll()
-      .where('documentId', '=', documentId)
-      .execute()
-    expect(branchesAfter.map((b) => b.name).sort()).toEqual(['feature', 'main'])
-
     const versionsAfter = await db
       .selectFrom('versions')
       .selectAll()
@@ -298,7 +291,11 @@ describe('renameDocumentPath', () => {
     // Content is untouched by the move — same documentId, same value.
     expect((await loadDocument('session1', 'b')).toJSON()).toEqual(contentBefore)
 
-    // loadDocumentBranches also resolves under the new path.
+    // Branches survive the move and resolve under the new path. This used to
+    // read the `branches` rows as well; branches live on the workspace
+    // record now, and the record is keyed by documentId, so the path change
+    // cannot reach them — which is the property, stated once through the
+    // reader everything else uses.
     const branches = await loadDocumentBranches('session1', 'b')
     expect(branches.branches.map((b) => b.name).sort()).toEqual(['feature', 'main'])
   })

--- a/packages/mcp-server/src/server/store/document-store.ts
+++ b/packages/mcp-server/src/server/store/document-store.ts
@@ -17,6 +17,7 @@
  */
 import { unlink } from 'node:fs/promises'
 import type { DocumentSummary } from '@kamiazya/whiteboard-daemon-client/api-contracts/document'
+import { readWorkspaceBranchTips } from '@kamiazya/whiteboard-history'
 import {
   createWorkspaceDocumentAtPath,
   projectWorkspaceDocument,
@@ -880,18 +881,31 @@ async function retainedHistoryCut(
     .select(['tipFrontiers', 'name', 'documentId'])
     .where('workspaceId', '=', workspaceId)
     .execute()
+  // Both readings, because the move off rows is per document: a document
+  // written since the move has its branches on the record and no rows, one
+  // written before has rows and no plane. Never both, so this is a union
+  // rather than a merge — and a tip counted twice would be harmless anyway,
+  // since the cut is a pointwise MINIMUM.
+  const tips = [
+    ...readWorkspaceBranchTips(doc),
+    ...rows.map((row) => ({
+      documentId: row.documentId,
+      name: row.name,
+      tipFrontiers: row.tipFrontiers,
+    })),
+  ]
   const pins: { frontiers: Frontiers; branch: string }[] = []
-  for (const row of rows) {
+  for (const tip of tips) {
     // An empty tip is a branch nothing has written to yet — it pins nothing.
-    if (row.tipFrontiers.length === 0) continue
+    if (tip.tipFrontiers.length === 0) continue
     try {
       pins.push({
-        frontiers: decodeFrontiers(new Uint8Array(Buffer.from(row.tipFrontiers, 'base64'))),
-        branch: `${row.documentId}#${row.name}`,
+        frontiers: decodeFrontiers(new Uint8Array(Buffer.from(tip.tipFrontiers, 'base64'))),
+        branch: `${tip.documentId}#${tip.name}`,
       })
     } catch (error) {
       throw corruptStoredData(
-        `${workspaceId}/branches/${row.documentId}#${row.name}`,
+        `${workspaceId}/branches/${tip.documentId}#${tip.name}`,
         `tipFrontiers could not be decoded (${error instanceof Error ? error.message : String(error)})`,
       )
     }


### PR DESCRIPTION
## Summary

- **The daemon reads and writes branches on the workspace record's branch plane**, with HEAD staying the node's `currentBranch` where it already was. `branches-store` keeps its per-workspace lock and its read-modify-write; only where the state lives changed.
- **Why a row had to go.** A `branches` row is not something a replica can carry — which is why the browser keeper has no variations at all, and also why a workspace promoted from a browser to the daemon (ADR-0023) would arrive with its branches invisible. A variation lost in a move is exactly the kind of loss nothing goes red for. The record already reaches every replica, so both keepers can now read the same branch the same way.
- **Compaction reads both planes for the length of the migration**, as a union rather than a merge — no document is ever in both. `file-gc` needed no change at all: it already asks `loadDocumentBranches`.
- This is what wires the plane that #1423 added; `userReach` is satisfied here, and the browser backend follows in 段3.

## The migration: per document, read-through, no boot fold

A document whose branches are still rows reads them. The first write moves it onto the plane and drops its rows, **in that order** — so a failure leaves the rows as the reading, which is a state the load path already handles, rather than leaving the document with neither.

Nothing folds at boot. That is the point: there is no partial fold to recover from, no marker to keep in step with a second writer (the trap `.claude/rules/vocabulary.md` records, where `prepareDataDir` re-invoked a boot writer after a migration), and no window in which a document has half a plane and half its rows. A document has one or the other.

The retirement is per **document**, never per workspace: writing one document's branches must not drop another's rows before anything has read them onto its plane. `keeps another document’s rows when one document moves` is the case for that.

## Two existing tests changed — both because what they asserted moved

Neither is a weakening, and both are worth a reviewer's eye:

- **`records the workspaceId on every branch row` is deleted.** It pinned a column whose whole purpose was letting a workspace-scoped read skip a join. On the record the tree *is* the scope, so the column has nothing left to buy — and the same property is now asserted directly, by `readWorkspaceBranchTips` finding every document's tips across the workspace from the record alone. That is the replacement case, not an omission.
- **`still reports switchedHead when reconciliation fails AFTER the head switch persisted` moves its failure injection.** The head switch is itself a record save now, so rejecting *every* save fails the switch this case needs to have SUCCEEDED, and the test would assert nothing. The rejection is armed at the one moment between the two — `sendHeadChanged`, which the cleanup calls after the switch has persisted and before the reconcile. (This is the second time that injection point has moved with the storage; the comment it replaces documents the first.)
- The rename lifecycle case drops its `branches` row query and keeps the property it was there for: a rename cannot reach branches, because the record is keyed by documentId. That is stated once, through the reader everything else uses.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — `packages/mcp-server/src/server/store/branches-store.record.test.ts`, 5 cases, each written red first: a created branch answered from the record **with the rows asserted gone** (the discriminator — asserting only that it reads back would pass against the row store unchanged), a branch that exists only as a row still read, a row-backed document moved onto the record by its first write, every tip in the workspace answered from the record across documents, and another document's rows left alone.
- [x] The existing merge, compaction-pin, file-gc, branches-store and lifecycle suites all pass unchanged except the three cases above — including `compact-branch-pin`, which exercises the union.
- [x] Suites for the area, run locally on this branch: `--project mcp-node --project history-node --project loro-adapter-node --project arch-lint-node --project daemon-client-node` → **433 files / 4782 tests passed, 9 skipped**. `pnpm -r typecheck` clean, `pnpm lint` clean (the 3 warnings are main's `docker-contract.test.ts`, outside this diff), `pnpm knip` clean.
- [x] Swept for anything still reading the table directly. Three touches remain and each is deliberate: the row delete on document delete (still needed for an un-migrated document), the compaction pin's row half, and the fallback read plus the retirement delete in `branches-store`. Every hit in `routes/branches.ts` is a URL segment, not the table.
- [ ] Manual verification completed — the daemon's own branch routes, merge and compaction are what exercise this, and their suites run above against the real store rather than a mock. The defect this increment actually surfaced was found by driving that path, not by reading it: see #1423's second commit.
- [ ] E2E coverage added or extended where applicable — not applicable; no user flow changes, and the flows that use branches are already covered.

## Follow-ups, deliberately not here

Dropping the `branches` table needs every document to have been written at least once, so it waits for a later increment with its own migration. Until then the table is vestigial for a migrated document and authoritative for one nobody has touched, which is exactly what the union above is for.

## Visual evidence

Visual evidence: none — no user-visible change. Every route, MCP tool and response shape is byte-identical; this moves where the daemon keeps a branch, not what a branch is or what anybody sees.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — neither changes; `branches-store`'s own header carries the new storage and the migration's shape, where the next reader of that file will find it
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema — the state is `packages/history`'s `documentBranchesStateSchema` throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh)_