### PR TITLE
feat(web): the Proposals inspector, an index that takes you to the card

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -483,9 +483,10 @@ write), a filled cap on a broken stroke is the daemon's "not keeping"
   is the middle, so arriving decelerates and leaving accelerates.
   Entrances are fade + small rise/scale (0.98→1); no entrance animation
   without an explicit reason.
-  **A PANE's motion is decided once, in `InspectorPanel`** — all four
-  inspectors (properties, comments, connections, history) stand in that one
-  vessel, so a fifth inherits how a pane arrives rather than restating it.
+  **A PANE's motion is decided once, in `InspectorPanel`** — all five
+  inspectors (properties, comments, proposals, connections, history) stand in
+  that one vessel, so a sixth inherits how a pane arrives rather than
+  restating it.
   Each shape enters from where it lives: the phone sheet rises off the
   bottom edge it is anchored to, the desktop column slides in from the edge
   it borders. What is deliberately NOT animated there is the column's
@@ -549,6 +550,24 @@ once there is more than one change (`Adopt 2 changes`), and each row's pair
 names what it decides (`Adopt: Move “the plan”`) — the names do the
 distinguishing that the icons deliberately do not.
 
+**The Proposals inspector is an INDEX, and decides nothing** (`ProposalsPanel`,
+ADR-0029 decisions 1 and 9). The card on the document is the one place a change
+is answered, so the panel lists what is still waiting, says how much of each
+is, and a row press moves the board onto that proposal's chrome and opens the
+card that already sits there — `SpatialEditorHandle.openProposal`, the same
+card the bubble opens. A second Adopt in the panel would be a second place
+answering one question, and the two would eventually disagree about what
+"adopt" meant.
+
+What it is FOR is the one thing the in-place surface cannot do. A proposal
+anchored four thousand pixels off-screen is drawn correctly and seen by
+nobody, and the opener is drawn at nought and pressable (user decision,
+2026-09-07) because "none waiting" is a fact worth being able to check, and a
+member that comes and goes is a control that moves under the finger reaching
+for its neighbour. A markdown document gets the index without the jump: its
+passages are drawn in the body already, and there is no viewport to move —
+so the row is not a button rather than being a dead one.
+
 Both vessels — the right-click list menu and the ⋯ grid — draw the SAME
 catalog in the SAME band order: property rows (color, z-order, arrows;
 the menu stays open), then verbs (one-shot; the menu closes), then the
@@ -566,9 +585,10 @@ share (ADR-0026 decision 5; `useCommentsRail` holds its state,
 `CommentsRailAside` is its vessel — a column where there is width, a bottom
 sheet over the editor under 768px, since a 288px column beside a 412px phone
 screen left the editor a strip a finger could not write in). The rail is one
-of four panels sharing the page's ONE inspector slot (`lib/inspector.ts`,
+of five panels sharing the page's ONE inspector slot (`lib/inspector.ts`,
 vessel `InspectorPanel`): a markdown document's properties, its comments, the
-documents linking to it (a daemon keeper only), its history. Opening any one
+changes somebody wants made to it, the documents linking to it (a daemon
+keeper only), its history. Opening any one
 closes the others and every opener reads released, because two panels beside
 one editor — measured on a phone as the display popover, the comments sheet
 and the history sheet all open at once — is what the header retune set out to

