### PR TITLE
ci(mcp-server): make the docker cache report say why it reads 0%

### DIFF
--- a/packages/mcp-server/scripts/release/buildx-progress.mjs
+++ b/packages/mcp-server/scripts/release/buildx-progress.mjs
@@ -199,7 +199,10 @@ function addDiagnostic(into, line) {
  * the build every run, in the one number the whole report exists to trend.
  *
  * @param {CacheReport} report
- * @param {{ elapsedSeconds?: number }} [timing]
+ * @param {{
+ *   elapsedSeconds?: number,
+ *   cacheCredentials?: { present: string[], absent: string[] },
+ * }} [timing]
  */
 export function formatCacheReport(report, timing = {}) {
   if (!report.parsed) {
@@ -236,5 +239,31 @@ export function formatCacheReport(report, timing = {}) {
   for (const diagnostic of report.diagnostics) {
     lines.push(`  ${diagnostic}`)
   }
+  lines.push(...credentialLines(timing.cacheCredentials))
   return lines
+}
+
+/**
+ * Whether the backend had anything to authenticate WITH.
+ *
+ * A cache that was never configured and a cache that missed every layer both
+ * report 0%, and they want opposite fixes — expose the variables, or go find
+ * what invalidated the layers. Docker's gha backend falls back to these
+ * environment variables, and its own documentation says an inline `docker
+ * buildx` invocation has to expose them by hand.
+ *
+ * NAMES and presence only. ACTIONS_RUNTIME_TOKEN is a credential; a report
+ * that printed its value would be a worse defect than the one it exists to
+ * find.
+ *
+ * @param {{ present: string[], absent: string[] } | undefined} credentials
+ */
+function credentialLines(credentials) {
+  // No reading taken — a local `docker build` has no backend to report on, and
+  // inventing "absent" there would report a problem that does not exist.
+  if (!credentials) return []
+  const { present, absent } = credentials
+  if (absent.length === 0) return [`  cache credentials: all present (${present.join(', ')})`]
+  if (present.length === 0) return [`  cache credentials: none of ${absent.join(', ')} are set`]
+  return [`  cache credentials: ${present.join(', ')} set; ${absent.join(', ')} NOT set`]
 }

--- a/packages/mcp-server/scripts/release/buildx-progress.mjs
+++ b/packages/mcp-server/scripts/release/buildx-progress.mjs
@@ -15,7 +15,14 @@
 // a number that can be compared with last week's — not a wall of text.
 
 /**
- * @typedef {{ id: string, name: string, cached: boolean, seconds: number | null, layer: boolean }} BuildStep
+ * @typedef {{
+ *   id: string,
+ *   name: string,
+ *   cached: boolean,
+ *   error: boolean,
+ *   seconds: number | null,
+ *   layer: boolean,
+ * }} BuildStep
  * @typedef {{
  *   parsed: boolean,
  *   steps: BuildStep[],
@@ -26,8 +33,33 @@
  *   cacheHitRatio: number | null,
  *   executedStepSeconds: number,
  *   slowest: BuildStep[],
+ *   importSeen: boolean,
+ *   exportSeen: boolean,
+ *   diagnostics: string[],
  * }} CacheReport
  */
+
+// A step's own stdout is streamed back prefixed with seconds since the step
+// began — `#13 0.234 Progress: resolved 1 …`. It is the one thing that looks
+// like a name and is not, so it is excluded by shape rather than by guessing.
+const STATUS_LINE = /^(DONE|CACHED|ERROR|WARNING|WARN|CANCELED)\b/
+const STREAMED_OUTPUT = /^\d+(\.\d+)?\s/
+
+/**
+ * Is this the line that NAMES a step?
+ *
+ * It used to be "starts with `[`", which every Dockerfile layer does and no
+ * cache step does — so `exporting cache to GitHub Actions Cache` and
+ * `importing cache manifest from …` were recorded as `#21` and `#22`. Two real
+ * runs then reported 0% cached with 43% of the build sitting inside those two
+ * nameless steps, which is precisely the evidence needed to tell a broken
+ * cache backend from a cold one.
+ *
+ * @param {string} rest the line with its `#<id> ` prefix removed
+ */
+function isNameLine(rest) {
+  return rest !== '' && !STATUS_LINE.test(rest) && !STREAMED_OUTPUT.test(rest)
+}
 
 /**
  * Is this step a Dockerfile LAYER, as opposed to build overhead?
@@ -61,29 +93,43 @@ function isLayer(name) {
  * @returns {CacheReport}
  */
 export function parseBuildxProgress(output) {
-  /** @type {Map<string, {name: string, cached: boolean, seconds: number | null}>} */
+  /** @type {Map<string, {name: string, cached: boolean, error: boolean, seconds: number | null}>} */
   const steps = new Map()
+  /** @type {string[]} */
+  const diagnostics = []
   for (const raw of String(output ?? '').split('\n')) {
     // GitHub prefixes each log line with a timestamp; strip it before matching.
     const line = raw.replace(/^\S+Z\s/, '').trim()
     const idMatch = line.match(/^#(\d+)\s+(.*)$/)
-    if (!idMatch) continue
+    if (!idMatch) {
+      // buildx writes its own failures with no step to attach them to. They
+      // are the shortest path from "0% cached" to a cause, so they are kept
+      // even though they belong to no step.
+      if (/^(WARNING|ERROR)\b/.test(line)) addDiagnostic(diagnostics, line)
+      continue
+    }
     const [, id, rest] = idMatch
-    const entry = steps.get(id) ?? { name: '', cached: false, seconds: null }
-    const named = rest.match(/^(\[[^\]]*\].*)$/)
-    if (named && entry.name === '') entry.name = named[1]
+    const entry = steps.get(id) ?? { name: '', cached: false, error: false, seconds: null }
+    if (entry.name === '' && isNameLine(rest)) entry.name = rest
     if (/^CACHED\b/.test(rest)) entry.cached = true
+    if (/^ERROR\b/.test(rest)) {
+      entry.error = true
+      addDiagnostic(diagnostics, `#${id} ${rest}`)
+    }
     const done = rest.match(/^DONE\s+([\d.]+)s/)
     if (done) entry.seconds = Number(done[1])
     steps.set(id, entry)
   }
 
+  // A step that ERRORed has no DONE line. Resolving on duration alone dropped
+  // it, which turned the loudest evidence a build can produce into silence.
   const resolved = [...steps.entries()]
-    .filter(([, s]) => s.cached || s.seconds !== null)
+    .filter(([, s]) => s.cached || s.seconds !== null || s.error)
     .map(([id, s]) => ({
       id,
       name: s.name || `#${id}`,
       cached: s.cached,
+      error: s.error,
       seconds: s.seconds,
       layer: isLayer(s.name),
     }))
@@ -102,6 +148,9 @@ export function parseBuildxProgress(output) {
       cacheHitRatio: null,
       executedStepSeconds: 0,
       slowest: [],
+      importSeen: false,
+      exportSeen: false,
+      diagnostics,
     }
   }
 
@@ -121,7 +170,22 @@ export function parseBuildxProgress(output) {
     cacheHitRatio: layers.length === 0 ? null : Number((cachedCount / layers.length).toFixed(3)),
     executedStepSeconds: Number(executedStepSeconds.toFixed(1)),
     slowest: [...ran].sort((a, b) => (b.seconds ?? 0) - (a.seconds ?? 0)).slice(0, 5),
+    importSeen: resolved.some((s) => /importing cache/i.test(s.name)),
+    exportSeen: resolved.some((s) => /exporting cache/i.test(s.name)),
+    diagnostics,
   }
+}
+
+/**
+ * Diagnostics are buildx's own text, so they are capped on both axes: a build
+ * can repeat a warning per step, and a single line can carry a whole URL.
+ *
+ * @param {string[]} into
+ * @param {string} line
+ */
+function addDiagnostic(into, line) {
+  const trimmed = line.length > 300 ? `${line.slice(0, 300)}…` : line
+  if (into.length < 10 && !into.includes(trimmed)) into.push(trimmed)
 }
 
 /**
@@ -143,6 +207,7 @@ export function formatCacheReport(report, timing = {}) {
       '[publish-dry-run:docker] cache report UNAVAILABLE: no buildx step lines were parsed.',
       '  The build ran, but its progress output did not match the `#<id> [stage] …` shape',
       '  this report reads. Re-run with WHITEBOARD_DOCKER_BUILD_LOG=1 to see the raw output.',
+      ...report.diagnostics.map((d) => `  ${d}`),
     ]
   }
   const ratio =
@@ -158,8 +223,18 @@ export function formatCacheReport(report, timing = {}) {
       `${report.ranCount} of ${report.stepCount} steps ran, ` +
       `${elapsed}${report.executedStepSeconds}s of step time`,
   ]
+  // Which HALF of the round trip ran. A build that exports cache and imports
+  // none misses every layer while looking, from the ratio alone, exactly like
+  // a build whose inputs all changed — and the two want opposite fixes.
+  lines.push(
+    `  cache backend: import ${report.importSeen ? 'seen' : 'NOT seen'}, ` +
+      `export ${report.exportSeen ? 'seen' : 'NOT seen'}`,
+  )
   for (const step of report.slowest) {
     lines.push(`  ${String(step.seconds ?? 0).padStart(7)}s  ${step.name}`)
+  }
+  for (const diagnostic of report.diagnostics) {
+    lines.push(`  ${diagnostic}`)
   }
   return lines
 }

--- a/packages/mcp-server/scripts/release/buildx-progress.test.ts
+++ b/packages/mcp-server/scripts/release/buildx-progress.test.ts
@@ -246,3 +246,52 @@ describe('the cache backend the report exists to judge', () => {
     expect(formatCacheReport(report).join('\n')).toContain('failed to get github token')
   })
 })
+
+// The report's third run answered the question it was rebuilt to answer, and
+// ruled out the guess behind it: `#21` and `#22` were `exporting to docker
+// image format` (65.8s) and `importing to docker` (25.1s) — the `--load` back
+// into the local daemon, not cache steps at all. No cache step existed in any
+// run. buildx took `--cache-to type=gha,mode=max` and did nothing, silently.
+//
+// Which leaves one guess standing, and a report that cannot see it. Docker's
+// gha backend falls back to ACTIONS_RUNTIME_TOKEN and ACTIONS_CACHE_URL from
+// the environment, and its own docs say an inline `docker buildx` invocation
+// must expose them manually — this job runs buildx from a `run:` step. So the
+// backend may never have been configured at all, which looks from the outside
+// exactly like a cache that is merely cold.
+//
+// Names and presence only, never a value: ACTIONS_RUNTIME_TOKEN is a
+// credential, and a report that printed one would be a worse defect than the
+// one it exists to find.
+describe('the credentials the GitHub Actions cache backend falls back to', () => {
+  it('says which are present and which are missing, by name', () => {
+    const report = parseBuildxProgress(PLAIN_OUTPUT)
+    const lines = formatCacheReport(report, {
+      cacheCredentials: { present: ['ACTIONS_CACHE_URL'], absent: ['ACTIONS_RUNTIME_TOKEN'] },
+    }).join('\n')
+    expect(lines).toContain('ACTIONS_RUNTIME_TOKEN')
+    expect(lines).toContain('ACTIONS_CACHE_URL')
+    expect(lines).toMatch(/absent|missing|NOT set/i)
+  })
+
+  it('separates a backend that was never configured from a cache that missed', () => {
+    // The two produce the same 0%, and want opposite fixes: expose the
+    // variables, or look at what invalidated the layers.
+    const report = parseBuildxProgress(PLAIN_OUTPUT)
+    const unconfigured = formatCacheReport(report, {
+      cacheCredentials: { present: [], absent: ['ACTIONS_RUNTIME_TOKEN', 'ACTIONS_CACHE_URL'] },
+    }).join('\n')
+    expect(unconfigured).toContain('cache credentials: none of')
+    const configured = formatCacheReport(report, {
+      cacheCredentials: { present: ['ACTIONS_RUNTIME_TOKEN', 'ACTIONS_CACHE_URL'], absent: [] },
+    }).join('\n')
+    expect(configured).toContain('cache credentials: all present')
+  })
+
+  it('says nothing at all when it was given no credential reading', () => {
+    // A local `docker build` has no backend to report on. Silence is right;
+    // inventing "absent" would report a problem that does not exist there.
+    const lines = formatCacheReport(parseBuildxProgress(PLAIN_OUTPUT)).join('\n')
+    expect(lines).not.toContain('cache credentials')
+  })
+})

--- a/packages/mcp-server/scripts/release/buildx-progress.test.ts
+++ b/packages/mcp-server/scripts/release/buildx-progress.test.ts
@@ -82,7 +82,7 @@ describe('the buildx cache report', () => {
     expect(report.cacheHitRatio).toBe(0.5)
     expect(report.steps.filter((s) => !s.layer).map((s) => s.name)).toEqual([
       '[internal] load build definition from Dockerfile.server',
-      '#20',
+      'exporting cache to GitHub Actions Cache',
     ])
   })
 
@@ -164,5 +164,85 @@ describe('the buildx cache report', () => {
     const lines = formatCacheReport(parseBuildxProgress(PLAIN_OUTPUT)).join(' ')
     expect(lines).toContain('2/4 layers CACHED (50%)')
     expect(lines).toContain('4 of 6 steps ran, 150.1s of step time')
+  })
+})
+
+// The report's first two real runs pinned a blind spot in the parser above.
+// Two consecutive main builds, eighteen minutes apart, both said `0/15 layers
+// CACHED` — and both spent 43% of the build (93.9s of 219.3s) in two steps the
+// report could only call `#21` and `#22`. Those two are exactly where a cache
+// backend reports itself: `exporting cache to GitHub Actions Cache` and, when
+// it happens at all, `importing cache manifest from …`.
+//
+// The cause was the name pattern: a step was named only by a line starting
+// `[`, which every Dockerfile layer does and no export step does. So the one
+// question the report exists to answer — is the cache backend working? — was
+// the one question its own output could not be read for.
+const CACHE_BACKEND_TAIL = `#4 importing cache manifest from gha:11
+#4 DONE 0.4s
+#13 [fetched 3/3] RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
+#13 0.234 Progress: resolved 1, reused 0, downloaded 0
+#13 DONE 21.7s
+#21 exporting to image
+#21 exporting layers
+#21 DONE 67.5s
+#22 exporting cache to GitHub Actions Cache
+#22 preparing build cache for export
+#22 DONE 26.4s
+`
+
+describe('the cache backend the report exists to judge', () => {
+  it('names a step whose first line is not a bracketed layer', () => {
+    const report = parseBuildxProgress(CACHE_BACKEND_TAIL)
+    const named = Object.fromEntries(report.steps.map((s) => [s.id, s.name]))
+    expect(named['21']).toBe('exporting to image')
+    expect(named['22']).toBe('exporting cache to GitHub Actions Cache')
+    expect(named['4']).toBe('importing cache manifest from gha:11')
+  })
+
+  it('never mistakes a RUN step’s streamed output for its name', () => {
+    // `#13 0.234 Progress: resolved 1 …` is the step's own stdout, prefixed
+    // with seconds since the step began. Accepting any non-bracketed line as a
+    // name would rename every RUN step after its first line of output.
+    const step = parseBuildxProgress(CACHE_BACKEND_TAIL).steps.find((s) => s.id === '13')
+    expect(step?.name).toContain('[fetched 3/3]')
+  })
+
+  it('answers whether the cache was imported and exported', () => {
+    const report = parseBuildxProgress(CACHE_BACKEND_TAIL)
+    expect(report.importSeen).toBe(true)
+    expect(report.exportSeen).toBe(true)
+  })
+
+  it('says so when a build exported cache but imported none', () => {
+    // The measured shape of both real runs: export ran, no import step existed
+    // at all, every layer missed. A reader seeing `0/15` needs to know which
+    // half of the round trip is broken, or the only move left is to guess.
+    const exportOnly = CACHE_BACKEND_TAIL.split('\n')
+      .filter((l) => !l.startsWith('#4 '))
+      .join('\n')
+    const report = parseBuildxProgress(exportOnly)
+    expect(report.importSeen).toBe(false)
+    expect(report.exportSeen).toBe(true)
+    expect(formatCacheReport(report).join(' ')).toContain('import NOT seen')
+  })
+
+  it('keeps a step that failed, rather than dropping it as unresolved', () => {
+    // A cache export that ERRORs has no DONE line, so the resolution filter
+    // discarded it — turning the loudest possible evidence into silence.
+    const report = parseBuildxProgress(
+      '#22 exporting cache to GitHub Actions Cache\n#22 ERROR: failed to configure gha cache exporter\n',
+    )
+    const step = report.steps.find((s) => s.id === '22')
+    expect(step?.error).toBe(true)
+    expect(step?.name).toBe('exporting cache to GitHub Actions Cache')
+  })
+
+  it('collects the warnings and errors buildx wrote outside any step', () => {
+    const report = parseBuildxProgress(
+      `WARNING: failed to get github token: unauthorized\n${CACHE_BACKEND_TAIL}`,
+    )
+    expect(report.diagnostics).toContain('WARNING: failed to get github token: unauthorized')
+    expect(formatCacheReport(report).join('\n')).toContain('failed to get github token')
   })
 })

--- a/packages/mcp-server/scripts/release/publish-dry-run-docker.mjs
+++ b/packages/mcp-server/scripts/release/publish-dry-run-docker.mjs
@@ -83,6 +83,25 @@ const buildArgs = isGitHubActions
       '.',
     ]
 
+// What `type=gha` falls back to when `--cache-from`/`--cache-to` name no url
+// or token of their own. Docker's documentation for the backend says an inline
+// `docker buildx` invocation — which this is, from a `run:` step — must expose
+// them manually, so their absence is the difference between a cache that never
+// ran and one that ran and missed. Read by NAME and reported as present or
+// absent; the values are credentials and never leave this process.
+const GHA_CACHE_ENV = [
+  'ACTIONS_RUNTIME_TOKEN',
+  'ACTIONS_CACHE_URL',
+  'ACTIONS_RESULTS_URL',
+  'ACTIONS_CACHE_SERVICE_V2',
+]
+
+/** @returns {{ present: string[], absent: string[] }} */
+function readCacheCredentials() {
+  const present = GHA_CACHE_ENV.filter((name) => (process.env[name] ?? '') !== '')
+  return { present, absent: GHA_CACHE_ENV.filter((name) => !present.includes(name)) }
+}
+
 const buildStartedAt = Date.now()
 const buildResult = spawnSync('docker', buildArgs, {
   cwd: REPO_ROOT,
@@ -104,7 +123,8 @@ if (buildResult.status !== 0 || buildResult.error) {
 // first real report, 214.4s of step time inside a 200s build.
 const elapsedSeconds = Number(((Date.now() - buildStartedAt) / 1000).toFixed(1))
 const cacheReport = parseBuildxProgress(buildResult.stderr ?? '')
-for (const line of formatCacheReport(cacheReport, { elapsedSeconds })) {
+const cacheCredentials = isGitHubActions ? readCacheCredentials() : undefined
+for (const line of formatCacheReport(cacheReport, { elapsedSeconds, cacheCredentials })) {
   process.stderr.write(`${line}\n`)
 }
 // The raw output stays available for the case the report cannot explain, but
@@ -141,7 +161,7 @@ const metadata = {
   // Full report, step names included: this file is an artifact of the same run
   // whose log already names them, and trending the slowest steps across runs is
   // what turns "the build is slow" into a specific layer.
-  cache: { ...cacheReport, elapsedSeconds },
+  cache: { ...cacheReport, elapsedSeconds, cacheCredentials },
 }
 writeFileSync(join(OUT_DIR, 'docker-image-metadata.json'), JSON.stringify(metadata, null, 2))
 

--- a/packages/mcp-server/scripts/release/publish-dry-run-docker.mjs
+++ b/packages/mcp-server/scripts/release/publish-dry-run-docker.mjs
@@ -155,8 +155,9 @@ process.stdout.write(
       artifactId: 'docker-image',
       imageTag: IMAGE_TAG,
       imageIdLength: imageId.length,
-      // Counts only. Step names stay out of stdout, which this script promises
-      // carries no build log.
+      // Counts and flags only. Step names and buildx's own diagnostics stay
+      // out of stdout, which this script promises carries no build log; both
+      // are in the stderr report and the metadata artifact instead.
       cache: {
         parsed: cacheReport.parsed,
         stepCount: cacheReport.stepCount,
@@ -164,6 +165,8 @@ process.stdout.write(
         ranCount: cacheReport.ranCount,
         cacheHitRatio: cacheReport.cacheHitRatio,
         executedStepSeconds: cacheReport.executedStepSeconds,
+        importSeen: cacheReport.importSeen,
+        exportSeen: cacheReport.exportSeen,
         elapsedSeconds,
       },
       sbomStatus: 'deferred',


### PR DESCRIPTION
## Summary

The cache report said `0/15 layers CACHED` on two consecutive `main` builds eighteen minutes apart, and could not say why — it put 43% of the build inside two steps it could only call `#21` and `#22`. This PR makes it say why, and the answer arrived while the PR was open.

- **Name every step.** A step was named only from a line starting `[`, which every Dockerfile layer does and no cache or export step does. So the one question the report exists to answer was the one its own output could not be read for.
- **Keep a step that `ERROR`ed** instead of dropping it as unresolved, which turned a failed cache export into silence.
- **Collect buildx's own `WARNING`/`ERROR` lines**, capped on count and length.
- **Report which half of the round trip ran** — a build that exports cache and imports none misses every layer while looking, from the ratio alone, exactly like a build whose inputs all changed, and the two want opposite fixes.
- **Report whether the backend had credentials at all**, by name and presence only.

## What it measured

The first commit's guess was that `#21`/`#22` were the cache steps. They were not:

```
cache backend: import NOT seen, export NOT seen
     63.0s  exporting to docker image format
     27.2s  importing to docker
```

Those are the `--load` back into the local daemon — **90.2s, 45% of the build** — and no cache step existed in any run. buildx took `--cache-to type=gha,mode=max` and did nothing, without a warning.

That left one guess standing, so the second commit put it on the instrument rather than acting on it. The verdict:

```
cache credentials: none of ACTIONS_RUNTIME_TOKEN, ACTIONS_CACHE_URL,
                   ACTIONS_RESULTS_URL, ACTIONS_CACHE_SERVICE_V2 are set
```

Zero of four. Docker's documentation for the `gha` backend says an inline `docker buildx` invocation must expose those variables by hand, and this job runs buildx from a `run:` step. **The cache was never configured — it was not cold, it was absent.**

The fix for that is deliberately not in this PR: it is a workflow change with a supply-chain choice attached, and it should be judged by this report rather than shipped alongside it. Note when judging it that the first run after any such fix is still legitimately 0% — nothing is in the cache yet — and `export seen` is what confirms it; hits appear on the second run.

Separately worth a follow-up, now that it has a name: `--load` costs more than every Dockerfile layer except the build steps.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [x] `pnpm test` passes locally — `mcp-node` release-scripts suite, 20 passed
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable

Nine new cases in `buildx-progress.test.ts`, each written red first. One existing expectation was changed rather than added: it pinned `'#20'` as the name of `exporting cache to GitHub Actions Cache` — it pinned the defect.

Verified end to end on CI three times, which is where the two findings above came from. Also run: `pnpm lint`, `pnpm --filter @kamiazya/whiteboard-mcp typecheck`.

The credential reading is names and presence only. `ACTIONS_RUNTIME_TOKEN` is a credential, and a report that printed one would be a worse defect than the one it exists to find.

## Visual evidence

Visual evidence: none — this changes CI log and artifact text only; nothing user-visible renders.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — n/a
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema — the test's local `CacheReport` interface mirrors the `.mjs` JSDoc typedef, as it already did; these are release scripts, outside the Zod contract surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173KdAbXzLi3Nypu4fyneDv