### PR TITLE
fix(annotations): an opened conversation reads as one, in one type scale

### DIFF
--- a/apps/web/src/components/annotations/CommentBody.browser.test.tsx
+++ b/apps/web/src/components/annotations/CommentBody.browser.test.tsx
@@ -66,3 +66,21 @@ it('keeps a body that will not parse on screen rather than losing the comment', 
   const { container } = render(<CommentBody body={'| broken |\n| --'} />)
   expect(container.textContent?.length ?? 0).toBeGreaterThan(0)
 })
+
+/**
+ * `compact` is the rail saying how much room it has, and until this it
+ * changed a class the SVG never read — the prose stayed at the bubble's
+ * 16px inside a panel whose own chrome runs at 11-12px.
+ */
+it('draws a dense surface at panel size and a floating one at the bubble size', async () => {
+  const { container } = render(<CommentBody body="tighten the copy" compact />)
+  const dense = container.querySelector('[data-comment-body] text')
+  if (dense === null) throw new Error('nothing drawn')
+  expect(getComputedStyle(dense).fontSize).toBe('14px')
+
+  cleanup()
+  const roomy = render(<CommentBody body="tighten the copy" />)
+  const bubble = roomy.container.querySelector('[data-comment-body] text')
+  if (bubble === null) throw new Error('nothing drawn')
+  expect(getComputedStyle(bubble).fontSize).toBe('16px')
+})

--- a/apps/web/src/components/annotations/CommentBody.tsx
+++ b/apps/web/src/components/annotations/CommentBody.tsx
@@ -76,9 +76,15 @@ export function CommentBody({ body, compact, className, measure }: CommentBodyPr
       measure: resolvedMeasure,
       fontFamily: SPATIAL_THEME_FONT_FAMILY,
       maxWidth: width ?? UNMEASURED_WIDTH_PX,
+      // What `compact` has always claimed and, until this, did not do: it
+      // set a `text-xs` class the SVG never reads, so a rail whose chrome
+      // runs at 11-12px drew its prose at the bubble's 16px — the largest
+      // text on the surface, and a third bigger than the row summarising
+      // the same sentence above it.
+      density: compact === true ? 'compact' : 'comfortable',
     })
     return renderSceneToKeyedSvg(scene, { padding: BODY_PADDING_PX })
-  }, [body, resolvedMeasure, width])
+  }, [body, compact, resolvedMeasure, width])
 
   const mount = useKeyedSvg(keyed)
   // One stable callback: an inline arrow here changes identity every render,
