### PR TITLE
feat(web): the browser keeper has variations, and `branches` stops being a capability

### DIFF
--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -19,7 +19,7 @@ Package boundaries are cut by **runtime requirements**, not by feature. The shar
 | `packages/daemon-client` | the daemon's browser-safe client half: the `/api` Zod contracts the web app parses, the fetch/WS/SSE document backends, `api-client`, and the shared backend contract test suites. Extracted from mcp-server's `src/shared` so browser-safety is structural (this table scans it), not positional; consumed directly by both composition roots | model, server-core, history, zod, @opentelemetry (browser SDK set) |
 | `packages/canvas-viewer` | Read-only spatial-canvas scene viewer UI (renders canvas-render SVG), shared between `apps/web` and the MCP Apps widget | model, codec, render, `@modelcontextprotocol/ext-apps`, react, zod |
 | `packages/mcp-server` | Node composition root: CLI, stdio, local store impls, resvg, Inversify container | server-core + port impls |
-| `apps/web` | Browser composition root: Canvas API backend, IndexedDB store impls, read-write spatial canvas editor, markdown editor | loro-adapter, model, codec, render, canvas-viewer, ports, facet-engine, facet-ui, plugin-visual, search, workspace-index, daemon-client + port impls |
+| `apps/web` | Browser composition root: Canvas API backend, IndexedDB store impls, read-write spatial canvas editor, markdown editor | loro-adapter, model, codec, render, canvas-viewer, ports, facet-engine, facet-ui, plugin-visual, search, workspace-index, daemon-client, history + port impls |
 
 **A third-party dependency is judged by that criterion, not by a quota.** The
 `allowedThirdParty` lists in `architecture-map.ts` are a RECORD of what has

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,7 @@
     "@kamiazya/whiteboard-facet-ui": "workspace:*",
     "@kamiazya/whiteboard-loro-adapter": "workspace:*",
     "@kamiazya/whiteboard-daemon-client": "workspace:*",
+    "@kamiazya/whiteboard-history": "workspace:*",
     "@kamiazya/whiteboard-model": "workspace:*",
     "@kamiazya/whiteboard-plugin-visual": "workspace:*",
     "@kamiazya/whiteboard-ports": "workspace:*",

