### PR TITLE
refactor(web): retire VersionTimelineCapabilities, whose two shapes agreed

### DIFF
--- a/apps/web/src/components/VersionTimeline.tsx
+++ b/apps/web/src/components/VersionTimeline.tsx
@@ -38,46 +38,24 @@ export interface VersionPreviewSession {
 }
 
 /**
- * What the keeper behind this history can do.
+ * A history is a history, whoever keeps it.
  *
- * A prop rather than a read of the provider's capability map, because these
- * are not the same question: that map says what the CONNECTION offers, and
- * this says what the history in front of you does. The two shapes below are
- * the only answers a keeper has, named so a mount states which keeper it is
- * instead of writing a literal that reads like a preference.
- */
-export interface VersionTimelineCapabilities {
-  readonly branches: boolean
-  readonly autoVersions: boolean
-}
-
-/** The daemon's history: lanes, and a checkpoint after work settles. */
-export const DAEMON_HISTORY_CAPABILITIES: VersionTimelineCapabilities = {
-  branches: true,
-  autoVersions: true,
-}
-
-/**
- * The browser's history, which now answers the same two questions the
- * daemon's does: its rows carry the variation they were taken on, and a
- * checkpoint lands on its own once editing settles.
+ * There was a `VersionTimelineCapabilities` prop here — `branches` and
+ * `autoVersions`, one shape per keeper — and it is gone because the two
+ * shapes had become identical: both keepers write rows carrying the
+ * variation they were taken on, and both land a checkpoint once editing
+ * settles. A pair that agrees declares no difference, which is the argument
+ * that retired the provider's capability map (ADR-0004's 2026-09-05
+ * addendum) one layer up.
  *
- * Equal to the daemon's, therefore, and a pair that agrees declares no
- * difference — the argument that retired the provider's capability map. What
- * keeps this one alive for the moment is not a difference but the component
- * below: `branches: false` and `autoVersions: false` still select real
- * rendering paths that `version-row.test.tsx` exercises, so removing the pair
- * means removing those too. That is the follow-up, not a drive-by here.
+ * What the `false` side actually held up, measured before deleting it: ONE
+ * assertion, the second direction of the lane test. The other four cases in
+ * `version-row.test.tsx` passed `branches: false` and never looked at a
+ * lane — they were rendering a configuration no keeper ships, for nothing.
  */
-export const BROWSER_HISTORY_CAPABILITIES: VersionTimelineCapabilities = {
-  branches: true,
-  autoVersions: true,
-}
-
 interface Props {
   workspaceId: string
   path: string
-  capabilities?: VersionTimelineCapabilities
   // Called after restore succeeds so the browser-side LoroUndoManager can be cleared.
   onRestored?: () => void
   /**
@@ -187,7 +165,6 @@ function RowShell({
 export default function VersionTimeline({
   workspaceId,
   path,
-  capabilities = DAEMON_HISTORY_CAPABILITIES,
   onRestored,
   onPreview,
   refreshSignal,
@@ -474,9 +451,8 @@ export default function VersionTimeline({
                   the trigger's timing lives, and the one nothing updates —
                   it read "~30s" through the whole life of the five-minute
                   pause that replaced it. */}
