### PR TITLE
perf(ci): let a version bump skip the image build it cannot affect

### DIFF
--- a/packages/mcp-server/src/server/release/docker-build-inputs.test.ts
+++ b/packages/mcp-server/src/server/release/docker-build-inputs.test.ts
@@ -18,20 +18,20 @@ const ROOT = join(__dirname, '../../../../..')
 
 const MODULE_PATH = join(ROOT, 'tools/checks/src/docker-build-inputs.mjs')
 
-const { dockerBuildTargets, workspaceClosure, indexManifests, affectsDockerBuild } = (await import(
-  pathToFileURL(MODULE_PATH).href
-)) as {
-  dockerBuildTargets: (dockerfileText: string) => string[]
-  workspaceClosure: (
-    roots: string[],
-    byName: Map<string, { dir: string; manifest: Record<string, unknown> }>,
-  ) => string[]
-  indexManifests: (
-    repoRoot: string,
-    manifestPaths: string[],
-  ) => Map<string, { dir: string; manifest: Record<string, unknown> }>
-  affectsDockerBuild: (changedPaths: string[], closureDirs: string[]) => boolean
-}
+const { dockerBuildTargets, workspaceClosure, indexManifests, affectsDockerBuild, inertChange } =
+  (await import(pathToFileURL(MODULE_PATH).href)) as {
+    dockerBuildTargets: (dockerfileText: string) => string[]
+    workspaceClosure: (
+      roots: string[],
+      byName: Map<string, { dir: string; manifest: Record<string, unknown> }>,
+    ) => string[]
+    indexManifests: (
+      repoRoot: string,
+      manifestPaths: string[],
+    ) => Map<string, { dir: string; manifest: Record<string, unknown> }>
+    affectsDockerBuild: (changedPaths: string[], closureDirs: string[]) => boolean
+    inertChange: (path: string, before: string | null, after: string | null) => boolean
+  }
 
 const dockerfile = readFileSync(join(ROOT, 'Dockerfile.server'), 'utf-8')
 // Manifest discovery mirrors the CLI's `git ls-files`, without shelling out:
