### PR TITLE
ci(mcp-server): report what the docker cache did, instead of discarding the evidence

### DIFF
--- a/packages/mcp-server/scripts/release/buildx-progress.mjs
+++ b/packages/mcp-server/scripts/release/buildx-progress.mjs
@@ -24,7 +24,7 @@
  *   cachedCount: number,
  *   ranCount: number,
  *   cacheHitRatio: number | null,
- *   ranSeconds: number,
+ *   executedStepSeconds: number,
  *   slowest: BuildStep[],
  * }} CacheReport
  */
@@ -100,7 +100,7 @@ export function parseBuildxProgress(output) {
       cachedCount: 0,
       ranCount: 0,
       cacheHitRatio: null,
-      ranSeconds: 0,
+      executedStepSeconds: 0,
       slowest: [],
     }
   }
@@ -110,7 +110,7 @@ export function parseBuildxProgress(output) {
   // Seconds are summed over EVERYTHING that ran, layer or not, so the number
   // still accounts for the build's wall clock rather than only part of it.
   const ran = resolved.filter((s) => !s.cached)
-  const ranSeconds = ran.reduce((sum, s) => sum + (s.seconds ?? 0), 0)
+  const executedStepSeconds = ran.reduce((sum, s) => sum + (s.seconds ?? 0), 0)
   return {
     parsed: true,
     steps: resolved,
@@ -119,13 +119,25 @@ export function parseBuildxProgress(output) {
     cachedCount,
     ranCount: ran.length,
     cacheHitRatio: layers.length === 0 ? null : Number((cachedCount / layers.length).toFixed(3)),
-    ranSeconds: Number(ranSeconds.toFixed(1)),
+    executedStepSeconds: Number(executedStepSeconds.toFixed(1)),
     slowest: [...ran].sort((a, b) => (b.seconds ?? 0) - (a.seconds ?? 0)).slice(0, 5),
   }
 }
 
-/** The report as lines a reader can scan in a CI log. */
-export function formatCacheReport(report) {
+/**
+ * The report as lines a reader can scan in a CI log.
+ *
+ * `elapsedSeconds` is passed in because the parser cannot know it: BuildKit
+ * runs steps in PARALLEL, so summing their durations is the total WORK, not
+ * the time anyone waited. Measured on this job's first real report, the two
+ * differ by more than rounding — 214.4s of step time inside a 200s step — so
+ * publishing the sum under a name that reads like elapsed time would overstate
+ * the build every run, in the one number the whole report exists to trend.
+ *
+ * @param {CacheReport} report
+ * @param {{ elapsedSeconds?: number }} [timing]
+ */
+export function formatCacheReport(report, timing = {}) {
   if (!report.parsed) {
     return [
       '[publish-dry-run:docker] cache report UNAVAILABLE: no buildx step lines were parsed.',
@@ -137,9 +149,14 @@ export function formatCacheReport(report) {
     report.cacheHitRatio === null
       ? 'no Dockerfile layer seen'
       : `${report.cachedCount}/${report.layerCount} layers CACHED (${Math.round(report.cacheHitRatio * 100)}%)`
+  const elapsed =
+    typeof timing.elapsedSeconds === 'number'
+      ? `${timing.elapsedSeconds.toFixed(1)}s elapsed, `
+      : ''
   const lines = [
     `[publish-dry-run:docker] cache report: ${ratio}; ` +
-      `${report.ranCount} of ${report.stepCount} steps ran, ${report.ranSeconds}s total`,
+      `${report.ranCount} of ${report.stepCount} steps ran, ` +
+      `${elapsed}${report.executedStepSeconds}s of step time`,
   ]
   for (const step of report.slowest) {
     lines.push(`  ${String(step.seconds ?? 0).padStart(7)}s  ${step.name}`)

--- a/packages/mcp-server/scripts/release/buildx-progress.mjs
+++ b/packages/mcp-server/scripts/release/buildx-progress.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+
+// Turn `docker buildx --progress=plain` output into a CACHE REPORT.
+//
+// The image build is the longest step in ci.yml's dry-run-docker job — 198s of
+// a 270s job, measured — and it runs with `--cache-from/--cache-to type=gha`.
+// Whether that cache is doing anything was, until this module, unanswerable:
+// publish-dry-run-docker.mjs captures buildx's output and prints it only when
+// the build FAILS, so every green run threw the evidence away. 198s might be a
+// warm cache doing its best or a cold one hitting nothing, and no number
+// anywhere told them apart.
+//
+// A report rather than a raw dump, for two reasons: the script's contract is
+// that full build logs never reach stdout, and what a reader actually needs is
+// a number that can be compared with last week's — not a wall of text.
+
+/**
+ * @typedef {{ id: string, name: string, cached: boolean, seconds: number | null, layer: boolean }} BuildStep
+ * @typedef {{
+ *   parsed: boolean,
+ *   steps: BuildStep[],
+ *   stepCount: number,
+ *   layerCount: number,
+ *   cachedCount: number,
+ *   ranCount: number,
+ *   cacheHitRatio: number | null,
+ *   ranSeconds: number,
+ *   slowest: BuildStep[],
+ * }} CacheReport
+ */
+
+/**
+ * Is this step a Dockerfile LAYER, as opposed to build overhead?
+ *
+ * The cache ratio is over layers alone. `[internal] load build definition`,
+ * `exporting cache to GitHub Actions Cache` and friends are never CACHED and
+ * always present, so counting them would depress the ratio by a fixed amount
+ * and make two runs incomparable — the one thing a trended number must not do.
+ * A layer's name carries its position in its stage, `[server 4/9]`; the
+ * internal steps carry no `n/m`.
+ *
+ * @param {string} name
+ */
+function isLayer(name) {
+  return /^\[[^\]]*\b\d+\/\d+\]/.test(name)
+}
+
+/**
+ * `--progress=plain` writes one `#<id>` prefixed line per event:
+ *
+ *   #12 [server 4/9] RUN pnpm install --frozen-lockfile
+ *   #12 CACHED
+ *   #13 [server 5/9] RUN pnpm --filter ... build
+ *   #13 DONE 45.3s
+ *
+ * A step is named by its first `[stage n/m] …` line and resolved by a later
+ * `CACHED` or `DONE <n>s`. Steps with neither (still running when the build
+ * died) are dropped, since a report is about what finished.
+ *
+ * @param {string} output buildx stderr
+ * @returns {CacheReport}
+ */
+export function parseBuildxProgress(output) {
+  /** @type {Map<string, {name: string, cached: boolean, seconds: number | null}>} */
+  const steps = new Map()
+  for (const raw of String(output ?? '').split('\n')) {
+    // GitHub prefixes each log line with a timestamp; strip it before matching.
+    const line = raw.replace(/^\S+Z\s/, '').trim()
+    const idMatch = line.match(/^#(\d+)\s+(.*)$/)
+    if (!idMatch) continue
+    const [, id, rest] = idMatch
+    const entry = steps.get(id) ?? { name: '', cached: false, seconds: null }
+    const named = rest.match(/^(\[[^\]]*\].*)$/)
+    if (named && entry.name === '') entry.name = named[1]
+    if (/^CACHED\b/.test(rest)) entry.cached = true
+    const done = rest.match(/^DONE\s+([\d.]+)s/)
+    if (done) entry.seconds = Number(done[1])
+    steps.set(id, entry)
+  }
+
+  const resolved = [...steps.entries()]
+    .filter(([, s]) => s.cached || s.seconds !== null)
+    .map(([id, s]) => ({
+      id,
+      name: s.name || `#${id}`,
+      cached: s.cached,
+      seconds: s.seconds,
+      layer: isLayer(s.name),
+    }))
+
+  // Not "0% cached": a parser that stopped matching would otherwise report a
+  // confident zero, which reads exactly like a cache that is failing. The
+  // caller says so instead of publishing a number it did not measure.
+  if (resolved.length === 0) {
+    return {
+      parsed: false,
+      steps: [],
+      stepCount: 0,
+      layerCount: 0,
+      cachedCount: 0,
+      ranCount: 0,
+      cacheHitRatio: null,
+      ranSeconds: 0,
+      slowest: [],
+    }
+  }
+
+  const layers = resolved.filter((s) => s.layer)
+  const cachedCount = layers.filter((s) => s.cached).length
+  // Seconds are summed over EVERYTHING that ran, layer or not, so the number
+  // still accounts for the build's wall clock rather than only part of it.
+  const ran = resolved.filter((s) => !s.cached)
+  const ranSeconds = ran.reduce((sum, s) => sum + (s.seconds ?? 0), 0)
+  return {
+    parsed: true,
+    steps: resolved,
+    stepCount: resolved.length,
+    layerCount: layers.length,
+    cachedCount,
+    ranCount: ran.length,
+    cacheHitRatio: layers.length === 0 ? null : Number((cachedCount / layers.length).toFixed(3)),
+    ranSeconds: Number(ranSeconds.toFixed(1)),
+    slowest: [...ran].sort((a, b) => (b.seconds ?? 0) - (a.seconds ?? 0)).slice(0, 5),
+  }
+}
+
+/** The report as lines a reader can scan in a CI log. */
+export function formatCacheReport(report) {
+  if (!report.parsed) {
+    return [
+      '[publish-dry-run:docker] cache report UNAVAILABLE: no buildx step lines were parsed.',
+      '  The build ran, but its progress output did not match the `#<id> [stage] …` shape',
+      '  this report reads. Re-run with WHITEBOARD_DOCKER_BUILD_LOG=1 to see the raw output.',
+    ]
+  }
+  const ratio =
+    report.cacheHitRatio === null
+      ? 'no Dockerfile layer seen'
+      : `${report.cachedCount}/${report.layerCount} layers CACHED (${Math.round(report.cacheHitRatio * 100)}%)`
+  const lines = [
+    `[publish-dry-run:docker] cache report: ${ratio}; ` +
+      `${report.ranCount} of ${report.stepCount} steps ran, ${report.ranSeconds}s total`,
+  ]
+  for (const step of report.slowest) {
+    lines.push(`  ${String(step.seconds ?? 0).padStart(7)}s  ${step.name}`)
+  }
+  return lines
+}

--- a/packages/mcp-server/scripts/release/buildx-progress.test.ts
+++ b/packages/mcp-server/scripts/release/buildx-progress.test.ts
@@ -29,7 +29,7 @@ interface CacheReport {
   cachedCount: number
   ranCount: number
   cacheHitRatio: number | null
-  ranSeconds: number
+  executedStepSeconds: number
   slowest: BuildStep[]
 }
 
@@ -37,7 +37,7 @@ const { parseBuildxProgress, formatCacheReport } = (await import(
   join(__dirname, 'buildx-progress.mjs')
 )) as {
   parseBuildxProgress: (output: unknown) => CacheReport
-  formatCacheReport: (report: CacheReport) => string[]
+  formatCacheReport: (report: CacheReport, timing?: { elapsedSeconds?: number }) => string[]
 }
 
 // The shape `docker buildx build --progress=plain` writes to stderr. Both
@@ -98,9 +98,29 @@ describe('the buildx cache report', () => {
 
   it('sums the seconds of everything that ran, overhead included', () => {
     // A cached step has no duration to add. Overhead does, and it is counted:
-    // the number has to account for the build's wall clock, not just its
-    // layers, or the report cannot explain where 198s went.
-    expect(parseBuildxProgress(PLAIN_OUTPUT).ranSeconds).toBeCloseTo(150.1, 1)
+    // the number has to account for where the build's time went, not just its
+    // layers.
+    expect(parseBuildxProgress(PLAIN_OUTPUT).executedStepSeconds).toBeCloseTo(150.1, 1)
+  })
+
+  it('calls the sum step TIME, never elapsed time', () => {
+    // BuildKit runs steps in parallel, so the sum is total WORK and can exceed
+    // the time anyone waited. Measured on this job's first real report: 214.4s
+    // of step time inside a 200s build. Publishing the sum under a name that
+    // reads like elapsed would overstate every run, in the one number the
+    // report exists to trend — so elapsed is passed in, from a clock the
+    // parser cannot see.
+    const report = parseBuildxProgress(PLAIN_OUTPUT)
+    expect(report).not.toHaveProperty('elapsedSeconds')
+    const withElapsed = formatCacheReport(report, { elapsedSeconds: 121.5 }).join(' ')
+    expect(withElapsed).toContain('121.5s elapsed')
+    expect(withElapsed).toContain('150.1s of step time')
+  })
+
+  it('says only what it measured when no clock was passed', () => {
+    const line = formatCacheReport(parseBuildxProgress(PLAIN_OUTPUT)).join(' ')
+    expect(line).not.toContain('elapsed')
+    expect(line).toContain('150.1s of step time')
   })
 
   it('names the slowest steps, worst first', () => {
@@ -143,6 +163,6 @@ describe('the buildx cache report', () => {
   it('says how many steps it saw when it did read the output', () => {
     const lines = formatCacheReport(parseBuildxProgress(PLAIN_OUTPUT)).join(' ')
     expect(lines).toContain('2/4 layers CACHED (50%)')
-    expect(lines).toContain('4 of 6 steps ran, 150.1s total')
+    expect(lines).toContain('4 of 6 steps ran, 150.1s of step time')
   })
 })

--- a/packages/mcp-server/scripts/release/buildx-progress.test.ts
+++ b/packages/mcp-server/scripts/release/buildx-progress.test.ts
@@ -1,0 +1,148 @@
+// The report this parser produces is the only evidence anyone has about the
+// docker cache: publish-dry-run-docker.mjs prints buildx's own output solely on
+// failure, so before this existed a green run said nothing about whether the
+// 198s build hit the cache at all.
+//
+// That makes ONE case load-bearing above the rest: output the parser cannot
+// read must report itself unreadable, never "0% cached". A confident zero is
+// indistinguishable from a cache that is genuinely failing, and it would send
+// a reader to rebuild the cache configuration that was fine.
+
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+interface BuildStep {
+  id: string
+  name: string
+  cached: boolean
+  seconds: number | null
+  layer: boolean
+}
+interface CacheReport {
+  parsed: boolean
+  steps: BuildStep[]
+  stepCount: number
+  layerCount: number
+  cachedCount: number
+  ranCount: number
+  cacheHitRatio: number | null
+  ranSeconds: number
+  slowest: BuildStep[]
+}
+
+const { parseBuildxProgress, formatCacheReport } = (await import(
+  join(__dirname, 'buildx-progress.mjs')
+)) as {
+  parseBuildxProgress: (output: unknown) => CacheReport
+  formatCacheReport: (report: CacheReport) => string[]
+}
+
+// The shape `docker buildx build --progress=plain` writes to stderr. Both
+// build paths in publish-dry-run-docker.mjs already pass that flag.
+//
+// SYNTHETIC, and deliberately recorded as such: no run in this repo's history
+// has a real sample to pin, because the script only ever printed buildx output
+// when the build failed and no build has failed since the job joined CI.
+// Replace it with a captured run the first time the report says UNAVAILABLE —
+// which is the whole reason that branch reports rather than returning zero.
+const PLAIN_OUTPUT = `#1 [internal] load build definition from Dockerfile.server
+#1 transferring dockerfile: 2.31kB done
+#1 DONE 0.0s
+#5 [base 1/4] FROM docker.io/library/node:24-slim@sha256:abc
+#5 CACHED
+#8 [base 2/4] RUN corepack enable
+#8 CACHED
+#12 [server 4/9] RUN pnpm install --frozen-lockfile
+#12 DONE 45.3s
+#13 [server 5/9] RUN pnpm --filter @kamiazya/whiteboard-mcp build:server
+#13 DONE 92.7s
+#20 exporting cache to GitHub Actions Cache
+#20 DONE 12.1s
+`
+
+describe('the buildx cache report', () => {
+  it('counts cached and ran steps', () => {
+    const report = parseBuildxProgress(PLAIN_OUTPUT)
+    expect(report.parsed).toBe(true)
+    expect(report.stepCount).toBe(6)
+    expect(report.ranCount).toBe(4)
+  })
+
+  it('takes the cache ratio over Dockerfile layers, not build overhead', () => {
+    // `[internal] load build definition` and `exporting cache to …` are never
+    // CACHED and always present, so counting them would depress the ratio by a
+    // fixed amount and make two runs incomparable — which is the one thing a
+    // trended number must not do. Six resolved steps here, four of them layers.
+    const report = parseBuildxProgress(PLAIN_OUTPUT)
+    expect(report.layerCount).toBe(4)
+    expect(report.cachedCount).toBe(2)
+    expect(report.cacheHitRatio).toBe(0.5)
+    expect(report.steps.filter((s) => !s.layer).map((s) => s.name)).toEqual([
+      '[internal] load build definition from Dockerfile.server',
+      '#20',
+    ])
+  })
+
+  it('has no ratio to report when it saw no layer at all', () => {
+    // Overhead-only output is not a 0% cache; it is a build whose layers were
+    // never described.
+    const report = parseBuildxProgress('#20 exporting cache\n#20 DONE 1.0s\n')
+    expect(report.parsed).toBe(true)
+    expect(report.layerCount).toBe(0)
+    expect(report.cacheHitRatio).toBeNull()
+    expect(formatCacheReport(report)[0]).toContain('no Dockerfile layer seen')
+  })
+
+  it('sums the seconds of everything that ran, overhead included', () => {
+    // A cached step has no duration to add. Overhead does, and it is counted:
+    // the number has to account for the build's wall clock, not just its
+    // layers, or the report cannot explain where 198s went.
+    expect(parseBuildxProgress(PLAIN_OUTPUT).ranSeconds).toBeCloseTo(150.1, 1)
+  })
+
+  it('names the slowest steps, worst first', () => {
+    const slowest = parseBuildxProgress(PLAIN_OUTPUT).slowest
+    expect(slowest[0]?.name).toContain('build:server')
+    expect(slowest[1]?.name).toContain('pnpm install')
+    expect(slowest.map((s) => s.seconds)).toEqual(
+      [...slowest.map((s) => s.seconds)].sort((a, b) => (b ?? 0) - (a ?? 0)),
+    )
+  })
+
+  it('reads a step whose name and result arrive on separate lines', () => {
+    // The format never puts them together, so a parser that only looked at one
+    // line would find every step nameless.
+    const step = parseBuildxProgress(PLAIN_OUTPUT).steps.find((s) => s.id === '12')
+    expect(step?.name).toContain('[server 4/9]')
+    expect(step?.seconds).toBe(45.3)
+  })
+
+  it('strips the timestamp a downloaded CI log carries', () => {
+    // Pinning a real sample means downloading it from the Actions API, which
+    // prefixes every line. A parser that choked on that could never be given
+    // the real output it exists to read.
+    const stamped = PLAIN_OUTPUT.split('\n')
+      .map((l) => (l ? `2026-09-06T07:00:00.1234567Z ${l}` : l))
+      .join('\n')
+    expect(parseBuildxProgress(stamped).stepCount).toBe(6)
+  })
+
+  it('reports itself unreadable rather than claiming 0% cached', () => {
+    for (const input of ['', 'Successfully built abc123', null, undefined, 42]) {
+      const report = parseBuildxProgress(input)
+      expect(report.parsed, `input ${JSON.stringify(input)}`).toBe(false)
+      // Not zero: a ratio of 0 is a measurement, and none was taken.
+      expect(report.cacheHitRatio).toBeNull()
+      expect(formatCacheReport(report).join(' ')).toContain('UNAVAILABLE')
+    }
+  })
+
+  it('says how many steps it saw when it did read the output', () => {
+    const lines = formatCacheReport(parseBuildxProgress(PLAIN_OUTPUT)).join(' ')
+    expect(lines).toContain('2/4 layers CACHED (50%)')
+    expect(lines).toContain('4 of 6 steps ran, 150.1s total')
+  })
+})

--- a/packages/mcp-server/scripts/release/publish-dry-run-docker.mjs
+++ b/packages/mcp-server/scripts/release/publish-dry-run-docker.mjs
@@ -5,11 +5,19 @@
 // No cosign, no OIDC material, no registry credentials used.
 // Output: structured JSON summary to stdout on success; generic message to
 // stderr and exit 1 on failure. Full build logs never reach stdout.
+//
+// A CACHE REPORT does reach stderr, and its counts reach stdout. The build is
+// the longest step in ci.yml's dry-run-docker job — 198s of a 270s job,
+// measured — and runs with `--cache-from/--cache-to type=gha`. Whether that
+// cache was doing anything used to be unanswerable, because the output below
+// was captured and then printed only on FAILURE: every green run threw the
+// evidence away, so a warm cache and a cold one looked identical from outside.
 
 import { spawnSync } from 'node:child_process'
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { formatCacheReport, parseBuildxProgress } from './buildx-progress.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const PACKAGE_ROOT = resolve(__dirname, '../..')
@@ -88,6 +96,19 @@ if (buildResult.status !== 0 || buildResult.error) {
   fail('docker build')
 }
 
+// The build succeeded, so report what the cache did. `--progress=plain` is
+// already on both build paths above; buildx writes it to stderr.
+const cacheReport = parseBuildxProgress(buildResult.stderr ?? '')
+for (const line of formatCacheReport(cacheReport)) {
+  process.stderr.write(`${line}\n`)
+}
+// The raw output stays available for the case the report cannot explain, but
+// behind a flag: it is long, and the point of the report is to make reading it
+// unnecessary.
+if (process.env.WHITEBOARD_DOCKER_BUILD_LOG === '1' && buildResult.stderr) {
+  process.stderr.write(buildResult.stderr)
+}
+
 // Step 2: capture locally-built image ID (sha256 digest of the image config).
 // RepoDigests are only populated after a registry push; use .Id for local builds.
 const inspectResult = spawnSync('docker', ['image', 'inspect', IMAGE_TAG, '--format', '{{.Id}}'], {
@@ -112,6 +133,10 @@ const metadata = {
   sbomStatus: 'deferred',
   signingStatus: 'deferred',
   note: 'No registry push. SBOM (docker buildx --sbom=true) and cosign keyless signing deferred to publish-workflow slice.',
+  // Full report, step names included: this file is an artifact of the same run
+  // whose log already names them, and trending the slowest steps across runs is
+  // what turns "the build is slow" into a specific layer.
+  cache: cacheReport,
 }
 writeFileSync(join(OUT_DIR, 'docker-image-metadata.json'), JSON.stringify(metadata, null, 2))
 
@@ -125,6 +150,16 @@ process.stdout.write(
       artifactId: 'docker-image',
       imageTag: IMAGE_TAG,
       imageIdLength: imageId.length,
+      // Counts only. Step names stay out of stdout, which this script promises
+      // carries no build log.
+      cache: {
+        parsed: cacheReport.parsed,
+        stepCount: cacheReport.stepCount,
+        cachedCount: cacheReport.cachedCount,
+        ranCount: cacheReport.ranCount,
+        cacheHitRatio: cacheReport.cacheHitRatio,
+        ranSeconds: cacheReport.ranSeconds,
+      },
       sbomStatus: 'deferred',
       signingStatus: 'deferred',
       note: 'no registry push; no cosign signing; publish-workflow slice required',

--- a/packages/mcp-server/scripts/release/publish-dry-run-docker.mjs
+++ b/packages/mcp-server/scripts/release/publish-dry-run-docker.mjs
@@ -83,6 +83,7 @@ const buildArgs = isGitHubActions
       '.',
     ]
 
+const buildStartedAt = Date.now()
 const buildResult = spawnSync('docker', buildArgs, {
   cwd: REPO_ROOT,
   encoding: 'utf-8',
@@ -98,8 +99,12 @@ if (buildResult.status !== 0 || buildResult.error) {
 
 // The build succeeded, so report what the cache did. `--progress=plain` is
 // already on both build paths above; buildx writes it to stderr.
+// Wall clock, kept apart from the summed step time: BuildKit runs steps in
+// parallel, so the sum is the total WORK and this is the wait. Measured on the
+// first real report, 214.4s of step time inside a 200s build.
+const elapsedSeconds = Number(((Date.now() - buildStartedAt) / 1000).toFixed(1))
 const cacheReport = parseBuildxProgress(buildResult.stderr ?? '')
-for (const line of formatCacheReport(cacheReport)) {
+for (const line of formatCacheReport(cacheReport, { elapsedSeconds })) {
   process.stderr.write(`${line}\n`)
 }
 // The raw output stays available for the case the report cannot explain, but
@@ -136,7 +141,7 @@ const metadata = {
   // Full report, step names included: this file is an artifact of the same run
   // whose log already names them, and trending the slowest steps across runs is
   // what turns "the build is slow" into a specific layer.
-  cache: cacheReport,
+  cache: { ...cacheReport, elapsedSeconds },
 }
 writeFileSync(join(OUT_DIR, 'docker-image-metadata.json'), JSON.stringify(metadata, null, 2))
 
@@ -158,7 +163,8 @@ process.stdout.write(
         cachedCount: cacheReport.cachedCount,
         ranCount: cacheReport.ranCount,
         cacheHitRatio: cacheReport.cacheHitRatio,
-        ranSeconds: cacheReport.ranSeconds,
+        executedStepSeconds: cacheReport.executedStepSeconds,
+        elapsedSeconds,
       },
       sbomStatus: 'deferred',
       signingStatus: 'deferred',

--- a/packages/mcp-server/src/server/docker-contract.test.ts
+++ b/packages/mcp-server/src/server/docker-contract.test.ts
@@ -356,6 +356,11 @@ const DOCKERFILE_USES = {
     builds: false,
     reason: 'covers the reuse contract with an injected docker, never a real build',
   },
+  'packages/mcp-server/scripts/release/buildx-progress.test.ts': {
+    builds: false,
+    reason:
+      'its sample of buildx progress output quotes the Dockerfile name, as real output does; the parser under test reads text and never runs a build',
+  },
 } satisfies Record<string, DockerfileUse>
 
 // Directories a build invocation could plausibly live in. Deliberately not the


### PR DESCRIPTION
The instrument, and only the instrument. No attempt to make the build faster yet — there was nothing to judge such an attempt by, which is `measured-change`'s whole point.

**It has already answered.** First real report, from this PR's own CI:

```
[publish-dry-run:docker] cache report: 0/15 layers CACHED (0%); 22 of 22 steps ran,
                                       201.1s elapsed, 217.4s of step time
     33.5s  [build 5/5] RUN pnpm --filter @kamiazya/whiteboard-mcp deploy --legacy /deploy
       23s  [build 4/5] RUN pnpm --filter @kamiazya/whiteboard-mcp build
     21.9s  [fetched 3/3] RUN --mount=type=cache,id=pnpm,target=/pnpm/store  pnpm fetch
```

`--cache-from type=gha` is configured and **not one of the 15 layers hits it**. 201s is recomputed from scratch every run. That is the finding; acting on it is a separate change.

## Why here

`dry-run-docker` is now ci.yml's wall clock. Measured over 30 recent runs:

| job | median finish | median duration |
|---|---|---|
| **dry-run-docker** | **310s** | 270s |
| `test-jsdom` (before sharding) | 302s | 290s |
| `test-jsdom (1)` / `(2)` (after) | 196s / 142s | 192s / 138s |
| `dry-run-npm` | 228s | 44s (179s waiting on `verify`) |

Run wall clock median **313s**, and `dry-run-docker` is the last job on **12 of 20** docker-building PR runs. Sharding `test-jsdom` (#1433) did its job; the ceiling moved.

## The problem this fixes

**198s of that 270s job was one step, and nothing said what happened inside it.**

buildx already ran with `--cache-from` / `--cache-to type=gha,mode=max` **and** `--progress=plain`. But `publish-dry-run-docker.mjs` captured that output and printed it **only when the build failed**:

```js
if (buildResult.status !== 0 || buildResult.error) {
  if (buildResult.stderr) process.stderr.write(buildResult.stderr)
  fail('docker build')
}
```

Every green run threw the evidence away, so a warm cache and a cold one produced identical logs. It turns out to have been cold all along — but before this, that was unknowable.

## What lands

Counts, not a log dump, so the script's stated contract ("full build logs never reach stdout") stays intact: report → **stderr**, counts → **stdout JSON**, full report with step names → the **metadata artifact**, raw buildx output → stderr behind `WHITEBOARD_DOCKER_BUILD_LOG=1`.

## Three decisions worth stating

**The ratio is over Dockerfile LAYERS, not all steps.** `[internal] load build definition` and `exporting cache to GitHub Actions Cache` are never CACHED and always present, so counting them depresses the ratio by a fixed amount and makes two runs incomparable — the one thing a trended number must not do.

**Output it cannot read reports `UNAVAILABLE` with a null ratio, never "0% cached".** That distinction is load-bearing here: the 0% above is a measurement, and the report says so rather than being a parser that quietly matched nothing.

**Elapsed time and summed step time are separate, and named for what they are.** CodeRabbit caught that the sum can exceed the wall clock under BuildKit's parallelism, and this PR's own first report confirmed it — **214.4s of step time inside a 200s build**. Publishing the sum under a name that reads like elapsed would have overstated every build in the one number the report exists to trend. `elapsedSeconds` is measured around the build's `spawnSync`, since the parser reads text and has no clock; cross-checked against GitHub's own step timing on the next run — 201.1s self-measured vs 203s reported.

## Verification

- 11 parser tests, mutation-checked in six directions: removing the unparsed branch, counting overhead as a layer, summing cached steps into the total, dropping the CI-log timestamp strip, leaving the slowest list unsorted, and publishing the sum as elapsed. Each fails at least one case.
- `src/server/` + `scripts/` — 303/304 files, 3346 tests (the one failure is `local-node-version.test.ts`, the guard naming this container's Node 22 against the pin of 24).
- `pnpm lint`, `pnpm -r typecheck` — clean. 24/24 CI checks green.

**The unit-test fixture is synthetic and the test says so** — no run in this repo's history had a real sample to pin, because the script only printed buildx output on failure and no build has failed since the job joined CI. The real CI reports above are the evidence that the format assumption holds.

Two of my own mistakes are recorded in the commits rather than smoothed over: an expectation that miscounted the fixture (the tests caught it, and that is how the layer/overhead split came to be noticed), and a mutation that silently failed to apply and came back "11 passed" — which reads exactly like a guard that caught nothing.

Visual evidence: none — a CI observability change with no user-visible surface. The reports above are the evidence.

## Follow-ups this enables (not in this PR)

- **C, now the priority**: 0/15 layers cached means ~201s is recomputed every run. Cause not yet established — cache scope/key, builder lifetime, and how `--mount=type=cache` interacts with the GHA backend are all candidates, and all guesses. Same method: measure the cache import/export lines before changing anything.
- **B**: the docker gate skips far less than the code comment claims — 3/23 sampled PR runs (13%) vs "21 of the last 40 main commits" (52%), different populations. Cause: `ALWAYS_AFFECTING`'s any-`package.json` rule, and release-please being **18 of the last 50 PR runs (36%)** while changing only the `version` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173KdAbXzLi3Nypu4fyneDv