### PR TITLE
fix(test): the reference property applies its canvas edits, and always makes one

### DIFF
--- a/packages/server-core/src/references/reference-semantics.property.test.ts
+++ b/packages/server-core/src/references/reference-semantics.property.test.ts
@@ -367,6 +367,38 @@ describe('reference semantics under command sequences', () => {
         fileRefs: [],
       })
 
+      // The CANVAS route, deterministically. A canvasEdit command needs a
+      // spatial document in a slot before it can fire, and the prelude seeds
+      // only markdown — so whether any run exercises a canvas reference at
+      // all is left to the generator. Measured against a real regression
+      // (#1454 flipping canvas-edit's default from apply to propose): 4 of 8
+      // unseeded runs caught it, and the change's own CI was one of the four
+      // that did not, landing 26/26 green.
+      //
+      // Off-pool like the shadow seeds, so it never contends with command
+      // traffic; it references 'alpha', which the commands DO move, so a
+      // canvas token also rides the follow pass on every run.
+      const seedCanvas = await wbDocumentCreate(deps, {
+        workspaceId: WS,
+        path: 'canvas-witness',
+        kind: 'spatial',
+      })
+      const witnessText = 'see [[alpha]]'
+      await editTool.execute({
+        workspaceId: WS,
+        documentId: seedCanvas.documentId,
+        mode: 'apply',
+        ops: [{ op: 'node.add', node: { id: 'n-witness', type: 'text', text: witnessText } }],
+      })
+      model.docs.set(seedCanvas.documentId, {
+        id: seedCanvas.documentId,
+        path: 'canvas-witness',
+        kind: 'spatial',
+        bodyTokens: scanReferences(witnessText).map((m) => m.target),
+        embedIds: [],
+        fileRefs: [],
+      })
+
       for (const cmd of cmds) {
         switch (cmd.t) {
           case 'create': {
@@ -426,6 +458,7 @@ describe('reference semantics under command sequences', () => {
               await editTool.execute({
                 workspaceId: WS,
                 documentId: doc.id,
+                mode: 'apply',
                 ops: [
                   {
                     op: 'node.add',
@@ -443,6 +476,7 @@ describe('reference semantics under command sequences', () => {
               await editTool.execute({
                 workspaceId: WS,
                 documentId: doc.id,
+                mode: 'apply',
                 ops: [{ op: 'node.add', node: { id: nodeId, type: 'file', file: cmd.node.file } }],
               })
               doc.fileRefs.push(cmd.node.file)
@@ -454,6 +488,7 @@ describe('reference semantics under command sequences', () => {
               await editTool.execute({
                 workspaceId: WS,
                 documentId: doc.id,
+                mode: 'apply',
                 ops: [{ op: 'node.add', node: { id: nodeId, type: 'text', text } }],
               })
               doc.bodyTokens.push(...scanReferences(text).map((m) => m.target))


### PR DESCRIPTION
## Summary

`main` has been red on `reference-semantics.property.test.ts`. #1454 flipped `canvas-edit`'s default from `apply` to `propose` and updated every affected test — **except this one**. Its canvas edits have since been stored as proposals, so the document never changed while the model recorded the write:

```
text tokens of beta/leaf: expected [] to deeply equal [ '01M1VFV77…' ]   (PR run, seed -1894987868)
backlinks of gamma:       expected Map{} to deeply equal Map{ '01M1VFYG45…' => 1 }   (main 6665824f, seed 2070360224)
```

Two different seeds, two different assertions, one shape: **the real pipeline holds nothing where the model expects a reference.**

## Bisected, not guessed

| commit | seed −1894987868 |
|---|---|
| `1e3e0bed^` | **PASS** |
| `1e3e0bed` — *feat(server-core)!: an agent proposes content by default* | **FAIL** |

Reproduced 8/8 at the broken commit; both reported seeds pass with `mode: 'apply'` on the three content edits, which is exactly what #1454 did to `backlinks.test.ts`, `follow-rename.test.ts`, `document-search.test.ts` and the rest.

## Why it reached main at all — the half worth keeping

A `canvasEdit` command needs a spatial document *already in a slot* before it can fire, and the prelude seeds only markdown. Whether a run exercises the canvas route is therefore left to the generator:

| | detection of this regression |
|---|---|
| unseeded runs, as the test stood | **4 / 8** |
| #1454's own CI | one of the four that missed — landed **26/26 green** |
| with the witness added | **6 / 6** |

So the prelude now seeds a spatial document carrying a reference — off-pool like the shadow seeds, for the same reason and in the same shape as the path reference already above it, which carries its own "without this, zero runs held a path reference at move time" note. It references `alpha`, which the commands move, so a canvas token rides the follow pass every run too.

Mutation-checked: with the witness's `mode: 'apply'` removed, 6 of 6 unseeded runs fail.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added — this is the test
- [x] `pnpm test` passes locally — `server-core-node`: 57 files, **504 passed**
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable

Every number above was measured, in this order: reproduce (8/8 at the broken commit), bisect (pass at parent, fail at commit), fix, re-verify both reported seeds (7/7), then measure the detection rate before (4/8) and after (6/6) the witness.

Also run: `pnpm lint` (2496 files), `pnpm -r typecheck`.

## Note for the next reader

The seed in a `@fast-check/vitest` title reproduces this one — 8 of 8 — so the recipe in `integrator-flow.md` works here. An earlier single seeded run of mine passed and looked like "not reproducible"; it was run against the commit *before* the break, which is the discriminator that matters when a base branch has moved under you.

## Visual evidence

Visual evidence: none — a test fix; nothing user-visible renders.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract — n/a
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173KdAbXzLi3Nypu4fyneDv

---
_Generated by [Claude Code](https://claude.ai/code/session_0173KdAbXzLi3Nypu4fyneDv)_