### PR TITLE
fix(web): the browser keeper's version rows carry `auto` and the variation, and cap the checkpoints

### DIFF
--- a/apps/web/src/lib/browser-branches-backend.merge.browser.test.tsx
+++ b/apps/web/src/lib/browser-branches-backend.merge.browser.test.tsx
@@ -23,6 +23,7 @@ import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
 import { BrowserBackend } from './browser-backend.js'
 import { createBrowserBranchesBackend } from './browser-branches-backend.js'
+import { BrowserVersionStore } from './browser-version-store.js'
 import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
 import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import { FoldingBrowserIndex } from './folding-browser-index.js'
@@ -107,5 +108,65 @@ describe('the browser keeper merges by adopting the source tip', () => {
     expect(after?.branches.find((b) => b.name === 'main')?.tipFrontiers).toBe(tip)
     // The source is cleaned up, as it is on the daemon: it has been absorbed.
     expect(after?.branches.map((b) => b.name)).not.toContain('idea')
+  })
+
+  it('records the pre-merge point as automatic and on the target variation', async () => {
+    const workspaceId = getBrowserWorkspaceId()
+    const index = new FoldingBrowserIndex()
+    await index.createWorkspace({ workspaceId })
+    const { documentId } = await index.createDocument({
+      workspaceId,
+      path: 'canvas-b',
+      kind: 'spatial',
+    })
+
+    const docs = new BrowserWorkspaceDocs()
+    const record = await docs.open(workspaceId)
+    if (record === null) throw new Error('no record')
+    writeWorkspaceDocumentContent(record, documentId, canvasWith('before'))
+    // HEAD is a NON-default variation, and so is the merge target. Both
+    // matter: `branchName` falls back to `main` for a row that carries none,
+    // so a point taken on `main` cannot tell a recorded branch from a missing
+    // one, and the assertion below would hold over either.
+    writeBranchesToRecord(record, documentId, {
+      branches: [
+        { name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '2026-01-01T00:00:00.000Z' },
+        { name: 'idea', tipFrontiers: '', color: '#9333ea', createdAt: '2026-01-02T00:00:00.000Z' },
+        {
+          name: 'extra',
+          tipFrontiers: frontiersToBase64(record.frontiers()),
+          color: '#e8590c',
+          createdAt: '2026-01-03T00:00:00.000Z',
+        },
+      ],
+      head: 'idea',
+    })
+    await docs.save(workspaceId, record)
+
+    backend = new BrowserBackend({ documentId, path: 'canvas-b', kind: 'spatial' }, docs)
+    backend.connect(NO_OP_HANDLERS)
+    await vi.waitFor(() => expect(backend.readRecord(() => true)).toBe(true))
+
+    // The REAL store, not a stub: what this pins is that the two fields the
+    // merge already passes survive as far as the row the History panel lists.
+    // They did not — the store accepted them and wrote neither, so the point
+    // a merge can be rewound past claimed to be a person's manual save on the
+    // default variation. A stub asserting the call arguments would have shown
+    // the same green over that.
+    const store = new BrowserVersionStore({ docs, index })
+    const branches = createBrowserBranchesBackend({
+      backend,
+      versions: { save: (w, p, o) => store.save(w, p, o) },
+    })
+    await branches.merge(workspaceId, 'canvas-b', 'extra', { into: 'idea', dryRun: false })
+
+    const rows = await store.list(workspaceId, 'canvas-b')
+    expect(rows).toEqual([
+      expect.objectContaining({
+        auto: true,
+        branchName: 'idea',
+        label: 'before merge: extra \u2192 idea',
+      }),
+    ])
   })
 })

--- a/apps/web/src/lib/browser-branches-backend.ts
+++ b/apps/web/src/lib/browser-branches-backend.ts
@@ -40,21 +40,23 @@ import { getAppLogger } from './app-logger.js'
 import type { BranchesBackend } from './branches-backend.js'
 import { BranchesUnsupportedError } from './branches-backend.js'
 import type { BrowserBackend } from './browser-backend.js'