@@ -96,7 +102,7 @@ export function CommentBody({ body, compact, className, measure }: CommentBodyPr
     <div
       ref={attach}
       data-comment-body=""
-      className={cn(compact === true && 'text-xs', className)}
+      className={cn(className)}
       // `currentColor`, not a palette value: canvas-render assigns markdown
       // body runs no fill of their own precisely so they inherit one, and
       // each `<text>` would otherwise take the SVG default — black — on

--- a/apps/web/src/components/annotations/CommentComposer.tsx
+++ b/apps/web/src/components/annotations/CommentComposer.tsx
@@ -112,7 +112,10 @@ export function CommentComposer({
       extensions={extensions}
       className={cn(
         'w-full rounded border bg-background',
-        compact ? 'text-xs' : 'text-inherit',
+        // `text-sm`, matching what a comment's prose is DRAWN at on a dense
+        // surface (`MARKDOWN_THEME_COMPACT`, 14px). At `text-xs` the reply
+        // you were typing was smaller than the reply once sent.
+        compact ? 'text-sm' : 'text-inherit',
         className,
       )}
     />

--- a/apps/web/src/components/annotations/CommentsPanel.browser.test.tsx
+++ b/apps/web/src/components/annotations/CommentsPanel.browser.test.tsx
@@ -611,3 +611,31 @@ it('draws a reply at the size the box that wrote it uses', async () => {
   if (field === null || prose === null) throw new Error('no field or no prose')
   expect(getComputedStyle(field).fontSize).toBe(getComputedStyle(prose).fontSize)
 })
+
+/**
+ * A summary is what a CLOSED conversation shows. Once it is open the
+ * messages themselves are right there, so drawing the summary above them
+ * puts the same sentence on screen twice — and at two sizes, since a row
+ * summary is 12px chrome and prose is 14px. The row keeps its identity for
+ * a screen reader (it is still the control that collapses this thread) and
+ * keeps saying how much is in here; what it stops doing is repeating the
+ * first message.
+ */
+it('stops summarising a conversation that is open, since the messages are right there', async () => {
+  render(<CommentsPanel threads={[OPEN]} />)
+  const summary = document.querySelector('.comment-row-subject')
+  if (summary === null) throw new Error('no summary')
+  expect(summary.getBoundingClientRect().width).toBeGreaterThan(20)
+
+  await userEvent.click(page.getByText('tighten the copy here'))
+
+  // Not drawn — but still the row's accessible name, so the control that
+  // collapses this conversation is still named by the conversation.
+  expect(summary.getBoundingClientRect().width).toBeLessThan(2)
+  const row = page.getByRole('button', { expanded: true })
+  expect((await row.element()).textContent).toContain('tighten the copy here')
+
+  // And it comes back: the summary is the CLOSED state's job.
+  await userEvent.click(row)
+  expect(summary.getBoundingClientRect().width).toBeGreaterThan(20)
+})

--- a/apps/web/src/components/annotations/CommentsPanel.browser.test.tsx
+++ b/apps/web/src/components/annotations/CommentsPanel.browser.test.tsx
@@ -108,8 +108,15 @@ it('opens a thread onto its whole conversation, not just the line the list shows
   await userEvent.click(page.getByText('tighten the copy here'))
 
   await expect.element(page.getByText('agreed')).toBeInTheDocument()
-  // Both messages, in the order the thread holds them.
-  await expect.element(page.getByText('tighten the copy here')).toBeInTheDocument()
+  // Both messages, in the order the thread holds them — read out of the
+  // opened column rather than off the page, because the row above it
+  // carries a summary of the opening message and a bare text query matches
+  // that one too.
+  const conversation = [...document.querySelectorAll('#thread-t-open [data-comment-body]')].map(
+    (node) => node.textContent,
+  )
+  expect(conversation[0]).toContain('tighten the copy here')
+  expect(conversation[1]).toContain('agreed')
 })
 
 it('names the author of a message that has one, and says nothing for a message that does not', async () => {
@@ -472,4 +479,135 @@ it('answers a conversation in a markdown editor, with the editing verbs the note
   await userEvent.keyboard('{Control>}b{/Control}')
 
   await vi.waitFor(() => expect(box.element().textContent).toBe('**later**'))
+})
+
+/**
+ * The shape of an opened conversation. Four claims that were all wrong at
+ * once on a phone, and each of them is about POSITION rather than content —
+ * so they are measured, not read off the DOM.
+ *
+ * What it looked like: the row's summary started at 54px (a 44px status dot,
+ * a 2px gap, 8px of padding) while the replies under it started at 17px,
+ * outdented by 37px from the message they answer. Between the two sat the
+ * Edit pencil, alone on a 44px row of its own. The reply box and its Send
+ * were stacked, leaving a band of nothing to the right of the field.
+ */
+function rectOf(selector: string): DOMRect {
+  const node = document.querySelector(selector)
+  if (node === null) throw new Error(`no element for ${selector}`)
+  return node.getBoundingClientRect()
+}
+
+/** How much of a vertical band two elements share — 0 when stacked. */
+function sharedRows(a: DOMRect, b: DOMRect): number {
+  return Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top)
+}
+
+it('draws the opening message as the first entry of the opened conversation, every time', async () => {
+  // Not only when the row's summary dropped something. A column whose first
+  // entry is the opening message on one thread and a REPLY on the next is a
+  // column a reader has to re-read to place; `tighten the copy here` is
+  // plain, so under the old rule it was drawn nowhere but the row.
+  render(<CommentsPanel threads={[OPEN]} />)
+  await userEvent.click(page.getByText('tighten the copy here'))
+
+  const bodies = document.querySelectorAll('#thread-t-open [data-comment-body]')
+  expect(bodies).toHaveLength(2)
+})
+
+it('stands the opened conversation on the same left edge as the row that holds it', async () => {
+  render(<CommentsPanel threads={[OPEN]} />)
+  await userEvent.click(page.getByText('tighten the copy here'))
+
+  const subject = rectOf('#thread-t-open')
+  // The row's own TEXT edge, read off the toggle's content box rather than
+  // off the summary span: what the axis has to line up with is where the row
+  // writes, which is a fact about the button whatever it currently draws.
+  const row = document.querySelector('li[data-thread-id="t-open"] button[aria-expanded]')
+  if (row === null) throw new Error('no row')
+  const textEdge =
+    row.getBoundingClientRect().left + Number.parseFloat(getComputedStyle(row).paddingLeft)
+  // One axis: what the row says and what the conversation says line up, so
+  // the indent alone tells a reader the messages belong to that dot.
+  expect(rectOf('#thread-t-open [data-comment-body]').left).toBeCloseTo(textEdge, 0)
+  // And the column hangs INSIDE the row's own text column rather than
+  // beside the status dot.
+  expect(subject.left).toBeGreaterThan(40)
+})
+
+it('carries the grouping in the spacing: further between messages than inside one', async () => {
+  // The rhythm claim, stated as the invariant rather than as a number. It
+  // was 8px between messages and 2px between a message's stamp and its
+  // body — a 4:1 ratio, which reads as one undifferentiated column.
+  render(<CommentsPanel threads={[OPEN]} />)
+  await userEvent.click(page.getByText('tighten the copy here'))
+
+  const list = document.querySelectorAll('#thread-t-open [data-comment-body]')
+  const stamps = document.querySelectorAll('#thread-t-open time')
+  expect(list.length).toBeGreaterThanOrEqual(2)
+  expect(stamps.length).toBeGreaterThanOrEqual(2)
+
+  const insideOne = list[0]!.getBoundingClientRect().top - stamps[0]!.getBoundingClientRect().bottom
+  const betweenTwo =
+    stamps[1]!.getBoundingClientRect().top - list[0]!.getBoundingClientRect().bottom
+  expect(betweenTwo).toBeGreaterThan(insideOne)
+})
+
+it('keeps Edit on the opening message stamp line, not on a row of its own', async () => {
+  render(<CommentsPanel threads={[OPEN]} onEditMessage={() => {}} />)
+  await userEvent.click(page.getByText('tighten the copy here'))
+
+  const edit = (
+    await page.getByRole('button', { name: 'Edit comment' }).element()
+  ).getBoundingClientRect()
+  const stamp = rectOf('#thread-t-open time')
+  // Beside the stamp it acts on, sharing its line — a 44px tap target sunk
+  // into an 11px row rather than pushing the conversation down by 44px.
+  expect(edit.left).toBeGreaterThan(stamp.right)
+  expect(sharedRows(edit, stamp)).toBeGreaterThan(8)
+  // And NEXT to it. Pushed to the trailing edge of a full-width message the
+  // pencil stood 239px from the stamp with nothing in between, and what it
+  // acts on was anybody's guess — proximity is the only thing saying so.
+  expect(edit.left - stamp.right).toBeLessThan(24)
+})
+
+it('puts the reply field and its Send on one line', async () => {
+  render(<CommentsPanel threads={[OPEN]} onReply={() => {}} />)
+  await userEvent.click(page.getByText('tighten the copy here'))
+
+  const field = (
+    await page.getByRole('textbox', { name: /reply/i }).element()
+  ).getBoundingClientRect()
+  const send = (
+    await page.getByRole('button', { name: 'Send reply' }).element()
+  ).getBoundingClientRect()
+  expect(send.left).toBeGreaterThanOrEqual(field.right - 1)
+  expect(sharedRows(field, send)).toBeGreaterThan(8)
+})
+
+it('says one time on a closed row, not the opening stamp and the last activity both', async () => {
+  // The row answers "how much is in here, and has it moved lately". The
+  // opening stamp is the first entry of the column one tap away, and two
+  // stamps on an 11px line at 390px is what made the row wrap.
+  render(<CommentsPanel threads={[OPEN]} />)
+  await expect.element(page.getByTestId('thread-message-count-t-open')).toBeInTheDocument()
+
+  expect(document.querySelectorAll('li[data-thread-id="t-open"] time')).toHaveLength(1)
+})
+
+/**
+ * One reading size on the surface. The rail's chrome is 11-12px and its
+ * message bodies were laid out at the bubble's 16px, so the largest text in
+ * the panel was the prose — a third bigger than the row summarising the very
+ * same sentence directly above it. The box you type a reply INTO was 12px
+ * while the reply it posts drew at 16px.
+ */
+it('draws a reply at the size the box that wrote it uses', async () => {
+  render(<CommentsPanel threads={[OPEN]} onReply={() => {}} />)
+  await userEvent.click(page.getByText('tighten the copy here'))
+
+  const field = document.querySelector('#thread-t-open .cm-content')
+  const prose = document.querySelector('#thread-t-open [data-comment-body] text')
+  if (field === null || prose === null) throw new Error('no field or no prose')
+  expect(getComputedStyle(field).fontSize).toBe(getComputedStyle(prose).fontSize)
 })

--- a/apps/web/src/components/annotations/CommentsPanel.browser.test.tsx
+++ b/apps/web/src/components/annotations/CommentsPanel.browser.test.tsx
@@ -639,3 +639,34 @@ it('stops summarising a conversation that is open, since the messages are right 
   await userEvent.click(row)
   expect(summary.getBoundingClientRect().width).toBeGreaterThan(20)
 })
+
+/**
+ * The messages carry the weight, not the row above them.
+ *
+ * `TOGGLE_STATE_CLASS` fills a control that is ON, which is right for a
+ * toggle whose effect is somewhere else — the header button that opens this
+ * rail has no other way to say so. A DISCLOSURE says it by disclosing: the
+ * conversation appears directly under the row, indented and ruled. Filling
+ * the row as well made a solid slab out of the one line on screen that is
+ * pure chrome, above the prose that is the point.
+ */
+it('leaves an open row unfilled, since the conversation under it is the state', async () => {
+  render(<CommentsPanel threads={[OPEN]} />)
+  // Opened WITHOUT moving the pointer: `userEvent.click` drives the real
+  // mouse and leaves it parked on the row, so `hover:bg-accent` answers the
+  // question this test is asking and the reading says nothing about the
+  // open state at all. A bubbled click runs the same handler with the
+  // pointer nowhere near.
+  const row = document.querySelector('li[data-thread-id="t-open"] button[aria-expanded]')
+  if (!(row instanceof HTMLElement)) throw new Error('no row')
+  row.click()
+
+  await vi.waitFor(() => expect(row.getAttribute('aria-expanded')).toBe('true'))
+  // The pointer is a REAL one and it stays where the last test in this file
+  // left it — which, since every test here renders the same panel at the
+  // same place, is often this very row. Park it somewhere harmless first or
+  // `hover:bg-accent` answers instead, and the test passes alone while
+  // failing in its own file.
+  await page.getByRole('button', { name: 'All' }).hover()
+  expect(getComputedStyle(row).backgroundColor).toBe('rgba(0, 0, 0, 0)')
+})

--- a/apps/web/src/components/annotations/CommentsPanel.tsx
+++ b/apps/web/src/components/annotations/CommentsPanel.tsx
@@ -562,10 +562,26 @@ export function CommentsPanel({
                     onClick={() => toggle(thread)}
                     className={cn(
                       'min-w-0 flex-1 rounded px-2 py-1.5 text-left text-xs hover:bg-accent',
+                      // Open, the row is one meta line; centring it in the
+                      // dot's own 44px keeps the collapse target a target.
+                      expanded && 'flex min-h-11 flex-col justify-center',
                       TOGGLE_STATE_CLASS,
                     )}
                   >
-                    <span className="comment-row-subject line-clamp-2 text-neutral-800 dark:text-neutral-200">
+                    {/* A summary is what a CLOSED conversation shows. Open,
+                        the messages are right below it, so drawing this too
+                        put the same sentence on screen twice — and at two
+                        sizes, 12px row chrome against 14px prose. `sr-only`
+                        rather than unrendered: it is still the name of the
+                        control that collapses this conversation, and a row
+                        named "whole document 3 messages 0s ago" is not one
+                        anybody could act on. */}
+                    <span
+                      className={cn(
+                        'comment-row-subject line-clamp-2 text-neutral-800 dark:text-neutral-200',
+                        expanded && 'sr-only',
+                      )}
+                    >
                       {excerptOf(thread)}
                     </span>
                     <span className="comment-row-meta mt-0.5 flex items-center gap-2 text-[11px] text-neutral-500">

--- a/apps/web/src/components/annotations/CommentsPanel.tsx
+++ b/apps/web/src/components/annotations/CommentsPanel.tsx
@@ -151,22 +151,6 @@ function excerptOf(thread: CommentThread): string {
 }
 
 /**
- * Whether the expanded conversation should draw its opening message, given
- * that the row above it is already showing a summary of the same message.
- *
- * The panel used to draw it unconditionally and that was reverted, for a
- * reason that still holds: on a one-line plain comment the two are the same
- * sentence twice. What changed is that the row is now a LOSSY summary — the
- * syntax stripped, the blocks joined, clamped to two lines — so for a body
- * that has any of that in it the rendering is not a repeat, it is the
- * message. Comparing the two is what tells them apart, rather than a taste
- * call about which comments deserve it.
- */
-function excerptLosesSomething(body: string): boolean {
-  return commentExcerpt(body) !== body.trim()
-}
-
-/**
  * What a thread is about, for the anchors that have no in-place projection
  * to say it for them: the document, a node set, a region. A pin, a passage
  * highlight or an edge comment is found by its place; these are found here.
@@ -484,15 +468,16 @@ export function CommentsPanel({
               About the {anchorLabel(composeAnchor)}
             </p>
           )}
-          <CommentComposer
-            apiRef={composeRef}
-            label="Comment"
-            value={composeDraft}
-            onChange={setComposeDraft}
-            onSubmit={submitCompose}
-            compact
-          />
-          <div className="flex justify-end">
+          <div className="flex items-end gap-1">
+            <CommentComposer
+              apiRef={composeRef}
+              label="Comment"
+              value={composeDraft}
+              onChange={setComposeDraft}
+              onSubmit={submitCompose}
+              compact
+              className="min-w-0 flex-1"
+            />
             {/* Guarded on submit rather than disabled, so pressing Enter in
                 the field takes the same rule — but with no label to read, a
                 press that does nothing has to say why BEFORE it is pressed. */}
@@ -501,7 +486,7 @@ export function CommentsPanel({
               aria-label="Send comment"
               title="Send comment"
               aria-disabled={composeDraft.trim() === ''}
-              className={cn(ICON_VERB_CLASS, 'aria-disabled:opacity-40')}
+              className={cn(ICON_VERB_CLASS, '-my-2 aria-disabled:opacity-40')}
             >
               <SendHorizontal aria-hidden="true" className="size-4" />
             </button>
@@ -589,7 +574,16 @@ export function CommentsPanel({
                           {anchorLabel(thread.anchor)}
                         </span>
                       )}
-                      <MessageBy message={thread.messages[0]} />
+                      {/* Exactly one of these draws, by construction:
+                          `ThreadActivity` is silent on a lone remark, whose
+                          only stamp IS the opening message's. A conversation
+                          shows what a closed row can answer — how much is in
+                          here and whether it moved lately — and leaves the
+                          opening stamp to the first entry of the column one
+                          tap away. Both at once wrapped the row at 390px. */}
+                      {thread.messages.length <= 1 ? (
+                        <MessageBy message={thread.messages[0]} />
+                      ) : null}
                       <ThreadActivity thread={thread} />
                       {resolveAnchor?.(thread) === 'orphaned' ? (
                         <span data-testid={`thread-orphaned-${thread.id}`}>
@@ -604,72 +598,102 @@ export function CommentsPanel({
                 </div>
 
                 {expanded ? (
-                  <div id={`thread-${thread.id}`} className="mt-1 flex flex-col gap-2 pl-2">
-                    {/* Only Edit here now. Resolve moved ONTO the status dot
-                        on the row above — the state and the verb became one
-                        object, and it is reachable without opening the
-                        conversation first. */}
-                    {onEditMessage === undefined || editing?.threadId === thread.id ? null : (
-                      <div className="flex items-center">
-                        <button
-                          type="button"
-                          aria-label="Edit comment"
-                          title="Edit comment"
-                          onClick={() =>
-                            setEditing({
-                              threadId: thread.id,
-                              body: thread.messages[0]?.body ?? '',
-                            })
-                          }
-                          className={ICON_VERB_CLASS}
-                        >
-                          <Pencil aria-hidden="true" className="size-4" />
-                        </button>
+                  // ONE column for the whole conversation, standing on the
+                  // row's own text edge: `44px` of status dot puts the row's
+                  // 2px gap at 44 and its text at 54, so the rule fills that
+                  // gap channel and the column's content lands on 54 — under
+                  // the summary it belongs to. Before this the summary
+                  // started at 54px and the replies at 17px, outdented from
+                  // the message they answer with nothing tying either to the
+                  // dot.
+                  //
+                  // `border-l-2`, the weight the compose box's quote already
+                  // uses for the same job. Measured at `border-l` first: the
+                  // token resolves to `oklch(1 0 0 / 0.1)` in the dark theme,
+                  // which on this ground is invisible — a connector nobody
+                  // can see is not one.
+                  <div
+                    id={`thread-${thread.id}`}
+                    className="mt-1 ml-[44px] flex flex-col gap-3 border-l-2 pl-2"
+                  >
+                    <div className="flex flex-col gap-0.5">
+                      {/* The opening message's own stamp line, and the one
+                          verb that acts on it. Only Edit: Resolve moved ONTO
+                          the status dot on the row above, where the state
+                          and the verb are one object. */}
+                      {/* Next to the stamp, not at the message's trailing
+                          edge: on a full-width message that put 239px of
+                          nothing between the pencil and the only other thing
+                          on its line, and what it edits was a guess.
+                          Proximity is what names an unlabelled verb. */}
+                      <div className="flex min-h-4 items-center gap-1">
+                        <MessageBy message={thread.messages[0]} />
+                        {onEditMessage === undefined || editing?.threadId === thread.id ? null : (
+                          <button
+                            type="button"
+                            aria-label="Edit comment"
+                            title="Edit comment"
+                            onClick={() =>
+                              setEditing({
+                                threadId: thread.id,
+                                body: thread.messages[0]?.body ?? '',
+                              })
+                            }
+                            // Sunk into the stamp line rather than given a
+                            // row: `-my-3.5` spends the 44px tap target
+                            // across the 16px line it sits on, so the verb
+                            // is beside what it edits instead of a lone
+                            // pencil pushing the conversation down by 44px.
+                            className={cn(ICON_VERB_CLASS, '-my-3.5')}
+                          >
+                            <Pencil aria-hidden="true" className="size-4" />
+                          </button>
+                        )}
                       </div>
-                    )}
-                    {onEditMessage !== undefined && editing?.threadId === thread.id ? (
-                      <form
-                        data-testid="comment-edit"
-                        className="flex flex-col gap-1"
-                        onSubmit={(event) => {
-                          event.preventDefault()
-                          commitEdit(thread)
-                        }}
-                      >
-                        <CommentComposer
-                          apiRef={editRef}
-                          label="Edit comment text"
-                          value={editing.body}
-                          onChange={(body) => setEditing({ threadId: thread.id, body })}
-                          onSubmit={() => commitEdit(thread)}
-                          compact
-                        />
-                        {/* No Cancel button: Escape already leaves the edit,
-                            and an X here would be the third meaning of that
-                            glyph in one panel. */}
-                        <div className="flex justify-end">
+                      {onEditMessage !== undefined && editing?.threadId === thread.id ? (
+                        <form
+                          data-testid="comment-edit"
+                          className="flex items-end gap-1"
+                          onSubmit={(event) => {
+                            event.preventDefault()
+                            commitEdit(thread)
+                          }}
+                        >
+                          <CommentComposer
+                            apiRef={editRef}
+                            label="Edit comment text"
+                            value={editing.body}
+                            onChange={(body) => setEditing({ threadId: thread.id, body })}
+                            onSubmit={() => commitEdit(thread)}
+                            compact
+                            className="min-w-0 flex-1"
+                          />
+                          {/* No Cancel button: Escape already leaves the edit,
+                              and an X here would be the third meaning of that
+                              glyph in one panel. */}
                           <button
                             type="submit"
                             aria-label="Save"
                             title="Save"
                             aria-disabled={editing.body.trim() === ''}
-                            className={cn(ICON_VERB_CLASS, 'aria-disabled:opacity-40')}
+                            className={cn(ICON_VERB_CLASS, '-my-2 aria-disabled:opacity-40')}
                           >
                             <Check aria-hidden="true" className="size-4" />
                           </button>
-                        </div>
-                      </form>
-                    ) : null}
-                    {/* The opening message as WRITTEN, when the row's
-                        summary of it dropped something — see
-                        `excerptLosesSomething`. */}
-                    {excerptLosesSomething(thread.messages[0]?.body ?? '') ? (
-                      <CommentBody
-                        body={thread.messages[0]?.body ?? ''}
-                        compact
-                        className="text-neutral-800 dark:text-neutral-200"
-                      />
-                    ) : null}
+                        </form>
+                      ) : (
+                        // Always, not only when the row's summary dropped
+                        // something. The column's first entry is the opening
+                        // message on every conversation, so a reader never
+                        // has to work out whether they are looking at the
+                        // start of one or at a reply.
+                        <CommentBody
+                          body={thread.messages[0]?.body ?? ''}
+                          compact
+                          className="text-neutral-800 dark:text-neutral-200"
+                        />
+                      )}
+                    </div>
 
                     <ThreadReplies thread={thread} compact />
 

--- a/apps/web/src/components/annotations/CommentsPanel.tsx
+++ b/apps/web/src/components/annotations/CommentsPanel.tsx
@@ -560,12 +560,19 @@ export function CommentsPanel({
                     aria-expanded={expanded}
                     aria-controls={`thread-${thread.id}`}
                     onClick={() => toggle(thread)}
+                    // No `TOGGLE_STATE_CLASS` here, deliberately. That fill
+                    // is how a control whose effect is ELSEWHERE says it is
+                    // on — the header button that opens this rail has no
+                    // other way to say so. A disclosure says it by
+                    // disclosing: the conversation appears right under this
+                    // row, indented and ruled. Filling the row as well made
+                    // a solid slab of the one line on screen that is pure
+                    // chrome, sitting above the prose that is the point.
                     className={cn(
                       'min-w-0 flex-1 rounded px-2 py-1.5 text-left text-xs hover:bg-accent',
                       // Open, the row is one meta line; centring it in the
                       // dot's own 44px keeps the collapse target a target.
                       expanded && 'flex min-h-11 flex-col justify-center',
-                      TOGGLE_STATE_CLASS,
                     )}
                   >
                     {/* A summary is what a CLOSED conversation shows. Open,

--- a/apps/web/src/components/annotations/ReplyComposer.tsx
+++ b/apps/web/src/components/annotations/ReplyComposer.tsx
@@ -46,8 +46,13 @@ export function ReplyComposer({ onReply, compact = false, autoFocus = false }: R
   }
 
   return (
+    // ONE line, bottom-aligned. Stacked, the Send sat under the field with
+    // a band of nothing beside it, and read as a control belonging to the
+    // panel rather than to the box above it. Bottom rather than centre
+    // because the field GROWS: while a reply runs to three lines the Send
+    // stays beside the line being written.
     <form
-      className="flex flex-col gap-1"
+      className="flex items-end gap-1"
       onSubmit={(event) => {
         event.preventDefault()
         commit()
@@ -61,18 +66,23 @@ export function ReplyComposer({ onReply, compact = false, autoFocus = false }: R
         placeholderText="Reply…"
         autoFocus={autoFocus}
         compact={compact}
+        className="min-w-0 flex-1"
       />
       {/* Icon-only, like every other verb on a conversation — and inert
           while there is nothing to send. The submit stays GUARDED rather
           than disabled so the Meta+Enter path takes the same rule, but with
           no label to read, a press that does nothing has to say why before
-          it is pressed. */}
+          it is pressed.
+
+          `-my-2` keeps the 44px tap target while letting the row be as
+          tall as the FIELD: a 44px button sets the height of a row holding
+          a 26px box otherwise, and the reply box floats in it. */}
       <button
         type="submit"
         aria-label="Send reply"
         title="Send reply"
         aria-disabled={draft.trim() === ''}
-        className={cn(ICON_VERB_CLASS, 'self-end aria-disabled:opacity-40')}
+        className={cn(ICON_VERB_CLASS, '-my-2 aria-disabled:opacity-40')}
       >
         <SendHorizontal aria-hidden="true" className="size-4" />
       </button>

--- a/apps/web/src/components/annotations/ThreadReplies.tsx
+++ b/apps/web/src/components/annotations/ThreadReplies.tsx
@@ -1,10 +1,19 @@
 /**
  * The replies under a conversation's opening message — the list both hosts
- * draw once the subject line is already on screen. The REPLIES, not the
- * whole conversation over again: the card and the panel row each carry the
- * opening message as the subject, and repeating it here read as the same
- * sentence twice. Replies indent under it instead. Nothing when there are
- * none, so a host renders this unconditionally.
+ * draw once the opening message is already on screen. Nothing when there
+ * are none, so a host renders this unconditionally.
+ *
+ * The list, its rhythm and its typography; NOT its indent. Where the
+ * replies sit relative to what they answer is the host's own question and
+ * the two hosts answer it differently — the card indents them inside its
+ * bubble, while the rail stands the whole conversation, opening message
+ * included, in one column under the row's status dot. Owning a `border-l`
+ * here gave the rail a second line inside its first.
+ *
+ * The rhythm is the grouping: 12px between messages against 2px between a
+ * message's stamp and its body. It was 8px against 2px, a ratio too close
+ * to read, and the column had no visible seams — which is what a reader
+ * calls "everything is jumbled together".
  */
 import type { CommentThread } from '@kamiazya/whiteboard-model'
 import { cn } from '../../lib/utils.js'
@@ -20,7 +29,7 @@ export interface ThreadRepliesProps {
 export function ThreadReplies({ thread, compact = false }: ThreadRepliesProps) {
   if (thread.messages.length <= 1) return null
   return (
-    <ol className={cn('flex flex-col border-l pl-2', compact ? 'gap-2' : 'gap-1.5')}>
+    <ol className="flex flex-col gap-3">
       {thread.messages.slice(1).map((message) => (
         <li key={message.id} className="flex flex-col gap-0.5">
           <MessageBy message={message} />

--- a/apps/web/src/components/annotations/comments-panel-focus.browser.test.tsx
+++ b/apps/web/src/components/annotations/comments-panel-focus.browser.test.tsx
@@ -58,7 +58,10 @@ it('follows the host to another conversation rather than staying on the first', 
   await expect.element(page.getByRole('button', { expanded: true })).toHaveFocus()
 
   rerender(<CommentsPanel threads={[OPEN, RESOLVED]} revealThreadId="t-resolved" />)
-  await expect.element(page.getByText('settled last week')).toBeInTheDocument()
+  // Waited on by the ROW, not by the text: an opened conversation draws its
+  // opening message as the first entry of its column, so the same words are
+  // on screen twice and a text query matches both.
+  await expect.element(page.getByRole('button', { expanded: true })).toHaveFocus()
   expect(document.activeElement?.textContent).toContain('settled last week')
 })
 

--- a/apps/web/src/components/spatial-editor/CommentThreadCard.tsx
+++ b/apps/web/src/components/spatial-editor/CommentThreadCard.tsx
@@ -184,7 +184,13 @@ export function CommentThreadCard({
         </div>
       </div>
 
-      <ThreadReplies thread={thread} />
+      {/* The card's own answer to where replies sit: indented inside the
+          bubble, under the opening message above them. The rail answers it
+          differently (one column for the whole conversation), which is why
+          the line is here and not in `ThreadReplies`. */}
+      <div className="border-l pl-2 empty:hidden">
+        <ThreadReplies thread={thread} />
+      </div>
       <ReplyComposer onReply={onReply} />
     </div>
   )

--- a/apps/web/src/pages/BrowserDocumentPage.comments-panel.browser.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.comments-panel.browser.test.tsx
@@ -318,7 +318,9 @@ it('opens a conversation from the markdown body, end to end', async () => {
   await userEvent.fill(screen.getByRole('textbox', { name: /comment/i }), 'why Friday?')
   await userEvent.click(screen.getByRole('button', { name: /send comment/i }))
 
-  await waitFor(() => expect(screen.getByText('why Friday?')).toBeInTheDocument(), {
+  // `getAllBy`: the conversation opens on the message it was just given, so
+  // the words are in the row's summary AND in the column's first entry.
+  await waitFor(() => expect(screen.getAllByText('why Friday?').length).toBeGreaterThan(0), {
     timeout: 15_000,
   })
   // Read back from the layer, not from the draft that was typed: the count
@@ -618,7 +620,9 @@ it('starts a conversation about the whole document from the rail, on a note', as
   await userEvent.fill(screen.getByRole('textbox', { name: /comment/i }), 'retire this note?')
   await userEvent.click(screen.getByRole('button', { name: /send comment/i }))
 
-  await waitFor(() => expect(screen.getByText('retire this note?')).toBeInTheDocument(), {
+  // `getAllBy`: see the note on the same wait above — the row's summary and
+  // the opened column's first entry both carry the message.
+  await waitFor(() => expect(screen.getAllByText('retire this note?').length).toBeGreaterThan(0), {
     timeout: 15_000,
   })
   expect(screen.getByText('whole document')).toBeInTheDocument()

--- a/packages/canvas-render/src/index.ts
+++ b/packages/canvas-render/src/index.ts
@@ -125,7 +125,11 @@ export type { KeyedSvgGroup, KeyedSvgRender } from './svg/keyed.js'
 export { renderSceneToKeyedSvg } from './svg/keyed.js'
 export { SPATIAL_THEME_FONT_FAMILY } from './theme/font-family.js'
 export type { MarkdownTheme } from './theme/markdown-theme.js'
-export { MARKDOWN_THEME_DOCUMENT, MARKDOWN_THEME_NODE } from './theme/markdown-theme.js'
+export {
+  MARKDOWN_THEME_COMPACT,
+  MARKDOWN_THEME_DOCUMENT,
+  MARKDOWN_THEME_NODE,
+} from './theme/markdown-theme.js'
 export type { SpatialGeometry } from './theme/spatial-geometry.js'
 export { SPATIAL_THEME_GEOMETRY } from './theme/spatial-geometry.js'
 export type {

--- a/packages/canvas-render/src/layout/comment-body.test.ts
+++ b/packages/canvas-render/src/layout/comment-body.test.ts
@@ -5,7 +5,11 @@
 import { describe, expect, it } from 'vitest'
 import type { SceneNode, TextRunNode } from '../scene-graph.js'
 import { createFakeMeasure } from '../test-utils/fake-measure.js'
-import { MARKDOWN_THEME_DOCUMENT, MARKDOWN_THEME_NODE } from '../theme/markdown-theme.js'
+import {
+  MARKDOWN_THEME_COMPACT,
+  MARKDOWN_THEME_DOCUMENT,
+  MARKDOWN_THEME_NODE,
+} from '../theme/markdown-theme.js'
 import { COMMENT_TEXT_MAX_WIDTH_PX, layoutCommentBody } from './comment-body.js'
 
 const measure = createFakeMeasure()
@@ -91,4 +95,39 @@ describe('a body that will not parse', () => {
     const scene = layoutCommentBody('half a sentence', { ...base, parseBody: boom })
     expect(runs(scene.nodes)).not.toHaveLength(0)
   })
+})
+
+/**
+ * The density axis, which is NOT the theme axis this file's other tests
+ * guard. A comment is never laid out as a DOCUMENT — that stays fixed. What
+ * a surface may say is how much room it has: the bubble floats on a canvas
+ * at reading size, while the rail is a 300px column whose own chrome is
+ * 11-12px, and 16px prose inside it is the largest text on the surface by a
+ * third.
+ */
+it('lays a comment out at the surface density it is asked for, and stays comfortable by default', () => {
+  const comfortable = runs(layoutCommentBody('body text', { ...base }).nodes)[0]
+  const compact = runs(layoutCommentBody('body text', { ...base, density: 'compact' }).nodes)[0]
+
+  expect(comfortable?.appearance?.fontSize).toBe(MARKDOWN_THEME_NODE.bodyFontSizePx)
+  expect(compact?.appearance?.fontSize).toBe(MARKDOWN_THEME_COMPACT.bodyFontSizePx)
+  expect(compact?.appearance?.fontSize ?? 0).toBeLessThan(comfortable?.appearance?.fontSize ?? 0)
+})
+
+it('compresses a compact heading further than the bubble does, rather than scaling it flat', () => {
+  // The ratios are not uniform — the same reason the document theme is a
+  // second constant instead of a multiplier. A heading that stayed at the
+  // bubble's ramp would tower over 14px prose.
+  const bubble = runs(layoutCommentBody('# Heading', { ...base }).nodes)[0]
+  const dense = runs(layoutCommentBody('# Heading', { ...base, density: 'compact' }).nodes)[0]
+
+  expect(bubble?.appearance?.fontSize).toBe(MARKDOWN_THEME_NODE.headingFontSizePx[1])
+  expect(dense?.appearance?.fontSize).toBe(MARKDOWN_THEME_COMPACT.headingFontSizePx[1])
+  // The heading keeps its rank: still bigger than the prose beside it.
+  expect(dense?.appearance?.fontSize ?? 0).toBeGreaterThan(MARKDOWN_THEME_COMPACT.bodyFontSizePx)
+})
+
+it('never lets a compact comment reach document typography', () => {
+  const dense = runs(layoutCommentBody('# Heading', { ...base, density: 'compact' }).nodes)[0]
+  expect(dense?.appearance?.fontSize).not.toBe(MARKDOWN_THEME_DOCUMENT.headingFontSizePx[1])
 })

--- a/packages/canvas-render/src/layout/comment-body.ts
+++ b/packages/canvas-render/src/layout/comment-body.ts
@@ -21,6 +21,13 @@
  *   prose wraps to when the surface has no opinion. A surface with one — a
  *   rail wider than a bubble — passes its own, and everything else about
  *   the layout still agrees.
+ * - **The density**, and ONLY that. A surface says how much room it has
+ *   (`comfortable` on a bubble floating at canvas reading size, `compact`
+ *   in a 300px rail whose own chrome is 11-12px); it never says which
+ *   THEME, so no surface can reach document typography by picking. The
+ *   rail shipped at the bubble's 16px first and it was the largest text on
+ *   a panel of 11-12px chrome — the same sentence, drawn a third bigger
+ *   than the row summarising it directly above.
  * - **The degradation.** `parseBody` ends in a Zod parse and can throw on a
  *   body being typed, so a comment that will not parse has to keep drawing
  *   something. It degrades to one run rather than aborting the layout that
@@ -30,6 +37,7 @@
 import { parseMarkdownBody } from '@kamiazya/whiteboard-codec'
 import type { MdastRoot } from '@kamiazya/whiteboard-model/mdast'
 import type { Scene } from '../scene-graph.js'
+import { MARKDOWN_THEME_COMPACT, MARKDOWN_THEME_NODE } from '../theme/markdown-theme.js'
 import { layoutMdastBlocks, type MdastLayoutOptions } from './nodes/mdast-blocks.js'
 
 /**
@@ -47,6 +55,12 @@ export const COMMENT_TEXT_MAX_WIDTH_PX = 200
  * that a comment's metrics are not a per-surface choice.
  */
 export interface CommentBodyLayoutOptions extends Omit<MdastLayoutOptions, 'theme' | 'maxWidth'> {
+  /**
+   * How much room the surface drawing this has. Defaults to `comfortable`,
+   * the bubble's metrics — so a surface that says nothing keeps the answer
+   * every surface had before this axis existed.
+   */
+  readonly density?: CommentDensity
   /** markdown -> mdast. Defaults to codec's parser, like every body layout. */
   readonly parseBody?: (text: string) => MdastRoot
   /** Defaults to `COMMENT_TEXT_MAX_WIDTH_PX`. */
@@ -59,6 +73,14 @@ export interface CommentBodyLayoutOptions extends Omit<MdastLayoutOptions, 'them
   readonly onParseFailure?: (err: unknown) => void
 }
 
+/** What a surface may say about the room it has. Not a theme. */
+export type CommentDensity = 'comfortable' | 'compact'
+
+const THEME_FOR_DENSITY = {
+  comfortable: MARKDOWN_THEME_NODE,
+  compact: MARKDOWN_THEME_COMPACT,
+} as const
+
 /** The literal body, as the one paragraph a failed parse falls back to. */
 function literalRoot(text: string): MdastRoot {
   return {
@@ -68,8 +90,12 @@ function literalRoot(text: string): MdastRoot {
 }
 
 export function layoutCommentBody(text: string, options: CommentBodyLayoutOptions): Scene {
-  const { parseBody, maxWidth, onParseFailure, ...rest } = options
-  const mdast: MdastLayoutOptions = { ...rest, maxWidth: maxWidth ?? COMMENT_TEXT_MAX_WIDTH_PX }
+  const { parseBody, maxWidth, onParseFailure, density, ...rest } = options
+  const mdast: MdastLayoutOptions = {
+    ...rest,
+    maxWidth: maxWidth ?? COMMENT_TEXT_MAX_WIDTH_PX,
+    theme: THEME_FOR_DENSITY[density ?? 'comfortable'],
+  }
   let root: MdastRoot
   try {
     root = parseBody === undefined ? parseMarkdownBody(text) : parseBody(text)

--- a/packages/canvas-render/src/theme/markdown-theme.ts
+++ b/packages/canvas-render/src/theme/markdown-theme.ts
@@ -131,3 +131,31 @@ export const MARKDOWN_THEME_DOCUMENT: MarkdownTheme = Object.freeze({
   headingSpaceAbovePx: 24,
   listIndentPx: 28,
 })
+
+/**
+ * The same object typography at PANEL density, for a surface that reads a
+ * comment beside the document rather than on it: the comments rail, whose
+ * own chrome (stamps, row summaries, the reply box) runs at 11-12px.
+ *
+ * A third constant rather than a `density` multiplier over the node theme,
+ * for the reason the document theme is a constant: the ratios are not
+ * uniform. Body drops 16 -> 14 while h1 drops 24 -> 19, because a heading
+ * scaled by the same factor keeps towering over prose that got smaller; and
+ * h4-h6 stay AT body size, since no surface may set a heading below the
+ * prose under it.
+ *
+ * It is not a smaller DOCUMENT theme and must never become one — a comment
+ * is an object wherever it is drawn. What varies here is how much room the
+ * surface has, not what kind of thing the prose is.
+ */
+export const MARKDOWN_THEME_COMPACT: MarkdownTheme = Object.freeze({
+  ...MARKDOWN_THEME_NODE,
+  bodyFontSizePx: 14,
+  headingFontSizePx: Object.freeze({ 1: 19, 2: 17, 3: 15, 4: 14, 5: 14, 6: 14 }),
+  blockGapPx: 10,
+  headingSpaceAbovePx: 14,
+  listIndentPx: 18,
+  codeBlockPaddingPx: 12,
+  blockquoteGapPx: 12,
+  tableCellPaddingXPx: 10,
+})


### PR DESCRIPTION
## Summary

Reported from a phone: the parent message and its replies read as unrelated, and the reply box and its Send were stacked. Measured at 390px, four things were wrong at once — each is a position or a size, so each is measured rather than judged.

- **One column.** The row's summary started at 54px (a 44px status dot, a 2px gap, 8px of padding) while the replies started at 17px — outdented by 37px from the message they answer, with nothing tying either to the status dot. The conversation now stands in one column on the row's own text edge, with a rule filling the row's gap channel and 12px between messages against 2px inside one.
- **One reading size.** Message bodies drew at the bubble's 16px inside a panel whose chrome runs at 11–12px, so the prose was the largest text on the surface — and the box you typed a reply INTO was 12px while the reply it posted drew at 16px. `CommentBody`'s `compact` set a class the SVG never read, so canvas-render gains a **density** axis: `MARKDOWN_THEME_COMPACT` (14px body, 19px h1) beside the node and document themes, selected by `layoutCommentBody`'s `density`. A surface still cannot choose a *theme*, so a comment can never reach document typography.
- **A verb beside what it acts on.** The Edit pencil sat alone on a 44px row; moved to a full-width message's trailing edge it stood 239px from the only other thing on its line. It now sits next to the stamp it edits (4px), keeping its 44px tap target by sinking into the 16px line.
- **Send on the field's line**, bottom-aligned so it stays beside the line being written as a reply grows. Same shape for the compose and edit forms.

A row summarises a conversation only while it is **closed**: open, the messages are right below it, so the summary was the same sentence on screen twice at two sizes. It stays as the row's accessible name (`sr-only`) — a control named "whole document 3 messages 0s ago" is not one anybody could act on.

`ThreadReplies` no longer owns a `border-l`. Where replies sit relative to what they answer is the host's question and the two hosts answer it differently; the canvas card keeps its indent at its own call site. The one-line composer is shared, so **the canvas comment card gets it too** — intended, and agreed before the work started.

## Test plan

- [x] New or updated `mcp-node` / `mcp-jsdom` / `mcp-browser` / `web-browser` tests added
- [x] `pnpm test` passes locally
- [x] Manual verification completed (describe below)
- [ ] E2E coverage added or extended where applicable

New tests, each written red first:

- `CommentsPanel.browser.test.tsx` — the column stands on the row's text edge; the opening message is drawn every time; grouping carried by spacing (further between messages than inside one); Edit shares the stamp's line and sits within 24px of it; field and Send share a row; one time on a closed row; a reply is drawn at the size the box that wrote it uses; the summary is dropped while open and returns when closed.
- `CommentBody.browser.test.tsx` — a dense surface draws at 14px, a floating one at 16px.
- `comment-body.test.ts` (canvas-render) — density picks the compact theme, compresses a heading further than the bubble does, and can never reach document typography.

Suites run: `canvas-render-node` + `canvas-viewer-node` (1232 passed), the `web-browser` annotation area (71 passed), `web-jsdom` annotation area (39 passed), `pnpm -r typecheck`, `biome check`, `pnpm knip`.

One pre-existing `web-jsdom` failure is unrelated and reproduces identically on `origin/main` (`VersionTimeline` › "fetches the thumbnail through the authorized daemon fetch … objectURL", `1 failed | 28 passed` on both) — this container runs Node 22 while `.node-version` says 24.

Manual verification: the real app at 390px in the dark theme, driven through create note → open the rail → comment on the document → two replies. Measured on that screen after the change: summary left 62px and every message body 62px (one axis), 2px inside a message against 12px between messages, prose 14px and reply field 14px, Edit at x=102.7 against a stamp ending at x=98.7, Send beside the field rather than under it.

## Visual evidence

A before/after figure was rendered through the same driven flow (both panels are real screenshots of the running app at 390px, `before` sha256 `39e774be361d`, `after` `ba25d46c8723`, figure `8fa0282410b1`) but **could not be attached from this environment** — there is no `gh` CLI here and the GitHub API tools available cannot upload an image. The same claims as numbers, before → after:

| | before | after |
|---|---|---|
| row summary left / reply body left | 62px / 25px | 62px / 62px (one axis) |
| inside a message / between messages | 2px / 8px | 2px / 12px |
| message prose / reply field | 16px / 12px | 14px / 14px |
| Edit ← stamp | 239px, own 44px row | 4px, on the stamp's line |
| Send | stacked under the field | on the field's line |

## Checklist

- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [x] PR title is a valid Conventional Commit title (it becomes the squash-merge commit message)
- [ ] Docs updated if this changes user-visible behavior or a published contract
- [x] No `console.*` calls added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPGrBEknX78whd38tHXnLH

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPGrBEknX78whd38tHXnLH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Redesigned expanded comment conversations with clearer indentation, spacing, and visual connectors.
  - Positioned Edit, Save, Reply, and Send actions more consistently alongside message content.
  - Updated reply forms so the editor and action button appear on a single line.
  - Improved comment and reply typography, including compact sizing for panel views.
  - Simplified closed-thread metadata and removed the filled appearance from open rows.
  - Replies in comment cards now appear indented beneath the opening message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->