### PR TITLE
test(web): web-jsdom fails a swallowed failure too, and the claims assert

### DIFF
--- a/.claude/rules/test-authoring.md
+++ b/.claude/rules/test-authoring.md
@@ -37,8 +37,9 @@ The write-time rules, so the skill is a lookup rather than a prerequisite:
     growth loop floors that dimension — otherwise the slower machine gets the stricter test.
 14. `act` comes from `@testing-library/react`, never `react`, and never wraps a `waitFor` /
     `findBy*` (RTL turns the act environment off inside those, deliberately).
-15. A test that provokes a logged failure claims it with `await expectLoggedFailure('<fragment>')`,
-    which asserts the report arrived — never an allowlist entry.
+15. A test that provokes a logged failure claims it — `await expectLoggedFailure('<fragment>')`
+    in `web-jsdom`, which asserts the report arrived; `expectLoggedFailures()` in `web-browser`,
+    which returns the records to assert on. Never an allowlist entry.
 
 Executable rungs already hold most of these (`pnpm lint`'s GritQL plugin, `arch-lint`'s scans,
 the jsdom setup's teardown). A shape that costs a real defect twice moves up the ladder —

--- a/.claude/rules/test-authoring.md
+++ b/.claude/rules/test-authoring.md
@@ -37,6 +37,8 @@ The write-time rules, so the skill is a lookup rather than a prerequisite:
     growth loop floors that dimension — otherwise the slower machine gets the stricter test.
 14. `act` comes from `@testing-library/react`, never `react`, and never wraps a `waitFor` /
     `findBy*` (RTL turns the act environment off inside those, deliberately).
+15. A test that provokes a logged failure claims it with `await expectLoggedFailure('<fragment>')`,
+    which asserts the report arrived — never an allowlist entry.
 
 Executable rungs already hold most of these (`pnpm lint`'s GritQL plugin, `arch-lint`'s scans,
 the jsdom setup's teardown). A shape that costs a real defect twice moves up the ladder —

--- a/.claude/skills/steward/reference/failure-modes.md
+++ b/.claude/skills/steward/reference/failure-modes.md
@@ -20,6 +20,7 @@ order effects.
 | every test PASSED and the file exits 1, `NotFoundError: removeChild` | A teardown doing `document.body.innerHTML = ''` while React roots are mounted. Use `cleanup()` |
 | "the list does not contain this item" | No list was opened — the trigger was clicked while a menu was still dismissing. Wait for `[role="menu"]` to be gone |
 | an assertion reads an empty value that was definitely typed | The element was remounted and the held reference is detached. Query inside the assertion |
+| `stress-changed-tests` red while both `test-jsdom` shards are green | The two steps split the classes: five fresh processes catch order/module-state flakes, `--repeats=3` catches state carried BETWEEN repetitions of one test. A once-per-process record (a memoised startup attempt) passes the first and fails the second |
 | a `web-browser` test fails saying it logged a failure and carried on | Exactly what it says: something was caught and swallowed. The record is in the message; the assertion that would have broken is elsewhere. Claim it with `expectLoggedFailures()` only if the test provokes it on purpose |
 | a test times out only under the full suite | An `await import()` of a heavy module inside a test body, or a `React.lazy` page racing a `findBy*` (testing-library's budget is 1000ms). Hoist the import |
 | an assertion on a global counter or a "most recent" handle | Another test's `SharedWorker` is still alive. Scope every assertion to a handle the test itself minted |

--- a/.claude/skills/testing-techniques/resources/executable-rungs.md
+++ b/.claude/skills/testing-techniques/resources/executable-rungs.md
@@ -24,6 +24,7 @@ justified it (how many occurrences today, what the false-positive rate would be)
 | `apps/web/vitest.setup.ts`, `src/test-utils/browser-setup.ts`, `vitest.browser.shared.ts` | setup guard | unmounted trees, leaked fake timers (fails the test by name), `localStorage`, missing stylesheet, 1000ms async budget, trace growth |
 | `src/test-utils/browser-setup.ts`'s `expectLoggedFailures` | setup guard (`web-browser`) | any `console.error`/`warn` in a browser test — a failure that was caught, logged and swallowed. Strict, no allowlist; opt in per test to claim one |
 | `apps/web/vitest.setup.ts`'s act guard | setup guard (`web-jsdom`) | React's act complaints — `act` inside a `waitFor`/`findBy*`, or imported from `react` rather than RTL |
+| `src/test-utils/logged-failures.ts`'s `expectLoggedFailure` | setup guard (`web-jsdom`) | any other `console.error`/`warn` — a failure caught, logged and swallowed. The claim is an ASSERTION: it waits for the named record and fails if it never arrives |
 | `background-work-costs.test.ts` + `loop-availability.ts` | `mcp-node` | a declared stall ceiling no test asserts |
 
 ## Adding a GritQL shape
@@ -110,29 +111,43 @@ Whether that becomes a guard or a ledger is a MEASUREMENT, not a judgement:
 | project | records | over | verdict |
 |---|---|---|---|
 | `web-browser` | **1**, the one a test provokes on purpose | 235 files, 1237 tests | free — strict, no allowlist |
-| `web-jsdom` | **43**, across 35 tests | 377 files, 3947 tests | a ledger of ~35 claims, not yet written |
+| `web-jsdom` | **0** unclaimed, 24 tests claiming | 368 files, 3819 tests | guarded |
 
-`web-jsdom` started at 219, and two thirds of that was never a judgement call:
+Both are guarded now. `web-jsdom` started at 219 records, and **two thirds of
+that was never a judgement call** — the reduction ran before the ledger, which
+is the order worth keeping:
 
 | | records | tests | what it was |
 |---|---|---|---|
 | measured | 219 | 70 | |
 | after the act fixes | 82 | 63 | React's act-environment complaint, 138 of them (below) |
-| after mocking the fold | **43** | **35** | jsdom has no IndexedDB, so `foldWorkspaceDocuments` throws; the production path catches it and continues, and the guarded warn on the way was 36 records over 29 tests in six files |
+| after mocking the fold | 43 | 35 | jsdom has no IndexedDB, so `foldWorkspaceDocuments` throws; the guarded warn on the way was 36 records over 29 tests in six files |
+| after fixing one fixture | 36 | 29 | a mock answered the schema-checked GET `/versions` with the catch-all `{}`, so five tests quietly exercised a schema failure none of them is about |
+| claimed | **0** unclaimed | 24 claiming | tests driving a failure path on purpose |
 
-Neither reduction weakened a test. The fold one is behaviour-identical — those
-tests already ran under the guarded continue, and the mock returns the same
-outcome the throw produced — so it removes noise rather than coverage.
+**Before writing a ledger, subtract the entries that are the environment rather
+than a decision.** Two thirds of this one dissolved that way, and what was left
+was small enough to write honestly.
 
-What is left is a ledger of ~35 claims: tests driving a failure path
-deliberately (`canvas exploded`, `network down`, a refused tool registration),
-where logging is the right behaviour and each needs an entry saying so. Real
-work, worth doing on its own merits rather than as a side effect. The act
-family is guarded already, because that part became free.
+### A claim that asserts beats an allowlist that exempts
 
-The order generalises: **before writing a ledger, subtract the entries that are
-the environment rather than a decision.** Two thirds of this one dissolved, and
-the remainder is small enough to write honestly.
+The 24 that remain do not get an exemption. `expectLoggedFailure('<fragment>')`
+claims the record AND waits for it, so a test that stops producing its degraded
+report fails rather than passing quietly — the direction a bare allowlist cannot
+see. Each of those tests was already asserting that a failure is SURVIVED
+(`celebrate` resolves, `reloadFresh` still reloads, the registry does not take
+the page down); the claim adds the half they were all missing, that the failure
+is also REPORTED.
+
+Two mechanics it cost, both measured:
+
+- **The claim must WAIT.** These reports are fire-and-forget catches on rejected
+  promises, so they land after the body that provoked them. A synchronous
+  assertion saw `(none)` and let the record leak into the NEXT test — one cause,
+  two failing tests. `vi.waitFor`, and the fragment is claimed BEFORE the wait
+  so a record arriving during it is already spoken for.
+- **State on `globalThis`**, for the reason `browser-setup.ts` records: the
+  setup file and a test importing the helper are two module instances.
 
 ### Take this measurement with a RECORDER, never a throwing guard
 

--- a/.claude/skills/testing-techniques/resources/executable-rungs.md
+++ b/.claude/skills/testing-techniques/resources/executable-rungs.md
@@ -111,18 +111,25 @@ Whether that becomes a guard or a ledger is a MEASUREMENT, not a judgement:
 | project | records | over | verdict |
 |---|---|---|---|
 | `web-browser` | **1**, the one a test provokes on purpose | 235 files, 1237 tests | free — strict, no allowlist |
-| `web-jsdom` | **0** unclaimed, 24 tests claiming | 368 files, 3819 tests | guarded |
+| `web-jsdom` | **0** unclaimed, 24 tests claiming | 368 files, 3819 collected | guarded |
 
 Both are guarded now. `web-jsdom` started at 219 records, and **two thirds of
 that was never a judgement call** — the reduction ran before the ledger, which
 is the order worth keeping:
 
+Each row is an independent measurement of the whole project on the tree at that
+point, not a delta from the row above — the test counts move between rows too,
+so subtracting two rows does not give the size of one cause. What each cause
+cost is stated in its own row: 138 of the 219, then 36 of the 43, then 8 of the
+36. (`3819` is what the project COLLECTS; the PR that landed this reports 3818
+passed, the difference being the one pre-existing wrong-Node-major failure.)
+
 | | records | tests | what it was |
 |---|---|---|---|
 | measured | 219 | 70 | |
-| after the act fixes | 82 | 63 | React's act-environment complaint, 138 of them (below) |
-| after mocking the fold | 43 | 35 | jsdom has no IndexedDB, so `foldWorkspaceDocuments` throws; the guarded warn on the way was 36 records over 29 tests in six files |
-| after fixing one fixture | 36 | 29 | a mock answered the schema-checked GET `/versions` with the catch-all `{}`, so five tests quietly exercised a schema failure none of them is about |
+| after the act fixes | 82 | 63 | 138 of the 219: React's act-environment complaint (below) |
+| after mocking the fold | 43 | 35 | 36 of the 82: jsdom has no IndexedDB, so `foldWorkspaceDocuments` throws, and the guarded warn on the way spanned 29 tests in six files |
+| after fixing one fixture | 36 | 29 | 8 of the 43: a mock answered the schema-checked GET `/versions` with the catch-all `{}`, so five tests quietly exercised a schema failure none of them is about |
 | claimed | **0** unclaimed | 24 claiming | tests driving a failure path on purpose |
 
 **Before writing a ledger, subtract the entries that are the environment rather

--- a/.claude/skills/testing-techniques/resources/executable-rungs.md
+++ b/.claude/skills/testing-techniques/resources/executable-rungs.md
@@ -139,6 +139,16 @@ see. Each of those tests was already asserting that a failure is SURVIVED
 the page down); the claim adds the half they were all missing, that the failure
 is also REPORTED.
 
+A third, and the one `stress-changed-tests` caught rather than a reviewer:
+**a claim must name a failure the test PROVOKES, not one the environment
+produces once per process.** `App.test.tsx` claimed
+`fold before counting failed` — jsdom having no IndexedDB — and the module
+memoises the attempt, so the record exists on the FIRST execution and never
+again. Five fresh-process runs passed and the in-process `--repeats=3` run
+failed, which is exactly the split those two steps exist to separate. The fix
+is the same as everywhere else that record appears: mock the fold, and do not
+claim it.
+
 Two mechanics it cost, both measured:
 
 - **The claim must WAIT.** These reports are fire-and-forget catches on rejected

--- a/apps/web/src/App.notfound-chunk.test.tsx
+++ b/apps/web/src/App.notfound-chunk.test.tsx
@@ -15,6 +15,7 @@ vi.mock('./components/status/NotFoundPage.js', () => {
 import { App } from './App.js'
 import { errorBoundaryLog } from './components/ErrorBoundary.js'
 import type { ProviderState } from './lib/provider.js'
+import { expectLoggedFailure } from './test-utils/logged-failures.js'
 
 afterEach(cleanup)
 
@@ -32,5 +33,6 @@ describe('App not-found chunk failure', () => {
     )
     expect(await screen.findByRole('alert')).toBeTruthy()
     reportSpy.mockRestore()
+    await expectLoggedFailure('error when mocking a module')
   })
 })

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -50,6 +50,18 @@ let receivedInitialPath: string | undefined
 // Toggled by the error-boundary test to force the mocked page to throw
 // during render, so App's ErrorBoundary wiring has something real to catch.
 let throwInBrowserDocumentPage = false
+// jsdom has no IndexedDB, so the counts panel's startup fold cannot run: it
+// throws, the production path catches it and continues, and that guarded
+// continue is what this file already ran under. Mocked to the same outcome
+// because the warn on the way is ONCE PER PROCESS — the module memoises the
+// attempt — so it cannot be claimed by a test either. Measured:
+// `stress-changed-tests` runs a touched file five times and the claim passed
+// five times and failed on the repeat, which is exactly the shape that job
+// exists to find.
+vi.mock('./lib/fold-workspace.js', () => ({
+  foldWorkspaceDocuments: async () => ({ folded: 0, skipped: 0 }),
+}))
+
 vi.mock('./pages/BrowserDocumentPage.js', () => ({
   BrowserDocumentPage: ({ initialPath }: { initialPath?: string }) => {
     receivedInitialPath = initialPath
@@ -1022,7 +1034,6 @@ describe('App daemon provider state', () => {
       throwInDaemonDocumentPage = false
       reportSpy.mockRestore()
     }
-    await expectLoggedFailure('fold before counting failed')
     await expectLoggedFailure('The above error occurred')
   })
 })

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -30,6 +30,7 @@ import './components/status/NotFoundPage.js'
 import './pages/PairConsentPage.js'
 import { type ProviderState, resolveHostedProviderStateFromRaw } from './lib/provider.js'
 import { createUserSettingsStore, STORAGE_KEY } from './lib/user-settings-store.js'
+import { expectLoggedFailure } from './test-utils/logged-failures.js'
 
 afterEach(() => {
   cleanup()
@@ -1021,6 +1022,8 @@ describe('App daemon provider state', () => {
       throwInDaemonDocumentPage = false
       reportSpy.mockRestore()
     }
+    await expectLoggedFailure('fold before counting failed')
+    await expectLoggedFailure('The above error occurred')
   })
 })
 
@@ -1509,6 +1512,7 @@ describe('App error boundary', () => {
     expect(screen.getByText('Something went wrong')).toBeTruthy()
     expect(reportSpy).toHaveBeenCalled()
     reportSpy.mockRestore()
+    await expectLoggedFailure('The above error occurred')
   })
 
   it('catches an error surfacing through the paired branch lazy path (boundary sits outside Suspense)', async () => {
@@ -1539,6 +1543,7 @@ describe('App error boundary', () => {
       mockDaemonConnectionResult = { status: 'none' }
       reportSpy.mockRestore()
     }
+    await expectLoggedFailure('The above error occurred')
   })
 })
 