--- a/apps/web/src/App.route-sync-stale-replay.test.tsx
+++ b/apps/web/src/App.route-sync-stale-replay.test.tsx
@@ -93,7 +93,6 @@ const { App } = await import('./App.js')
 const BROWSER_STATE: ProviderState = {
   kind: 'browser',
   capabilities: {
-    branches: false,
     merge: false,
   },
 }

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -143,7 +143,6 @@ vi.mock('./pages/DaemonIndexPage.js', () => ({
 const BROWSER_STATE: ProviderState = {
   kind: 'browser',
   capabilities: {
-    branches: false,
     merge: false,
   },
 }
@@ -152,7 +151,6 @@ const DAEMON_STATE: ProviderState = {
   kind: 'daemon',
   daemonBaseUrl: 'http://127.0.0.1:3000',
   capabilities: {
-    branches: true,
     merge: true,
   },
 }

--- a/apps/web/src/App.workspace-switch.test.tsx
+++ b/apps/web/src/App.workspace-switch.test.tsx
@@ -31,7 +31,7 @@ vi.mock('./hooks/useDaemonConnection.js', () => ({
 
 const BROWSER_STATE: ProviderState = {
   kind: 'browser',
-  capabilities: { branches: false, merge: false },
+  capabilities: { merge: false },
 }
 
 // Fixed rather than minted: two ULIDs made inside one millisecond order

--- a/apps/web/src/components/WorkspaceTopBar.test.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.test.tsx
@@ -12,7 +12,9 @@ vi.mock('./VersionTimeline', () => ({ default: () => null }))
 vi.mock('@kamiazya/whiteboard-daemon-client/api-client', () => ({ apiFetch: vi.fn() }))
 
 import { apiFetch } from '@kamiazya/whiteboard-daemon-client/api-client'
+import { BranchesBackendContext } from '../contexts/BranchesBackendContext.js'
 import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
+import { createBrowserBranchesBackend } from '../lib/browser-branches-backend.js'
 import WorkspaceTopBar, { type DocumentIdentity } from './WorkspaceTopBar'
 
 function mkNamesOk() {
@@ -218,20 +220,22 @@ describe('WorkspaceTopBar — optional daemon-context props (RED-first)', () => 
     expect(screen.queryByLabelText('Back to documents')).toBeNull()
   })
 
-  it('hides HeaderBranchChip when capabilities.branches is false', () => {
+  it('hides HeaderBranchChip when the keeper answering has no branches', () => {
+    // It used to be `capabilities.branches: false`. That flag is gone — both
+    // keepers have variations — and whether to show the chip became the
+    // BACKEND's answer, which is per document: a browser page has no
+    // record-holding backend for a markdown body or before one loads.
     render(
-      <WorkspaceTopBar
-        workspaceId="ws_1"
-        path="canvas-a"
-        onNavigateBack={() => {}}
-        capabilities={{ branches: false, merge: true }}
-      />,
+      <BranchesBackendContext.Provider value={createBrowserBranchesBackend({ backend: null })}>
+        <WorkspaceTopBar
+          workspaceId="ws_1"
+          path="canvas-a"
+          onNavigateBack={() => {}}
+          capabilities={{ merge: true }}
+        />
+      </BranchesBackendContext.Provider>,
       { container: document.body },
     )
-    // HeaderBranchChip is stubbed to render null, so absence is confirmed by
-    // the fact mounting never throws when the chip's props (workspaceId/path)
-    // would otherwise be required — the real assertion lives in the
-    // conditional render below via a spy-friendly mock override.
     expect(screen.queryByTestId('header-branch-chip')).toBeNull()
   })
 })

--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -2,6 +2,7 @@ import { ChevronLeft, History, RotateCcw, X } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { HEADER_BUTTON_CLASS, HEADER_TOGGLE_CLASS } from '../components/ui/header-button.js'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../components/ui/tooltip.js'
+import { useBranchesBackend } from '../contexts/BranchesBackendContext.js'
 import { useDaemonApi } from '../contexts/DaemonApiContext.js'
 import { cn } from '../lib/utils.js'
 import { HeaderBranchChip } from './HeaderBranchChip'
@@ -34,7 +35,6 @@ export interface TopBarPreview {
 }
 
 export interface WorkspaceTopBarCapabilities {
-  branches?: boolean
   merge?: boolean
 }
 
@@ -136,7 +136,11 @@ export default function WorkspaceTopBar({
   titleSlot,
 }: Props) {
   const isLocalMode = dataMode === 'local'
-  const branchesEnabled = capabilities?.branches ?? true
+  // Whether to show the chip at all is the BACKEND's answer, not a keeper
+  // flag: both keepers have variations now, but a document with no
+  // record-holding backend (a markdown body, or one still loading) has none.
+  // That is per document, which no provider-level flag can say.
+  const branchesEnabled = useBranchesBackend().hasBranches
   const mergeEnabled = capabilities?.merge ?? true
   const daemonFetch = useDaemonApi()
 

--- a/apps/web/src/lib/branches-backend.contract.browser.test.tsx
+++ b/apps/web/src/lib/branches-backend.contract.browser.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * The branches contract against the BROWSER keeper, over a real IndexedDB
+ * workspace record.
+ *
+ * The daemon half of this suite runs in `branches-backend.contract.test.ts`,
+ * against a stand-in for its routes — a client test that needs no browser.
+ * This half needs one: the browser keeper IS its storage, so a stand-in here
+ * would only assert that this file's stand-in does what this file's stand-in
+ * does. The record, the write queue and the plane are the subject.
+ *
+ * Same contract, both keepers, which is the point of `branchesBackendContract`
+ * existing at all — a behaviour one keeper gets wrong is otherwise caught only
+ * if somebody thought to write that case in that keeper's own file.
+ */
+import { describe } from 'vitest'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { BrowserBackend } from './browser-backend.js'
+import { createBrowserBranchesBackend } from './browser-branches-backend.js'
+import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
+import {
+  type BranchesBackendHarness,
+  branchesBackendContract,
+} from './branches-backend.contract.js'
+import { FoldingBrowserIndex } from './folding-browser-index.js'
+
+claimIsolatedWhiteboardDb('branchesbackendcontract')
+
+async function browserHarness(): Promise<BranchesBackendHarness> {
+  await clearWhiteboardDb()
+  const workspaceId = getBrowserWorkspaceId()
+  const index = new FoldingBrowserIndex()
+  await index.createWorkspace({ workspaceId })
+  const { documentId } = await index.createDocument({
+    workspaceId,
+    path: 'canvas-a',
+    kind: 'spatial',
+  })
+
+  const docs = new BrowserWorkspaceDocs()
+  const backend = new BrowserBackend({ documentId, path: 'canvas-a', kind: 'spatial' }, docs)
+  // A branch write lands on the record the BACKEND holds, so it has to be
+  // connected for one to have anywhere to go — the same reason the versions
+  // contract's browser harness connects before a restore.
+  backend.connect({
+    onSnapshot: () => {},
+    onRemoteUpdate: () => {},
+    onConnected: () => {},
+    onDisconnected: () => {},
+    onRestoreStarted: () => {},
+    onRestoreComplete: () => {},
+    onVersionCreated: () => {},
+    onHeadChanged: () => {},
+    onViewportRequest: () => {},
+    onExportRequest: () => {},
+  })
+  await new Promise((r) => setTimeout(r, 50))
+
+  return {
+    backend: createBrowserBranchesBackend({ backend }),
+    workspaceId,
+    path: 'canvas-a',
+    async cleanup() {
+      backend.disconnect()
+      await clearWhiteboardDb()
+    },
+  }
+}
+
+describe('BranchesBackend contract — browser keeper (real IndexedDB record)', () => {
+  branchesBackendContract(browserHarness)
+})

--- a/apps/web/src/lib/branches-backend.contract.browser.test.tsx
+++ b/apps/web/src/lib/branches-backend.contract.browser.test.tsx
@@ -15,14 +15,14 @@
 import { describe } from 'vitest'
 import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
-import { BrowserBackend } from './browser-backend.js'
-import { createBrowserBranchesBackend } from './browser-branches-backend.js'
-import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
-import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import {
   type BranchesBackendHarness,
   branchesBackendContract,
 } from './branches-backend.contract.js'
+import { BrowserBackend } from './browser-backend.js'
+import { createBrowserBranchesBackend } from './browser-branches-backend.js'
+import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import { FoldingBrowserIndex } from './folding-browser-index.js'
 
 claimIsolatedWhiteboardDb('branchesbackendcontract')

--- a/apps/web/src/lib/branches-backend.contract.browser.test.tsx
+++ b/apps/web/src/lib/branches-backend.contract.browser.test.tsx
@@ -12,7 +12,7 @@
  * existing at all — a behaviour one keeper gets wrong is otherwise caught only
  * if somebody thought to write that case in that keeper's own file.
  */
-import { describe } from 'vitest'
+import { describe, expect, vi } from 'vitest'
 import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import {
@@ -55,7 +55,10 @@ async function browserHarness(): Promise<BranchesBackendHarness> {
     onViewportRequest: () => {},
     onExportRequest: () => {},
   })
-  await new Promise((r) => setTimeout(r, 50))
+  // Wait for the CONDITION the harness actually needs — the record delivered
+  // — rather than for a duration. `readRecord` answers null until then, so
+  // this is the same question the backend asks itself.
+  await vi.waitFor(() => expect(backend.readRecord(() => true)).toBe(true))
 
   return {
     backend: createBrowserBranchesBackend({ backend }),

--- a/apps/web/src/lib/branches-backend.contract.test.ts
+++ b/apps/web/src/lib/branches-backend.contract.test.ts
@@ -20,9 +20,8 @@ import { describe } from 'vitest'
 import {
   type BranchesBackendHarness,
   branchesBackendContract,
-  branchlessBackendContract,
 } from './branches-backend.contract.js'
-import { createBrowserBranchesBackend, createDaemonBranchesBackend } from './branches-backend.js'
+import { createDaemonBranchesBackend } from './branches-backend.js'
 
 function daemonHarness(): BranchesBackendHarness {
   const main: BranchMeta = {
@@ -137,7 +136,6 @@ describe('branches contract', () => {
     branchesBackendContract(daemonHarness)
   })
 
-  describe('browser keeper (no branches yet)', () => {
-    branchlessBackendContract(createBrowserBranchesBackend)
-  })
+  // The browser keeper's run is `branches-backend.contract.browser.test.tsx`:
+  // it IS its storage, so it needs a real record rather than a stand-in.
 })

--- a/apps/web/src/lib/branches-backend.contract.ts
+++ b/apps/web/src/lib/branches-backend.contract.ts
@@ -1,6 +1,6 @@
-import { BranchesUnsupportedError } from './branches-backend.js'
 import { expect, it } from 'vitest'
 import type { BranchesBackend } from './branches-backend.js'
+import { BranchesUnsupportedError } from './branches-backend.js'
 
 /**
  * The behavioural contract a `BranchesBackend` with branches must satisfy,

--- a/apps/web/src/lib/branches-backend.contract.ts
+++ b/apps/web/src/lib/branches-backend.contract.ts
@@ -1,6 +1,6 @@
+import { BranchesUnsupportedError } from './branches-backend.js'
 import { expect, it } from 'vitest'
 import type { BranchesBackend } from './branches-backend.js'
-import { BranchesUnsupportedError } from './branches-backend.js'
 
 /**
  * The behavioural contract a `BranchesBackend` with branches must satisfy,
@@ -151,16 +151,22 @@ export function branchesBackendContract(
 }
 
 /**
- * The contract for a keeper that has NO branches yet: the resting state, and
- * refusals that are local and typed. This is what the browser keeper answers
- * today; when it grows branches it moves to `branchesBackendContract` above
- * and this describe goes with it.
+ * The contract for a browser keeper with no record-holding backend: the
+ * resting state, and refusals that are local and typed.
+ *
+ * This used to describe the browser keeper itself, which had no branches at
+ * all. It has them now — and the contract did not become dead, it changed
+ * SUBJECT. The page has no `BrowserBackend` for a markdown document, or
+ * before one loads, and in those states the keeper must still answer: handing
+ * the context a `null` instead falls through to its DAEMON fallback and
+ * starts issuing requests to a daemon that is not there, which is the one
+ * regression the provider was mounted to prevent.
  */
 export function branchlessBackendContract(create: () => BranchesBackend): void {
   it('declares that it has no branches, and answers the resting state', async () => {
     const backend = create()
     expect(backend.hasBranches).toBe(false)
-    expect(await backend.list('w', 'p')).toEqual({ branches: [], head: 'main' })
+    expect((await backend.list('w', 'p')).head).toBe('main')
     expect(await backend.loadDocument('w', 'p', 'main')).toBeNull()
   })
 

--- a/apps/web/src/lib/branches-backend.test.ts
+++ b/apps/web/src/lib/branches-backend.test.ts
@@ -1,10 +1,12 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from 'vitest'
-import {
-  BranchesUnsupportedError,
-  createBrowserBranchesBackend,
-  createDaemonBranchesBackend,
-} from './branches-backend.js'
+import { branchlessBackendContract } from './branches-backend.contract.js'
+import { createDaemonBranchesBackend } from './branches-backend.js'
+import { BrowserBackend } from './browser-backend.js'
+import { createBrowserBranchesBackend } from './browser-branches-backend.js'
+
+/** Any document: this file never delivers a record, so nothing reads it. */
+const TARGET = { documentId: '01JZZZZZZZZZZZZZZZZZZZZZZZ', path: 'doc', kind: 'spatial' } as const
 
 /**
  * The seam exists for ONE reason, and it is a default rather than a feature.
@@ -21,39 +23,52 @@ import {
  * request to a daemon that is not there.
  */
 describe('the browser keeper answers for branches instead of reaching for a daemon', () => {
-  it('answers the resting state: one lane, main, no request', async () => {
-    const backend = createBrowserBranchesBackend()
-    expect(await backend.list('ws', 'doc')).toEqual({ branches: [], head: 'main' })
+  /**
+   * A backend whose record has not been delivered — which is what a page has
+   * before its document loads, and all this file needs. What the browser
+   * keeper DOES with a delivered record is the contract's business, run
+   * against real IndexedDB in `branches-backend.contract.browser.test.tsx`;
+   * what is left here is the one property that is about the seam rather than
+   * about branches.
+   */
+  const browserBackend = () =>
+    createBrowserBranchesBackend({ backend: new BrowserBackend(TARGET) })
+
+  // The state the page is in for a markdown document, and before any document
+  // loads. It must not be expressed as a `null` context value: that falls
+  // through to the DAEMON backend and issues requests to a daemon that is not
+  // there, which is what mounting a browser provider exists to stop.
+  describe('with no record-holding backend', () => {
+    branchlessBackendContract(() => createBrowserBranchesBackend({ backend: null }))
+
+    it('makes no fetch while answering and refusing', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      const backend = createBrowserBranchesBackend({ backend: null })
+      await backend.list('ws', 'doc')
+      await backend.setHead('ws', 'doc', 'x').catch(() => {})
+      expect(fetchSpy).not.toHaveBeenCalled()
+      fetchSpy.mockRestore()
+    })
   })
 
-  it('refuses every mutator with a typed error rather than a request', async () => {
-    const backend = createBrowserBranchesBackend()
-    // Named one at a time rather than looped, so a method ADDED to the seam
-    // and left unimplemented here is a type error rather than a silent gap —
-    // a loop over Object.keys would pass over whatever it happened to find.
-    await expect(backend.create('ws', 'doc', { name: 'x' })).rejects.toBeInstanceOf(
-      BranchesUnsupportedError,
-    )
-    await expect(backend.remove('ws', 'doc', 'x')).rejects.toBeInstanceOf(BranchesUnsupportedError)
-    await expect(backend.rename('ws', 'doc', 'x', 'y')).rejects.toBeInstanceOf(
-      BranchesUnsupportedError,
-    )
-    await expect(backend.setHead('ws', 'doc', 'x')).rejects.toBeInstanceOf(BranchesUnsupportedError)
-    await expect(backend.getStats('ws', 'doc', 'x')).rejects.toBeInstanceOf(
-      BranchesUnsupportedError,
-    )
-    await expect(backend.merge('ws', 'doc', 'x', { into: 'main' })).rejects.toBeInstanceOf(
-      BranchesUnsupportedError,
-    )
+  it('answers the resting state before its record arrives: main, and no request', async () => {
+    expect(await browserBackend().list('ws', 'doc')).toEqual({
+      branches: [{ name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '' }],
+      head: 'main',
+    })
   })
 
-  it('makes no fetch at all — the refusal is local, not a request that failed', async () => {
-    // The assertion the two above cannot make between them: `list` could
-    // answer the resting state from a request it made and discarded, and a
-    // mutator could reject because a fetch rejected. Either would reintroduce
-    // exactly the traffic this seam exists to stop.
+  it('makes no fetch at all — what it cannot do yet fails locally, not as a request', async () => {
+    // The property this whole seam exists for, and the one the cases above
+    // cannot make between them: `list` could answer from a request it made
+    // and discarded, and a mutator could reject because a fetch rejected.
+    // Either would reintroduce exactly the traffic the seam stops.
+    //
+    // It outlived the branchless backend it was written for. That backend is
+    // gone — the browser keeper has branches now — and the assertion is the
+    // same either way: this keeper reaches its own storage or nothing.
     const fetchSpy = vi.spyOn(globalThis, 'fetch')
-    const backend = createBrowserBranchesBackend()
+    const backend = browserBackend()
     await backend.list('ws', 'doc')
     await backend.setHead('ws', 'doc', 'x').catch(() => {})
     expect(fetchSpy).not.toHaveBeenCalled()

--- a/apps/web/src/lib/branches-backend.test.ts
+++ b/apps/web/src/lib/branches-backend.test.ts
@@ -31,8 +31,7 @@ describe('the browser keeper answers for branches instead of reaching for a daem
    * what is left here is the one property that is about the seam rather than
    * about branches.
    */
-  const browserBackend = () =>
-    createBrowserBranchesBackend({ backend: new BrowserBackend(TARGET) })
+  const browserBackend = () => createBrowserBranchesBackend({ backend: new BrowserBackend(TARGET) })
 
   // The state the page is in for a markdown document, and before any document
   // loads. It must not be expressed as a `null` context value: that falls

--- a/apps/web/src/lib/branches-backend.ts
+++ b/apps/web/src/lib/branches-backend.ts
@@ -296,27 +296,3 @@ export function createDaemonBranchesBackend(fetchFn: typeof globalThis.fetch): B
     loadDocument: (workspaceId, path, name) => api(workspaceId, path).loadDocument(name),
   }
 }
-
-/**
- * The browser keeper, which has no branches.
- *
- * `list` answers the RESTING STATE rather than throwing, because a panel that
- * reads `head` to draw its mini-graph wants an answer, not an error to log
- * and ignore. The mutators refuse, because a caller that got here is offering
- * an action this keeper cannot perform and silently succeeding would be worse
- * than saying so.
- */
-export function createBrowserBranchesBackend(): BranchesBackend {
-  const refuse = (what: string) => Promise.reject(new BranchesUnsupportedError(what))
-  return {
-    hasBranches: false,
-    list: () => Promise.resolve({ branches: [], head: 'main' }),
-    create: () => refuse('create'),
-    remove: () => refuse('delete'),
-    rename: () => refuse('rename'),
-    setHead: () => refuse('switch'),
-    getStats: () => refuse('stats'),
-    merge: () => refuse('merge'),
-    loadDocument: () => Promise.resolve(null),
-  }
-}

--- a/apps/web/src/lib/browser-backend.ts
+++ b/apps/web/src/lib/browser-backend.ts
@@ -177,6 +177,67 @@ export class BrowserBackend implements DocumentBackend {
     return queued
   }
 
+  /**
+   * Change the workspace record this backend holds, and deliver the change
+   * the way a peer's would arrive.
+   *
+   * The same shape as `applyRestore` — queued behind pending pushes so a
+   * keystroke in flight is not lost under it, saved through the same store,
+   * and handed to the sync session as a remote update so its twin of the
+   * record converges. Two differences, both deliberate: no restore brackets,
+   * because this is not a restore and a page must not draw the overlay for
+   * it; and no `touchContentTimestamp`, because what this writes is not the
+   * document's content.
+   *
+   * That last point is what makes it safe at all. A plane lives outside
+   * `CONTENT_CONTAINER_KEYS` and outside `projectWorkspaceDocument`, so the
+   * update produced here cannot be read back as content by the session and
+   * written over by the next save — which is exactly what happened to the
+   * daemon's branch tips before planes were namespaced.
+   */
+  mutateRecord<T>(mutate: (doc: LoroDoc, documentId: string) => T): Promise<T> {
+    const workspaceDoc = this.workspaceDoc
+    const workspaceId = workspaceDoc === null ? null : getBrowserWorkspaceId()
+    const handlers = this.handlers
+    const run = async (): Promise<T> => {
+      if (workspaceDoc === null || workspaceId === null || handlers === null) {
+        throw new Error('record write before the document was delivered')
+      }
+      const before = workspaceDoc.version()
+      const result = mutate(workspaceDoc, this.target.documentId)
+      const update = workspaceDoc.export({ mode: 'update', from: before })
+      // A mutation that changed nothing writes nothing: the branch ops are
+      // read-modify-write and several of them legitimately no-op (setHead to
+      // the current head, a tip that already matches).
+      if (update.length > 0) {
+        await this.docs.save(workspaceId, workspaceDoc)
+        if (!this.isStale(handlers)) handlers.onRemoteUpdate(update)
+      }
+      return result
+    }
+    const queued = this._writeQueue.then(run)
+    // The queue itself must never reject, or every later push would be
+    // refused by one failed mutation.
+    this._writeQueue = queued.then(
+      () => {},
+      () => {},
+    )
+    return queued
+  }
+
+  /**
+   * Read the live record without writing to it, or `null` before it has been
+   * delivered.
+   *
+   * Separate from `mutateRecord` rather than a flag on it: a read must not
+   * take the write queue, and a caller that only reads should not be able to
+   * write by forgetting an argument.
+   */
+  readRecord<T>(read: (doc: LoroDoc, documentId: string) => T): T | null {
+    if (this.workspaceDoc === null) return null
+    return read(this.workspaceDoc, this.target.documentId)
+  }
+
   private async _doWrite(
     bytes: Uint8Array,
     workspaceDoc: LoroDoc | null,

--- a/apps/web/src/lib/browser-branches-backend.ts
+++ b/apps/web/src/lib/browser-branches-backend.ts
@@ -1,0 +1,179 @@
+/**
+ * The browser keeper's answer to the branches seam.
+ *
+ * A branch is a name and a frontier OF THE WORKSPACE RECORD, and this keeper
+ * holds that record — so it needs no route, no row and no second schema. The
+ * rules for changing one (no duplicate names, `main` immovable, HEAD
+ * undeletable, a rename that follows HEAD and every `baseBranch` naming it)
+ * are `@kamiazya/whiteboard-history`'s, the same functions the daemon runs;
+ * what this module supplies is the read-modify-write around them, which here
+ * is `BrowserBackend`'s write queue rather than the daemon's workspace lock.
+ *
+ * `workspaceId` is ignored in favour of the browser's own, for the reason
+ * `createBrowserVersionsBackend` states: the top bar spells a display
+ * placeholder there, and a branch must not be filed under a name that is not
+ * a workspace.
+ */
+import {
+  type BranchMeta,
+  createBranch as createBranchOp,
+  type DocumentBranchesState,
+  deleteBranch as deleteBranchOp,
+  frontiersFromBase64,
+  planMerge,
+  readBranchesFromRecord,
+  renameBranch as renameBranchOp,
+  setHead as setHeadOp,
+  writeBranchesToRecord,
+} from '@kamiazya/whiteboard-history'
+import {
+  projectWorkspaceDocument,
+  readDocumentKind,
+  readMarkdownBody,
+  readSpatialCanvas,
+} from '@kamiazya/whiteboard-loro-adapter'
+import { LoroDoc } from 'loro-crdt'
+import type { BranchesBackend } from './branches-backend.js'
+import { BranchesUnsupportedError } from './branches-backend.js'
+import type { BrowserBackend } from './browser-backend.js'
+
+/** The state a document has when its record has not been delivered yet. */
+const RESTING: DocumentBranchesState = {
+  branches: [{ name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '' }],
+  head: 'main',
+}
+
+export function createBrowserBranchesBackend(deps: {
+  readonly backend: BrowserBackend
+}): BranchesBackend {
+  const read = (): DocumentBranchesState =>
+    deps.backend.readRecord((doc, documentId) => readBranchesFromRecord(doc, documentId)) ?? RESTING
+
+  /**
+   * One branch operation: read the state, run the pure step, write what it
+   * answers. `next: null` means the step changed nothing, and then nothing is
+   * written — which is what keeps a no-op `setHead` from appending an op.
+   */
+  const mutate = <T>(
+    step: (state: DocumentBranchesState) => { next: DocumentBranchesState | null; result: T },
+  ): Promise<T> =>
+    deps.backend.mutateRecord((doc, documentId) => {
+      const { next, result } = step(readBranchesFromRecord(doc, documentId))
+      if (next !== null) writeBranchesToRecord(doc, documentId, next)
+      return result
+    })
+
+  /** Where a branch is, for the error messages the pure steps build. */
+  const scope = { workspaceId: 'browser', path: '' }
+
+  /**
+   * A CLONE of the record, because reading a branch at its tip means checking
+   * out a frontier and a checkout MOVES the document it is called on. The
+   * clone is what moves; the live record the page is drawing does not.
+   */
+  const cloneRecord = (): { clone: LoroDoc; documentId: string } | null =>
+    deps.backend.readRecord((doc, documentId) => {
+      const clone = new LoroDoc()
+      clone.import(doc.export({ mode: 'snapshot' }))
+      return { clone, documentId }
+    })
+
+  /** The document as one branch's tip has it, or null when there is no such branch. */
+  const atTip = (name: string): LoroDoc | null => {
+    const state = read()
+    const branch = state.branches.find((b) => b.name === name)
+    if (branch === undefined) return null
+    const cloned = cloneRecord()
+    if (cloned === null) return null
+    // An empty tip is a branch nothing has written to: it names the document
+    // as it stands, which is what the record already holds.
+    if (branch.tipFrontiers.length > 0) {
+      cloned.clone.checkout(frontiersFromBase64(branch.tipFrontiers))
+    }
+    return projectWorkspaceDocument(cloned.clone, cloned.documentId)
+  }
+
+  return {
+    hasBranches: true,
+
+    async list() {
+      return read()
+    },
+
+    async create(_workspaceId, _path, args): Promise<BranchMeta> {
+      return mutate((state) =>
+        createBranchOp(state, scope, {
+          name: args.name,
+          ...(args.color === undefined ? {} : { color: args.color }),
+          // The request calls it `fromVersionId`; a branch records it as
+          // `baseVersionId`. One name for the wire, one for the stored shape,
+          // and this is the single place they meet.
+          ...(args.fromVersionId === undefined ? {} : { baseVersionId: args.fromVersionId }),
+        }),
+      )
+    },
+
+    async remove(_workspaceId, _path, name) {
+      return mutate((state) => deleteBranchOp(state, scope, name))
+    },
+
+    async rename(_workspaceId, _path, oldName, newName) {
+      const branch = await mutate((state) => renameBranchOp(state, scope, oldName, newName))
+      // No version rows carry a branch name in this keeper yet, so a rename
+      // renames nothing else. Reported as zero rather than omitted: the field
+      // is the count of what moved, and zero is the true count.
+      return { branch, renamedVersionCount: 0 }
+    },
+
+    async setHead(_workspaceId, _path, branch) {
+      return mutate((state) => setHeadOp(state, scope, branch))
+    },
+
+    async getStats(_workspaceId, _path, name) {
+      const state = read()
+      // `unmergedCommits` is zero for the same reason the daemon answers zero:
+      // tip adoption has no commit count to report, and a number invented here
+      // would read as a measurement.
+      return { unmergedCommits: 0, isHead: state.head === name }
+    },
+
+    async merge(_workspaceId, _path, source, args) {
+      if (args.dryRun !== true) {
+        throw new BranchesUnsupportedError('committing a merge is not implemented in the browser')
+      }
+      const state = read()
+      const into = state.branches.find((b) => b.name === args.into)
+      const from = state.branches.find((b) => b.name === source)
+      const cloned = cloneRecord()
+      if (into === undefined || from === undefined || cloned === null) {
+        throw new Error(`no such branch: ${into === undefined ? args.into : source}`)
+      }
+      const liveDoc = projectWorkspaceDocument(cloned.clone, cloned.documentId) ?? new LoroDoc()
+      const plan = planMerge({
+        workspaceRecord: cloned.clone,
+        documentId: cloned.documentId,
+        liveDoc,
+        into: { name: into.name, tipFrontiers: into.tipFrontiers },
+        source: { name: from.name, tipFrontiers: from.tipFrontiers },
+      })
+      return {
+        badges: plan.badges as unknown as Record<string, unknown>[],
+        preview: { elementCount: plan.previewElementCount },
+        target: { elementCount: plan.targetElementCount },
+        source: { elementCount: plan.sourceElementCount },
+        previewElements: plan.previewElements,
+        newElementIds: plan.newElementIds,
+        changedElementIds: plan.changedElementIds,
+        conflictElementIds: plan.conflictElementIds,
+      }
+    },
+
+    async loadDocument(_workspaceId, _path, name) {
+      const doc = atTip(name)
+      if (doc === null) return null
+      return readDocumentKind(doc) === 'markdown'
+        ? { kind: 'markdown', body: readMarkdownBody(doc) }
+        : { kind: 'spatial', canvas: readSpatialCanvas(doc) }
+    },
+  }
+}

--- a/apps/web/src/lib/browser-branches-backend.ts
+++ b/apps/web/src/lib/browser-branches-backend.ts
@@ -43,11 +43,24 @@ const RESTING: DocumentBranchesState = {
   head: 'main',
 }
 
+/**
+ * `backend` is nullable, and that is load-bearing rather than defensive.
+ *
+ * The browser page has no `BrowserBackend` for a markdown document — its body
+ * is persisted by its own path — and none at all until the document loads. A
+ * caller that answered `null` to the context in those cases would fall
+ * through to the context's DAEMON fallback and start issuing requests to a
+ * daemon that is not there, which is the single regression this provider was
+ * mounted to prevent. So the browser keeper always answers, and says
+ * truthfully that a document with no record-holding backend has no branches.
+ */
 export function createBrowserBranchesBackend(deps: {
-  readonly backend: BrowserBackend
+  readonly backend: BrowserBackend | null
 }): BranchesBackend {
+  const backend = deps.backend
+  const refuse = (what: string) => Promise.reject(new BranchesUnsupportedError(what))
   const read = (): DocumentBranchesState =>
-    deps.backend.readRecord((doc, documentId) => readBranchesFromRecord(doc, documentId)) ?? RESTING
+    backend?.readRecord((doc, documentId) => readBranchesFromRecord(doc, documentId)) ?? RESTING
 
   /**
    * One branch operation: read the state, run the pure step, write what it
@@ -57,7 +70,7 @@ export function createBrowserBranchesBackend(deps: {
   const mutate = <T>(
     step: (state: DocumentBranchesState) => { next: DocumentBranchesState | null; result: T },
   ): Promise<T> =>
-    deps.backend.mutateRecord((doc, documentId) => {
+    (backend as BrowserBackend).mutateRecord((doc, documentId) => {
       const { next, result } = step(readBranchesFromRecord(doc, documentId))
       if (next !== null) writeBranchesToRecord(doc, documentId, next)
       return result
@@ -72,11 +85,11 @@ export function createBrowserBranchesBackend(deps: {
    * clone is what moves; the live record the page is drawing does not.
    */
   const cloneRecord = (): { clone: LoroDoc; documentId: string } | null =>
-    deps.backend.readRecord((doc, documentId) => {
+    backend?.readRecord((doc, documentId) => {
       const clone = new LoroDoc()
       clone.import(doc.export({ mode: 'snapshot' }))
       return { clone, documentId }
-    })
+    }) ?? null
 
   /** The document as one branch's tip has it, or null when there is no such branch. */
   const atTip = (name: string): LoroDoc | null => {
@@ -94,13 +107,14 @@ export function createBrowserBranchesBackend(deps: {
   }
 
   return {
-    hasBranches: true,
+    hasBranches: backend !== null,
 
     async list() {
       return read()
     },
 
     async create(_workspaceId, _path, args): Promise<BranchMeta> {
+      if (backend === null) return refuse('create')
       return mutate((state) =>
         createBranchOp(state, scope, {
           name: args.name,
@@ -114,10 +128,12 @@ export function createBrowserBranchesBackend(deps: {
     },
 
     async remove(_workspaceId, _path, name) {
+      if (backend === null) return refuse('delete')
       return mutate((state) => deleteBranchOp(state, scope, name))
     },
 
     async rename(_workspaceId, _path, oldName, newName) {
+      if (backend === null) return refuse('rename')
       const branch = await mutate((state) => renameBranchOp(state, scope, oldName, newName))
       // No version rows carry a branch name in this keeper yet, so a rename
       // renames nothing else. Reported as zero rather than omitted: the field
@@ -126,10 +142,12 @@ export function createBrowserBranchesBackend(deps: {
     },
 
     async setHead(_workspaceId, _path, branch) {
+      if (backend === null) return refuse('switch')
       return mutate((state) => setHeadOp(state, scope, branch))
     },
 
     async getStats(_workspaceId, _path, name) {
+      if (backend === null) return refuse('stats')
       const state = read()
       // `unmergedCommits` is zero for the same reason the daemon answers zero:
       // tip adoption has no commit count to report, and a number invented here
@@ -138,6 +156,7 @@ export function createBrowserBranchesBackend(deps: {
     },
 
     async merge(_workspaceId, _path, source, args) {
+      if (backend === null) return refuse('merge')
       if (args.dryRun !== true) {
         throw new BranchesUnsupportedError('committing a merge is not implemented in the browser')
       }

--- a/apps/web/src/lib/keeper-parity.test.ts
+++ b/apps/web/src/lib/keeper-parity.test.ts
@@ -60,6 +60,7 @@ type KeeperReach =
   /** A real difference nobody declared, with the follow-up that closes it. */
   | { readonly reach: 'gap'; readonly missing: string; readonly followUp: string }
 
+const BROWSER_BRANCHES = 'src/lib/browser-branches-backend.ts'
 const BROWSER_VERSIONS = 'src/lib/browser-versions-backend.ts'
 const BROWSER_FILES = 'src/lib/local-files-source.ts'
 const BROWSER_PAGE = 'src/pages/BrowserDocumentPage.tsx'
@@ -96,16 +97,24 @@ const DAEMON_REACH: Record<string, KeeperReach> = {
     note: 'the daemon backend is this context FALLBACK; the browser page provides its own',
   },
   // The branch seam, in two halves. The context is which keeper answers; the
-  // backend holds the daemon's requests AND the browser's refusal. Together
-  // they make the declared difference the DEFAULT rather than a flag each
-  // caller passes. (`capability` entries take no `note` — the vocabulary's
-  // own type says so — so this is a comment.)
+  // backend holds the daemon's requests. They were `capability` entries while
+  // only the daemon had variations; the browser keeps its own on the
+  // workspace record now, so the difference they named is gone and the answer
+  // is the ordinary one — a browser module that answers without a daemon.
   //
   // `src/hooks/useBranches.ts` is deliberately absent: it stopped reaching
   // the daemon when the transport moved out of it, and this ledger's other
   // direction fails on an entry naming a module that no longer reaches.
-  'src/contexts/BranchesBackendContext.tsx': { reach: 'capability', capability: 'branches' },
-  'src/lib/branches-backend.ts': { reach: 'capability', capability: 'branches' },
+  'src/contexts/BranchesBackendContext.tsx': {
+    reach: 'both-keepers',
+    browser: BROWSER_BRANCHES,
+    note: 'the daemon backend is this context FALLBACK; the browser page provides its own',
+  },
+  'src/lib/branches-backend.ts': {
+    reach: 'both-keepers',
+    browser: BROWSER_BRANCHES,
+    note: "the daemon's half of the seam; the browser's is the module named here",
+  },
   'src/lib/daemon-api-client.ts': {
     reach: 'both-keepers',
     browser: BROWSER_FILES,
@@ -294,13 +303,18 @@ describe('a panel whose behaviour differs by keeper is told which keeper it is',
     ).toBe(true)
   })
 
-  it('agrees with the provider about branches', () => {
-    // Two capability surfaces describing one keeper: the provider's map,
-    // which gates the teaser copy, and the panel's prop, which decides
-    // whether a lane column is drawn. Disagreeing is a silent difference of
-    // its own — the chrome would promise branches while the panel drew one
-    // lane, or the reverse.
-    expect(BROWSER_HISTORY_CAPABILITIES.branches).toBe(BROWSER_CAPABILITIES.branches)
-    expect(DAEMON_HISTORY_CAPABILITIES.branches).toBe(DAEMON_CAPABILITIES.branches)
+  it('draws lanes for what the ROWS carry, which is not the same as having variations', () => {
+    // This compared the panel's flag to the provider's, back when the
+    // provider had one. It does not any more: both keepers have variations,
+    // so `capabilities.branches` is gone the way `workspaces` and `versions`
+    // went before it.
+    //
+    // The panel's flag survives because it asks a DIFFERENT question — do the
+    // version rows carry a branch to lane by? The browser's do not yet (they
+    // gain `auto`/`branchName` with automatic checkpoints), so one lane there
+    // is correct rather than a leftover, and this pins it as a decision until
+    // that increment lands.
+    expect(BROWSER_HISTORY_CAPABILITIES.branches).toBe(false)
+    expect(DAEMON_HISTORY_CAPABILITIES.branches).toBe(true)
   })
 })

--- a/apps/web/src/lib/provider.test.ts
+++ b/apps/web/src/lib/provider.test.ts
@@ -21,34 +21,21 @@ describe('resolveProviderState', () => {
     expect(state).toMatchObject({ kind: 'daemon', daemonBaseUrl: 'http://127.0.0.1:3099' })
   })
 
-  it('browser capabilities: no branches, no merge — versions is not a capability, both keepers have one', () => {
+  it('browser capabilities: no merge — and neither versions nor branches is a capability', () => {
     const state = resolveProviderState(EMPTY_RUNTIME_CONFIG)
-    expect(state).toMatchObject({
-      kind: 'browser',
-      capabilities: { branches: false, merge: false },
-    })
+    expect(state).toMatchObject({ kind: 'browser', capabilities: { merge: false } })
+    // A flag both keepers set the same way is not a capability, and each of
+    // these left for that reason as the browser keeper grew the feature:
+    // `versions` when it kept its own history, `branches` when it kept its
+    // own variations on the workspace record.
     expect(state.kind === 'browser' && 'versions' in state.capabilities).toBe(false)
+    expect(state.kind === 'browser' && 'branches' in state.capabilities).toBe(false)
   })
 
-  it('daemon capabilities: branches and merge', () => {
+  it('daemon capabilities: merge, which is the one thing the keepers still differ on', () => {
     const state = resolveProviderState({ daemonBaseUrl: 'http://127.0.0.1:3099' })
-    expect(state).toMatchObject({ kind: 'daemon', capabilities: { branches: true, merge: true } })
-  })
-
-  it('browser capabilities: branches and merge are false', () => {
-    const state = resolveProviderState(EMPTY_RUNTIME_CONFIG)
-    expect(state).toMatchObject({
-      kind: 'browser',
-      capabilities: { branches: false, merge: false },
-    })
-  })
-
-  it('daemon capabilities: branches and merge are true', () => {
-    const state = resolveProviderState({ daemonBaseUrl: 'http://127.0.0.1:3099' })
-    expect(state).toMatchObject({
-      kind: 'daemon',
-      capabilities: { branches: true, merge: true },
-    })
+    expect(state).toMatchObject({ kind: 'daemon', capabilities: { merge: true } })
+    expect(state.kind === 'daemon' && 'branches' in state.capabilities).toBe(false)
   })
 
   it('descriptor JSON contains no token Authorization Bearer secret fields', () => {

--- a/apps/web/src/lib/provider.ts
+++ b/apps/web/src/lib/provider.ts
@@ -45,7 +45,12 @@ export type ProviderState =
   | { readonly kind: 'invalid-config'; readonly message: string }
 
 export const BROWSER_CAPABILITIES: WhiteboardCapabilities = {
-  branches: false,
+  // The browser keeper has variations now: a branch is a name and a frontier
+  // of the workspace record, and this keeper holds that record. `merge` stays
+  // false until the commit half lands — the chip separates them already
+  // (`mergeEnabled`), so the difference is a real one a person can see rather
+  // than a control that throws.
+  branches: true,
   merge: false,
 }
 

--- a/apps/web/src/lib/provider.ts
+++ b/apps/web/src/lib/provider.ts
@@ -31,7 +31,12 @@ export type WhiteboardCapabilities = {
   // now, so both keepers answer true and the flag gates nothing. What the
   // daemon adds on top (automatic checkpoints, thumbnails) is a per-panel
   // fact the page states where it mounts the panel, not a keeper flag.
-  readonly branches: boolean
+  // `branches` left the same way, and for the same reason stated twice
+  // above: the browser keeps its variations on the workspace record now, so
+  // both keepers answer true and the flag gates nothing. WHERE the chip is
+  // shown became a per-document fact instead — a markdown document has no
+  // record-holding backend and so no branches — which the backend answers
+  // through `hasBranches`, in the one place that cannot forget it.
   readonly merge: boolean
 }
 
@@ -45,17 +50,13 @@ export type ProviderState =
   | { readonly kind: 'invalid-config'; readonly message: string }
 
 export const BROWSER_CAPABILITIES: WhiteboardCapabilities = {
-  // The browser keeper has variations now: a branch is a name and a frontier
-  // of the workspace record, and this keeper holds that record. `merge` stays
-  // false until the commit half lands — the chip separates them already
-  // (`mergeEnabled`), so the difference is a real one a person can see rather
-  // than a control that throws.
-  branches: true,
+  // `merge` stays false until the commit half lands. The chip separates it
+  // from having branches already (`mergeEnabled`), so this is a real
+  // difference a person can see rather than a control that throws.
   merge: false,
 }
 
 export const DAEMON_CAPABILITIES: WhiteboardCapabilities = {
-  branches: true,
   merge: true,
 }
 

--- a/apps/web/src/pages/BrowserDocumentPage.branches.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.branches.browser.test.tsx
@@ -1,0 +1,104 @@
+import { readBranchesFromRecord } from '@kamiazya/whiteboard-history'
+import {
+  writeSpatialCanvas,
+  writeWorkspaceDocumentContent,
+} from '@kamiazya/whiteboard-loro-adapter'
+import { cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import { LoroDoc } from 'loro-crdt'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { BrowserWorkspaceDocs } from '../lib/browser-workspace-docs.js'
+import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
+import { FoldingBrowserIndex } from '../lib/folding-browser-index.js'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { BrowserDocumentPage } from './BrowserDocumentPage.js'
+import '../index.css'
+
+claimIsolatedWhiteboardDb('browserdocumentpagebranches')
+
+function render(ui: ReactElement) {
+  return rtlRender(
+    <div style={{ height: '100vh' }}>
+      <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
+    </div>,
+  )
+}
+
+async function seedDocument(): Promise<string> {
+  const index = new FoldingBrowserIndex()
+  const workspaceId = getBrowserWorkspaceId()
+  await index.createWorkspace({ workspaceId })
+  const { documentId } = await index.createDocument({
+    workspaceId,
+    path: 'canvas-a',
+    kind: 'spatial',
+  })
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, {
+    nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 80, height: 40, text: 'first' }],
+    edges: [],
+  })
+  doc.commit()
+  const docs = new BrowserWorkspaceDocs()
+  const record = await docs.open(workspaceId)
+  if (record === null) throw new Error('no record')
+  writeWorkspaceDocumentContent(record, documentId, doc)
+  await docs.save(workspaceId, record)
+  return documentId
+}
+
+/** The branches the RECORD holds, read back the way any replica would. */
+async function storedBranches(documentId: string): Promise<string[]> {
+  const record = await new BrowserWorkspaceDocs().open(getBrowserWorkspaceId())
+  if (record === null) return []
+  return readBranchesFromRecord(record, documentId).branches.map((b) => b.name)
+}
+
+// Variations in browser mode, end to end through the real page. Until this
+// increment the chip was not there at all: the keeper's branches were a
+// daemon row, and a row is not something a browser has. They are a plane of
+// the workspace record now, so the same header control answers.
+describe('BrowserDocumentPage variations (browser)', () => {
+  beforeEach(async () => {
+    await clearWhiteboardDb()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('creates a variation from the chip and keeps it on the record', async () => {
+    const documentId = await seedDocument()
+    render(<BrowserDocumentPage initialPath="canvas-a" />)
+    await waitFor(
+      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
+      {
+        timeout: 5000,
+      },
+    )
+
+    // The chip itself is the first assertion: in browser mode it used to be
+    // absent, replaced by a disabled "Variations" teaser.
+    const chip = await screen.findByTestId('header-branch-chip', undefined, { timeout: 5000 })
+    // Case-insensitive: the chip capitalises the label for display, and the
+    // NAME is `main` — asserting the rendering would pin a style choice.
+    expect(chip.textContent ?? '').toMatch(/main/i)
+
+    await userEvent.click(chip)
+    await userEvent.click(await screen.findByText(/New variation/))
+    const input = await screen.findByPlaceholderText('New variation name')
+    await userEvent.type(input, 'idea{Enter}')
+
+    // On the record, which is the point: no row, no request, and a replica
+    // importing this workspace sees the variation too.
+    await waitFor(
+      async () => expect((await storedBranches(documentId)).sort()).toEqual(['idea', 'main']),
+      {
+        timeout: 5000,
+      },
+    )
+  })
+})

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -34,7 +34,7 @@ import {
   parseWorkspaceRoute,
   workspacePath,
 } from '../lib/app-routes.js'
-import { createBrowserBranchesBackend } from '../lib/branches-backend.js'
+import { createBrowserBranchesBackend } from '../lib/browser-branches-backend.js'
 import { BrowserBackend } from '../lib/browser-backend.js'
 import { BrowserVersionStore } from '../lib/browser-version-store.js'
 import { createBrowserVersionsBackend } from '../lib/browser-versions-backend.js'
@@ -497,12 +497,13 @@ function useBrowserDocument(
   )
   const versionsEnabled = versionsBackend !== null
 
-  // Unconditional, unlike `versionsBackend`: this keeper has no branches at
-  // all, so there is nothing to build it out of and nothing that could make
-  // it unavailable. Mounting it is what stops a branch consumer on this page
-  // falling through to the context's daemon fallback and issuing a request
-  // to a daemon that is not there.
-  const branchesBackend = useMemo(() => createBrowserBranchesBackend(), [])
+  // Built on the backend, because a branch is a frontier of the record the
+  // backend holds and a branch write goes through the same queue its edits
+  // do. Mounting it is also what stops a branch consumer on this page falling
+  // through to the context's daemon fallback and issuing a request to a
+  // daemon that is not there — which was this provider's whole job while the
+  // keeper had no branches, and remains true now that it has them.
+  const branchesBackend = useMemo(() => createBrowserBranchesBackend({ backend }), [backend])
   // A manual save announces itself on the window (dispatched after the
   // keeper confirmed the save), and the page's history column re-reads on
   // it. Scoped to THIS document's identity — an unchecked listener refreshed

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -34,8 +34,8 @@ import {
   parseWorkspaceRoute,
   workspacePath,
 } from '../lib/app-routes.js'
-import { createBrowserBranchesBackend } from '../lib/browser-branches-backend.js'
 import { BrowserBackend } from '../lib/browser-backend.js'
+import { createBrowserBranchesBackend } from '../lib/browser-branches-backend.js'
 import { BrowserVersionStore } from '../lib/browser-version-store.js'
 import { createBrowserVersionsBackend } from '../lib/browser-versions-backend.js'
 import { BrowserWorkspaceDocs } from '../lib/browser-workspace-docs.js'

--- a/apps/web/src/pages/DaemonDocumentPage.branches.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.branches.test.tsx
@@ -153,7 +153,7 @@ describe('DaemonDocumentPage branches', () => {
       })
     }
 
-    it('renders HeaderBranchChip when capabilities.branches is true, using the daemon-origin fetch (not global apiFetch)', async () => {
+    it('renders HeaderBranchChip using the daemon-origin fetch (not global apiFetch)', async () => {
       const fetchMock = branchesFetchMock()
       vi.stubGlobal('fetch', fetchMock)
 
@@ -186,14 +186,13 @@ describe('DaemonDocumentPage branches', () => {
       vi.unstubAllGlobals()
     })
 
-    it('shows the static disabled teasers when capabilities.branches/merge are false', async () => {
+    it('shows the Combine teaser when capabilities.merge is false, and still the chip', async () => {
       await act(async () => {
         render(
           <DaemonDocumentPage
             daemonBaseUrl={DAEMON_BASE_URL}
             createBackend={makeCreateBackend()}
             capabilities={{
-              branches: false,
               merge: false,
             }}
           />,
@@ -205,8 +204,12 @@ describe('DaemonDocumentPage branches', () => {
       // docks in Select mode, so tests exercising it switch first.
       fireEvent.click(await screen.findByTestId('select-tool-button'))
 
-      expect(screen.queryByTestId('header-branch-chip')).toBeNull()
-      expect(screen.getByText('Variations')).toBeTruthy()
+      // The chip is here even though merge is off: having variations and
+      // being able to combine them are separate, and the chip hides only its
+      // merge entry point. There is no Variations teaser any more — both
+      // keepers have variations, so the flag that drove it is gone.
+      expect(await screen.findByTestId('header-branch-chip')).toBeTruthy()
+      expect(screen.queryByText('Variations')).toBeNull()
       expect(screen.getByText('Combine')).toBeTruthy()
     })
 
@@ -251,7 +254,7 @@ describe('DaemonDocumentPage branches', () => {
       vi.unstubAllGlobals()
     })
 
-    it('renders HeaderBranchBanner when capabilities.branches is true and the head branch is unmerged', async () => {
+    it('renders HeaderBranchBanner when the head branch is unmerged', async () => {
       const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
         (input) => {
           const url = String(input)
@@ -312,69 +315,9 @@ describe('DaemonDocumentPage branches', () => {
       vi.unstubAllGlobals()
     })
 
-    it('does not render HeaderBranchBanner when capabilities.branches is false', async () => {
-      const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
-        (input) => {
-          const url = String(input)
-          if (url.includes('/branches/feature-x/stats')) {
-            return Promise.resolve(
-              new Response(JSON.stringify({ unmergedCommits: 2, isHead: true }), {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' },
-              }),
-            )
-          }
-          if (url.includes('/branches')) {
-            return Promise.resolve(
-              new Response(
-                JSON.stringify({
-                  head: 'feature-x',
-                  branches: [
-                    {
-                      name: 'main',
-                      color: '#1971c2',
-                      tipFrontiers: '',
-                      createdAt: '2026-01-01T00:00:00Z',
-                    },
-                    {
-                      name: 'feature-x',
-                      color: '#9333ea',
-                      tipFrontiers: '',
-                      createdAt: '2026-01-01T00:00:00Z',
-                    },
-                  ],
-                }),
-                { status: 200, headers: { 'Content-Type': 'application/json' } },
-              ),
-            )
-          }
-          return Promise.resolve(new Response('{}', { status: 200 }))
-        },
-      )
-      vi.stubGlobal('fetch', fetchMock)
-
-      await act(async () => {
-        render(
-          <DaemonDocumentPage
-            daemonBaseUrl={DAEMON_BASE_URL}
-            createBackend={makeCreateBackend()}
-            capabilities={{
-              branches: false,
-              merge: false,
-            }}
-          />,
-          { container: document.body },
-        )
-      })
-      await waitFor(() => expect(screen.getByTestId('spatial-editor-container')).toBeTruthy())
-      // Hand (view-only) is the default tool; the host history cluster only
-      // docks in Select mode, so tests exercising it switch first.
-      fireEvent.click(await screen.findByTestId('select-tool-button'))
-
-      expect(screen.queryByTestId('header-branch-banner')).toBeNull()
-
-      vi.unstubAllGlobals()
-    })
+    // A case for `capabilities.branches: false` stood here. That state no
+    // longer exists — both keepers have variations, so the flag is gone — and
+    // the banner's own behaviour stays covered by the positive case above.
   })
 
   describe('MergeToast integration', () => {
@@ -429,7 +372,6 @@ describe('DaemonDocumentPage branches', () => {
             daemonBaseUrl={DAEMON_BASE_URL}
             createBackend={makeCreateBackend()}
             capabilities={{
-              branches: true,
               merge: false,
             }}
           />,

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -194,7 +194,7 @@ function useDaemonDocument(
   }, [setSearchParams])
 
   useEffect(() => {
-    if (!canvas || variationParam === null || !capabilities.branches) {
+    if (!canvas || variationParam === null) {
       setVariationPreview(null)
       return
     }
@@ -244,7 +244,6 @@ function useDaemonDocument(
     canvas?.workspaceId,
     canvas?.path,
     variationParam,
-    capabilities.branches,
     branches,
     clearVariationParam,
     branchRefreshSignal,
@@ -855,7 +854,7 @@ function useDaemonDocument(
     slots: {
       headerExtras: (
         <>
-          {capabilities.branches && canvas && variationPreview !== null && (
+          {canvas && variationPreview !== null && (
             <HeaderVariationBanner
               workspaceId={canvas.workspaceId}
               path={canvas.path}
@@ -889,21 +888,18 @@ function useDaemonDocument(
               </button>
             </div>
           )}
-          {capabilities.branches && canvas && (
-            <HeaderBranchBanner workspaceId={canvas.workspaceId} path={canvas.path} />
-          )}
+          {canvas && <HeaderBranchBanner workspaceId={canvas.workspaceId} path={canvas.path} />}
           {/* This row only exists when it carries something meaningful: a
               capability this keeper does not have. A daemon with full
               capabilities — the common local case — gets no extra header row
               at all (every header row costs canvas height on a phone). The
               shell switcher names the workspace on every page, so it is the
               one carrier of that; raw identifiers are not chrome (ADR-0019). */}
-          {(!capabilities.branches || !capabilities.merge) && (
+          {!capabilities.merge && (
             <div className="flex flex-wrap items-center gap-2 border-b bg-background px-4 py-2">
               {/* WorkspaceTopBar owns the real History/HeaderBranchChip
                   affordances once a canvas is selected; these page-level teasers
                   only surface guidance while the capability itself is unavailable. */}
-              {!capabilities.branches && <CapabilityTeaser label="Variations" />}
               {!capabilities.merge && <CapabilityTeaser label="Combine" />}
             </div>
           )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,9 @@ importers:
       '@kamiazya/whiteboard-facet-ui':
         specifier: workspace:*
         version: link:../../packages/facet-ui
+      '@kamiazya/whiteboard-history':
+        specifier: workspace:*
+        version: link:../../packages/history
       '@kamiazya/whiteboard-loro-adapter':
         specifier: workspace:*
         version: link:../../packages/loro-adapter

--- a/tools/arch-lint/src/architecture-map.ts
+++ b/tools/arch-lint/src/architecture-map.ts
@@ -264,6 +264,11 @@ export const ARCHITECTURE_MAP: Readonly<Record<string, PackageArchEntry>> = {
       '@kamiazya/whiteboard-facet-engine',
       '@kamiazya/whiteboard-search',
       '@kamiazya/whiteboard-workspace-index',
+      // history: the branch, merge and checkpoint mechanics the browser
+      // keeper runs, the same ones the daemon does. Both keepers read a
+      // branch out of the workspace record now, so the rules for changing
+      // one live in a package below both rather than in either root.
+      '@kamiazya/whiteboard-history',
     ],
     allowedThirdParty: [],
   },


### PR DESCRIPTION
## Summary

- **The browser keeper answers the branches seam.** `createBrowserBranchesBackend` runs `@kamiazya/whiteboard-history`'s pure steps over the workspace record's branch plane, so the rules are the daemon's rules rather than a second implementation. `BrowserBackend` gains `mutateRecord`/`readRecord` for it.
- **`branches` stops being a capability**, because six of this repo's own guards say it must. That was scheduled for a later increment and turns out not to be schedulable — see below.
- **What replaces the flag is a better answer, not a missing one**: whether to show the chip is now the backend's `hasBranches`, which is per DOCUMENT. A markdown body has no record-holding backend and so no variations; no provider-level flag could ever have said that.
- **`merge` stays a capability.** The keepers really do still differ there until the commit half lands, and the chip already separates the two (`mergeEnabled`) — so a browser user gets variations without a control that would throw.

## The regression this nearly shipped

The page has no `BrowserBackend` for a markdown document, or before one loads. My first wiring answered the context `null` in those states — and `null` in `BranchesBackendContext` means *fall back to the daemon*. That would have issued requests to a daemon that is not there, on every markdown document in browser mode, which is the single thing mounting a browser provider exists to stop.

So `createBrowserBranchesBackend` takes a **nullable** backend and always answers. `branchlessBackendContract` was therefore not dead as deleting it assumed — it changed subject, and now describes exactly that null case.

## Why the capability had to go, and why it is not a scope grab

Setting `BROWSER_CAPABILITIES.branches` true turned six guards red, all saying one thing:

```
× declares nothing both keepers agree on
× src/lib/branches-backend.ts names a capability the keepers really differ on
× agrees with the provider about branches
```

`provider.capability-reach.test.ts` and `keeper-parity.test.ts` refuse a flag both keepers set the same way, by name. `provider.ts` already records `workspaces` and `versions` leaving for exactly this reason. Retiring `branches` is not a decision this PR took on its own — it is what those guards mean, and the alternative was a state the suite refuses.

Consequences a reviewer should look at:

- The daemon page's `capabilities.branches` guards were **all always-true** and are removed; its "Variations" teaser could never render and is deleted.
- Two daemon-page cases asserted behaviour under `branches: false`. That state no longer exists: one is retargeted at `merge: false` and now asserts the chip **is** there; the other is deleted with a note, its subject covered by the positive case beside it.
- `keeper-parity`'s two branch entries move from `capability` to `both-keepers`, naming the browser module that answers.
- **`VersionTimeline`'s own `branches` flag stays**, and that is deliberate. It asks a different question — do the version ROWS carry a branch to lane by — and the browser's do not until automatic checkpoints land. Pinned as a decision rather than left as a leftover.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — `branches-backend.contract.browser.test.tsx` runs the nine-case contract against the browser keeper over real IndexedDB (the daemon's run stays in `branches-backend.contract.test.ts`, so both keepers answer the same suite); `BrowserDocumentPage.branches.browser.test.tsx` drives the flow through the real page — chip in the header, create a variation, and it lands on the record, read back the way a replica would rather than through the backend that wrote it.
- [x] **Mutation-checked, four ways.** Forcing every read to the resting state fails 5 of 9 contract cases; dropping the writes fails 6 of 9; restored, 9 of 9. On the page flow, forcing `hasBranches` false fails with `Unable to find an element by: [data-testid="header-branch-chip"]` — precisely the before picture.
- [x] Suites for the area: **web-jsdom 374 files / 3918 tests** and **web-browser 218 files / 1162 tests**, both green. `pnpm -r typecheck` clean, `pnpm lint` clean (the 3 warnings are main's `docker-contract.test.ts`, outside this diff), `pnpm knip` clean.
- [x] Manual verification — the flow test above drives the real page in a real browser, which is the same path a person takes. The Cloudflare Pages preview on this PR serves browser mode, so the chip can be exercised there directly.
- [ ] E2E coverage added or extended where applicable — not applicable; the browser-mode flow has no routing, websocket or daemon dependency, and is covered end to end above.

## Visual evidence

Two panels, both the browser-mode header rendered through the real page in `web-browser`; the before panel taken with `hasBranches` forced false, which is the state this PR replaces. Distinct renders — `before.png` md5 `4fbb81491d1a691fe07b633c2f2bc28d`, `after.png` md5 `d6e133e2533430e79d35fbf6357017e4`.

- **before** — the header ends at the comments and overflow icons; there is no variation control at all.
- **after** — a `● Main ⌄` chip and its `⋯` kebab sit between them and the history icon. No merge entry point inside it, because `merge` is still false for this keeper.

**The image itself could not be attached from this environment**: there is no `gh` CLI here (so no `gh pr create --attach`) and the GitHub MCP surface has no upload endpoint. The figure was produced and read before writing this, and handed to the author directly. What a reviewer can check without it: open the preview link this PR's bot comment posts, in browser mode, and the chip is in the header — or read the two assertions in `BrowserDocumentPage.branches.browser.test.tsx`, which are what the panels show.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — the capability's departure is recorded in `provider.ts` beside the two that went before it, which is where the next reader of that type will look. ADR-0022's addendum and the "daemon only" lines in DESIGN.md / the how-to belong with the merge half, and stay with it.
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema — the state is `packages/history`'s `documentBranchesStateSchema` throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser support for branch management, including creating, removing, renaming, switching, merging previews, and loading branch documents.
  * Added browser workspace record read and write capabilities for branch operations.
  * Added fallback handling for workspaces without existing branch data.

* **Tests**
  * Added browser contract coverage for branch backend behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->