### PR TITLE
feat(annotations): the markdown markers cross to the resolved look instead of cutting

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -810,6 +810,34 @@ Two things measurement corrected after the mechanism worked:
   patch — the viewBox is the union of everything in the scene, so a ghost is
   the only thing that can ever be outside it.
 
+**The markdown markers cross rather than leave, and that is the opposite of
+the canvas for a measured reason.** This editor is handed EVERY thread,
+resolved ones included, so nothing goes: the gutter dot, the passage
+underline and the preview marker all stay and change. A leave animation
+would be wrong here for the same reason a cross would be wrong there.
+
+Three markers, and DOM identity did not agree across them — measured over
+one resolve, not assumed:
+
+- **The CodeMirror gutter dot was REPLACED** (`same-element=false`), so
+  nothing could transition on it. Its `.cm-gutterElement` wrapper was the
+  same element throughout, and that is where the state moved. It cannot ride
+  the dot's own marker: CodeMirror re-reads `elementClass` only when a
+  line's marker set differs, and decides that with the same `eq` that
+  governs whether the dot's DOM is reused — so one marker cannot both keep
+  its element and announce a new class. An `elementClass` getter on it never
+  reached the wrapper at all. `gutterLineClass` is the facet provided for
+  exactly this, and `ResolvedLineMarker` satisfies its contract: a class, no
+  `toDOM`.
+- **The passage highlight is replaced too**, and is left cutting. Its state
+  is carried by a `Decoration.mark` class, which has no wrapper to move to;
+  the same trick would need a second decoration layer for a span that is
+  already legible from the dot beside it.
+- **The preview marker was reused** by React key and said nothing about
+  resolved at all — a closed conversation's marker was drawn exactly like an
+  open one, which is a gap rather than a motion problem. With `data-status`
+  present the crossing needs nothing but a class.
+
 **The rail's verbs are icon-first, and the status dot IS the Resolve
 toggle.** "Object-action surfaces are icon-first" below was written, the
 canvas card followed it (`CardAction`), and the rail never got held to it:

--- a/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
@@ -7,6 +7,7 @@ import type { MeasureText, ReferenceSeams } from '@kamiazya/whiteboard-canvas-re
 import { createBrowserMeasureText } from '@kamiazya/whiteboard-canvas-viewer'
 import {
   type CommentThread,
+  type CommentThreadStatus,
   documentIdSchema,
   type StoredCoreFacets,
 } from '@kamiazya/whiteboard-model'
