### PR TITLE
feat(web): a markdown note reaches its own history

### DIFF
--- a/apps/web/src/lib/browser-versions-backend.browser.test.tsx
+++ b/apps/web/src/lib/browser-versions-backend.browser.test.tsx
@@ -84,7 +84,7 @@ describe('the browser versions backend files a manual save on the current variat
     await vi.waitFor(() => expect(backend.readRecord(() => true)).toBe(true))
 
     const store = new BrowserVersionStore({ docs, index })
-    const versions = createBrowserVersionsBackend({ backend, store })
+    const versions = createBrowserVersionsBackend({ record: backend, store, kind: 'spatial' })
     await versions.save(workspaceId, 'canvas-a', { label: 'by hand' })
 
     expect(await store.list(workspaceId, 'canvas-a')).toEqual([

--- a/apps/web/src/lib/browser-versions-backend.ts
+++ b/apps/web/src/lib/browser-versions-backend.ts
@@ -1,19 +1,38 @@
 import { readBranchesFromRecord } from '@kamiazya/whiteboard-history'
-import {
-  readDocumentKind,
-  readMarkdownBody,
-  readSpatialCanvas,
-} from '@kamiazya/whiteboard-loro-adapter'
-import type { BrowserBackend } from './browser-backend.js'
+import { readMarkdownBody, readSpatialCanvas } from '@kamiazya/whiteboard-loro-adapter'
+import type { DocumentKind } from '@kamiazya/whiteboard-model'
+import type { LoroDoc } from 'loro-crdt'
 import type { BrowserVersionStore } from './browser-version-store.js'
 import { getBrowserWorkspaceId } from './browser-workspace-id.js'
 import type { VersionsBackend } from './versions-backend.js'
 
 /**
+ * The live workspace record, as much of it as versions need: read one thing
+ * off it, and reconcile a past state onto it.
+ *
+ * A SEAM rather than `BrowserBackend` itself, because the two kinds of
+ * document this keeper holds reach the record by different routes and only
+ * one of them has a backend. A spatial canvas has `BrowserBackend`, which
+ * satisfies this structurally; a markdown note deliberately has none — the
+ * spatial sync layer would clobber the body `useMarkdownDocument` writes —
+ * and that hook supplies its own (`MarkdownRecordSeam`).
+ *
+ * Naming the backend here is what made a note's history unreachable: the
+ * rows were always there, keyed on the same record and written by the same
+ * checkpoint scheduler, and the only thing missing was a way to read and
+ * restore one.
+ */
+export interface VersionsRecordSeam {
+  readonly readRecord: <T>(read: (doc: LoroDoc, documentId: string) => T) => T | null
+  readonly applyRestore: (past: LoroDoc, label?: string) => Promise<void>
+}
+
+/**
  * The browser keeper's answer to the versions seam: rows from the
- * IndexedDB store, restores through the backend that holds the live
+ * IndexedDB store, restores through whichever seam holds the live
  * workspace record — the two halves the daemon keeps in one process, here
- * kept in one page.
+ * kept in one page. Which route reaches that record is the seam's
+ * business, not this module's.
  *
  * The `workspaceId` the UI passes is ignored in favour of the browser's
  * own: the top bar spells `"local"` there as a display placeholder (see its
@@ -22,7 +41,20 @@ import type { VersionsBackend } from './versions-backend.js'
  */
 export function createBrowserVersionsBackend(deps: {
   readonly store: BrowserVersionStore
-  readonly backend: BrowserBackend
+  readonly record: VersionsRecordSeam
+  /**
+   * What `loadPast` should read a past state AS.
+   *
+   * Supplied rather than read off the state itself, because it is not in
+   * there to read. A workspace-tree document keeps its kind in the NODE's
+   * meta, and `projectWorkspaceDocument` carries content only — measured on
+   * a seeded markdown note, `readDocumentKind` answers `undefined` for both
+   * the projection and the live containers while the body reads back
+   * `'# first'`. Asking the state was therefore always answering "not
+   * markdown", which a canvas survives by being the fallback and a note does
+   * not: it drew an empty CanvasViewer where its prose should be.
+   */
+  readonly kind: DocumentKind
 }): VersionsBackend {
   return {
     list: (_workspaceId, path) => deps.store.list(getBrowserWorkspaceId(), path),
@@ -37,9 +69,8 @@ export function createBrowserVersionsBackend(deps: {
       // A record that cannot answer falls back to the store's own default,
       // exactly as the daemon's route does.
       const head =
-        deps.backend.readRecord(
-          (doc, documentId) => readBranchesFromRecord(doc, documentId).head,
-        ) ?? null
+        deps.record.readRecord((doc, documentId) => readBranchesFromRecord(doc, documentId).head) ??
+        null
       return deps.store.save(getBrowserWorkspaceId(), path, {
         label,
         ...(head === null || head === '' ? {} : { branchName: head }),
@@ -54,7 +85,7 @@ export function createBrowserVersionsBackend(deps: {
       // keeper that never held one could still implement it.
       const past = await deps.store.loadPast(getBrowserWorkspaceId(), path, versionId)
       if (past === null) return null
-      return readDocumentKind(past) === 'markdown'
+      return deps.kind === 'markdown'
         ? { kind: 'markdown', body: readMarkdownBody(past) }
         : { kind: 'spatial', canvas: readSpatialCanvas(past) }
     },
@@ -69,7 +100,7 @@ export function createBrowserVersionsBackend(deps: {
       const label = (await deps.store.list(workspaceId, path)).find(
         (v) => v.id === versionId,
       )?.label
-      await deps.backend.applyRestore(past, label)
+      await deps.record.applyRestore(past, label)
       // The merge point, recorded the same way the daemon's operation
       // records it: a restore reconciles a past state onto the live one, so
       // what comes out is a descendant of both, and a merge that leaves no

--- a/apps/web/src/lib/versions-backend.contract.browser.test.tsx
+++ b/apps/web/src/lib/versions-backend.contract.browser.test.tsx
@@ -100,7 +100,7 @@ async function browserHarness(): Promise<VersionsBackendHarness> {
   }
 
   return {
-    backend: createBrowserVersionsBackend({ store, backend }),
+    backend: createBrowserVersionsBackend({ store, record: backend, kind: 'spatial' }),
     workspaceId,
     path: 'canvas-a',
     write,

--- a/apps/web/src/pages/BrowserDocumentPage.markdown.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.markdown.browser.test.tsx
@@ -138,10 +138,12 @@ async function openDocumentMenu(): Promise<void> {
   )
 }
 
-const displayRow = () =>
+const menuRow = (label: string) =>
   [...document.querySelectorAll('[role="menuitem"]')].find(
-    (item) => item.textContent?.trim() === 'Display…',
+    (item) => item.textContent?.trim() === label,
   )
+
+const displayRow = () => menuRow('Display…')
 
 describe('BrowserDocumentPage markdown 導線 (real IndexedDB)', () => {
   beforeEach(async () => {
@@ -283,6 +285,48 @@ describe('BrowserDocumentPage markdown 導線 (real IndexedDB)', () => {
     // The rest of the row does carry over: the hidden persistence fact rides
     // the same slot the spatial row uses.
     expect(document.querySelector('[data-testid="persistence-state"]')).toBeTruthy()
+  })
+
+  it('a markdown note offers no Copy as JSON Canvas - it holds no canvas', async () => {
+    const store = new IdbDocumentIndex()
+    await seedIdbDocument(store, { path: 'note', kind: 'markdown', makeDefault: true })
+    render(<BrowserDocumentPage store={store} />)
+    await waitFor(() => {
+      expect(document.querySelector('[contenteditable="true"]')).not.toBeNull()
+    })
+
+    await openDocumentMenu()
+    await waitFor(() => {
+      expect(document.querySelector('[role="menu"]')).not.toBeNull()
+    })
+    // Serialising a markdown note as JSON Canvas hands back the empty
+    // extended document the page's `canvas` fallback holds — a file whose
+    // content is not this note's, offered under a verb that says it is.
+    expect(menuRow('Copy as JSON Canvas')).toBeUndefined()
+    // The kind-agnostic rows do carry over, so this is a gate rather than an
+    // empty menu.
+    expect(menuRow('Duplicate')).toBeDefined()
+    expect(menuRow('Delete')).toBeDefined()
+  })
+
+  it('a markdown note reaches its own history, and can bookmark a point', async () => {
+    const store = new IdbDocumentIndex()
+    await seedIdbDocument(store, { path: 'note', kind: 'markdown', makeDefault: true })
+    render(<BrowserDocumentPage store={store} />)
+    await waitFor(() => {
+      expect(document.querySelector('[contenteditable="true"]')).not.toBeNull()
+    })
+
+    // History is the DOCUMENT's, not the spatial editor's: a markdown note's
+    // versions are frontiers of the same workspace record a canvas's are.
+    const history = await screen.findByRole('button', { name: 'History' })
+    expect(history.closest('[data-testid="inspector-segment"]')).toBeTruthy()
+
+    await openDocumentMenu()
+    await waitFor(() => {
+      expect(document.querySelector('[role="menu"]')).not.toBeNull()
+    })
+    expect(menuRow('Bookmark this point…')).toBeDefined()
   })
 
   it("the title survives a remount and is the document's one name", async () => {

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -567,14 +567,26 @@ function useBrowserDocument(
   }, [sync.loaded])
 
   // The browser's version history for this document: rows in IndexedDB,
-  // restores through the backend holding the live record. Null while there
-  // is no spatial backend (a markdown document, or nothing loaded yet), in
-  // which case the save control is hidden rather than left to fall back onto
-  // the daemon's routes.
+  // restores through whichever seam holds the live workspace record.
+  //
+  // Which seam that is follows the KIND, and this is the one line the
+  // parity turned on. A version is a frontier of the workspace record, and
+  // both kinds live in the same record — but this was built from `backend`
+  // alone, which a markdown note deliberately never has, so a note's rows
+  // were written by the checkpoint scheduler and reachable by nothing. Null
+  // only while nothing is loaded, and then the control is hidden rather
+  // than left to fall back onto the daemon's routes.
+  const versionsRecord = backend ?? markdownDoc.records
   const versionsBackend = useMemo(
     () =>
-      backend === null ? null : createBrowserVersionsBackend({ backend, store: versionStore }),
-    [backend, versionStore],
+      versionsRecord === null
+        ? null
+        : createBrowserVersionsBackend({
+            record: versionsRecord,
+            store: versionStore,
+            kind: documentKind,
+          }),
+    [versionsRecord, versionStore, documentKind],
   )
   const versionsEnabled = versionsBackend !== null
 
@@ -930,19 +942,24 @@ function useBrowserDocument(
       menuTriggerRef: canvasOpsButtonRef,
       menuItems: (
         <>
-          <DropdownMenuItem
-            onSelect={() => {
-              // Text on the clipboard survives any chat/paste channel intact,
-              // which a binary download cannot — the phone-friendly way to
-              // hand the exact canvas (coordinates included) to a debugger.
-              void navigator.clipboard
-                ?.writeText(serializeSpatial(canvas, 'extended'))
-                .catch(() => {})
-            }}
-          >
-            <Braces aria-hidden="true" className="size-3.5" />
-            Copy as JSON Canvas
-          </DropdownMenuItem>
+          {/* Spatial only: `canvas` falls back to an empty document on a
+              markdown note, so this row would hand back a well-formed file
+              whose content is not the note's — under a verb saying it is. */}
+          {documentKind === 'spatial' && (
+            <DropdownMenuItem
+              onSelect={() => {
+                // Text on the clipboard survives any chat/paste channel intact,
+                // which a binary download cannot — the phone-friendly way to
+                // hand the exact canvas (coordinates included) to a debugger.
+                void navigator.clipboard
+                  ?.writeText(serializeSpatial(canvas, 'extended'))
+                  .catch(() => {})
+              }}
+            >
+              <Braces aria-hidden="true" className="size-3.5" />
+              Copy as JSON Canvas
+            </DropdownMenuItem>
+          )}
           <DropdownMenuItem disabled={isDuplicating} onSelect={() => void handleDuplicate()}>
             <Copy aria-hidden="true" className="size-3.5" />
             Duplicate

--- a/apps/web/src/pages/BrowserDocumentPage.versions.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.versions.browser.test.tsx
@@ -1,8 +1,10 @@
 import {
   documentContainers,
   projectWorkspaceDocument,
+  readMarkdownBody,
   readSpatialCanvas,
   writeCommentThread,
+  writeMarkdownBody,
   writeSpatialCanvas,
   writeWorkspaceDocumentContent,
 } from '@kamiazya/whiteboard-loro-adapter'
@@ -70,6 +72,29 @@ async function storedText(documentId: string): Promise<string | undefined> {
   const projected = record === null ? null : projectWorkspaceDocument(record, documentId)
   const node = projected === null ? undefined : readSpatialCanvas(projected).nodes[0]
   return node?.type === 'text' ? node.text : undefined
+}
+
+async function writeBody(documentId: string, body: string): Promise<void> {
+  const docs = new BrowserWorkspaceDocs()
+  const record = await docs.open(getBrowserWorkspaceId())
+  if (record === null) throw new Error('no record')
+  writeMarkdownBody(documentContainers(record, documentId), body)
+  await docs.save(getBrowserWorkspaceId(), record)
+}
+
+async function storedBody(documentId: string): Promise<string> {
+  const record = await new BrowserWorkspaceDocs().open(getBrowserWorkspaceId())
+  if (record === null) throw new Error('no record')
+  return readMarkdownBody(documentContainers(record, documentId))
+}
+
+async function openNotePage() {
+  const view = render(<BrowserDocumentPage initialPath="note-a" />)
+  await waitFor(() => expect(document.querySelector('.cm-content')).not.toBeNull(), {
+    timeout: 10_000,
+  })
+  await screen.findByRole('button', { name: 'Back to documents' }, { timeout: 5000 })
+  return view
 }
 
 async function openPage() {
@@ -232,6 +257,61 @@ describe('BrowserDocumentPage version history (browser)', () => {
       timeout: 5000,
     })
   })
+  it('a markdown note bookmarks a point and restores its body', async () => {
+    const index = new FoldingBrowserIndex()
+    const workspaceId = getBrowserWorkspaceId()
+    await index.createWorkspace({ workspaceId })
+    const { documentId } = await index.createDocument({
+      workspaceId,
+      path: 'note-a',
+      kind: 'markdown',
+    })
+    await writeBody(documentId, '# first')
+
+    const view = await openNotePage()
+    // The same opener a canvas has, in the same segment: a version is a
+    // frontier of the workspace record, and a note lives in that record too.
+    await userEvent.click(screen.getByRole('button', { name: 'History' }))
+    const panel = await screen.findByTestId('history-panel')
+    await userEvent.click(within(panel).getByRole('button', { name: 'Bookmark this point' }))
+    await userEvent.fill(
+      await within(panel).findByRole('textbox', { name: 'Name this point' }),
+      'first draft',
+    )
+    await userEvent.keyboard('{Enter}')
+    await waitFor(() => expect(within(panel).getAllByTestId('version-row').length).toBe(1), {
+      timeout: 5000,
+    })
+
+    // The note moves on behind the page's back, then is reopened — a reload,
+    // so the page holds the later state.
+    view.unmount()
+    await writeBody(documentId, '# second')
+    expect(await storedBody(documentId)).toBe('# second')
+    await openNotePage()
+
+    await userEvent.click(screen.getByRole('button', { name: 'History' }))
+    const reopened = await screen.findByTestId('history-panel')
+    await waitFor(() => expect(within(reopened).getAllByTestId('version-row').length).toBe(1), {
+      timeout: 5000,
+    })
+    const row = within(reopened).getAllByTestId('version-row')[0]
+    const restoreTarget = row?.querySelector('button')
+    if (!restoreTarget) throw new Error('the version row is not restorable')
+    await userEvent.click(restoreTarget)
+
+    // Look before applying, exactly as on a canvas.
+    const preview = await screen.findByTestId('document-preview')
+    await waitFor(() => expect(preview.textContent ?? '').toContain('first'))
+    expect(await storedBody(documentId)).toBe('# second')
+
+    const chrome = screen.getByRole('banner')
+    await userEvent.click(within(chrome).getByRole('button', { name: 'Restore this version' }))
+    await waitFor(async () => expect(await storedBody(documentId)).toBe('# first'), {
+      timeout: 5000,
+    })
+  })
+
   it('shows the picture the bookmark carries, without waiting for a reload', async () => {
     const index = new FoldingBrowserIndex()
     const workspaceId = getBrowserWorkspaceId()

--- a/apps/web/src/pages/use-markdown-document.ts
+++ b/apps/web/src/pages/use-markdown-document.ts
@@ -41,6 +41,7 @@ import {
   writeCoreFacets,
   writeMarkdownBody,
   writeThreadMessage,
+  writeWorkspaceDocumentContent,
 } from '@kamiazya/whiteboard-loro-adapter'
 import type {
   CommentMessage,
@@ -49,7 +50,7 @@ import type {
   StoredCoreFacets,
 } from '@kamiazya/whiteboard-model'
 import { Loro, type LoroText } from 'loro-crdt'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { isGeneratedDocumentPath } from '../components/workspace-files/new-document-path.js'
 import { sameAnnotations, sameThreadMarks } from '../lib/annotations-equal.js'
 import { getAppLogger } from '../lib/app-logger.js'
@@ -132,6 +133,29 @@ export const DEFAULT_MARKDOWN_CORE_FACETS: StoredCoreFacets = { type: 'markdown'
  */
 const INITIAL_SAVE_STATE: BrowserPersistenceState = { kind: 'saved', lastSavedAt: null }
 
+/**
+ * What a keeper has to answer for a note's HISTORY, and the two things a
+ * markdown note has no `BrowserBackend` to answer them with.
+ *
+ * A version is a frontier of the WORKSPACE RECORD — the same record a
+ * canvas's versions point into — so a note's history was never missing for
+ * want of rows. It was missing because the seam that reads and restores one
+ * was built from the spatial backend, and a markdown note deliberately has
+ * none (the sync layer would clobber the body this hook writes). This is
+ * that pair, supplied by the hook that DOES hold the record.
+ */
+export interface MarkdownRecordSeam {
+  /** Read the live workspace record, or `null` before it is loaded. */
+  readonly readRecord: <T>(read: (doc: Loro, documentId: string) => T) => T | null
+  /**
+   * Reconcile a past state onto the live note. A diff and never a rewrite,
+   * exactly as `BrowserBackend.applyRestore` is — the doc subscription this
+   * hook holds is what then carries it into `body` state and schedules the
+   * save, the same path a CRDT binding's own commit takes.
+   */
+  readonly applyRestore: (past: Loro) => Promise<void>
+}
+
 export interface MarkdownDocumentState {
   /** Null until the initial load resolves — render nothing editable before. */
   readonly body: string | null
@@ -165,6 +189,14 @@ export interface MarkdownDocumentState {
    * across a move.
    */
   readonly bodyTextOf: (doc: Loro) => LoroText
+  /**
+   * How this note's history is read and put back. Null until the load
+   * resolves, and null in LEGACY mode: a legacy host's doc is a
+   * per-document snapshot rather than the workspace record a version's
+   * frontier points into, so there is no history to reach and answering
+   * would be a lie the History panel would render as an empty list.
+   */
+  readonly records: MarkdownRecordSeam | null
   /**
    * Every conversation on this document (ADR-0026 step 3).
    *
@@ -652,6 +684,34 @@ export function useMarkdownDocument(
     writeThreadMessage(host.containers, threadId, message)
   }, [])
 
+  /**
+   * Built from the same `hostRef` every writer here uses, so it cannot point
+   * at a document the hook has moved on from. `mode` gates it rather than
+   * `documentId`, for the reason `MarkdownRecordSeam` states.
+   */
+  const records = useMemo((): MarkdownRecordSeam | null => {
+    if (documentId === null) return null
+    return {
+      readRecord: (read) => {
+        const host = hostRef.current
+        if (host === null || host.mode !== 'workspace') return null
+        return read(host.doc, documentId)
+      },
+      applyRestore: async (past) => {
+        const host = hostRef.current
+        if (host === null || host.mode !== 'workspace') {
+          throw new Error('restore before the note was loaded')
+        }
+        writeWorkspaceDocumentContent(host.doc, documentId, past)
+        // The subscription refreshed `body` and armed the debounce; this
+        // lands it, so a restore is durable by the time it resolves rather
+        // than 500ms later — a page a person closes on the confirmation
+        // would otherwise keep the state it restored FROM.
+        await queueSave(documentId, () => host.save())
+      },
+    }
+  }, [documentId])
+
   const createThread = useCallback((thread: CommentThread) => {
     const host = hostRef.current
     if (host === null) return
@@ -688,6 +748,7 @@ export function useMarkdownDocument(
     setCoreFacets,
     doc,
     bodyTextOf,
+    records,
     annotations,
     threadMarks,
     replyToThread,

--- a/packages/mcp-server/src/server/file-size-budget.test.ts
+++ b/packages/mcp-server/src/server/file-size-budget.test.ts
@@ -165,7 +165,16 @@ const FILE_SIZE_GRANDFATHER: Record<string, number> = {
   // arrived and a document opened ON a variation kept naming the default one.
   // Most of the added lines is that reason — the bug is invisible in the
   // three lines of state that fix it.
-  'apps/web/src/pages/BrowserDocumentPage.tsx': 1011,
+  // Raised again to 1028 by kind parity on the versions seam. Two lines pick
+  // the record seam by kind and supply the document's kind to it; the rest is
+  // the two findings behind them, neither recoverable from the code. A note's
+  // version ROWS were always written — a version is a frontier of the
+  // workspace record — and only the seam that reads and restores one was
+  // built from a backend a note never has. And `loadPast` asked the past
+  // STATE its kind, which a tree-hosted document keeps in its node meta, so
+  // the answer was always "not markdown": the fallback saved a canvas and
+  // drew a note an empty viewer.
+  'apps/web/src/pages/BrowserDocumentPage.tsx': 1028,
   'packages/canvas-render/src/layout/nodes/mdast-blocks.ts': 1674,
   'packages/canvas-render/src/layout/spatial-canvas.ts': 1840,
   'packages/canvas-render/src/layout/edges/spatial-edges.ts': 2069,


### PR DESCRIPTION
## Summary

P8 of the header retune (P1 #1393 … P7 #1436). P7 made the row read the same on both kinds; this makes the row's members mean the same thing on both.

**The rows were always there.** `BrowserVersionStore` files a version as a frontier of the WORKSPACE RECORD, and a note lives in that record like a canvas does — the checkpoint scheduler had been writing points for notes all along. What was missing was a way to READ and RESTORE one: the seam was built from `BrowserBackend`, which a markdown note deliberately never has (the spatial sync layer would clobber the body `useMarkdownDocument` writes). So `versionsEnabled` was false on every note, and History, `Bookmark this point…` and restore were all hidden behind that one flag.

- **`VersionsRecordSeam`** is the pair the versions seam actually needs — read the live record, reconcile a past state onto it. `BrowserBackend` satisfies it structurally; `useMarkdownDocument` now publishes its own (`MarkdownRecordSeam`), whose restore is the same `writeWorkspaceDocumentContent` diff, landed through the save queue the hook already owns. The doc subscription the hook already holds carries it into the body state — the same path a CRDT binding's own commit takes.
- **`Copy as JSON Canvas` is gated to spatial.** On a note, `canvas` is the page's empty fallback, so the row handed back a well-formed file whose content is not the note's, under a verb saying it is.

## A second defect, silent by construction

`loadPast` asked the past STATE what kind it was. A workspace-tree document keeps its kind in the node's meta, and `projectWorkspaceDocument` carries content only. Measured on a seeded note:

```
liveKind: undefined   liveBody: '# first'
projKind: undefined   projBody: '# first'
```

So the answer was always "not markdown" — which a canvas survives by being the fallback, and a note does not: it drew an empty `CanvasViewer` where its prose should be. The kind is now supplied by the composition root, which knows it. Both halves are mutation-checked: reverting either the seam or the kind fails `a markdown note bookmarks a point and restores its body`, the second with `expected '' to contain 'first'` — the empty viewer itself.

## What this deliberately does NOT do

**Variations stay absent on a note, and that is now a stated decision rather than a gap.** Wiring the chip needs only a `mutateRecord` on the same seam — but `planMerge` answers in spatial elements (`badges`, `newElementIds`, `conflictElementIds`, `previewElementCount`; `plan-merge.ts:39-43,178-190`), so a merge UI opened on prose would report zeroes about a change it cannot see. Create/switch/rename/delete are meaningful on a note; merge is undesigned. That question comes first, and it is filed.

## Visual repro

Same viewport (1280px), same fresh markdown note on the browser keeper, ⋯ open, main vs this branch, composed with `compose-figure.mjs` (digests `6673122c` / `6e812721`). Measured from the running app:

| | row | ⋯ menu |
|---|---|---|
| before | `Back, Properties, Comments, More actions` | `Export…, Copy as JSON Canvas, Duplicate, Delete` |
| after | `Back, Properties, Comments, History, More actions` | `Export…, Bookmark this point…, Duplicate, Delete` |

`gh` is unavailable in this environment, so the figure was handed to the author directly rather than attached here.

## Test plan

- [x] New or updated tests — three: a note offers no `Copy as JSON Canvas`, a note reaches History and can bookmark, and the full bookmark → edit → preview → restore flow. All confirmed RED first (the first two on the unfixed page, the third against each production half in turn).
- [x] Manual verification in the running app, driven end to end: typed `first draft of the note` → bookmarked → appended ` PLUS SECOND EDIT` → the preview showed `first draft of the note` → Restore put it back in the live editor.
- [x] Five fresh-process runs of the changed files: **40/40 ×5**
- [x] `pnpm --filter @kamiazya/whiteboard-web test` (CI's `test-jsdom`): `web-jsdom` 3916/3916, `web-node` 91/91, exit 0
- [x] `pnpm test:browser`: **1200/1200**, no `Re-optimizing` in the log
- [x] `pnpm check:local` exit 0
- [x] `keeper-parity` 25/25 — `versions-backend.ts` already declared `both-keepers` with this browser module; the parity it named is now true for both kinds rather than only one
- [ ] E2E coverage — not applicable; the flow is covered at the real-browser layer with real IndexedDB

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [ ] Docs updated — no user-facing doc claims a note has no history; nothing to correct
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_