-              {capabilities.autoVersions
-                ? 'A checkpoint is saved a little after you stop editing. Bookmark this point with the button above, or ⌘/Ctrl+S.'
-                : 'Save one with the button above, or ⌘/Ctrl+S.'}
+              A checkpoint is saved a little after you stop editing. Bookmark this point with the
+              button above, or ⌘/Ctrl+S.
             </div>
           ) : (
             visibleVersions.map((v) => {
@@ -488,17 +464,18 @@ export default function VersionTimeline({
                 restoredSource === undefined ? null : versionTitle(restoredSource)
               return (
                 <div key={v.id} data-testid="version-row" className="flex items-stretch gap-1.5">
-                  {/* The lane column, only where lanes exist. A keeper with
-                      one branch drew a straight line down the left of every
-                      row and spent the width saying nothing. */}
-                  {/* The lane is drawn for BRANCHES or for lineage. It used
-                      to be branches-only, which left the browser keeper — one
-                      lane, and restores like any other — with nowhere to draw
-                      the arc a restore leaves. */}
-                  {(capabilities.branches ||
-                    row?.restoredFrom !== undefined ||
-                    row?.isRestoreSource === true ||
-                    row?.isRestoreArcThrough === true) && (
+                  {/* The lane column, on every row. It was gated on the
+                      keeper having branches, widened to lineage when the
+                      browser keeper's restores needed an arc to draw, and
+                      then always true once that keeper grew variations — so
+                      what is left is a condition, not a decision.
+
+                      A single lane down a document nobody has branched is
+                      still 24px saying little, which is what the gate was
+                      originally for. That question is about the DOCUMENT
+                      (how many lanes does it have?), not about the keeper,
+                      and answering it is not this deletion's job. */}
+                  {
                     /* biome-ignore lint/a11y/noSvgWithoutTitle: decorative graph, aria-hidden removes it from the accessibility tree */
                     <svg
                       data-testid="version-lane"
@@ -575,7 +552,7 @@ export default function VersionTimeline({
                         />
                       )}
                     </svg>
-                  )}
+                  }
                   {/* Restore is offered on HEAD's lane only. Showing another
                       variation's history is not the same as offering to
                       restore from it: what restoring one variation's version

--- a/apps/web/src/components/version-row.test.tsx
+++ b/apps/web/src/components/version-row.test.tsx
@@ -74,11 +74,7 @@ function backendOf(list: () => Promise<typeof ROWS>): VersionsBackend {
 function renderTimeline(backend: VersionsBackend) {
   return render(
     <VersionsBackendContext.Provider value={backend}>
-      <VersionTimeline
-        workspaceId="ws"
-        path="doc"
-        capabilities={{ branches: false, autoVersions: true }}
-      />
+      <VersionTimeline workspaceId="ws" path="doc" />
     </VersionsBackendContext.Provider>,
   )
 }
@@ -135,25 +131,19 @@ describe('a version row is written from the content side', () => {
     expect(screen.queryByText('manual')).toBeNull()
   })
 
-  it('draws the lane column only for a keeper that HAS branches', async () => {
-    // Both directions, or "absent" is indistinguishable from a testid that
-    // was never added.
-    const withBranches = render(
-      <VersionsBackendContext.Provider value={backendOf(async () => ROWS)}>
-        <VersionTimeline
-          workspaceId="ws"
-          path="doc"
-          capabilities={{ branches: true, autoVersions: true }}
-        />
-      </VersionsBackendContext.Provider>,
-    )
-    await screen.findAllByTestId('version-row')
-    expect(withBranches.container.querySelectorAll('[data-testid="version-lane"]').length).toBe(3)
-    cleanup()
-
-    const noBranches = renderTimeline(backendOf(async () => ROWS))
-    await screen.findAllByTestId('version-row')
-    expect(noBranches.container.querySelector('[data-testid="version-lane"]')).toBeNull()
+  it('draws a lane beside every row, so the graph has somewhere to land', async () => {
+    // This asserted BOTH directions while the lane was gated on a keeper
+    // having branches — the second one being that a keeper without them drew
+    // none. Both keepers have them now, the gate went with
+    // `VersionTimelineCapabilities`, and a direction no configuration can
+    // reach is not a direction.
+    //
+    // What is left is a count rather than a presence: one lane per row is
+    // what `mini-graph` computes a dot, a colour and connectors FOR, and a
+    // count cannot pass vacuously the way a `queryBy…` returning null can.
+    const view = renderTimeline(backendOf(async () => ROWS))
+    const rows = await screen.findAllByTestId('version-row')
+    expect(view.container.querySelectorAll('[data-testid="version-lane"]').length).toBe(rows.length)
   })
 
   it('says so when the list could not be read, instead of showing stale rows in silence', async () => {
@@ -165,12 +155,7 @@ describe('a version row is written from the content side', () => {
     })
     const view = render(
       <VersionsBackendContext.Provider value={backend}>
-        <VersionTimeline
-          workspaceId="ws"
-          path="doc"
-          capabilities={{ branches: false, autoVersions: true }}
-          refreshSignal={0}
-        />
+        <VersionTimeline workspaceId="ws" path="doc" refreshSignal={0} />
       </VersionsBackendContext.Provider>,
     )
     await screen.findAllByTestId('version-row')
@@ -179,12 +164,7 @@ describe('a version row is written from the content side', () => {
     // Drive the refetch rather than waiting out the 15s poll.
     view.rerender(
       <VersionsBackendContext.Provider value={backend}>
-        <VersionTimeline
-          workspaceId="ws"
-          path="doc"
-          capabilities={{ branches: false, autoVersions: true }}
-          refreshSignal={1}
-        />
+        <VersionTimeline workspaceId="ws" path="doc" refreshSignal={1} />
       </VersionsBackendContext.Provider>,
     )
     // A refresh that fails leaves the rows on screen — they are still the

--- a/apps/web/src/components/workspace-top-bar/VersionPanel.tsx
+++ b/apps/web/src/components/workspace-top-bar/VersionPanel.tsx
@@ -1,15 +1,11 @@
 import type { ReactNode, Ref } from 'react'
-import VersionTimeline, {
-  type VersionPreviewSession,
-  type VersionTimelineCapabilities,
-} from '../../components/VersionTimeline.js'
+import VersionTimeline, { type VersionPreviewSession } from '../../components/VersionTimeline.js'
 import { InspectorPanel } from '../document-editor/InspectorPanel.js'
 
 interface VersionPanelProps {
   panelRef?: Ref<HTMLDivElement>
   workspaceId: string
   path: string
-  capabilities?: VersionTimelineCapabilities
   onRestored?: () => void
   refreshSignal?: number
   onPreview?: (session: VersionPreviewSession | null) => void
@@ -30,7 +26,6 @@ export function VersionPanel({
   panelRef,
   workspaceId,
   path,
-  capabilities,
   onRestored,
   refreshSignal,
   onPreview,
@@ -46,7 +41,6 @@ export function VersionPanel({
       <VersionTimeline
         workspaceId={workspaceId}
         path={path}
-        capabilities={capabilities}
         onRestored={onRestored}
         refreshSignal={refreshSignal}
         onPreview={onPreview}

--- a/apps/web/src/lib/keeper-parity.test.ts
+++ b/apps/web/src/lib/keeper-parity.test.ts
@@ -24,20 +24,18 @@
  * the point is not that both keepers must have everything, it is that a
  * difference is a decision somebody took rather than one nobody noticed.
  *
- * What the scan cannot see, and what the second block here is for: a
- * difference that lives entirely in the daemon's own server code reaches no
- * apps/web module at all. Automatic checkpoints are the standing example —
- * the daemon saves one after work settles and the browser keeper saves only
- * when asked, and nothing in this app fetches that. It surfaces here as a
- * PROP, and a prop with a default surfaces as nothing: the mount that
- * forgets it claims the daemon's shape in silence.
+ * What the scan cannot see: a difference living entirely in the daemon's own
+ * server code reaches no apps/web module at all. A second block here used to
+ * cover one such case — automatic checkpoints, which surfaced as a
+ * `VersionTimelineCapabilities` prop whose default silently claimed the
+ * daemon's shape — and it is gone because the difference is: the browser
+ * keeper checkpoints too, the prop was deleted with the pair, and a guard
+ * whose subject no longer exists is a guard that cannot fail. A difference
+ * of that shape again needs a new guard written against whatever carries it,
+ * not this one revived.
  */
 
 import { describe, expect, it } from 'vitest'
-import {
-  BROWSER_HISTORY_CAPABILITIES,
-  DAEMON_HISTORY_CAPABILITIES,
-} from '../components/VersionTimeline.js'
 import { assertScannedLedger } from '../test-utils/coverage-ledger.js'
 
 type KeeperReach =
@@ -255,63 +253,5 @@ describe('each answer is checked, so none of them can be a word in front of an o
   it.each(daemonItself)('%s says why there is nothing to mirror', (_path, entry) => {
     if (entry.reach !== 'daemon-itself') return
     expect(entry.why.split(/\s+/).length).toBeGreaterThan(8)
-  })
-})
-
-describe('a panel whose behaviour differs by keeper is told which keeper it is', () => {
-  const mounts = Object.entries(sources)
-    .filter(([path]) => !path.includes('.test.'))
-    .flatMap(([path, text]) =>
-      // The props group is OPTIONAL. Requiring whitespace after the name
-      // skipped `<VersionTimeline/>` — a mount with no props at all, which
-      // is precisely the mount this guard exists to catch, since it is the
-      // one that takes the daemon's shape by default with nothing on the
-      // line to say so.
-      [...text.matchAll(/<(VersionPanel|VersionTimeline)(\s[^>]*?)?\/?>/g)].map((m) => ({
-        path: path.replace(/^\//, ''),
-        component: m[1] as string,
-        props: m[2] ?? '',
-      })),
-    )
-
-  it('finds every production mount of the history panel', () => {
-    // The shared DocumentPage decides once (both keepers render through
-    // it), and VersionPanel forwards to VersionTimeline. A regex that
-    // stopped matching would report zero mounts and pass every case below
-    // vacuously.
-    expect(mounts.length).toBeGreaterThanOrEqual(2)
-  })
-
-  it.each(
-    mounts.map((m) => [`${m.path} -> ${m.component}`, m] as const),
-  )('%s states its keeper', (_label, mount) => {
-    // `VersionTimelineCapabilities` defaults to the daemon's shape so that
-    // a test mount reads as one line. That default is exactly what makes a
-    // production mount able to claim automatic checkpoints and branches it
-    // does not have, without a word of code saying so — which is how a
-    // keeper difference goes back to being invisible.
-    expect(
-      /\bcapabilities=/.test(mount.props),
-      `${mount.path} mounts ${mount.component} without capabilities, so it silently takes the daemon's shape — pass DAEMON_HISTORY_CAPABILITIES or BROWSER_HISTORY_CAPABILITIES, or forward the prop it was given`,
-    ).toBe(true)
-  })
-
-  it('draws lanes and expects checkpoints for BOTH keepers now', () => {
-    // This pinned the two apart, as a decision held "until that increment
-    // lands". It has landed: the browser's rows carry `auto` and the
-    // variation they were taken on, and a checkpoint arrives once editing
-    // settles — so one lane and a hand-only history would now be wrong about
-    // this keeper rather than correct.
-    //
-    // Which makes the pair EQUAL, and a pair that agrees declares no
-    // difference — the argument that retired the provider's capability map.
-    // It is not deleted here only because `false` still selects real
-    // rendering paths in the component (`version-row.test.tsx` drives them),
-    // so the deletion is theirs to carry, not this increment's. Until then
-    // this pins the agreement rather than a difference, so nothing can drift
-    // back to claiming one.
-    expect(BROWSER_HISTORY_CAPABILITIES).toEqual(DAEMON_HISTORY_CAPABILITIES)
-    expect(BROWSER_HISTORY_CAPABILITIES.branches).toBe(true)
-    expect(BROWSER_HISTORY_CAPABILITIES.autoVersions).toBe(true)
   })
 })

--- a/apps/web/src/lib/provider.ts
+++ b/apps/web/src/lib/provider.ts
@@ -37,11 +37,16 @@ function toInvalidConfigState(err: unknown): Extract<ProviderState, { kind: 'inv
  *
  * What replaced it is better than a flag, and this is the part worth
  * carrying forward: where the keepers still differ, the difference is a fact
- * about a DOCUMENT or a PANEL rather than about a keeper —
- * `BranchesBackend`'s `hasBranches` (a markdown body has no record-holding
- * backend, so no variations) and `VersionTimelineCapabilities` (the browser's
- * version rows carry no branch to lane by). Each is answered where it is
- * known, by something that cannot forget to mention it.
+ * about a DOCUMENT rather than about a keeper — `BranchesBackend`'s
+ * `hasBranches` (a markdown body has no record-holding backend, so no
+ * variations), answered where it is known by something that cannot forget to
+ * mention it.
+ *
+ * `VersionTimelineCapabilities` stood beside it here as the second example,
+ * and it is gone: the browser keeper's rows grew the variation they were
+ * taken on and its checkpoints landed, so the pair said `{true, true}` on
+ * both sides and declared nothing. The relocation is the durable idea; that
+ * one instance of it expired.
  */
 export type ProviderState =
   | { readonly kind: 'browser' }

--- a/apps/web/src/pages/BrowserDocumentPage.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.tsx
@@ -21,7 +21,6 @@ import {
   AlertDialogTitle,
 } from '../components/ui/alert-dialog.js'
 import { DropdownMenuItem } from '../components/ui/dropdown-menu.js'
-import { BROWSER_HISTORY_CAPABILITIES } from '../components/VersionTimeline'
 import { BranchesBackendContext } from '../contexts/BranchesBackendContext.js'
 import { VersionsBackendContext } from '../contexts/VersionsBackendContext.js'
 import type { CommentsRailWrite } from '../hooks/use-comments-rail.js'
@@ -887,7 +886,6 @@ function useBrowserDocument(
       enabled: versionsEnabled,
       workspaceId,
       path: loadedPath,
-      historyCapabilities: BROWSER_HISTORY_CAPABILITIES,
       backend: versionsBackend,
       save: async (label) => {
         if (versionsBackend === null) {

--- a/apps/web/src/pages/DaemonDocumentPage.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.tsx
@@ -14,7 +14,6 @@ import type { ConnectionsBacklink } from '../components/connections/ConnectionsP
 import { DocumentPageSkeleton } from '../components/DocumentPageSkeleton.js'
 import { LoadDegradedView } from '../components/document-editor/LoadDegradedView.js'
 import { Button } from '../components/ui/button.js'
-import { DAEMON_HISTORY_CAPABILITIES } from '../components/VersionTimeline'
 import { BranchesBackendContext } from '../contexts/BranchesBackendContext.js'
 import { DaemonApiContext } from '../contexts/DaemonApiContext.js'
 import { useVersionsBackend } from '../contexts/VersionsBackendContext.js'
@@ -660,7 +659,6 @@ function useDaemonDocument(
       enabled: canvas !== null,
       workspaceId: canvas?.workspaceId ?? '',
       path: canvas?.path ?? '',
-      historyCapabilities: DAEMON_HISTORY_CAPABILITIES,
       backend: versionsBackend,
       save: async (label) => {
         if (canvas === null) throw new Error('saveVersion: no canvas')

--- a/apps/web/src/pages/DocumentPage.tsx
+++ b/apps/web/src/pages/DocumentPage.tsx
@@ -362,7 +362,6 @@ function DocumentPageBody({
           <VersionPanel
             workspaceId={versions.workspaceId}
             path={versions.path}
-            capabilities={versions.historyCapabilities}
             onRestored={sync.clearLocalUndo}
             onPreview={setPreview}
             refreshSignal={versionRefreshSignal}

--- a/apps/web/src/pages/document-page-model.ts
+++ b/apps/web/src/pages/document-page-model.ts
@@ -14,11 +14,10 @@
  * a named position rather than by a keeper branch inside it.
  */
 import type { DocumentKind, SpatialCanvas, StoredCoreFacets } from '@kamiazya/whiteboard-model'
-import type { ComponentProps, ReactNode, RefObject } from 'react'
+import type { ReactNode, RefObject } from 'react'
 import type { ConnectionsPanelProps } from '../components/connections/ConnectionsPanel.js'
 import type { MarkdownDocumentSession } from '../components/document-editor/DocumentEditorSurface.js'
 import type { SpatialEditorPaneProps } from '../components/document-editor/SpatialEditorPane.js'
-import type { VersionPanel } from '../components/workspace-top-bar/VersionPanel.js'
 import type { CommentsRailWrite } from '../hooks/use-comments-rail.js'
 import type { UseDocumentFileSeamsOptions } from '../hooks/use-document-file-seams.js'
 import type { ReferenceLoader } from '../hooks/use-reference-seams.js'
@@ -101,7 +100,6 @@ export interface DocumentPageModel {
     readonly enabled: boolean
     readonly workspaceId: string
     readonly path: string
-    readonly historyCapabilities: ComponentProps<typeof VersionPanel>['capabilities']
     /** Where a bookmark's picture goes; null when this keeper has no history for the document. */
     readonly backend: Pick<VersionsBackend, 'putThumbnail'> | null
     readonly save: (


### PR DESCRIPTION
## Summary

- **`VersionTimelineCapabilities` had one shape per keeper, and they had become identical.** `{branches, autoVersions}` said `{true, true}` on both sides once the browser keeper's rows grew the variation they were taken on and its checkpoints started landing. A pair that agrees declares no difference — the argument that retired the provider's capability map one layer up (ADR-0004's 2026-09-05 addendum).
- `keeper-parity.test.ts` pinned that agreement and said the deletion was a separate increment, because `false` still selected real rendering paths. This is that increment. **−175/+64 across 9 files**, no user-visible change.

## What the `false` side actually held up, measured before deleting it

**One assertion**: the second direction of the lane test. Removing the `capabilities` prop from `version-row.test.tsx`'s five mounts and running the file gave

```
× draws the lane column only for a keeper that HAS branches
AssertionError: expected SVGSVGElement{ …(2), …(2) } to be null
Tests  1 failed | 4 passed (5)
```

The other four cases passed `branches: false` and never looked at a lane — they were rendering a configuration no keeper ships, for nothing. That is worth stating because "the tests drive the false paths" was the whole reason the pair was kept alive, and it was true of one case out of five.

## What changes in the component

- **The empty state says the checkpoint sentence unconditionally.** The `false` copy (`Save one with the button above…`) was dead. Two existing tests already pin the surviving copy (`VersionTimeline.test.ts`, `BrowserDocumentPage.versions.browser.test.tsx`).
- **The lane draws on every row.** The gate read `capabilities.branches || <lineage disjuncts>`; with the flag always true, both halves were already dead, and both keepers passed `true` — so nothing a person sees moves.

## What goes with the prop

The whole passthrough, which is the part a grep for the type name does not show: `VersionPanel`'s prop, the page model's `historyCapabilities`, `DocumentPage`'s forward, and the constant each keeper page imported to fill it.

`keeper-parity.test.ts` also loses the block that required every production mount of the history panel to name its keeper. **Its subject is the prop**, and a guard whose subject does not exist cannot fail — it would sit there reading like a check. Its docblock now says a difference of that shape again needs a guard written against whatever carries it, rather than this one revived.

## The test that survives, and how

`draws the lane column only for a keeper that HAS branches` asserted both directions, and the second is now unreachable by any configuration. It becomes **one lane per row** — a count, which cannot pass vacuously the way a `queryBy…` returning `null` can, and which is what `mini-graph` computes a dot, a colour and connectors *for*.

Mutation-checked two ways, both red: renaming the `version-lane` testid, and re-gating the lane so it draws for fewer rows (`expected +0 to be 3`).

## What is deliberately NOT answered

The gate's ORIGINAL purpose was that "a keeper with one branch drew a straight line down the left of every row and spent the width saying nothing". That is still true of a document nobody has branched — but it is a question about the **document** (how many lanes does it have?), not about the keeper, and the flag was only ever answering "is this the daemon?". Said in place at the lane, not silently changed while deleting a flag.

## Test plan

- [x] New or updated tests — this increment REMOVES behaviour, so what it adds is the rewritten lane assertion above (mutation-checked twice) and the two guards' updated reasons. The lane test's second direction is deleted because the behaviour it asserted is deleted.
- [x] `pnpm test` passes locally — **web-jsdom 375 files / 3919 tests**, **web-node 15 / 91**, **arch-lint-node + mcp-node 384 / 4211** (9 skipped), **`pnpm test:browser` standalone 228 / 1201** (no `Re-optimizing` in the run log), all green. Re-run after merging current main: the touched area (`components` + `pages` + `keeper-parity`) is **199 files / 1737 tests** green. `pnpm -r typecheck` clean, `pnpm lint` clean (the 3 warnings are main's `docker-contract.test.ts`), `pnpm knip` clean.
- [x] Manual verification — not applicable in the usual sense: both call sites were already taking the `true` branch in every shipped configuration, which is the claim the diff rests on and which the mutation checks verify mechanically. Nothing on screen differs.
- [ ] E2E coverage added or extended where applicable — not applicable; no routing, websocket, persistence or daemon dependency changes.

## Visual evidence

`Visual evidence: none — nothing a person sees changes.` Both keepers passed `{branches: true, autoVersions: true}`, so both use sites were already rendering the branch this diff makes unconditional. Two identical panels would be exactly what `compose-figure.mjs` refuses, and rightly.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — no user-visible change; `provider.ts`'s docblock is corrected, since it named this pair as a live example of a keeper difference and that stopped being true in 段5
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema — this diff deletes an interface and adds none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BShH3sARZ7hbayQKoijwfh)_