@@ -501,6 +502,7 @@ export function MarkdownEditor({
       readonly top: number
       readonly selected: boolean
       readonly messages: number
+      readonly status: CommentThreadStatus
     }[]
   >([])
   const previewInnerRef = useRef<HTMLDivElement | null>(null)
@@ -763,6 +765,10 @@ export function MarkdownEditor({
       placeThreads(debouncedValue, projectedThreads, projectedMarks).map((placed) => ({
         threadId: placed.threadId,
         messages: messageCounts.get(placed.threadId) ?? 1,
+        // `PlacedThread` already carries it, and the preview said nothing
+        // about it: a resolved conversation's marker was drawn exactly like
+        // an open one, so a reader in Read mode could not tell them apart.
+        status: placed.status,
         top:
           svgTop +
           documentYForLine(
@@ -963,6 +969,7 @@ export function MarkdownEditor({
                   type="button"
                   data-testid="comment-preview-marker"
                   data-thread-id={marker.threadId}
+                  data-status={marker.status}
                   aria-label={
                     marker.messages > 1
                       ? `Open comment, ${marker.messages} messages`
@@ -972,7 +979,7 @@ export function MarkdownEditor({
                   // In the column's own left padding, on the block's top edge.
                   style={{ top: marker.top }}
                   className={cn(
-                    'absolute left-0 flex size-6 items-center justify-center rounded text-(--annotation) hover:bg-accent',
+                    'comment-preview-marker absolute left-0 flex size-6 items-center justify-center rounded text-(--annotation) hover:bg-accent',
                     marker.selected && 'bg-accent',
                   )}
                 >

--- a/apps/web/src/components/markdown-editor/annotation-decorations.ts
+++ b/apps/web/src/components/markdown-editor/annotation-decorations.ts
@@ -29,7 +29,14 @@ import {
   StateEffect,
   StateField,
 } from '@codemirror/state'
-import { Decoration, type DecorationSet, EditorView, GutterMarker, gutter } from '@codemirror/view'
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  GutterMarker,
+  gutter,
+  gutterLineClass,
+} from '@codemirror/view'
 import type { CommentThread, CommentThreadStatus } from '@kamiazya/whiteboard-model'
 import { type LivePassage, resolveTextAnchor } from '../../lib/text-anchor.js'
 
@@ -122,7 +129,6 @@ function gutterLabel(messages: number, threads: number): string {
 class ThreadGutterMarker extends GutterMarker {
   constructor(
     private readonly threadId: string,
-    private readonly status: CommentThreadStatus,
     private readonly selected: boolean,
     private readonly messages: number,
     private readonly threads: number,
@@ -130,10 +136,19 @@ class ThreadGutterMarker extends GutterMarker {
     super()
   }
 
+  /**
+   * Status is deliberately absent, and `elementClass` below is why.
+   *
+   * CodeMirror REPLACES a marker's DOM when `eq` is false — measured across
+   * one resolve, the dot came back as a different element — and a fresh
+   * element has no value to transition from, so the colour cut however the
+   * CSS was written. The `.cm-gutterElement` wrapper is the same element
+   * throughout (measured in the same run), so the state rides there and the
+   * dot, now reused, crosses.
+   */
   override eq(other: ThreadGutterMarker): boolean {
     return (
       other.threadId === this.threadId &&
-      other.status === this.status &&
       other.selected === this.selected &&
       other.messages === this.messages &&
       other.threads === this.threads
@@ -145,7 +160,6 @@ class ThreadGutterMarker extends GutterMarker {
     dot.type = 'button'
     dot.className = 'cm-annotation-gutter-marker'
     dot.dataset.threadId = this.threadId
-    if (this.status === 'resolved') dot.dataset.threadStatus = 'resolved'
     if (this.selected) dot.dataset.selected = 'true'
     // The one digit this dot can hold belongs to the CONVERSATION, not to
     // the line: a reader scanning a body is deciding whether to open this
@@ -170,6 +184,23 @@ class ThreadGutterMarker extends GutterMarker {
     return dot
   }
 }
+
+/**
+ * The RESOLVED state of the line, carried by a marker of its own.
+ *
+ * It cannot ride `ThreadGutterMarker`: CodeMirror only re-reads
+ * `elementClass` when a line's marker set actually differs, and it decides
+ * that with the same `eq` that governs whether the dot's DOM is reused. One
+ * marker cannot both keep its element and announce a new class — measured,
+ * an `elementClass` getter on the dot's own marker never reached the wrapper.
+ * `gutterLineClass` is the facet CodeMirror provides for exactly this, and
+ * its contract is what this class satisfies: an `elementClass`, no `toDOM`.
+ */
+class ResolvedLineMarker extends GutterMarker {
+  override elementClass = 'cm-annotation-resolved-line'
+}
+
+const RESOLVED_LINE_MARKER = new ResolvedLineMarker()
 
 function project(doc: string, projection: AnnotationProjection): AnnotationState {
   const placed = placeThreads(doc, projection.threads, projection.marks)
@@ -238,6 +269,21 @@ export function annotationMarks(): Extension {
 export function annotationDecorations(handlers: AnnotationHandlers = {}): Extension {
   return [
     annotationField,
+    // The line's state, separate from the dot that sits on it — see
+    // `ResolvedLineMarker`.
+    gutterLineClass.compute([annotationField], (state) => {
+      const { placed } = state.field(annotationField)
+      const builder = new RangeSetBuilder<GutterMarker>()
+      const lines = new Set<number>()
+      for (const one of placed) {
+        if (one.status !== 'resolved') continue
+        lines.add(state.doc.lineAt(one.from).from)
+      }
+      for (const lineStart of [...lines].sort((a, b) => a - b)) {
+        builder.add(lineStart, lineStart, RESOLVED_LINE_MARKER)
+      }
+      return builder.finish()
+    }),
     gutter({
       class: 'cm-annotation-gutter',
       markers: (view) => {
@@ -268,7 +314,6 @@ export function annotationDecorations(handlers: AnnotationHandlers = {}): Extens
             lineStart,
             new ThreadGutterMarker(
               lead.threadId,
-              lead.status,
               lead.threadId === selectedThreadId,
               messageCounts.get(lead.threadId) ?? 1,
               bucket.length,

--- a/apps/web/src/components/markdown-editor/annotation-resolve-motion.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/annotation-resolve-motion.browser.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Resolving a conversation CROSSES its markdown markers to the resolved look,
+ * the way the rail's row already crosses.
+ *
+ * This surface is the opposite of the canvas, measured rather than assumed:
+ * the markdown editor is handed every thread including resolved ones, so
+ * nothing leaves — the gutter dot and the passage stay and change colour.
+ * A leave animation would be wrong here for the same reason a cross would be
+ * wrong there.
+ *
+ * What blocked it was DOM identity, and the three markers did not agree.
+ * Measured across one resolve: the CodeMirror gutter dot was REPLACED
+ * (`same-element=false`), so nothing could transition on it; its
+ * `.cm-gutterElement` wrapper was the same element throughout; and the
+ * preview marker was reused by React key but carried no resolved state at
+ * all, so a reader in Read mode could not tell an open conversation from a
+ * closed one.
+ *
+ * Real browser: a computed `transition-duration` and element identity are
+ * both claims jsdom cannot make.
+ */
+import type { CommentThread } from '@kamiazya/whiteboard-model'
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MarkdownEditor } from './MarkdownEditor.js'
+
+afterEach(cleanup)
+
+const BODY = ['# The plan', '', 'First paragraph, which opens the document.', ''].join('\n')
+const EXACT = 'First paragraph'
+
+function thread(status: 'open' | 'resolved'): CommentThread {
+  const start = BODY.indexOf(EXACT)
+  return {
+    id: 't1',
+    anchor: { kind: 'text', quote: { exact: EXACT }, start, end: start + EXACT.length },
+    status,
+    messages: [{ id: 'm1', body: 'why Friday?' }],
+  }
+}
+
+const view = (status: 'open' | 'resolved') => (
+  <MarkdownEditor
+    value={BODY}
+    onChange={vi.fn()}
+    initialViewMode="split"
+    previewDebounceMs={0}
+    threads={[thread(status)]}
+  />
+)
+
+const gutterDot = () => document.querySelector('.cm-annotation-gutter-marker')
+const previewMarker = () => document.querySelector('[data-testid="comment-preview-marker"]')
+
+async function resolveOne() {
+  const { rerender } = render(view('open'))
+  await vi.waitFor(() => expect(gutterDot()).not.toBeNull(), { timeout: 4000 })
+  await vi.waitFor(() => expect(previewMarker()).not.toBeNull(), { timeout: 4000 })
+  const before = { gutter: gutterDot(), preview: previewMarker() }
+  rerender(view('resolved'))
+  return before
+}
+
+describe('the source pane gutter on resolve', () => {
+  it('keeps the same dot and crosses it, instead of swapping in a new one', async () => {
+    const before = await resolveOne()
+    await vi.waitFor(
+      () =>
+        expect(
+          gutterDot()
+            ?.closest('.cm-gutterElement')
+            ?.classList.contains('cm-annotation-resolved-line'),
+        ).toBe(true),
+      { timeout: 4000 },
+    )
+    // Identity is the whole claim: a replaced element has no value to
+    // transition FROM, which is why the state moved onto the wrapper
+    // CodeMirror keeps.
+    expect(gutterDot()).toBe(before.gutter)
+  })
+
+  it('declares the crossing on the dot, so the colour is not a cut', async () => {
+    await resolveOne()
+    const dot = gutterDot()?.querySelector('.cm-annotation-gutter-dot')
+    if (dot === null || dot === undefined) throw new Error('no gutter dot')
+    expect(getComputedStyle(dot).transitionDuration).not.toBe('0s')
+  })
+})
+
+describe('the preview marker on resolve', () => {
+  it('says which state it is in at all, which it did not before', async () => {
+    const before = await resolveOne()
+    await vi.waitFor(
+      () => expect((previewMarker() as HTMLElement | null)?.dataset.status).toBe('resolved'),
+      { timeout: 4000 },
+    )
+    // Reused by React key, so the crossing needs nothing but the class.
+    expect(previewMarker()).toBe(before.preview)
+    expect(getComputedStyle(previewMarker() as Element).transitionDuration).not.toBe('0s')
+  })
+})

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -269,9 +269,37 @@
     line-height: 8px;
     text-align: center;
   }
-  .cm-annotation-gutter-marker[data-thread-status='resolved'] .cm-annotation-gutter-dot {
+  /*
+   * Resolved rides the LINE's gutter element rather than the dot, because
+   * CodeMirror replaces a marker's DOM when its identity changes and a
+   * fresh element has nothing to cross from — measured across one resolve.
+   * The wrapper is the same element throughout, so the dot is reused and
+   * this reads as the state moving rather than as a swap.
+   */
+  .cm-annotation-resolved-line .cm-annotation-gutter-dot {
     border-style: dotted;
     background: transparent;
+  }
+  /*
+   * The preview's marker crosses the same way, and it needs no wrapper
+   * trick: React keys it by thread id, so the element survives the change
+   * and the class is enough. It said nothing about resolved before this —
+   * a closed conversation's marker was drawn exactly like an open one.
+   */
+  .comment-preview-marker {
+    transition:
+      opacity var(--motion-duration-normal) var(--motion-ease-out),
+      background-color var(--motion-duration-normal) var(--motion-ease-out);
+  }
+  .comment-preview-marker[data-status='resolved'] {
+    opacity: 0.45;
+  }
+
+  .cm-annotation-gutter-dot {
+    transition:
+      background-color var(--motion-duration-normal) var(--motion-ease-out),
+      border-color var(--motion-duration-normal) var(--motion-ease-out),
+      color var(--motion-duration-normal) var(--motion-ease-out);
   }
   .cm-annotation-gutter-marker[data-selected='true'] .cm-annotation-gutter-dot {
     background: var(--annotation);

--- a/packages/mcp-server/src/server/file-size-budget.test.ts
+++ b/packages/mcp-server/src/server/file-size-budget.test.ts
@@ -115,7 +115,11 @@ const FILE_SIZE_GRANDFATHER: Record<string, number> = {
   // and the definition carries why — inside the preview column that query
   // answers with a comment MARKER's own icon, so the placement was reading
   // its own previous output.
-  'apps/web/src/components/markdown-editor/MarkdownEditor.tsx': 1066,
+  // +7: the preview marker carries the conversation's STATUS. It said
+  // nothing about resolved before, so a closed conversation's marker was
+  // drawn exactly like an open one — and with the state present the marker
+  // crosses to it rather than staying put.
+  'apps/web/src/components/markdown-editor/MarkdownEditor.tsx': 1073,
   // +1: `CONTENT_CONTAINER_KEYS` gains the proposal layer's plane
   // (ADR-0029). One line, and it has to be here — the list is what a
   // tree-node host pre-attaches from, and a container attached on first


### PR DESCRIPTION
## Summary

The last two surfaces where resolving a conversation was a hard cut: the source pane's gutter dot and the preview marker. The rail crosses, the canvas ramps out — these still swapped between frames.

**This surface is the OPPOSITE of the canvas, and the measurement is what says so.** The markdown editor is handed every thread including resolved ones (`threads.annotations`, unfiltered), so nothing leaves — the gutter dot, the passage underline and the preview marker stay and change. A leave animation would be wrong here for the same reason a cross would be wrong there.

DOM identity did not agree across the three markers, measured over one resolve rather than reasoned about:

| marker | on resolve | what it needed |
|---|---|---|
| CodeMirror gutter dot | **replaced** (`same-element=false`) | the state moved to `.cm-gutterElement`, which was the same element throughout |
| preview marker | **reused** (React key), but carried no resolved state at all | `data-status` — a gap, not a motion problem |
| passage underline | replaced | left cutting, deliberately (below) |

**The gutter took a wrong turn first, and the reason is worth having on the record.** The obvious move — an `elementClass` getter on `ThreadGutterMarker` — never reached the wrapper. CodeMirror re-reads `elementClass` only when a line's marker set actually differs, and it decides that with the same `eq` that governs whether the dot's DOM is reused (`setMarkers` runs behind `!sameMarkers(...)`, and `compare` is `eq`). So **one marker cannot both keep its element and announce a new class.** `gutterLineClass` is the facet provided for exactly this, and `ResolvedLineMarker` satisfies its documented contract: an `elementClass`, no `toDOM`.

**The preview finding may matter more than the motion.** A resolved conversation's marker was drawn exactly like an open one, so a reader in Read mode could not tell them apart at all.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [x] `pnpm test` passes locally
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable

`annotation-resolve-motion.browser.test.tsx` (`web-browser`) holds three claims: the gutter dot is the SAME element after a resolve while its wrapper carries the resolved class; the dot declares a colour crossing; and the preview marker says which state it is in, is reused, and crosses.

```
web-browser        235 files, 1236 tests passed
web-jsdom + mcp-node (annotation, file-size-budget)   green
pnpm -r typecheck  0 errors
pnpm lint          clean
```

Five fresh-process runs of the new file, then the whole project. All four claims mutation-checked — restoring `status` to `eq` (so the dot is replaced again), removing the line-class facet, dropping the marker's `data-status`, and removing the transitions each turn a test red.

`ThreadGutterMarker` loses its `status` field entirely: it is the line's business now, and an unread field would have been the omission with a name on it. `file-size-budget.test.ts` raises `MarkdownEditor.tsx` 1066 → 1073, with the reason beside it.

Manual verification in a real browser, and the numbers the figure is labelled with come from `getComputedStyle` in that same run: the gutter dot goes `solid` → `dotted`, the preview marker `opacity: 1` → `0.45`.

## Visual evidence

`markdown-resolve.png` — the split view before and after one resolve. **Not inline**: this environment has no `gh` CLI, so `gh pr create --attach` is unavailable and there is no API path to upload a binary into a PR body. The PNG was handed back in the session and can be dropped into this description directly. Digest: `c8f6ad18464f06196204a90694c2c5cc`.

Left panel is the open conversation — solid gutter dot, solid passage underline, full-strength preview marker. Right is the same document resolved: dotted dot, dotted underline, faded marker, everything else untouched.

What it cannot show is the crossing itself, which is behaviour over time; the computed `transition-duration` is asserted instead, in a real browser, because a declared transition and a running one are different claims and only one is visible to jsdom.

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [x] Docs updated if this changes user-visible behavior or a published contract
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

`apps/web/DESIGN.md` records why this surface crosses where the canvas ramps out, and the CodeMirror mechanism above.

## Left cutting, deliberately

The passage underline. Its state is a `Decoration.mark` class, and a mark has no stable wrapper to move to — the same trick would need a second decoration layer over a span whose meaning the dot beside it already carries. Recorded in `DESIGN.md` rather than left for a reader to wonder about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPGrBEknX78whd38tHXnLH

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPGrBEknX78whd38tHXnLH)_