--- a/apps/web/src/boot.test.ts
+++ b/apps/web/src/boot.test.ts
@@ -17,6 +17,7 @@ import {
 import { IdbDocumentIndex } from './lib/idb-document-index.js'
 import { loadWorkspaceDocumentProjection } from './lib/workspace-content.js'
 import { clearNamedDb } from './test-utils/browser-document.js'
+import { expectLoggedFailure } from './test-utils/logged-failures.js'
 
 const REAL_DB_NAME = 'whiteboard-boot-test'
 
@@ -110,6 +111,7 @@ describe('startBootSequence — resolver rejection does not block render', () =>
     const recovered = await resolveBrowserWorkspaceId(REAL_DB_NAME)
     expect(recovered).toMatch(/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/)
     expect(getBrowserWorkspaceId()).toBe(recovered)
+    await expectLoggedFailure('browser workspace id resolution failed')
   })
 
   it('renders anyway when the resolver never settles, rather than holding the splash', async () => {
@@ -137,6 +139,7 @@ describe('startBootSequence — resolver rejection does not block render', () =>
     // never waited for the resolver at all.
     expect(Date.now() - start).toBeGreaterThanOrEqual(2500)
     expect(() => getBrowserWorkspaceId()).toThrow(/resolveBrowserWorkspaceId/)
+    await expectLoggedFailure('browser workspace id resolution did not settle')
   }, 15_000)
 
   it('refuses a sole workspace key that is not a canonical id', async () => {

--- a/apps/web/src/hooks/useDocumentSync.test.ts
+++ b/apps/web/src/hooks/useDocumentSync.test.ts
@@ -31,6 +31,7 @@ vi.mock('@kamiazya/whiteboard-canvas-viewer', async (importOriginal) => ({
 import type { SpatialEditorProps } from '../components/spatial-editor/index.js'
 import type { EditorCommand } from '../lib/spatial/commands.js'
 import { applyCommand } from '../lib/spatial/commands.js'
+import { expectLoggedFailure } from '../test-utils/logged-failures.js'
 import { type UseDocumentSyncResult, useDocumentSync } from './useDocumentSync.js'
 
 type FakeBackendControl = {
@@ -226,6 +227,7 @@ describe('useDocumentSync', () => {
     })
     expect(result.current.persistence.kind).toBe('saved')
     expect(result.current.persistence.lastSavedAt).not.toBeNull()
+    await expectLoggedFailure('editor command target missing')
   })
 
   it('sets syncStatus to "error" when onError fires', () => {

--- a/apps/web/src/lib/browser-backend.read-failure.test.ts
+++ b/apps/web/src/lib/browser-backend.read-failure.test.ts
@@ -28,6 +28,7 @@
 import { StoredDocumentUnreadableError } from '@kamiazya/whiteboard-ports'
 import type { WorkspaceDocs } from '@kamiazya/whiteboard-workspace-index'
 import { describe, expect, it, vi } from 'vitest'
+import { expectLoggedFailure } from '../test-utils/logged-failures.js'
 import { BrowserBackend } from './browser-backend.js'
 import type { DocumentFileStore } from './document-file-store.js'
 import type { LoroStore } from './loro-store.js'
@@ -79,6 +80,7 @@ describe('what a failed workspace read is reported as', () => {
       new StoredDocumentUnreadableError('malformed', 'chunks do not match the manifest'),
     )
     await vi.waitFor(() => expect(reasons).toEqual(['corrupt-snapshot']))
+    await expectLoggedFailure('opening the workspace record failed')
   })
 
   it('reports a read that never completed as unavailable, not as damage', async () => {
@@ -88,6 +90,7 @@ describe('what a failed workspace read is reported as', () => {
       new Error('another tab has this app open at an older version; close it and reload'),
     )
     await vi.waitFor(() => expect(reasons).toEqual(['read-unavailable']))
+    await expectLoggedFailure('opening the workspace record failed')
   })
 
   it('treats an aborted IndexedDB transaction the same way', async () => {
@@ -96,5 +99,6 @@ describe('what a failed workspace read is reported as', () => {
     // that neither says anything about the bytes.
     const { reasons } = connectAgainst(new DOMException('transaction aborted', 'AbortError'))
     await vi.waitFor(() => expect(reasons).toEqual(['read-unavailable']))
+    await expectLoggedFailure('opening the workspace record failed')
   })
 })

--- a/apps/web/src/lib/celebrate.test.ts
+++ b/apps/web/src/lib/celebrate.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { expectLoggedFailure } from '../test-utils/logged-failures.js'
 import { celebrate } from './celebrate.js'
 
 const confettiMock = vi.hoisted(() => vi.fn())
@@ -34,5 +35,8 @@ describe('celebrate', () => {
   it('never throws when the burst itself fails', async () => {
     confettiMock.mockRejectedValue(new Error('canvas exploded'))
     await expect(celebrate()).resolves.toBeUndefined()
+    // Swallowing it is only half the contract: a burst that failed silently
+    // and one that never ran look identical from here.
+    await expectLoggedFailure('confetti burst failed')
   })
 })

--- a/apps/web/src/lib/daemon-file-adapter.test.ts
+++ b/apps/web/src/lib/daemon-file-adapter.test.ts
@@ -11,6 +11,7 @@ import {
 } from '@kamiazya/whiteboard-loro-adapter'
 import { Loro } from 'loro-crdt'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { expectLoggedFailure } from '../test-utils/logged-failures.js'
 import { createDaemonFileAdapter } from './daemon-file-adapter.js'
 
 const BASE = 'http://127.0.0.1:3099'
@@ -131,6 +132,7 @@ describe('createDaemonFileAdapter', () => {
     await expect(
       adapter.storeImage(new File(['x'], 'x.png', { type: 'image/png' })),
     ).resolves.toBeUndefined()
+    await expectLoggedFailure('image upload rejected')
   })
 
   it('loads a referenced canvas from its snapshot', async () => {
@@ -230,6 +232,7 @@ describe('createDaemonFileAdapter', () => {
     })
 
     await expect(adapter.loadDocument('sibling')).resolves.toBeUndefined()
+    await expectLoggedFailure('referenced document load failed')
   })
 
   it('percent-encodes a path on its way into the path', async () => {

--- a/apps/web/src/lib/local-files-source.test.ts
+++ b/apps/web/src/lib/local-files-source.test.ts
@@ -8,6 +8,7 @@ import { Loro } from 'loro-crdt'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { expectLoggedFailure } from '../test-utils/logged-failures.js'
 import {
   getBrowserWorkspaceId,
   resetBrowserWorkspaceIdForTests,
@@ -197,6 +198,7 @@ describe('createLocalFilesSource tags', () => {
     const entries = await createLocalFilesSource().listDocuments()
     expect(entries.find((e) => e.path === 'tagged')?.tags).toEqual(['release', 'q3'])
     expect(entries.find((e) => e.path === 'plain')?.tags).toBeUndefined()
+    await expectLoggedFailure('startup fold left documents behind')
   })
 })
 

--- a/apps/web/src/lib/webmcp/use-browser-tool-registry.test.tsx
+++ b/apps/web/src/lib/webmcp/use-browser-tool-registry.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
+import { expectLoggedFailure } from '../../test-utils/logged-failures.js'
 import { createWhiteboardCommands } from '../commands/create-commands.js'
 import type { WhiteboardCommands } from '../commands/index.js'
 import { webMcpTools } from './tool-definitions.js'
@@ -151,7 +152,7 @@ describe('useBrowserToolRegistry', () => {
     expect(live).toEqual(webMcpTools.map((tool) => tool.name))
   })
 
-  it('a duplicate-name refusal is caught instead of taking down the page', () => {
+  it('a duplicate-name refusal is caught instead of taking down the page', async () => {
     // Chrome throws InvalidStateError synchronously for an already-live name.
     const fake = createFakeModelContext()
     document.modelContext = fake
@@ -163,6 +164,7 @@ describe('useBrowserToolRegistry', () => {
     })
 
     expect(() => render(<TestHarness commands={fakeCommands()} documentKey="c1" />)).not.toThrow()
+    await expectLoggedFailure('registerTool(whiteboard_get_app_context) failed')
   })
 
   it('a synchronous registration failure is caught and never escapes the effect', async () => {
@@ -181,6 +183,7 @@ describe('useBrowserToolRegistry', () => {
     } finally {
       process.off('unhandledRejection', onUnhandledRejection)
     }
+    await expectLoggedFailure('registerTool(whiteboard_get_app_context) failed')
   })
 
   it('does not attempt registration when documentKey is null (no canvas open)', async () => {

--- a/apps/web/src/pages/BrowserDocumentPage.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.test.tsx
@@ -24,6 +24,7 @@ import type { LoroLoadResult } from '../lib/loro-store.js'
 import { getShellConnection, resetShellStatusForTests } from '../lib/shell-status-store.js'
 import type { DocumentSnapshot } from '../lib/whiteboard-client.js'
 import { LocalStoreDouble } from '../test-utils/local-index.js'
+import { expectLoggedFailure } from '../test-utils/logged-failures.js'
 import { assertNoSetStateInRenderWarning } from '../test-utils/no-setstate-in-render.js'
 import { BrowserDocumentPage } from './BrowserDocumentPage.js'
 import type { LoroStoreLike } from './use-browser-document-controller.js'
@@ -984,6 +985,7 @@ describe('?new=canvas launch shortcut', () => {
       expect((await store.listDocuments()).length).toBe(1)
     })
     window.history.replaceState(null, '', '/')
+    await expectLoggedFailure('launcher shortcut create failed')
   })
 })
 

--- a/apps/web/src/pages/BrowserDocumentPage.unreadable-content.test.tsx
+++ b/apps/web/src/pages/BrowserDocumentPage.unreadable-content.test.tsx
@@ -19,6 +19,7 @@ import { IdbDocumentIndex } from '../lib/idb-document-index.js'
 import { ensureLocalWorkspace, IdbDefaultDocumentPointer } from '../lib/local-document-summary.js'
 import { clearWhiteboardDb } from '../test-utils/browser-document.js'
 import { claimIsolatedWhiteboardDb } from '../test-utils/isolated-whiteboard-db.js'
+import { expectLoggedFailure } from '../test-utils/logged-failures.js'
 import { seedSyncDocument } from '../test-utils/seed-sync-document.js'
 import { BrowserDocumentPage } from './BrowserDocumentPage.js'
 
@@ -70,6 +71,7 @@ describe('a document this build cannot read', () => {
     // The half that protects the document: no editor, so nothing can save
     // over it.
     expect(screen.queryByTestId('mock-spatial-editor')).toBeNull()
+    await expectLoggedFailure('startup fold left documents behind')
   })
 
   it('says the data is corrupt when the bytes are not Loro', async () => {
@@ -84,6 +86,7 @@ describe('a document this build cannot read', () => {
       expect(screen.getByRole('alert').textContent).toMatch(/could not be read/i)
     })
     expect(screen.queryByTestId('mock-spatial-editor')).toBeNull()
+    await expectLoggedFailure('startup fold left documents behind')
   })
 
   it('stops reporting the failure once a readable document is opened', async () => {
@@ -117,5 +120,6 @@ describe('a document this build cannot read', () => {
 
     await waitFor(() => expect(screen.getByTestId('mock-spatial-editor')).toBeTruthy())
     expect(screen.queryByRole('alert')).toBeNull()
+    await expectLoggedFailure('startup fold left documents behind')
   })
 })

--- a/apps/web/src/pages/DaemonDocumentPage.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.test.tsx
@@ -739,6 +739,17 @@ describe('DaemonDocumentPage', () => {
               }),
             )
           }
+          // The panel LISTS versions on mount, and this mock only answered the
+          // POST — so the catch-all reached `versionsResponseSchema` and this
+          // test quietly exercised a schema failure it is not about.
+          if (url.includes('/workspaces/w1/documents/main/versions') && init?.method !== 'POST') {
+            return Promise.resolve(
+              new Response(JSON.stringify({ versions: [] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              }),
+            )
+          }
           if (url.includes('/workspaces/w1/documents/main/versions') && init?.method === 'POST') {
             return Promise.resolve(
               new Response(

--- a/apps/web/src/pages/DaemonDocumentPage.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.test.tsx
@@ -742,7 +742,10 @@ describe('DaemonDocumentPage', () => {
           // The panel LISTS versions on mount, and this mock only answered the
           // POST — so the catch-all reached `versionsResponseSchema` and this
           // test quietly exercised a schema failure it is not about.
-          if (url.includes('/workspaces/w1/documents/main/versions') && init?.method !== 'POST') {
+          if (
+            url.includes('/workspaces/w1/documents/main/versions') &&
+            (init?.method ?? 'GET') === 'GET'
+          ) {
             return Promise.resolve(
               new Response(JSON.stringify({ versions: [] }), {
                 status: 200,

--- a/apps/web/src/pages/DaemonDocumentPage.versions.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.versions.test.tsx
@@ -15,6 +15,7 @@ import type { ReactElement, ReactNode } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as daemonApiClient from '../lib/daemon-api-client.js'
+import { expectLoggedFailure } from '../test-utils/logged-failures.js'
 import { DaemonDocumentPage } from './DaemonDocumentPage.js'
 
 function MemoryRouterWrapper({ children }: { children: ReactNode }) {
@@ -163,6 +164,18 @@ describe('DaemonDocumentPage versions', () => {
               }),
             )
           }
+          // The panel LISTS versions on mount, and this mock only answered the
+          // POST — so the catch-all `{}` below reached `versionsResponseSchema`
+          // and every one of these tests quietly exercised a schema failure it
+          // is not about, logging it and carrying on.
+          if (url.includes('/workspaces/w1/documents/main/versions') && init?.method !== 'POST') {
+            return Promise.resolve(
+              new Response(JSON.stringify({ versions: [] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              }),
+            )
+          }
           if (url.includes('/workspaces/w1/documents/main/versions') && init?.method === 'POST') {
             return Promise.resolve(
               new Response(
@@ -227,6 +240,18 @@ describe('DaemonDocumentPage versions', () => {
           if (url.includes('/branches')) {
             return Promise.resolve(
               new Response(JSON.stringify({ head: 'main', branches: [] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              }),
+            )
+          }
+          // The panel LISTS versions on mount, and this mock only answered the
+          // POST — so the catch-all `{}` below reached `versionsResponseSchema`
+          // and every one of these tests quietly exercised a schema failure it
+          // is not about, logging it and carrying on.
+          if (url.includes('/workspaces/w1/documents/main/versions') && init?.method !== 'POST') {
+            return Promise.resolve(
+              new Response(JSON.stringify({ versions: [] }), {
                 status: 200,
                 headers: { 'Content-Type': 'application/json' },
               }),
@@ -319,6 +344,18 @@ describe('DaemonDocumentPage versions', () => {
               }),
             )
           }
+          // The panel LISTS versions on mount, and this mock only answered the
+          // POST — so the catch-all `{}` below reached `versionsResponseSchema`
+          // and every one of these tests quietly exercised a schema failure it
+          // is not about, logging it and carrying on.
+          if (url.includes('/workspaces/w1/documents/main/versions') && init?.method !== 'POST') {
+            return Promise.resolve(
+              new Response(JSON.stringify({ versions: [] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              }),
+            )
+          }
           if (url.includes('/workspaces/w1/documents/main/versions') && init?.method === 'POST') {
             // Malformed 200: missing the `version` envelope the schema requires.
             return Promise.resolve(
@@ -353,6 +390,7 @@ describe('DaemonDocumentPage versions', () => {
       await waitFor(() => expect(screen.getByText(/save failed/i)).toBeTruthy())
 
       vi.unstubAllGlobals()
+      await expectLoggedFailure('POST /versions response did not match')
     })
 
     it('shows an inline error when the save request fails', async () => {
@@ -362,6 +400,18 @@ describe('DaemonDocumentPage versions', () => {
           if (url.includes('/branches')) {
             return Promise.resolve(
               new Response(JSON.stringify({ head: 'main', branches: [] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              }),
+            )
+          }
+          // The panel LISTS versions on mount, and this mock only answered the
+          // POST — so the catch-all `{}` below reached `versionsResponseSchema`
+          // and every one of these tests quietly exercised a schema failure it
+          // is not about, logging it and carrying on.
+          if (url.includes('/workspaces/w1/documents/main/versions') && init?.method !== 'POST') {
+            return Promise.resolve(
+              new Response(JSON.stringify({ versions: [] }), {
                 status: 200,
                 headers: { 'Content-Type': 'application/json' },
               }),

--- a/apps/web/src/pages/DaemonDocumentPage.versions.test.tsx
+++ b/apps/web/src/pages/DaemonDocumentPage.versions.test.tsx
@@ -168,7 +168,10 @@ describe('DaemonDocumentPage versions', () => {
           // POST — so the catch-all `{}` below reached `versionsResponseSchema`
           // and every one of these tests quietly exercised a schema failure it
           // is not about, logging it and carrying on.
-          if (url.includes('/workspaces/w1/documents/main/versions') && init?.method !== 'POST') {
+          if (
+            url.includes('/workspaces/w1/documents/main/versions') &&
+            (init?.method ?? 'GET') === 'GET'
+          ) {
             return Promise.resolve(
               new Response(JSON.stringify({ versions: [] }), {
                 status: 200,
@@ -249,7 +252,10 @@ describe('DaemonDocumentPage versions', () => {
           // POST — so the catch-all `{}` below reached `versionsResponseSchema`
           // and every one of these tests quietly exercised a schema failure it
           // is not about, logging it and carrying on.
-          if (url.includes('/workspaces/w1/documents/main/versions') && init?.method !== 'POST') {
+          if (
+            url.includes('/workspaces/w1/documents/main/versions') &&
+            (init?.method ?? 'GET') === 'GET'
+          ) {
             return Promise.resolve(
               new Response(JSON.stringify({ versions: [] }), {
                 status: 200,
@@ -348,7 +354,10 @@ describe('DaemonDocumentPage versions', () => {
           // POST — so the catch-all `{}` below reached `versionsResponseSchema`
           // and every one of these tests quietly exercised a schema failure it
           // is not about, logging it and carrying on.
-          if (url.includes('/workspaces/w1/documents/main/versions') && init?.method !== 'POST') {
+          if (
+            url.includes('/workspaces/w1/documents/main/versions') &&
+            (init?.method ?? 'GET') === 'GET'
+          ) {
             return Promise.resolve(
               new Response(JSON.stringify({ versions: [] }), {
                 status: 200,
@@ -409,7 +418,10 @@ describe('DaemonDocumentPage versions', () => {
           // POST — so the catch-all `{}` below reached `versionsResponseSchema`
           // and every one of these tests quietly exercised a schema failure it
           // is not about, logging it and carrying on.
-          if (url.includes('/workspaces/w1/documents/main/versions') && init?.method !== 'POST') {
+          if (
+            url.includes('/workspaces/w1/documents/main/versions') &&
+            (init?.method ?? 'GET') === 'GET'
+          ) {
             return Promise.resolve(
               new Response(JSON.stringify({ versions: [] }), {
                 status: 200,

--- a/apps/web/src/pwa/register-sw.test.ts
+++ b/apps/web/src/pwa/register-sw.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { expectLoggedFailure } from '../test-utils/logged-failures.js'
 import { setupSwRegistration } from './register-sw.js'
 
 function fireWindowLoad(): void {
@@ -150,6 +151,7 @@ describe('setupSwRegistration', () => {
     } finally {
       window.removeEventListener('unhandledrejection', onUnhandledRejection)
     }
+    await expectLoggedFailure('failed to register the service worker')
   })
 
   it('passes both onNeedRefresh and onRegisteredSW to registerSW', async () => {
@@ -242,6 +244,7 @@ describe('setupSwRegistration', () => {
       window.removeEventListener('unhandledrejection', onUnhandledRejection)
       vi.doUnmock('./sw-update-scheduler.js')
     }
+    await expectLoggedFailure('failed to load the service worker update scheduler')
   })
 
   it('does not throw and schedules nothing when onRegisteredSW is invoked with no registration', async () => {

--- a/apps/web/src/pwa/reload-fresh.test.ts
+++ b/apps/web/src/pwa/reload-fresh.test.ts
@@ -10,6 +10,7 @@
  * bundle is offering a button that does nothing.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { expectLoggedFailure } from '../test-utils/logged-failures.js'
 import { reloadFresh } from './reload-fresh.js'
 
 interface Recorder {
@@ -92,5 +93,6 @@ describe('reloadFresh', () => {
       reloaded += 1
     })
     expect(reloaded).toBe(1)
+    await expectLoggedFailure('could not drop the service worker before reloading')
   })
 })

--- a/apps/web/src/pwa/sw-status-store.test.ts
+++ b/apps/web/src/pwa/sw-status-store.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { expectLoggedFailure } from '../test-utils/logged-failures.js'
 import {
   applyUpdate,
   bindApplyUpdate,
@@ -49,6 +50,7 @@ describe('sw-status-store', () => {
     bindCheckForUpdates(() => Promise.reject(new Error('offline')))
     await checkForUpdates()
     expect(getSwStatus().checking).toBe(false)
+    await expectLoggedFailure('manual service worker update check failed')
   })
 
   it('bindApplyUpdate marks an update ready; applyUpdate calls the handler', async () => {

--- a/apps/web/src/test-utils/logged-failures.ts
+++ b/apps/web/src/test-utils/logged-failures.ts
@@ -1,0 +1,73 @@
+/**
+ * A jsdom test that logs a failure and carries on fails, unless it says which
+ * failure it meant to provoke.
+ *
+ * The shape this exists for is an exception that is CAUGHT, logged, and
+ * swallowed: the run keeps going and breaks somewhere unrelated. Measured on
+ * CI, a crashed CodeMirror ViewPlugin disabled a CRDT binding for the life of
+ * the view and the failure surfaced ten seconds later as an assertion about a
+ * document NAME. `web-browser` has held that line since; this is the same line
+ * for `web-jsdom`.
+ *
+ * **The claim is an ASSERTION, not an exemption.** `expectLoggedFailure` fails
+ * when the record it names never arrived, so a test that stops producing its
+ * degraded report fails rather than passing quietly — which is the direction a
+ * bare allowlist cannot see. A test claiming `'network down'` is therefore
+ * making the stronger statement it always meant to: not "noise here is fine"
+ * but "this failure is reported, and here is the report".
+ *
+ * State on `globalThis` rather than in module scope, because there are TWO
+ * instances of this module: the one `vitest.setup.ts` loads and the one a test
+ * imports by path. Module-scoped state gave each its own copy, and the setup's
+ * `afterEach` read its own untouched list — measured, the claiming test failed
+ * holding the record it had just claimed.
+ */
+import { expect, vi } from 'vitest'
+
+interface LoggedFailureState {
+  seen: string[]
+  claimed: string[]
+}
+
+const KEY = '__whiteboardJsdomLoggedFailures'
+const globalScope = globalThis as Record<string, unknown>
+globalScope[KEY] ??= { seen: [], claimed: [] } satisfies LoggedFailureState
+const state = globalScope[KEY] as LoggedFailureState
+
+/** Called by the setup's console interception. Not for tests. */
+export function recordLoggedFailure(level: string, args: readonly unknown[]): void {
+  state.seen.push(`${level}: ${args.map((arg) => String(arg)).join(' ')}`)
+}
+
+/**
+ * Names a failure this test provokes on purpose, and asserts it was reported.
+ *
+ * Call it AFTER the action that should produce the record. `fragment` is
+ * matched as a substring, so quote the part that identifies the failure rather
+ * than the whole line — the tail usually carries an object dump whose spelling
+ * is not this test's business.
+ */
+export async function expectLoggedFailure(fragment: string): Promise<void> {
+  // Claimed BEFORE the wait, so a record that lands while we are waiting is
+  // already spoken for — the report is usually a fire-and-forget catch on a
+  // rejected promise, which resolves after the body that provoked it. Measured:
+  // asserting synchronously saw `(none)` and let the record leak into the NEXT
+  // test, failing two tests for one cause.
+  state.claimed.push(fragment)
+  await vi.waitFor(() => {
+    expect(
+      state.seen.filter((record) => record.includes(fragment)),
+      `expected a logged failure containing ${JSON.stringify(fragment)}, but the records were:\n${state.seen.join('\n') || '(none)'}`,
+    ).not.toHaveLength(0)
+  })
+}
+
+/** Called by the setup's `afterEach`. Not for tests. */
+export function takeUnclaimedLoggedFailures(): readonly string[] {
+  const unclaimed = state.seen.filter(
+    (record) => !state.claimed.some((fragment) => record.includes(fragment)),
+  )
+  state.seen.length = 0
+  state.claimed.length = 0
+  return unclaimed
+}

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -3,6 +3,10 @@ import { cleanup } from '@testing-library/react'
 import { afterEach, expect, vi } from 'vitest'
 import { BROWSER_DEFAULT_SEGMENT } from './src/lib/browser-idb.js'
 import { setBrowserWorkspaceIdForTests } from './src/lib/browser-workspace-id.js'
+import {
+  recordLoggedFailure,
+  takeUnclaimedLoggedFailures,
+} from './src/test-utils/logged-failures.js'
 import { drainSchedulerMacrotasks } from './src/test-utils/scheduler-drain.js'
 
 // jsdom page/hook tests read `getBrowserWorkspaceId()` at their existing
@@ -184,10 +188,16 @@ let reactActComplaints: string[] = []
 // Intercepting this sink IS the guard — React reports here and nowhere else.
 // The original is called through, so nothing is swallowed by the guard itself.
 const realConsoleErrorForAct = console.error.bind(console)
+const realConsoleWarnForFailures = console.warn.bind(console)
 console.error = (...args: unknown[]): void => {
   const message = args.map((arg) => String(arg)).join(' ')
   if (REACT_ACT_COMPLAINT.test(message)) reactActComplaints.push(message.slice(0, 200))
+  else recordLoggedFailure('error', args)
   realConsoleErrorForAct(...args)
+}
+console.warn = (...args: unknown[]): void => {
+  recordLoggedFailure('warn', args)
+  realConsoleWarnForFailures(...args)
 }
 
 afterEach(() => {
@@ -196,6 +206,26 @@ afterEach(() => {
   if (seen.length > 0) {
     throw new Error(
       `React complained about act() in this test.\nIf the call is inside a waitFor/findBy* (RTL turns the act environment OFF in those, deliberately), drop the act — they manage it themselves. If \`act\` came from 'react', import it from '@testing-library/react'.\n${seen.join('\n')}`,
+    )
+  }
+})
+
+/**
+ * The wider line `web-browser` already holds: a jsdom test that logs a failure
+ * and carries on fails, unless it claims the failure it meant to provoke.
+ *
+ * The claim is an assertion rather than an exemption — see
+ * `test-utils/logged-failures.ts`. Getting here was mostly subtraction: 219
+ * records at the start, of which 138 were React act complaints with two
+ * mechanical causes, 36 were jsdom having no IndexedDB, and 8 were one fixture
+ * answering a schema-checked route with `{}`. None of those was a decision
+ * anybody had taken.
+ */
+afterEach(() => {
+  const unclaimed = takeUnclaimedLoggedFailures()
+  if (unclaimed.length > 0) {
+    throw new Error(
+      `This test logged a failure and carried on. Something was caught and swallowed — the assertion that eventually breaks will be somewhere else.\nIf the test provokes this on purpose, call \`expectLoggedFailure('<fragment>')\` after the action: it claims the record AND asserts it arrived.\n${unclaimed.join('\n')}`,
     )
   }
 })


### PR DESCRIPTION
## Summary

- Brings `web-jsdom` to the line `web-browser` has held since #1478: a test that logs a failure and carries on **fails**, because the assertion that eventually breaks will be somewhere else.
- The ledger was filed at ~63 claims. It came in at **24**, because two thirds of the noise was never a judgement call — the subtraction ran before the ledger.
- The 24 that remain **do not get an exemption**. The claim waits for the named record and fails if it never arrives.

### Sizing down came first, and that is the reusable part

| | records | tests | what it was |
|---|---|---|---|
| measured | 219 | 70 | |
| after the act fixes (#1478) | 82 | 63 | React's act-environment complaint, 138 of them |
| after mocking the fold (#1478) | 43 | 35 | jsdom has no IndexedDB, so `foldWorkspaceDocuments` throws; the guarded warn was 36 records over 29 tests |
| after fixing one fixture | 36 | 29 | **new here** — see below |
| claimed | **0 unclaimed** | 24 claiming | tests driving a failure path on purpose |

**Before writing a ledger, subtract the entries that are the environment rather than a decision.**

The fixture one was a real gap: five `DaemonDocumentPage` version tests mocked only the **POST** `/versions`, so the panel's own **GET** fell through to the catch-all `new Response('{}')` and failed `versionsResponseSchema`. Those tests are about saving a version and announcing a bookmark — they were quietly exercising a schema failure none of them is about, logging it and carrying on. They serve the listing now.

### A claim that asserts beats an allowlist that exempts

`await expectLoggedFailure('<fragment>')` claims the record **and waits for it**, so a test that stops producing its degraded report fails rather than passing quietly — the direction a bare allowlist cannot see.

Each of those 24 already asserted that a failure is **survived** — `celebrate` resolves, `reloadFresh` still reloads, the tool registry does not take the page down. The claim adds the half every one of them was missing: that the failure is also **reported**. So this is not 24 exemptions bought; it is 24 tests that got stronger.

Two mechanics it cost, both measured rather than reasoned:

- **The claim must WAIT.** These reports are fire-and-forget catches on rejected promises and land *after* the body that provoked them. Asserting synchronously saw `(none)` and let the record leak into the NEXT test — one cause, two failing tests. The fragment is claimed *before* the wait, so a record arriving during it is already spoken for.
- **State on `globalThis`**, for the reason `browser-setup.ts` already records: the setup file and a test importing the helper are two module instances. Module scope gave each its own copy and failed the test that had just claimed its record.

## Test plan

- [x] New or updated tests — 24 tests gain an assertion they were missing; one fixture fixed
- [x] `web-jsdom` passes: **3818 passed, 0 unclaimed records**
- [ ] Manual verification — not applicable; this is test infrastructure, pinned by the mutation check below
- [ ] E2E — not applicable

Mutation-checked in both directions on `celebrate`:

| mutation | result |
|---|---|
| drop the claim | test fails as an unclaimed record |
| make the failure stop happening | claim fails: `expected a logged failure containing "confetti burst failed"` |

The second is the one that matters — it is what makes this an assertion rather than an allowlist entry.

**One pre-existing failure stays red locally and is unrelated**: `VersionTimeline` / thumbnail-via-objectURL is the documented wrong-Node-major symptom (this container has Node 22, `.node-version` pins 24). Unchanged by this diff, and `test-jsdom` is green on main.

## Visual evidence

Visual evidence: none — test infrastructure only, no production code in the diff and no pixel moves.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR title is a valid Conventional Commit title
- [x] Docs updated — `executable-rungs.md` carries the full sizing table and both mechanics; `test-authoring.md` gains the write-time rule
- [x] No `console.*` added to `src/server/**`
- [x] No hand-written interfaces duplicating a Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173KdAbXzLi3Nypu4fyneDv

---
_Generated by [Claude Code](https://claude.ai/code/session_0173KdAbXzLi3Nypu4fyneDv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for expected console errors and warnings across failure scenarios.
  * Tests now verify that expected failure messages are logged, rather than only checking fallback behavior.
  * Added automatic detection of unverified console failures to reduce silently swallowed test errors.
* **Documentation**
  * Updated testing guidance with instructions and examples for asserting expected logged failures.
  * Documented how failure tracking and asynchronous assertions work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->