@@ -163,5 +163,123 @@ describe('ci.yml gates the expensive steps on the detection output', () => {
       header,
       'a job-level if: would make this a skipped check, not a reporting one',
     ).not.toMatch(/^\s{4}if:/m)
+  })
+})
+
+// The release-please branch is open continuously and rewritten on every push
+// to main, so its CI runs are a standing cost rather than an occasional one:
+// measured over the last 40 pull_request runs of ci.yml, 7 of the 31 image
+// builds — 23% — were that branch.
+//
+// What it changes, measured from the live branch rather than assumed: version
+// strings and changelog entries, in `package.json`, `CHANGELOG.md`,
+// `server.json`, `gemini-extension.json`, `.release-please-manifest.json` and
+// the plugin manifests. Neither can change the one question the job answers,
+// "does Dockerfile.server still build" — verified on both halves it could
+// have: `pnpm-lock.yaml` records no workspace package's OWN version, so a bump
+// cannot fail `--frozen-lockfile`, and the image build is tsup plus the widget
+// build, which read no changelog.
+//
+// The comparison has to be on PARSED JSON, not text. release-please rewrites
+// these files with different array formatting, so the textual diff of a
+// version bump also carries reflowed `keywords` and `args` arrays — noise that
+// a line-based rule would read as a real change.
+describe('a change that cannot alter whether the image builds', () => {
+  it('treats a version-only manifest rewrite as inert, formatting and all', () => {
+    const before = '{"name":"x","version":"0.0.19","keywords":["a","b"]}'
+    const after = `{
+  "name": "x",
+  "version": "0.1.0",
+  "keywords": [
+    "a",
+    "b"
+  ]
+}`
+    expect(inertChange('package.json', before, after)).toBe(true)
+  })
+
+  it('reads release-please’s own manifest, whose keys are paths not "version"', () => {
+    const before = '{".":"0.0.19","packages/mcp-server":"0.0.19"}'
+    const after = '{".":"0.1.0","packages/mcp-server":"0.1.0"}'
+    expect(inertChange('.release-please-manifest.json', before, after)).toBe(true)
+  })
+
+  it('is NOT inert when a dependency range moves', () => {
+    // The case the whole rule must not swallow: a dependency bump is also a
+    // semver string moving, and it can fail `pnpm install --frozen-lockfile`
+    // inside the build — which is exactly what this job exists to catch.
+    const before = '{"version":"1.0.0","dependencies":{"zod":"3.0.0"}}'
+    const after = '{"version":"1.0.1","dependencies":{"zod":"4.0.0"}}'
+    expect(inertChange('package.json', before, after)).toBe(false)
+  })
+
+  it('is NOT inert when anything else in the manifest moves', () => {
+    const before = '{"version":"1.0.0","scripts":{"build":"tsup"}}'
+    const after = '{"version":"1.0.1","scripts":{"build":"tsc"}}'
+    expect(inertChange('package.json', before, after)).toBe(false)
+  })
+
+  it('treats a changelog as inert wherever it lives', () => {
+    expect(inertChange('CHANGELOG.md', '# 0.0.19\n', '# 0.1.0\n')).toBe(true)
+    expect(inertChange('packages/mcp-server/CHANGELOG.md', 'a', 'b')).toBe(true)
+  })
+
+  it('is NOT inert for a file it cannot read both sides of', () => {
+    // An added or deleted file has no before side. Failing open here keeps the
+    // module's existing posture: a needless build costs minutes, a skipped one
+    // costs a broken Dockerfile reaching a release tag.
+    expect(inertChange('package.json', null, '{"version":"0.1.0"}')).toBe(false)
+    expect(inertChange('src/index.ts', 'a', 'b')).toBe(false)
+    expect(inertChange('package.json', '{not json', '{"a":1}')).toBe(false)
+  })
+
+  it('lets the whole measured release diff skip the build', () => {
+    const releaseDiff = [
+      'package.json',
+      'CHANGELOG.md',
+      'server.json',
+      'gemini-extension.json',
+      '.release-please-manifest.json',
+      'packages/mcp-server/package.json',
+      'packages/mcp-server/CHANGELOG.md',
+    ]
+    const bump = (p: string) =>
+      p.endsWith('.md')
+        ? (['x', 'y'] as const)
+        : p === '.release-please-manifest.json'
+          ? (['{".":"0.0.19"}', '{".":"0.1.0"}'] as const)
+          : (['{"version":"0.0.19"}', '{"version":"0.1.0"}'] as const)
+    const remaining = releaseDiff.filter((p) => {
+      const [before, after] = bump(p)
+      return !inertChange(p, before, after)
+    })
+    expect(remaining).toEqual([])
+    expect(affectsDockerBuild(remaining, ['packages/mcp-server'])).toBe(false)
+  })
+})
+
+describe('a version nested inside an array element', () => {
+  // Ran against the live release-please branch before believing the unit
+  // cases: 8 of its 10 files came back inert and two did not. Both carry the
+  // bumped version inside an ARRAY — `server.json`'s `packages[0].version` and
+  // `.claude-plugin/marketplace.json`'s `plugins[0].version` — which the
+  // comparison was treating as one opaque differing leaf. Every hand-written
+  // case had the version at an object key, so all of them passed.
+  it('descends into arrays rather than calling the whole array one difference', () => {
+    const before = '{"version":"0.0.19","packages":[{"registryType":"npm","version":"0.0.19"}]}'
+    const after = '{"version":"0.1.0","packages":[{"registryType":"npm","version":"0.1.0"}]}'
+    expect(inertChange('server.json', before, after)).toBe(true)
+  })
+
+  it('is NOT inert when an array element changes anything else', () => {
+    const before = '{"packages":[{"registryType":"npm","version":"0.0.19"}]}'
+    const after = '{"packages":[{"registryType":"oci","version":"0.1.0"}]}'
+    expect(inertChange('server.json', before, after)).toBe(false)
+  })
+
+  it('is NOT inert when an array gains or loses an element', () => {
+    const before = '{"packages":[{"version":"0.0.19"}]}'
+    const after = '{"packages":[{"version":"0.1.0"},{"version":"0.1.0"}]}'
+    expect(inertChange('server.json', before, after)).toBe(false)
   })
 })

--- a/tools/checks/src/docker-build-inputs.mjs
+++ b/tools/checks/src/docker-build-inputs.mjs
@@ -99,6 +99,121 @@ export function indexManifests(repoRoot, manifestPaths) {
   return byName
 }
 