+import type { BrowserVersionStore } from './browser-version-store.js'
 import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 
 const log = getAppLogger('browser-branches')
 
-/** The one method of the version store a merge needs — narrowed so this module takes no store. */
-type BrowserVersionSave = (
-  workspaceId: string,
-  path: string,
-  options: {
-    auto?: boolean
-    label?: string
-    branchName?: string
-    operator?: { kind: 'system'; peerId: string; displayName: string }
-  },
-) => Promise<{ id: string }>
+/**
+ * The one method of the version store a merge needs, taken FROM the store so
+ * the two cannot drift.
+ *
+ * It was hand-written here, and the drift it allowed is the reason it is not
+ * any more: this module passed `auto` and `branchName`, the store's own
+ * options had neither, and the assignment was accepted — so the point a merge
+ * can be rewound past was written as a person's manual save on the default
+ * variation, with nothing red anywhere. `import type` keeps this module free
+ * of the store at runtime, which is all the narrowing was ever for.
+ */
+type BrowserVersionSave = BrowserVersionStore['save']
 
 /** The state a document has when its record has not been delivered yet. */
 const RESTING: DocumentBranchesState = {

--- a/apps/web/src/lib/browser-version-store.browser.test.tsx
+++ b/apps/web/src/lib/browser-version-store.browser.test.tsx
@@ -1,3 +1,4 @@
+import { MAX_AUTO_PER_DOCUMENT } from '@kamiazya/whiteboard-history'
 import {
   readSpatialCanvas,
   writeSpatialCanvas,
@@ -143,5 +144,82 @@ describe('BrowserVersionStore (real IndexedDB)', () => {
     // The refusal loadPast makes, for the same reason: an id alone must not
     // read a history that is not this document's.
     expect(await store.loadThumbnail(workspaceId, 'canvas-a', theirs.id)).toBeNull()
+  })
+})
+
+describe('automatic checkpoints', () => {
+  beforeEach(async () => {
+    await clearWhiteboardDb()
+  })
+
+  it('records a checkpoint as automatic and on the branch it was taken from', async () => {
+    const { index, workspaceId, documentId } = await seedDocument('canvas-auto')
+    const docs = new BrowserWorkspaceDocs()
+    await writeContent(docs, documentId, 'work')
+    const store = new BrowserVersionStore({ docs, index })
+
+    const auto = await store.save(workspaceId, 'canvas-auto', {
+      auto: true,
+      branchName: 'wide-layout',
+    })
+
+    expect(auto).toMatchObject({ auto: true, branchName: 'wide-layout' })
+    // Read back rather than trusting the return: the row is what the panel
+    // lists, and a field the save answers but does not persist would pass a
+    // return-value assertion and show nothing in the history.
+    const listed = await new BrowserVersionStore({ docs, index }).list(workspaceId, 'canvas-auto')
+    expect(listed).toEqual([expect.objectContaining({ auto: true, branchName: 'wide-layout' })])
+  })
+
+  it("leaves a manual save's own defaults alone, so a row written before this reads as it did", async () => {
+    const { index, workspaceId, documentId } = await seedDocument('canvas-manual')
+    const docs = new BrowserWorkspaceDocs()
+    await writeContent(docs, documentId, 'work')
+    const store = new BrowserVersionStore({ docs, index })
+
+    const manual = await store.save(workspaceId, 'canvas-manual', { label: 'by hand' })
+
+    expect(manual).toMatchObject({ auto: false, branchName: 'main' })
+  })
+
+  it('keeps the newest 50 automatic checkpoints and lets the older ones go, sparing manual saves', async () => {
+    const { index, workspaceId, documentId } = await seedDocument('canvas-cap')
+    const docs = new BrowserWorkspaceDocs()
+    await writeContent(docs, documentId, 'work')
+    const store = new BrowserVersionStore({ docs, index })
+
+    const manual = await store.save(workspaceId, 'canvas-cap', { label: 'by hand' })
+    for (let i = 0; i < MAX_AUTO_PER_DOCUMENT + 3; i += 1) {
+      await store.save(workspaceId, 'canvas-cap', { auto: true })
+    }
+
+    const rows = await store.list(workspaceId, 'canvas-cap')
+    const autos = rows.filter((r) => r.auto)
+    expect(autos).toHaveLength(MAX_AUTO_PER_DOCUMENT)
+    // A manual save is not a checkpoint and the cap never reaches it.
+    expect(rows.filter((r) => !r.auto).map((r) => r.id)).toEqual([manual.id])
+  })
+
+  it('never sweeps a restore merge or the point it names, even past the cap', async () => {
+    const { index, workspaceId, documentId } = await seedDocument('canvas-lineage')
+    const docs = new BrowserWorkspaceDocs()
+    await writeContent(docs, documentId, 'work')
+    const store = new BrowserVersionStore({ docs, index })
+
+    // The two ends of a restore, both automatic and both the OLDEST rows, so
+    // an unqualified cap would take them first. Lineage is what spares them:
+    // the merge names its source, and the source is named by the merge.
+    const named = await store.save(workspaceId, 'canvas-lineage', { auto: true })
+    const merge = await store.save(workspaceId, 'canvas-lineage', {
+      auto: true,
+      restoredFrom: named.id,
+    })
+    for (let i = 0; i < MAX_AUTO_PER_DOCUMENT + 1; i += 1) {
+      await store.save(workspaceId, 'canvas-lineage', { auto: true })
+    }
+
+    const ids = new Set((await store.list(workspaceId, 'canvas-lineage')).map((r) => r.id))
+    expect(ids.has(merge.id)).toBe(true)
+    expect(ids.has(named.id)).toBe(true)
   })
 })

