### PR TITLE
feat(web): the browser keeper takes automatic checkpoints

### DIFF
--- a/apps/web/src/components/VersionTimeline.tsx
+++ b/apps/web/src/components/VersionTimeline.tsx
@@ -57,10 +57,21 @@ export const DAEMON_HISTORY_CAPABILITIES: VersionTimelineCapabilities = {
   autoVersions: true,
 }
 
-/** The browser's history: one lane, and a point only when asked for. */
+/**
+ * The browser's history, which now answers the same two questions the
+ * daemon's does: its rows carry the variation they were taken on, and a
+ * checkpoint lands on its own once editing settles.
+ *
+ * Equal to the daemon's, therefore, and a pair that agrees declares no
+ * difference — the argument that retired the provider's capability map. What
+ * keeps this one alive for the moment is not a difference but the component
+ * below: `branches: false` and `autoVersions: false` still select real
+ * rendering paths that `version-row.test.tsx` exercises, so removing the pair
+ * means removing those too. That is the follow-up, not a drive-by here.
+ */
 export const BROWSER_HISTORY_CAPABILITIES: VersionTimelineCapabilities = {
-  branches: false,
-  autoVersions: false,
+  branches: true,
+  autoVersions: true,
 }
 
 interface Props {

--- a/apps/web/src/hooks/useDocumentSync.ts
+++ b/apps/web/src/hooks/useDocumentSync.ts
@@ -296,6 +296,11 @@ export function useDocumentSync(
       ...(optionsRef.current.contentDocumentId === undefined
         ? {}
         : { contentDocumentId: optionsRef.current.contentDocumentId }),
+      // Captured once per session for the same reason as the scope above: a
+      // checkpoint belongs to the document this backend serves.
+      ...(optionsRef.current.checkpoints === undefined
+        ? {}
+        : { checkpoints: optionsRef.current.checkpoints }),
     })
     sessionRef.current = session
     const unsubscribe = session.subscribe((next, origin) => {

--- a/apps/web/src/lib/browser-versions-backend.browser.test.tsx
+++ b/apps/web/src/lib/browser-versions-backend.browser.test.tsx
@@ -1,0 +1,94 @@
+import { writeBranchesToRecord } from '@kamiazya/whiteboard-history'
+import {
+  writeSpatialCanvas,
+  writeWorkspaceDocumentContent,
+} from '@kamiazya/whiteboard-loro-adapter'
+import { LoroDoc } from 'loro-crdt'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { BrowserBackend } from './browser-backend.js'
+import { BrowserVersionStore } from './browser-version-store.js'
+import { createBrowserVersionsBackend } from './browser-versions-backend.js'
+import { BrowserWorkspaceDocs } from './browser-workspace-docs.js'
+import { getBrowserWorkspaceId } from './browser-workspace-id.js'
+import { FoldingBrowserIndex } from './folding-browser-index.js'
+
+claimIsolatedWhiteboardDb('browserversionsbackend')
+
+const NO_OP_HANDLERS = {
+  onSnapshot: () => {},
+  onRemoteUpdate: () => {},
+  onConnected: () => {},
+  onDisconnected: () => {},
+  onRestoreStarted: () => {},
+  onRestoreComplete: () => {},
+  onVersionCreated: () => {},
+  onHeadChanged: () => {},
+  onViewportRequest: () => {},
+  onExportRequest: () => {},
+}
+
+/**
+ * What the shared `versionsBackendContract` cannot express, so it lives here
+ * with the keeper it belongs to: the seam's `save` carries a label and
+ * nothing else, and which VARIATION a manual save lands on is the keeper's
+ * to resolve — the daemon's route reads HEAD before writing the row, and
+ * this is the browser's half of that.
+ */
+describe('the browser versions backend files a manual save on the current variation', () => {
+  let backend: BrowserBackend
+
+  beforeEach(async () => {
+    await clearWhiteboardDb()
+  })
+
+  afterEach(() => {
+    backend.disconnect()
+  })
+
+  it('records the variation HEAD is on, not the default', async () => {
+    const workspaceId = getBrowserWorkspaceId()
+    const index = new FoldingBrowserIndex()
+    await index.createWorkspace({ workspaceId })
+    const { documentId } = await index.createDocument({
+      workspaceId,
+      path: 'canvas-a',
+      kind: 'spatial',
+    })
+
+    const docs = new BrowserWorkspaceDocs()
+    const record = await docs.open(workspaceId)
+    if (record === null) throw new Error('no record')
+    const content = new LoroDoc()
+    writeSpatialCanvas(content, {
+      nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 80, height: 40, text: 'work' }],
+      edges: [],
+    })
+    content.commit()
+    writeWorkspaceDocumentContent(record, documentId, content)
+    // A NON-default HEAD, which is the whole point: `main` is also what a row
+    // carrying no variation reads as, so a save taken there cannot tell a
+    // resolved value from an unresolved one.
+    writeBranchesToRecord(record, documentId, {
+      branches: [
+        { name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '2026-01-01T00:00:00.000Z' },
+        { name: 'idea', tipFrontiers: '', color: '#9333ea', createdAt: '2026-01-02T00:00:00.000Z' },
+      ],
+      head: 'idea',
+    })
+    await docs.save(workspaceId, record)
+
+    backend = new BrowserBackend({ documentId, path: 'canvas-a', kind: 'spatial' }, docs)
+    backend.connect(NO_OP_HANDLERS)
+    await vi.waitFor(() => expect(backend.readRecord(() => true)).toBe(true))
+
+    const store = new BrowserVersionStore({ docs, index })
+    const versions = createBrowserVersionsBackend({ backend, store })
+    await versions.save(workspaceId, 'canvas-a', { label: 'by hand' })
+
+    expect(await store.list(workspaceId, 'canvas-a')).toEqual([
+      expect.objectContaining({ label: 'by hand', auto: false, branchName: 'idea' }),
+    ])
+  })
+})

