### PR TITLE
feat(document-editor): the inspector's panes arrive and leave with motion

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -495,7 +495,16 @@ write), a filled cap on a broken stroke is the daemon's "not keeping"
   re-typeset every frame and change the editor's MODE mid-slide. Leaving
   needs the pane to outlive its own unmount, which is
   `contexts/inspector-presence.ts`; a pane that finds nothing animating
-  releases itself on the next frame rather than waiting out a ceiling. **Stateful colour is the one paint-property
+  releases itself on the next frame rather than waiting out a ceiling.
+  **A pane that REPLACES another plays no entrance**, and that is measured
+  rather than chosen: the entrance fades in from nothing, the outgoing pane
+  leaves in the same commit, and for those frames nothing covers what is
+  under the slot. On the canvas at 390px, switching Comments to History, the
+  incoming pane read 0.00 opacity on the first frame and 0.65 by the fifth,
+  with the dock beneath showing through for all of them. The slot's previous
+  occupancy therefore reaches the pane, which reads it ONCE at mount —
+  reading it per render would flip the class mid-animation and cut the
+  entrance it exists to protect. **Stateful colour is the one paint-property
   exception**: where the colour IS the state (the shell mark's cap, a hover
   affordance), it crosses with `transition-colors` on the normal token
   rather than cutting. There is no transform/opacity encoding of "which

--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -472,9 +472,30 @@ write), a filled cap on a broken stroke is the daemon's "not keeping"
   instead of ad-hoc numbers: `--motion-duration-fast` (150ms,
   hover/press feedback), `--motion-duration-normal` (220ms, state
   changes and small surfaces like popovers/toasts),
-  `--motion-ease-out` (soft ease-out — never bouncy in chrome).
+  `--motion-ease-out` (soft ease-out — never bouncy in chrome), and
+  `--motion-ease-enter` / `--motion-ease-exit` for anything whose perceived
+  change is OPACITY. **The last pair is not a style preference.**
+  `--motion-ease-out` is shaped for a MOVE — arrive fast, settle — and on a
+  fade it spends the declared duration on a change nobody can see. Measured
+  twice: the comment pin was 65% faded 40ms into a 220ms ramp, and the
+  inspector panel reached 0.61 opacity at 30ms and 0.85 at 60ms, so three
+  quarters of its duration went on the last 15%. Opacity's perceived moment
+  is the middle, so arriving decelerates and leaving accelerates.
   Entrances are fade + small rise/scale (0.98→1); no entrance animation
-  without an explicit reason. **Stateful colour is the one paint-property
+  without an explicit reason.
+  **A PANE's motion is decided once, in `InspectorPanel`** — all four
+  inspectors (properties, comments, connections, history) stand in that one
+  vessel, so a fifth inherits how a pane arrives rather than restating it.
+  Each shape enters from where it lives: the phone sheet rises off the
+  bottom edge it is anchored to, the desktop column slides in from the edge
+  it borders. What is deliberately NOT animated there is the column's
+  WIDTH, and that is measured rather than chosen — `MarkdownEditor` observes
+  its container width, re-typesets the preview whenever it changes, and
+  flips split→write below 640px, so an animated in-flow width would
+  re-typeset every frame and change the editor's MODE mid-slide. Leaving
+  needs the pane to outlive its own unmount, which is
+  `contexts/inspector-presence.ts`; a pane that finds nothing animating
+  releases itself on the next frame rather than waiting out a ceiling. **Stateful colour is the one paint-property
   exception**: where the colour IS the state (the shell mark's cap, a hover
   affordance), it crosses with `transition-colors` on the normal token
   rather than cutting. There is no transform/opacity encoding of "which

--- a/apps/web/src/components/document-editor/DocumentPageShell.aside.test.tsx
+++ b/apps/web/src/components/document-editor/DocumentPageShell.aside.test.tsx
@@ -8,9 +8,10 @@
  * document had no dock to anchor it to — so the shell that both pages already
  * stand in is where the column belongs, and both pages get it at once.
  */
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 import { DocumentPageShell } from './DocumentPageShell.js'
+import { InspectorPanel } from './InspectorPanel.js'
 
 afterEach(() => cleanup())
 
@@ -57,5 +58,57 @@ describe('DocumentPageShell places the history column', () => {
     // The same DOM node, still attached: a remount would have replaced it.
     expect(screen.getByTestId('editor')).toBe(editorBefore)
     expect(editorBefore.isConnected).toBe(true)
+  })
+})
+
+/**
+ * The shell holds a leaving pane so it can animate out, and that hold has to
+ * end even where nothing animates.
+ *
+ * jsdom runs no CSS animations, so the `animationend` the exit waits on
+ * never arrives — and a build that dropped the animation utilities would
+ * behave the same. Left to the shell's ceiling the pane sits over the
+ * editor for a second, which is how this was found: a page test asserting
+ * the History panel is gone after a second click on its toggle.
+ *
+ * `InspectorPanel` is the subject rather than a bare `<aside>`, because
+ * letting go is its half of the contract.
+ */
+describe('DocumentPageShell lets a leaving pane go', () => {
+  function Host({ open }: { readonly open: boolean }) {
+    return (
+      <DocumentPageShell
+        srTitle="doc"
+        header={<div />}
+        {...(open
+          ? {
+              aside: (
+                <InspectorPanel kind="comments" onClose={() => {}}>
+                  <p>a conversation</p>
+                </InspectorPanel>
+              ),
+            }
+          : {})}
+      >
+        <div data-testid="editor" />
+      </DocumentPageShell>
+    )
+  }
+
+  it('at once when no animation runs, rather than leaving it over the editor', async () => {
+    const { rerender } = render(<Host open />)
+    expect(screen.queryByTestId('comments-rail')).not.toBeNull()
+
+    rerender(<Host open={false} />)
+
+    // Well inside the shell's 1000ms ceiling, and that bound is the whole
+    // test: testing-library's default `waitFor` timeout is 1000ms too, so
+    // the first version of this passed whether the pane left on the next
+    // frame or sat until the ceiling dropped it — a guard that could not
+    // fail. Mutation-checked at this timeout: removing the early let-go
+    // fails it.
+    await waitFor(() => expect(screen.queryByTestId('comments-rail')).toBeNull(), {
+      timeout: 200,
+    })
   })
 })