--- a/apps/web/src/lib/browser-version-store.ts
+++ b/apps/web/src/lib/browser-version-store.ts
@@ -3,6 +3,7 @@ import {
   type VersionEntry,
   versionEntrySchema,
 } from '@kamiazya/whiteboard-daemon-client/api-contracts/index'
+import { autoVersionsOverCap } from '@kamiazya/whiteboard-history'
 import { projectWorkspaceDocument, readSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
 import { generateDocumentId } from '@kamiazya/whiteboard-model'
 import type { DocumentIndex } from '@kamiazya/whiteboard-ports'
@@ -34,6 +35,18 @@ const versionRowSchema = z
     operator: operatorInfoSchema.optional(),
     /** Set only on the point a restore produced; see `versionEntrySchema`. */
     restoredFrom: z.string().optional(),
+    /**
+     * Whether a checkpoint took this point rather than a person.
+     *
+     * Optional for the reason `hasThumbnail` is, and it is the load-bearing
+     * reason on this schema: it is `.strict()` and its reader SKIPS a row
+     * that fails to parse, so making either of these REQUIRED would silently
+     * delete the whole history of anyone who has rows from before them.
+     * Absent reads as `false`, which is what every existing row is.
+     */
+    auto: z.boolean().optional(),
+    /** The variation HEAD was on when the point was taken; absent reads as `main`. */
+    branchName: z.string().min(1).optional(),
     /**
      * Whether `versionThumbnails` holds a picture for this point. Optional
      * because rows written before v17 have none — and because this schema is
@@ -81,6 +94,10 @@ export class BrowserVersionStore {
       operator?: VersionRow['operator']
       /** Records that this point is the merge a restore produced. */
       restoredFrom?: string
+      /** A checkpoint took this point, not a person. */
+      auto?: boolean
+      /** The variation HEAD was on. Omitted leaves the row on the default one. */
+      branchName?: string
     } = {},
   ): Promise<VersionEntry> {
     const placement = await this.deps.index.resolveDocument({ workspaceId, path })
@@ -98,6 +115,12 @@ export class BrowserVersionStore {
       elementCount: projection === null ? 0 : countNodes(projection),
       ...(input.operator === undefined ? {} : { operator: input.operator }),
       ...(input.restoredFrom === undefined ? {} : { restoredFrom: input.restoredFrom }),
+      // Written only when true / named, so a manual save on the default
+      // variation keeps writing exactly the row it wrote before this existed.
+      ...(input.auto === true ? { auto: true } : {}),
+      ...(input.branchName === undefined || input.branchName === ''
+        ? {}
+        : { branchName: input.branchName }),
       // The STORED record's frontier, never a live doc's: a checkpoint has to
       // point at ops that are on disk, and `open` reads what is.
       frontiers: new Uint8Array(encodeFrontiers(record.oplogFrontiers())),
@@ -105,7 +128,48 @@ export class BrowserVersionStore {
     await inTransaction(this.deps.dbName, [VERSIONS_STORE], 'readwrite', async (tx) => {
       await request(tx.objectStore(VERSIONS_STORE).put(versionRowSchema.parse(row)))
     })
+    // Only a checkpoint can push the document over the cap, so only a
+    // checkpoint pays for the sweep — a manual save reads no rows at all.
+    if (input.auto === true) await this.pruneAutoOverCap(workspaceId, placement.documentId)
     return toEntry(row, path)
+  }
+
+  /**
+   * Drop the automatic checkpoints past the cap, newest kept.
+   *
+   * Which rows go is the mechanic's call
+   * (`@kamiazya/whiteboard-history`'s `autoVersionsOverCap`, the same one the
+   * daemon asks); the rows, the delete and the thumbnail blobs are this
+   * store's. `referenced` is built over EVERY row rather than the automatic
+   * ones, because a manual save can be a restore's merge point too and the
+   * point it names must outlive the cap either way.
+   */
+  private async pruneAutoOverCap(workspaceId: string, documentId: string): Promise<void> {
+    const rows = await this.rowsOf(workspaceId, documentId)
+    const autosNewestFirst = rows
+      .filter((row) => row.auto === true)
+      .sort((a, b) => b.createdAt - a.createdAt || b.id.localeCompare(a.id))
+      .map((row) => ({ id: row.id, restoredFrom: row.restoredFrom ?? null }))
+    const referenced = new Set(
+      rows.flatMap((row) => (row.restoredFrom === undefined ? [] : [row.restoredFrom])),
+    )
+    const toRemove = autoVersionsOverCap(autosNewestFirst, referenced)
+    if (toRemove.length === 0) return
+    await inTransaction(
+      this.deps.dbName,
+      [VERSIONS_STORE, VERSION_THUMBNAILS_STORE],
+      'readwrite',
+      async (tx) => {
+        const versions = tx.objectStore(VERSIONS_STORE)
+        const thumbnails = tx.objectStore(VERSION_THUMBNAILS_STORE)
+        for (const id of toRemove) {
+          await request(versions.delete(id))
+          // A point with no picture deletes nothing, which IndexedDB treats
+          // as success — so this needs no existence check.
+          await request(thumbnails.delete(id))
+        }
+      },
+    )
   }
 
   /** Newest first, as the History panel lists them. */
@@ -244,9 +308,9 @@ function toEntry(row: VersionRow, path: string): VersionEntry {
     path,
     createdAt: new Date(row.createdAt).toISOString(),
     elementCount: row.elementCount,
-    auto: false,
+    auto: row.auto === true,
     hasThumbnail: row.hasThumbnail === true,
-    branchName: 'main',
+    branchName: row.branchName ?? 'main',
     ...(row.label === undefined ? {} : { label: row.label }),
     ...(row.operator === undefined ? {} : { operator: row.operator }),
     ...(row.restoredFrom === undefined ? {} : { restoredFrom: row.restoredFrom }),


### PR DESCRIPTION
## Summary

- **A browser version row could not say a checkpoint took it, nor which variation it was on.** `toEntry` answered a hardcoded `auto: false` and `branchName: 'main'` for every row; both are real fields now, written by `save` and read back by the panel.
- **Checkpoints are capped** the way the daemon caps them — `autoVersionsOverCap` from `@kamiazya/whiteboard-history`, so both keepers ask the same mechanic.
- **This is a FIX, not groundwork** — see below. A caller was already passing both fields and the store was dropping them.

## The drift this was hiding

The merge commit's pre-merge point — the point a person rewinds a merge past — already passed `auto: true` and the target variation. The store accepted the object and wrote neither. So a point taken by the machine was recorded as **a person's manual save on the default variation**, with nothing red anywhere.

What let it through is the shape AGENTS.md warns about one level up: a hand-written signature (`BrowserVersionSave`) sitting beside the store's real options. TypeScript's parameter bivariance accepted the assignment and the extra fields went to `undefined` at runtime.

So the fix is structural as well as behavioural — the type is derived now:

```ts
type BrowserVersionSave = BrowserVersionStore['save']
```

`import type`, so the module still takes no store at runtime, which is all the narrowing was ever for. That promotes this class of drift from a prose rule to an **executable** one.

## Why both fields are optional on the row schema

Load-bearing rather than cautious. The row schema is `.strict()` and its reader **skips** a row that fails to parse — a deliberate choice so one bad row cannot hide a document's whole history. Making either field required would therefore not fail loudly; it would silently delete the entire history of anyone holding rows from before them. Absent reads as the old hardcoded answer, which is what every existing row is.

## Mutation checks — four, each field independently

| mutation | what failed |
|---|---|
| `auto` not persisted | `expected "auto": true, got false` |
| `branchName` not persisted | `expected "idea", got "main"` |
| lineage exemption removed (`referenced` emptied) | the restore merge point was swept — `expected false to be true` |
| `auto` removed from the store's options | **compile error** at the merge call site |

The `branchName` check needed the test restructured to earn its keep. The first version merged into `main` — which is also the fallback for a row carrying no branch, so it could not tell a recorded value from a missing one and held over either. Merging into a non-default variation (HEAD on `idea`, `extra` merged into it) makes both halves discriminate. The test also uses the **real** store rather than a stub: a stub asserting the call arguments would have shown the same green over the whole drift.

## Two scope decisions

- **The sandwich pass is not here.** Its only caller is `StorageReportCard`'s daemon route, so a browser twin would be built and unreachable — what `userReach` exists to refuse. It belongs with the browser action that invokes it.
- **The cap runs after an automatic save only**, mirroring the daemon: only a checkpoint can push a document over the cap, so a manual save reads no rows at all. `referenced` is built over **every** row rather than the automatic ones, because a manual save can be a restore's merge point too and the point it names must outlive the cap either way.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — 5 new `web-browser` cases over real IndexedDB: the two fields persisted and read back through a fresh store, a manual save's defaults unchanged, the cap at 50 sparing manual saves, lineage surviving the cap, and the pre-merge point's row.
- [x] `pnpm test` passes locally — **web-jsdom 372 files / 3907 tests**, **web-node 15 / 91**, **arch-lint-node + mcp-node 383 / 4207**, **test:browser 224 / 1189**. `pnpm -r typecheck` clean, `pnpm lint` clean (the 3 warnings are main's `docker-contract.test.ts`), `pnpm knip` clean.
- [x] Manual verification completed — in a real Chromium via `web-browser`, over real IndexedDB rather than a stubbed store, which is the same storage a person's history comes from. Nothing on screen changes yet (see below).
- [ ] E2E coverage added or extended where applicable — not applicable; storage-local, no routing, websocket or daemon dependency.

## Visual evidence

Visual evidence: none — nothing a person can see changes. The one row this corrects (a merge's pre-merge point) already appeared in the History panel; what changed is what it *says about itself*, which the panel does not yet render differently for a browser-kept document. The figure belongs with the increment that starts producing checkpoints and lanes them by variation.

## userReach

`foundation:` — nothing produces automatic checkpoints in the browser yet. The pre-merge point is the one caller, and its row is now correct. **Wired by the next increment**, which puts `createCheckpointScheduler` on the browser's sync session and flushes it on `pagehide` — the cap ships here rather than there so the unbounded state never exists.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — neither; the reasoning lives on the schema fields and the derived type, where the next reader of each will meet it
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema — this diff **deletes** one that did, and the row schema stays the single source for the stored shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh)_