### PR TITLE
fix(web): the offline replica page resolves its own references

### DIFF
--- a/apps/web/src/pages/ReplicaReadPage.browser.test.tsx
+++ b/apps/web/src/pages/ReplicaReadPage.browser.test.tsx
@@ -33,6 +33,8 @@ claimIsolatedWhiteboardDb('replica-read-page')
 const DAEMON_WS = '01ARZ3NDEKTSV4RRFFQ69G5FB0'
 const DOC_MD = '01ARZ3NDEKTSV4RRFFQ69G5FB1'
 const DOC_SP = '01ARZ3NDEKTSV4RRFFQ69G5FB2'
+const DOC_LINKER = '01ARZ3NDEKTSV4RRFFQ69G5FB3'
+const DOC_EMBEDDER = '01ARZ3NDEKTSV4RRFFQ69G5FB4'
 const SYNCED = '2026-09-01T12:00:00.000Z'
 
 async function seedReplica(): Promise<void> {
@@ -46,6 +48,34 @@ async function seedReplica(): Promise<void> {
   createWorkspaceDocumentAtPath(record, { path: 'sketch', documentId: DOC_SP, kind: 'spatial' })
   writeSpatialCanvas(documentContainers(record, DOC_SP), {
     nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 120, height: 40, text: 'cached node' }],
+    edges: [],
+  })
+  // Two documents that POINT at `notes/plan`: one a markdown body with a
+  // wiki link, one a canvas whose text node embeds it. The replica record
+  // holds every document, so both are resolvable entirely offline.
+  createWorkspaceDocumentAtPath(record, {
+    path: 'notes/linker',
+    documentId: DOC_LINKER,
+    kind: 'markdown',
+  })
+  writeMarkdownBody(documentContainers(record, DOC_LINKER), '# Linker\n\n[[notes/plan]]')
+  createWorkspaceDocumentAtPath(record, {
+    path: 'embedder',
+    documentId: DOC_EMBEDDER,
+    kind: 'spatial',
+  })
+  writeSpatialCanvas(documentContainers(record, DOC_EMBEDDER), {
+    nodes: [
+      {
+        id: 'e1',
+        type: 'text',
+        x: 0,
+        y: 0,
+        width: 320,
+        height: 220,
+        text: 'See:\n\n![[notes/plan]]',
+      },
+    ],
     edges: [],
   })
   record.commit()