--- a/apps/web/src/components/document-editor/InspectorSegment.test.tsx
+++ b/apps/web/src/components/document-editor/InspectorSegment.test.tsx
@@ -31,7 +31,7 @@ describe('InspectorSegment', () => {
       <InspectorSegment
         open={null}
         onToggle={noop}
-        tabs={{ history: {}, comments: {}, connections: {}, properties: {} }}
+        tabs={{ history: {}, comments: {}, proposals: {}, connections: {}, properties: {} }}
       />,
     )
 
@@ -41,8 +41,35 @@ describe('InspectorSegment', () => {
         ?.replace(/[,(].*$/, '')
         .trim(),
     )
-    expect(names).toEqual(['Properties', 'Comments', 'Connections', 'History'])
+    expect(names).toEqual(['Properties', 'Comments', 'Proposals', 'Connections', 'History'])
     expect(names).toHaveLength(INSPECTOR_ORDER.length)
+  })
+
+  // ADR-0029 decision 9's place. Proposals sit beside comments rather than
+  // beside history because both are what somebody put ON this document
+  // through the annotation layer — ADR-0026's residents — where history is
+  // what the document WAS. (User decision, this session.)
+  it('offers Proposals at nought, pressable, the way Comments is', () => {
+    render(
+      <InspectorSegment
+        open={null}
+        onToggle={noop}
+        tabs={{ comments: {}, proposals: { count: 0 } }}
+      />,
+    )
+
+    const proposals = screen.getByRole('button', { name: /^Proposals/ })
+    expect(proposals.hasAttribute('disabled')).toBe(false)
+    // A conversation anyone can start says just "Comments" at nought; a
+    // proposal nobody can start says the same, because the opener's job at
+    // nought is to be in the same place tomorrow when one arrives.
+    expect(proposals.getAttribute('aria-label')).toBe('Proposals')
+  })
+
+  it('says how many proposals are open, the way Comments says its threads', () => {
+    render(<InspectorSegment open={null} onToggle={noop} tabs={{ proposals: { count: 3 } }} />)
+
+    expect(screen.getByRole('button', { name: 'Proposals, 3 open' })).not.toBeNull()
   })
 
   it('offers only what the document has — a canvas has no frontmatter, a browser keeper no backlinks', () => {

--- a/apps/web/src/components/document-editor/InspectorSegment.test.tsx
+++ b/apps/web/src/components/document-editor/InspectorSegment.test.tsx
@@ -18,7 +18,7 @@
 
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { INSPECTOR_ORDER } from '../../lib/inspector.js'
+import { INSPECTOR_CHROME, INSPECTOR_ORDER } from '../../lib/inspector.js'
 import { InspectorSegment } from './InspectorSegment'
 
 afterEach(cleanup)
@@ -64,6 +64,32 @@ describe('InspectorSegment', () => {
     // proposal nobody can start says the same, because the opener's job at
     // nought is to be in the same place tomorrow when one arrives.
     expect(proposals.getAttribute('aria-label')).toBe('Proposals')
+  })
+
+  // The name and the BADGE are two renderings of one rule, and they were two
+  // spellings of it until a review found them disagreeing: `proposals` was in
+  // the name's backlog test and not the badge's, so this opener read
+  // "Proposals" and drew a `0`. Every backlog member is driven here, so a
+  // third one cannot be added to the name alone.
+  it.each([
+    'comments',
+    'proposals',
+  ] as const)('draws no digit for %s at nought, matching what it says', (kind) => {
+    render(<InspectorSegment open={null} onToggle={noop} tabs={{ [kind]: { count: 0 } }} />)
+
+    const opener = screen.getByRole('button')
+    expect(opener.textContent ?? '').not.toMatch(/\d/)
+    expect(opener.getAttribute('aria-label')).toBe(INSPECTOR_CHROME[kind].label)
+  })
+
+  // The other side of the same rule: a SIZE is reported at nought, because
+  // "no documents link here" is the answer rather than an empty place.
+  it('keeps drawing a size at nought — connections is not a backlog', () => {
+    render(<InspectorSegment open={null} onToggle={noop} tabs={{ connections: { count: 0 } }} />)
+
+    const opener = screen.getByRole('button')
+    expect(opener.textContent).toContain('0')
+    expect(opener.getAttribute('aria-label')).toBe('Connections (0)')
   })
 
   it('says how many proposals are open, the way Comments says its threads', () => {

--- a/apps/web/src/components/document-editor/InspectorSegment.tsx
+++ b/apps/web/src/components/document-editor/InspectorSegment.tsx
@@ -1,5 +1,5 @@
 import type { LucideIcon } from 'lucide-react'
-import { History, Info, MessageSquare, Waypoints } from 'lucide-react'
+import { GitPullRequestArrow, History, Info, MessageSquare, Waypoints } from 'lucide-react'
 import type { JSX } from 'react'
 import { INSPECTOR_CHROME, INSPECTOR_ORDER, type InspectorKind } from '../../lib/inspector.js'
 import { cn } from '../../lib/utils.js'
@@ -45,6 +45,7 @@ export interface InspectorSegmentProps {
 const GLYPHS = {
   properties: Info,
   comments: MessageSquare,
+  proposals: GitPullRequestArrow,
   connections: Waypoints,
   history: History,
 } as const satisfies Record<InspectorKind, LucideIcon>
@@ -57,7 +58,13 @@ const GLYPHS = {
 function accessibleName(kind: InspectorKind, count: number | null | undefined): string {
   const label = INSPECTOR_CHROME[kind].label
   if (count === undefined || count === null) return label
-  if (kind === 'comments') return count === 0 ? label : `${label}, ${count} open`
+  // Both say "N open" and both fall back to the bare label at nought: an
+  // opener at nought is holding its place for tomorrow, not reporting a
+  // zero. The other members read `(N)` because their count is a size, not a
+  // backlog.
+  if (kind === 'comments' || kind === 'proposals') {
+    return count === 0 ? label : `${label}, ${count} open`
+  }
   return `${label} (${count})`
 }
 

--- a/apps/web/src/components/document-editor/InspectorSegment.tsx
+++ b/apps/web/src/components/document-editor/InspectorSegment.tsx
@@ -55,16 +55,26 @@ const GLYPHS = {
  * controls already carried, so a browser flow finding them by name keeps
  * finding them.
  */
+/**
+ * Whether this member's count is a BACKLOG — things waiting on a person —
+ * rather than a SIZE. The two are said differently ("N open" against
+ * "(N)") and drawn differently (a backlog at nought shows nothing, because
+ * the opener is holding its place for tomorrow rather than reporting a
+ * zero), so the split is named once here.
+ *
+ * It used to be spelled twice — `kind === 'comments' || kind === 'proposals'`
+ * in the name and a bare `kind !== 'comments'` in the badge — and the two
+ * disagreed the moment `proposals` arrived: a screen reader heard
+ * "Proposals" while the eye saw a `0`.
+ */
+function countIsBacklog(kind: InspectorKind): boolean {
+  return kind === 'comments' || kind === 'proposals'
+}
+
 function accessibleName(kind: InspectorKind, count: number | null | undefined): string {
   const label = INSPECTOR_CHROME[kind].label
   if (count === undefined || count === null) return label
-  // Both say "N open" and both fall back to the bare label at nought: an
-  // opener at nought is holding its place for tomorrow, not reporting a
-  // zero. The other members read `(N)` because their count is a size, not a
-  // backlog.
-  if (kind === 'comments' || kind === 'proposals') {
-    return count === 0 ? label : `${label}, ${count} open`
-  }
+  if (countIsBacklog(kind)) return count === 0 ? label : `${label}, ${count} open`
   return `${label} (${count})`
 }
 
@@ -95,7 +105,7 @@ export function InspectorSegment({ open, onToggle, tabs }: InspectorSegmentProps
                 className={cn(HEADER_WIDE_TOGGLE_CLASS, 'text-xs tabular-nums')}
               >
                 <Glyph aria-hidden="true" className="size-4" />
-                {typeof count === 'number' && (kind !== 'comments' || count > 0) ? count : null}
+                {typeof count === 'number' && (!countIsBacklog(kind) || count > 0) ? count : null}
               </button>
             </TooltipTrigger>
             <TooltipContent>{INSPECTOR_CHROME[kind].label}</TooltipContent>

--- a/apps/web/src/components/proposals/ProposalsPanel.test.tsx
+++ b/apps/web/src/components/proposals/ProposalsPanel.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+
+/**
+ * The Proposals panel is an INDEX (ADR-0029 decision 1): it says what is
+ * waiting and takes you to where it is drawn. It is not a second place to
+ * decide — the card on the board is the one place a change is adopted, and
+ * a panel that grew its own Adopt would let the two disagree about what is
+ * being answered.
+ */
+
+import type { Proposal } from '@kamiazya/whiteboard-model'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ProposalsPanel } from './ProposalsPanel'
+
+afterEach(cleanup)
+
+function moveNode(id: string, status: 'open' | 'adopted'): Proposal['changes'][number] {
+  return { id, op: 'node.patch', status, nodeId: 'n1', patch: { x: 40 }, assumed: { x: 0 } }
+}
+
+const waiting: Proposal = {
+  id: 'p1',
+  createdAt: '2026-09-06T00:00:00.000Z',
+  changes: [moveNode('c1', 'open'), moveNode('c2', 'adopted')],
+}
+
+const decided: Proposal = { id: 'p2', changes: [moveNode('c3', 'adopted')] }
+
+describe('ProposalsPanel', () => {
+  it('lists only what is still waiting, and says how much of each is', () => {
+    render(<ProposalsPanel proposals={[waiting, decided]} onOpen={() => {}} />)
+
+    const rows = screen.getAllByRole('button')
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.textContent).toContain('1 change waiting')
+  })
+
+  it('names the verbs in words rather than in op ids', () => {
+    render(<ProposalsPanel proposals={[waiting]} onOpen={() => {}} />)
+
+    expect(screen.getByRole('button').textContent).toContain('Move or restyle a node')
+    expect(screen.getByRole('button').textContent).not.toContain('node.patch')
+  })
+
+  // Decision 1 again: the row is the way BACK to the board, so pressing it
+  // hands the proposal's id to whoever can reveal it. It decides nothing.
+  it('hands the row press to the host, which reveals it in place', () => {
+    const onOpen = vi.fn()
+    render(<ProposalsPanel proposals={[waiting]} onOpen={onOpen} />)
+
+    fireEvent.click(screen.getByRole('button'))
+    expect(onOpen).toHaveBeenCalledWith('p1')
+  })
+
+  // A host with no in-place surface to jump to (a markdown body draws its
+  // passages itself and has no viewport to move) still gets the index. The
+  // row stops being a button rather than becoming a dead one.
+  it('draws rows that are not pressable when the host cannot reveal one', () => {
+    render(<ProposalsPanel proposals={[waiting]} />)
+
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+    expect(screen.getByText(/1 change waiting/)).not.toBeNull()
+  })
+
+  it('says what an empty panel means rather than drawing nothing', () => {
+    render(<ProposalsPanel proposals={[decided]} onOpen={() => {}} />)
+
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+    expect(screen.getByText(/Nothing waiting/)).not.toBeNull()
+  })
+})

--- a/apps/web/src/components/proposals/ProposalsPanel.tsx
+++ b/apps/web/src/components/proposals/ProposalsPanel.tsx
@@ -1,0 +1,113 @@
+/**
+ * The proposal layer's document-level surface (ADR-0029), standing in the
+ * inspector's one slot beside the editor.
+ *
+ * It is an INDEX and deliberately nothing more. Decision 1 says a person is
+ * never sent elsewhere to see what changed, so the place a change is decided
+ * is the card drawn on the document itself — on the board for a canvas, in
+ * the body for a passage. A panel that grew its own Adopt would be a second
+ * place answering the same question, and the two would eventually disagree
+ * about what "adopt" meant.
+ *
+ * What it is FOR is the thing the in-place surface cannot do: say how much is
+ * waiting without hunting for it, and take you to one. Off-screen chrome is
+ * the case that motivated it — a proposal on a node four thousand pixels away
+ * is drawn correctly and seen by nobody.
+ */
+
+import type { Proposal, ProposedChange } from '@kamiazya/whiteboard-model'
+import { openChangeCount, openProposals } from '../../lib/open-proposals.js'
+
+/**
+ * What each verb is called to a person. A closed record over the union, so a
+ * new op cannot arrive without someone deciding how the index names it — the
+ * op id is a wire spelling and reading `node.patch` in a panel is the surface
+ * leaking its schema.
+ */
+const VERB_WORDS = {
+  'node.add': 'Add a node',
+  'node.patch': 'Move or restyle a node',
+  'node.remove': 'Remove a node',
+  'edge.add': 'Add a connection',
+  'edge.patch': 'Restyle a connection',
+  'edge.remove': 'Remove a connection',
+  'body.replace': 'Replace a passage',
+} as const satisfies Record<ProposedChange['op'], string>
+
+/** The distinct verbs still waiting, in the order they first appear. */
+function waitingVerbs(proposal: Proposal): readonly string[] {
+  const seen = new Set<string>()
+  for (const change of proposal.changes) {
+    if (change.status === 'open') seen.add(VERB_WORDS[change.op])
+  }
+  return [...seen]
+}
+
+export interface ProposalsPanelProps {
+  readonly proposals: readonly Proposal[]
+  /**
+   * Reveals one proposal where it is drawn. Absent means this host has no
+   * viewport to move — a markdown body draws its passages in place already,
+   * so the index still counts them and simply has nowhere to send you.
+   */
+  readonly onOpen?: (proposalId: string) => void
+}
+
+export function ProposalsPanel({ proposals, onOpen }: ProposalsPanelProps) {
+  const waiting = openProposals(proposals)
+  return (
+    <section aria-label="Proposals" className="px-3 py-2">
+      <p className="text-muted-foreground mb-1 text-[11px] font-semibold uppercase tracking-wide">
+        Waiting {waiting.length}
+      </p>
+      {waiting.length === 0 ? (
+        <p className="text-muted-foreground py-2 text-sm">
+          Nothing waiting — changes an agent proposes land here, and on the document itself.
+        </p>
+      ) : (
+        <ul className="flex flex-col">
+          {waiting.map((proposal) => (
+            <li key={proposal.id}>
+              <Row proposal={proposal} {...(onOpen === undefined ? {} : { onOpen })} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+function Row({
+  proposal,
+  onOpen,
+}: {
+  readonly proposal: Proposal
+  readonly onOpen?: (proposalId: string) => void
+}) {
+  const open = openChangeCount(proposal)
+  const body = (
+    <>
+      <span className="text-sm font-medium">
+        {open} {open === 1 ? 'change' : 'changes'} waiting
+      </span>
+      {waitingVerbs(proposal)
+        .slice(0, 2)
+        .map((verb) => (
+          <span key={verb} className="text-muted-foreground truncate text-xs">
+            {verb}
+          </span>
+        ))}
+    </>
+  )
+  const shape = 'flex min-w-0 flex-col gap-0.5 rounded px-2 py-1.5 text-left'
+  // Not a disabled button: a host with no viewport to move is not a control
+  // that failed, it is a surface that has no jump to offer. A dead button
+  // invites the press that does nothing.
+  return onOpen === undefined ? (
+    <div className={shape}>{body}</div>
+  ) : (
+    <button type="button" onClick={() => onOpen(proposal.id)} className={`hover:bg-muted ${shape}`}>
+      {body}
+    </button>
+  )
+}

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -694,8 +694,20 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           const scoped = nodeIds === undefined ? boxes : boxes.filter((b) => nodeIds.includes(b.id))
           setViewport(fitViewportToBoxes(scoped.map((b) => b.box)))
         },
+        openProposal(proposalId) {
+          // The CHROME box, not the changed nodes: a proposal that adds a
+          // node anchors on ids the canvas does not hold yet, and fitting to
+          // those lands on nothing. The chrome is what a person is looking
+          // for, and it is on screen by definition.
+          const chrome = proposalChromeBoxes.find((entry) => entry.proposalId === proposalId)
+          if (chrome === undefined) return false
+          const { x, y, w, h } = chrome.bbox
+          setViewport(fitViewportToBoxes([{ x, y, width: w, height: h }]))
+          setOpenProposalId(proposalId)
+          return true
+        },
       }),
-      [boxes],
+      [boxes, proposalChromeBoxes],
     )
 
     const isMultiSelection = selectionMembers.length > 1

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -99,7 +99,9 @@ import {
   fitViewportToBoxes,
   type Point,
   panBy,
+  proposalAt,
   screenToCanvas,
+  viewportRevealingProposal,
   viewportTransformCss,
   zoomAt,
 } from '../../lib/spatial/viewport.js'
@@ -367,16 +369,6 @@ const DEFAULT_TEST_ID = 'spatial-editor'
  */
 const COMMENT_PRESS_SLOP_PX = 4
 
-/**
- * How far in from the viewport's corner a revealed proposal lands.
- *
- * `fitViewportToBoxes` pins the union's top-left to the origin rather than
- * centring it, which is right for `fitToContent` (the union is the board) and
- * leaves a single small box flush against the editor's edge — with the card,
- * which opens at that box's own screen position, half outside it.
- */
-const PROPOSAL_REVEAL_INSET_PX = 80
-
 /** Screen distance between two points — how far a press travelled. */
 function travelled(from: Point, to: Point): number {
   return Math.hypot(from.x - to.x, from.y - to.y)
@@ -613,22 +605,8 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
     const pressedProposalRef = useRef<{ readonly id: string; readonly startScreen: Point } | null>(
       null,
     )
-    const hitTestProposal = (point: Point): string | undefined => {
-      for (let i = proposalChromeBoxes.length - 1; i >= 0; i -= 1) {
-        const entry = proposalChromeBoxes[i]
-        if (entry === undefined) continue
-        const { bbox } = entry
-        if (
-          point.x >= bbox.x &&
-          point.x <= bbox.x + bbox.w &&
-          point.y >= bbox.y &&
-          point.y <= bbox.y + bbox.h
-        ) {
-          return entry.proposalId
-        }
-      }
-      return undefined
-    }
+    const hitTestProposal = (point: Point): string | undefined =>
+      proposalAt(proposalChromeBoxes, point)
     // The committed surface without the comment in flight (see
     // keyedWithoutPrefix for why it leaves rather than hides).
     const draggedCommentId = commentDrag?.comment.id
@@ -705,30 +683,9 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           setViewport(fitViewportToBoxes(scoped.map((b) => b.box)))
         },
         openProposal(proposalId) {
-          // The CHROME box, not the changed nodes: a proposal that adds a
-          // node anchors on ids the canvas does not hold yet, and fitting to
-          // those lands on nothing. The chrome is what a person is looking
-          // for, and it is on screen by definition.
-          const chrome = proposalChromeBoxes.find((entry) => entry.proposalId === proposalId)
-          if (chrome === undefined) return false
-          const { x, y, w, h } = chrome.bbox
-          // Inset, because `fitViewportToBoxes` PINS the union's top-left to
-          // the origin rather than centring it — which is right for
-          // `fitToContent`, where the union is the whole board, and wrong
-          // here. The card opens at the chrome's own screen position, so
-          // without this it lands half off the left edge with the change it
-          // is about outside the frame. Caught by looking at the figure, not
-          // by a test that passed.
-          setViewport(
-            fitViewportToBoxes([
-              {
-                x: x - PROPOSAL_REVEAL_INSET_PX,
-                y: y - PROPOSAL_REVEAL_INSET_PX,
-                width: w,
-                height: h,
-              },
-            ]),
-          )
+          const at = viewportRevealingProposal(proposalChromeBoxes, proposalId)
+          if (at === null) return false
+          setViewport(at)
           setOpenProposalId(proposalId)
           return true
         },

--- a/apps/web/src/components/spatial-editor/SpatialEditor.tsx
+++ b/apps/web/src/components/spatial-editor/SpatialEditor.tsx
@@ -367,6 +367,16 @@ const DEFAULT_TEST_ID = 'spatial-editor'
  */
 const COMMENT_PRESS_SLOP_PX = 4
 
+/**
+ * How far in from the viewport's corner a revealed proposal lands.
+ *
+ * `fitViewportToBoxes` pins the union's top-left to the origin rather than
+ * centring it, which is right for `fitToContent` (the union is the board) and
+ * leaves a single small box flush against the editor's edge — with the card,
+ * which opens at that box's own screen position, half outside it.
+ */
+const PROPOSAL_REVEAL_INSET_PX = 80
+
 /** Screen distance between two points — how far a press travelled. */
 function travelled(from: Point, to: Point): number {
   return Math.hypot(from.x - to.x, from.y - to.y)
@@ -702,7 +712,23 @@ export const SpatialEditor = forwardRef<SpatialEditorHandle, SpatialEditorProps>
           const chrome = proposalChromeBoxes.find((entry) => entry.proposalId === proposalId)
           if (chrome === undefined) return false
           const { x, y, w, h } = chrome.bbox
-          setViewport(fitViewportToBoxes([{ x, y, width: w, height: h }]))
+          // Inset, because `fitViewportToBoxes` PINS the union's top-left to
+          // the origin rather than centring it — which is right for
+          // `fitToContent`, where the union is the whole board, and wrong
+          // here. The card opens at the chrome's own screen position, so
+          // without this it lands half off the left edge with the change it
+          // is about outside the frame. Caught by looking at the figure, not
+          // by a test that passed.
+          setViewport(
+            fitViewportToBoxes([
+              {
+                x: x - PROPOSAL_REVEAL_INSET_PX,
+                y: y - PROPOSAL_REVEAL_INSET_PX,
+                width: w,
+                height: h,
+              },
+            ]),
+          )
           setOpenProposalId(proposalId)
           return true
         },

--- a/apps/web/src/components/spatial-editor/proposal-open-in-place.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/proposal-open-in-place.browser.test.tsx
@@ -1,0 +1,105 @@
+// ADR-0029 decision 1: never send a person elsewhere to see what changed.
+//
+// The Proposals panel is an INDEX, not a second place to decide — so a row
+// press has to land the reader on the card that is already drawn on the
+// board. That is one seam (`SpatialEditorHandle.openProposal`) doing two
+// things a page cannot do from outside: move the viewport onto the chrome,
+// and open the card that sits there.
+import type { Proposal, SpatialCanvas } from '@kamiazya/whiteboard-model'
+import { cleanup, render } from '@testing-library/react'
+import { useRef } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { page } from 'vitest/browser'
+import type { SpatialEditorHandle } from '../../lib/spatial/editor-handle.js'
+import { SpatialEditor } from './SpatialEditor.js'
+
+afterEach(cleanup)
+
+// Far enough from the origin that a viewport fitted to the whole canvas
+// cannot have the chrome centred by accident — the pan has to be real.
+const start: SpatialCanvas = {
+  nodes: [
+    { id: 'near', type: 'text', x: 0, y: 0, width: 120, height: 60, text: 'here' },
+    { id: 'far', type: 'text', x: 4000, y: 3000, width: 120, height: 60, text: 'over there' },
+  ],
+  edges: [],
+}
+
+const proposal: Proposal = {
+  id: 'p-far',
+  changes: [
+    {
+      id: 'node:far',
+      op: 'node.patch',
+      status: 'open',
+      nodeId: 'far',
+      patch: { x: 4400 },
+      assumed: { x: 4000 },
+    },
+  ],
+}
+
+function makeHost() {
+  const handle: { current: SpatialEditorHandle | null } = { current: null }
+  function Host() {
+    const ref = useRef<SpatialEditorHandle | null>(null)
+    handle.current = ref.current
+    return (
+      <div style={{ width: 900, height: 700 }}>
+        <SpatialEditor
+          ref={(node) => {
+            ref.current = node
+            handle.current = node
+          }}
+          defaultTool="select"
+          canvas={start}
+          proposals={[proposal]}
+          onChange={() => {}}
+          theme="light"
+        />
+      </div>
+    )
+  }
+  return { Host, handle }
+}
+
+/**
+ * Where the far node is drawn RIGHT NOW. Re-queried every time: the pan
+ * re-renders the scene, and a node reference held across it reads the
+ * position it had when it was detached.
+ */
+function farNodeLeft(root: HTMLElement): number {
+  const el = root.querySelector('[data-testid="canvas-content"] [data-wb-key="far"]') as SVGGElement
+  return el.getBoundingClientRect().left
+}
+
+it('opens a proposal where it sits, and answers whether it could', async () => {
+  const { Host, handle } = makeHost()
+  const { container } = render(<Host />)
+  await expect.element(page.getByTestId('canvas-content')).toBeInTheDocument()
+  expect(container.querySelector('[data-testid="proposal-card"]')).toBeNull()
+  const framedOnLoad = farNodeLeft(container)
+
+  expect(handle.current?.openProposal('p-far')).toBe(true)
+
+  // Both halves of decision 1, and neither alone is the behaviour: the
+  // board moved onto the chrome, AND the card drawn there is now open.
+  await expect.element(page.getByTestId('proposal-card')).toBeInTheDocument()
+  await vi.waitFor(() => expect(farNodeLeft(container)).not.toBe(framedOnLoad))
+})
+
+// The guard, not a signal: a panel's list can outrun the scene by a frame,
+// and the answer is what stops the viewport being moved to nowhere while it
+// catches up. So the caller's job is to do nothing, and this pins that
+// nothing is what happens.
+it('answers false for a proposal the canvas draws no chrome for', async () => {
+  const { Host, handle } = makeHost()
+  const { container } = render(<Host />)
+  await expect.element(page.getByTestId('canvas-content')).toBeInTheDocument()
+  const framedOnLoad = farNodeLeft(container)
+
+  expect(handle.current?.openProposal('p-nowhere')).toBe(false)
+
+  expect(container.querySelector('[data-testid="proposal-card"]')).toBeNull()
+  expect(farNodeLeft(container)).toBe(framedOnLoad)
+})

--- a/apps/web/src/components/spatial-editor/proposal-open-in-place.browser.test.tsx
+++ b/apps/web/src/components/spatial-editor/proposal-open-in-place.browser.test.tsx
@@ -86,6 +86,16 @@ it('opens a proposal where it sits, and answers whether it could', async () => {
   // board moved onto the chrome, AND the card drawn there is now open.
   await expect.element(page.getByTestId('proposal-card')).toBeInTheDocument()
   await vi.waitFor(() => expect(farNodeLeft(container)).not.toBe(framedOnLoad))
+
+  // And the card is WHOLLY on screen. The fit pins the box's top-left to the
+  // origin rather than centring it, so without an inset the card — which
+  // opens at that box's own screen position — hangs off the left edge with
+  // the change it is about outside the frame. Found by looking at the
+  // figure; the two assertions above passed over it.
+  const surface = (await page.getByTestId('spatial-editor').element()).getBoundingClientRect()
+  const card = (await page.getByTestId('proposal-card').element()).getBoundingClientRect()
+  expect(card.left).toBeGreaterThan(surface.left)
+  expect(card.top).toBeGreaterThan(surface.top)
 })
 
 // The guard, not a signal: a panel's list can outrun the scene by a frame,

--- a/apps/web/src/lib/inspector.ts
+++ b/apps/web/src/lib/inspector.ts
@@ -11,10 +11,11 @@
  *
  * Every member is the same kind of thing — information ABOUT the open
  * document, read or written beside it: its frontmatter (`properties`, a
- * markdown document only), its conversations, the documents that link to it
+ * markdown document only), its conversations, the changes somebody wants
+ * made to it (`proposals`, ADR-0029), the documents that link to it
  * (`connections`, a daemon keeper only), its history.
  */
-export type InspectorKind = 'properties' | 'comments' | 'connections' | 'history'
+export type InspectorKind = 'properties' | 'comments' | 'proposals' | 'connections' | 'history'
 
 /**
  * The order the four read IN — the header's segment, left to right.
@@ -29,11 +30,19 @@ export type InspectorKind = 'properties' | 'comments' | 'connections' | 'history
  *
  * Properties first: ADR-0006 puts an object's properties ahead of its
  * verbs, and the rest run outward from the document — its own frontmatter,
- * the talk about it, what points at it, what it was.
+ * the talk about it, the changes proposed to it, what points at it, what it
+ * was.
+ *
+ * `proposals` sits beside `comments` rather than beside `history` because
+ * both are what somebody put ON this document through ADR-0026's annotation
+ * layer — a proposal is a resident of it carrying a change where a comment
+ * carries a message — while history is what the document WAS. (User
+ * decision, 2026-09-07.)
  */
 export const INSPECTOR_ORDER = [
   'properties',
   'comments',
+  'proposals',
   'connections',
   'history',
 ] as const satisfies readonly InspectorKind[]
@@ -46,6 +55,7 @@ export const INSPECTOR_ORDER = [
 export const INSPECTOR_CHROME = {
   properties: { label: 'Properties', testId: 'properties-panel' },
   comments: { label: 'Comments', testId: 'comments-rail' },
+  proposals: { label: 'Proposals', testId: 'proposals-panel' },
   connections: { label: 'Connections', testId: 'connections-panel' },
   history: { label: 'History', testId: 'history-panel' },
 } as const satisfies Record<InspectorKind, { label: string; testId: string }>

--- a/apps/web/src/lib/open-proposals.test.ts
+++ b/apps/web/src/lib/open-proposals.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import type { Proposal } from '@kamiazya/whiteboard-model'
+import { isOpenProposal, openChangeCount, openProposals } from './open-proposals.js'
+
+function proposal(id: string, ...statuses: Array<'open' | 'adopted' | 'dismissed'>): Proposal {
+  return {
+    id,
+    // `node.remove` carries `assumed` — the node as it stood, which is what
+    // the renderer draws struck through. The verb is irrelevant here; what
+    // these cases are about is the `status` beside it.
+    changes: statuses.map((status, i) => ({
+      id: `${id}-c${i}`,
+      status,
+      op: 'node.remove' as const,
+      nodeId: `n${i}`,
+      assumed: { id: `n${i}`, type: 'text' as const, x: 0, y: 0, width: 10, height: 10, text: '' },
+    })),
+  }
+}
+
+describe('open proposals', () => {
+  it('keeps a batch open while one change waits', () => {
+    expect(isOpenProposal(proposal('p', 'adopted', 'open', 'dismissed'))).toBe(true)
+  })
+
+  // Both verdicts close a change: an adopted one and a dismissed one have
+  // each been answered, which is the whole question the count asks.
+  it('closes a batch every change of which is decided, either way', () => {
+    expect(isOpenProposal(proposal('p', 'adopted', 'dismissed'))).toBe(false)
+    expect(isOpenProposal(proposal('p', 'adopted'))).toBe(false)
+    expect(isOpenProposal(proposal('p', 'dismissed'))).toBe(false)
+  })
+
+  it('filters to the open ones, in the order given', () => {
+    const list = [proposal('a', 'open'), proposal('b', 'adopted'), proposal('c', 'open')]
+    expect(openProposals(list).map((p) => p.id)).toEqual(['a', 'c'])
+  })
+
+  it('counts the changes still waiting inside one proposal', () => {
+    expect(openChangeCount(proposal('p', 'open', 'adopted', 'open'))).toBe(2)
+  })
+})

--- a/apps/web/src/lib/open-proposals.test.ts
+++ b/apps/web/src/lib/open-proposals.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
 import type { Proposal } from '@kamiazya/whiteboard-model'
+import { describe, expect, it } from 'vitest'
 import { isOpenProposal, openChangeCount, openProposals } from './open-proposals.js'
 
 function proposal(id: string, ...statuses: Array<'open' | 'adopted' | 'dismissed'>): Proposal {

--- a/apps/web/src/lib/open-proposals.ts
+++ b/apps/web/src/lib/open-proposals.ts
@@ -1,0 +1,29 @@
+import type { Proposal, ProposedChange } from '@kamiazya/whiteboard-model'
+
+/**
+ * Which proposals are still waiting on a person.
+ *
+ * A proposal carries no status of its own (ADR-0029): whether it is open
+ * follows from its changes, because "nine of these are right and one is not"
+ * is the common case and a per-batch verdict cannot say it. So one open
+ * change keeps the batch open, and a batch every change of which is decided
+ * is done — however it was decided, since an adopted change and a dismissed
+ * one are both answered.
+ *
+ * Derived rather than stored for the reason the ADR gives: a second place to
+ * write it leaves "which one counts?" unanswerable the moment the two
+ * disagree.
+ */
+export function isOpenProposal(proposal: Proposal): boolean {
+  return proposal.changes.some((change: ProposedChange) => change.status === 'open')
+}
+
+/** The open proposals, in the order they were given. */
+export function openProposals(proposals: readonly Proposal[]): readonly Proposal[] {
+  return proposals.filter(isOpenProposal)
+}
+
+/** How many changes in this proposal are still waiting — what a row says. */
+export function openChangeCount(proposal: Proposal): number {
+  return proposal.changes.filter((change: ProposedChange) => change.status === 'open').length
+}

--- a/apps/web/src/lib/spatial/editor-handle.ts
+++ b/apps/web/src/lib/spatial/editor-handle.ts
@@ -7,4 +7,15 @@ export interface SpatialEditorHandle {
   setViewport(viewport: Viewport): void
   /** Fits the viewport to the given node ids, or to every node when omitted. */
   fitToContent(nodeIds?: readonly string[]): void
+  /**
+   * Brings a proposal into view and opens its card where it sits.
+   *
+   * The inspector's Proposals panel is an INDEX, not a second place to
+   * decide (ADR-0029 decision 1: a person is never sent elsewhere to see
+   * what changed), so a row hands the proposal back to the canvas rather
+   * than rendering it. Answers false when the id names no proposal the
+   * canvas is drawing chrome for — a caller's list can outrun the scene by
+   * a frame, and moving the viewport to nowhere is worse than not moving.
+   */
+  openProposal(proposalId: string): boolean
 }

--- a/apps/web/src/lib/spatial/viewport.ts
+++ b/apps/web/src/lib/spatial/viewport.ts
@@ -242,3 +242,66 @@ export function panToShowTarget(
   // The shifts are screen pixels; the viewport origin is canvas units.
   return { ...viewport, x: viewport.x + dx / viewport.zoom, y: viewport.y + dy / viewport.zoom }
 }
+
+/**
+ * How far in from the viewport's corner a revealed proposal lands.
+ *
+ * `fitViewportToBoxes` pins the union's top-left to the origin rather than
+ * centring it, which is right for `fitToContent` (the union is the board) and
+ * leaves a single small box flush against the editor's edge — with the
+ * proposal card, which opens at that box's own screen position, half outside
+ * it. Found by looking at a figure, not by a test that passed.
+ */
+const PROPOSAL_REVEAL_INSET_PX = 80
+
+/** One proposal's chrome, as the scene projection reports it. */
+export interface ProposalChromeBox {
+  readonly proposalId: string
+  readonly bbox: { readonly x: number; readonly y: number; readonly w: number; readonly h: number }
+}
+
+/**
+ * Where to stand to see one proposal, or `null` when the canvas draws no
+ * chrome for it — a panel's list can outrun the scene by a frame, and moving
+ * the viewport to nowhere is worse than not moving.
+ *
+ * The CHROME box, not the changed nodes: a proposal that adds a node anchors
+ * on ids the canvas does not hold yet, and fitting to those lands on nothing.
+ * The chrome is what a person is looking for, and it is in the scene by
+ * definition.
+ */
+export function viewportRevealingProposal(
+  chrome: readonly ProposalChromeBox[],
+  proposalId: string,
+): Viewport | null {
+  const found = chrome.find((entry) => entry.proposalId === proposalId)
+  if (found === undefined) return null
+  const { x, y, w, h } = found.bbox
+  return fitViewportToBoxes([
+    { x: x - PROPOSAL_REVEAL_INSET_PX, y: y - PROPOSAL_REVEAL_INSET_PX, width: w, height: h },
+  ])
+}
+
+/**
+ * The proposal whose chrome covers this canvas point, or `undefined`.
+ *
+ * Topmost first — later chrome is drawn over earlier, so a press belongs to
+ * whichever bubble the person can actually see.
+ */
+export function proposalAt(
+  chrome: readonly ProposalChromeBox[],
+  point: { readonly x: number; readonly y: number },
+): string | undefined {
+  for (let i = chrome.length - 1; i >= 0; i -= 1) {
+    const entry = chrome[i]
+    if (entry === undefined) continue
+    const { bbox } = entry
+    const inside =
+      point.x >= bbox.x &&
+      point.x <= bbox.x + bbox.w &&
+      point.y >= bbox.y &&
+      point.y <= bbox.y + bbox.h
+    if (inside) return entry.proposalId
+  }
+  return undefined
+}

--- a/apps/web/src/lib/viewport-request.test.ts
+++ b/apps/web/src/lib/viewport-request.test.ts
@@ -12,14 +12,22 @@ function payload(
 
 describe('applyViewportRequest', () => {
   it('routes mode: fit to fitToContent, scoped to the given elementIds', () => {
-    const handle: SpatialEditorHandle = { setViewport: vi.fn(), fitToContent: vi.fn() }
+    const handle: SpatialEditorHandle = {
+      setViewport: vi.fn(),
+      fitToContent: vi.fn(),
+      openProposal: vi.fn(),
+    }
     applyViewportRequest(payload({ mode: 'fit', elementIds: ['a', 'b'] }), handle)
     expect(handle.fitToContent).toHaveBeenCalledWith(['a', 'b'])
     expect(handle.setViewport).not.toHaveBeenCalled()
   })
 
   it('routes mode: move to setViewport', () => {
-    const handle: SpatialEditorHandle = { setViewport: vi.fn(), fitToContent: vi.fn() }
+    const handle: SpatialEditorHandle = {
+      setViewport: vi.fn(),
+      fitToContent: vi.fn(),
+      openProposal: vi.fn(),
+    }
     applyViewportRequest(payload({ mode: 'move', scrollX: 10, scrollY: 20, zoom: 2 }), handle)
     expect(handle.setViewport).toHaveBeenCalledWith({ x: 10, y: 20, zoom: 2 })
     expect(handle.fitToContent).not.toHaveBeenCalled()
@@ -30,14 +38,22 @@ describe('applyViewportRequest', () => {
   })
 
   it('defaults an absent mode to fit, matching the daemon route contract', () => {
-    const handle: SpatialEditorHandle = { setViewport: vi.fn(), fitToContent: vi.fn() }
+    const handle: SpatialEditorHandle = {
+      setViewport: vi.fn(),
+      fitToContent: vi.fn(),
+      openProposal: vi.fn(),
+    }
     applyViewportRequest(payload({ elementIds: ['a'] }), handle)
     expect(handle.fitToContent).toHaveBeenCalledWith(['a'])
     expect(handle.setViewport).not.toHaveBeenCalled()
   })
 
   it('degrades missing scroll/zoom fields to the identity viewport rather than throwing', () => {
-    const handle: SpatialEditorHandle = { setViewport: vi.fn(), fitToContent: vi.fn() }
+    const handle: SpatialEditorHandle = {
+      setViewport: vi.fn(),
+      fitToContent: vi.fn(),
+      openProposal: vi.fn(),
+    }
     applyViewportRequest(payload({ mode: 'move' }), handle)
     expect(handle.setViewport).toHaveBeenCalledWith({ x: 0, y: 0, zoom: 1 })
   })

--- a/apps/web/src/pages/DaemonDocumentPage.comments-panel.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.comments-panel.test.tsx
@@ -461,6 +461,12 @@ describe('DaemonDocumentPage comments panel', () => {
   // (`CommentsPanel.browser.test.tsx`); what is no longer covered at the
   // PAGE level is `writable={preview === null}`, which a version preview
   // still exercises and nothing yet tests here.
+  //
+  // A SECOND panel now reads the same state: the Proposals index withholds
+  // its row action under a preview, because the spatial editor is unmounted
+  // there and the handle a row would call is null. Same rule, same gap —
+  // and it is one gap rather than two, so the fixture that closes it closes
+  // both.
 })
 
 /** Every thread resolved: the zero-open branch of the opener's label. */

--- a/apps/web/src/pages/DaemonDocumentPage.proposal-card.browser.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.proposal-card.browser.test.tsx
@@ -164,3 +164,42 @@ it('an agent’s proposal is drawn in place, and Adopt moves the node and closes
   await vi.waitFor(() => expect(contentOf(root).textContent).not.toContain('proposed change'))
   expect(document.querySelector('[data-testid="proposal-card"]')).toBeNull()
 })
+
+// The inspector's index (ADR-0029 decision 9's place). Its whole job is to
+// say what is waiting without hunting for it, and to take you to one — so
+// the row press has to land on the SAME card the bubble opens, not on a
+// second place to decide. A proposal on a node four thousand pixels away is
+// drawn correctly and seen by nobody, which is what the index is for.
+it('the Proposals opener counts what is waiting, and a row opens the card in place', async () => {
+  sessionStorage.setItem('wb.lastTool', 'select')
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response('{}', { status: 404 })),
+  )
+  render(
+    <DaemonDocumentPage
+      daemonBaseUrl="http://127.0.0.1:3099"
+      workspaceId="w1"
+      path="board"
+      createBackend={() => new FakeBackend()}
+    />,
+  )
+  await screen.findByTestId('spatial-editor', undefined, { timeout: 15_000 })
+
+  const opener = await screen.findByRole(
+    'button',
+    { name: /^Proposals, 1 open/ },
+    { timeout: 15_000 },
+  )
+  await userEvent.click(opener)
+
+  const panel = await screen.findByTestId('proposals-panel')
+  const row = await waitFor(() =>
+    [...panel.querySelectorAll('button')].find((b) => b.textContent?.includes('1 change waiting')),
+  )
+  expect(row).toBeDefined()
+
+  expect(document.querySelector('[data-testid="proposal-card"]')).toBeNull()
+  fireEvent.click(row as HTMLButtonElement)
+  await expect.element(page.getByTestId('proposal-card')).toBeInTheDocument()
+})

--- a/apps/web/src/pages/DocumentPage.tsx
+++ b/apps/web/src/pages/DocumentPage.tsx
@@ -436,10 +436,16 @@ function DocumentPageBody({
           <InspectorPanel kind="proposals" onClose={() => setInspector(null)}>
             <ProposalsPanel
               proposals={threads.proposals}
-              // Only a canvas has a viewport to move. A markdown body draws
-              // its passages where they are already, so the index counts
-              // them and has nowhere to send you — see the panel's `onOpen`.
-              {...(documentKind === 'spatial'
+              // Two ways to have no viewport to move, and the panel wants
+              // the same answer for both. A markdown body draws its
+              // passages where they are already; and while a past state is
+              // on screen the live editor is UNMOUNTED (`preview ?
+              // DocumentPreview : DocumentEditorSurface` below), so the
+              // handle is null and a row would be a button that does
+              // nothing. The index still counts either way — it just has
+              // nowhere to send you, which the panel draws as a row that is
+              // not a button rather than a dead one.
+              {...(documentKind === 'spatial' && preview === null
                 ? { onOpen: (id: string) => spatialHandle.current?.openProposal(id) }
                 : {})}
             />

--- a/apps/web/src/pages/DocumentPage.tsx
+++ b/apps/web/src/pages/DocumentPage.tsx
@@ -21,6 +21,7 @@ import {
   DocumentFacetsEditor,
   DocumentProperties,
 } from '../components/document-properties/DocumentProperties.js'
+import { ProposalsPanel } from '../components/proposals/ProposalsPanel.js'
 import { CanvasDisplaySettings } from '../components/spatial-editor/CanvasDisplaySettings.js'
 import type { VersionPreviewSession } from '../components/VersionTimeline'
 import { BookmarkAction } from '../components/workspace-top-bar/BookmarkAction.js'
@@ -39,7 +40,9 @@ import { captureBookmarkPicture } from '../lib/bookmark-picture.js'
 import { useWhiteboardCommands } from '../lib/commands/index.js'
 import type { InspectorKind } from '../lib/inspector.js'
 import { fileRefOptions } from '../lib/link-entries.js'
+import { openProposals } from '../lib/open-proposals.js'
 import { applyCommand } from '../lib/spatial/commands.js'
+import type { SpatialEditorHandle } from '../lib/spatial/editor-handle.js'
 import { createUserSettingsStore } from '../lib/user-settings-store.js'
 import { cn } from '../lib/utils.js'
 import { buildVersionSaveBody } from '../lib/version-save-body.js'
@@ -135,6 +138,29 @@ function DocumentPageBody({
   const toggleInspector = (kind: InspectorKind) =>
     setInspector((open) => (open === kind ? null : kind))
   const setCommentsOpen = useCallback((open: boolean) => setInspector(open ? 'comments' : null), [])
+
+  /**
+   * The page's own hold on the spatial editor, so an inspector row can reach
+   * back into the board (ADR-0029 decision 1: the panel is an index, and a
+   * row press takes you to where the change is already drawn — it does not
+   * open a second place to decide).
+   *
+   * Merged with whatever ref the keeper supplied rather than replacing it:
+   * the daemon page holds one for MCP viewport requests, and both want the
+   * same handle.
+   */
+  const spatialHandle = useRef<SpatialEditorHandle | null>(null)
+  const keeperEditorRef = model.spatial.editorRef
+  const attachSpatialHandle = useCallback(
+    (node: SpatialEditorHandle | null) => {
+      spatialHandle.current = node
+      if (typeof keeperEditorRef === 'function') keeperEditorRef(node)
+      else if (keeperEditorRef !== null && keeperEditorRef !== undefined) {
+        keeperEditorRef.current = node
+      }
+    },
+    [keeperEditorRef],
+  )
   // Bumped by whoever asks for a bookmark (see requestBookmark below), which
   // opens the column with its naming field ready. Nothing here takes one.
   const [bookmarkArmed, setBookmarkArmed] = useState(0)
@@ -307,6 +333,11 @@ function DocumentPageBody({
         // (ADR-0009 decision 3); the keeper answers none for a spatial one.
         ...(model.properties.facets === undefined ? {} : { properties: {} }),
         comments: { count: commentsRail.openThreadCount },
+        // Always offered, and pressable at nought (user decision,
+        // 2026-09-07): a document with no proposals is a fact worth being
+        // able to check, and a member that comes and goes is a control that
+        // moves under the finger reaching for its neighbour.
+        proposals: { count: openProposals(threads.proposals).length },
         // `null` until the backlinks fetch answers: the member waits rather
         // than claiming zero, which is what the chip did before it moved.
         ...(model.connections === undefined
@@ -401,6 +432,18 @@ function DocumentPageBody({
             threads={threads.annotations}
             writable={preview === null}
           />
+        ) : inspector === 'proposals' ? (
+          <InspectorPanel kind="proposals" onClose={() => setInspector(null)}>
+            <ProposalsPanel
+              proposals={threads.proposals}
+              // Only a canvas has a viewport to move. A markdown body draws
+              // its passages where they are already, so the index counts
+              // them and has nowhere to send you — see the panel's `onOpen`.
+              {...(documentKind === 'spatial'
+                ? { onOpen: (id: string) => spatialHandle.current?.openProposal(id) }
+                : {})}
+            />
+          </InspectorPanel>
         ) : inspector === 'connections' &&
           model.connections !== undefined &&
           model.connections.backlinks !== null ? (
@@ -524,9 +567,7 @@ function DocumentPageBody({
                   className="relative h-full min-h-0"
                   editorKey={documentKey}
                   canvasLoaded={sync.loaded}
-                  {...(model.spatial.editorRef === undefined
-                    ? {}
-                    : { editorRef: model.spatial.editorRef })}
+                  editorRef={attachSpatialHandle}
                   {...(model.spatial.agentTouchedNodeIds === undefined
                     ? {}
                     : { agentTouchedNodeIds: model.spatial.agentTouchedNodeIds })}

--- a/apps/web/src/scoped-screen-state.test.ts
+++ b/apps/web/src/scoped-screen-state.test.ts
@@ -375,6 +375,14 @@ const DOCUMENT_PAGE_STATE: Record<string, ScopeCoverage> = {
     'no subject: mirrors the scope itself, reassigned every render — it is what a save outliving its document asks to find out whether its outcome still belongs on screen',
   versionRefreshSignal:
     'no subject: a counter that nudges the History column to refetch; the list it refreshes is the column’s own, and the column remounts per document',
+  // The same answer `spatialEditorRef` gives on the daemon page, and for the
+  // same reason — this is the page-level half of that handle. Clearing it in
+  // the SCOPE RESET effect would be WRONG rather than merely redundant:
+  // effects run after refs are attached, so by the time that effect fires the
+  // arrived editor has already bound itself, and nulling it there would
+  // discard the live handle instead of a stale one.
+  spatialHandle:
+    'no subject: the mounted editor’s imperative handle, and the editor is keyed per document — React swaps the handle on a switch without anything here clearing it',
 }
 
 const BROWSER_DOCUMENT_PAGE_STATE: Record<string, ScopeCoverage> = {

--- a/docs/contributing/adr/0029-proposal-layer.md
+++ b/docs/contributing/adr/0029-proposal-layer.md
@@ -20,10 +20,16 @@ were measured before the change (see
 cut is now the earliest version row alone, and file-GC no longer counts a
 tip's checkout as a live reference set.
 
-What is NOT done: decision 9's place in the inspector segment, and
-`versions.branchName` — a label on a version row rather than a branch object,
-which leaves through the published version wire and the browser's IndexedDB
-schema, so it is its own increment.
+Decision 9's place in the inspector segment is done: `proposals` is a member
+of `InspectorKind`, and its panel (`apps/web`'s `ProposalsPanel`) is an INDEX
+— it counts what is waiting and a row press moves the board onto that
+proposal's chrome and opens the card already drawn there, rather than growing
+a second Adopt. What that leaves open is the half a panel cannot answer:
+what the CANVAS looks like under forty markers (see the Consequences below).
+
+What is NOT done: `versions.branchName` — a label on a version row rather
+than a branch object, which leaves through the published version wire and the
+browser's IndexedDB schema, so it is its own increment.
 
 ## Context
 
@@ -375,7 +381,11 @@ Harder, and these are real:
   is a person expecting their edit to be a proposal, or the reverse.
 - **A pile of open proposals is a new state to design.** Decision 9 says
   collapse to a count, which is a direction, not a finished answer for what a
-  document with forty open proposals looks like.
+  document with forty open proposals looks like. Half answered: the inspector
+  segment's Proposals member carries the count, and its panel is the index
+  that finds one without hunting the board for it. The unanswered half is the
+  BOARD — forty bubbles drawn at once, each placed to avoid the last, is a
+  density nothing has looked at, and the panel does not make it better.
 - **`wb_canvas_edit`'s default changes.** Existing callers that expect a write
   to land will propose instead. This is a published surface on a `0.0.x`
   package with no users, so it is a break taken deliberately rather than a

--- a/packages/mcp-server/src/server/file-size-budget.test.ts
+++ b/packages/mcp-server/src/server/file-size-budget.test.ts
@@ -260,7 +260,14 @@ const FILE_SIZE_GRANDFATHER: Record<string, number> = {
   // tells `useDragLayers` that a comment is in flight — both so the
   // annotation ramp is neither clipped by a re-fitted envelope nor mistaken
   // for an edit when a gesture takes the pin over.
-  'apps/web/src/components/spatial-editor/SpatialEditor.tsx': 2727,
+  //
+  // -5, NET, over a seam that added 38: `openProposal` and the proposal
+  // hit-test are geometry over the scene's chrome boxes, so they moved to
+  // `lib/spatial/viewport.ts` (`viewportRevealingProposal`, `proposalAt`)
+  // where the earlier splits put this file's pure core. This guard is what
+  // asked the question — the growth read as the feature's cost until it
+  // turned out two thirds of it was misfiled.
+  'apps/web/src/components/spatial-editor/SpatialEditor.tsx': 2722,
 }
 
 describe('file-size budget: files stay under 800 lines (shrink-only grandfather)', () => {


### PR DESCRIPTION
## Summary

- **ADR-0029 decision 9's place in the inspector segment, wired.** `ProposalsPanel` lists the proposals still waiting on a person, and a row press moves the board onto that proposal's chrome and opens the card already drawn there — `SpatialEditorHandle.openProposal`, the same card the bubble opens.
- **It is an INDEX and nothing more** (decision 1: a person is never sent elsewhere to see what changed). The card on the document stays the one place a change is answered; a second Adopt in the panel would be a second place answering one question, and the two would eventually disagree about what "adopt" meant.
- **What it is FOR is the one thing the in-place surface cannot do.** A proposal anchored four thousand pixels off-screen is drawn correctly and seen by nobody, and there was no way to learn a document had any without finding one.

Three decisions taken by the project owner this session, recorded where the code makes them rather than in a commit nobody re-reads:

| decision | where |
|---|---|
| the member is **always offered and pressable at nought** — "none waiting" is a fact worth checking, and a member that comes and goes moves under the finger reaching for its neighbour | `DocumentPage`'s `tabs` |
| a row **pans to the anchor and opens the card in place**, rather than rendering the change in the panel | `SpatialEditorHandle.openProposal` |
| `proposals` sits **between `comments` and `connections`** — both are what somebody put ON this document through ADR-0026's annotation layer, where history is what the document WAS | `INSPECTOR_ORDER` (landed in the previous increment) |

Two things worth a reviewer's attention:

- **The page keeps its own hold on the editor handle and MERGES it** with whatever ref the keeper supplied, rather than replacing it: the daemon page holds one for MCP viewport requests, and both want the same handle. That is also what gives the browser keeper the reveal for free — it never held a ref at all.
- **A markdown document gets the index without the jump.** Its passages are drawn in the body already and there is no viewport to move, so `onOpen` is absent and the row is not a button rather than being a dead one.

## The three commits, and why the third exists

| commit | what |
|---|---|
| `e275d4b4` | the panel, the wiring, the docs |
| `d8376cc4` | the inset fix the figure found (below) |
| `f79b7506` | **`file-size-budget` refused the diff**, and it was right |

The guard flagged `SpatialEditor.tsx` at 2766 against a shrink-only ceiling of 2727. The growth read as the seam's cost until it turned out most of it was **misfiled**: `viewportRevealingProposal` and `proposalAt` (the latter was `hitTestProposal`, inline) are pure geometry over the scene's chrome boxes, so they moved to `lib/spatial/viewport.ts` — where the earlier splits of this file (#151–153) put its pure core. **Net −5 rather than +38**, and the ceiling ratchets down with it rather than being raised.

## Test plan

- [x] New or updated `web-jsdom` / `web-browser` tests added
- [x] Manual verification completed (described below)
- [x] Nearest-layer suites pass locally; full suites are CI's job

| layer | what it holds |
|---|---|
| `open-proposals.test.ts` + `ProposalsPanel.test.tsx` (web-jsdom, 9) | the open-batch filter, the verbs in words rather than op ids, the row press, the not-pressable row, the empty state |
| `proposal-open-in-place.browser.test.tsx` (new) | the seam pans **and** opens; answers `false` **without moving** for a proposal the canvas draws no chrome for; the card lands wholly inside the editor |
| `DaemonDocumentPage.proposal-card.browser.test.tsx` (extended) | the page-level flow — the opener counts what is waiting, a row opens the card |

`pnpm vitest run --project web-jsdom`: **3805 passed**. `pnpm -r typecheck`, `pnpm lint`: clean. `pnpm install --frozen-lockfile` clean after the main merge.

**Mutation-checked, three ways.** Dropping `proposals` from the page's `tabs` fails the page test; dropping `setOpenProposalId` from the seam fails both browser files; dropping the viewport inset fails the new on-screen assertion with `expected 0 to be greater than 0`.

**`scoped-screen-state`'s ledger caught the new ref and made me answer for it**, which is the ledger doing its job. The answer is `no subject:`, the same one `spatialEditorRef` gives on the daemon page — and the entry says why marking it "cleared on switch" would be *wrong* rather than merely redundant: effects run after refs attach, so nulling it in the SCOPE RESET effect would discard the **arrived** editor's handle, not the departed one's.

## Visual evidence

**A figure was produced and looked at, and it is what found `d8376cc4`'s defect** — but it could not be uploaded: this environment has no `gh` CLI, and the GitHub API surface available here has no attachment endpoint. It is at `tmp/screenshots/figure.png` (digests `b1732f6e` / `4bf750b0`), regenerable from the throwaway test the commit describes.

What it shows, in two panels of the real page:

1. **Top** — a canvas with two proposals. One is drawn on the board as a bubble; the other is anchored at `(3800, 2600)` and **drawn nowhere in the viewport**. The panel counts both. That is the argument for the panel, made visible: without it the second proposal is correct, rendered, and invisible.
2. **Bottom** — the row for that second proposal, pressed. The board has panned to it and its card is open with Adopt / Dismiss, and the row reads selected.

**The figure earned its keep immediately.** In the first version of panel 2 the card was drawn *half outside the left edge*, with the change it was about out of frame — `fitViewportToBoxes` pins the union's top-left to the origin rather than centring it, which is right for `fitToContent` (the union is the whole board) and wrong for one small box. Both assertions already on that seam passed straight over it, because each was true: the board moved, and the card opened.

**What the figure still shows imperfectly, said rather than cropped out:** the change's dashed outline is *still* partly clipped, because the inset applies to the bubble's bbox and the outline is drawn beside it. Framing the whole proposal needs `proposalChromeBoxes` to carry the union of its chrome — a scene-projection change with its own coverage, so it is filed as follow-up rather than widened into this PR. A larger inset would be a guess that fails wherever the outline sits on another side.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — `apps/web/DESIGN.md`'s "four panels" becomes five in both places and gains the index rule; ADR-0029's status says decision 9's inspector place is done and names what stays open
- [x] No `console.*` added to `src/server/**` (this PR does not touch the server's runtime; the only file it edits there is the `file-size-budget` guard)
- [x] No hand-written interfaces duplicating a Zod schema — `Proposal` / `ProposedChange` come from `@kamiazya/whiteboard-model`, and `VERB_WORDS` is `satisfies Record<ProposedChange['op'], string>` so a new verb cannot arrive unnamed

## What ADR-0029 still leaves open

Decision 9's inspector place is done; the ADR's status now says so. The half a panel **cannot** answer is the BOARD — forty bubbles drawn at once, each placed to avoid the last, is a density nothing has looked at, and an index does not make it better. Recorded in the ADR's Consequences rather than quietly marked done.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2