### PR TITLE
feat(web): the variation chip is identity, so it sits before the act menu

### DIFF
--- a/apps/web/src/components/WorkspaceTopBar.tsx
+++ b/apps/web/src/components/WorkspaceTopBar.tsx
@@ -2,10 +2,8 @@ import { ChevronLeft, RotateCcw, X } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { HEADER_BUTTON_CLASS } from '../components/ui/header-button.js'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../components/ui/tooltip.js'
-import { useBranchesBackend } from '../contexts/BranchesBackendContext.js'
 import { useDaemonApi } from '../contexts/DaemonApiContext.js'
 import { cn } from '../lib/utils.js'
-import { HeaderBranchChip } from './HeaderBranchChip'
 import { useDocumentNames } from './workspace-top-bar/useDocumentNames'
 
 /** What the top bar knows about the open document's NAME, handed to `titleSlot`. */
@@ -48,9 +46,6 @@ interface Props {
    * Defaults to 'daemon' so every existing caller keeps fetching `/names`.
    */
   dataMode?: 'daemon' | 'local'
-  // Passed through to HeaderBranchChip: preview a variation without
-  // switching. The page owns the address, so it owns the handler.
-  onPreviewVariation?: (name: string) => void
   /**
    * Opens and closes the document's history. The PAGE owns both the state and
    * the panel: history is a column of the editor row, not a popover hanging
@@ -74,13 +69,6 @@ interface Props {
    * is not currently drawn.
    */
   preview?: TopBarPreview
-  // Bumped by the host page on an externally observed HEAD/version change
-  // (another client, an MCP tool call) so the chip/timeline refetch without
-  // waiting for their own poll interval.
-  // Bumped by the host page on an externally observed HEAD/version change
-  // (another client, an MCP tool call) so the chip/timeline refetch without
-  // waiting for their own poll interval.
-  branchRefreshSignal?: number
   /**
    * The merged canvas row's flexible middle (title + properties triggers),
    * provided by the page — the header is one row, so pages inject their
@@ -114,17 +102,10 @@ export default function WorkspaceTopBar({
   path,
   onNavigateBack,
   dataMode = 'daemon',
-  onPreviewVariation,
   preview,
-  branchRefreshSignal,
   titleSlot,
 }: Props) {
   const isLocalMode = dataMode === 'local'
-  // Whether to show the chip at all is the BACKEND's answer, not a keeper
-  // flag: both keepers have variations now, but a document with no
-  // record-holding backend (a markdown body, or one still loading) has none.
-  // That is per document, which no provider-level flag can say.
-  const branchesEnabled = useBranchesBackend().hasBranches
   const daemonFetch = useDaemonApi()
 
   const { effectiveNames, renameDocument } = useDocumentNames({
@@ -207,22 +188,6 @@ export default function WorkspaceTopBar({
           name: canvasCustomName ?? path,
           ...(isLocalMode ? {} : { onRename: (next: string) => void renameDocument(path, next) }),
         })}
-
-        {/* Branch chip with switch, create, rename, delete, and merge actions.
-            This is the top bar's only destructive control (branch delete,
-            confirmed via AlertDialog inside HeaderBranchChip); it stays in
-            this left-side group and is not part of the <400px collapse. */}
-        {branchesEnabled && (
-          <>
-            <span className="mx-1 hidden h-4 w-px bg-border sm:inline-block" aria-hidden />
-            <HeaderBranchChip
-              workspaceId={workspaceId}
-              path={path}
-              refreshSignal={branchRefreshSignal}
-              onPreviewVariation={onPreviewVariation}
-            />
-          </>
-        )}
       </div>
     </header>
   )

