### PR TITLE
fix: two write paths that failed silently, and the guards that name them

### DIFF
--- a/.claude/rules/test-authoring.md
+++ b/.claude/rules/test-authoring.md
@@ -33,6 +33,8 @@ The write-time rules, so the skill is a lookup rather than a prerequisite:
 10. A title is an identifier: behaviour, not chronology or a count/ordinal of something that grows; unique in its `describe`.
 11. Wait for a condition (`vi.waitFor`, `expect.poll`, fake timers), never for time; the sleep ledger only goes down.
 12. Before pushing: five fresh-process runs of the file, then one inside its whole project.
+13. A threshold computed from the run divides by the dimension the fixture grows, and the
+    growth loop floors that dimension — otherwise the slower machine gets the stricter test.
 
 Executable rungs already hold most of these (`pnpm lint`'s GritQL plugin, `arch-lint`'s scans,
 the jsdom setup's teardown). A shape that costs a real defect twice moves up the ladder —

--- a/.claude/rules/test-authoring.md
+++ b/.claude/rules/test-authoring.md
@@ -35,6 +35,8 @@ The write-time rules, so the skill is a lookup rather than a prerequisite:
 12. Before pushing: five fresh-process runs of the file, then one inside its whole project.
 13. A threshold computed from the run divides by the dimension the fixture grows, and the
     growth loop floors that dimension — otherwise the slower machine gets the stricter test.
+14. `act` comes from `@testing-library/react`, never `react`, and never wraps a `waitFor` /
+    `findBy*` (RTL turns the act environment off inside those, deliberately).
 
 Executable rungs already hold most of these (`pnpm lint`'s GritQL plugin, `arch-lint`'s scans,
 the jsdom setup's teardown). A shape that costs a real defect twice moves up the ladder —

--- a/.claude/skills/steward/reference/failure-modes.md
+++ b/.claude/skills/steward/reference/failure-modes.md
@@ -6,7 +6,8 @@ so a symptom string can be recognised before it is investigated. One entry
 points elsewhere, and says so in the row: a test-infrastructure defect with no
 PR attached belongs beside the technique, not in the CI-flakes section.
 
-Contents: browser suites · property tests · environment · order effects.
+Contents: browser suites · property tests · measured thresholds · environment ·
+order effects.
 
 ## Browser and jsdom suites
 
@@ -30,6 +31,13 @@ Contents: browser suites · property tests · environment · order effects.
 | `Test timed out in 5000ms ... (with seed=N)` | A **timeout**, not a property failure. `@fast-check/vitest` prints the seed in the test name either way. Do not hunt a counterexample; check whether the code under it got more expensive |
 | a genuine shrunk counterexample | **Never a flake**, however random it looks. Reproduce with `withDefaults({ seed })`. A different seed passing means the generator missed the input |
 | a reachability/density guard fails intermittently | The generator is too sparse. Denser domain plus a measured floor — never a pinned seed, never fewer assertions |
+
+## Measured thresholds
+
+| What you see | Verdict |
+|---|---|
+| the two numbers in the message are EQUAL (`expected 50.1 to be less than 50.1`) | The threshold was computed from the same run and the fixture is sitting on its boundary. Not a re-run — find the fixture dimension the ratio divides by, and floor it |
+| a measurement assertion that only fails on the SLOWER runner | A growth loop stopping on elapsed alone: the slow machine settles for a smaller fixture, which makes the assertion stricter. Both fixes and the worked pair: `testing-techniques/resources/stability-checks.md` |
 
 ## Environment
 

--- a/.claude/skills/steward/reference/failure-modes.md
+++ b/.claude/skills/steward/reference/failure-modes.md
@@ -20,6 +20,7 @@ order effects.
 | every test PASSED and the file exits 1, `NotFoundError: removeChild` | A teardown doing `document.body.innerHTML = ''` while React roots are mounted. Use `cleanup()` |
 | "the list does not contain this item" | No list was opened — the trigger was clicked while a menu was still dismissing. Wait for `[role="menu"]` to be gone |
 | an assertion reads an empty value that was definitely typed | The element was remounted and the held reference is detached. Query inside the assertion |
+| a `web-browser` test fails saying it logged a failure and carried on | Exactly what it says: something was caught and swallowed. The record is in the message; the assertion that would have broken is elsewhere. Claim it with `expectLoggedFailures()` only if the test provokes it on purpose |
 | a test times out only under the full suite | An `await import()` of a heavy module inside a test body, or a `React.lazy` page racing a `findBy*` (testing-library's budget is 1000ms). Hoist the import |
 | an assertion on a global counter or a "most recent" handle | Another test's `SharedWorker` is still alive. Scope every assertion to a handle the test itself minted |
 | a page reports `This canvas's data could not be read.` as the lone failure | Not the page. A cleanup resolved while its `deleteDatabase` was still `blocked`, so this file started on the previous one's rows. Went through `rename` and twice through `delete-confirm` reading as a missing kebab menu. Fix and measurements: `testing-techniques/resources/isolation-and-state.md` |

--- a/.claude/skills/testing-techniques/resources/executable-rungs.md
+++ b/.claude/skills/testing-techniques/resources/executable-rungs.md
@@ -110,15 +110,29 @@ Whether that becomes a guard or a ledger is a MEASUREMENT, not a judgement:
 | project | records | over | verdict |
 |---|---|---|---|
 | `web-browser` | **1**, the one a test provokes on purpose | 235 files, 1237 tests | free — strict, no allowlist |
-| `web-jsdom` | **82**, across 63 tests | 377 files, 3947 tests | a ledger of ~63 claims, not yet written |
+| `web-jsdom` | **43**, across 35 tests | 377 files, 3947 tests | a ledger of ~35 claims, not yet written |
 
-`web-jsdom` started at 219. **138 were React's act-environment complaint** and
-are now gone entirely (below); the remaining **82**, spread over 63 tests, are
-mostly tests driving a failure path deliberately (`canvas exploded`,
-`network down`, a refused tool registration). Logging is the right behaviour
-there, so guarding the project on `console.error` at large still means claiming
-each one — real work, worth doing on its own merits. The act family is guarded
-already, because that part became free.
+`web-jsdom` started at 219, and two thirds of that was never a judgement call:
+
+| | records | tests | what it was |
+|---|---|---|---|
+| measured | 219 | 70 | |
+| after the act fixes | 82 | 63 | React's act-environment complaint, 138 of them (below) |
+| after mocking the fold | **43** | **35** | jsdom has no IndexedDB, so `foldWorkspaceDocuments` throws; the production path catches it and continues, and the guarded warn on the way was 36 records over 29 tests in six files |
+
+Neither reduction weakened a test. The fold one is behaviour-identical — those
+tests already ran under the guarded continue, and the mock returns the same
+outcome the throw produced — so it removes noise rather than coverage.
+
+What is left is a ledger of ~35 claims: tests driving a failure path
+deliberately (`canvas exploded`, `network down`, a refused tool registration),
+where logging is the right behaviour and each needs an entry saying so. Real
+work, worth doing on its own merits rather than as a side effect. The act
+family is guarded already, because that part became free.
+
+The order generalises: **before writing a ledger, subtract the entries that are
+the environment rather than a decision.** Two thirds of this one dissolved, and
+the remainder is small enough to write honestly.
 
 ### Take this measurement with a RECORDER, never a throwing guard
 

--- a/.claude/skills/testing-techniques/resources/executable-rungs.md
+++ b/.claude/skills/testing-techniques/resources/executable-rungs.md
@@ -104,25 +104,74 @@ keeps going and breaks somewhere unrelated. The measured case — a
 of the view, surfacing ten seconds later as `expected 'untitled' to be 'Weekly
 review'`, an assertion about a document NAME in a different panel.
 
-Whether that becomes a guard or a ledger is a MEASUREMENT, not a judgement.
-Take it by installing the strict guard temporarily and reading what turns red —
-the failures are the data, and they arrive with test names attached:
+Whether that becomes a guard or a ledger is a MEASUREMENT, not a judgement:
 
-| project | records in one full run | verdict |
+| project | records | over | verdict |
+|---|---|---|---|
+| `web-browser` | **1**, the one a test provokes on purpose | 235 files, 1237 tests | free — strict, no allowlist |
+| `web-jsdom` | **219**, across 70 tests | 376 files, 3944 tests | a ledger of ~65 claims, not yet written |
+
+`web-jsdom`'s 219 split two ways: **138** are React's act-environment complaint
+(below), and the other **81**, spread over 65 tests, are mostly tests driving a
+failure path deliberately (`canvas exploded`, `network down`, a refused tool
+registration). Logging is the right behaviour there, so guarding the project
+means claiming each one — real work, worth doing on its own merits.
+
+### Take this measurement with a RECORDER, never a throwing guard
+
+The obvious way to size it — install the strict guard and read what turns red —
+is wrong here, and wrong in both directions at once. Throwing in `afterEach`
+breaks the shared teardown: React trees stay mounted, and every later test in
+the file cascades. Measured, same suite, same commit:
+
+|  | throwing guard | file recorder |
 |---|---|---|
-| `web-browser` | **1**, the one a test provokes on purpose (235 files, 1237 tests) | free — strict, no allowlist |
-| `web-jsdom` | **~100 across 73 tests** (376 files) | a ledger of claims, not yet taken |
+| records | ~100 | **219** |
+| tests reporting | 73 | **70** |
+| un-acted React updates | 878 | **0** |
 
-`web-jsdom`'s are mostly tests driving a failure path deliberately (`canvas
-exploded`, `network down`, a refused tool registration), which is a legitimate
-reason to log. Guarding it means claiming each, which is real work and has to
-be worth it on its own.
+It under-reported the records (each test aborts at its FIRST one) while
+inventing 878 un-acted updates that do not exist — the cascade from its own
+broken teardown. A throwing guard is the right SHIPPING shape and the wrong
+measuring instrument.
 
-Two things the measurement found on the way, both invisible while nothing read
-these lines:
+Two traps beside it, both of which produced a confident wrong number here:
 
-- **56 `The current testing environment is not configured to support act(...)`.**
-  React state updates outside `act`, in a suite that reports green.
+- **Vitest's terminal output carries no test console records in these runs.**
+  Grepping the run's stdout for a warning returns 0 whether or not it happened.
+  Every count above comes from a recorder appending to a file, with
+  `expect.getState().currentTestName` for attribution.
+- **A `console.error` format string is recorded raw.** The message is
+  `An update to %s inside a test was not wrapped in act(...)`; grepping for the
+  formatted component name finds nothing.
+
+### The act flag, measured and rejected
+
+`IS_REACT_ACT_ENVIRONMENT` is set nowhere, so React logs
+`The current testing environment is not configured to support act(...)` — a
+complaint about configuration that says nothing about any test. Setting it in
+the jsdom setup looks like the obvious fix. Measured over the full project:
+
+| | config warning | un-acted updates | total records |
+|---|---|---|---|
+| flag off (shipped) | 138, in 8 tests | 0 reported | 219 |
+| flag on | 103 | **502** | 689 |
+
+So it does two unhelpful things at once. It fails to clear the noise it targets
+— 99 of the 138 are one file, `BrowserDocumentPage.test.tsx`, which keeps
+warning with the flag set — and it turns on 502 genuine un-acted-update reports
+that nothing reads, tripling the channel this whole rung exists to keep clean.
+The 502 are a real finding and a real backlog; the flag is not the increment
+that pays for them.
+
+### What the measurement found
+
+Neither of these was found by reading code. Both fell out of asking a suite to
+stop swallowing:
+
+- **502 un-acted React updates**, invisible until the flag is set, over 26
+  distinct components — about a quarter of them Radix internals (Tooltip,
+  Presence, Popper) rather than this repo's own hygiene.
 - **`[document-sync] backfilling thread marks failed Index out of bound. The
   given pos is 20, but the length is 19`, in three PASSING tests.**
   `document-sync-session.ts` computes passage offsets against
@@ -135,9 +184,6 @@ these lines:
   and never bounds `end` against the text, so the throw comes from inside Loro
   naming neither the thread nor the document. Consequence: conversations on
   those documents never get their passage marks.
-
-Neither was found by reading code. Both fell out of asking a suite to stop
-swallowing.
 
 ## Adding a source-scan test
 

--- a/.claude/skills/testing-techniques/resources/executable-rungs.md
+++ b/.claude/skills/testing-techniques/resources/executable-rungs.md
@@ -23,6 +23,7 @@ justified it (how many occurrences today, what the false-positive rate would be)
 | `.claude/scripts/quarantine.test.mjs`, `biome-plugin.test.mjs` | `pnpm test:scripts` | quarantine cap/age/undeclared skips; a GritQL pattern that stopped matching |
 | `apps/web/vitest.setup.ts`, `src/test-utils/browser-setup.ts`, `vitest.browser.shared.ts` | setup guard | unmounted trees, leaked fake timers (fails the test by name), `localStorage`, missing stylesheet, 1000ms async budget, trace growth |
 | `src/test-utils/browser-setup.ts`'s `expectLoggedFailures` | setup guard (`web-browser`) | any `console.error`/`warn` in a browser test — a failure that was caught, logged and swallowed. Strict, no allowlist; opt in per test to claim one |
+| `apps/web/vitest.setup.ts`'s act guard | setup guard (`web-jsdom`) | React's act complaints — `act` inside a `waitFor`/`findBy*`, or imported from `react` rather than RTL |
 | `background-work-costs.test.ts` + `loop-availability.ts` | `mcp-node` | a declared stall ceiling no test asserts |
 
 ## Adding a GritQL shape
@@ -109,13 +110,15 @@ Whether that becomes a guard or a ledger is a MEASUREMENT, not a judgement:
 | project | records | over | verdict |
 |---|---|---|---|
 | `web-browser` | **1**, the one a test provokes on purpose | 235 files, 1237 tests | free — strict, no allowlist |
-| `web-jsdom` | **219**, across 70 tests | 376 files, 3944 tests | a ledger of ~65 claims, not yet written |
+| `web-jsdom` | **82**, across 63 tests | 377 files, 3947 tests | a ledger of ~63 claims, not yet written |
 
-`web-jsdom`'s 219 split two ways: **138** are React's act-environment complaint
-(below), and the other **81**, spread over 65 tests, are mostly tests driving a
-failure path deliberately (`canvas exploded`, `network down`, a refused tool
-registration). Logging is the right behaviour there, so guarding the project
-means claiming each one — real work, worth doing on its own merits.
+`web-jsdom` started at 219. **138 were React's act-environment complaint** and
+are now gone entirely (below); the remaining **82**, spread over 63 tests, are
+mostly tests driving a failure path deliberately (`canvas exploded`,
+`network down`, a refused tool registration). Logging is the right behaviour
+there, so guarding the project on `console.error` at large still means claiming
+each one — real work, worth doing on its own merits. The act family is guarded
+already, because that part became free.
 
 ### Take this measurement with a RECORDER, never a throwing guard
 
@@ -145,24 +148,41 @@ Two traps beside it, both of which produced a confident wrong number here:
   `An update to %s inside a test was not wrapped in act(...)`; grepping for the
   formatted component name finds nothing.
 
-### The act flag, measured and rejected
+### The act flag, measured and rejected — and what worked instead
 
-`IS_REACT_ACT_ENVIRONMENT` is set nowhere, so React logs
-`The current testing environment is not configured to support act(...)` — a
-complaint about configuration that says nothing about any test. Setting it in
-the jsdom setup looks like the obvious fix. Measured over the full project:
+`IS_REACT_ACT_ENVIRONMENT` was set nowhere, so React logged
+`The current testing environment is not configured to support act(...)` 138
+times. Setting it in the jsdom setup looks like the obvious fix. Measured over
+the full project:
 
 | | config warning | un-acted updates | total records |
 |---|---|---|---|
-| flag off (shipped) | 138, in 8 tests | 0 reported | 219 |
+| flag off | 138, in 8 tests | 0 reported | 219 |
 | flag on | 103 | **502** | 689 |
 
-So it does two unhelpful things at once. It fails to clear the noise it targets
-— 99 of the 138 are one file, `BrowserDocumentPage.test.tsx`, which keeps
-warning with the flag set — and it turns on 502 genuine un-acted-update reports
-that nothing reads, tripling the channel this whole rung exists to keep clean.
-The 502 are a real finding and a real backlog; the flag is not the increment
-that pays for them.
+It fails to clear the noise it targets and triples the channel. **Rejected.**
+
+The real causes were two, with no syntax in common, and three mechanical fixes
+took all 138 to **0**:
+
+- **`act()` wrapping an RTL async utility** (103). `@testing-library/react`
+  sets the flag to FALSE around `waitFor`/`findBy*` on purpose, so an `act`
+  call inside one warns — measured at the warning itself, `flag=false`. The
+  wrapper is also unnecessary: those utilities manage `act` themselves. Both
+  call sites wrapped a HELPER that used `findBy*` internally, which is why
+  neither a reader nor a lint rule looking at one file could see it. Five
+  wrappers deleted, tests unchanged and still passing.
+- **`act` imported from `react`** (35). RTL's `act` sets the environment flag
+  itself; React's bare one does not, so every call warns. Two files, import
+  changed.
+
+That left the guard FREE, which is the point — it is in
+`apps/web/vitest.setup.ts` and fails any test React complains about, narrow to
+the act family rather than `console.error` at large. Mutation-checked: putting
+one wrapper back fails that test with `React complained about act() in this
+test.`
+
+Records over the whole project: **219 to 82**, over 70 tests to 63.
 
 ### What the measurement found
 

--- a/.claude/skills/testing-techniques/resources/executable-rungs.md
+++ b/.claude/skills/testing-techniques/resources/executable-rungs.md
@@ -22,6 +22,7 @@ justified it (how many occurrences today, what the false-positive rate would be)
 | `tools/checks/src/vitest-projects.mjs` (+ `ci-verify-coverage`, `docs-contract`) | `mcp-node` | a vitest project CI never runs; a project without `name:` |
 | `.claude/scripts/quarantine.test.mjs`, `biome-plugin.test.mjs` | `pnpm test:scripts` | quarantine cap/age/undeclared skips; a GritQL pattern that stopped matching |
 | `apps/web/vitest.setup.ts`, `src/test-utils/browser-setup.ts`, `vitest.browser.shared.ts` | setup guard | unmounted trees, leaked fake timers (fails the test by name), `localStorage`, missing stylesheet, 1000ms async budget, trace growth |
+| `src/test-utils/browser-setup.ts`'s `expectLoggedFailures` | setup guard (`web-browser`) | any `console.error`/`warn` in a browser test — a failure that was caught, logged and swallowed. Strict, no allowlist; opt in per test to claim one |
 | `background-work-costs.test.ts` + `loop-availability.ts` | `mcp-node` | a declared stall ceiling no test asserts |
 
 ## Adding a GritQL shape
@@ -94,6 +95,49 @@ The rung for "every test in this project, at runtime". `apps/web/vitest.setup.ts
 exercise it directly (throw + restore), and reporting the offending test BY NAME rather than
 restoring silently. Order matters inside it — unmount first, so a file that also leaks fake
 timers still gets its trees torn down.
+
+## The swallowed failure, and why one project is guarded and the other is not
+
+A caught-and-logged exception is the worst failure shape a suite has: the run
+keeps going and breaks somewhere unrelated. The measured case — a
+`@codemirror/view` ViewPlugin crash that disabled the CRDT binding for the life
+of the view, surfacing ten seconds later as `expected 'untitled' to be 'Weekly
+review'`, an assertion about a document NAME in a different panel.
+
+Whether that becomes a guard or a ledger is a MEASUREMENT, not a judgement.
+Take it by installing the strict guard temporarily and reading what turns red —
+the failures are the data, and they arrive with test names attached:
+
+| project | records in one full run | verdict |
+|---|---|---|
+| `web-browser` | **1**, the one a test provokes on purpose (235 files, 1237 tests) | free — strict, no allowlist |
+| `web-jsdom` | **~100 across 73 tests** (376 files) | a ledger of claims, not yet taken |
+
+`web-jsdom`'s are mostly tests driving a failure path deliberately (`canvas
+exploded`, `network down`, a refused tool registration), which is a legitimate
+reason to log. Guarding it means claiming each, which is real work and has to
+be worth it on its own.
+
+Two things the measurement found on the way, both invisible while nothing read
+these lines:
+
+- **56 `The current testing environment is not configured to support act(...)`.**
+  React state updates outside `act`, in a suite that reports green.
+- **`[document-sync] backfilling thread marks failed Index out of bound. The
+  given pos is 20, but the length is 19`, in three PASSING tests.**
+  `document-sync-session.ts` computes passage offsets against
+  `readMarkdownBody(content)` and applies them to
+  `containers.getText(MARKDOWN_BODY_KEY)` — and those are not the same string:
+  `readMarkdownBody` falls back to the legacy text NODE when the container is
+  empty. It is exactly the mistake `use-markdown-document.ts` documents and
+  avoids ("asking the wrong one would go wrong silently if they ever stopped
+  agreeing"), going wrong silently. `markThreadPassages` bounds `end <= start`
+  and never bounds `end` against the text, so the throw comes from inside Loro
+  naming neither the thread nor the document. Consequence: conversations on
+  those documents never get their passage marks.
+
+Neither was found by reading code. Both fell out of asking a suite to stop
+swallowing.
 
 ## Adding a source-scan test
 

--- a/.claude/skills/testing-techniques/resources/executable-rungs.md
+++ b/.claude/skills/testing-techniques/resources/executable-rungs.md
@@ -173,17 +173,25 @@ stop swallowing:
   distinct components — about a quarter of them Radix internals (Tooltip,
   Presence, Popper) rather than this repo's own hygiene.
 - **`[document-sync] backfilling thread marks failed Index out of bound. The
-  given pos is 20, but the length is 19`, in three PASSING tests.**
-  `document-sync-session.ts` computes passage offsets against
-  `readMarkdownBody(content)` and applies them to
-  `containers.getText(MARKDOWN_BODY_KEY)` — and those are not the same string:
-  `readMarkdownBody` falls back to the legacy text NODE when the container is
-  empty. It is exactly the mistake `use-markdown-document.ts` documents and
-  avoids ("asking the wrong one would go wrong silently if they ever stopped
-  agreeing"), going wrong silently. `markThreadPassages` bounds `end <= start`
-  and never bounds `end` against the text, so the throw comes from inside Loro
-  naming neither the thread nor the document. Consequence: conversations on
-  those documents never get their passage marks.
+  given pos is 20, but the length is 19`, in three PASSING tests.** Two
+  defects, one throw. `resolveTextAnchor`'s stored-offsets shortcut compared
+  `body.slice(anchor.start, anchor.end) === exact` — and `slice` CLAMPS, so on
+  a body shorter than the stored `end` it returns the tail rather than
+  nothing, and a stored range whose width disagrees with its own quote MATCHES
+  and is answered verbatim. `markThreadPassages` then handed that `end`
+  straight to `LoroText.mark`, which throws from inside the CRDT naming
+  neither the thread nor the document, into a catch that logs and carries on.
+  Consequence: those conversations never got their passage marks.
+
+  Worth recording as a diagnosis, because two confident explanations came
+  first and both were wrong. "It measures offsets against `readMarkdownBody`
+  and applies them to the text container" does not fit the numbers — a
+  non-empty container makes those the same string. "Loro indexes text by code
+  point while JS counts UTF-16" was refuted by probing the installed version:
+  `text.length` is 18 for a body JS also calls 18. The mechanism only came out
+  by reading what produces the range, and the fixture confirms it — the anchor
+  is `{ exact: 'is this still true?', start: 0, end: 20 }`, and that quote is
+  19 characters.
 
 ## Adding a source-scan test
 

--- a/.claude/skills/testing-techniques/resources/stability-checks.md
+++ b/.claude/skills/testing-techniques/resources/stability-checks.md
@@ -46,6 +46,45 @@ that run is never the isolated one.
 - Before publishing a cause, a "not a regression", or a by-hand verification: the
   `diagnosis-evidence` skill — choose an observation that could REFUTE the claim.
 
+## A threshold taken from the same run
+
+`expect(measured.a).toBeLessThan(measured.b * k)` is the shape, and it hides a
+fixture dimension whenever the yields it is about happen ONCE PER ITEM. The
+worked pair, both in `mcp-server/src/server/store/`:
+
+|  | yields per pass | real `worst/elapsed` | `worst/elapsed` with the yield removed |
+|---|---|---|---|
+| `workspace-tail-loop-availability` | one per workspace, so N | ~2.4/N | 1.0 |
+| `file-gc-loop-availability` | many per document | 0.052-0.058 | 0.96 |
+
+The second is genuinely scale-free: measured 0.056 at two documents and 0.058
+at six, against a bound of 0.5. The first is not. `worst/elapsed` there is
+`worst/mean ÷ N`, so a fixed bound of 0.5 reads `worst/mean < N/2` — **six on
+this machine and two on CI, from a quantity that measures 2.09-3.32 on both.**
+It failed on main at `expected 50.1 to be less than 50.1`, at the LOWEST
+worst/mean ever recorded for it.
+
+Two things follow, and the second is the one that is easy to miss:
+
+- **Divide by the dimension the fixture grows**, when the effect is per-item.
+  `loopTurnShare` is the same move already made for sample counts; there is no
+  shared helper for the stall ratio because the two sites above genuinely want
+  different denominators, and one that forced a denominator on `file-gc` would
+  break its mutation check (`worst/mean` there is ~1, well under any usable
+  bound).
+- **A growth loop that stops on ELAPSED alone lets machine speed pick the
+  fixture size**, and a slower machine settles for a smaller one — so the
+  assertion is STRICTER on the runner that is worse at satisfying it. CI
+  reached 50ms on four workspaces at ~25ms each where this machine needed
+  twelve at ~8.5ms. Floor the count as well as the duration, and assert the
+  floor was reached.
+
+Pick the bound so it sits between the real distribution and the value the
+mutation produces, and say both numbers beside it. When no such number exists
+— at four workspaces the mutation value is 4 and the real one is 2-3.3 — the
+fixture is too small for the measurement to mean anything, and no phrasing of
+the assertion fixes that.
+
 ## When it is a flake
 
 - **A flake is only a flake once.** One `gh run rerun --failed` on a known shape; the SECOND

--- a/apps/web/src/components/markdown-editor/loro-binding.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/loro-binding.browser.test.tsx
@@ -15,6 +15,7 @@ import { LoroSyncPlugin } from 'loro-codemirror'
 import { Loro, type LoroDoc } from 'loro-crdt'
 import { afterEach, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
+import { expectCodeMirrorPluginCrash } from '../../test-utils/browser-setup.js'
 import { focusEditable } from '../../test-utils/focus-editable.js'
 import { MarkdownEditor } from './MarkdownEditor.js'
 
@@ -75,4 +76,51 @@ it('a remote edit merges into the editor and shifts the caret exactly', async ()
   await vi.waitFor(() => {
     expect(doc.getText('body').toString()).toBe('REMOTE alpha Xomega')
   })
+})
+
+/**
+ * The container a binding addresses is resolved LIVE, and a resolver that
+ * answers with a different container under an already-mounted view kills the
+ * binding outright.
+ *
+ * `LoroSyncPlugin` maps CodeMirror positions onto whatever the accessor hands
+ * it at that moment, so an answer that changes identity leaves the view's
+ * offsets addressing text that container never had. loro-crdt throws
+ * `Index out of bound`, `@codemirror/view` catches it, logs
+ * `CodeMirror plugin crashed` and DISABLES the plugin for good — the pane
+ * keeps taking input and reaches nothing.
+ *
+ * `use-markdown-document`'s `bodyTextOf` is a live resolver of exactly this
+ * shape: it reads `hostRef.current` on every call and answers with the
+ * workspace tree-node container or the root one depending on what it finds.
+ * This pins the consequence rather than the trigger, and doubles as the
+ * detector's own mutation check — a run that finds nothing here is looking at
+ * a guard that stopped guarding.
+ */
+it('reports a binding whose container changes under the mounted view', async () => {
+  const crashes = expectCodeMirrorPluginCrash()
+  const doc = new Loro()
+  doc.getText('body').insert(0, 'hello ')
+  doc.commit()
+  let key = 'body'
+  const binding = [LoroSyncPlugin(doc as LoroDoc, (d) => d.getText(key))]
+  const { container } = render(
+    <div style={{ width: 800, height: 300 }}>
+      <MarkdownEditor
+        initialViewMode="write"
+        value="hello "
+        onChange={() => {}}
+        previewDebounceMs={0}
+        sourceExtensions={binding}
+      />
+    </div>,
+  )
+  await focusEditable(() => container.querySelector('.cm-content'))
+  key = 'somewhere-else'
+  await userEvent.keyboard('{End}world')
+
+  await vi.waitFor(() => {
+    expect(crashes.length).toBeGreaterThan(0)
+  })
+  expect(crashes.join('\n')).toContain('Index out of bound')
 })

--- a/apps/web/src/components/markdown-editor/loro-binding.browser.test.tsx
+++ b/apps/web/src/components/markdown-editor/loro-binding.browser.test.tsx
@@ -15,7 +15,7 @@ import { LoroSyncPlugin } from 'loro-codemirror'
 import { Loro, type LoroDoc } from 'loro-crdt'
 import { afterEach, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
-import { expectCodeMirrorPluginCrash } from '../../test-utils/browser-setup.js'
+import { expectLoggedFailures } from '../../test-utils/browser-setup.js'
 import { focusEditable } from '../../test-utils/focus-editable.js'
 import { MarkdownEditor } from './MarkdownEditor.js'
 
@@ -98,7 +98,7 @@ it('a remote edit merges into the editor and shifts the caret exactly', async ()
  * a guard that stopped guarding.
  */
 it('reports a binding whose container changes under the mounted view', async () => {
-  const crashes = expectCodeMirrorPluginCrash()
+  const crashes = expectLoggedFailures()
   const doc = new Loro()
   doc.getText('body').insert(0, 'hello ')
   doc.commit()

--- a/apps/web/src/hooks/use-identity-event.test.tsx
+++ b/apps/web/src/hooks/use-identity-event.test.tsx
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 
-import { renderHook } from '@testing-library/react'
-import { act } from 'react'
+import { act, renderHook } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { DOCUMENT_SYNC_VERSION_SAVED_EVENT } from '../lib/document-sync-types.js'
 import { useIdentityEvent } from './use-identity-event.js'

--- a/apps/web/src/lib/browser-backend.contract.test.ts
+++ b/apps/web/src/lib/browser-backend.contract.test.ts
@@ -17,10 +17,21 @@ import type { DocumentBackendHarness } from '@kamiazya/whiteboard-daemon-client/
 import { documentBackendContract } from '@kamiazya/whiteboard-daemon-client/test-utils/document-backend-contract'
 import type { WorkspaceDocs } from '@kamiazya/whiteboard-workspace-index'
 import { LoroDoc } from 'loro-crdt'
-import { describe } from 'vitest'
+import { describe, vi } from 'vitest'
 import { BrowserBackend } from './browser-backend.js'
 import type { DocumentFileStore } from './document-file-store.js'
 import type { LoroStore } from './loro-store.js'
+
+// jsdom has no IndexedDB, so the startup fold cannot run here: it throws, the
+// production path catches it and continues, and that guarded continue is
+// exactly what these tests already run under. Mocked to the same outcome
+// rather than left to throw, because the warn it logs on the way is noise in a
+// channel that has to stay readable — `vitest.setup.ts`'s act guard and
+// `web-browser`'s wider one both live there. Measured: 36 of the project's 78
+// console records were this one line.
+vi.mock('./fold-workspace.js', () => ({
+  foldWorkspaceDocuments: async () => ({ folded: 0, skipped: 0 }),
+}))
 
 const DOC_ID = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
 

--- a/apps/web/src/lib/browser-backend.read-failure.test.ts
+++ b/apps/web/src/lib/browser-backend.read-failure.test.ts
@@ -32,6 +32,17 @@ import { BrowserBackend } from './browser-backend.js'
 import type { DocumentFileStore } from './document-file-store.js'
 import type { LoroStore } from './loro-store.js'
 
+// jsdom has no IndexedDB, so the startup fold cannot run here: it throws, the
+// production path catches it and continues, and that guarded continue is
+// exactly what these tests already run under. Mocked to the same outcome
+// rather than left to throw, because the warn it logs on the way is noise in a
+// channel that has to stay readable — `vitest.setup.ts`'s act guard and
+// `web-browser`'s wider one both live there. Measured: 36 of the project's 78
+// console records were this one line.
+vi.mock('./fold-workspace.js', () => ({
+  foldWorkspaceDocuments: async () => ({ folded: 0, skipped: 0 }),
+}))
+
 const TARGET = {
   documentId: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
   path: 'notes/reviewed',

--- a/apps/web/src/pages/BrowserDocumentPage.markdown-orphan.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.markdown-orphan.test.tsx
@@ -23,6 +23,17 @@ import { afterEach, expect, it, vi } from 'vitest'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
 import { LocalStoreDouble } from '../test-utils/local-index.js'
 
+// jsdom has no IndexedDB, so the startup fold cannot run here: it throws, the
+// production path catches it and continues, and that guarded continue is
+// exactly what these tests already run under. Mocked to the same outcome
+// rather than left to throw, because the warn it logs on the way is noise in a
+// channel that has to stay readable — `vitest.setup.ts`'s act guard and
+// `web-browser`'s wider one both live there. Measured: 36 of the project's 78
+// console records were this one line.
+vi.mock('../lib/fold-workspace.js', () => ({
+  foldWorkspaceDocuments: async () => ({ folded: 0, skipped: 0 }),
+}))
+
 vi.mock('../components/spatial-editor/index.js', () => ({
   SpatialEditor: () => <div data-testid="mock-spatial-editor" />,
 }))

--- a/apps/web/src/pages/BrowserDocumentPage.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.test.tsx
@@ -259,9 +259,7 @@ describe('BrowserDocumentPage', () => {
         />,
       )
     })
-    await act(async () => {
-      await openDeleteConfirm()
-    })
+    await openDeleteConfirm()
     expect(screen.getByRole('alertdialog')).toBeTruthy()
     const cancelBtn = screen.getByRole('button', { name: /cancel/i })
     await act(async () => {
@@ -556,9 +554,7 @@ describe('BrowserDocumentPage', () => {
         />,
       )
     })
-    await act(async () => {
-      await openDeleteConfirm()
-    })
+    await openDeleteConfirm()
     const confirmBtn = await screen.findByRole('button', { name: /^delete$/i })
     await act(async () => {
       confirmBtn.click()
@@ -589,9 +585,7 @@ describe('BrowserDocumentPage', () => {
         />,
       )
     })
-    await act(async () => {
-      await openDeleteConfirm()
-    })
+    await openDeleteConfirm()
     const confirmBtn = await screen.findByRole('button', { name: /^delete$/i })
     await act(async () => {
       confirmBtn.click()

--- a/apps/web/src/pages/DaemonDocumentPage.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.test.tsx
@@ -400,9 +400,7 @@ describe('DaemonDocumentPage', () => {
 
     const oldBackend = createdBackends[0]!
 
-    await act(async () => {
-      await switchDocumentViaConnections('Second board')
-    })
+    await switchDocumentViaConnections('Second board')
 
     expect(oldBackend.disconnectCount).toBe(1)
     expect(createdBackends).toHaveLength(2)
@@ -506,9 +504,7 @@ describe('DaemonDocumentPage', () => {
     })
     expect(getShellConnection()?.state).toEqual({ keeper: 'daemon', session: 'sync-off' })
 
-    await act(async () => {
-      await switchDocumentViaConnections('Second board')
-    })
+    await switchDocumentViaConnections('Second board')
 
     // The stale sync-off state must not outlive the backend that produced it.
     expect(getShellConnection()?.state).toEqual({ keeper: 'daemon', session: 'synced' })

--- a/apps/web/src/pages/body-text-resolver.test.ts
+++ b/apps/web/src/pages/body-text-resolver.test.ts
@@ -1,0 +1,74 @@
+/**
+ * The container a mounted CRDT binding addresses must not move under it.
+ *
+ * `LoroSyncPlugin` maps the editor's offsets onto whatever the resolver it was
+ * built with answers AT THE MOMENT OF EACH EDIT. A workspace document's body
+ * lives on its tree node and a legacy one's on the doc's root, and those are
+ * genuinely different containers — so a resolver that can change its mind
+ * between two keystrokes points the second one at text the first never wrote.
+ */
+import {
+  createWorkspaceDocumentAtPath,
+  documentContainers,
+  MARKDOWN_BODY_KEY,
+} from '@kamiazya/whiteboard-loro-adapter'
+import { generateDocumentId } from '@kamiazya/whiteboard-model'
+import { Loro } from 'loro-crdt'
+import { describe, expect, it } from 'vitest'
+import { bodyTextResolver } from './use-markdown-document.js'
+
+const DOCUMENT_ID = generateDocumentId()
+const BODY = 'a body only the tree node has'
+
+function workspaceWithBody(): Loro {
+  const workspace = new Loro()
+  createWorkspaceDocumentAtPath(workspace, {
+    path: 'note',
+    documentId: DOCUMENT_ID,
+    kind: 'markdown',
+  })
+  documentContainers(workspace, DOCUMENT_ID).getText(MARKDOWN_BODY_KEY).insert(0, BODY)
+  workspace.commit()
+  return workspace
+}
+
+describe('bodyTextResolver', () => {
+  it('reads a workspace document from its tree node, not the doc root', () => {
+    const workspace = workspaceWithBody()
+    const resolve = bodyTextResolver({ mode: 'workspace' } as never, DOCUMENT_ID)
+
+    expect(resolve(workspace).toString()).toBe(BODY)
+  })
+
+  it('answers a container the workspace root does not have', () => {
+    // The two branches are not interchangeable, which is what makes swapping
+    // between them catastrophic rather than merely wrong: the root container
+    // of a workspace document is EMPTY, so offsets from the tree node address
+    // nothing at all. Measured on CI as `Index out of bound. The given pos is
+    // 1, but the length is 0`.
+    const workspace = workspaceWithBody()
+    const asLegacy = bodyTextResolver(null, DOCUMENT_ID)
+
+    expect(asLegacy(workspace).toString()).toBe('')
+    expect(asLegacy(workspace).length).toBe(0)
+  })
+
+  it('keeps answering the host it was built with after a later host exists', () => {
+    // The regression itself. The load effect clears its host reference
+    // synchronously on every re-run while the editor stays mounted; a resolver
+    // that read that reference took the legacy branch for the whole of the
+    // next load and answered the empty root. Holding the host as a parameter
+    // is what makes that unavailable rather than merely discouraged.
+    const workspace = workspaceWithBody()
+    const resolve = bodyTextResolver({ mode: 'workspace' } as never, DOCUMENT_ID)
+    const first = resolve(workspace).toString()
+
+    // Whatever else the hook does to its own state afterwards, this closure
+    // cannot see it — there is no reference here to reach.
+    bodyTextResolver(null, DOCUMENT_ID)
+    bodyTextResolver({ mode: 'legacy' } as never, DOCUMENT_ID)
+
+    expect(resolve(workspace).toString()).toBe(first)
+    expect(resolve(workspace).toString()).toBe(BODY)
+  })
+})

--- a/apps/web/src/pages/use-markdown-document.annotations.test.ts
+++ b/apps/web/src/pages/use-markdown-document.annotations.test.ts
@@ -21,9 +21,20 @@ import {
 } from '@kamiazya/whiteboard-loro-adapter'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { type Loro, LoroDoc } from 'loro-crdt'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { LoroStoreLike } from './use-browser-document-controller.js'
 import { useMarkdownDocument } from './use-markdown-document.js'
+
+// jsdom has no IndexedDB, so the startup fold cannot run here: it throws, the
+// production path catches it and continues, and that guarded continue is
+// exactly what these tests already run under. Mocked to the same outcome
+// rather than left to throw, because the warn it logs on the way is noise in a
+// channel that has to stay readable — `vitest.setup.ts`'s act guard and
+// `web-browser`'s wider one both live there. Measured: 36 of the project's 78
+// console records were this one line.
+vi.mock('../lib/fold-workspace.js', () => ({
+  foldWorkspaceDocuments: async () => ({ folded: 0, skipped: 0 }),
+}))
 
 /**
  * A store holding one document, seeded with whatever the caller wrote into a

--- a/apps/web/src/pages/use-markdown-document.switch-race.test.ts
+++ b/apps/web/src/pages/use-markdown-document.switch-race.test.ts
@@ -22,8 +22,7 @@
  * `VersionTimeline` drops its rows "immediately on canvas change so a stale
  * row ... never renders under the new canvas while the refetch is in flight".
  */
-import { renderHook, waitFor } from '@testing-library/react'
-import { act } from 'react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import type { LoroStoreLike } from './use-browser-document-controller.js'
 import { SAVE_DEBOUNCE_MS, useMarkdownDocument } from './use-markdown-document.js'

--- a/apps/web/src/pages/use-markdown-document.switch-race.test.ts
+++ b/apps/web/src/pages/use-markdown-document.switch-race.test.ts
@@ -23,9 +23,20 @@
  * row ... never renders under the new canvas while the refetch is in flight".
  */
 import { act, renderHook, waitFor } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { LoroStoreLike } from './use-browser-document-controller.js'
 import { SAVE_DEBOUNCE_MS, useMarkdownDocument } from './use-markdown-document.js'
+
+// jsdom has no IndexedDB, so the startup fold cannot run here: it throws, the
+// production path catches it and continues, and that guarded continue is
+// exactly what these tests already run under. Mocked to the same outcome
+// rather than left to throw, because the warn it logs on the way is noise in a
+// channel that has to stay readable — `vitest.setup.ts`'s act guard and
+// `web-browser`'s wider one both live there. Measured: 36 of the project's 78
+// console records were this one line.
+vi.mock('../lib/fold-workspace.js', () => ({
+  foldWorkspaceDocuments: async () => ({ folded: 0, skipped: 0 }),
+}))
 
 interface GatedStore extends LoroStoreLike {
   /** Every save, with the id it was addressed to. */

--- a/apps/web/src/pages/use-markdown-document.test.ts
+++ b/apps/web/src/pages/use-markdown-document.test.ts
@@ -15,9 +15,20 @@ import {
 } from '@kamiazya/whiteboard-loro-adapter'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { type Loro, LoroDoc } from 'loro-crdt'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { LoroStoreLike } from './use-browser-document-controller.js'
 import { useMarkdownDocument } from './use-markdown-document.js'
+
+// jsdom has no IndexedDB, so the startup fold cannot run here: it throws, the
+// production path catches it and continues, and that guarded continue is
+// exactly what these tests already run under. Mocked to the same outcome
+// rather than left to throw, because the warn it logs on the way is noise in a
+// channel that has to stay readable — `vitest.setup.ts`'s act guard and
+// `web-browser`'s wider one both live there. Measured: 36 of the project's 78
+// console records were this one line.
+vi.mock('../lib/fold-workspace.js', () => ({
+  foldWorkspaceDocuments: async () => ({ folded: 0, skipped: 0 }),
+}))
 
 function fakeStore(): LoroStoreLike & { saves: Uint8Array[] } {
   const saves: Uint8Array[] = []

--- a/apps/web/src/pages/use-markdown-document.ts
+++ b/apps/web/src/pages/use-markdown-document.ts
@@ -400,6 +400,43 @@ async function openLegacyHost(loro: LoroStoreLike, documentId: string): Promise<
   }
 }
 
+/**
+ * Which text container a document's body lives in — a WORKSPACE document's is
+ * on its tree node, a legacy one's is the doc's own root.
+ *
+ * Takes its host as an ARGUMENT and closes over it, which is the whole point.
+ * It used to read `hostRef.current` on every call, and a resolver handed to a
+ * long-lived binding must never be able to change its answer: `LoroSyncPlugin`
+ * maps the mounted editor's offsets onto whatever this returns at that moment,
+ * so a swap leaves those offsets addressing text the new container never had.
+ *
+ * The window was not exotic. The load effect sets `hostRef.current = null`
+ * SYNCHRONOUSLY on every re-run — a document switch, or `enabled` flipping as
+ * the kind resolves — while the editor stays mounted with its plugin installed.
+ * For the whole of the next load the resolver therefore took the legacy branch
+ * and answered the workspace doc's ROOT container, which for a workspace
+ * document is empty. The editor still held the text, so the next keystroke
+ * addressed a position that container did not have.
+ *
+ * Observed on CI as `CodeMirror plugin crashed: Index out of bound. The given
+ * pos is 1, but the length is 0`. `@codemirror/view` catches a ViewPlugin
+ * exception and DISABLES the plugin for the life of the view, so every later
+ * keystroke reached CodeMirror and nothing else — no deltas, no commits, no
+ * save — and the run failed ten seconds later on a document's NAME.
+ *
+ * A parameter rather than a rule, so the mistake stops being available.
+ */
+export function bodyTextResolver(
+  host: ContentHost | null,
+  documentId: string | null,
+): (target: Loro) => LoroText {
+  const workspaceScoped = host !== null && host.mode === 'workspace' && documentId !== null
+  return (target: Loro): LoroText =>
+    workspaceScoped
+      ? documentContainers(target, documentId).getText(MARKDOWN_BODY_KEY)
+      : target.getText(MARKDOWN_BODY_KEY)
+}
+
 export function useMarkdownDocument(
   loro: LoroStoreLike,
   documentId: string | null,
@@ -419,6 +456,10 @@ export function useMarkdownDocument(
   currentDocumentIdRef.current = documentId
   const [coreFacets, setCoreMetaState] = useState<StoredCoreFacets | null>(null)
   const [doc, setDoc] = useState<Loro | null>(null)
+  // Beside `doc` rather than read from `hostRef` when needed: `bodyTextResolver`
+  // must capture the host that owns the doc it is asked about, and a ref is
+  // cleared out from under an already-installed binding. See its doc comment.
+  const [contentHost, setContentHost] = useState<ContentHost | null>(null)
   const [annotations, setAnnotations] = useState<readonly CommentThread[]>(NO_ANNOTATIONS)
   const [threadMarks, setThreadMarks] = useState<ReadonlyMap<string, PassageRange>>(NO_THREAD_MARKS)
   const hostRef = useRef<ContentHost | null>(null)
@@ -447,6 +488,7 @@ export function useMarkdownDocument(
     // is not its own. Measured: typing under c2 while c2 loaded produced
     // `save('c1', …)`.
     hostRef.current = null
+    setContentHost(null)
     setDoc(null)
     setBodyState(null)
     setCoreMetaState(null)
@@ -513,6 +555,7 @@ export function useMarkdownDocument(
           publishAnnotations()
           if (event.by === 'local') scheduleSaveRef.current?.()
         })
+        setContentHost(host)
         setDoc(host.doc)
         // A document written before the writers were unified stores its body
         // as a text NODE, and reading it is not enough: `LoroSyncPlugin`
@@ -729,15 +772,9 @@ export function useMarkdownDocument(
     }
   }, [])
 
-  const bodyTextOf = useCallback(
-    (target: Loro): LoroText => {
-      const host = hostRef.current
-      if (host !== null && host.mode === 'workspace' && documentId !== null) {
-        return documentContainers(target, documentId).getText(MARKDOWN_BODY_KEY)
-      }
-      return target.getText(MARKDOWN_BODY_KEY)
-    },
-    [documentId],
+  const bodyTextOf = useMemo(
+    () => bodyTextResolver(contentHost, documentId),
+    [contentHost, documentId],
   )
 
   return {

--- a/apps/web/src/scoped-screen-state.test.ts
+++ b/apps/web/src/scoped-screen-state.test.ts
@@ -301,6 +301,12 @@ const MARKDOWN_DOCUMENT_STATE: Record<string, ScopeCoverage> = {
   body: 'cleared on switch',
   coreFacets: 'cleared on switch',
   hostRef: 'cleared on switch',
+  // The same host `hostRef` holds, kept as STATE because `bodyTextResolver`
+  // has to capture it: a resolver handed to a mounted CRDT binding must not be
+  // able to change which container it answers, and a ref is cleared out from
+  // under one. Cleared on switch for the same reason every entry above is —
+  // it names the departed document's content.
+  contentHost: 'cleared on switch',
 
   saveState: 'cleared on switch',
   // The conversations on THIS document. Left standing across a switch it

--- a/apps/web/src/test-utils/browser-setup.ts
+++ b/apps/web/src/test-utils/browser-setup.ts
@@ -16,6 +16,7 @@
  */
 import { generateDocumentId } from '@kamiazya/whiteboard-model'
 import { configure } from '@testing-library/react'
+import { afterEach } from 'vitest'
 import '../index.css'
 import { BROWSER_DEFAULT_SEGMENT } from '../lib/browser-idb.js'
 import { setBrowserWorkspaceIdForTests } from '../lib/browser-workspace-id.js'
@@ -45,3 +46,76 @@ setBrowserWorkspaceIdForTests(generateDocumentId(), BROWSER_DEFAULT_SEGMENT)
  * slows nothing down that succeeds.
  */
 configure({ asyncUtilTimeout: 5_000 })
+
+/**
+ * A crashed CodeMirror ViewPlugin fails the test that caused it.
+ *
+ * `@codemirror/view` catches an exception thrown by a plugin's update, logs
+ * `CodeMirror plugin crashed: …` and DISABLES that plugin for the life of the
+ * view. Nothing throws, nothing rejects, and the editor keeps accepting input
+ * — so a CRDT binding that dies this way leaves a pane that looks perfectly
+ * healthy and reaches no document at all.
+ *
+ * What that costs without this guard, measured on CI: the markdown binding
+ * crashed with `Index out of bound. The given pos is 1, but the length is 0`,
+ * every later keystroke went only into CodeMirror, no save was ever scheduled,
+ * and the failure surfaced ten seconds later as `expected 'untitled' to be
+ * 'Weekly review'` — an assertion about a document NAME, in a different panel,
+ * naming neither the plugin nor the exception. The line that said what
+ * happened was a `stderr` the run printed and nothing read.
+ *
+ * Narrow on purpose: only this marker, not `console.error` at large. A test
+ * that provokes a crash deliberately calls `expectCodeMirrorPluginCrash()`
+ * and reads what was caught.
+ */
+const CODEMIRROR_CRASH_MARKER = 'CodeMirror plugin crashed'
+
+/**
+ * On `globalThis`, not in module scope, because there are TWO instances of
+ * this module: the one vitest loads as a `setupFiles` entry, and the one a
+ * test that wants the escape hatch imports by path. Module-scoped state gave
+ * each its own copy — the setup's `afterEach` read its own untouched flag and
+ * failed the test that had just claimed the crash. Measured: the provoking
+ * test below failed with the guard's own message while holding the exception
+ * it asked for.
+ */
+interface CodeMirrorCrashState {
+  seen: string[]
+  expected: boolean
+}
+const CRASH_STATE_KEY = '__whiteboardCodeMirrorCrashes'
+const globalScope = globalThis as Record<string, unknown>
+globalScope[CRASH_STATE_KEY] ??= { seen: [], expected: false } satisfies CodeMirrorCrashState
+const crashState = globalScope[CRASH_STATE_KEY] as CodeMirrorCrashState
+
+/**
+ * Claims the crashes this test provokes, and returns the live list. Also the
+ * guard's own mutation check: a test that provokes one and finds this empty is
+ * looking at a detector that stopped detecting.
+ */
+export function expectCodeMirrorPluginCrash(): readonly string[] {
+  crashState.expected = true
+  return crashState.seen
+}
+
+// biome-ignore lint/suspicious/noConsole: intercepting this sink IS the guard — @codemirror/view reports a crashed plugin here and nowhere else
+const realConsoleError = console.error.bind(console)
+// biome-ignore lint/suspicious/noConsole: same interception; the original is called through, so nothing is swallowed
+console.error = (...args: unknown[]): void => {
+  if (args.some((arg) => typeof arg === 'string' && arg.includes(CODEMIRROR_CRASH_MARKER))) {
+    crashState.seen.push(args.map((arg) => String(arg)).join(' '))
+  }
+  realConsoleError(...args)
+}
+
+afterEach(() => {
+  const seen = [...crashState.seen]
+  const expected = crashState.expected
+  crashState.seen.length = 0
+  crashState.expected = false
+  if (seen.length > 0 && !expected) {
+    throw new Error(
+      `A CodeMirror plugin crashed and was silently disabled — every later edit in that view reached nothing.\n${seen.join('\n')}`,
+    )
+  }
+})

--- a/apps/web/src/test-utils/browser-setup.ts
+++ b/apps/web/src/test-utils/browser-setup.ts
@@ -48,74 +48,93 @@ setBrowserWorkspaceIdForTests(generateDocumentId(), BROWSER_DEFAULT_SEGMENT)
 configure({ asyncUtilTimeout: 5_000 })
 
 /**
- * A crashed CodeMirror ViewPlugin fails the test that caused it.
+ * Anything a browser test writes to `console.error` or `console.warn` fails
+ * that test.
  *
- * `@codemirror/view` catches an exception thrown by a plugin's update, logs
- * `CodeMirror plugin crashed: …` and DISABLES that plugin for the life of the
- * view. Nothing throws, nothing rejects, and the editor keeps accepting input
- * — so a CRDT binding that dies this way leaves a pane that looks perfectly
- * healthy and reaches no document at all.
+ * The shape this exists for: an exception that is CAUGHT, logged, and
+ * swallowed, leaving the run to fail somewhere else entirely. Measured on CI —
+ * `@codemirror/view` caught a ViewPlugin exception, logged
+ * `CodeMirror plugin crashed: Index out of bound. The given pos is 1, but the
+ * length is 0`, and DISABLED that plugin for the life of the view. Every later
+ * keystroke went into CodeMirror and never into the CRDT, no save was ever
+ * scheduled, and the failure surfaced ten seconds later as
+ * `expected 'untitled' to be 'Weekly review'` — an assertion about a document
+ * NAME, in a different panel, naming neither the plugin nor the exception. The
+ * one line that said what happened was a `stderr` the run printed and nothing
+ * read.
  *
- * What that costs without this guard, measured on CI: the markdown binding
- * crashed with `Index out of bound. The given pos is 1, but the length is 0`,
- * every later keystroke went only into CodeMirror, no save was ever scheduled,
- * and the failure surfaced ten seconds later as `expected 'untitled' to be
- * 'Weekly review'` — an assertion about a document NAME, in a different panel,
- * naming neither the plugin nor the exception. The line that said what
- * happened was a `stderr` the run printed and nothing read.
+ * Strict, with no allowlist, because it costs nothing: measured over the whole
+ * `web-browser` project — 235 files, 1237 tests — the ONLY record in the run is
+ * the one `loro-binding.browser.test.tsx` provokes on purpose. `app-logger`
+ * routes through `console[level]` under `import.meta.env.DEV`, which is what a
+ * browser test runs as, so this catches the app's own swallowed-failure warns
+ * (`log.warn('reading annotations failed', err)`) as well as React's and the
+ * platform's.
  *
- * Narrow on purpose: only this marker, not `console.error` at large. A test
- * that provokes a crash deliberately calls `expectCodeMirrorPluginCrash()`
- * and reads what was caught.
+ * `web-jsdom` is deliberately NOT held to this yet, and the reason is a
+ * measurement rather than caution: the same guard there reports ~100 records
+ * across 73 tests, most of them tests driving a failure path on purpose
+ * (`canvas exploded`, `network down`, a refused registration). That is a ledger
+ * of claims, not a free guard — see `testing-techniques/resources/
+ * executable-rungs.md` for the two real defects the measurement turned up.
+ *
+ * A test that means to provoke one calls `expectLoggedFailures()` and reads
+ * what was caught.
  */
-const CODEMIRROR_CRASH_MARKER = 'CodeMirror plugin crashed'
 
 /**
  * On `globalThis`, not in module scope, because there are TWO instances of
  * this module: the one vitest loads as a `setupFiles` entry, and the one a
  * test that wants the escape hatch imports by path. Module-scoped state gave
  * each its own copy — the setup's `afterEach` read its own untouched flag and
- * failed the test that had just claimed the crash. Measured: the provoking
- * test below failed with the guard's own message while holding the exception
- * it asked for.
+ * failed the test that had just claimed the record. Measured: the provoking
+ * test in `loro-binding.browser.test.tsx` failed with this guard's own message
+ * while holding the exception it asked for.
  */
-interface CodeMirrorCrashState {
+interface LoggedFailureState {
   seen: string[]
   expected: boolean
 }
-const CRASH_STATE_KEY = '__whiteboardCodeMirrorCrashes'
+const LOGGED_FAILURE_KEY = '__whiteboardLoggedFailures'
 const globalScope = globalThis as Record<string, unknown>
-globalScope[CRASH_STATE_KEY] ??= { seen: [], expected: false } satisfies CodeMirrorCrashState
-const crashState = globalScope[CRASH_STATE_KEY] as CodeMirrorCrashState
+globalScope[LOGGED_FAILURE_KEY] ??= { seen: [], expected: false } satisfies LoggedFailureState
+const loggedFailures = globalScope[LOGGED_FAILURE_KEY] as LoggedFailureState
 
 /**
- * Claims the crashes this test provokes, and returns the live list. Also the
+ * Claims the records this test provokes, and returns the live list. Also the
  * guard's own mutation check: a test that provokes one and finds this empty is
  * looking at a detector that stopped detecting.
  */
-export function expectCodeMirrorPluginCrash(): readonly string[] {
-  crashState.expected = true
-  return crashState.seen
+export function expectLoggedFailures(): readonly string[] {
+  loggedFailures.expected = true
+  return loggedFailures.seen
 }
 
-// biome-ignore lint/suspicious/noConsole: intercepting this sink IS the guard — @codemirror/view reports a crashed plugin here and nowhere else
+function record(level: string, args: unknown[]): void {
+  loggedFailures.seen.push(`${level}: ${args.map((arg) => String(arg)).join(' ')}`)
+}
+
+// biome-ignore lint/suspicious/noConsole: intercepting these sinks IS the guard — a swallowed failure is reported here and nowhere else; both originals are called through, so nothing is swallowed by the guard itself
 const realConsoleError = console.error.bind(console)
-// biome-ignore lint/suspicious/noConsole: same interception; the original is called through, so nothing is swallowed
+// biome-ignore lint/suspicious/noConsole: same interception
+const realConsoleWarn = console.warn.bind(console)
 console.error = (...args: unknown[]): void => {
-  if (args.some((arg) => typeof arg === 'string' && arg.includes(CODEMIRROR_CRASH_MARKER))) {
-    crashState.seen.push(args.map((arg) => String(arg)).join(' '))
-  }
+  record('error', args)
   realConsoleError(...args)
+}
+console.warn = (...args: unknown[]): void => {
+  record('warn', args)
+  realConsoleWarn(...args)
 }
 
 afterEach(() => {
-  const seen = [...crashState.seen]
-  const expected = crashState.expected
-  crashState.seen.length = 0
-  crashState.expected = false
+  const seen = [...loggedFailures.seen]
+  const expected = loggedFailures.expected
+  loggedFailures.seen.length = 0
+  loggedFailures.expected = false
   if (seen.length > 0 && !expected) {
     throw new Error(
-      `A CodeMirror plugin crashed and was silently disabled — every later edit in that view reached nothing.\n${seen.join('\n')}`,
+      `This test logged a failure and carried on. Something was caught and swallowed — the assertion that eventually breaks will be somewhere else.\n${seen.join('\n')}`,
     )
   }
 })

--- a/apps/web/src/test-utils/browser-setup.ts
+++ b/apps/web/src/test-utils/browser-setup.ts
@@ -72,11 +72,13 @@ configure({ asyncUtilTimeout: 5_000 })
  * platform's.
  *
  * `web-jsdom` is deliberately NOT held to this yet, and the reason is a
- * measurement rather than caution: the same guard there reports ~100 records
- * across 73 tests, most of them tests driving a failure path on purpose
+ * measurement rather than caution: 219 records across 70 of its 3944 tests.
+ * 138 of those are React's act-environment complaint, and the other 81 are
+ * spread over 65 tests, most driving a failure path on purpose
  * (`canvas exploded`, `network down`, a refused registration). That is a ledger
- * of claims, not a free guard — see `testing-techniques/resources/
- * executable-rungs.md` for the two real defects the measurement turned up.
+ * of ~65 claims, not a free guard — see `testing-techniques/resources/
+ * executable-rungs.md` for the numbers, the two real defects the measurement
+ * turned up, and why a throwing guard cannot take this measurement at all.
  *
  * A test that means to provoke one calls `expectLoggedFailures()` and reads
  * what was caught.

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -148,3 +148,54 @@ export async function runSharedTestTeardown(currentTestName: string | undefined)
 afterEach(async () => {
   await runSharedTestTeardown(expect.getState().currentTestName)
 })
+
+/**
+ * A React `act` complaint fails the test that produced it.
+ *
+ * Free, because the suite is silent: measured over the whole `web-jsdom`
+ * project, 0 records across 3947 tests. It was 138 before three mechanical
+ * fixes, and the shape of those is why this is a runtime guard rather than a
+ * lint rule — the two causes have no syntax in common, and only one of them
+ * is visible in a single file:
+ *
+ * - **`act()` wrapping an RTL async utility** (103). `@testing-library/react`
+ *   sets `IS_REACT_ACT_ENVIRONMENT` to FALSE around `waitFor`/`findBy*` on
+ *   purpose, so an `act` call inside one warns. Measured at the warning:
+ *   `flag=false`. The wrapper is also unnecessary — those utilities manage
+ *   `act` themselves. Both call sites wrapped a HELPER that used `findBy*`
+ *   internally, so nothing a lint rule can see in one file said so.
+ * - **`act` imported from `react`** (35). RTL's `act` sets the environment
+ *   flag itself; React's bare one does not, so every call warns.
+ *
+ * Setting `globalThis.IS_REACT_ACT_ENVIRONMENT = true` in this file looks like
+ * the fix for both and is not: measured, it left 103 of the 138 in place —
+ * RTL turns it back off — while switching on 502 un-acted-update reports that
+ * nothing reads. The numbers are in
+ * `testing-techniques/resources/executable-rungs.md`.
+ *
+ * Deliberately narrow: React's act family, not `console.error` at large.
+ * `web-browser` holds the wider line (any `console.error`/`warn`), which it
+ * can afford because its suite is clean; this project still has ~78 records
+ * over ~62 tests, nearly all of them tests driving a failure path on purpose.
+ */
+const REACT_ACT_COMPLAINT =
+  /configured to support act\(|not wrapped in act\(|resolves suspended data/
+let reactActComplaints: string[] = []
+// Intercepting this sink IS the guard — React reports here and nowhere else.
+// The original is called through, so nothing is swallowed by the guard itself.
+const realConsoleErrorForAct = console.error.bind(console)
+console.error = (...args: unknown[]): void => {
+  const message = args.map((arg) => String(arg)).join(' ')
+  if (REACT_ACT_COMPLAINT.test(message)) reactActComplaints.push(message.slice(0, 200))
+  realConsoleErrorForAct(...args)
+}
+
+afterEach(() => {
+  const seen = reactActComplaints
+  reactActComplaints = []
+  if (seen.length > 0) {
+    throw new Error(
+      `React complained about act() in this test.\nIf the call is inside a waitFor/findBy* (RTL turns the act environment OFF in those, deliberately), drop the act — they manage it themselves. If \`act\` came from 'react', import it from '@testing-library/react'.\n${seen.join('\n')}`,
+    )
+  }
+})

--- a/packages/loro-adapter/src/thread-marks.test.ts
+++ b/packages/loro-adapter/src/thread-marks.test.ts
@@ -90,6 +90,27 @@ describe('a thread passage marked in the body', () => {
     expect(marked(reader, 't1')).toBe(PASSAGE)
   })
 
+  it('marks what remains of a passage whose range runs past the body', () => {
+    // A caller can hand over a range the text does not have. The resolver is
+    // one source (its stored-offsets shortcut has answered an out-of-range
+    // `end`), and `document-sync-session`'s create-thread path is another —
+    // it passes `thread.anchor.start`/`end` straight through with no
+    // resolution at all. Unbounded, `LoroText.mark` throws
+    // `Index out of bound. The given pos is N, but the length is M` from
+    // inside the CRDT, naming neither the thread nor the document, and every
+    // caller here has it behind a catch that logs and carries on — so the
+    // conversation silently never gets its mark.
+    const doc = withBody()
+    markThreadPassage(doc, 't1', { start: BODY.length - 6, end: BODY.length + 40 })
+    expect(marked(doc, 't1')).toBe(BODY.slice(-6))
+  })
+
+  it('marks nothing for a range that starts past the body, rather than throwing', () => {
+    const doc = withBody()
+    markThreadPassage(doc, 't1', { start: BODY.length + 5, end: BODY.length + 9 })
+    expect(readThreadMarks(doc).get('t1')).toBeUndefined()
+  })
+
   it('answers nothing for a body nobody has marked', () => {
     expect([...readThreadMarks(withBody()).keys()]).toEqual([])
   })

--- a/packages/loro-adapter/src/thread-marks.ts
+++ b/packages/loro-adapter/src/thread-marks.ts
@@ -132,8 +132,23 @@ export function markThreadPassages(
   configureThreadStyles(doc, ids)
   const text = containers.getText(MARKDOWN_BODY_KEY)
   for (const [threadId, range] of passages) {
-    if (range.end <= range.start) continue
-    text.mark(range, threadStyleKey(threadId), true)
+    // Bounded against the text, because a caller can hand over a range it
+    // does not have and `mark` answers that with a throw from inside the CRDT
+    // — `Index out of bound. The given pos is 20, but the length is 19` —
+    // naming neither the thread nor the document, which every caller here has
+    // behind a catch that logs and carries on. Two sources, both real: the
+    // resolver's stored-offsets shortcut used to answer an `end` past the
+    // body, and `document-sync-session`'s create-thread path passes
+    // `thread.anchor` straight through with no resolution at all.
+    //
+    // Clamped rather than skipped: a passage whose tail was deleted still HAS
+    // a place in this body, and marking what survived is the same answer
+    // `readThreadMarks` gives for a partial deletion. Only a range with
+    // nothing left of it inside the text is dropped.
+    const start = Math.min(range.start, text.length)
+    const end = Math.min(range.end, text.length)
+    if (end <= start) continue
+    text.mark({ start, end }, threadStyleKey(threadId), true)
   }
   containers.commit()
 }

--- a/packages/mcp-server/src/server/store/workspace-tail-loop-availability.test.ts
+++ b/packages/mcp-server/src/server/store/workspace-tail-loop-availability.test.ts
@@ -51,6 +51,24 @@ function canvasReferencing(prefix: string, nodes: number): SpatialCanvas {
 const MIN_PASS_MS = 50
 
 /**
+ * And enough workspaces for the answer to be an answer.
+ *
+ * `worstStallMs` without the yield is the WHOLE pass, so what the assertion
+ * below has to separate is `worst/mean` against the real distribution from
+ * `worst/mean` against the workspace count. Those are 2.09-3.32 and N, and at
+ * N=4 there is no number between them — the measurement cannot tell a yielding
+ * pass from a blocking one however it is phrased. Twelve is the first fixture
+ * round that leaves room for one.
+ *
+ * A floor on the COUNT rather than on elapsed alone, because which round the
+ * growth loop stops at is decided by how slow the machine is: CI reached 50ms
+ * of elapsed on round 0's four workspaces at ~25ms each, where this machine
+ * needs twelve at ~8.5ms. The slower the runner, the smaller the fixture it
+ * settles for, and the smaller the fixture the less the measurement means.
+ */
+const MIN_WORKSPACES = 12
+
+/**
  * What the workspace tail costs the loop that is serving requests, which is
  * the answer `background-work.ts` declares for it.
  *
@@ -85,7 +103,10 @@ const MIN_PASS_MS = 50
  *
  * A ratio rather than a duration, for the reason `snapshot-blocking.test.ts`
  * gives: "the loop keeps getting turns" is stable across machines in a way a
- * millisecond figure is not.
+ * millisecond figure is not. Which ratio matters, though — see
+ * `MIN_WORKSPACES` and the stall assertion. The stable quantity is the worst
+ * stall over ONE workspace's catch-up; the same number over the whole pass
+ * carries the workspace count inside it and only looks scale-free.
  */
 describe('a workspace-tail pass', () => {
   it('keeps handing the event loop back between workspaces', async () => {
@@ -136,14 +157,14 @@ describe('a workspace-tail pass', () => {
 
       availability = (await measureLoopAvailability(() => tail.pollOnce(), { intervalMs: 5 }))
         .availability
-      if (availability.elapsedMs > MIN_PASS_MS) break
+      if (availability.elapsedMs > MIN_PASS_MS && subscribed.length >= MIN_WORKSPACES) break
     }
 
     // Reached, not assumed — and the pass really caught something up rather
     // than baselining past every workspace.
     expect(availability.elapsedMs).toBeGreaterThan(MIN_PASS_MS)
     expect(emitted).toBeGreaterThan(0)
-    expect(subscribed.length).toBeGreaterThanOrEqual(4)
+    expect(subscribed.length).toBeGreaterThanOrEqual(MIN_WORKSPACES)
 
     // A SHARE of the ticks the sampler asked for, not a count — the scale-free
     // form `loopTurnShare` exists for, and the one both loop-availability
@@ -164,7 +185,22 @@ describe('a workspace-tail pass', () => {
     // each workspace's catch-up dearer and proportionally fewer ticks land —
     // one more way that fixture flattered the picture.
     expect(loopTurnShare(availability)).toBeGreaterThan(0.05)
-    expect(availability.worstStallMs).toBeLessThan(availability.elapsedMs * 0.5)
+
+    // The worst stall is a small multiple of ONE workspace's catch-up rather
+    // than the pass, which is the whole of what the yield buys. Measured
+    // worst/mean: 2.09-3.32 over five runs here at twelve workspaces, and
+    // 2.00 on the CI run below. Without the yield it is N, because the pass is
+    // one unbroken stall — so 8 sits 2.4x above the real distribution and 1.5x
+    // below the mutation at the floor `MIN_WORKSPACES` sets.
+    //
+    // This was `worstStallMs < elapsedMs * 0.5`, which is this assertion with
+    // the workspace count folded invisibly into the constant: at N workspaces
+    // it reads `worst/mean < N/2`, so it demanded 6 on this machine and 2 on
+    // CI, from a quantity that measures 2.09-3.32 on both. It failed on main
+    // at `expected 50.1 to be less than 50.1` — worst/mean 2.00, the LOWEST
+    // value ever recorded for it, at four workspaces.
+    const meanWorkspaceStallMs = availability.elapsedMs / subscribed.length
+    expect(availability.worstStallMs).toBeLessThan(meanWorkspaceStallMs * 8)
 
     // The declaration, checked rather than written down. `background-work.ts`
     // publishes what this worker may cost the serving loop, and before this

--- a/packages/model/src/text-anchor.property.test.ts
+++ b/packages/model/src/text-anchor.property.test.ts
@@ -84,6 +84,58 @@ describe('resolveTextAnchor', () => {
     },
   )
 
+  fcTest.prop([built, fc.integer({ min: -4, max: 8 }), fc.integer({ min: 0, max: 6 })])(
+    'never answers with a range the body does not have',
+    (b, widthDrift, trimmed) => {
+      // Two independent ways the stored anchor stops agreeing with the body,
+      // because the invariant has to hold under both and each alone misses the
+      // defect this property exists for.
+      //
+      // `widthDrift` is the one that matters and the one a naive generator
+      // never produces: an anchor whose WIDTH disagrees with its own quote.
+      // `built` always stores `end = start + quote.length`, and under that
+      // invariant `slice`'s clamping can never fabricate a match — the tail of
+      // a shortened body is shorter than the quote, so the comparison fails
+      // honestly. Measured: with `widthDrift` fixed at 0 this property passes
+      // against the unfixed resolver, which is the vacuous version of it.
+      //
+      // Every consumer indexes the body with a `placed` answer;
+      // `markThreadPassages` hands it straight to `LoroText.mark`, where an
+      // end past the text is a throw from inside the CRDT naming neither the
+      // thread nor the document.
+      const shorter = b.body.slice(0, Math.max(0, b.body.length - trimmed))
+      const resolved = resolveTextAnchor(shorter, {
+        ...b.anchor,
+        end: Math.max(b.anchor.start, b.anchor.end + widthDrift),
+      })
+      if (resolved.kind !== 'placed') return
+
+      expect(resolved.start).toBeGreaterThanOrEqual(0)
+      expect(resolved.end).toBeGreaterThanOrEqual(resolved.start)
+      expect(resolved.end).toBeLessThanOrEqual(shorter.length)
+    },
+  )
+
+  it('refuses the stored offsets when they run past the end of the body', () => {
+    // `String.prototype.slice` CLAMPS, so the shortcut that trusts the stored
+    // offsets cannot tell "the quote is still there" from "the body ends
+    // early and what remains happens to equal the quote". Measured:
+    // `'hello world'.slice(6, 20)` is `'world'`, so the comparison succeeds
+    // and the branch returns `end: 20` for an eleven-character body.
+    //
+    // Observed as `[document-sync] backfilling thread marks failed Index out
+    // of bound. The given pos is 20, but the length is 19`, swallowed by a
+    // catch, in three PASSING tests.
+    const resolved = resolveTextAnchor('hello world', {
+      kind: 'text',
+      quote: { exact: 'world' },
+      start: 6,
+      end: 20,
+    })
+
+    expect(resolved).toEqual({ kind: 'placed', start: 6, end: 11 })
+  })
+
   fcTest.prop([built], withDefaults())('says a passage that was deleted is orphaned', (b) => {
     // The alphabets are disjoint, so removing the passage removes every
     // occurrence of it — this is a real deletion, not a move.

--- a/packages/model/src/text-anchor.ts
+++ b/packages/model/src/text-anchor.ts
@@ -116,7 +116,17 @@ export function resolveTextAnchor(
   // only: 8KB body 0.5ms vs 12.3ms (24x), 48KB 0.4ms vs 61.0ms (170x), 200KB
   // 0.1ms vs 228.1ms (2016x). The search scans the whole body once per
   // anchor; this compares `exact.length` characters and stops.
-  if (body.slice(anchor.start, anchor.end) === exact) {
+  //
+  // The length check is not redundant with the comparison: `slice` CLAMPS, so
+  // on a body shorter than the stored `end` it returns the tail rather than
+  // nothing, and a stored range whose width disagrees with its own quote then
+  // MATCHES and is answered verbatim — an `end` the body does not have.
+  // Measured: `'hello world'.slice(6, 20)` is `'world'`. Reached in practice
+  // by an anchor stored with `end - start !== exact.length`, which is ordinary
+  // once a quote and its offsets are written by different paths; observed as
+  // `Index out of bound. The given pos is 20, but the length is 19` thrown
+  // from inside Loro by `markThreadPassages`, and swallowed by a catch.
+  if (anchor.end <= body.length && body.slice(anchor.start, anchor.end) === exact) {
     return { kind: 'placed', start: anchor.start, end: anchor.end }
   }
 


### PR DESCRIPTION
## Summary

- Root-causes the two flakes on main, and the second turns out to have been hiding a **crashed CodeMirror plugin** — `@codemirror/view` catches a ViewPlugin exception and DISABLES it for the life of the view, so every later keystroke reached CodeMirror and nothing else: no deltas, no commits, no save. The run failed ten seconds later on a document's NAME, naming neither the plugin nor the exception. The one line that said what happened was a `stderr` nothing read.
- Fixes **two real defects** found by making that channel readable, both of which lost user data silently: an anchor resolving to a range the body does not have (conversations never got their passage marks), and a CRDT binding whose container moved under the mounted editor.
- Adds the guards that would have named each, and takes `web-jsdom`'s console noise from **219 records to 43** without weakening a test.

### The two flakes

**`workspace-tail`: `expected 50.1 to be less than 50.1`.** `worstStallMs < elapsedMs * 0.5` looks scale-free and is not — the tail yields once per workspace, so it reads `worst/mean < N/2`. That demanded 6 locally and 2 on CI, from a quantity measuring 2.09–3.32 on both; the failing run's 2.00 is the *lowest value ever recorded for it*. The growth loop stopped on elapsed alone, so the slower machine settled for four workspaces and got the stricter test. Now divided by the workspace count, with the constant sized between the real distribution (≤3.32) and the mutation (N), and the loop floors the count at twelve — at four there is no number between 2–3.3 and 4, so no phrasing works there. `file-gc` keeps its `* 0.5`: measured 0.052 at two documents and 0.058 at six, because it yields many times per item.

**`BrowserDocumentPage.markdown`: `expected 'untitled' to be 'Weekly review'`.** Not timing — the crash above. `bodyTextOf` read `hostRef.current` on every call, and `LoroSyncPlugin` maps the mounted editor's offsets onto whatever it answers *at that moment*. A workspace document's body is on its tree node, a legacy one's on the doc root, and the root of a workspace document is **empty**. The load effect clears that ref *synchronously* on every re-run while the editor stays mounted, so for the whole of the next load the resolver answered the empty root and the next keystroke addressed pos 1 of a zero-length container. `bodyTextResolver(host, documentId)` now takes its host as a parameter, so the mistake is unavailable rather than discouraged.

### The two defects the guard surfaced

**`resolveTextAnchor` answered a range the body does not have.** `String.slice` CLAMPS, so a stored anchor whose width disagrees with its own quote still matched and was returned verbatim — `'hello world'.slice(6, 20)` is `'world'`. `markThreadPassages` handed that to `LoroText.mark`, which threw from inside the CRDT into a catch that logs and carries on, in **three passing tests**. Conversations on those documents never got their passage marks. Both bounded now.

**Two earlier explanations were wrong and are recorded beside the right one** so the next reader does not re-derive them: "offsets measured against `readMarkdownBody`" does not fit the numbers, and "Loro indexes by code point while JS counts UTF-16" was refuted by probing the installed version.

### The guards

| rung | catches |
|---|---|
| `browser-setup.ts` (`web-browser`) | any `console.error`/`warn` — a failure caught, logged and swallowed. Strict, no allowlist |
| `vitest.setup.ts` (`web-jsdom`) | React's act complaints |

Both are free, and both are free *because it was measured*: `web-browser` produces exactly one record in a full run (the one a test provokes on purpose). Setting `IS_REACT_ACT_ENVIRONMENT` — the obvious fix for jsdom's 138 act warnings — was **measured and rejected**: it left 103 in place and switched on 502 un-acted-update reports nothing reads. The real causes were `act()` wrapping an RTL async utility (RTL turns the act environment *off* in those, deliberately — measured `flag=false`) and `act` imported from `react`. Three mechanical fixes took 138 to 0.

A runtime guard rather than GritQL, deliberately: the two causes share no syntax, and the wrapping one is invisible in the file that commits it — the `findBy*` lives in the helper.

## Test plan

- [x] New or updated tests added — `web-jsdom`, `web-browser`, `model-node`, `loro-adapter-node`, `mcp-node`
- [x] Suites for the touched areas pass (see below); full suites left to CI per AGENTS.md
- [ ] Manual verification — not applicable; every change here is a test-layer or invariant fix, and each is pinned by a mutation check instead
- [ ] E2E coverage — not applicable

Every fix is mutation-checked in both directions:

| fix | mutation | result |
|---|---|---|
| workspace-tail bound | yield removed | worst/mean 12, fails `191.6 < 127.7` |
| act guard | one wrapper restored | `React complained about act() in this test.` |
| swallowed-failure guard | claim removed | test fails with the exception |
| anchor property | fix reverted | property fails on its own seed |
| `bodyTextResolver` | shared-mutable host restored | `expected '' to be 'a body only the tree node has'` |

The anchor property **existed and was too sparse to catch this** — `built` always stores `end = start + quote.length`, and under that invariant clamping can never fabricate a match. The generator now drifts the stored width; with the drift fixed at 0 it passes against the unfixed resolver, which is the vacuous version of it.

Local: `model-node` + `loro-adapter-node` 548 passed · `web-jsdom` 3817 passed · `web-browser` 235 files / 1237 tests passed · `mcp-node` 4132 passed · lint · typecheck.

**One pre-existing failure is unrelated and stays red locally**: `VersionTimeline` / thumbnail-via-objectURL is the documented wrong-Node-major symptom — this container has Node 22 and `.node-version` pins 24. Identical with and without every change here, and `test-jsdom` is green on main.

## Visual evidence

Visual evidence: none — no change here moves a pixel. The two user-visible defects are *absences* (a passage mark that never appears, a save that never happens), so a before/after capture would be two identical screenshots; `compose-figure.mjs` refuses that pair by design. The evidence is the mutation table above.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — `testing-techniques/resources/executable-rungs.md` and `stability-checks.md` carry every measurement; `test-authoring.md` gains two write-time rules; `steward/reference/failure-modes.md` gains three symptom rows
- [x] No `console.*` added to `src/server/**`
- [x] No hand-written interfaces duplicating a Zod schema

### Still open, filed rather than half-done

`web-jsdom`'s wider console guard needs a ledger of ~35 claims — tests driving a failure path deliberately, where logging is right and each entry needs an honest reason. Two thirds of the original 219 dissolved first (act, then the IndexedDB fold, which was 36 records over 29 tests in six files and behaviour-identical to mock). The order generalises and is written down: **before writing a ledger, subtract the entries that are the environment rather than a decision.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173KdAbXzLi3Nypu4fyneDv

---
_Generated by [Claude Code](https://claude.ai/code/session_0173KdAbXzLi3Nypu4fyneDv)_