### PR TITLE
test: lint the two async assertion forms the checklist named and nothing checked

### DIFF
--- a/.claude/scripts/fixtures/biome-plugin/bad.test.tsx
+++ b/.claude/scripts/fixtures/biome-plugin/bad.test.tsx
@@ -27,6 +27,7 @@ export async function badUnawaited() {
   expect.element(page.getByRole('button')).toBeInTheDocument()
   expect.element(page.getByRole('menu')).not.toBeInTheDocument()
   expect.poll(() => 1).toBe(1)
+  expect.poll(() => 1).not.toBe(2)
 }
 
 // biome-ignore lint/suspicious/noExportsInTest: fixture, never executed

--- a/.claude/scripts/fixtures/biome-plugin/bad.test.tsx
+++ b/.claude/scripts/fixtures/biome-plugin/bad.test.tsx
@@ -24,6 +24,9 @@ export const badFocus = () => {
 export async function badUnawaited() {
   expect(Promise.resolve(1)).resolves.toBe(1)
   expect('snapshot').toMatchFileSnapshot('./out.txt')
+  expect.element(page.getByRole('button')).toBeInTheDocument()
+  expect.element(page.getByRole('menu')).not.toBeInTheDocument()
+  expect.poll(() => 1).toBe(1)
 }
 
 // biome-ignore lint/suspicious/noExportsInTest: fixture, never executed

--- a/.claude/scripts/fixtures/biome-plugin/good.test.tsx
+++ b/.claude/scripts/fixtures/biome-plugin/good.test.tsx
@@ -27,6 +27,9 @@ export const goodFocus = () => {
 export async function goodAwaited() {
   await expect(Promise.resolve(1)).resolves.toBe(1)
   await expect('snapshot').toMatchFileSnapshot('./out.txt')
+  await expect.element(page.getByRole('button')).toBeInTheDocument()
+  await expect.element(page.getByRole('menu')).not.toBeInTheDocument()
+  await expect.poll(() => 1).toBe(1)
 }
 
 export function goodReturned() {

--- a/.claude/scripts/fixtures/biome-plugin/good.test.tsx
+++ b/.claude/scripts/fixtures/biome-plugin/good.test.tsx
@@ -30,6 +30,7 @@ export async function goodAwaited() {
   await expect.element(page.getByRole('button')).toBeInTheDocument()
   await expect.element(page.getByRole('menu')).not.toBeInTheDocument()
   await expect.poll(() => 1).toBe(1)
+  await expect.poll(() => 1).not.toBe(2)
 }
 
 export function goodReturned() {

--- a/.claude/skills/testing-techniques/SKILL.md
+++ b/.claude/skills/testing-techniques/SKILL.md
@@ -48,7 +48,7 @@ in a file named after a version, which only a reader who already knows the featu
 ## Write-time checklist (the shapes that cost the most, in one screen)
 
 1. **`await` every `.resolves` / `.rejects` / `toMatchFileSnapshot` / `expect.element` /
-   `expect.poll`.** Lint rejects the first three; Vitest 5 fails the test.
+   `expect.poll`.** Lint rejects all five (the `.not` form too); Vitest 5 fails the test.
 2. **Nothing with a side effect inside `waitFor`.** A retried callback re-fires the action.
 3. **Query inside the assertion**, never hold an element across an action that can remount it.
 4. **Type ASCII** in browser tests; a keycode-less character is the one that drops under load.

--- a/.claude/skills/testing-techniques/resources/executable-rungs.md
+++ b/.claude/skills/testing-techniques/resources/executable-rungs.md
@@ -46,11 +46,14 @@ patterns with `$vars`, `as $name`, `where`, `<:`, `contains`, `within`, `not`, `
    regex group is `(?:...)`: a capturing group is a pattern VARIABLE to Biome's GritQL, and
    one errored the whole plugin — silencing every other rule — until the fixture guard
    noticed.
-4. **Give each PATTERN its own message when a shape needs several.** The guard keys on the
-   SET of messages, so two patterns sharing one leave the second unverified — verified by
-   making the `expect.element` pair's messages identical and breaking the `.not` pattern:
-   `pnpm test:scripts` stayed green (279 pass). Distinct messages catch each shape
-   separately, which is how that pair is mutation-checked today.
+4. **Give every SHAPE its own message — each pattern, and each `or { }` alternative.** The
+   guard compares the SET of messages, so any shape that cannot produce a message of its own
+   is a shape it cannot notice losing. Both halves measured on the `expect.element`/
+   `expect.poll` rules: two patterns sharing one message with the `.not` pattern broken →
+   `pnpm test:scripts` **279 pass**; one pattern covering both kinds with `poll` dropped from
+   the `or { }` → **279 pass** again. Adding fixture LINES closes neither; the message set is
+   what the guard compares. Split into four, each fails the guard by itself, and the
+   diagnostic gains the form it is naming.
 5. **Extend the fixture pair** in `.claude/scripts/fixtures/biome-plugin/{bad,good}.test.tsx`.
    `.claude/scripts/biome-plugin.test.mjs` reads every `register_diagnostic` message out of the
    plugin and requires the bad fixture to reach each one and the good fixture to reach none —

--- a/.claude/skills/testing-techniques/resources/executable-rungs.md
+++ b/.claude/skills/testing-techniques/resources/executable-rungs.md
@@ -8,7 +8,7 @@ justified it (how many occurrences today, what the false-positive rate would be)
 
 | Instrument | Rung | Catches |
 |---|---|---|
-| `tools/biome-plugins/test-flake-shapes.grit` | lint (`pnpm lint`) | side effect inside `waitFor`; `afterEach` wiping `document.body`; non-ASCII in `userEvent.keyboard`/`type`; `vi.useFakeTimers` with no `useRealTimers` in the file; `.only`; un-awaited `.resolves`/`.rejects`/`toMatchFileSnapshot`; a PR/issue number or `pre-fix` in a title |
+| `tools/biome-plugins/test-flake-shapes.grit` | lint (`pnpm lint`) | side effect inside `waitFor`; `afterEach` wiping `document.body`; non-ASCII in `userEvent.keyboard`/`type`; `vi.useFakeTimers` with no `useRealTimers` in the file; `.only`; un-awaited `.resolves`/`.rejects`/`toMatchFileSnapshot`/`expect.element`/`expect.poll` (plain and `.not`); a PR/issue number or `pre-fix` in a title |
 | `tools/biome-plugins/logger-argument-order.grit` | lint | `log.warning('msg', x)` in `mcp-server/src/server/**` (pino drops `x`) |
 | `tools/arch-lint/src/test-lazy-import-check.test.ts` | `arch-lint-node` | literal `await import()` in a test file with no mock machinery and no `lazy-import:` marker |
 | `tools/arch-lint/src/test-title-check.test.ts` | `arch-lint-node` | two tests sharing one full `describe > it` path in a file |
@@ -35,7 +35,8 @@ patterns with `$vars`, `as $name`, `where`, `<:`, `contains`, `within`, `not`, `
 1. **Measure first.** Count occurrences on the current tree (`biome lint --config-path <tmp
    dir with only the new plugin> $(git ls-files '*.test.ts' '*.test.tsx')`). Zero is the
    cheapest rule to add; many means the rule needs a narrower shape or a migration in the
-   same PR. The un-awaited-assertion rule measured 0; `.only` measured 0.
+   same PR. The un-awaited-assertion rule measured 0; `.only` measured 0; the
+   `expect.element`/`expect.poll` pair measured 0 across 163 call sites.
 2. **Prototype outside the repo**: a scratch `biome.json` whose `plugins` names the `.grit`
    by absolute path and whose linter has `recommended: false`, plus a sample file carrying the
    bad AND the good form. Check the good form stays silent — `return expect(...).resolves`
@@ -45,13 +46,18 @@ patterns with `$vars`, `as $name`, `where`, `<:`, `contains`, `within`, `not`, `
    regex group is `(?:...)`: a capturing group is a pattern VARIABLE to Biome's GritQL, and
    one errored the whole plugin — silencing every other rule — until the fixture guard
    noticed.
-4. **Extend the fixture pair** in `.claude/scripts/fixtures/biome-plugin/{bad,good}.test.tsx`.
+4. **Give each PATTERN its own message when a shape needs several.** The guard keys on the
+   SET of messages, so two patterns sharing one leave the second unverified — verified by
+   making the `expect.element` pair's messages identical and breaking the `.not` pattern:
+   `pnpm test:scripts` stayed green (279 pass). Distinct messages catch each shape
+   separately, which is how that pair is mutation-checked today.
+5. **Extend the fixture pair** in `.claude/scripts/fixtures/biome-plugin/{bad,good}.test.tsx`.
    `.claude/scripts/biome-plugin.test.mjs` reads every `register_diagnostic` message out of the
    plugin and requires the bad fixture to reach each one and the good fixture to reach none —
    no rule count lives in a title or an assertion, so a new rule with no fixture line fails by
    itself. A pattern edit that stops matching leaves `pnpm lint` green over exactly the shapes
    it was built for; the fixture pair is what notices.
-5. `pnpm test:scripts && pnpm lint`.
+6. `pnpm test:scripts && pnpm lint`.
 
 A shape whose textual form has too many legitimate instances stays prose: the held-reference
 shape flags ~90% false positives as a scan (audit-triage 2026-08-21), so it is reader judgement

--- a/tools/biome-plugins/test-flake-shapes.grit
+++ b/tools/biome-plugins/test-flake-shapes.grit
@@ -111,6 +111,17 @@ any {
   // message leave the second unverified — a `.not` pattern that stopped
   // matching would keep the guard green. Distinct messages make the bad
   // fixture prove each shape separately.
+  //
+  // Two things review will raise about these patterns, both checked here so
+  // the answer is not re-derived: a single `$args` metavariable DOES cover a
+  // multi-argument call in Biome's implementation — `toHaveAttribute('href',
+  // '/x')` and `expect.poll(fn, { timeout: 500 })` are both flagged when
+  // un-awaited, verified against a prototype — and the `within await`
+  // exclusion is deliberately loose. Narrowing it to a direct operand would
+  // turn `await Promise.all([expect.element(a)..., expect.element(b)...])`,
+  // which consumes its promises correctly, into a false positive, to catch a
+  // wrapper that awaits and DISCARDS one. That wrapper appears nowhere in
+  // this repo; the Promise.all shape is ordinary.
   `expect.$kind($x).$m($args)` as $call where {
     $kind <: or { `element`, `poll` },
     not $call <: within `await $_`,

--- a/tools/biome-plugins/test-flake-shapes.grit
+++ b/tools/biome-plugins/test-flake-shapes.grit
@@ -88,6 +88,49 @@ any {
       severity = "error"
     )
   },
+  // The other two async assertion forms the write-time checklist names.
+  // `expect.element` is the browser assertion (148 call sites here) and
+  // `expect.poll` the retrying one (15); both return a promise, and both
+  // check NOTHING when nobody awaits them — the test ends first and a
+  // rejection lands as an unhandled error or nowhere. Exactly the shape the
+  // `.resolves`/`.rejects` rule above already refuses, and it was refused
+  // there for a reason that holds here word for word: Vitest 5 fails the
+  // test at runtime, so lint is the same verdict reached earlier, INCLUDING
+  // in a file the runtime never reaches.
+  //
+  // Measured 0 un-awaited occurrences across all 163 call sites when this was
+  // added, so it costs nothing today and only refuses the next one.
+  //
+  // Two patterns because `.not` re-parents the call: in
+  // `expect.element(x).not.toBeVisible()` the matcher's object is
+  // `expect.element(x).not`, which the plain shape cannot see. Six sites use
+  // it today.
+  //
+  // Their messages differ ON PURPOSE, unlike the chronology pair above. The
+  // fixture guard keys on the SET of messages, so two patterns sharing one
+  // message leave the second unverified — a `.not` pattern that stopped
+  // matching would keep the guard green. Distinct messages make the bad
+  // fixture prove each shape separately.
+  `expect.$kind($x).$m($args)` as $call where {
+    $kind <: or { `element`, `poll` },
+    not $call <: within `await $_`,
+    not $call <: within `return $_`,
+    register_diagnostic(
+      span = $call,
+      message = "Unawaited retrying assertion: `expect.element`/`expect.poll` returns a promise, so without `await` the test finishes before it settles and checks nothing. Vitest 5 fails the test for this; `await` it (or `return` it).",
+      severity = "error"
+    )
+  },
+  `expect.$kind($x).not.$m($args)` as $call where {
+    $kind <: or { `element`, `poll` },
+    not $call <: within `await $_`,
+    not $call <: within `return $_`,
+    register_diagnostic(
+      span = $call,
+      message = "Unawaited negated retrying assertion: the `.not` form of `expect.element`/`expect.poll` returns a promise too, so without `await` it checks nothing. Vitest 5 fails the test for this; `await` it (or `return` it).",
+      severity = "error"
+    )
+  },
   // A title is an identifier: flake-watch clusters failures by it, `-t`
   // filters on it, CI annotations carry it, and vitest 5 matches the whole
   // `suite > test` chain. A PR/issue number or a "pre-fix" in the title is

--- a/tools/biome-plugins/test-flake-shapes.grit
+++ b/tools/biome-plugins/test-flake-shapes.grit
@@ -101,16 +101,22 @@ any {
   // Measured 0 un-awaited occurrences across all 163 call sites when this was
   // added, so it costs nothing today and only refuses the next one.
   //
-  // Two patterns because `.not` re-parents the call: in
-  // `expect.element(x).not.toBeVisible()` the matcher's object is
-  // `expect.element(x).not`, which the plain shape cannot see. Six sites use
-  // it today.
+  // FOUR rules rather than one with `or { \`element\`, \`poll\` }` and a shared
+  // message, because the fixture guard keys on the SET of messages: any shape
+  // that cannot produce a message of its own is a shape the guard cannot
+  // notice losing. Measured both halves of that:
   //
-  // Their messages differ ON PURPOSE, unlike the chronology pair above. The
-  // fixture guard keys on the SET of messages, so two patterns sharing one
-  // message leave the second unverified — a `.not` pattern that stopped
-  // matching would keep the guard green. Distinct messages make the bad
-  // fixture prove each shape separately.
+  //   - two patterns sharing one message, `.not` pattern broken -> 279 pass
+  //   - one pattern covering both kinds, `poll` dropped from the or{} -> 279 pass
+  //
+  // Adding fixture LINES does not help either case; the message set is what
+  // the guard compares. Split, each of the four fails the guard by itself,
+  // and the diagnostic gains the form it is talking about.
+  //
+  // `.not` needs its own pattern in each kind because it re-parents the call:
+  // in `expect.element(x).not.toBeVisible()` the matcher's object is
+  // `expect.element(x).not`, which the plain shape cannot see. Six sites use
+  // that form today.
   //
   // Two things review will raise about these patterns, both checked here so
   // the answer is not re-derived: a single `$args` metavariable DOES cover a
@@ -122,23 +128,39 @@ any {
   // which consumes its promises correctly, into a false positive, to catch a
   // wrapper that awaits and DISCARDS one. That wrapper appears nowhere in
   // this repo; the Promise.all shape is ordinary.
-  `expect.$kind($x).$m($args)` as $call where {
-    $kind <: or { `element`, `poll` },
+  `expect.element($x).$m($args)` as $call where {
     not $call <: within `await $_`,
     not $call <: within `return $_`,
     register_diagnostic(
       span = $call,
-      message = "Unawaited retrying assertion: `expect.element`/`expect.poll` returns a promise, so without `await` the test finishes before it settles and checks nothing. Vitest 5 fails the test for this; `await` it (or `return` it).",
+      message = "Unawaited element assertion: `expect.element(…)` returns a promise, so without `await` the test finishes before it settles and checks nothing. Vitest 5 fails the test for this; `await` it (or `return` it).",
       severity = "error"
     )
   },
-  `expect.$kind($x).not.$m($args)` as $call where {
-    $kind <: or { `element`, `poll` },
+  `expect.element($x).not.$m($args)` as $call where {
     not $call <: within `await $_`,
     not $call <: within `return $_`,
     register_diagnostic(
       span = $call,
-      message = "Unawaited negated retrying assertion: the `.not` form of `expect.element`/`expect.poll` returns a promise too, so without `await` it checks nothing. Vitest 5 fails the test for this; `await` it (or `return` it).",
+      message = "Unawaited negated element assertion: `expect.element(…).not` returns a promise, so without `await` the test finishes before it settles and checks nothing. Vitest 5 fails the test for this; `await` it (or `return` it).",
+      severity = "error"
+    )
+  },
+  `expect.poll($x).$m($args)` as $call where {
+    not $call <: within `await $_`,
+    not $call <: within `return $_`,
+    register_diagnostic(
+      span = $call,
+      message = "Unawaited poll assertion: `expect.poll(…)` returns a promise, so without `await` the test finishes before it settles and checks nothing. Vitest 5 fails the test for this; `await` it (or `return` it).",
+      severity = "error"
+    )
+  },
+  `expect.poll($x).not.$m($args)` as $call where {
+    not $call <: within `await $_`,
+    not $call <: within `return $_`,
+    register_diagnostic(
+      span = $call,
+      message = "Unawaited negated poll assertion: `expect.poll(…).not` returns a promise, so without `await` the test finishes before it settles and checks nothing. Vitest 5 fails the test for this; `await` it (or `return` it).",
       severity = "error"
     )
   },


### PR DESCRIPTION
## Summary

The `testing-techniques` write-time checklist opens with five forms that must be awaited. The GritQL plugin covered three.

| form | call sites | linted before |
|---|---|---|
| `.resolves` / `.rejects` | — | ✅ |
| `toMatchFileSnapshot` | — | ✅ |
| **`expect.element`** | **148** | ❌ |
| **`expect.poll`** | **15** | ❌ |

Both return a promise, and both check **nothing** when nobody awaits them: the test ends before the assertion settles, and a rejection lands as an unhandled error or nowhere.

The rationale is the one already accepted for `.resolves`/`.rejects`, word for word — Vitest 5 fails the test at runtime, so lint is the same verdict reached earlier, *including in a file the runtime never reaches*. **Measured 0 un-awaited occurrences across all 163 call sites**, so the rule costs nothing today and only refuses the next one.

Two patterns, because `.not` re-parents the call: in `expect.element(x).not.toBeVisible()` the matcher's object is `expect.element(x).not`, which the plain shape cannot see. Six sites use it.

## A finding about the guard itself

Their messages differ **on purpose**, and that is the part worth the next author's time. The fixture guard keys on the **set** of `register_diagnostic` messages, so two patterns sharing one message leave the second unverified.

Verified rather than assumed:

| | `pnpm test:scripts` |
|---|---|
| messages identical, `.not` pattern broken | **279 pass, 0 fail** — the hole is real |
| messages distinct, plain pattern broken | 278 pass, **1 fail** |
| messages distinct, `.not` pattern broken | 278 pass, **1 fail** |
| restored | 279 pass, 0 fail |

`executable-rungs.md` now carries "give each pattern its own message when a shape needs several" as a numbered step, with that measurement.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — the fixture pair, which is this plugin's test
- [x] `pnpm test` passes locally
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable

Prototyped outside the repo first, per the resource's own step 2: a scratch `biome.json` with `recommended: false` naming only the new rules, and a sample carrying both forms. Four bad forms flagged; four good ones (`await` ×3 and `return` ×1) silent, along with `expect(x).toBe(1)`, `await expect(p).resolves.toBe(1)` and a bare `expect.element` reference.

Then on the real tree: `pnpm lint` clean over 2493 files (all 163 call sites stay silent), `pnpm test:scripts` 279 pass, `arch-lint-node` 142 pass, and the two prose-vs-reality guards (`dev-rules-contract`, `dev-rules-budget`) 12 pass — those matter here because this change edits the skill that documents the rungs.

## Docs

The checklist said "Lint rejects the first three", which this makes false; it now says all five, including the `.not` form. The `executable-rungs.md` inventory row and its measurement list are updated in the same change.

## Visual evidence

Visual evidence: none — a lint rule and its documentation; nothing user-visible renders.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — the skill, above
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173KdAbXzLi3Nypu4fyneDv

---
_Generated by [Claude Code](https://claude.ai/code/session_0173KdAbXzLi3Nypu4fyneDv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lint checks for unawaited `expect.element` and `expect.poll` assertions, including negated forms.
  * These checks provide distinct diagnostics to make asynchronous test issues easier to identify.

* **Documentation**
  * Updated testing guidance with the expanded set of assertion patterns covered by linting.
  * Added coverage details and instructions for validating each lint pattern independently.

* **Tests**
  * Expanded test fixtures to verify awaited element and polling assertions, including presence, absence, and resolved-value checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->