--- a/apps/web/src/components/document-properties/DocumentProperties.tsx
+++ b/apps/web/src/components/document-properties/DocumentProperties.tsx
@@ -44,6 +44,16 @@ export interface DocumentPropertiesProps {
    * the canvas row's layout, not the operations themselves.
    */
   readonly actions?: ReactNode
+  /**
+   * Beside the name: what else says WHICH document this is — today the
+   * variation chip.
+   *
+   * A slot of its own rather than a leading item in `actions`, because the
+   * row's one divide is identity from act, and putting the two in one bag
+   * is what let identity drift to the right of the act menu. This one is
+   * anchored to the title; `actions` is anchored to the right edge.
+   */
+  readonly identity?: ReactNode
 }
 
 /**
@@ -64,6 +74,7 @@ export function DocumentProperties({
   onTitleChange,
   status,
   actions,
+  identity,
 }: DocumentPropertiesProps) {
   // Null means "not being edited" — the box then shows the canonical name.
   // While it is a string the box shows that instead, because the name comes
@@ -144,6 +155,7 @@ export function DocumentProperties({
             inline ? 'text-sm' : 'text-base'
           }`}
         />
+        {identity}
         {actions !== undefined && (
           <div className="ml-auto flex shrink-0 items-center gap-1.5">{actions}</div>
         )}

--- a/apps/web/src/components/document-properties/DocumentProperties.tsx
+++ b/apps/web/src/components/document-properties/DocumentProperties.tsx
@@ -107,6 +107,21 @@ export function DocumentProperties({
           id={`${suggestionsId}-title`}
           enterKeyHint="done"
           value={draftTitle ?? title}
+          // Sized to the NAME, not to the row.
+          //
+          // What follows a document's name — today the variation chip — says
+          // WHICH document this is, so it has to read as attached to the
+          // name. A `flex-1` box made the title the row's spacer instead, and
+          // the chip landed a third of the width away: measured at 1280px,
+          // `Untitled` at x=48 and `main` at x=1036. `size` is in average
+          // character widths, so a proportional face lands a little wide —
+          // slack after the name, which is what a title bar wants anyway.
+          //
+          // The floor keeps an empty or one-word name a comfortable rename
+          // target now that the box no longer fills the row; the ceiling
+          // stops a long name pushing the chip off the end, and past it the
+          // name ellipsises the way any title does.
+          size={Math.min(Math.max((draftTitle ?? title).length + 2, 14), 44)}
           onChange={(event) => {
             if (onTitleChange === undefined) return
             setDraftTitle(event.target.value)
@@ -151,7 +166,7 @@ export function DocumentProperties({
           // canonical name, which is already trimmed.
           onBlur={() => setDraftTitle(null)}
           placeholder="Untitled"
-          className={`text-foreground placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent font-medium outline-none ${
+          className={`text-foreground placeholder:text-muted-foreground min-w-0 shrink truncate bg-transparent font-medium outline-none ${
             inline ? 'text-sm' : 'text-base'
           }`}
         />

--- a/apps/web/src/pages/BrowserDocumentPage.branches.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.branches.browser.test.tsx
@@ -70,6 +70,36 @@ describe('BrowserDocumentPage variations (browser)', () => {
     cleanup()
   })
 
+  it('the chip is identity: it sits with the title, left of the act menu', async () => {
+    await seedDocument()
+    render(<BrowserDocumentPage initialPath="canvas-a" />)
+    await waitFor(
+      () => expect(screen.getByTestId('spatial-editor-container')).toBeInTheDocument(),
+      {
+        timeout: 5000,
+      },
+    )
+    const chip = await screen.findByRole('button', { name: /^Switch variation/ })
+    const kebab = await screen.findByRole('button', { name: 'More actions' })
+    const segment = screen.getByTestId('inspector-segment')
+
+    // Reading order, taken from the row itself rather than from x
+    // coordinates: what a screen reader and the tab sequence follow is the
+    // DOM, and `DOCUMENT_POSITION_FOLLOWING` says one node comes after
+    // another in it.
+    const follows = (a: Element, b: Element) =>
+      (a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0
+
+    // Which variation you are on is WHICH DOCUMENT you are looking at — the
+    // same question the title answers — so it belongs beside the title, not
+    // after the things that act on it. Measured before this increment at
+    // 1280px: `Comments@1022, History@1056, More actions@1108, Switch
+    // variation@1165`, identity pushed to the far right of the row by
+    // `HeaderBranchChip` rendering after the slot the act controls moved into.
+    expect(follows(chip, segment)).toBe(true)
+    expect(follows(chip, kebab)).toBe(true)
+  })
+
   it('creates a variation from the chip and keeps it on the record', async () => {
     const documentId = await seedDocument()
     render(<BrowserDocumentPage initialPath="canvas-a" />)

--- a/apps/web/src/pages/BrowserDocumentPage.branches.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.branches.browser.test.tsx
@@ -98,6 +98,21 @@ describe('BrowserDocumentPage variations (browser)', () => {
     // `HeaderBranchChip` rendering after the slot the act controls moved into.
     expect(follows(chip, segment)).toBe(true)
     expect(follows(chip, kebab)).toBe(true)
+
+    // …and ADJACENT to the NAME, which reading order alone cannot say.
+    //
+    // Asserted on the title's BOX, not on the gap to it. The gap is the wrong
+    // instrument and measured so: the chip is glued to the input's right
+    // edge, so when the input grows the chip travels with it and the gap
+    // reads 25px either way. The first version of this guard asserted on that
+    // gap, PASSED its own mutation check, and had to be rewritten. What
+    // actually differs is the box — 132px sized to the name against 959px
+    // filling the row, same 1280px viewport — so that is what this reads. The
+    // ceiling sits far from both readings: a shape check, not a measurement.
+    const title = screen.getByRole('textbox', { name: /title/i })
+    const row = title.closest('header') as HTMLElement
+    const share = title.getBoundingClientRect().width / row.getBoundingClientRect().width
+    expect(share).toBeLessThan(0.45)
   })
 
   it('creates a variation from the chip and keeps it on the record', async () => {

--- a/apps/web/src/pages/DocumentPage.tsx
+++ b/apps/web/src/pages/DocumentPage.tsx
@@ -22,6 +22,7 @@ import {
   DocumentProperties,
 } from '../components/document-properties/DocumentProperties.js'
 import { HeaderBranchBanner } from '../components/HeaderBranchBanner.js'
+import { HeaderBranchChip } from '../components/HeaderBranchChip.js'
 import { MergeToast } from '../components/MergeToast.js'
 import { CanvasDisplaySettings } from '../components/spatial-editor/CanvasDisplaySettings.js'
 import type { VersionPreviewSession } from '../components/VersionTimeline'
@@ -31,6 +32,7 @@ import { sanitizeExportFilenameBase } from '../components/workspace-top-bar/expo
 import { useBookmarkShortcut } from '../components/workspace-top-bar/useBookmarkShortcut.js'
 import { useSceneExport } from '../components/workspace-top-bar/useSceneExport.js'
 import { VersionPanel } from '../components/workspace-top-bar/VersionPanel.js'
+import { useBranchesBackend } from '../contexts/BranchesBackendContext.js'
 import { useCommentsRail } from '../hooks/use-comments-rail.js'
 import { useDocumentFileSeams } from '../hooks/use-document-file-seams.js'
 import { useFullscreen } from '../hooks/use-fullscreen.js'
@@ -326,6 +328,37 @@ function DocumentPageBody({
   )
 
   const topBar = model.topBar
+  // Per DOCUMENT rather than per keeper: a document with no record-holding
+  // backend has no variations to name, which no provider-level flag can say.
+  const branchesEnabled = useBranchesBackend().hasBranches
+
+  // Identity, not act: which variation you are on is WHICH document you are
+  // looking at, the same question the title answers. It renders in
+  // `DocumentProperties`'s identity slot — beside the name — rather than in
+  // `WorkspaceTopBar`, where it sat after `titleSlot` and so ended up to the
+  // RIGHT of the act menu once P4 moved the row's actions INTO that slot.
+  //
+  // Whether to draw it at all is the BACKEND's answer rather than a keeper
+  // flag, for the reason the bar used to state: both keepers have variations,
+  // and a document with no record-holding backend (a markdown body, or one
+  // still loading) has none.
+  const branchIdentity =
+    topBar === null || !branchesEnabled ? null : (
+      <>
+        <span className="bg-border mx-1 hidden h-4 w-px shrink-0 sm:inline-block" aria-hidden />
+        <HeaderBranchChip
+          workspaceId={topBar.workspaceId}
+          path={topBar.path}
+          {...(topBar.branchRefreshSignal === undefined
+            ? {}
+            : { refreshSignal: topBar.branchRefreshSignal })}
+          {...(topBar.onPreviewVariation === undefined
+            ? {}
+            : { onPreviewVariation: topBar.onPreviewVariation })}
+        />
+      </>
+    )
+
   // Fullscreen means the DOCUMENT, maximised: the whole top-bar row —
   // back, title, menus — steps aside with the shell's row above it, which
   // owns the control and floats the way back out. The dock stays because
@@ -432,6 +465,7 @@ function DocumentPageBody({
                           ? {}
                           : { status: model.properties.status })}
                         actions={rowActions}
+                        {...(branchIdentity === null ? {} : { identity: branchIdentity })}
                       />
                     ) : null}
                   </>
@@ -442,12 +476,6 @@ function DocumentPageBody({
                 {...(topBar.onNavigateBack === undefined
                   ? {}
                   : { onNavigateBack: topBar.onNavigateBack })}
-                {...(topBar.branchRefreshSignal === undefined
-                  ? {}
-                  : { branchRefreshSignal: topBar.branchRefreshSignal })}
-                {...(topBar.onPreviewVariation === undefined
-                  ? {}
-                  : { onPreviewVariation: topBar.onPreviewVariation })}
                 {...(preview === null ? {} : { preview })}
               />
             </Suspense>


### PR DESCRIPTION
## Summary

P9 of the header retune (P1 #1393 … P8 #1438). P6 wrote the rule — a control's role follows its SUBJECT, and the row runs identity → inspect → act. One control was still on the wrong side of it.

Measured at 1280px on `main`: `Comments@1022, History@1056, More actions@1108, Switch variation@1165, Variation actions@1244`. Which variation you are on is WHICH document you are looking at, the same question the title answers — and it was sitting to the right of everything that acts on that document.

**Nobody put it there.** `WorkspaceTopBar` rendered `HeaderBranchChip` after `titleSlot`, which was correct until P4 moved the row's actions INTO that slot. Identity was pushed right by a change that never mentioned it, and no test looked at the order.

- **`DocumentProperties` gains an `identity` slot**, anchored to the title rather than to the right edge. A slot of its own rather than a leading item in `actions`, because the row's one divide is identity from act — one bag for both is what allowed the drift.
- **`WorkspaceTopBar` loses the chip**, the `useBranchesBackend` hook and the two props that fed it. Deleted rather than moved twice, as P7 did with the three inspect openers.
- **The title is sized to its NAME, not to the row.** It is an `<input>` with `flex-1`, so it WAS the row's spacer: the chip stayed glued to its right edge and travelled wherever that edge landed. `size`, floored at 14 characters and capped at 44, sizes the box to the name; `ml-auto` on the actions already pushes them right, so no spacer is needed.

After: `Switch variation@1036, Variation actions@1115, Comments@1150, History@1184, More actions@1236` for reading order, and the chip follows the name's right edge by **25px at every name length** — `Untitled` and `Sprint plan` both end at x=184 with the chip at 209, a 59-character name ends at 397 with the chip at 422. Blurred, a name past the cap ellipsises and the box scrolls back to the start, which is what a title bar does.

## The guard had to be rewritten after its own mutation check passed

The first version asserted the **gap** between the input's right edge and the chip. That gap is 25px whether or not the input grows — the chip moves with the edge — so putting `flex-1` back left it green. A guard that cannot fail reads exactly like a guard that checked.

What actually differs is the **box**: 132px sized to the name against 959px filling the row, same 1280px viewport. It reads that now, and the mutation fails it at `0.749` against a `0.45` ceiling. Reading order is asserted separately, from the DOM (`DOCUMENT_POSITION_FOLLOWING`) rather than from x — what a screen reader and the tab sequence follow is the DOM, and the coordinates were only ever the symptom.

## What this does not address

**The phone row is still full.** Measured at 390px with this branch: nothing overflows (`scrollWidth` 390 = row width 390), but six controls run 12→378 and the title is left 86px. That is the agreed design's `<768px` rule — collapse the segment into the ⋯, leaving only what is open — which is still unimplemented and is its own increment, not a side effect of moving one control.

## Visual repro

Same viewport (1280px), same fresh canvas, main vs this branch, composed with `compose-figure.mjs` (digests `4405d0e3` / `16312af8`, plus a later capture of the adjacent form). Look at what sits either side of the `⋮`. `gh` is unavailable in this environment, so the figures were handed to the author directly rather than attached here.

## Test plan

- [x] New test — `the chip is identity: it sits with the title, left of the act menu`, confirmed RED first (`expected false to be true`), and its adjacency half mutation-checked after being rewritten
- [x] Five fresh-process runs of the changed file: **2/2 ×5**
- [x] `pnpm --filter @kamiazya/whiteboard-web test` (CI's `test-jsdom`): `web-jsdom` 3916/3916, `web-node` 91/91, exit 0
- [x] `pnpm test:browser`: **1201/1201**, no `Re-optimizing` in the log
- [x] `pnpm check:local` exit 0
- [x] `--project mcp-node file-size-budget` 5/5 — run explicitly, since it is the guard that lives outside every apps/web-scoped run and caught P8 in CI instead
- [x] Manual verification in the running app at three name lengths and at 390px, order and geometry taken from the row itself
- [ ] E2E coverage — not applicable; the row is covered at the browser-mode layer

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [ ] Docs updated — not needed; DESIGN.md's four-roles rule (P6, #1420) already states this order. This makes the row obey it.
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Variation switching is now available beside the document identity, keeping related preview and refresh controls together.
  * Document headers can display identity information alongside the title and actions.

* **UI Improvements**
  * Document titles now size to their content within defined limits and truncate when too long.
  * Header layout keeps identity controls near the title while preserving space for inspectors and additional actions.

* **Tests**
  * Added browser coverage verifying variation-switch placement and document header proportions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->