### PR TITLE
chore(mcp-server): drop app-helpers' imports, orphaned by its own deletions

### DIFF
--- a/packages/mcp-server/src/server/app-helpers.ts
+++ b/packages/mcp-server/src/server/app-helpers.ts
@@ -1,7 +1,3 @@
-import { decodeFrontiers, LoroDoc } from 'loro-crdt'
-import { errorMessage } from '../shared/error-message.js'
-import { corruptStoredData } from './store/corrupt-stored-data.js'
-
 export function shouldLogMcpHttpDebug(env: NodeJS.ProcessEnv = process.env): boolean {
   return env.MCP_HTTP_DEBUG === '1'
 }


### PR DESCRIPTION
## Summary

- `app-helpers.ts` kept four imports (`decodeFrontiers`, `LoroDoc`, `errorMessage`, `corruptStoredData`) that lost their only readers when #1476 deleted the two branch functions using them. Its remaining exports need none of them.

**This is my miss, and the same one twice in a row, so it is worth stating plainly rather than filed as tidy-up.** I read `pnpm lint`'s **exit code** and not its **warning count**. These findings are warnings — the command exits 0 while reporting them — so `lint=0` reads exactly like "lint is clean". The first sweep used `biome check --write --unsafe`, which is what actually removes an unused import; the follow-up commit dropped `--unsafe`, fixed nothing, and I confirmed it with the wrong signal.

The gate that would have caught it is the one I already had: `pnpm lint` prints `Found N warnings` on its last line. Reading that line, not `$?`, is the difference.

## Test plan

- [x] `pnpm lint` reports **0 findings** — checked by reading the count, not the exit status
- [x] `pnpm knip` clean
- [x] `pnpm -r typecheck` clean
- [x] `app-helpers` tests: 25 passed

## Visual evidence

`Visual evidence: none — four unused import bindings removed; nothing a person can see changes.`

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — n/a
- [x] No `console.*` added to `src/server/**`
- [x] No hand-written TypeScript interfaces duplicate a Zod schema

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2

---
_Generated by [Claude Code](https://claude.ai/code/session_016W8zfiQN2orUM1hJt5ygs2)_