### PR TITLE
fix(web): the changed dot joins the badge blue the app already had

### DIFF
--- a/apps/web/BRAND.md
+++ b/apps/web/BRAND.md
@@ -51,6 +51,15 @@ Brand surfaces are mid-gray on any ground, plus exactly one accent:
   brand surface. It appears when the AI acts (the tidy phase of the splash
   story, the spark on the OG card). Do not use it decoratively; its meaning
   is the point.
+- **Badges** — the small round dot on a control, ringed in the page
+  background — carry the spark too, for the same reason the syncing dot
+  does: a badge says the system has something for you. Two exist, the
+  settings nudge ("a setup step is waiting") and the card's
+  changed-since-you-opened-it dot, and `badge-colour-surface.test.ts` holds
+  them to one literal so a third cannot invent a second blue. Note the
+  settings nudge stretches the spark's meaning further than the card's does
+  — a setup step is not the AI acting — so if the spark is ever reserved
+  more strictly, that badge is the one to move.
 - **Status colors** (favicon dot): green `#16a34a` saved / amber `#d97706`
   unsaved / blue `#3b6ecc` syncing / gray + **dashed frame** + faded mark =
   offline. These are *state* colors, not accents; the syncing dot reuses

--- a/apps/web/src/badge-colour-surface.test.ts
+++ b/apps/web/src/badge-colour-surface.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment node
+/**
+ * Every small round badge on a control speaks ONE colour.
+ *
+ * The app already had one — the settings nudge, "a setup step is waiting" —
+ * in `#3b6ecc`, which BRAND.md reserves as the blue spark, the AI's hand,
+ * and the hue its favicon's syncing dot deliberately reuses because "the
+ * system is at work" is the same semantic family as the AI acting.
+ *
+ * The changed-since-you-looked dot shipped in `sky-500` instead: a SECOND
+ * blue for a signal in that same family, invented rather than found. This
+ * scan is the rung that stops the third one. It asserts the literal is
+ * shared rather than naming the colour, so a brand change moves one value
+ * and nothing here needs editing.
+ *
+ * Deliberately NOT a token: `#3b6ecc` is a brand constant spelled raw in
+ * `favicon.ts`, `celebrate.ts` and the marks, and BRAND.md is its source of
+ * truth. Folding those into a CSS variable is a wider increment than this
+ * file's subject, and a token would not reach the favicon or the OG card,
+ * which are painted outside the theme.
+ *
+ * `?raw` rather than `node:fs`: apps/web is browser-only and
+ * `web-app-boundary.test.ts` enforces it.
+ */
+import { describe, expect, it } from 'vitest'
+
+const sources = import.meta.glob(
+  ['./components/AppShell.tsx', './components/workspace-files/FolderContentsList.tsx'],
+  { query: '?raw', eager: true, import: 'default' },
+) as Record<string, string>
+
+/** A `bg-[#rrggbb]` on an element that also carries the badge idiom's ring. */
+const BADGE = /className="[^"]*\brounded-full\b[^"]*"/g
+const HEX = /bg-\[(#[0-9a-fA-F]{6})\]/
+
+function badgeColours(source: string): string[] {
+  return [...source.matchAll(BADGE)]
+    .map((match) => match[0].match(HEX)?.[1])
+    .filter((hex): hex is string => hex !== undefined)
+}
+
+describe('badge colour is spoken once', () => {
+  const found = Object.entries(sources).flatMap(([file, source]) =>
+    badgeColours(source).map((hex) => ({ file, hex })),
+  )
+
+  // The count proves the scan reaches its subject: a regex that stopped
+  // matching would otherwise report perfect agreement over nothing.
+  it('finds a hex badge in both files that carry one', () => {
+    expect(new Set(found.map((each) => each.file)).size).toBe(2)
+  })
+
+  it('agrees on one colour across every badge', () => {
+    expect(new Set(found.map((each) => each.hex)).size).toBe(1)
+  })
+})

--- a/apps/web/src/components/workspace-files/FolderContentsList.tsx
+++ b/apps/web/src/components/workspace-files/FolderContentsList.tsx
@@ -198,17 +198,24 @@ export function FolderContentsList({
                   role="img"
                   aria-label="Changed since you last opened it"
                   data-testid="card-changed-dot"
-                  // A HUE, not `--primary`. This theme's primary is
-                  // `oklch(0.205 0 0)` — chroma zero — so the dot shipped
-                  // black in light mode and white in dark, reading as
-                  // punctuation rather than as a status. Blue is the unread
-                  // convention; a raw palette colour rather than a token
-                  // because the conflict badge below does the same, and
-                  // `--manipulation` is spoken for (it means selection and
-                  // handles on the canvas, not "something happened here").
-                  // The ring keeps it legible over a thumbnail of any
-                  // colour, which is what a real document renders as.
-                  className="absolute top-1 right-1 size-2.5 rounded-full bg-sky-500 ring-2 ring-background dark:bg-sky-400"
+                  // The SAME badge as the settings nudge, deliberately.
+                  // BRAND.md reserves `#3b6ecc` as the blue spark, the AI's
+                  // hand — and says the favicon's syncing dot reuses that hue
+                  // because "the system is at work" is the same semantic
+                  // family as the AI acting. A document rewritten while the
+                  // person was elsewhere is that family: in this product the
+                  // thing that rewrote it is usually an agent.
+                  //
+                  // Not `--primary`, which is chroma zero here and drew this
+                  // as ink. Not amber, which the conflict badge below already
+                  // spends on this same card. Not a second blue of my own:
+                  // `badge-colour-surface.test.ts` holds every badge to one
+                  // literal, because that is exactly what went wrong.
+                  //
+                  // Fixed across themes on purpose — a brand hue is chosen to
+                  // read on both grounds — with the ring carrying it over a
+                  // thumbnail of any colour.
+                  className="absolute top-1 right-1 size-2 rounded-full bg-[#3b6ecc] ring-2 ring-background"
                 />
               )}
               {selection !== undefined && (

--- a/apps/web/src/components/workspace-files/changed-dot.browser.test.tsx
+++ b/apps/web/src/components/workspace-files/changed-dot.browser.test.tsx
@@ -113,13 +113,17 @@ describe('changed since you last opened it', () => {
     expect(dotFor('Tokens')).toBeNull()
   })
 
-  it('is drawn in a hue rather than in ink, and answers to the theme', async () => {
+  it('is drawn in a hue rather than in ink, on both grounds', async () => {
     // `bg-primary` shipped first and this theme's `--primary` is
     // `oklch(0.205 0 0)` — chroma ZERO — so the dot came out black in light
     // mode and white in dark, reading as punctuation rather than as a
-    // status. The invariant is not a particular blue: it is that the dot is
-    // not grey, and that the dark variant is a DIFFERENT colour rather than
-    // a `dark:` class nobody checked.
+    // status.
+    //
+    // The colour is now the settings nudge's, which BRAND.md reserves as the
+    // blue spark; that agreement is pinned by source in
+    // `badge-colour-surface.test.ts`. What THIS test adds is the rendered
+    // half: not grey, and unchanged by the theme, because a brand hue is
+    // chosen to read on both grounds rather than swapped per mode.
     renderPanel()
     await openCard('Roadmap')
     cleanup()
@@ -131,9 +135,7 @@ describe('changed since you last opened it', () => {
     expect(isChromatic(light)).toBe(true)
 
     document.documentElement.classList.add('dark')
-    const dark = getComputedStyle(dotFor('Roadmap') as HTMLElement).backgroundColor
-    expect(isChromatic(dark)).toBe(true)
-    expect(dark).not.toBe(light)
+    expect(getComputedStyle(dotFor('Roadmap') as HTMLElement).backgroundColor).toBe(light)
   })
 
   it('clears once the person opens it again', async () => {


### PR DESCRIPTION
Reported: **the settings icon's unconfigured badge is blue, and this is not a new use of colour.** Correct — and I had missed it twice: once when choosing `bg-primary`, and again when "fixing" that to `sky-500`, which invented a *second* blue for a signal the app already had one for.

## What the search should have found first

- `AppShell.tsx` has drawn a `#3b6ecc` badge on the settings button since before this work — same idiom, same ring, same shape of meaning.
- **BRAND.md reserves `#3b6ecc` as the blue spark, the AI's hand**: *"do not use it decoratively; its meaning is the point"*. It also says the favicon's syncing dot reuses that hue deliberately, because *"the system is at work" is the same semantic family as the AI acting*.

A document rewritten while the person was elsewhere is that family — in this product the thing that rewrote it is usually an agent — so the dot now takes the same literal, at the same size, with the same ring.

Amber was the other candidate and is wrong here: the conflict badge spends it on this very card, so two ambers would collide on one object.

## Visual repro

![before — sky-500, a second blue for a signal the app already had one for; after — the settings badge's own blue, BRAND.md's spark](tmp/screenshots/badge-colour-figure.png)

> Not uploaded: `gh` here is 2.97.0 and `--attach` landed in 2.99.0. Panels `8aa5a2b6` / `d2d5ede5`.
>
> What the figure **cannot** show is the claim that matters — agreement with the settings badge, which lives in the shell and would need a much heavier harness to render beside the panel. That claim is carried mechanically by the scan below, not by the picture.

## The rung that stops a third blue

`badge-colour-surface.test.ts` reads both files and asserts every hex badge shares **one literal**, so the colour can change in one place and nothing in the test needs editing. Guarded from both sides — either badge drifting fails it — and it asserts a **count** first, because a regex that stopped matching would otherwise report perfect agreement over nothing.

The rendered half stays in the browser test, since the scan cannot see it: not grey, and now *unchanged* by the theme, because a brand hue is chosen to read on both grounds rather than swapped per mode.

## A note for the owner

BRAND.md gains the badge convention, which was true in the code and written down nowhere. It also says plainly that **the settings nudge is the one stretching the spark's meaning** — "a setup step is waiting" is not the AI acting — so if the spark is ever reserved more strictly, that badge is the one to move, not this one.

## Verification

Mutation-checked, each asserted to have applied: the dot drifting to another blue (1 red), the settings nudge drifting instead (1 red), and both going back to ink — which the scan accepts and the render test refuses (1 red).

`web-jsdom` **3909/3909**, `web-browser` **1167/1167** across 218 files. Typecheck, lint and knip clean.