+// Keys whose subtree decides what gets INSTALLED or RUN inside the image. A
+// version string moving under any of these is a real change to the build, and
+// is exactly what this job exists to catch — a dependency bump can fail
+// `pnpm install --frozen-lockfile` in the `build` stage.
+const BUILD_DECIDING_KEYS = new Set([
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+  'overrides',
+  'resolutions',
+  'pnpm',
+  'scripts',
+  'engines',
+  'packageManager',
+])
+
+/**
+ * Every JSON leaf path where two documents differ, as `a/b/c` strings.
+ *
+ * @param {unknown} before
+ * @param {unknown} after
+ * @param {string[]} trail
+ * @returns {string[][]}
+ */
+function differingLeaves(before, after, trail = []) {
+  if (JSON.stringify(before) === JSON.stringify(after)) return []
+  // Arrays are descended into as well as objects, by index. Treating an array
+  // as one opaque leaf is what made `server.json` and the marketplace manifest
+  // look material: both carry the bumped version INSIDE an array element, and
+  // every hand-written case had it at an object key.
+  if (Array.isArray(before) && Array.isArray(after)) {
+    // A different length is a real change, not a moved value.
+    if (before.length !== after.length) return [trail]
+    return before.flatMap((item, index) =>
+      differingLeaves(item, after[index], [...trail, String(index)]),
+    )
+  }
+  const bothObjects =
+    typeof before === 'object' &&
+    before !== null &&
+    !Array.isArray(before) &&
+    typeof after === 'object' &&
+    after !== null &&
+    !Array.isArray(after)
+  if (!bothObjects) return [trail]
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)])
+  return [...keys].flatMap((key) =>
+    differingLeaves(
+      /** @type {Record<string, unknown>} */ (before)[key],
+      /** @type {Record<string, unknown>} */ (after)[key],
+      [...trail, key],
+    ),
+  )
+}
+
+/**
+ * Is this path worth reading both sides of at all?
+ *
+ * Exported so the CLI can skip spawning `git show` twice for every source
+ * file in a diff; everything else is decided by path alone.
+ *
+ * @param {string} path repo-relative path
+ */
+export function couldBeInert(path) {
+  return /(^|\/)CHANGELOG\.md$/.test(path) || path.endsWith('.json')
+}
+
+/**
+ * Can this path's change be ignored outright?
+ *
+ * The release-please branch is open continuously and rewritten on every push
+ * to main, and its diff is version strings plus changelog entries — measured
+ * at 7 of the last 31 image builds. Neither can change whether
+ * Dockerfile.server compiles: `pnpm-lock.yaml` records no workspace package's
+ * OWN version, so a bump cannot fail `--frozen-lockfile`, and the build is
+ * tsup plus the widget build, neither of which reads a changelog.
+ *
+ * PARSED JSON, never text: release-please rewrites these files with different
+ * array formatting, so a version bump's textual diff also carries reflowed
+ * `keywords` and `args` arrays. A line-based rule would read that as a real
+ * change and never skip anything.
+ *
+ * Fails OPEN like the rest of this module — an unreadable or unparseable side
+ * is not inert.
+ *
+ * @param {string} path repo-relative path
+ * @param {string | null} before content at the base ref, or null
+ * @param {string | null} after content at HEAD, or null
+ * @returns {boolean}
+ */
+export function inertChange(path, before, after) {
+  if (!couldBeInert(path)) return false
+  if (/(^|\/)CHANGELOG\.md$/.test(path)) return true
+  if (before === null || after === null) return false
+  let parsedBefore
+  let parsedAfter
+  try {
+    parsedBefore = JSON.parse(before)
+    parsedAfter = JSON.parse(after)
+  } catch {
+    return false
+  }
+  const leaves = differingLeaves(parsedBefore, parsedAfter)
+  if (leaves.length === 0) return true
+  return leaves.every(
+    (trail) =>
+      trail.length > 0 &&
+      !trail.some((key) => BUILD_DECIDING_KEYS.has(key)) &&
+      // release-please's own manifest keys are package paths, not `version`;
+      // nothing but release-please reads that file.
+      (trail[trail.length - 1] === 'version' || path === '.release-please-manifest.json'),
+  )
+}
+
 /**
  * @param {string[]} changedPaths repo-relative paths changed by the diff
  * @param {string[]} closureDirs from workspaceClosure()
@@ -142,14 +257,32 @@ if (process.argv[1]?.endsWith('docker-build-inputs.mjs')) {
     const changed = git(['diff', '--name-only', `${baseRef}...HEAD`])
       .split('\n')
       .filter(Boolean)
+    // `A...HEAD` diffs from the merge base, so that is the side to read.
+    const mergeBase = git(['merge-base', baseRef, 'HEAD'])
+    /** @param {string} ref @param {string} path */
+    const show = (ref, path) => {
+      try {
+        return execFileSync('git', ['show', `${ref}:${path}`], { encoding: 'utf-8' })
+      } catch {
+        // Added or deleted on one side; inertChange treats that as material.
+        return null
+      }
+    }
+    const material = changed.filter(
+      (path) =>
+        !couldBeInert(path) || !inertChange(path, show(mergeBase, path), show('HEAD', path)),
+    )
     const manifests = git(['ls-files', 'package.json', '*/package.json'])
       .split('\n')
       .filter((p) => p.length > 0 && !p.includes('node_modules/'))
     const targets = dockerBuildTargets(readFileSync(join(repoRoot, 'Dockerfile.server'), 'utf-8'))
     if (targets.length === 0) throw new Error('Dockerfile.server declares no pnpm --filter build')
     const closure = workspaceClosure(targets, indexManifests(repoRoot, manifests))
