### PR TITLE
feat(web): the browser keeper commits a merge, by adopting the source tip

### DIFF
--- a/apps/web/src/lib/branches-backend.contract.ts
+++ b/apps/web/src/lib/branches-backend.contract.ts
@@ -126,6 +126,36 @@ export function branchesBackendContract(
     }
   })
 
+  it('a committed merge says it committed, where a dry run says it did not', async () => {
+    const h = await create()
+    try {
+      await h.backend.create(h.workspaceId, h.path, { name: 'idea' })
+
+      const committed = await h.backend.merge(h.workspaceId, h.path, 'idea', {
+        into: 'main',
+        dryRun: false,
+      })
+
+      expect(committed.committed).toBeDefined()
+    } finally {
+      await h.cleanup()
+    }
+  })
+
+  // What this contract deliberately does NOT assert: that the target's tip
+  // becomes the source's — which is what the merge IS (tip adoption, "source
+  // wins"). It is unobservable from here, because nothing in this seam can
+  // give a branch a tip: `create` takes a version id, not a frontier, and
+  // `updateBranchTip` is a keeper's own business. A version of this case that
+  // compared the two tips passed on the first run against a stand-in that
+  // moves nothing, because both were the empty string — vacuous, and it read
+  // exactly like coverage.
+  //
+  // So tip adoption is pinned where the storage is reachable: `mcp-node`'s
+  // branch-merge suite for the daemon, and the browser keeper's own test over
+  // its record. The pair above is what the seam can honestly see — a dry run
+  // leaves `committed` undefined (asserted in its own case), a commit sets it.
+
   it('answers null for a variation that is not there, rather than throwing', async () => {
     const h = await create()
     try {

--- a/apps/web/src/lib/browser-branches-backend.merge.browser.test.tsx
+++ b/apps/web/src/lib/browser-branches-backend.merge.browser.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Tip adoption on the browser keeper, which is what a merge IS.
+ *
+ * `branchesBackendContract` deliberately stops short of this and says why:
+ * nothing in the seam can give a branch a tip, so a contract case comparing
+ * two tips compares two empty strings and passes against a keeper that moves
+ * nothing. Here the storage is reachable, so the tip can be real — and the
+ * case is the one the contract defers to, for this keeper. The daemon's half
+ * lives in `mcp-node`'s branch-merge suite.
+ */
+import {
+  frontiersToBase64,
+  readBranchesFromRecord,
+  writeBranchesToRecord,
+} from '@kamiazya/whiteboard-history'
+import {
+  writeSpatialCanvas,
+  writeWorkspaceDocumentContent,
+} from '@kamiazya/whiteboard-loro-adapter'
+import { LoroDoc } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { BrowserBackend } from './browser-backend.js'
+import { createBrowserBranchesBackend } from './browser-branches-backend.js'
+import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
+import { FoldingBrowserIndex } from './folding-browser-index.js'
+
+claimIsolatedWhiteboardDb('browserbranchesmerge')
+
+const NO_OP_HANDLERS = {
+  onSnapshot: () => {},
+  onRemoteUpdate: () => {},
+  onConnected: () => {},
+  onDisconnected: () => {},
+  onRestoreStarted: () => {},
+  onRestoreComplete: () => {},
+  onVersionCreated: () => {},
+  onHeadChanged: () => {},
+  onViewportRequest: () => {},
+  onExportRequest: () => {},
+}
+
+function canvasWith(text: string): LoroDoc {
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, {
+    nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 80, height: 40, text }],
+    edges: [],
+  })
+  doc.commit()
+  return doc
+}
+
+describe('the browser keeper merges by adopting the source tip', () => {
+  let backend: BrowserBackend
+
+  beforeEach(async () => {
+    await clearWhiteboardDb()
+  })
+
+  afterEach(() => {
+    backend.disconnect()
+  })
+
+  it('moves the target onto a REAL source tip, which an empty one cannot show', async () => {
+    const workspaceId = getBrowserWorkspaceId()
+    const index = new FoldingBrowserIndex()
+    await index.createWorkspace({ workspaceId })
+    const { documentId } = await index.createDocument({
+      workspaceId,
+      path: 'canvas-a',
+      kind: 'spatial',
+    })
+
+    const docs = new BrowserWorkspaceDocs()
+    const record = await docs.open(workspaceId)
+    if (record === null) throw new Error('no record')
+    writeWorkspaceDocumentContent(record, documentId, canvasWith('first'))
+    // A real frontier of the record, which is what a tip is. Written straight
+    // onto the plane because the seam has no way to hand one over — the whole
+    // reason this case is here rather than in the contract.
+    const tip = frontiersToBase64(record.frontiers())
+    writeBranchesToRecord(record, documentId, {
+      branches: [
+        { name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '2026-01-01T00:00:00.000Z' },
+        {
+          name: 'idea',
+          tipFrontiers: tip,
+          color: '#9333ea',
+          createdAt: '2026-01-02T00:00:00.000Z',
+        },
+      ],
+      head: 'main',
+    })
+    await docs.save(workspaceId, record)
+    expect(tip.length).toBeGreaterThan(0)
+
+    backend = new BrowserBackend({ documentId, path: 'canvas-a', kind: 'spatial' }, docs)
+    backend.connect(NO_OP_HANDLERS)
+    await vi.waitFor(() => expect(backend.readRecord(() => true)).toBe(true))
+
+    const branches = createBrowserBranchesBackend({ backend })
+    await branches.merge(workspaceId, 'canvas-a', 'idea', { into: 'main', dryRun: false })
+
+    const after = backend.readRecord((doc, id) => readBranchesFromRecord(doc, id))
+    expect(after?.branches.find((b) => b.name === 'main')?.tipFrontiers).toBe(tip)
+    // The source is cleaned up, as it is on the daemon: it has been absorbed.
+    expect(after?.branches.map((b) => b.name)).not.toContain('idea')
+  })
+})

