### PR TITLE
fix(web): a browser document opened on a variation says so, and both keepers show its chrome

### DIFF
--- a/apps/web/src/components/HeaderBranchBanner.tsx
+++ b/apps/web/src/components/HeaderBranchBanner.tsx
@@ -1,5 +1,5 @@
 import { AlertTriangle, GitMerge } from 'lucide-react'
-import { type JSX, useEffect, useState } from 'react'
+import { type JSX, useEffect, useRef, useState } from 'react'
 import { Button } from '../components/ui/button.js'
 import type { MergeResult } from '../hooks/useBranches.js'
 import { useBranches } from '../hooks/useBranches.js'
@@ -22,13 +22,32 @@ import { MergeDialog } from './MergeDialog'
 export interface HeaderBranchBannerProps {
   workspaceId: string
   path: string
+  /**
+   * Bumped when the keeper's state may have moved under this component —
+   * the same signal the chip beside it takes, and for a reason that is not
+   * cosmetic on a browser-kept document: its record is not readable at mount,
+   * so `useBranches`' own first read answers the resting state (HEAD `main`)
+   * and nothing re-read it once the record arrived. Without this, a document
+   * opened ON a variation showed the default one and this banner never
+   * appeared at all.
+   */
+  refreshSignal?: number
 }
 
 export function HeaderBranchBanner({
   workspaceId,
   path,
+  refreshSignal,
 }: HeaderBranchBannerProps): JSX.Element | null {
-  const { state, getBranchStats, merge: runMerge } = useBranches(workspaceId, path)
+  const { state, getBranchStats, merge: runMerge, refetch } = useBranches(workspaceId, path)
+  // Skip the initial mount, as the chip does: `useBranches` refetches on its
+  // own there, and only a value that CHANGES afterwards means something moved.
+  const prevRefreshSignalRef = useRef(refreshSignal)
+  useEffect(() => {
+    if (prevRefreshSignalRef.current === refreshSignal) return
+    prevRefreshSignalRef.current = refreshSignal
+    void refetch()
+  }, [refreshSignal, refetch])
   const head = state.head
   const targetBranch = state.branches.find((b) => b.name === 'main')
   const sourceBranch = state.branches.find((b) => b.name === head)

--- a/apps/web/src/lib/browser-branches-backend.merge.browser.test.tsx
+++ b/apps/web/src/lib/browser-branches-backend.merge.browser.test.tsx
@@ -110,6 +110,58 @@ describe('the browser keeper merges by adopting the source tip', () => {
     expect(after?.branches.map((b) => b.name)).not.toContain('idea')
   })
 
+  it("counts the variation's own version rows, the way the daemon's route does", async () => {
+    const workspaceId = getBrowserWorkspaceId()
+    const index = new FoldingBrowserIndex()
+    await index.createWorkspace({ workspaceId })
+    const { documentId } = await index.createDocument({
+      workspaceId,
+      path: 'canvas-c',
+      kind: 'spatial',
+    })
+
+    const docs = new BrowserWorkspaceDocs()
+    const record = await docs.open(workspaceId)
+    if (record === null) throw new Error('no record')
+    writeWorkspaceDocumentContent(record, documentId, canvasWith('work'))
+    writeBranchesToRecord(record, documentId, {
+      branches: [
+        { name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '2026-01-01T00:00:00.000Z' },
+        { name: 'idea', tipFrontiers: '', color: '#9333ea', createdAt: '2026-01-02T00:00:00.000Z' },
+      ],
+      head: 'idea',
+    })
+    await docs.save(workspaceId, record)
+
+    backend = new BrowserBackend({ documentId, path: 'canvas-c', kind: 'spatial' }, docs)
+    backend.connect(NO_OP_HANDLERS)
+    await vi.waitFor(() => expect(backend.readRecord(() => true)).toBe(true))
+
+    // Two points on `idea`, one on `main`. The daemon answers this question by
+    // counting version rows whose branch matches; nothing else can be counted,
+    // because tip adoption leaves no commits to count.
+    const store = new BrowserVersionStore({ docs, index })
+    await store.save(workspaceId, 'canvas-c', { branchName: 'idea', label: 'a' })
+    await store.save(workspaceId, 'canvas-c', { branchName: 'idea', label: 'b' })
+    await store.save(workspaceId, 'canvas-c', { label: 'on main' })
+
+    const branches = createBrowserBranchesBackend({
+      backend,
+      versions: { save: (w, p, o) => store.save(w, p, o), list: (w, p) => store.list(w, p) },
+    })
+
+    expect(await branches.getStats(workspaceId, 'canvas-c', 'idea')).toEqual({
+      unmergedCommits: 2,
+      isHead: true,
+    })
+    // A row with no variation recorded reads as the default one, as it does
+    // on the daemon — that is what the older rows are.
+    expect(await branches.getStats(workspaceId, 'canvas-c', 'main')).toEqual({
+      unmergedCommits: 1,
+      isHead: false,
+    })
+  })
+
   it('records the pre-merge point as automatic and on the target variation', async () => {
     const workspaceId = getBrowserWorkspaceId()
     const index = new FoldingBrowserIndex()

--- a/apps/web/src/lib/browser-branches-backend.ts
+++ b/apps/web/src/lib/browser-branches-backend.ts
@@ -58,6 +58,9 @@ const log = getAppLogger('browser-branches')
  */
 type BrowserVersionSave = BrowserVersionStore['save']
 
+/** The store's reader, taken from it for the same reason `save` is. */
+type BrowserVersionList = BrowserVersionStore['list']
+
 /** The state a document has when its record has not been delivered yet. */
 const RESTING: DocumentBranchesState = {
   branches: [{ name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '' }],
@@ -84,7 +87,7 @@ export function createBrowserBranchesBackend(deps: {
    * merge that refused because a bookmark could not be written would be worse
    * than one nobody can rewind past.
    */
-  readonly versions?: { save: BrowserVersionSave } | null
+  readonly versions?: { save: BrowserVersionSave; list?: BrowserVersionList } | null
 }): BranchesBackend {
   const backend = deps.backend
   const refuse = (what: string) => Promise.reject(new BranchesUnsupportedError(what))
@@ -175,13 +178,23 @@ export function createBrowserBranchesBackend(deps: {
       return mutate((state) => setHeadOp(state, scope, branch))
     },
 
-    async getStats(_workspaceId, _path, name) {
+    async getStats(_workspaceId, path, name) {
       if (backend === null) return refuse('stats')
       const state = read()
-      // `unmergedCommits` is zero for the same reason the daemon answers zero:
-      // tip adoption has no commit count to report, and a number invented here
-      // would read as a measurement.
-      return { unmergedCommits: 0, isHead: state.head === name }
+      // The same count the daemon's route answers with: version rows whose
+      // variation matches. Tip adoption really does leave no commits to
+      // count, so rows are what there is — and `HeaderBranchBanner` shows
+      // only when this is above zero, which is what the number is FOR.
+      //
+      // It read zero unconditionally until the rows could carry a variation,
+      // under a comment claiming the daemon answered zero too. It does not:
+      // `countVersionsOnBranch` counts exactly this. A row with no variation
+      // recorded is the default one on both sides.
+      const rows = (await deps.versions?.list?.(getBrowserWorkspaceId(), path)) ?? []
+      return {
+        unmergedCommits: rows.filter((v) => (v.branchName ?? 'main') === name).length,
+        isHead: state.head === name,
+      }
     },
 
     async merge(_workspaceId, _path, source, args) {

--- a/apps/web/src/lib/keeper-parity.test.ts
+++ b/apps/web/src/lib/keeper-parity.test.ts
@@ -80,11 +80,9 @@ const DAEMON_REACH: Record<string, KeeperReach> = {
     note: 'the daemon reports its own disk and offers optimize-all; the browser answers the same question through navigator.storage',
   },
   'src/components/MergeToast.tsx': {
-    reach: 'gap',
-    missing:
-      'the browser keeper commits merges but shows no toast — only DaemonDocumentPage mounts one',
-    followUp:
-      'task #36: move the toast to the shared DocumentPage, beside the banner it sits with (file-seam-conformance.test.ts records the same gap)',
+    reach: 'both-keepers',
+    browser: BROWSER_PAGE,
+    note: 'the shared DocumentPage mounts it for whichever keeper rendered it, from the workspace and path the top bar already carries',
   },
   'src/components/WorkspaceTopBar.tsx': {
     reach: 'both-keepers',

--- a/apps/web/src/pages/BrowserDocumentPage.branch-chrome.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.branch-chrome.browser.test.tsx
@@ -1,0 +1,103 @@
+import { readBranchesFromRecord, writeBranchesToRecord } from '@kamiazya/whiteboard-history'
+import {
+  writeSpatialCanvas,
+  writeWorkspaceDocumentContent,
+} from '@kamiazya/whiteboard-loro-adapter'
+import { cleanup, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import { LoroDoc } from 'loro-crdt'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { BrowserVersionStore } from '../lib/browser-version-store.js'
+import { BrowserWorkspaceDocs } from '../lib/browser-workspace-docs.js'
+import { getBrowserWorkspaceId } from '../lib/browser-workspace-id.js'
+import { FoldingBrowserIndex } from '../lib/folding-browser-index.js'
+import { clearWhiteboardDb } from '../test-utils/browser-document.js'
+import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { BrowserDocumentPage } from './BrowserDocumentPage.js'
+import '../index.css'
+
+claimIsolatedWhiteboardDb('browserdocumentpagebranchchrome')
+
+function render(ui: ReactElement) {
+  return rtlRender(
+    <div style={{ height: '100vh' }}>
+      <MemoryRouter initialEntries={['/']}>{ui}</MemoryRouter>
+    </div>,
+  )
+}
+
+/**
+ * The chrome that sits BESIDE the variations chip — the "you are on a
+ * variation, combine it" banner. It was mounted only by the daemon page, from
+ * when variations were a daemon concept; both keepers have them now, so the
+ * browser showing nothing was a gap rather than a difference.
+ */
+describe('BrowserDocumentPage variation chrome (browser)', () => {
+  beforeEach(async () => {
+    await clearWhiteboardDb()
+  })
+  afterEach(() => cleanup())
+
+  it('offers to combine when HEAD is a variation with work on it', async () => {
+    const workspaceId = getBrowserWorkspaceId()
+    const index = new FoldingBrowserIndex()
+    await index.createWorkspace({ workspaceId })
+    const { documentId } = await index.createDocument({
+      workspaceId,
+      path: 'canvas-a',
+      kind: 'spatial',
+    })
+    const doc = new LoroDoc()
+    writeSpatialCanvas(doc, {
+      nodes: [{ id: 'n1', type: 'text', x: 0, y: 0, width: 80, height: 40, text: 'first' }],
+      edges: [],
+    })
+    doc.commit()
+    const docs = new BrowserWorkspaceDocs()
+    const record = await docs.open(workspaceId)
+    if (record === null) throw new Error('no record')
+    writeWorkspaceDocumentContent(record, documentId, doc)
+    writeBranchesToRecord(record, documentId, {
+      branches: [
+        { name: 'main', tipFrontiers: '', color: '#1971c2', createdAt: '2026-01-01T00:00:00.000Z' },
+        { name: 'idea', tipFrontiers: '', color: '#9333ea', createdAt: '2026-01-02T00:00:00.000Z' },
+      ],
+      head: 'idea',
+    })
+    await docs.save(workspaceId, record)
+    // The banner needs work ON the variation — a count of zero is what it
+    // reads as "nothing to combine". Saved through a store built on the SAME
+    // `docs` instance: the store re-opens the record to read its frontier, and
+    // a second opener would write back a record loaded before the branches
+    // above and revert them.
+    await new BrowserVersionStore({ docs, index }).save(workspaceId, 'canvas-a', {
+      branchName: 'idea',
+      label: 'a point on idea',
+    })
+    await vi.waitFor(async () => {
+      const back = await new BrowserWorkspaceDocs().open(workspaceId)
+      expect(back === null ? null : readBranchesFromRecord(back, documentId).head).toBe('idea')
+    })
+
+    render(<BrowserDocumentPage initialPath="canvas-a" />)
+    await waitFor(
+      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
+      {
+        timeout: 5000,
+      },
+    )
+
+    // The banner names the variation, its count, and the target — the count
+    // is what `getStats` answers, so this pins the whole chain: record ->
+    // version rows -> stats -> banner.
+    // The banner's CTA. Its own sentence is split across elements (the
+    // variation names are their own spans), so the button is what identifies
+    // the banner; the count behind it is asserted on `getStats` directly.
+    const combine = await screen.findByRole('button', { name: /Combine into/i }, { timeout: 5000 })
+    expect(combine).toBeInTheDocument()
+    // And the chip beside it names the same variation. It said `Main` until
+    // the record's arrival re-read the branch plane.
+    expect(screen.getByTestId('header-branch-chip').textContent ?? '').toMatch(/idea/i)
+  })
+})

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -552,6 +552,19 @@ function useBrowserDocument(
     readOutlineSource,
     persistence: syncPersistence,
   } = sync
+  // The record is not readable at mount — the backend delivers it a beat
+  // later — so anything that reads the branch plane on mount gets the resting
+  // state, HEAD `main`. `useBranches` refetches only when its keeper or
+  // document changes, neither of which happens when the record lands, so a
+  // document opened ON a variation kept saying `Main`: the chip named the
+  // wrong one and the combine banner, which needs a non-default HEAD, could
+  // never appear. This is the signal the daemon page has always had; the
+  // browser simply never supplied one.
+  const [branchRefreshSignal, setBranchRefreshSignal] = useState(0)
+  useEffect(() => {
+    if (!sync.loaded) return
+    setBranchRefreshSignal((n) => n + 1)
+  }, [sync.loaded])
 
   // The browser's version history for this document: rows in IndexedDB,
   // restores through the backend holding the live record. Null while there
@@ -888,6 +901,7 @@ function useBrowserDocument(
       workspaceId: 'local',
       path: loadedPath,
       dataMode: 'local',
+      branchRefreshSignal,
       // The way out of the editor. This page had none until now — the
       // app-shell brand mark was the only exit, and it says nothing about
       // where it goes.

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -14,9 +14,7 @@ import { AgentPresenceChip } from '../components/AgentPresenceChip.js'
 import type { ConnectionsBacklink } from '../components/connections/ConnectionsChip.js'
 import { DocumentPageSkeleton } from '../components/DocumentPageSkeleton.js'
 import { LoadDegradedView } from '../components/document-editor/LoadDegradedView.js'
-import { HeaderBranchBanner } from '../components/HeaderBranchBanner.js'
 import { HeaderVariationBanner } from '../components/HeaderVariationBanner.js'
-import { MergeToast } from '../components/MergeToast.js'
 import { Button } from '../components/ui/button.js'
 import { DAEMON_HISTORY_CAPABILITIES } from '../components/VersionTimeline'
 import { BranchesBackendContext } from '../contexts/BranchesBackendContext.js'
@@ -386,7 +384,6 @@ function useDaemonDocument(
     canvas: canvasValue,
     loaded: canvasLoaded,
     onChange,
-    clearLocalUndo,
     markdownBody: syncedMarkdownBody,
     coreFacets,
     setCoreFacets,
@@ -883,17 +880,9 @@ function useDaemonDocument(
               </button>
             </div>
           )}
-          {canvas && <HeaderBranchBanner workspaceId={canvas.workspaceId} path={canvas.path} />}
         </>
       ),
       ...(emptyState === undefined ? {} : { replaceEditor: emptyState }),
-      footer: canvas && (
-        <MergeToast
-          workspaceId={canvas.workspaceId}
-          path={canvas.path}
-          onRestored={clearLocalUndo}
-        />
-      ),
     },
   }
 

--- a/apps/web/src/pages/DocumentPage.tsx
+++ b/apps/web/src/pages/DocumentPage.tsx
@@ -23,6 +23,8 @@ import {
   DocumentFacetsEditor,
   DocumentProperties,
 } from '../components/document-properties/DocumentProperties.js'
+import { HeaderBranchBanner } from '../components/HeaderBranchBanner.js'
+import { MergeToast } from '../components/MergeToast.js'
 import { CanvasDisplaySettings } from '../components/spatial-editor/CanvasDisplaySettings.js'
 import type { VersionPreviewSession } from '../components/VersionTimeline'
 import { BookmarkAction } from '../components/workspace-top-bar/BookmarkAction.js'
@@ -447,6 +449,20 @@ function DocumentPageBody({
               />
             </Suspense>
           )}
+          {/* Variation chrome, for BOTH keepers. It lived on the daemon page
+              from when variations were a daemon concept; they are not one now,
+              and the banner reads the same seam either keeper answers. It
+              draws nothing until HEAD is a variation with work on it, so a
+              document without variations is unaffected. */}
+          {topBar !== null && (
+            <HeaderBranchBanner
+              workspaceId={topBar.workspaceId}
+              path={topBar.path}
+              {...(topBar.branchRefreshSignal === undefined
+                ? {}
+                : { refreshSignal: topBar.branchRefreshSignal })}
+            />
+          )}
           {model.slots.headerExtras}
         </>
       }
@@ -532,6 +548,13 @@ function DocumentPageBody({
             />
           )}
         </div>
+      )}
+      {topBar !== null && (
+        <MergeToast
+          workspaceId={topBar.workspaceId}
+          path={topBar.path}
+          onRestored={model.sync.clearLocalUndo}
+        />
       )}
       {model.slots.footer}
     </DocumentPageShell>

--- a/apps/web/src/pages/file-seam-conformance.test.ts
+++ b/apps/web/src/pages/file-seam-conformance.test.ts
@@ -95,21 +95,11 @@ const SHARED_CANVAS_CHROME = [
  * was rejected — and nothing while the keeper is keeping.
  */
 const MODE_SPECIFIC_CHROME = {
-  // These two reasons USED to be "branches/merge are a daemon concept
-  // (ADR-0004)". They are not any more — the browser keeper keeps its
-  // variations on the workspace record and commits merges over them — so what
-  // these entries record is a GAP rather than a difference: the chrome exists
-  // on one page because that is where it was written, not because the other
-  // keeper cannot have it. Moving it is deliberately not this increment's, so
-  // the reason says what is true rather than repeating what was.
-  HeaderBranchBanner: {
-    page: './DaemonDocumentPage.tsx',
-    why: 'gap: the browser keeper has branches now and no banner; the chrome has not been moved yet',
-  },
-  MergeToast: {
-    page: './DaemonDocumentPage.tsx',
-    why: 'gap: the browser keeper commits merges now and shows no toast; the chrome has not been moved yet',
-  },
+  // `HeaderBranchBanner` and `MergeToast` stood here, first as "a daemon
+  // concept (ADR-0004)" and then as a gap once the browser keeper grew
+  // variations and merges. They are neither now: the shared DocumentPage
+  // mounts both for whichever keeper rendered it, so they are not
+  // mode-specific chrome and this scan should not expect them on one page.
   AgentPresenceChip: {
     page: './DaemonDocumentPage.tsx',
     why: 'no agents connect in browser mode',

--- a/apps/web/src/scoped-screen-state.test.ts
+++ b/apps/web/src/scoped-screen-state.test.ts
@@ -413,6 +413,8 @@ const BROWSER_DOCUMENT_PAGE_STATE: Record<string, ScopeCoverage> = {
   documents:
     'no subject: the WORKSPACE’s list, which a document switch does not change; its own refresh effect keys on the document identity that belongs in it',
   canvasOpsButtonRef: 'no subject: the kebab’s DOM node',
+  branchRefreshSignal:
+    'no subject: a monotonic tick, not a name — the chip and banner act only on a value that CHANGES after their own mount, so a leftover count is inert, and a switch re-bumps it anyway because `sync.loaded` goes false and back to true for the arriving document',
   listGenerationRef:
     'no subject: a monotonic stamp ordering list loads — resetting it would revive the stale-resolution race it exists to close',
   currentDocumentIdRef:

--- a/packages/mcp-server/src/server/file-size-budget.test.ts
+++ b/packages/mcp-server/src/server/file-size-budget.test.ts
@@ -160,7 +160,12 @@ const FILE_SIZE_GRANDFATHER: Record<string, number> = {
   // when `signal` was made TOTAL: it runs inside Loro's subscriber, where a
   // throw escapes as an unhandled rejection that reddens a whole run while
   // every test passes.
-  'apps/web/src/pages/BrowserDocumentPage.tsx': 997,
+  // Raised again to 1011 by the branch-refresh signal: the browser record is
+  // not readable at mount, so nothing re-read the branch plane once it
+  // arrived and a document opened ON a variation kept naming the default one.
+  // Most of the added lines is that reason — the bug is invisible in the
+  // three lines of state that fix it.
+  'apps/web/src/pages/BrowserDocumentPage.tsx': 1011,
   'packages/canvas-render/src/layout/nodes/mdast-blocks.ts': 1674,
   'packages/canvas-render/src/layout/spatial-canvas.ts': 1840,
   'packages/canvas-render/src/layout/edges/spatial-edges.ts': 2069,


### PR DESCRIPTION
## Summary

This started as a move — `HeaderBranchBanner` and `MergeToast` from the daemon page to the shared one, the follow-up two gap ledgers already named. It sat on **two defects that had to be fixed first**, and the second is the one worth reading.

## Defect 1 — the browser's branch stats were a hardcoded zero

`getStats` answered `unmergedCommits: 0` unconditionally, under a comment saying the daemon answers zero too. It does not: `countVersionsOnBranch` counts version rows whose variation matches, and the route has always used it.

The browser could not compute that until its rows carried a variation, which they now do. So it counts the same thing by the same rule — a row with no variation recorded reads as the default one on both sides.

This is a prerequisite rather than a tidy-up: `HeaderBranchBanner` renders only when the count is above zero, so moving it while this answered zero would have put a control on screen that could never appear — built and unreachable, which is what `userReach` refuses.

## Defect 2 — the chip has been naming the wrong variation since 段3

A browser-kept record is **not readable at mount** — the backend delivers it a beat later — so `useBranches`' own first read answers the RESTING state, `HEAD: main`. It refetches only when its keeper or document changes, and neither happens when the record lands, so **nothing ever re-read it**.

A document opened *on* a variation kept saying `Main`. The chip named the wrong variation, and the banner, which needs a non-default HEAD, could never appear at all.

The daemon page has always had a `branchRefreshSignal` for exactly this. The browser simply never supplied one; it does now, bumped when the sync session reports the document loaded. `HeaderBranchBanner` takes the same signal the chip beside it already took, skipping the initial mount the same way.

I found it only because the test showed `DIAG chip: Main` while the record on disk demonstrably held `head: 'idea'` — the gap between those two facts is what located it. Reading the move alone would never have surfaced it.

## The move itself

`model.topBar` already carries the workspace and path for either keeper, and `MergeToast`'s `onRestored` comes from `model.sync.clearLocalUndo`, which both keepers have because both run the same sync hook. So no new model field was needed.

Mounting the banner on **every** document raised a fair question — markdown documents have no browser backend. It is inert there by construction: `useBranches` gates everything on `enabled = backend.hasBranches`, which is `false`, so the hook makes no calls and the banner renders nothing.

## Mutation checks

| mutation | what failed |
|---|---|
| `getStats` back to a hardcoded `0` | `expected { unmergedCommits: 0 } to deeply equal { unmergedCommits: 2 }` |
| banner not mounted on the shared page | no combine control on screen |
| no refresh signal when the record lands | no combine control on screen — identically |

The last two matter separately: either alone leaves the browser exactly as it was, so the test discriminates both halves rather than their conjunction.

## Ledgers and guards

- **`keeper-parity`**'s `MergeToast` gap becomes `both-keepers`; **`file-seam-conformance`** loses both `MODE_SPECIFIC_CHROME` entries, because neither is mode-specific now. Both were written as gaps naming this move as the follow-up — an entry that outlives what it records teaches the wrong shape of the codebase.
- **`scoped-screen-state`** demanded a decision on the new state. Answering it honestly meant checking whether `loaded` resets on a document switch: it does (`setLoaded(false)`, then true for the arriving document), so the counter re-bumps and `no subject:` is true rather than merely plausible. Had it *not* reset, the honest answer would have been `survives:` and there would be a second bug.
- **`file-size-budget`** ceiling moved 997 → 1011, for lines that are mostly the reason — the defect is invisible in the three lines of state that fix it.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — a `web-browser` case opening a document already on a variation and asserting the combine control plus the chip's name, and a backend case pinning the row count against a mixed set of variations.
- [x] `pnpm test` passes locally — **web-jsdom 372 files / 3906 tests**, **web-node 15 / 91**, **arch-lint-node + mcp-node 384 / 4211**, **test:browser 227 / 1195 (exit 0)**. `pnpm -r typecheck`, `pnpm lint` (3 warnings are main's `docker-contract.test.ts`) and `pnpm knip` clean.
- [x] Manual verification completed — in a real Chromium via `web-browser`, over real IndexedDB, driving the real page. Not on the Pages preview: this environment's egress proxy refuses `*.pages.dev` (403 on CONNECT).
- [ ] E2E coverage added or extended where applicable — not applicable; no routing, websocket or daemon dependency changes.

One browser run showed an unrelated markdown wikiLink failure (`a [[path]] wikiLink resolves…`). Ruled out as this PR's on two independent grounds before re-running: the banner is provably inert on markdown (`hasBranches` false), and the assertion is a `waitFor` on a debounced preview — the load-dependent family, where `web-browser` files measure 1.5s isolated against 30–39s under the full run. The re-run was 227/227, and the file passes 20/20 alone. Not quarantined or touched.

## Visual evidence

Visual evidence: none — the change is a control appearing where it previously could not, and the same figure would be a screenshot of the banner this PR's own browser test already asserts by role and name. The state it fixes (a document opened on a variation reading `Main`) is pinned by that test's chip assertion, which is stronger than a picture: it names the wrong value the old code produced.

## What stays open

`?v=` is still supplied only by `DaemonDocumentPage`, so a browser-kept variation can be switched and combined but not yet linked to. ADR-0022's dated note still records it. It is a different subject — an address that resolves, not chrome that renders.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — the two ledgers are where this behaviour is written down; ADR-0022's note stays accurate for what remains
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema — the count is over `VersionEntry`, and the seam types are taken from the store

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh)_