--- a/apps/web/src/components/document-editor/DocumentPageShell.tsx
+++ b/apps/web/src/components/document-editor/DocumentPageShell.tsx
@@ -1,4 +1,8 @@
-import type { ReactNode } from 'react'
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  type InspectorPresence,
+  InspectorPresenceContext,
+} from '../../contexts/inspector-presence.js'
 
 /**
  * The two-row grid shell both document pages stand in.
@@ -22,6 +26,14 @@ import type { ReactNode } from 'react'
  * 768px it is a bottom sheet, positioned against this row so it covers the
  * editor and not the top bar above it.
  *
+ * It also owns the inspector's PRESENCE. React drops the pane the instant
+ * the page releases the slot, so a leaving animation would have nothing to
+ * run on; this keeps the outgoing pane rendered until it says it has
+ * finished (`contexts/inspector-presence.ts`). Only when the slot goes
+ * EMPTY — a SWAP between two panes is not an exit, and drawing the old one
+ * over the new for a beat would read as two inspectors open at once, which
+ * is the thing the single slot exists to prevent.
+ *
  * Nothing here goes fullscreen: the shell fullscreens the whole document
  * (`hooks/use-fullscreen.ts`), so this element needs no ref to be promoted
  * through and no ground of its own — a `<main>` promoted to the top layer
@@ -42,6 +54,36 @@ export function DocumentPageShell({
   /** The document's inspector, beside the editor row (a sheet over it when narrow). */
   aside?: ReactNode
 }) {
+  const [leaving, setLeaving] = useState<ReactNode>(null)
+  const lastAside = useRef<ReactNode>(null)
+  useEffect(() => {
+    if (aside !== undefined) {
+      lastAside.current = aside
+      // A swap replaces the outgoing pane outright: whatever was leaving is
+      // gone, and the arriving pane plays its own entrance.
+      setLeaving(null)
+      return
+    }
+    if (lastAside.current === null) return
+    setLeaving(lastAside.current)
+    lastAside.current = null
+  }, [aside])
+
+  const presence = useMemo<InspectorPresence>(
+    () => ({ state: 'closed', onLeft: () => setLeaving(null) }),
+    [],
+  )
+  // A pane that never animates would otherwise stay on screen forever,
+  // covering the editor. The frame is the fallback, not the mechanism:
+  // whichever arrives first wins, and under prefers-reduced-motion the
+  // 0.01ms animation ends on that same frame.
+  const drop = useCallback(() => setLeaving(null), [])
+  useEffect(() => {
+    if (leaving === null) return
+    const timer = setTimeout(drop, LEAVING_CEILING_MS)
+    return () => clearTimeout(timer)
+  }, [leaving, drop])
+
   return (
     <main className="relative grid h-full w-full grid-rows-[auto_minmax(0,1fr)]">
       <div className="min-w-0">
@@ -50,8 +92,22 @@ export function DocumentPageShell({
       </div>
       <div className="relative flex min-h-0 min-w-0">
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">{children}</div>
-        {aside}
+        {aside ??
+          (leaving === null ? null : (
+            <InspectorPresenceContext.Provider value={presence}>
+              {leaving}
+            </InspectorPresenceContext.Provider>
+          ))}
       </div>
     </main>
   )
 }
+
+/**
+ * How long a leaving pane may stay before it is dropped regardless.
+ *
+ * A CEILING on a failure, not the exit's duration — the exit ends on its own
+ * `animationend`. It is generous on purpose: too tight and it would cut a
+ * real animation short, which is the one thing this must not do.
+ */
+const LEAVING_CEILING_MS = 1000

--- a/apps/web/src/components/document-editor/DocumentPageShell.tsx
+++ b/apps/web/src/components/document-editor/DocumentPageShell.tsx
@@ -69,9 +69,25 @@ export function DocumentPageShell({
     lastAside.current = null
   }, [aside])
 
-  const presence = useMemo<InspectorPresence>(
-    () => ({ state: 'closed', onLeft: () => setLeaving(null) }),
+  // Whether the slot held a pane on the PREVIOUS render. Updated in an
+  // effect, so during the render that mounts a new pane it still holds the
+  // answer for the moment before — which is exactly the question that pane
+  // asks itself once, on mount.
+  const wasOccupied = useRef(false)
+  useEffect(() => {
+    wasOccupied.current = aside !== undefined
+  })
+
+  const closing = useMemo<InspectorPresence>(
+    () => ({ state: 'closed', slotWasOccupied: false, onLeft: () => setLeaving(null) }),
     [],
+  )
+  const live = useMemo<InspectorPresence>(
+    () => ({ state: 'open', slotWasOccupied: wasOccupied.current, onLeft: () => {} }),
+    // Rebuilt per `aside` rather than on the ref, which is not a dependency
+    // React can track — and the pane below captures the value once on mount
+    // anyway, so a later object with a staler flag reaches nobody.
+    [aside],
   )
   // A pane that never animates would otherwise stay on screen forever,
   // covering the editor. The frame is the fallback, not the mechanism:
@@ -92,12 +108,17 @@ export function DocumentPageShell({
       </div>
       <div className="relative flex min-h-0 min-w-0">
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">{children}</div>
-        {aside ??
-          (leaving === null ? null : (
-            <InspectorPresenceContext.Provider value={presence}>
+        {aside === undefined ? (
+          leaving === null ? null : (
+            <InspectorPresenceContext.Provider value={closing}>
               {leaving}
             </InspectorPresenceContext.Provider>
-          ))}
+          )
+        ) : (
+          <InspectorPresenceContext.Provider value={live}>
+            {aside}
+          </InspectorPresenceContext.Provider>
+        )}
       </div>
     </main>
   )

--- a/apps/web/src/components/document-editor/DocumentPageShell.tsx
+++ b/apps/web/src/components/document-editor/DocumentPageShell.tsx
@@ -54,20 +54,28 @@ export function DocumentPageShell({
   /** The document's inspector, beside the editor row (a sheet over it when narrow). */
   aside?: ReactNode
 }) {
+  // Adjusted DURING RENDER, not in an effect — React's documented shape for
+  // reacting to a changed prop, and here it is load-bearing rather than
+  // stylistic. An effect runs after the commit in which `aside` became
+  // undefined, so that commit renders NO pane: React unmounts it, and the
+  // effect then mounts a fresh one from `leaving`. The pane "held" for the
+  // exit was a different instance every time.
+  //
+  // Measured before this was written, by tagging the live DOM node and
+  // looking for the tag after the close: `sameNode: false` on every frame.
+  // The cost was not only a flash — a remounted `VersionTimeline` refetches
+  // the version list, so closing History played its "Loading…" for two
+  // frames and made a request nobody asked for, and any state inside the
+  // pane (a scroll position, an open preview) was thrown away on the way
+  // out.
   const [leaving, setLeaving] = useState<ReactNode>(null)
-  const lastAside = useRef<ReactNode>(null)
-  useEffect(() => {
-    if (aside !== undefined) {
-      lastAside.current = aside
-      // A swap replaces the outgoing pane outright: whatever was leaving is
-      // gone, and the arriving pane plays its own entrance.
-      setLeaving(null)
-      return
-    }
-    if (lastAside.current === null) return
-    setLeaving(lastAside.current)
-    lastAside.current = null
-  }, [aside])
+  const [shown, setShown] = useState(aside)
+  if (aside !== shown) {
+    setShown(aside)
+    // A SWAP is not an exit: the outgoing pane is replaced outright, because
+    // the four panes share one slot exactly so two are never drawn at once.
+    setLeaving(aside === undefined ? shown : null)
+  }
 
   // Whether the slot held a pane on the PREVIOUS render. Updated in an
   // effect, so during the render that mounts a new pane it still holds the

--- a/apps/web/src/components/document-editor/InspectorPanel.motion.browser.test.tsx
+++ b/apps/web/src/components/document-editor/InspectorPanel.motion.browser.test.tsx
@@ -10,6 +10,7 @@ import { cleanup, render } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, beforeEach, expect, it, vi } from 'vitest'
 import { page, userEvent } from 'vitest/browser'
+import { InspectorPresenceContext } from '../../contexts/inspector-presence.js'
 import { DocumentPageShell } from './DocumentPageShell.js'
 import { InspectorPanel } from './InspectorPanel.js'
 
@@ -225,4 +226,43 @@ it('holds the very same pane on the way out, rather than rebuilding it', async (
 
   expect(panel()).toBe(before)
   await vi.waitFor(() => expect(panel()).toBeNull(), { timeout: 4000 })
+})
+
+/**
+ * A pane that has finished leaving stays where the exit left it.
+ *
+ * `animate-out` carries no fill mode of its own, so the moment the
+ * animation ends the element reverts to its natural state — fully opaque,
+ * back at its start position — and React needs a further commit to remove
+ * it. That gap is painted. Measured frame by frame on the closing history
+ * sheet at 390px: twelve monotone frames (top 479.6 -> 495.2, opacity 1.00
+ * -> 0.02, height constant, so the stage transition is not involved), then
+ * ONE frame at top 479.6 and opacity 1.00 with no animations left, then
+ * gone. That one frame is the jump back up a reader sees.
+ *
+ * Held open here by a presence whose `onLeft` does nothing, so the question
+ * is only what the element looks like after its exit — the shell's own job
+ * of letting go is pinned by the tests above.
+ */
+it('holds where the exit left it, rather than snapping back before it goes', async () => {
+  render(
+    <InspectorPresenceContext.Provider
+      value={{ state: 'closed', slotWasOccupied: false, onLeft: () => {} }}
+    >
+      <div style={{ position: 'relative', width: 390, height: 600 }}>
+        <InspectorPanel kind="comments" onClose={() => {}}>
+          <p>a conversation</p>
+        </InspectorPanel>
+      </div>
+    </InspectorPresenceContext.Provider>,
+  )
+
+  const el = panel()
+  if (el === null) throw new Error('no panel')
+  const exits = el.getAnimations()
+  expect(exits).not.toHaveLength(0)
+
+  await Promise.all(exits.map((animation) => animation.finished))
+
+  expect(Number(getComputedStyle(el).opacity)).toBeLessThan(0.05)
 })

--- a/apps/web/src/components/document-editor/InspectorPanel.motion.browser.test.tsx
+++ b/apps/web/src/components/document-editor/InspectorPanel.motion.browser.test.tsx
@@ -197,3 +197,32 @@ it('animates again the next time it opens into an empty slot', async () => {
   expect(again?.getAttribute('data-state')).toBe('open')
   expect(again?.getAnimations() ?? []).not.toHaveLength(0)
 })
+
+/**
+ * The leaving pane is the SAME one, not a fresh copy of it.
+ *
+ * This is the load-bearing half of holding a pane, and it was wrong while
+ * every other test here passed: `leaving` was set in an EFFECT, which runs
+ * after the commit in which the slot emptied — so that commit rendered no
+ * pane at all, React unmounted it, and the effect mounted a new one. The
+ * exit animated, the pane converged, and the tests were green over a pane
+ * that was destroyed and rebuilt every time it closed.
+ *
+ * What it cost in the running app: a remounted `VersionTimeline` refetches,
+ * so closing History flashed its "Loading…" for two frames and made a
+ * request nobody asked for, and anything the pane held — a scroll position,
+ * an open preview — went with it.
+ *
+ * Identity is asserted on the DOM node because that is what a remount
+ * replaces and what no amount of "it is still on screen" can distinguish.
+ */
+it('holds the very same pane on the way out, rather than rebuilding it', async () => {
+  render(<ShellHost />)
+  await vi.waitFor(() => expect(panel()).not.toBeNull())
+  const before = panel()
+
+  await userEvent.click(page.getByRole('button', { name: 'toggle' }))
+
+  expect(panel()).toBe(before)
+  await vi.waitFor(() => expect(panel()).toBeNull(), { timeout: 4000 })
+})

--- a/apps/web/src/components/document-editor/InspectorPanel.motion.browser.test.tsx
+++ b/apps/web/src/components/document-editor/InspectorPanel.motion.browser.test.tsx
@@ -121,6 +121,27 @@ it('grows between its two stages instead of jumping, on the sheet only', async (
  * plays its entrance would draw exactly that for a beat.
  */
 it('replaces one pane with another outright, never showing both', async () => {
+  // Two DIFFERENT components, because that is what the app does and it is
+  // what decides the case: `CommentsRailAside` and `VersionPanel` are
+  // distinct types, so React unmounts one and mounts the other. Rendering
+  // `<InspectorPanel kind={...}>` directly for both — the first shape of
+  // this fixture — keeps ONE instance and changes a prop, which never
+  // remounts, never re-runs the entrance, and so cannot reproduce the flash
+  // at all. It passed the opacity assertion for entirely the wrong reason.
+  function CommentsPane() {
+    return (
+      <InspectorPanel kind="comments" onClose={() => {}}>
+        <p>comments</p>
+      </InspectorPanel>
+    )
+  }
+  function HistoryPane() {
+    return (
+      <InspectorPanel kind="history" onClose={() => {}}>
+        <p>history</p>
+      </InspectorPanel>
+    )
+  }
   function Swap() {
     const [kind, setKind] = useState<'comments' | 'history'>('comments')
     return (
@@ -132,11 +153,7 @@ it('replaces one pane with another outright, never showing both', async () => {
               swap
             </button>
           }
-          aside={
-            <InspectorPanel kind={kind} onClose={() => {}}>
-              <p>{kind}</p>
-            </InspectorPanel>
-          }
+          aside={kind === 'comments' ? <CommentsPane /> : <HistoryPane />}
         >
           <p>the editor</p>
         </DocumentPageShell>
@@ -146,8 +163,37 @@ it('replaces one pane with another outright, never showing both', async () => {
   render(<Swap />)
   await userEvent.click(page.getByRole('button', { name: 'swap' }))
 
-  await vi.waitFor(() =>
-    expect(document.querySelector('[data-testid="history-panel"]')).not.toBeNull(),
-  )
+  const arrived = document.querySelector('[data-testid="history-panel"]')
+  expect(arrived).not.toBeNull()
   expect(panel()).toBeNull()
+
+  // And it arrives OPAQUE. The entrance fades in from nothing, which is
+  // right for an empty slot and wrong here: the outgoing pane is gone in
+  // the same commit, so a fade would leave nothing covering what is under
+  // the slot. Measured on the canvas at 390px before this: the incoming
+  // pane read 0.00 on the first frame and 0.65 by the fifth, and the dock
+  // beneath showed through for all of them.
+  expect(arrived?.getAttribute('data-state')).toBe('replaced')
+  expect(Number(getComputedStyle(arrived as Element).opacity)).toBe(1)
+})
+
+/**
+ * The other half of that, and the one a silent regression hides in: the
+ * slot going EMPTY has to reset the answer. If it did not, every open after
+ * the first would take the replacing path and no pane would ever animate
+ * again — with all the other tests here still green, since they open into a
+ * fresh mount.
+ */
+it('animates again the next time it opens into an empty slot', async () => {
+  render(<ShellHost />)
+  await vi.waitFor(() => expect(panel()).not.toBeNull())
+
+  await userEvent.click(page.getByRole('button', { name: 'toggle' }))
+  await vi.waitFor(() => expect(panel()).toBeNull(), { timeout: 4000 })
+
+  await userEvent.click(page.getByRole('button', { name: 'toggle' }))
+
+  const again = panel()
+  expect(again?.getAttribute('data-state')).toBe('open')
+  expect(again?.getAnimations() ?? []).not.toHaveLength(0)
 })

--- a/apps/web/src/components/document-editor/InspectorPanel.motion.browser.test.tsx
+++ b/apps/web/src/components/document-editor/InspectorPanel.motion.browser.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * The inspector's four panes arrive and leave with motion, in both shapes.
+ *
+ * A real browser: the claim is that an animation RUNS, which is
+ * `getAnimations()`, and jsdom has none. It is pinned on the one vessel
+ * rather than per pane deliberately — `InspectorPanel` is what all four
+ * stand in, so a fifth inherits this instead of restating it.
+ */
+import { cleanup, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
+import { DocumentPageShell } from './DocumentPageShell.js'
+import { InspectorPanel } from './InspectorPanel.js'
+
+afterEach(cleanup)
+
+// The viewport is GLOBAL and the sheet/column split is a `md:` rule that
+// reads it, so a test that narrows it would otherwise decide the shape of
+// every test after it. Each test states the width it means.
+beforeEach(async () => {
+  await page.viewport(1024, 700)
+})
+
+function Host({ startOpen = true }: { readonly startOpen?: boolean }) {
+  const [open, setOpen] = useState(startOpen)
+  return (
+    <div style={{ position: 'relative', width: 390, height: 600 }}>
+      <button type="button" onClick={() => setOpen((v) => !v)}>
+        toggle
+      </button>
+      {open ? (
+        <InspectorPanel kind="comments" onClose={() => setOpen(false)}>
+          <p>a conversation</p>
+        </InspectorPanel>
+      ) : null}
+    </div>
+  )
+}
+
+const panel = () => document.querySelector('[data-testid="comments-rail"]')
+
+it('rises into place when the slot opens, rather than appearing between two frames', async () => {
+  render(<Host startOpen={false} />)
+  await userEvent.click(page.getByRole('button', { name: 'toggle' }))
+
+  const el = panel()
+  expect(el).not.toBeNull()
+  expect(el?.getAnimations() ?? []).not.toHaveLength(0)
+})
+
+/**
+ * Through the SHELL, not the panel alone: the panel cannot keep itself on
+ * screen — its parent is what stops rendering it — so `DocumentPageShell`
+ * is where presence lives and where the claim has to be made.
+ */
+function ShellHost() {
+  const [open, setOpen] = useState(true)
+  return (
+    <div style={{ width: 390, height: 600 }}>
+      <DocumentPageShell
+        srTitle="a document"
+        header={
+          <button type="button" onClick={() => setOpen((v) => !v)}>
+            toggle
+          </button>
+        }
+        {...(open
+          ? {
+              aside: (
+                <InspectorPanel kind="comments" onClose={() => setOpen(false)}>
+                  <p>a conversation</p>
+                </InspectorPanel>
+              ),
+            }
+          : {})}
+      >
+        <p>the editor</p>
+      </DocumentPageShell>
+    </div>
+  )
+}
+
+it('stays on screen going out, then lets go', async () => {
+  render(<ShellHost />)
+  await vi.waitFor(() => expect(panel()).not.toBeNull())
+
+  await userEvent.click(page.getByRole('button', { name: 'toggle' }))
+
+  // Still drawn, and animating: React released the slot, and the pane has
+  // not left the screen with it.
+  const leaving = panel()
+  expect(leaving).not.toBeNull()
+  expect(leaving?.getAnimations() ?? []).not.toHaveLength(0)
+
+  // And it converges — a pane stranded on screen would cover the editor.
+  await vi.waitFor(() => expect(panel()).toBeNull(), { timeout: 4000 })
+})
+
+it('grows between its two stages instead of jumping, on the sheet only', async () => {
+  // A phone VIEWPORT, not a narrow container: the sheet shape and its stage
+  // toggle are `md:` rules, which read the viewport. Sizing the host alone
+  // leaves the toggle `md:hidden` and the click waits forever.
+  await page.viewport(390, 700)
+  render(<Host />)
+  const el = panel()
+  if (el === null) throw new Error('no panel')
+
+  await userEvent.click(page.getByRole('button', { name: /expand comments/i }))
+
+  // A height transition, which is only animatable because BOTH ends are
+  // definite — 45% and 100%. An `auto` end would not animate at all, and
+  // this test would pass over a jump.
+  const heights = el.getAnimations().map((a) => (a as CSSTransition).transitionProperty)
+  expect(heights).toContain('height')
+})
+
+/**
+ * A swap is not an exit. The four panes share ONE slot precisely so two are
+ * never open at once, and holding the outgoing one on screen while the next
+ * plays its entrance would draw exactly that for a beat.
+ */
+it('replaces one pane with another outright, never showing both', async () => {
+  function Swap() {
+    const [kind, setKind] = useState<'comments' | 'history'>('comments')
+    return (
+      <div style={{ width: 390, height: 600 }}>
+        <DocumentPageShell
+          srTitle="a document"
+          header={
+            <button type="button" onClick={() => setKind('history')}>
+              swap
+            </button>
+          }
+          aside={
+            <InspectorPanel kind={kind} onClose={() => {}}>
+              <p>{kind}</p>
+            </InspectorPanel>
+          }
+        >
+          <p>the editor</p>
+        </DocumentPageShell>
+      </div>
+    )
+  }
+  render(<Swap />)
+  await userEvent.click(page.getByRole('button', { name: 'swap' }))
+
+  await vi.waitFor(() =>
+    expect(document.querySelector('[data-testid="history-panel"]')).not.toBeNull(),
+  )
+  expect(panel()).toBeNull()
+})

--- a/apps/web/src/components/document-editor/InspectorPanel.tsx
+++ b/apps/web/src/components/document-editor/InspectorPanel.tsx
@@ -130,8 +130,16 @@ export function InspectorPanel({
         'data-[state=open]:ease-(--motion-ease-enter) data-[state=closed]:ease-(--motion-ease-exit)',
         'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-bottom-4',
         'md:data-[state=open]:slide-in-from-bottom-0 md:data-[state=open]:slide-in-from-right-4',
-        // And back out the way it came in.
-        'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-bottom-4',
+        // And back out the way it came in — HOLDING where it ended, which
+        // `animate-out` does not do on its own. Without a fill the element
+        // reverts to its natural state the instant the animation ends, and
+        // React needs a further commit to remove it; that gap gets painted.
+        // Measured frame by frame on the closing sheet at 390px: twelve
+        // monotone frames (top 479.6 -> 495.2, opacity 1.00 -> 0.02, height
+        // constant), then ONE frame back at top 479.6 and opacity 1.00 with
+        // no animation left, then gone. It reads as the sheet jumping back
+        // up before it disappears.
+        'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-bottom-4 data-[state=closed]:fill-mode-forwards',
         'md:data-[state=closed]:slide-out-to-bottom-0 md:data-[state=closed]:slide-out-to-right-4',
         // Stage: 45% -> 100% and back. Safe to transition because BOTH
         // ends are definite — an `auto` end would not animate at all, which

--- a/apps/web/src/components/document-editor/InspectorPanel.tsx
+++ b/apps/web/src/components/document-editor/InspectorPanel.tsx
@@ -33,7 +33,7 @@
 
 import { ChevronUp, X } from 'lucide-react'
 import type { ReactNode, Ref } from 'react'
-import { useState } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
 import { useInspectorPresence } from '../../contexts/inspector-presence.js'
 import { INSPECTOR_CHROME, type InspectorKind } from '../../lib/inspector.js'
 import { cn } from '../../lib/utils.js'
@@ -53,11 +53,38 @@ export function InspectorPanel({
 }) {
   const [expanded, setExpanded] = useState(false)
   const presence = useInspectorPresence()
+  const root = useRef<HTMLDivElement | null>(null)
+
+  // Let go AT ONCE when nothing is actually animating.
+  //
+  // The exit is driven by `animationend`, which is the right signal when an
+  // animation runs — but it never fires where none does: jsdom runs no CSS
+  // animations at all, and a build that dropped the animation utilities
+  // would behave the same. Without this the pane sits on screen, covering
+  // the editor, until the shell's ceiling fires a second later. Asked after
+  // a frame, because the class that starts the animation lands with this
+  // render and the animation is not registered until the next one.
+  useLayoutEffect(() => {
+    if (presence.state !== 'closed') return
+    const element = root.current
+    if (element === null || typeof element.getAnimations !== 'function') {
+      presence.onLeft()
+      return
+    }
+    const frame = requestAnimationFrame(() => {
+      if (element.getAnimations().length === 0) presence.onLeft()
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [presence])
   const { label, testId } = INSPECTOR_CHROME[kind]
   const lower = label.toLowerCase()
   return (
     <div
-      ref={panelRef}
+      ref={(node) => {
+        root.current = node
+        if (typeof panelRef === 'function') panelRef(node)
+        else if (panelRef !== null && panelRef !== undefined) panelRef.current = node
+      }}
       data-testid={testId}
       data-stage={expanded ? 'full' : 'peek'}
       data-state={presence.state}

--- a/apps/web/src/components/document-editor/InspectorPanel.tsx
+++ b/apps/web/src/components/document-editor/InspectorPanel.tsx
@@ -17,11 +17,24 @@
  *
  * Position-agnostic within that: the shell's `aside` slot owns where the
  * panel sits, and the sheet positions against the row the shell wraps.
+ *
+ * MOTION lives here for the same reason the two shapes do: all four panes
+ * stand in this one vessel, so a fifth inherits the way a pane arrives
+ * instead of restating it. What is deliberately NOT animated is the
+ * COLUMN'S WIDTH — measured, not chosen. `MarkdownEditor` observes its
+ * container width, feeds it to `previewWidth`, and re-typesets the preview
+ * whenever it changes (that value is a dependency of the typeset effect);
+ * it also flips split -> write below `SPLIT_MIN_WIDTH` (640). An animated
+ * in-flow width would therefore re-typeset the document on every frame of
+ * the animation AND cross that threshold mid-slide, changing the editor's
+ * MODE as a side effect of a panel opening. The column takes its width in
+ * one step, as it always did, and its content slides into the space.
  */
 
 import { ChevronUp, X } from 'lucide-react'
 import type { ReactNode, Ref } from 'react'
 import { useState } from 'react'
+import { useInspectorPresence } from '../../contexts/inspector-presence.js'
 import { INSPECTOR_CHROME, type InspectorKind } from '../../lib/inspector.js'
 import { cn } from '../../lib/utils.js'
 import { HEADER_BUTTON_CLASS } from '../ui/header-button.js'
@@ -39,6 +52,7 @@ export function InspectorPanel({
   readonly children: ReactNode
 }) {
   const [expanded, setExpanded] = useState(false)
+  const presence = useInspectorPresence()
   const { label, testId } = INSPECTOR_CHROME[kind]
   const lower = label.toLowerCase()
   return (
@@ -46,10 +60,38 @@ export function InspectorPanel({
       ref={panelRef}
       data-testid={testId}
       data-stage={expanded ? 'full' : 'peek'}
+      data-state={presence.state}
+      // The shell is holding this pane past its own unmount so this can
+      // run; telling it the animation is over is what lets it go. Guarded
+      // on the target because a child's animation bubbles here too — the
+      // stage chevron's rotate would otherwise drop the pane mid-exit.
+      onAnimationEnd={(event) => {
+        if (presence.state === 'closed' && event.target === event.currentTarget) {
+          presence.onLeft()
+        }
+      }}
       className={cn(
         'absolute inset-x-0 bottom-0 z-20 flex min-h-0 flex-col border-t bg-background shadow-[0_-8px_24px_-12px_rgb(0_0_0/0.35)]',
         expanded ? 'h-full' : 'h-[45%] rounded-t-2xl',
         'md:static md:z-auto md:h-auto md:w-[300px] md:max-w-[calc(100vw-1.5rem)] md:shrink-0 md:rounded-none md:border-t-0 md:border-l md:shadow-none',
+        // The panel arrives with motion, in the vocabulary the dialogs
+        // already speak (tw-animate-css over this app's own motion tokens)
+        // — one convention for "a surface appeared", not two.
+        //
+        // The two shapes enter from where they LIVE: the sheet rises off
+        // the bottom edge it is anchored to, and the column slides in from
+        // the edge it borders. Both fade, so the first frame is not a slab
+        // of background over the editor.
+        'duration-(--motion-duration-normal) ease-(--motion-ease-out)',
+        'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-bottom-4',
+        'md:data-[state=open]:slide-in-from-bottom-0 md:data-[state=open]:slide-in-from-right-4',
+        // And back out the way it came in.
+        'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-bottom-4',
+        'md:data-[state=closed]:slide-out-to-bottom-0 md:data-[state=closed]:slide-out-to-right-4',
+        // Stage: 45% -> 100% and back. Safe to transition because BOTH
+        // ends are definite — an `auto` end would not animate at all, which
+        // is the usual reason a height transition is said not to work.
+        'transition-[height] duration-(--motion-duration-normal) ease-(--motion-ease-out) md:transition-none',
       )}
     >
       <div className="flex shrink-0 items-center justify-between gap-2 px-2 pt-1.5 md:hidden">

--- a/apps/web/src/components/document-editor/InspectorPanel.tsx
+++ b/apps/web/src/components/document-editor/InspectorPanel.tsx
@@ -54,6 +54,10 @@ export function InspectorPanel({
   const [expanded, setExpanded] = useState(false)
   const presence = useInspectorPresence()
   const root = useRef<HTMLDivElement | null>(null)
+  // Captured ONCE, at mount: a pane that took over an occupied slot plays
+  // no entrance. Reading `presence` per render instead would flip the class
+  // mid-animation and cut the very entrance this protects.
+  const [replacing] = useState(presence.slotWasOccupied)
 
   // Let go AT ONCE when nothing is actually animating.
   //
@@ -87,7 +91,14 @@ export function InspectorPanel({
       }}
       data-testid={testId}
       data-stage={expanded ? 'full' : 'peek'}
-      data-state={presence.state}
+      // `replaced` rather than `open` for a pane that took over from
+      // another: the entrance fades in from nothing, which is right for an
+      // arrival into an EMPTY slot and wrong here, because the outgoing
+      // pane leaves in the same commit and for those frames nothing covers
+      // what is under the slot — the canvas dock showed through for about
+      // five frames. Still an ordinary `data-state` so the exit, which is
+      // the same either way, keeps its one selector.
+      data-state={presence.state === 'closed' ? 'closed' : replacing ? 'replaced' : 'open'}
       // The shell is holding this pane past its own unmount so this can
       // run; telling it the animation is over is what lets it go. Guarded
       // on the target because a child's animation bubbles here too — the

--- a/apps/web/src/components/document-editor/InspectorPanel.tsx
+++ b/apps/web/src/components/document-editor/InspectorPanel.tsx
@@ -109,7 +109,14 @@ export function InspectorPanel({
         // the bottom edge it is anchored to, and the column slides in from
         // the edge it borders. Both fade, so the first frame is not a slab
         // of background over the editor.
-        'duration-(--motion-duration-normal) ease-(--motion-ease-out)',
+        // `--motion-ease-enter` / `-exit`, NOT `--motion-ease-out`: what
+        // changes here is mostly opacity, and that token is shaped for a
+        // move. Measured on this panel before the swap — opacity 0.61 at
+        // 30ms and 0.85 at 60ms of a 220ms animation, so it read as a flash
+        // rather than a rise. The same measurement was taken on the comment
+        // pin's ramp earlier and reached the same pair.
+        'duration-(--motion-duration-normal)',
+        'data-[state=open]:ease-(--motion-ease-enter) data-[state=closed]:ease-(--motion-ease-exit)',
         'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-bottom-4',
         'md:data-[state=open]:slide-in-from-bottom-0 md:data-[state=open]:slide-in-from-right-4',
         // And back out the way it came in.
@@ -118,6 +125,8 @@ export function InspectorPanel({
         // Stage: 45% -> 100% and back. Safe to transition because BOTH
         // ends are definite — an `auto` end would not animate at all, which
         // is the usual reason a height transition is said not to work.
+        // The stage change IS a move (the sheet's edge travels), so it
+        // keeps the move curve.
         'transition-[height] duration-(--motion-duration-normal) ease-(--motion-ease-out) md:transition-none',
       )}
     >

--- a/apps/web/src/components/workspace-top-bar/VersionPanel.narrow.browser.test.tsx
+++ b/apps/web/src/components/workspace-top-bar/VersionPanel.narrow.browser.test.tsx
@@ -57,6 +57,18 @@ afterEach(async () => {
   await page.viewport(1280, 900)
 })
 
+// The panel ARRIVES with motion now, and changes stage with a height
+// transition (`InspectorPanel`), so a rect read on the frame it mounts is a
+// rect mid-slide — measured here as 9.4px of the entrance's 16px still to
+// travel, which reads as the sheet not being anchored to the bottom edge at
+// all. This file is about the sheet's resting SHAPE; the motion itself is
+// pinned by `InspectorPanel.motion.browser.test.tsx`.
+async function settled(element: Element): Promise<void> {
+  await Promise.all(
+    element.getAnimations().map((animation) => animation.finished.catch(() => undefined)),
+  )
+}
+
 // The editor row both document pages build: a stand-in editor, the history
 // beside it, and the positioned wrapper the shell provides.
 function renderRow() {
@@ -77,6 +89,7 @@ describe('VersionPanel narrow screens', () => {
 
     const row = container.querySelector('div.relative') as HTMLElement
     const panel = await screen.findByTestId('history-panel')
+    await settled(panel)
 
     // A sheet: full width, anchored to the bottom, leaving the document
     // above it visible. A 300px column beside a 375px editor is not a
@@ -101,12 +114,14 @@ describe('VersionPanel narrow screens', () => {
 
     const collapse = await screen.findByRole('button', { name: 'Collapse history' })
     expect(collapse).toHaveAttribute('aria-expanded', 'true')
+    await settled(panel)
     const full = panel.getBoundingClientRect()
     expect(full.height / rowRect.height).toBeGreaterThan(0.9)
     expect(full.bottom).toBeCloseTo(rowRect.bottom, 0)
 
     collapse.click()
     await screen.findByRole('button', { name: 'Expand history' })
+    await settled(panel)
     expect(panel.getBoundingClientRect().height).toBeCloseTo(peek.height, 0)
   })
 
@@ -116,6 +131,7 @@ describe('VersionPanel narrow screens', () => {
 
     const row = container.querySelector('div.relative') as HTMLElement
     const panel = await screen.findByTestId('history-panel')
+    await settled(panel)
 
     const rowRect = row.getBoundingClientRect()
     const rect = panel.getBoundingClientRect()

--- a/apps/web/src/contexts/inspector-presence.ts
+++ b/apps/web/src/contexts/inspector-presence.ts
@@ -25,11 +25,27 @@ import { createContext, useContext } from 'react'
 
 export interface InspectorPresence {
   readonly state: 'open' | 'closed'
+  /**
+   * Whether another pane was in the slot when this one arrived.
+   *
+   * A pane that REPLACES another must not fade in from nothing: the
+   * outgoing pane is gone in the same commit, so for the length of the
+   * entrance there is nothing covering what sits under the slot, and the
+   * dock beneath it shows through. Measured on the canvas at 390px,
+   * switching Comments -> History: the incoming pane read 0.00 opacity on
+   * the first frame and only 0.65 by the fifth, with the outgoing pane
+   * already gone on the first.
+   *
+   * Read ONCE, at mount, by the pane — see `InspectorPanel`. Reading it per
+   * render would flip the class mid-animation and cut the entrance it is
+   * there to protect.
+   */
+  readonly slotWasOccupied: boolean
   /** The pane, saying it has finished leaving. */
   readonly onLeft: () => void
 }
 
-const OPEN: InspectorPresence = { state: 'open', onLeft: () => {} }
+const OPEN: InspectorPresence = { state: 'open', slotWasOccupied: false, onLeft: () => {} }
 
 export const InspectorPresenceContext = createContext<InspectorPresence>(OPEN)
 

--- a/apps/web/src/contexts/inspector-presence.ts
+++ b/apps/web/src/contexts/inspector-presence.ts
@@ -1,0 +1,39 @@
+/**
+ * Whether the inspector slot is showing its pane or letting it go.
+ *
+ * It exists because React unmounts the pane the instant the slot is
+ * released, so a leaving animation has nothing to run on — the problem
+ * Radix solves with its Presence primitive, which is not a dependency here
+ * (only the handful of Radix packages `apps/web/package.json` names).
+ *
+ * A context rather than a prop because of WHERE the two halves sit: the
+ * page decides which pane the slot holds, `DocumentPageShell` renders it,
+ * and `InspectorPanel` is the element that has to stay on screen. Passing
+ * it down as a prop would mean every pane component forwarded a value it
+ * has no use for, and a fifth pane could forget to.
+ *
+ * `onLeft` is called by the pane when its exit animation ENDS, rather than
+ * the shell timing the exit out: the duration is a CSS token and reading it
+ * back in JS would make a second producer of it. It also gets
+ * `prefers-reduced-motion` right for free — the global block in index.css
+ * cuts durations to 0.01ms rather than 0 precisely so `animationend` still
+ * fires, so a reader who asked for less motion drops the pane on the next
+ * frame instead of watching it sit there for the length of an animation
+ * that never played.
+ */
+import { createContext, useContext } from 'react'
+
+export interface InspectorPresence {
+  readonly state: 'open' | 'closed'
+  /** The pane, saying it has finished leaving. */
+  readonly onLeft: () => void
+}
+
+const OPEN: InspectorPresence = { state: 'open', onLeft: () => {} }
+
+export const InspectorPresenceContext = createContext<InspectorPresence>(OPEN)
+
+/** Defaults to `open`, so a pane mounted outside the shell simply shows. */
+export function useInspectorPresence(): InspectorPresence {
+  return useContext(InspectorPresenceContext)
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -40,6 +40,23 @@
   --motion-duration-fast: 150ms;
   --motion-duration-normal: 220ms;
   --motion-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  /*
+   * The pair for anything whose perceived change is OPACITY, which
+   * `--motion-ease-out` above is the wrong curve for. That token is shaped
+   * for a MOVE — arrive fast, settle — and applied to a fade it spends the
+   * declared duration on a change nobody can see: measured on the comment
+   * pin, 65% faded 40ms into a 220ms ramp; measured again on the inspector
+   * panel, opacity 0.61 at 30ms and 0.85 at 60ms, so three quarters of the
+   * duration went on the last 15%. Opacity's perceived moment is the
+   * MIDDLE, so arriving decelerates and leaving accelerates.
+   *
+   * `lib/keyed-svg-patcher.ts` states the same two curves as JS literals,
+   * because it drives `element.animate()` rather than CSS. That is a
+   * deliberate duplication, noted at both ends: reading a custom property
+   * back per animation would put a layout read on the patch path.
+   */
+  --motion-ease-enter: cubic-bezier(0, 0, 0.2, 1);
+  --motion-ease-exit: cubic-bezier(0.4, 0, 1, 1);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);

--- a/apps/web/src/lib/keyed-svg-patcher.ts
+++ b/apps/web/src/lib/keyed-svg-patcher.ts
@@ -70,6 +70,12 @@ const MIN_MOVE_PX = 0.5
  * a declared 220ms ramp spent its remaining half on the last hundredth of
  * a percent nobody can see. Opacity's perceived moment is the middle, so
  * these are the standard accelerate/decelerate pair instead.
+ *
+ * The same two curves are `--motion-ease-exit` / `--motion-ease-enter` in
+ * index.css, for the CSS-driven surfaces (the inspector panel). Stated
+ * twice on purpose: this path drives `element.animate()` per patch, and
+ * reading a custom property back off the document each time would put a
+ * layout read on it.
  */
 const FADE_DURATION_MS = 220
 /** Leaving accelerates: it lingers long enough to be read, then goes. */


### PR DESCRIPTION
## Summary

- Opening Comments, History, Properties or Connections put a slab of panel over the editor's edge between two frames, and closing it took the slab away the same way. They now arrive and leave with motion — animated once on `InspectorPanel`, the vessel all four stand in, so a fifth inherits it rather than restating it, and in the vocabulary the dialogs already speak (`tw-animate-css` over this repo's motion tokens) rather than a second one.
- Each shape enters from where it lives: the phone sheet rises off the bottom edge it is anchored to, the desktop column slides in from the edge it borders. The peek/full stage transitions its height.
- Two defects came out of building it, both fixed here and both found by running rather than reading: a leaving pane sat over the editor for a second wherever nothing animates, and the fade was using the curve shaped for a move.

## Test plan

- [x] New or updated `web-browser` / `web-jsdom` tests added — `InspectorPanel.motion.browser.test.tsx` (enter, exit, the stage change, and that a SWAP shows only one pane), plus a jsdom case pinning that a pane with no animation is released at once
- [x] `pnpm test` passes locally — `pnpm --filter @kamiazya/whiteboard-web test` (CI's `test-jsdom` command) is down to the 3 pre-existing thumbnail failures this container's Node 22 causes, verified identical on `origin/main`; `pnpm lint`, `pnpm -r typecheck`, `pnpm knip` clean
- [x] Manual verification completed — drove the running app with Playwright at 390px and 1280px, both shapes, no console errors, and measured the animation rather than eyeballing it (below)
- [ ] E2E coverage added or extended where applicable — not extended: this is chrome motion with no routing, websocket or daemon behaviour in it

## Visual evidence

`tmp/screenshots/pane-motion.png` — three scrubbed frames of the sheet arriving in the running app at 390px: invisible at 0ms with the space already taken, ~0.65 opaque and ~5px low at 70ms, settled at 220ms. **This session has no `gh` CLI, so it cannot attach a binary through the GitHub MCP tools**; the file has been handed to the author.

The figure needed the click and the pause in ONE tick — a 220ms animation is over before a second round trip lands, and the first attempt photographed the settled state three times without noticing. The numbers below are the real evidence; the picture only illustrates them.

## What was measured, and what it changed

**The fade was on the wrong curve.** Pausing the panel's animation and scrubbing it:

| | 30ms | 60ms | 110ms |
|---|---|---|---|
| before | 0.61 | 0.85 | 0.97 |
| after | 0.38 | 0.61 | 0.84 |

Three quarters of a declared 220ms went on the last 15% of the change, so the arrival read as a flash. `--motion-ease-out` is shaped for a MOVE — arrive fast, settle — and is wrong for anything whose perceived change is opacity. **This is the second time that has been measured in this repo**: the comment pin's ramp reached the same conclusion (65% faded 40ms in) and its fix has been sitting as two JS literals in `keyed-svg-patcher.ts` since. They are tokens now (`--motion-ease-enter` / `--motion-ease-exit`) so the next surface inherits the answer. The stage change keeps the move curve, because that one really is a move.

**The column's width is deliberately not animated**, and that is measured rather than chosen. `MarkdownEditor` observes its container width and feeds `previewWidth`, which is a dependency of the typeset effect (its own comment: "a resize re-typesets the document"), and it flips split→write below `SPLIT_MIN_WIDTH` (640). A 300px width animation would re-typeset the document every frame AND change the editor's MODE mid-slide. The column takes its width in one step, as it always did, and its content slides into the space.

**A leaving pane needed a seam.** React drops the pane the instant the page releases the slot, so `data-[state=closed]:animate-out` had nothing to run on — the problem Radix solves with a Presence primitive, which is not a dependency here. `DocumentPageShell` holds the outgoing pane until the pane says it has finished. It reports `animationend` rather than the shell timing the exit out: the duration is a CSS token and reading it back in JS would make a second producer of it, and it gets `prefers-reduced-motion` right for free — the global block cuts durations to 0.01ms rather than 0 precisely so that event still fires.

That introduced a real defect, caught by CI's jsdom command: jsdom runs no CSS animations, so `animationend` never arrives and the pane sat over the editor until the 1000ms ceiling. A pane that lingers a second after being closed is the defect, not the test — it now asks one frame in whether anything is animating and releases itself when nothing is.

A SWAP is handled as its own case, not as an exit: the four panes share one slot exactly so two are never open at once, and holding the outgoing one while the next plays its entrance would draw that for a beat.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — DESIGN.md gains the fade-curve measurement and, separately, where a pane's motion is decided, why the column's width is not animated, and how a leaving pane outlives its own unmount
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

## Notes for the reviewer

One test could not have failed and was rewritten: the guard for "released at once when nothing animates" used `waitFor`'s default 1000ms timeout against the shell's 1000ms ceiling, so it passed whether the pane left on the next frame or sat until the ceiling dropped it. The mutation check found it by coming back green. At a 200ms window it discriminates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPGrBEknX78whd38tHXnLH

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPGrBEknX78whd38tHXnLH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added smooth enter and exit animations for Inspector panes in both sheet and column layouts.
  - Inspector panes now remain visible long enough to complete their exit animation when closed.
  - Added animated height transitions when switching sheet stages.
  - Pane changes no longer briefly display both the outgoing and incoming panes.

- **Bug Fixes**
  - Prevented panes from lingering when animations are unavailable or interrupted.
  - Improved behavior when replacing one Inspector pane with another.

- **Documentation**
  - Updated motion guidance and easing token documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->