--- a/apps/web/src/lib/browser-branches-backend.ts
+++ b/apps/web/src/lib/browser-branches-backend.ts
@@ -20,10 +20,12 @@ import {
   type DocumentBranchesState,
   deleteBranch as deleteBranchOp,
   frontiersFromBase64,
+  MAIN_BRANCH,
   planMerge,
   readBranchesFromRecord,
   renameBranch as renameBranchOp,
   setHead as setHeadOp,
+  updateBranchTip as updateBranchTipOp,
   writeBranchesToRecord,
 } from '@kamiazya/whiteboard-history'
 import {
@@ -31,11 +33,28 @@ import {
   readDocumentKind,
   readMarkdownBody,
   readSpatialCanvas,
+  writeWorkspaceDocumentContent,
 } from '@kamiazya/whiteboard-loro-adapter'
 import { LoroDoc } from 'loro-crdt'
 import type { BranchesBackend } from './branches-backend.js'
 import { BranchesUnsupportedError } from './branches-backend.js'
+import { getAppLogger } from './app-logger.js'
 import type { BrowserBackend } from './browser-backend.js'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
+
+const log = getAppLogger('browser-branches')
+
+/** The one method of the version store a merge needs — narrowed so this module takes no store. */
+type BrowserVersionSave = (
+  workspaceId: string,
+  path: string,
+  options: {
+    auto?: boolean
+    label?: string
+    branchName?: string
+    operator?: { kind: 'system'; peerId: string; displayName: string }
+  },
+) => Promise<{ id: string }>
 
 /** The state a document has when its record has not been delivered yet. */
 const RESTING: DocumentBranchesState = {
@@ -56,6 +75,14 @@ const RESTING: DocumentBranchesState = {
  */
 export function createBrowserBranchesBackend(deps: {
   readonly backend: BrowserBackend | null
+  /**
+   * Where a pre-merge point is kept. Optional because a page can mount this
+   * before its version store exists, and because a merge whose snapshot fails
+   * still commits — the daemon treats that failure as a warning too, and a
+   * merge that refused because a bookmark could not be written would be worse
+   * than one nobody can rewind past.
+   */
+  readonly versions?: { save: BrowserVersionSave } | null
 }): BranchesBackend {
   const backend = deps.backend
   const refuse = (what: string) => Promise.reject(new BranchesUnsupportedError(what))
@@ -157,9 +184,6 @@ export function createBrowserBranchesBackend(deps: {
 
     async merge(_workspaceId, _path, source, args) {
       if (backend === null) return refuse('merge')
-      if (args.dryRun !== true) {
-        throw new BranchesUnsupportedError('committing a merge is not implemented in the browser')
-      }
       const state = read()
       const into = state.branches.find((b) => b.name === args.into)
       const from = state.branches.find((b) => b.name === source)
@@ -175,7 +199,7 @@ export function createBrowserBranchesBackend(deps: {
         into: { name: into.name, tipFrontiers: into.tipFrontiers },
         source: { name: from.name, tipFrontiers: from.tipFrontiers },
       })
-      return {
+      const counts = {
         badges: plan.badges as unknown as Record<string, unknown>[],
         preview: { elementCount: plan.previewElementCount },
         target: { elementCount: plan.targetElementCount },
@@ -184,6 +208,72 @@ export function createBrowserBranchesBackend(deps: {
         newElementIds: plan.newElementIds,
         changedElementIds: plan.changedElementIds,
         conflictElementIds: plan.conflictElementIds,
+      }
+      if (args.dryRun === true) return counts
+
+      // The same four steps the daemon commits in, in the same order, over
+      // this keeper's storage instead of its own.
+
+      // 1. The point before the merge, so it can be rewound past. Best effort
+      //    for the reason `versions` is optional above.
+      let preMergeVersionId: string | undefined
+      try {
+        const saved = await deps.versions?.save(getBrowserWorkspaceId(), _path, {
+          auto: true,
+          label: `before merge: ${source} → ${args.into}`,
+          branchName: args.into,
+          operator: { kind: 'system', peerId: 'browser', displayName: 'merge' },
+        })
+        preMergeVersionId = saved?.id
+      } catch (err) {
+        log.warn('pre-merge snapshot failed', err)
+      }
+
+      // 2. Tip adoption, which IS the merge: the target takes the source's
+      //    tip. An uninitialised source has no tip to adopt and moves nothing.
+      if (from.tipFrontiers.length > 0) {
+        await mutate((s) => updateBranchTipOp(s, scope, args.into, from.tipFrontiers))
+      }
+
+      // 3. When the target is HEAD, the document itself becomes the preview.
+      //    `writeWorkspaceDocumentContent` is a DIFF and never a rewrite — the
+      //    same call `applyRestore` reconciles a past state with — so the ops
+      //    it emits reach the sync session as a peer's would.
+      const latest = read()
+      if (latest.head === args.into && from.tipFrontiers.length > 0) {
+        await backend.mutateRecord((doc, documentId) => {
+          writeWorkspaceDocumentContent(doc, documentId, plan.previewDoc)
+        })
+      }
+
+      // 4. Cleanup, warned about rather than fatal: the merge has committed
+      //    by now, and failing here would report a merge that did not happen.
+      let switchedHead: { from: string; to: string } | undefined
+      let deletedSource: string | undefined
+      try {
+        const afterCommit = read()
+        if (afterCommit.head === source && source !== args.into) {
+          await mutate((s) => setHeadOp(s, scope, args.into))
+          switchedHead = { from: source, to: args.into }
+        }
+      } catch (err) {
+        log.warn('post-merge head switch failed', err)
+      }
+      if (source !== MAIN_BRANCH && source !== args.into) {
+        try {
+          await mutate((s) => deleteBranchOp(s, scope, source))
+          deletedSource = source
+        } catch (err) {
+          log.warn('post-merge delete source failed', err)
+        }
+      }
+
+      return {
+        ...counts,
+        committed: { elementCount: plan.previewElementCount },
+        ...(preMergeVersionId === undefined ? {} : { preMergeVersionId }),
+        ...(switchedHead === undefined ? {} : { switchedHead }),
+        ...(deletedSource === undefined ? {} : { deletedSource }),
       }
     },
 

--- a/apps/web/src/lib/browser-branches-backend.ts
+++ b/apps/web/src/lib/browser-branches-backend.ts
@@ -36,9 +36,9 @@ import {
   writeWorkspaceDocumentContent,
 } from '@kamiazya/whiteboard-loro-adapter'
 import { LoroDoc } from 'loro-crdt'
+import { getAppLogger } from './app-logger.js'
 import type { BranchesBackend } from './branches-backend.js'
 import { BranchesUnsupportedError } from './branches-backend.js'
-import { getAppLogger } from './app-logger.js'
 import type { BrowserBackend } from './browser-backend.js'
 import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 

--- a/apps/web/src/lib/provider.ts
+++ b/apps/web/src/lib/provider.ts
@@ -50,9 +50,16 @@ export type ProviderState =
   | { readonly kind: 'invalid-config'; readonly message: string }
 
 export const BROWSER_CAPABILITIES: WhiteboardCapabilities = {
-  // `merge` stays false until the commit half lands. The chip separates it
-  // from having branches already (`mergeEnabled`), so this is a real
-  // difference a person can see rather than a control that throws.
+  // The browser keeper can commit a merge now, so this flag is on borrowed
+  // time: both keepers agree, and a flag both keepers agree on is not a
+  // capability — `provider.capability-reach.test.ts` refuses it by name the
+  // moment it is flipped, exactly as it refused `branches`.
+  //
+  // It stays false for one increment because turning it true retires the
+  // capability SYSTEM rather than this flag: `WhiteboardCapabilities` has
+  // nothing else left in it, and the prop threads through App, both pages,
+  // the top bar and `CapabilityTeaser`. That is its own diff to review, and
+  // it is what turns the browser's merge on.
   merge: false,
 }
 

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -485,15 +485,18 @@ function useBrowserDocument(
   // is no spatial backend (a markdown document, or nothing loaded yet), in
   // which case the save control is hidden rather than left to fall back onto
   // the daemon's routes.
+  // The store, not the seam, is what a merge's pre-merge point needs: the
+  // seam's `save` carries a label and nothing else, while a checkpoint has to
+  // say it is automatic and which variation it belongs to. So it is built
+  // once here and handed to both.
+  const versionStore = useMemo(
+    () => new BrowserVersionStore({ docs: new BrowserWorkspaceDocs(), index: store }),
+    [store],
+  )
   const versionsBackend = useMemo(
     () =>
-      backend === null
-        ? null
-        : createBrowserVersionsBackend({
-            backend,
-            store: new BrowserVersionStore({ docs: new BrowserWorkspaceDocs(), index: store }),
-          }),
-    [backend, store],
+      backend === null ? null : createBrowserVersionsBackend({ backend, store: versionStore }),
+    [backend, versionStore],
   )
   const versionsEnabled = versionsBackend !== null
 
@@ -503,7 +506,13 @@ function useBrowserDocument(
   // through to the context's daemon fallback and issuing a request to a
   // daemon that is not there — which was this provider's whole job while the
   // keeper had no branches, and remains true now that it has them.
-  const branchesBackend = useMemo(() => createBrowserBranchesBackend({ backend }), [backend])
+  const branchesBackend = useMemo(
+    // The version store rides along so a merge can leave the point before it.
+    // Same instance the versions seam uses, so a pre-merge point is an
+    // ordinary row in the same history rather than a second kind of record.
+    () => createBrowserBranchesBackend({ backend, versions: versionStore }),
+    [backend, versionStore],
+  )
   // A manual save announces itself on the window (dispatched after the
   // keeper confirmed the save), and the page's history column re-reads on
   // it. Scoped to THIS document's identity — an unchecked listener refreshed

--- a/packages/mcp-server/src/server/file-size-budget.test.ts
+++ b/packages/mcp-server/src/server/file-size-budget.test.ts
@@ -135,7 +135,13 @@ const FILE_SIZE_GRANDFATHER: Record<string, number> = {
   // than a merge — a document is never in both — and the comment saying so is
   // most of the 14 lines.
   'packages/mcp-server/src/server/store/document-store.ts': 1145,
-  'apps/web/src/pages/BrowserDocumentPage.tsx': 926,
+  // Raised from 926 by the version STORE being built once and shared. A
+  // merge's pre-merge point cannot go through the versions seam — that
+  // `save` carries a label and nothing else, while a checkpoint has to say
+  // it is automatic and which variation it belongs to — so the store is
+  // built here and handed to both seams, and the comment saying why is most
+  // of the seven lines.
+  'apps/web/src/pages/BrowserDocumentPage.tsx': 933,
   'packages/canvas-render/src/layout/nodes/mdast-blocks.ts': 1674,
   'packages/canvas-render/src/layout/spatial-canvas.ts': 1840,
   'packages/canvas-render/src/layout/edges/spatial-edges.ts': 2069,


### PR DESCRIPTION
## Summary

- **The browser keeper can commit a merge**, in the same four steps and the same order the daemon commits in, over this keeper's storage instead of its own: the point before the merge, tip adoption, the document itself when the target is HEAD, then cleanup (switch HEAD off the source, delete the absorbed source).
- The dry run already worked and landed with the previous increment; this is only the commit half.
- **`userReach: foundation: the browser's merge entry point is still hidden (`merge` is false for this keeper), so no person can reach this yet — wired by the follow-up below, which is what turns it on.`**

## Two of the four steps a reviewer should look at

**The pre-merge point goes through the version STORE, not the versions seam.** That seam's `save` carries a label and nothing else, while a checkpoint has to say it is automatic and which variation it belongs to. So the store is built once on the page and handed to both seams, and a pre-merge point is an ordinary row in the same history rather than a second kind of record. Best effort, as it is on the daemon: a merge that refused because a bookmark could not be written would be worse than one nobody can rewind past.

**Reconciling the document is `writeWorkspaceDocumentContent`** — a DIFF and never a rewrite, the same call `applyRestore` uses — so the ops it emits reach the sync session the way a peer's would.

## What the contract deliberately does not assert

The commit case in `branchesBackendContract` asserts that a commit sets `committed` where a dry run leaves it undefined. It does **not** compare the target's tip to the source's, and that is the finding rather than an omission:

A first version did compare them, and **passed on the very first run** — because nothing in the seam can give a branch a tip (`create` takes a version id, not a frontier; `updateBranchTip` is a keeper's own business), so both were the empty string. Vacuous, against a stand-in that moves nothing, and it read exactly like coverage.

So tip adoption is pinned where the storage is reachable. `browser-branches-backend.merge.browser.test.ts` writes a **real** frontier of the record onto the plane and asserts the target takes it. Mutation-checked by skipping the adoption step:

```
AssertionError: expected '' to be 'AZG9p52SxqKnrAEC'
```

A real frontier, not an empty string — which is precisely the difference between that case and the one the contract could have held. The daemon's half stays pinned in `mcp-node`'s branch-merge suite.

## Why `merge` is still false, and what turns it on

Both keepers commit merges now, so `merge` has stopped being a difference between them — and this repo refuses a flag both keepers agree on (`provider.capability-reach.test.ts`, `keeper-parity.test.ts`; `workspaces`, `versions` and now `branches` all left for that reason). Flipping it here turns **four** guards red, saying exactly that.

But turning it true retires the capability **system**, not this flag: `WhiteboardCapabilities` has nothing else left in it once `branches` is gone, and the prop threads through `App`, both document pages, the top bar and `CapabilityTeaser` — **21 files**. That is its own diff, and bundling it here would put a mechanical 21-file removal in the same review as a merge implementation. So it is the immediate follow-up, and it is what makes this reachable.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — the contract's commit case (run against both keepers), and `browser-branches-backend.merge.browser.test.ts` for tip adoption over a real IndexedDB record.
- [x] Mutation-checked — skipping the adoption step fails with the real-frontier message above; the vacuous first version of the contract case is described rather than kept.
- [x] Suites for the area: **web-browser 219 files / 1164 tests**, **web-jsdom 374 files / 3919 tests**, **arch-lint-node + mcp-node 383 files / 4206 tests**, all green. `pnpm -r typecheck` clean, `pnpm lint` clean (the 3 warnings are main's `docker-contract.test.ts`), `pnpm knip` clean.
- [ ] Manual verification completed — not reachable by hand yet, by design: the merge entry point is hidden while `merge` is false. The browser test drives the backend directly over a real record, which is the same path the chip will take.
- [ ] E2E coverage added or extended where applicable — not applicable; no routing, websocket or daemon dependency.

## Visual evidence

Visual evidence: none — nothing a person can see changes. The merge entry point stays hidden in browser mode for this increment (`merge` is false), so the header, the chip and the dialog all render exactly as they do on main. The figure belongs with the follow-up that turns it on.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — no user-visible change yet; `provider.ts` records why `merge` is still false and what retires it
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema — the merge response is `daemon-client`'s `mergeResponseSchema` shape, and the branch state is `packages/history`'s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh)_