--- a/apps/web/src/lib/browser-versions-backend.ts
+++ b/apps/web/src/lib/browser-versions-backend.ts
@@ -1,3 +1,4 @@
+import { readBranchesFromRecord } from '@kamiazya/whiteboard-history'
 import {
   readDocumentKind,
   readMarkdownBody,
@@ -25,13 +26,28 @@ export function createBrowserVersionsBackend(deps: {
 }): VersionsBackend {
   return {
     list: (_workspaceId, path) => deps.store.list(getBrowserWorkspaceId(), path),
-    save: (_workspaceId, path, { label }) =>
-      deps.store.save(getBrowserWorkspaceId(), path, {
+    save(_workspaceId, path, { label }) {
+      // WHICH variation this lands on is the keeper's to resolve — the seam
+      // carries a label and nothing else, and the daemon's route reads HEAD
+      // the same way before writing its row. Without this a browser document
+      // with variations files every manual save on the default lane while
+      // its automatic checkpoints lane correctly, which reads as a history
+      // that lost track of where the work happened.
+      //
+      // A record that cannot answer falls back to the store's own default,
+      // exactly as the daemon's route does.
+      const head =
+        deps.backend.readRecord(
+          (doc, documentId) => readBranchesFromRecord(doc, documentId).head,
+        ) ?? null
+      return deps.store.save(getBrowserWorkspaceId(), path, {
         label,
+        ...(head === null || head === '' ? {} : { branchName: head }),
         // The person at this browser. The daemon names its humans by their
         // sync peer; the browser has one person and no peer to name.
         operator: { kind: 'human', peerId: 'browser' },
-      }),
+      })
+    },
     async loadPast(_workspaceId, path, versionId) {
       // The store answers a LoroDoc; the seam answers something to draw. The
       // projection happens here so the seam stays free of CRDT types and a

--- a/apps/web/src/lib/document-sync-session.test.ts
+++ b/apps/web/src/lib/document-sync-session.test.ts
@@ -337,6 +337,38 @@ describe('createDocumentSyncSession', () => {
       }
     })
 
+    // The automatic-checkpoint trigger rides the same two signals, and its
+    // flush must come AFTER the edit flush above — a checkpoint taken first
+    // would point at the record as it stood before the last edit landed,
+    // which is the one state nobody wants bookmarked. Registering a second
+    // listener from the page would leave that order to registration timing,
+    // so the session owns both.
+    it('signals the checkpoint trigger on a local edit, and flushes it when the page goes away', async () => {
+      vi.useFakeTimers()
+      const checkpoints = { signal: vi.fn(), flush: vi.fn() }
+      try {
+        const backend = makeFakeBackend()
+        const session = createDocumentSyncSession(backend, makeDeps({ checkpoints }))
+        session.connect()
+        backend._ctrl.handlers!.onSnapshot(makeSnapshot(twoNodeCanvas()))
+        const move: EditorCommand = { kind: 'move-node', id: 'n-a', x: 10, y: 20 }
+        session.onChange(applyCommand(twoNodeCanvas(), move), move)
+        window.dispatchEvent(new Event('pagehide'))
+        // Microtasks only, for the reason `editThen` above gives: the
+        // debounce timer must not be what lands the edit this signals on.
+        await flushMicrotasks()
+
+        // Both, and this order: the edit reaches the record on the same
+        // signal, so a checkpoint flushed before it would bookmark the state
+        // without it.
+        expect(checkpoints.signal).toHaveBeenCalled()
+        expect(checkpoints.flush).toHaveBeenCalledTimes(1)
+        session.dispose()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
     // The control: becoming VISIBLE is the same event name and must not
     // flush, or every tab switch back would write mid-gesture.
     it('not on visibilitychange to visible', async () => {

--- a/apps/web/src/lib/document-sync-session.ts
+++ b/apps/web/src/lib/document-sync-session.ts
@@ -203,6 +203,20 @@ export interface SessionDeps {
    * only WHERE content containers are found changes.
    */
   contentDocumentId?: string
+  /**
+   * The automatic-checkpoint trigger, for a keeper that takes them.
+   *
+   * A narrow pair rather than the scheduler itself: the session's business is
+   * WHEN the document changed and when the page is going away, not what a
+   * checkpoint is or where it goes. `signal` is cheap and safe per update
+   * (the scheduler debounces); `flush` takes any pending one now.
+   *
+   * It lives here rather than as the page's own `pagehide` listener because
+   * the ORDER against the edit flush is load-bearing and two independent
+   * listeners would leave it to registration timing: a checkpoint taken
+   * before the edit lands bookmarks the state without it.
+   */
+  checkpoints?: { readonly signal: () => void; readonly flush: () => void }
 }
 
 export interface DocumentSyncSession {
@@ -933,11 +947,16 @@ export function createDocumentSyncSession(
   // store, and the edit is still lost — the same as without this listener.
   // Closing that last gap means not having a window at all (write at once,
   // commit later), not a better signal.
+  // The edit flush first in both, then the checkpoint: the edit is what the
+  // checkpoint would be bookmarking.
   function onVisibilityChange(): void {
-    if (document.visibilityState === 'hidden') onCanvasChange.flush()
+    if (document.visibilityState !== 'hidden') return
+    onCanvasChange.flush()
+    deps.checkpoints?.flush()
   }
   function onPageHide(): void {
     onCanvasChange.flush()
+    deps.checkpoints?.flush()
   }
   function listenForPageLeaving(): void {
     if (typeof document === 'undefined' || typeof window === 'undefined') return
@@ -1037,6 +1056,12 @@ export function createDocumentSyncSession(
           // it, the transport could already be closed by the time this push
           // happens, silently losing the last edit before a canvas switch or
           // unmount.
+          // "This document just changed locally" — the browser's analogue of
+          // the update the daemon's trigger rides. Before the push rather
+          // than after it: the scheduler only arms a timer here, and a
+          // checkpoint that waited for durability would miss the edits a
+          // failing store is exactly when you want bookmarked.
+          deps.checkpoints?.signal()
           inFlightPushes++
           const epochAtPush = failureEpoch
           void Promise.resolve(backend.pushLocalUpdate(update)).then(

--- a/apps/web/src/lib/document-sync-types.ts
+++ b/apps/web/src/lib/document-sync-types.ts
@@ -73,6 +73,14 @@ export interface UseDocumentSyncOptions {
    * travel together.
    */
   contentDocumentId?: string
+  /**
+   * The automatic-checkpoint trigger, for a keeper that takes them — see
+   * SessionDeps.checkpoints for why the session owns the flush rather than
+   * the page. Captured when the session is constructed, like
+   * `contentDocumentId` and for the same reason: it is bound to the document
+   * this backend serves.
+   */
+  checkpoints?: { readonly signal: () => void; readonly flush: () => void }
 }
 
 // Dispatches a window event carrying { workspaceId, path } as detail, but only

--- a/apps/web/src/lib/keeper-parity.test.ts
+++ b/apps/web/src/lib/keeper-parity.test.ts
@@ -298,18 +298,22 @@ describe('a panel whose behaviour differs by keeper is told which keeper it is',
     ).toBe(true)
   })
 
-  it('draws lanes for what the ROWS carry, which is not the same as having variations', () => {
-    // This compared the panel's flag to the provider's, back when the
-    // provider had one. It does not any more: both keepers have variations,
-    // so `capabilities.branches` is gone the way `workspaces` and `versions`
-    // went before it.
+  it('draws lanes and expects checkpoints for BOTH keepers now', () => {
+    // This pinned the two apart, as a decision held "until that increment
+    // lands". It has landed: the browser's rows carry `auto` and the
+    // variation they were taken on, and a checkpoint arrives once editing
+    // settles — so one lane and a hand-only history would now be wrong about
+    // this keeper rather than correct.
     //
-    // The panel's flag survives because it asks a DIFFERENT question — do the
-    // version rows carry a branch to lane by? The browser's do not yet (they
-    // gain `auto`/`branchName` with automatic checkpoints), so one lane there
-    // is correct rather than a leftover, and this pins it as a decision until
-    // that increment lands.
-    expect(BROWSER_HISTORY_CAPABILITIES.branches).toBe(false)
-    expect(DAEMON_HISTORY_CAPABILITIES.branches).toBe(true)
+    // Which makes the pair EQUAL, and a pair that agrees declares no
+    // difference — the argument that retired the provider's capability map.
+    // It is not deleted here only because `false` still selects real
+    // rendering paths in the component (`version-row.test.tsx` drives them),
+    // so the deletion is theirs to carry, not this increment's. Until then
+    // this pins the agreement rather than a difference, so nothing can drift
+    // back to claiming one.
+    expect(BROWSER_HISTORY_CAPABILITIES).toEqual(DAEMON_HISTORY_CAPABILITIES)
+    expect(BROWSER_HISTORY_CAPABILITIES.branches).toBe(true)
+    expect(BROWSER_HISTORY_CAPABILITIES.autoVersions).toBe(true)
   })
 })

--- a/apps/web/src/pages/BrowserDocumentPage.checkpoints.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.checkpoints.browser.test.tsx
@@ -1,0 +1,102 @@
+import {
+  writeSpatialCanvas,
+  writeWorkspaceDocumentContent,
+} from '@kamiazya/whiteboard-loro-adapter'
+import { cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import { LoroDoc } from 'loro-crdt'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { BrowserVersionStore } from '../lib/browser-version-store.js'
+import { BrowserWorkspaceDocs } from '../lib/browser-workspace-docs.js'
+import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
+import { FoldingBrowserIndex } from '../lib/folding-browser-index.js'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { BrowserDocumentPage } from './BrowserDocumentPage.js'
+import '../index.css'
+
+claimIsolatedWhiteboardDb('browserdocumentpagecheckpoints')
+
+function render(ui: ReactElement) {
+  return rtlRender(
+    <div style={{ height: '100vh' }}>
+      <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
+    </div>,
+  )
+}
+
+async function seedDocument(): Promise<{ index: FoldingBrowserIndex; documentId: string }> {
+  const index = new FoldingBrowserIndex()
+  const workspaceId = getBrowserWorkspaceId()
+  await index.createWorkspace({ workspaceId })
+  const { documentId } = await index.createDocument({
+    workspaceId,
+    path: 'canvas-a',
+    kind: 'spatial',
+  })
+  const doc = new LoroDoc()
+  writeSpatialCanvas(doc, {
+    nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 80, height: 40, text: 'first' }],
+    edges: [],
+  })
+  doc.commit()
+  const docs = new BrowserWorkspaceDocs()
+  const record = await docs.open(workspaceId)
+  if (record === null) throw new Error('no record')
+  writeWorkspaceDocumentContent(record, documentId, doc)
+  await docs.save(workspaceId, record)
+  return { index, documentId }
+}
+
+// Automatic checkpoints in browser mode, end to end through the real page.
+// The scheduler's own quiet window is five minutes, so what this drives is
+// the OTHER way a checkpoint lands: the page going away. That is not a
+// shortcut around the debounce — it is the case a person actually hits, and
+// the one the daemon has no equivalent of.
+describe('BrowserDocumentPage automatic checkpoints (browser)', () => {
+  beforeEach(async () => {
+    await clearWhiteboardDb()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('leaves a checkpoint behind when the page goes away after an edit', async () => {
+    const { index } = await seedDocument()
+    render(<BrowserDocumentPage initialPath="canvas-a" />)
+    await waitFor(
+      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
+      {
+        timeout: 5000,
+      },
+    )
+
+    const store = new BrowserVersionStore({ docs: new BrowserWorkspaceDocs(), index })
+    const workspaceId = getBrowserWorkspaceId()
+    // Nothing yet: an untouched document has no checkpoint, which is what
+    // makes the row below evidence of the edit rather than of mounting.
+    expect(await store.list(workspaceId, 'canvas-a')).toEqual([])
+
+    // A real edit through the editor, not a write straight to the store.
+    await userEvent.click(await screen.findByTestId('select-tool-button'))
+    await userEvent.dblClick(screen.getByTestId('spatial-editor-container'))
+
+    // Immediately, with the edit still inside the debounce window — which is
+    // what a person closing a tab does, and the ordering this pins. The
+    // commit the edit flush performs reaches `subscribeLocalUpdates` on a
+    // LATER microtask, so a checkpoint flush that ran here would find nothing
+    // armed and leave no row.
+    window.dispatchEvent(new Event('pagehide'))
+
+    await waitFor(
+      async () => {
+        const rows = await store.list(workspaceId, 'canvas-a')
+        expect(rows).toEqual([expect.objectContaining({ auto: true, branchName: 'main' })])
+      },
+      { timeout: 5000 },
+    )
+  })
+})

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -501,8 +501,18 @@ function useBrowserDocument(
       // A document with no path yet has nowhere to file a row; the record
       // is what a checkpoint points at, so both must be there.
       if (documentPath === null) return
-      const record = backend?.readRecord((doc) => doc) ?? null
-      if (record !== null) checkpoints(getBrowserWorkspaceId(), documentPath, record)
+      // Total, and deliberately so. This runs inside Loro's local-update
+      // subscriber, where a throw does not fail the edit — it escapes as an
+      // UNHANDLED REJECTION, which vitest reports as `Errors 1` with every
+      // test still passing and only the exit code red. A missed checkpoint is
+      // not worth that, and nothing here is worth failing an edit for either:
+      // a backend that cannot answer for a record has no record to bookmark.
+      try {
+        const record = backend?.readRecord?.((doc) => doc) ?? null
+        if (record !== null) checkpoints(getBrowserWorkspaceId(), documentPath, record)
+      } catch (err) {
+        log.warn('could not arm an automatic checkpoint', err)
+      }
     }
     return {
       signal,

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -1,4 +1,6 @@
 import { createUniqueNameResolver, serializeSpatial } from '@kamiazya/whiteboard-codec'
+import type { VersionEntry } from '@kamiazya/whiteboard-daemon-client/api-contracts/index'
+import { createCheckpointScheduler, readBranchesFromRecord } from '@kamiazya/whiteboard-history'
 import type { DocumentKind } from '@kamiazya/whiteboard-model'
 import { isImageRef } from '@kamiazya/whiteboard-model'
 import type { DocumentIndex } from '@kamiazya/whiteboard-ports'
@@ -458,6 +460,71 @@ function useBrowserDocument(
     [documentId, documentKind],
   )
 
+  // The store, not the seam, is what a merge's pre-merge point needs: the
+  // seam's `save` carries a label and nothing else, while a checkpoint has to
+  // say it is automatic and which variation it belongs to. So it is built
+  // once here and handed to both.
+  const versionStore = useMemo(
+    () => new BrowserVersionStore({ docs: new BrowserWorkspaceDocs(), index: store }),
+    [store],
+  )
+
+  // Automatic checkpoints, on the same mechanic the daemon runs
+  // (`@kamiazya/whiteboard-history`): a trailing debounce that lands a point
+  // once the document has been quiet, so a row marks where a person stopped
+  // rather than an arbitrary interval.
+  //
+  // The `doc` the scheduler is handed is the WORKSPACE RECORD, not this
+  // document's content — it uses the frontier only to ask "has anything
+  // changed since the last checkpoint", and the record's frontier is what
+  // the store saves. Keying on the content doc would compare a frontier
+  // against a row taken from a different one, and never match.
+  const checkpoints = useMemo(() => {
+    const scheduler = createCheckpointScheduler<VersionEntry>({
+      save: (workspaceId, path, _doc, branchName) =>
+        versionStore.save(workspaceId, path, {
+          auto: true,
+          ...(branchName === null ? {} : { branchName }),
+          // The person at this browser is not who took this one.
+          operator: { kind: 'system', peerId: 'browser', displayName: 'auto-save' },
+        }),
+      getHeadBranch: async (_workspaceId, _path) =>
+        backend?.readRecord((doc, id) => readBranchesFromRecord(doc, id)?.head ?? null) ?? null,
+      onError: (err) => log.warn('automatic checkpoint failed', err),
+    })
+    return scheduler
+  }, [backend, versionStore])
+
+  // Bound to the record the backend holds, and a no-op until one is there.
+  const checkpointPair = useMemo(() => {
+    const signal = (): void => {
+      // A document with no path yet has nowhere to file a row; the record
+      // is what a checkpoint points at, so both must be there.
+      if (documentPath === null) return
+      const record = backend?.readRecord((doc) => doc) ?? null
+      if (record !== null) checkpoints(getBrowserWorkspaceId(), documentPath, record)
+    }
+    return {
+      signal,
+      // Signal, THEN flush. The session flushes the pending edit before
+      // calling this, but the commit that performs reaches
+      // `subscribeLocalUpdates` — where `signal` lives — only on a later
+      // microtask, so flushing alone finds nothing armed and a person who
+      // edits and closes the tab leaves no checkpoint. Signalling here arms
+      // it against the record as it stands, which is what a checkpoint
+      // points at anyway: the store saves the frontier that is ON DISK, so
+      // an edit still in flight is simply not part of this point, rather
+      // than making it wrong.
+      flush: () => {
+        signal()
+        void checkpoints.flush()
+      },
+    }
+  }, [backend, checkpoints, documentPath])
+
+  // Nothing pending survives leaving this document for another.
+  useEffect(() => () => checkpoints.stop(), [checkpoints])
+
   // useDocumentSync tolerates a null backend (idle, no writes) and reconnects
   // whenever the backend identity changes, so the not-yet-loaded state is
   // represented as null instead of a throwaway placeholder canvas id.
@@ -465,6 +532,7 @@ function useBrowserDocument(
     // The backend delivers the WORKSPACE document; this scopes the session's
     // reads and writes to the tree node carrying this document's content.
     ...(documentId === null ? {} : { contentDocumentId: documentId }),
+    checkpoints: checkpointPair,
   })
   const {
     canvas,
@@ -480,14 +548,6 @@ function useBrowserDocument(
   // is no spatial backend (a markdown document, or nothing loaded yet), in
   // which case the save control is hidden rather than left to fall back onto
   // the daemon's routes.
-  // The store, not the seam, is what a merge's pre-merge point needs: the
-  // seam's `save` carries a label and nothing else, while a checkpoint has to
-  // say it is automatic and which variation it belongs to. So it is built
-  // once here and handed to both.
-  const versionStore = useMemo(
-    () => new BrowserVersionStore({ docs: new BrowserWorkspaceDocs(), index: store }),
-    [store],
-  )
   const versionsBackend = useMemo(
     () =>
       backend === null ? null : createBrowserVersionsBackend({ backend, store: versionStore }),

--- a/apps/web/src/pages/BrowserDocumentPage.versions.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.versions.browser.test.tsx
@@ -112,11 +112,11 @@ describe('BrowserDocumentPage version history (browser)', () => {
     // refresh the save announces — not through the panel's mount fetch.
     await userEvent.click(screen.getByRole('button', { name: 'History' }))
     const panel = await screen.findByTestId('history-panel')
-    // The browser's own empty-state copy: no auto-save to wait for, and it
-    // points at the panel's own save icon rather than at a shortcut a phone
-    // does not have.
+    // The empty-state copy, which says a checkpoint is coming — because for
+    // this keeper one now is. It used to point only at the save button, and
+    // that was correct until automatic checkpoints reached the browser.
     const empty = await within(panel).findByText(/No versions yet/)
-    expect(empty.textContent).toContain('Save one with the button above, or ⌘/Ctrl+S.')
+    expect(empty.textContent).toContain('A checkpoint is saved a little after you stop editing.')
 
     // ⌘/Ctrl+S asks for a bookmark rather than taking one: it opens the
     // history with its naming field ready. An unnamed mark would be titled

--- a/packages/mcp-server/src/server/file-size-budget.test.ts
+++ b/packages/mcp-server/src/server/file-size-budget.test.ts
@@ -156,8 +156,11 @@ const FILE_SIZE_GRANDFATHER: Record<string, number> = {
   // "anything changed" check on a frontier, and the record's is what the
   // store saves), and the pair's `flush` signals BEFORE it flushes, because
   // the edit flush's commit reaches `subscribeLocalUpdates` only on a later
-  // microtask and a flush alone would find nothing armed.
-  'apps/web/src/pages/BrowserDocumentPage.tsx': 987,
+  // microtask and a flush alone would find nothing armed. Raised again to 997
+  // when `signal` was made TOTAL: it runs inside Loro's subscriber, where a
+  // throw escapes as an unhandled rejection that reddens a whole run while
+  // every test passes.
+  'apps/web/src/pages/BrowserDocumentPage.tsx': 997,
   'packages/canvas-render/src/layout/nodes/mdast-blocks.ts': 1674,
   'packages/canvas-render/src/layout/spatial-canvas.ts': 1840,
   'packages/canvas-render/src/layout/edges/spatial-edges.ts': 2069,

--- a/packages/mcp-server/src/server/file-size-budget.test.ts
+++ b/packages/mcp-server/src/server/file-size-budget.test.ts
@@ -127,7 +127,14 @@ const FILE_SIZE_GRANDFATHER: Record<string, number> = {
   // four call sites building their own. Both are paid once; the keeper
   // conversion also took the browser page below from 981 to 926.
   'apps/web/src/pages/DaemonDocumentPage.tsx': 942,
-  'apps/web/src/lib/document-sync-session.ts': 1366,
+  // Raised from 1366 by the automatic-checkpoint trigger: a narrow
+  // `{signal, flush}` pair on SessionDeps, signalled from
+  // `subscribeLocalUpdates` and flushed from the two page-leaving handlers
+  // beside the edit flush. Most of the 25 lines is the reason the FLUSH lives
+  // here rather than as the page's own listener — its order against the edit
+  // flush is load-bearing, and two independent listeners would leave that to
+  // registration timing.
+  'apps/web/src/lib/document-sync-session.ts': 1391,
   // Raised from 1131 because compaction's retained-history cut now reads
   // branch tips from BOTH planes for the length of the migration: the record,
   // where a document goes the first time its branches are written, and the
@@ -141,7 +148,16 @@ const FILE_SIZE_GRANDFATHER: Record<string, number> = {
   // it is automatic and which variation it belongs to — so the store is
   // built here and handed to both seams, and the comment saying why is most
   // of the seven lines.
-  'apps/web/src/pages/BrowserDocumentPage.tsx': 933,
+  // Raised from 933 by the checkpoint scheduler being BUILT here — the
+  // keeper's `save`, the HEAD lookup its rows are laned by, and the pair the
+  // session signals. Most of the 54 lines is two pieces of reasoning a reader
+  // cannot recover from the code: the doc handed to the scheduler is the
+  // workspace RECORD rather than this document's content (it keys the
+  // "anything changed" check on a frontier, and the record's is what the
+  // store saves), and the pair's `flush` signals BEFORE it flushes, because
+  // the edit flush's commit reaches `subscribeLocalUpdates` only on a later
+  // microtask and a flush alone would find nothing armed.
+  'apps/web/src/pages/BrowserDocumentPage.tsx': 987,
   'packages/canvas-render/src/layout/nodes/mdast-blocks.ts': 1674,
   'packages/canvas-render/src/layout/spatial-canvas.ts': 1840,
   'packages/canvas-render/src/layout/edges/spatial-edges.ts': 2069,


### PR DESCRIPTION
## Summary

- **A browser-kept document now checkpoints itself**, on the same mechanic the daemon runs (`createCheckpointScheduler` from `@kamiazya/whiteboard-history`) — a trailing debounce, so a point marks where somebody stopped rather than an arbitrary interval.
- The session signals it on every local update and flushes it when the page goes away; the page builds it over the version store 段5a landed.
- **Three of the four commits are defects the tests forced out**, not planned work. Each is below, because each is the kind that reads as correct.

## The wiring

`SessionDeps` gains a narrow `{signal, flush}` pair rather than the scheduler itself — the session's business is *when* the document changed and *when* the page is leaving, not what a checkpoint is. `signal` rides `subscribeLocalUpdates` (the browser's analogue of the update the daemon's trigger rides); `flush` rides the `pagehide` / `visibilitychange` signals the edit flush already uses.

The flush lives in the session rather than as the page's own listener because **its order against the edit flush is load-bearing**, and two independent listeners would leave that to registration timing.

## Defect 1 — order alone was not enough

`onCanvasChange.flush()` commits synchronously, but that commit reaches `subscribeLocalUpdates` — where `signal` lives — only on a **later microtask**. So a checkpoint flush running immediately after it finds nothing armed, and **a person who edits and closes the tab leaves no checkpoint at all**.

The end-to-end test caught this; no amount of reading would have. The page's `flush` therefore signals before it flushes. Mutation-checked: without the leading `signal()` the case fails with an empty history — the original symptom.

What a checkpoint points at is unchanged and deliberate: the store saves the frontier that is **on disk**, so an edit still in flight is simply not part of this point rather than making it wrong.

## Defect 2 — the increment made manual saves inconsistent

The daemon's manual-save route resolves HEAD before writing its row. The browser's backend did not, so every manual save was filed on `main`.

Harmless while browser rows carried no variation at all — `toEntry` answered `main` for everything, uniformly. It stops being harmless here: checkpoints now carry the real HEAD, so a document with variations would show correctly-laned automatic points beside manual points all claiming the default lane. Worse than the uniform answer it replaces.

Mutation-checked: without the lookup the row reads `main` where the test put HEAD on `idea`. The case lives in a keeper-specific file because `versionsBackendContract` **structurally cannot express it** — its `save` takes a label, and there is no way through the seam to put HEAD anywhere.

## Defect 3 — arming could redden a whole run

`signal` called `backend.readRecord`, which only the real `BrowserBackend` has; `BrowserDocumentPage.comments-panel.browser.test.tsx` `vi.mock`s that module with a stand-in that has none.

The shape is what makes it worth stating. `signal` runs inside Loro's subscriber, so the throw does not fail the edit — it escapes as an **unhandled rejection**, and the suite reports `226 passed (226)`, `1191 passed (1191)` **and exits 1**. Running only the file I was working on would have shipped it.

Arming is total now. Neither half is padding: a backend that cannot answer for a record has no record to bookmark, and no missed checkpoint is worth failing someone's edit for. Mutation-checked: without the guard that one file exits 1 carrying `TypeError: backend?.readRecord is not a function` while its 13 tests pass.

## Defect 4 — the panel would have lied

`BROWSER_HISTORY_CAPABILITIES` said one lane and no automatic points. Both halves are false as of this increment, and the empty state is **driven by that flag** — it reads "Save one with the button above" for a keeper about to save one by itself. Copy that becomes false on merge, not a rough edge.

`keeper-parity` had already written down that this was coming: its guard held one lane as correct *"until that increment lands"*, naming `auto`/`branchName` as what would land it. It now pins the opposite — that the two are **equal** — so nothing can drift back to claiming a difference that is gone.

Equal is also, by the argument that retired the provider's capability map, a pair that should not exist. **Not deleted here**, because `false` still selects real rendering paths that `version-row.test.tsx` drives, so the deletion has to carry those away too. Both the constant and the guard name it as the follow-up rather than leaving the redundancy unremarked.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — a session-layer case pinning signal-on-edit and flush-on-leaving (each half mutation-checked), an end-to-end `web-browser` case driving the real page over real IndexedDB (edit → leave → a checkpoint row), and the keeper-specific manual-save case.
- [x] `pnpm test` passes locally — **web-jsdom 372 files / 3908 tests**, **web-node 15 / 91**, **arch-lint-node + mcp-node 383 / 4207**, **test:browser 226 / 1191 (exit 0)**. `pnpm -r typecheck`, `pnpm lint` (3 warnings are main's `docker-contract.test.ts`) and `pnpm knip` clean.
- [x] Manual verification completed — in a real Chromium via `web-browser`, driving the real page over real IndexedDB, which is the path a person takes. Not on the Pages preview: this environment's egress proxy refuses `*.pages.dev` (403 on CONNECT), so that link is for a reviewer.
- [ ] E2E coverage added or extended where applicable — not applicable; storage-local, no routing, websocket or daemon dependency.

## Visual evidence

The browser-mode History panel, immediately after an edit and leaving the page. Both panels are the real page in `web-browser`; the before panel reverts **only the two things this PR turns on** — the `checkpoints:` wiring line and the two flags — so it is main's actual state rather than a simulation. Distinct renders: `before.png` sha256 `3d64de8140f1`, `after.png` `f97960fccc99`.

- **before** — "No versions yet. Save one with the button above, or ⌘/Ctrl+S." Nothing, and none promised.
- **after** — one row, `2s ago · auto-save · 2 els`, on its lane.

**The image could not be attached from this environment**: no `gh` CLI (so no `--attach`), no upload endpoint on the GitHub MCP surface, and ImageMagick — which `compose-figure.mjs` shells out to — is not installed, so the panels were composed with resvg while keeping that script's one executable rung, its refusal of two identical panels. The figure was produced, read, and handed to the author directly.

## Two scope notes

- **The sandwich retention pass is still absent.** Its only caller is `StorageReportCard`'s daemon route, so a browser twin would be built and unreachable. It belongs with the browser action that invokes it.
- **`?v=` is still supplied only by `DaemonDocumentPage`** (ADR-0022's dated note records it), so a browser-kept variation can be switched and combined but not yet linked to.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — the user-visible copy is the panel's own empty state, corrected here; the reasoning lives on the flag and the guard, where the next reader meets it
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema — the checkpoint's row is `packages/history`'s `VersionEntry` throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh)_