### PR TITLE
feat(web): decide a proposed passage in the body

### DIFF
--- a/apps/web/src/components/document-editor/DocumentEditorSurface.tsx
+++ b/apps/web/src/components/document-editor/DocumentEditorSurface.tsx
@@ -43,6 +43,8 @@ export interface MarkdownDocumentSession
     | 'selectedThreadId'
     | 'onSelectThread'
     | 'onComposeThread'
+    | 'proposals'
+    | 'onDecidePassage'
   > {
   /** Null until the document has hydrated — nothing editable renders before. */
   readonly body: string | null

--- a/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
@@ -9,6 +9,7 @@ import {
   type CommentThread,
   type CommentThreadStatus,
   documentIdSchema,
+  type Proposal,
   type StoredCoreFacets,
 } from '@kamiazya/whiteboard-model'
 import { MessageSquare } from 'lucide-react'
@@ -42,6 +43,7 @@ import { DocumentHeader } from './DocumentHeader.js'
 import { EditorToolbar, type MarkdownViewMode } from './EditorToolbar.js'
 import { LinkPickerDialog } from './LinkPickerDialog.js'
 import { MinimapRail } from './MinimapRail.js'
+import { PassageProposalCard } from './PassageProposalCard.js'
 import { PreviewPane } from './PreviewPane.js'
 import {
   previewWidth as computePreviewWidth,
@@ -50,6 +52,11 @@ import {
   railFits,
   railScrollable,
 } from './preview-width.js'
+import {
+  placePassages,
+  proposalDecorations,
+  setProposalProjection,
+} from './proposal-decorations.js'
 import { SourcePane, type SourcePaneApi } from './SourcePane.js'
 import { useDebouncedValue } from './use-debounced-value.js'
 import { verbCatalogItems } from './verb-catalog.js'
@@ -164,10 +171,30 @@ export interface MarkdownEditorProps {
    * offers no such row rather than an inert one.
    */
   onComposeThread?: (anchor: TextAnchor) => void
+  /**
+   * The proposal layer's open changes, projected onto the body: the passage
+   * each one would replace is marked in the text and named by a gutter
+   * marker beside it (ADR-0029 decision 1, for prose).
+   *
+   * Only `body.replace` changes are drawn — a canvas change is about a
+   * surface this document has not got — and only open ones, since a decision
+   * the person already made must not be asked again.
+   */
+  proposals?: readonly Proposal[]
+  /**
+   * The person decided one passage. Absent means this host has no proposal
+   * layer, and no card is offered rather than an inert one.
+   */
+  onDecidePassage?: (
+    proposalId: string,
+    changeId: string,
+    decision: 'adopted' | 'dismissed',
+  ) => void
 }
 
 /** Stable identity, so the projection effect below does not fire per render. */
 const NO_THREADS: readonly CommentThread[] = []
+const NO_PROPOSALS: readonly Proposal[] = []
 /** Same purpose as NO_THREADS, for the passages beside them. */
 const NO_MARKS: ReadonlyMap<string, LivePassage> = new Map()
 
@@ -339,6 +366,8 @@ export function MarkdownEditor({
   threadMarks,
   selectedThreadId = null,
   onSelectThread,
+  proposals,
+  onDecidePassage,
   onComposeThread,
 }: MarkdownEditorProps) {
   const resolvedMeasure = useMemo(() => measure ?? createBrowserMeasureText(), [measure])
@@ -384,13 +413,39 @@ export function MarkdownEditor({
   // passes is a fresh closure on every render.
   const onSelectThreadRef = useRef(onSelectThread)
   onSelectThreadRef.current = onSelectThread
+  const [openPassage, setOpenPassage] = useState<{
+    proposalId: string
+    changeId: string
+    x: number
+    y: number
+  } | null>(null)
+  const proposalExtension = useMemo(
+    () =>
+      proposalDecorations({
+        onSelectPassage: (proposalId, changeId, at) => {
+          const rect = rootRef.current?.getBoundingClientRect()
+          setOpenPassage({
+            proposalId,
+            changeId,
+            x: at.clientX - (rect?.left ?? 0),
+            y: at.clientY - (rect?.top ?? 0),
+          })
+        },
+      }),
+    [],
+  )
   const annotationExtension = useMemo(
     () => annotationDecorations({ onSelectThread: (id) => onSelectThreadRef.current?.(id) }),
     [],
   )
   const paneExtensions = useMemo(
-    () => [completionExtension, annotationExtension, ...(sourceExtensions ?? [])],
-    [annotationExtension, completionExtension, sourceExtensions],
+    () => [
+      completionExtension,
+      annotationExtension,
+      proposalExtension,
+      ...(sourceExtensions ?? []),
+    ],
+    [annotationExtension, completionExtension, proposalExtension, sourceExtensions],
   )
   const debouncedValue = useDebouncedValue(value, previewDebounceMs)
   // Watches the DEBOUNCED value: fragment sources only exist once the
@@ -457,6 +512,33 @@ export function MarkdownEditor({
       }),
     ])
   }, [projectedThreads, projectedMarks, selectedThreadId])
+
+  const projectedProposals = proposals ?? NO_PROPOSALS
+  useEffect(() => {
+    sourceApiRef.current?.applyEffects([
+      setProposalProjection.of({
+        proposals: projectedProposals,
+        selectedChangeId: openPassage?.changeId ?? null,
+      }),
+    ])
+  }, [projectedProposals, openPassage])
+
+  // The card follows the DOCUMENT, not the press: once the passage it is
+  // about stops resolving — the person adopted it, dismissed it, or edited
+  // the words out from under it — there is nothing left to decide, and a
+  // card still offering the verbs would write against a passage that is
+  // gone.
+  const openPlacedPassage = useMemo(() => {
+    if (openPassage === null) return null
+    return (
+      placePassages(value, projectedProposals).find(
+        (one) => one.changeId === openPassage.changeId,
+      ) ?? null
+    )
+  }, [openPassage, projectedProposals, value])
+  useEffect(() => {
+    if (openPassage !== null && openPlacedPassage === null) setOpenPassage(null)
+  }, [openPassage, openPlacedPassage])
 
   // Scroll to the passage when the SELECTION changes, and only then. `value`
   // is a dependency because the passage's offset is derived from it, but a
@@ -1043,6 +1125,19 @@ export function MarkdownEditor({
           />
         )}
       </div>
+      {openPassage !== null && openPlacedPassage !== null && onDecidePassage !== undefined && (
+        <PassageProposalCard
+          current={value.slice(openPlacedPassage.from, openPlacedPassage.to)}
+          proposed={openPlacedPassage.text}
+          conflicted={openPlacedPassage.conflicted}
+          at={{ x: openPassage.x, y: openPassage.y }}
+          onDecide={(decision) => {
+            onDecidePassage(openPassage.proposalId, openPassage.changeId, decision)
+            setOpenPassage(null)
+          }}
+          onClose={() => setOpenPassage(null)}
+        />
+      )}
       {linkPicker !== null && linkTargets !== undefined && (
         <LinkPickerDialog
           targets={linkTargets}

--- a/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/markdown-editor/MarkdownEditor.tsx
@@ -1,6 +1,6 @@
 import { acceptCompletion, autocompletion, completionStatus } from '@codemirror/autocomplete'
 import { redo, undo } from '@codemirror/commands'
-import type { Extension } from '@codemirror/state'
+import type { Extension, StateEffect } from '@codemirror/state'
 import { Prec } from '@codemirror/state'
 import { keymap } from '@codemirror/view'
 import type { MeasureText, ReferenceSeams } from '@kamiazya/whiteboard-canvas-render'
@@ -52,13 +52,9 @@ import {
   railFits,
   railScrollable,
 } from './preview-width.js'
-import {
-  placePassages,
-  proposalDecorations,
-  setProposalProjection,
-} from './proposal-decorations.js'
 import { SourcePane, type SourcePaneApi } from './SourcePane.js'
 import { useDebouncedValue } from './use-debounced-value.js'
+import { usePassageProposals } from './use-passage-proposals.js'
 import { verbCatalogItems } from './verb-catalog.js'
 import {
   wikiLinkCompletionSource,
@@ -413,27 +409,18 @@ export function MarkdownEditor({
   // passes is a fresh closure on every render.
   const onSelectThreadRef = useRef(onSelectThread)
   onSelectThreadRef.current = onSelectThread
-  const [openPassage, setOpenPassage] = useState<{
-    proposalId: string
-    changeId: string
-    x: number
-    y: number
-  } | null>(null)
-  const proposalExtension = useMemo(
-    () =>
-      proposalDecorations({
-        onSelectPassage: (proposalId, changeId, at) => {
-          const rect = rootRef.current?.getBoundingClientRect()
-          setOpenPassage({
-            proposalId,
-            changeId,
-            x: at.clientX - (rect?.left ?? 0),
-            y: at.clientY - (rect?.top ?? 0),
-          })
-        },
-      }),
-    [],
-  )
+  const rootRef = useRef<HTMLDivElement | null>(null)
+
+  const applyProposalEffects = useCallback((effects: readonly StateEffect<unknown>[]) => {
+    sourceApiRef.current?.applyEffects(effects)
+  }, [])
+  const passageProposals = usePassageProposals({
+    value,
+    proposals: proposals ?? NO_PROPOSALS,
+    applyEffects: applyProposalEffects,
+    rootRef,
+  })
+
   const annotationExtension = useMemo(
     () => annotationDecorations({ onSelectThread: (id) => onSelectThreadRef.current?.(id) }),
     [],
@@ -442,10 +429,10 @@ export function MarkdownEditor({
     () => [
       completionExtension,
       annotationExtension,
-      proposalExtension,
+      passageProposals.extension,
       ...(sourceExtensions ?? []),
     ],
-    [annotationExtension, completionExtension, proposalExtension, sourceExtensions],
+    [annotationExtension, completionExtension, passageProposals.extension, sourceExtensions],
   )
   const debouncedValue = useDebouncedValue(value, previewDebounceMs)
   // Watches the DEBOUNCED value: fragment sources only exist once the
@@ -486,7 +473,7 @@ export function MarkdownEditor({
 
   // Source-pane share of the split, clamped so neither pane can vanish.
   const [splitRatio, setSplitRatio] = useState(0.5)
-  const rootRef = useRef<HTMLDivElement | null>(null)
+
   const sourceWrapRef = useRef<HTMLDivElement | null>(null)
   const previewScrollRef = useRef<HTMLDivElement | null>(null)
   const sourceApiRef = useRef<SourcePaneApi | null>(null)
@@ -512,33 +499,6 @@ export function MarkdownEditor({
       }),
     ])
   }, [projectedThreads, projectedMarks, selectedThreadId])
-
-  const projectedProposals = proposals ?? NO_PROPOSALS
-  useEffect(() => {
-    sourceApiRef.current?.applyEffects([
-      setProposalProjection.of({
-        proposals: projectedProposals,
-        selectedChangeId: openPassage?.changeId ?? null,
-      }),
-    ])
-  }, [projectedProposals, openPassage])
-
-  // The card follows the DOCUMENT, not the press: once the passage it is
-  // about stops resolving — the person adopted it, dismissed it, or edited
-  // the words out from under it — there is nothing left to decide, and a
-  // card still offering the verbs would write against a passage that is
-  // gone.
-  const openPlacedPassage = useMemo(() => {
-    if (openPassage === null) return null
-    return (
-      placePassages(value, projectedProposals).find(
-        (one) => one.changeId === openPassage.changeId,
-      ) ?? null
-    )
-  }, [openPassage, projectedProposals, value])
-  useEffect(() => {
-    if (openPassage !== null && openPlacedPassage === null) setOpenPassage(null)
-  }, [openPassage, openPlacedPassage])
 
   // Scroll to the passage when the SELECTION changes, and only then. `value`
   // is a dependency because the passage's offset is derived from it, but a
@@ -1125,19 +1085,25 @@ export function MarkdownEditor({
           />
         )}
       </div>
-      {openPassage !== null && openPlacedPassage !== null && onDecidePassage !== undefined && (
-        <PassageProposalCard
-          current={value.slice(openPlacedPassage.from, openPlacedPassage.to)}
-          proposed={openPlacedPassage.text}
-          conflicted={openPlacedPassage.conflicted}
-          at={{ x: openPassage.x, y: openPassage.y }}
-          onDecide={(decision) => {
-            onDecidePassage(openPassage.proposalId, openPassage.changeId, decision)
-            setOpenPassage(null)
-          }}
-          onClose={() => setOpenPassage(null)}
-        />
-      )}
+      {passageProposals.open !== null &&
+        passageProposals.placed !== null &&
+        onDecidePassage !== undefined && (
+          <PassageProposalCard
+            current={value.slice(passageProposals.placed.from, passageProposals.placed.to)}
+            proposed={passageProposals.placed.text}
+            conflicted={passageProposals.placed.conflicted}
+            at={{ x: passageProposals.open.x, y: passageProposals.open.y }}
+            onDecide={(decision) => {
+              onDecidePassage(
+                passageProposals.open?.proposalId as string,
+                passageProposals.open?.changeId as string,
+                decision,
+              )
+              passageProposals.close()
+            }}
+            onClose={passageProposals.close}
+          />
+        )}
       {linkPicker !== null && linkTargets !== undefined && (
         <LinkPickerDialog
           targets={linkTargets}

--- a/apps/web/src/components/markdown-editor/PassageProposalCard.tsx
+++ b/apps/web/src/components/markdown-editor/PassageProposalCard.tsx
@@ -1,0 +1,98 @@
+/**
+ * What a person decides a proposed passage on, drawn beside the words it
+ * would replace (ADR-0029 decision 1, for prose).
+ *
+ * The canvas card and this one are the same act in two places, so they share
+ * the grammar rather than each inventing one: icon verbs at
+ * `ICON_VERB_CLASS`, a circled glyph for a verb that WRITES something, and
+ * the accessible name carrying what the bare icon cannot.
+ *
+ * What differs is the subject. A canvas change is described ("Move the
+ * risk"); a passage change is SHOWN — the words it would put there are the
+ * whole content of the decision, and a summary of them would be a worse
+ * version of the thing itself.
+ */
+import { CircleCheck, CircleX } from 'lucide-react'
+import type { CSSProperties } from 'react'
+import { ICON_VERB_CLASS } from '../ui/icon-verb.js'
+
+export interface PassageProposalCardProps {
+  /** The words the body holds there now. */
+  readonly current: string
+  /** The words the change would put there. */
+  readonly proposed: string
+  /**
+   * Whether the passage stopped saying what the change assumed. Decision 5:
+   * the proposal followed the document, and adopting now would replace words
+   * the agent never read — which is the person's call to make, and theirs to
+   * be told about.
+   */
+  readonly conflicted: boolean
+  readonly at: { readonly x: number; readonly y: number }
+  readonly onDecide: (decision: 'adopted' | 'dismissed') => void
+  readonly onClose: () => void
+}
+
+export function PassageProposalCard({
+  current,
+  proposed,
+  conflicted,
+  at,
+  onDecide,
+  onClose,
+}: PassageProposalCardProps) {
+  const style: CSSProperties = { left: at.x, top: at.y }
+  return (
+    <div
+      className="absolute z-30 w-72 max-w-[min(18rem,calc(100vw-2rem))] rounded-md border border-border bg-popover p-2 text-popover-foreground shadow-md"
+      style={style}
+      role="dialog"
+      aria-label="Proposed change to this passage"
+      data-testid="passage-proposal-card"
+    >
+      {conflicted ? (
+        <p className="mb-1.5 text-xs text-amber-700 dark:text-amber-400">
+          These words changed after this was proposed.
+        </p>
+      ) : null}
+      <div className="mb-2 space-y-1 text-sm">
+        <p className="whitespace-pre-wrap break-words text-muted-foreground line-through">
+          {current}
+        </p>
+        <p className="whitespace-pre-wrap break-words">{proposed}</p>
+      </div>
+      <div className="flex items-center justify-end gap-1">
+        {/* Dismiss first, Adopt last: the rightmost is the one a thumb
+            reaches without looking, and adopting is the act that writes. */}
+        <button
+          type="button"
+          className={ICON_VERB_CLASS}
+          aria-label="Dismiss this change"
+          title="Dismiss this change"
+          onClick={() => onDecide('dismissed')}
+        >
+          <CircleX aria-hidden="true" className="size-5" />
+        </button>
+        <button
+          type="button"
+          className={ICON_VERB_CLASS}
+          aria-label="Adopt this change"
+          title="Adopt this change"
+          onClick={() => onDecide('adopted')}
+        >
+          <CircleCheck aria-hidden="true" className="size-5" />
+        </button>
+      </div>
+      {/* A bare × is chrome, not a verb — it decides nothing about the
+          passage, it puts the card away. */}
+      <button
+        type="button"
+        className="absolute right-1 top-1 grid size-6 place-items-center rounded text-muted-foreground hover:text-foreground"
+        aria-label="Close"
+        onClick={onClose}
+      >
+        <span aria-hidden="true">×</span>
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/components/markdown-editor/passage-proposal.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/passage-proposal.browser.test.tsx
@@ -99,6 +99,32 @@ describe('a proposed passage in the body', () => {
     )
   })
 
+  it('opens the card from the keyboard, because the gutter target is a real button', async () => {
+    const { container, getByTestId, queryByTestId } = render(
+      <MarkdownEditor
+        initialViewMode="write"
+        value={BODY}
+        onChange={vi.fn()}
+        proposals={proposalOf('Thursday', 'Friday')}
+        onDecidePassage={vi.fn()}
+      />,
+    )
+
+    const marker = await vi.waitFor(() => {
+      const found = container.querySelector<HTMLElement>('.cm-proposal-gutter-marker')
+      expect(found).not.toBeNull()
+      return found as HTMLElement
+    })
+    // It is reachable by tab, so it has to answer what a tab-reached button
+    // answers to. Enter and Space synthesize a `click`, never a `mousedown`.
+    expect(marker.tabIndex).toBe(0)
+    expect(queryByTestId('passage-proposal-card')).toBeNull()
+
+    marker.focus()
+    await userEvent.keyboard('{Enter}')
+    expect(getByTestId('passage-proposal-card').textContent).toContain('Friday')
+  })
+
   it('draws nothing for a change the person already decided', async () => {
     const decided: readonly Proposal[] = [
       {

--- a/apps/web/src/components/markdown-editor/passage-proposal.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/passage-proposal.browser.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Deciding a proposed passage from the body, in a real browser.
+ *
+ * Every half of this needs a live CodeMirror: the highlight is a decoration
+ * the view builds, the affordance is a gutter marker it renders, and the card
+ * is positioned from that marker's own box. A jsdom render has none of them.
+ */
+import type { Proposal } from '@kamiazya/whiteboard-model'
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { MarkdownEditor } from './MarkdownEditor.js'
+
+afterEach(cleanup)
+
+const BODY = 'The plan is to ship on Thursday.'
+
+function proposalOf(exact: string, text: string, assumed = exact): readonly Proposal[] {
+  const start = BODY.indexOf(exact)
+  return [
+    {
+      id: 'p1',
+      changes: [
+        {
+          id: 'c1',
+          op: 'body.replace',
+          status: 'open',
+          anchor: { kind: 'text', quote: { exact }, start, end: start + exact.length },
+          text,
+          assumed,
+        },
+      ],
+    },
+  ]
+}
+
+describe('a proposed passage in the body', () => {
+  it('draws the passage and opens a card that decides it', async () => {
+    const onDecidePassage = vi.fn()
+    const { container, getByRole, getByTestId, queryByTestId } = render(
+      <MarkdownEditor
+        initialViewMode="write"
+        value={BODY}
+        onChange={vi.fn()}
+        proposals={proposalOf('Thursday', 'Friday')}
+        onDecidePassage={onDecidePassage}
+      />,
+    )
+
+    // The passage is marked where its quote is, not merely somewhere.
+    const marked = await vi.waitFor(() => {
+      const found = container.querySelector('.cm-proposal')
+      expect(found?.textContent).toBe('Thursday')
+      return found as HTMLElement
+    })
+    expect(marked.dataset.changeId).toBe('c1')
+
+    // The gutter is the press target — the passage itself must stay
+    // ordinary editable text.
+    expect(queryByTestId('passage-proposal-card')).toBeNull()
+    const marker = await vi.waitFor(() => {
+      const found = container.querySelector<HTMLElement>('.cm-proposal-gutter-marker')
+      expect(found).not.toBeNull()
+      return found as HTMLElement
+    })
+    await userEvent.click(marker)
+
+    const card = getByTestId('passage-proposal-card')
+    expect(card.textContent).toContain('Thursday')
+    expect(card.textContent).toContain('Friday')
+
+    await userEvent.click(getByRole('button', { name: 'Adopt this change' }))
+    expect(onDecidePassage).toHaveBeenCalledWith('p1', 'c1', 'adopted')
+    // The card closes on a decision: it was asking a question that now has
+    // an answer, and leaving it open invites the same press twice.
+    expect(queryByTestId('passage-proposal-card')).toBeNull()
+  })
+
+  it('says so when the words changed after the proposal was written', async () => {
+    const { container, getByTestId } = render(
+      <MarkdownEditor
+        initialViewMode="write"
+        value={BODY}
+        onChange={vi.fn()}
+        proposals={proposalOf('Thursday', 'Friday', 'Wednesday')}
+        onDecidePassage={vi.fn()}
+      />,
+    )
+
+    const marker = await vi.waitFor(() => {
+      const found = container.querySelector<HTMLElement>('.cm-proposal-gutter-marker')
+      expect(found?.dataset.conflicted).toBe('true')
+      return found as HTMLElement
+    })
+    await userEvent.click(marker)
+
+    expect(getByTestId('passage-proposal-card').textContent).toContain(
+      'These words changed after this was proposed',
+    )
+  })
+
+  it('draws nothing for a change the person already decided', async () => {
+    const decided: readonly Proposal[] = [
+      {
+        id: 'p1',
+        changes: [
+          {
+            id: 'c1',
+            op: 'body.replace',
+            status: 'adopted',
+            anchor: { kind: 'text', quote: { exact: 'Thursday' }, start: 23, end: 31 },
+            text: 'Friday',
+            assumed: 'Thursday',
+          },
+        ],
+      },
+    ]
+    const { container } = render(
+      <MarkdownEditor
+        initialViewMode="write"
+        value={BODY}
+        onChange={vi.fn()}
+        proposals={decided}
+        onDecidePassage={vi.fn()}
+      />,
+    )
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('.cm-proposal-gutter-marker')).toBeNull()
+      expect(container.querySelector('.cm-proposal')).toBeNull()
+    })
+  })
+})

--- a/apps/web/src/components/markdown-editor/proposal-decorations.test.ts
+++ b/apps/web/src/components/markdown-editor/proposal-decorations.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+/**
+ * The source pane's half of the proposal layer: which passages of the body
+ * an open proposed change is drawn over.
+ *
+ * Placement is tested apart from CodeMirror for the reason its annotation
+ * twin is — a range is a pair of offsets into text, and an off-by-one puts
+ * the highlight over the wrong words. Whether the decoration reaches the DOM
+ * is UI wiring, and the browser test beside this one covers that.
+ */
+import type { Proposal, ProposedChange, ProposedChangeStatus } from '@kamiazya/whiteboard-model'
+import { describe, expect, it } from 'vitest'
+import { placePassages } from './proposal-decorations.js'
+
+function passage(
+  id: string,
+  body: string,
+  exact: string,
+  text: string,
+  status: ProposedChangeStatus = 'open',
+): ProposedChange {
+  const start = body.indexOf(exact)
+  return {
+    id,
+    op: 'body.replace',
+    status,
+    anchor: { kind: 'text', quote: { exact }, start, end: start + exact.length },
+    text,
+    assumed: exact,
+  }
+}
+
+function proposal(id: string, changes: readonly ProposedChange[]): Proposal {
+  return { id, changes: [...changes] }
+}
+
+const BODY = 'Ship on Thursday. Review on Friday.'
+
+describe('placePassages', () => {
+  it('places an open passage over the words it quotes', () => {
+    const change = passage('c1', BODY, 'Thursday', 'Monday')
+    expect(placePassages(BODY, [proposal('p1', [change])])).toEqual([
+      { proposalId: 'p1', changeId: 'c1', from: 8, to: 16, text: 'Monday', conflicted: false },
+    ])
+  })
+
+  it('finds the passage by its quote after an edit moved it', () => {
+    const change = passage('c1', BODY, 'Thursday', 'Monday')
+    const edited = `> Added since.\n\n${BODY}`
+    expect(placePassages(edited, [proposal('p1', [change])])).toEqual([
+      { proposalId: 'p1', changeId: 'c1', from: 24, to: 32, text: 'Monday', conflicted: false },
+    ])
+  })
+
+  it('draws nothing for a change the person has already decided', () => {
+    const adopted = passage('c1', BODY, 'Thursday', 'Monday', 'adopted')
+    const dismissed = passage('c2', BODY, 'Friday', 'Tuesday', 'dismissed')
+    expect(placePassages(BODY, [proposal('p1', [adopted, dismissed])])).toEqual([])
+  })
+
+  it('draws nothing for a passage that is gone', () => {
+    const change = passage('c1', BODY, 'Thursday', 'Monday')
+    expect(placePassages('The plan changed entirely.', [proposal('p1', [change])])).toEqual([])
+  })
+
+  it('ignores a canvas change, whose subject is another surface', () => {
+    const canvasChange: ProposedChange = {
+      id: 'node:n1',
+      op: 'node.patch',
+      status: 'open',
+      nodeId: 'n1',
+      patch: { x: 240 },
+      assumed: { x: 0 },
+    }
+    expect(placePassages(BODY, [proposal('p1', [canvasChange])])).toEqual([])
+  })
+
+  it('marks a passage the body no longer agrees with as conflicted', () => {
+    // Decision 5: the proposal followed the document, and what it assumed is
+    // no longer what the passage says. It is still drawn — the person is the
+    // one who decides — but the disagreement has to reach them.
+    const change: ProposedChange = {
+      id: 'c1',
+      op: 'body.replace',
+      status: 'open',
+      anchor: { kind: 'text', quote: { exact: 'Thursday' }, start: 8, end: 16 },
+      text: 'Monday',
+      assumed: 'Wednesday',
+    }
+    expect(placePassages(BODY, [proposal('p1', [change])])).toEqual([
+      { proposalId: 'p1', changeId: 'c1', from: 8, to: 16, text: 'Monday', conflicted: true },
+    ])
+  })
+
+  it('returns passages in document order, across proposals', () => {
+    const later = passage('c2', BODY, 'Friday', 'Tuesday')
+    const earlier = passage('c1', BODY, 'Thursday', 'Monday')
+    const placed = placePassages(BODY, [proposal('p2', [later]), proposal('p1', [earlier])])
+    expect(placed.map((one) => one.changeId)).toEqual(['c1', 'c2'])
+  })
+})

--- a/apps/web/src/components/markdown-editor/proposal-decorations.ts
+++ b/apps/web/src/components/markdown-editor/proposal-decorations.ts
@@ -210,6 +210,13 @@ class PassageGutterMarker extends GutterMarker {
  * in through `setProposalProjection`, because the view is created once per
  * mount and a changing extension array would not reach it.
  */
+function markerOf(event: Event): HTMLElement | undefined {
+  return (
+    (event.target as HTMLElement | null)?.closest<HTMLElement>('.cm-proposal-gutter-marker') ??
+    undefined
+  )
+}
+
 export function proposalDecorations(handlers: ProposalHandlers = {}): Extension {
   return [
     proposalField,
@@ -248,20 +255,29 @@ export function proposalDecorations(handlers: ProposalHandlers = {}): Extension 
         return builder.finish()
       },
       domEventHandlers: {
+        // The two halves are deliberately split. `mousedown` only holds the
+        // caret back; the ACTIVATION is on `click`, which is the event a
+        // native button answers to however it was reached — pointer, Enter,
+        // or Space. Handling it on `mousedown` alone made a tab-focusable
+        // button that no keyboard could press.
         mousedown: (_view, _line, event) => {
-          const button = (event.target as HTMLElement | null)?.closest<HTMLElement>(
-            '.cm-proposal-gutter-marker',
-          )
-          if (button === null || button === undefined) return false
+          if (markerOf(event) === undefined) return false
+          // Before the default, which would move the caret into the line and
+          // take focus off the card that is about to open. It does not stop
+          // the `click` that follows.
+          event.preventDefault()
+          return true
+        },
+        click: (_view, _line, event) => {
+          const button = markerOf(event)
+          if (button === undefined) return false
           const { proposalId, changeId } = button.dataset
           if (proposalId === undefined || changeId === undefined) return false
-          // Before the default, which would move the caret into the line and
-          // take focus off the card that is about to open.
-          event.preventDefault()
           const rect = button.getBoundingClientRect()
           // The MARKER's box, not the pointer: a card anchored to where the
           // finger happened to land drifts by up to the target's size, and
-          // this target is deliberately large enough for a thumb.
+          // this target is deliberately large enough for a thumb. It is also
+          // the only anchor a keyboard press has.
           handlers.onSelectPassage?.(proposalId, changeId, {
             clientX: rect.right,
             clientY: rect.top,

--- a/apps/web/src/components/markdown-editor/proposal-decorations.ts
+++ b/apps/web/src/components/markdown-editor/proposal-decorations.ts
@@ -1,0 +1,274 @@
+/**
+ * The proposal layer's in-place projection on a markdown body (ADR-0029
+ * decision 1, for prose): the passage a change would replace, drawn over the
+ * words it means, with a reachable affordance in the gutter beside it.
+ *
+ * The canvas draws a proposal as chrome on a bubble the renderer placed.
+ * Prose has no bubble, so this is the other half of decision 1 — and it is
+ * shaped like the annotation layer's projection deliberately, because a
+ * reader looking at a body should not have to learn two ways of being shown
+ * "something is about these words".
+ *
+ * **The gutter is the click target, not the highlight**, for the reason
+ * `annotation-decorations` gives: the passage is ordinary editable text, so a
+ * click on it has to keep meaning "put the caret here". A proposed passage is
+ * text the reader may well want to edit BEFORE deciding, which makes the rule
+ * stronger here rather than weaker.
+ *
+ * Placement goes through `resolveTextAnchor`, the same function the
+ * annotation projection and the adopt write path both read. One answer, so
+ * what is highlighted and what adoption rewrites cannot disagree.
+ */
+
+import {
+  type Extension,
+  RangeSet,
+  RangeSetBuilder,
+  StateEffect,
+  StateField,
+} from '@codemirror/state'
+import { Decoration, type DecorationSet, EditorView, GutterMarker, gutter } from '@codemirror/view'
+import type { Proposal } from '@kamiazya/whiteboard-model'
+import { resolveTextAnchor } from '@kamiazya/whiteboard-model'
+
+/** Where one open proposed passage sits in the body as it stands right now. */
+export interface PlacedPassage {
+  readonly proposalId: string
+  readonly changeId: string
+  readonly from: number
+  readonly to: number
+  /** What the change would put there. */
+  readonly text: string
+  /**
+   * Whether the passage still reads what the change assumed.
+   *
+   * Decision 5: a proposal FOLLOWS the document, so this is not a reason to
+   * hide it — the person is the one who decides. It is a reason to say so
+   * where they can see it, since adopting would replace words the agent
+   * never read.
+   */
+  readonly conflicted: boolean
+}
+
+/**
+ * Every open passage change that still finds its place, in document order.
+ *
+ * Ordered because a `RangeSet` is built from it directly and CodeMirror
+ * requires sorted input; sorting here rather than at the call site keeps the
+ * two consumers (marks and gutter markers) from each having to remember.
+ *
+ * A DECIDED change is not drawn: the person answered it, and re-offering the
+ * question is the one thing a decision has to stop. A canvas change is not
+ * drawn either — its subject is a surface this document has not got, which is
+ * what `placeThreads` says about a spatial anchor.
+ */
+export function placePassages(
+  body: string,
+  proposals: readonly Proposal[],
+): readonly PlacedPassage[] {
+  const placed: PlacedPassage[] = []
+  for (const proposal of proposals) {
+    for (const change of proposal.changes) {
+      if (change.op !== 'body.replace' || change.status !== 'open') continue
+      const resolved = resolveTextAnchor(body, change.anchor)
+      if (resolved.kind !== 'placed') continue
+      placed.push({
+        proposalId: proposal.id,
+        changeId: change.id,
+        from: resolved.start,
+        to: resolved.end,
+        text: change.text,
+        conflicted: body.slice(resolved.start, resolved.end) !== change.assumed,
+      })
+    }
+  }
+  return placed.sort((a, b) => a.from - b.from || a.to - b.to)
+}
+
+/**
+ * What the pane should draw. One effect rather than two, for the reason the
+ * annotation projection gives: a passage list and the selection naming one of
+ * its entries applied a frame apart would light up nothing and read as the
+ * press being ignored.
+ */
+export interface ProposalProjection {
+  readonly proposals: readonly Proposal[]
+  readonly selectedChangeId: string | null
+}
+
+export const setProposalProjection = StateEffect.define<ProposalProjection>()
+
+const EMPTY_PROJECTION: ProposalProjection = { proposals: [], selectedChangeId: null }
+
+interface ProposalState {
+  readonly projection: ProposalProjection
+  readonly placed: readonly PlacedPassage[]
+  readonly marks: DecorationSet
+}
+
+function project(doc: string, projection: ProposalProjection): ProposalState {
+  const placed = placePassages(doc, projection.proposals)
+  const marks = new RangeSetBuilder<Decoration>()
+  // No empty-range branch, for `annotation-decorations`' reason: CodeMirror
+  // throws on an empty mark, and `textQuoteSelectorSchema`'s `exact` carries
+  // a `min(1)`, so a placed range is always at least one character wide.
+  for (const one of placed) {
+    const selected = one.changeId === projection.selectedChangeId
+    marks.add(
+      one.from,
+      one.to,
+      Decoration.mark({
+        class: [
+          'cm-proposal',
+          one.conflicted ? 'cm-proposal-conflicted' : '',
+          selected ? 'cm-proposal-selected' : '',
+        ]
+          .filter(Boolean)
+          .join(' '),
+        attributes: { 'data-change-id': one.changeId },
+      }),
+    )
+  }
+  return { projection, placed, marks: marks.finish() }
+}
+
+const proposalField = StateField.define<ProposalState>({
+  create: (state) => project(state.doc.toString(), EMPTY_PROJECTION),
+  update(value, tr) {
+    // `tr.newDoc`, never `tr.state.doc` — a state field's update runs while
+    // the new state is being built.
+    for (const effect of tr.effects) {
+      if (effect.is(setProposalProjection)) return project(tr.newDoc.toString(), effect.value)
+    }
+    // Re-resolve rather than map through the change set: the adopt write path
+    // reads the same resolver, and a mapped range would let the two disagree
+    // about where a passage is — including about whether it still exists.
+    if (tr.docChanged) return project(tr.newDoc.toString(), value.projection)
+    return value
+  },
+  provide: (field) => EditorView.decorations.from(field, (value) => value.marks),
+})
+
+/** Where the press landed, so the host can put its card beside the words. */
+export interface PassagePressPoint {
+  readonly clientX: number
+  readonly clientY: number
+}
+
+export interface ProposalHandlers {
+  /** A gutter marker was pressed; the host opens that passage's card. */
+  readonly onSelectPassage?: (proposalId: string, changeId: string, at: PassagePressPoint) => void
+}
+
+/** What the marker beside a line says out loud. */
+function gutterLabel(passages: number, conflicted: boolean): string {
+  const subject = passages > 1 ? `${passages} proposed changes on this line` : 'A proposed change'
+  return conflicted ? `${subject}, on words that have since changed` : subject
+}
+
+class PassageGutterMarker extends GutterMarker {
+  constructor(
+    private readonly proposalId: string,
+    private readonly changeId: string,
+    private readonly selected: boolean,
+    private readonly passages: number,
+    private readonly conflicted: boolean,
+  ) {
+    super()
+  }
+
+  override eq(other: PassageGutterMarker): boolean {
+    return (
+      other.changeId === this.changeId &&
+      other.selected === this.selected &&
+      other.passages === this.passages &&
+      other.conflicted === this.conflicted
+    )
+  }
+
+  override toDOM(): Node {
+    const button = document.createElement('button')
+    button.type = 'button'
+    button.className = 'cm-proposal-gutter-marker'
+    button.dataset.proposalId = this.proposalId
+    button.dataset.changeId = this.changeId
+    if (this.selected) button.dataset.selected = 'true'
+    if (this.conflicted) button.dataset.conflicted = 'true'
+    if (this.passages > 1) button.dataset.passages = String(this.passages)
+    button.setAttribute('aria-label', gutterLabel(this.passages, this.conflicted))
+    button.title = gutterLabel(this.passages, this.conflicted)
+    const glyph = document.createElement('span')
+    glyph.className = 'cm-proposal-gutter-glyph'
+    glyph.setAttribute('aria-hidden', 'true')
+    button.append(glyph)
+    return button
+  }
+}
+
+/**
+ * The extension a host adds to the source pane. Static — the proposals travel
+ * in through `setProposalProjection`, because the view is created once per
+ * mount and a changing extension array would not reach it.
+ */
+export function proposalDecorations(handlers: ProposalHandlers = {}): Extension {
+  return [
+    proposalField,
+    gutter({
+      class: 'cm-proposal-gutter',
+      markers: (view) => {
+        const { placed } = view.state.field(proposalField)
+        if (placed.length === 0) return RangeSet.empty
+        const { selectedChangeId } = view.state.field(proposalField).projection
+        const perLine = new Map<number, PlacedPassage[]>()
+        for (const one of placed) {
+          const lineStart = view.state.doc.lineAt(one.from).from
+          const forLine = perLine.get(lineStart)
+          if (forLine === undefined) perLine.set(lineStart, [one])
+          else forLine.push(one)
+        }
+        const builder = new RangeSetBuilder<GutterMarker>()
+        for (const [lineStart, forLine] of [...perLine.entries()].sort((a, b) => a[0] - b[0])) {
+          // The line's marker names the FIRST passage on it, which is the one
+          // a reader reaching for the gutter is looking at. A second on the
+          // same line keeps its own highlight and is reachable through the
+          // card the first one opens.
+          const first = forLine[0] as PlacedPassage
+          builder.add(
+            lineStart,
+            lineStart,
+            new PassageGutterMarker(
+              first.proposalId,
+              first.changeId,
+              forLine.some((one) => one.changeId === selectedChangeId),
+              forLine.length,
+              forLine.some((one) => one.conflicted),
+            ),
+          )
+        }
+        return builder.finish()
+      },
+      domEventHandlers: {
+        mousedown: (_view, _line, event) => {
+          const button = (event.target as HTMLElement | null)?.closest<HTMLElement>(
+            '.cm-proposal-gutter-marker',
+          )
+          if (button === null || button === undefined) return false
+          const { proposalId, changeId } = button.dataset
+          if (proposalId === undefined || changeId === undefined) return false
+          // Before the default, which would move the caret into the line and
+          // take focus off the card that is about to open.
+          event.preventDefault()
+          const rect = button.getBoundingClientRect()
+          // The MARKER's box, not the pointer: a card anchored to where the
+          // finger happened to land drifts by up to the target's size, and
+          // this target is deliberately large enough for a thumb.
+          handlers.onSelectPassage?.(proposalId, changeId, {
+            clientX: rect.right,
+            clientY: rect.top,
+          })
+          return true
+        },
+      },
+    }),
+  ]
+}

--- a/apps/web/src/components/markdown-editor/use-passage-proposals.ts
+++ b/apps/web/src/components/markdown-editor/use-passage-proposals.ts
@@ -1,0 +1,90 @@
+/**
+ * The proposal layer's half of the source pane, held apart from the editor
+ * that mounts it.
+ *
+ * Four things that only make sense together, which is why they are one hook
+ * rather than four members of an already-long component: the extension the
+ * view is built with, the projection effect that feeds it, which passage the
+ * person has open, and where that passage currently sits.
+ */
+import type { Extension } from '@codemirror/state'
+import type { Proposal } from '@kamiazya/whiteboard-model'
+import { type RefObject, useEffect, useMemo, useState } from 'react'
+import {
+  type PlacedPassage,
+  placePassages,
+  proposalDecorations,
+  setProposalProjection,
+} from './proposal-decorations.js'
+
+/** Where the card sits, in the editor root's own coordinates. */
+export interface OpenPassage {
+  readonly proposalId: string
+  readonly changeId: string
+  readonly x: number
+  readonly y: number
+}
+
+export interface PassageProposals {
+  /** Added to the source pane's extensions; static, so the view keeps it. */
+  readonly extension: Extension
+  readonly open: OpenPassage | null
+  /** Where the open passage is right now, or null when it has none. */
+  readonly placed: PlacedPassage | null
+  readonly close: () => void
+}
+
+export interface PassageProposalsHost {
+  /** The body as the pane currently holds it. */
+  readonly value: string
+  readonly proposals: readonly Proposal[]
+  /** Applies CodeMirror effects to the live view. */
+  readonly applyEffects: (effects: readonly ReturnType<typeof setProposalProjection.of>[]) => void
+  /** The element a card's coordinates are relative to. */
+  readonly rootRef: RefObject<HTMLElement | null>
+}
+
+export function usePassageProposals(host: PassageProposalsHost): PassageProposals {
+  const { value, proposals, applyEffects, rootRef } = host
+  const [open, setOpen] = useState<OpenPassage | null>(null)
+
+  const extension = useMemo(
+    () =>
+      proposalDecorations({
+        onSelectPassage: (proposalId, changeId, at) => {
+          const rect = rootRef.current?.getBoundingClientRect()
+          setOpen({
+            proposalId,
+            changeId,
+            x: at.clientX - (rect?.left ?? 0),
+            y: at.clientY - (rect?.top ?? 0),
+          })
+        },
+      }),
+    [rootRef],
+  )
+
+  useEffect(() => {
+    applyEffects([
+      setProposalProjection.of({ proposals, selectedChangeId: open?.changeId ?? null }),
+    ])
+  }, [proposals, open, applyEffects])
+
+  // The card follows the DOCUMENT, not the press: once the passage it is
+  // about stops resolving — the person adopted it, dismissed it, or edited
+  // the words out from under it — there is nothing left to decide, and a
+  // card still offering the verbs would write against a passage that is
+  // gone.
+  const placed = useMemo(() => {
+    if (open === null) return null
+    return placePassages(value, proposals).find((one) => one.changeId === open.changeId) ?? null
+  }, [open, proposals, value])
+  useEffect(() => {
+    if (open !== null && placed === null) setOpen(null)
+  }, [open, placed])
+
+  return useMemo(
+    () => ({ extension, open, placed, close: () => setOpen(null) }),
+    [extension, open, placed],
+  )
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -78,6 +78,9 @@
    * not a ruler, and not destruction.
    */
   --annotation: oklch(0.649 0.153 62.5);
+  /* The proposal layer, distinct from the annotation layer's amber: a
+     proposed passage is a change waiting on a decision, not a remark. */
+  --proposal: oklch(0.588 0.158 254.2);
 }
 
 .dark {
@@ -104,6 +107,7 @@
   --manipulation-halo: color-mix(in srgb, oklch(0.707 0.165 254.62) 18%, transparent);
   /* Amber-500 rather than 600: the darker tone loses against a dark ground. */
   --annotation: oklch(0.769 0.165 70.08);
+  --proposal: oklch(0.714 0.143 254.6);
 }
 
 /*
@@ -222,6 +226,66 @@
   .cm-annotation-selected {
     background-color: color-mix(in oklch, var(--annotation) 18%, transparent);
     border-bottom-color: var(--annotation);
+  }
+  /*
+   * The proposal layer's in-place projection (ADR-0029 decision 1, for
+   * prose). Shaped like the annotation layer's above deliberately — a reader
+   * looking at a body should not have to learn two ways of being shown
+   * "something is about these words" — and coloured apart from it, because
+   * one is a remark and the other is a change waiting on a decision.
+   *
+   * Dashed rather than solid, matching how the canvas draws a proposed node:
+   * the same "not yet part of the document" the outline says there.
+   */
+  .cm-proposal {
+    border-bottom: 2px dashed color-mix(in oklch, var(--proposal) 65%, transparent);
+  }
+  .cm-proposal-conflicted {
+    border-bottom-color: var(--annotation);
+  }
+  .cm-proposal-selected {
+    background-color: color-mix(in oklch, var(--proposal) 18%, transparent);
+    border-bottom-color: var(--proposal);
+  }
+  /* Reserved for the same reason the annotation gutter is: a proposal
+     arriving from an agent must not reflow the body under whoever is
+     typing in it. */
+  .cm-proposal-gutter {
+    min-width: 26px;
+  }
+  /* Press area and picture split for the annotation marker's reason — a
+     12px glyph is right beside prose and half of WCAG 2.5.8's 24x24
+     minimum in each dimension. */
+  .cm-proposal-gutter-marker {
+    display: grid;
+    place-items: center;
+    width: 26px;
+    height: 24px;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+  }
+  .cm-proposal-gutter-glyph {
+    display: block;
+    width: 12px;
+    height: 12px;
+    border-radius: 3px;
+    border: 2px dashed var(--proposal);
+    background: color-mix(in oklch, var(--proposal) 20%, transparent);
+  }
+  .cm-proposal-gutter-marker[data-conflicted='true'] .cm-proposal-gutter-glyph {
+    border-color: var(--annotation);
+    background: color-mix(in oklch, var(--annotation) 20%, transparent);
+  }
+  .cm-proposal-gutter-marker[data-selected='true'] .cm-proposal-gutter-glyph {
+    border-style: solid;
+    background: var(--proposal);
+  }
+  /* A square glyph is one proposed change; two stacked squares say the line
+     carries more than the marker can name. */
+  .cm-proposal-gutter-marker[data-passages] .cm-proposal-gutter-glyph {
+    box-shadow: 2px 2px 0 -1px var(--proposal);
   }
   /*
    * Reserved whether or not this document has any conversations, on purpose:

--- a/apps/web/src/lib/apply-adopted-passages.ts
+++ b/apps/web/src/lib/apply-adopted-passages.ts
@@ -1,0 +1,48 @@
+import type { DocumentContainers } from '@kamiazya/whiteboard-loro-adapter'
+import { readMarkdownBody, writeMarkdownBody } from '@kamiazya/whiteboard-loro-adapter'
+import type {
+  BodyProposedChange,
+  ProposedChange,
+  ResolvedPassage,
+} from '@kamiazya/whiteboard-model'
+import { applyBodyChange, resolveTextAnchor } from '@kamiazya/whiteboard-model'
+
+/**
+ * Rewrites the body for every `body.replace` change in an adopted decision.
+ *
+ * Where each passage sits is resolved HERE rather than carried on the
+ * command, through the same `resolveTextAnchor` the in-place projection draws
+ * with — so what the person saw highlighted and what adoption rewrites are
+ * one answer, not two that could disagree. The changes themselves still
+ * travel with the command; only their position is re-read, because the body
+ * may have moved under them between the card being drawn and the click.
+ *
+ * A passage that no longer resolves is SKIPPED, not refused: its change is
+ * already being stamped decided by the caller, and leaving it open would ask
+ * the person the same question every time they opened the note. Nothing is
+ * written for it, which is the only honest thing to do with a passage that is
+ * not there.
+ *
+ * Applied from the last passage backwards so an earlier rewrite never shifts
+ * the offsets a later one was resolved at — every position comes from ONE
+ * read of the body, exactly as `wb_body_edit` does it on the other side.
+ */
+export function applyAdoptedPassages(
+  doc: DocumentContainers,
+  changes: readonly ProposedChange[],
+): void {
+  const passages = changes.filter((change) => change.op === 'body.replace')
+  if (passages.length === 0) return
+  const body = readMarkdownBody(doc)
+  const placed: { readonly change: BodyProposedChange; readonly at: ResolvedPassage }[] = []
+  for (const change of passages) {
+    const resolved = resolveTextAnchor(body, change.anchor)
+    if (resolved.kind !== 'placed') continue
+    placed.push({ change, at: { start: resolved.start, end: resolved.end } })
+  }
+  if (placed.length === 0) return
+  const next = [...placed]
+    .sort((a, b) => b.at.start - a.at.start)
+    .reduce((text, { change, at }) => applyBodyChange(text, change, at), body)
+  if (next !== body) writeMarkdownBody(doc, next)
+}

--- a/apps/web/src/lib/apply-adopted-passages.ts
+++ b/apps/web/src/lib/apply-adopted-passages.ts
@@ -1,5 +1,5 @@
 import type { DocumentContainers } from '@kamiazya/whiteboard-loro-adapter'
-import { readMarkdownBody, writeMarkdownBody } from '@kamiazya/whiteboard-loro-adapter'
+import { readMarkdownBody } from '@kamiazya/whiteboard-loro-adapter'
 import type {
   BodyProposedChange,
   ProposedChange,
@@ -23,6 +23,10 @@ import { applyBodyChange, resolveTextAnchor } from '@kamiazya/whiteboard-model'
  * written for it, which is the only honest thing to do with a passage that is
  * not there.
  *
+ * The body is READ from `doc` and WRITTEN through `write`, so the caller
+ * decides the commit boundary — today `withDocumentBatch`, which folds this
+ * rewrite into the same commit as the statuses it closes.
+ *
  * Applied from the last passage backwards so an earlier rewrite never shifts
  * the offsets a later one was resolved at — every position comes from ONE
  * read of the body, exactly as `wb_body_edit` does it on the other side.
@@ -30,6 +34,7 @@ import { applyBodyChange, resolveTextAnchor } from '@kamiazya/whiteboard-model'
 export function applyAdoptedPassages(
   doc: DocumentContainers,
   changes: readonly ProposedChange[],
+  write: (body: string) => void,
 ): void {
   const passages = changes.filter((change) => change.op === 'body.replace')
   if (passages.length === 0) return
@@ -44,5 +49,5 @@ export function applyAdoptedPassages(
   const next = [...placed]
     .sort((a, b) => b.at.start - a.at.start)
     .reduce((text, { change, at }) => applyBodyChange(text, change, at), body)
-  if (next !== body) writeMarkdownBody(doc, next)
+  if (next !== body) write(next)
 }

--- a/apps/web/src/lib/document-sync-session.test.ts
+++ b/apps/web/src/lib/document-sync-session.test.ts
@@ -2584,6 +2584,33 @@ describe('adopting a proposed passage (ADR-0029 decision 6)', () => {
     expect(session.getProposals()[0]?.changes[0]?.status).toBe('adopted')
   })
 
+  it('lands as ONE update payload, because a decision is one act', async () => {
+    const backend = makeFakeBackend()
+    const session = createDocumentSyncSession(backend, makeDeps())
+    session.connect()
+    const changes = [
+      passageChange('c1', 'Thursday', 'Friday'),
+      passageChange('c2', '# Plan', '# The plan'),
+    ]
+    backend._ctrl.handlers?.onSnapshot(seededNote(changes))
+
+    const command: EditorCommand = {
+      kind: 'decide-proposal',
+      proposalId: 'p1',
+      decision: 'adopted',
+      changes,
+    }
+    session.onChange(applyCommand(session.getCanvas(), command), command)
+    await vi.advanceTimersByTimeAsync(300)
+
+    // Two statuses, the canvas and the body are four writes of one act. A
+    // commit each would ship four independent deltas, so a transport that
+    // died between them would leave the change marked adopted with the words
+    // it promised to rewrite still on the page.
+    expect(backend._ctrl.pushLocalUpdateCalls).toHaveLength(1)
+    expect(session.getMarkdownBody()).toBe('# The plan\n\nThe plan is to ship on Friday.\n')
+  })
+
   it('leaves the body alone when the passage is dismissed', async () => {
     const backend = makeFakeBackend()
     const session = createDocumentSyncSession(backend, makeDeps())

--- a/apps/web/src/lib/document-sync-session.test.ts
+++ b/apps/web/src/lib/document-sync-session.test.ts
@@ -18,6 +18,7 @@ import {
   setNodeLock,
   writeCanvasComment,
   writeCommentThread,
+  writeDocumentKind,
   writeMarkdownBody,
   writeProposal,
   writeSpatialCanvas,
@@ -2521,5 +2522,165 @@ describe('deciding ONE change of a proposal', () => {
     const stored = session.getProposals()[0]?.changes ?? []
     expect(stored.find((c) => c.id === 'node:n1')?.status).toBe('dismissed')
     expect(stored.find((c) => c.id === 'node:n2')?.status).toBe('open')
+  })
+})
+
+describe('adopting a proposed passage (ADR-0029 decision 6)', () => {
+  // The half a canvas card cannot reach: `body.replace`'s subject is a
+  // markdown body, so adopting one has to WRITE that body. Stamping the
+  // status alone leaves the person looking at an "adopted" change and an
+  // unchanged document, which is the worst of the three possible states.
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const BODY = '# Plan\n\nThe plan is to ship on Thursday.\n'
+
+  function passageChange(
+    id: string,
+    exact: string,
+    text: string,
+    assumed = exact,
+    body = BODY,
+  ): ProposedChange {
+    const start = body.indexOf(exact)
+    return {
+      id,
+      op: 'body.replace',
+      status: 'open',
+      anchor: { kind: 'text', quote: { exact }, start, end: start + exact.length },
+      text,
+      assumed,
+    }
+  }
+
+  function seededNote(changes: readonly ProposedChange[], body = BODY): Uint8Array {
+    const doc = new LoroDoc()
+    writeDocumentKind(doc, 'markdown')
+    writeMarkdownBody(doc, body)
+    writeProposal(doc, { id: 'p1', createdAt: '2026-09-06T00:00:00.000Z', changes: [...changes] })
+    return doc.export({ mode: 'snapshot' })
+  }
+
+  it('rewrites the passage and closes the change', async () => {
+    const backend = makeFakeBackend()
+    const session = createDocumentSyncSession(backend, makeDeps())
+    session.connect()
+    backend._ctrl.handlers?.onSnapshot(seededNote([passageChange('c1', 'Thursday', 'Friday')]))
+
+    const command: EditorCommand = {
+      kind: 'decide-proposal',
+      proposalId: 'p1',
+      decision: 'adopted',
+      changes: [passageChange('c1', 'Thursday', 'Friday')],
+    }
+    session.onChange(applyCommand(session.getCanvas(), command), command)
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(session.getMarkdownBody()).toBe('# Plan\n\nThe plan is to ship on Friday.\n')
+    expect(session.getProposals()[0]?.changes[0]?.status).toBe('adopted')
+  })
+
+  it('leaves the body alone when the passage is dismissed', async () => {
+    const backend = makeFakeBackend()
+    const session = createDocumentSyncSession(backend, makeDeps())
+    session.connect()
+    backend._ctrl.handlers?.onSnapshot(seededNote([passageChange('c1', 'Thursday', 'Friday')]))
+
+    const command: EditorCommand = {
+      kind: 'decide-proposal',
+      proposalId: 'p1',
+      decision: 'dismissed',
+      changes: [passageChange('c1', 'Thursday', 'Friday')],
+    }
+    session.onChange(applyCommand(session.getCanvas(), command), command)
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(session.getMarkdownBody()).toBe(BODY)
+    expect(session.getProposals()[0]?.changes[0]?.status).toBe('dismissed')
+  })
+
+  it('finds the passage by its quote when an edit has moved it', async () => {
+    const backend = makeFakeBackend()
+    const session = createDocumentSyncSession(backend, makeDeps())
+    session.connect()
+    // The change was written against BODY; the document now carries a note
+    // above it, so every offset is stale by that prefix. The quote is what
+    // still finds the passage.
+    const edited = `> Added since.\n\n${BODY}`
+    backend._ctrl.handlers?.onSnapshot(
+      seededNote([passageChange('c1', 'Thursday', 'Friday')], edited),
+    )
+
+    const command: EditorCommand = {
+      kind: 'decide-proposal',
+      proposalId: 'p1',
+      decision: 'adopted',
+      changes: [passageChange('c1', 'Thursday', 'Friday')],
+    }
+    session.onChange(applyCommand(session.getCanvas(), command), command)
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(session.getMarkdownBody()).toBe(
+      '> Added since.\n\n# Plan\n\nThe plan is to ship on Friday.\n',
+    )
+  })
+
+  it('applies several passages without the earlier one shifting the later', async () => {
+    const backend = makeFakeBackend()
+    const session = createDocumentSyncSession(backend, makeDeps())
+    session.connect()
+    const body = 'Ship on Thursday. Review on Thursday too.\n'
+    const first = passageChange(
+      'c1',
+      'Ship on Thursday',
+      'Ship on Monday',
+      'Ship on Thursday',
+      body,
+    )
+    const second = passageChange(
+      'c2',
+      'Review on Thursday',
+      'Review on Wednesday',
+      'Review on Thursday',
+      body,
+    )
+    backend._ctrl.handlers?.onSnapshot(seededNote([first, second], body))
+
+    const command: EditorCommand = {
+      kind: 'decide-proposal',
+      proposalId: 'p1',
+      decision: 'adopted',
+      changes: [first, second],
+    }
+    session.onChange(applyCommand(session.getCanvas(), command), command)
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(session.getMarkdownBody()).toBe('Ship on Monday. Review on Wednesday too.\n')
+  })
+
+  it('leaves a passage that is gone alone rather than writing it somewhere', async () => {
+    const backend = makeFakeBackend()
+    const session = createDocumentSyncSession(backend, makeDeps())
+    session.connect()
+    const gone = passageChange('c1', 'Thursday', 'Friday')
+    backend._ctrl.handlers?.onSnapshot(seededNote([gone], 'The plan changed entirely.\n'))
+
+    const command: EditorCommand = {
+      kind: 'decide-proposal',
+      proposalId: 'p1',
+      decision: 'adopted',
+      changes: [gone],
+    }
+    session.onChange(applyCommand(session.getCanvas(), command), command)
+    await vi.advanceTimersByTimeAsync(300)
+
+    // The status still closes: the person answered, and an orphaned passage
+    // that stayed open would ask them again every time they opened the note.
+    expect(session.getMarkdownBody()).toBe('The plan changed entirely.\n')
+    expect(session.getProposals()[0]?.changes[0]?.status).toBe('adopted')
   })
 })

--- a/apps/web/src/lib/document-sync-session.ts
+++ b/apps/web/src/lib/document-sync-session.ts
@@ -19,7 +19,7 @@ import {
   resolveWorkspaceDocumentById,
   type SpatialBatchWriter,
   setCommentThreadStatus,
-  setProposedChangeStatus,
+  withDocumentBatch,
   withSpatialBatch,
   setEdgeLock as workspaceSetEdgeLock,
   setNodeLock as workspaceSetNodeLock,
@@ -436,24 +436,28 @@ function writeCommandTarget(
       writeThreadMessage(doc, command.threadId, command.message)
       return true
     case 'decide-proposal': {
-      // Two planes in one commit, because a decision is one act: the
+      // Every plane in ONE commit, because a decision is one act: the
       // changes are stamped where the proposal lives, and an ADOPTED one
-      // also rewrites the board. The canvas write is the full resync
-      // deliberately — a proposal reaches whatever elements it names, and
-      // there is no single target to write fine-grained.
-      for (const change of command.changes) {
-        setProposedChangeStatus(doc, command.proposalId, change.id, command.decision)
-      }
-      if (command.decision === 'adopted') {
-        writeSpatialCanvas(doc, next)
+      // also rewrites the board and the body. A commit each would be four
+      // independent deltas for one press — see `withDocumentBatch` for the
+      // measurement and for what a transport dying between them left behind.
+      // The canvas write is the full resync deliberately: a proposal reaches
+      // whatever elements it names, and there is no single target to write
+      // fine-grained.
+      withDocumentBatch(doc, (writer) => {
+        for (const change of command.changes) {
+          writer.setProposedChangeStatus(command.proposalId, change.id, command.decision)
+        }
+        if (command.decision !== 'adopted') return
+        writer.writeSpatialCanvas(next)
         // And the OTHER subject a proposal can have (ADR-0029 decision 6).
         // `applyCommand` folds the canvas and cannot reach a body, so a
         // passage adopted here would otherwise close its change against a
         // document that never changed — the worst of the three states,
         // since the person is looking at an "adopted" verdict and their own
         // words still on the page.
-        applyAdoptedPassages(doc, command.changes)
-      }
+        applyAdoptedPassages(doc, command.changes, (body) => writer.writeMarkdownBody(body))
+      })
       return true
     }
     case 'create-thread':

--- a/apps/web/src/lib/document-sync-session.ts
+++ b/apps/web/src/lib/document-sync-session.ts
@@ -43,11 +43,15 @@ const NO_THREAD_MARKS: ReadonlyMap<string, PassageRange> = new Map()
 export type BackendErrorReason = Parameters<NonNullable<DocumentBackendHandlers['onError']>>[0]
 
 import type {
+  BodyProposedChange,
   CommentThread,
   Proposal,
+  ProposedChange,
+  ResolvedPassage,
   SpatialCanvas,
   StoredCoreFacets,
 } from '@kamiazya/whiteboard-model'
+import { applyBodyChange, resolveTextAnchor } from '@kamiazya/whiteboard-model'
 import { LoroDoc, UndoManager } from 'loro-crdt'
 import { sameAnnotations, sameThreadMarks } from './annotations-equal.js'
 import { getAppLogger } from './app-logger.js'
@@ -377,6 +381,43 @@ export interface DocumentSyncSession {
  * merge granularity a whole-document rewrite would discard: a concurrent
  * peer edit to a different node survives a merge against this write.
  */
+/**
+ * Rewrites the body for every `body.replace` change in an adopted decision.
+ *
+ * Where each passage sits is resolved HERE rather than carried on the
+ * command, through the same `resolveTextAnchor` the in-place projection draws
+ * with — so what the person saw highlighted and what adoption rewrites are
+ * one answer, not two that could disagree. The changes themselves still
+ * travel with the command; only their position is re-read, because the body
+ * may have moved under them between the card being drawn and the click.
+ *
+ * A passage that no longer resolves is SKIPPED, not refused: its change is
+ * already being stamped decided by the caller, and leaving it open would ask
+ * the person the same question every time they opened the note. Nothing is
+ * written for it, which is the only honest thing to do with a passage that is
+ * not there.
+ *
+ * Applied from the last passage backwards so an earlier rewrite never shifts
+ * the offsets a later one was resolved at — every position comes from ONE
+ * read of the body, exactly as `wb_body_edit` does it on the other side.
+ */
+function applyAdoptedPassages(doc: DocumentContainers, changes: readonly ProposedChange[]): void {
+  const passages = changes.filter((change) => change.op === 'body.replace')
+  if (passages.length === 0) return
+  const body = readMarkdownBody(doc)
+  const placed: { readonly change: BodyProposedChange; readonly at: ResolvedPassage }[] = []
+  for (const change of passages) {
+    const resolved = resolveTextAnchor(body, change.anchor)
+    if (resolved.kind !== 'placed') continue
+    placed.push({ change, at: { start: resolved.start, end: resolved.end } })
+  }
+  if (placed.length === 0) return
+  const next = [...placed]
+    .sort((a, b) => b.at.start - a.at.start)
+    .reduce((text, { change, at }) => applyBodyChange(text, change, at), body)
+  if (next !== body) writeMarkdownBody(doc, next)
+}
+
 function writeCommandTarget(
   host: LoroDoc,
   doc: DocumentContainers,
@@ -443,7 +484,16 @@ function writeCommandTarget(
       for (const change of command.changes) {
         setProposedChangeStatus(doc, command.proposalId, change.id, command.decision)
       }
-      if (command.decision === 'adopted') writeSpatialCanvas(doc, next)
+      if (command.decision === 'adopted') {
+        writeSpatialCanvas(doc, next)
+        // And the OTHER subject a proposal can have (ADR-0029 decision 6).
+        // `applyCommand` folds the canvas and cannot reach a body, so a
+        // passage adopted here would otherwise close its change against a
+        // document that never changed — the worst of the three states,
+        // since the person is looking at an "adopted" verdict and their own
+        // words still on the page.
+        applyAdoptedPassages(doc, command.changes)
+      }
       return true
     }
     case 'create-thread':

--- a/apps/web/src/lib/document-sync-session.ts
+++ b/apps/web/src/lib/document-sync-session.ts
@@ -43,18 +43,15 @@ const NO_THREAD_MARKS: ReadonlyMap<string, PassageRange> = new Map()
 export type BackendErrorReason = Parameters<NonNullable<DocumentBackendHandlers['onError']>>[0]
 
 import type {
-  BodyProposedChange,
   CommentThread,
   Proposal,
-  ProposedChange,
-  ResolvedPassage,
   SpatialCanvas,
   StoredCoreFacets,
 } from '@kamiazya/whiteboard-model'
-import { applyBodyChange, resolveTextAnchor } from '@kamiazya/whiteboard-model'
 import { LoroDoc, UndoManager } from 'loro-crdt'
 import { sameAnnotations, sameThreadMarks } from './annotations-equal.js'
 import { getAppLogger } from './app-logger.js'
+import { applyAdoptedPassages } from './apply-adopted-passages.js'
 import type { BrowserPersistenceState } from './browser-persistence-state.js'
 import { contentStateOf } from './document-state.js'
 import {
@@ -381,43 +378,6 @@ export interface DocumentSyncSession {
  * merge granularity a whole-document rewrite would discard: a concurrent
  * peer edit to a different node survives a merge against this write.
  */
-/**
- * Rewrites the body for every `body.replace` change in an adopted decision.
- *
- * Where each passage sits is resolved HERE rather than carried on the
- * command, through the same `resolveTextAnchor` the in-place projection draws
- * with — so what the person saw highlighted and what adoption rewrites are
- * one answer, not two that could disagree. The changes themselves still
- * travel with the command; only their position is re-read, because the body
- * may have moved under them between the card being drawn and the click.
- *
- * A passage that no longer resolves is SKIPPED, not refused: its change is
- * already being stamped decided by the caller, and leaving it open would ask
- * the person the same question every time they opened the note. Nothing is
- * written for it, which is the only honest thing to do with a passage that is
- * not there.
- *
- * Applied from the last passage backwards so an earlier rewrite never shifts
- * the offsets a later one was resolved at — every position comes from ONE
- * read of the body, exactly as `wb_body_edit` does it on the other side.
- */
-function applyAdoptedPassages(doc: DocumentContainers, changes: readonly ProposedChange[]): void {
-  const passages = changes.filter((change) => change.op === 'body.replace')
-  if (passages.length === 0) return
-  const body = readMarkdownBody(doc)
-  const placed: { readonly change: BodyProposedChange; readonly at: ResolvedPassage }[] = []
-  for (const change of passages) {
-    const resolved = resolveTextAnchor(body, change.anchor)
-    if (resolved.kind !== 'placed') continue
-    placed.push({ change, at: { start: resolved.start, end: resolved.end } })
-  }
-  if (placed.length === 0) return
-  const next = [...placed]
-    .sort((a, b) => b.at.start - a.at.start)
-    .reduce((text, { change, at }) => applyBodyChange(text, change, at), body)
-  if (next !== body) writeMarkdownBody(doc, next)
-}
-
 function writeCommandTarget(
   host: LoroDoc,
   doc: DocumentContainers,

--- a/apps/web/src/pages/DocumentPage.tsx
+++ b/apps/web/src/pages/DocumentPage.tsx
@@ -44,6 +44,7 @@ import { captureBookmarkPicture } from '../lib/bookmark-picture.js'
 import { useWhiteboardCommands } from '../lib/commands/index.js'
 import type { InspectorKind } from '../lib/inspector.js'
 import { fileRefOptions } from '../lib/link-entries.js'
+import { applyCommand } from '../lib/spatial/commands.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
 import { cn } from '../lib/utils.js'
 import { buildVersionSaveBody } from '../lib/version-save-body.js'
@@ -227,6 +228,33 @@ function DocumentPageBody({
     canvas: threads.railCanvas,
     write: threads.write,
   })
+
+  /**
+   * A passage decided from the body (ADR-0029 decision 6). The same command
+   * the canvas card issues, so the two surfaces cannot mean different things
+   * by "adopt" — the write path in `document-sync-session` is what knows a
+   * body.replace has to rewrite the body, and it is reached from here for
+   * the same reason it is reached from there.
+   *
+   * The command carries the CHANGE, read from the proposal it names rather
+   * than rebuilt: what gets applied is exactly what the card showed.
+   */
+  const decidePassage = useCallback(
+    (proposalId: string, changeId: string, decision: 'adopted' | 'dismissed') => {
+      const change = sync.proposals
+        .find((one) => one.id === proposalId)
+        ?.changes.find((one) => one.id === changeId)
+      if (change === undefined) return
+      const command = {
+        kind: 'decide-proposal',
+        proposalId,
+        decision,
+        changes: [change],
+      } as const
+      sync.onChange(applyCommand(sync.canvas, command), command)
+    },
+    [sync.canvas, sync.onChange, sync.proposals],
+  )
 
   const nodeInEditor = useNodeInEditor(sync.canvas, sync.onChange, model.scopeKey)
 
@@ -584,6 +612,8 @@ function DocumentPageBody({
                       selectedThreadId: commentsRail.selectedThreadId,
                       onSelectThread: commentsRail.revealThread,
                       onComposeThread: commentsRail.composeThread,
+                      proposals: sync.proposals,
+                      onDecidePassage: decidePassage,
                     }
               }
               spatial={() => (

--- a/packages/loro-adapter/src/document-batch.ts
+++ b/packages/loro-adapter/src/document-batch.ts
@@ -1,0 +1,55 @@
+import type { ProposedChangeStatus, SpatialCanvas } from '@kamiazya/whiteboard-model'
+import type { DocumentContainers } from './containers.js'
+import { writeMarkdownBodyInto, writeSpatialCanvasInto } from './loro-bridge.js'
+import { setProposedChangeStatusInto } from './proposals.js'
+
+/**
+ * The writes one act of a person may span, across a document's subjects
+ * rather than only its canvas.
+ */
+export interface DocumentBatchWriter {
+  setProposedChangeStatus(proposalId: string, changeId: string, status: ProposedChangeStatus): void
+  writeSpatialCanvas(canvas: SpatialCanvas): void
+  writeMarkdownBody(body: string): void
+}
+
+/**
+ * `withSpatialBatch`'s sibling for an act that touches more than the canvas:
+ * every write in `fn` lands in ONE Loro commit — one local-update payload,
+ * one undo step.
+ *
+ * Deciding a proposal is why it exists. That act stamps a status per change,
+ * resyncs the canvas, and rewrites the body; each committing helper on its
+ * own made that four independent deltas (measured: three synchronous commits
+ * produce three separate `subscribeLocalUpdates` payloads, one produces one).
+ * A transport that died between them left the change marked adopted with the
+ * words it promised to rewrite still on the page — and undoing the decision
+ * took as many presses as it had written commits.
+ *
+ * Error contract, matching `withSpatialBatch`: if `fn` throws, NOTHING is
+ * committed and the partial ops stay pending on the doc, for the caller's
+ * converging write (document-sync-session's `writeSpatialCanvas(doc, next)`
+ * fallback) to absorb into one commit.
+ */
+export function withDocumentBatch(
+  doc: DocumentContainers,
+  fn: (writer: DocumentBatchWriter) => void,
+): void {
+  let wrote = false
+  const writer: DocumentBatchWriter = {
+    setProposedChangeStatus(proposalId, changeId, status) {
+      setProposedChangeStatusInto(doc, proposalId, changeId, status)
+      wrote = true
+    },
+    writeSpatialCanvas(canvas) {
+      writeSpatialCanvasInto(doc, canvas)
+      wrote = true
+    },
+    writeMarkdownBody(body) {
+      writeMarkdownBodyInto(doc, body)
+      wrote = true
+    },
+  }
+  fn(writer)
+  if (wrote) doc.commit()
+}

--- a/packages/loro-adapter/src/index.ts
+++ b/packages/loro-adapter/src/index.ts
@@ -8,6 +8,7 @@ export {
 } from './comment-threads.js'
 export type { DocumentContainers } from './containers.js'
 export { contentDigestOfDocument } from './content-digest.js'
+export { type DocumentBatchWriter, withDocumentBatch } from './document-batch.js'
 export { collectImageRefIds } from './image-refs.js'
 export {
   CONTENT_CONTAINER_KEYS,

--- a/packages/loro-adapter/src/loro-bridge.ts
+++ b/packages/loro-adapter/src/loro-bridge.ts
@@ -164,6 +164,12 @@ function commentToFields(comment: CanvasComment): Fields {
 }
 
 export function writeSpatialCanvas(doc: DocumentContainers, canvas: SpatialCanvas): void {
+  writeSpatialCanvasInto(doc, canvas)
+  doc.commit()
+}
+
+/** The resync itself, without the commit — see `withDocumentBatch`. */
+export function writeSpatialCanvasInto(doc: DocumentContainers, canvas: SpatialCanvas): void {
   const nodesMap = doc.getMap(NODES_KEY)
   const edgesMap = doc.getMap(EDGES_KEY)
   // Deleted rather than left behind when the canvas drops it: a canvas that
@@ -217,8 +223,6 @@ export function writeSpatialCanvas(doc: DocumentContainers, canvas: SpatialCanva
     edgesMap.delete(id)
     dropLockInto(doc, EDGE_LOCKS_KEY, id)
   }
-
-  doc.commit()
 }
 
 // Non-committing internals shared by the single committing helpers below
@@ -870,6 +874,12 @@ function markdownBodyFromCanvas(canvas: SpatialCanvas): string {
  * a later reader to find.
  */
 export function writeMarkdownBody(doc: DocumentContainers, body: string): void {
+  writeMarkdownBodyInto(doc, body)
+  doc.commit()
+}
+
+/** The body splice itself, without the commit — see `withDocumentBatch`. */
+export function writeMarkdownBodyInto(doc: DocumentContainers, body: string): void {
   const text = doc.getText(MARKDOWN_BODY_KEY)
   // Only what CHANGED. A whole-document replace is correct and ruinous:
   // every character is deleted and re-inserted, so one keystroke ships the
@@ -884,9 +894,8 @@ export function writeMarkdownBody(doc: DocumentContainers, body: string): void {
   // unconditional rewrite would add CRDT operations — and a save — for a
   // change nobody made.
   if (doc.getMap(NODES_KEY).size > 0 || doc.getMap(EDGES_KEY).size > 0) {
-    writeSpatialCanvas(doc, { nodes: [], edges: [] })
+    writeSpatialCanvasInto(doc, { nodes: [], edges: [] })
   }
-  doc.commit()
 }
 
 /**

--- a/packages/loro-adapter/src/proposals.ts
+++ b/packages/loro-adapter/src/proposals.ts
@@ -71,6 +71,17 @@ export function setProposedChangeStatus(
   changeId: string,
   status: ProposedChangeStatus,
 ): void {
+  setProposedChangeStatusInto(doc, proposalId, changeId, status)
+  doc.commit()
+}
+
+/** The stamp itself, without the commit — see `withDocumentBatch`. */
+export function setProposedChangeStatusInto(
+  doc: DocumentContainers,
+  proposalId: string,
+  changeId: string,
+  status: ProposedChangeStatus,
+): void {
   const container = proposalContainer(doc, proposalId)
   if (container === undefined) return
   const changes = changesOf(container)
@@ -78,7 +89,6 @@ export function setProposedChangeStatus(
   const stored = changes.get(changeId)
   if (stored === undefined || stored === null || typeof stored !== 'object') return
   changes.set(changeId, { ...(stored as Record<string, unknown>), [STATUS_FIELD]: status })
-  doc.commit()
 }
 
 /**

--- a/packages/mcp-server/src/server/file-size-budget.test.ts
+++ b/packages/mcp-server/src/server/file-size-budget.test.ts
@@ -119,7 +119,13 @@ const FILE_SIZE_GRANDFATHER: Record<string, number> = {
   // nothing about resolved before, so a closed conversation's marker was
   // drawn exactly like an open one — and with the state present the marker
   // crosses to it rather than staying put.
-  'apps/web/src/components/markdown-editor/MarkdownEditor.tsx': 1073,
+  // +64: the proposal layer's in-place surface (ADR-0029 decision 1, for
+  // prose) — two props with the doc comments that say what they are for,
+  // and the card render. The cohesive half is already out: everything with
+  // a seam (the open passage, its extension, the projection effect, where
+  // the passage currently sits) is `use-passage-proposals.ts`, and what is
+  // left is the component's own prop surface and one conditional render.
+  'apps/web/src/components/markdown-editor/MarkdownEditor.tsx': 1137,
   // +1: `CONTENT_CONTAINER_KEYS` gains the proposal layer's plane
   // (ADR-0029). One line, and it has to be here — the list is what a
   // tree-node host pre-attaches from, and a container attached on first
@@ -165,7 +171,11 @@ const FILE_SIZE_GRANDFATHER: Record<string, number> = {
   // +70 for the proposal plane: the publish channel beside annotations, and
   // the two-plane write a decision is — statuses where the proposal lives,
   // plus the canvas when it was adopted.
-  'apps/web/src/lib/document-sync-session.ts': 1461,
+  // +10: adopting a proposed passage writes the BODY, not only the status
+  // (ADR-0029 decision 6). The write itself is `apply-adopted-passages.ts`;
+  // these ten lines are its import, its call, and the comment saying why a
+  // decision has to reach two planes here.
+  'apps/web/src/lib/document-sync-session.ts': 1471,
   // Raised from 1131 because compaction's retained-history cut now reads
   // branch tips from BOTH planes for the length of the migration: the record,
   // where a document goes the first time its branches are written, and the

--- a/packages/mcp-server/src/server/file-size-budget.test.ts
+++ b/packages/mcp-server/src/server/file-size-budget.test.ts
@@ -130,7 +130,11 @@ const FILE_SIZE_GRANDFATHER: Record<string, number> = {
   // (ADR-0029). One line, and it has to be here — the list is what a
   // tree-node host pre-attaches from, and a container attached on first
   // READ instead clears the UndoManager's redo stack.
-  'packages/loro-adapter/src/loro-bridge.ts': 943,
+  // +9: `writeSpatialCanvas` and `writeMarkdownBody` each split into a
+  // committing wrapper over a non-committing `*Into`, so `withDocumentBatch`
+  // can fold a whole act into ONE commit. The bodies did not grow; these are
+  // the two wrappers and the two lines saying what the split is for.
+  'packages/loro-adapter/src/loro-bridge.ts': 952,
   'packages/canvas-render/src/layout/edges/edge-rules.ts': 948,
   // +49: propose mode (ADR-0029 decision 7) — two input fields, one output
   // field, and the branch that stores a proposal instead of the board. Most
@@ -175,7 +179,9 @@ const FILE_SIZE_GRANDFATHER: Record<string, number> = {
   // (ADR-0029 decision 6). The write itself is `apply-adopted-passages.ts`;
   // these ten lines are its import, its call, and the comment saying why a
   // decision has to reach two planes here.
-  'apps/web/src/lib/document-sync-session.ts': 1471,
+  // +4: the decide-proposal arm moved inside `withDocumentBatch`, so its
+  // three subjects land as one delta and one undo step instead of four.
+  'apps/web/src/lib/document-sync-session.ts': 1475,
   // Raised from 1131 because compaction's retained-history cut now reads
   // branch tips from BOTH planes for the length of the migration: the record,
   // where a document goes the first time its branches are written, and the


### PR DESCRIPTION
## Summary

ADR-0029 decision 1's other half. The canvas draws a proposal as chrome on a bubble the renderer placed; prose has no bubble, so a passage proposal had nowhere to be seen and nothing to press — `wb_body_edit` could store one and **no surface could show it**.

Two commits, and the first is a defect the second would otherwise have exposed:

1. **`applyCommand` folds a `SpatialCanvas`**, so a `body.replace` change had nowhere to land: adopting one stamped its status and left the document untouched. That is the worst of the three possible states — the person looking at an "adopted" verdict and their own words still on the page.
2. **The in-place projection**: passage marked in the text, affordance in the gutter beside it, a card that shows the words and decides them.

### The decisions, and where each is pinned

| | choice | why |
|---|---|---|
| position at adopt time | resolved through `resolveTextAnchor`, not carried on the command | the changes still travel with the command; only their position is re-read, because the body can move between the card being drawn and the click |
| apply order | last passage backwards | an earlier rewrite must not shift offsets a later one was resolved at |
| an unresolvable passage | skipped, not refused | its change is stamped decided either way; leaving it open would ask the person again every time they opened the note |
| the press target | the **gutter**, never the highlight | `annotation-decorations`' rule: the passage is ordinary editable text and a click has to keep meaning "put the caret here". A proposed passage is text somebody may want to edit BEFORE deciding, which makes that rule *stronger* here |
| what the card shows | the words themselves, not a description | the one place this and the canvas card diverge on purpose — a canvas change is described ("Move the risk"); the replacement words ARE the decision, and a summary would be a worse version of the thing itself |
| a passage whose words changed | drawn, and says so | decision 5 makes that the person's call, and theirs to be told about |
| a decided change / a canvas change | not drawn | a decision has to stop re-asking; a canvas change's subject is a surface this document has not got |

Placement goes through the same `resolveTextAnchor` the rail reads and the adopt write path resolves with, so what is highlighted and what adoption rewrites cannot disagree.

### Found by running it, not by reading it

The gutter marker rendered with **no size** until its CSS existed, so the press target was unreachable — `element is not visible`, twice, before the styles landed. A jsdom render would have reported the button present and the test green.

## Test plan

- [x] `placePassages` tested apart from CodeMirror (7 cases) — a range is a pair of offsets, and an off-by-one puts the highlight over the wrong words
- [x] `document-sync-session` gains 5 cases for the write path
- [x] **`web-browser`** covers the flow a person performs — the highlight lands on the quoted words, the gutter opens the card, Adopt reports the decision, the card closes
- [x] `pnpm check:local` exit 0
- [x] `pnpm --filter @kamiazya/whiteboard-web test` → **3959 passed (377 files)** + **97 passed (16 files)**
- [x] `pnpm test:browser` → **1263 passed (242 files)**, exit 0, and **zero `Re-optimizing` lines** — the tree stayed quiet through the run, so the result is believable
- [x] Mutation-checked, five ways, each failing exactly the cases it should:
  - document order instead of back-to-front → 1
  - trusting stored offsets instead of resolving → 2
  - no body write at all → 3
  - decided changes still drawn → 1
  - nothing ever marked conflicted → 1

## Visual evidence

Visual evidence: none — the surface it adds cannot be rendered through `canvas-render`, which is what `compose-figure.mjs` and the corpus pipeline exist for; this is a CodeMirror decoration plus a React card, and a screenshot of a highlight would show less than the browser test already asserts. The `web-browser` run above is the evidence that matters: it presses the real gutter marker in a real browser and reads the real card.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs — no user-facing doc names this surface yet; ADR-0029 already records the decision this implements
- [x] No `console.*` added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added passage proposals to the markdown editor, with highlighted suggested changes and clickable markers.
  - View the original and proposed text in a proposal card, including warnings when the document has changed.
  - Adopt or dismiss proposals directly from the editor.

- **Improvements**
  - Adopting a proposal now updates the corresponding markdown passage automatically.
  - Proposal decisions remain synchronized across document editing surfaces.

- **Tests**
  - Added coverage for proposal display, conflicts, decisions, ordering, and applying multiple changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->