@@ -155,6 +185,36 @@ describe('ReplicaReadPage', () => {
     await screen.findAllByText(/Hello from the cache/)
     const after = (await new BrowserWorkspaceDocs().open(DAEMON_WS))!.oplogVersion().encode()
     expect(Array.from(after)).toEqual(Array.from(before))
+  })
+
+  it('resolves a wiki link from the replica record alone, with no daemon to ask', async () => {
+    // The replica holds every document in the workspace, so a reference is
+    // answerable offline — the alias table from its own entries, the body
+    // from its own containers. Without seams the editor draws the literal
+    // brackets, which is what the reader sees on the one page that exists
+    // BECAUSE the keeper is unreachable.
+    await seedReplica()
+    render(<ReplicaReadPage workspaceId={DAEMON_WS} syncedAt={SYNCED} />)
+    await userEvent.click(await screen.findByText('linker'))
+
+    await vi.waitFor(() => {
+      const anchor = document.querySelector(`a[href="${DOC_MD}"]`)
+      if (anchor === null) throw new Error('the wiki link did not resolve to the document')
+      return anchor
+    })
+  })
+
+  it("draws an embedded note inside a canvas text node, from the replica's own copy", async () => {
+    await seedReplica()
+    render(<ReplicaReadPage workspaceId={DAEMON_WS} syncedAt={SYNCED} />)
+    await userEvent.click(await screen.findByText('embedder'))
+
+    await vi.waitFor(() => {
+      const drawn = [...document.querySelectorAll('svg text')]
+        .map((node) => node.textContent ?? '')
+        .join(' ')
+      expect(drawn).toContain('Hello from the cache')
+    })
   })
 
   it('a markdown edit persists to the replica record, and files no index row', async () => {

--- a/apps/web/src/pages/ReplicaReadPage.tsx
+++ b/apps/web/src/pages/ReplicaReadPage.tsx
@@ -23,6 +23,7 @@ import {
   referenceTargets,
   referenceWire,
 } from '@kamiazya/whiteboard-canvas-render'
+import { createUniqueNameResolver } from '@kamiazya/whiteboard-codec'
 import {
   documentContainers,
   readMarkdownBody,
@@ -40,6 +41,7 @@ import { formatRelative } from '../components/workspace-files/format-relative.js
 import { WorkspaceFileTree } from '../components/workspace-files/WorkspaceFileTree.js'
 import { BrowserWorkspaceDocs } from '../lib/browser-workspace-docs.js'
 import type { WorkspaceDocumentEntry } from '../lib/document-entry.js'
+import { type LinkableDocument, linkEntries, linkTitles } from '../lib/link-entries.js'
 
 export interface ReplicaReadPageProps {
   /** The daemon workspace's canonical id — the replica registry's key. */
@@ -154,12 +156,30 @@ export function ReplicaReadPage({ workspaceId, displayName, syncedAt }: ReplicaR
   // on the one page that exists BECAUSE the daemon is unreachable — and it
   // stays inside the page's own rule, since reading a container is not an
   // index write.
+  // The same two tables both keeper pages build, over this record's own
+  // entries — so a `[[...]]` written here resolves by the rules the rest of
+  // the app already applies (path or id; a display name is a label, never a
+  // target) rather than by a lookup this page invented for itself.
+  const linkable = useMemo(
+    (): readonly LinkableDocument[] =>
+      state.kind === 'ready'
+        ? state.entries.map((entry) => ({
+            id: entry.documentId,
+            path: entry.path,
+            ...(entry.name === undefined ? {} : { displayName: entry.name }),
+            ...(entry.kind === undefined ? {} : { kind: entry.kind }),
+          }))
+        : [],
+    [state],
+  )
+  const resolveAlias = useMemo(() => createUniqueNameResolver(linkEntries(linkable)), [linkable])
+  const resolveTitle = useMemo(() => linkTitles(linkable), [linkable])
+
   const references = useMemo((): ReferenceWire | undefined => {
     if (state.kind !== 'ready' || selected === undefined) return undefined
-    const byPath = new Map(state.entries.map((entry) => [entry.path, entry]))
     const byId = new Map(state.entries.map((entry) => [entry.documentId, entry]))
     const load = (target: string): LoadedReference | null => {
-      const entry = byPath.get(target) ?? byId.get(target)
+      const entry = byId.get(resolveAlias(target) ?? target) ?? byId.get(target)
       if (entry === undefined) return null
       const containers = documentContainers(state.record, entry.documentId)
       return {
@@ -186,11 +206,8 @@ export function ReplicaReadPage({ workspaceId, displayName, syncedAt }: ReplicaR
       if (wanted.length === 0) break
       for (const target of wanted) graph.set(target, load(target))
     }
-    return referenceWire(graph, {
-      resolveAlias: (alias) => byPath.get(alias)?.documentId ?? null,
-      resolveTitle: (documentId) => byId.get(documentId)?.name,
-    })
-  }, [state, selected])
+    return referenceWire(graph, { resolveAlias, resolveTitle })
+  }, [state, selected, resolveAlias, resolveTitle])
 
   const seams = useMemo(
     () => (references === undefined ? undefined : referenceSeamsFromWire(references)),

--- a/apps/web/src/pages/ReplicaReadPage.tsx
+++ b/apps/web/src/pages/ReplicaReadPage.tsx
@@ -17,6 +17,13 @@
  */
 
 import {
+  type LoadedReference,
+  type ReferenceWire,
+  referenceSeamsFromWire,
+  referenceTargets,
+  referenceWire,
+} from '@kamiazya/whiteboard-canvas-render'
+import {
   documentContainers,
   readMarkdownBody,
   readSpatialCanvas,
@@ -140,6 +147,56 @@ export function ReplicaReadPage({ workspaceId, displayName, syncedAt }: ReplicaR
     latestRecord.current = state.kind === 'ready' ? state.record : null
   }, [state])
 
+  // What the selected document points at, answered from the replica record
+  // itself. Nothing here reaches a keeper: the alias table is the record's
+  // own entries, and every target's body or canvas is read from the same
+  // record through `documentContainers`. That is what makes references work
+  // on the one page that exists BECAUSE the daemon is unreachable — and it
+  // stays inside the page's own rule, since reading a container is not an
+  // index write.
+  const references = useMemo((): ReferenceWire | undefined => {
+    if (state.kind !== 'ready' || selected === undefined) return undefined
+    const byPath = new Map(state.entries.map((entry) => [entry.path, entry]))
+    const byId = new Map(state.entries.map((entry) => [entry.documentId, entry]))
+    const load = (target: string): LoadedReference | null => {
+      const entry = byPath.get(target) ?? byId.get(target)
+      if (entry === undefined) return null
+      const containers = documentContainers(state.record, entry.documentId)
+      return {
+        documentId: entry.documentId,
+        ...(entry.name === undefined ? {} : { name: entry.name }),
+        ...(entry.kind === 'spatial'
+          ? { canvas: readSpatialCanvas(containers) }
+          : { body: readMarkdownBody(containers) }),
+      }
+    }
+    // Seeded from what the SELECTED document says, then walked the way every
+    // other keeper walks it — `referenceTargets` re-reads the graph as it
+    // grows, so a referenced body's own links load too, under its own caps.
+    const containers = documentContainers(state.record, selected.documentId)
+    const seeds =
+      selected.kind === 'spatial'
+        ? { canvases: [readSpatialCanvas(containers)] }
+        : { bodies: [readMarkdownBody(containers)] }
+    const graph = new Map<string, LoadedReference | null>()
+    for (;;) {
+      const wanted = referenceTargets({ ...seeds, loaded: graph }).filter(
+        (target) => !graph.has(target),
+      )
+      if (wanted.length === 0) break
+      for (const target of wanted) graph.set(target, load(target))
+    }
+    return referenceWire(graph, {
+      resolveAlias: (alias) => byPath.get(alias)?.documentId ?? null,
+      resolveTitle: (documentId) => byId.get(documentId)?.name,
+    })
+  }, [state, selected])
+
+  const seams = useMemo(
+    () => (references === undefined ? undefined : referenceSeamsFromWire(references)),
+    [references],
+  )
+
   const content = useMemo(() => {
     if (state.kind !== 'ready' || selected === undefined) return null
     const containers = documentContainers(state.record, selected.documentId)
@@ -234,6 +291,7 @@ export function ReplicaReadPage({ workspaceId, displayName, syncedAt }: ReplicaR
                 initialViewMode="split"
                 value={draft}
                 onChange={onDraftChange}
+                references={seams}
               />
             )}
             {content?.kind === 'spatial' && spatialDraft !== null && (
@@ -246,6 +304,7 @@ export function ReplicaReadPage({ workspaceId, displayName, syncedAt }: ReplicaR
                 // should not need a tool switch first.
                 defaultTool="select"
                 className="h-full"
+                references={references}
               />
             )}
           </div>


### PR DESCRIPTION
## Summary

`ReplicaReadPage` mounted both editors without `references`, and the prop is optional on each — so it **compiled clean and degraded silently** to raw ids and bracket literals. It is the only document-editing surface in `apps/web` reaching neither `useDocumentFileSeams` nor `useReferenceSeams`, and the one where the gap reads worst: this page exists **because** the daemon that keeps the workspace is unreachable, so a reader who follows a link has nothing else to fall back on.

**Nothing new has to be fetched.** The replica record already holds every document in the workspace, so the page answers a reference from its own copy: the alias table and the titles from `state.entries`, each target's body or canvas through `documentContainers` on the same record. That stays inside the page's own stated rule — reading a container is not an index write, and no keeper is asked.

The walk is `referenceTargets` seeded from the *selected* document and re-read as the graph grows, the way both keepers walk it, so a referenced body's own links resolve too under the same depth and budget caps. Both forms are built once: `referenceWire` for `SpatialEditor` (which posts it to its layout worker) and `referenceSeamsFromWire` for `MarkdownEditor`.

Found by a wiring-gaps audit of the reference layer — the third and last finding from it, after `canvas_view` (#1421).

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — two cases in the file that already pins this page's read-only-era invariants, over **real IndexedDB**: a wiki link in a replica markdown body resolving to its document id, and a canvas text node's `[[notes/plan]]` drawing the referenced note's prose. The seed gains two documents that point at an existing one, so no existing assertion moves.
- [x] Red first, and **mutation-checked**: with either `references` prop removed, both fail — the link no longer resolves and the prose no longer draws. Verified as one simultaneous mutation, since the two props are independent paths.
- [x] `pnpm test` passes locally — `pnpm -r typecheck`, `pnpm lint`, `pnpm knip` clean; the apps/web structural guards (`layer-order`, `component-reach`, `mock-specifiers`, `entry-graph-loro-free`) 140 tests; `web-browser` over `pages/` + `markdown-editor/` 48 files / 197 tests; the changed file run three more times for stability.
- [x] Manual verification completed — the browser tests drive the real page against real IndexedDB and read the rendered anchor and SVG text, which is the behaviour itself rather than a stand-in.
- [ ] E2E coverage added or extended where applicable — not needed: no routing, transport or MCP surface changes; the page is mounted directly and its persistence is already pinned in the same file.

## Visual evidence

Visual evidence: none — this session cannot upload an image to GitHub (no `gh`, and the GitHub MCP surface carries no asset upload). Both pixel-level claims are asserted instead of pictured: the resolved link as an `a[href="<documentId>"]` in the rendered preview, and the embedded note as its prose inside the canvas's `svg text`. The Cloudflare preview on this PR shows it live for anyone who wants to look.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — no doc described the old limitation; the page's own comment now states where its references come from and why that respects its no-index rule
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8HzhgLpsT6XLvJNcz2fxD

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8HzhgLpsT6XLvJNcz2fxD)_