-    answer = affectsDockerBuild(changed, closure)
-    why = `${changed.length} changed path(s) against ${closure.length} closure package(s)`
+    answer = affectsDockerBuild(material, closure)
+    const inert = changed.length - material.length
+    why =
+      `${material.length} material path(s) against ${closure.length} closure package(s)` +
+      (inert > 0 ? `; ${inert} inert (version bump / changelog)` : '')
   } catch (error) {
     if (!(typeof error === 'object' && error !== null && 'handled' in error)) {
       answer = true


### PR DESCRIPTION
## Summary

The `release-please--branches--main` branch is open continuously and rewritten on every push to main, so its CI runs are a standing cost rather than an occasional one. Measured over the last 40 `pull_request` runs of ci.yml:

| | count |
|---|---|
| image builds that ran | 31 |
| **of those, on the release branch** | **7 (23%)** |
| skipped by the existing gate | 4 |

Each of those is now a 160s image build answering a question the diff cannot change.

## What it actually changes, read off the live branch

Version strings and changelog entries, across `package.json`, `CHANGELOG.md`, `server.json`, `gemini-extension.json`, `.release-please-manifest.json` and the plugin manifests. Both halves that could have made that material were checked rather than assumed:

- `pnpm-lock.yaml` records no workspace package's **own** version, so a bump cannot fail `pnpm install --frozen-lockfile` in the `build` stage.
- The image build is tsup (`tsconfig.server.json`) plus the widget build. Neither reads a changelog; `CHANGELOG.md` appears only in the npm `files` array.

So a changed path is dropped before the closure test when its change is inert: a `CHANGELOG.md`, or a JSON file whose parsed content differs only at keys named `version` — **never** under `dependencies`, `scripts`, `engines` or `packageManager`, where a semver string moving is exactly what this job exists to catch.

**Parsed JSON, never text**, and that is not a detail: release-please rewrites these files with different array formatting, so a version bump's textual diff also carries reflowed `keywords` and `args` arrays. A line-based rule would call every release PR material and skip nothing.

## Verified against the live branch, which is what caught the real gap

The first implementation passed all its unit cases and still left **2 of 10 files material**. `server.json` and `.claude-plugin/marketplace.json` carry the bumped version *inside an array element* (`packages[0].version`, `plugins[0].version`), and the comparison treated an array as one opaque leaf — every hand-written case happened to put the version at an object key. Arrays are descended into now, by index, with a length change counting as material.

```
before the array fix:  docker=true  (2 material, 8 inert)
after:                 docker=false (0 material, 10 inert)
```

Both directions confirmed on real diffs:

| diff | answer |
|---|---|
| live `release-please--branches--main` | **false** — 10 inert |
| `feat(web): a person adopts a proposal…` (#1450) | true |
| `feat(annotations): focus handoff…` (#1448) | true |
| this PR's own diff | true — 2 material |

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [x] `pnpm test` passes locally — see the note below
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable

Ten new cases in `docker-build-inputs.test.ts`, written red first, including the three the live branch demanded (version inside an array; an array element changing anything else; an array gaining an element). The negative cases are the load-bearing ones: a dependency range moving and a script changing must both stay material.

Manual verification is the table above — the module run against real branches, not fixtures.

Also run: `pnpm lint`, `pnpm test:scripts`, `pnpm --filter @kamiazya/whiteboard-mcp typecheck`, and the whole of `src/server`.

One pre-existing failure there is environmental, not from this diff: `local-node-version.test.ts` reports this container on Node 22.22.2 against a pinned 24. No Node 24 or version manager is available here; CI installs 24, which is what that guard exists to say.

## Visual evidence

Visual evidence: none — CI gating logic only; nothing user-visible renders.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — n/a
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema — the test's import type mirrors the module's JSDoc, as it already did; `tools/checks` stays dependency-free by design

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173KdAbXzLi3Nypu4fyneDv

---
_Generated by [Claude Code](https://claude.ai/code/session_0173KdAbXzLi3Nypu4fyneDv)_